### PR TITLE
Do not stop collecting external metrics after 3 failures

### DIFF
--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -124,7 +124,7 @@ func (p *datadogProvider) externalMetricsSetter(ctx context.Context) {
 			log.Infof("Received instruction to terminate collection of External Metrics, stopping async loop")
 			return
 		default:
-			if p.isServing = true {
+			if p.isServing == true {
 				currentBackoff = EXTERNAL_METRICS_BASE_BACKOFF
 			} else {
 				currentBackoff = currentBackoff * 2

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -76,8 +76,6 @@ func (p *datadogProvider) externalMetricsSetter(ctx context.Context) {
 	log.Infof("Starting async loop to collect External Metrics")
 	tick := time.NewTicker(time.Duration(p.maxAge) * time.Second)
 	defer tick.Stop()
-
-	// If we exceed 3 retries trying to access the ConfigMap, we permafail and stop trying to refresh the External Metrics.
 	ctxCancel, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"math"
 
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/releasenotes/notes/prevent_hpa_metrics_from_hanging-47209b1e001ad816.yaml
+++ b/releasenotes/notes/prevent_hpa_metrics_from_hanging-47209b1e001ad816.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The External Metrics Setter no longer stops trying to get metrics after 3 failed attempts. Instead, it will retry indefinitely.
+


### PR DESCRIPTION
### What does this PR do?

- Do not give up trying to refresh external metrics after repeated failures trying to [list external metrics](https://github.com/DataDog/datadog-agent/blob/master/pkg/clusteragent/custommetrics/provider.go#L91)

- Stop trying to refresh external metrics if the underlying ConfigMap is deleted

### Motivation

The `cluster-agent` is responsible for refreshing the external metrics consumed by [HorizontalPodAutoscalers](https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/). The current behaviour, explicitly stated as a code comment, is as follows:
`// If we exceed 3 retries trying to access the ConfigMap, we permafail and stop trying to refresh the External Metrics.` ([see ref](https://github.com/DataDog/datadog-agent/blob/master/pkg/clusteragent/custommetrics/provider.go#L81))

Unfortunately, the API-server may become temporarily unreachable due to reasons both routine and unforeseen. This has led to the following scenario:

- A deployment is managed by an HPA
- A flapping master causes the API-server to become unreachable for a few minutes
- The `cluster-agent` stops updating external metrics and they become stale
- The API-server becomes reachable again, but we have stopped trying to refresh metrics
- The HPA managing the deploy is now useless until we manually kick the `cluster-agent`

In light of this, it makes more sense for the `cluster-agent` to continually retry, instead of bailing out prematurely.

### Additional Notes

The default timeout between attempts is 30 seconds; the cost of continually trying to connect to the API-server in the event of unreachability is therefore quite small. As a first pass, I think this PR is sufficient, but it might be worthwhile in the future to account for various different failure modes. the `k8serrors` package has been imported to provide an easier interface when checking against API-server responses.
