### PR TITLE
add note about host tags format

### DIFF
--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -32,7 +32,7 @@ Starting with the 6.0 release configuration files will now be stored in
 
 ### Agent configuration file
 
-Please refer to [this section][config] of the documentation for a detailed list
+Refer to the [Configuration Options][config] for a detailed list
 of the configuration options that were either changed or deprecated in the new Agent.
 
 In addition to the location change, the primary agent configuration file has been

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -326,6 +326,8 @@ are ported, excepted the following deprecations:
     Kubernetes and Openshift (default to true). This will avoid removing
     them from the exclude list by error
 
+The format of the `DD_TAGS`  global option has changed. In v5 it is comma-separated; in v6 it is space-separated, i.e. `simple-tag-0 tag-key-1:tag-value-1`.
+
 The [`import`](#configuration-files) will help you converting the old
 `docker_daemon.yaml` to the new `docker.yaml`. The command will also move
 needed settings from `docker_daemon.yaml` to `datadog.yaml`.

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -32,6 +32,9 @@ Starting with the 6.0 release configuration files will now be stored in
 
 ### Agent configuration file
 
+Please refer to [this section][config] of the documentation for a detailed list
+of the configuration options that were either changed or deprecated in the new Agent.
+
 In addition to the location change, the primary agent configuration file has been
 transitioned from **INI** format to **YAML** to better support complex configurations and
 for a more consistent experience across the Agent and the Checks; as such `datadog.conf`
@@ -42,9 +45,6 @@ may use the agent command: `sudo -u dd-agent -- datadog-agent import`.
 The command will parse an existing `datadog.conf` and convert all the bits that
 the new Agent still supports to the new format, in the new file. It also copies
 configuration files for checks that are currently enabled.
-
-Please refer to [this section][config] of the documentation for a detailed list
-of the configuration options that were either changed or deprecated in the new Agent.
 
 ### Checks configuration files
 

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -326,8 +326,6 @@ are ported, excepted the following deprecations:
     Kubernetes and Openshift (default to true). This will avoid removing
     them from the exclude list by error
 
-The format of the `DD_TAGS`  global option has changed. In v5 it is comma-separated; in v6 it is space-separated, i.e. `simple-tag-0 tag-key-1:tag-value-1`.
-
 The [`import`](#configuration-files) will help you converting the old
 `docker_daemon.yaml` to the new `docker.yaml`. The command will also move
 needed settings from `docker_daemon.yaml` to `datadog.yaml`.

--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -73,7 +73,7 @@ to disable the OS-level service units, but that will require your manual interve
 you ever wish to re-enable any of the agents.
 
 
-## New options in version 6
+## Changed options in version 6
 
 This is the list of configuration options that are either new, renamed or changed
 in any way.
@@ -86,6 +86,7 @@ in any way.
 | `syslog_host`  | `syslog_uri`  | The Syslog configuration is now expressed as an URI |
 || `syslog_pem`  | Syslog configuration client certificate for TLS client validation |
 || `syslog_key`  | Syslog configuration client private key for TLS client validation |
+| `DD_TAGS` | `DD_TAGS` | The format is space-separated, i.e. `simple-tag-0 tag-key-1:tag-value-1` |
 
 
 ## Integrations instance configuration

--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -86,7 +86,7 @@ in any way.
 | `syslog_host`  | `syslog_uri`  | The Syslog configuration is now expressed as an URI |
 || `syslog_pem`  | Syslog configuration client certificate for TLS client validation |
 || `syslog_key`  | Syslog configuration client private key for TLS client validation |
-| `DD_TAGS` | `DD_TAGS` | The format is space-separated, i.e. `simple-tag-0 tag-key-1:tag-value-1` |
+| `DD_TAGS` | `DD_TAGS` | Environment variable. In v6, the format is space-separated, i.e. `simple-tag-0 tag-key-1:tag-value-1`. In v5, the format is comma-separated (e.g. `simple-tag-0,tag-key-1:tag-value-1`).|
 
 
 ## Integrations instance configuration


### PR DESCRIPTION
### What does this PR do?
Adds a documentation note about different host tags format for Docker agent in v6.

### Motivation

See https://github.com/DataDog/datadog-agent/pull/2000

### Additional Notes

Anything else we should know when reviewing?
