### PR TITLE
Configure install for datadog-agent-sysprobe

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
@@ -12,3 +12,6 @@ ExecStart=<%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/s
 # it is also supported to have it here.
 StartLimitInterval=10
 StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?
Adds the [Install] section to the datadog-agent-sysprobe Systemd unit file. This allows customers to enable the systemd unit file to start at host startup with 'systemctl enable datadog-agent-sysprobe.service'.

### Motivation

Currently testing out the beta product and was running into issues getting the service to start after reboots and on new instance deploys. Turns out, without an `[Install]` section, systemd doesn't know how to 'enable' the service:
```
root@test01:~$ systemctl enable datadog-agent-sysprobe.service
The unit files have no installation config (WantedBy, RequiredBy, Also, Alias
settings in the [Install] section, and DefaultInstance for template units).
This means they are not meant to be enabled using systemctl.
Possible reasons for having this kind of units are:
1) A unit may be statically enabled by being symlinked from another unit's
   .wants/ or .requires/ directory.
2) A unit's purpose may be to act as a helper for some other unit which has
   a requirement dependency on it.
3) A unit may be started when needed via activation (socket, path, timer,
   D-Bus, udev, scripted systemctl call, ...).
4) In case of template units, the unit is meant to be enabled with some
   instance name specified.
```

I've chosen to simply mirror what is already setup for the following DataDog unit files:
* https://github.com/DataDog/datadog-agent/blob/6.12.1/omnibus/config/templates/datadog-agent/systemd.process.service.erb#L17
* https://github.com/DataDog/datadog-agent/blob/6.12.1/omnibus/config/templates/datadog-agent/systemd.service.erb#L17-L18
* https://github.com/DataDog/datadog-agent/blob/6.12.1/omnibus/config/templates/datadog-agent/systemd.trace.service.erb#L17-L18

### Additional Notes
I would actually love for someone on the DataDog to confirm if this can run independetly from the `datadog-agent` service itself. If not, it might make sense to have `After=` include `datadog-agent.service` 
