### PR TITLE
Fixed an issue where short lived container logs for docker with AD config would not be collected

### DIFF
--- a/pkg/logs/input/docker/container.go
+++ b/pkg/logs/input/docker/container.go
@@ -10,6 +10,7 @@ package docker
 import (
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	dockerUtil "github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -26,15 +27,18 @@ const configPath = "com.datadoghq.ad.logs"
 
 // Container represents a container to tail logs from.
 type Container struct {
-	container types.Container
-	service   *service.Service
+	container     types.Container
+	service       *service.Service
+	shortLived    bool
+	discoveryTime time.Time
 }
 
 // NewContainer returns a new Container
 func NewContainer(container types.Container, service *service.Service) *Container {
 	return &Container{
-		container: container,
-		service:   service,
+		container:     container,
+		service:       service,
+		discoveryTime: time.Now(),
 	}
 }
 
@@ -58,6 +62,21 @@ func (c *Container) FindSource(sources []*config.LogSource) *config.LogSource {
 		}
 	}
 	return bestMatch
+}
+
+// SetShortLived changes the short-lived state of the container.
+func (c *Container) SetShortLived(shortLived bool) {
+	c.shortLived = shortLived
+}
+
+// IsShortLived returns true if the container is short lived.
+func (c *Container) IsShortLived() bool {
+	return c.shortLived
+}
+
+// DiscoveryTime returns the discovery time of the container.
+func (c *Container) DiscoveryTime() time.Time {
+	return c.discoveryTime
 }
 
 // getShortImageName resolves the short image name of a container by calling the docker daemon

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -49,7 +49,7 @@ func (s *Scheduler) Schedule(configs []integration.Config) {
 		}
 		switch {
 		case s.newSources(config):
-			log.Infof("Received a new logs config: %v", s.configName(config))
+			log.Debugf("Received a new logs config: %v", s.configName(config))
 			sources, err := s.toSources(config)
 			if err != nil {
 				log.Warnf("Invalid configuration: %v", err)
@@ -81,7 +81,7 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 		}
 		switch {
 		case s.newSources(config):
-			log.Infof("New source to remove: entity: %v", config.Entity)
+			log.Debugf("New source to remove: entity: %v", config.Entity)
 
 			_, identifier, err := s.parseEntity(config.Entity)
 			if err != nil {
@@ -96,7 +96,7 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 			}
 		case s.newService(config):
 			// new service to remove
-			log.Infof("New service to remove: entity: %v", config.Entity)
+			log.Debugf("New service to remove: entity: %v", config.Entity)
 			service, err := s.toService(config)
 			if err != nil {
 				log.Warnf("Invalid service: %v", err)


### PR DESCRIPTION
### What does this PR do?

* Keep containers in cache if they have not been tailed yet after a `delete container` event, this can happen when they are short lived and the config has been provided yet.

* Make sure short lived containers are stopped at after a reasonable amount of time

* Added a logic to evict pending short lived containers if they are too old to avoid memory leaks

### Motivation

Fix an issue where short lived containers would not be tailed when using the docker socket + an AD config

### Additional Notes

This should fix this issue https://github.com/DataDog/datadog-agent/issues/3955

### TODO

Add unit-tests, this is a proposal, not a final implementation