### PR TITLE
[test/kitchen] Improve perfs of kitchen tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -684,10 +684,10 @@ kitchen_windows:
     - cd $DD_AGENT_TESTING_DIR
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
-    - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20181122"
-    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2012r2,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20181125"
-    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2016,MicrosoftWindowsServer:WindowsServer:2016-Datacenter:2016.127.20181122"
-    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2019,MicrosoftWindowsServer:WindowsServer:2019-Datacenter:2019.0.20181122"
+    - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190603"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2012r2,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20190603"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2016,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:2016.127.20190603"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2019,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:2019.0.20190603"
     - bash -l tasks/run-test-kitchen.sh
   artifacts:
     expire_in: 2 weeks
@@ -708,7 +708,7 @@ kitchen_windows_installer:
     - cd $DD_AGENT_TESTING_DIR
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
-    - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20181122"
+    - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190603"
     - bash -l tasks/run-test-kitchen.sh windows-install-test
   artifacts:
     expire_in: 2 weeks
@@ -730,7 +730,7 @@ kitchen_centos:
     - cd $DD_AGENT_TESTING_DIR
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
-    - export TEST_PLATFORMS="centos-74,OpenLogic:CentOS:7.4:7.4.20171110"
+    - export TEST_PLATFORMS="centos-76,OpenLogic:CentOS:7.6:7.6.20190402"
     - bash -l tasks/run-test-kitchen.sh
   artifacts:
     expire_in: 2 weeks
@@ -752,8 +752,8 @@ kitchen_ubuntu:
     - cd $DD_AGENT_TESTING_DIR
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
-    - export TEST_PLATFORMS="ubuntu-14-04,Canonical:UbuntuServer:14.04.5-LTS:14.04.201803080"
-    - export TEST_PLATFORMS="$TEST_PLATFORMS|ubuntu-16-04,Canonical:UbuntuServer:16.04.0-LTS:16.04.201802220"
+    - export TEST_PLATFORMS="ubuntu-14-04,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|ubuntu-16-04,Canonical:UbuntuServer:16.04.0-LTS:16.04.201906170"
     - bash -l tasks/run-test-kitchen.sh
   artifacts:
     expire_in: 2 weeks
@@ -775,7 +775,7 @@ kitchen_suse:
     - cd $DD_AGENT_TESTING_DIR
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
-    - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP3:2018.09.04"
+    - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP4:2019.06.17"
     - bash -l tasks/run-test-kitchen.sh
   artifacts:
     expire_in: 2 weeks
@@ -797,7 +797,7 @@ kitchen_debian:
     - cd $DD_AGENT_TESTING_DIR
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
-    - export TEST_PLATFORMS="debian-8,credativ:Debian:8:8.0.201803130"
+    - export TEST_PLATFORMS="debian-8,credativ:Debian:8:8.20190313.0"
     - bash -l tasks/run-test-kitchen.sh
   artifacts:
     expire_in: 2 weeks

--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -1,6 +1,6 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'datadog', '~>2.18.0', git: "https://github.com/datadog/chef-datadog.git"
+cookbook 'datadog', '~> 2.19.0', git: "https://github.com/datadog/chef-datadog.git", branch: "v2.x"
 
 # We pin an old version of the apt cookbook because this cookbook triggers an "apt update" by default
 # and in newer versions this update is not allowed to fail, while in 3.X it is. For some reason

