### PR TITLE
pkg/trace/agent: add a feature flag to allow 15k resource lengths

### DIFF
--- a/pkg/trace/agent/truncator.go
+++ b/pkg/trace/agent/truncator.go
@@ -1,14 +1,22 @@
 package agent
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// MaxResourceLen the maximum length the resource can have
+var MaxResourceLen = 5000
+
+func init() {
+	if config.HasFeature("big_resource") {
+		MaxResourceLen = 15000
+	}
+}
+
 const (
-	// MaxResourceLen the maximum length the resource can have
-	MaxResourceLen = 5000
 	// MaxMetaKeyLen the maximum length of metadata key
 	MaxMetaKeyLen = 100
 	// MaxMetaValLen the maximum length of metadata value


### PR DESCRIPTION
This change adds a feature flag which increases the maximum length
allowed for a resource from 5k to 15k. To use it:

    DD_APM_FEATURES=big_resource