### PR TITLE
Improve three::_findSubclassOf resiliency based on two's code.

### DIFF
--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -504,11 +504,13 @@ error:
 
 PyObject *Three::_findSubclassOf(PyObject *base, PyObject *module)
 {
+    // baseClass is not a Class type
     if (base == NULL || !PyType_Check(base)) {
         setError("base class is not of type 'Class'");
         return NULL;
     }
 
+    // module is not a Module object
     if (module == NULL || !PyModule_Check(module)) {
         setError("module is not of type 'Module'");
         return NULL;
@@ -516,50 +518,64 @@ PyObject *Three::_findSubclassOf(PyObject *base, PyObject *module)
 
     PyObject *dir = PyObject_Dir(module);
     if (dir == NULL) {
+        PyErr_Clear();
         setError("there was an error calling dir() on module object");
         return NULL;
     }
 
     PyObject *klass = NULL;
     for (int i = 0; i < PyList_GET_SIZE(dir); i++) {
-        // get symbol name
-        char *symbol_name;
-        PyObject *symbol = PyList_GetItem(dir, i);
-        if (symbol != NULL) {
-            symbol_name = as_string(symbol);
-            if (symbol_name == NULL)
-                continue;
-        } else {
-            // Gets exception reason
-            PyObject *reason = PyUnicodeDecodeError_GetReason(PyExc_IndexError);
+        // Reset `klass` at every iteration so its state is always clean when we
+        // continue the loop or return early. Reset at first iteration is useless
+        // but it keeps the code readable.
+        Py_XDECREF(klass);
+        klass = NULL;
 
-            // Clears exception and sets error
-            PyException_SetTraceback(PyExc_IndexError, Py_None);
-            setError((const char *)PyBytes_AsString(reason));
+        // get the symbol in current list item
+        PyObject *symbol = PyList_GetItem(dir, i);
+        if (symbol == NULL) {
+            // This should never happen as it means we're out of bounds
+            PyErr_Clear();
+            setError("there was an error browsing dir() output");
             goto done;
         }
 
+        // get symbol name (not a copy, should not be modified or freed)
+        char *symbol_name = as_string(symbol);
+        if (symbol_name == NULL) {
+            // as_string returns NULL if `symbol` is not a string object
+            // and raises TypeError. Let's clear the error and keep going.
+            PyErr_Clear();
+            continue;
+        }
+
+        // get symbol instance. It's a new ref but in case of success we don't
+        // DecRef since we return it and the caller will be owner
         klass = PyObject_GetAttrString(module, symbol_name);
         ::_free(symbol_name);
         if (klass == NULL) {
+            PyErr_Clear();
             continue;
         }
 
         // Not a class, ignore
         if (!PyType_Check(klass)) {
-            Py_XDECREF(klass);
             continue;
         }
 
         // Unrelated class, ignore
         if (!PyType_IsSubtype((PyTypeObject *)klass, (PyTypeObject *)base)) {
-            Py_XDECREF(klass);
             continue;
         }
 
-        // `klass` is actually `base` itself, ignore
-        if (PyObject_RichCompareBool(klass, base, Py_EQ) == 1) {
-            Py_XDECREF(klass);
+        // check whether `klass` is actually `base` itself
+        int retval = PyObject_RichCompareBool(klass, base, Py_EQ);
+        if (retval == 1) {
+            // `klass` is indeed `base`, continue
+            continue;
+        } else if (retval == -1) {
+            // an error occurred calling __eq__, clear and continue
+            PyErr_Clear();
             continue;
         }
 
@@ -567,7 +583,7 @@ PyObject *Three::_findSubclassOf(PyObject *base, PyObject *module)
         char func_name[] = "__subclasses__";
         PyObject *children = PyObject_CallMethod(klass, func_name, NULL);
         if (children == NULL) {
-            Py_XDECREF(klass);
+            PyErr_Clear();
             continue;
         }
 
@@ -577,7 +593,6 @@ PyObject *Three::_findSubclassOf(PyObject *base, PyObject *module)
 
         // Agent integrations are supposed to have no subclasses
         if (children_count > 0) {
-            Py_XDECREF(klass);
             continue;
         }
 
@@ -585,11 +600,14 @@ PyObject *Three::_findSubclassOf(PyObject *base, PyObject *module)
         goto done;
     }
 
+    // we couldn't find any good subclass, set an error and reset
+    // `klass` state for one last time before moving to `done`.
     setError("cannot find a subclass");
+    Py_XDECREF(klass);
     klass = NULL;
 
 done:
-    Py_DECREF(dir);
+    Py_XDECREF(dir);
     return klass;
 }
 

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -540,7 +540,7 @@ PyObject *Three::_findSubclassOf(PyObject *base, PyObject *module)
             goto done;
         }
 
-        // get symbol name (not a copy, should not be modified or freed)
+        // get symbol name, as_string returns a new object that we have to free
         char *symbol_name = as_string(symbol);
         if (symbol_name == NULL) {
             // as_string returns NULL if `symbol` is not a string object


### PR DESCRIPTION
### What does this PR do?

Mimics the `two::_findSubclassOf` behavior in `three::_findSubclassOf` because the `two`'s implementation has been well tested since and the changes were not reflected on the `three`'s implementation.

### Motivation

The original goal is to improve the resiliency of `_findSubclassOf` in the `three` implementation.
It should not have any impact and it doesn't have any logic change, just code clarity.

### Additional Notes

Ref PR: https://github.com/DataDog/datadog-agent/pull/3487