### PR TITLE
Skip irrelevant network modes when collecting docker IPs

### DIFF
--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -218,6 +218,10 @@ func parseContainerNetworkAddresses(ports []types.Port, netSettings *types.Summa
 		}
 	}
 	for _, network := range netSettings.Networks {
+		if network.IPAddress == "" {
+			log.Debugf("No IP found for container %s in network %s", container, network.NetworkID)
+			continue
+		}
 		IP := net.ParseIP(network.IPAddress)
 		if IP == nil {
 			log.Warnf("Unable to parse IP: %v for container: %s", network.IPAddress, container)


### PR DESCRIPTION
### What does this PR do?

#3315 Introduced potential log pollution when using `host` and `none` docker network modes. This is typically the case for pause containers on a Kubernetes cluster since the CNI takes over the network plumbing part. This PR avoids that by skipping networks with no IP address.

See for instance #3796 for a more detailed occurence of the issue.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
