### PR TITLE
exit datadog_agent.set_external_tags on failure to iterate over the tag list

### DIFF
--- a/six/common/builtins/datadog_agent.c
+++ b/six/common/builtins/datadog_agent.c
@@ -334,7 +334,8 @@ static PyObject *set_external_tags(PyObject *self, PyObject *args)
         for (j = 0; j < tags_len; j++) {
             PyObject *s = PyList_GetItem(value, j);
             if (s == NULL) {
-                goto error;
+                PyErr_Clear();
+                break;
             }
 
             char *tag = as_string(s);

--- a/six/common/builtins/datadog_agent.c
+++ b/six/common/builtins/datadog_agent.c
@@ -334,8 +334,7 @@ static PyObject *set_external_tags(PyObject *self, PyObject *args)
         for (j = 0; j < tags_len; j++) {
             PyObject *s = PyList_GetItem(value, j);
             if (s == NULL) {
-                PyErr_Clear();
-                continue;
+                goto error;
             }
 
             char *tag = as_string(s);

--- a/six/common/builtins/datadog_agent.c
+++ b/six/common/builtins/datadog_agent.c
@@ -334,6 +334,7 @@ static PyObject *set_external_tags(PyObject *self, PyObject *args)
         for (j = 0; j < tags_len; j++) {
             PyObject *s = PyList_GetItem(value, j);
             if (s == NULL) {
+                PyErr_Clear();
                 continue;
             }
 


### PR DESCRIPTION
### What does this PR do?

Exit datadog_agent.set_external_tags on failure to iterate over the tag list

### Motivation

Six audit.

### Notes

I am not even sure if there is a way for this call to fail and return NULL tbh but since we handle the case in the code let's cleanly exit.