### PR TITLE
Fix agent panic when install an unknown integration

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -660,7 +660,7 @@ func getVersionFromReqLine(integration string, lines string) (*semver.Version, e
 
 	groups := exp.FindAllStringSubmatch(lines, 2)
 	if groups == nil {
-		return nil, nil
+		return nil, fmt.Errorf("unknown integration '%s'", integration)
 	}
 
 	if len(groups) > 1 {


### PR DESCRIPTION
### What does this PR do?

When installing an unknown Datadog wheels (a wheel with the `datadog-` prefix) the agent would not detect it and panic.