### PR TITLE
Poll AD docker config more frequently

### DIFF
--- a/Dockerfiles/agent/datadog-docker.yaml
+++ b/Dockerfiles/agent/datadog-docker.yaml
@@ -7,6 +7,7 @@ listeners:
 config_providers:
   - name: docker
     polling: true
+    poll_interval: 1s
 
 # Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:

--- a/Dockerfiles/agent/datadog-k8s-docker.yaml
+++ b/Dockerfiles/agent/datadog-k8s-docker.yaml
@@ -11,6 +11,7 @@ config_providers:
   # needed to support legacy docker label config templates
   - name: docker
     polling: true
+    poll_interval: 1s
 
 # Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:

--- a/releasenotes/notes/docker-polling-frequency-613d65da180f29c8.yaml
+++ b/releasenotes/notes/docker-polling-frequency-613d65da180f29c8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Docker label autodiscovery configurations are now polled more often by default.


### PR DESCRIPTION
### What does this PR do?

Lower config polling interval for docker from 10s to 1s.

### Motivation

Docker events are streamed so it's cheap to lower this and will enhance short lived containers detection
