### PR TITLE
Enable process agent when system-probe is enabled

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -151,6 +151,12 @@ func NewDefaultAgentConfig() *AgentConfig {
 	//       need a few minutes to be ready.
 	_, err = util.GetContainers()
 	canAccessContainers := err == nil
+	canAccessContainers = false
+
+	enabledChecks := make([]string, 0)
+	if canAccessContainers {
+		enabledChecks = containerChecks
+	}
 
 	ac := &AgentConfig{
 		Enabled:            canAccessContainers, // We'll always run inside of a container.
@@ -184,7 +190,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		ConntrackShortTermBufferSize: defaultConntrackShortTermBufferSize,
 
 		// Check config
-		EnabledChecks: containerChecks,
+		EnabledChecks: enabledChecks,
 		CheckIntervals: map[string]time.Duration{
 			"process":     10 * time.Second,
 			"rtprocess":   2 * time.Second,

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -152,6 +152,11 @@ func NewDefaultAgentConfig() *AgentConfig {
 	_, err = util.GetContainers()
 	canAccessContainers := err == nil
 
+	enabledChecks := make([]string, 0)
+	if canAccessContainers {
+		enabledChecks = containerChecks
+	}
+
 	ac := &AgentConfig{
 		Enabled:            canAccessContainers, // We'll always run inside of a container.
 		APIEndpoints:       []APIEndpoint{{Endpoint: u}},
@@ -184,7 +189,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		ConntrackShortTermBufferSize: defaultConntrackShortTermBufferSize,
 
 		// Check config
-		EnabledChecks: containerChecks,
+		EnabledChecks: enabledChecks,
 		CheckIntervals: map[string]time.Duration{
 			"process":     10 * time.Second,
 			"rtprocess":   2 * time.Second,

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -152,11 +152,6 @@ func NewDefaultAgentConfig() *AgentConfig {
 	_, err = util.GetContainers()
 	canAccessContainers := err == nil
 
-	enabledChecks := make([]string, 0)
-	if canAccessContainers {
-		enabledChecks = containerChecks
-	}
-
 	ac := &AgentConfig{
 		Enabled:            canAccessContainers, // We'll always run inside of a container.
 		APIEndpoints:       []APIEndpoint{{Endpoint: u}},
@@ -189,7 +184,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		ConntrackShortTermBufferSize: defaultConntrackShortTermBufferSize,
 
 		// Check config
-		EnabledChecks: enabledChecks,
+		EnabledChecks: containerChecks,
 		CheckIntervals: map[string]time.Duration{
 			"process":     10 * time.Second,
 			"rtprocess":   2 * time.Second,

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -151,7 +151,6 @@ func NewDefaultAgentConfig() *AgentConfig {
 	//       need a few minutes to be ready.
 	_, err = util.GetContainers()
 	canAccessContainers := err == nil
-	canAccessContainers = false
 
 	enabledChecks := make([]string, 0)
 	if canAccessContainers {

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -152,7 +152,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 	_, err = util.GetContainers()
 	canAccessContainers := err == nil
 
-	enabledChecks := make([]string, 0)
+	var enabledChecks []string
 	if canAccessContainers {
 		enabledChecks = containerChecks
 	}

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -161,7 +161,6 @@ func TestDefaultConfig(t *testing.T) {
 	// assert that some sane defaults are set
 	assert.Equal("info", agentConfig.LogLevel)
 	assert.Equal(true, agentConfig.AllowRealTime)
-	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 	assert.Equal(true, agentConfig.Scrubber.Enabled)
 
 	os.Setenv("DOCKER_DD_AGENT", "yes")
@@ -169,7 +168,6 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(os.Getenv("HOST_PROC"), "")
 	assert.Equal(os.Getenv("HOST_SYS"), "")
 	os.Setenv("DOCKER_DD_AGENT", "no")
-	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 	assert.Equal(6062, agentConfig.ProcessExpVarPort)
 
 	os.Unsetenv("DOCKER_DD_AGENT")

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -47,6 +47,7 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 
 	if config.Datadog.GetBool(key(spNS, "enabled")) {
 		a.EnabledChecks = append(a.EnabledChecks, "connections")
+		a.Enabled = true
 		a.EnableSystemProbe = true
 	}
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -46,9 +46,11 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	a.CollectLocalDNS = config.Datadog.GetBool(key(spNS, "collect_local_dns"))
 
 	if config.Datadog.GetBool(key(spNS, "enabled")) {
-		log.Info("enabling process-agent for connections check as the system-probe is enabled")
 		a.EnabledChecks = append(a.EnabledChecks, "connections")
-		a.Enabled = true
+		if !a.Enabled {
+			log.Info("enabling process-agent for connections check as the system-probe is enabled")
+			a.Enabled = true
+		}
 		a.EnableSystemProbe = true
 	}
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -46,6 +46,7 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	a.CollectLocalDNS = config.Datadog.GetBool(key(spNS, "collect_local_dns"))
 
 	if config.Datadog.GetBool(key(spNS, "enabled")) {
+		log.Info("enabling process-agent for connections check as the system-probe is enabled")
 		a.EnabledChecks = append(a.EnabledChecks, "connections")
 		a.Enabled = true
 		a.EnableSystemProbe = true

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -162,10 +162,13 @@ func (a *AgentConfig) loadProcessYamlConfig(path string) error {
 		//   If "true" we will collect containers and processes.
 		//   If "disabled" the agent will be disabled altogether and won't start.
 		enabled := config.Datadog.GetString(k)
-		if ok, _ := isAffirmative(enabled); ok {
+		ok, err := isAffirmative(enabled)
+		if ok {
 			a.Enabled, a.EnabledChecks = true, processChecks
 		} else if enabled == "disabled" {
 			a.Enabled = false
+		} else if !ok && err == nil {
+			a.Enabled, a.EnabledChecks = true, containerChecks
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

If the system probe is enabled, the process agent should enable itself since it's required to send network data to datadog.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
