### PR TITLE
[system-probe] remove problematic command line check

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -90,10 +90,7 @@ func main() {
 	}
 
 	// run check command if the flag is specified
-	if len(os.Args) > 1 && os.Args[1] != "check" {
-		fmt.Fprintln(os.Stderr, "unknown command argument: ", os.Args[1])
-		os.Exit(1)
-	} else if len(os.Args) >= 2 && os.Args[1] == "check" {
+	if len(os.Args) >= 2 && os.Args[1] == "check" {
 		err = checkCmd.Parse(os.Args[2:])
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in https://github.com/DataDog/datadog-agent/pull/3714. The check for argument `check` was not only unnecessary but also blocking all other flags. cc: @DataDog/burrito 

### Motivation

Bug fix.

### Additional Notes

Anything else we should know when reviewing?
