### PR TITLE
Adds ddagentuser to "Event Log Readers", which allows access to

### DIFF
--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -164,7 +164,7 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall) {
             keyInstall.setStringValue(installCreatedDDDomain.c_str(), data.getDomainPtr());
         }
     }
-    if(!ddUserExists || !ddServiceExists)
+    if(!ddUserExists)
     {
         // since we just created the user, fix up all the rights we want
         DWORD nErr = NERR_Success;

--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -166,11 +166,8 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall) {
     }
     if(!ddUserExists || !ddServiceExists)
     {
-        LOCALGROUP_MEMBERS_INFO_0 lmi0;
-        memset(&lmi0, 0, sizeof(LOCALGROUP_MEMBERS_INFO_0));
-        DWORD nErr  = 0;
-        std::wstring groupname;
         // since we just created the user, fix up all the rights we want
+        DWORD nErr = NERR_Success;
         hr = -1;
         sid = GetSidForUser(NULL, data.getQualifiedUsername().c_str());
         if (!sid) {
@@ -198,30 +195,13 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall) {
             WcaLog(LOGMSG_STANDARD, "failed to add service login right");
             goto LExit;
         }
-        // add the user to the "performance monitor users" group
-        lmi0.lgrmi0_sid = sid;
-        // need to look up the group name by SID; the group name can be localized
-        {
-            PSID groupsid = NULL;
-            if(!ConvertStringSidToSid(L"S-1-5-32-558", &groupsid)) {
-                WcaLog(LOGMSG_STANDARD, "failed to convert sid string to sid; attempting default");
-                groupname = L"Performance Monitor Users";
-            } else {
-                if(!GetNameForSid(NULL, groupsid, groupname)) {
-                    WcaLog(LOGMSG_STANDARD, "failed to get group name for sid; using default");
-                    groupname = L"Performance Monitor Users";
-                }
-                LocalFree((LPVOID) groupsid);
-            }
+        nErr = AddUserToGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
+        if (nErr != NERR_Success) {
+            WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", nErr);
+            goto LExit;
         }
-        nErr = NetLocalGroupAddMembers(NULL, groupname.c_str(), 0, (LPBYTE)&lmi0, 1);
-        if (nErr == NERR_Success) {
-            WcaLog(LOGMSG_STANDARD, "Added ddagentuser to Performance Monitor Users");
-        }
-        else if (nErr == ERROR_MEMBER_IN_GROUP || nErr == ERROR_MEMBER_IN_ALIAS) {
-            WcaLog(LOGMSG_STANDARD, "User already in group, continuing %d", nErr);
-        }
-        else {
+        nErr = AddUserToGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
+        if (nErr != NERR_Success) {
             WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", nErr);
             goto LExit;
         }
@@ -469,17 +449,8 @@ UINT doUninstallAs(MSIHANDLE hInstall, UNINSTALL_TYPE t)
         removeUserPermsFromFile(datadogyamlfile, sid);
 
         // remove dd user from Performance monitor users
-        lmi0.lgrmi0_sid = sid;
-        nErr = NetLocalGroupDelMembers(NULL, L"Performance Monitor Users", 0, (LPBYTE)&lmi0, 1);
-        if (nErr == NERR_Success) {
-            WcaLog(LOGMSG_STANDARD, "removed ddagentuser from Performance Monitor Users");
-        }
-        else if (nErr == ERROR_NO_SUCH_MEMBER || nErr == ERROR_MEMBER_NOT_IN_ALIAS) {
-            WcaLog(LOGMSG_STANDARD, "User wasn't in group, continuing %d", nErr);
-        }
-        else {
-            WcaLog(LOGMSG_STANDARD, "Unexpected error removing user from group %d", nErr);
-        }
+        DelUserFromGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
+        DelUserFromGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
 
         // remove dd user right for
         //   SE_SERVICE_LOGON NAME

--- a/omnibus/resources/agent/msi/cal/customaction.h
+++ b/omnibus/resources/agent/msi/cal/customaction.h
@@ -17,6 +17,8 @@ DWORD DeleteUser(const wchar_t* host, const wchar_t* name);
 bool AddPrivileges(PSID AccountSID, LSA_HANDLE PolicyHandle, LPCWSTR rightToAdd);
 bool RemovePrivileges(PSID AccountSID, LSA_HANDLE PolicyHandle, LPCWSTR rightToAdd);
 int EnableServiceForUser(CustomActionData& data, const std::wstring& service);
+DWORD AddUserToGroup(PSID userSid, wchar_t* groupSidString, wchar_t* defaultGroupName);
+DWORD DelUserFromGroup(PSID userSid, wchar_t* groupSidString, wchar_t* defaultGroupName);
 bool InitLsaString(
 	PLSA_UNICODE_STRING pLsaString,
 	LPCWSTR pwszString);

--- a/releasenotes/notes/wineventgroup-5bd775df01b169d8.yaml
+++ b/releasenotes/notes/wineventgroup-5bd775df01b169d8.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, "ddagentuser" (the user context under which the Agent runs),
+    is now added to the "Event Log Readers" group, granting access to 
+    Security event logs.


### PR DESCRIPTION
security logs (needed for event log integration and event log --
event log tailing)

Also only attempts to modify the user (group membership and other rights) if we created
the user.  Was causing failure on RODC

### Motivation

Customer issue

### Additional Notes

Anything else we should know when reviewing?
