### PR TITLE
[docs] Document a dropped config option

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -112,7 +112,8 @@ because they're either:
 | `proxy_user` | superseded by `proxy` |
 | `proxy_password` | superseded by `proxy` |
 | `proxy_forbid_method_switch` | obsolete |
-| `use_mount` | deprecated in v5 |
+| `use_mount` | deprecated in Agent-level config since v5, use in `disk` check config instead |
+| `device_blacklist_re` | deprecated in Agent-level config since v5, use `device_blacklist` in `disk` check config instead |
 | `use_curl_http_client` | obsolete |
 | `exclude_process_args` | deprecated feature |
 | `check_timings` | superseded by internal stats |


### PR DESCRIPTION
### What does this PR do?

Document a config option that was dropped in late v6 versions.

### Motivation

`device_blacklist_re` has been superseded in v6 since https://github.com/DataDog/integrations-core/pull/2848, but it hadn't been documented here
