### PR TITLE
Don't fail installation if an integration doesn't already exist

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -335,11 +335,7 @@ func install(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to get version of %s to install: %v", integration, err)
 	}
 	currentVersion, err := installedVersion(integration)
-	if err != nil {
-		return fmt.Errorf("could not get current version of %s: %v", integration, err)
-	}
-
-	if currentVersion != nil && versionToInstall.Equal(*currentVersion) {
+	if err == nil && versionToInstall.Equal(*currentVersion) {
 		fmt.Printf("%s %s is already installed. Nothing to do.\n", integration, versionToInstall)
 		return nil
 	}


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/datadog-agent/commit/f2e28a34ed904e62fe0c45bda1270882f579e960 prevented possible panics (i.e. not checking the error and value) but that prevents new integrations from being installed and even shipped integrations that were removed too.

Now we only do the version comparison when there is one to compare to