### PR TITLE
[omnibus] Stop whitelisting all embedded python libs during omnibus health check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,7 +50,10 @@
 
 /Dockerfiles/                           @DataDog/container-integrations
 /docs/trace-agent                       @DataDog/apm-agent
+
 /omnibus/                               @DataDog/agent-core
+/omnibus/config/software/datadog-agent-integrations-*.rb  @DataDog/agent-integrations
+
 /tasks/trace.py                         @DataDog/apm-agent
 
 /Makefile.trace                         @DataDog/apm-agent

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Install omnibus
-gem 'omnibus', git: 'https://github.com/DataDog/omnibus-ruby.git', branch: (ENV['OMNIBUS_RUBY_VERSION'] || 'datadog-5.5.0')
+gem 'omnibus', git: 'https://github.com/DataDog/omnibus-ruby.git', branch: "kserrania/macos-loader-path-fix" #(ENV['OMNIBUS_RUBY_VERSION'] || 'datadog-5.5.0')
 
 # Use Chef's software definitions. It is recommended that you write your own
 # software definitions, but you can clone/fork Chef's to get you started.

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Install omnibus
-gem 'omnibus', git: 'https://github.com/DataDog/omnibus-ruby.git', branch: "kserrania/macos-loader-path-fix" #(ENV['OMNIBUS_RUBY_VERSION'] || 'datadog-5.5.0')
+gem 'omnibus', git: 'https://github.com/DataDog/omnibus-ruby.git', branch: (ENV['OMNIBUS_RUBY_VERSION'] || 'datadog-5.5.0')
 
 # Use Chef's software definitions. It is recommended that you write your own
 # software definitions, but you can clone/fork Chef's to get you started.

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -31,7 +31,7 @@ if linux?
 end
 
 relative_path 'integrations-core'
-whitelist_file "embedded/lib/python2.7"
+whitelist_file "embedded/lib/python2.7/site-packages/psycopg2"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -32,6 +32,8 @@ end
 
 relative_path 'integrations-core'
 whitelist_file "embedded/lib/python2.7/site-packages/psycopg2"
+whitelist_file "embedded/lib/python2.7/site-packages/wrapt"
+whitelist_file "embedded/lib/python2.7/site-packages/pymqi"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -31,7 +31,7 @@ if linux?
 end
 
 relative_path 'integrations-core'
-whitelist_file "embedded/lib/python3.7"
+whitelist_file "embedded/lib/python3.7/site-packages/psycopg2"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -32,6 +32,7 @@ end
 
 relative_path 'integrations-core'
 whitelist_file "embedded/lib/python3.7/site-packages/psycopg2"
+whitelist_file "embedded/lib/python3.7/site-packages/pymqi"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 


### PR DESCRIPTION
### What does this PR do?

Changes the `datadog-agent-integrations-py2` and `datadog-agent-integrations-py3` software definitions to only whitelist the problematic libraries.
Also changes the `CODEOWNERS` file since the integrations team owns these two software definitions.

### Motivation

The health check step of the omnibus build checks that libraries have the necessary dependencies they'll need at runtime. This allows us to see if we missed adding some libraries when packaging the releases. However, due to three of the python libs (`psycopg2`, `wrapt`, `pymqi`) having strange dependencies (outside of the build folders), we ended up whitelisting all the python libs.
