### PR TITLE
Install VCRedist141 only when using python 3

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -436,7 +436,7 @@
       <ComponentRef Id="RTLOADERDLLS" />
       <ComponentRef Id="DATADOGAPMSERVICE" />
       <ComponentRef Id="DATADOGPROCESSSERVICE" />
-   <!--       <ComponentGroupRef Id="ExtraEXAMPLECONFSLOCATION" /> -->
+      <ComponentGroupRef Id="ExtraEXAMPLECONFSLOCATION" />
       <ComponentRef Id="CleanupMainApplicationFolder" />
       <ComponentRef Id="RegisterConfVariables" />
       <ComponentRef Id="MSVCRUNTIME" />

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -385,16 +385,16 @@
         </Component>
       </Directory>
     </DirectoryRef>
-	
-	<?if $(var.IncludePython3) = true ?>
-		<DirectoryRef Id="TARGETDIR">
-			<Merge Id="VCRedist141" SourceFile="$(var.BinFiles)/Microsoft_VC141_CRT_x64.msm" DiskId="1" Language="0"/>
-		</DirectoryRef>
-		
-		<Feature Id="VCRedist141" Title="Visual C++ 2015 Runtime" AllowAdvertise="no" Display="hidden" Level="1">
-			<MergeRef Id="VCRedist141"/>
-		</Feature>
-	<?endif ?>
+
+    <?if $(var.IncludePython3) = true ?>
+        <DirectoryRef Id="TARGETDIR">
+            <Merge Id="VCRedist141" SourceFile="$(var.BinFiles)/Microsoft_VC141_CRT_x64.msm" DiskId="1" Language="0"/>
+        </DirectoryRef>
+
+        <Feature Id="VCRedist141" Title="Visual C++ 2015 Runtime" AllowAdvertise="no" Display="hidden" Level="1">
+            <MergeRef Id="VCRedist141"/>
+        </Feature>
+    <?endif ?>
     <InstallExecuteSequence>
       <Custom Action='WixCloseApplications' Before='RemoveFiles'> </Custom>
 

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -385,12 +385,16 @@
         </Component>
       </Directory>
     </DirectoryRef>
-    <DirectoryRef Id="TARGETDIR">
-        <Merge Id="VCRedist141" SourceFile="$(var.BinFiles)/Microsoft_VC141_CRT_x64.msm" DiskId="1" Language="0"/>
-    </DirectoryRef>
-    <Feature Id="VCRedist141" Title="Visual C++ 2015 Runtime" AllowAdvertise="no" Display="hidden" Level="1">
-        <MergeRef Id="VCRedist141"/>
-    </Feature>
+	
+	<?if $(var.IncludePython3) = true ?>
+		<DirectoryRef Id="TARGETDIR">
+			<Merge Id="VCRedist141" SourceFile="$(var.BinFiles)/Microsoft_VC141_CRT_x64.msm" DiskId="1" Language="0"/>
+		</DirectoryRef>
+		
+		<Feature Id="VCRedist141" Title="Visual C++ 2015 Runtime" AllowAdvertise="no" Display="hidden" Level="1">
+			<MergeRef Id="VCRedist141"/>
+		</Feature>
+	<?endif ?>
     <InstallExecuteSequence>
       <Custom Action='WixCloseApplications' Before='RemoveFiles'> </Custom>
 
@@ -432,7 +436,7 @@
       <ComponentRef Id="RTLOADERDLLS" />
       <ComponentRef Id="DATADOGAPMSERVICE" />
       <ComponentRef Id="DATADOGPROCESSSERVICE" />
-      <ComponentGroupRef Id="ExtraEXAMPLECONFSLOCATION" />
+   <!--       <ComponentGroupRef Id="ExtraEXAMPLECONFSLOCATION" /> -->
       <ComponentRef Id="CleanupMainApplicationFolder" />
       <ComponentRef Id="RegisterConfVariables" />
       <ComponentRef Id="MSVCRUNTIME" />


### PR DESCRIPTION
### What does this PR do?

Install `VCRedist141` only when python 3 is enabled

### Motivation

Installer failed when python 3 is not enabled.

Note: I am testing locally the build but open the pr to check if gitlab check are ok.