### PR TITLE
Allow the check command to display memory profiling data

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -150,7 +150,10 @@ var checkCmd = &cobra.Command{
 				}
 
 				defer func() {
-					_ = os.RemoveAll(profileMemoryDir)
+					cleanupErr := os.RemoveAll(profileMemoryDir)
+					if cleanupErr != nil {
+						fmt.Printf("%s\n", cleanupErr)
+					}
 				}()
 			}
 

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -8,8 +8,12 @@ package app
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -28,14 +32,25 @@ import (
 )
 
 var (
-	checkRate  bool
-	checkTimes int
-	checkPause int
-	checkName  string
-	checkDelay int
-	logLevel   string
-	formatJSON bool
-	breakPoint string
+	checkRate            bool
+	checkTimes           int
+	checkPause           int
+	checkName            string
+	checkDelay           int
+	logLevel             string
+	formatJSON           bool
+	breakPoint           string
+	profileMemory        bool
+	profileMemoryDir     string
+	profileMemoryFrames  string
+	profileMemoryGC      string
+	profileMemoryCombine string
+	profileMemorySort    string
+	profileMemoryLimit   string
+	profileMemoryDiff    string
+	profileMemoryFilters string
+	profileMemoryUnit    string
+	profileMemoryVerbose string
 )
 
 // Make the check cmd aggregator never flush by setting a very high interval
@@ -48,9 +63,33 @@ func init() {
 	checkCmd.Flags().IntVarP(&checkTimes, "check-times", "t", 1, "number of times to run the check")
 	checkCmd.Flags().IntVar(&checkPause, "pause", 0, "pause between multiple runs of the check, in milliseconds")
 	checkCmd.Flags().StringVarP(&logLevel, "log-level", "l", "", "set the log level (default 'off')")
-	checkCmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in miliseconds")
+	checkCmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in milliseconds")
 	checkCmd.Flags().BoolVarP(&formatJSON, "json", "", false, "format aggregator and check runner output as json")
 	checkCmd.Flags().StringVarP(&breakPoint, "breakpoint", "b", "", "set a breakpoint at a particular line number (Python checks only)")
+	checkCmd.Flags().BoolVarP(&profileMemory, "profile-memory", "m", false, "run the memory profiler (Python checks only)")
+
+	// Power user flags - mark as hidden
+	checkCmd.Flags().StringVar(&profileMemoryDir, "m-dir", "", "an existing directory in which to store memory profiling data, ignoring clean-up")
+	checkCmd.Flags().StringVar(&profileMemoryFrames, "m-frames", "", "the number of stack frames to consider")
+	checkCmd.Flags().StringVar(&profileMemoryGC, "m-gc", "", "whether or not to run the garbage collector to remove noise")
+	checkCmd.Flags().StringVar(&profileMemoryCombine, "m-combine", "", "whether or not to aggregate over all traceback frames")
+	checkCmd.Flags().StringVar(&profileMemorySort, "m-sort", "", "what to sort by between: lineno | filename | traceback")
+	checkCmd.Flags().StringVar(&profileMemoryLimit, "m-limit", "", "the maximum number of sorted results to show")
+	checkCmd.Flags().StringVar(&profileMemoryDiff, "m-diff", "", "how to order diff results between: absolute | positive")
+	checkCmd.Flags().StringVar(&profileMemoryFilters, "m-filters", "", "comma-separated list of file path glob patterns to filter by")
+	checkCmd.Flags().StringVar(&profileMemoryUnit, "m-unit", "", "the binary unit to represent memory usage (kib, mb, etc.). the default is dynamic")
+	checkCmd.Flags().StringVar(&profileMemoryVerbose, "m-verbose", "", "whether or not to include potentially noisy sources")
+	checkCmd.Flags().MarkHidden("m-dir")
+	checkCmd.Flags().MarkHidden("m-frames")
+	checkCmd.Flags().MarkHidden("m-gc")
+	checkCmd.Flags().MarkHidden("m-combine")
+	checkCmd.Flags().MarkHidden("m-sort")
+	checkCmd.Flags().MarkHidden("m-limit")
+	checkCmd.Flags().MarkHidden("m-diff")
+	checkCmd.Flags().MarkHidden("m-filters")
+	checkCmd.Flags().MarkHidden("m-unit")
+	checkCmd.Flags().MarkHidden("m-verbose")
+
 	checkCmd.SetArgs([]string{"checkName"})
 }
 
