### PR TITLE
[omnibus] Avoid shipping 2 copies of the system-probe

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -60,6 +60,7 @@ build do
     conf_dir = "#{install_dir}/etc/datadog-agent"
   end
   mkdir conf_dir
+  mkdir "#{install_dir}/bin"
   unless windows?
     mkdir "#{install_dir}/run/"
     mkdir "#{install_dir}/scripts/"
@@ -74,9 +75,7 @@ build do
   move 'bin/agent/dist/datadog.yaml', "#{conf_dir}/datadog.yaml.example"
   move 'bin/agent/dist/system-probe.yaml', "#{conf_dir}/system-probe.yaml.example"
   move 'bin/agent/dist/conf.d', "#{conf_dir}/"
-
-  copy 'bin', install_dir
-
+  copy 'bin/agent', "#{install_dir}/bin/"
 
   block do
     # defer compilation step in a block to allow getting the project's build version, which is populated

--- a/releasenotes/notes/system-probe-duplicated-copy-fix-5b97780a55a43a8b.yaml
+++ b/releasenotes/notes/system-probe-duplicated-copy-fix-5b97780a55a43a8b.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Removes an unused duplicate copy of the ``system-probe`` binary from the Linux packages


### PR DESCRIPTION
### What does this PR do?

Avoids shipping 2 copies of the `system-probe` binary in the Agent Linux packages.

### Additional Notes

See commit description:

```
The system-probe binary is already present in `bin/system-probe/`
(in the build directory of the `datadog-agent` software def) at
the start of the omnibus build, so we need to make sure to only copy
`bin/agent/` to the install dir instead of the entire `bin/` directory,
in order to avoid copying `system-probe` to
`#{install_dir}/bin/system-probe`.
```

TODO: check on the resulting packages that the `system-probe` binary is only present in `/opt/datadog-agent/embedded/bin/`, and that `/opt/datadog-agent/bin/agent/` is unchanged.