### PR TITLE
Re-use ConnectionStats in process/checks/net.go

### DIFF
--- a/pkg/process/net/network_linux.go
+++ b/pkg/process/net/network_linux.go
@@ -72,8 +72,9 @@ func GetRemoteSystemProbeUtil() (*RemoteSysProbeUtil, error) {
 	return globalUtil, nil
 }
 
-// GetConnections returns a set of active network connections, retrieved from the system probe service
-func (r *RemoteSysProbeUtil) GetConnections(clientID string) ([]ebpf.ConnectionStats, error) {
+// GetConnections returns a set of active network connections, retrieved from the system probe service.
+// The connections will be read into the input slices of ebpf.ConnectionStats.
+func (r *RemoteSysProbeUtil) GetConnections(clientID string, in []ebpf.ConnectionStats) ([]ebpf.ConnectionStats, error) {
 	resp, err := r.httpClient.Get(fmt.Sprintf("%s?client_id=%s", connectionsURL, clientID))
 	if err != nil {
 		return nil, err
@@ -86,7 +87,7 @@ func (r *RemoteSysProbeUtil) GetConnections(clientID string) ([]ebpf.ConnectionS
 		return nil, err
 	}
 
-	conn := &ebpf.Connections{}
+	conn := ebpf.Connections{Conns: in}
 	if err := conn.UnmarshalJSON(body); err != nil {
 		return nil, err
 	}

--- a/pkg/process/net/network_nolinux.go
+++ b/pkg/process/net/network_nolinux.go
@@ -18,7 +18,7 @@ func GetRemoteSystemProbeUtil() (*RemoteSysProbeUtil, error) {
 }
 
 // GetConnections is only implemented on linux
-func (r *RemoteSysProbeUtil) GetConnections(clientID string) ([]ebpf.ConnectionStats, error) {
+func (r *RemoteSysProbeUtil) GetConnections(clientID string, in []ebpf.ConnectionStats) ([]ebpf.ConnectionStats, error) {
 	return nil, ebpf.ErrNotImplemented
 }
 


### PR DESCRIPTION
### What does this PR do?

Instead of creating a new []ConnectionStats every time the network check runs, use a shared slice. 

### Motivation

This should avoid a lot of allocations and hopefully cut down on RSS.     

### Additional Notes