### PR TITLE
[DCA] show endpoint checks in `agent clusterchecks` command

### DIFF
--- a/cmd/cluster-agent/api/v1/endpointschecks.go
+++ b/cmd/cluster-agent/api/v1/endpointschecks.go
@@ -18,7 +18,7 @@ import (
 // Install registers v1 API endpoints for endpoints checks
 func installEndpointsCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
 	r.HandleFunc("/endpointschecks/configs/{nodeName}", getEndpointsCheckConfigs(sc)).Methods("GET")
-	r.HandleFunc("/endpointschecks", getEndpointsChecksState(sc)).Methods("GET")
+	r.HandleFunc("/endpointschecks/configs", getAllEndpointsCheckConfigs(sc)).Methods("GET")
 }
 
 // getEndpointsCheckConfigs is used by the node-agent's config provider
@@ -45,14 +45,14 @@ func getEndpointsCheckConfigs(sc clusteragent.ServerContext) func(w http.Respons
 	}
 }
 
-// getEndpointsChecksState is used by clusterchecks command to retrieve the endpointscheck configs
-func getEndpointsChecksState(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
+// getAllEndpointsCheckConfigs is used by clusterchecks command to retrieve the endpointscheck configs
+func getAllEndpointsCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
 	if sc.ClusterCheckHandler == nil {
 		return clusterChecksDisabledHandler
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		response, err := sc.ClusterCheckHandler.GetEndpointsChecksState()
+		response, err := sc.ClusterCheckHandler.GetAllEndpointsCheckConfigs()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			incrementRequestMetric("GetEndpointsChecksState", http.StatusInternalServerError)

--- a/cmd/cluster-agent/api/v1/endpointschecks.go
+++ b/cmd/cluster-agent/api/v1/endpointschecks.go
@@ -18,6 +18,7 @@ import (
 // Install registers v1 API endpoints for endpoints checks
 func installEndpointsCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
 	r.HandleFunc("/endpointschecks/configs/{nodeName}", getEndpointsCheckConfigs(sc)).Methods("GET")
+	r.HandleFunc("/endpointschecks", getEndpointsChecksState(sc)).Methods("GET")
 }
 
 // getEndpointsCheckConfigs is used by the node-agent's config provider
@@ -41,5 +42,23 @@ func getEndpointsCheckConfigs(sc clusteragent.ServerContext) func(w http.Respons
 		}
 
 		writeJSONResponse(w, response, "GetEndpointsConfigs")
+	}
+}
+
+// getEndpointsChecksState is used by clusterchecks command to retrieve the endpointscheck configs
+func getEndpointsChecksState(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
+	if sc.ClusterCheckHandler == nil {
+		return clusterChecksDisabledHandler
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		response, err := sc.ClusterCheckHandler.GetEndpointsChecksState()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			incrementRequestMetric("GetEndpointsChecksState", http.StatusInternalServerError)
+			return
+		}
+
+		writeJSONResponse(w, response, "GetEndpointsChecksState")
 	}
 }

--- a/cmd/cluster-agent/app/clusterchecks.go
+++ b/cmd/cluster-agent/app/clusterchecks.go
@@ -40,6 +40,10 @@ var clusterChecksCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		err = flare.GetEndpointsChecks(color.Output)
+		if err != nil {
+			return err
+		}
 		return nil
 	},
 }

--- a/cmd/cluster-agent/app/clusterchecks.go
+++ b/cmd/cluster-agent/app/clusterchecks.go
@@ -29,21 +29,19 @@ var clusterChecksCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// we'll search for a config file named `datadog-cluster.yaml`
 		config.Datadog.SetConfigName("datadog-cluster")
-		err := common.SetupConfig(confPath)
-		if err != nil {
-			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
-		}
 		if flagNoColor {
 			color.NoColor = true
 		}
