### PR TITLE
Adds ability to sign using pfx (pkcs12) cert file rather than require

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -94,6 +94,9 @@ package :msi do
   if ENV['SIGN_WINDOWS']
     signing_identity "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C", machine_store: true, algorithm: "SHA256"
   end
+  if ENV['SIGN_PFX']
+    signing_identity_file "#{ENV['SIGN_PFX']}", password: "#{ENV['SIGN_PFX_PW']}", algorithm: "SHA256"
+  end
   parameters({
     'InstallDir' => install_dir,
     'InstallFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files",


### PR DESCRIPTION
cert be added to cert store


### Motivation

Have more secure storage of certificates

### Additional Notes

Should not affect existing build process.
