### PR TITLE
Fix iostat counter wrap for await times

### DIFF
--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -48,14 +48,14 @@ func roundFloat(val float64) float64 {
 	return math.Round(val*100) / 100
 }
 
-// Can't use values from math.MaxInt* because this should depend on the machine's word size
-const maxInt = int64(^uint(0) >> 1)
+// Can't use values from math.MaxUint* because C size for longs changes on 32/64 bit machines
+const maxLong = int64(^uint(0) >> 1)
 
 // Compute the increment between two iostats values, taking into account they can overflow
-func incrementWithOverflow(currentValue, lastValue uint64) int64 {
+func incrementWithOverflow(currentValue, lastValue uint64, maxValue int64) int64 {
 	ret := int64(currentValue - lastValue)
 	if ret < 0 {
-		ret = ret + maxInt
+		ret = ret + maxValue
 	}
 	return ret
 }
@@ -112,37 +112,40 @@ func (c *IOCheck) nixIO() error {
 		}
 
 		// computing kB/s
-		rkbs := float64(incrementWithOverflow(ioStats.ReadBytes, lastIOStats.ReadBytes)) / kB / deltaSecond
-		wkbs := float64(incrementWithOverflow(ioStats.WriteBytes, lastIOStats.WriteBytes)) / kB / deltaSecond
-		avgqusz := float64(incrementWithOverflow(ioStats.WeightedIO, lastIOStats.WeightedIO)) / kB / deltaSecond
+		rkbs := float64(incrementWithOverflow(ioStats.ReadBytes, lastIOStats.ReadBytes, maxLong)) / kB / deltaSecond
+		wkbs := float64(incrementWithOverflow(ioStats.WriteBytes, lastIOStats.WriteBytes, maxLong)) / kB / deltaSecond
+		avgqusz := float64(incrementWithOverflow(ioStats.WeightedIO, lastIOStats.WeightedIO, maxLong)) / kB / deltaSecond
 
 		rAwait := 0.0
 		wAwait := 0.0
-		diffNRIO := float64(incrementWithOverflow(ioStats.ReadCount, lastIOStats.ReadCount))
-		diffNWIO := float64(incrementWithOverflow(ioStats.WriteCount, lastIOStats.WriteCount))
+		diffNRIO := float64(incrementWithOverflow(ioStats.ReadCount, lastIOStats.ReadCount, maxLong))
+		diffNWIO := float64(incrementWithOverflow(ioStats.WriteCount, lastIOStats.WriteCount, maxLong))
 		if diffNRIO != 0 {
-			rAwait = float64(incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime)) / diffNRIO
+			//Note we use math.MaxUint32 because this value is always 32-bit, even on 64 bit machines
+			rAwait = float64(incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime, math.MaxUint32)) / diffNRIO
 		}
 		if diffNWIO != 0 {
-			wAwait = float64(incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime)) / diffNWIO
+			//Note we use math.MaxUint32 because this value is always 32-bit, even on 64 bit machines
+			wAwait = float64(incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime, math.MaxUint32)) / diffNWIO
 		}
 
 		avgrqsz := 0.0
 		aWait := 0.0
 		diffNIO := diffNRIO + diffNWIO
 		if diffNIO != 0 {
-			avgrqsz = float64((incrementWithOverflow(ioStats.ReadBytes, lastIOStats.ReadBytes)+
-				incrementWithOverflow(ioStats.WriteBytes, lastIOStats.WriteBytes))/SectorSize) / diffNIO
+			avgrqsz = float64((incrementWithOverflow(ioStats.ReadBytes, lastIOStats.ReadBytes, maxLong)+
+				incrementWithOverflow(ioStats.WriteBytes, lastIOStats.WriteBytes, maxLong))/SectorSize) / diffNIO
+			//Note we use math.MaxUint32 because these values are always 32-bit, even on 64 bit machines
 			aWait = float64(
-				incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime)+
-					incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime)) / diffNIO
+				incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime, math.MaxUint32)+
+					incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime, math.MaxUint32)) / diffNIO
 		}
 
 		// we are aligning ourselves with the metric reported by
 		// sysstat, so itv is a time interval in 1/100th of a second
 		itv := delta / 10
 		tput := diffNIO * 100 / itv
-		util := float64(incrementWithOverflow(ioStats.IoTime, lastIOStats.IoTime)) / itv * 100
+		util := float64(incrementWithOverflow(ioStats.IoTime, lastIOStats.IoTime, maxLong)) / itv * 100
 		svctime := 0.0
 		if tput != 0 {
 			svctime = util / tput

--- a/pkg/collector/corechecks/system/iostats_nix_test.go
+++ b/pkg/collector/corechecks/system/iostats_nix_test.go
@@ -8,6 +8,7 @@
 package system
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -36,30 +37,35 @@ var currentStats = map[string]disk.IOCountersStat{
 
 var lastStats = map[string]disk.IOCountersStat{
 	"sda": {
-		ReadCount:        uint64(maxInt),
-		MergedReadCount:  uint64(maxInt),
-		WriteCount:       uint64(maxInt),
-		MergedWriteCount: uint64(maxInt),
-		ReadBytes:        uint64(maxInt),
-		WriteBytes:       uint64(maxInt),
-		ReadTime:         uint64(maxInt),
-		WriteTime:        uint64(maxInt),
+		ReadCount:        uint64(maxLong),
+		MergedReadCount:  uint64(maxLong),
+		WriteCount:       uint64(maxLong),
+		MergedWriteCount: uint64(maxLong),
+		ReadBytes:        uint64(maxLong),
+		WriteBytes:       uint64(maxLong),
+		ReadTime:         uint64(math.MaxUint32),
+		WriteTime:        uint64(math.MaxUint32),
 		IopsInProgress:   0,
-		IoTime:           uint64(maxInt),
-		WeightedIO:       uint64(maxInt),
+		IoTime:           uint64(maxLong),
+		WeightedIO:       uint64(maxLong),
 		Name:             "sda",
 		SerialNumber:     "123456789WD",
 	},
 }
 
+func TestWithRealValues(t *testing.T) {
+	increment := incrementWithOverflow(6176672, 4292830204, math.MaxUint32)
+	assert.Equal(t, int64(8313763), increment)
+}
+
 func TestIncrementWithOverflow(t *testing.T) {
-	prev := uint64(maxInt) - 2
+	prev := uint64(maxLong) - 2
 	for i := -1; i < 2; i++ {
-		curr := uint64(maxInt) + uint64(i)
-		if curr >= uint64(maxInt) {
-			curr -= uint64(maxInt)
+		curr := uint64(maxLong) + uint64(i)
+		if curr >= uint64(maxLong) {
+			curr -= uint64(maxLong)
 		}
-		increment := incrementWithOverflow(curr, prev)
+		increment := incrementWithOverflow(curr, prev, maxLong)
 		assert.Equal(t, int64(1), increment)
 		prev = curr
 	}


### PR DESCRIPTION
Use MaxUint32 for await counters, since they are unsigned int and not long values in the kernel. int size is always 4 bytes both in 32 and 64 bit, while long size depends on the arch.

In case the counters were *unsigned* longs instead of longs as the code assumes (I think they are for every other counter), then they would never go negative and this code does nothing.