### PR TITLE
[dockerfile] agent-dev py2+py3 image for integrations-core

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -925,12 +925,12 @@ build_agent6_jmx:
     TESTING_ARG:  --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=2
 
 # build agent6 jmx unified image (including python3)
-build_agent6_jmx:
+build_agent6_py2py3_jmx:
   <<: *docker_build_job_definition
   variables:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
-    TAG_SUFFIX: -unified-jmx
+    TAG_SUFFIX: -py2py3-jmx
     BUILD_ARG: --target release --build-arg WITH_JMX=true
     TESTING_ARG:  --target testing --build-arg WITH_JMX=true
 
@@ -1041,6 +1041,7 @@ dev_branch_docker_hub:
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py2-jmx datadog/agent-dev:${CI_COMMIT_REF_SLUG}-jmx
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py2-jmx datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py2-jmx
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3-jmx datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py2py3-jmx datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py2py3-jmx
     - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd-dev:${CI_COMMIT_REF_SLUG}
 
 dev_master_docker_hub:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -924,6 +924,7 @@ build_agent6_jmx:
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=2
     TESTING_ARG:  --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=2
 
+# TESTING ONLY: This image is for internal testing purposes, not customer facing.
 # build agent6 jmx unified image (including python3)
 build_agent6_py2py3_jmx:
   <<: *docker_build_job_definition

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -924,6 +924,16 @@ build_agent6_jmx:
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=2
     TESTING_ARG:  --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=2
 
+# build agent6 jmx unified image (including python3)
+build_agent6_jmx:
+  <<: *docker_build_job_definition
+  variables:
+    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    BUILD_CONTEXT: Dockerfiles/agent
+    TAG_SUFFIX: -unified-jmx
+    BUILD_ARG: --target release --build-arg WITH_JMX=true
+    TESTING_ARG:  --target testing --build-arg WITH_JMX=true
+
 # build agent7 image
 build_agent7:
   <<: *docker_build_job_definition

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -121,9 +121,13 @@ RUN tar xzf s6.tgz \
  && chmod 500 /readsecret.py
 
 # Update links to python binaries
-RUN ln -sfn /opt/datadog-agent/embedded/bin/python${PYTHON_VERSION} /opt/datadog-agent/embedded/bin/python \
+
+RUN if [ ! -z "$PYTHON_VERSION" ]; then \
+ ln -sfn /opt/datadog-agent/embedded/bin/python${PYTHON_VERSION} /opt/datadog-agent/embedded/bin/python \
  && ln -sfn /opt/datadog-agent/embedded/bin/python${PYTHON_VERSION}-config /opt/datadog-agent/embedded/bin/python-config \
- && ln -sfn /opt/datadog-agent/embedded/bin/pip${PYTHON_VERSION} /opt/datadog-agent/embedded/bin/pip
+ && ln -sfn /opt/datadog-agent/embedded/bin/pip${PYTHON_VERSION} /opt/datadog-agent/embedded/bin/pip ; \
+ fi
+
 
 # Override the exit script by ours to fix --pid=host operations
 COPY init-stage3 /etc/s6/init/init-stage3

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -237,7 +237,9 @@ def image_build(ctx, base_dir="omnibus", python_version=2, skip_tests=False):
 
     # Pull base image with content trust enabled
     pull_base_images(ctx, "Dockerfiles/agent/Dockerfile", signed_pull=True)
-    common_build_opts = "-t {} --build-arg PYTHON_VERSION={}".format(AGENT_TAG, python_version)
+    common_build_opts = "-t {}".format(AGENT_TAG)
+    if python_version:
+        common_build_opts = "{} --build-arg PYTHON_VERSION={}".format(common_build_opts, python_version)
 
     # Build with the testing target
     if not skip_tests:


### PR DESCRIPTION
### What does this PR do?

Creates one final image on `datadog/agent-dev` this one with jmx+py2+py3, required for testing.

### Motivation

`integrations-core` testing broke because they rely on an image with both python's on their toolkit. 

### Additional Notes

This image should never be released as a production image, purely for testing.

Any suggestions for a better image tag?!?!
