### PR TITLE
[e2e] bumping flask to latest version

### DIFF
--- a/test/e2e/containers/fake_datadog/app/requirements.txt
+++ b/test/e2e/containers/fake_datadog/app/requirements.txt
@@ -1,4 +1,4 @@
-Flask==0.12.3
+Flask==1.1.1
 gunicorn==19.7.1
 ujson==1.35
 pymongo==3.6.1


### PR DESCRIPTION
### What does this PR do?

Bumps Flask to `1.1.1`, latest version.

### Motivation

Best practice.
