### PR TITLE
Added common utility for socks5 proxy and use it for logs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,6 +73,7 @@ type Proxy struct {
 	HTTP    string   `mapstructure:"http"`
 	HTTPS   string   `mapstructure:"https"`
 	NoProxy []string `mapstructure:"no_proxy"`
+	SOCKS5  string   `mapstructure:"socks5"`
 }
 
 func init() {
@@ -562,12 +563,21 @@ func loadProxyFromEnv(config Config) {
 		p.NoProxy = strings.Split(noProxy, ",") // comma-separated list, consistent with other tools that use the NO_PROXY env var
 	}
 
+	if socks5, found := lookupEnv("DD_PROXY_SOCKS5"); found {
+		isSet = true
+		p.SOCKS5 = socks5
+	} else if socks5, found := lookupEnvCaseInsensitive("SOCKS5_PROXY"); found {
+		isSet = true
+		p.SOCKS5 = socks5
+	}
+
 	// We have to set each value individually so both config.Get("proxy")
 	// and config.Get("proxy.http") work
 	if isSet {
 		config.Set("proxy.http", p.HTTP)
 		config.Set("proxy.https", p.HTTPS)
 		config.Set("proxy.no_proxy", p.NoProxy)
+		config.Set("proxy.socks5", p.SOCKS5)
 		proxies = p
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -429,7 +429,7 @@ func TestLoadProxyConfOnly(t *testing.T) {
 	config := setupConf()
 
 	// check value loaded before aren't overwrite when no env variables are set
-	p := &Proxy{HTTP: "test", HTTPS: "test2", NoProxy: []string{"a", "b", "c"}}
+	p := &Proxy{HTTP: "test", HTTPS: "test2", NoProxy: []string{"a", "b", "c"}, SOCKS5: "test3"}
 	config.Set("proxy", p)
 
 	// circleCI set some proxy setting
@@ -449,6 +449,7 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 	os.Setenv("HTTP_PROXY", "http_url")
 	os.Setenv("HTTPS_PROXY", "https_url")
 	os.Setenv("NO_PROXY", "a,b,c") // comma-separated list
+	os.Setenv("SOCKS5_PROXY", "socks5_url")
 
 	loadProxyFromEnv(config)
 
@@ -457,9 +458,11 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 		&Proxy{
 			HTTP:    "http_url",
 			HTTPS:   "https_url",
-			NoProxy: []string{"a", "b", "c"}},
+			NoProxy: []string{"a", "b", "c"},
+			SOCKS5:  "socks5_url"},
 		proxies)
 
+	os.Unsetenv("SOCKS5_PROXY")
 	os.Unsetenv("NO_PROXY")
 	os.Unsetenv("HTTPS_PROXY")
 	os.Unsetenv("HTTP_PROXY")
@@ -469,6 +472,7 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 	os.Setenv("http_proxy", "http_url2")
 	os.Setenv("https_proxy", "https_url2")
 	os.Setenv("no_proxy", "1,2,3") // comma-separated list
+	os.Setenv("socks5_proxy", "socks5_url2")
 
 	loadProxyFromEnv(config)
 	proxies = GetProxies()
@@ -476,9 +480,11 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 		&Proxy{
 			HTTP:    "http_url2",
 			HTTPS:   "https_url2",
-			NoProxy: []string{"1", "2", "3"}},
+			NoProxy: []string{"1", "2", "3"},
+			SOCKS5:  "socks5_url2"},
 		proxies)
 
+	os.Unsetenv("socks5_proxy")
 	os.Unsetenv("no_proxy")
 	os.Unsetenv("https_proxy")
 	os.Unsetenv("http_proxy")
@@ -490,6 +496,7 @@ func TestLoadProxyDDSpecificEnvOnly(t *testing.T) {
 	os.Setenv("DD_PROXY_HTTP", "http_url")
 	os.Setenv("DD_PROXY_HTTPS", "https_url")
 	os.Setenv("DD_PROXY_NO_PROXY", "a b c") // space-separated list
+	os.Setenv("DD_PROXY_SOCKS5", "socks5_url")
 
 	loadProxyFromEnv(config)
 
@@ -498,12 +505,14 @@ func TestLoadProxyDDSpecificEnvOnly(t *testing.T) {
 		&Proxy{
 			HTTP:    "http_url",
 			HTTPS:   "https_url",
-			NoProxy: []string{"a", "b", "c"}},
+			NoProxy: []string{"a", "b", "c"},
+			SOCKS5:  "socks5_url"},
 		proxies)
 
 	os.Unsetenv("DD_PROXY_HTTP")
 	os.Unsetenv("DD_PROXY_HTTPS")
 	os.Unsetenv("DD_PROXY_NO_PROXY")
