### PR TITLE
[dep] Update Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2013,7 +2013,6 @@
     "github.com/gogo/protobuf/jsonpb",
     "github.com/gogo/protobuf/proto",
     "github.com/gogo/protobuf/types",
-    "github.com/golang/protobuf/proto",
     "github.com/gorilla/mux",
     "github.com/hashicorp/consul/api",
     "github.com/hectane/go-acl",


### PR DESCRIPTION
### What does this PR do?

Update `Gopkg.lock` so that it's consistent with Gopkg.toml + project imports. Result of a `dep ensure` execution.

### Additional Notes

Consistent with what a new CI job added in https://github.com/DataDog/datadog-agent/pull/3816 finds (runs `dep check -skip-vendor`).
