### PR TITLE
[Cluster-Agent] Cherry-pick `agent flare` fix commit

### DIFF
--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -2,6 +2,52 @@
 Release Notes
 =============
 
+.. _Release Notes_1.3.0:
+
+1.3.0
+=====
+
+.. _Release Notes_1.3.0_Prelude:
+
+Prelude
+-------
+
+Released on: 2019-05-07
+
+The Datadog Cluster Agent can now auto-discover config templates for kubernetes endpoints checks and expose them to node Agents via its API. This feature is compatible with the version 6.12.0 and up of the Datadog Agent.
+
+Refer to `the official documentation <https://docs.datadoghq.com/agent/autodiscovery/endpointschecks/>`_ to read more about this feature.
+
+
+1.3.0-rc.3
+==========
+2019-05-03
+
+Bug Fixes
+---------
+- Fix race condition: immutable MetaBundle stored in DCA cache.
+
+Bug Fixes
+---------
+- Fix race condition in Cluster Agent's API handler.
+
+1.3.0-rc.1
+==========
+2019-04-24
+
+New Features
+------------
+- The Cluster Agent can now auto-discover config templates for kubernetes endpoints checks and expose them to node Agents via its API
+- Add the ``config`` and ``configcheck`` command to the cluster agent CLI
+- Add the ``diagnose`` command to the cluster agent CLI and flare
+- Add cluster_checks.extra_tags option
+
+Enhancement Notes
+-----------------
+- Improving Lifecycle of the External Metrics Provider
+- Support milliquantities for the External Metrics Provider
+- Move logs info to debug
+
 .. _Release Notes_1.2.0:
 
 1.2.0

--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -2,6 +2,12 @@
 Release Notes
 =============
 
