### PR TITLE
system-probe: Allow centos 7 if kernel is >= 3.10.0

### DIFF
--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -46,4 +46,12 @@ func TestExcludedKernelVersion(t *testing.T) {
 	ok, err = verifyOSVersion(linuxKernelVersionCode(5, 5, 2), "debian", exclusionList)
 	assert.True(t, ok)
 	assert.Nil(t, err)
+
+	ok, err = verifyOSVersion(linuxKernelVersionCode(3, 10, 0), "Linux-3.10.0-957.5.1.el7.x86_64-x86_64-with-centos-7.6.1810-Core", exclusionList)
+	assert.True(t, ok)
+	assert.Nil(t, err)
+
+	ok, err = verifyOSVersion(linuxKernelVersionCode(3, 9, 0), "Linux-3.9.0.x86_64-x86_64-with-centos-7.5", exclusionList)
+	assert.False(t, ok)
+	assert.Error(t, err)
 }

--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -109,7 +110,12 @@ func GetPlatform() (string, error) {
 		return lsbOut, nil
 	}
 
-	return "", fmt.Errorf("error retrieving platform, with python: %s, with lsb_release: %s", pyErr, lsbErr)
+	redhatRaw, redhatErr := ioutil.ReadFile("/etc/redhat-release")
+	if redhatErr == nil {
+		return strings.ToLower(string(redhatRaw)), nil
+	}
+
+	return "", fmt.Errorf("error retrieving platform, with python: %s, with lsb_release: %s, reading redhat-release: %s", pyErr, lsbErr, redhatErr)
 }
 
 // IsDebugfsMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs is mounted or not

--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -98,7 +98,7 @@ func GetDockerSocketPath() (string, error) {
 	return sockPath, nil
 }
 
-// GetPlatform returns the current platform we are running on by calling "python -mplatform" then "lsb_release -a" if python fails
+// GetPlatform returns the current platform we are running on by calling "python -mplatform" then "lsb_release -a" if python fails and finally reading redhat-release if both python and lsb_release failed
 func GetPlatform() (string, error) {
 	pyOut, pyErr := execCmd("python", "-m", "platform")
 	if pyErr == nil {


### PR DESCRIPTION
### What does this PR do?

Previously we checked if the kernel versions of the current host was >= 4.4.0 however ebpf got backported to centos, see [here](https://www.redhat.com/en/blog/introduction-ebpf-red-hat-enterprise-linux-7), this will allow the probe to run on recent centos hosts.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

This is a temporary fix, in the future we should check if `bpf_perf_events`, `bpf_maps`, etc. are available on the current host.
