### PR TITLE
pkg/trace/agent: enable parallel_process by default

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -125,11 +125,7 @@ func (a *Agent) Run() {
 	go a.StatsWriter.Run()
 	go a.ServiceWriter.Run()
 
-	n := 1
-	if config.HasFeature("parallel_process") {
-		n = runtime.NumCPU()
-	}
-	for i := 0; i < n; i++ {
+	for i := 0; i < runtime.NumCPU(); i++ {
 		go a.work()
 	}
 


### PR DESCRIPTION
This change removes the feature flag "parallel_process" and enables it
by default. It sets the number of processing goroutines as equal to the
number of CPUs.