--- a/test/kitchen/Rakefile
+++ b/test/kitchen/Rakefile
@@ -26,10 +26,10 @@ def generate_test_and_parallel_test(name, description, shell_command, driver, de
   end
 
   desc description + " in parallel with the #{driver} driver"
-  task "#{name}-#{driver}-parallel".to_sym, :concurrency do |t, args|
+  task "#{name}-#{driver}-parallel".to_sym do |t, args|
     Rake::Task['berks'].invoke
-    concurrency = args[:concurrency] || "4"
-    sh shell_command + " '^dd*.*-#{driver}$'" + ' --concurrency=' + concurrency + " -d #{destroy_strategy}"
+    # By default, the -c option defaults the number of concurrent tasks to the number of instances
+    sh shell_command + " '^dd*.*-#{driver}$'" + ' -c' + " -d #{destroy_strategy}"
   end
 end
 

--- a/test/kitchen/kitchen-azure-winstall.yml
+++ b/test/kitchen/kitchen-azure-winstall.yml
@@ -72,12 +72,12 @@ platforms:
     )
 
     sizes = [
-      "Standard_D1",
-      "Standard_A1",
+      "Standard_D1_v2",
+      "Standard_A1_v2",
     ]
 
     windows_sizes = [
-      "Standard_D1"
+      "Standard_D1_v2"
     ]
 
     location = "North Central US"

--- a/test/kitchen/kitchen-azure-winstall.yml
+++ b/test/kitchen/kitchen-azure-winstall.yml
@@ -80,12 +80,7 @@ platforms:
       "Standard_D1"
     ]
 
-    # we wanna spread out our quotas
-    locations = [
-      "North Central US",
-      "South Central US",
-      "Central US",
-    ]
+    location = "North Central US"
 
     drivers = %w(
       azurerm
@@ -99,7 +94,6 @@ platforms:
     idx = 0
     azure_test_platforms.product(chef_versions).each do |platform, chef_version|
     idx += 1
-    location = locations[idx % locations.length]
 
     host = "azure"
     if ENV['KITCHEN_DRIVER'] && ENV['KITCHEN_DRIVER'] == "hyperv"

--- a/test/kitchen/kitchen-azure.yml
+++ b/test/kitchen/kitchen-azure.yml
@@ -79,12 +79,7 @@ platforms:
       "Standard_D1"
     ]
 
-    # we wanna spread out our quotas
-    locations = [
-      "North Central US",
-      "South Central US",
-      "Central US",
-    ]
+    location = "North Central US"
 
     drivers = %w(
       azurerm
@@ -98,7 +93,6 @@ platforms:
     idx = 0
     azure_test_platforms.product(chef_versions).each do |platform, chef_version|
     idx += 1
-    location = locations[idx % locations.length]
 
     host = "azure"
     if ENV['KITCHEN_DRIVER'] && ENV['KITCHEN_DRIVER'] == "hyperv"

--- a/test/kitchen/kitchen-azure.yml
+++ b/test/kitchen/kitchen-azure.yml
@@ -71,12 +71,12 @@ platforms:
     )
 
     sizes = [
-      "Standard_D1",
-      "Standard_A1",
+      "Standard_D1_v2",
+      "Standard_A1_v2",
     ]
 
     windows_sizes = [
-      "Standard_D1"
+      "Standard_D1_v2"
     ]
 
     location = "North Central US"

--- a/test/kitchen/tasks/apt-test-6.sh
+++ b/test/kitchen/tasks/apt-test-6.sh
@@ -58,4 +58,4 @@ kitchen diagnose --no-instances --loader
 mkdir -p ~/.ssh
 [[ -f /.dockerenv ]] && echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
 
-rake dd-agent-azure-parallel[40]
+rake dd-agent-azure-parallel

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -97,4 +97,4 @@ kitchen diagnose --no-instances --loader
 rm -rf cookbooks
 rm -f Berksfile.lock
 
-rake dd-agent-azure-parallel[20]
+rake dd-agent-azure-parallel

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -34,50 +34,67 @@ def agent_command
   end
 end
 
+def wait_until_stopped
+  for _ in 1..15 do
+    break if !is_running?
+    sleep 1
+  end
+end
+
+def wait_until_started
+  for _ in 1..15 do
+    break if is_running?
+    sleep 1
+  end
+end
+
 def stop
   if os == :windows
     # forces the trace agent (and other dependent services) to stop
-    system 'net stop /y datadogagent 2>&1'
-    sleep 15
+    result = system 'net stop /y datadogagent 2>&1'
   else
     if has_systemctl
-      system 'sudo systemctl stop datadog-agent.service && sleep 10'
+      result = system 'sudo systemctl stop datadog-agent.service'
     else
