### PR TITLE
Turn connection closed log to DEBUG

### DIFF
--- a/pkg/logs/client/tcp/connection_manager.go
+++ b/pkg/logs/client/tcp/connection_manager.go
@@ -129,7 +129,7 @@ func (cm *ConnectionManager) address() string {
 // CloseConnection closes a connection on the client side
 func (cm *ConnectionManager) CloseConnection(conn net.Conn) {
 	conn.Close()
-	log.Info("Connection closed")
+	log.Debug("Connection closed")
 }
 
 // handleServerClose lets the connection manager detect when a connection


### PR DESCRIPTION
### What does this PR do?

I see sporadic connection closed logs when in INFO, which makes little
sense as we don't have the connection opening message. Let's move it to
debug.