### PR TITLE
[windows] quote the service binary name for the agent.

### DIFF
--- a/omnibus/resources/agent/msi/cal/strings.cpp
+++ b/omnibus/resources/agent/msi/cal/strings.cpp
@@ -152,7 +152,7 @@ void getOsStrings()
     confddir = programdataroot + confdsuffix;
     logdir = programdataroot + logsdirsuffix;
 
-    agent_exe = installdir + L"bin\\agent.exe";
+    agent_exe = L"\"" + installdir + L"bin\\agent.exe\"";
     process_exe = L"\"" + installdir + L"bin\\agent\\process-agent.exe\" --config=" + programdataroot + L"datadog.yaml" ;
     trace_exe   = L"\"" + installdir + L"bin\\agent\\trace-agent.exe\" --config=" + programdataroot + L"datadog.yaml" ;
 

--- a/releasenotes/notes/quotesvc-9c3f7b93dc2374aa.yaml
+++ b/releasenotes/notes/quotesvc-9c3f7b93dc2374aa.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    On Windows, quote the service name when registering service.  Mitigates
+    CVE-2014-5455. Note that vulnerability is strictly theoretical; since the
+    Agent is not running as admin, even a successful attack would not give 
+    admin rights as specified in the CVE.


### PR DESCRIPTION
Unquoted leaves a (small) security risk, since there's a space in the
path name.

### What does this PR do?

registers the service with a quoted path name

### Motivation

Customer reported question against CVE-2014-5455:

### Additional Notes

Note that vulnerability (for us) is strictly theoretical; since we're not running as admin,
even a successful attack would not give admin rights as specified in the CVE.  Cleaning up anyway.
