### PR TITLE
Removes quotes from systemd templates

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.process.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.process.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog Process Agent"
+Description=Datadog Process Agent
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
 

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog Agent"
+Description=Datadog Agent
 After=network.target
 Wants=datadog-agent-trace.service datadog-agent-process.service
 

--- a/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog System Probe"
+Description=Datadog System Probe
 Requires=sys-kernel-debug.mount
 After=network.target sys-kernel-debug.mount
 

--- a/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog Trace Agent (APM)"
+Description=Datadog Trace Agent (APM)
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
 

--- a/omnibus/config/templates/datadog-dogstatsd/systemd.service.erb
+++ b/omnibus/config/templates/datadog-dogstatsd/systemd.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description=Datadog statsd server
+Description=Datadog Statsd Server
 After=network.target
 
 [Service]

--- a/omnibus/config/templates/datadog-dogstatsd/systemd.service.erb
+++ b/omnibus/config/templates/datadog-dogstatsd/systemd.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog statsd server"
+Description=Datadog statsd server
 After=network.target
 
 [Service]

--- a/omnibus/config/templates/datadog-puppy/systemd.service.erb
+++ b/omnibus/config/templates/datadog-puppy/systemd.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog Agent"
+Description=Datadog Agent
 After=network.target
 
 [Service]


### PR DESCRIPTION
### What does this PR do?

This PR removes unnecessary quotes from `systemd` configuration files.

Currently the Datadog services descriptions look like, note the extra quotes:

```
$ systemctl list-units | grep -C 2 Datadog
containerd.service                loaded active running   containerd container runtime
cron.service                      loaded active running   Regular background program processing daemon
datadog-agent-trace.service       loaded active running   "Datadog Trace Agent (APM)"
datadog-agent.service             loaded active running   "Datadog Agent"
dbus.service                      loaded active running   D-Bus System Message Bus
docker.service                    loaded active running   Docker Application Container Engine
```

Example from systemd documentation:

```
[Unit]
Description=Simple firewall
```

source: https://www.freedesktop.org/software/systemd/man/systemd.service.html

### Motivation

Cleaner output when displaying descriptions using `systemctl` for example.

### Additional Notes

