### PR TITLE
Revert "allow test kitchen failures on centos and suse (#3760)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -719,7 +719,7 @@ kitchen_windows_installer:
 # run dd-agent-testing on centos
 kitchen_centos:
   stage: testkitchen_testing
-  allow_failure: true
+  allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   <<: *run_when_testkitchen_triggered
   before_script:
@@ -764,7 +764,7 @@ kitchen_ubuntu:
 # run dd-agent-testing on suse
 kitchen_suse:
   stage: testkitchen_testing
-  allow_failure: true
+  allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   <<: *run_when_testkitchen_triggered
   before_script:


### PR DESCRIPTION
This reverts commit 84d39e6fb79e651eabea72d0b2115bae72c07883.

Reverts #3760