### PR TITLE
Handle 32bits overflow on 64bits system

### DIFF
--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -48,14 +48,21 @@ func roundFloat(val float64) float64 {
 	return math.Round(val*100) / 100
 }
 
-// Can't use values from math.MaxUint* because C size for longs changes on 32/64 bit machines
-const maxLong = int64(^uint(0) >> 1)
+// We can't use values from math.MaxUint* because C size for longs changes on 32/64 bit machines
+const maxULong = uint64(^uint(0)) // local max value for an uint (uint64 or uint32)
+const maxULong32 = math.MaxUint32
 
 // Compute the increment between two iostats values, taking into account they can overflow
-func incrementWithOverflow(currentValue, lastValue uint64, maxValue int64) int64 {
+func incrementWithOverflow(currentValue, lastValue uint64) int64 {
 	ret := int64(currentValue - lastValue)
 	if ret < 0 {
-		ret = ret + maxValue
+		// even on 64bit machines some values overflow at max32bit (like WeightedIO)
+		maxValue := maxULong
+		if lastValue <= maxULong32 {
+			maxValue = maxULong32
+		}
+		// +1 is for the overflow that pushed the value from its max to 0
+		ret = int64(currentValue + (maxValue - lastValue) + 1)
 	}
 	return ret
 }
@@ -112,40 +119,40 @@ func (c *IOCheck) nixIO() error {
 		}
 
 		// computing kB/s
-		rkbs := float64(incrementWithOverflow(ioStats.ReadBytes, lastIOStats.ReadBytes, maxLong)) / kB / deltaSecond
-		wkbs := float64(incrementWithOverflow(ioStats.WriteBytes, lastIOStats.WriteBytes, maxLong)) / kB / deltaSecond
-		avgqusz := float64(incrementWithOverflow(ioStats.WeightedIO, lastIOStats.WeightedIO, maxLong)) / kB / deltaSecond
+		rkbs := float64(incrementWithOverflow(ioStats.ReadBytes, lastIOStats.ReadBytes)) / kB / deltaSecond
+		wkbs := float64(incrementWithOverflow(ioStats.WriteBytes, lastIOStats.WriteBytes)) / kB / deltaSecond
+		avgqusz := float64(incrementWithOverflow(ioStats.WeightedIO, lastIOStats.WeightedIO)) / kB / deltaSecond
 
 		rAwait := 0.0
 		wAwait := 0.0
-		diffNRIO := float64(incrementWithOverflow(ioStats.ReadCount, lastIOStats.ReadCount, maxLong))
-		diffNWIO := float64(incrementWithOverflow(ioStats.WriteCount, lastIOStats.WriteCount, maxLong))
+		diffNRIO := float64(incrementWithOverflow(ioStats.ReadCount, lastIOStats.ReadCount))
+		diffNWIO := float64(incrementWithOverflow(ioStats.WriteCount, lastIOStats.WriteCount))
 		if diffNRIO != 0 {
 			//Note we use math.MaxUint32 because this value is always 32-bit, even on 64 bit machines
-			rAwait = float64(incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime, math.MaxUint32)) / diffNRIO
+			rAwait = float64(incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime)) / diffNRIO
 		}
 		if diffNWIO != 0 {
 			//Note we use math.MaxUint32 because this value is always 32-bit, even on 64 bit machines
-			wAwait = float64(incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime, math.MaxUint32)) / diffNWIO
+			wAwait = float64(incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime)) / diffNWIO
 		}
 
 		avgrqsz := 0.0
 		aWait := 0.0
 		diffNIO := diffNRIO + diffNWIO
 		if diffNIO != 0 {
-			avgrqsz = float64((incrementWithOverflow(ioStats.ReadBytes, lastIOStats.ReadBytes, maxLong)+
-				incrementWithOverflow(ioStats.WriteBytes, lastIOStats.WriteBytes, maxLong))/SectorSize) / diffNIO
+			avgrqsz = float64((incrementWithOverflow(ioStats.ReadBytes, lastIOStats.ReadBytes)+
+				incrementWithOverflow(ioStats.WriteBytes, lastIOStats.WriteBytes))/SectorSize) / diffNIO
 			//Note we use math.MaxUint32 because these values are always 32-bit, even on 64 bit machines
 			aWait = float64(
-				incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime, math.MaxUint32)+
-					incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime, math.MaxUint32)) / diffNIO
+				incrementWithOverflow(ioStats.ReadTime, lastIOStats.ReadTime)+
+					incrementWithOverflow(ioStats.WriteTime, lastIOStats.WriteTime)) / diffNIO
 		}
 
 		// we are aligning ourselves with the metric reported by
 		// sysstat, so itv is a time interval in 1/100th of a second
 		itv := delta / 10
 		tput := diffNIO * 100 / itv
