### PR TITLE
[test/kitchen] Fix is_port_bound test for SUSE >= 15

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -187,7 +187,8 @@ def is_port_bound(port)
     port_regex = Regexp.new(port.to_s)
     port_regex.match(`netstat -n -b -a -p TCP 2>&1`)
   else
-    system("sudo netstat -lntp | grep #{port} 1>/dev/null")
+    # If netstat is not found (eg. on SUSE >= 15), use ss to get the list of ports used.
+    system("sudo netstat -lntp | grep #{port} 1>/dev/null") || system("sudo ss -lntp | grep #{port} 1>/dev/null")
   end
 end
 


### PR DESCRIPTION
### What does this PR do?

Added an alternative way of checking if the agent port is bound using `ss`.

### Motivation

On SUSE >= 15 systems, the `netstat` command has been deprecated and the `ss` command should be used in its place.

