### PR TITLE
Adds code to be able to work around if the go runtime can't find the

### DIFF
--- a/pkg/api/security/platform_windows.go
+++ b/pkg/api/security/platform_windows.go
@@ -6,8 +6,10 @@
 package security
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os/user"
+	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	acl "github.com/hectane/go-acl"
@@ -32,15 +34,72 @@ func init() {
 	}
 }
 
+// lookupUsernameAndDomain obtains the username and domain for usid.
+func lookupUsernameAndDomain(usid *syscall.SID) (username, domain string, e error) {
+	username, domain, t, e := usid.LookupAccount("")
+	if e != nil {
+		return "", "", e
+	}
+	if t != syscall.SidTypeUser {
+		return "", "", fmt.Errorf("user: should be user account type, not %d", t)
+	}
+	return username, domain, nil
+}
+
 // writes auth token(s) to a file with the same permissions as datadog.yaml
 func saveAuthToken(token, tokenPath string) error {
 	// get the current user
+	var sidString string
 	currUser, err := user.Current()
 	if err != nil {
 		log.Warnf("Unable to get current user %v", err)
-		return err
+		log.Infof("Attempting to get current user information directly")
+		tok, e := syscall.OpenCurrentProcessToken()
+		if e != nil {
+			log.Warnf("Couldn't get process token %v", e)
+			return e
+		}
+		defer tok.Close()
+		user, e := tok.GetTokenUser()
+		if e != nil {
+			log.Warnf("Couldn't get  token user %v", e)
+			return e
+		}
+		sidString, e = user.User.Sid.String()
+		if e != nil {
+			log.Warnf("Couldn't get  user sid string %v", e)
+			return e
+		}
+
+		log.Infof("Got sidstring from token user")
+
+		// now just do some debugging, see what we weren't able to get.
+		pg, e := tok.GetTokenPrimaryGroup()
+		if e != nil {
+			log.Warnf("Would have failed getting token PG %v", e)
+		}
+		_, e = pg.PrimaryGroup.String()
+		if e != nil {
+			log.Warnf("Would have failed getting  PG  string %v", e)
+		}
+		dir, e := tok.GetUserProfileDirectory()
+		if e != nil {
+			log.Warnf("Would have failed getting  primary directory %v", e)
+		} else {
+			log.Infof("Profile directory is %v", dir)
+		}
+		username, domain, e := lookupUsernameAndDomain(user.User.Sid)
+		if e != nil {
+			log.Warnf("Would have failed getting username and domain %v", e)
+		} else {
+			log.Infof("Username/domain is %v %v", username, domain)
+		}
+
+	} else {
+		log.Infof("Getting sidstring from current user")
+		sidString = currUser.Uid
 	}
-	currUserSid, err := windows.StringToSid(currUser.Uid)
+	currUserSid, err := windows.StringToSid(sidString)
 	if err != nil {
 		log.Warnf("Unable to get current user sid %v", err)
 		return err

--- a/releasenotes/notes/noprofiledir-fc12ac2f9e1a6f29.yaml
+++ b/releasenotes/notes/noprofiledir-fc12ac2f9e1a6f29.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, fixes bug in which Agent can't start if the Go runtime can't
+    determine the ddagentuser's profile directory.  This information isn't
+    used, so shouldn't cause a failure


### PR DESCRIPTION
profiledirectory.  Agent doesn't need it, anyway.  All we require
is the users's SID.  Was needlessly preventing agent from starting.

Adds additional logging to detect this case in the future, even when
agent starts correctly


### Motivation

Customer bug report

### Additional Notes

Anything else we should know when reviewing?
