### PR TITLE
[Fix] Make container_id as a prefix for kuberenetes containers entities

### DIFF
--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -186,12 +186,24 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 	}
 	cfg.Type = config.FileType
 	cfg.Path = l.getPath(basePath, pod, container)
-	cfg.Identifier = container.ID
+	cfg.Identifier = getTaggerEntityID(container.ID)
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid kubernetes annotation: %v", err)
 	}
 
 	return config.NewLogSource(l.getSourceName(pod, container), cfg), nil
+}
+
+// getTaggerEntityID builds an entity ID from a kubernetes container ID
+// Transforms the <runtime>:// prefix into container_id://
+// Returns the original container ID if an error occurred
+func getTaggerEntityID(ctrID string) string {
+	taggerEntityID, err := kubelet.KubeContainerIDToTaggerEntityID(ctrID)
+	if err != nil {
+		log.Warnf("Could not get tagger entity ID: %v", err)
+		return ctrID
+	}
+	return taggerEntityID
 }
 
 // configPath refers to the configuration that can be passed over a pod annotation,

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -186,24 +186,18 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 	}
 	cfg.Type = config.FileType
 	cfg.Path = l.getPath(basePath, pod, container)
-	cfg.Identifier = getTaggerEntityID(container.ID)
+	taggerEntityID, err := kubelet.KubeContainerIDToTaggerEntityID(container.ID)
+	if err != nil {
+		log.Warnf("Could not get tagger entity ID: %v", err)
+		cfg.Identifier = container.ID
+	} else {
+		cfg.Identifier = taggerEntityID
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid kubernetes annotation: %v", err)
 	}
 
 	return config.NewLogSource(l.getSourceName(pod, container), cfg), nil
-}
-
-// getTaggerEntityID builds an entity ID from a kubernetes container ID
-// Transforms the <runtime>:// prefix into container_id://
-// Returns the original container ID if an error occurred
-func getTaggerEntityID(ctrID string) string {
-	taggerEntityID, err := kubelet.KubeContainerIDToTaggerEntityID(ctrID)
-	if err != nil {
-		log.Warnf("Could not get tagger entity ID: %v", err)
-		return ctrID
-	}
-	return taggerEntityID
 }
 
 // configPath refers to the configuration that can be passed over a pod annotation,

--- a/pkg/logs/input/kubernetes/launcher_test.go
+++ b/pkg/logs/input/kubernetes/launcher_test.go
@@ -142,6 +142,11 @@ func TestContainerCollectAll(t *testing.T) {
 		Image: "barImage",
 		ID:    "docker://barID",
 	}
+	containerBaz := kubelet.ContainerStatus{
+		Name:  "bazName",
+		Image: "bazImage",
+		ID:    "containerd://bazID",
+	}
 	podFoo := &kubelet.Pod{
 		Metadata: kubelet.PodMetadata{
 			Name:      "podName",
@@ -165,20 +170,34 @@ func TestContainerCollectAll(t *testing.T) {
 			Containers: []kubelet.ContainerStatus{containerFoo, containerBar},
 		},
 	}
+	podBaz := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{
+			Name:      "podName",
+			Namespace: "podNamespace",
+			UID:       "podUIDBaz",
+		},
+		Status: kubelet.Status{
+			Containers: []kubelet.ContainerStatus{containerBaz},
+		},
+	}
 
 	source, err := launcherCollectAll.getSource(podFoo, containerFoo)
 	assert.Nil(t, err)
-	assert.Equal(t, "docker://fooID", source.Config.Identifier)
+	assert.Equal(t, "container_id://fooID", source.Config.Identifier)
 	source, err = launcherCollectAll.getSource(podBar, containerBar)
 	assert.Nil(t, err)
-	assert.Equal(t, "docker://barID", source.Config.Identifier)
+	assert.Equal(t, "container_id://barID", source.Config.Identifier)
 
 	source, err = launcherCollectAllDisabled.getSource(podFoo, containerFoo)
 	assert.Nil(t, err)
-	assert.Equal(t, "docker://fooID", source.Config.Identifier)
+	assert.Equal(t, "container_id://fooID", source.Config.Identifier)
 	source, err = launcherCollectAllDisabled.getSource(podBar, containerBar)
 	assert.Equal(t, collectAllDisabledError, err)
 	assert.Nil(t, source)
+
+	source, err = launcherCollectAll.getSource(podBaz, containerBaz)
+	assert.Nil(t, err)
+	assert.Equal(t, "container_id://bazID", source.Config.Identifier)
 }
 
 func TestGetPath(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

After https://github.com/DataDog/datadog-agent/pull/3821 the tagger must be called with `container_id://` as a prefix instead of `<runtime>://`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
