### PR TITLE
Global tags for Fargate

### DIFF
--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -36,12 +36,10 @@ func (c *ECSFargateCollector) parseMetadata(meta ecs.TaskMetadata, parseAll bool
 			tags := utils.NewTagList()
 
 			// global tags
-			if len(globalTags) > 0 {
-				for _, value := range globalTags {
-					if strings.Contains(value, ":") {
-						tag := strings.SplitN(value, ":", 2)
-						tags.AddLow(tag[0], tag[1])
-					}
+			for _, value := range globalTags {
+				if strings.Contains(value, ":") {
+					tag := strings.SplitN(value, ":", 2)
+					tags.AddLow(tag[0], tag[1])
 				}
 			}
 

--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -28,10 +29,21 @@ func (c *ECSFargateCollector) parseMetadata(meta ecs.TaskMetadata, parseAll bool
 	if meta.KnownStatus != "RUNNING" {
 		return output, fmt.Errorf("Task %s is in %s status, skipping", meta.Family, meta.KnownStatus)
 	}
+	globalTags := config.Datadog.GetStringSlice("tags")
 
 	for _, ctr := range meta.Containers {
 		if c.expire.Update(ctr.DockerID, now) || parseAll {
 			tags := utils.NewTagList()
+
+			// global tags
+			if len(globalTags) > 0 {
+				for _, value := range globalTags {
+					if strings.Contains(value, ":") {
+						tag := strings.SplitN(value, ":", 2)
+						tags.AddLow(tag[0], tag[1])
+					}
+				}
+			}
 
 			// cluster
 			tags.AddLow("cluster_name", parseECSClusterName(meta.ClusterName))

--- a/releasenotes/notes/fargate-global-tags-0ff45a9cd6b719b7.yaml
+++ b/releasenotes/notes/fargate-global-tags-0ff45a9cd6b719b7.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds the ability to use `DD_TAGS` to set global tags in Fargate.


### PR DESCRIPTION
### What does this PR do?

Allows for global tags in Fargate.

### Motivation

Matching the functionality of the traditional host-based agent tagging feature to apply tags on `ecs.fargate.*` metrics as well as integration metrics. 

![](https://cl.ly/9c4bcd76ce7b/Image%202019-06-26%20at%2012.43.50%20PM.png)

### Additional Notes

Dogstatsd metric tagging should be handled via `dogstatsd_tags`.