### PR TITLE
Fixed wrong formatting of docker logs when being collected on Kubernetes from /var/log/pods

### DIFF
--- a/pkg/logs/config/source.go
+++ b/pkg/logs/config/source.go
@@ -14,6 +14,8 @@ import (
 type SourceType string
 
 const (
+	// DockerSourceType docker source type
+	DockerSourceType SourceType = "docker"
 	// KubernetesSourceType kubernetes source type
 	KubernetesSourceType SourceType = "kubernetes"
 )

--- a/pkg/logs/input/docker/json_parser.go
+++ b/pkg/logs/input/docker/json_parser.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package docker
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/parser"
+)
+
+// stream types.
+const (
+	stderr = "stderr"
+	stdout = "stdout"
+)
+
+// JSONParser is a shared json parser.
+var JSONParser parser.Parser = &jsonParser{}
+
+// logLine contains all the attributes of a container log.
+type logLine struct {
+	Log    string
+	Stream string
+	Time   string
+}
+
+// jsonParser parses raw JSON lines to log fields.
+type jsonParser struct{}
+
+// Parse parses a raw JSON line to a container line and then returns all its fields,
+// returns an error if it failed.
+// For example:
+// {"log":"a message","stream":"stderr","time":"2019-06-06T16:35:55.930852911Z"}
+// returns:
+// "a message", "error", "2019-06-06T16:35:55.930852911Z", nil
+func (p *jsonParser) Parse(data []byte) ([]byte, string, string, error) {
+	var log *logLine
+	err := json.Unmarshal(data, &log)
+	if err != nil {
+		return data, message.StatusInfo, "", fmt.Errorf("cannot parse docker message, invalid JSON: %v", err)
+	}
+
+	var status string
+	switch log.Stream {
+	case stderr:
+		status = message.StatusError
+	case stdout:
+		status = message.StatusInfo
+	default:
+		status = ""
+	}
+
+	content := []byte(log.Log)
+	length := len(content)
+	if length > 0 && log.Log[length-1] == '\n' {
+		content = content[:length-1]
+	}
+	return content, status, log.Time, nil
+}

--- a/pkg/logs/input/docker/json_parser_test.go
+++ b/pkg/logs/input/docker/json_parser_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+func TestJSONParser(t *testing.T) {
+	var (
+		content   []byte
+		status    string
+		timestamp string
+		err       error
+	)
+
+	parser := JSONParser
+
+	content, status, timestamp, err = parser.Parse([]byte(`{"log":"a message","stream":"stderr","time":"2019-06-06T16:35:55.930852911Z"}`))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("a message"), content)
+	assert.Equal(t, message.StatusError, status)
+	assert.Equal(t, "2019-06-06T16:35:55.930852911Z", timestamp)
+
+	content, status, timestamp, err = parser.Parse([]byte(`{"log":"a second message","stream":"stdout","time":"2019-06-06T16:35:55.930852912Z"}`))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("a second message"), content)
+	assert.Equal(t, message.StatusInfo, status)
+	assert.Equal(t, "2019-06-06T16:35:55.930852912Z", timestamp)
+
+	content, status, timestamp, err = parser.Parse([]byte(`{"log":"a third message\n","stream":"stdout","time":"2019-06-06T16:35:55.930852913Z"}`))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("a third message"), content)
+	assert.Equal(t, message.StatusInfo, status)
+	assert.Equal(t, "2019-06-06T16:35:55.930852913Z", timestamp)
+
+	content, status, _, err = parser.Parse([]byte("a wrong message"))
+	assert.NotNil(t, err)
+	assert.Equal(t, []byte("a wrong message"), content)
+	assert.Equal(t, message.StatusInfo, status)
+
+	content, status, timestamp, err = parser.Parse([]byte(`{"log":"","stream":"stdout","time":"2019-06-06T16:35:55.930852914Z"}`))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), content)
+	assert.Equal(t, message.StatusInfo, status)
+	assert.Equal(t, "2019-06-06T16:35:55.930852914Z", timestamp)
+
+	content, status, timestamp, err = parser.Parse([]byte(`{"log":"\n","stream":"stdout","time":"2019-06-06T16:35:55.930852915Z"}`))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), content)
+	assert.Equal(t, message.StatusInfo, status)
+	assert.Equal(t, "2019-06-06T16:35:55.930852915Z", timestamp)
+}

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
+	"github.com/DataDog/datadog-agent/pkg/logs/input/docker"
 	"github.com/DataDog/datadog-agent/pkg/logs/input/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/tag"
@@ -58,9 +59,12 @@ type Tailer struct {
 func NewTailer(outputChan chan *message.Message, source *config.LogSource, path string, sleepDuration time.Duration, isWildcardPath bool) *Tailer {
 	// TODO: remove those checks and add to source a reference to a tagProvider and a lineParser.
 	var parser lineParser.Parser
-	if source.GetSourceType() == config.KubernetesSourceType {
+	switch source.GetSourceType() {
+	case config.KubernetesSourceType:
 		parser = kubernetes.Parser
-	} else {
+	case config.DockerSourceType:
+		parser = docker.JSONParser
+	default:
 		parser = lineParser.NoopParser
 	}
 	var tagProvider tag.Provider

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -135,9 +135,7 @@ func (l *Launcher) addSource(svc *service.Service) {
 
 	switch svc.Type {
 	case config.DockerType:
-		// docker uses the NJSON format as opposed to other container runtimes
-		// to write log lines to files so there is no need for the custom kubernetes parser.
-		break
+		source.SetSourceType(config.DockerSourceType)
 	default:
 		source.SetSourceType(config.KubernetesSourceType)
 	}

--- a/releasenotes/notes/logs-docker-kubernetes-format-fix-8f0101796f2fe46c.yaml
+++ b/releasenotes/notes/logs-docker-kubernetes-format-fix-8f0101796f2fe46c.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue where logs collected from kubernetes using '/var/log/pods' would show up with a wrong format '{"log":"x","stream":"y","time":"z"}' on the logs explorer when using docker as container runtime.


### PR DESCRIPTION
### What does this PR do?

Make sure log line from docker container files are properly parsed when being collected.

### Motivation

Make sure logs show up properly on the logs explorer.

### Additional Notes

If the log exceeds 16kb, it will be truncated, this has to be fixed for `6.13`

This should fix https://github.com/DataDog/datadog-agent/issues/3510
