### PR TITLE
Since we don't call PyFinalize, don't free pythonHome

### DIFF
--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -44,7 +44,6 @@ Three::~Three()
     // For more information on why Py_Finalize() isn't called here please
     // refer to the header file or the doxygen documentation.
     PyEval_RestoreThread(_threadState);
-    PyMem_RawFree((void *)_pythonHome);
     Py_XDECREF(_baseClass);
 }
 

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -50,7 +50,7 @@ Three::~Three()
 
 void Three::initPythonHome(const char *pythonHome)
 {
-    PyMem_RawFree((void *)_pythonHome);
+    wchar_t *oldPythonHome = _pythonHome;
     if (pythonHome == NULL || strlen(pythonHome) == 0) {
         _pythonHome = Py_DecodeLocale(_defaultPythonHome, NULL);
     } else {
@@ -58,6 +58,7 @@ void Three::initPythonHome(const char *pythonHome)
     }
 
     Py_SetPythonHome(_pythonHome);
+    PyMem_RawFree((void *)oldPythonHome);
 }
 
 bool Three::init()

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -56,6 +56,7 @@ void Three::initPythonHome(const char *pythonHome)
         _pythonHome = Py_DecodeLocale(pythonHome, NULL);
     }
 
+    // Py_SetPythonHome stores a pointer to the string we pass to it, so we must keep it in memory
     Py_SetPythonHome(_pythonHome);
     PyMem_RawFree((void *)oldPythonHome);
 }

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -47,6 +47,7 @@ public:
       thread id>,) in <module 'threading'".
       Even if Python ignores it, the exception ends up in the log files for
       upstart/syslog/...
+      Since we don't call Py_Finalize, we don't free _pythonHome here either.
 
       More info here:
       https://stackoverflow.com/questions/8774958/keyerror-in-module-threading-after-a-successful-py-test-run/12639040#12639040

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -52,7 +52,7 @@ Two::~Two()
 
 void Two::initPythonHome(const char *pythonHome)
 {
-    free(_pythonHome);
+    char *oldPythonHome = _pythonHome;
     if (pythonHome == NULL || strlen(pythonHome) == 0) {
         _pythonHome = _strdup(_defaultPythonHome);
     } else {
@@ -60,6 +60,7 @@ void Two::initPythonHome(const char *pythonHome)
     }
 
     Py_SetPythonHome(_pythonHome);
+    free(oldPythonHome);
 }
 
 bool Two::init()

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -46,7 +46,6 @@ Two::~Two()
     // For more information on why Py_Finalize() isn't called here please
     // refer to the header file or the doxygen documentation.
     PyEval_RestoreThread(_threadState);
-    free(_pythonHome);
     Py_XDECREF(_baseClass);
 }
 

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -58,6 +58,7 @@ void Two::initPythonHome(const char *pythonHome)
         _pythonHome = _strdup(pythonHome);
     }
 
+    // Py_SetPythonHome stores a pointer to the string we pass to it, so we must keep it in memory
     Py_SetPythonHome(_pythonHome);
     free(oldPythonHome);
 }

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -46,6 +46,7 @@ public:
       thread id>,) in <module 'threading'".
       Even if Python ignores it, the exception ends up in the log files for
       upstart/syslog/...
+      Since we don't call Py_Finalize, we don't free _pythonHome here either.
 
       More info here:
       https://stackoverflow.com/questions/8774958/keyerror-in-module-threading-after-a-successful-py-test-run/12639040#12639040


### PR DESCRIPTION
Plus: do not free current pythonHome before setting a new one