### PR TITLE
Remove call to Py_Finalize

### DIFF
--- a/six/three/three.cpp
+++ b/six/three/three.cpp
@@ -46,7 +46,19 @@ Three::~Three()
         PyMem_RawFree((void *)_pythonHome);
     }
     Py_XDECREF(_baseClass);
-    Py_Finalize();
+
+    // We do not call Py_Finalize() since we won't be calling it from the same
+    // thread where we called Py_Initialize(), as the go runtime switch thread
+    // all the time. It's not really an issue here as we destroy this class
+    // just before exiting the agent.
+    // Calling Py_Finalize from a different thread cause the "threading"
+    // package to raise an exception: "Exception KeyError: KeyError(<current
+    // thread id>,) in <module 'threading'".
+    // Even if Python ignore it, the exception end up in the log files for
+    // upstart/syslog/...
+    //
+    // More info here:
+    // https://stackoverflow.com/questions/8774958/keyerror-in-module-threading-after-a-successful-py-test-run/12639040#12639040
 }
 
 void Three::initPythonHome(const char *pythonHome)


### PR DESCRIPTION
### What does this PR do?

Remove call to `Py_Finalize`

### Motivation

We do not call Py_Finalize() since we won't be calling it from the same
thread where we called Py_Initialize(), as the go runtime switch thread
all the time. It's not really an issue here as we destroy this class
just before exiting the agent.
Calling Py_Finalize from a different thread cause the "threading"
package to raise an exception: "Exception KeyError: KeyError(<current
thread id>,) in <module 'threading'".
Even if Python ignore it, the exception end up in the log files for
upstart/syslog/...

### Additional Notes

More info here:
https://stackoverflow.com/questions/8774958/keyerror-in-module-threading-after-a-successful-py-test-run/12639040#12639040