### PR TITLE
Added a support for socks5 proxy for logs sent over HTTP

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -135,8 +135,10 @@ func buildTCPEndpoints() (*Endpoints, error) {
 }
 
 func buildHTTPEndpoints() (*Endpoints, error) {
+	proxyAddress := coreConfig.Datadog.GetString("logs_config.socks5_proxy_address")
 	main := Endpoint{
-		APIKey: getLogsAPIKey(coreConfig.Datadog),
+		APIKey:       getLogsAPIKey(coreConfig.Datadog),
+		ProxyAddress: proxyAddress,
 	}
 
 	switch {
@@ -160,6 +162,7 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 	}
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
+		additionals[i].ProxyAddress = proxyAddress
 	}
 
 	return NewEndpoints(main, additionals, false, true), nil

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -127,6 +127,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	endpoint = endpoints.Main
 	suite.True(endpoint.UseSSL)
 	suite.Equal("agent-http-intake.logs.datadoghq.com", endpoint.Host)
+	suite.Equal("", endpoint.ProxyAddress)
 }
 
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPConfigAndOverride() {
@@ -144,6 +145,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	endpoint = endpoints.Main
 	suite.True(endpoint.UseSSL)
 	suite.Equal("foo", endpoint.Host)
+	suite.Equal("", endpoint.ProxyAddress)
 }
 
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidProxyConfig() {
@@ -162,6 +164,26 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidProxyCo
 	suite.True(endpoint.UseSSL)
 	suite.Equal("foo", endpoint.Host)
 	suite.Equal(1234, endpoint.Port)
+	suite.Equal("", endpoint.ProxyAddress)
+}
+
+func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidSOCKS5Config() {
+	var endpoints *Endpoints
+	var endpoint Endpoint
+	var err error
+
+	suite.config.Set("logs_config.use_http", true)
+	suite.config.Set("logs_config.dd_url", "foo")
+	suite.config.Set("logs_config.socks5_proxy_address", "bar:1234")
+
+	endpoints, err = BuildEndpoints()
+	suite.Nil(err)
+	suite.True(endpoints.UseHTTP)
+
+	endpoint = endpoints.Main
+	suite.True(endpoint.UseSSL)
+	suite.Equal("foo", endpoint.Host)
+	suite.Equal("bar:1234", endpoint.ProxyAddress)
 }
 
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFailWithInvalidProxyConfig() {


### PR DESCRIPTION
### What does this PR do?

Added support for SOCKS for HTTP for logs

### Motivation

Make sure the logs-agent won't break for customers that use a socks5 proxy when they switch to using HTTP.

### Additional Notes

Anything else we should know when reviewing?