+	os.Unsetenv("DD_PROXY_SOCKS5")
 }
 
 func TestLoadProxyDDSpecificEnvPrecedenceOverStdEnv(t *testing.T) {
@@ -512,9 +521,11 @@ func TestLoadProxyDDSpecificEnvPrecedenceOverStdEnv(t *testing.T) {
 	os.Setenv("DD_PROXY_HTTP", "dd_http_url")
 	os.Setenv("DD_PROXY_HTTPS", "dd_https_url")
 	os.Setenv("DD_PROXY_NO_PROXY", "a b c")
+	os.Setenv("DD_PROXY_SOCKS5", "dd_socks5_url")
 	os.Setenv("HTTP_PROXY", "env_http_url")
 	os.Setenv("HTTPS_PROXY", "env_https_url")
 	os.Setenv("NO_PROXY", "d,e,f")
+	os.Setenv("SOCKS5_PROXY", "env_socks5_url")
 
 	loadProxyFromEnv(config)
 
@@ -523,15 +534,18 @@ func TestLoadProxyDDSpecificEnvPrecedenceOverStdEnv(t *testing.T) {
 		&Proxy{
 			HTTP:    "dd_http_url",
 			HTTPS:   "dd_https_url",
-			NoProxy: []string{"a", "b", "c"}},
+			NoProxy: []string{"a", "b", "c"},
+			SOCKS5:  "dd_socks5_url"},
 		proxies)
 
+	os.Unsetenv("SOCKS5_PROXY")
 	os.Unsetenv("NO_PROXY")
 	os.Unsetenv("HTTPS_PROXY")
 	os.Unsetenv("HTTP_PROXY")
 	os.Unsetenv("DD_PROXY_HTTP")
 	os.Unsetenv("DD_PROXY_HTTPS")
 	os.Unsetenv("DD_PROXY_NO_PROXY")
+	os.Unsetenv("DD_PROXY_SOCKS5")
 }
 
 func TestLoadProxyStdEnvAndConf(t *testing.T) {
@@ -540,6 +554,7 @@ func TestLoadProxyStdEnvAndConf(t *testing.T) {
 	os.Setenv("HTTP_PROXY", "http_env")
 	config.Set("proxy.no_proxy", []string{"d", "e", "f"})
 	config.Set("proxy.http", "http_conf")
+	config.Set("proxy.socks5", "socks5_url")
 	defer os.Unsetenv("HTTP")
 
 	loadProxyFromEnv(config)
@@ -548,7 +563,8 @@ func TestLoadProxyStdEnvAndConf(t *testing.T) {
 		&Proxy{
 			HTTP:    "http_env",
 			HTTPS:   "",
-			NoProxy: []string{"d", "e", "f"}},
+			NoProxy: []string{"d", "e", "f"},
+			SOCKS5:  "socks5_url"},
 		proxies)
 }
 
@@ -558,6 +574,7 @@ func TestLoadProxyDDSpecificEnvAndConf(t *testing.T) {
 	os.Setenv("DD_PROXY_HTTP", "http_env")
 	config.Set("proxy.no_proxy", []string{"d", "e", "f"})
 	config.Set("proxy.http", "http_conf")
+	config.Set("proxy.socks5", "socks5_url")
 	defer os.Unsetenv("DD_PROXY_HTTP")
 
 	loadProxyFromEnv(config)
@@ -566,7 +583,8 @@ func TestLoadProxyDDSpecificEnvAndConf(t *testing.T) {
 		&Proxy{
 			HTTP:    "http_env",
 			HTTPS:   "",
-			NoProxy: []string{"d", "e", "f"}},
+			NoProxy: []string{"d", "e", "f"},
+			SOCKS5:  "socks5_url"},
 		proxies)
 }
 
@@ -575,9 +593,11 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 
 	os.Setenv("DD_PROXY_HTTP", "")
 	os.Setenv("DD_PROXY_NO_PROXY", "a b c")