-      system 'sudo initctl stop datadog-agent && sleep 10'
+      result = system 'sudo initctl stop datadog-agent'
     end
   end
+  wait_until_stopped
+  result
 end
 
 def start
   if os == :windows
-    system 'net start datadogagent 2>&1'
-    sleep 15
+    result = system 'net start datadogagent 2>&1'
   else
     if has_systemctl
-      system 'sudo systemctl start datadog-agent.service && sleep 10'
+      result = system 'sudo systemctl start datadog-agent.service'
     else
-      system 'sudo initctl start datadog-agent && sleep 10'
+      result = system 'sudo initctl start datadog-agent'
     end
   end
+  wait_until_started
+  result
 end
 
 def restart
   if os == :windows
     # forces the trace agent (and other dependent services) to stop
     if is_running?
-      system 'net stop /y datadogagent 2>&1'
-      sleep 15
+      result = system 'net stop /y datadogagent 2>&1'
+      wait_until_stopped
     end
-    system 'net start datadogagent 2>&1'
-    sleep 15
+    result = system 'net start datadogagent 2>&1'
+    wait_until_started
   else
     if has_systemctl
-      system 'sudo systemctl restart datadog-agent.service && sleep 10'
+      result = system 'sudo systemctl restart datadog-agent.service && sleep 10'
     else
       # initctl can't restart
-      system '(sudo initctl restart datadog-agent || sudo initctl start datadog-agent) && sleep 10'
+      result = system '(sudo initctl restart datadog-agent || sudo initctl start datadog-agent) && sleep 10'
     end
   end
+  result
 end
 
 def has_systemctl
@@ -279,19 +296,18 @@ shared_examples_for "a running Agent with no errors" do
   end
 
   it 'has running checks' do
-    # On systems that use systemd (on which the `start` script returns immediately)
-    # sleep a few seconds to let the collector finish its first run
-    # This seems to happen on windows, too
-    if os != :windows
-      system('command -v systemctl 2>&1 > /dev/null && sleep 300')
-    else
-      sleep 30
+    result = false
+    for _ in 1..30 do
+      json_info_output = json_info
+      if json_info_output.key?('runnerStats') &&
+        json_info_output['runnerStats'].key?('Checks') &&
+        !json_info_output['runnerStats']['Checks'].empty?
+        result = true
+        break
+      end
+      sleep 1
     end
-
-    json_info_output = json_info
-    expect(json_info_output).to have_key("runnerStats")
-    expect(json_info_output['runnerStats']).to have_key("Checks")
-    expect(json_info_output['runnerStats']['Checks']).not_to be_empty
+    expect(result).to be_truthy
   end
 
   it 'has an info command' do
@@ -374,7 +390,6 @@ shared_examples_for 'an Agent that stops' do
   end
 
   it 'is not running any agent processes' do
-    sleep 5 # need to wait for the Agent to stop
     expect(agent_processes_running?).to be_falsey
   end
 


### PR DESCRIPTION
### What does this PR do?

Does the following in hope of reducing the time taken by kitchen tests:
- Changes locations of kitchen VMs so that they are run in a single region (No notable impact on kitchen tests time, maybe we shouldn't do this after all? Then again, we have drastically increased the quotas of the region, so that shouldn't be a problem),
- Changes concurrency parameters so that all instances are run at the same time (No impact for now since we already run everything concurrently, but could be useful when adding new test platforms and/or suites),
- Fixes kitchen tests so that arbitrary long `sleep` commands are less used (5 minutes improvement on average),
- Use newer images (5 minutes improvement on Win2016, which was the slowest image by far).

=> Up to a 10-minute improvement on the kitchen tests duration (managed to finish the `Testkitchen_testing` stage in around 16 to 18 minutes, compared to 22 to 30 minutes before).

### Motivation

Reducing the time a full gitlab pipeline takes.

### Additional Notes

Things that still need to be worked on:
- Debian 8 instances convergence is slower than other Linux instances (even Ubuntu), apt takes a very long time unpackaging,
- Windows instances are still kind of slow during the convergence phase.