### PR TITLE
Remove dependency on WMI.

### DIFF
--- a/omnibus/resources/agent/msi/cal/stopservices.cpp
+++ b/omnibus/resources/agent/msi/cal/stopservices.cpp
@@ -741,7 +741,7 @@ int installServices(MSIHANDLE hInstall, CustomActionData& data, const wchar_t *p
     serviceDef services[NUM_SERVICES] = {
         serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
                    agent_exe.c_str(),
-                   L"winmgmt\0\0", SERVICE_AUTO_START, data.getFullUsername().c_str(), password),
+                   NULL, SERVICE_AUTO_START, data.getFullUsername().c_str(), password),
         serviceDef(traceService.c_str(), L"DataDog Trace Agent", L"Send tracing metrics to DataDog",
                    trace_exe.c_str(),
                    L"datadogagent\0\0", SERVICE_DEMAND_START, data.getFullUsername().c_str(), password),

--- a/releasenotes/notes/delwmidep-1219234765112adf.yaml
+++ b/releasenotes/notes/delwmidep-1219234765112adf.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    The Windows agent no longer depends on the Windows WMI service.  
+    If the WMI service stops for any reason, the Windows agent will no 
+    longer stop with it.  However, any integrations that do use WMI
+    (wmi_check and win32_event_log) will not be able to function until 
+    the WMI service restarts.


### PR DESCRIPTION
We've removed most of our WMI based code; the WMI service has been
linked to the agent stopping for no apparent reason

