### PR TITLE
[rtloader] Fix undefined __THROW on MacOS

### DIFF
--- a/rtloader/common/rtloader_mem.h
+++ b/rtloader/common/rtloader_mem.h
@@ -51,7 +51,10 @@ void _free(void *ptr);
 #ifdef __cplusplus
 #    ifdef _WIN32
 #        define __THROW
+#    elif __APPLE__
+#        define __THROW
 #    endif
+
 char *strdupe(const char *s1) __THROW;
 #else
 char *strdupe(const char *s1);


### PR DESCRIPTION
### What does this PR do?

Define `__THROW` on Apple devices since it's not defined.

### Motivation

MacOS 10.14 is shipped with `g++ 4.2.1`, and doesn't recognise the `__THROW` macro.

### Additional Notes

Alternative implementation idea: would this work? 
```
#ifdef __cplusplus
#    ifndef __THROW
#        define __THROW
#    endif
```