+	os.Setenv("DD_PROXY_SOCKS5", "")
 	os.Setenv("HTTP_PROXY", "env_http_url")
 	os.Setenv("HTTPS_PROXY", "")
 	os.Setenv("NO_PROXY", "")
+	os.Setenv("SOCKS5_PROXY", "socks5_url")
 	config.Set("proxy.https", "https_conf")
 
 	loadProxyFromEnv(config)
@@ -587,7 +607,8 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 		&Proxy{
 			HTTP:    "",
 			HTTPS:   "",
-			NoProxy: []string{"a", "b", "c"}},
+			NoProxy: []string{"a", "b", "c"},
+			SOCKS5:  ""},
 		proxies)
 
 	os.Unsetenv("NO_PROXY")
@@ -596,6 +617,7 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 	os.Unsetenv("DD_PROXY_HTTP")
 	os.Unsetenv("DD_PROXY_HTTPS")
 	os.Unsetenv("DD_PROXY_NO_PROXY")
+	os.Unsetenv("DD_PROXY_SOCKS5")
 }
 
 func TestSanitizeAPIKey(t *testing.T) {

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -33,14 +33,17 @@ type Destination struct {
 }
 
 // NewDestination returns a new Destination.
-// TODO: add support for SOCKS5
 func NewDestination(endpoint config.Endpoint, destinationsContext *client.DestinationsContext) *Destination {
+	transport := util.CreateHTTPTransport()
+	if endpoint.ProxyAddress != "" {
+		transport.Dial = util.GetSOCKS5DialFunc(endpoint.ProxyAddress)
+	}
 	return &Destination{
 		url: buildURL(endpoint),
 		client: &http.Client{
 			Timeout: time.Second * 10,
 			// reusing core agent HTTP transport to benefit from proxy settings.
-			Transport: util.CreateHTTPTransport(),
+			Transport: transport,
 		},
 		destinationsContext: destinationsContext,
 	}

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -138,8 +138,10 @@ func buildTCPEndpoints() (*Endpoints, error) {
 
 func buildHTTPEndpoints() (*Endpoints, error) {
 	var useSSL bool
+	proxyAddress := coreConfig.Datadog.GetString("logs_config.socks5_proxy_address")
 	main := Endpoint{
-		APIKey: getLogsAPIKey(coreConfig.Datadog),
+		APIKey:       getLogsAPIKey(coreConfig.Datadog),
+		ProxyAddress: proxyAddress,
 	}
 
 	switch {
@@ -164,6 +166,7 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 	}
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = useSSL
+		additionals[i].ProxyAddress = proxyAddress
 	}
 
 	return NewEndpoints(main, additionals, false, true), nil

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -127,6 +127,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	endpoint = endpoints.Main
 	suite.True(endpoint.UseSSL)
 	suite.Equal("agent-http-intake.logs.datadoghq.com", endpoint.Host)
+	suite.Equal("", endpoint.ProxyAddress)
 }
 
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPConfigAndOverride() {
@@ -144,6 +145,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	endpoint = endpoints.Main
 	suite.True(endpoint.UseSSL)
 	suite.Equal("foo", endpoint.Host)
+	suite.Equal("", endpoint.ProxyAddress)
 }
 
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidProxyConfig() {
@@ -162,6 +164,26 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidProxyCo
 	suite.True(endpoint.UseSSL)
 	suite.Equal("foo", endpoint.Host)
 	suite.Equal(1234, endpoint.Port)
+	suite.Equal("", endpoint.ProxyAddress)
+}
+
+func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidSOCKS5Config() {
+	var endpoints *Endpoints
+	var endpoint Endpoint
+	var err error
+
+	suite.config.Set("logs_config.use_http", true)
+	suite.config.Set("logs_config.dd_url", "foo")
+	suite.config.Set("logs_config.socks5_proxy_address", "bar:1234")
+
+	endpoints, err = BuildEndpoints()
+	suite.Nil(err)
+	suite.True(endpoints.UseHTTP)
+
+	endpoint = endpoints.Main
+	suite.True(endpoint.UseSSL)
+	suite.Equal("foo", endpoint.Host)
+	suite.Equal("bar:1234", endpoint.ProxyAddress)
 }
 
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFailWithInvalidProxyConfig() {


### PR DESCRIPTION
### What does this PR do?

Added a common utility for socks5 proxy and use it for logs

### Motivation

Make sure the logs-agent won't break for customers that use a socks5 proxy when they switch to using HTTP.

### Additional Notes

