### PR TITLE
pkg/trace/api: add "Datadog-Meta-Lang-Interpreter-Vendor" HTTP header support

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -269,6 +269,7 @@ func (r *HTTPReceiver) tagStats(req *http.Request) *info.TagStats {
 	return r.Stats.GetTagStats(info.Tags{
 		Lang:          req.Header.Get("Datadog-Meta-Lang"),
 		LangVersion:   req.Header.Get("Datadog-Meta-Lang-Version"),
+		LangVendor:    req.Header.Get("Datadog-Meta-Lang-Interpreter-Vendor"),
 		Interpreter:   req.Header.Get("Datadog-Meta-Lang-Interpreter"),
 		TracerVersion: req.Header.Get("Datadog-Meta-Tracer-Version"),
 	})

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -431,7 +431,7 @@ func (ts *TagStats) WarnString() string {
 
 // Tags holds the tags we parse when we handle the header of the payload.
 type Tags struct {
-	Lang, LangVersion, Interpreter, TracerVersion string
+	Lang, LangVersion, LangVendor, Interpreter, TracerVersion string
 }
 
 // toArray will transform the Tags struct into a slice of string.
@@ -444,6 +444,9 @@ func (t *Tags) toArray() []string {
 	}
 	if t.LangVersion != "" {
 		tags = append(tags, "lang_version:"+t.LangVersion)
+	}
+	if t.LangVendor != "" {
+		tags = append(tags, "lang_vendor:"+t.LangVendor)
 	}
 	if t.Interpreter != "" {
 		tags = append(tags, "interpreter:"+t.Interpreter)

--- a/releasenotes/notes/apm-lang-vendor-header-e089c335c0b06e8b.yaml
+++ b/releasenotes/notes/apm-lang-vendor-header-e089c335c0b06e8b.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: API emitted metrics now have a lang_vendor tag when the Datadog-Meta-Lang-Vendor
+    HTTP header is sent by clients.


### PR DESCRIPTION
This change allows clients to send the `Datadog-Meta-Lang-Vendor` HTTP header. Its value will be attached to some metrics emitted by the API (`datadog.trace_agent.receiver.*`)