### PR TITLE
[process-agent/system-probe] system-probe could extract container id and pid relationship without process check to run

### DIFF
--- a/pkg/process/checks/container_nolinux.go
+++ b/pkg/process/checks/container_nolinux.go
@@ -51,3 +51,7 @@ func chunkContainers(ctrList []*containers.Container, lastRates map[string]util.
 func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.ContainerRateMetrics, lastRun time.Time) []*model.Container {
 	return make([]*model.Container, 0)
 }
+
+func (c *ContainerCheck) filterCtrIDsByPIDs(pids []int32) map[int32]string {
+	return map[int32]string{}
+}

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -144,7 +144,15 @@ func batchConnections(cfg *config.AgentConfig, groupID int32, cxs []*model.Conne
 
 	for len(cxs) > 0 {
 		batchSize := min(cfg.MaxConnsPerMessage, len(cxs))
-		ctrIDForPID := Process.filterCtrIDsByPIDs(connectionPIDs(cxs[:batchSize]))
+		// get the container and process relationship from either process check or container check
+		var ctrIDForPID map[int32]string
+		// process check is never run, use container check instead
+		if Process.lastRun.IsZero() {
+			ctrIDForPID = Container.filterCtrIDsByPIDs(connectionPIDs(cxs[:batchSize]))
+		} else {
+			ctrIDForPID = Process.filterCtrIDsByPIDs(connectionPIDs(cxs[:batchSize]))
+		}
+
 		batches = append(batches, &model.CollectorConnections{
 			HostName:        cfg.HostName,
 			Connections:     cxs[:batchSize],

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/model"
@@ -25,6 +26,8 @@ func TestNetworkConnectionBatching(t *testing.T) {
 	for _, proc := range p {
 		Process.lastCtrIDForPID[proc.Pid] = fmt.Sprintf("%d", proc.Pid)
 	}
+	// update lastRun to indicate that Process check is enabled and ran
+	Process.lastRun = time.Now()
 
 	cfg := config.NewDefaultAgentConfig()
 


### PR DESCRIPTION
### What does this PR do?

Currently system-probe would only work if process-agent is running process and container check. This is could also work with just container check running. This PR implements this. cc: @DataDog/burrito 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
