### PR TITLE
system-probe: Allow to force skip the linux version check

### DIFF
--- a/cmd/system-probe/probe.go
+++ b/cmd/system-probe/probe.go
@@ -40,7 +40,7 @@ func CreateSystemProbe(cfg *config.AgentConfig) (*SystemProbe, error) {
 	nt := &SystemProbe{}
 
 	// Checking whether the current OS + kernel version is supported by the tracer
-	if nt.supported, err = ebpf.IsTracerSupportedByOS(cfg.ExcludedBPFLinuxVersions); err != nil {
+	if nt.supported, err = ebpf.IsTracerSupportedByOS(cfg.SkipLinuxVersionCheck, cfg.ExcludedBPFLinuxVersions); err != nil {
 		return nil, fmt.Errorf("%s: %s", ErrTracerUnsupported, err)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -446,6 +446,7 @@ func initConfig(config Config) {
 	config.SetKnown("system_probe_config.max_closed_connections_buffered")
 	config.SetKnown("system_probe_config.max_connection_state_buffered")
 	config.SetKnown("system_probe_config.excluded_linux_versions")
+	config.SetKnown("system_probe_config.skip_linux_version_check")
 
 	// APM
 	config.SetKnown("apm_config.enabled")

--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -8,6 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
@@ -46,7 +47,12 @@ func linuxKernelVersionCode(major, minor, patch uint32) uint32 {
 }
 
 // IsTracerSupportedByOS returns whether or not the current kernel version supports tracer functionality
-func IsTracerSupportedByOS(exclusionList []string) (bool, error) {
+func IsTracerSupportedByOS(skipCheck bool, exclusionList []string) (bool, error) {
+	if skipCheck {
+		log.Info("Skipping check to see if the tracer is supported by the current OS")
+		return true, nil
+	}
+
 	currentKernelCode, err := CurrentKernelVersion()
 	if err != nil {
 		return false, fmt.Errorf("could not get kernel version: %s", err)

--- a/pkg/ebpf/nettop/main.go
+++ b/pkg/ebpf/nettop/main.go
@@ -17,7 +17,7 @@ func main() {
 	}
 	fmt.Printf("-- Kernel: %d (%d.%d)--\n", kernelVersion, (kernelVersion>>16)&0xff, (kernelVersion>>8)&0xff)
 
-	if ok, err := ebpf.IsTracerSupportedByOS(nil); err != nil {
+	if ok, err := ebpf.IsTracerSupportedByOS(true, nil); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	} else if !ok {

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -41,7 +41,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		c.useLocalTracer = true
 
 		// Checking whether the current kernel version is supported by the tracer
-		if _, err = ebpf.IsTracerSupportedByOS(cfg.ExcludedBPFLinuxVersions); err != nil {
+		if _, err = ebpf.IsTracerSupportedByOS(cfg.SkipLinuxVersionCheck, cfg.ExcludedBPFLinuxVersions); err != nil {
 			// err is always returned when false, so the above catches the !ok case as well
 			log.Warnf("system probe unsupported by OS: %s", err)
 			return

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -84,6 +84,7 @@ type AgentConfig struct {
 	MaxTrackedConnections        uint
 	SysProbeBPFDebug             bool
 	ExcludedBPFLinuxVersions     []string
+	SkipLinuxVersionCheck        bool
 	EnableConntrack              bool
 	ConntrackShortTermBufferSize int
 	SystemProbeDebugPort         int

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -55,6 +55,10 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		a.ExcludedBPFLinuxVersions = config.Datadog.GetStringSlice(key(spNS, "excluded_linux_versions"))
 	}
 
+	if config.Datadog.IsSet(key(spNS, "skip_linux_version_check")) {
+		a.SkipLinuxVersionCheck = config.Datadog.GetBool(key(spNS, "skip_linux_version_check"))
+	}
+
 	// The full path to the location of the unix socket where connections will be accessed
 	if socketPath := config.Datadog.GetString(key(spNS, "sysprobe_socket")); socketPath != "" {
 		a.SystemProbeSocketPath = socketPath


### PR DESCRIPTION
### What does this PR do?

This adds a config option to allow to force skip the linux version check (in case eBPF is backported to older OS like centos/7 for instance).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
