### PR TITLE
[kitchen] Test the commit's install script in kitchen

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -291,7 +291,7 @@ system_probe-build:
 
 #
 # integration_test
-
+#
 
 # run benchmarks on deb
 # run_benchmarks-deb_x64:
@@ -330,8 +330,7 @@ run_dogstatsd_size_test:
 
 #
 # package_build
-
-
+#
 
 # build Agent package for deb-x64
 agent_deb-x64:

--- a/test/kitchen/kitchen-azure.yml
+++ b/test/kitchen/kitchen-azure.yml
@@ -315,6 +315,7 @@ suites:
     dd-agent-install-script:
       api_key: <%= api_key %>
       candidate_repo_branch: pipeline-<%= ENV['CI_PIPELINE_ID'] %>
+      install_script_url: https://raw.githubusercontent.com/DataDog/datadog-agent/<%= ENV['CI_COMMIT_SHA'] %>/cmd/agent/install_script.sh
       install_candidate: true
     dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>


### PR DESCRIPTION
### What does this PR do?

The kitchen configuration has been changed to use the current
commit's install script.

### Motivation

Until now, the kitchen tests used the install script on master
to do their tests. This is not practical if someone wants to
change the install script (as the person would have to wait
until their PR is merged before being able to test with kitchen).
