### PR TITLE
[pkg/forwarder] Set User-Agent on api key validation request

### DIFF
--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 var (
@@ -128,7 +129,15 @@ func (fh *forwarderHealth) validateAPIKey(apiKey, domain string) (bool, error) {
 		Timeout:   fh.timeout,
 	}
 
-	resp, err := client.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		fh.setAPIKeyStatus(apiKey, domain, &apiKeyStatusUnknown)
+		return false, err
+	}
+
+	req.Header.Set(useragentHTTPHeaderKey, fmt.Sprintf("datadog-agent/%s", version.AgentVersion))
+
+	resp, err := client.Do(req)
 	if err != nil {
 		fh.setAPIKeyStatus(apiKey, domain, &apiKeyStatusUnknown)
 		return false, err


### PR DESCRIPTION



### What does this PR do?

This sets the User-Agent to `datadog-agent/<agent-version>` for the api key validation request, so that it is the same as all other requests.

### Motivation

During 6.12 QA, saw that pull request #2375 sets the User-Agent string for all forwarder requests except for the initial `/api/v1/validate` request which checks the validity of the api key provided by the user.

