### PR TITLE
[test/kitchen] Update and re-format kitchen docs

### DIFF
--- a/test/kitchen/README.md
+++ b/test/kitchen/README.md
@@ -100,7 +100,7 @@ executed on each platform.
 
 ### Platforms Tested:
 
-See [kitchen.yml](kitchen.yml)
+See [kitchen-azure.yml](kitchen-azure.yml)
 
 ### Packaging Test Suites
 
@@ -114,8 +114,11 @@ Agent packaging methods tested:
   [chef-datadog](https://github.com/DataDog/chef-datadog). The recipe will
   determine if the base Agent should be installed instead of the regular one
   (based on the system version of Python).
-- `dd-agent-upgrade`: Installs the latest release Agent (the latest publicly
-  available Agent version), then upgrades it to the latest release candidate
+- `dd-agent-upgrade-agent6`: Installs the latest release Agent 6 (the latest publicly
+  available Agent 6 version), then upgrades it to the latest release candidate
+  using the platform's package manager.
+- `dd-agent-upgrade-agent5`: Installs the latest release Agent 5 (the latest publicly
+  available Agent 5 version), then upgrades it to the latest Agent 6 release candidate
   using the platform's package manager.
 - `dd-agent-install-script`: Installs the latest release candidate using our [Agent
   install script](https://raw.github.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh).
@@ -174,12 +177,12 @@ For basic test-kitchen usage, see its [Getting Started
 guide](https://github.com/opscode/test-kitchen/wiki/Getting-Started).
 
 ### Adding a Platform
-Tests are executed on Azure. Platforms are defined in `.kitchen-azure.yml`.
+Tests are executed on Azure. Platforms are defined in `kitchen-azure.yml`.
 
 ### Adding a Suite
 Suites define the commands that should be run on a platform as Chef recipes,
 and tests that verify the outcome of these commands written in RSpec. Suites
-are defined in `kitchen.yml`.
+are defined in `kitchen-azure.yml`.
 
 Add new cookbooks by describing them in `Berksfile`. If you want to write your
 own cookbook that is specific to this repository, place it in the

--- a/test/kitchen/docs/README.md
+++ b/test/kitchen/docs/README.md
@@ -4,18 +4,18 @@
 
 #### Configuration (.gitlab-ci.yml)
 
-The gitlab pipelines which require kitchen testing have 3 independent steps for provisioning kitchen testing, running kitchen testing, and cleaning up (removing the artifacts).  The _deploy\_<platform>\_testing_ stages copy the build artifacts to an S3 bucket.  The _kitchen\_<platform> stages execute the kitchen tests.  The _testkitchen\_cleanup tasks clean up the s3 buckets and the azure virtual machines.
+The gitlab pipelines which require kitchen testing have 3 independent steps for provisioning kitchen testing, running kitchen testing, and cleaning up (removing the artifacts).  The _deploy\_\<platform\>\_testing_ tasks copy the build artifacts to an S3 bucket.  The _kitchen\_\<platform\>_ tasks execute the kitchen tests.  The _testkitchen\_cleanup\_\<cloud_provider\>_ tasks clean up the s3 buckets and the azure virtual machines.
 
 ##### Test execution
 
 Each individual test environment is controlled from _.gitlab\_ci.yml_.  The tests are set up using an environment variable, which is a list of test platforms which are turned into test kitchen platforms.  In _.gitlab\_ci.yml_, the platform list has the following syntax:
-        short_name1,azure_full_qualified_name1|short_name2,azure_full_qualified_name1|
+        `short_name1,azure_full_qualified_name1|short_name2,azure_full_qualified_name2`
 
 This configuration is fed to the script _tasks/run-test-kitchen.sh_. That script in turn sets up additional variables for Azure (authentication/environment variables), and then executes the actual kitchen command.  Using the ruby _erb_ syntax, a full matrix of platforms and tests is generated and executed.
 
 There are currently two input files.
-1. .kitchen-azure.yml contains a set of installation and upgrade tests that are executed on all of the available platforms
-2. .kitchen-azure-winstall.yml contains a set of  Windows specific tests for command-line installation options. These tests are currently (as configured in .gitlab-ci.yml) only run on one Windows OS for brevity.
+1. _.kitchen-azure.yml_ contains a set of installation and upgrade tests that are executed on all of the available platforms
+2. _.kitchen-azure-winstall.yml_ contains a set of  Windows specific tests for command-line installation options. These tests are currently (as configured in _.gitlab-ci.yml_) only run on one Windows OS for brevity.
 
 ### Test Implementation
 
@@ -72,4 +72,4 @@ Note that each directory contains a symbolic link for spec_helper.rb to the comm
 
 #### Test definition
 
-The test suites are defined in the various .kitchen-*.yml files.  Each test suite runs one or more chef recipes (usually to install the agent in various ways), and then its verifier.  The verifier is assumed (by kitchen) to be in the directory that has the name of the suite.  So, the `dd-agent-installopts` suite runs the verifier script in `dd-agent-installopts/rspec/dd-agent-installopts_spec.rb`.
+The test suites are defined in the various _.kitchen-*.yml_ files.  Each test suite runs one or more chef recipes (usually to install the agent in various ways), and then its verifier.  The verifier is assumed (by kitchen) to be in the directory that has the name of the suite.  So, the `dd-agent-installopts` suite runs the verifier script in `dd-agent-installopts/rspec/dd-agent-installopts_spec.rb`.

--- a/test/kitchen/docs/README.md
+++ b/test/kitchen/docs/README.md
@@ -14,8 +14,8 @@ Each individual test environment is controlled from _.gitlab\_ci.yml_.  The test
 This configuration is fed to the script _tasks/run-test-kitchen.sh_. That script in turn sets up additional variables for Azure (authentication/environment variables), and then executes the actual kitchen command.  Using the ruby _erb_ syntax, a full matrix of platforms and tests is generated and executed.
 
 There are currently two input files.
-1. _.kitchen-azure.yml_ contains a set of installation and upgrade tests that are executed on all of the available platforms
-2. _.kitchen-azure-winstall.yml_ contains a set of  Windows specific tests for command-line installation options. These tests are currently (as configured in _.gitlab-ci.yml_) only run on one Windows OS for brevity.
+1. _kitchen-azure.yml_ contains a set of installation and upgrade tests that are executed on all of the available platforms
+2. _kitchen-azure-winstall.yml_ contains a set of  Windows specific tests for command-line installation options. These tests are currently (as configured in _.gitlab-ci.yml_) only run on one Windows OS for brevity.
 
 ### Test Implementation
 


### PR DESCRIPTION


### What does this PR do?

Corrects some outdated info, links and fomatting errors.

### Motivation

Some test suites listed in the `README` were outdated. Some file links were also outdated.
In the `docs` folder, the `README` had some formatting errors which made some text disappear.

### Additional Notes

- In the `docs` folder, when referring to files and CI steps, we alternate (arbitrarily) between _emphasis_  and `code` formatting. I think we should harmonise this by choosing either one or the other.
- The `README` mentions that some *supported platforms* are not tested in kitchen. However, I see *FreeBSD* and *SmartOS* listed, but our [official documentation](https://docs.datadoghq.com/agent/?tab=agentv6#supported-os-versions) doesn't say anything about them being supported. Is this list still up-to-date?