### PR TITLE
system-probe: Make sure that we don't run the sysprobe if IsTracerSupportedByOS returns false

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -116,7 +116,7 @@ func main() {
 	}
 
 	sysprobe, err := CreateSystemProbe(cfg)
-	if err != nil && strings.HasPrefix(err.Error(), ErrTracerUnsupported.Error()) {
+	if err != nil && strings.HasPrefix(err.Error(), ErrSysprobeUnsupported.Error()) {
 		// If tracer is unsupported by this operating system, then exit gracefully
 		log.Infof("%s, exiting.", err)
 		gracefulExit()

--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -53,20 +53,24 @@ func linuxKernelVersionCode(major, minor, patch uint32) uint32 {
 }
 
 // IsTracerSupportedByOS returns whether or not the current kernel version supports tracer functionality
-func IsTracerSupportedByOS(exclusionList []string) (bool, error) {
+// along with some context on why it's not supported
+func IsTracerSupportedByOS(exclusionList []string) (bool, string) {
 	currentKernelCode, err := CurrentKernelVersion()
 	if err != nil {
-		return false, fmt.Errorf("could not get kernel version: %s", err)
+		return false, fmt.Sprintf("could not get kernel version: %s", err)
 	}
 
-	platform, _ := util.GetPlatform()
+	platform, err := util.GetPlatform()
+	if err != nil {
+		log.Warnf("error retrieving current platform: %s", err)
+	}
 	return verifyOSVersion(currentKernelCode, platform, exclusionList)
 }
 
-func verifyOSVersion(kernelCode uint32, platform string, exclusionList []string) (bool, error) {
+func verifyOSVersion(kernelCode uint32, platform string, exclusionList []string) (bool, string) {
 	for _, version := range exclusionList {
 		if code := stringToKernelCode(version); code == kernelCode {
-			return false, fmt.Errorf(
+			return false, fmt.Sprintf(
 				"current kernel version (%s) is in the exclusion list: %s (list: %+v)",
 				kernelCodeToString(kernelCode),
 				version,
@@ -78,26 +82,30 @@ func verifyOSVersion(kernelCode uint32, platform string, exclusionList []string)
 	// Hardcoded exclusion list
 	if platform == "" {
 		// If we can't retrieve the platform just return true to avoid blocking the tracer from running
-		return true, nil
+		return true, ""
 	}
 
 	if isUbuntu(platform) {
 		if kernelCode >= linuxKernelVersionCode(4, 4, 119) && kernelCode <= linuxKernelVersionCode(4, 4, 126) {
-			return false, fmt.Errorf("got ubuntu kernel %s with known bug on platform: %s, see: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCodeToString(kernelCode), platform)
+			return false, fmt.Sprintf("got ubuntu kernel %s with known bug on platform: %s, see: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCodeToString(kernelCode), platform)
 		}
 	}
 
-	supported, err := verifyKernelFuncs(path.Join(util.GetProcRoot(), "kallsyms"))
+	missing, err := verifyKernelFuncs(path.Join(util.GetProcRoot(), "kallsyms"))
 	if err != nil {
 		log.Warnf("error reading /proc/kallsyms file: %s (check your kernel version, current is: %s)", err, kernelCodeToString(kernelCode))
 		// If we can't read the /proc/kallsyms file let's just return true to avoid blocking the tracer from running
-		return true, nil
+		return true, ""
 	}
 
-	return supported, nil
+	if len(missing) == 0 {
+		return true, ""
+	}
+
+	return false, fmt.Sprintf("some required functions are missing: %s", strings.Join(missing, ", "))
 }
 
-func verifyKernelFuncs(path string) (bool, error) {
+func verifyKernelFuncs(path string) ([]string, error) {
 	// Will hold the found functions
 	found := make(map[string]bool, len(requiredKernelFuncs))
 	for _, f := range requiredKernelFuncs {
@@ -106,7 +114,7 @@ func verifyKernelFuncs(path string) (bool, error) {
 
 	f, err := os.Open(path)
 	if err != nil {
-		return true, errors.Wrapf(err, "error reading kallsyms file from: %s", path)
+		return nil, errors.Wrapf(err, "error reading kallsyms file from: %s", path)
 	}
 	defer f.Close()
 
@@ -125,12 +133,14 @@ func verifyKernelFuncs(path string) (bool, error) {
 		}
 	}
 
-	supported := true
-	for _, b := range found {
-		supported = supported && b
+	missing := []string{}
+	for probe, b := range found {
+		if !b {
+			missing = append(missing, probe)
+		}
 	}
 
-	return supported, nil
+	return missing, nil
 }
 
 // In lack of binary.NativeEndian ...

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -65,6 +65,6 @@ func TestVerifyKernelFuncs(t *testing.T) {
 	assert.NotEmpty(t, missing)
 	assert.Empty(t, err)
 
-	missing, err = verifyKernelFuncs("./testdata/kallsyms.d_o_n_o_t_e_x_i_s_t")
+	_, err = verifyKernelFuncs("./testdata/kallsyms.d_o_n_o_t_e_x_i_s_t")
 	assert.NotEmpty(t, err)
 }

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -21,7 +21,7 @@ func TestUbuntu44119NotSupported(t *testing.T) {
 	for i := uint32(119); i < 127; i++ {
 		ok, err := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "linux-4.4-with-ubuntu", nil)
 		assert.False(t, ok)
-		assert.Error(t, err)
+		assert.NotEmpty(t, err)
 	}
 }
 
@@ -29,43 +29,42 @@ func TestExcludedKernelVersion(t *testing.T) {
 	exclusionList := []string{"5.5.1", "6.3.2"}
 	ok, err := verifyOSVersion(linuxKernelVersionCode(4, 4, 121), "ubuntu", exclusionList)
 	assert.False(t, ok)
-	assert.Error(t, err)
+	assert.NotEmpty(t, err)
 
 	ok, err = verifyOSVersion(linuxKernelVersionCode(5, 5, 1), "debian", exclusionList)
 	assert.False(t, ok)
-	assert.Error(t, err)
+	assert.NotEmpty(t, err)
 
 	ok, err = verifyOSVersion(linuxKernelVersionCode(6, 3, 2), "debian", exclusionList)
 	assert.False(t, ok)
-	assert.Error(t, err)
+	assert.NotEmpty(t, err)
 
 	ok, err = verifyOSVersion(linuxKernelVersionCode(6, 3, 1), "debian", exclusionList)
 	assert.True(t, ok)
-	assert.Nil(t, err)
+	assert.Empty(t, err)
 
 	ok, err = verifyOSVersion(linuxKernelVersionCode(5, 5, 2), "debian", exclusionList)
 	assert.True(t, ok)
-	assert.Nil(t, err)
+	assert.Empty(t, err)
 
 	ok, err = verifyOSVersion(linuxKernelVersionCode(3, 10, 0), "Linux-3.10.0-957.5.1.el7.x86_64-x86_64-with-centos-7.6.1810-Core", exclusionList)
 	assert.True(t, ok)
-	assert.Nil(t, err)
+	assert.Empty(t, err)
 }
 
 func TestVerifyKernelFuncs(t *testing.T) {
-	ok, err := verifyKernelFuncs("./testdata/kallsyms.supported")
-	assert.True(t, ok)
-	assert.NoError(t, err)
+	missing, err := verifyKernelFuncs("./testdata/kallsyms.supported")
+	assert.Empty(t, missing)
+	assert.Empty(t, err)
 
-	ok, err = verifyKernelFuncs("./testdata/kallsyms.unsupported")
-	assert.False(t, ok)
-	assert.NoError(t, err)
+	missing, err = verifyKernelFuncs("./testdata/kallsyms.unsupported")
+	assert.NotEmpty(t, missing)
+	assert.Empty(t, err)
 
-	ok, err = verifyKernelFuncs("./testdata/kallsyms.empty")
-	assert.False(t, ok)
-	assert.NoError(t, err)
+	missing, err = verifyKernelFuncs("./testdata/kallsyms.empty")
+	assert.NotEmpty(t, missing)
+	assert.Empty(t, err)
 
-	ok, err = verifyKernelFuncs("./testdata/kallsyms.d_o_n_o_t_e_x_i_s_t")
-	assert.True(t, ok)
-	assert.Error(t, err)
+	missing, err = verifyKernelFuncs("./testdata/kallsyms.d_o_n_o_t_e_x_i_s_t")
+	assert.NotEmpty(t, err)
 }

--- a/pkg/ebpf/nettop/main.go
+++ b/pkg/ebpf/nettop/main.go
@@ -17,11 +17,8 @@ func main() {
 	}
 	fmt.Printf("-- Kernel: %d (%d.%d)--\n", kernelVersion, (kernelVersion>>16)&0xff, (kernelVersion>>8)&0xff)
 
-	if ok, err := ebpf.IsTracerSupportedByOS(nil); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	} else if !ok {
-		fmt.Fprintln(os.Stderr, "tracer is not supported by current OS")
+	if supported, msg := ebpf.IsTracerSupportedByOS(nil); !supported {
+		fmt.Fprintf(os.Stderr, "system-probe is not supported: %s\n", msg)
 		os.Exit(1)
 	}
 

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -32,8 +32,6 @@ type ConnectionsCheck struct {
 
 // Init initializes a ConnectionsCheck instance.
 func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemInfo) {
-	var err error
-
 	// We use the current process PID as the local tracer client ID
 	c.tracerClientID = fmt.Sprintf("%d", os.Getpid())
 	if cfg.EnableLocalSystemProbe {
@@ -41,9 +39,9 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		c.useLocalTracer = true
 
 		// Checking whether the current kernel version is supported by the tracer
-		if _, err = ebpf.IsTracerSupportedByOS(cfg.ExcludedBPFLinuxVersions); err != nil {
+		if supported, msg := ebpf.IsTracerSupportedByOS(cfg.ExcludedBPFLinuxVersions); !supported {
 			// err is always returned when false, so the above catches the !ok case as well
-			log.Warnf("system probe unsupported by OS: %s", err)
+			log.Warnf("system probe unsupported by OS: %s", msg)
 			return
 		}
 


### PR DESCRIPTION
### What does this PR do?

Previously we would fill in the `SystemProbe.supported` attribute but it was not used.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
