### PR TITLE
[rtloader] python instance memory tracking

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -223,19 +223,24 @@ func getFormattedStatus(w http.ResponseWriter, r *http.Request) {
 func getCheckMemoryStatus(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	component := vars["component"]
+
+	w.Header().Set("Content-Type", "application/json")
 	switch component {
 	case "py":
 		jsonStatus, err := status.GetPythonCheckMemoryUsage(common.Coll)
 		if err != nil {
-			log.Errorf("unable to collect python check memory usage: %s", err.Error())
-			http.Error(w, err.Error(), 500)
+			log.Errorf("Unable to collect python check memory usage: %s", err.Error())
+			body, _ := json.Marshal(map[string]string{"error": err.Error()})
+			http.Error(w, string(body), 500)
+			return
 		}
 
 		w.Write(jsonStatus)
 	default:
-		err := fmt.Errorf("bad url or resource does not exist")
-		log.Errorf("%s", err.Error())
-		http.Error(w, err.Error(), 404)
+		err := fmt.Errorf("Bad url or resource does not exist")
+		log.Errorf("Unable to get check memory status: %s", err.Error())
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 404)
 	}
 }
 

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -140,6 +140,9 @@ build do
       end
     end
 
+    # Adding pympler for memory debug purposes
+    requirements.push("pympler==0.7")
+
     # Render the filtered requirements file
     erb source: "static_requirements.txt.erb",
         dest: "#{static_reqs_out_file}",

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -139,6 +139,9 @@ build do
       end
     end
 
+    # Adding pympler for memory debug purposes
+    requirements.push("pympler==0.7")
+
     # Render the filtered requirements file
     erb source: "static_requirements.txt.erb",
         dest: "#{static_reqs_out_file}",

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -228,6 +228,19 @@ func (c *Collector) getAllInstanceIDs(checkName string) []check.ID {
 	return instances
 }
 
