### PR TITLE
Added the possibility to send logs to multiple destinations with HTTP

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -27,6 +28,8 @@ type Destination struct {
 	url                 string
 	client              *http.Client
 	destinationsContext *client.DestinationsContext
+	once                sync.Once
+	payloadChan         chan []byte
 }
 
 // NewDestination returns a new Destination.
@@ -86,9 +89,29 @@ func (d *Destination) Send(payload []byte) error {
 	}
 }
 
-// SendAsync is not implemented for HTTP.
+// SendAsync sends a payload in background.
 func (d *Destination) SendAsync(payload []byte) {
-	return
+	d.once.Do(func() {
+		payloadChan := make(chan []byte, 100)
+		d.sendInBackground(payloadChan)
+		d.payloadChan = payloadChan
+	})
+	d.payloadChan <- payload
+}
+
+// sendInBackground sends all payloads from payloadChan in background.
+func (d *Destination) sendInBackground(payloadChan chan []byte) {
+	ctx := d.destinationsContext.Context()
+	go func() {
+		for {
+			select {
+			case payload := <-payloadChan:
+				d.Send(payload)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 // builURL buils a url from a config endpoint.

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -92,7 +92,7 @@ func (d *Destination) Send(payload []byte) error {
 // SendAsync sends a payload in background.
 func (d *Destination) SendAsync(payload []byte) {
 	d.once.Do(func() {
-		payloadChan := make(chan []byte, 100)
+		payloadChan := make(chan []byte, config.ChanSize)
 		d.sendInBackground(payloadChan)
 		d.payloadChan = payloadChan
 	})

--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -16,9 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// FIXME: Changed chanSize to a constant once we refactor packages
 const (
-	chanSize      = 100
 	warningPeriod = 1000
 )
 
@@ -79,7 +77,7 @@ func (d *Destination) Send(payload []byte) error {
 func (d *Destination) SendAsync(payload []byte) {
 	host := d.connManager.endpoint.Host
 	d.once.Do(func() {
-		inputChan := make(chan []byte, chanSize)
+		inputChan := make(chan []byte, config.ChanSize)
 		d.inputChan = inputChan
 		metrics.DestinationLogsDropped.Set(host, &expvar.Int{})
 		go d.runAsync()

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -87,7 +87,6 @@ func BuildEndpoints() (*Endpoints, error) {
 }
 
 func buildTCPEndpoints() (*Endpoints, error) {
-	var useSSL bool
 	useProto := coreConfig.Datadog.GetBool("logs_config.dev_mode_use_proto")
 	proxyAddress := coreConfig.Datadog.GetString("logs_config.socks5_proxy_address")
 	main := Endpoint{
@@ -105,11 +104,11 @@ func buildTCPEndpoints() (*Endpoints, error) {
 		}
 		main.Host = host
 		main.Port = port
-		useSSL = !coreConfig.Datadog.GetBool("logs_config.logs_no_ssl")
+		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.logs_no_ssl")
 	case coreConfig.Datadog.GetBool("logs_config.use_port_443"):
 		main.Host = coreConfig.Datadog.GetString("logs_config.dd_url_443")
 		main.Port = 443
-		useSSL = true
+		main.UseSSL = true
 	default:
 		// If no proxy is set, we default to 'logs_config.dd_url' if set, or to 'site'.
 		// if none of them is set, we default to the US agent endpoint.
@@ -119,9 +118,8 @@ func buildTCPEndpoints() (*Endpoints, error) {
 		} else {
 			main.Port = coreConfig.Datadog.GetInt("logs_config.dd_port")
 		}
-		useSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
+		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
 	}
-	main.UseSSL = useSSL
 
 	var additionals []Endpoint
 	err := coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &additionals)
@@ -129,7 +127,7 @@ func buildTCPEndpoints() (*Endpoints, error) {
 		log.Warnf("Could not parse additional_endpoints for logs: %v", err)
 	}
 	for i := 0; i < len(additionals); i++ {
-		additionals[i].UseSSL = useSSL
+		additionals[i].UseSSL = main.UseSSL
 		additionals[i].ProxyAddress = proxyAddress
 	}
 
@@ -137,7 +135,6 @@ func buildTCPEndpoints() (*Endpoints, error) {
 }
 
 func buildHTTPEndpoints() (*Endpoints, error) {
-	var useSSL bool
 	main := Endpoint{
 		APIKey: getLogsAPIKey(coreConfig.Datadog),
 	}
@@ -150,12 +147,11 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 		}
 		main.Host = host
 		main.Port = port
-		useSSL = !coreConfig.Datadog.GetBool("logs_config.logs_no_ssl")
+		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.logs_no_ssl")
 	default:
 		main.Host = coreConfig.GetMainEndpoint(httpEndpointPrefix, "logs_config.dd_url")
-		useSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
+		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
 	}
-	main.UseSSL = useSSL
 
 	var additionals []Endpoint
 	err := coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &additionals)
@@ -163,7 +159,7 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 		log.Warnf("Could not parse additional_endpoints for logs: %v", err)
 	}
 	for i := 0; i < len(additionals); i++ {
-		additionals[i].UseSSL = useSSL
+		additionals[i].UseSSL = main.UseSSL
 	}
 
 	return NewEndpoints(main, additionals, false, true), nil

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -19,7 +19,10 @@ import (
 const ContainerCollectAll = "container_collect_all"
 
 // logs-intake endpoint prefix.
-const endpointPrefix = "agent-intake.logs."
+const (
+	tcpEndpointPrefix  = "agent-intake.logs."
+	httpEndpointPrefix = "agent-http-intake.logs."
+)
 
 // logs-intake endpoints depending on the site and environment.
 var logsEndpoints = map[string]int{
@@ -110,7 +113,7 @@ func buildTCPEndpoints() (*Endpoints, error) {
 	default:
 		// If no proxy is set, we default to 'logs_config.dd_url' if set, or to 'site'.
 		// if none of them is set, we default to the US agent endpoint.
-		main.Host = coreConfig.GetMainEndpoint(endpointPrefix, "logs_config.dd_url")
+		main.Host = coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url")
 		if port, found := logsEndpoints[main.Host]; found {
 			main.Port = port
 		} else {
@@ -139,9 +142,6 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 	}
 
 	switch {
-	case isSetAndNotEmpty(coreConfig.Datadog, "logs_config.dd_url"):
-		main.Host = coreConfig.GetMainEndpoint("", "logs_config.dd_url")
-		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
 	case isSetAndNotEmpty(coreConfig.Datadog, "logs_config.logs_dd_url"):
 		host, port, err := parseAddress(coreConfig.Datadog.GetString("logs_config.logs_dd_url"))
 		if err != nil {
@@ -151,7 +151,8 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 		main.Port = port
 		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.logs_no_ssl")
 	default:
-		return nil, fmt.Errorf("no url specified for http endpoint")
+		main.Host = coreConfig.GetMainEndpoint(httpEndpointPrefix, "logs_config.dd_url")
+		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
 	}
 
 	return NewEndpoints(main, nil, false, true), nil

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -221,6 +221,40 @@ func (suite *EndpointsTestSuite) TestOverrideApiKey() {
 	suite.Equal("wassuplogskey", endpoints.Main.APIKey)
 }
 
+func (suite *EndpointsTestSuite) TestAdditionalEndpoints() {
+	var (
+		endpoints *Endpoints
+		endpoint  Endpoint
+		err       error
+	)
+
+	suite.config.Set("logs_config.additional_endpoints", []map[string]interface{}{
+		{
+			"host":    "foo",
+			"api_key": "1234",
+		},
+	})
+
+	endpoints, err = BuildEndpoints()
+	suite.Nil(err)
+	suite.Len(endpoints.Additionals, 1)
+
+	endpoint = endpoints.Additionals[0]
+	suite.Equal("foo", endpoint.Host)
+	suite.Equal("1234", endpoint.APIKey)
+	suite.True(endpoint.UseSSL)
+
+	suite.config.Set("logs_config.use_http", true)
+	endpoints, err = BuildEndpoints()
+	suite.Nil(err)
+	suite.Len(endpoints.Additionals, 1)
+
+	endpoint = endpoints.Additionals[0]
+	suite.Equal("foo", endpoint.Host)
+	suite.Equal("1234", endpoint.APIKey)
+	suite.True(endpoint.UseSSL)
+}
+
 func TestEndpointsTestSuite(t *testing.T) {
 	suite.Run(t, new(EndpointsTestSuite))
 }

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -23,35 +23,35 @@ func (suite *EndpointsTestSuite) SetupTest() {
 }
 
 func (suite *EndpointsTestSuite) TestLogsEndpointConfig() {
-	suite.Equal("agent-intake.logs.datadoghq.com", coreConfig.GetMainEndpoint(endpointPrefix, "logs_config.dd_url"))
+	suite.Equal("agent-intake.logs.datadoghq.com", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
 	endpoints, err := BuildEndpoints()
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
 
 	suite.config.Set("site", "datadoghq.com")
-	suite.Equal("agent-intake.logs.datadoghq.com", coreConfig.GetMainEndpoint(endpointPrefix, "logs_config.dd_url"))
+	suite.Equal("agent-intake.logs.datadoghq.com", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
 	endpoints, err = BuildEndpoints()
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
 
 	suite.config.Set("site", "datadoghq.eu")
-	suite.Equal("agent-intake.logs.datadoghq.eu", coreConfig.GetMainEndpoint(endpointPrefix, "logs_config.dd_url"))
+	suite.Equal("agent-intake.logs.datadoghq.eu", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
 	endpoints, err = BuildEndpoints()
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.eu", endpoints.Main.Host)
 	suite.Equal(443, endpoints.Main.Port)
 
 	suite.config.Set("logs_config.dd_url", "lambda.logs.datadoghq.co.jp")
-	suite.Equal("lambda.logs.datadoghq.co.jp", coreConfig.GetMainEndpoint(endpointPrefix, "logs_config.dd_url"))
+	suite.Equal("lambda.logs.datadoghq.co.jp", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
 	endpoints, err = BuildEndpoints()
 	suite.Nil(err)
 	suite.Equal("lambda.logs.datadoghq.co.jp", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
 
 	suite.config.Set("logs_config.logs_dd_url", "azure.logs.datadoghq.co.uk:1234")
-	suite.Equal("azure.logs.datadoghq.co.uk:1234", coreConfig.GetMainEndpoint(endpointPrefix, "logs_config.logs_dd_url"))
+	suite.Equal("azure.logs.datadoghq.co.uk:1234", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.logs_dd_url"))
 	endpoints, err = BuildEndpoints()
 	suite.Nil(err)
 	suite.Equal("azure.logs.datadoghq.co.uk", endpoints.Main.Host)
@@ -119,6 +119,22 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	var err error
 
 	suite.config.Set("logs_config.use_http", true)
+
+	endpoints, err = BuildEndpoints()
+	suite.Nil(err)
+	suite.True(endpoints.UseHTTP)
+
+	endpoint = endpoints.Main
+	suite.True(endpoint.UseSSL)
+	suite.Equal("agent-http-intake.logs.datadoghq.com", endpoint.Host)
+}
+
+func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPConfigAndOverride() {
+	var endpoints *Endpoints
+	var endpoint Endpoint
+	var err error
+
+	suite.config.Set("logs_config.use_http", true)
 	suite.config.Set("logs_config.dd_url", "foo")
 
 	endpoints, err = BuildEndpoints()
@@ -128,15 +144,6 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	endpoint = endpoints.Main
 	suite.True(endpoint.UseSSL)
 	suite.Equal("foo", endpoint.Host)
-}
-
-func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithInvalidHTTPConfig() {
-	var err error
-
-	suite.config.Set("logs_config.use_http", true)
-
-	_, err = BuildEndpoints()
-	suite.NotNil(err)
 }
 
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidProxyConfig() {


### PR DESCRIPTION
### What does this PR do?

Make sure additional endpoints are parsed for HTTP config and updated the client to sends logs in async 

### Motivation

Send logs to multiple destinations with HTTP

### Additional Notes

Anything else we should know when reviewing?
