### PR TITLE
system-probe: Enable telemetry kretprobe on tcp_sendmsg only in debug mode

### DIFF
--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -91,12 +91,15 @@ func (c *Config) EnabledKProbes() map[KProbeName]struct{} {
 
 	if c.CollectTCPConns {
 		enabled[TCPSendMsg] = struct{}{}
-		enabled[TCPSendMsgReturn] = struct{}{}
 		enabled[TCPCleanupRBuf] = struct{}{}
 		enabled[TCPClose] = struct{}{}
 		enabled[TCPRetransmit] = struct{}{}
 		enabled[InetCskAcceptReturn] = struct{}{}
 		enabled[TCPv4DestroySock] = struct{}{}
+
+		if c.BPFDebug {
+			enabled[TCPSendMsgReturn] = struct{}{}
+		}
 	}
 
 	if c.CollectUDPConns {


### PR DESCRIPTION
### What does this PR do?

This should only be enabled in debug mode.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
