### PR TITLE
process-agent: Get bind_host from the main config and not the process agent subconfig

### DIFF
--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -286,7 +286,7 @@ func (a *AgentConfig) loadProcessYamlConfig(path string) error {
 		a.StatsdPort = config.Datadog.GetInt(k)
 	}
 
-	if bindHost := config.Datadog.GetString(key(ns, "bind_host")); bindHost != "" {
+	if bindHost := config.Datadog.GetString("bind_host"); bindHost != "" {
 		a.StatsdHost = bindHost
 	}
 


### PR DESCRIPTION
### What does this PR do?

The process-agent should be using the `bind_host` defined by the core agent and not one defined under `process_config`.

Also see: https://github.com/DataDog/datadog-agent/pull/3735

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
