### PR TITLE
Fix entity in service removal

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -610,9 +610,9 @@ func (ac *AutoConfig) processNewService(svc listeners.Service) {
 
 // processDelService takes a service, stops its associated checks, and updates the cache
 func (ac *AutoConfig) processDelService(svc listeners.Service) {
-	ac.store.removeServiceForEntity(svc.GetTaggerEntity())
-	configs := ac.store.getConfigsForService(svc.GetTaggerEntity())
-	ac.store.removeConfigsForService(svc.GetTaggerEntity())
+	ac.store.removeServiceForEntity(svc.GetEntity())
+	configs := ac.store.getConfigsForService(svc.GetEntity())
+	ac.store.removeConfigsForService(svc.GetEntity())
 	ac.processRemovedConfigs(configs)
 	ac.store.removeTagsHashForService(svc.GetTaggerEntity())
 	// FIXME: unschedule remove services as well


### PR DESCRIPTION
### What does this PR do?

Fix a bug introduced in #3821 that is currently causing e2e tests to fail on master.

### Motivation

Fix unscheduling for AD checks.

### Additional Notes

e2e are green ✅ 
