### PR TITLE
[gitlab-ci] Change kitchen stage order & fix kitchen logs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -705,6 +705,7 @@ kitchen_windows:
   script:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
+    - rm -rf $CI_PROJECT_DIR/kitchen_logs
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20181122"
@@ -729,6 +730,7 @@ kitchen_windows_installer:
   script:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
+    - rm -rf $CI_PROJECT_DIR/kitchen_logs
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20181122"
@@ -751,6 +753,7 @@ kitchen_centos:
   script:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
+    - rm -rf $CI_PROJECT_DIR/kitchen_logs
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="centos-74,OpenLogic:CentOS:7.4:7.4.20171110"
@@ -773,6 +776,7 @@ kitchen_ubuntu:
   script:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
+    - rm -rf $CI_PROJECT_DIR/kitchen_logs
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="ubuntu-14-04,Canonical:UbuntuServer:14.04.5-LTS:14.04.201803080"
@@ -796,6 +800,7 @@ kitchen_suse:
   script:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
+    - rm -rf $CI_PROJECT_DIR/kitchen_logs
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP4:2019.06.17"
@@ -818,6 +823,7 @@ kitchen_debian:
   script:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
+    - rm -rf $CI_PROJECT_DIR/kitchen_logs
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="debian-8,credativ:Debian:8:8.0.201803130"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,6 @@ stages:
   - e2e
   - testkitchen_cleanup
 
-
 variables:
   # The SRC_PATH is in the GOPATH of the builders which
   # currently is /go

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -705,6 +705,7 @@ kitchen_windows:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
     - rm -rf $CI_PROJECT_DIR/kitchen_logs
+    - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20181122"
@@ -730,6 +731,7 @@ kitchen_windows_installer:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
     - rm -rf $CI_PROJECT_DIR/kitchen_logs
+    - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20181122"
@@ -753,6 +755,7 @@ kitchen_centos:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
     - rm -rf $CI_PROJECT_DIR/kitchen_logs
+    - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="centos-74,OpenLogic:CentOS:7.4:7.4.20171110"
@@ -776,6 +779,7 @@ kitchen_ubuntu:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
     - rm -rf $CI_PROJECT_DIR/kitchen_logs
+    - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="ubuntu-14-04,Canonical:UbuntuServer:14.04.5-LTS:14.04.201803080"
@@ -800,6 +804,7 @@ kitchen_suse:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
     - rm -rf $CI_PROJECT_DIR/kitchen_logs
+    - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP4:2019.06.17"
@@ -823,6 +828,7 @@ kitchen_debian:
     - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
     - rm -rf $CI_PROJECT_DIR/kitchen_logs
+    - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
     - export TEST_PLATFORMS="debian-8,credativ:Debian:8:8.0.201803130"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,12 +7,13 @@ stages:
   - check_deploy
   - testkitchen_deploy
   - testkitchen_testing
-  - testkitchen_cleanup
   - image_build
   - image_deploy
   - deploy
   - deploy_invalidate
   - e2e
+  - testkitchen_cleanup
+
 
 variables:
   # The SRC_PATH is in the GOPATH of the builders which

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -6,8 +6,6 @@
 IFS=$'\n\t'
 set -euxo pipefail
 
-rm -rf .kitchen
-
 # Ensure that the ssh key is never reused between tests
 if [ -f $(pwd)/ssh-key ]; then
   rm ssh-key


### PR DESCRIPTION
### What does this PR do?

- Moves `testkitchen_cleanup` stage to the end of the pipeline, so that we waste less time waiting for a task scheduled in a previous task to finish,
- Changes command order during kitchen testing so that we can have kitchen logs as artefacts.

### Motivation

- When kitchen tests do not crash, the VMs used for the tests are scheduled to be deleted in `testkitchen_testing`. In this case, the cleanup phase only waits for the deletion to be done. Instead of waiting 7 to 15 minutes to delete them, this stage has been placed last so that we waste less time doing nothing.
- A previous change accidentally removes the symlink between the folder that should contain the artefacts and the kitchen log folder.