### PR TITLE
pkg/ebpf/encoding: Ensure fields are all encoded (even if zeroed) when encoding to JSON

### DIFF
--- a/pkg/ebpf/encoding/encoding.go
+++ b/pkg/ebpf/encoding/encoding.go
@@ -5,11 +5,16 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/process/model"
+	"github.com/gogo/protobuf/jsonpb"
 )
 
 var (
 	pSerializer = protoSerializer{}
-	jSerializer = jsonSerializer{}
+	jSerializer = jsonSerializer{
+		marshaller: jsonpb.Marshaler{
+			EmitDefaults: true,
+		},
+	}
 )
 
 // Marshaler is an interface implemented by all Connections serializers


### PR DESCRIPTION
### What does this PR do?

Previously connections zeroed fields would not appear in the JSON fields after encoding, so payloads looked like:

```
    {
      "pid": 2503,
      "laddr": {
        "ip": "127.0.0.1",
        "port": 7777
      },
      "raddr": {
        "ip": "127.0.0.1",
        "port": 43360
      },
      "totalBytesSent": "5664",
      "totalBytesReceived": "155",
      "lastBytesSent": "5664",
      "lastBytesReceived": "155",
      "direction": "local",
      "netNS": 4026531957
    },
```

(Notice the missing "lastRetransmits" field for instance)

With this change it should look like:

```
{
      "pid": 1928,
      "laddr": {
        "ip": "10.0.2.15",
        "port": 22,
        "containerId": "",
        "hostId": 0
      },
      "raddr": {
        "ip": "10.0.2.2",
        "port": 50901,
        "containerId": "",
        "hostId": 0
      },
      "family": "v4",
      "type": "tcp",
      "pidCreateTime": "0",
      "totalBytesSent": "728",
      "totalBytesReceived": "36",
      "totalRetransmits": 0,
      "lastBytesSent": "0",
      "lastBytesReceived": "0",
      "lastRetransmits": 0,
      "direction": "incoming",
      "netNS": 4026531957,
      "ipTranslation": null
    }
```

This will be more handy when hitting the debug endpoints / using the `check` sub-command of the system-probe

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
