### PR TITLE
[LOGS]: Removed logs_config.http_dd_url to use logs_config.dd_url instead

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -356,7 +356,6 @@ func initConfig(config Config) {
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	config.BindEnv("logs_config.dd_url")
-	config.BindEnv("logs_config.http_dd_url")
 	config.BindEnvAndSetDefault("logs_config.use_http", false)
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -139,8 +139,8 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 	}
 
 	switch {
-	case isSetAndNotEmpty(coreConfig.Datadog, "logs_config.http_dd_url"):
-		main.Host = coreConfig.GetMainEndpoint("", "logs_config.http_dd_url")
+	case isSetAndNotEmpty(coreConfig.Datadog, "logs_config.dd_url"):
+		main.Host = coreConfig.GetMainEndpoint("", "logs_config.dd_url")
 		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
 	case isSetAndNotEmpty(coreConfig.Datadog, "logs_config.logs_dd_url"):
 		host, port, err := parseAddress(coreConfig.Datadog.GetString("logs_config.logs_dd_url"))

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -119,7 +119,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	var err error
 
 	suite.config.Set("logs_config.use_http", true)
-	suite.config.Set("logs_config.http_dd_url", "foo")
+	suite.config.Set("logs_config.dd_url", "foo")
 
 	endpoints, err = BuildEndpoints()
 	suite.Nil(err)


### PR DESCRIPTION
### What does this PR do?

Removed logs_config.http_dd_url to use logs_config.dd_url instead

### Motivation

Don't add another config variable while we can reuse an existing one.

### Additional Notes

Anything else we should know when reviewing?
