### PR TITLE
[system-probe] add better error messages for debugfs detection

### DIFF
--- a/cmd/system-probe/probe.go
+++ b/cmd/system-probe/probe.go
@@ -45,15 +45,8 @@ func CreateSystemProbe(cfg *config.AgentConfig) (*SystemProbe, error) {
 	}
 
 	// make sure debugfs is mounted
-	err = util.IsDebugfsMounted()
-	if err != nil {
-		if os.IsPermission(err) {
-			return nil, fmt.Errorf("%s: system-probe does not have permission to access debugfs", ErrTracerUnsupported)
-		} else if os.IsNotExist(err) {
-			return nil, fmt.Errorf("%s: debugfs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t debugfs none /sys/kernel/debug\" to mount debugfs", ErrTracerUnsupported)
-		} else {
-			return nil, fmt.Errorf("%s: an error occurred while accessing debugfs: %s", ErrTracerUnsupported, err)
-		}
+	if mounted, msg := util.IsDebugfsMounted(); !mounted {
+		return nil, fmt.Errorf("%s: %s", ErrTracerUnsupported, msg)
 	}
 
 	log.Infof("Creating tracer for: %s", filepath.Base(os.Args[0]))

--- a/cmd/system-probe/probe.go
+++ b/cmd/system-probe/probe.go
@@ -48,7 +48,7 @@ func CreateSystemProbe(cfg *config.AgentConfig) (*SystemProbe, error) {
 	err = util.IsDebugfsMounted()
 	if err != nil {
 		if os.IsPermission(err) {
-			return nil, fmt.Errorf("%s: system-probe does not have permission to access debugfs, please run system-probe with root permission", ErrTracerUnsupported)
+			return nil, fmt.Errorf("%s: system-probe does not have permission to access debugfs", ErrTracerUnsupported)
 		} else if os.IsNotExist(err) {
 			return nil, fmt.Errorf("%s: debugfs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t debugfs none /sys/kernel/debug\" to mount debugfs", ErrTracerUnsupported)
 		} else {

--- a/cmd/system-probe/probe.go
+++ b/cmd/system-probe/probe.go
@@ -45,9 +45,15 @@ func CreateSystemProbe(cfg *config.AgentConfig) (*SystemProbe, error) {
 	}
 
 	// make sure debugfs is mounted
-	mounted := util.IsDebugfsMounted()
-	if !mounted {
-		return nil, fmt.Errorf("%s: debugfs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t debugfs none /sys/kernel/debug\" to mount debugfs", ErrTracerUnsupported)
+	err = util.IsDebugfsMounted()
+	if err != nil {
+		if os.IsPermission(err) {
+			return nil, fmt.Errorf("%s: system-probe does not have permission to access debugfs, please run system-probe with root permission", ErrTracerUnsupported)
+		} else if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%s: debugfs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t debugfs none /sys/kernel/debug\" to mount debugfs", ErrTracerUnsupported)
+		} else {
+			return nil, fmt.Errorf("%s: an error occurred while accessing debugfs: %s", ErrTracerUnsupported, err)
+		}
 	}
 
 	log.Infof("Creating tracer for: %s", filepath.Base(os.Args[0]))

--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -120,9 +120,23 @@ func GetPlatform() (string, error) {
 }
 
 // IsDebugfsMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs is mounted or not
-func IsDebugfsMounted() error {
+// returns a boolean and a possible error message
+func IsDebugfsMounted() (mounted bool, msg string) {
 	_, err := os.Stat("/sys/kernel/debug/tracing/kprobe_events")
-	return err
+
+	if err != nil {
+		if os.IsPermission(err) {
+			msg = "system-probe does not have permission to access debugfs"
+		} else if os.IsNotExist(err) {
+			msg = "debugfs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t debugfs none /sys/kernel/debug\" to mount debugfs"
+		} else {
+			msg = fmt.Sprintf("an error occurred while accessing debugfs: %s", err)
+		}
+	} else {
+		mounted = true
+	}
+
+	return
 }
 
 func execCmd(head string, args ...string) (string, error) {

--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -121,22 +121,19 @@ func GetPlatform() (string, error) {
 
 // IsDebugfsMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs is mounted or not
 // returns a boolean and a possible error message
-func IsDebugfsMounted() (mounted bool, msg string) {
+func IsDebugfsMounted() (bool, string) {
 	_, err := os.Stat("/sys/kernel/debug/tracing/kprobe_events")
 
 	if err != nil {
 		if os.IsPermission(err) {
-			msg = "system-probe does not have permission to access debugfs"
+			return false, "system-probe does not have permission to access debugfs"
 		} else if os.IsNotExist(err) {
-			msg = "debugfs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t debugfs none /sys/kernel/debug\" to mount debugfs"
+			return false, "debugfs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t debugfs none /sys/kernel/debug\" to mount debugfs"
 		} else {
-			msg = fmt.Sprintf("an error occurred while accessing debugfs: %s", err)
+			return false, fmt.Sprintf("an error occurred while accessing debugfs: %s", err)
 		}
-	} else {
-		mounted = true
 	}
-
-	return
+	return true, ""
 }
 
 func execCmd(head string, args ...string) (string, error) {

--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -120,9 +120,9 @@ func GetPlatform() (string, error) {
 }
 
 // IsDebugfsMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs is mounted or not
-func IsDebugfsMounted() bool {
+func IsDebugfsMounted() error {
 	_, err := os.Stat("/sys/kernel/debug/tracing/kprobe_events")
-	return err == nil
+	return err
 }
 
 func execCmd(head string, args ...string) (string, error) {


### PR DESCRIPTION
### What does this PR do?

Add better error messages for debugfs detection. @DataDog/burrito 

### Motivation

Currently system-probe would give "debugfs not mounted" message when system-probe is not given sudo permission. This is misleading so better messages are needed.

### Additional Notes

Anything else we should know when reviewing?
