### PR TITLE
Set SilenceUsage to true by default for root agent command.

### DIFF
--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -26,6 +26,7 @@ var (
 The Datadog Agent faithfully collects events and metrics and brings them
 to Datadog on your behalf so that you can do something useful with your
 monitoring and performance data.`,
+		SilenceUsage: true,
 	}
 	// confFilePath holds the path to the folder containing the configuration
 	// file, to allow overrides from the command line

--- a/releasenotes/notes/dont-display-help-message-when-cmd-fails-152218c44ac88373.yaml
+++ b/releasenotes/notes/dont-display-help-message-when-cmd-fails-152218c44ac88373.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When a valid command is passed to the agent but the command fails, don't display the help usage message.


### PR DESCRIPTION
### What does this PR do?

This PR sets the "SilenceUsage" flag of the root agent command to true by default. This prevents the help usage message from being displayed when a command encounters an error.

### Motivation

When a valid command is passed to the agent but it fails, the help message is displayed anyway.

