### PR TITLE
Remove exit file logic for JMXFetch on Windows

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/runner.go
+++ b/pkg/collector/corechecks/embed/jmx/runner.go
@@ -38,15 +38,9 @@ type checkInitCfg struct {
 	JavaOptions    string   `yaml:"java_options,omitempty"`
 }
 
-const windowsExitFile = "jmxfetch_exit"
-
 func (r *runner) initRunner() {
 	r.jmxfetch = &jmxfetch.JMXFetch{}
 	r.jmxfetch.LogLevel = config.Datadog.GetString("log_level")
-
-	if runtime.GOOS == "windows" {
-		r.jmxfetch.JmxExitFile = windowsExitFile
-	}
 }
 
 func (r *runner) startRunner() error {

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -10,10 +10,10 @@ package jmxfetch
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -22,7 +22,6 @@ import (
 	api "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
-	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -63,7 +62,6 @@ type JMXFetch struct {
 	JavaToolsJarPath   string
 	JavaCustomJarPaths []string
 	LogLevel           string
-	JmxExitFile        string
 	Command            string
 	ReportOnConsole    bool
 	Checks             []string
@@ -71,7 +69,6 @@ type JMXFetch struct {
 	IPCHost            string
 	defaultJmxCommand  string
 	cmd                *exec.Cmd
-	exitFilePath       string
 	managed            bool
 	shutdown           chan struct{}
 	stopped            chan struct{}
@@ -99,7 +96,6 @@ func (j *JMXFetch) setDefaults() {
 func (j *JMXFetch) Start(manage bool) error {
 	j.setDefaults()
 
-	here, _ := executable.Folder()
 	classpath := filepath.Join(common.GetDistPath(), "jmx", jmxJarName)
 	if j.JavaToolsJarPath != "" {
 		classpath = fmt.Sprintf("%s%s%s", j.JavaToolsJarPath, string(os.PathListSeparator), classpath)
@@ -185,13 +181,6 @@ func (j *JMXFetch) Start(manage bool) error {
 
 	subprocessArgs = append(subprocessArgs, j.Command)
 
-	if j.JmxExitFile != "" {
-		j.exitFilePath = filepath.Join(here, "dist", "jmx", j.JmxExitFile) // FIXME : At some point we should have a `run` folder
-		// Signal handlers are not supported on Windows:
-		// use a file to trigger JMXFetch exit instead
-		subprocessArgs = append(subprocessArgs, "--exit_file_location", j.exitFilePath)
-	}
-
 	j.cmd = exec.Command(j.JavaBinPath, subprocessArgs...)
 
 	// set environment + token
@@ -199,11 +188,6 @@ func (j *JMXFetch) Start(manage bool) error {
 		os.Environ(),
 		fmt.Sprintf("SESSION_TOKEN=%s", api.GetAuthToken()),
 	)
-
-	// remove the exit file trigger (windows)
-	if j.JmxExitFile != "" {
-		os.Remove(j.exitFilePath)
-	}
 
 	// forward the standard output to the Agent logger
 	stdout, err := j.cmd.StdoutPipe()
@@ -248,8 +232,7 @@ func (j *JMXFetch) Start(manage bool) error {
 // Stop stops the JMXFetch process
 func (j *JMXFetch) Stop() error {
 	var stopChan chan struct{}
-
-	if j.JmxExitFile == "" {
+	if runtime.GOOS != "windows" {
 		// Unix
 		err := j.cmd.Process.Signal(syscall.SIGTERM)
 		if err != nil {
@@ -277,15 +260,11 @@ func (j *JMXFetch) Stop() error {
 			}
 		case <-stopChan:
 		}
-
+		return nil
 	} else {
 		// Windows
-		if err := ioutil.WriteFile(j.exitFilePath, nil, 0644); err != nil {
-			log.Warnf("Could not signal JMXFetch to exit, killing instead: %v", err)
-			return j.cmd.Process.Kill()
-		}
+		return j.cmd.Process.Kill()
 	}
-	return nil
 }
 
 // Wait waits for the end of the JMXFetch process and returns the error code

--- a/pkg/jmxfetch/jmxfetch_nix.go
+++ b/pkg/jmxfetch/jmxfetch_nix.go
@@ -9,6 +9,8 @@
 package jmxfetch
 
 import (
+	"os"
+	"syscall"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -60,4 +62,38 @@ func (j *JMXFetch) Monitor() {
 	}
 
 	<-j.shutdown
+}
+
+// Stop stops the JMXFetch process
+func (j *JMXFetch) Stop() error {
+	var stopChan chan struct{}
+
+	err := j.cmd.Process.Signal(syscall.SIGTERM)
+	if err != nil {
+		return err
+	}
+
+	if j.managed {
+		stopChan = j.stopped
+		close(j.shutdown)
+	} else {
+		stopChan = make(chan struct{})
+
+		go func() {
+			j.Wait()
+			close(stopChan)
+		}()
+	}
+
+	select {
+	case <-time.After(time.Millisecond * 500):
+		log.Warnf("Jmxfetch did not exit during it's grace period, killing it")
+		err = j.cmd.Process.Signal(os.Kill)
+		if err != nil {
+			log.Warnf("Could not kill jmxfetch: %v", err)
+		}
+	case <-stopChan:
+	}
+	return nil
+
 }

--- a/pkg/jmxfetch/jmxfetch_windows.go
+++ b/pkg/jmxfetch/jmxfetch_windows.go
@@ -8,3 +8,8 @@
 package jmxfetch
 
 func (j *JMXFetch) Monitor() {}
+
+// Stop stops the JMXFetch process
+func (j *JMXFetch) Stop() error {
+	return j.cmd.Process.Kill()
+}


### PR DESCRIPTION
The exit file logic was broken and we ended up always killing it anyway. 