### PR TITLE
[kitchen] update berksfile to use datadog 2.19.0 properly.

### DIFF
--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -1,6 +1,6 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'datadog', '~>2.18.0', git: "https://github.com/datadog/chef-datadog.git"
+cookbook 'datadog', '~> 2.19.0', git: "https://github.com/datadog/chef-datadog.git", branch: "v2.x"
 
 # We pin an old version of the apt cookbook because this cookbook triggers an "apt update" by default
 # and in newer versions this update is not allowed to fail, while in 3.X it is. For some reason


### PR DESCRIPTION
### What does this PR do?

Fix the dependency to the `datadog` cookbook in the kitchen tests.

`master` of the `chef-datadog` repo now contains the 3.x versions of the cookbook, the Berksfile was looking for a 2.x version.