### PR TITLE
Fix kitchen signing certificate check.

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -270,12 +270,22 @@ shared_examples_for "an installed Agent" do
     JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('skip_windows_signing_test')
   }
   
+  
   it 'is properly signed' do
     puts "swsc is #{skip_windows_signing_check}"
+    #puts "is an upgrade is #{is_upgrade}"
     if os == :windows and !skip_windows_signing_check
       # The user in the yaml file is "datadog", however the default test kitchen user is azure.
       # This allows either to be used without changing the test.
       msi_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\cache\\ddagent-cli.msi"
+      msi_path_upgrade = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\cache\\ddagent-up.msi"
+      
+      # The upgrade file should only be present when doing an upgrade test.  Therefore,
+      # check the file we're upgrading to, not the file we're upgrading from
+      if File.file?(msi_path_upgrade)
+        msi_path = msi_path_upgrade
+      end
+      puts "checking file #{msi_path}"
       expect(File).to exist(msi_path)
       output = `powershell -command "get-authenticodesignature #{msi_path}"`
       signature_hash = "3B79DBE9410471E4FFBDFDAD646A83A1CD47D5AA"


### PR DESCRIPTION
Check for the existence of the ugprade file.  If present, check the
signature on that (not the "from" file)


### Motivation

Change to new certificate exposed flaw in test logic.

### Additional Notes

Anything else we should know when reviewing?
