### PR TITLE
add the golang version to the version command

### DIFF
--- a/cmd/agent/app/version.go
+++ b/cmd/agent/app/version.go
@@ -7,6 +7,7 @@ package app
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -34,11 +35,12 @@ var versionCmd = &cobra.Command{
 		}
 		fmt.Fprintln(
 			color.Output,
-			fmt.Sprintf("Agent %s %s- Commit: %s - Serialization version: %s",
+			fmt.Sprintf("Agent %s %s- Commit: %s - Serialization version: %s - Go version: %s",
 				color.CyanString(av.GetNumberAndPre()),
 				meta,
 				color.GreenString(av.Commit),
 				color.MagentaString(serializer.AgentPayloadVersion),
+				color.BlueString(runtime.Version()),
 			),
 		)
 	},

--- a/releasenotes/notes/go-version-59ed0a4e948ddef4.yaml
+++ b/releasenotes/notes/go-version-59ed0a4e948ddef4.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The `datadog-agent` command now prints the version of Golang the agent was
+    compiled with.


### PR DESCRIPTION
### What does this PR do?

Add the golang version to the `agent version` command.

### Motivation

Faster to use than `strings | grep`