-		err = flare.GetClusterChecks(color.Output)
-		if err != nil {
+
+		var err error
+		if err = common.SetupConfig(confPath); err != nil {
+			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
+		}
+
+		if err = flare.GetClusterChecks(color.Output); err != nil {
 			return err
 		}
-		err = flare.GetEndpointsChecks(color.Output)
-		if err != nil {
-			return err
-		}
-		return nil
+
+		return flare.GetEndpointsChecks(color.Output)
 	},
 }

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	Provider      string       `json:"provider"`       // the provider that issued the config
 	Entity        string       `json:"-"`              // the id of the entity (optional)
 	ClusterCheck  bool         `json:"cluster_check"`  // cluster-check configuration flag
-	NodeName      string       `json:"-"`              // Node name in case of an endpoint check backed by a pod
+	NodeName      string       `json:"node_name"`      // node name in case of an endpoint check backed by a pod
 	CreationTime  CreationTime `json:"-"`              // creation time of service
 }
 

--- a/pkg/autodiscovery/providers/kube_endpoints.go
+++ b/pkg/autodiscovery/providers/kube_endpoints.go
@@ -208,5 +208,5 @@ func getPodEntity(podUID string) string {
 }
 
 func init() {
-	RegisterProvider("kube_endpoints", NewKubeEndpointsConfigProvider)
+	RegisterProvider(KubeEndpointsProviderName, NewKubeEndpointsConfigProvider)
 }

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -25,7 +25,7 @@ const (
 	Zookeeper       = "zookeeper"
 )
 
-// Define the kube endpoints provider name
+// KubeEndpointsProviderName defines the kube endpoints provider name
 const KubeEndpointsProviderName = "kube_endpoints"
 
 // ProviderCatalog keeps track of config providers by name

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -25,6 +25,9 @@ const (
 	Zookeeper       = "zookeeper"
 )
 
+// Define the kube endpoints provider name
+const KubeEndpointsProviderName = "kube_endpoints"
+
 // ProviderCatalog keeps track of config providers by name
 var ProviderCatalog = make(map[string]ConfigProviderFactory)
 

--- a/pkg/clusteragent/clusterchecks/api.go
+++ b/pkg/clusteragent/clusterchecks/api.go
@@ -78,3 +78,13 @@ func (h *Handler) GetEndpointsConfigs(nodeName string) (types.ConfigResponse, er
 	}
 	return response, err
 }
+
+// GetEndpointsChecksState returns all pod-backed dispatched endpointscheck configurations
+func (h *Handler) GetEndpointsChecksState() (types.ConfigResponse, error) {
+	configs, err := h.dispatcher.getEndpointsChecksState()
+	response := types.ConfigResponse{
+		Configs:    configs,
+		LastChange: 0,
+	}
+	return response, err
+}

--- a/pkg/clusteragent/clusterchecks/api.go
+++ b/pkg/clusteragent/clusterchecks/api.go
@@ -79,9 +79,9 @@ func (h *Handler) GetEndpointsConfigs(nodeName string) (types.ConfigResponse, er
 	return response, err
 }
 