@@ -112,7 +151,44 @@ var checkCmd = &cobra.Command{
 
 		allConfigs := common.AC.GetAllConfigs()
 
-		if breakPoint != "" {
+		if profileMemory {
+			// If no directory is specified, make a temporary one
+			if profileMemoryDir == "" {
+				profileMemoryDir, err = ioutil.TempDir("", "datadog-agent-memory-profiler")
+				if err != nil {
+					return err
+				}
+
+				defer func() {
+					_ = os.RemoveAll(profileMemoryDir)
+				}()
+			}
+
+			for idx := range allConfigs {
+				conf := &allConfigs[idx]
+				if conf.Name != checkName {
+					continue
+				}
+
+				var data map[string]interface{}
+
+				yaml.Unmarshal(conf.InitConfig, &data)
+				if data == nil {
+					data = make(map[string]interface{})
+				}
+
+				data["profile_memory"] = profileMemoryDir
+				err = populateMemoryProfileConfig(data)
+				if err != nil {
+					return err
+				}
+
+				y, _ := yaml.Marshal(data)
+				conf.InitConfig = y
+
+				break
+			}
+		} else if breakPoint != "" {
 			breakPointLine, err := strconv.Atoi(breakPoint)
 			if err != nil {
 				fmt.Printf("breakpoint must be an integer\n")
@@ -136,6 +212,8 @@ var checkCmd = &cobra.Command{
 
 				y, _ := yaml.Marshal(data)
 				conf.InitConfig = y
+
+				break
 			}
 		}
 
@@ -198,6 +276,59 @@ var checkCmd = &cobra.Command{
 					"runner":     runnerData,
 				}
 				instancesData = append(instancesData, instanceData)
+			} else if profileMemory {
+				// Every instance will create its own directory
+				instanceID := strings.SplitN(string(c.ID()), ":", 2)[1]
+				// Colons can't be part of Windows file paths
+				instanceID = strings.Replace(instanceID, ":", "_", -1)
+				profileDataDir := filepath.Join(profileMemoryDir, checkName, instanceID)
+
+				snapshotDir := filepath.Join(profileDataDir, "snapshots")
+				if _, err := os.Stat(snapshotDir); !os.IsNotExist(err) {
+					snapshots, err := ioutil.ReadDir(snapshotDir)
+					if err != nil {
+						return err
+					}
+
+					numSnapshots := len(snapshots)
+					if numSnapshots > 0 {
+						lastSnapshot := snapshots[numSnapshots-1]
+						snapshotContents, err := ioutil.ReadFile(filepath.Join(snapshotDir, lastSnapshot.Name()))
+						if err != nil {
+							return err
+						}
+
+						color.HiWhite(string(snapshotContents))
+					} else {
+						return fmt.Errorf("no snapshots found in %s", snapshotDir)
+					}
+				} else {
+					return fmt.Errorf("no snapshot data found in %s", profileDataDir)
+				}
+
+				diffDir := filepath.Join(profileDataDir, "diffs")
+				if _, err := os.Stat(diffDir); !os.IsNotExist(err) {
+					diffs, err := ioutil.ReadDir(diffDir)
+					if err != nil {
+						return err
+					}
+
+					numDiffs := len(diffs)
+					if numDiffs > 0 {
+						lastDiff := diffs[numDiffs-1]
+						diffContents, err := ioutil.ReadFile(filepath.Join(diffDir, lastDiff.Name()))
+						if err != nil {
+							return err
+						}
+
+						color.HiCyan(fmt.Sprintf("\n%s\n\n", strings.Repeat("=", 50)))
+						color.HiWhite(string(diffContents))
+					} else {
+						return fmt.Errorf("no diffs found in %s", diffDir)
+					}
+				} else if !singleCheckRun() {
+					return fmt.Errorf("no diff data found in %s", profileDataDir)
+				}
 			} else {
 				printMetrics(agg)
 				checkStatus, _ := status.GetCheckStatus(c, s)
@@ -213,8 +344,12 @@ var checkCmd = &cobra.Command{
 			fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("JSON")))
 			instancesJSON, _ := json.MarshalIndent(instancesData, "", "  ")
 			fmt.Println(string(instancesJSON))
-		} else if checkRate == false && checkTimes < 2 {
-			color.Yellow("Check has run only once, if some metrics are missing you can try again with --check-rate to see any other metric if available.")
+		} else if singleCheckRun() {
+			if profileMemory {
+				color.Yellow("Check has run only once, to collect diff data run the check multiple times with the -t/--check-times flag.")
+			} else {
+				color.Yellow("Check has run only once, if some metrics are missing you can try again with --check-rate to see any other metric if available.")
+			}
 		}
 
 		return nil
@@ -311,4 +446,80 @@ func printWindowsUserWarning(op string) {
 	fmt.Printf("The %s command runs in a different user context than the running service\n", op)
 	fmt.Printf("This could affect results if the command relies on specific permissions and/or user contexts\n")
 	fmt.Printf("\n")
+}
+
+func singleCheckRun() bool {
+	return checkRate == false && checkTimes < 2
+}
+
+func populateMemoryProfileConfig(initConfig map[string]interface{}) error {
+	if profileMemoryFrames != "" {
+		profileMemoryFrames, err := strconv.Atoi(profileMemoryFrames)
+		if err != nil {
+			return fmt.Errorf("--m-frames must be an integer")
+		}
+		initConfig["profile_memory_frames"] = profileMemoryFrames
+	}
+
+	if profileMemoryGC != "" {
+		profileMemoryGC, err := strconv.Atoi(profileMemoryGC)
+		if err != nil {
+			return fmt.Errorf("--m-gc must be an integer")
+		}
+
+		initConfig["profile_memory_gc"] = profileMemoryGC
+	}
+
+	if profileMemoryCombine != "" {
+		profileMemoryCombine, err := strconv.Atoi(profileMemoryCombine)
+		if err != nil {
+			return fmt.Errorf("--m-combine must be an integer")
+		}
+
+		if profileMemoryCombine != 0 && profileMemorySort == "traceback" {
+			return fmt.Errorf("--m-combine cannot be sorted (--m-sort) by traceback")
+		}
+
+		initConfig["profile_memory_combine"] = profileMemoryCombine
+	}
+
+	if profileMemorySort != "" {
+		if profileMemorySort != "lineno" && profileMemorySort != "filename" && profileMemorySort != "traceback" {
+			return fmt.Errorf("--m-sort must one of: lineno | filename | traceback")
+		}
+		initConfig["profile_memory_sort"] = profileMemorySort
+	}
+
+	if profileMemoryLimit != "" {
+		profileMemoryLimit, err := strconv.Atoi(profileMemoryLimit)
+		if err != nil {
+			return fmt.Errorf("--m-limit must be an integer")
+		}
+		initConfig["profile_memory_limit"] = profileMemoryLimit
+	}
+
+	if profileMemoryDiff != "" {
+		if profileMemoryDiff != "absolute" && profileMemoryDiff != "positive" {
+			return fmt.Errorf("--m-diff must one of: absolute | positive")
+		}
+		initConfig["profile_memory_diff"] = profileMemoryDiff
+	}
+
+	if profileMemoryFilters != "" {
+		initConfig["profile_memory_filters"] = profileMemoryFilters
+	}
+
+	if profileMemoryUnit != "" {
+		initConfig["profile_memory_unit"] = profileMemoryUnit
+	}
+
+	if profileMemoryVerbose != "" {
+		profileMemoryVerbose, err := strconv.Atoi(profileMemoryVerbose)
+		if err != nil {
+			return fmt.Errorf("--m-verbose must be an integer")
+		}
+		initConfig["profile_memory_verbose"] = profileMemoryVerbose
+	}
+
+	return nil
 }

--- a/releasenotes/notes/add-memory-profiling-check-command-e9619c714179609e.yaml
+++ b/releasenotes/notes/add-memory-profiling-check-command-e9619c714179609e.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allow the check command to display and/or store memory profiling data.


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/4166

### Additional Notes

The available options (without prefix) are:

- `dir`: an existing directory in which to store memory profiling data, ignoring clean-up. otherwise a temporary directory will be used
- `frames`: the number of stack frames to consider
- `gc`: whether or not to run the garbage collector before each snapshot to remove noise
- `combine`: whether or not to aggregate over all traceback frames. useful only to tell which particular usage of a function triggered areas of interest
- `sort`: what to group results by between: `lineno` | `filename` | `traceback`
- `limit`: the maximum number of sorted results to show
- `diff`: how to order diff results between:
    - `absolute`: absolute value of the difference between consecutive snapshots
    - `positive`: same as absolute, but memory increases will be shown first
- `filters`: comma-separated list of file path glob patterns to filter by
- `unit`: the binary unit to represent memory usage (kib, mb, etc.). the default is dynamic
- `verbose`: whether or not to include potentially noisy sources
