### PR TITLE
[omnibus] Use the new RPM GPG key to sign RPM packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -403,9 +403,9 @@ agent_rpm-x64:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     - set +x
-    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_private_key --with-decryption --query "Parameter.Value" --out text)
+    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_private_key_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
+    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Retrieve the system-probe from S3
     - $S3_CP_CMD $S3_ARTEFACTS_URI/system-probe $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe
@@ -437,9 +437,9 @@ agent_suse-x64:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     - set +x
-    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_private_key --with-decryption --query "Parameter.Value" --out text)
+    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_private_key_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
+    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Retrieve the system-probe from S3
     - $S3_CP_CMD $S3_ARTEFACTS_URI/system-probe $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -18,8 +18,12 @@ if ohai['platform'] == "windows"
   python_3_embedded "#{install_dir}/embedded3"
   maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
 else
+  if redhat? || suse?
+    maintainer 'Datadog, Inc <package@datadoghq.com>'
+  else
+    maintainer 'Datadog Packages <package@datadoghq.com>'
+  end
   install_dir '/opt/datadog-agent'
-  maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 
 # build_version is computed by an invoke command/function.

--- a/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
@@ -40,6 +40,7 @@ when 'rhel'
       gpgcheck=1
       repo_gpgcheck=0
       gpgkey=#{protocol}://yum.datadoghq.com/DATADOG_RPM_KEY.public
+             #{protocol}://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     EOF
   end
 
@@ -60,12 +61,14 @@ when 'suse'
       gpgcheck=1
       repo_gpgcheck=0
       gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+             https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     EOF
   end
 
   execute 'install suse' do
     command <<-EOF
       sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+      sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
       sudo zypper --non-interactive refresh datadog
       sudo zypper --non-interactive install #{node['dd-agent-step-by-step']['package_name']}
     EOF


### PR DESCRIPTION
### What does this PR do?

Changes the signing key we use to a new one, and updates the kitchen step-by-step instructions to match the change.

### Motivation

The time has come.

### Additional Notes

In case we're not ready to completely support the new key when we release 6.14, just revert this PR and we'll be fine.