-// GetEndpointsChecksState returns all pod-backed dispatched endpointscheck configurations
-func (h *Handler) GetEndpointsChecksState() (types.ConfigResponse, error) {
-	configs, err := h.dispatcher.getEndpointsChecksState()
+// GetAllEndpointsCheckConfigs returns all pod-backed dispatched endpointscheck configurations
+func (h *Handler) GetAllEndpointsCheckConfigs() (types.ConfigResponse, error) {
+	configs, err := h.dispatcher.getAllEndpointsCheckConfigs()
 	response := types.ConfigResponse{
 		Configs:    configs,
 		LastChange: 0,

--- a/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
@@ -23,6 +23,19 @@ func (d *dispatcher) getEndpointsConfigs(nodeName string) ([]integration.Config,
 	return nodeConfigs, nil
 }
 
+// getEndpointsChecksState provides all config templates of endpoints checks
+func (d *dispatcher) getEndpointsChecksState() ([]integration.Config, error) {
+	configs := []integration.Config{}
+	d.store.RLock()
+	for _, configMap := range d.store.endpointsConfigs {
+		for _, config := range configMap {
+			configs = append(configs, config)
+		}
+	}
+	d.store.RUnlock()
+	return configs, nil
+}
+
 // addEndpointConfig stores a given endpoint configuration by node name
 func (d *dispatcher) addEndpointConfig(config integration.Config, nodename string) {
 	d.store.Lock()
@@ -51,6 +64,7 @@ func (d *dispatcher) patchEndpointsConfiguration(in integration.Config) (integra
 	// Deep copy the instances to avoid modifying the original
 	out.Instances = make([]integration.Data, len(in.Instances))
 	copy(out.Instances, in.Instances)
+	out.NodeName = in.NodeName
 
 	for i := range out.Instances {
 		// Inject extra tags if not empty

--- a/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
@@ -23,16 +23,16 @@ func (d *dispatcher) getEndpointsConfigs(nodeName string) ([]integration.Config,
 	return nodeConfigs, nil
 }
 
-// getEndpointsChecksState provides all config templates of endpoints checks
-func (d *dispatcher) getEndpointsChecksState() ([]integration.Config, error) {
+// getAllEndpointsCheckConfigs provides all config templates of endpoints checks
+func (d *dispatcher) getAllEndpointsCheckConfigs() ([]integration.Config, error) {
 	configs := []integration.Config{}
 	d.store.RLock()
+	defer d.store.RUnlock()
 	for _, configMap := range d.store.endpointsConfigs {
 		for _, config := range configMap {
 			configs = append(configs, config)
 		}
 	}
-	d.store.RUnlock()
 	return configs, nil
 }
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -510,3 +510,23 @@ func TestExtraTags(t *testing.T) {
 		})
 	}
 }
+
+func TestGetEndpointsChecksState(t *testing.T) {
+	dispatcher := newDispatcher()
+
+	// Register configs to different nodes
+	dispatcher.addEndpointConfig(generateEndpointsIntegration("endpoints-check1", "node1"), "node1")
+	dispatcher.addEndpointConfig(generateEndpointsIntegration("endpoints-check2", "node1"), "node1")
+	dispatcher.addEndpointConfig(generateEndpointsIntegration("endpoints-check3", "node2"), "node2")
+
+	// Get state
+	configs, err := dispatcher.getEndpointsChecksState()
+
+	assert.NoError(t, err)
+	assert.Len(t, configs, 3)
+	assert.Contains(t, configs, generateEndpointsIntegration("endpoints-check1", "node1"))
+	assert.Contains(t, configs, generateEndpointsIntegration("endpoints-check2", "node1"))
+	assert.Contains(t, configs, generateEndpointsIntegration("endpoints-check3", "node2"))
+
+	requireNotLocked(t, dispatcher.store)
+}

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -511,7 +511,7 @@ func TestExtraTags(t *testing.T) {
 	}
 }
 
-func TestGetEndpointsChecksState(t *testing.T) {
+func TestGetAllEndpointsCheckConfigs(t *testing.T) {
 	dispatcher := newDispatcher()
 
 	// Register configs to different nodes
@@ -520,7 +520,7 @@ func TestGetEndpointsChecksState(t *testing.T) {
 	dispatcher.addEndpointConfig(generateEndpointsIntegration("endpoints-check3", "node2"), "node2")
 
 	// Get state
-	configs, err := dispatcher.getEndpointsChecksState()
+	configs, err := dispatcher.getAllEndpointsCheckConfigs()
 
 	assert.NoError(t, err)
 	assert.Len(t, configs, 3)

--- a/pkg/flare/cluster_checks.go
+++ b/pkg/flare/cluster_checks.go
@@ -15,11 +15,10 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
-
-const kubeEndpointsProviderName string = "kube_endpoints"
 
 // GetClusterChecks dumps the clustercheck dispatching state to the writer
 func GetClusterChecks(w io.Writer) error {
@@ -155,7 +154,7 @@ func GetEndpointsChecks(w io.Writer) error {
 
 func endpointschecksEnabled() bool {
 	for _, provider := range config.Datadog.GetStringSlice("extra_config_providers") {
-		if provider == kubeEndpointsProviderName {
+		if provider == providers.KubeEndpointsProviderName {
 			return true
 		}
 	}

--- a/pkg/flare/cluster_checks.go
+++ b/pkg/flare/cluster_checks.go
@@ -19,6 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+const kubeEndpointsProviderName string = "kube_endpoints"
+
 // GetClusterChecks dumps the clustercheck dispatching state to the writer
 func GetClusterChecks(w io.Writer) error {
 	urlstr := fmt.Sprintf("https://localhost:%v/api/v1/clusterchecks", config.Datadog.GetInt("cluster_agent.cmd_port"))
@@ -109,43 +111,43 @@ func GetClusterChecks(w io.Writer) error {
 
 // GetEndpointsChecks dumps the endpointschecks dispatching state to the writer
 func GetEndpointsChecks(w io.Writer) error {
-	if endpointschecksEnabled() {
-		urlstr := fmt.Sprintf("https://localhost:%v/api/v1/endpointschecks", config.Datadog.GetInt("cluster_agent.cmd_port"))
+	if !endpointschecksEnabled() {
+		return nil
+	}
 
-		if w != color.Output {
-			color.NoColor = true
+	urlstr := fmt.Sprintf("https://localhost:%v/api/v1/endpointschecks/configs", config.Datadog.GetInt("cluster_agent.cmd_port"))
+
+	if w != color.Output {
+		color.NoColor = true
+	}
+
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+
+	// Set session token
+	if err := util.SetAuthToken(); err != nil {
+		return err
+	}
+
+	// Query the cluster agent API
+	r, err := util.DoGet(c, urlstr)
+	if err != nil {
+		if r != nil && string(r) != "" {
+			fmt.Fprintln(w, fmt.Sprintf("The agent ran into an error while checking config: %s", string(r)))
+		} else {
+			fmt.Fprintln(w, fmt.Sprintf("Failed to query the agent (running?): %s", err))
 		}
+		return err
+	}
 
-		c := util.GetClient(false) // FIX: get certificates right then make this true
+	var cr types.ConfigResponse
+	if err = json.Unmarshal(r, &cr); err != nil {
+		return err
+	}
 
-		// Set session token
-		err := util.SetAuthToken()
-		if err != nil {
-			return err
-		}
-
-		// Query the cluster agent API
-		r, err := util.DoGet(c, urlstr)
-		if err != nil {
-			if r != nil && string(r) != "" {
-				fmt.Fprintln(w, fmt.Sprintf("The agent ran into an error while checking config: %s", string(r)))
-			} else {
-				fmt.Fprintln(w, fmt.Sprintf("Failed to query the agent (running?): %s", err))
-			}
-			return err
-		}
-
-		var cr types.ConfigResponse
-		err = json.Unmarshal(r, &cr)
-		if err != nil {
-			return err
-		}
-
-		// Print summary of pod-backed endpointschecks
-		fmt.Fprintln(w, fmt.Sprintf("\n===== %d Pod-backed Endpoints-Checks scheduled =====", len(cr.Configs)))
-		for _, c := range cr.Configs {
-			PrintConfig(w, c)
-		}
+	// Print summary of pod-backed endpointschecks
+	fmt.Fprintln(w, fmt.Sprintf("\n===== %d Pod-backed Endpoints-Checks scheduled =====", len(cr.Configs)))
+	for _, c := range cr.Configs {
+		PrintConfig(w, c)
 	}
 
 	return nil
@@ -153,7 +155,7 @@ func GetEndpointsChecks(w io.Writer) error {
 
 func endpointschecksEnabled() bool {
 	for _, provider := range config.Datadog.GetStringSlice("extra_config_providers") {
-		if provider == "kube_endpoints" {
+		if provider == kubeEndpointsProviderName {
 			return true
 		}
 	}

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -132,5 +132,9 @@ func PrintConfig(w io.Writer, c integration.Config) {
 			fmt.Fprintln(w, fmt.Sprintf("* %s", color.CyanString(id)))
 		}
 	}
+	if c.NodeName != "" {
+		state := fmt.Sprintf("dispatched to %s", c.NodeName)
+		fmt.Fprintln(w, fmt.Sprintf("%s: %s", color.BlueString("State"), color.CyanString(state)))
+	}
 	fmt.Fprintln(w, "===")
 }


### PR DESCRIPTION
### What does this PR do?

- The DCA now exposes its scheduled endpointscheck config on `/api/v1/endpointschecks/configs`
- Make the `agent clusterchecks` command show the scheduled endpoint check configs

### Motivation

debugging endpoint checks

### Additional Notes

Example output
```
# agent clusterchecks
=== 4 node-agents reporting ===

Name                                                              Running checks
default-pool-4658d5d4-f4c8.c.datadog-sandbox.internal   1
default-pool-4658d5d4-k2sn.c.datadog-sandbox.internal   1
default-pool-4658d5d4-p39c.c.datadog-sandbox.internal   0
default-pool-4658d5d4-qfnt.c.datadog-sandbox.internal   0

===== Checks on default-pool-4658d5d4-f4c8.c.datadog-sandbox.internal =====

=== http_check check ===
Source: kubernetes-services
Instance ID: http_check:My Nginx Service:7e63f5ef5b72bad6
empty_default_hostname: true
name: My Nginx Service
tags:
- kube_service:nginx
- kube_namespace:default
- cluster_name:XX
timeout: 1
url: http://10.3.255.214
~
Init Config:
{}
===

===== Checks on default-pool-4658d5d4-k2sn.c.datadog-sandbox.internal =====

=== kube_apiserver_metrics check ===
Source: kubernetes-endpoints
Instance ID: kube_apiserver_metrics:add9a66b3f38fab6
empty_default_hostname: true
prometheus_url: 3X.XXX.XX.X8/metrics
tags:
- kube_endpoint_ip:3X.XXX.XX.X8
- kube_service:kubernetes
- kube_namespace:default
- cluster_name:XX
~
Init Config:
{}
===

===== 3 Pod-backed Endpoints-Checks scheduled =====

=== nginx check ===
Source: kubernetes-endpoints
Instance ID: nginx:My Nginx Service Endpoints:c52cb393ff6f33cf
name: My Nginx Service Endpoints
nginx_status_url: http://10.0.0.3/nginx_status/
tags:
- kube_endpoint_ip:10.0.0.3
- kube_service:nginx
- kube_namespace:default
- cluster_name:XX
~
Init Config:
{}
Auto-discovery IDs:
* kube_endpoint://default/nginx/10.0.0.3
* kubernetes_pod://5400ac4e-9d14-11e9-8a1e-42010af001e2
State: dispatched to default-pool-4658d5d4-f4c8
===

=== nginx check ===
Source: kubernetes-endpoints
Instance ID: nginx:My Nginx Service Endpoints:77986b5e8068bdc1
name: My Nginx Service Endpoints
nginx_status_url: http://10.0.0.5/nginx_status/
tags:
- kube_endpoint_ip:10.0.0.5
- cluster_name:XX
- kube_service:nginx
- kube_namespace:default
~
Init Config:
{}
Auto-discovery IDs:
* kube_endpoint://default/nginx/10.0.0.5
* kubernetes_pod://540bec47-9d14-11e9-8a1e-42010af001e2
State: dispatched to default-pool-4658d5d4-f4c8
===

=== nginx check ===
Source: kubernetes-endpoints
Instance ID: nginx:My Nginx Service Endpoints:122c12f17e585817
name: My Nginx Service Endpoints
nginx_status_url: http://10.0.4.2/nginx_status/
tags:
- kube_service:nginx
- kube_namespace:default
- kube_endpoint_ip:10.0.4.2
- cluster_name:XX
~
Init Config:
{}
Auto-discovery IDs:
* kube_endpoint://default/nginx/10.0.4.2
* kubernetes_pod://a9421750-9d14-11e9-8a1e-42010af001e2
State: dispatched to default-pool-4658d5d4-k2sn
===
```
