### PR TITLE
[system-probe] separate expvars into different categories

### DIFF
--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -454,7 +454,7 @@ func (t *Tracer) getLatestTimestamp() (uint64, bool, error) {
 func (t *Tracer) getEbpfTelemetry() map[string]int64 {
 	mp, err := t.getMap(telemetryMap)
 	if err != nil {
-		log.Warn("error retrieving telemetry map", err)
+		log.Warnf("error retrieving telemetry map", err)
 		return map[string]int64{}
 	}
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -20,11 +20,17 @@ import (
 )
 
 var (
-	probeExpvar *expvar.Map
+	conntrackExpvar *expvar.Map
+	stateExpvar     *expvar.Map
+	tracerExpvar    *expvar.Map
+	ebpfExpvar      *expvar.Map
 )
 
 func init() {
-	probeExpvar = expvar.NewMap("systemprobe")
+	conntrackExpvar = expvar.NewMap("conntrack")
+	stateExpvar = expvar.NewMap("state")
+	tracerExpvar = expvar.NewMap("tracer")
+	ebpfExpvar = expvar.NewMap("ebpf")
 }
 
 type Tracer struct {
@@ -177,7 +183,7 @@ func (t *Tracer) expvarStats() {
 			for metric, val := range tracerStats.(map[string]int64) {
 				currVal := &expvar.Int{}
 				currVal.Set(val)
-				probeExpvar.Set(snakeToCapInitialCamel(metric), currVal)
+				tracerExpvar.Set(snakeToCapInitialCamel(metric), currVal)
 			}
 		}
 
@@ -185,7 +191,7 @@ func (t *Tracer) expvarStats() {
 			for metric, val := range ebpfStats.(map[string]int64) {
 				currVal := &expvar.Int{}
 				currVal.Set(val)
-				probeExpvar.Set(fmt.Sprintf("Ebpf%s", snakeToCapInitialCamel(metric)), currVal)
+				ebpfExpvar.Set(fmt.Sprintf("Ebpf%s", snakeToCapInitialCamel(metric)), currVal)
 			}
 		}
 
@@ -194,7 +200,7 @@ func (t *Tracer) expvarStats() {
 				for metric, val := range telemetry.(map[string]int64) {
 					currVal := &expvar.Int{}
 					currVal.Set(val)
-					probeExpvar.Set(snakeToCapInitialCamel(metric), currVal)
+					stateExpvar.Set(snakeToCapInitialCamel(metric), currVal)
 				}
 			}
 		}
@@ -203,7 +209,7 @@ func (t *Tracer) expvarStats() {
 			for metric, val := range conntrackStats.(map[string]int64) {
 				currVal := &expvar.Int{}
 				currVal.Set(val)
-				probeExpvar.Set(fmt.Sprintf("Conntrack%s", snakeToCapInitialCamel(metric)), currVal)
+				conntrackExpvar.Set(fmt.Sprintf("Conntrack%s", snakeToCapInitialCamel(metric)), currVal)
 			}
 		}
 	}
@@ -450,7 +456,7 @@ func (t *Tracer) getLatestTimestamp() (uint64, bool, error) {
 func (t *Tracer) getEbpfTelemetry() map[string]int64 {
 	mp, err := t.getMap(telemetryMap)
 	if err != nil {
-		log.Warnf("error retrieving telemetry map", err)
+		log.Warn("error retrieving telemetry map", err)
 		return map[string]int64{}
 	}
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -20,17 +20,15 @@ import (
 )
 
 var (
-	conntrackExpvar *expvar.Map
-	stateExpvar     *expvar.Map
-	tracerExpvar    *expvar.Map
-	ebpfExpvar      *expvar.Map
+	expvarEndpoints map[string]*expvar.Map
+	expvarTypes     = [4]string{"conntrack", "state", "tracer", "ebpf"}
 )
 
 func init() {
-	conntrackExpvar = expvar.NewMap("conntrack")
-	stateExpvar = expvar.NewMap("state")
-	tracerExpvar = expvar.NewMap("tracer")
-	ebpfExpvar = expvar.NewMap("ebpf")
+	expvarEndpoints = make(map[string]*expvar.Map, len(expvarTypes))
+	for _, name := range expvarTypes {
+		expvarEndpoints[name] = expvar.NewMap(name)
+	}
 }
 
 type Tracer struct {
@@ -183,7 +181,7 @@ func (t *Tracer) expvarStats() {
 			for metric, val := range tracerStats.(map[string]int64) {
 				currVal := &expvar.Int{}
 				currVal.Set(val)
-				tracerExpvar.Set(snakeToCapInitialCamel(metric), currVal)
+				expvarEndpoints["tracer"].Set(snakeToCapInitialCamel(metric), currVal)
 			}
 		}
 
@@ -191,7 +189,7 @@ func (t *Tracer) expvarStats() {
 			for metric, val := range ebpfStats.(map[string]int64) {
 				currVal := &expvar.Int{}
 				currVal.Set(val)
-				ebpfExpvar.Set(fmt.Sprintf("Ebpf%s", snakeToCapInitialCamel(metric)), currVal)
+				expvarEndpoints["ebpf"].Set(fmt.Sprintf("Ebpf%s", snakeToCapInitialCamel(metric)), currVal)
 			}
 		}
 
@@ -200,7 +198,7 @@ func (t *Tracer) expvarStats() {
 				for metric, val := range telemetry.(map[string]int64) {
 					currVal := &expvar.Int{}
 					currVal.Set(val)
-					stateExpvar.Set(snakeToCapInitialCamel(metric), currVal)
+					expvarEndpoints["state"].Set(snakeToCapInitialCamel(metric), currVal)
 				}
 			}
 		}
@@ -209,7 +207,7 @@ func (t *Tracer) expvarStats() {
 			for metric, val := range conntrackStats.(map[string]int64) {
 				currVal := &expvar.Int{}
 				currVal.Set(val)
-				conntrackExpvar.Set(fmt.Sprintf("Conntrack%s", snakeToCapInitialCamel(metric)), currVal)
+				expvarEndpoints["conntrack"].Set(fmt.Sprintf("Conntrack%s", snakeToCapInitialCamel(metric)), currVal)
 			}
 		}
 	}

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -41,7 +41,7 @@ func TestTracerExpvar(t *testing.T) {
 
 	expectedExpvars := []map[string]float64{
 		map[string]float64{
-			"ConntrackNoopConntracker": 0,
+			"NoopConntracker": 0,
 		},
 		map[string]float64{
 			"UnorderedConns":     0,
@@ -57,7 +57,7 @@ func TestTracerExpvar(t *testing.T) {
 			"ExpiredTcpConns":           0,
 		},
 		map[string]float64{
-			"EbpfTcpSentMiscounts": 0,
+			"TcpSentMiscounts": 0,
 		},
 	}
 

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -40,23 +40,23 @@ func TestTracerExpvar(t *testing.T) {
 	<-time.After(time.Second)
 
 	expectedExpvars := []map[string]float64{
-		map[string]float64{
+		{
 			"NoopConntracker": 0,
 		},
-		map[string]float64{
+		{
 			"UnorderedConns":     0,
 			"ConnDropped":        0,
 			"ClosedConnDropped":  0,
 			"StatsResets":        0,
 			"TimeSyncCollisions": 0,
 		},
-		map[string]float64{
+		{
 			"ClosedConnPollingLost":     0,
 			"ClosedConnPollingReceived": 0,
 			"ConnValidSkipped":          0,
 			"ExpiredTcpConns":           0,
 		},
-		map[string]float64{
+		{
 			"TcpSentMiscounts": 0,
 		},
 	}

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -39,42 +39,33 @@ func TestTracerExpvar(t *testing.T) {
 
 	<-time.After(time.Second)
 
-	expectedConntrack := map[string]float64{
-		"ConntrackNoopConntracker": 0,
+	expectedExpvars := []map[string]float64{
+		map[string]float64{
+			"ConntrackNoopConntracker": 0,
+		},
+		map[string]float64{
+			"UnorderedConns":     0,
+			"ConnDropped":        0,
+			"ClosedConnDropped":  0,
+			"StatsResets":        0,
+			"TimeSyncCollisions": 0,
+		},
+		map[string]float64{
+			"ClosedConnPollingLost":     0,
+			"ClosedConnPollingReceived": 0,
+			"ConnValidSkipped":          0,
+			"ExpiredTcpConns":           0,
+		},
+		map[string]float64{
+			"EbpfTcpSentMiscounts": 0,
+		},
 	}
-	expectedState := map[string]float64{
-		"UnorderedConns":     0,
-		"ConnDropped":        0,
-		"ClosedConnDropped":  0,
-		"StatsResets":        0,
-		"TimeSyncCollisions": 0,
+
+	for i, et := range expvarTypes {
+		expvar := map[string]float64{}
+		require.NoError(t, json.Unmarshal([]byte(expvarEndpoints[et].String()), &expvar))
+		assert.Equal(t, expectedExpvars[i], expvar)
 	}
-	expectedTracer := map[string]float64{
-		"ClosedConnPollingLost":     0,
-		"ClosedConnPollingReceived": 0,
-		"ConnValidSkipped":          0,
-		"ExpiredTcpConns":           0,
-	}
-	expectedEbpf := map[string]float64{
-		"EbpfTcpSentMiscounts": 0,
-	}
-
-	conntrackVars := map[string]float64{}
-	require.NoError(t, json.Unmarshal([]byte(conntrackExpvar.String()), &conntrackVars))
-
-	stateVars := map[string]float64{}
-	require.NoError(t, json.Unmarshal([]byte(stateExpvar.String()), &stateVars))
-
-	tracerVars := map[string]float64{}
-	require.NoError(t, json.Unmarshal([]byte(tracerExpvar.String()), &tracerVars))
-
-	ebpfVars := map[string]float64{}
-	require.NoError(t, json.Unmarshal([]byte(ebpfExpvar.String()), &ebpfVars))
-
-	assert.Equal(t, expectedConntrack, conntrackVars)
-	assert.Equal(t, expectedState, stateVars)
-	assert.Equal(t, expectedTracer, tracerVars)
-	assert.Equal(t, expectedEbpf, ebpfVars)
 }
 
 func TestSnakeToCamel(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Update go_expvar in system-probe to have different sections rather than include all in `systemProbe`. cc: @DataDog/burrito 

### Motivation

Using this would make the go_expvar configs in datadog-agent be easier. As long as a top level namespace is defined, none of the expvars will have conflict with other processes.

### Additional Notes

Anything else we should know when reviewing?
