### PR TITLE
Make two and three manage pythonHome the same way

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -224,15 +224,15 @@ func Initialize(paths ...string) error {
 
 	var pyErr *C.char = nil
 	if pythonVersion == "2" {
-		// Do not free this CString which stores the path of the python home: it is passed to `Py_SetPythonHome`,
-		// which explicitly needs it to be kept around until the interpreter exits.
-		rtloader = C.make2(C.CString(pythonHome2), &pyErr)
+		csPythonHome2 := C.CString(pythonHome2)
+		rtloader = C.make2(csPythonHome2, &pyErr)
+		C.free(unsafe.Pointer(csPythonHome2))
 		log.Infof("Initializing rtloader with python2 %s", pythonHome2)
 		PythonHome = pythonHome2
 	} else if pythonVersion == "3" {
-		// Do not free this CString which stores the path of the python home: it is passed to `Py_SetPythonHome`,
-		// which explicitly needs it to be kept around until the interpreter exits.
-		rtloader = C.make3(C.CString(pythonHome3), &pyErr)
+		csPythonHome3 := C.CString(pythonHome3)
+		rtloader = C.make3(csPythonHome3, &pyErr)
+		C.free(unsafe.Pointer(csPythonHome3))
 		log.Infof("Initializing rtloader with python3 %s", pythonHome3)
 		PythonHome = pythonHome3
 	} else {

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -32,8 +32,8 @@ typedef struct rtloader_pyobject_s rtloader_pyobject_t;
 /*! \fn rtloader_t *make2(const char *python_home, char **error)
     \brief Factory function to load the python2 backend DLL and create its relevant RtLoader
     instance.
-    \param python_home A C-string containing the expected PYTHONhOME for said DLL.
-    \param error A C-stringi pointer output parameter to return error messages.
+    \param python_home A C-string with the path to the PYTHONHOME for said DLL.
+    \param error A C-string pointer output parameter to return error messages.
     \return A rtloader_t * pointer to the RtLoader instance.
     \sa rtloader_t
 */
@@ -41,8 +41,8 @@ DATADOG_AGENT_RTLOADER_API rtloader_t *make2(const char *pythonhome, char **erro
 /*! \fn rtloader_t *make3(const char *python_home, char **error)
     \brief Factory function to load the python3 backend DLL and create its relevant RtLoader
     instance.
-    \param python_home A C-string containing the expected PYTHONhOME for said DLL.
-    \param error A C-stringi pointer output parameter to return error messages.
+    \param python_home A C-string with the path to the PYTHONHOME for said DLL.
+    \param error A C-string pointer output parameter to return error messages.
     \return A rtloader_t * pointer to the RtLoader instance.
     \sa rtloader_t
 */

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -372,7 +372,7 @@ private:
 /*! create_t function prototype
   \typedef create_t defines the factory function prototype to create RtLoader instances for
   the underlying python runtimes.
-  \param python_home A C-string representation of the python home for the target python runtime.
+  \param python_home A C-string path to the python home for the target python runtime.
   \return A pointer to the RtLoader instance created by the implementing function.
 */
 typedef RtLoader *(create_t)(const char *python_home);

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -44,9 +44,7 @@ Three::~Three()
     // For more information on why Py_Finalize() isn't called here please
     // refer to the header file or the doxygen documentation.
     PyEval_RestoreThread(_threadState);
-    if (_pythonHome) {
-        PyMem_RawFree((void *)_pythonHome);
-    }
+    PyMem_RawFree((void *)_pythonHome);
     Py_XDECREF(_baseClass);
 }
 
@@ -55,9 +53,7 @@ void Three::initPythonHome(const char *pythonHome)
     if (pythonHome == NULL || strlen(pythonHome) == 0) {
         _pythonHome = Py_DecodeLocale(_defaultPythonHome, NULL);
     } else {
-        if (_pythonHome) {
-            PyMem_RawFree((void *)_pythonHome);
-        }
+       PyMem_RawFree((void *)_pythonHome);
         _pythonHome = Py_DecodeLocale(pythonHome, NULL);
     }
 

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -50,10 +50,10 @@ Three::~Three()
 
 void Three::initPythonHome(const char *pythonHome)
 {
+    PyMem_RawFree((void *)_pythonHome);
     if (pythonHome == NULL || strlen(pythonHome) == 0) {
         _pythonHome = Py_DecodeLocale(_defaultPythonHome, NULL);
     } else {
-       PyMem_RawFree((void *)_pythonHome);
         _pythonHome = Py_DecodeLocale(pythonHome, NULL);
     }
 

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -26,8 +26,8 @@ class Three : public RtLoader
 public:
     //! Constructor.
     /*!
-      \param python_home A C-string representation to the python home for the
-      underlying python interpreter.
+      \param python_home A C-string with the path to the python home for the
+      python interpreter.
 
       Basic constructor, initializes the _error string to an empty string and
       errorFlag to false and set the supplied PYTHONHOME.

--- a/rtloader/two/constants.h.in
+++ b/rtloader/two/constants.h.in
@@ -1,5 +1,5 @@
 #ifdef _WIN32
-static const char *_pythonHome = "@Python2_STDLIB@\\..";
+static const char *_defaultPythonHome = "@Python2_STDLIB@\\..";
 #else
-static const char *_pythonHome = "@Python2_STDLIB@/../..";
+static const char *_defaultPythonHome = "@Python2_STDLIB@/../..";
 #endif

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -34,6 +34,7 @@ extern "C" DATADOG_AGENT_RTLOADER_API void destroy(RtLoader *p)
 
 Two::Two(const char *python_home)
     : RtLoader()
+    , _pythonHome(NULL)
     , _baseClass(NULL)
     , _pythonPaths()
 {
@@ -42,17 +43,23 @@ Two::Two(const char *python_home)
 
 Two::~Two()
 {
+    // For more information on why Py_Finalize() isn't called here please
+    // refer to the header file or the doxygen documentation.
     PyEval_RestoreThread(_threadState);
+    free(_pythonHome);
     Py_XDECREF(_baseClass);
 }
 
 void Two::initPythonHome(const char *pythonHome)
 {
-    if (pythonHome != NULL && strlen(pythonHome) != 0) {
-        _pythonHome = pythonHome;
+    free(_pythonHome);
+    if (pythonHome == NULL || strlen(pythonHome) == 0) {
+        _pythonHome = _strdup(_defaultPythonHome);
+    } else {
+        _pythonHome = _strdup(pythonHome);
     }
 
-    Py_SetPythonHome(const_cast<char *>(_pythonHome));
+    Py_SetPythonHome(_pythonHome);
 }
 
 bool Two::init()

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -158,6 +158,7 @@ private:
     */
     typedef std::vector<std::string> PyPaths;
 
+    char *_pythonHome; /*!< string with the PYTHONHOME for the underlying interpreter */
     PyObject *_baseClass; /*!< PyObject * pointer to the base Agent check class */
     PyPaths _pythonPaths; /*!< string vector containing paths in the PYTHONPATH */
     PyThreadState *_threadState; /*!< PyThreadState * pointer to the saved Python interpreter thread state */

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -25,8 +25,8 @@ class Two : public RtLoader
 public:
     //! Constructor.
     /*!
-      \param python_home A C-string representation to the python home for the
-      underlying python interpreter.
+      \param python_home A C-string with the path to the python home for the
+      python interpreter.
 
       Basic constructor, initializes the _error string to an empty string and
       errorFlag to false and set the supplied PYTHONHOME.


### PR DESCRIPTION
- Makes two and three manage pythonHome the same way.
- Removes an unnecessary check for null
- Fixes a possible leak if initPythonHome was called multiple times.
- Removes a special case in go, where we would not free a C string.