### PR TITLE
[system-probe] add closed_channel_size to known config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -455,6 +455,7 @@ func initConfig(config Config) {
 	config.SetKnown("system_probe_config.max_closed_connections_buffered")
 	config.SetKnown("system_probe_config.max_connection_state_buffered")
 	config.SetKnown("system_probe_config.excluded_linux_versions")
+	config.SetKnown("system_probe_config.closed_channel_size")
 
 	// APM
 	config.SetKnown("apm_config.enabled")


### PR DESCRIPTION
### What does this PR do?

I forgot to set the config `closed_channel_size` to known configs.

cc: @DataDog/burrito 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
