### PR TITLE
Install conntrack tool to get more network infos

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -79,6 +79,10 @@ RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-8 from stable" \
  && rm /etc/apt/sources.list.d/stretch.list \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; fi
 
+# Install conntrack tool to get additionnal network infos
+# cf /etc/datadog-agent/conf.d/network.d/conf.yaml.default
+RUN apt-get install -y conntrack
+
 # make sure we have recent dependencies
 RUN apt-get update \
   # CVE-fixing time!


### PR DESCRIPTION
In /etc/datadog-agent/conf.d/network.d/conf.yaml.default we can read :

```
    ## @param conntrack_path - string - optional
    ## Linux only.
    ## The location of the conntrack executable in order to get the stats from conntrack -S.
    ## It will be run with sudo, so an entry needs to be added to the sudoers file.
    ## By default, these metrics will not be sent.
    #
    # conntrack_path: /usr/sbin/conntrack
```

So we need it in some cases.

### What does this PR do?

Install "conntrack" tool in the docker image.

### Motivation

"conntrack" is require to get some stats

### Additional Notes

NA
