### PR TITLE
system-probe: Fix s6-service, the system-probe would not start when bundled with the other agents

### DIFF
--- a/Dockerfiles/agent/s6-services/sysprobe/finish
+++ b/Dockerfiles/agent/s6-services/sysprobe/finish
@@ -4,7 +4,7 @@
 
 
 # First check if the system-probe exists
-if { s6-test -x "$(command -v system-probe)" }
+if { s6-test -x "/opt/datadog-agent/embedded/bin/system-probe" }
 
 ifthenelse
     { s6-test ${1} -eq 0 }

--- a/Dockerfiles/agent/s6-services/sysprobe/run
+++ b/Dockerfiles/agent/s6-services/sysprobe/run
@@ -2,11 +2,12 @@
 
 # Check if the system-probe exists before running it
 ifthenelse
-    { s6-test -x "$(command -v system-probe)" }
+    { s6-test -x "/opt/datadog-agent/embedded/bin/system-probe" }
     {
         foreground { /initlog.sh "starting system-probe" }
         system-probe --config=/etc/datadog-agent/system-probe.yaml
     }
     {
-        foreground { /initlog.sh "system-probe not bundled, it will not start" }
+        foreground { /initlog.sh "system-probe not bundled, disabling" }
+        foreground { /bin/s6-svc -d /var/run/s6/services/sysprobe/ }
     }


### PR DESCRIPTION
### What does this PR do?

Since `command` is a shell builtin the s6-service for the system-probe was failing to find the binary and always going through the `/initlog.sh "system-probe not bundled, disabling"` path which did not disable the system-probe and just kept retrying.

This change should fix the two issues:
- Checking if the system-probe is bundled correctly by hardcoding the path to it (and not using `command`)
- If the system-probe is not found disable its service to avoid retrying to start it (hence log lines)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
