### PR TITLE
Homogenize agent commands code

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -62,7 +62,7 @@ func init() {
 	checkCmd.Flags().BoolVarP(&checkRate, "check-rate", "r", false, "check rates by running the check twice with a 1sec-pause between the 2 runs")
 	checkCmd.Flags().IntVarP(&checkTimes, "check-times", "t", 1, "number of times to run the check")
 	checkCmd.Flags().IntVar(&checkPause, "pause", 0, "pause between multiple runs of the check, in milliseconds")
-	checkCmd.Flags().StringVarP(&logLevel, "log-level", "l", "", "set the log level (default 'off')")
+	checkCmd.Flags().StringVarP(&logLevel, "log-level", "l", "", "set the log level (default 'off') (deprecated, use the env var DD_LOG_LEVEL instead)")
 	checkCmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in milliseconds")
 	checkCmd.Flags().BoolVarP(&formatJSON, "json", "", false, "format aggregator and check runner output as json")
 	checkCmd.Flags().StringVarP(&breakPoint, "breakpoint", "b", "", "set a breakpoint at a particular line number (Python checks only)")
@@ -88,34 +88,25 @@ var checkCmd = &cobra.Command{
 	Short: "Run the specified check",
 	Long:  `Use this to run a specific check with a specific rate`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		overrides := make(map[string]interface{})
+
+		if logLevel != "" {
+			// Honour the deprecated --log-level argument
+			overrides := make(map[string]interface{})
+			overrides["log_level"] = logLevel
+			config.SetOverrides(overrides)
+		} else {
+			logLevel = config.GetEnv("DD_LOG_LEVEL", "off")
+		}
 
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		if logLevel != "" {
-			// Python calls config.Datadog.GetString("log_level")
-			overrides["log_level"] = logLevel
-		}
-
-		// Global Agent configuration
-		config.SetOverrides(overrides)
 		err := common.SetupConfig(confFilePath)
 		if err != nil {
-			fmt.Printf("Cannot setup config, exiting: %v\n", err)
-			return err
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
 
-		if logLevel == "" {
-			if confFilePath != "" {
-				logLevel = config.Datadog.GetString("log_level")
-			} else {
-				logLevel = "off"
-			}
-		}
-
-		// Setup logger
 		err = config.SetupLogger(loggerName, logLevel, "", "", false, true, false)
 		if err != nil {
 			fmt.Printf("Cannot setup logger, exiting: %v\n", err)

--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -29,16 +29,25 @@ var configCommand = &cobra.Command{
 	Short: "Print the runtime configuration of a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
 		err = util.SetAuthToken()
 		if err != nil {
 			return err
-		}
-		if flagNoColor {
-			color.NoColor = true
 		}
 
 		runtimeConfig, err := requestConfig()

--- a/cmd/agent/app/config_check.go
+++ b/cmd/agent/app/config_check.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 
 	"github.com/fatih/color"
@@ -28,13 +29,22 @@ var configCheckCommand = &cobra.Command{
 	Short: "Print all configurations loaded & resolved of a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		err := common.SetupConfig(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
-		if flagNoColor {
-			color.NoColor = true
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
 		}
+
 		err = flare.GetConfigCheck(color.Output, withDebug)
 		if err != nil {
 			return err

--- a/cmd/agent/app/dogstatsd_stats.go
+++ b/cmd/agent/app/dogstatsd_stats.go
@@ -38,13 +38,22 @@ var dogstatsdStatsCmd = &cobra.Command{
 	Short: "Print basic statistics on the metrics processed by dogstatsd",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
-		if flagNoColor {
-			color.NoColor = true
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
 		}
+
 		return requestDogstatsdStats()
 	},
 }

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -99,10 +99,6 @@ func requestFlare(caseID string) error {
 		}
 		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally."))
 		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFile)
-		// enable back color output
-		if flagNoColor {
-			color.NoColor = true
-		}
 		if e != nil {
 			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 			return e

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -37,13 +37,21 @@ var flareCmd = &cobra.Command{
 	Short: "Collect a flare and send it to Datadog",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := common.SetupConfig(confFilePath)
-		if err != nil {
-			return err
-		}
 
 		if flagNoColor {
 			color.NoColor = true
+		}
+
+		err := common.SetupConfig(confFilePath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+		}
+
+		// The flare command should not log anything, all errors should be reported directly to the console without the log format
+		err = config.SetupLogger(loggerName, "off", "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
 		}
 
 		caseID := ""
@@ -51,8 +59,6 @@ var flareCmd = &cobra.Command{
 			caseID = args[0]
 		}
 
-		// The flare command should not log anything, all errors should be reported directly to the console without the log format
-		config.SetupLogger(loggerName, "off", "", "", false, true, false)
 		if customerEmail == "" {
 			var err error
 			customerEmail, err = input.AskForEmail()

--- a/cmd/agent/app/health.go
+++ b/cmd/agent/app/health.go
@@ -31,18 +31,27 @@ var healthCmd = &cobra.Command{
 	Long:         ``,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
 		return requestHealth()
 	},
 }
 
 func requestHealth() error {
-	if flagNoColor {
-		color.NoColor = true
-	}
 
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 	urlstr := fmt.Sprintf("https://localhost:%v/agent/status/health", config.Datadog.GetInt("cmd_port"))

--- a/cmd/agent/app/hostname.go
+++ b/cmd/agent/app/hostname.go
@@ -27,11 +27,18 @@ var getHostnameCommand = &cobra.Command{
 
 // query for the version
 func doGetHostname(cmd *cobra.Command, args []string) error {
-	config.SetupLogger(loggerName, "off", "", "", false, true, false)
+
 	err := common.SetupConfigWithoutSecrets(confFilePath)
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
+
+	err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+	if err != nil {
+		fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+		return err
+	}
+
 	hname, err := util.GetHostname()
 	if err != nil {
 		return fmt.Errorf("Error getting the hostname: %v", err)

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -82,7 +82,7 @@ var (
 )
 
 func init() {
-	jmxCmd.PersistentFlags().StringVarP(&jmxLogLevel, "log-level", "l", "debug", "set the log level")
+	jmxCmd.PersistentFlags().StringVarP(&jmxLogLevel, "log-level", "l", "debug", "set the log level for jmxfetch")
 
 	// attach list and collect commands to jmx command
 	jmxCmd.AddCommand(jmxListCmd)
@@ -122,16 +122,21 @@ func doJmxListNotCollected(cmd *cobra.Command, args []string) error {
 	return runJmxCommand("list_not_matching_attributes")
 }
 
-func setupAgent() error {
+func runJmxCommand(command string) error {
+
 	overrides := make(map[string]interface{})
-
-	// let the os assign an available port
-	overrides["cmd_port"] = 0
-
+	overrides["cmd_port"] = 0 // let the os assign an available port
 	config.SetOverrides(overrides)
+
 	err := common.SetupConfig(confFilePath)
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
+
+	err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+	if err != nil {
+		fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+		return err
 	}
 
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
@@ -139,21 +144,6 @@ func setupAgent() error {
 	// start the cmd HTTP server
 	if err := api.StartServer(); err != nil {
 		return fmt.Errorf("Error while starting api server, exiting: %v", err)
-	}
-
-	return nil
-}
-
-func runJmxCommand(command string) error {
-	err := config.SetupLogger(loggerName, jmxLogLevel, "", "", false, true, false)
-	if err != nil {
-		fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-		return err
-	}
-
-	err = setupAgent()
-	if err != nil {
-		return err
 	}
 
 	runner := &jmxfetch.JMXFetch{}

--- a/cmd/agent/app/listchecks.go
+++ b/cmd/agent/app/listchecks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -24,10 +25,22 @@ var listCheckCommand = &cobra.Command{
 	Short: "Query the agent for the list of checks running",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
 		return doListChecks()
 	},
 }

--- a/cmd/agent/app/reloadcheck.go
+++ b/cmd/agent/app/reloadcheck.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -27,6 +28,22 @@ var reloadCheckCommand = &cobra.Command{
 	Short: "Reload a running check",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
+		err := common.SetupConfigWithoutSecrets(confFilePath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
 		var checkName string
 		if len(args) != 0 {
 			checkName = args[0]
@@ -34,10 +51,6 @@ var reloadCheckCommand = &cobra.Command{
 			return fmt.Errorf("missing arguments")
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath)
-		if err != nil {
-			return fmt.Errorf("unable to set up global agent configuration: %v", err)
-		}
 		return doReloadCheck(checkName)
 	},
 }

--- a/cmd/agent/app/secret.go
+++ b/cmd/agent/app/secret.go
@@ -28,18 +28,26 @@ var secretInfoCommand = &cobra.Command{
 	Short: "Print information about decrypted secrets in configuration.",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := common.SetupConfigWithoutSecrets(confFilePath); err != nil {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
+		err := common.SetupConfigWithoutSecrets(confFilePath)
+		if err != nil {
 			fmt.Printf("unable to set up global agent configuration: %v", err)
 			return nil
+		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
 		}
 
 		if err := util.SetAuthToken(); err != nil {
 			fmt.Printf("%s", err)
 			return nil
-		}
-
-		if flagNoColor {
-			color.NoColor = true
 		}
 
 		if err := showSecretInfo(); err != nil {

--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -38,13 +38,22 @@ var statusCmd = &cobra.Command{
 	Short: "Print the current status",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
-		if flagNoColor {
-			color.NoColor = true
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
 		}
+
 		return requestStatus()
 	},
 }

--- a/cmd/agent/app/tagger_list.go
+++ b/cmd/agent/app/tagger_list.go
@@ -30,13 +30,22 @@ var taggerListCommand = &cobra.Command{
 	Short: "Print the tagger content of a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
-		if flagNoColor {
-			color.NoColor = true
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
 		}
+
 		c := util.GetClient(false) // FIX: get certificates right then make this true
 
 		// Set session token

--- a/cmd/cluster-agent/app/clusterchecks.go
+++ b/cmd/cluster-agent/app/clusterchecks.go
@@ -27,15 +27,22 @@ var clusterChecksCmd = &cobra.Command{
 	Use:   "clusterchecks",
 	Short: "Prints the active cluster check configurations",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// we'll search for a config file named `datadog-cluster.yaml`
-		config.Datadog.SetConfigName("datadog-cluster")
+
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		var err error
-		if err = common.SetupConfig(confPath); err != nil {
+		// we'll search for a config file named `datadog-cluster.yaml`
+		config.Datadog.SetConfigName("datadog-cluster")
+		err := common.SetupConfig(confPath)
+		if err != nil {
 			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
+		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
 		}
 
 		if err = flare.GetClusterChecks(color.Output); err != nil {

--- a/cmd/cluster-agent/app/config.go
+++ b/cmd/cluster-agent/app/config.go
@@ -31,17 +31,27 @@ var configCommand = &cobra.Command{
 	Short: "Print the runtime configuration of a running cluster agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
+		// we'll search for a config file named `datadog-cluster.yaml`
 		config.Datadog.SetConfigName("datadog-cluster")
 		err := common.SetupConfig(confPath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
 		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
 		err = util.SetAuthToken()
 		if err != nil {
 			return err
-		}
-		if flagNoColor {
-			color.NoColor = true
 		}
 
 		runtimeConfig, err := requestConfig()

--- a/cmd/cluster-agent/app/config_check.go
+++ b/cmd/cluster-agent/app/config_check.go
@@ -31,14 +31,24 @@ var configCheckCommand = &cobra.Command{
 	Short: "Print all configurations loaded & resolved of a running cluster agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
+		// we'll search for a config file named `datadog-cluster.yaml`
 		config.Datadog.SetConfigName("datadog-cluster")
 		err := common.SetupConfig(confPath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
 		}
-		if flagNoColor {
-			color.NoColor = true
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
 		}
+
 		err = flare.GetClusterAgentConfigCheck(color.Output, withDebug)
 		if err != nil {
 			return err

--- a/cmd/cluster-agent/app/flare.go
+++ b/cmd/cluster-agent/app/flare.go
@@ -103,10 +103,6 @@ func requestFlare(caseID string) error {
 		}
 		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally, some logs will be mising."))
 		filePath, e = flare.CreateDCAArchive(true, common.GetDistPath(), logFile)
-		// enable back color output
-		if flagNoColor {
-			color.NoColor = true
-		}
 		if e != nil {
 			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 			return e

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -33,12 +34,24 @@ One can easily identify which pods are running on which nodes,
 as well as which services are serving the pods. Or the deployment name for the pod`,
 	Example: "datadog-cluster-agent metamap ip-10-0-115-123",
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		// we'll search for a config file named `datadog-cluster.yaml`
 		config.Datadog.SetConfigName("datadog-cluster")
 		err := common.SetupConfig(confPath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
 		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
 		nodeName := ""
 		if len(args) > 0 {
 			nodeName = args[0]

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -39,12 +40,24 @@ var statusCmd = &cobra.Command{
 	Short: "Print the current status",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		// we'll search for a config file named `datadog-cluster.yaml`
 		config.Datadog.SetConfigName("datadog-cluster")
 		err := common.SetupConfig(confPath)
 		if err != nil {
-			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
 		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
 		err = requestStatus()
 		if err != nil {
 			return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -812,6 +812,16 @@ func FileUsedDir() string {
 	return filepath.Dir(Datadog.ConfigFileUsed())
 }
 
+// GetEnv retrieves the value of the environment variable named by the key,
+// or def if the environment variable was not set.
+func GetEnv(key, def string) string {
+	value, found := os.LookupEnv(key)
+	if !found {
+		return def
+	}
+	return value
+}
+
 // IsKubernetes returns whether the Agent is running on a kubernetes cluster
 func IsKubernetes() bool {
 	// Injected by Kubernetes itself

--- a/releasenotes/notes/cmds_dd_log_level-567a4952908e3fab.yaml
+++ b/releasenotes/notes/cmds_dd_log_level-567a4952908e3fab.yaml
@@ -4,5 +4,5 @@ enhancements:
     Agent commands now honor the DD_LOG_LEVEL env variable if set.
 deprecations:
   - |
-    The `--log-level` argument in `agent check` command has been
-    deprecated in favor of the DD_LOG_LEVEL env variable.
+    The `--log-level` argument in `agent check` and `agent jmx` commands
+    has been deprecated in favor of the DD_LOG_LEVEL env variable.

--- a/releasenotes/notes/cmds_dd_log_level-567a4952908e3fab.yaml
+++ b/releasenotes/notes/cmds_dd_log_level-567a4952908e3fab.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Agent commands now honor the DD_LOG_LEVEL env variable if set.
+deprecations:
+  - |
+    The `--log-level` argument in `agent check` command has been
+    deprecated in favor of the DD_LOG_LEVEL env variable.


### PR DESCRIPTION
- Refactored cmds so they all initialize the logger and config the same way
- Make commands honor `DD_LOG_LEVEL` if set
- Updated cluster-agent's flare to include changes made to agent's flare
- Deprecated `--log-level` argument in `agent check` command