### PR TITLE
Add the histogram bucket bridge

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -125,6 +125,7 @@ func init() {
 	aggregatorExpvars.Set("NumberOfFlush", &aggregatorNumberOfFlush)
 	aggregatorExpvars.Set("DogstatsdMetricSample", &aggregatorDogstatsdMetricSample)
 	aggregatorExpvars.Set("ChecksMetricSample", &aggregatorChecksMetricSample)
+	aggregatorExpvars.Set("ChecksHistogramBucketMetricSample", &aggregatorCheckHistogramBucketMetricSample)
 	aggregatorExpvars.Set("ServiceCheck", &aggregatorServiceCheck)
 	aggregatorExpvars.Set("Event", &aggregatorEvent)
 	aggregatorExpvars.Set("HostnameUpdate", &aggregatorHostnameUpdate)

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -18,6 +18,7 @@ type CheckSampler struct {
 	series          []*metrics.Serie
 	contextResolver *ContextResolver
 	metrics         metrics.ContextMetrics
+	sketchMap       sketchMap
 }
 
 // newCheckSampler returns a newly initialized CheckSampler
@@ -26,6 +27,7 @@ func newCheckSampler() *CheckSampler {
 		series:          make([]*metrics.Serie, 0),
 		contextResolver: newContextResolver(),
 		metrics:         metrics.MakeContextMetrics(),
+		sketchMap:       make(sketchMap),
 	}
 }
 
@@ -35,6 +37,10 @@ func (cs *CheckSampler) addSample(metricSample *metrics.MetricSample) {
 	if err := cs.metrics.AddSample(contextKey, metricSample, metricSample.Timestamp, 1); err != nil {
 		log.Debug("Ignoring sample '%s' on host '%s' and tags '%s': %s", metricSample.Name, metricSample.Host, metricSample.Tags, err)
 	}
+}
+
+func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
+	log.Errorf("Adding bucket %v", bucket)
 }
 
 func (cs *CheckSampler) commit(timestamp float64) {

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -100,7 +100,7 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
 	}
 
 	if bucket.Value < 0 {
-		log.Warnf("Negative bucket value %d for metric %s discarding", bucket.Value, bucket.Name)
+		log.Warnf("Negative bucket delta %d for metric %s discarding", bucket.Value, bucket.Name)
 		return
 	}
 	if bucket.Value == 0 {

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -40,6 +40,8 @@ func (cs *CheckSampler) addSample(metricSample *metrics.MetricSample) {
 }
 
 func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
+	// contextKey := cs.contextResolver.trackContext(bucket, bucket.Timestamp)
+
 	log.Errorf("Adding bucket %v", bucket)
 }
 

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+func benchmarkAddBucket(bucketValue int, b *testing.B) {
+	checkSampler := newCheckSampler()
+
+	bucket := &metrics.HistogramBucket{
+		Name:       "my.histogram",
+		Value:      bucketValue,
+		LowerBound: 10.0,
+		UpperBound: 20.0,
+		Tags:       []string{"foo", "bar"},
+		Timestamp:  12345.0,
+	}
+
+	for n := 0; n < b.N; n++ {
+		checkSampler.addBucket(bucket)
+		// reset bucket cache
+		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int)
+		checkSampler.lastSeenBucket = make(map[ckey.ContextKey]time.Time)
+	}
+}
+
+func BenchmarkAddBucket1(b *testing.B)        { benchmarkAddBucket(1, b) }
+func BenchmarkAddBucket100(b *testing.B)      { benchmarkAddBucket(100, b) }
+func BenchmarkAddBucket10000(b *testing.B)    { benchmarkAddBucket(10000, b) }
+func BenchmarkAddBucket1000000(b *testing.B)  { benchmarkAddBucket(1000000, b) }
+func BenchmarkAddBucket10000000(b *testing.B) { benchmarkAddBucket(10000000, b) }

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -34,7 +34,9 @@ func benchmarkAddBucket(bucketValue int, b *testing.B) {
 }
 
 func BenchmarkAddBucket1(b *testing.B)        { benchmarkAddBucket(1, b) }
+func BenchmarkAddBucket10(b *testing.B)       { benchmarkAddBucket(10, b) }
 func BenchmarkAddBucket100(b *testing.B)      { benchmarkAddBucket(100, b) }
