### PR TITLE
Remove in-development wording in front of system-probe env var parsing

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -333,7 +333,7 @@ func loadEnvVariables() {
 		"DD_STRIP_PROCESS_ARGS":             "process_config.strip_proc_arguments",
 		"DD_PROCESS_AGENT_URL":              "process_config.process_dd_url",
 
-		// Note: this feature is in development and should not be used in production environments
+		// System probe specific configuration (Beta)
 		"DD_SYSTEM_PROBE_ENABLED":   "system_probe_config.enabled",
 		"DD_SYSPROBE_SOCKET":        "system_probe_config.sysprobe_socket",
 		"DD_DISABLE_TCP_TRACING":    "system_probe_config.disable_tcp",


### PR DESCRIPTION
### What does this PR do?

Remove in-development wording in front of system-probe env var parsing

### Motivation

@DataDog/burrito 

### Additional Notes

Anything else we should know when reviewing?
