### PR TITLE
Avoid large allocations for []ebpf.ConnectionStats

### DIFF
--- a/pkg/ebpf/event_common.go
+++ b/pkg/ebpf/event_common.go
@@ -66,7 +66,7 @@ func (d ConnectionDirection) String() string {
 // Connections wraps a collection of ConnectionStats
 //easyjson:json
 type Connections struct {
-	Conns []ConnectionStats `json:"connections"`
+	Conns []*ConnectionStats `json:"connections"`
 }
 
 // ConnectionStats stores statistics for a single connection.  Field order in the struct should be 8-byte aligned

--- a/pkg/ebpf/event_common_easyjson.go
+++ b/pkg/ebpf/event_common_easyjson.go
@@ -4,7 +4,6 @@ package ebpf
 
 import (
 	json "encoding/json"
-
 	netlink "github.com/DataDog/datadog-agent/pkg/ebpf/netlink"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
@@ -46,16 +45,24 @@ func easyjson5f1d7f40DecodeGithubComDataDogDatadogAgentPkgEbpf(in *jlexer.Lexer,
 				in.Delim('[')
 				if out.Conns == nil {
 					if !in.IsDelim(']') {
-						out.Conns = make([]ConnectionStats, 0, 1)
+						out.Conns = make([]*ConnectionStats, 0, 8)
 					} else {
-						out.Conns = []ConnectionStats{}
+						out.Conns = []*ConnectionStats{}
 					}
 				} else {
 					out.Conns = (out.Conns)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v1 ConnectionStats
-					(v1).UnmarshalEasyJSON(in)
+					var v1 *ConnectionStats
+					if in.IsNull() {
+						in.Skip()
+						v1 = nil
+					} else {
+						if v1 == nil {
+							v1 = new(ConnectionStats)
+						}
+						(*v1).UnmarshalEasyJSON(in)
+					}
 					out.Conns = append(out.Conns, v1)
 					in.WantComma()
 				}
@@ -79,7 +86,6 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf(out *jwriter.Writ
 		const prefix string = ",\"connections\":"
 		if first {
 			first = false
-			_ = first
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
@@ -92,7 +98,11 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf(out *jwriter.Writ
 				if v2 > 0 {
 					out.RawByte(',')
 				}
-				(v3).MarshalEasyJSON(out)
+				if v3 == nil {
+					out.RawString("null")
+				} else {
+					(*v3).MarshalEasyJSON(out)
+				}
 			}
 			out.RawByte(']')
 		}
@@ -386,7 +396,6 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		const prefix string = ",\"iptr\":"
 		if first {
 			first = false
-			_ = first
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)

--- a/pkg/ebpf/netlink/event_easyjson.go
+++ b/pkg/ebpf/netlink/event_easyjson.go
@@ -4,7 +4,6 @@ package netlink
 
 import (
 	json "encoding/json"
-
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -93,7 +92,6 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgEbpfNetlink(out *jwrit
 		const prefix string = ",\"r_dport\":"
 		if first {
 			first = false
-			_ = first
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)

--- a/pkg/ebpf/tracer-ebpf.go
+++ b/pkg/ebpf/tracer-ebpf.go
@@ -161,7 +161,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"tracer-ebpf.o":       tracerEbpfO,
+	"tracer-ebpf.o": tracerEbpfO,
 	"tracer-ebpf-debug.o": tracerEbpfDebugO,
 }
 
@@ -204,10 +204,9 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
-	"tracer-ebpf-debug.o": {tracerEbpfDebugO, map[string]*bintree{}},
-	"tracer-ebpf.o":       {tracerEbpfO, map[string]*bintree{}},
+	"tracer-ebpf-debug.o": &bintree{tracerEbpfDebugO, map[string]*bintree{}},
+	"tracer-ebpf.o": &bintree{tracerEbpfO, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory
@@ -256,3 +255,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -99,7 +99,7 @@ func (c *ConnectionsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	return batchConnections(cfg, groupID, c.formatConnections(conns)), nil
 }
 
-func (c *ConnectionsCheck) getConnections() ([]ebpf.ConnectionStats, error) {
+func (c *ConnectionsCheck) getConnections() ([]*ebpf.ConnectionStats, error) {
 	if c.useLocalTracer { // If local tracer is set up, use that
 		if c.localTracer == nil {
 			return nil, fmt.Errorf("using local system probe, but no tracer was initialized")
@@ -121,7 +121,7 @@ func (c *ConnectionsCheck) getConnections() ([]ebpf.ConnectionStats, error) {
 
 // Connections are split up into a chunks of at most 100 connections per message to
 // limit the message size on intake.
-func (c *ConnectionsCheck) formatConnections(conns []ebpf.ConnectionStats) []*model.Connection {
+func (c *ConnectionsCheck) formatConnections(conns []*ebpf.ConnectionStats) []*model.Connection {
 	// Process create-times required to construct unique process hash keys on the backend
 	createTimeForPID := Process.createTimesforPIDs(connectionStatsPIDs(conns))
 
@@ -262,7 +262,7 @@ func groupSize(total, maxBatchSize int) int32 {
 	return int32(groupSize)
 }
 
-func connectionStatsPIDs(conns []ebpf.ConnectionStats) []uint32 {
+func connectionStatsPIDs(conns []*ebpf.ConnectionStats) []uint32 {
 	ps := make(map[uint32]struct{}) // Map used to represent a set
 	for _, c := range conns {
 		ps[c.Pid] = struct{}{}

--- a/pkg/process/net/network_linux.go
+++ b/pkg/process/net/network_linux.go
@@ -73,7 +73,7 @@ func GetRemoteSystemProbeUtil() (*RemoteSysProbeUtil, error) {
 }
 
 // GetConnections returns a set of active network connections, retrieved from the system probe service
-func (r *RemoteSysProbeUtil) GetConnections(clientID string) ([]ebpf.ConnectionStats, error) {
+func (r *RemoteSysProbeUtil) GetConnections(clientID string) ([]*ebpf.ConnectionStats, error) {
 	resp, err := r.httpClient.Get(fmt.Sprintf("%s?client_id=%s", connectionsURL, clientID))
 	if err != nil {
 		return nil, err

--- a/pkg/process/net/network_nolinux.go
+++ b/pkg/process/net/network_nolinux.go
@@ -18,7 +18,7 @@ func GetRemoteSystemProbeUtil() (*RemoteSysProbeUtil, error) {
 }
 
 // GetConnections is only implemented on linux
-func (r *RemoteSysProbeUtil) GetConnections(clientID string) ([]ebpf.ConnectionStats, error) {
+func (r *RemoteSysProbeUtil) GetConnections(clientID string) ([]*ebpf.ConnectionStats, error) {
 	return nil, ebpf.ErrNotImplemented
 }
 


### PR DESCRIPTION
### What does this PR do?

Change allocations of `[]ebpf.ConnectionStats` to `[]*ebpf.ConnectionStats` which will avoid allocating large contiguous blocks of memory and instead allocate many `ConectionStats` sized blocks.

### Motivation

This should get along better with the Go 1.11 GC.  

### Additional Notes

Anything else we should know when reviewing?
