### PR TITLE
bogus error log when events are submited without timestamps, handle error in aggregator.submit_event

### DIFF
--- a/pkg/collector/python/aggregator.go
+++ b/pkg/collector/python/aggregator.go
@@ -103,12 +103,7 @@ func SubmitEvent(checkID *C.char, event *C.event_t) {
 		AlertType:      metrics.EventAlertType(eventParseString(event.alert_type, "alert_type")),
 		AggregationKey: eventParseString(event.aggregation_key, "aggregation_key"),
 		SourceTypeName: eventParseString(event.source_type_name, "source_type_name"),
-	}
-
-	if event.ts == 0 {
-		log.Errorf("Can't cast timestamp to integer in event submitted from python check")
-	} else {
-		_event.Ts = int64(event.ts)
+		Ts:             int64(event.ts),
 	}
 
 	sender.Event(_event)

--- a/six/common/builtins/aggregator.c
+++ b/six/common/builtins/aggregator.c
@@ -253,7 +253,7 @@ static PyObject *submit_event(PyObject *self, PyObject *args)
         ev->ts = PyLong_AsLong(PyDict_GetItemString(event_dict, "timestamp"));
         if (ev->ts == -1) {
             PyErr_Clear();
-            ev->ts = 0
+            ev->ts = 0;
         }
     } else {
         ev->ts = 0;

--- a/six/common/builtins/aggregator.c
+++ b/six/common/builtins/aggregator.c
@@ -251,6 +251,9 @@ static PyObject *submit_event(PyObject *self, PyObject *args)
     if (PyDict_GetItemString(event_dict, "timestamp") != NULL) {
         ev->ts = PyLong_AsLong(PyDict_GetItemString(event_dict, "timestamp"));
         if (ev->ts == -1) {
+            // we ignore the error and set the timestamp to 0 (magic value that
+            // will result in the current time) to ensure backward compatibility
+            // with the pre-six API
             PyErr_Clear();
             ev->ts = 0;
         }

--- a/six/common/builtins/aggregator.c
+++ b/six/common/builtins/aggregator.c
@@ -220,7 +220,6 @@ static PyObject *submit_event(PyObject *self, PyObject *args)
     PyObject *check = NULL; // borrowed
     PyObject *event_dict = NULL; // borrowed
     PyObject *py_tags = NULL; // borrowed
-    PyObject *timestamp = NULL; // borrowed
     char *check_id = NULL;
     event_t *ev = NULL;
     PyObject * retval = NULL;

--- a/six/common/builtins/aggregator.c
+++ b/six/common/builtins/aggregator.c
@@ -220,6 +220,7 @@ static PyObject *submit_event(PyObject *self, PyObject *args)
     PyObject *check = NULL; // borrowed
     PyObject *event_dict = NULL; // borrowed
     PyObject *py_tags = NULL; // borrowed
+    PyObject *timestamp = NULL; // borrowed
     char *check_id = NULL;
     event_t *ev = NULL;
     PyObject * retval = NULL;
@@ -250,6 +251,10 @@ static PyObject *submit_event(PyObject *self, PyObject *args)
     // PyLong_AsLong will fail if called passing a NULL argument, be safe
     if (PyDict_GetItemString(event_dict, "timestamp") != NULL) {
         ev->ts = PyLong_AsLong(PyDict_GetItemString(event_dict, "timestamp"));
+        if (ev->ts == -1) {
+            PyErr_Clear();
+            ev->ts = 0
+        }
     } else {
         ev->ts = 0;
     }


### PR DESCRIPTION
### What does this PR do?

We were logging an error in Goland if an event was submitted without a timestamp. 
The following would trigger the issue:
```python
self.event({'msg_text': 'sometext'})
> Can't cast timestamp to integer in event submitted from python check
```

Not setting a timestamp is perfectly normal and will result in the event getting applied the current time when it reaches the aggregator:
https://github.com/DataDog/datadog-agent/blob/1b4f1711f40d180376d545662679804e60c0cc8d/pkg/aggregator/aggregator.go#L325-L327

This check was bogus:
https://github.com/DataDog/datadog-agent/blob/1b4f1711f40d180376d545662679804e60c0cc8d/pkg/collector/python/aggregator.go#L108-L112

Prior to `six` this was done at a lower level:
https://github.com/DataDog/datadog-agent/blob/fa373515349a7db22351afc8247399e45edac0b6/pkg/collector/py/api.go#L178-L186



### Motivation

Avoid log spam.

### Additional Notes

Unfortunately we are losing logging with the current PR. I don't think we have a way to report this kind of non critical errors back right now ?
