### PR TITLE
Change software def for py2 and py3 to point to python packages

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -74,7 +74,7 @@ else
 
   dependency "vc_redist"
   source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-nopip-amd64.zip",
-         :sha256 => "528c33b78be915731f3cb9e6e1f9328abd58e43911ea7941e3e4057a2ec130df",
+         :sha256 => "b9878cf2e64084c35a98ae1acd68f93bd7bc36e232e01088cba7692153068f67",
          :extract => :seven_zip
 
   build do

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -73,8 +73,8 @@ else
   default_version "2.7.16"
 
   dependency "vc_redist"
-  source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-amd64.zip",
-         :sha256 => "6b9fdc51dde1ba6ae4cb698451900e1f8f1900ff1d56d9166dbeab06b10a4dce",
+  source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-nopip-amd64.zip",
+         :sha256 => "528c33b78be915731f3cb9e6e1f9328abd58e43911ea7941e3e4057a2ec130df",
          :extract => :seven_zip
 
   build do

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -66,11 +66,11 @@ if ohai["platform"] != "windows"
 
 else
   dependency "vc_redist_14"
-  default_version "3.7.3"
+  default_version "3.7.4"
 
   # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
   source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-amd64.zip",
-         :sha256 => "b539e29904969788dad8a377f0604c6e96eb62e0b8724e7272baedd94183e0ac"
+         :sha256 => "ce1782db64be81aa81e8a38102b4850ee03a0b30bf152a7d2b4b36a7a6e0c381"
 
   build do
     command "XCOPY /YEHIR *.* \"#{windows_safe_path(python_3_embedded)}\""

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -66,10 +66,11 @@ if ohai["platform"] != "windows"
 
 else
   dependency "vc_redist_14"
-  default_version "3.7.1"
+  default_version "3.7.3"
 
+  # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
   source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-amd64.zip",
-         :sha256 => "2ebd2eb2155f7c82ec3d2ba5203e0a250b6bbf60c7c5404f1e03f4bc71a096e1"
+         :sha256 => "b539e29904969788dad8a377f0604c6e96eb62e0b8724e7272baedd94183e0ac"
 
   build do
     command "XCOPY /YEHIR *.* \"#{windows_safe_path(python_3_embedded)}\""

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "master",
+		"INTEGRATIONS_CORE_VERSION": "ofek/j",
 		"OMNIBUS_SOFTWARE_VERSION": "master",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
 		"JMXFETCH_VERSION": "0.30.0",

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "ofek/j",
+		"INTEGRATIONS_CORE_VERSION": "master",
 		"OMNIBUS_SOFTWARE_VERSION": "master",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
 		"JMXFETCH_VERSION": "0.30.0",


### PR DESCRIPTION
that don't have pip in them

### What does this PR do?

Updates software def to point to python zips that don't include pip

### Motivation

Removing duplicate pip installation so that integrations-installed pip is only one installed.

### Additional Notes

Used name `-nopip-` on the 2.7.16 zip because we already had a 2.7.16 zip, and wanted to maintain ability to build old releases.

3.7.3 is a newer version than previously used, so there's no collision
