### PR TITLE
[pip2] Remove python 2.7 deprecation warnings

### DIFF
--- a/omnibus/config/patches/pip2/remove-python27-deprecation-warning.patch
+++ b/omnibus/config/patches/pip2/remove-python27-deprecation-warning.patch
@@ -1,0 +1,20 @@
+--- a/src/pip/_internal/cli/base_command.py
++++ b/src/pip/_internal/cli/base_command.py
+@@ -145,17 +145,6 @@ class Command(object):
+                 replacement=None,
+                 gone_in='19.2',
+             )
+-        elif sys.version_info[:2] == (2, 7):
+-            message = (
+-                "A future version of pip will drop support for Python 2.7."
+-            )
+-            if platform.python_implementation() == "CPython":
+-                message = (
+-                    "Python 2.7 will reach the end of its life on January "
+-                    "1st, 2020. Please upgrade your Python as Python 2.7 "
+-                    "won't be maintained after that date. "
+-                ) + message
+-            deprecated(message, replacement=None, gone_in=None)
+
+         # TODO: Try to get these passing down from the command?
+         #       without resorting to os.environ to hold these.

--- a/omnibus/config/software/pip2.rb
+++ b/omnibus/config/software/pip2.rb
@@ -13,6 +13,8 @@ relative_path "pip-#{version}"
 build do
   ship_license "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
 
+  patch :source => "remove-python27-deprecation-warning.patch"
+
   if ohai["platform"] == "windows"
     python_bin = "#{windows_safe_path(python_2_embedded)}\\python.exe"
     python_prefix = "#{windows_safe_path(python_2_embedded)}"


### PR DESCRIPTION
### What does this PR do?

Patches pip2 so that it doesn't print python 2.7 deprecation warnings.

### Motivation

These deprecation warnings aren't useful in the context of the Agent, until it actually includes python 3.

### Additional notes

* `pip3` doesn't need the same patch, since it'll run python 3.
* I've checked that the patch works as expected on both Linux and Windows, on the resulting packages. There is an unrelated issue in the Windows build at the moment that makes us ship both pip 18 and 19, I've created a separate card to address it for 6.12.