### PR TITLE
Use port defined in YAML for NTP check.

### DIFF
--- a/cmd/agent/dist/conf.d/ntp.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/ntp.d/conf.yaml.default
@@ -14,6 +14,6 @@ instances:
     #  - 1.europe.pool.ntp.org
     #  - 2.europe.pool.ntp.org
     #  - 3.europe.pool.ntp.org
-    # port: ntp
+    # port: 123
     # version: 3
     # timeout: 5

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -42,7 +42,7 @@ type ntpInstanceConfig struct {
 	OffsetThreshold       int      `yaml:"offset_threshold"`
 	Host                  string   `yaml:"host"`
 	Hosts                 []string `yaml:"hosts"`
-	Port                  string   `yaml:"port"`
+	Port                  int      `yaml:"port"`
 	Timeout               int      `yaml:"timeout"`
 	Version               int      `yaml:"version"`
 	MinCollectionInterval int      `yaml:"min_collection_interval"`
@@ -64,7 +64,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 	var initConf ntpInitConfig
 	defaultVersion := 3
 	defaultTimeout := 1
-	defaultPort := "ntp"
+	defaultPort := 123
 	defaultOffsetThreshold := 60
 	defaultMinCollectionInterval := 900 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
 	defaultHosts := []string{"0.datadog.pool.ntp.org", "1.datadog.pool.ntp.org", "2.datadog.pool.ntp.org", "3.datadog.pool.ntp.org"}
@@ -91,7 +91,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 	if c.instance.Hosts == nil {
 		c.instance.Hosts = defaultHosts
 	}
-	if c.instance.Port == "" {
+	if c.instance.Port == 0 {
 		c.instance.Port = defaultPort
 	}
 	if c.instance.Version == 0 {
@@ -175,7 +175,7 @@ func (c *NTPCheck) queryOffset() (float64, error) {
 	offsets := []float64{}
 
 	for _, host := range c.cfg.instance.Hosts {
-		response, err := ntpQuery(host, ntp.QueryOptions{Version: c.cfg.instance.Version})
+		response, err := ntpQuery(host, ntp.QueryOptions{Version: c.cfg.instance.Version, Port: c.cfg.instance.Port})
 		if err != nil {
 			log.Infof("There was an error querying the ntp host %s: %s", host, err)
 			continue

--- a/pkg/collector/corechecks/net/ntp_test.go
+++ b/pkg/collector/corechecks/net/ntp_test.go
@@ -359,7 +359,8 @@ func TestNTPPortConfig(t *testing.T) {
 offset_threshold: 60
 port: %d
 `, expectedPort))
-	ntpCheck.Configure(ntpCfg, []byte(""))
+	err := ntpCheck.Configure(ntpCfg, []byte(""))
+	assert.Nil(t, err)
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 	mockSender.SetupAcceptAll()
@@ -369,4 +370,14 @@ port: %d
 	for _, port := range detectedPorts {
 		assert.Equal(t, expectedPort, port)
 	}
+}
+
+func TestNTPPortNotInt(t *testing.T) {
+	ntpCheck := new(NTPCheck)
+	ntpCfg := []byte(`
+offset_threshold: 60 
+port: ntp`)
+
+	err := ntpCheck.Configure(ntpCfg, []byte(""))
+	assert.EqualError(t, err, "yaml: unmarshal errors:\n  line 3: cannot unmarshal !!str `ntp` into int")
 }

--- a/releasenotes/notes/use-NTP-port-de18dae830c08d9d.yaml
+++ b/releasenotes/notes/use-NTP-port-de18dae830c08d9d.yaml
@@ -4,4 +4,4 @@ upgrade:
     The ``port`` option in the NTP check configuration is now parsed as an integer instead of a string.
 fixes:
   - |
-    Use NTP port.
+    The NTP check now properly uses the ``port`` configuration option.

--- a/releasenotes/notes/use-NTP-port-de18dae830c08d9d.yaml
+++ b/releasenotes/notes/use-NTP-port-de18dae830c08d9d.yaml
@@ -1,7 +1,7 @@
 ---
 upgrade:
   - |
-    The port defined in the NTP configuration is no longer a string. Now, it is an integer.
+    The ``port`` option in the NTP check configuration is now parsed as an integer instead of a string.
 fixes:
   - |
     Use NTP port.

--- a/releasenotes/notes/use-NTP-port-de18dae830c08d9d.yaml
+++ b/releasenotes/notes/use-NTP-port-de18dae830c08d9d.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The port defined in the NTP configuration is no longer a string. Now, it is an integer.
+fixes:
+  - |
+    Use NTP port.


### PR DESCRIPTION
### What does this PR do?

Use NTP Port.

### Motivation

NTP port was not used.

### Additional Notes

There is a config breaking change in the yaml (`Port` was `string`, now it is `int`)