+// GetAllCheckInstances gets all the check instances configured in the collector
+func (c *Collector) GetAllCheckInstances() []check.Check {
+	c.m.RLock()
+	defer c.m.RUnlock()
+
+	instances := []check.Check{}
+	for _, check := range c.checks {
+		instances = append(instances, check)
+	}
+
+	return instances
+}
+
 // ReloadAllCheckInstances completely restarts a check with a new configuration
 func (c *Collector) ReloadAllCheckInstances(name string, newInstances []check.Check) ([]check.ID, error) {
 	if !c.started() {

--- a/pkg/collector/python/memory.go
+++ b/pkg/collector/python/memory.go
@@ -9,7 +9,6 @@ package python
 
 import (
 	"expvar"
-	// "log"
 	"runtime/debug"
 	"sync"
 	"unsafe"

--- a/pkg/status/status_nopython.go
+++ b/pkg/status/status_nopython.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+// +build !python
+
+package status
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/collector"
+)
+
+// GetPythonCheckMemoryUsage gets the memory usage for all checks as JSON
+func GetPythonCheckMemoryUsage(c *collector.Collector) ([]byte, error) {
+	return nil, fmt.Errorf("Python support unavailable on build")
+}

--- a/pkg/status/status_python.go
+++ b/pkg/status/status_python.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+// +build python
+
+package status
+
+import (
+	"encoding/json"
+
+	"github.com/DataDog/datadog-agent/pkg/collector"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/python"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// GetPythonCheckMemoryUsage gets the memory usage for all checks as JSON
+func GetPythonCheckMemoryUsage(c *collector.Collector) ([]byte, error) {
+	instances := c.GetAllCheckInstances()
+	stats := make(map[string]map[check.ID]int64)
+
+	for _, chk := range instances {
+		pyCheck, ok := chk.(*python.PythonCheck)
+		if !ok {
+			continue
+		}
+
+		cSize, err := pyCheck.SizeOfCheck()
+		size := int64(cSize)
+		if err != nil {
+			log.Errorf("Error collecting size for instance %v: %v", pyCheck.ID(), err)
+			continue
+		}
+
+		_, ok = stats[pyCheck.String()]
+		if !ok {
+			stats[pyCheck.String()] = make(map[check.ID]int64)
+		}
+		stats[pyCheck.String()][pyCheck.ID()] = size
+	}
+
+	statsJSON, err := json.Marshal(stats)
+	if err != nil {
+		return nil, err
+	}
+
+	return statsJSON, nil
+}

--- a/releasenotes/notes/instance-memory-usage-pympler-14483a3f1c2d9a09.yaml
+++ b/releasenotes/notes/instance-memory-usage-pympler-14483a3f1c2d9a09.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Python check instance memory tracking/status with pympler.
+    Statistics available via the API.

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -187,6 +187,15 @@ DATADOG_AGENT_RTLOADER_API int get_check_deprecated(rtloader_t *rtloader, rtload
 */
 DATADOG_AGENT_RTLOADER_API char *run_check(rtloader_t *, rtloader_pyobject_t *check);
 
+/*! \fn const int size_of_check(rtloader_t *rtloader, rtloader_pyobject_t *check)
+    \brief Calculates the size of a check instance.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param check A rtloader_pyobject_t * pointer to the check instance we wish to run.
+    \return An int with the estimated size of the check instance.
+    \sa rtloader_pyobject_t, rtloader_t
+*/
+DATADOG_AGENT_RTLOADER_API long size_of_check(rtloader_t *, rtloader_pyobject_t *check);
+
 /*! \fn char **get_checks_warnings(rtloader_t *, rtloader_pyobject_t *check)
     \brief Get all warnings, if any, for a check instance.
     \param rtloader_t A rtloader_t * pointer to the RtLoader instance.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -111,6 +111,15 @@ public:
     */
     virtual char *runCheck(RtLoaderPyObject *check) = 0;
 
+    //! Pure virtual sizeOfCheck member.
+    /*!
+      \param check The python object pointer to the check we wish to sizeOfCheck.
+      \return An integer with the size of the check instance.
+    */
+#define _PY_PYMPLER_SIZING_MODULE "pympler.asizeof"
+#define _PY_PYMPLER_SIZING_FUNCTION "asizeof"
+    virtual long sizeOfCheck(RtLoaderPyObject *check) = 0;
+
     //! Pure virtual getCheckWarnings member.
     /*!
       \param check The python object pointer to the check we wish to collect existing warnings for.

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -293,6 +293,11 @@ char *run_check(rtloader_t *rtloader, rtloader_pyobject_t *check)
     return AS_TYPE(RtLoader, rtloader)->runCheck(AS_TYPE(RtLoaderPyObject, check));
 }
 
+long size_of_check(rtloader_t *rtloader, rtloader_pyobject_t *check)
+{
+    return AS_TYPE(RtLoader, rtloader)->sizeOfCheck(AS_TYPE(RtLoaderPyObject, check));
+}
+
 char **get_checks_warnings(rtloader_t *rtloader, rtloader_pyobject_t *check)
 {
     return AS_TYPE(RtLoader, rtloader)->getCheckWarnings(AS_TYPE(RtLoaderPyObject, check));

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -407,6 +407,61 @@ done:
     return ret;
 }
 
+long Three::sizeOfCheck(RtLoaderPyObject *check)
+{
+    long size = -1;
+    char format[] = "(O)";
+    PyObject *pyPympler = NULL, *pySizer = NULL, *pyArgs = NULL;
+    PyObject *result = NULL;
+
+    if (check == NULL) {
+        return 0;
+    }
+
+    PyObject *py_check = reinterpret_cast<PyObject *>(check);
+
+    rtloader_gilstate_t state = GILEnsure();
+
+    pyPympler = PyImport_ImportModule(_PY_PYMPLER_SIZING_MODULE);
+    if (pyPympler == NULL) {
+        setError("unable to import " _PY_PYMPLER_SIZING_MODULE " module: " + _fetchPythonError());
+        goto done;
+    }
+
+    pySizer = PyObject_GetAttrString(pyPympler, _PY_PYMPLER_SIZING_FUNCTION);
+    if (pySizer == NULL) {
+        setError("could not fetch " _PY_PYMPLER_SIZING_FUNCTION " attr: " + _fetchPythonError());
+        goto done;
+    }
+
+    pyArgs = Py_BuildValue(format, check);
+    if (pyArgs == NULL) {
+        setError("could not build args tuple: " + _fetchPythonError());
+        goto done;
+    }
+
+    result = PyObject_Call(pySizer, pyArgs, NULL);
+    if (result == NULL) {
+        setError("error invoking '" _PY_PYMPLER_SIZING_MODULE "." _PY_PYMPLER_SIZING_FUNCTION "' function: "
+                 + _fetchPythonError());
+        goto done;
+    }
+
+    // result is a python integer...
+    size = PyLong_AsLong(result);
+    if (size == -1) {
+        setError("error converting '" _PY_PYMPLER_SIZING_MODULE "." _PY_PYMPLER_SIZING_FUNCTION "' result to long: "
+                 + _fetchPythonError());
+        goto done;
+    }
+
+done:
+    Py_XDECREF(result);
+    GILRelease(state);
+
+    return size;
+}
+
 char **Three::getCheckWarnings(RtLoaderPyObject *check)
 {
     if (check == NULL) {

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -67,6 +67,7 @@ public:
                   RtLoaderPyObject *&check);
 
     char *runCheck(RtLoaderPyObject *check);
+    long sizeOfCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);
     void decref(RtLoaderPyObject *obj);
     void incref(RtLoaderPyObject *obj);

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -66,6 +66,7 @@ public:
                   RtLoaderPyObject *&check);
 
     char *runCheck(RtLoaderPyObject *check);
+    long sizeOfCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);
     void decref(RtLoaderPyObject *obj);
     void incref(RtLoaderPyObject *obj);


### PR DESCRIPTION
### What does this PR do?

This PR adds support for reporting python check instance memory usage.

### Motivation

Adding tooling for additional insights into the python runtime, and memory tracking in general.

### Additional Notes

This PR was based off #3961 - so merge that first, then change the `base` to `master`, then this.

Unsure if we should set the `ignored`: `pympler.asizeof.asizeof(*objs, **opts)` option to `True`, it might make sense. See here: https://pythonhosted.org/Pympler/asizeof.html