### PR TITLE
Add logger helper to rtloader

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -51,6 +51,16 @@ void initCgoFree(rtloader_t *rtloader) {
 }
 
 //
+// init log method
+//
+
+void LogMessage(char *, int);
+
+void initLogger(rtloader_t *rtloader) {
+	set_log_cb(rtloader, LogMessage);
+}
+
+//
 // datadog_agent module
 //
 // This also init "util" module who expose the same "headers" function
@@ -61,7 +71,6 @@ void GetHostname(char **);
 void GetClusterName(char **);
 void Headers(char **);
 void GetConfig(char*, char **);
-void LogMessage(char *, int);
 void SetExternalTags(char *, char *, char **);
 
 void initDatadogAgentModule(rtloader_t *rtloader) {
@@ -69,7 +78,6 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 	set_get_hostname_cb(rtloader, GetHostname);
 	set_get_clustername_cb(rtloader, GetClusterName);
 	set_headers_cb(rtloader, Headers);
-	set_log_cb(rtloader, LogMessage);
 	set_get_config_cb(rtloader, GetConfig);
 	set_set_external_tags_cb(rtloader, SetExternalTags);
 }
@@ -259,6 +267,7 @@ func Initialize(paths ...string) error {
 
 	// Setup custom builtin before RtLoader initialization
 	C.initCgoFree(rtloader)
+	C.initLogger(rtloader)
 	C.initDatadogAgentModule(rtloader)
 	C.initAggregatorModule(rtloader)
 	C.initUtilModule(rtloader)

--- a/rtloader/common/builtins/datadog_agent.c
+++ b/rtloader/common/builtins/datadog_agent.c
@@ -6,6 +6,7 @@
 #include "cgo_free.h"
 
 #include <stringutils.h>
+#include <log.h>
 
 // these must be set by the Agent
 static cb_get_version_t cb_get_version = NULL;
@@ -13,7 +14,6 @@ static cb_get_config_t cb_get_config = NULL;
 static cb_headers_t cb_headers = NULL;
 static cb_get_hostname_t cb_get_hostname = NULL;
 static cb_get_clustername_t cb_get_clustername = NULL;
-static cb_log_t cb_log = NULL;
 static cb_set_external_tags_t cb_set_external_tags = NULL;
 
 // forward declarations
@@ -76,11 +76,6 @@ void _set_get_hostname_cb(cb_get_hostname_t cb)
 void _set_get_clustername_cb(cb_get_clustername_t cb)
 {
     cb_get_clustername = cb;
-}
-
-void _set_log_cb(cb_log_t cb)
-{
-    cb_log = cb;
 }
 
 void _set_set_external_tags_cb(cb_set_external_tags_t cb)
@@ -307,11 +302,6 @@ PyObject *get_clustername(PyObject *self, PyObject *args)
 */
 static PyObject *log_message(PyObject *self, PyObject *args)
 {
-    // callback must be set
-    if (cb_log == NULL) {
-        Py_RETURN_NONE;
-    }
-
     char *message = NULL;
     int log_level;
 
@@ -321,7 +311,7 @@ static PyObject *log_message(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    cb_log(message, log_level);
+    agent_log(log_level, message);
     Py_RETURN_NONE;
 }
 

--- a/rtloader/common/log.c
+++ b/rtloader/common/log.c
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+#include "log.h"
+
+// these must be set by the Agent
+static cb_log_t cb_log = NULL;
+
+void _set_log_cb(cb_log_t cb)
+{
+    cb_log = cb;
+}
+
+// Logs a message to the agent logger. Caller is in charge of freeing the
+// message if needed.
+void agent_log(log_level_t log_level, char *message) {
+    if (cb_log == NULL || message == NULL) {
+        return;
+    }
+    cb_log(message, log_level);
+}

--- a/rtloader/common/log.h
+++ b/rtloader/common/log.h
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+#ifndef DATADOG_AGENT_RTLOADER_LOG_H
+#define DATADOG_AGENT_RTLOADER_LOG_H
+
+/*! \file log.h
+    \brief RtLoader log builtin header file.
+
+    The prototypes here provide functions to logs messages from rtloader to the
+    agent logger.
+*/
+
+#include "rtloader_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! \fn void _set_log_cb(cb_log_t)
+    \brief Sets a callback to be used by rtloader to logs messages to the agent
+    logger.
+    \param object A function pointer to the callback function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
+void _set_log_cb(cb_log_t);
+
+/*! \fn void agent_log( log_level_t, char *)
+    \brief Logs the message to the agent loggers.
+    \param log_level_t The log level to use to log the message.
+    \param char* A pointer to the message.
+*/
+void agent_log(log_level_t, char *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/rtloader/common/stringutils.c
+++ b/rtloader/common/stringutils.c
@@ -16,9 +16,9 @@ PyObject * dumper = NULL;
 
 /**
  * returns a C (NULL terminated UTF-8) string from a python string.
- * 
+ *
  * \param object  A Python string to be converted to C-string.
- * 
+ *
  * \return A standard C string (NULL terminated character pointer)
  *  The returned pointer is allocated from the heap and must be
  * deallocated (free()ed) by the caller

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -68,6 +68,15 @@ typedef struct py_info_s {
     char *path;
 } py_info_t;
 
+typedef enum {
+    DATADOG_AGENT_TRACE = 7,
+    DATADOG_AGENT_DEBUG = 10,
+    DATADOG_AGENT_INFO = 20,
+    DATADOG_AGENT_WARNING = 30,
+    DATADOG_AGENT_ERROR = 40,
+    DATADOG_AGENT_CRITICAL = 50
+} log_level_t;
+
 /*
  * custom builtins
  */

--- a/rtloader/three/CMakeLists.txt
+++ b/rtloader/three/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(datadog-agent-three SHARED
     three.cpp
     ../common/cgo_free.c
     ../common/stringutils.c
+    ../common/log.c
     ../common/builtins/aggregator.c
     ../common/builtins/datadog_agent.c
     ../common/builtins/util.c

--- a/rtloader/two/CMakeLists.txt
+++ b/rtloader/two/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(datadog-agent-two SHARED
     two.cpp
     ../common/cgo_free.c
     ../common/stringutils.c
+    ../common/log.c
     ../common/builtins/aggregator.c
     ../common/builtins/datadog_agent.c
     ../common/builtins/util.c


### PR DESCRIPTION
### What does this PR do?

RtLoader can now log directly to the Agent logger the same way Python checks log to the agent.
