### PR TITLE
[Prod] Remove MacOS from list of OS that ship with trace agent

### DIFF
--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -259,7 +259,7 @@ Prior releases were logging to multiple files in that directory (`collector.log`
 ## APM agent
 
 The APM agent (also known as _trace agent_) is shipped by default with the
-Agent 6 in the Linux, MacOS and Windows packages.
+Agent 6 in the Linux and Windows packages.
 
 The APM agent is enabled by default on linux.
 To enable the check on other platforms or disable it on linux,


### PR DESCRIPTION
### What does this PR do?
Remove MacOS from list of OS that ship with trace agent

### Motivation
Contrary to our documentation:
https://docs.datadoghq.com/tracing/#setting-up-apm
>(On macOS, install and run the Trace Agent in addition to the Datadog Agent. See the macOS Trace Agent documentation for more information)

And we also seem to provide an external install:
https://github.com/DataDog/datadog-agent/releases?after=6.12.0-rc.6

