### PR TITLE
pkg/trace/agent: remove sampling goroutine

### DIFF
--- a/releasenotes/notes/apm-remove-sampling-goroutine-9dfd0df2f19fd560.yaml
+++ b/releasenotes/notes/apm-remove-sampling-goroutine-9dfd0df2f19fd560.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Improved processing concurrency and as a result, CPU usage decreased
+    by 20% in some scenarios.


### PR DESCRIPTION
This channel removes the sampling goroutine. It serves no real benefit or purpose. Immediate improvements can be noticed in some scenarios. Up to 25% reduction in CPU usage can be observed.

### 58k spans/s: 0.5 CPU core (50%) reduction
<img width="854" alt="58k" src="https://user-images.githubusercontent.com/6686356/60838772-80885f80-a199-11e9-9871-deb96814dc9d.png">

### 24k spans/s: 0.2 CPU core (20%) reduction
<img width="853" alt="24k" src="https://user-images.githubusercontent.com/6686356/60838823-9dbd2e00-a199-11e9-9c1b-ad5b7c30c28e.png">

This change also removes the `parallel_process` feature flag and enables it by default.