### PR TITLE
Fixed a concurrency issue in logs-agent when using HTTP and dual-shipping

### DIFF
--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -45,7 +45,7 @@ func NewPipeline(outputChan chan *message.Message, processingRules []*config.Pro
 
 	var strategy sender.Strategy
 	if endpoints.UseHTTP {
-		strategy = sender.NewBatchStrategy(sender.NewArraySerializer())
+		strategy = sender.NewBatchStrategy(sender.ArraySerializer)
 	} else {
 		strategy = sender.StreamStrategy
 	}

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -34,7 +34,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsFull(t *testing.T) {
 		return nil
 	}
 
-	go newBatchStrategyWithLimits(NewLineSerializer(), 2, 2, 100*time.Millisecond).Send(input, output, success)
+	go newBatchStrategyWithLimits(LineSerializer, 2, 2, 100*time.Millisecond).Send(input, output, success)
 
 	content = []byte("a\nb")
 
@@ -59,7 +59,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsFull(t *testing.T) {
 // 		return nil
 // 	}
 
-// 	go newBatchStrategyWithLimits(NewLineSerializer(), 2, 2, 100*time.Millisecond).Send(input, output, success)
+// 	go newBatchStrategyWithLimits(LineSerializer, 2, 2, 100*time.Millisecond).Send(input, output, success)
 
 // 	content = []byte("a")
 
@@ -96,7 +96,7 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 		return nil
 	}
 
-	go newBatchStrategyWithLimits(NewLineSerializer(), 2, 2, 100*time.Millisecond).Send(input, output, success)
+	go newBatchStrategyWithLimits(LineSerializer, 2, 2, 100*time.Millisecond).Send(input, output, success)
 
 	content = []byte("a")
 
@@ -128,7 +128,7 @@ func TestBatchStrategyShouldNotBlockWhenForceStopping(t *testing.T) {
 		close(input)
 	}()
 
-	newBatchStrategyWithLimits(NewLineSerializer(), 2, 2, 100*time.Millisecond).Send(input, output, success)
+	newBatchStrategyWithLimits(LineSerializer, 2, 2, 100*time.Millisecond).Send(input, output, success)
 }
 
 func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
@@ -147,5 +147,5 @@ func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 		assert.Equal(t, message, <-output)
 	}()
 
-	newBatchStrategyWithLimits(NewLineSerializer(), 2, 2, 100*time.Millisecond).Send(input, output, success)
+	newBatchStrategyWithLimits(LineSerializer, 2, 2, 100*time.Millisecond).Send(input, output, success)
 }

--- a/pkg/logs/sender/serializer_test.go
+++ b/pkg/logs/sender/serializer_test.go
@@ -17,7 +17,7 @@ func TestLineSerializer(t *testing.T) {
 	var messages []*message.Message
 	var payload []byte
 
-	serializer := NewLineSerializer()
+	serializer := LineSerializer
 
 	payload = serializer.Serialize(messages)
 	assert.Len(t, payload, 0)
@@ -35,7 +35,7 @@ func TestArraySerializer(t *testing.T) {
 	var messages []*message.Message
 	var payload []byte
 
-	serializer := NewArraySerializer()
+	serializer := ArraySerializer
 
 	payload = serializer.Serialize(messages)
 	assert.Equal(t, []byte("[]"), payload)


### PR DESCRIPTION
### What does this PR do?

Recreate a new byte buffer for each message to make sure the payload slice is not share between concurrent destinations that may reset and send it at the same time.

### Motivation

Fix a concurrency issue that would lead to dual ship misformatted payload 

### Additional Notes

Anything else we should know when reviewing?
