### PR TITLE
Remove home directory when removing user

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -473,6 +473,7 @@ build_windows_msi_x64:
     - if exist %OMNIBUS_BASE_DIR_WIN% rd /s/q %OMNIBUS_BASE_DIR_WIN%
     - if exist \opt\datadog-agent rd /s/q \opt\datadog-agent
     - if exist %GOPATH%\src rd /s/q %GOPATH%\src
+    - if exist %GOPATH%\pkg\dep\sources rd /s/q %GOPATH%\pkg\dep\sources
     - mkdir %GOPATH%\src\github.com\DataDog\datadog-agent
     - xcopy /q/h/e/s * %GOPATH%\src\github.com\DataDog\datadog-agent
     - cd %GOPATH%\src\github.com\DataDog\datadog-agent

--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -501,9 +501,21 @@ UINT doUninstallAs(MSIHANDLE hInstall, UNINSTALL_TYPE t)
                 WcaLog(LOGMSG_STANDARD, "failed to remove service login right");
             }
         }
+        // get the home directory for deleting later
+        std::wstring homedir;
+        er = getUserHomeDirectory(installedUser.c_str(), homedir);
+        if(NERR_Success != er) {
+            WcaLog(LOGMSG_STANDARD, "Failed to retrieve home directory, can't delete");
+        }
         // delete the user
         er = DeleteUser(NULL, installedUser.c_str());
-        if (0 != er) {
+        if ( 0 == er ) {
+            if(!installedUser.empty()) {
+                WcaLog(LOGMSG_STANDARD, "Deleting home directory");
+                RemoveDirectory(homedir.c_str());
+            }
+        }
+        else  {
             // don't actually fail on failure.  We're doing an uninstall,
             // and failing will just leave the system in a more confused state
             WcaLog(LOGMSG_STANDARD, "Didn't delete the datadog user %d", er);

--- a/omnibus/resources/agent/msi/cal/customaction.h
+++ b/omnibus/resources/agent/msi/cal/customaction.h
@@ -12,7 +12,7 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data, bool isDC = 
 void removeUserPermsFromFile(std::wstring &filename, PSID sidremove);
 
 DWORD DeleteUser(const wchar_t* host, const wchar_t* name);
-
+int getUserHomeDirectory(const wchar_t* name, std::wstring &path);
 
 bool AddPrivileges(PSID AccountSID, LSA_HANDLE PolicyHandle, LPCWSTR rightToAdd);
 bool RemovePrivileges(PSID AccountSID, LSA_HANDLE PolicyHandle, LPCWSTR rightToAdd);

--- a/omnibus/resources/agent/msi/cal/usercreate.cpp
+++ b/omnibus/resources/agent/msi/cal/usercreate.cpp
@@ -250,7 +250,17 @@ int doCreateUser(const std::wstring& name, const wchar_t * domain, std::wstring&
 
 }
 
-
+int getUserHomeDirectory(const wchar_t* name, std::wstring &path)
+{
+    DWORD ret = 0;
+    USER_INFO_2 *ui = NULL;
+    ret = NetUserGetInfo(NULL, name, 2, (LPBYTE*) &ui);
+    if (NERR_Success == ret) {
+        path = ui->usri2_home_dir;
+        NetApiBufferFree((LPVOID)ui);
+    }
+    return ret;
+}
 
 DWORD DeleteUser(const wchar_t* host, const wchar_t* name){
     NET_API_STATUS ret = NetUserDel(NULL, name);


### PR DESCRIPTION
### What does this PR do?

Removes home directory when we remove the DD agent user.

### Motivation

Leaving artifacts around is not desirable

