### PR TITLE
Revert "Revert "[system-probe] auto mount debugfs""

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
@@ -1,6 +1,7 @@
 [Unit]
 Description="Datadog System Probe"
-After=network.target
+Requires=sys-kernel-debug.mount
+After=network.target sys-kernel-debug.mount
 
 [Service]
 Type=simple

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.sysprobe.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.sysprobe.erb
@@ -51,12 +51,25 @@ do_start()
 	# on this one.  As a last resort, sleep for some time.
 }
 
+#
+# Function that tries to mount debugfs
+#
+mount_debugfs()
+{
+  if [ -d /sys/kernel/debug ]; then
+    if ! grep -qs '/sys/kernel/debug ' /proc/mounts; then
+      mount -t debugfs none /sys/kernel/debug
+    fi
+  fi
+}
+
 
 #
 # Start the agent and wait for it to be up
 #
 start_and_wait()
 {
+	mount_debugfs
 	log_daemon_msg "Starting $DESC" "$NAME"
 	do_start
 	case "$?" in

--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -12,6 +12,15 @@ normal exit 0
 console log
 env DD_LOG_TO_CONSOLE=false
 
+# mount debugfs before start
+pre-start script
+  if [ -d /sys/kernel/debug ]; then
+    if ! grep -qs '/sys/kernel/debug ' /proc/mounts; then
+      mount -t debugfs none /sys/kernel/debug
+    fi
+  fi
+end script
+
 script
   exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
 end script

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -8,13 +8,6 @@ normal exit 0
 
 console output
 
-script
-  # Logging to console from the agent is disabled since the agent already logs using file or
-  # syslog depending on its configuration. We then redirect the stdout/stderr of the agent process
-  # to log panic/crashes.
-  exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid &>> /var/log/datadog/system-probe-errors.log
-end script
-
 pre-start script
   # Manual rotation of errors log
   log_file_size=`du -b /var/log/datadog/system-probe-errors.log | cut -f1`
@@ -22,6 +15,20 @@ pre-start script
     # Rotate log file if it's larger than 5MB
     mv /var/log/datadog/system-probe-errors.log /var/log/datadog/system-probe-errors.log.1
   fi
+
+  # mount debugfs before start
+  if [ -d /sys/kernel/debug ]; then
+    if ! grep -qs '/sys/kernel/debug ' /proc/mounts; then
+      mount -t debugfs none /sys/kernel/debug
+    fi
+  fi
+end script
+
+script
+  # Logging to console from the agent is disabled since the agent already logs using file or
+  # syslog depending on its configuration. We then redirect the stdout/stderr of the agent process
+  # to log panic/crashes.
+  exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid &>> /var/log/datadog/system-probe-errors.log
 end script
 
 post-stop script


### PR DESCRIPTION
Reverts DataDog/datadog-agent#3757. The original PR https://github.com/DataDog/datadog-agent/pull/3563 got merged accidentally before 6.12.0 is finished releasing so it was reverted. This PR puts it back again.