### PR TITLE
[windows] remove pip2 declaration to reduce pip version confusion

### DIFF
--- a/omnibus/config/software/datadog-a7-py2.rb
+++ b/omnibus/config/software/datadog-a7-py2.rb
@@ -1,7 +1,11 @@
 name "datadog-a7-py2"
 default_version "0.0.6"
 
-dependency "pip2"
+if windows?
+  dependency "python2" ## for pip
+else
+  dependency "pip2"
+end
 
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/datadog-checks-shared/master/LICENSE"


### PR DESCRIPTION
### What does this PR do?

removes the pip2 definition dependency, so that we don't have multiple pip installs

