### PR TITLE
[install-script] Make install script trust new RPM key on SUSE

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -185,10 +185,11 @@ elif [ $OS = "SUSE" ]; then
   fi
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"
-  $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.${repo_url}/suse/stable/6/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public' > /etc/zypp/repos.d/datadog.repo"
+  $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.${repo_url}/suse/stable/6/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/zypp/repos.d/datadog.repo"
 
-  echo -e "\033[34m\n* Importing the Datadog GPG Key\n\033[0m"
+  echo -e "\033[34m\n* Importing the Datadog GPG Keys\n\033[0m"
   $sudo_cmd rpm --import https://yum.${repo_url}/DATADOG_RPM_KEY.public
+  $sudo_cmd rpm --import https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public
 
   echo -e "\033[34m\n* Refreshing repositories\n\033[0m"
   $sudo_cmd zypper --non-interactive --no-gpg-check refresh datadog


### PR DESCRIPTION

### What does this PR do?

In the SUSE install, also import the new RPM key.

### Motivation

In the near future, we're going to sign our RPM packages with our
newer GPG key. To minimize the number of upgrade problems our clients
may run into, it's best that they start trusting our new key as
soon as possible.

### Additional Notes

Waiting on [this kitchen PR](https://github.com/DataDog/datadog-agent/pull/3900) so that I can test the script with kitchen tests.
