### PR TITLE
[logs] Fix TLS handshake hanging forever

### DIFF
--- a/releasenotes/notes/logs-fix-tls-handshake-hanging-forever-84a91b400fe18ec6.yaml
+++ b/releasenotes/notes/logs-fix-tls-handshake-hanging-forever-84a91b400fe18ec6.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fix TLS connection handshake that hang forever making the whole logs
+    pipeline to be stucked resulting in logs not being tailed and file
+    descriptor not being closed. 


### PR DESCRIPTION
### What does this PR do?

Fix TLS handshake hanging forever by adding manually a timeout like  in
`tls.DialWithDialer`, see https://github.com/golang/go/blob/dev.boringcrypto.go1.11/src/crypto/tls/tls.go#L98.

### Motivation

This bug makes the whole logs pipeline stuck resulting in logs not being tail and leaking of file descriptors if using rotating log files.

### Additional Notes

It is a bug in golang that is known but not fixed:
* https://github.com/golang/go/issues/2263
* https://github.com/golang/go/issues/17708