### PR TITLE
cgo_free/rtloader free review

### DIFF
--- a/pkg/collector/python/test_check.go
+++ b/pkg/collector/python/test_check.go
@@ -75,7 +75,7 @@ void rtloader_free(rtloader_t *s, void *p) {
 int run_check_calls = 0;
 char *run_check_return = NULL;
 rtloader_pyobject_t *run_check_instance = NULL;
-const char *run_check(rtloader_t *s, rtloader_pyobject_t *check) {
+char *run_check(rtloader_t *s, rtloader_pyobject_t *check) {
 	run_check_instance = check;
 	run_check_calls++;
 	return run_check_return;

--- a/rtloader/common/builtins/datadog_agent.c
+++ b/rtloader/common/builtins/datadog_agent.c
@@ -105,7 +105,7 @@ PyObject *get_version(PyObject *self, PyObject *args)
         Py_RETURN_NONE;
     }
 
-    char *v;
+    char *v = NULL;
     cb_get_version(&v);
 
     if (v != NULL) {
@@ -360,7 +360,7 @@ static PyObject *set_external_tags(PyObject *self, PyObject *args)
     PyGILState_STATE gstate = PyGILState_Ensure();
 
     // function expects only one positional arg containing a list
-    // the reference count in the returned object (input list) is _not_ 
+    // the reference count in the returned object (input list) is _not_
     // incremented
     if (!PyArg_ParseTuple(args, "O", &input_list)) {
         PyGILState_Release(gstate);

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -167,16 +167,16 @@ DATADOG_AGENT_RTLOADER_API int get_check_deprecated(rtloader_t *rtloader, rtload
                                                     const char *check_name, const char *agent_config,
                                                     rtloader_pyobject_t **check);
 
-/*! \fn const char *run_check(rtloader_t *, rtloader_pyobject_t *check)
+/*! \fn char *run_check(rtloader_t *, rtloader_pyobject_t *check)
     \brief Runs a check instance.
     \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
     \param check A rtloader_pyobject_t * pointer to the check instance we wish to run.
-    \return A const C-string with the check summary.
+    \return A C-string with the check summary.
     \sa rtloader_pyobject_t, rtloader_t
 
     This function is deprecated in favor of `get_check()`.
 */
-DATADOG_AGENT_RTLOADER_API const char *run_check(rtloader_t *, rtloader_pyobject_t *check);
+DATADOG_AGENT_RTLOADER_API char *run_check(rtloader_t *, rtloader_pyobject_t *check);
 
 /*! \fn char **get_checks_warnings(rtloader_t *, rtloader_pyobject_t *check)
     \brief Get all warnings, if any, for a check instance.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -108,7 +108,7 @@ public:
       \param check The python object pointer to the check we wish to run.
       \return A C-string with the check result.
     */
-    virtual const char *runCheck(RtLoaderPyObject *check) = 0;
+    virtual char *runCheck(RtLoaderPyObject *check) = 0;
 
     //! Pure virtual getCheckWarnings member.
     /*!

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -282,7 +282,7 @@ int get_check_deprecated(rtloader_t *rtloader, rtloader_pyobject_t *py_class, co
         : 0;
 }
 
-const char *run_check(rtloader_t *rtloader, rtloader_pyobject_t *check)
+char *run_check(rtloader_t *rtloader, rtloader_pyobject_t *check)
 {
     return AS_TYPE(RtLoader, rtloader)->runCheck(AS_TYPE(RtLoaderPyObject, check));
 }

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -374,7 +374,7 @@ done:
     return true;
 }
 
-const char *Three::runCheck(RtLoaderPyObject *check)
+char *Three::runCheck(RtLoaderPyObject *check)
 {
     if (check == NULL) {
         return NULL;

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -66,7 +66,7 @@ public:
                   const char *check_id_str, const char *check_name, const char *agent_config_str,
                   RtLoaderPyObject *&check);
 
-    const char *runCheck(RtLoaderPyObject *check);
+    char *runCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);
     void decref(RtLoaderPyObject *obj);
     void incref(RtLoaderPyObject *obj);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -379,7 +379,7 @@ done:
     return true;
 }
 
-const char *Two::runCheck(RtLoaderPyObject *check)
+char *Two::runCheck(RtLoaderPyObject *check)
 {
     if (check == NULL) {
         return NULL;

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -65,7 +65,7 @@ public:
                   const char *check_id_str, const char *check_name, const char *agent_config_str,
                   RtLoaderPyObject *&check);
 
-    const char *runCheck(RtLoaderPyObject *check);
+    char *runCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);
     void decref(RtLoaderPyObject *obj);
     void incref(RtLoaderPyObject *obj);


### PR DESCRIPTION
### What does this PR do?

- Make sure all variable for the callbacks are initialized before using them
- `run_check` actually return a allocated char*: removing the `const` qualifier.