### PR TITLE
expose number of bytes received by dogstatsd

### DIFF
--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -20,11 +20,13 @@ var (
 	udpExpvars             = expvar.NewMap("dogstatsd-udp")
 	udpPacketReadingErrors = expvar.Int{}
 	udpPackets             = expvar.Int{}
+	udpBytes               = expvar.Int{}
 )
 
 func init() {
 	udpExpvars.Set("PacketReadingErrors", &udpPacketReadingErrors)
 	udpExpvars.Set("Packets", &udpPackets)
+	udpExpvars.Set("Bytes", &udpBytes)
 }
 
 // UDPListener implements the StatsdListener interface for UDP protocol.
@@ -89,7 +91,7 @@ func (l *UDPListener) Listen() {
 			udpPacketReadingErrors.Add(1)
 			continue
 		}
-
+		udpBytes.Add(int64(n))
 		packet.Contents = packet.buffer[:n]
 
 		// packetBuffer handles the forwarding of the packets to the dogstatsd server intake channel

--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -23,12 +23,14 @@ var (
 	udsOriginDetectionErrors = expvar.Int{}
 	udsPacketReadingErrors   = expvar.Int{}
 	udsPackets               = expvar.Int{}
+	udsBytes                 = expvar.Int{}
 )
 
 func init() {
 	udsExpvars.Set("OriginDetectionErrors", &udsOriginDetectionErrors)
 	udsExpvars.Set("PacketReadingErrors", &udsPacketReadingErrors)
 	udsExpvars.Set("Packets", &udsPackets)
+	udsExpvars.Set("Bytes", &udsBytes)
 }
 
 // UDSListener implements the StatsdListener interface for Unix Domain
@@ -151,6 +153,7 @@ func (l *UDSListener) Listen() {
 			continue
 		}
 
+		udsBytes.Add(int64(n))
 		packet.Contents = packet.buffer[:n]
 
 		// packetBuffer handles the forwarding of the packets to the dogstatsd server intake channel

--- a/releasenotes/notes/dogstatsd-bytes-fa88ce5094970f2f.yaml
+++ b/releasenotes/notes/dogstatsd-bytes-fa88ce5094970f2f.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The total number of bytes received by dogstatsd is now reported by the
+    `dogstatsd-udp/Bytes` and `dogstatsd-uds/Bytes` expvar.


### PR DESCRIPTION
### What does this PR do?

Expose number of bytes received by dogstatsd.

### Motivation

Be able to compute drop rate, buffering ratio & friends from the agent point of view.

### Additional Notes

Anything else we should know when reviewing?
