### PR TITLE
fixed typo on init_config

### DIFF
--- a/cmd/agent/dist/conf.d/containerd.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/containerd.d/conf.yaml.example
@@ -1,4 +1,4 @@
-init_configs:
+init_config:
 instances:
   -
     ## @param filters - list of containerd filters - optional

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -1,4 +1,4 @@
-init_configs:
+init_config:
 instances:
   - ## Tagging
     ##


### PR DESCRIPTION
### What does this PR do?

Fix the conf.yaml.example for the containerd check and the api server check.

### Motivation

The containerd conf.yaml.example is mentioned here: https://github.com/DataDog/integrations-core/tree/master/containerd and if customer copy/paste it, they will have a yaml error.
