### PR TITLE
Separate tag watching logic in podwatcher

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -65,7 +65,7 @@ func init() {
 }
 
 func NewKubeletListener() (ServiceListener, error) {
-	watcher, err := kubelet.NewPodWatcher(15 * time.Second)
+	watcher, err := kubelet.NewPodWatcher(15*time.Second, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -35,7 +35,7 @@ type KubeletCollector struct {
 
 // Detect tries to connect to the kubelet
 func (c *KubeletCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
-	watcher, err := kubelet.NewPodWatcher(5 * time.Minute)
+	watcher, err := kubelet.NewPodWatcher(5*time.Minute, true)
 	if err != nil {
 		return NoCollection, err
 	}

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -31,8 +31,9 @@ type PodWatcher struct {
 	isWatchingTags bool
 }
 
-// NewPodWatcher creates a new watcher. User call must then trigger PullChanges
-// and ExpireContainers when needed.
+// NewPodWatcher creates a new watcher given an expiry duration
+// and if the watcher should watch label/annotation changes on pods.
+// User call must then trigger PullChanges and Expire when needed.
 func NewPodWatcher(expiryDuration time.Duration, isWatchingTags bool) (*PodWatcher, error) {
 	kubeutil, err := GetKubeUtil()
 	if err != nil {
@@ -127,7 +128,7 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 			}
 		}
 
-		if newStaticPod || updatedContainer || (w.isWatchingTags && newLabelsOrAnnotations) {
+		if newStaticPod || updatedContainer || newLabelsOrAnnotations {
 			updatedPods = append(updatedPods, pod)
 		}
 	}

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -47,7 +47,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChanges() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
-		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -90,7 +89,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChangesInConditions() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
-		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -132,7 +130,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherWithInitContainers() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
-		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -161,7 +158,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherWithShortLivedContainers() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
-		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -190,7 +186,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherReadinessChange() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
-		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -292,7 +287,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireUnready() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
-		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -338,6 +332,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
+		isWatchingTags: true,
 	}
 
 	_, err = watcher.computeChanges(sourcePods)
@@ -380,6 +375,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
+		isWatchingTags: true,
 	}
 
 	_, err = watcher.computeChanges(sourcePods)
@@ -436,7 +432,7 @@ func (suite *PodwatcherTestSuite) TestPullChanges() {
 	mockConfig.Set("kubernetes_https_kubelet_port", kubeletPort)
 	mockConfig.Set("kubelet_tls_verify", false)
 
-	watcher, err := NewPodWatcher(5 * time.Minute)
+	watcher, err := NewPodWatcher(5*time.Minute, false)
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), watcher)
 	<-kubelet.Requests // Throwing away the first /pods GET
@@ -457,6 +453,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherLabelsValueChange() {
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
+		isWatchingTags: true,
 	}
 	twoPods := sourcePods[:2]
 	changes, err := watcher.computeChanges(twoPods)
@@ -499,6 +496,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherAnnotationsValueChange() {
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
+		isWatchingTags: true,
 	}
 	twoPods := sourcePods[:2]
 	changes, err := watcher.computeChanges(twoPods)

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -332,7 +332,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
-		isWatchingTags: true,
 	}
 
 	_, err = watcher.computeChanges(sourcePods)
@@ -375,7 +374,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
-		isWatchingTags: true,
 	}
 
 	_, err = watcher.computeChanges(sourcePods)
@@ -453,7 +451,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherLabelsValueChange() {
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
-		isWatchingTags: true,
 	}
 	twoPods := sourcePods[:2]
 	changes, err := watcher.computeChanges(twoPods)
@@ -496,7 +493,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherAnnotationsValueChange() {
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
-		isWatchingTags: true,
 	}
 	twoPods := sourcePods[:2]
 	changes, err := watcher.computeChanges(twoPods)


### PR DESCRIPTION
### What does this PR do?

Separate the logic of watching labels/annotation in pod watcher to only be used in the tagger.
This logic should not be used in the pod watcher of the kubelet service listener.

### Motivation

Due to the change in #3253 a change in annotation/labels on a pod could cause a check to be scheduled a second time if targeted by autodiscovery.