+1.3.1
+=====
+2019-06-19
+
+- Fix "Kube Services" service: `kube service` tags attached to pod are not consistent. 
+
 .. _Release Notes_1.3.0:
 
 1.3.0

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -31,29 +31,16 @@ type flareResponse struct {
 
 // SendFlareWithHostname sends a flare with a set hostname
 func SendFlareWithHostname(archivePath string, caseID string, email string, hostname string) (string, error) {
-	r, err := readAndPostFlareFileWithRedirects(archivePath, caseID, email, hostname)
+	r, err := readAndPostFlareFile(archivePath, caseID, email, hostname)
 	return analyzeResponse(r, err)
 }
 
-func readAndPostFlareFileWithRedirects(archivePath string, caseID string, email string, hostname string) (*http.Response, error) {
-	// Handle redirects manually. Go's http.Client doesn't know how to do it when it can't seek
-	// back to the beginning of the body. Since we are using a pipe, seeking isn't possible.
-	// Re-sending a POST is only legal for status 307, so we only need to check for that code.
-	var url = mkURL(caseID)
-	for redirectHops := 0; ; redirectHops++ {
-		r, err := readAndPostFlareFile(url, archivePath, caseID, email, hostname)
-		if r != nil && r.StatusCode == 307 && redirectHops < 5 {
-			url = r.Header.Get("Location")
-		} else {
-			return r, err
-		}
-	}
-}
-
-func readAndPostFlareFile(url string, archivePath string, caseID string, email string, hostname string) (*http.Response, error) {
+func getFlareReader(multipartBoundary, archivePath, caseID, email, hostname string) io.ReadCloser {
+	//No need to close the reader, http.Client does it for us
 	bodyReader, bodyWriter := io.Pipe()
-	defer bodyReader.Close()
+
 	writer := multipart.NewWriter(bodyWriter)
+	writer.SetBoundary(multipartBoundary)
 
 	//Write stuff to the pipe will block until it is read from the other end, so we don't load everything in memory
 	go func() {
@@ -68,7 +55,6 @@ func readAndPostFlareFile(url string, archivePath string, caseID string, email s
 			writer.WriteField("email", email)
 		}
 
-		//Flare file
 		p, err := writer.CreateFormFile("flare_file", filepath.Base(archivePath))
 		if err != nil {
 			bodyWriter.CloseWithError(err)
@@ -92,10 +78,34 @@ func readAndPostFlareFile(url string, archivePath string, caseID string, email s
 
 	}()
 
-	request, err := http.NewRequest("POST", url, bodyReader)
-	request.Header.Set("Content-Type", writer.FormDataContentType())
+	return bodyReader
+}
+
+func readAndPostFlareFile(archivePath, caseID, email, hostname string) (*http.Response, error) {
+
+	var url = mkURL(caseID)
+
+	request, err := http.NewRequest("POST", url, nil) //nil body, we set it manually later
 	if err != nil {
 		return nil, err
+	}
+
+	// We need to set the Content-Type header here, but we still haven't created the writer
+	// to obtain it from. Here we create one which only purpose is to give us a proper
+	// Content-Type. Note that this Content-Type header will contain a random multipart
+	// boundary, so we need to make sure that the actual writter uses the same boundary.
+	boundaryWriter := multipart.NewWriter(nil)
+	request.Header.Set("Content-Type", boundaryWriter.FormDataContentType())
+
+	// Manually set the Body and ContentLenght. http.NewRequest doesn't do all of this
+	// for us, since a PipeReader is not one of the Reader types it knows how to handle.
+	request.Body = getFlareReader(boundaryWriter.Boundary(), archivePath, caseID, email, hostname)
+	// -1 here means 'unknown' and makes this a 'chunked' request. See https://github.com/golang/go/issues/18117
+	request.ContentLength = -1
+	// Setting a GetBody function makes the request replayable in case there is a redirect.
+	// Otherwise, since the body is a pipe, what has been already read can't be read again.
+	request.GetBody = func() (io.ReadCloser, error) {
+		return getFlareReader(boundaryWriter.Boundary(), archivePath, caseID, email, hostname), nil
 	}
 
 	client := mkHTTPClient()

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -31,6 +31,26 @@ type flareResponse struct {
 
 // SendFlareWithHostname sends a flare with a set hostname
 func SendFlareWithHostname(archivePath string, caseID string, email string, hostname string) (string, error) {
+	r, err := readAndPostFlareFileWithRedirects(archivePath, caseID, email, hostname)
+	return analyzeResponse(r, err)
+}
+
+func readAndPostFlareFileWithRedirects(archivePath string, caseID string, email string, hostname string) (*http.Response, error) {
+	// Handle redirects manually. Go's http.Client doesn't know how to do it when it can't seek
+	// back to the beginning of the body. Since we are using a pipe, seeking isn't possible.
+	// Re-sending a POST is only legal for status 307, so we only need to check for that code.
+	var url = mkURL(caseID)
+	for redirectHops := 0; ; redirectHops++ {
+		r, err := readAndPostFlareFile(url, archivePath, caseID, email, hostname)
+		if r != nil && r.StatusCode == 307 && redirectHops < 5 {
+			url = r.Header.Get("Location")
+		} else {
+			return r, err
+		}
+	}
+}
+
+func readAndPostFlareFile(url string, archivePath string, caseID string, email string, hostname string) (*http.Response, error) {
 	bodyReader, bodyWriter := io.Pipe()
 	defer bodyReader.Close()
 	writer := multipart.NewWriter(bodyWriter)
@@ -72,17 +92,14 @@ func SendFlareWithHostname(archivePath string, caseID string, email string, host
 
 	}()
 
-	var url = mkURL(caseID)
 	request, err := http.NewRequest("POST", url, bodyReader)
 	request.Header.Set("Content-Type", writer.FormDataContentType())
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	client := mkHTTPClient()
-	r, err := client.Do(request)
-
-	return analyzeResponse(r, err)
+	return client.Do(request)
 }
 
 // SendFlare will send a flare and grab the local hostname


### PR DESCRIPTION
### What does this PR do?

Fix the `cluster-agent flare` command.
Cherry-pick fix commits from `master branch` (PR #3632 #3642)

### Motivation

Fix was done for the `agent` 6.12.x, but `cluster-agent` 1.3.1 was release before the fix.

### Additional Notes

Anything else we should know when reviewing?
