### PR TITLE
pkg/trace/writer: fix integration tests

### DIFF
--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -85,8 +85,8 @@ type ReplaceRule struct {
 	Repl string `mapstructure:"repl"`
 }
 
-// SenderConfig specifies the configuration for the sender.
-type SenderConfig struct {
+// WriterConfig specifies configuration for an API writer.
+type WriterConfig struct {
 	// ConnectionLimit specifies the maximum number of concurrent outgoing
 	// connections allowed for the sender.
 	ConnectionLimit int `mapstructure:"connection_limit"`
@@ -94,6 +94,10 @@ type SenderConfig struct {
 	// QueueSize specifies the maximum number or payloads allowed to be queued
 	// in the sender.
 	QueueSize int `mapstructure:"queue_size"`
+
+	// FlushPeriodSeconds specifies the frequency at which the writer's buffer
+	// will be flushed to the sender, in seconds. Fractions are permitted.
+	FlushPeriodSeconds float64 `mapstructure:"flush_period_seconds"`
 }
 
 func (c *AgentConfig) applyDatadogConfig() error {
@@ -229,7 +233,7 @@ func (c *AgentConfig) applyDatadogConfig() error {
 	}
 
 	// undocumented writers
-	for key, cfg := range map[string]*SenderConfig{
+	for key, cfg := range map[string]*WriterConfig{
 		"apm_config.trace_writer": c.TraceWriter,
 		"apm_config.stats_writer": c.StatsWriter,
 	} {

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -75,8 +75,8 @@ type AgentConfig struct {
 	ReceiverTimeout int
 
 	// Writers
-	StatsWriter *SenderConfig
-	TraceWriter *SenderConfig
+	StatsWriter *WriterConfig
+	TraceWriter *WriterConfig
 
 	// internal telemetry
 	StatsdHost string
@@ -132,8 +132,8 @@ func New() *AgentConfig {
 		ReceiverPort:    8126,
 		ConnectionLimit: 2000,
 
-		StatsWriter: new(SenderConfig),
-		TraceWriter: new(SenderConfig),
+		StatsWriter: new(WriterConfig),
+		TraceWriter: new(WriterConfig),
 
 		StatsdHost: "localhost",
 		StatsdPort: 8125,

--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -184,7 +184,7 @@ func testStatsWriter() (*StatsWriter, chan []stats.Bucket, *testServer) {
 		Hostname:    testHostname,
 		DefaultEnv:  testEnv,
 		Endpoints:   []*config.Endpoint{{Host: srv.URL, APIKey: "123"}},
-		StatsWriter: &config.SenderConfig{ConnectionLimit: 20, QueueSize: 20},
+		StatsWriter: &config.WriterConfig{ConnectionLimit: 20, QueueSize: 20},
 	}
 	return NewStatsWriter(cfg, in), in, srv
 }

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -24,7 +24,7 @@ func TestTraceWriter(t *testing.T) {
 			APIKey: "123",
 			Host:   srv.URL,
 		}},
-		TraceWriter: &config.SenderConfig{ConnectionLimit: 200, QueueSize: 40},
+		TraceWriter: &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40},
 	}
 
 	t.Run("ok", func(t *testing.T) {
@@ -71,6 +71,7 @@ func randomSampledSpans(spans, events int) *SampledSpans {
 
 // payloadContains checks that the given payload contains the given set of sampled spans.
 func payloadContains(t *testing.T, p *payload, sampledSpans []*SampledSpans) {
+	t.Helper()
 	assert := assert.New(t)
 	gzipr, err := gzip.NewReader(p.body)
 	assert.NoError(err)

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -75,7 +75,7 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
     if remote_docker:
         test_args["exec_opts"] = "-exec \"inv docker.dockerize-test\""
 
-    go_cmd = 'INTEGRATION=yes go test {race_opt} -tags "{go_build_tags}" {exec_opts}'.format(**test_args)
+    go_cmd = 'INTEGRATION=yes go test {race_opt} -v'.format(**test_args)
 
     prefixes = [
         "./pkg/trace/test/testsuite/...",


### PR DESCRIPTION
This change adds the undocumented `apm_config.trace_writer.flush_period_seconds`
option back. It is used in integration tests to speed up flushing to the edge.

Integration tests can be run using:
```
INTEGRATION=1 go test ./pkg/trace/test/testsuite
```
This change also makes sure integration tests run correctly as part of the test suite.