### PR TITLE
Bundle libyaml

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -25,6 +25,7 @@ if ohai["platform"] != "windows"
   dependency "openssl"
   dependency "bzip2"
   dependency "libsqlite3"
+  dependency "libyaml"
 
   source :url => "http://python.org/ftp/python/#{version}/Python-#{version}.tgz",
          :sha256 => "01da813a3600876f03f46db11cc5c408175e99f03af2ba942ef324389a83bad5"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -10,6 +10,7 @@ if ohai["platform"] != "windows"
   dependency "bzip2"
   dependency "libsqlite3"
   dependency "liblzma"
+  dependency "libyaml"
 
   version "3.6.7" do
     source :sha256 => "b7c36f7ed8f7143b2c46153b7332db2227669f583ea0cce753facf549d1a4239"


### PR DESCRIPTION
We currently aren't bundling libyaml and thus relying on it being installed system-wide to use it from pyyaml.

On our docker image libyaml wasn't present, so pyyaml was falling back to the python implementation instead of using the C library. This caused an increase in our memory footprint by ~30Mb.