### PR TITLE
process-agent: bump gopsutil version and use the same handleSignal helper for all platforms

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,7 +42,7 @@
   revision = "43b075bb9705588cd89c71363d6d72937e3020c7"
 
 [[projects]]
-  digest = "1:f5a67538206ad242703731b55fb4abc6cf7b44de436d4b989572bd82cf3c3e12"
+  digest = "1:84c22eb14ecdebefff6a3764e5d3769739a775095f31d90919dfd10e887170fb"
   name = "github.com/DataDog/gopsutil"
   packages = [
     "cpu",
@@ -53,7 +53,7 @@
     "process",
   ]
   pruneopts = ""
-  revision = "fe7986fb54b7a36afebec4610af9daa8e5f34f89"
+  revision = "3ca45fa2b07679737219be93796a178822ff878f"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -187,7 +187,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/gopsutil"
-  revision = "fe7986fb54b7a36afebec4610af9daa8e5f34f89"
+  revision = "3ca45fa2b07679737219be93796a178822ff878f"
 
 [[constraint]]
   name = "github.com/iovisor/gobpf"

--- a/pkg/process/util/signal_nowindows.go
+++ b/pkg/process/util/signal_nowindows.go
@@ -1,4 +1,4 @@
-// +build docker
+// +build !windows
 
 package util
 

--- a/pkg/process/util/signal_windows.go
+++ b/pkg/process/util/signal_windows.go
@@ -1,4 +1,4 @@
-// +build !docker
+// +build windows
 
 package util
 


### PR DESCRIPTION
### What does this PR do?

This bumps the gopsutil version we use to have: https://github.com/DataDog/gopsutil/pull/23 (this was causing issues on macos)
Also the sigchild was very noisy on macos so I just merged the two handleSignal helpers.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
