### PR TITLE
[Logs]: Use docker integration to collect logs by default on kubernetes.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -352,6 +352,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.open_files_limit", 100)
 	// add global processing rules that are applied on all logs
 	config.BindEnv("logs_config.processing_rules")
+	// enforce the agent to use files to collect container logs on kubernetes environment
+	config.BindEnvAndSetDefault("logs_config.k8s_container_use_file", false)
 
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -56,7 +56,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 	// setup the inputs
 	inputs := []restart.Restartable{
 		file.NewScanner(sources, coreConfig.Datadog.GetInt("logs_config.open_files_limit"), pipelineProvider, auditor, file.DefaultSleepDuration),
-		container.NewLauncher(coreConfig.Datadog.GetBool("logs_config.container_collect_all"), sources, services, pipelineProvider, auditor),
+		container.NewLauncher(coreConfig.Datadog.GetBool("logs_config.container_collect_all"), coreConfig.Datadog.GetBool("logs_config.k8s_container_use_file"), sources, services, pipelineProvider, auditor),
 		listener.NewLauncher(sources, coreConfig.Datadog.GetInt("logs_config.frame_size"), pipelineProvider),
 		journald.NewLauncher(sources, pipelineProvider, auditor),
 		windowsevent.NewLauncher(sources, pipelineProvider),

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -39,6 +39,8 @@ func (suite *ConfigTestSuite) TestDefaultDatadogConfig() {
 	suite.Equal(30, suite.config.GetInt("logs_config.stop_grace_period"))
 	suite.Equal(nil, suite.config.Get("logs_config.processing_rules"))
 	suite.Equal("", suite.config.GetString("logs_config.processing_rules"))
+	suite.Equal(false, suite.config.GetBool("logs_config.use_http"))
+	suite.Equal(false, suite.config.GetBool("logs_config.k8s_container_use_file"))
 }
 
 func (suite *ConfigTestSuite) TestDefaultSources() {

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -21,7 +21,7 @@ import (
 // By default returns a docker launcher if the docker socket is mounted and fallback to
 // a kubernetes launcher if '/var/log/pods' is mounted ; this behaviour is reversed when
 // collectFromFiles is enabled.
-// Returns a noop launcher is none of those volumes are mounted.
+// Returns a noop launcher if none of those volumes are mounted.
 func NewLauncher(collectAll bool, collectFromFiles bool, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) restart.Restartable {
 	var (
 		launcher restart.Restartable

--- a/releasenotes/notes/logs-container-configuration-toggle-f5f8b2831c6a575f.yaml
+++ b/releasenotes/notes/logs-container-configuration-toggle-f5f8b2831c6a575f.yaml
@@ -6,7 +6,7 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-fixes:
+upgrade:
   - |
     Breaking change - In the version 6.11.2 logic was added in the Agent to first look for K8s container files if `/var/log/pods` was not available and then to go for the Docker socket.
     This created some permission issues as `/var/log/pods` can be a symlink in some configuration and the Agent also needed access to the symlink directory.

--- a/releasenotes/notes/logs-container-configuration-toggle-f5f8b2831c6a575f.yaml
+++ b/releasenotes/notes/logs-container-configuration-toggle-f5f8b2831c6a575f.yaml
@@ -8,4 +8,9 @@
 ---
 fixes:
   - |
-    Switched back to enabling by default the docker integration to collect logs on kubernetes and fallback to using files when the docker socket is not mounted. This behaviour can now be reversed using the configuration parameter 'logs_config.k8s_container_use_file'.
+    Breaking change - In the version 6.11.2 logic was added in the Agent to first look for K8s container files if `/var/log/pods` was not available and then to go for the Docker socket.
+    This created some permission issues as `/var/log/pods` can be a symlink in some configuration and the Agent also needed access to the symlink directory.
+
+    This logic is reverted to its prior behaviour which prioritise the Docker socket for container log collection.
+    It is still possible to force the agent to go for the K8s log files even if the Docker socket is mounted by using the `logs_config.k8s_container_use_file' or `DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE`. parameter.
+    This is recommended when more than 10 containers are running on the same pod.

--- a/releasenotes/notes/logs-container-configuration-toggle-f5f8b2831c6a575f.yaml
+++ b/releasenotes/notes/logs-container-configuration-toggle-f5f8b2831c6a575f.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Switched back to enabling by default the docker integration to collect logs on kubernetes and fallback to using files when the docker socket is not mounted. This behaviour can now be reversed using the configuration parameter 'logs_config.k8s_container_use_file'.


### PR DESCRIPTION
### What does this PR do?

Use the docker integration by default to collect logs on kubernetes and added a config parameter to override the default logic.

### Motivation

We changed the logic in `6.11.2` but the kubernetes integration does not have all the features of the docker one.

### Additional Notes

https://github.com/DataDog/datadog-agent/pull/3340
