### PR TITLE
disable fast fallback aka "happy eyeballs" on go 1.12

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -208,10 +208,8 @@ func CreateHTTPTransport() *http.Transport {
 			Timeout: 30 * time.Second,
 			// Enables TCP keepalives to detect broken connections
 			KeepAlive: 30 * time.Second,
-			// Disable happy eyeballs. This option will be deprecated in go 1.12.
-			// At this point we will need to disable it by setting a new attribute to false.
-			// See https://github.com/DataDog/datadog-agent/pull/2464
-			DualStack: false,
+			// Disable RFC 6555 Fast Fallback ("Happy Eyeballs")
+			FallbackDelay: -1 * time.Nanosecond,
 		}).DialContext,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 5,


### PR DESCRIPTION
### What does this PR do?

Follow up of https://github.com/DataDog/datadog-agent/pull/2464. "happy eyeballs" is now enabled by default on 1.12, let's disable it for the same reasons we had in the past.

[1.12 changelog entry](https://golang.org/doc/go1.12#net)

This is blocked on the upgrade to 1.12