### PR TITLE
Add safety nil filtering on pod

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -199,6 +199,15 @@ func (ku *KubeUtil) GetLocalPodList() ([]*Pod, error) {
 		return nil, err
 	}
 
+	// ensure we dont have nil pods
+	tmpSlice := make([]*Pod, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if pod != nil {
+			tmpSlice = append(tmpSlice, pod)
+		}
+	}
+	pods.Items = tmpSlice
+
 	// cache the podList to reduce pressure on the kubelet
 	cache.Cache.Set(podListCacheKey, pods, ku.podListCacheDuration)
 

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_null_pod.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_null_pod.json
@@ -1,0 +1,10 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {},
+        null,
+        {}
+    ]
+}


### PR DESCRIPTION
### What does this PR do?

`null` pods in the podlist can cause having `nil` `*Pod`, this adds filtering for additional safety

### Motivation

Attempt to fix some `runtime error`

### Additional Notes

Anything else we should know when reviewing?
