### PR TITLE
Change info structure allocation.

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -286,8 +286,7 @@ func Initialize(paths ...string) error {
 		cache.Cache.Set(key, PythonVersion, cache.NoExpiration)
 
 		PythonPath = C.GoString(pyInfo.path)
-		C.rtloader_free(rtloader, unsafe.Pointer(pyInfo.path))
-		C.rtloader_free(rtloader, unsafe.Pointer(pyInfo))
+		C.free_py_info(rtloader, pyInfo)
 	} else {
 		log.Errorf("Could not query python information: %s", C.GoString(C.get_error(rtloader)))
 	}

--- a/pkg/collector/python/test_loader.go
+++ b/pkg/collector/python/test_loader.go
@@ -62,12 +62,23 @@ int get_attr_string(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const c
 
 py_info_t *get_py_info(rtloader_t *sic) {
 	py_info_t *i = malloc(sizeof(py_info_t));
-	i->version = "fake python";
-	i->path = "/fake/path";
+	i->version = strdup("fake python");
+	i->path = strdup("/fake/path");
 
 	return i;
 }
 
+void free_py_info(rtloader_t *sic, py_info_t *info) {
+	if(info->version){
+        free(info->version);
+    }
+    if(info->path){
+        free(info->path);
+    }
+    free(info);
+    return;
+
+}
 void reset_loader_mock() {
 	get_class_calls = 0;
 	get_class_return = 0;

--- a/rtloader/demo/main.c
+++ b/rtloader/demo/main.c
@@ -111,8 +111,7 @@ int main(int argc, char *argv[])
     py_info_t *info = get_py_info(rtloader);
     if (info) {
         printf("Embedding Python version %s\n\tPath: %s\n\n", info->version, info->path);
-        rtloader_free(rtloader, info->path);
-        rtloader_free(rtloader, info);
+        free_py_info(rtloader, info);
     } else {
         printf("Error info is null %s\n", get_error(rtloader));
     }

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -259,7 +259,7 @@ DATADOG_AGENT_RTLOADER_API py_info_t *get_py_info(rtloader_t *);
 
     Frees the structure and appropriate structure memebers.
 */
-DATADOG_AGENT_RTLOADER_API void free_py_info(rtloader_t *, py_info_t*);
+DATADOG_AGENT_RTLOADER_API void free_py_info(rtloader_t *, py_info_t *);
 /*! \fn int run_simple_string(const rtloader_t *, const char *code)
     \brief Routine to execute a simple piece of python code on the RtLoader python runtime
     implementation.

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -248,10 +248,18 @@ DATADOG_AGENT_RTLOADER_API rtloader_pyobject_t *get_none(const rtloader_t *);
     error.
     \sa py_info_t, rtloader_t
 
-    Allocates memory for the returned `py_info_t` structure and should be freed accordingly.
+    Allocates memory for the returned `py_info_t` structure and should be freed by calling free_py_info()
 */
 DATADOG_AGENT_RTLOADER_API py_info_t *get_py_info(rtloader_t *);
 
+/*! \fn py_info_t *free_py_info(rtloader_t *)
+    \brief Routine to free structure returned from get_py_info
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param A py_info_t * pointer previously returned form get_py_info
+
+    Frees the structure and appropriate structure memebers.
+*/
+DATADOG_AGENT_RTLOADER_API void free_py_info(rtloader_t *, py_info_t*);
 /*! \fn int run_simple_string(const rtloader_t *, const char *code)
     \brief Routine to execute a simple piece of python code on the RtLoader python runtime
     implementation.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -166,8 +166,8 @@ public:
 
       Frees all memory allocated in a previous call to getPyInfo
      */
-    virtual void freePyInfo(py_info_t*) = 0;
-    
+    virtual void freePyInfo(py_info_t *) = 0;
+
     //! Pure virtual runSimpleString member.
     /*!
       \param code A C-string representation of python code we wish to run on the underlying python runtime.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -154,9 +154,20 @@ public:
     //! Pure virtual getPyInfo member.
     /*!
       \return A py_info_t struct with the details (version and path) of the underlying python runtime.
+
+      Structure returned must be freed with a call to freePyInfo()
     */
     virtual py_info_t *getPyInfo() = 0;
 
+    // Public Const API
+    //! Pure virtual freePyInfo member
+    /*!
+      \return none
+
+      Frees all memory allocated in a previous call to getPyInfo
+     */
+    virtual void freePyInfo(py_info_t*) = 0;
+    
     //! Pure virtual runSimpleString member.
     /*!
       \param code A C-string representation of python code we wish to run on the underlying python runtime.

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -64,7 +64,9 @@ typedef struct event_s {
 } event_t;
 
 typedef struct py_info_s {
-    const char *version;
+    // all strings are owned by the structure.  Must be freed
+    // by calling freePyInfo()
+    char *version;
     char *path;
 } py_info_t;
 

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -65,7 +65,7 @@ typedef struct event_s {
 
 typedef struct py_info_s {
     const char *version; // returned by Py_GetInfo(); is static string owned by python
-    char *path;          // allocated within getPyInfo()
+    char *path; // allocated within getPyInfo()
 } py_info_t;
 
 /*

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -64,10 +64,8 @@ typedef struct event_s {
 } event_t;
 
 typedef struct py_info_s {
-    // all strings are owned by the structure.  Must be freed
-    // by calling freePyInfo()
-    char *version;
-    char *path;
+    const char *version; // returned by Py_GetInfo(); is static string owned by python
+    char *path;          // allocated within getPyInfo()
 } py_info_t;
 
 /*

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -223,7 +223,7 @@ py_info_t *get_py_info(rtloader_t *rtloader)
     return AS_TYPE(RtLoader, rtloader)->getPyInfo();
 }
 
-void free_py_info(rtloader_t* rtloader, py_info_t* info)
+void free_py_info(rtloader_t *rtloader, py_info_t *info)
 {
     AS_TYPE(RtLoader, rtloader)->freePyInfo(info);
 }

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -223,6 +223,11 @@ py_info_t *get_py_info(rtloader_t *rtloader)
     return AS_TYPE(RtLoader, rtloader)->getPyInfo();
 }
 
+void free_py_info(rtloader_t* rtloader, py_info_t* info)
+{
+    AS_TYPE(RtLoader, rtloader)->freePyInfo(info);
+}
+
 int run_simple_string(const rtloader_t *rtloader, const char *code)
 {
     return AS_CTYPE(RtLoader, rtloader)->runSimpleString(code) ? 1 : 0;

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	rtloader     *C.rtloader_t
-	tmpfile *os.File
+	rtloader *C.rtloader_t
+	tmpfile  *os.File
 )
 
 func setUp() error {
@@ -57,6 +57,7 @@ func getPyInfo() (string, string) {
 	state := C.ensure_gil(rtloader)
 
 	info := C.get_py_info(rtloader)
+	defer C.free_py_info(rtloader, info)
 
 	C.release_gil(rtloader, state)
 	runtime.UnlockOSThread()

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -118,6 +118,9 @@ done:
     return _baseClass != NULL;
 }
 
+/**
+ * getPyInfo()
+ */
 py_info_t *Three::getPyInfo()
 {
     PyObject *sys = NULL;
@@ -129,8 +132,10 @@ py_info_t *Three::getPyInfo()
         setError("could not allocate a py_info_t struct");
         return NULL;
     }
-
-    info->version = Py_GetVersion();
+    const char* v = Py_GetVersion();
+    if(v){
+        info->version = strdup(v);
+    }
     info->path = NULL;
 
     sys = PyImport_ImportModule("sys");
@@ -159,7 +164,21 @@ done:
     Py_XDECREF(str_path);
     return info;
 }
+/**
+ * freePyInfo()
+ */
 
+void Three::freePyInfo(py_info_t* info) {
+    if(info->version){
+        free(info->version);
+    }
+    if(info->path){
+        free(info->path);
+    }
+    free(info);
+    return;
+    
+}
 bool Three::runSimpleString(const char *code) const
 {
     return PyRun_SimpleString(code) == 0;

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -165,15 +165,15 @@ done:
  * freePyInfo()
  */
 
-void Three::freePyInfo(py_info_t* info) {
+void Three::freePyInfo(py_info_t *info)
+{
     info->version = NULL;
-    if(info->path){
+    if (info->path) {
         free(info->path);
         info->version = NULL;
     }
     free(info);
     return;
-    
 }
 bool Three::runSimpleString(const char *code) const
 {

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -132,10 +132,7 @@ py_info_t *Three::getPyInfo()
         setError("could not allocate a py_info_t struct");
         return NULL;
     }
-    const char* v = Py_GetVersion();
-    if(v){
-        info->version = strdup(v);
-    }
+    info->version = Py_GetVersion();
     info->path = NULL;
 
     sys = PyImport_ImportModule("sys");
@@ -169,11 +166,10 @@ done:
  */
 
 void Three::freePyInfo(py_info_t* info) {
-    if(info->version){
-        free(info->version);
-    }
+    info->version = NULL;
     if(info->path){
         free(info->path);
+        info->version = NULL;
     }
     free(info);
     return;

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -74,6 +74,7 @@ public:
 
     // const API
     py_info_t *getPyInfo();
+    void freePyInfo(py_info_t *);
     bool runSimpleString(const char *path) const;
     RtLoaderPyObject *getNone() const
     {

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -167,14 +167,14 @@ done:
 /**
  * freePyInfo()
  */
-void Two::freePyInfo(py_info_t* info) {
+void Two::freePyInfo(py_info_t *info)
+{
     info->version = NULL;
-    if(info->path){
+    if (info->path) {
         free(info->path);
     }
     free(info);
     return;
-    
 }
 
 bool Two::runSimpleString(const char *code) const

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -135,7 +135,10 @@ py_info_t *Two::getPyInfo()
         return NULL;
     }
 
-    info->version = Py_GetVersion();
+    const char* v = Py_GetVersion();
+    if(v){
+        info->version = strdup(v);
+    }
     info->path = NULL;
 
     sys = PyImport_ImportModule("sys");
@@ -163,6 +166,20 @@ done:
     Py_XDECREF(path);
     Py_XDECREF(str_path);
     return info;
+}
+/**
+ * freePyInfo()
+ */
+void Two::freePyInfo(py_info_t* info) {
+    if(info->version){
+        free(info->version);
+    }
+    if(info->path){
+        free(info->path);
+    }
+    free(info);
+    return;
+    
 }
 
 bool Two::runSimpleString(const char *code) const

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -135,10 +135,7 @@ py_info_t *Two::getPyInfo()
         return NULL;
     }
 
-    const char* v = Py_GetVersion();
-    if(v){
-        info->version = strdup(v);
-    }
+    info->version = Py_GetVersion();
     info->path = NULL;
 
     sys = PyImport_ImportModule("sys");
@@ -171,9 +168,7 @@ done:
  * freePyInfo()
  */
 void Two::freePyInfo(py_info_t* info) {
-    if(info->version){
-        free(info->version);
-    }
+    info->version = NULL;
     if(info->path){
         free(info->path);
     }

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -73,6 +73,7 @@ public:
 
     // const API
     py_info_t *getPyInfo();
+    void freePyInfo(py_info_t *);
     bool runSimpleString(const char *code) const;
     RtLoaderPyObject *getNone() const
     {


### PR DESCRIPTION
1) Have all members allocated by getPyInfo().  Removes confusion over
which members need to be freed and which are static
2) Provide method to free.  Removes need for caller to have internal
knowledge of implementation, and know which members to free and which
not to free
3) Allows future change of structure without having to change calling
code


### Motivation

audit, more maintainable code.

