### PR TITLE
pkg/trace/config: add DD_APM_REPLACE_TAGS

### DIFF
--- a/pkg/trace/config/env.go
+++ b/pkg/trace/config/env.go
@@ -77,7 +77,7 @@ func loadEnv() {
 		if err == nil {
 			config.Datadog.Set("apm_config.replace_tags", replaceTags)
 		} else {
-			log.Errorf("Bad format for %s it should be of the form '[{\"name\": \"tag_name\",\"pattern\":\"pattern\",\"replace\":\"replace_str\"}]', error: %v", "DD_APM_REPLACE_TAGS", err)
+			log.Errorf("Bad format for %s it should be of the form '[{\"name\": \"tag_name\",\"pattern\":\"pattern\",\"repl\":\"replace_str\"}]', error: %v", "DD_APM_REPLACE_TAGS", err)
 		}
 	}
 }

--- a/pkg/trace/config/env.go
+++ b/pkg/trace/config/env.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -71,6 +72,14 @@ func loadEnv() {
 			log.Errorf("Bad format for %s it should be of the form \"service_name|operation_name=rate,other_service|other_operation=rate\", error: %v", "DD_APM_ANALYZED_SPANS", err)
 		}
 	}
+	if v := os.Getenv("DD_APM_REPLACE_TAGS"); v != "" {
+		replaceTags, err := parseReplaceTags(v)
+		if err == nil {
+			config.Datadog.Set("apm_config.replace_tags", replaceTags)
+		} else {
+			log.Errorf("Bad format for %s it should be of the form '[{\"name\": \"tag_name\",\"pattern\":\"pattern\",\"replace\":\"replace_str\"}]', error: %v", "DD_APM_REPLACE_TAGS", err)
+		}
+	}
 }
 
 func parseNameAndRate(token string) (string, float64, error) {
@@ -101,4 +110,13 @@ func parseAnalyzedSpans(env string) (analyzedSpans map[string]float64, err error
 		analyzedSpans[name] = rate
 	}
 	return
+}
+
+func parseReplaceTags(env string) ([]map[string]string, error) {
+	var replaceTags []map[string]string
+	err := json.Unmarshal([]byte(env), &replaceTags)
+	if err != nil {
+		return nil, err
+	}
+	return replaceTags, nil
 }

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -216,6 +216,29 @@ func TestLoadEnv(t *testing.T) {
 				}, cfg.AnalyzedSpansByService)
 			})
 
+			env = "DD_APM_REPLACE_TAGS"
+			t.Run(env, func(t *testing.T) {
+				assert := assert.New(t)
+				err := os.Setenv(env, `[{"name":"name1", "pattern":"pattern1"}, {"name":"name2","pattern":"pattern2","repl":"replace2"}]`)
+				assert.NoError(err)
+				defer os.Unsetenv(env)
+				cfg, err := Load("./testdata/full." + ext)
+				assert.NoError(err)
+				rule1 := &ReplaceRule{
+					Name:    "name1",
+					Pattern: "pattern1",
+					Repl:    "",
+				}
+				rule2 := &ReplaceRule{
+					Name:    "name2",
+					Pattern: "pattern2",
+					Repl:    "replace2",
+				}
+				compileReplaceRules([]*ReplaceRule{rule1, rule2})
+				assert.Contains(cfg.ReplaceTags, rule1)
+				assert.Contains(cfg.ReplaceTags, rule2)
+			})
+
 			for _, envKey := range []string{
 				"DD_CONNECTION_LIMIT", // deprecated
 				"DD_APM_CONNECTION_LIMIT",

--- a/releasenotes/notes/bind_replace-2d64290b8f49ee9e.yaml
+++ b/releasenotes/notes/bind_replace-2d64290b8f49ee9e.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Bind ``apm_config.replace_tags`` parameter to ``DD_APM_REPLACE_TAGS`` environment variable.
+    It accepts a JSON formatted string of the form ``[{"name":"tag_name","pattern":"pattern","repl":"repl_str"}]``


### PR DESCRIPTION
### What does this PR do?

Bind `replace_tags` to an environment variable `DD_APM_REPLACE_TAGS` so that it's configurable in the pcf buildpack 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?