### PR TITLE
[system-probe] fix encoding marshaler for unix socket endpoint

### DIFF
--- a/pkg/ebpf/encoding/encoding.go
+++ b/pkg/ebpf/encoding/encoding.go
@@ -25,7 +25,7 @@ type Unmarshaler interface {
 
 // GetMarshaler returns the appropriate Marshaler based on the given accept header
 func GetMarshaler(accept string) Marshaler {
-	if strings.Contains(ContentTypeProtobuf, accept) {
+	if strings.Contains(accept, ContentTypeProtobuf) {
 		return pSerializer
 	}
 
@@ -34,7 +34,7 @@ func GetMarshaler(accept string) Marshaler {
 
 // GetUnmarshaler returns the appropriate Unmarshaler based on the given content type
 func GetUnmarshaler(ctype string) Unmarshaler {
-	if strings.Contains(ContentTypeProtobuf, ctype) {
+	if strings.Contains(ctype, ContentTypeProtobuf) {
 		return pSerializer
 	}
 

--- a/pkg/ebpf/encoding/encoding_test.go
+++ b/pkg/ebpf/encoding/encoding_test.go
@@ -83,6 +83,21 @@ func TestSerialization(t *testing.T) {
 		assert.Equal(out, result)
 	})
 
+	t.Run("requesting empty serialization", func(t *testing.T) {
+		assert := assert.New(t)
+		marshaler := GetMarshaler("")
+		// in case we request empty serialization type, default to application/json
+		assert.Equal("application/json", marshaler.ContentType())
+
+		blob, err := marshaler.Marshal(in)
+		require.NoError(t, err)
+
+		unmarshaler := GetUnmarshaler("")
+		result, err := unmarshaler.Unmarshal(blob)
+		require.NoError(t, err)
+		assert.Equal(out, result)
+	})
+
 	t.Run("requesting application/protobuf serialization", func(t *testing.T) {
 		assert := assert.New(t)
 		marshaler := GetMarshaler("application/protobuf")


### PR DESCRIPTION
### What does this PR do?

The signature for `strings.Contains()` is `func Contains(s, substr string) bool`, but the code here puts it in reverse. This causes problem when no explicit `Accept` type is specified in the request and a protobuf response is encoded using json encoder.

cc: @DataDog/burrito 

### Motivation


### Additional Notes

Anything else we should know when reviewing?
