### PR TITLE
Added a support for new log directory pattern for kubernetes logs

### DIFF
--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -10,6 +10,7 @@ package kubernetes
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -20,8 +21,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 )
 
-// The path to the pods log directory.
-const podsDirectoryPath = "/var/log/pods"
+const (
+	basePath   = "/var/log/pods"
+	anyLogFile = "*.log"
+)
 
 var collectAllDisabledError = fmt.Errorf("%s disabled", config.ContainerCollectAll)
 
@@ -39,9 +42,8 @@ type Launcher struct {
 // NewLauncher returns a new launcher.
 func NewLauncher(sources *config.LogSources, services *service.Services, collectAll bool) (*Launcher, error) {
 	if !isIntegrationAvailable() {
-		return nil, fmt.Errorf("%s not found", podsDirectoryPath)
+		return nil, fmt.Errorf("%s not found", basePath)
 	}
-
 	kubeutil, err := kubelet.GetKubeUtil()
 	if err != nil {
 		return nil, err
@@ -63,7 +65,7 @@ func NewLauncher(sources *config.LogSources, services *service.Services, collect
 }
 
 func isIntegrationAvailable() bool {
-	if _, err := os.Stat(podsDirectoryPath); err != nil {
+	if _, err := os.Stat(basePath); err != nil {
 		return false
 	}
 
@@ -183,7 +185,7 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 		}
 	}
 	cfg.Type = config.FileType
-	cfg.Path = l.getPath(pod, container)
+	cfg.Path = l.getPath(basePath, pod, container)
 	cfg.Identifier = container.ID
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid kubernetes annotation: %v", err)
@@ -220,9 +222,23 @@ func (l *Launcher) getSourceName(pod *kubelet.Pod, container kubelet.ContainerSt
 	return fmt.Sprintf("%s/%s/%s", pod.Metadata.Namespace, pod.Metadata.Name, container.Name)
 }
 
-// getPath returns the path where all the logs of the container of the pod are stored.
-func (l *Launcher) getPath(pod *kubelet.Pod, container kubelet.ContainerStatus) string {
-	return fmt.Sprintf("%s/%s/%s/*.log", podsDirectoryPath, pod.Metadata.UID, container.Name)
+// getPath returns a wildcard matching with any logs file of container in pod.
+func (l *Launcher) getPath(basePath string, pod *kubelet.Pod, container kubelet.ContainerStatus) string {
+	// the pattern for container logs is different depending on the version of Kubernetes
+	// so we need to try both format,
+	// previously it was `/var/log/pods/{pod_uid}/{container_name}/{n}.log`,
+	// then it changed to `/var/log/pods/{pod_namespace}_{pod_name}_{pod_uid}/{container_name}/{n}.log`.
+	// see: https://github.com/kubernetes/kubernetes/pull/74441 for more information.
+	oldDirectory := filepath.Join(basePath, pod.Metadata.UID)
+	if _, err := os.Stat(oldDirectory); err == nil {
+		return filepath.Join(basePath, pod.Metadata.UID, container.Name, anyLogFile)
+	}
+	return filepath.Join(basePath, l.getPodDirectory(pod), container.Name, anyLogFile)
+}
+
+// getPodDirectory returns the name of the directory of pod containers.
+func (l *Launcher) getPodDirectory(pod *kubelet.Pod) string {
+	return fmt.Sprintf("%s_%s_%s", pod.Metadata.Namespace, pod.Metadata.Name, pod.Metadata.UID)
 }
 
 // getShortImageName returns the short image name of a container

--- a/releasenotes/notes/logs-k8s-support-new-log-directory-pattern-a9f4085ad2244a5a.yaml
+++ b/releasenotes/notes/logs-k8s-support-new-log-directory-pattern-a9f4085ad2244a5a.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-    Added a support for the new pod log directory pattern of the latest version of Kubernetes to make sure
+    Added a support for the new pod log directory pattern introduced in version 1.14 of Kubernetes to make sure
     the agent keeps on collecting logs after upgrade of a Kubernetes cluster.

--- a/releasenotes/notes/logs-k8s-support-new-log-directory-pattern-a9f4085ad2244a5a.yaml
+++ b/releasenotes/notes/logs-k8s-support-new-log-directory-pattern-a9f4085ad2244a5a.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added a support for the new pod log directory pattern of the latest version of Kubernetes to make sure
+    the agent keeps on collecting logs after upgrade of a Kubernetes cluster.


### PR DESCRIPTION
### What does this PR do?

Changed the path returned to collect logs on Kubernetes to support the latest format.

### Motivation

Make sure users can still collect logs after deploying the agent on a cluster running the latest version of Kubernetes.

### Additional Notes

This change should be backward compatible and should fix https://github.com/DataDog/datadog-agent/issues/3822.
