### PR TITLE
Use new serialization for events and check

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -187,6 +187,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("histogram_percentiles", []string{"0.95"})
 	// Serializer
 	config.BindEnvAndSetDefault("enable_stream_payload_serialization", true)
+	config.BindEnvAndSetDefault("enable_events_stream_payload_serialization", false)
 	// Warning: do not change the two following values. Your payloads will get dropped by Datadog's intake.
 	config.BindEnvAndSetDefault("serializer_max_payload_size", 2*megaByte+megaByte/2)
 	config.BindEnvAndSetDefault("serializer_max_uncompressed_payload_size", 4*megaByte)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -188,6 +188,8 @@ func initConfig(config Config) {
 	// Serializer
 	config.BindEnvAndSetDefault("enable_stream_payload_serialization", true)
 	config.BindEnvAndSetDefault("enable_events_stream_payload_serialization", false)
+	config.BindEnvAndSetDefault("enable_service_checks_stream_payload_serialization", false)
+
 	// Warning: do not change the two following values. Your payloads will get dropped by Datadog's intake.
 	config.BindEnvAndSetDefault("serializer_max_payload_size", 2*megaByte+megaByte/2)
 	config.BindEnvAndSetDefault("serializer_max_uncompressed_payload_size", 4*megaByte)

--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -255,7 +255,7 @@ func (events Events) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayloa
 		stream.WriteMore()
 		startNewSourceType = true
 	} else {
-		// As SupportJSONSeparatorInsertion returns false, we need the separator between items
+		// As AddJSONSeparatoraAutomatically returns false, we need the separator between items
 		stream.WriteMore()
 	}
 
@@ -275,9 +275,9 @@ func (events Events) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayloa
 	return stream.Flush()
 }
 
