### PR TITLE
[cmd/agent/app] Rewrite CLI input confirmation messages

### DIFF
--- a/cmd/agent/app/dogstatsd_stats.go
+++ b/cmd/agent/app/dogstatsd_stats.go
@@ -103,7 +103,7 @@ func requestDogstatsdStats() error {
 
 	// if the file is already existing, ask for a confirmation.
 	if _, err := os.Stat(dsdStatsFilePath); err == nil {
-		if !input.AskForConfirmation(fmt.Sprintf("'%s' existing, do you wan't to overwrite it? [Y/N]", dsdStatsFilePath)) {
+		if !input.AskForConfirmation(fmt.Sprintf("'%s' already exists, do you want to overwrite it? [y/N]", dsdStatsFilePath)) {
 			fmt.Println("Canceling.")
 			return nil
 		}

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -107,7 +107,7 @@ func requestFlare(caseID string) error {
 
 	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
 	if !autoconfirm {
-		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [Y/N]")
+		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [y/N]")
 		if !confirmation {
 			fmt.Fprintln(color.Output, fmt.Sprintf("Aborting. (You can still use %s)", color.YellowString(filePath)))
 			return nil


### PR DESCRIPTION
### What does this PR do?

Fixes some typos and changes `[y/N]` notation to clearly show what is the default option.

### Motivation

Saw this during 6.12 QA.