### PR TITLE
[tasks] Make GOPATH optional

### DIFF
--- a/tasks/bootstrap.py
+++ b/tasks/bootstrap.py
@@ -4,6 +4,8 @@ Boostrapping related logic goes here
 import os
 import json
 
+from .utils import get_gopath
+
 # Bootstrap dependencies description
 BOOTSTRAP_DEPS = "bootstrap.json"
 BOOTSTRAP_ORDER_KEY = "order"
@@ -42,14 +44,7 @@ def process_deps(ctx, target, version, kind, step, verbose=False):
     if kind == "go":
         if step == "checkout":
             # download tools
-            gopath = os.environ.get("GOPATH")
-            if not gopath:
-                for line in ctx.run("go env", hide=True).stdout.splitlines():
-                    [name, value] = line.split("=", 1)
-                    if name == "GOPATH":
-                        gopath = value
-                        break
-            path = os.path.join(gopath, 'src', target)
+            path = os.path.join(get_gopath(ctx), 'src', target)
             if not os.path.exists(path):
                 ctx.run("go get{} -d -u {}".format(verbosity, target))
 

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -108,4 +108,4 @@ def protobuf(ctx):
     cmd = "protoc {proto_dir}/agent.proto -I {gopath}/src -I vendor -I {proto_dir} --gogofaster_out {gopath}/src"
     proto_dir = os.path.join(".", "pkg", "process", "proto")
 
-    ctx.run(cmd.format(gopath=os.environ["GOPATH"], proto_dir=proto_dir))
+    ctx.run(cmd.format(gopath=get_gopath(ctx), proto_dir=proto_dir))

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -7,7 +7,7 @@ import sys
 from invoke import task
 from subprocess import check_output
 
-from .utils import bin_name, get_build_flags, REPO_PATH, get_version, get_git_branch_name, get_go_version, get_git_commit, get_version_numeric_only
+from .utils import bin_name, get_gopath, get_build_flags, REPO_PATH, get_version, get_git_branch_name, get_go_version, get_git_commit, get_version_numeric_only
 from .build_tags import get_default_build_tags
 
 BIN_DIR = os.path.join(".", "bin", "process-agent")

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -28,6 +28,12 @@ def bin_name(name, android=False):
         return "{}.exe".format(name)
     return name
 
+def get_gopath(ctx):
+    gopath = os.environ.get("GOPATH")
+    if not gopath:
+        gopath = ctx.run("go env GOPATH", hide=True).stdout.strip()
+
+    return gopath
 
 def get_multi_python_location(embedded_path=None, rtloader_root=None):
     if rtloader_root is None:
@@ -57,7 +63,7 @@ def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
 
     if embedded_path is None:
         # fall back to local dev path
-        embedded_path = "{}/src/github.com/DataDog/datadog-agent/dev".format(os.environ.get('GOPATH'))
+        embedded_path = "{}/src/github.com/DataDog/datadog-agent/dev".format(get_gopath(ctx))
 
     rtloader_lib, rtloader_headers = get_multi_python_location(embedded_path, rtloader_root)
 


### PR DESCRIPTION
### What does this PR do?

Make `GOPATH` optional in our invoke tasks.

### Motivation

Fixes https://github.com/DataDog/datadog-agent/issues/3617. Golang does not require the `GOPATH` env var to be set anymore (defaults to `$HOME/go`).

### Additional Notes

This PR mostly fixes the logic in `bootstrap.process_deps`, and extracts
out the logic into a function that should be called instead of querying
`GOPATH` from the env directly.
