### PR TITLE
[docs] Update Agent omnibus docker build command

### DIFF
--- a/docs/dev/agent_omnibus.md
+++ b/docs/dev/agent_omnibus.md
@@ -19,7 +19,7 @@ From the `datadog-agent` source folder, use the following command to run the
 `agent.omnibus-build` task in a Docker container:
 
 ```
-docker run -v "$PWD:/datadog-agent" -v "/tmp/omnibus:/omnibus" -v "/tmp/opt/datadog-agent:/opt/datadog-agent" -v"/tmp/gems:/gems" --workdir=/datadog-agent datadog/agent-buildimages-deb_x64 inv -e agent.omnibus-build --base-dir=/omnibus --gem-path=/gems
+docker run -v "$PWD:/go/src/github.com/DataDog/datadog-agent" -v "/tmp/omnibus:/omnibus" -v "/tmp/opt/datadog-agent:/opt/datadog-agent" -v"/tmp/gems:/gems" --workdir=/go/src/github.com/DataDog/datadog-agent datadog/agent-buildimages-deb_x64 inv -e agent.omnibus-build --base-dir=/omnibus --gem-path=/gems
 ```
 
 The container will share 3 volumes with the host to avoid starting from scratch


### PR DESCRIPTION
### What does this PR do?

Changes the docker command used to do the omnibus build within docker so that it doesn't fail at the `dep ensure` step.

### Motivation

The working directory needs to be within `/go/src`, otherwise `dep ensure` fails.
