### PR TITLE
[HOLD] Fix bad default and add soft limit

### DIFF
--- a/cmd/agent/dist/conf.d/systemd.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/systemd.d/conf.yaml.example
@@ -2,17 +2,17 @@ init_config:
 
 instances:
     -
-    ## @param unit_names - list of strings - optional
+    ## @param unit_names - list of strings - required if unit_regexes is not set
     ## List of systemd units to monitor (full name e.g. ssh.service).
-    ## If `unit_names` and `unit_regexes` are both NOT specified, the check monitors all units.
+    ## Either `unit_names` or `unit_regexes` must be specified.
     #
-    # unit_names:
-    #   - <UNIT_NAME>
+    unit_names:
+      - <UNIT_NAME>
 
-    ## @param unit_regexes - list of strings - optional
+    ## @param unit_regexes - list of strings - required if unit_names is not set
     ## Regex pattern[s] matching the names of units to monitor.
-    ## If `unit_names` and `unit_regexes` are both NOT specified, the check monitors all units.
-    ## 
+    ## Either `unit_names` or `unit_regexes` must be specified.
+    ##
     ## If the number of units managed by systemd is unbounded, it might increase
     ## the number of custom metrics send by this check which may impact your billing.
     ## Learn more about custom metrics: https://docs.datadoghq.com/developers/metrics/custom_metrics/#how-is-a-custom-metric-defined

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -38,7 +38,7 @@ const (
 	systemStateServiceCheck = "systemd.system.state"
 	unitStateServiceCheck   = "systemd.unit.state"
 
-	defaultMaxUnits = 100
+	defaultMaxUnits = 50
 )
 
 var dbusTypeMap = map[string]string{

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -78,7 +78,7 @@ func TestDefaultConfiguration(t *testing.T) {
 	assert.Equal(t, []string(nil), check.config.instance.UnitNames)
 	assert.Equal(t, []string(nil), check.config.instance.UnitRegexStrings)
 	assert.Equal(t, []*regexp.Regexp(nil), check.config.instance.UnitRegexPatterns)
-	assert.Equal(t, 100, check.config.instance.MaxUnits)
+	assert.Equal(t, 50, check.config.instance.MaxUnits)
 }
 
 func TestBasicConfiguration(t *testing.T) {

--- a/releasenotes/notes/improve-systemd-config-a82bca0014f6ccc6.yaml
+++ b/releasenotes/notes/improve-systemd-config-a82bca0014f6ccc6.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Update systemd configuration. Before if `unit_names` and `unit_regexes`
+    are not set, all units are monitored. Now either `unit_names` or
+    `unit_regexes` must be set, and only matching units will be monitored.
+  - |
+    New systemd soft limit config `max_units` have been added.


### PR DESCRIPTION
### What does this PR do?

Fix bad default and add soft limit.

### Motivation

The previous default was risky since if `unit_names` and `unit_regexes` are not set, the integration will monitor ALL units.

### Additional Notes

This is a subset of https://github.com/DataDog/datadog-agent/pull/3974

If this PR is merged, https://github.com/DataDog/datadog-agent/pull/3974 need to be updated.
