### PR TITLE
[DCA] Fix kubernetes_apiserver default config file

### DIFF
--- a/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -1,4 +1,4 @@
-init_configs:
+init_config:
 instances:
   - ## Tagging
     ##


### PR DESCRIPTION
### What does this PR do?

~`init_configs`~ -> `init_config`

### Motivation

```
CLUSTER | WARN | (pkg/autodiscovery/providers/file.go:264 in GetIntegrationConfigFromFile) | reading config file /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default: yaml: unmarshal errors:
  line 1: field init_configs not found in type providers.configFormat
```

