### PR TITLE
Verify we don't have leftover files on uninstall

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -435,6 +435,14 @@ shared_examples_for 'an Agent that is removed' do
     expect(agent_processes_running?).to be_falsey
   end
 
+  it 'should remove the installation directory' do
+    if os == :windows
+      expect(File).not_to exist("C:\\Program Files\\Datadog\\Datadog Agent\\")
+    else
+      expect(File).not_to exist("/opt/datadog-agent/")
+    end
+  end
+
   if os != :windows
     it 'should remove the agent link from bin' do
       expect(File).not_to exist('/usr/bin/datadog-agent')

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -435,23 +435,12 @@ shared_examples_for 'an Agent that is removed' do
     expect(agent_processes_running?).to be_falsey
   end
 
-  it 'should remove the agent binary' do
-    if os != :windows
-      agent_path = '/usr/bin/datadog-agent'
-    else
-      agent_path = "C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe"
+  if os != :windows
+    it 'should remove the agent link from bin' do
+      expect(File).not_to exist('/usr/bin/datadog-agent')
     end
-    expect(File).not_to exist(agent_path)
   end
 
-  it 'should remove the trace-agent binary' do
-    if os == :windows
-      trace_agent_path = "C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent\\trace-agent"
-    else
-      trace_agent_path = '/opt/datadog-agent/bin/trace-agent'
-    end
-    expect(File).not_to exist(trace_agent_path)
-  end
 end
 
 shared_examples_for 'an Agent with APM enabled' do


### PR DESCRIPTION
Add a kitchen test that verifies that Agent packages clean up after themselves on uninstall.