### PR TITLE
[dep] Update Gopkg.lock with new import

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2064,6 +2064,7 @@
     "gopkg.in/zorkian/go-datadog-api.v2",
     "k8s.io/api/autoscaling/v2beta1",
     "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",


### PR DESCRIPTION
### What does this PR do?

Update Gopkg.lock with new import introduced in https://github.com/DataDog/datadog-agent/pull/3704. `inv deps`/`dep ensure` needed to be run so that `Gopkg.lock` is updated accordingly, the present PR simply does that.

### Motivation

Inconsistency caught by the new `run_dep_check_lock` gitlab job introduced in https://github.com/DataDog/datadog-agent/pull/3816.
