### PR TITLE
Added the possibility to send logs to multiple destinations with HTTP

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -27,6 +28,8 @@ type Destination struct {
 	url                 string
 	client              *http.Client
 	destinationsContext *client.DestinationsContext
+	once                sync.Once
+	payloadChan         chan []byte
 }
 
 // NewDestination returns a new Destination.
@@ -86,9 +89,29 @@ func (d *Destination) Send(payload []byte) error {
 	}
 }
 
-// SendAsync is not implemented for HTTP.
+// SendAsync sends a payload in background.
 func (d *Destination) SendAsync(payload []byte) {
-	return
+	d.once.Do(func() {
+		payloadChan := make(chan []byte, 100)
+		d.sendInBackground(payloadChan)
+		d.payloadChan = payloadChan
+	})
+	d.payloadChan <- payload
+}
+
+// sendInBackground sends all payloads from payloadChan in background.
+func (d *Destination) sendInBackground(payloadChan chan []byte) {
+	ctx := d.destinationsContext.Context()
+	go func() {
+		for {
+			select {
+			case payload := <-payloadChan:
+				d.Send(payload)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 // builURL buils a url from a config endpoint.

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -221,6 +221,41 @@ func (suite *EndpointsTestSuite) TestOverrideApiKey() {
 	suite.Equal("wassuplogskey", endpoints.Main.APIKey)
 }
 
+func (suite *EndpointsTestSuite) TestAdditionalEndpoints() {
+	var (
+		endpoints *Endpoints
+		endpoint  Endpoint
+		err       error
+	)
+
+	suite.config.Set("logs_config.additional_endpoints", []map[string]interface{}{
+		{
+			"host":    "foo",
+			"api_key": "1234",
+		},
+	})
+
+	endpoints, err = BuildEndpoints()
+	suite.Nil(err)
+	suite.Len(endpoints.Additionals, 1)
+
+	endpoint = endpoints.Additionals[0]
+	suite.Equal("foo", endpoint.Host)
+	suite.Equal("1234", endpoint.APIKey)
+	suite.True(endpoint.UseSSL)
+
+	suite.config.Set("logs_config.use_http", true)
+	endpoints, err = BuildEndpoints()
+	suite.Nil(err)
+	suite.Len(endpoints.Additionals, 1)
+
+	endpoint = endpoints.Additionals[0]
+	suite.Equal("foo", endpoint.Host)
+	suite.Equal("1234", endpoint.APIKey)
+	suite.True(endpoint.UseSSL)
+
+}
+
 func TestEndpointsTestSuite(t *testing.T) {
 	suite.Run(t, new(EndpointsTestSuite))
 }


### PR DESCRIPTION
### What does this PR do?

Make sure additional endpoints are parsed for HTTP config and updated the client to sends logs in async 

### Motivation

Send logs to multiple destinations with HTTP

### Additional Notes

Anything else we should know when reviewing?
