### PR TITLE
Fixing placeholder to match new marathon conf.yaml file

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-mesos.sh
+++ b/Dockerfiles/agent/entrypoint/50-mesos.sh
@@ -27,5 +27,5 @@ fi
 if [[ $MARATHON_URL ]] && [[ ! -e $CONFD/marathon.d/conf.yaml.default ]]; then
   mv $CONFD/marathon.d/conf.yaml.example \
      $CONFD/marathon.d/conf.yaml.default
-  sed -i -e "s@# - url: \"https://server:port\"@- url: ${MARATHON_URL}@" $CONFD/marathon.d/conf.yaml.default
+  sed -i -e "s@# - url: \"https://<SERVER>:<PORT>\"@- url: ${MARATHON_URL}@" $CONFD/marathon.d/conf.yaml.default
 fi

--- a/Dockerfiles/agent/entrypoint/50-mesos.sh
+++ b/Dockerfiles/agent/entrypoint/50-mesos.sh
@@ -27,5 +27,5 @@ fi
 if [[ $MARATHON_URL ]] && [[ ! -e $CONFD/marathon.d/conf.yaml.default ]]; then
   mv $CONFD/marathon.d/conf.yaml.example \
      $CONFD/marathon.d/conf.yaml.default
-  sed -i -e "s@# - url: \"https://<SERVER>:<PORT>\"@- url: ${MARATHON_URL}@" $CONFD/marathon.d/conf.yaml.default
+  sed -i -e "s@ - url: \"https://<SERVER>:<PORT>\"@- url: ${MARATHON_URL}@" $CONFD/marathon.d/conf.yaml.default
 fi

--- a/releasenotes/notes/fix-marathon-entry-point-1fc2727e0fdac0c7.yaml
+++ b/releasenotes/notes/fix-marathon-entry-point-1fc2727e0fdac0c7.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed placeholder value for the marathon entry point to match the new configuration file layout. 


### PR DESCRIPTION
### What does this PR do?

There is an issue where since Agent 6.12+ we are not changing the URL of the `conf.yaml` from the env var `MARATHON_URL` as we are supposed to. 

The url in the template yaml file had been changed to `https://<SERVER>:<PORT>`, this caused a mismatch to our sed command here which is still looking for `https://server:port`.

The change is due to a standardization initiative - [github PR](https://github.com/DataDog/integrations-core/pull/3195/files/cee2b961e6e3c3876ddaa8c3b5276bd04a315525) and it caused a mismatch in our SED expression [here](https://github.com/DataDog/datadog-agent/blob/6a0668670fe37784b09073556fd198027e477e2d/Dockerfiles/agent/entrypoint/50-mesos.sh#L30) and maybe [here, for docker agent 5](https://github.com/DataDog/docker-dd-agent/blob/b926a52322383e7d728ed3327a10ecd716fb57db/entrypoint.sh#L90).
