### PR TITLE
[pkg/status] Refer to the web app as "Datadog" instead of "web app"

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -27,7 +27,7 @@
       {{- if .ntpOffset}}
         <br>NTP Offset: {{ humanizeDuration .ntpOffset "s"}}
         {{- if ntpWarning .ntpOffset}}
-        <br><span class="warning">NTP Offset is high. The web application may ignore metrics sent by this agent.</span>
+        <br><span class="warning">NTP Offset is high. Datadog may ignore metrics sent by this Agent.</span>
         {{- end}}
       {{end}}
       <br>Go Version: {{.platform.goV}}

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -32,7 +32,7 @@ NOTE: Changes made to this template should be reflected on the following templat
     {{- if .ntpOffset }}
     NTP offset: {{ humanizeDuration .ntpOffset "s"}}
     {{- if ntpWarning .ntpOffset}}
-    {{yellowText "NTP offset is high. The web application may ignore metrics sent by this agent."}}
+    {{yellowText "NTP offset is high. Datadog may ignore metrics sent by this Agent."}}
     {{- end }}
     {{- end }}
     System UTC time: {{.time}}

--- a/releasenotes/notes/add-warning-ntp-offset-too-high-4ecabb07d0fd3417.yaml
+++ b/releasenotes/notes/add-warning-ntp-offset-too-high-4ecabb07d0fd3417.yaml
@@ -10,4 +10,4 @@ enhancements:
   - |
     Added a warning message on agent status command and status gui
     tab when ntp offset is too large and may result in metrics
-    ignored by the web application.
+    ignored by Datadog.


### PR DESCRIPTION
### What does this PR do?

Refers to the web app as "Datadog" instead of "web app", follow up to #3450 

### Motivation

Just to be more in line with the way we refer to Datadog (see for example our [docs](https://docs.datadoghq.com/agent/?tab=agentv6)).
