### PR TITLE
Move int64 variables to top of struct so that they are aligned in mem…

### DIFF
--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -31,14 +31,14 @@ const defaultCloseTimeout = 60 * time.Second
 
 // Tailer tails one file and sends messages to an output channel
 type Tailer struct {
+	readOffset    int64
+	decodedOffset int64
+
 	path           string
 	fullpath       string
 	file           *os.File
 	isWildcardPath bool
 	tags           []string
-
-	readOffset    int64
-	decodedOffset int64
 
 	outputChan  chan *message.Message
 	decoder     *decoder.Decoder


### PR DESCRIPTION
…ory for workaround for Go ARM architecture bug.

There is a bug in Go that integer 64-bit variables have to be aligned for atomic access on ARM processor. This is a workaround by putting the variable definitions at the top of the struct.