### PR TITLE
Skip irrelevant entities instead of processing them

### DIFF
--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -88,8 +88,8 @@ func (c *DockerCollector) Stop() error {
 
 // Fetch inspect a given container to get its tags on-demand (cache miss)
 func (c *DockerCollector) Fetch(entity string) ([]string, []string, []string, error) {
-	_, cID := containers.SplitEntityName(entity)
-	if len(cID) == 0 {
+	entityType, cID := containers.SplitEntityName(entity)
+	if entityType != containers.ContainerEntityName || len(cID) == 0 {
 		return nil, nil, nil, nil
 	}
 	return c.fetchForDockerID(cID)

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -57,9 +57,9 @@ func (c *ECSCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 }
 
 // Fetch fetches ECS tags
-func (c *ECSCollector) Fetch(container string) ([]string, []string, []string, error) {
-	_, cID := containers.SplitEntityName(container)
-	if len(cID) == 0 {
+func (c *ECSCollector) Fetch(entity string) ([]string, []string, []string, error) {
+	entityType, cID := containers.SplitEntityName(entity)
+	if entityType != containers.ContainerEntityName || len(cID) == 0 {
 		return nil, nil, nil, nil
 	}
 
@@ -82,12 +82,12 @@ func (c *ECSCollector) Fetch(container string) ([]string, []string, []string, er
 	}
 
 	for _, info := range updates {
-		if info.Entity == container {
+		if info.Entity == entity {
 			return info.LowCardTags, info.OrchestratorCardTags, info.HighCardTags, nil
 		}
 	}
 	// container not found in updates
-	return []string{}, []string{}, []string{}, errors.NewNotFound(container)
+	return []string{}, []string{}, []string{}, errors.NewNotFound(entity)
 }
 
 func ecsFactory() Collector {


### PR DESCRIPTION
### What does this PR do?

It fixes a tag collection issue for docker following #3821: it could indeed happen that the docker collector was trying to fetch tags for irrelevant entities leading to a loop of failed attempts.

Running into this scenario would typically produce those logs:

```
2019-07-19 14:19:37 UTC | CORE | DEBUG | (pkg/tagger/collectors/docker_main.go:123 in fetchForDockerID) | cache miss for docker, collecting tags for kubernetes_pod_uid://81666584-a956-11e9-be75-42010a840268
2019-07-19 14:19:37 UTC | CORE | DEBUG | (pkg/tagger/collectors/docker_main.go:123 in fetchForDockerID) | cache miss for docker, collecting tags for kubernetes_pod_uid://8153ad86-a956-11e9-be75-42010a840268
2019-07-19 14:19:37 UTC | CORE | DEBUG | (pkg/tagger/collectors/docker_main.go:123 in fetchForDockerID) | cache miss for docker, collecting tags for kubernetes_pod_uid://06777dd5-a957-11e9-be75-42010a840268
2019-07-19 14:19:37 UTC | CORE | DEBUG | (pkg/tagger/collectors/docker_main.go:123 in fetchForDockerID) | cache miss for docker, collecting tags for kubernetes_pod_uid://06930fd2-a957-11e9-be75-42010a840268
```