### PR TITLE
Resubmit service on phase change

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -865,10 +865,7 @@
 [[projects]]
   digest = "1:961dc3b1d11f969370533390fdf203813162980c858e1dabe827b60940c909a5"
   name = "github.com/magiconair/properties"
-  packages = [
-    ".",
-    "assert",
-  ]
+  packages = ["."]
   pruneopts = ""
   revision = "c2353362d570a7bfa228149c62842019201cfb71"
   version = "v1.8.0"
@@ -2029,8 +2026,8 @@
     "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider",
     "github.com/lxn/walk",
     "github.com/lxn/win",
-    "github.com/magiconair/properties/assert",
     "github.com/mailru/easyjson",
+    "github.com/mailru/easyjson/buffer",
     "github.com/mailru/easyjson/jlexer",
     "github.com/mailru/easyjson/jwriter",
     "github.com/mholt/archiver",

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -73,7 +73,7 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 
 		// static pods are included specifically because they won't have any container
 		// as they're not updated in the pod list after creation
-		if isPodStatic(pod) == true && foundPod == false {
+		if isPodStatic(pod) && !foundPod {
 			newStaticPod = true
 		}
 
@@ -87,8 +87,8 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 			// We check if the container has an ID instead (has run or is running)
 			if !container.IsPending() {
 				// We store readiness in the cache key to resubmit the container on pod phase change
-				containerCacheKey := container.ID + "-" + strconv.FormatBool(IsPodReady(pod))
-				if _, found := w.lastSeen[containerCacheKey]; found == false {
+				containerCacheKey := container.ID + "-ready:" + strconv.FormatBool(IsPodReady(pod))
+				if _, found := w.lastSeen[containerCacheKey]; !found {
 					newContainer = true
 				}
 				w.lastSeen[containerCacheKey] = now

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -86,10 +86,12 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 			// We don't check container readiness as init containers are never ready
 			// We check if the container has an ID instead (has run or is running)
 			if !container.IsPending() {
-				if _, found := w.lastSeen[container.ID]; found == false {
+				// We store readiness in the cache key to resubmit the container on pod phase change
+				containerCacheKey := container.ID + "-" + strconv.FormatBool(IsPodReady(pod))
+				if _, found := w.lastSeen[containerCacheKey]; found == false {
 					newContainer = true
 				}
-				w.lastSeen[container.ID] = now
+				w.lastSeen[containerCacheKey] = now
 			}
 		}
 

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -228,7 +228,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 	require.Len(suite.T(), expire, 0)
 
 	// Try
-	testContainerID := "docker://b3e4cd65204e04d1a2d4b7683cae2f59b2075700f033a6b09890bd0d3fecf6b6-true"
+	testContainerID := "docker://b3e4cd65204e04d1a2d4b7683cae2f59b2075700f033a6b09890bd0d3fecf6b6-ready:true"
 
 	// 4 minutes should NOT be enough to expire
 	watcher.lastSeen[testContainerID] = watcher.lastSeen[testContainerID].Add(-4 * time.Minute)
@@ -286,7 +286,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 	require.Nil(suite.T(), err)
 	expectedExpire := []string{
 		"kubernetes_pod://d91aa43c-0769-11e8-afcc-000c29dea4f6",
-		"docker://3e13513f94b41d23429804243820438fb9a214238bf2d4f384741a48b575670a-true",
+		"docker://3e13513f94b41d23429804243820438fb9a214238bf2d4f384741a48b575670a-ready:true",
 		"kubernetes_pod://260c2b1d43b094af6d6b4ccba082c2db",
 	}
 

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -178,6 +178,34 @@ func (suite *PodwatcherTestSuite) TestPodWatcherWithShortLivedContainers() {
 	require.False(suite.T(), IsPodReady(changes[0]))
 }
 
+func (suite *PodwatcherTestSuite) TestPodWatcherReadinessChange() {
+	sourcePods, err := loadPodsFixture("./testdata/podlist_container_not_ready.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 5)
+
+	watcher := &PodWatcher{
+		lastSeen:       make(map[string]time.Time),
+		tagsDigest:     make(map[string]string),
+		expiryDuration: 5 * time.Minute,
+	}
+
+	changes, err := watcher.computeChanges(sourcePods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 5, fmt.Sprintf("%d", len(changes)))
+
+	// The container goes into ready state
+	sourcePods, err = loadPodsFixture("./testdata/podlist_container_ready.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 5)
+
+	// Should detect the change of state of the redis container
+	changes, err = watcher.computeChanges(sourcePods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 1)
+	assert.Equal(suite.T(), "redis-unready", changes[0].Spec.Containers[0].Name)
+	require.True(suite.T(), IsPodReady(changes[0]))
+}
+
 func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 	sourcePods, err := loadPodsFixture("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
@@ -200,7 +228,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 	require.Len(suite.T(), expire, 0)
 
 	// Try
-	testContainerID := "docker://b3e4cd65204e04d1a2d4b7683cae2f59b2075700f033a6b09890bd0d3fecf6b6"
+	testContainerID := "docker://b3e4cd65204e04d1a2d4b7683cae2f59b2075700f033a6b09890bd0d3fecf6b6-true"
 
 	// 4 minutes should NOT be enough to expire
 	watcher.lastSeen[testContainerID] = watcher.lastSeen[testContainerID].Add(-4 * time.Minute)
@@ -258,7 +286,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 	require.Nil(suite.T(), err)
 	expectedExpire := []string{
 		"kubernetes_pod://d91aa43c-0769-11e8-afcc-000c29dea4f6",
-		"docker://3e13513f94b41d23429804243820438fb9a214238bf2d4f384741a48b575670a",
+		"docker://3e13513f94b41d23429804243820438fb9a214238bf2d4f384741a48b575670a-true",
 		"kubernetes_pod://260c2b1d43b094af6d6b4ccba082c2db",
 	}
 

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_container_not_ready.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_container_not_ready.json
@@ -1,0 +1,831 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "metadata": {
+                "name": "redis-unready-69cfd574f5-wg9vb",
+                "generateName": "redis-unready-69cfd574f5-",
+                "namespace": "default",
+                "selfLink": "/api/v1/namespaces/default/pods/redis-unready-69cfd574f5-wg9vb",
+                "uid": "b4e03af2-8608-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "2059",
+                "creationTimestamp": "2019-06-03T14:05:56Z",
+                "labels": {
+                    "app": "redis",
+                    "pod-template-hash": "2579813091"
+                },
+                "annotations": {
+                    "ad.datadoghq.com/redis-unready.check_names": "[\"redisdb\"]",
+                    "ad.datadoghq.com/redis-unready.init_configs": "[{}]",
+                    "ad.datadoghq.com/redis-unready.instances": "[{\"host\": \"%%host%%\", \"port\": \"%%port%%\"}]",
+                    "kubernetes.io/config.seen": "2019-06-03T14:05:56.415340087Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "name": "redis-unready-69cfd574f5",
+                        "uid": "252e1d8a-8603-11e9-892f-02c6fa0ccfb0",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-rct6f",
+                        "secret": {
+                            "secretName": "default-token-rct6f",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "redis-unready",
+                        "image": "redis",
+                        "ports": [
+                            {
+                                "name": "redis",
+                                "containerPort": 6379,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "128Mi"
+                            },
+                            "requests": {
+                                "cpu": "50m",
+                                "memory": "64Mi"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-rct6f",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "tcpSocket": {
+                                "port": 6379
+                            },
+                            "initialDelaySeconds": 60,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 1,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T14:05:56Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "False",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T14:05:56Z",
+                        "reason": "ContainersNotReady",
+                        "message": "containers with unready status: [redis-unready]"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T14:05:56Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.15",
+                "startTime": "2019-06-03T14:05:56Z",
+                "containerStatuses": [
+                    {
+                        "name": "redis-unready",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T14:05:58Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": false,
+                        "restartCount": 0,
+                        "image": "redis:latest",
+                        "imageID": "docker-pullable://redis@sha256:e549a30b3c31e6305b973e0d9113a3d38d60566708137af9ed7cbdce5650c5cc",
+                        "containerID": "docker://84adac90973fa1263ccf1e296cec72acb4128b6e19fd25bffe4fafb059adafc0"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-controller-manager",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-controller-manager",
+                "uid": "3137267a-85f7-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "171",
+                "creationTimestamp": "2019-06-03T12:00:34Z",
+                "labels": {
+                    "app": "kube-controller-manager"
+                },
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"kube-controller-manager\"},\"name\":\"kube-controller-manager\",\"namespace\":\"kube-system\"},\"spec\":{\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"/hyperkube\",\"controller-manager\",\"--master=http://127.0.0.1:8080\",\"--leader-elect=true\",\"--leader-elect-lease-duration=150s\",\"--leader-elect-renew-deadline=100s\",\"--leader-elect-retry-period=20s\",\"--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate\",\"--cluster-signing-key-file=/etc/secrets/pupernetes.private_key\",\"--root-ca-file=/etc/secrets/pupernetes.issuing_ca\",\"--service-account-private-key-file=/etc/secrets/service-accounts.rsa\",\"--concurrent-deployment-syncs=2\",\"--concurrent-endpoint-syncs=2\",\"--concurrent-gc-syncs=5\",\"--concurrent-namespace-syncs=3\",\"--concurrent-replicaset-syncs=2\",\"--concurrent-resource-quota-syncs=2\",\"--concurrent-service-syncs=1\",\"--concurrent-serviceaccount-token-syncs=2\",\"--horizontal-pod-autoscaler-use-rest-clients=true\"],\"image\":\"gcr.io/google_containers/hyperkube:v1.10.7\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":15},\"name\":\"kube-controller-manager\",\"readinessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":5},\"resources\":{\"limits\":{\"cpu\":\"250m\"},\"requests\":{\"cpu\":\"100m\"}},\"volumeMounts\":[{\"mountPath\":\"/etc/secrets\",\"name\":\"secrets\"}]}],\"hostNetwork\":true,\"nodeName\":\"ci-pierremargueritte\",\"serviceAccountName\":\"kube-controller-manager\",\"volumes\":[{\"hostPath\":{\"path\":\"/opt/state/secrets\"},\"name\":\"secrets\"}]}}\n",
+                    "kubernetes.io/config.seen": "2019-06-03T12:00:34.068047648Z",
+                    "kubernetes.io/config.source": "api"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "secrets",
+                        "hostPath": {
+                            "path": "/opt/state/secrets",
+                            "type": ""
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-controller-manager",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "controller-manager",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate",
+                            "--cluster-signing-key-file=/etc/secrets/pupernetes.private_key",
+                            "--root-ca-file=/etc/secrets/pupernetes.issuing_ca",
+                            "--service-account-private-key-file=/etc/secrets/service-accounts.rsa",
+                            "--concurrent-deployment-syncs=2",
+                            "--concurrent-endpoint-syncs=2",
+                            "--concurrent-gc-syncs=5",
+                            "--concurrent-namespace-syncs=3",
+                            "--concurrent-replicaset-syncs=2",
+                            "--concurrent-resource-quota-syncs=2",
+                            "--concurrent-service-syncs=1",
+                            "--concurrent-serviceaccount-token-syncs=2",
+                            "--horizontal-pod-autoscaler-use-rest-clients=true"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "250m"
+                            },
+                            "requests": {
+                                "cpu": "100m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "secrets",
+                                "mountPath": "/etc/secrets"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-controller-manager",
+                "serviceAccount": "kube-controller-manager",
+                "automountServiceAccountToken": false,
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:00:34Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:14Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:00:34Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-06-03T12:00:34Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-controller-manager",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T12:01:08Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "docker-pullable://gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "docker://bfcd62d56d00667d8026c822c0061b56d1d4e91dbec3ad148652dad10fa0f267"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-proxy-d9fx4",
+                "generateName": "kube-proxy-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-proxy-d9fx4",
+                "uid": "47ea1faf-85f7-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "224",
+                "creationTimestamp": "2019-06-03T12:01:12Z",
+                "labels": {
+                    "app": "kube-proxy",
+                    "controller-revision-hash": "713792516",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-06-03T12:01:12.152818694Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-proxy",
+                        "uid": "31417f22-85f7-11e9-892f-02c6fa0ccfb0",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config",
+                        "configMap": {
+                            "name": "kube-proxy",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "kube-proxy-token-62tlw",
+                        "secret": {
+                            "secretName": "kube-proxy-token-62tlw",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-proxy",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "proxy",
+                            "--config=/var/lib/kubernetes/config.yaml"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config",
+                                "mountPath": "/var/lib/kubernetes/"
+                            },
+                            {
+                                "name": "kube-proxy-token-62tlw",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                            "privileged": true
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-proxy",
+                "serviceAccount": "kube-proxy",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:12Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:21Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:12Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-06-03T12:01:12Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-proxy",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T12:01:12Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "docker-pullable://gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "docker://f8222454e2866de60831bd99cec33d282ea9a6e7e8d63a09593d303c6c570b2c"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-scheduler-4p822",
+                "generateName": "kube-scheduler-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-scheduler-4p822",
+                "uid": "47f9ff9f-85f7-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "228",
+                "creationTimestamp": "2019-06-03T12:01:12Z",
+                "labels": {
+                    "app": "kube-scheduler",
+                    "controller-revision-hash": "2740278040",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-06-03T12:01:12.253094997Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-scheduler",
+                        "uid": "31454f28-85f7-11e9-892f-02c6fa0ccfb0",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-j4258",
+                        "secret": {
+                            "secretName": "default-token-j4258",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-scheduler",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "scheduler",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--housekeeping-interval=15s"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-j4258",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:12Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:23Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:12Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-06-03T12:01:12Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-scheduler",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T12:01:13Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "docker-pullable://gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "docker://a81499862d97c3902889651bf63b39295cf7a7b7e96e3839499d212a5aa0688c"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "coredns-747dbcf5df-ks57g",
+                "generateName": "coredns-747dbcf5df-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/coredns-747dbcf5df-ks57g",
+                "uid": "47af7bf2-85f7-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "249",
+                "creationTimestamp": "2019-06-03T12:01:11Z",
+                "labels": {
+                    "dns": "coredns",
+                    "pod-template-hash": "3038679189"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-06-03T12:01:17.649990268Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "name": "coredns-747dbcf5df",
+                        "uid": "479e621f-85f7-11e9-892f-02c6fa0ccfb0",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config-volume",
+                        "configMap": {
+                            "name": "coredns",
+                            "items": [
+                                {
+                                    "key": "Corefile",
+                                    "path": "Corefile"
+                                }
+                            ],
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "coredns-token-cvdcz",
+                        "secret": {
+                            "secretName": "coredns-token-cvdcz",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "coredns",
+                        "image": "coredns/coredns:1.1.1",
+                        "args": [
+                            "-conf",
+                            "/etc/coredns/Corefile"
+                        ],
+                        "ports": [
+                            {
+                                "name": "dns",
+                                "containerPort": 53,
+                                "protocol": "UDP"
+                            },
+                            {
+                                "name": "dns-tcp",
+                                "containerPort": 53,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "metrics",
+                                "containerPort": 9153,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config-volume",
+                                "mountPath": "/etc/coredns"
+                            },
+                            {
+                                "name": "coredns-token-cvdcz",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "Default",
+                "serviceAccountName": "coredns",
+                "serviceAccount": "coredns",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "CriticalAddonsOnly",
+                        "operator": "Exists"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:17Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:28Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:17Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.2",
+                "startTime": "2019-06-03T12:01:17Z",
+                "containerStatuses": [
+                    {
+                        "name": "coredns",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T12:01:23Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "coredns/coredns:1.1.1",
+                        "imageID": "docker-pullable://coredns/coredns@sha256:399cc5b2e2f0d599ef22f43aab52492e88b4f0fd69da9b10545e95a4253c86ce",
+                        "containerID": "docker://3698873b7d4ebc30f230d15fdfd46cca6ab6b312be4f6c23b8860a2522f5f90b"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        }
+    ]
+}

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_container_ready.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_container_ready.json
@@ -1,0 +1,829 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "metadata": {
+                "name": "kube-controller-manager",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-controller-manager",
+                "uid": "3137267a-85f7-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "171",
+                "creationTimestamp": "2019-06-03T12:00:34Z",
+                "labels": {
+                    "app": "kube-controller-manager"
+                },
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"kube-controller-manager\"},\"name\":\"kube-controller-manager\",\"namespace\":\"kube-system\"},\"spec\":{\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"/hyperkube\",\"controller-manager\",\"--master=http://127.0.0.1:8080\",\"--leader-elect=true\",\"--leader-elect-lease-duration=150s\",\"--leader-elect-renew-deadline=100s\",\"--leader-elect-retry-period=20s\",\"--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate\",\"--cluster-signing-key-file=/etc/secrets/pupernetes.private_key\",\"--root-ca-file=/etc/secrets/pupernetes.issuing_ca\",\"--service-account-private-key-file=/etc/secrets/service-accounts.rsa\",\"--concurrent-deployment-syncs=2\",\"--concurrent-endpoint-syncs=2\",\"--concurrent-gc-syncs=5\",\"--concurrent-namespace-syncs=3\",\"--concurrent-replicaset-syncs=2\",\"--concurrent-resource-quota-syncs=2\",\"--concurrent-service-syncs=1\",\"--concurrent-serviceaccount-token-syncs=2\",\"--horizontal-pod-autoscaler-use-rest-clients=true\"],\"image\":\"gcr.io/google_containers/hyperkube:v1.10.7\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":15},\"name\":\"kube-controller-manager\",\"readinessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":5},\"resources\":{\"limits\":{\"cpu\":\"250m\"},\"requests\":{\"cpu\":\"100m\"}},\"volumeMounts\":[{\"mountPath\":\"/etc/secrets\",\"name\":\"secrets\"}]}],\"hostNetwork\":true,\"nodeName\":\"ci-pierremargueritte\",\"serviceAccountName\":\"kube-controller-manager\",\"volumes\":[{\"hostPath\":{\"path\":\"/opt/state/secrets\"},\"name\":\"secrets\"}]}}\n",
+                    "kubernetes.io/config.seen": "2019-06-03T12:00:34.068047648Z",
+                    "kubernetes.io/config.source": "api"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "secrets",
+                        "hostPath": {
+                            "path": "/opt/state/secrets",
+                            "type": ""
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-controller-manager",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "controller-manager",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate",
+                            "--cluster-signing-key-file=/etc/secrets/pupernetes.private_key",
+                            "--root-ca-file=/etc/secrets/pupernetes.issuing_ca",
+                            "--service-account-private-key-file=/etc/secrets/service-accounts.rsa",
+                            "--concurrent-deployment-syncs=2",
+                            "--concurrent-endpoint-syncs=2",
+                            "--concurrent-gc-syncs=5",
+                            "--concurrent-namespace-syncs=3",
+                            "--concurrent-replicaset-syncs=2",
+                            "--concurrent-resource-quota-syncs=2",
+                            "--concurrent-service-syncs=1",
+                            "--concurrent-serviceaccount-token-syncs=2",
+                            "--horizontal-pod-autoscaler-use-rest-clients=true"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "250m"
+                            },
+                            "requests": {
+                                "cpu": "100m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "secrets",
+                                "mountPath": "/etc/secrets"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-controller-manager",
+                "serviceAccount": "kube-controller-manager",
+                "automountServiceAccountToken": false,
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:00:34Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:14Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:00:34Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-06-03T12:00:34Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-controller-manager",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T12:01:08Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "docker-pullable://gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "docker://bfcd62d56d00667d8026c822c0061b56d1d4e91dbec3ad148652dad10fa0f267"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-proxy-d9fx4",
+                "generateName": "kube-proxy-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-proxy-d9fx4",
+                "uid": "47ea1faf-85f7-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "224",
+                "creationTimestamp": "2019-06-03T12:01:12Z",
+                "labels": {
+                    "app": "kube-proxy",
+                    "controller-revision-hash": "713792516",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-06-03T12:01:12.152818694Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-proxy",
+                        "uid": "31417f22-85f7-11e9-892f-02c6fa0ccfb0",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config",
+                        "configMap": {
+                            "name": "kube-proxy",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "kube-proxy-token-62tlw",
+                        "secret": {
+                            "secretName": "kube-proxy-token-62tlw",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-proxy",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "proxy",
+                            "--config=/var/lib/kubernetes/config.yaml"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config",
+                                "mountPath": "/var/lib/kubernetes/"
+                            },
+                            {
+                                "name": "kube-proxy-token-62tlw",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                            "privileged": true
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-proxy",
+                "serviceAccount": "kube-proxy",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:12Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:21Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:12Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-06-03T12:01:12Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-proxy",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T12:01:12Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "docker-pullable://gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "docker://f8222454e2866de60831bd99cec33d282ea9a6e7e8d63a09593d303c6c570b2c"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-scheduler-4p822",
+                "generateName": "kube-scheduler-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-scheduler-4p822",
+                "uid": "47f9ff9f-85f7-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "228",
+                "creationTimestamp": "2019-06-03T12:01:12Z",
+                "labels": {
+                    "app": "kube-scheduler",
+                    "controller-revision-hash": "2740278040",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-06-03T12:01:12.253094997Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-scheduler",
+                        "uid": "31454f28-85f7-11e9-892f-02c6fa0ccfb0",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-j4258",
+                        "secret": {
+                            "secretName": "default-token-j4258",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-scheduler",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "scheduler",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--housekeeping-interval=15s"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-j4258",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:12Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:23Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:12Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-06-03T12:01:12Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-scheduler",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T12:01:13Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "docker-pullable://gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "docker://a81499862d97c3902889651bf63b39295cf7a7b7e96e3839499d212a5aa0688c"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "coredns-747dbcf5df-ks57g",
+                "generateName": "coredns-747dbcf5df-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/coredns-747dbcf5df-ks57g",
+                "uid": "47af7bf2-85f7-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "249",
+                "creationTimestamp": "2019-06-03T12:01:11Z",
+                "labels": {
+                    "dns": "coredns",
+                    "pod-template-hash": "3038679189"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-06-03T12:01:17.649990268Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "name": "coredns-747dbcf5df",
+                        "uid": "479e621f-85f7-11e9-892f-02c6fa0ccfb0",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config-volume",
+                        "configMap": {
+                            "name": "coredns",
+                            "items": [
+                                {
+                                    "key": "Corefile",
+                                    "path": "Corefile"
+                                }
+                            ],
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "coredns-token-cvdcz",
+                        "secret": {
+                            "secretName": "coredns-token-cvdcz",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "coredns",
+                        "image": "coredns/coredns:1.1.1",
+                        "args": [
+                            "-conf",
+                            "/etc/coredns/Corefile"
+                        ],
+                        "ports": [
+                            {
+                                "name": "dns",
+                                "containerPort": 53,
+                                "protocol": "UDP"
+                            },
+                            {
+                                "name": "dns-tcp",
+                                "containerPort": 53,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "metrics",
+                                "containerPort": 9153,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config-volume",
+                                "mountPath": "/etc/coredns"
+                            },
+                            {
+                                "name": "coredns-token-cvdcz",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "Default",
+                "serviceAccountName": "coredns",
+                "serviceAccount": "coredns",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "CriticalAddonsOnly",
+                        "operator": "Exists"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:17Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:28Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T12:01:17Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.2",
+                "startTime": "2019-06-03T12:01:17Z",
+                "containerStatuses": [
+                    {
+                        "name": "coredns",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T12:01:23Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "coredns/coredns:1.1.1",
+                        "imageID": "docker-pullable://coredns/coredns@sha256:399cc5b2e2f0d599ef22f43aab52492e88b4f0fd69da9b10545e95a4253c86ce",
+                        "containerID": "docker://3698873b7d4ebc30f230d15fdfd46cca6ab6b312be4f6c23b8860a2522f5f90b"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "redis-unready-69cfd574f5-wg9vb",
+                "generateName": "redis-unready-69cfd574f5-",
+                "namespace": "default",
+                "selfLink": "/api/v1/namespaces/default/pods/redis-unready-69cfd574f5-wg9vb",
+                "uid": "b4e03af2-8608-11e9-892f-02c6fa0ccfb0",
+                "resourceVersion": "2059",
+                "creationTimestamp": "2019-06-03T14:05:56Z",
+                "labels": {
+                    "app": "redis",
+                    "pod-template-hash": "2579813091"
+                },
+                "annotations": {
+                    "ad.datadoghq.com/redis-unready.check_names": "[\"redisdb\"]",
+                    "ad.datadoghq.com/redis-unready.init_configs": "[{}]",
+                    "ad.datadoghq.com/redis-unready.instances": "[{\"host\": \"%%host%%\", \"port\": \"%%port%%\"}]",
+                    "kubernetes.io/config.seen": "2019-06-03T14:05:56.415340087Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "name": "redis-unready-69cfd574f5",
+                        "uid": "252e1d8a-8603-11e9-892f-02c6fa0ccfb0",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-rct6f",
+                        "secret": {
+                            "secretName": "default-token-rct6f",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "redis-unready",
+                        "image": "redis",
+                        "ports": [
+                            {
+                                "name": "redis",
+                                "containerPort": 6379,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "128Mi"
+                            },
+                            "requests": {
+                                "cpu": "50m",
+                                "memory": "64Mi"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-rct6f",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "tcpSocket": {
+                                "port": 6379
+                            },
+                            "initialDelaySeconds": 60,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 1,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T14:05:56Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T14:06:58Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-06-03T14:05:56Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.15",
+                "startTime": "2019-06-03T14:05:56Z",
+                "containerStatuses": [
+                    {
+                        "name": "redis-unready",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-06-03T14:05:58Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "redis:latest",
+                        "imageID": "docker-pullable://redis@sha256:e549a30b3c31e6305b973e0d9113a3d38d60566708137af9ed7cbdce5650c5cc",
+                        "containerID": "docker://84adac90973fa1263ccf1e296cec72acb4128b6e19fd25bffe4fafb059adafc0"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### What does this PR do?

Due to #3372 we send to autodiscovery all running services but only ready ones will be resolved for check scheduling.
If no readiness probe is used, running = ready but if a readiness probe is used there's a delay in-between, so we need to resubmit the service on phase change so that the check config can be resolved.

### Motivation

Fix AD with readiness probes

### Additional Notes

This should not impact logs as won't tail twice the same service
