### PR TITLE
pkg/trace/agent: simplify channels

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -561,7 +561,7 @@ func benchThroughput(file string) func(*testing.B) {
 		// start the agent without the trace and stats writers; we will be draining
 		// these channels ourselves in the benchmarks, plus we don't want the writers
 		// resource usage to show up in the results.
-		agnt.spansOut = make(chan *writer.SampledSpans)
+		agnt.Out = make(chan *writer.SampledSpans)
 		go agnt.Run()
 
 		// wait for receiver to start:
@@ -614,7 +614,7 @@ func benchThroughput(file string) func(*testing.B) {
 		loop:
 			for {
 				select {
-				case <-agnt.spansOut:
+				case <-agnt.Out:
 					got++
 					if got == count {
 						// processed everything!

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -144,7 +144,7 @@ func TestLegacyReceiver(t *testing.T) {
 
 			// now we should be able to read the trace data
 			select {
-			case rt := <-tc.r.Out:
+			case rt := <-tc.r.out:
 				assert.Len(rt.Spans, 1)
 				span := rt.Spans[0]
 				assert.Equal(uint64(42), span.TraceID)
@@ -207,7 +207,7 @@ func TestReceiverJSONDecoder(t *testing.T) {
 
 			// now we should be able to read the trace data
 			select {
-			case rt := <-tc.r.Out:
+			case rt := <-tc.r.out:
 				assert.Len(rt.Spans, 1)
 				span := rt.Spans[0]
 				assert.Equal(uint64(42), span.TraceID)
@@ -274,7 +274,7 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 
 				// now we should be able to read the trace data
 				select {
-				case rt := <-tc.r.Out:
+				case rt := <-tc.r.out:
 					assert.Len(rt.Spans, 1)
 					span := rt.Spans[0]
 					assert.Equal(uint64(42), span.TraceID)
@@ -296,7 +296,7 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 
 				// now we should be able to read the trace data
 				select {
-				case rt := <-tc.r.Out:
+				case rt := <-tc.r.out:
 					assert.Len(rt.Spans, 1)
 					span := rt.Spans[0]
 					assert.Equal(uint64(42), span.TraceID)
@@ -375,7 +375,7 @@ func TestHandleTraces(t *testing.T) {
 	for n := 0; n < 10; n++ {
 		// consume the traces channel without doing anything
 		select {
-		case <-receiver.Out:
+		case <-receiver.out:
 		default:
 		}
 
@@ -497,7 +497,7 @@ func BenchmarkHandleTracesFromOneApp(b *testing.B) {
 		b.StopTimer()
 		// consume the traces channel without doing anything
 		select {
-		case <-receiver.Out:
+		case <-receiver.out:
 		default:
 		}
 
@@ -537,7 +537,7 @@ func BenchmarkHandleTracesFromMultipleApps(b *testing.B) {
 		b.StopTimer()
 		// consume the traces channel without doing anything
 		select {
-		case <-receiver.Out:
+		case <-receiver.out:
 		default:
 		}
 
@@ -652,7 +652,7 @@ func TestWatchdog(t *testing.T) {
 		defer r.Stop()
 		go func() {
 			for {
-				<-r.Out
+				<-r.out
 			}
 		}()
 
@@ -734,7 +734,7 @@ func TestOOMKill(t *testing.T) {
 	defer r.Stop()
 	go func() {
 		for {
-			<-r.Out
+			<-r.out
 		}
 	}()
 


### PR DESCRIPTION
This change simplifies the way the channels are defined in the Agent
structure, by putting the responsibility of receiving from the receiver
channel into its maker. It makes more sense from an API standpoint where
a channel is passed to a constructor, rather than accessing that
structure's field directly (Receiver.Out).