### PR TITLE
[integrations] refactor success message

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -314,7 +314,7 @@ func install(cmd *cobra.Command, args []string) error {
 		}
 
 		fmt.Println(color.GreenString(fmt.Sprintf(
-			"Successfully installed %s", integration,
+			"Successfully completed the installation of %s", integration,
 		)))
 
 		return nil


### PR DESCRIPTION
Currently the integration install message might be misleading since the wheel might be already installed.

```
sudo -u dd-agent datadog-agent integration install -w .../datadog_mongo-1.10.1-py2.py3-none-any.whl
Requirement already satisfied: datadog-mongo==1.10.1 from file:///repos/dd/integrations-core/mongo/dist/datadog_mongo-1.10.1-py2.py3-none-any.whl in /opt/datadog-agent/embedded/lib/python2.7/site-packages (1.10.1)
Successfully copied configuration file conf.yaml.example
Successfully completed the installation of datadog-mongo
```