-		util := float64(incrementWithOverflow(ioStats.IoTime, lastIOStats.IoTime, maxLong)) / itv * 100
+		util := float64(incrementWithOverflow(ioStats.IoTime, lastIOStats.IoTime)) / itv * 100
 		svctime := 0.0
 		if tput != 0 {
 			svctime = util / tput

--- a/pkg/collector/corechecks/system/iostats_nix_test.go
+++ b/pkg/collector/corechecks/system/iostats_nix_test.go
@@ -19,16 +19,16 @@ import (
 
 var currentStats = map[string]disk.IOCountersStat{
 	"sda": {
-		ReadCount:        42,
-		MergedReadCount:  42,
-		WriteCount:       42,
-		MergedWriteCount: 42,
+		ReadCount:        41,
+		MergedReadCount:  41,
+		WriteCount:       41,
+		MergedWriteCount: 41,
 		ReadBytes:        42 * kB,
 		WriteBytes:       42 * kB,
-		ReadTime:         42,
-		WriteTime:        42,
+		ReadTime:         41,
+		WriteTime:        41,
 		IopsInProgress:   0,
-		IoTime:           42,
+		IoTime:           41,
 		WeightedIO:       42 * kB,
 		Name:             "sda",
 		SerialNumber:     "123456789WD",
@@ -37,38 +37,47 @@ var currentStats = map[string]disk.IOCountersStat{
 
 var lastStats = map[string]disk.IOCountersStat{
 	"sda": {
-		ReadCount:        uint64(maxLong),
-		MergedReadCount:  uint64(maxLong),
-		WriteCount:       uint64(maxLong),
-		MergedWriteCount: uint64(maxLong),
-		ReadBytes:        uint64(maxLong),
-		WriteBytes:       uint64(maxLong),
+		ReadCount:        uint64(maxULong),
+		MergedReadCount:  uint64(maxULong),
+		WriteCount:       uint64(maxULong),
+		MergedWriteCount: uint64(maxULong),
+		ReadBytes:        uint64(maxULong),
+		WriteBytes:       uint64(maxULong),
 		ReadTime:         uint64(math.MaxUint32),
 		WriteTime:        uint64(math.MaxUint32),
 		IopsInProgress:   0,
-		IoTime:           uint64(maxLong),
-		WeightedIO:       uint64(maxLong),
+		IoTime:           uint64(maxULong),
+		WeightedIO:       uint64(math.MaxUint32),
 		Name:             "sda",
 		SerialNumber:     "123456789WD",
 	},
 }
 
-func TestWithRealValues(t *testing.T) {
-	increment := incrementWithOverflow(6176672, 4292830204, math.MaxUint32)
-	assert.Equal(t, int64(8313763), increment)
+func TestOverflow32(t *testing.T) {
+	increment := incrementWithOverflow(0, math.MaxUint32)
+	assert.Equal(t, int64(1), increment)
+}
+
+func TestOverflow64(t *testing.T) {
+	increment := incrementWithOverflow(0, math.MaxUint64)
+	assert.Equal(t, int64(1), increment)
+}
+
+func TestWithRealValues32(t *testing.T) {
+	increment := incrementWithOverflow(123456, math.MaxUint32-2)
+	assert.Equal(t, int64(123459), increment)
+}
+
+func TestWithRealValues64(t *testing.T) {
+	increment := incrementWithOverflow(123456, math.MaxUint64-2)
+	assert.Equal(t, int64(123459), increment)
 }
 
 func TestIncrementWithOverflow(t *testing.T) {
-	prev := uint64(maxLong) - 2
-	for i := -1; i < 2; i++ {
-		curr := uint64(maxLong) + uint64(i)
-		if curr >= uint64(maxLong) {
-			curr -= uint64(maxLong)
-		}
-		increment := incrementWithOverflow(curr, prev, maxLong)
-		assert.Equal(t, int64(1), increment)
-		prev = curr
-	}
+	assert.Equal(t, int64(1), incrementWithOverflow(maxULong-1, maxULong-2))
+	assert.Equal(t, int64(1), incrementWithOverflow(maxULong, maxULong-1))
+	assert.Equal(t, int64(1), incrementWithOverflow(0, maxULong))
+	assert.Equal(t, int64(1), incrementWithOverflow(1, 0))
 }
 
 func TestIoStatsOverflow(t *testing.T) {
@@ -83,10 +92,10 @@ func TestIoStatsOverflow(t *testing.T) {
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
-	mock.On("Rate", "system.io.r_s", 42.0, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Rate", "system.io.w_s", 42.0, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Rate", "system.io.rrqm_s", 42.0, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Rate", "system.io.wrqm_s", 42.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Rate", "system.io.r_s", 41.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Rate", "system.io.w_s", 41.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Rate", "system.io.rrqm_s", 41.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Rate", "system.io.wrqm_s", 41.0, "", []string{"device:sda"}).Return().Times(1)
 	mock.On("Gauge", "system.io.rkb_s", 42.0, "", []string{"device:sda"}).Return().Times(1)
 	mock.On("Gauge", "system.io.wkb_s", 42.0, "", []string{"device:sda"}).Return().Times(1)
 	mock.On("Gauge", "system.io.avg_rq_sz", 2.0, "", []string{"device:sda"}).Return().Times(1)

--- a/releasenotes/notes/fix-iostat-spikes-e40d0e4208582662.yaml
+++ b/releasenotes/notes/fix-iostat-spikes-e40d0e4208582662.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix spikes for `system.io.avg_q_sz` metrics on Linux when the kernel counter
+    was wrapping back to 0.
+  - |
+    Fix system.io.* metrics on Linux that were off by 1 when the kernel counters
+    were wrapping back to 0.


### PR DESCRIPTION
### What does this PR do?

Some value in /proc/diskstats overflow at maxUInt32 even when running on
a 64bit system.

We now detect if the value overflowed at the maxUInt32 mark or
maxUInt64. This fixes spikes in metrics when the values wrap back to 0.
