### PR TITLE
[kitchen] Use chef-datadog 3.2.0 cookbook

### DIFF
--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -1,7 +1,6 @@
 source 'https://supermarket.chef.io'
 
-# FIXME: Go back to pinning a version instead of a branch when 'kserrania/fix-sles-gpg-key-add' gets merged.
-cookbook 'datadog', git: "https://github.com/datadog/chef-datadog.git", branch: "kserrania/fix-sles-gpg-key-add"
+cookbook 'datadog', '~> 3.2.0'
 
 # We pin an old version of the apt cookbook because this cookbook triggers an "apt update" by default
 # and in newer versions this update is not allowed to fail, while in 3.X it is. For some reason


### PR DESCRIPTION
### What does this PR do?

Switch to using version `3.2.0` of the `chef-datadog` cookbook.

### Motivation

The SLES 15 fix that was introduced in the branch we were tracking has been added to the cookbook.
