### PR TITLE
process-agent: Add default value for process_config.enabled

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -332,6 +332,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("apm_config.enabled", true)
 
 	// Process agent
+	config.SetDefault("process_config.enabled", "false")
 	config.BindEnv("process_config.process_dd_url", "")
 
 	// Logs Agent

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -157,12 +157,10 @@ func (a *AgentConfig) loadProcessYamlConfig(path string) error {
 		//   If "true" we will collect containers and processes.
 		//   If "disabled" the agent will be disabled altogether and won't start.
 		enabled := config.Datadog.GetString(k)
-		if ok, err := isAffirmative(enabled); ok {
+		if ok, _ := isAffirmative(enabled); ok {
 			a.Enabled, a.EnabledChecks = true, processChecks
 		} else if enabled == "disabled" {
 			a.Enabled = false
-		} else if !ok && err == nil {
-			a.Enabled, a.EnabledChecks = true, containerChecks
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Issue: on Windows the agent rewrites the configuration file [here](https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/common/common_windows.go#L294), which removes the processes section.

By adding a default value, this will ensure that there will always be:
```
process_config:
  enabled: "false"
```

after the rewrite.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
