### PR TITLE
Update DataDog/gopsutil to the latest rev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,17 +29,17 @@ templates:
           # If incremental dep fails, increase the cache gen number
           # in restore_deps AND save_deps
           # See https://github.com/DataDog/datadog-agent/pull/2384
-          - gen14-godeps-{{ .Branch }}-{{ .Revision }}
-          - gen14-godeps-{{ .Branch }}-
-          - gen14-godeps-master-
+          - gen15-godeps-{{ .Branch }}-{{ .Revision }}
+          - gen15-godeps-{{ .Branch }}-
+          - gen15-godeps-master-
     - save_cache: &save_deps
-        key: gen14-godeps-{{ .Branch }}-{{ .Revision }}
+        key: gen15-godeps-{{ .Branch }}-{{ .Revision }}
     - restore_cache: &restore_source
         keys:
           # Cache retrieval is faster than full git checkout
-          - v3-repo-{{ .Revision }}
+          - v4-repo-{{ .Revision }}
     - save_cache: &save_source
-        key: v3-repo-{{ .Revision }}
+        key: v4-repo-{{ .Revision }}
 
 jobs:
   checkout_code:
@@ -59,6 +59,15 @@ jobs:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - run:
+          name: setup python deps
+          command: |
+            pip install wheel
+            pip install -r requirements.txt
+      - run:
+          name: grab go deps
+          command: |
+            inv deps --verbose
+      - run:
           name: build six
           command: |
             inv six.build --install-prefix=/go/src/github.com/DataDog/datadog-agent/dev
@@ -74,16 +83,6 @@ jobs:
             # remove base check before running tests, go on if pip fails
             pip uninstall datadog-checks-base -y || :
             inv six.test
-      - run:
-          name: setup python deps
-          command: |
-            pip install wheel
-            pip install -r requirements.txt
-      - run:
-          name: grab go deps
-          command: |
-            pip install -U invoke
-            inv deps --verbose
       - run:
           name: pre-compile go deps
           command: inv -e agent.build --race --precompile-only

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,7 +42,7 @@
   revision = "43b075bb9705588cd89c71363d6d72937e3020c7"
 
 [[projects]]
-  digest = "1:659f95740262dbc680ea46666b4b3c6dae97a0de4f231e3d9688601f7b94a918"
+  digest = "1:f5a67538206ad242703731b55fb4abc6cf7b44de436d4b989572bd82cf3c3e12"
   name = "github.com/DataDog/gopsutil"
   packages = [
     "cpu",
@@ -53,7 +53,7 @@
     "process",
   ]
   pruneopts = ""
-  revision = "aea6a47ff66c0ded148f385a8276d74321d8fc1a"
+  revision = "fe7986fb54b7a36afebec4610af9daa8e5f34f89"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -187,7 +187,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/gopsutil"
-  revision = "aea6a47ff66c0ded148f385a8276d74321d8fc1a"
+  revision = "fe7986fb54b7a36afebec4610af9daa8e5f34f89"
 
 [[constraint]]
   name = "github.com/iovisor/gobpf"

--- a/releasenotes/notes/Update-gopsutil-7688e96a4276f4f3.yaml
+++ b/releasenotes/notes/Update-gopsutil-7688e96a4276f4f3.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Updated the DataDog/gopsutil library to include changes related to excessive DEBUG logging in the process agent 


### PR DESCRIPTION
### What does this PR do?

Updates DataDog/gopsutil to the latest rev to pull in https://github.com/DataDog/gopsutil/pull/22

### Motivation

Customer complaints about excessive logging when the log level is set to DEBUG

