### PR TITLE
Refactor permissions for the integration command

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -197,10 +197,6 @@ func validateArgs(args []string, local bool) error {
 }
 
 func pip(args []string, stdout io.Writer, stderr io.Writer) error {
-	if !allowRoot && !authorizedUser() {
-		return errors.New("Please use this tool as the agent-running user")
-	}
-
 	if flagNoColor {
 		color.NoColor = true
 	}
@@ -257,8 +253,9 @@ func pip(args []string, stdout io.Writer, stderr io.Writer) error {
 }
 
 func install(cmd *cobra.Command, args []string) error {
-	if !isIntegrationUser() {
-		return fmt.Errorf("Installation requires an elevated/root user")
+	err := validateUser(allowRoot)
+	if err != nil {
+		return err
 	}
 	if err := validateArgs(args, localWheel); err != nil {
 		return err
@@ -722,8 +719,9 @@ func moveConfigurationFiles(srcFolder string, dstFolder string) error {
 }
 
 func remove(cmd *cobra.Command, args []string) error {
-	if !isIntegrationUser() {
-		return fmt.Errorf("Removal requires an elevated/root user")
+	err := validateUser(allowRoot)
+	if err != nil {
+		return err
 	}
 
 	if err := validateArgs(args, false); err != nil {

--- a/cmd/agent/app/integrations_darwin.go
+++ b/cmd/agent/app/integrations_darwin.go
@@ -8,6 +8,8 @@
 package app
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 )
 
@@ -22,10 +24,9 @@ var (
 	relConstraintsPath     = filepath.Join("..", "..", constraintsFile)
 )
 
-func authorizedUser() bool {
-	return true
-}
-
-func isIntegrationUser() bool {
-	return true
+func validateUser(allowRoot bool) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("Please run this tool with the root user.")
+	}
+	return nil
 }

--- a/cmd/agent/app/integrations_nix.go
+++ b/cmd/agent/app/integrations_nix.go
@@ -9,6 +9,7 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -24,10 +25,9 @@ var (
 	relConstraintsPath     = filepath.Join("..", "..", constraintsFile)
 )
 
-func authorizedUser() bool {
-	return (os.Geteuid() != 0)
-}
-
-func isIntegrationUser() bool {
-	return true
+func validateUser(allowRoot bool) error {
+	if os.Geteuid() == 0 && !allowRoot {
+		return fmt.Errorf("Operation is disabled for root user. Please run this tool with the agent-running user or add '--allow-root/-r' to force.")
+	}
+	return nil
 }

--- a/cmd/agent/app/integrations_windows.go
+++ b/cmd/agent/app/integrations_windows.go
@@ -9,6 +9,7 @@
 package app
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
@@ -25,12 +26,10 @@ var (
 	relConstraintsPath     = filepath.Join("..", constraintsFile)
 )
 
-func authorizedUser() bool {
-	// TODO: implement something useful
-	return true
-}
-
-func isIntegrationUser() bool {
+func validateUser(allowRoot bool) error {
 	elevated, _ := winutil.IsProcessElevated()
-	return elevated
+	if !elevated {
+		return fmt.Errorf("Operation is not possible for unelevated process.")
+	}
+	return nil
 }

--- a/releasenotes/notes/refactor-integration-command-permissions-50232ce90d1010c7.yaml
+++ b/releasenotes/notes/refactor-integration-command-permissions-50232ce90d1010c7.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Refactored permissions check in the integration command.


### PR DESCRIPTION
### What does this PR do?

Refactor permissions checks of the integration command.

### Motivation

The command was using two different methods to check permissions `authorizedUser` and `isIntegrationUser` that were both called during the same function calls.

Also adds an error message on mac for non-root users as the integration command requires it for install/remove.

Results:

#### Mac

Random user
```shell
$ datadog-agent integration remove datadog-vault
Error: Please run this tool with the root user.

$ datadog-agent integration install datadog-vault==1.4.0
Error: Please run this tool with the root user.

$ datadog-agent integration freeze
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
datadog-a7==0.0.6
datadog-activemq==1.1.0
datadog-activemq-xml==1.2.0
...
```

No dd-agent on mac

Root
```shell
# datadog-agent integration remove datadog-vault
Uninstalling datadog-vault-1.4.0:
  Successfully uninstalled datadog-vault-1.4.0

# datadog-agent integration install datadog-vault==1.4.0
/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/downloader/data/repo/targets/simple/datadog-vault/datadog_vault-1.4.0-py2.py3-none-any.whl
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Processing /opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/downloader/data/repo/targets/simple/datadog-vault/datadog_vault-1.4.0-py2.py3-none-any.whl
Installing collected packages: datadog-vault
Successfully installed datadog-vault-1.4.0
Successfully copied configuration file conf.yaml.example
Successfully installed datadog-vault 1.4.0

# datadog-agent integration freeze
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
datadog-a7==0.0.6
datadog-activemq==1.1.0
datadog-activemq-xml==1.2.0
...
```

#### Ubuntu

Random user 
Permissions errors are the same as before
```shell

$ datadog-agent integration freeze
datadog-a7==0.0.6
datadog-activemq==1.1.0
datadog-activemq-xml==1.2.0
... 

$ datadog-agent integration remove datadog-vault
Uninstalling datadog-vault-1.4.0:
Exception:
Traceback (most recent call last):
...
OSError: [Errno 13] Permission denied: '/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/vault/__init__.pyc'

$ datadog-agent integration install datadog-vault==1.4.0
Cannot setup config, exiting: unable to load Datadog config file: open /etc/datadog-agent/datadog.yaml: permission denied
Error: error when downloading the wheel for datadog-vault 1.4.0: unable to load Datadog config file: open /etc/datadog-agent/datadog.yaml: permission denied
```

dd-agent

```shell

$ datadog-agent integration freeze
datadog-a7==0.0.6
datadog-activemq==1.1.0
datadog-activemq-xml==1.2.0
... 

$ datadog-agent integration remove datadog-vault
Uninstalling datadog-vault-1.4.0:
  Successfully uninstalled datadog-vault-1.4.0

$ datadog-agent integration install datadog-vault==1.4.0
/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/downloader/data/repo/targets/simple/datadog-vault/datadog_vault-1.4.0-py2.py3-none-any.whl
Processing /opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/downloader/data/repo/targets/simple/datadog-vault/datadog_vault-1.4.0-py2.py3-none-any.whl
Installing collected packages: datadog-vault
Successfully installed datadog-vault-1.4.0
Successfully copied configuration file conf.yaml.example
Successfully installed datadog-vault 1.4.0
```

Root

```shell
$ datadog-agent integration freeze
datadog-a7==0.0.6
datadog-activemq==1.1.0
datadog-activemq-xml==1.2.0
... 

# datadog-agent integration install datadog-vault==1.4.0
Error: Operation is disabled for root user. Pleas run this tool with the agent-running user or add '--allow-root/-r' to force.

# datadog-agent integration remove datadog-vault
Error: Operation is disabled for root user. Pleas run this tool with the agent-running user or add '--allow-root/-r' to force.

```

#### Windows

Also works but couldn't test with non-elevated process.

### Additional Notes

Anything else we should know when reviewing?
