### PR TITLE
[tagger] add kube_cronjob tag

### DIFF
--- a/cmd/cluster-agent/app/config.go
+++ b/cmd/cluster-agent/app/config.go
@@ -61,7 +61,7 @@ func requestConfig() (string, error) {
 	r, err := util.DoGet(c, apiConfigURL)
 	if err != nil {
 		var errMap = make(map[string]string)
-		json.Unmarshal(r, errMap)
+		json.Unmarshal(r, &errMap)
 		// If the error has been marshalled into a json object, check it and return it properly
 		if e, found := errMap["error"]; found {
 			return "", fmt.Errorf(e)

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -70,7 +70,7 @@ func requestStatus() error {
 	r, e := util.DoGet(c, urlstr)
 	if e != nil {
 		var errMap = make(map[string]string)
-		json.Unmarshal(r, errMap)
+		json.Unmarshal(r, &errMap)
 		// If the error has been marshalled into a json object, check it and return it properly
 		if err, found := errMap["error"]; found {
 			e = fmt.Errorf(err)

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -90,7 +90,13 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 			case "StatefulSet":
 				tags.AddLow("kube_stateful_set", owner.Name)
 			case "Job":
-				tags.AddOrchestrator("kube_job", owner.Name) // TODO detect if no from cronjob, then low card
+				cronjob := c.parseCronJobForJob(owner.Name)
+				if cronjob != "" {
+					tags.AddOrchestrator("kube_job", owner.Name)
+					tags.AddLow("kube_cronjob", cronjob)
+				} else {
+					tags.AddLow("kube_job", owner.Name)
+				}
 			case "ReplicaSet":
 				deployment := c.parseDeploymentForReplicaset(owner.Name)
 				if len(deployment) > 0 {
@@ -184,6 +190,29 @@ func (c *KubeletCollector) parseDeploymentForReplicaset(name string) string {
 	}
 
 	if !utils.StringInRuneset(suffix, Digits) && !utils.StringInRuneset(suffix, KubeAllowedEncodeStringAlphaNums) {
+		// Invalid suffix
+		return ""
+	}
+
+	return name[:lastDash]
+}
+
+// parseCronJobForJob gets the cronjob name from a job,
+// or returns an empty string if no parent cronjob is found.
+// https://github.com/kubernetes/kubernetes/blob/b4e3bd381bd4d7c0db1959341b39558b45187345/pkg/controller/cronjob/utils.go#L156
+func (c *KubeletCollector) parseCronJobForJob(name string) string {
+	lastDash := strings.LastIndexAny(name, "-")
+	if lastDash == -1 {
+		// No dash
+		return ""
+	}
+	suffix := name[lastDash+1:]
+	if len(suffix) < 3 {
+		// Suffix is variable length but we cutoff at 3+ characters
+		return ""
+	}
+
+	if !utils.StringInRuneset(suffix, Digits) {
 		// Invalid suffix
 		return ""
 	}

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -90,7 +90,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 			case "StatefulSet":
 				tags.AddLow("kube_stateful_set", owner.Name)
 			case "Job":
-				cronjob := c.parseCronJobForJob(owner.Name)
+				cronjob := parseCronJobForJob(owner.Name)
 				if cronjob != "" {
 					tags.AddOrchestrator("kube_job", owner.Name)
 					tags.AddLow("kube_cronjob", cronjob)
@@ -98,7 +98,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 					tags.AddLow("kube_job", owner.Name)
 				}
 			case "ReplicaSet":
-				deployment := c.parseDeploymentForReplicaset(owner.Name)
+				deployment := parseDeploymentForReplicaset(owner.Name)
 				if len(deployment) > 0 {
 					tags.AddOrchestrator("kube_replica_set", owner.Name)
 					tags.AddLow("kube_deployment", deployment)
@@ -177,7 +177,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 
 // parseDeploymentForReplicaset gets the deployment name from a replicaset,
 // or returns an empty string if no parent deployment is found.
-func (c *KubeletCollector) parseDeploymentForReplicaset(name string) string {
+func parseDeploymentForReplicaset(name string) string {
 	lastDash := strings.LastIndexAny(name, "-")
 	if lastDash == -1 {
 		// No dash
@@ -200,7 +200,7 @@ func (c *KubeletCollector) parseDeploymentForReplicaset(name string) string {
 // parseCronJobForJob gets the cronjob name from a job,
 // or returns an empty string if no parent cronjob is found.
 // https://github.com/kubernetes/kubernetes/blob/b4e3bd381bd4d7c0db1959341b39558b45187345/pkg/controller/cronjob/utils.go#L156
-func (c *KubeletCollector) parseCronJobForJob(name string) string {
+func parseCronJobForJob(name string) string {
 	lastDash := strings.LastIndexAny(name, "-")
 	if lastDash == -1 {
 		// No dash

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -586,8 +586,25 @@ func TestParseDeploymentForReplicaset(t *testing.T) {
 		"frontend-56a89cfff7": "", // no vowels allowed
 	} {
 		t.Run(fmt.Sprintf("case: %s", in), func(t *testing.T) {
-			collector := &KubeletCollector{}
-			assert.Equal(t, out, collector.parseDeploymentForReplicaset(in))
+			assert.Equal(t, out, parseDeploymentForReplicaset(in))
+		})
+	}
+}
+
+func TestParseCronJobForJob(t *testing.T) {
+	for in, out := range map[string]string{
+		"hello-1562319360": "hello",
+		"hello-600":        "hello",
+		"hello-world":      "",
+		"hello":            "",
+		"-hello1562319360": "",
+		"hello1562319360":  "",
+		"hello60":          "",
+		"hello-60":         "",
+		"hello-1562319a60": "",
+	} {
+		t.Run(fmt.Sprintf("case: %s", in), func(t *testing.T) {
+			assert.Equal(t, out, parseCronJobForJob(in))
 		})
 	}
 }

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -509,6 +509,41 @@ func TestParsePods(t *testing.T) {
 				OrchestratorCardTags: []string{},
 				HighCardTags:         []string{"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f"},
 			}},
+		}, {
+			desc: "cronjob",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:      "hello-1562187720-xzbzh",
+					Namespace: "default",
+					Owners: []kubelet.PodOwner{
+						{
+							Kind: "Job",
+							Name: "hello-1562187720",
+							ID:   "d0dcc17b-9dd5-11e9-b6f0-42010a840064",
+						},
+					},
+				},
+				Status: dockerContainerStatus,
+				Spec:   dockerContainerSpec,
+			},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_namespace:default",
+					"image_name:datadog/docker-dd-agent",
+					"image_tag:latest5",
+					"kube_container_name:dd-agent",
+					"short_image:docker-dd-agent",
+					"pod_phase:running",
+					"kube_cronjob:hello",
+				},
+				OrchestratorCardTags: []string{"kube_job:hello-1562187720", "pod_name:hello-1562187720-xzbzh"},
+				HighCardTags: []string{
+					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+					"display_container_name:dd-agent_hello-1562187720-xzbzh",
+				},
+			}},
 		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {

--- a/releasenotes/notes/[tagger]-add-kube_cronjob-tag-7344c2d73f5efd1b.yaml
+++ b/releasenotes/notes/[tagger]-add-kube_cronjob-tag-7344c2d73f5efd1b.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add a kube_cronjob tag in the tagger. It applies to container metrics, autodiscovery metrics and logs.


### PR DESCRIPTION
### What does this PR do?

Add kube_cronjob tag in the tagger. Applies to container metrics, metrics from autodiscovery, and logs.

### Motivation

Feature request

### Additional Notes

Also fix some error handling issues that go vet spotted.
