### PR TITLE
use the long version of Datadog GPG key ID

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -156,7 +156,7 @@ elif [ $OS = "Debian" ]; then
     fi
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
     $sudo_cmd sh -c "echo 'deb https://apt.${repo_url}/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-    $sudo_cmd apt-key adv --recv-keys --keyserver ${keyserver} 382E94DE
+    $sudo_cmd apt-key adv --recv-keys --keyserver ${keyserver} A2923DFF56EDA6E76E55E492D3A80E30382E94DE
 
     printf "\033[34m\n* Installing the Datadog Agent package\n\033[0m\n"
     ERROR_MESSAGE="ERROR
@@ -258,13 +258,13 @@ else
 fi
 
 
-# Use /usr/sbin/service by default. 
+# Use /usr/sbin/service by default.
 # Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`
 restart_cmd="$sudo_cmd service datadog-agent restart"
 stop_instructions="$sudo_cmd service datadog-agent stop"
 start_instructions="$sudo_cmd service datadog-agent start"
 
-if command -v systemctl 2>&1; then 
+if command -v systemctl 2>&1; then
   # Use systemd if systemctl binary exists
   restart_cmd="$sudo_cmd systemctl restart datadog-agent.service"
   stop_instructions="$sudo_cmd systemctl stop datadog-agent"

--- a/docs/agent/downgrade.md
+++ b/docs/agent/downgrade.md
@@ -23,7 +23,7 @@ sudo apt-get install apt-transport-https
 ```shell
 sudo rm /etc/apt/sources.list.d/datadog-beta.list
 [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
 ```
 
 ##### Update apt and downgrade the agent

--- a/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
@@ -12,7 +12,7 @@ when 'debian'
   execute 'install debian' do
     command <<-EOF
       sudo sh -c "echo \'deb http://#{node['dd-agent-step-by-step']['repo_domain_apt']}/ #{node['dd-agent-step-by-step']['repo_branch_apt']} main\' > /etc/apt/sources.list.d/datadog.list"
-      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 382E94DE
+      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE
       sudo apt-get update
       sudo apt-get install #{node['dd-agent-step-by-step']['package_name']} -y -q
     EOF

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -15,7 +15,7 @@ if node['dd-agent-upgrade']['add_new_repo']
 
     apt_repository 'datadog-update' do
       keyserver 'keyserver.ubuntu.com'
-      key '382E94DE'
+      key 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
       uri node['dd-agent-upgrade']['aptrepo']
       distribution node['dd-agent-upgrade']['aptrepo_dist']
       components ['main']
@@ -96,7 +96,7 @@ if node['platform_family'] == 'windows'
       dd_agent_installer_basename = "datadog-agent-6.0.0-beta.latest.amd64"
     end
   end
-  
+
   temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-up').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
 
   dd_agent_installer = "#{dd_agent_installer_basename}.msi"


### PR DESCRIPTION
### What does this PR do?
This PR changes documentation and install scripts to use the long version of DataDog packaging GPG key instead of the short one.

### Motivation
Use of short GPG key IDs should be avoided because of the high risk of collisions there is with those.

### Additional Notes
Reference: https://evil32.com/
