### PR TITLE
set logging_frequency to 500

### DIFF
--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // FIXTURE
@@ -115,6 +116,10 @@ func TestWork(t *testing.T) {
 }
 
 func TestLogging(t *testing.T) {
+	defaultFrequency := config.Datadog.GetInt64("logging_frequency")
+	config.Datadog.SetDefault("logging_frequency", int64(20))
+	defer config.Datadog.SetDefault("logging_frequency", defaultFrequency)
+
 	r := NewRunner()
 	c := newTestCheck(false, "1")
 	s := &check.Stats{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,7 +107,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("log_level", "info")
 	config.BindEnvAndSetDefault("log_to_syslog", false)
 	config.BindEnvAndSetDefault("log_to_console", true)
-	config.BindEnvAndSetDefault("logging_frequency", int64(20))
+	config.BindEnvAndSetDefault("logging_frequency", int64(500))
 	config.BindEnvAndSetDefault("disable_file_logging", false)
 	config.BindEnvAndSetDefault("syslog_uri", "")
 	config.BindEnvAndSetDefault("syslog_rfc", false)

--- a/releasenotes/notes/reduce-log-checkruns-dc850866929f4826.yaml
+++ b/releasenotes/notes/reduce-log-checkruns-dc850866929f4826.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Logs informing about check runs and payload submission are now displayed once
+    every 500 events instead of every 20 events.


### PR DESCRIPTION
### What does this PR do?

Sets `logging_frequency` to 500 by default.
Affected logs are payload sent and check runs. They will only be logged once every 500 runs after the first one.  They will still be logged every run if the log_level is set to `debug`.

### Motivation

It was judged too spammy.

