### PR TITLE
[dep] Use `vendor-only` go dep option in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: grab go deps
           command: |
-            inv deps --verbose
+            inv deps --verbose --dep-vendor-only
       - run:
           name: build rtloader
           command: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -351,7 +351,8 @@ agent_deb-x64:
     - $S3_CP_CMD $S3_ARTEFACTS_URI/system-probe $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
     - dpkg -c $OMNIBUS_BASE_DIR/pkg/datadog-agent*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-agent*_amd64.deb $S3_ARTEFACTS_URI/datadog-agent_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-agent*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -378,7 +379,8 @@ puppy_deb-x64:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --skip-deps
     - dpkg -c $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb $S3_ARTEFACTS_URI/datadog-puppy_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -412,7 +414,8 @@ agent_rpm-x64:
     - set -x
     # Retrieve the system-probe from S3
     - $S3_CP_CMD $S3_ARTEFACTS_URI/system-probe $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
+    # use --skip-deps since the deps are installed by `before_script`
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
     - rpm -i $OMNIBUS_BASE_DIR/pkg/*.rpm
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -445,7 +448,8 @@ agent_suse-x64:
     - set -x
     # Retrieve the system-probe from S3
     - $S3_CP_CMD $S3_ARTEFACTS_URI/system-probe $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache
+    # use --skip-deps since the deps are installed by `before_script`
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache --skip-deps
     - mkdir -p $OMNIBUS_PACKAGE_DIR_SUSE && cp $OMNIBUS_BASE_DIR_SUSE/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR_SUSE
     # FIXME: skip the installation step until we fix the preinst/postinst scripts in the rpm package
     # to also work with SUSE11
@@ -476,7 +480,7 @@ build_windows_msi_x64:
     - mkdir %GOPATH%\src\github.com\DataDog\datadog-agent
     - xcopy /q/h/e/s * %GOPATH%\src\github.com\DataDog\datadog-agent
     - cd %GOPATH%\src\github.com\DataDog\datadog-agent
-    - inv -e deps --verbose --dep-vendor-only
+    - inv -e deps --verbose --dep-vendor-only --no-checks
   stage: package_build
   variables:
     WINDOWS_BUILDER: 'true'
@@ -485,7 +489,8 @@ build_windows_msi_x64:
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - cd %GOPATH%\src\github.com\DataDog\datadog-agent
-    - inv agent.omnibus-build --release-version %RELEASE_VERSION% --omnibus-s3-cache --base-dir %OMNIBUS_BASE_DIR_WIN_OMNIBUS%
+    # use --skip-deps since the deps are installed by `before_script`
+    - inv agent.omnibus-build --release-version %RELEASE_VERSION% --omnibus-s3-cache --base-dir %OMNIBUS_BASE_DIR_WIN_OMNIBUS% --skip-deps
     # copy the results from the build dir to here, because artifacts must be relative to the project directory
     - copy %OMNIBUS_BASE_DIR_WIN%\pkg\* %WIN_CI_PROJECT_DIR%\.omnibus\pkg
   artifacts:
@@ -505,7 +510,7 @@ agent_android_apk:
     - cd $SRC_PATH
     - pip install -U pip
     - pip install -r requirements.txt
-    - inv -e deps --android --dep-vendor-only
+    - inv -e deps --android --dep-vendor-only --no-checks
     # Some Android license has changed, we have to accept the new version.
     # But on top of that, there is a bug in sdkmanager not updating correctly
     # the existing license, so, we have to manually accept the new license.
@@ -517,7 +522,8 @@ agent_android_apk:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # for now do the steps manually.  Should eventually move this to an invoke
     # task
-    - inv -e android.build
+    # Use --skip-deps since the deps are installed by `before_script`
+    - inv -e android.build --skip-deps
     - mkdir -p $OMNIBUS_PACKAGE_DIR
     - cp ./bin/agent/ddagent-*-unsigned.apk $OMNIBUS_PACKAGE_DIR
   artifacts:
@@ -537,7 +543,8 @@ dogstatsd_deb-x64:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
     - dpkg -c $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb $S3_ARTEFACTS_URI/datadog-dogstatsd_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -570,7 +577,8 @@ dogstatsd_rpm-x64:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
     - rpm -i $OMNIBUS_BASE_DIR/pkg/*.rpm
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -603,7 +611,8 @@ dogstatsd_suse-x64:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache --skip-deps
     - rpm -i $OMNIBUS_BASE_DIR_SUSE/pkg/*.rpm
     - mkdir -p $OMNIBUS_PACKAGE_DIR_SUSE && cp $OMNIBUS_BASE_DIR_SUSE/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR_SUSE
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,8 @@ run_dep_check_lock:
     - pip install -r requirements.txt
   script:
     - inv -e deps --no-dep-ensure
-    - dep check --skip-vendor || printf "Gopkg.lock is not in sync with Gopkg.toml and project imports. Please run 'inv deps' and commit the change on Gopkg.lock"
+    # Print a message and fail if dep check fails
+    - dep check --skip-vendor || (echo "Gopkg.lock is out of sync with Gopkg.toml and project imports. Please run 'inv deps' and commit the change on Gopkg.lock." && false)
 
 #
 # binary_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -213,7 +213,7 @@ run_security_scan_test:
       snyk monitor --project-name=datadog-agent-gopkg.lock --file=Gopkg.lock
 
 # check consistency of Gopkg.lock
-check_dep_gopkglock_consistency:
+run_dep_check_lock:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -223,12 +223,8 @@ check_dep_gopkglock_consistency:
     - pip install --upgrade --ignore-installed pip setuptools
     - pip install -r requirements.txt
   script:
-    - inv -e deps --verbose --dep-no-vendor
-    - git_diff="$(git diff-files -p Gopkg.lock)"
-    - git_diff_number="$(git diff-files Gopkg.lock | wc -l)"
-    # if there's a change on Gopkg.lock, that means it's not in sync and should be updated: print error message and fail.
-    - test "0" -eq "$git_diff_number" || printf "Gopkg.lock is not in sync with Gopkg.toml and project imports. Please run 'inv deps' and commit the change on Gopkg.lock. Diff:\n$git_diff\n"
-    - test "0" -eq "$git_diff_number"
+    - inv -e deps --no-dep-ensure
+    - dep check --skip-vendor || printf "Gopkg.lock is not in sync with Gopkg.toml and project imports. Please run 'inv deps' and commit the change on Gopkg.lock"
 
 #
 # binary_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -217,6 +217,7 @@ check_dep_gopkglock_consistency:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
+  allow_failure: true # FIXME as soon as Gopkg.lock is consistent
   before_script:
     - cd $SRC_PATH
     - pip install --upgrade --ignore-installed pip setuptools
@@ -225,7 +226,7 @@ check_dep_gopkglock_consistency:
     - inv -e deps --verbose --dep-no-vendor
     - git_diff="$(git diff-files -p Gopkg.lock)"
     # if there's a change on Gopkg.lock, that means it's not in sync and should be updated: print error message and fail.
-    - test -z "$git_diff" || printf "Gopkg.lock is not in sync with Gopkg.toml and project imports. Please run inv deps and commit the change on Gopkg.lock. Diff:\n$git_diff\n"
+    - test -z "$git_diff" || printf "Gopkg.lock is not in sync with Gopkg.toml and project imports. Please run 'inv deps' and commit the change on Gopkg.lock. Diff:\n$git_diff\n"
     - test -z "$git_diff"
 
 #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -217,13 +217,12 @@ run_dep_check_lock:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
-  allow_failure: true # FIXME as soon as Gopkg.lock is consistent
   before_script:
     - cd $SRC_PATH
     - pip install --upgrade --ignore-installed pip setuptools
     - pip install -r requirements.txt
+    - inv -e deps --no-dep-ensure --no-checks
   script:
-    - inv -e deps --no-dep-ensure
     # Print a message and fail if dep check fails
     - dep check --skip-vendor || (echo "Gopkg.lock is out of sync with Gopkg.toml and project imports. Please run 'inv deps' and commit the change on Gopkg.lock." && false)
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,9 +225,10 @@ check_dep_gopkglock_consistency:
   script:
     - inv -e deps --verbose --dep-no-vendor
     - git_diff="$(git diff-files -p Gopkg.lock)"
+    - git_diff_number="$(git diff-files Gopkg.lock | wc -l)"
     # if there's a change on Gopkg.lock, that means it's not in sync and should be updated: print error message and fail.
-    - test -z "$git_diff" || printf "Gopkg.lock is not in sync with Gopkg.toml and project imports. Please run 'inv deps' and commit the change on Gopkg.lock. Diff:\n$git_diff\n"
-    - test -z "$git_diff"
+    - test "0" -eq "$git_diff_number" || printf "Gopkg.lock is not in sync with Gopkg.toml and project imports. Please run 'inv deps' and commit the change on Gopkg.lock. Diff:\n$git_diff\n"
+    - test "0" -eq "$git_diff_number"
 
 #
 # binary_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,7 +67,7 @@ before_script:
   - cd $SRC_PATH
   - pip install --upgrade --ignore-installed pip setuptools
   - pip install -r requirements.txt
-  - inv -e deps
+  - inv -e deps --dep-vendor-only
 
 #
 # Trigger conditions
@@ -160,7 +160,7 @@ run_tests_deb-x64:
     - inv -e rtloader.install
     - inv -e rtloader.format
     - inv -e rtloader.test
-    - inv deps --verbose
+    - inv deps --verbose --dep-vendor-only
   script:
     - inv -e test --race --profile --cpus 4
 
@@ -183,7 +183,7 @@ run_tests_ebpf:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/ebpf:go1.10.1
   before_script:
     - cd $SRC_PATH
-    - inv -e deps --verbose
+    - inv -e deps --verbose --dep-vendor-only
   tags: [ "runner:main", "size:large" ]
   script:
     # For now only check bpf bytes since we don't have a way to run eBPF tests without mounting a debugfs
@@ -203,7 +203,7 @@ run_security_scan_test:
     - rsync -azr --delete ./ $GOPATH/src/github.com/DataDog/datadog-agent
     - cd $GOPATH/src/github.com/DataDog/datadog-agent
     - pip install -r requirements.txt
-    - inv deps
+    - inv deps --dep-vendor-only
   script:
     - set +x     # don't print the api key to the logs
     # send the list of the dependencies to snyk
@@ -211,6 +211,22 @@ run_security_scan_test:
       snyk monitor --project-name=datadog-agent-requirements.txt --file=requirements.txt --package-manager=pip
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
       snyk monitor --project-name=datadog-agent-gopkg.lock --file=Gopkg.lock
+
+# check consistency of Gopkg.lock
+check_dep_gopkglock_consistency:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  before_script:
+    - cd $SRC_PATH
+    - pip install --upgrade --ignore-installed pip setuptools
+    - pip install -r requirements.txt
+  script:
+    - inv -e deps --verbose --dep-no-vendor
+    - git_diff="$(git diff-files -p Gopkg.lock)"
+    # if there's a change on Gopkg.lock, that means it's not in sync and should be updated: print error message and fail.
+    - test -z "$git_diff" || printf "Gopkg.lock is not in sync with Gopkg.toml and project imports. Please run inv deps and commit the change on Gopkg.lock. Diff:\n$git_diff\n"
+    - test -z "$git_diff"
 
 #
 # binary_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -522,8 +522,7 @@ agent_android_apk:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # for now do the steps manually.  Should eventually move this to an invoke
     # task
-    # Use --skip-deps since the deps are installed by `before_script`
-    - inv -e android.build --skip-deps
+    - inv -e android.build
     - mkdir -p $OMNIBUS_PACKAGE_DIR
     - cp ./bin/agent/ddagent-*-unsigned.apk $OMNIBUS_PACKAGE_DIR
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -287,7 +287,7 @@ system_probe-build:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/ebpf:go1.10.1
   before_script:
     - cd $SRC_PATH
-    - inv -e deps --verbose
+    - inv -e deps --verbose --dep-vendor-only
   tags: [ "runner:main", "size:large" ]
   script:
     - inv -e system-probe.build
@@ -476,7 +476,7 @@ build_windows_msi_x64:
     - mkdir %GOPATH%\src\github.com\DataDog\datadog-agent
     - xcopy /q/h/e/s * %GOPATH%\src\github.com\DataDog\datadog-agent
     - cd %GOPATH%\src\github.com\DataDog\datadog-agent
-    - inv -e deps --verbose
+    - inv -e deps --verbose --dep-vendor-only
   stage: package_build
   variables:
     WINDOWS_BUILDER: 'true'
@@ -505,7 +505,7 @@ agent_android_apk:
     - cd $SRC_PATH
     - pip install -U pip
     - pip install -r requirements.txt
-    - inv -e deps --android
+    - inv -e deps --android --dep-vendor-only
     # Some Android license has changed, we have to accept the new version.
     # But on top of that, there is a bug in sdkmanager not updating correctly
     # the existing license, so, we have to manually accept the new license.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ test_script:
   - inv -e rtloader.install
   - inv -e rtloader.format
   - inv -e rtloader.test
-  - inv -e deps
+  - inv -e deps --dep-vendor-only
   - inv -e test --coverage --profile --fail-on-fmt --python-home-2=C:\Python27-x64 --python-home-3=C:\Python37-x64
   - codecov -f profile.cov -F windows
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -198,11 +198,10 @@ def misspell(ctx, targets):
         print("misspell found no issues")
 
 @task
-def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False):
+def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False, dep_vendor_only=False, dep_no_vendor=False):
     """
     Setup Go dependencies
     """
-    verbosity = ' -v' if verbose else ''
     deps = get_deps('deps')
     order = deps.get("order", deps.keys())
     for dependency in order:
@@ -232,7 +231,10 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False):
     # source level deps
     print("calling dep ensure")
     start = datetime.datetime.now()
-    ctx.run("dep ensure{}".format(verbosity))
+    verbosity = ' -v' if verbose else ''
+    vendor_only = ' --vendor-only' if dep_vendor_only else ''
+    no_vendor = ' --no-vendor' if dep_no_vendor else ''
+    ctx.run("dep ensure{}{}{}".format(verbosity, vendor_only, no_vendor))
     dep_done = datetime.datetime.now()
 
     # If github.com/DataDog/datadog-agent gets vendored too - nuke it


### PR DESCRIPTION
### What does this PR do?

* Use `dep ensure --vendor-only` for all Gitlab jobs that don't strictly require Go Dep to check the consistency of `Gopkg.lock`, and for circleCI and AppVeyor
* Add a gitlab job that checks the consistency of `Gopkg.lock` by running `dep check --skip-vendor`.

### Motivation

Make `dep ensure` faster in situations where we don't need to check whether `Gopkg.lock` is really consistent, and avoid flaky errors when dep has dependency resolution issues (sometimes network-related).

On the `run_tests_deb-x64` job:

```
# before: `dep ensure`
dep ensure, elapsed:    0:02:59.473505
# after: `dep ensure --vendor-only`
dep ensure, elapsed:    0:01:13.385422
```

On AppVeyor, the `dep ensure` step goes from lasting `15min` to `7min`.

### Additional Notes

I'm making an assumption here, I believe it's true but I'm not 100% sure: `dep` resolves dependencies the same way on all platforms (typically: Linux, macOS, Windows), so a `Gopkg.lock` file that `dep check --skip-vendor` has determined is in-sync on Debian will also be in-sync on Windows.