### PR TITLE
Enable compression for sketches now that the backend supports it

### DIFF
--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -244,7 +244,7 @@ func (s *Serializer) SendSketch(sketches marshaler.Marshaler) error {
 		return nil
 	}
 
-	compress := false // TODO: enable compression once the backend supports it on this endpoint
+	compress := true
 	useV1API := false // Sketches only have a v2 endpoint
 	splitSketches, extraHeaders, err := s.serializePayload(sketches, compress, useV1API)
 	if err != nil {

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -270,8 +270,8 @@ func TestSendSeries(t *testing.T) {
 
 func TestSendSketch(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
-	payloads, _ := mkPayloads(protobufString, false)
-	f.On("SubmitSketchSeries", payloads, protobufExtraHeaders).Return(nil).Times(1)
+	payloads, _ := mkPayloads(protobufString, true)
+	f.On("SubmitSketchSeries", payloads, protobufExtraHeadersWithCompression).Return(nil).Times(1)
 
 	s := NewSerializer(f)
 

--- a/releasenotes/notes/compress-distribution-payloads-635b3074b4964c74.yaml
+++ b/releasenotes/notes/compress-distribution-payloads-635b3074b4964c74.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Distributions: Distribution payloads are now compressed before being sent to
+    Datadog if the agent is built with either zlib or zstd.


### PR DESCRIPTION
### What does this PR do?

Turns on compression for sketch payloads sent by the agent.

### Motivation

We're adding support for compression in the whole sketch pipeline and can save bandwidth from the agent as well.