### PR TITLE
[test/kitchen] Clean up kitchen yamls and fix upgrade-agent-6 suite

### DIFF
--- a/test/kitchen/kitchen-azure-winstall.yml
+++ b/test/kitchen/kitchen-azure-winstall.yml
@@ -67,10 +67,6 @@ platforms:
     # TEST_PLATFORMS syntax is `short_name1,parent vhd folder,parent_vhd_name|...`
     azure_test_platforms = ENV['TEST_PLATFORMS'].split('|').map { |p| p.split(',') }
 
-    chef_versions = %w(
-      13.6.4
-    )
-
     sizes = [
       "Standard_D1",
       "Standard_A1",
@@ -87,17 +83,11 @@ platforms:
       "Central US",
     ]
 
-    drivers = %w(
-      azurerm
-    )
-
-    platforms_x64 = azure_test_platforms.product(chef_versions, drivers).select{|p, c, d| not p[0].include? "i386"}.collect{|p, c, d| p[0] + "-" + c + "-" + d}
-
     exclude_platforms = []
     windows_platforms = []
 
     idx = 0
-    azure_test_platforms.product(chef_versions).each do |platform, chef_version|
+    azure_test_platforms.each do |platform|
     idx += 1
     location = locations[idx % locations.length]
 
@@ -109,7 +99,6 @@ platforms:
     windows = platform_name.include?("win")
     if windows
       windows_platforms << platform_name
-      size = "Standard_D1"
       size = windows_sizes[idx % windows_sizes.length]
     else
       size = sizes[idx % sizes.length]

--- a/test/kitchen/kitchen-azure.yml
+++ b/test/kitchen/kitchen-azure.yml
@@ -211,9 +211,8 @@ suites:
       agent6: true
       agent6_aptrepo: http://apt.datadoghq.com/
       agent6_aptrepo_dist: stable
-      yumrepo: http://yum.datadoghq.com/beta/x86_64/
-      agent6_yumrepo: http://yum.datadoghq.com/beta/x86_64/
-      agent6_yumrepo_suse: http://yum.datadoghq.com/suse/beta/x86_64/
+      agent6_yumrepo: http://yum.datadoghq.com/stable/6/x86_64/
+      agent6_yumrepo_suse: http://yum.datadoghq.com/suse/stable/6/x86_64/
       windows_agent_url: https://s3.amazonaws.com/ddagent-windows-stable/
     dd-agent-install:
       agent6: true

--- a/test/kitchen/kitchen-azure.yml
+++ b/test/kitchen/kitchen-azure.yml
@@ -66,10 +66,6 @@ platforms:
     # TEST_PLATFORMS syntax is `short_name1,parent vhd folder,parent_vhd_name|...`
     azure_test_platforms = ENV['TEST_PLATFORMS'].split('|').map { |p| p.split(',') }
 
-    chef_versions = %w(
-      13.6.4
-    )
-
     sizes = [
       "Standard_D1",
       "Standard_A1",
@@ -86,17 +82,11 @@ platforms:
       "Central US",
     ]
 
-    drivers = %w(
-      azurerm
-    )
-
-    platforms_x64 = azure_test_platforms.product(chef_versions, drivers).select{|p, c, d| not p[0].include? "i386"}.collect{|p, c, d| p[0] + "-" + c + "-" + d}
-
     exclude_platforms = []
     windows_platforms = []
 
     idx = 0
-    azure_test_platforms.product(chef_versions).each do |platform, chef_version|
+    azure_test_platforms.each do |platform|
     idx += 1
     location = locations[idx % locations.length]
 
@@ -108,7 +98,6 @@ platforms:
     windows = platform_name.include?("win")
     if windows
       windows_platforms << platform_name
-      size = "Standard_D1"
       size = windows_sizes[idx % windows_sizes.length]
     else
       size = sizes[idx % sizes.length]
@@ -220,24 +209,14 @@ suites:
       # Get the latest release agents. The upgrade recipe will take care of
       # adding the staging repo and upgrading to the latest candidate
       agent6: true
-      aptrepo: http://apt.datadoghq.com/
-      aptrepo_dist: stable
+      agent6_aptrepo: http://apt.datadoghq.com/
+      agent6_aptrepo_dist: stable
       yumrepo: http://yum.datadoghq.com/beta/x86_64/
       agent6_yumrepo: http://yum.datadoghq.com/beta/x86_64/
       agent6_yumrepo_suse: http://yum.datadoghq.com/suse/beta/x86_64/
       windows_agent_url: https://s3.amazonaws.com/ddagent-windows-stable/
     dd-agent-install:
-      <% dd_agent_config.each do |key, value| %>
-      <%= key %>: <%= value %>
-      <% end %>
-      # Get the latest release agents. The upgrade recipe will take care of
-      # adding the staging repo and upgrading to the latest candidate
       agent6: true
-      aptrepo: http://apt.datadoghq.com/
-      aptrepo_dist: stable
-      yumrepo: http://yum.datadoghq.com/beta/x86_64/
-      agent6_yumrepo: http://yum.datadoghq.com/beta/x86_64/
-      agent6_yumrepo_suse: http://yum.datadoghq.com/suse/beta/x86_64/
       windows_agent_url: https://s3.amazonaws.com/ddagent-windows-stable/
       windows_agent_filename: datadog-agent-6-latest.amd64
     dd-agent-upgrade:


### PR DESCRIPTION
### What does this PR do?

Removes some unused parameters (`driver`, `chef_version`) as they're handled differently now.
Also fixes the `upgrade-agent-6` test suite, which didn't behave correctly: instead of installing the latest release agent and then installing the current pipeline's agent, it directly installed the later.

### Motivation

One of our test suites didn't behave correctly, and some old unused code was still there in our `kitchen` configuration.
