### PR TITLE
Fix tagger regression behavior with SIX

### DIFF
--- a/releasenotes/notes/Fix-tagger-regression-behavior-with-SIX-d1994c01432ff815.yaml
+++ b/releasenotes/notes/Fix-tagger-regression-behavior-with-SIX-d1994c01432ff815.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the `tagger` behavior returning `None` when no tags are present for the `kubelet` and `fargate` integration.

--- a/rtloader/common/builtins/tagger.c
+++ b/rtloader/common/builtins/tagger.c
@@ -49,12 +49,11 @@ int parseArgs(PyObject *args, char **id, int *cardinality)
 */
 PyObject *buildTagsList(char **tags)
 {
+    PyObject *res = PyList_New(0);
     if (tags == NULL) {
-        // Py_RETURN_NONE macro increases the refcount on Py_None
-        Py_RETURN_NONE;
+        return res;
     }
 
-    PyObject *res = PyList_New(0);
     int i;
     for (i = 0; tags[i]; i++) {
         PyObject *pyTag = PyStringFromCString(tags[i]);

--- a/rtloader/test/tagger/tagger_test.go
+++ b/rtloader/test/tagger/tagger_test.go
@@ -60,7 +60,7 @@ func TestGetTagsUnknown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "null" {
+	if out != "[]" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 }
@@ -146,7 +146,7 @@ func TestTagsUnknown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out != "null" {
+	if out != "[]" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Previously in a python check, a call to the tagger.tag function, always
return a list (empty or not). With the introduction of SIX, in case of
the absence of associated tag stored in the tagger, the function returns
"NONE" that can break some checks (Kubelet check of instance).

This fix restores the previous behavior.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
