### PR TITLE
pkg/trace/agent: remove concentrator routine

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -302,7 +302,7 @@ func TestSampling(t *testing.T) {
 				sampler.SetSamplingPriority(pt.Root, 1)
 			}
 
-			sampled, rate := a.sample(pt)
+			sampled, rate := a.runSamplers(pt)
 			assert.EqualValues(t, tt.wantRate, rate)
 			assert.EqualValues(t, tt.wantSampled, sampled)
 		})
@@ -567,7 +567,7 @@ func benchThroughput(file string) func(*testing.B) {
 			for {
 				select {
 				case <-agnt.ServiceExtractor.outServices:
-				case <-agnt.Concentrator.OutStats:
+				case <-agnt.Concentrator.Out:
 				case <-exit:
 					return
 				}

--- a/pkg/trace/agent/processed_trace.go
+++ b/pkg/trace/agent/processed_trace.go
@@ -13,7 +13,6 @@ type ProcessedTrace struct {
 	Root          *pb.Span
 	Env           string
 	Sublayers     stats.SublayerMap
-	Sampled       bool
 }
 
 // Weight returns the weight at the root span.

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -73,7 +73,7 @@ func TestConcentratorOldestTs(t *testing.T) {
 		// Running cold, all spans in the past should end up in the current time bucket.
 		flushTime := now
 		c := NewConcentrator([]string{}, testBucketInterval, statsChan)
-		c.Add(testTrace)
+		c.addNow(testTrace, time.Now().UnixNano())
 
 		for i := 0; i < c.bufferLen; i++ {
 			stats := c.flushNow(flushTime)
@@ -104,7 +104,7 @@ func TestConcentratorOldestTs(t *testing.T) {
 		flushTime := now
 		c := NewConcentrator([]string{}, testBucketInterval, statsChan)
 		c.oldestTs = alignTs(now, c.bsize) - int64(c.bufferLen-1)*c.bsize
-		c.Add(testTrace)
+		c.addNow(testTrace, time.Now().UnixNano())
 
 		for i := 0; i < c.bufferLen-1; i++ {
 			stats := c.flushNow(flushTime)
@@ -178,7 +178,7 @@ func TestConcentratorStatsTotals(t *testing.T) {
 		Env:   "none",
 		Trace: wt,
 	}
-	c.Add(testTrace)
+	c.addNow(testTrace, time.Now().UnixNano())
 
 	var hits float64
 	var duration float64
@@ -283,7 +283,7 @@ func TestConcentratorStatsCounts(t *testing.T) {
 		Env:   "none",
 		Trace: wt,
 	}
-	c.Add(testTrace)
+	c.addNow(testTrace, time.Now().UnixNano())
 
 	// flush every testBucketInterval
 	flushTime := now
@@ -363,7 +363,7 @@ func TestConcentratorSublayersStatsCounts(t *testing.T) {
 		Sublayers: sublayers,
 	}
 
-	c.Add(testTrace)
+	c.addNow(testTrace, time.Now().UnixNano())
 	stats := c.flushNow(alignedNow + int64(c.bufferLen)*c.bsize)
 
 	if !assert.Equal(1, len(stats), "We should get exactly 1 Bucket") {


### PR DESCRIPTION
This PR removes the concentrator goroutine, which served no purpose. It instead adds "number of cores" goroutines as workers to process stats.

### 58k spans/s

<img width="867" alt="Screen Shot 2019-07-09 at 9 56 24 AM" src="https://user-images.githubusercontent.com/6686356/60894328-75344300-a230-11e9-9233-74e82d0df7c8.png">