+func BenchmarkAddBucket1000(b *testing.B)     { benchmarkAddBucket(1000, b) }
 func BenchmarkAddBucket10000(b *testing.B)    { benchmarkAddBucket(10000, b) }
 func BenchmarkAddBucket1000000(b *testing.B)  { benchmarkAddBucket(1000000, b) }
 func BenchmarkAddBucket10000000(b *testing.B) { benchmarkAddBucket(10000000, b) }

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -9,12 +9,14 @@ import (
 	// stdlib
 	"sort"
 	"testing"
+	"time"
 
 	// 3p
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/quantile"
 )
 
 func TestCheckGaugeSampling(t *testing.T) {
@@ -190,4 +192,73 @@ func TestHistogramIntervalSampling(t *testing.T) {
 	}
 
 	assert.True(t, foundCount)
+}
+
+func TestCheckHistogramBucketSampling(t *testing.T) {
+	checkSampler := newCheckSampler()
+	checkSampler.bucketExpiry = 10 * time.Millisecond
+
+	bucket1 := &metrics.HistogramBucket{
+		Name:       "my.histogram",
+		Value:      4.0,
+		LowerBound: 10.0,
+		UpperBound: 20.0,
+		Tags:       []string{"foo", "bar"},
+		Timestamp:  12345.0,
+	}
+	checkSampler.addBucket(bucket1)
+	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
+	assert.Equal(t, len(checkSampler.lastSeenBucket), 1)
+
+	checkSampler.commit(12349.0)
+	_, flushed := checkSampler.flush()
+
+	expSketch := &quantile.Sketch{}
+	// linear interpolated values
+	expSketch.Insert(quantile.Default(), 10.0, 12.5, 15.0, 17.5)
+
+	assert.Equal(t, 1, len(flushed))
+	metrics.AssertSketchSeriesEqual(t, metrics.SketchSeries{
+		Name: "my.histogram",
+		Tags: []string{"foo", "bar"},
+		Points: []metrics.SketchPoint{
+			{Ts: 12345.0, Sketch: expSketch},
+		},
+		ContextKey: generateContextKey(bucket1),
+	}, flushed[0])
+
+	bucket2 := &metrics.HistogramBucket{
+		Name:       "my.histogram",
+		Value:      6.0,
+		LowerBound: 10.0,
+		UpperBound: 20.0,
+		Tags:       []string{"foo", "bar"},
+		Timestamp:  12400.0,
+	}
+	checkSampler.addBucket(bucket2)
+	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
+	assert.Equal(t, len(checkSampler.lastSeenBucket), 1)
+
+	checkSampler.commit(12401.0)
+	_, flushed = checkSampler.flush()
+
+	expSketch = &quantile.Sketch{}
+	// linear interpolated values (only 2 since we stored the delta)
+	expSketch.Insert(quantile.Default(), 10.0, 15.0)
+
+	assert.Equal(t, 1, len(flushed))
+	metrics.AssertSketchSeriesEqual(t, metrics.SketchSeries{
+		Name: "my.histogram",
+		Tags: []string{"foo", "bar"},
+		Points: []metrics.SketchPoint{
+			{Ts: 12400.0, Sketch: expSketch},
+		},
+		ContextKey: generateContextKey(bucket1),
+	}, flushed[0])
+
+	// garbage collection
+	time.Sleep(11 * time.Millisecond)
+	checkSampler.flush()
+	assert.Equal(t, len(checkSampler.lastBucketValue), 0)
+	assert.Equal(t, len(checkSampler.lastSeenBucket), 0)
 }

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -7,6 +7,7 @@ package aggregator
 
 import (
 	// stdlib
+	"math"
 	"sort"
 	"testing"
 	"time"
@@ -261,4 +262,72 @@ func TestCheckHistogramBucketSampling(t *testing.T) {
 	checkSampler.flush()
 	assert.Equal(t, len(checkSampler.lastBucketValue), 0)
 	assert.Equal(t, len(checkSampler.lastSeenBucket), 0)
+}
+
+func TestCheckHistogramBucketInfinityBucket(t *testing.T) {
+	checkSampler := newCheckSampler()
+	checkSampler.bucketExpiry = 10 * time.Millisecond
+
+	bucket1 := &metrics.HistogramBucket{
+		Name:       "my.histogram",
+		Value:      4.0,
+		LowerBound: 9000.0,
+		UpperBound: math.Inf(1),
+		Tags:       []string{"foo", "bar"},
+		Timestamp:  12345.0,
+	}
+	checkSampler.addBucket(bucket1)
+	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
+	assert.Equal(t, len(checkSampler.lastSeenBucket), 1)
+
+	checkSampler.commit(12349.0)
+	_, flushed := checkSampler.flush()
+
+	expSketch := &quantile.Sketch{}
+	expSketch.InsertMany(quantile.Default(), []float64{9000.0, 9000.0, 9000.0, 9000.0})
+
+	assert.Equal(t, 1, len(flushed))
+	metrics.AssertSketchSeriesEqual(t, metrics.SketchSeries{
+		Name: "my.histogram",
+		Tags: []string{"foo", "bar"},
+		Points: []metrics.SketchPoint{
+			{Ts: 12345.0, Sketch: expSketch},
+		},
+		ContextKey: generateContextKey(bucket1),
+	}, flushed[0])
+}
+
+func TestCheckHistogramBucketInterpolationGranularity(t *testing.T) {
+	checkSampler := newCheckSampler()
+	checkSampler.bucketExpiry = 10 * time.Millisecond
+	// we should have 2 groups of 2 values
+	checkSampler.interpolationGranularity = 2
+
+	bucket1 := &metrics.HistogramBucket{
+		Name:       "my.histogram",
+		Value:      4.0,
+		LowerBound: 10.0,
+		UpperBound: 20.0,
+		Tags:       []string{"foo", "bar"},
+		Timestamp:  12345.0,
+	}
+	checkSampler.addBucket(bucket1)
+	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
+	assert.Equal(t, len(checkSampler.lastSeenBucket), 1)
+
+	checkSampler.commit(12349.0)
+	_, flushed := checkSampler.flush()
+
+	expSketch := &quantile.Sketch{}
+	expSketch.InsertMany(quantile.Default(), []float64{10.0, 10.0, 15.0, 15.0})
+
+	assert.Equal(t, 1, len(flushed))
+	metrics.AssertSketchSeriesEqual(t, metrics.SketchSeries{
+		Name: "my.histogram",
+		Tags: []string{"foo", "bar"},
+		Points: []metrics.SketchPoint{
+			{Ts: 12345.0, Sketch: expSketch},
+		},
+		ContextKey: generateContextKey(bucket1),
+	}, flushed[0])
 }

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -50,7 +50,8 @@ func TestCheckGaugeSampling(t *testing.T) {
 	checkSampler.addSample(&mSample3)
 
 	checkSampler.commit(12349.0)
-	orderedSeries := OrderedSeries{checkSampler.flush()}
+	s, _ := checkSampler.flush()
+	orderedSeries := OrderedSeries{s}
 	sort.Sort(orderedSeries)
 	series := orderedSeries.series
 
@@ -117,7 +118,7 @@ func TestCheckRateSampling(t *testing.T) {
 	checkSampler.addSample(&mSample3)
 
 	checkSampler.commit(12349.0)
-	series := checkSampler.flush()
+	series, _ := checkSampler.flush()
 
 	expectedSerie := &metrics.Serie{
 		Name:           "my.metric.name",
@@ -166,7 +167,7 @@ func TestHistogramIntervalSampling(t *testing.T) {
 	checkSampler.addSample(&mSample3)
 
 	checkSampler.commit(12349.0)
-	series := checkSampler.flush()
+	series, _ := checkSampler.flush()
 
 	// Check that the `.count` metric returns a raw count of the samples, with no interval normalization
 	expectedCountSerie := &metrics.Serie{

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -206,6 +206,7 @@ func TestCheckHistogramBucketSampling(t *testing.T) {
 		UpperBound: 20.0,
 		Tags:       []string{"foo", "bar"},
 		Timestamp:  12345.0,
+		Monotonic:  true,
 	}
 	checkSampler.addBucket(bucket1)
 	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
@@ -235,6 +236,7 @@ func TestCheckHistogramBucketSampling(t *testing.T) {
 		UpperBound: 20.0,
 		Tags:       []string{"foo", "bar"},
 		Timestamp:  12400.0,
+		Monotonic:  true,
 	}
 	checkSampler.addBucket(bucket2)
 	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
@@ -277,8 +279,6 @@ func TestCheckHistogramBucketInfinityBucket(t *testing.T) {
 		Timestamp:  12345.0,
 	}
 	checkSampler.addBucket(bucket1)
-	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
-	assert.Equal(t, len(checkSampler.lastSeenBucket), 1)
 
 	checkSampler.commit(12349.0)
 	_, flushed := checkSampler.flush()
@@ -312,8 +312,6 @@ func TestCheckHistogramBucketInterpolationGranularity(t *testing.T) {
 		Timestamp:  12345.0,
 	}
 	checkSampler.addBucket(bucket1)
-	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
-	assert.Equal(t, len(checkSampler.lastSeenBucket), 1)
 
 	checkSampler.commit(12349.0)
 	_, flushed := checkSampler.flush()

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -6,7 +6,6 @@
 package aggregator
 
 import (
-	// stdlib
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
@@ -27,8 +26,8 @@ type ContextResolver struct {
 }
 
 // generateContextKey generates the contextKey associated with the context of the metricSample
-func generateContextKey(metricSample *metrics.MetricSample) ckey.ContextKey {
-	return ckey.Generate(metricSample.Name, metricSample.Host, metricSample.Tags)
+func generateContextKey(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
+	return ckey.Generate(metricSampleContext.GetName(), metricSampleContext.GetHost(), metricSampleContext.GetTags())
 }
 
 func newContextResolver() *ContextResolver {
@@ -39,13 +38,13 @@ func newContextResolver() *ContextResolver {
 }
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
-func (cr *ContextResolver) trackContext(metricSample *metrics.MetricSample, currentTimestamp float64) ckey.ContextKey {
-	contextKey := generateContextKey(metricSample)
+func (cr *ContextResolver) trackContext(metricSampleContext metrics.MetricSampleContext, currentTimestamp float64) ckey.ContextKey {
+	contextKey := generateContextKey(metricSampleContext)
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
 		cr.contextsByKey[contextKey] = &Context{
-			Name: metricSample.Name,
-			Tags: metricSample.Tags,
-			Host: metricSample.Host,
+			Name: metricSampleContext.GetName(),
+			Tags: metricSampleContext.GetTags(),
+			Host: metricSampleContext.GetHost(),
 		}
 	}
 	cr.lastSeenByKey[contextKey] = currentTimestamp

--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -30,6 +30,12 @@ func (m *MockSender) AssertMetric(t *testing.T, method string, metric string, va
 	return m.Mock.AssertCalled(t, method, metric, value, hostname, MatchTagsContains(tags))
 }
 
+// AssertHistogramBucket allows to assert a histogram bucket was emitted with given parameters.
+// Additional tags over the ones specified don't make it fail
+func (m *MockSender) AssertHistogramBucket(t *testing.T, method string, metric string, value int, lowerBound float64, upperBound float64, monotonic bool, hostname string, tags []string) bool {
+	return m.Mock.AssertCalled(t, method, metric, value, lowerBound, upperBound, monotonic, hostname, tags)
+}
+
 // AssertMetricInRange allows to assert a metric was emitted with given parameters, with a value in a given range.
 // Additional tags over the ones specified don't make it fail
 func (m *MockSender) AssertMetricInRange(t *testing.T, method string, metric string, min float64, max float64, hostname string, tags []string) bool {

--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -59,6 +59,11 @@ func (m *MockSender) Event(e metrics.Event) {
 	m.Called(e)
 }
 
+//HistogramBucket enables the histogram bucket mock call.
+func (m *MockSender) HistogramBucket(metric string, value int, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string) {
+	m.Called(metric, value, lowerBound, upperBound, monotonic, hostname, tags)
+}
+
 //Commit enables the commit mock call.
 func (m *MockSender) Commit() {
 	m.Called()

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -49,6 +49,15 @@ func (m *MockSender) SetupAcceptAll() {
 		mock.AnythingOfType("string"),                     // message
 	).Return()
 	m.On("Event", mock.AnythingOfType("metrics.Event")).Return()
+	m.On("HistogramBucket",
+		mock.AnythingOfType("string"),   // metric name
+		mock.AnythingOfType("int"),      // value
+		mock.AnythingOfType("float64"),  // lower bound
+		mock.AnythingOfType("float64"),  // upper bound
+		mock.AnythingOfType("bool"),     // monotonic
+		mock.AnythingOfType("string"),   // hostname
+		mock.AnythingOfType("[]string"), // tags
+	).Return()
 	m.On("GetMetricStats", mock.AnythingOfType("map[string]int64")).Return()
 	m.On("DisableDefaultHostname", mock.AnythingOfType("bool")).Return()
 	m.On("SetCheckCustomTags", mock.AnythingOfType("[]string")).Return()

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -269,7 +269,19 @@ func (s *checkSender) Histogram(metric string, value float64, hostname string, t
 
 // HistogramBucket should be called to directly send raw buckets to be submitted as distribution metrics
 func (s *checkSender) HistogramBucket(metric string, value int, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string) {
-	// todo
+	tags = append(tags, s.checkTags...)
+
+	log.Tracef(
+		"Histogram Bucket %s submitted: %v [%f-%f] monotonic: %v for host %s tags: %v",
+		metric,
+		value,
+		lowerBound,
+		upperBound,
+		monotonic,
+		hostname,
+		tags,
+	)
+
 	histogramBucket := &metrics.HistogramBucket{
 		Name:       metric,
 		Value:      value,
@@ -278,6 +290,7 @@ func (s *checkSender) HistogramBucket(metric string, value int, lowerBound, uppe
 		Monotonic:  monotonic,
 		Host:       hostname,
 		Tags:       tags,
+		Timestamp:  timeNowNano(),
 	}
 
 	if hostname == "" && !s.defaultHostnameDisabled {

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -185,6 +185,7 @@ func (s *checkSender) GetMetricStats() map[string]int64 {
 	metricStats["MetricSamples"] = s.priormetricStats.MetricSamples
 	metricStats["Events"] = s.priormetricStats.Events
 	metricStats["ServiceChecks"] = s.priormetricStats.ServiceChecks
+	metricStats["HistogramBuckets"] = s.priormetricStats.HistogramBuckets
 
 	return metricStats
 }

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -111,7 +111,8 @@ func TestGetAndSetSender(t *testing.T) {
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
 	eventChan := make(chan metrics.Event, 10)
-	testCheckSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan)
+	bucketChan := make(chan senderHistogramBucket, 10)
+	testCheckSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan)
 
 	err := SetSender(testCheckSender, checkID1)
 	assert.Nil(t, err)
@@ -142,7 +143,8 @@ func TestGetSenderAddCheckCustomTagsMetrics(t *testing.T) {
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
 	eventChan := make(chan metrics.Event, 10)
-	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan)
+	bucketChan := make(chan senderHistogramBucket, 10)
+	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan)
 
 	// no custom tags
 	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", nil, metrics.CounterType)
@@ -178,7 +180,8 @@ func TestGetSenderAddCheckCustomTagsService(t *testing.T) {
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
 	eventChan := make(chan metrics.Event, 10)
-	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan)
+	bucketChan := make(chan senderHistogramBucket, 10)
+	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan)
 
 	// no custom tags
 	checkSender.ServiceCheck("test", metrics.ServiceCheckOK, "testhostname", nil, "test message")
@@ -214,7 +217,8 @@ func TestGetSenderAddCheckCustomTagsEvent(t *testing.T) {
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
 	eventChan := make(chan metrics.Event, 10)
-	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan)
+	bucketChan := make(chan senderHistogramBucket, 10)
+	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan)
 
 	event := metrics.Event{
 		Title: "title",
@@ -258,7 +262,8 @@ func TestCheckSenderInterface(t *testing.T) {
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
 	eventChan := make(chan metrics.Event, 10)
-	checkSender := newCheckSender(checkID1, "default-hostname", senderMetricSampleChan, serviceCheckChan, eventChan)
+	bucketChan := make(chan senderHistogramBucket, 10)
+	checkSender := newCheckSender(checkID1, "default-hostname", senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan)
 	checkSender.Gauge("my.metric", 1.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Rate("my.rate_metric", 2.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Count("my.count_metric", 123.0, "my-hostname", []string{"foo", "bar"})
@@ -359,7 +364,8 @@ func TestCheckSenderHostname(t *testing.T) {
 			senderMetricSampleChan := make(chan senderMetricSample, 10)
 			serviceCheckChan := make(chan metrics.ServiceCheck, 10)
 			eventChan := make(chan metrics.Event, 10)
-			checkSender := newCheckSender(checkID1, defaultHostname, senderMetricSampleChan, serviceCheckChan, eventChan)
+			bucketChan := make(chan senderHistogramBucket, 10)
+			checkSender := newCheckSender(checkID1, defaultHostname, senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan)
 			checkSender.DisableDefaultHostname(tc.defaultHostnameDisabled)
 
 			checkSender.Gauge("my.metric", 1.0, tc.submittedHostname, []string{"foo", "bar"})
@@ -404,7 +410,8 @@ func TestChangeAllSendersDefaultHostname(t *testing.T) {
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
 	eventChan := make(chan metrics.Event, 10)
-	checkSender := newCheckSender(checkID1, "hostname1", senderMetricSampleChan, serviceCheckChan, eventChan)
+	bucketChan := make(chan senderHistogramBucket, 10)
+	checkSender := newCheckSender(checkID1, "hostname1", senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan)
 	SetSender(checkSender, checkID1)
 
 	checkSender.Gauge("my.metric", 1.0, "", nil)

--- a/pkg/aggregator/sketch_map.go
+++ b/pkg/aggregator/sketch_map.go
@@ -35,6 +35,15 @@ func (m sketchMap) insert(ts int64, ck ckey.ContextKey, v float64) bool {
 	return true
 }
 
+func (m sketchMap) insertN(ts int64, ck ckey.ContextKey, v float64, n uint) bool {
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		return false
+	}
+
+	m.getOrCreate(ts, ck).InsertN(v, n)
+	return true
+}
+
 func (m sketchMap) getOrCreate(ts int64, ck ckey.ContextKey) *quantile.Agent {
 	// level 1: ts -> ctx
 	byCtx, ok := m[ts]

--- a/pkg/collector/python/aggregator.go
+++ b/pkg/collector/python/aggregator.go
@@ -109,3 +109,24 @@ func SubmitEvent(checkID *C.char, event *C.event_t) {
 	sender.Event(_event)
 	return
 }
+
+// SubmitHistogramBucket is the method exposed to Python scripts to submit metrics
+//export SubmitHistogramBucket
+func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.int, lowerBound C.float, upperBound C.float, monotonic C.int, hostname *C.char, tags **C.char) {
+	goCheckID := C.GoString(checkID)
+	sender, err := aggregator.GetSender(chk.ID(goCheckID))
+	if err != nil || sender == nil {
+		log.Errorf("Error submitting histogram bucket to the Sender: %v", err)
+		return
+	}
+
+	_name := C.GoString(metricName)
+	_value := int(value)
+	_lowerBound := float64(lowerBound)
+	_upperBound := float64(upperBound)
+	_monotonic := (monotonic != 0)
+	_hostname := C.GoString(hostname)
+	_tags := cStringArrayToSlice(tags)
+
+	sender.HistogramBucket(_name, _value, _lowerBound, _upperBound, _monotonic, _hostname, _tags)
+}

--- a/pkg/collector/python/aggregator_test.go
+++ b/pkg/collector/python/aggregator_test.go
@@ -36,3 +36,7 @@ func TestSubmitServiceCheckEmptyHostame(t *testing.T) {
 func TestSubmitEvent(t *testing.T) {
 	testSubmitEvent(t)
 }
+
+func TestSubmitHistogramBucket(t *testing.T) {
+	testSubmitHistogramBucket(t)
+}

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -99,12 +99,13 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 void SubmitMetric(char *, metric_type_t, char *, float, char **, int, char *);
 void SubmitServiceCheck(char *, char *, int, char **, int, char *, char *);
 void SubmitEvent(char *, event_t *, int);
-void SubmitHistogramBucket(char *, char *, int, char **, int, char *, char *);
+void SubmitHistogramBucket(char *, char *, int, float, float, int, char **, char *, char **);
 
 void initAggregatorModule(rtloader_t *rtloader) {
 	set_submit_metric_cb(rtloader, SubmitMetric);
 	set_submit_service_check_cb(rtloader, SubmitServiceCheck);
 	set_submit_event_cb(rtloader, SubmitEvent);
+	set_submit_histogram_bucket_cb(rtloader, SubmitHistogramBucket);
 }
 
 //

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -99,7 +99,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 void SubmitMetric(char *, metric_type_t, char *, float, char **, int, char *);
 void SubmitServiceCheck(char *, char *, int, char **, int, char *, char *);
 void SubmitEvent(char *, event_t *, int);
-void SubmitHistogramBucket(char *, char *, int, float, float, int, char **, char *, char **);
+void SubmitHistogramBucket(char *, char *, int, float, float, int, char *, char **);
 
 void initAggregatorModule(rtloader_t *rtloader) {
 	set_submit_metric_cb(rtloader, SubmitMetric);

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -99,6 +99,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 void SubmitMetric(char *, metric_type_t, char *, float, char **, int, char *);
 void SubmitServiceCheck(char *, char *, int, char **, int, char *, char *);
 void SubmitEvent(char *, event_t *, int);
+void SubmitHistogramBucket(char *, char *, int, char **, int, char *, char *);
 
 void initAggregatorModule(rtloader_t *rtloader) {
 	set_submit_metric_cb(rtloader, SubmitMetric);

--- a/pkg/collector/python/test_aggregator.go
+++ b/pkg/collector/python/test_aggregator.go
@@ -182,3 +182,22 @@ func testSubmitEvent(t *testing.T) {
 	}
 	sender.AssertEvent(t, expectedEvent, 0)
 }
+
+func testSubmitHistogramBucket(t *testing.T) {
+	sender := mocksender.NewMockSender(check.ID("testID"))
+	sender.SetupAcceptAll()
+
+	cTags := []*C.char{C.CString("tag1"), C.CString("tag2"), nil}
+	SubmitHistogramBucket(
+		C.CString("testID"),
+		C.CString("test_histogram"),
+		C.int(42),
+		C.float(1.0),
+		C.float(2.0),
+		C.int(1),
+		C.CString("my_hostname"),
+		&cTags[0],
+	)
+
+	sender.AssertHistogramBucket(t, "HistogramBucket", "test_histogram", 42, 1.0, 2.0, true, "my_hostname", []string{"tag1", "tag2"})
+}

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -16,3 +16,20 @@ type HistogramBucket struct {
 	Host       string
 	Timestamp  float64
 }
+
+// Implement the MetricSampleContext interface
+
+// GetName returns the bucket name
+func (m *HistogramBucket) GetName() string {
+	return m.Name
+}
+
+// GetHost returns the bucket host
+func (m *HistogramBucket) GetHost() string {
+	return m.Host
+}
+
+// GetTags returns the bucket tags
+func (m *HistogramBucket) GetTags() []string {
+	return m.Tags
+}

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package metrics
+
+// HistogramBucket represents a prometheus/openmetrics histogram bucket
+type HistogramBucket struct {
+	Name       string
+	Value      int
+	LowerBound float64
+	UpperBound float64
+	Monotonic  bool
+	Tags       []string
+	Host       string
+	Timestamp  float64
+}

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -53,6 +53,13 @@ func (m MetricType) String() string {
 	}
 }
 
+// MetricSampleContext allows to access a sample context data
+type MetricSampleContext interface {
+	GetName() string
+	GetHost() string
+	GetTags() []string
+}
+
 // MetricSample represents a raw metric sample
 type MetricSample struct {
 	Name       string
@@ -65,11 +72,28 @@ type MetricSample struct {
 	Timestamp  float64
 }
 
-// Copy returns a deep copy of the src MetricSample
-func (src *MetricSample) Copy() *MetricSample {
+// Implement the MetricSampleContext interface
+
+// GetName returns the metric sample name
+func (m *MetricSample) GetName() string {
+	return m.Name
+}
+
+// GetHost returns the metric sample host
+func (m *MetricSample) GetHost() string {
+	return m.Host
+}
+
+// GetTags returns the metric sample tags
+func (m *MetricSample) GetTags() []string {
+	return m.Tags
+}
+
+// Copy returns a deep copy of the m MetricSample
+func (m *MetricSample) Copy() *MetricSample {
 	dst := &MetricSample{}
-	*dst = *src
-	dst.Tags = make([]string, len(src.Tags))
-	copy(dst.Tags, src.Tags)
+	*dst = *m
+	dst.Tags = make([]string, len(m.Tags))
+	copy(dst.Tags, m.Tags)
 	return dst
 }

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -61,7 +61,9 @@ func (a *Agent) Insert(v float64) {
 func (a *Agent) InsertN(v float64, n uint) {
 	a.Sketch.Basic.InsertN(v, n)
 
-	a.Buf = append(a.Buf, agentConfig.key(v))
+	for i := 0; i < int(n); i++ {
+		a.Buf = append(a.Buf, agentConfig.key(v))
+	}
 	if len(a.Buf) < agentBufCap {
 		return
 	}

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -56,3 +56,15 @@ func (a *Agent) Insert(v float64) {
 
 	a.flush()
 }
+
+// InsertN inserts v, n times into the sketch.
+func (a *Agent) InsertN(v float64, n uint) {
+	a.Sketch.Basic.InsertN(v, n)
+
+	a.Buf = append(a.Buf, agentConfig.key(v))
+	if len(a.Buf) < agentBufCap {
+		return
+	}
+
+	a.flush()
+}

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "mfpierre/openmetrics-send-histogram-bucket",
+		"INTEGRATIONS_CORE_VERSION": "master",
 		"OMNIBUS_SOFTWARE_VERSION": "master",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
 		"JMXFETCH_VERSION": "0.30.1",

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "master",
+		"INTEGRATIONS_CORE_VERSION": "mfpierre/openmetrics-send-histogram-bucket",
 		"OMNIBUS_SOFTWARE_VERSION": "master",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
 		"JMXFETCH_VERSION": "0.30.1",

--- a/releasenotes/notes/histogram-bucket-0550f34eab872c19.yaml
+++ b/releasenotes/notes/histogram-bucket-0550f34eab872c19.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    [preview] Checks can now send histogram buckets to the agent to be sent as distribution metrics.

--- a/rtloader/common/builtins/aggregator.h
+++ b/rtloader/common/builtins/aggregator.h
@@ -49,6 +49,13 @@
 
     The callback is expected to be provided by the rtloader caller - in go-context: CGO.
 */
+/*! \fn void _set_submit_histogram_bucket_cb(cb_submit_histogram_bucket_t)
+    \brief Sets the submit event callback to be used by rtloader for histogram bucket submission.
+    \param cb A function pointer with cb_submit_histogram_bucket_t prototype to the callback
+    function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
 
 #include <Python.h>
 #include <rtloader_types.h>
@@ -69,6 +76,7 @@ void Py2_init_aggregator();
 void _set_submit_metric_cb(cb_submit_metric_t cb);
 void _set_submit_service_check_cb(cb_submit_service_check_t cb);
 void _set_submit_event_cb(cb_submit_event_t cb);
+void _set_submit_histogram_bucket_cb(cb_submit_histogram_bucket_t cb);
 
 #ifdef __cplusplus
 }

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -367,6 +367,15 @@ DATADOG_AGENT_RTLOADER_API void set_submit_service_check_cb(rtloader_t *, cb_sub
 */
 DATADOG_AGENT_RTLOADER_API void set_submit_event_cb(rtloader_t *, cb_submit_event_t);
 
+/*! \fn void set_submit_histogram_bucket_cb(rtloader_t *, cb_submit_histogram_bucket_t)
+    \brief Sets the submit event callback to be used by rtloader for histogram bucket submission.
+    \param cb A function pointer with cb_submit_histogram_bucket_t prototype to the callback
+    function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
+DATADOG_AGENT_RTLOADER_API void set_submit_histogram_bucket_cb(rtloader_t *, cb_submit_histogram_bucket_t);
+
 // DATADOG_AGENT API
 /*! \fn void set_get_version_cb(rtloader_t *, cb_get_version_t)
     \brief Sets a callback to be used by rtloader to collect the agent version.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -261,6 +261,14 @@ public:
     */
     virtual void setSubmitEventCb(cb_submit_event_t) = 0;
 
+    //! setSubmitHistogramBucketCb member.
+    /*!
+      \param A cb_submit_histogram_bucket_t function pointer to the CGO callback.
+
+      Actual histogram buckets are submitted from go-land, this allows us to set the CGO callback.
+    */
+    virtual void setSubmitHistogramBucketCb(cb_submit_histogram_bucket_t) = 0;
+
     // datadog_agent API
 
     //! setGetVersionCb member.

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -97,6 +97,8 @@ typedef void (*cb_submit_metric_t)(char *, metric_type_t, char *, float, char **
 typedef void (*cb_submit_service_check_t)(char *, char *, int, char **, char *, char *);
 // (id, event)
 typedef void (*cb_submit_event_t)(char *, event_t *);
+// (id, metric_name, value, lower_bound, upper_bound, monotonic, hostname, tags)
+typedef void (*cb_submit_histogram_bucket_t)(char *, char *, int, float, float, int, char *, char **);
 
 // datadog_agent
 //

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -377,6 +377,11 @@ void set_submit_event_cb(rtloader_t *rtloader, cb_submit_event_t cb)
     AS_TYPE(RtLoader, rtloader)->setSubmitEventCb(cb);
 }
 
+void set_submit_histogram_bucket_cb(rtloader_t *rtloader, cb_submit_histogram_bucket_t cb)
+{
+    AS_TYPE(RtLoader, rtloader)->setSubmitHistogramBucketCb(cb);
+}
+
 /*
  * datadog_agent API
  */

--- a/rtloader/test/aggregator/aggregator.go
+++ b/rtloader/test/aggregator/aggregator.go
@@ -212,12 +212,12 @@ func submitEvent(id *C.char, ev *C.event_t) {
 func submitHistogramBucket(id *C.char, cMetricName *C.char, cVal C.int, cLowerBound C.float, cUpperBound C.float, cMonotonic C.int, cHostname *C.char, t **C.char) {
 	checkID = C.GoString(id)
 	name = C.GoString(cMetricName)
-    intValue = int(cVal)
-    lowerBound = float64(cLowerBound)
-    upperBound = float64(cUpperBound)
-    monotonic = (cMonotonic != 0)
-    hostname = C.GoString(cHostname)
-    if t != nil {
+	intValue = int(cVal)
+	lowerBound = float64(cLowerBound)
+	upperBound = float64(cUpperBound)
+	monotonic = (cMonotonic != 0)
+	hostname = C.GoString(cHostname)
+	if t != nil {
 		tags = append(tags, charArrayToSlice(t)...)
 	}
 }

--- a/rtloader/test/aggregator/aggregator_test.go
+++ b/rtloader/test/aggregator/aggregator_test.go
@@ -294,3 +294,41 @@ func TestEventCheckTagsError(t *testing.T) {
 		t.Errorf("wrong printed value: '%s'", out)
 	}
 }
+
+func TestSubmitHistogramBucket(t *testing.T) {
+	out, err := run(`aggregator.submit_histogram_bucket(None, 'id', 'name', 42, 1.0, 2.0, 1, 'myhost', ['foo', 21, 'bar', ["hey"]])`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out != "" {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+	if checkID != "id" {
+		t.Fatalf("Unexpected id value: %s", checkID)
+	}
+	if name != "name" {
+		t.Fatalf("Unexpected name value: %s", name)
+	}
+	if intValue != 42 {
+		t.Fatalf("Unexpected int value: %d", intValue)
+	}
+	if lowerBound != 1.0 {
+		t.Fatalf("Unexpected lower bound value: %f", lowerBound)
+	}
+	if upperBound != 2.0 {
+		t.Fatalf("Unexpected upper bound value: %f", upperBound)
+	}
+	if monotonic != true {
+		t.Fatalf("Unexpected monotonic value: %v", monotonic)
+	}
+	if hostname != "myhost" {
+		t.Fatalf("Unexpected hostname value: %s", hostname)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("Unexpected tags length: %d", len(tags))
+	}
+	if tags[0] != "foo" || tags[1] != "bar" {
+		t.Fatalf("Unexpected tags: %v", tags)
+	}
+}

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -788,6 +788,11 @@ void Three::setSubmitEventCb(cb_submit_event_t cb)
     _set_submit_event_cb(cb);
 }
 
+void Three::setSubmitHistogramBucketCb(cb_submit_histogram_bucket_t cb)
+{
+    _set_submit_histogram_bucket_cb(cb);
+}
+
 void Three::setGetVersionCb(cb_get_version_t cb)
 {
     _set_get_version_cb(cb);

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -88,6 +88,7 @@ public:
     void setSubmitMetricCb(cb_submit_metric_t);
     void setSubmitServiceCheckCb(cb_submit_service_check_t);
     void setSubmitEventCb(cb_submit_event_t);
+    void setSubmitHistogramBucketCb(cb_submit_histogram_bucket_t);
 
     // datadog_agent API
     void setGetVersionCb(cb_get_version_t);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -794,6 +794,11 @@ void Two::setSubmitEventCb(cb_submit_event_t cb)
     _set_submit_event_cb(cb);
 }
 
+void Two::setSubmitHistogramBucketCb(cb_submit_histogram_bucket_t cb)
+{
+    _set_submit_histogram_bucket_cb(cb);
+}
+
 void Two::setGetVersionCb(cb_get_version_t cb)
 {
     _set_get_version_cb(cb);

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -87,6 +87,7 @@ public:
     void setSubmitMetricCb(cb_submit_metric_t);
     void setSubmitServiceCheckCb(cb_submit_service_check_t);
     void setSubmitEventCb(cb_submit_event_t);
+    void setSubmitHistogramBucketCb(cb_submit_histogram_bucket_t);
 
     // datadog_agent API
     void setGetVersionCb(cb_get_version_t);


### PR DESCRIPTION
### What does this PR do?

* Add the histogram bucket bridge
* Add sketch support to the check sampler

### Motivation

Send prometheus/openmetrics histograms from checks to submit them as distribution metrics

### Additional Notes

Performance on the vanilla linear interpolation implementation:

```
BenchmarkAddBucket1-4          	 1000000	      1394 ns/op	     850 B/op	      10 allocs/op
BenchmarkAddBucket100-4        	  100000	     11483 ns/op	    1217 B/op	      12 allocs/op
BenchmarkAddBucket10000-4      	    2000	    702976 ns/op	   42537 B/op	     224 allocs/op
BenchmarkAddBucket1000000-4    	      20	  66036465 ns/op	 4174570 B/op	   21495 allocs/op
BenchmarkAddBucket10000000-4   	       2	 679800800 ns/op	41738508 B/op	  214864 allocs/op
```

With an interpolation granularity of 1000 using `insertN`:

```
BenchmarkAddBucket1-4          	 1000000	      1652 ns/op	     874 B/op	      11 allocs/op
BenchmarkAddBucket10-4         	 1000000	      2461 ns/op	     909 B/op	      11 allocs/op
BenchmarkAddBucket100-4        	  100000	     12185 ns/op	    1241 B/op	      13 allocs/op
BenchmarkAddBucket1000-4       	   20000	     98839 ns/op	    4997 B/op	      32 allocs/op
BenchmarkAddBucket10000-4      	    5000	    397713 ns/op	   81300 B/op	     241 allocs/op
BenchmarkAddBucket1000000-4    	      50	  25824508 ns/op	 4185665 B/op	   12011 allocs/op
BenchmarkAddBucket10000000-4   	       5	 283451953 ns/op	96373139 B/op	   21017 allocs/op
```

This is speeding up the `Summary` computation but the `sparseStore` still has values inserted one by one.

Integrations-core PR: https://github.com/DataDog/integrations-core/pull/4321
