### PR TITLE
Revert "Make sure we reuse destinations and connections for logs"

### DIFF
--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -7,6 +7,8 @@ package pipeline
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/processor"
@@ -21,8 +23,24 @@ type Pipeline struct {
 }
 
 // NewPipeline returns a new Pipeline
-func NewPipeline(outputChan chan *message.Message, processingRules []*config.ProcessingRule, endpoints *config.Endpoints, destinations *client.Destinations) *Pipeline {
-	inputChan := make(chan *message.Message, config.ChanSize)
+func NewPipeline(outputChan chan *message.Message, processingRules []*config.ProcessingRule, endpoints *config.Endpoints, destinationsContext *client.DestinationsContext) *Pipeline {
+	var destinations *client.Destinations
+	if endpoints.UseHTTP {
+		main := http.NewDestination(endpoints.Main, http.JSONContentType, destinationsContext)
+		additionals := []client.Destination{}
+		for _, endpoint := range endpoints.Additionals {
+			additionals = append(additionals, http.NewDestination(endpoint, http.JSONContentType, destinationsContext))
+		}
+		destinations = client.NewDestinations(main, additionals)
+	} else {
+		main := tcp.NewDestination(endpoints.Main, endpoints.UseProto, destinationsContext)
+		additionals := []client.Destination{}
+		for _, endpoint := range endpoints.Additionals {
+			additionals = append(additionals, tcp.NewDestination(endpoint, endpoints.UseProto, destinationsContext))
+		}
+		destinations = client.NewDestinations(main, additionals)
+	}
+
 	senderChan := make(chan *message.Message, config.ChanSize)
 
 	var strategy sender.Strategy
@@ -41,6 +59,8 @@ func NewPipeline(outputChan chan *message.Message, processingRules []*config.Pro
 	} else {
 		encoder = processor.RawEncoder
 	}
+
+	inputChan := make(chan *message.Message, config.ChanSize)
 	processor := processor.New(inputChan, senderChan, processingRules, encoder)
 
 	return &Pipeline{

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
-	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
-	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
@@ -54,23 +52,8 @@ func (p *provider) Start() {
 	// This requires the auditor to be started before.
 	p.outputChan = p.auditor.Channel()
 
-	var main client.Destination
-	var additionals []client.Destination
-	if p.endpoints.UseHTTP {
-		main = http.NewDestination(p.endpoints.Main, http.JSONContentType, p.destinationsContext)
-		for _, endpoint := range p.endpoints.Additionals {
-			additionals = append(additionals, http.NewDestination(endpoint, http.JSONContentType, p.destinationsContext))
-		}
-	} else {
-		main = tcp.NewDestination(p.endpoints.Main, p.endpoints.UseProto, p.destinationsContext)
-		for _, endpoint := range p.endpoints.Additionals {
-			additionals = append(additionals, tcp.NewDestination(endpoint, p.endpoints.UseProto, p.destinationsContext))
-		}
-	}
-	destinations := client.NewDestinations(main, additionals)
-
 	for i := 0; i < p.numberOfPipelines; i++ {
-		pipeline := NewPipeline(p.outputChan, p.processingRules, p.endpoints, destinations)
+		pipeline := NewPipeline(p.outputChan, p.processingRules, p.endpoints, p.destinationsContext)
 		pipeline.Start()
 		p.pipelines = append(p.pipelines, pipeline)
 	}


### PR DESCRIPTION
### What does this PR do?

Revert changes on reuse resources as it is causing an out of order delivery which is bad for logs.

### Motivation

We want to make sure we keep an out of order delivery by sending the logs from the same input to the same output connection.

### Additional Notes

Let's add a comment somewhere to remind that we should care about order of delivery.
