### PR TITLE
[releasenotes] Clarify purpose and usage of the `Upgrade Notes` section

### DIFF
--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -126,7 +126,7 @@ users and not its developers.
       collection, `kube_service` tagging) is not implemented
   ```
 
-- `upgrade`: List action to take or limitation that could arise upon upgrading the agent.
+- `upgrade`: List actions to take or limitations that could arise upon upgrading the agent. Notes here must include steps that users can follow to 1. know if they're affected and 2. handle the change gracefully on their end.
 
   example:
   ```yaml

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -126,7 +126,7 @@ users and not its developers.
       collection, `kube_service` tagging) is not implemented
   ```
 
-- `upgrade`: List actions to take or limitations that could arise upon upgrading the agent. Notes here must include steps that users can follow to 1. know if they're affected and 2. handle the change gracefully on their end.
+- `upgrade`: List actions to take or limitations that could arise upon upgrading the Agent. Notes here must include steps that users can follow to 1. know if they're affected and 2. handle the change gracefully on their end.
 
   example:
   ```yaml

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -15,8 +15,10 @@ template: |
           upgrade:
             - |
               List upgrade notes here, or remove this section.
-              Only list known/potential breaking changes, or behavior changes
-              that users should absolutely know about before upgrading.
+              Upgrade notes should be rare: only list known/potential breaking changes,
+              or major behaviorial changes that require user action before the upgrade.
+              Notes here must include steps that users can follow to 1. know if they're
+              affected and 2. handle the change gracefully on their end.
           features:
             - |
               List new features here, or remove this section.


### PR DESCRIPTION
### What does this PR do?

Clarifies the purpose and the usage of the `Upgrade Notes` section.

### Motivation

Allow devs to understand what this section is for. Notes in this section should remain rare so that it's easy for a user to quickly know what they need to pay attention to before upgrading.
