### PR TITLE
pkg/trace/writer: gzip in goroutine

### DIFF
--- a/releasenotes/notes/apm-gzip-routine-c2037b3700ab944a.yaml
+++ b/releasenotes/notes/apm-gzip-routine-c2037b3700ab944a.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: reduce memory usage in high traffic by up to 10x.


### PR DESCRIPTION
# Description

This change adds a goroutine when gzipping to significantly reduce the
blocking created by the writer under high traffic scenarios.

# Benchmark results

[A test](https://github.com/DataDog/trace-agent-test/blob/master/runs/54ksps3m.sh) was run sending 58k spans/s to the agent (all with priority=2 and 14 tags on average per span) over a period of 5 minutes. Results can be seen below:

## Compared to 6.12.0

The below results illustrate running the test against the previous agent version.

### Memory

| Before | After |
|--------|------|
| ![before-mem](https://user-images.githubusercontent.com/6686356/60422388-95428180-9bf4-11e9-8db7-c50968c7214a.png) |  ![after-mem](https://user-images.githubusercontent.com/6686356/60422395-996e9f00-9bf4-11e9-904b-379ec9e94215.png) |

### CPU

| Before | After |
|--------|------|
| ![before-cpu](https://user-images.githubusercontent.com/6686356/60422429-ad1a0580-9bf4-11e9-8333-950714f1db26.png) | ![after-cpu](https://user-images.githubusercontent.com/6686356/60422440-b2775000-9bf4-11e9-9233-c8ca18e572ed.png) |

### Blocking

| Before | After |
|--------|------|
|  <img width="413" alt="blocking-before" src="https://user-images.githubusercontent.com/6686356/60422453-bc00b800-9bf4-11e9-985e-3c3bae869bf9.png"> | <img width="412" alt="blocking-after" src="https://user-images.githubusercontent.com/6686356/60422458-befba880-9bf4-11e9-8e18-a72c48bd7ab8.png"> |

## Compared to current master branch

Current master branch already contains significant writer improvements. Even so, the gains are big.

### Memory

| Before | After |
|--------|------|
|  ![new-before-mem](https://user-images.githubusercontent.com/6686356/60422526-dd61a400-9bf4-11e9-9523-ae3aaa547f8f.png) |  ![new-after-mem](https://user-images.githubusercontent.com/6686356/60422538-e2265800-9bf4-11e9-9403-ca75498cc0b7.png) |

### CPU

| Before | After |
|--------|------|
|  ![new-before-cpu](https://user-images.githubusercontent.com/6686356/60422555-ec485680-9bf4-11e9-96fa-e16d103d89b5.png) |  ![new-after-cpu](https://user-images.githubusercontent.com/6686356/60422558-ef434700-9bf4-11e9-8d46-743dd89fca27.png) |

### Blocking

| Before | After |
|--------|------|
|  <img width="409" alt="new-blocking-before" src="https://user-images.githubusercontent.com/6686356/60422571-f5392800-9bf4-11e9-8b21-416e9e4f9524.png"> |  <img width="417" alt="new-blocking-after" src="https://user-images.githubusercontent.com/6686356/60422575-f8341880-9bf4-11e9-8f6c-465e93797f0a.png"> |