-// SupportJSONSeparatorInsertion returns true to add JSON separator automatically between two calls of WriteItem, false otherwise.
-func (events Events) SupportJSONSeparatorInsertion() bool {
-	// If SupportJSONSeparatorInsertion returns true, it leads to this output
+// AddJSONSeparatoraAutomatically returns true to add JSON separator automatically between two calls of WriteItem, false otherwise.
+func (events Events) AddJSONSeparatoraAutomatically() bool {
+	// If AddJSONSeparatoraAutomatically returns true, it leads to this output
 	//
 	// 	"events": {
 	// 		"SourceTypeName1": [  	// First WriteItem

--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -185,7 +185,7 @@ func (events Events) SplitPayload(times int) ([]marshaler.Marshaler, error) {
 }
 
 //// The following methods implement the StreamJSONMarshaler interface
-//// for support of the enable_stream_payload_serialization option.
+//// for support of the enable_events_stream_payload_serialization option.
 
 // Initialize the data for serialization. Call once before any other methods.
 func (events Events) Initialize() error {

--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -232,7 +232,7 @@ func (events Events) writeNoEventFooter(stream *jsoniter.Stream) error {
 	hostname, _ := util.GetHostname()
 	stream.WriteObjectField(internalHostnameJSONField)
 	stream.WriteString(hostname)
-	
+
 	stream.WriteObjectEnd()
 	return stream.Flush()
 }

--- a/pkg/metrics/event_test.go
+++ b/pkg/metrics/event_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/serializer/jsonstream"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -125,9 +126,9 @@ func TestSplitEvents(t *testing.T) {
 	require.Len(t, newEvents, 2)
 }
 
-func buildPayload(t *testing.T, events Events) [][]byte {
+func buildPayload(t *testing.T, m marshaler.StreamJSONMarshaler) [][]byte {
 	builder := jsonstream.NewPayloadBuilder()
-	payloads, err := builder.Build(events)
+	payloads, err := builder.Build(m)
 	assert.NoError(t, err)
 	var uncompressedPayloads [][]byte
 
@@ -140,9 +141,9 @@ func buildPayload(t *testing.T, events Events) [][]byte {
 	return uncompressedPayloads
 }
 
-func assertEqualToMarshalJSON(t *testing.T, events Events) {
-	payloads := buildPayload(t, events)
-	json, err := events.MarshalJSON()
+func assertEqualToMarshalJSON(t *testing.T, m marshaler.StreamJSONMarshaler) {
+	payloads := buildPayload(t, m)
+	json, err := m.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(payloads))
 	assert.Equal(t, strings.TrimSpace(string(json)), string(payloads[0]))
@@ -207,7 +208,8 @@ func TestPayloadsEventsSeveralPayloads(t *testing.T) {
 	}
 
 	payloads := buildPayload(t, allEvents)
-
+	assert.Equal(t, 3, len(payloads))
+	
 	for index, events := range eventsCollection {
 		json, err := events.MarshalJSON()
 		assert.NoError(t, err)

--- a/pkg/metrics/event_test.go
+++ b/pkg/metrics/event_test.go
@@ -209,7 +209,7 @@ func TestPayloadsEventsSeveralPayloads(t *testing.T) {
 
 	payloads := buildPayload(t, allEvents)
 	assert.Equal(t, 3, len(payloads))
-	
+
 	for index, events := range eventsCollection {
 		json, err := events.MarshalJSON()
 		assert.NoError(t, err)

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -235,8 +235,8 @@ func (series Series) WriteLastFooter(stream *jsoniter.Stream, itemWrittenCount i
 	return series.WriteFooter(stream)
 }
 
-// SupportJSONSeparatorInsertion returns true to add JSON separator automatically between two calls of WriteItem, false otherwise.
-func (series Series) SupportJSONSeparatorInsertion() bool { return true }
+// AddJSONSeparatoraAutomatically returns true to add JSON separator automatically between two calls of WriteItem, false otherwise.
+func (series Series) AddJSONSeparatoraAutomatically() bool { return true }
 
 // WriteItem prints the json representation of an item
 func (series Series) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayload int) error {

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -212,6 +212,9 @@ func (e Serie) String() string {
 //// The following methods implement the StreamJSONMarshaler interface
 //// for support of the enable_stream_payload_serialization option.
 
+// Initialize the data for serialization. Call once before any other methods.
+func (series Series) Initialize() error { return nil }
+
 // WriteHeader writes the payload header for this type
 func (series Series) WriteHeader(stream *jsoniter.Stream) error {
 	stream.WriteObjectStart()
@@ -226,6 +229,14 @@ func (series Series) WriteFooter(stream *jsoniter.Stream) error {
 	stream.WriteObjectEnd()
 	return stream.Flush()
 }
+
+// WriteLastFooter writes the last footer. Call once after any other methods.
+func (series Series) WriteLastFooter(stream *jsoniter.Stream, itemWrittenCount int) error {
+	return series.WriteFooter(stream)
+}
+
+// SupportJSONSeparatorInsertion returns true to add JSON separator automatically between two calls of WriteItem, false otherwise.
+func (series Series) SupportJSONSeparatorInsertion() bool { return true }
 
 // WriteItem prints the json representation of an item
 func (series Series) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayload int) error {

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -228,7 +228,7 @@ func (series Series) WriteFooter(stream *jsoniter.Stream) error {
 }
 
 // WriteItem prints the json representation of an item
-func (series Series) WriteItem(stream *jsoniter.Stream, i int) error {
+func (series Series) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayload int) error {
 	if i < 0 || i > len(series)-1 {
 		return errors.New("out of range")
 	}

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -6,17 +6,21 @@
 package metrics
 
 import (
+	"bytes"
+	"compress/zlib"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"testing"
 
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 
+	agentpayload "github.com/DataDog/agent-payload/gogen"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/serializer/jsonstream"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	agentpayload "github.com/DataDog/agent-payload/gogen"
 )
 
 func TestMarshalSeries(t *testing.T) {
@@ -378,100 +382,114 @@ func TestDescribeItem(t *testing.T) {
 	assert.Equal(t, "out of range", desc2)
 }
 
-// // test taken from the spliter
-// func TestPayloadsSeries(t *testing.T) {
-// 	testSeries := metrics.Series{}
-// 	for i := 0; i < 30000; i++ {
-// 		point := metrics.Serie{
-// 			Points: []metrics.Point{
-// 				{Ts: 12345.0, Value: float64(21.21)},
-// 				{Ts: 67890.0, Value: float64(12.12)},
-// 				{Ts: 2222.0, Value: float64(22.12)},
-// 				{Ts: 333.0, Value: float64(32.12)},
-// 				{Ts: 444444.0, Value: float64(42.12)},
-// 				{Ts: 882787.0, Value: float64(52.12)},
-// 				{Ts: 99990.0, Value: float64(62.12)},
-// 				{Ts: 121212.0, Value: float64(72.12)},
-// 				{Ts: 222227.0, Value: float64(82.12)},
-// 				{Ts: 808080.0, Value: float64(92.12)},
-// 				{Ts: 9090.0, Value: float64(13.12)},
-// 			},
-// 			MType:    metrics.APIGaugeType,
-// 			Name:     fmt.Sprintf("test.metrics%d", i),
-// 			Interval: 1,
-// 			Host:     "localHost",
-// 			Tags:     []string{"tag1", "tag2:yes"},
-// 		}
-// 		testSeries = append(testSeries, &point)
-// 	}
+// test taken from the spliter
+func TestPayloadsSeries(t *testing.T) {
+	testSeries := Series{}
+	for i := 0; i < 30000; i++ {
+		point := Serie{
+			Points: []Point{
+				{Ts: 12345.0, Value: float64(21.21)},
+				{Ts: 67890.0, Value: float64(12.12)},
+				{Ts: 2222.0, Value: float64(22.12)},
+				{Ts: 333.0, Value: float64(32.12)},
+				{Ts: 444444.0, Value: float64(42.12)},
+				{Ts: 882787.0, Value: float64(52.12)},
+				{Ts: 99990.0, Value: float64(62.12)},
+				{Ts: 121212.0, Value: float64(72.12)},
+				{Ts: 222227.0, Value: float64(82.12)},
+				{Ts: 808080.0, Value: float64(92.12)},
+				{Ts: 9090.0, Value: float64(13.12)},
+			},
+			MType:    APIGaugeType,
+			Name:     fmt.Sprintf("test.metrics%d", i),
+			Interval: 1,
+			Host:     "localHost",
+			Tags:     []string{"tag1", "tag2:yes"},
+		}
+		testSeries = append(testSeries, &point)
+	}
 
-// 	originalLength := len(testSeries)
-// 	builder := NewPayloadBuilder()
-// 	payloads, err := builder.Build(testSeries)
-// 	require.Nil(t, err)
-// 	var splitSeries = []metrics.Series{}
-// 	for _, compressedPayload := range payloads {
-// 		payload, err := decompressPayload(*compressedPayload)
-// 		require.NoError(t, err)
+	originalLength := len(testSeries)
+	builder := jsonstream.NewPayloadBuilder()
+	payloads, err := builder.Build(testSeries)
+	require.Nil(t, err)
+	var splitSeries = []Series{}
+	for _, compressedPayload := range payloads {
+		payload, err := decompressPayload(*compressedPayload)
+		require.NoError(t, err)
 
-// 		var s = map[string]metrics.Series{}
-// 		err = json.Unmarshal(payload, &s)
-// 		require.NoError(t, err)
-// 		splitSeries = append(splitSeries, s["series"])
-// 	}
+		var s = map[string]Series{}
+		err = json.Unmarshal(payload, &s)
+		require.NoError(t, err)
+		splitSeries = append(splitSeries, s["series"])
+	}
 
-// 	unrolledSeries := metrics.Series{}
-// 	for _, series := range splitSeries {
-// 		for _, s := range series {
-// 			unrolledSeries = append(unrolledSeries, s)
-// 		}
-// 	}
+	unrolledSeries := Series{}
+	for _, series := range splitSeries {
+		for _, s := range series {
+			unrolledSeries = append(unrolledSeries, s)
+		}
+	}
 
-// 	newLength := len(unrolledSeries)
-// 	require.Equal(t, originalLength, newLength)
-// }
+	newLength := len(unrolledSeries)
+	require.Equal(t, originalLength, newLength)
+}
 
-// var result forwarder.Payloads
+var result forwarder.Payloads
 
-// func BenchmarkPayloadsSeries(b *testing.B) {
-// 	testSeries := metrics.Series{}
-// 	for i := 0; i < 400000; i++ {
-// 		point := metrics.Serie{
-// 			Points: []metrics.Point{
-// 				{Ts: 12345.0, Value: 1.2 * float64(i)},
-// 			},
-// 			MType:    metrics.APIGaugeType,
-// 			Name:     fmt.Sprintf("test.metrics%d", i),
-// 			Interval: 1,
-// 			Host:     "localHost",
-// 			Tags:     []string{"tag1", "tag2:yes"},
-// 		}
-// 		testSeries = append(testSeries, &point)
-// 	}
+func BenchmarkPayloadsSeries(b *testing.B) {
+	testSeries := Series{}
+	for i := 0; i < 400000; i++ {
+		point := Serie{
+			Points: []Point{
+				{Ts: 12345.0, Value: 1.2 * float64(i)},
+			},
+			MType:    APIGaugeType,
+			Name:     fmt.Sprintf("test.metrics%d", i),
+			Interval: 1,
+			Host:     "localHost",
+			Tags:     []string{"tag1", "tag2:yes"},
+		}
+		testSeries = append(testSeries, &point)
+	}
 
-// 	var r forwarder.Payloads
-// 	builder := NewPayloadBuilder()
-// 	for n := 0; n < b.N; n++ {
-// 		// always record the result of Payloads to prevent
-// 		// the compiler eliminating the function call.
-// 		r, _ = builder.Build(testSeries)
-// 	}
-// 	// ensure we actually had to split
-// 	if len(r) != 13 {
-// 		panic(fmt.Sprintf("expecting two payloads, got %d", len(r)))
-// 	}
-// 	// test the compressed size
-// 	var compressedSize int
-// 	for _, p := range r {
-// 		if p == nil {
-// 			continue
-// 		}
-// 		compressedSize += len([]byte(*p))
-// 	}
-// 	if compressedSize > 3000000 {
-// 		panic(fmt.Sprintf("expecting no more than 3 MB, got %d", compressedSize))
-// 	}
-// 	// always store the result to a package level variable
-// 	// so the compiler cannot eliminate the Benchmark itself.
-// 	result = r
-// }
+	var r forwarder.Payloads
+	builder := jsonstream.NewPayloadBuilder()
+	for n := 0; n < b.N; n++ {
+		// always record the result of Payloads to prevent
+		// the compiler eliminating the function call.
+		r, _ = builder.Build(testSeries)
+	}
+	// ensure we actually had to split
+	if len(r) != 13 {
+		panic(fmt.Sprintf("expecting two payloads, got %d", len(r)))
+	}
+	// test the compressed size
+	var compressedSize int
+	for _, p := range r {
+		if p == nil {
+			continue
+		}
+		compressedSize += len([]byte(*p))
+	}
+	if compressedSize > 3000000 {
+		panic(fmt.Sprintf("expecting no more than 3 MB, got %d", compressedSize))
+	}
+	// always store the result to a package level variable
+	// so the compiler cannot eliminate the Benchmark itself.
+	result = r
+}
+
+func decompressPayload(payload []byte) ([]byte, error) {
+	r, err := zlib.NewReader(bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	dst, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return dst, nil
+}

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -377,3 +377,101 @@ func TestDescribeItem(t *testing.T) {
 	desc2 := series.DescribeItem(2)
 	assert.Equal(t, "out of range", desc2)
 }
+
+// // test taken from the spliter
+// func TestPayloadsSeries(t *testing.T) {
+// 	testSeries := metrics.Series{}
+// 	for i := 0; i < 30000; i++ {
+// 		point := metrics.Serie{
+// 			Points: []metrics.Point{
+// 				{Ts: 12345.0, Value: float64(21.21)},
+// 				{Ts: 67890.0, Value: float64(12.12)},
+// 				{Ts: 2222.0, Value: float64(22.12)},
+// 				{Ts: 333.0, Value: float64(32.12)},
+// 				{Ts: 444444.0, Value: float64(42.12)},
+// 				{Ts: 882787.0, Value: float64(52.12)},
+// 				{Ts: 99990.0, Value: float64(62.12)},
+// 				{Ts: 121212.0, Value: float64(72.12)},
+// 				{Ts: 222227.0, Value: float64(82.12)},
+// 				{Ts: 808080.0, Value: float64(92.12)},
+// 				{Ts: 9090.0, Value: float64(13.12)},
+// 			},
+// 			MType:    metrics.APIGaugeType,
+// 			Name:     fmt.Sprintf("test.metrics%d", i),
+// 			Interval: 1,
+// 			Host:     "localHost",
+// 			Tags:     []string{"tag1", "tag2:yes"},
+// 		}
+// 		testSeries = append(testSeries, &point)
+// 	}
+
+// 	originalLength := len(testSeries)
+// 	builder := NewPayloadBuilder()
+// 	payloads, err := builder.Build(testSeries)
+// 	require.Nil(t, err)
+// 	var splitSeries = []metrics.Series{}
+// 	for _, compressedPayload := range payloads {
+// 		payload, err := decompressPayload(*compressedPayload)
+// 		require.NoError(t, err)
+
+// 		var s = map[string]metrics.Series{}
+// 		err = json.Unmarshal(payload, &s)
+// 		require.NoError(t, err)
+// 		splitSeries = append(splitSeries, s["series"])
+// 	}
+
+// 	unrolledSeries := metrics.Series{}
+// 	for _, series := range splitSeries {
+// 		for _, s := range series {
+// 			unrolledSeries = append(unrolledSeries, s)
+// 		}
+// 	}
+
+// 	newLength := len(unrolledSeries)
+// 	require.Equal(t, originalLength, newLength)
+// }
+
+// var result forwarder.Payloads
+
+// func BenchmarkPayloadsSeries(b *testing.B) {
+// 	testSeries := metrics.Series{}
+// 	for i := 0; i < 400000; i++ {
+// 		point := metrics.Serie{
+// 			Points: []metrics.Point{
+// 				{Ts: 12345.0, Value: 1.2 * float64(i)},
+// 			},
+// 			MType:    metrics.APIGaugeType,
+// 			Name:     fmt.Sprintf("test.metrics%d", i),
+// 			Interval: 1,
+// 			Host:     "localHost",
+// 			Tags:     []string{"tag1", "tag2:yes"},
+// 		}
+// 		testSeries = append(testSeries, &point)
+// 	}
+
+// 	var r forwarder.Payloads
+// 	builder := NewPayloadBuilder()
+// 	for n := 0; n < b.N; n++ {
+// 		// always record the result of Payloads to prevent
+// 		// the compiler eliminating the function call.
+// 		r, _ = builder.Build(testSeries)
+// 	}
+// 	// ensure we actually had to split
+// 	if len(r) != 13 {
+// 		panic(fmt.Sprintf("expecting two payloads, got %d", len(r)))
+// 	}
+// 	// test the compressed size
+// 	var compressedSize int
+// 	for _, p := range r {
+// 		if p == nil {
+// 			continue
+// 		}
+// 		compressedSize += len([]byte(*p))
+// 	}
+// 	if compressedSize > 3000000 {
+// 		panic(fmt.Sprintf("expecting no more than 3 MB, got %d", compressedSize))
+// 	}
+// 	// always store the result to a package level variable
+// 	// so the compiler cannot eliminate the Benchmark itself.
+// 	result = r
+// }

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -312,15 +312,15 @@ func TestStreamJSONMarshaler(t *testing.T) {
 	stream.Reset(nil)
 
 	// Access an out-of-bounds item
-	err := series.WriteItem(stream, 10)
+	err := series.WriteItem(stream, 10, 0)
 	assert.EqualError(t, err, "out of range")
-	err = series.WriteItem(stream, -10)
+	err = series.WriteItem(stream, -10, 0)
 	assert.EqualError(t, err, "out of range")
 
 	// Test each item type
 	for i := range series {
 		stream.Reset(nil)
-		err = series.WriteItem(stream, i)
+		err = series.WriteItem(stream, i, 0)
 		assert.NoError(t, err)
 
 		// Make sure the output is valid and matches the original item
@@ -348,7 +348,7 @@ func TestStreamJSONMarshalerWithDevice(t *testing.T) {
 
 	stream := jsoniter.NewStream(jsoniter.ConfigDefault, nil, 0)
 
-	err := series.WriteItem(stream, 0)
+	err := series.WriteItem(stream, 0, 0)
 	assert.NoError(t, err)
 
 	// Make sure the output is valid and fields are as expected

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -180,8 +180,8 @@ func (sc ServiceChecks) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPay
 	return stream.Flush()
 }
 
-// SupportJSONSeparatorInsertion returns true to add JSON separator automatically between two calls of WriteItem, false otherwise.
-func (sc ServiceChecks) SupportJSONSeparatorInsertion() bool { return true }
+// AddJSONSeparatoraAutomatically returns true to add JSON separator automatically between two calls of WriteItem, false otherwise.
+func (sc ServiceChecks) AddJSONSeparatoraAutomatically() bool { return true }
 
 // Len returns the number of items to marshal
 func (sc ServiceChecks) Len() int {

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -146,7 +146,7 @@ func (sc ServiceCheck) String() string {
 }
 
 //// The following methods implement the StreamJSONMarshaler interface
-//// for support of the enable_services_checks_stream_payload_serialization option.
+//// for support of the enable_services_check_stream_payload_serialization option.
 
 // Initialize the data for serialization. Call once before any other methods.
 func (sc ServiceChecks) Initialize() error { return nil }

--- a/pkg/releasenotes/notes/use-new-serialization-for-events-and-servicechecks-2b9d2f1331444637.yaml
+++ b/pkg/releasenotes/notes/use-new-serialization-for-events-and-servicechecks-2b9d2f1331444637.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix 'Error code "413 Request Entity Too Large" received while sending transaction to "https://dd.agent.datadoghq.eu/api/v1/check_run?api_key=*************************28e95": Payload too big, dropping it'

--- a/pkg/serializer/jsonstream/compressor.go
+++ b/pkg/serializer/jsonstream/compressor.go
@@ -174,7 +174,7 @@ func (c *compressor) close(footerOverride []byte) ([]byte, error) {
 		}
 	}
 	// Add json footer
-	if footerOverride == nil || len(footerOverride) == 0 {
+	if len(footerOverride) == 0 {
 		return nil, errors.New("footerOverride is empty")
 	}
 

--- a/pkg/serializer/jsonstream/compressor_test.go
+++ b/pkg/serializer/jsonstream/compressor_test.go
@@ -27,9 +27,10 @@ var (
 )
 
 type dummyMarshaller struct {
-	items  []string
-	header string
-	footer string
+	items               []string
+	header              string
+	footer              string
+	itemIndexInPayloads []int
 }
 
 func resetDefaults() {
@@ -45,10 +46,11 @@ func (d *dummyMarshaller) Len() int {
 	return len(d.items)
 }
 
-func (d *dummyMarshaller) WriteItem(stream *jsoniter.Stream, i int) error {
+func (d *dummyMarshaller) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayload int) error {
 	if i < 0 || i > d.Len()-1 {
 		return errors.New("out of range")
 	}
+	d.itemIndexInPayloads = append(d.itemIndexInPayloads, itemIndexInPayload)
 	_, err := stream.Write([]byte(d.items[i]))
 	return err
 }
@@ -160,4 +162,5 @@ func TestTwoPayload(t *testing.T) {
 
 	require.Equal(t, "{[A,B,C]}", payloadToString(*payloads[0]))
 	require.Equal(t, "{[D,E,F]}", payloadToString(*payloads[1]))
+	require.Equal(t, []int{0, 1, 2, 3, 0, 1, 2}, m.itemIndexInPayloads)
 }

--- a/pkg/serializer/jsonstream/compressor_test.go
+++ b/pkg/serializer/jsonstream/compressor_test.go
@@ -10,7 +10,6 @@ package jsonstream
 import (
 	"bytes"
 	"compress/zlib"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -20,8 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/forwarder"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
 
@@ -163,102 +160,4 @@ func TestTwoPayload(t *testing.T) {
 
 	require.Equal(t, "{[A,B,C]}", payloadToString(*payloads[0]))
 	require.Equal(t, "{[D,E,F]}", payloadToString(*payloads[1]))
-}
-
-// test taken from the spliter
-func TestPayloadsSeries(t *testing.T) {
-	testSeries := metrics.Series{}
-	for i := 0; i < 30000; i++ {
-		point := metrics.Serie{
-			Points: []metrics.Point{
-				{Ts: 12345.0, Value: float64(21.21)},
-				{Ts: 67890.0, Value: float64(12.12)},
-				{Ts: 2222.0, Value: float64(22.12)},
-				{Ts: 333.0, Value: float64(32.12)},
-				{Ts: 444444.0, Value: float64(42.12)},
-				{Ts: 882787.0, Value: float64(52.12)},
-				{Ts: 99990.0, Value: float64(62.12)},
-				{Ts: 121212.0, Value: float64(72.12)},
-				{Ts: 222227.0, Value: float64(82.12)},
-				{Ts: 808080.0, Value: float64(92.12)},
-				{Ts: 9090.0, Value: float64(13.12)},
-			},
-			MType:    metrics.APIGaugeType,
-			Name:     fmt.Sprintf("test.metrics%d", i),
-			Interval: 1,
-			Host:     "localHost",
-			Tags:     []string{"tag1", "tag2:yes"},
-		}
-		testSeries = append(testSeries, &point)
-	}
-
-	originalLength := len(testSeries)
-	builder := NewPayloadBuilder()
-	payloads, err := builder.Build(testSeries)
-	require.Nil(t, err)
-	var splitSeries = []metrics.Series{}
-	for _, compressedPayload := range payloads {
-		payload, err := decompressPayload(*compressedPayload)
-		require.NoError(t, err)
-
-		var s = map[string]metrics.Series{}
-		err = json.Unmarshal(payload, &s)
-		require.NoError(t, err)
-		splitSeries = append(splitSeries, s["series"])
-	}
-
-	unrolledSeries := metrics.Series{}
-	for _, series := range splitSeries {
-		for _, s := range series {
-			unrolledSeries = append(unrolledSeries, s)
-		}
-	}
-
-	newLength := len(unrolledSeries)
-	require.Equal(t, originalLength, newLength)
-}
-
-var result forwarder.Payloads
-
-func BenchmarkPayloadsSeries(b *testing.B) {
-	testSeries := metrics.Series{}
-	for i := 0; i < 400000; i++ {
-		point := metrics.Serie{
-			Points: []metrics.Point{
-				{Ts: 12345.0, Value: 1.2 * float64(i)},
-			},
-			MType:    metrics.APIGaugeType,
-			Name:     fmt.Sprintf("test.metrics%d", i),
-			Interval: 1,
-			Host:     "localHost",
-			Tags:     []string{"tag1", "tag2:yes"},
-		}
-		testSeries = append(testSeries, &point)
-	}
-
-	var r forwarder.Payloads
-	builder := NewPayloadBuilder()
-	for n := 0; n < b.N; n++ {
-		// always record the result of Payloads to prevent
-		// the compiler eliminating the function call.
-		r, _ = builder.Build(testSeries)
-	}
-	// ensure we actually had to split
-	if len(r) != 13 {
-		panic(fmt.Sprintf("expecting two payloads, got %d", len(r)))
-	}
-	// test the compressed size
-	var compressedSize int
-	for _, p := range r {
-		if p == nil {
-			continue
-		}
-		compressedSize += len([]byte(*p))
-	}
-	if compressedSize > 3000000 {
-		panic(fmt.Sprintf("expecting no more than 3 MB, got %d", compressedSize))
-	}
-	// always store the result to a package level variable
-	// so the compiler cannot eliminate the Benchmark itself.
-	result = r
 }

--- a/pkg/serializer/jsonstream/compressor_test.go
+++ b/pkg/serializer/jsonstream/compressor_test.go
@@ -69,7 +69,7 @@ func (d *dummyMarshaller) WriteFooter(stream *jsoniter.Stream) error {
 	return err
 }
 
-func (p *dummyMarshaller) SupportJSONSeparatorInsertion() bool { return true }
+func (p *dummyMarshaller) AddJSONSeparatoraAutomatically() bool { return true }
 func (p *dummyMarshaller) WriteLastFooter(stream *jsoniter.Stream, itemWrittenCount int) error {
 	return p.WriteFooter(stream)
 }

--- a/pkg/serializer/jsonstream/json_raw_object_writer.go
+++ b/pkg/serializer/jsonstream/json_raw_object_writer.go
@@ -68,7 +68,7 @@ func (writer *JSONRawObjectWriter) AddStringValue(value string) {
 	writer.stream.WriteString(value)
 }
 
-// Close closes the JSON object and flush the stream
+// Close closes the JSON object and flushes the stream
 func (writer *JSONRawObjectWriter) Close() error {
 	writer.stream.WriteObjectEnd()
 	return writer.stream.Flush()

--- a/pkg/serializer/jsonstream/json_raw_object_writer.go
+++ b/pkg/serializer/jsonstream/json_raw_object_writer.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+
+package jsonstream
+
+import jsoniter "github.com/json-iterator/go"
+
+// JSONRawObjectWriter contains helper functions to write JSON using the raw API.
+type JSONRawObjectWriter struct {
+	stream                  *jsoniter.Stream
+	requireSeparatorByScope []bool
+}
+
+// NewJSONRawObjectWriter creates a new instance of JSONRawObjectWriter
+func NewJSONRawObjectWriter(stream *jsoniter.Stream) *JSONRawObjectWriter {
+	writer := &JSONRawObjectWriter{stream: stream}
+	writer.stream.WriteObjectStart()
+	writer.addScope()
+	return writer
+}
+
+// JSONRawObjectWriterEmptyPolicy defines the behavior when adding an empty string
+type JSONRawObjectWriterEmptyPolicy int
+
+const (
+	// OmitEmpty does not write the field if the string is empty
+	OmitEmpty JSONRawObjectWriterEmptyPolicy = iota
+
+	// AllowEmpty writes the string even if the string is empty
+	AllowEmpty
+)
+
+// AddStringField adds a new field of type string
+func (writer *JSONRawObjectWriter) AddStringField(fieldName string, value string, policy JSONRawObjectWriterEmptyPolicy) {
+	if value != "" || policy == AllowEmpty {
+		writer.writeSeparatorIfNeeded()
+		writer.stream.WriteObjectField(fieldName)
+		writer.stream.WriteString(value)
+	}
+}
+
+// AddInt64Field adds a new field of type int64
+func (writer *JSONRawObjectWriter) AddInt64Field(fieldName string, value int64) {
+	writer.writeSeparatorIfNeeded()
+	writer.stream.WriteObjectField(fieldName)
+	writer.stream.WriteInt64(value)
+}
+
+// StartArrayField starts a new field of type array
+func (writer *JSONRawObjectWriter) StartArrayField(fieldName string) {
+	writer.writeSeparatorIfNeeded()
+	writer.stream.WriteObjectField(fieldName)
+	writer.stream.WriteArrayStart()
+	writer.addScope()
+}
+
+// FinishArrayField finishes an array field
+func (writer *JSONRawObjectWriter) FinishArrayField() {
+	writer.stream.WriteArrayEnd()
+	writer.removeScope()
+}
+
+// AddStringValue adds a string (for example inside an array)
+func (writer *JSONRawObjectWriter) AddStringValue(value string) {
+	writer.writeSeparatorIfNeeded()
+	writer.stream.WriteString(value)
+}
+
+// Close closes the JSON object and flush the stream
+func (writer *JSONRawObjectWriter) Close() error {
+	writer.stream.WriteObjectEnd()
+	return writer.stream.Flush()
+}
+
+func (writer *JSONRawObjectWriter) toString() string {
+	return string(writer.stream.Buffer())
+}
+
+func (writer *JSONRawObjectWriter) writeSeparatorIfNeeded() {
+	if len(writer.requireSeparatorByScope) > 0 {
+		index := len(writer.requireSeparatorByScope) - 1
+		if writer.requireSeparatorByScope[index] {
+			writer.stream.WriteMore()
+		} else {
+			writer.requireSeparatorByScope[index] = true
+		}
+	}
+}
+
+func (writer *JSONRawObjectWriter) addScope() {
+	writer.requireSeparatorByScope = append(writer.requireSeparatorByScope, false)
+}
+
+func (writer *JSONRawObjectWriter) removeScope() {
+	len := len(writer.requireSeparatorByScope)
+	if len > 0 {
+		writer.requireSeparatorByScope = writer.requireSeparatorByScope[:len-1]
+	}
+}

--- a/pkg/serializer/jsonstream/json_raw_object_writer_test.go
+++ b/pkg/serializer/jsonstream/json_raw_object_writer_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+
+package jsonstream
+
+import (
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func newJSONRawObjectWriterTest() *JSONRawObjectWriter {
+	jsonStream := jsoniter.NewStream(jsoniter.ConfigDefault, nil, 0)
+
+	return NewJSONRawObjectWriter(jsonStream)
+}
+
+func TestJSONRawObjectWriterSimpleField(t *testing.T) {
+	writer := newJSONRawObjectWriterTest()
+
+	writer.AddStringField("f1", "1", AllowEmpty)
+	writer.AddStringField("f2", "", OmitEmpty)
+	writer.AddInt64Field("f3", 3)
+	writer.Close()
+
+	assert.Equal(t, `{"f1":"1","f3":3}`, writer.toString())
+}
+
+func TestJSONRawObjectWriterStringArray(t *testing.T) {
+	writer := newJSONRawObjectWriterTest()
+
+	writer.StartArrayField("array")
+	writer.AddStringValue("1")
+	writer.AddStringValue("2")
+	writer.AddStringValue("3")
+	writer.FinishArrayField()
+	writer.Close()
+
+	assert.Equal(t, `{"array":["1","2","3"]}`, writer.toString())
+}

--- a/pkg/serializer/jsonstream/payload_builder.go
+++ b/pkg/serializer/jsonstream/payload_builder.go
@@ -116,7 +116,10 @@ func (b *PayloadBuilder) Build(m marshaler.StreamJSONMarshaler) (forwarder.Paylo
 
 	// Close last payload
 	jsonStream.Reset(nil)
-	m.WriteLastFooter(jsonStream, itemIndexInPayload)
+	if err = m.WriteLastFooter(jsonStream, itemIndexInPayload); err != nil {
+		return nil, err
+	}
+
 	payload, err := compressor.close(jsonStream.Buffer())
 	if err != nil {
 		return payloads, err

--- a/pkg/serializer/jsonstream/payload_builder.go
+++ b/pkg/serializer/jsonstream/payload_builder.go
@@ -68,11 +68,12 @@ func (b *PayloadBuilder) Build(m marshaler.StreamJSONMarshaler) (forwarder.Paylo
 		return nil, err
 	}
 
+	itemIndexInPayload := 0
 	for i < itemCount {
 		// We keep reusing the same small buffer in the jsoniter stream. Note that we can do so
 		// because compressor.addItem copies given buffer.
 		jsonStream.Reset(nil)
-		err := m.WriteItem(jsonStream, i)
+		err := m.WriteItem(jsonStream, i, itemIndexInPayload)
 		if err != nil {
 			log.Warnf("error marshalling an item, skipping: %s", err)
 			i++
@@ -93,9 +94,11 @@ func (b *PayloadBuilder) Build(m marshaler.StreamJSONMarshaler) (forwarder.Paylo
 			if err != nil {
 				return nil, err
 			}
+			itemIndexInPayload = 0
 		case nil:
 			// All good, continue to next item
 			i++
+			itemIndexInPayload++
 			expvarsTotalItems.Add(1)
 			continue
 		default:

--- a/pkg/serializer/jsonstream/payload_builder.go
+++ b/pkg/serializer/jsonstream/payload_builder.go
@@ -66,7 +66,7 @@ func (b *PayloadBuilder) Build(m marshaler.StreamJSONMarshaler) (forwarder.Paylo
 	if err != nil {
 		return nil, err
 	}
-	insertSepBetweenItems := m.SupportJSONSeparatorInsertion()
+	insertSepBetweenItems := m.AddJSONSeparatoraAutomatically()
 	compressor, err := newCompressor(input, output, header.Bytes(), footer.Bytes(), insertSepBetweenItems)
 	if err != nil {
 		return nil, err

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -17,9 +17,12 @@ type Marshaler interface {
 // StreamJSONMarshaler is an interface for metrics that are able to serialize themselves in a stream
 type StreamJSONMarshaler interface {
 	Marshaler
+	Initialize() error
 	WriteHeader(*jsoniter.Stream) error
 	WriteFooter(*jsoniter.Stream) error
+	WriteLastFooter(stream *jsoniter.Stream, itemWrittenCount int) error
 	WriteItem(stream *jsoniter.Stream, index int, itemIndexInPayload int) error
 	Len() int
 	DescribeItem(i int) string
+	SupportJSONSeparatorInsertion() bool
 }

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -19,7 +19,7 @@ type StreamJSONMarshaler interface {
 	Marshaler
 	WriteHeader(*jsoniter.Stream) error
 	WriteFooter(*jsoniter.Stream) error
-	WriteItem(*jsoniter.Stream, int) error
+	WriteItem(stream *jsoniter.Stream, index int, itemIndexInPayload int) error
 	Len() int
 	DescribeItem(i int) string
 }

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -24,5 +24,5 @@ type StreamJSONMarshaler interface {
 	WriteItem(stream *jsoniter.Stream, index int, itemIndexInPayload int) error
 	Len() int
 	DescribeItem(i int) string
-	SupportJSONSeparatorInsertion() bool
+	AddJSONSeparatoraAutomatically() bool
 }

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -73,7 +73,7 @@ func initExtraHeaders() {
 // MetricSerializer represents the interface of method needed by the aggregator to serialize its data
 type MetricSerializer interface {
 	SendEvents(e marshaler.StreamJSONMarshaler) error
-	SendServiceChecks(sc marshaler.Marshaler) error
+	SendServiceChecks(sc marshaler.StreamJSONMarshaler) error
 	SendSeries(series marshaler.StreamJSONMarshaler) error
 	SendSketch(sketches marshaler.Marshaler) error
 	SendMetadata(m marshaler.Marshaler) error
@@ -92,27 +92,29 @@ type Serializer struct {
 	// might collect data considered too sensitive (database IP and
 	// such). By default every kind of payload is enabled since
 	// almost every user won't fall into this use case.
-	enableEvents           bool
-	enableSeries           bool
-	enableServiceChecks    bool
-	enableSketches         bool
-	enableJSONToV1Intake   bool
-	enableJSONStream       bool
-	enableEventsJSONStream bool
+	enableEvents                  bool
+	enableSeries                  bool
+	enableServiceChecks           bool
+	enableSketches                bool
+	enableJSONToV1Intake          bool
+	enableJSONStream              bool
+	enableEventsJSONStream        bool
+	enableServiceChecksJSONStream bool
 }
 
 // NewSerializer returns a new Serializer initialized
 func NewSerializer(forwarder forwarder.Forwarder) *Serializer {
 	s := &Serializer{
-		Forwarder:              forwarder,
-		seriesPayloadBuilder:   jsonstream.NewPayloadBuilder(),
-		enableEvents:           config.Datadog.GetBool("enable_payloads.events"),
-		enableSeries:           config.Datadog.GetBool("enable_payloads.series"),
-		enableServiceChecks:    config.Datadog.GetBool("enable_payloads.service_checks"),
-		enableSketches:         config.Datadog.GetBool("enable_payloads.sketches"),
-		enableJSONToV1Intake:   config.Datadog.GetBool("enable_payloads.json_to_v1_intake"),
-		enableJSONStream:       jsonstream.Available && config.Datadog.GetBool("enable_stream_payload_serialization"),
-		enableEventsJSONStream: jsonstream.Available && config.Datadog.GetBool("enable_events_stream_payload_serialization"),
+		Forwarder:                     forwarder,
+		seriesPayloadBuilder:          jsonstream.NewPayloadBuilder(),
+		enableEvents:                  config.Datadog.GetBool("enable_payloads.events"),
+		enableSeries:                  config.Datadog.GetBool("enable_payloads.series"),
+		enableServiceChecks:           config.Datadog.GetBool("enable_payloads.service_checks"),
+		enableSketches:                config.Datadog.GetBool("enable_payloads.sketches"),
+		enableJSONToV1Intake:          config.Datadog.GetBool("enable_payloads.json_to_v1_intake"),
+		enableJSONStream:              jsonstream.Available && config.Datadog.GetBool("enable_stream_payload_serialization"),
+		enableEventsJSONStream:        jsonstream.Available && config.Datadog.GetBool("enable_events_stream_payload_serialization"),
+		enableServiceChecksJSONStream: jsonstream.Available && config.Datadog.GetBool("enable_service_checks_stream_payload_serialization"),
 	}
 
 	if !s.enableEvents {
@@ -198,7 +200,7 @@ func (s *Serializer) SendEvents(e marshaler.StreamJSONMarshaler) error {
 }
 
 // SendServiceChecks serializes a list of serviceChecks and sends the payload to the forwarder
-func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
+func (s *Serializer) SendServiceChecks(sc marshaler.StreamJSONMarshaler) error {
 	if !s.enableServiceChecks {
 		log.Debug("service_checks payloads are disabled: dropping it")
 		return nil
@@ -206,8 +208,16 @@ func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
 
 	useV1API := !config.Datadog.GetBool("use_v2_api.service_checks")
 
-	compress := true
-	serviceCheckPayloads, extraHeaders, err := s.serializePayload(sc, compress, useV1API)
+	var serviceCheckPayloads forwarder.Payloads
+	var extraHeaders http.Header
+	var err error
+
+	if useV1API && s.enableServiceChecksJSONStream {
+		serviceCheckPayloads, extraHeaders, err = s.serializeStreamablePayload(sc)
+	} else {
+		compress := true
+		serviceCheckPayloads, extraHeaders, err = s.serializePayload(sc, compress, useV1API)
+	}
 	if err != nil {
 		return fmt.Errorf("dropping service check payload: %s", err)
 	}

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -116,7 +116,7 @@ func (p *testPayload) WriteFooter(stream *jsoniter.Stream) error {
 	_, err := stream.Write(jsonFooter)
 	return err
 }
-func (p *testPayload) WriteItem(stream *jsoniter.Stream, i int) error {
+func (p *testPayload) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayload int) error {
 	_, err := stream.Write(jsonItem)
 	return err
 }
@@ -139,7 +139,7 @@ func (p *testErrorPayload) WriteFooter(stream *jsoniter.Stream) error {
 	_, err := stream.Write(jsonFooter)
 	return err
 }
-func (p *testErrorPayload) WriteItem(stream *jsoniter.Stream, i int) error {
+func (p *testErrorPayload) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayload int) error {
 	return fmt.Errorf("some error")
 }
 func (p *testErrorPayload) Len() int                  { return 1 }

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -123,7 +123,7 @@ func (p *testPayload) WriteLastFooter(stream *jsoniter.Stream, itemWrittenCount 
 	return p.WriteFooter(stream)
 }
 
-func (p *testPayload) SupportJSONSeparatorInsertion() bool { return true }
+func (p *testPayload) AddJSONSeparatoraAutomatically() bool { return true }
 
 func (p *testPayload) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayload int) error {
 	_, err := stream.Write(jsonItem)
@@ -136,7 +136,7 @@ type testErrorPayload struct{}
 
 func (p *testErrorPayload) Initialize() error { return fmt.Errorf("some error") }
 
-func (p *testErrorPayload) SupportJSONSeparatorInsertion() bool { return true }
+func (p *testErrorPayload) AddJSONSeparatoraAutomatically() bool { return true }
 func (p *testErrorPayload) MarshalJSON() ([]byte, error)        { return nil, fmt.Errorf("some error") }
 func (p *testErrorPayload) Marshal() ([]byte, error)            { return nil, fmt.Errorf("some error") }
 func (p *testErrorPayload) SplitPayload(int) ([]marshaler.Marshaler, error) {

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -108,6 +108,8 @@ func (p *testPayload) SplitPayload(int) ([]marshaler.Marshaler, error) {
 	return []marshaler.Marshaler{}, nil
 }
 
+func (p *testPayload) Initialize() error { return nil }
+
 func (p *testPayload) WriteHeader(stream *jsoniter.Stream) error {
 	_, err := stream.Write(jsonHeader)
 	return err
@@ -116,6 +118,13 @@ func (p *testPayload) WriteFooter(stream *jsoniter.Stream) error {
 	_, err := stream.Write(jsonFooter)
 	return err
 }
+
+func (p *testPayload) WriteLastFooter(stream *jsoniter.Stream, itemWrittenCount int) error {
+	return p.WriteFooter(stream)
+}
+
+func (p *testPayload) SupportJSONSeparatorInsertion() bool { return true }
+
 func (p *testPayload) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayload int) error {
 	_, err := stream.Write(jsonItem)
 	return err
@@ -125,8 +134,11 @@ func (p *testPayload) DescribeItem(i int) string { return "description" }
 
 type testErrorPayload struct{}
 
-func (p *testErrorPayload) MarshalJSON() ([]byte, error) { return nil, fmt.Errorf("some error") }
-func (p *testErrorPayload) Marshal() ([]byte, error)     { return nil, fmt.Errorf("some error") }
+func (p *testErrorPayload) Initialize() error { return fmt.Errorf("some error") }
+
+func (p *testErrorPayload) SupportJSONSeparatorInsertion() bool { return true }
+func (p *testErrorPayload) MarshalJSON() ([]byte, error)        { return nil, fmt.Errorf("some error") }
+func (p *testErrorPayload) Marshal() ([]byte, error)            { return nil, fmt.Errorf("some error") }
 func (p *testErrorPayload) SplitPayload(int) ([]marshaler.Marshaler, error) {
 	return []marshaler.Marshaler{}, fmt.Errorf("some error")
 }
@@ -139,6 +151,11 @@ func (p *testErrorPayload) WriteFooter(stream *jsoniter.Stream) error {
 	_, err := stream.Write(jsonFooter)
 	return err
 }
+
+func (p *testErrorPayload) WriteLastFooter(stream *jsoniter.Stream, itemWrittenCount int) error {
+	return fmt.Errorf("some error")
+}
+
 func (p *testErrorPayload) WriteItem(stream *jsoniter.Stream, i int, itemIndexInPayload int) error {
 	return fmt.Errorf("some error")
 }

--- a/pkg/serializer/test_common.go
+++ b/pkg/serializer/test_common.go
@@ -17,12 +17,12 @@ type MockSerializer struct {
 }
 
 // SendEvents serializes a list of event and sends the payload to the forwarder
-func (s *MockSerializer) SendEvents(e marshaler.Marshaler) error {
+func (s *MockSerializer) SendEvents(e marshaler.StreamJSONMarshaler) error {
 	return s.Called(e).Error(0)
 }
 
 // SendServiceChecks serializes a list of serviceChecks and sends the payload to the forwarder
-func (s *MockSerializer) SendServiceChecks(sc marshaler.Marshaler) error {
+func (s *MockSerializer) SendServiceChecks(sc marshaler.StreamJSONMarshaler) error {
 	return s.Called(sc).Error(0)
 }
 


### PR DESCRIPTION
### What does this PR do?

Serialize payloads by building them incrementally for events and service checks.

### Motivation

The old split serialization logic, currently still used by those 2 payloads, was not checking the uncompressed size.

### Additional Notes

Reviewing commit by commit can help