### PR TITLE
Add NetworkID to host metadata

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -457,6 +457,9 @@ func initConfig(config Config) {
 	config.SetKnown("system_probe_config.excluded_linux_versions")
 	config.SetKnown("system_probe_config.closed_channel_size")
 
+	// Network
+	config.SetKnown("network.id")
+
 	// APM
 	config.SetKnown("apm_config.enabled")
 	config.SetKnown("apm_config.env")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -458,7 +458,7 @@ func initConfig(config Config) {
 	config.SetKnown("system_probe_config.closed_channel_size")
 
 	// Network
-	config.SetKnown("network.id")
+	config.BindEnv("network.id")
 
 	// APM
 	config.SetKnown("apm_config.enabled")

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -40,6 +40,7 @@ func GetPayload(hostname string) *Payload {
 		Meta:          meta,
 		HostTags:      getHostTags(),
 		ContainerMeta: getContainerMeta(1 * time.Second),
+		NetworkMeta:   getNetworkMeta(),
 	}
 
 	// Cache the metadata for use in other payloads
@@ -143,6 +144,11 @@ func getMeta() *Meta {
 	cache.Cache.Set(key, m, cache.NoExpiration)
 
 	return m
+}
+
+func getNetworkMeta() *NetworkMeta {
+	nid, _ := util.GetNetworkID()
+	return &NetworkMeta{ID: nid}
 }
 
 func getContainerMeta(timeout time.Duration) map[string]string {

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -150,7 +150,7 @@ func getNetworkMeta() *NetworkMeta {
 	nid, err := util.GetNetworkID()
 	if err != nil {
 		log.Errorf("could not get network metadata: %s", err)
-		return nil, err
+		return nil
 	}
 	return &NetworkMeta{ID: nid}
 }

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -147,7 +147,11 @@ func getMeta() *Meta {
 }
 
 func getNetworkMeta() *NetworkMeta {
-	nid, _ := util.GetNetworkID()
+	nid, err := util.GetNetworkID()
+	if err != nil {
+		log.Errorf("could not get network metadata: %s", err)
+		return nil, err
+	}
 	return &NetworkMeta{ID: nid}
 }
 

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -28,6 +28,10 @@ type Meta struct {
 	InstanceID     string   `json:"instance-id"`
 }
 
+type NetworkMeta struct {
+	ID string `json:"network-id"`
+}
+
 type tags struct {
 	System              []string `json:"system,omitempty"`
 	GoogleCloudPlatform []string `json:"google cloud platform,omitempty"`
@@ -41,4 +45,5 @@ type Payload struct {
 	Meta          *Meta             `json:"meta"`
 	HostTags      *tags             `json:"host-tags"`
 	ContainerMeta map[string]string `json:"container-meta,omitempty"`
+	NetworkMeta   *NetworkMeta      `json:"network"`
 }

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -28,6 +28,7 @@ type Meta struct {
 	InstanceID     string   `json:"instance-id"`
 }
 
+// NetworkMeta is metadata about the host's network
 type NetworkMeta struct {
 	ID string `json:"network-id"`
 }

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -36,6 +36,9 @@ func GetHostname() (string, error) {
 	return getMetadataItemWithMaxLength("/hostname", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 }
 
+// GetNetworkID retrieves the network ID using the EC2 metadata endpoint. For
+// EC2 instances, the the network ID is the VPC ID, if the instance is found to
+// be a part of exactly one VPC.
 func GetNetworkID() (string, error) {
 	resp, err := getMetadataItem("/network/interfaces/macs")
 	if err != nil {

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -49,6 +49,9 @@ func GetNetworkID() (string, error) {
 	vpcIDs := common.NewStringSet()
 
 	for _, mac := range macs {
+		if mac == "" {
+			continue
+		}
 		mac = strings.TrimSuffix(mac, "/")
 		id, err := getMetadataItem(fmt.Sprintf("/network/interfaces/macs/%s/vpc-id", mac))
 		if err != nil {

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -33,6 +34,34 @@ func GetInstanceID() (string, error) {
 // GetHostname fetches the hostname for current host from the EC2 metadata API
 func GetHostname() (string, error) {
 	return getMetadataItemWithMaxLength("/hostname", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+}
+
+func GetNetworkID() (string, error) {
+	resp, err := getMetadataItem("/network/interfaces/macs")
+	if err != nil {
+		return "", err
+	}
+
+	macs := strings.Split(strings.TrimSpace(resp), "\n")
+	vpcIDs := common.NewStringSet()
+
+	for _, mac := range macs {
+		mac = strings.TrimSuffix(mac, "/")
+		id, err := getMetadataItem(fmt.Sprintf("/network/interfaces/macs/%s/vpc-id", mac))
+		if err != nil {
+			return "", err
+		}
+		vpcIDs.Add(id)
+	}
+
+	switch len(vpcIDs) {
+	case 0:
+		return "", fmt.Errorf("EC2: GetNetworkID no mac addresses returned")
+	case 1:
+		return vpcIDs.GetAll()[0], nil
+	default:
+		return "", fmt.Errorf("EC2: GetNetworkID too many mac addresses returned")
+	}
 }
 
 func getMetadataItemWithMaxLength(endpoint string, maxLength int) (string, error) {

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -169,4 +169,5 @@ func TestGetInstanceIDMultipleVPC(t *testing.T) {
 
 	_, err := GetNetworkID()
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many mac addresses returned")
 }

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsDefaultHostname(t *testing.T) {
@@ -133,15 +134,15 @@ func TestGetNetworkID(t *testing.T) {
 
 func TestGetInstanceIDNoMac(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusNotFound)
+		io.WriteString(w, "")
 	}))
 
 	defer ts.Close()
 	metadataURL = ts.URL
 
 	_, err := GetNetworkID()
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no mac addresses returned")
 }
 
 func TestGetInstanceIDMultipleVPC(t *testing.T) {
@@ -168,6 +169,6 @@ func TestGetInstanceIDMultipleVPC(t *testing.T) {
 	metadataURL = ts.URL
 
 	_, err := GetNetworkID()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too many mac addresses returned")
 }

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -107,3 +107,27 @@ func TestExtractClusterName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNetworkID(t *testing.T) {
+	mac := "00:00:00:00:00"
+	vpc := "vpc-12345"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		switch r.RequestURI {
+		case "/network/interfaces/macs":
+			io.WriteString(w, mac+"/")
+		case "/network/interfaces/macs/00:00:00:00:00/vpc-id":
+			io.WriteString(w, vpc)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Printf("error %v\n", r.RequestURI)
+		}
+	}))
+
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetNetworkID()
+	assert.NoError(t, err)
+	assert.Equal(t, vpc, val)
+}

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -120,7 +120,6 @@ func TestGetNetworkID(t *testing.T) {
 			io.WriteString(w, vpc)
 		default:
 			w.WriteHeader(http.StatusNotFound)
-			fmt.Printf("error %v\n", r.RequestURI)
 		}
 	}))
 
@@ -130,4 +129,44 @@ func TestGetNetworkID(t *testing.T) {
 	val, err := GetNetworkID()
 	assert.NoError(t, err)
 	assert.Equal(t, vpc, val)
+}
+
+func TestGetInstanceIDNoMac(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	_, err := GetNetworkID()
+	assert.Error(t, err)
+}
+
+func TestGetInstanceIDMultipleVPC(t *testing.T) {
+	mac := "00:00:00:00:00"
+	vpc := "vpc-12345"
+	mac2 := "00:00:00:00:01"
+	vpc2 := "vpc-6789"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		switch r.RequestURI {
+		case "/network/interfaces/macs":
+			io.WriteString(w, mac+"/\n")
+			io.WriteString(w, mac2+"/\n")
+		case "/network/interfaces/macs/00:00:00:00:00/vpc-id":
+			io.WriteString(w, vpc)
+		case "/network/interfaces/macs/00:00:00:00:01/vpc-id":
+			io.WriteString(w, vpc2)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	_, err := GetNetworkID()
+	assert.Error(t, err)
 }

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -90,6 +90,9 @@ func GetNetworkID() (string, error) {
 	vpcIDs := common.NewStringSet()
 
 	for _, interfaceID := range interfaceIDs {
+		if interfaceID == "" {
+			continue
+		}
 		interfaceID = strings.TrimSuffix(interfaceID, "/")
 		id, err := getResponse(metadataURL + fmt.Sprintf("/instance/network-interfaces/%s/network", interfaceID))
 		if err != nil {

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/common"
 )
 
 // declare these as vars not const to ease testing
@@ -73,6 +75,35 @@ func GetClusterName() (string, error) {
 		return "", fmt.Errorf("unable to retrieve clustername from GCE: %s", err)
 	}
 	return clusterName, nil
+}
+
+func GetNetworkID() (string, error) {
+	resp, err := getResponse(metadataURL + "/instance/network-interfaces/")
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve network-interfaces from GCE: %s", err)
+	}
+
+	interfaceIDs := strings.Split(strings.TrimSpace(resp), "\n")
+	vpcIDs := common.NewStringSet()
+
+	for _, interfaceID := range interfaceIDs {
+		interfaceID = strings.TrimSuffix(interfaceID, "/")
+		id, err := getResponse(metadataURL + fmt.Sprintf("/instance/network-interfaces/%s/network", interfaceID))
+		if err != nil {
+			return "", err
+		}
+		vpcIDs.Add(id)
+	}
+
+	switch len(vpcIDs) {
+	case 0:
+		return "", fmt.Errorf("zero network interfaces detected")
+	case 1:
+		return vpcIDs.GetAll()[0], nil
+	default:
+		return "", fmt.Errorf("more than one network interface detected, cannot get network ID")
+	}
+
 }
 
 func getResponseWithMaxLength(endpoint string, maxLength int) (string, error) {

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -77,6 +77,9 @@ func GetClusterName() (string, error) {
 	return clusterName, nil
 }
 
+// GetNetworkID retrieves the network ID using the metadata endpoint. For
+// GCE instances, the the network ID is the VPC ID, if the instance is found to
+// be a part of exactly one VPC.
 func GetNetworkID() (string, error) {
 	resp, err := getResponse(metadataURL + "/instance/network-interfaces/")
 	if err != nil {

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetHostname(t *testing.T) {
@@ -112,13 +113,14 @@ func TestGetNetwork(t *testing.T) {
 func TestGetNetworkNoInferface(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusNotFound)
+		io.WriteString(w, "")
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
 
 	_, err := GetNetworkID()
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response body")
 }
 
 func TestGetNetworkMultipleVPC(t *testing.T) {
@@ -143,5 +145,6 @@ func TestGetNetworkMultipleVPC(t *testing.T) {
 	metadataURL = ts.URL
 
 	_, err := GetNetworkID()
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "more than one network interface")
 }

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -86,3 +86,25 @@ func TestGetClusterName(t *testing.T) {
 	assert.Equal(t, expected, val)
 	assert.Equal(t, "/instance/attributes/cluster-name", lastRequest.URL.Path)
 }
+
+func TestGetNetwork(t *testing.T) {
+	expected := "projects/123456789/networks/my-network-name"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		switch r.RequestURI {
+		case "/instance/network-interfaces/":
+			io.WriteString(w, "0/\n")
+		case "/instance/network-interfaces/0/network":
+			io.WriteString(w, expected)
+		default:
+			t.Errorf("unexpected request %s", r.RequestURI)
+		}
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetNetworkID()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, val)
+}

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -30,14 +30,14 @@ func GetNetworkID() (string, error) {
 	}
 
 	log.Debugf("GetNetworkID trying GCE")
-	if networkID, err := gce.GetNetworkID(); err != nil {
+	if networkID, err := gce.GetNetworkID(); err == nil {
 		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
 		log.Debugf("GetNetworkID: using network ID from GCE metadata: %s", networkID)
 		return networkID, nil
 	}
 
 	log.Debugf("GetNetworkID trying EC2")
-	if networkID, err := ec2.GetNetworkID(); err != nil {
+	if networkID, err := ec2.GetNetworkID(); err == nil {
 		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
 		log.Debugf("GetNetworkID: using network ID from EC2 metadata: %s", networkID)
 		return networkID, nil

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
+	"github.com/DataDog/datadog-agent/pkg/util/gce"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// GetNetworkID retrieves the network_id which can be used to improve network
+// connection resolution. This can be configured or detected.  The
+// following sources will be queried:
+// * configuration
+// * GCE
+// * EC2
+func GetNetworkID() (string, error) {
+	cacheNetworkIDKey := cache.BuildAgentKey("networkID")
+	if cacheNetworkID, found := cache.Cache.Get(cacheNetworkIDKey); found {
+		return cacheNetworkID.(string), nil
+	}
+
+	// the the id from configuration
+	if networkID := config.Datadog.GetString("network.id"); networkID != "" {
+		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
+		return networkID, nil
+	}
+
+	log.Debugf("GetNetworkID trying GCE")
+	if networkID, err := gce.GetNetworkID(); err != nil {
+		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
+		return networkID, nil
+	}
+
+	log.Debugf("GetNetworkID trying EC2")
+	if networkID, err := ec2.GetNetworkID(); err != nil {
+		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
+		return networkID, nil
+	}
+
+	return "", fmt.Errorf("could not detect network ID")
+}

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -25,18 +25,21 @@ func GetNetworkID() (string, error) {
 	// the the id from configuration
 	if networkID := config.Datadog.GetString("network.id"); networkID != "" {
 		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
+		log.Debugf("GetNetworkID: using configured network ID: %s", networkID)
 		return networkID, nil
 	}
 
 	log.Debugf("GetNetworkID trying GCE")
 	if networkID, err := gce.GetNetworkID(); err != nil {
 		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
+		log.Debugf("GetNetworkID: using network ID from GCE metadata: %s", networkID)
 		return networkID, nil
 	}
 
 	log.Debugf("GetNetworkID trying EC2")
 	if networkID, err := ec2.GetNetworkID(); err != nil {
 		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
+		log.Debugf("GetNetworkID: using network ID from EC2 metadata: %s", networkID)
 		return networkID, nil
 	}
 

--- a/releasenotes/notes/report-network-id-43e5afaa0976aeae.yaml
+++ b/releasenotes/notes/report-network-id-43e5afaa0976aeae.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+enhancements:
+  - |
+    Added detection of a network ID which will be used to improve destination
+    resolution of network connections.

--- a/releasenotes/notes/report-network-id-43e5afaa0976aeae.yaml
+++ b/releasenotes/notes/report-network-id-43e5afaa0976aeae.yaml
@@ -6,7 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-upgrade:
 enhancements:
   - |
     Added detection of a network ID which will be used to improve destination


### PR DESCRIPTION
### What does this PR do?

- Adds the concept of a network_id, a field that will be used to help with network address resolution to the agent
- The network ID is  optional, and detected as the VPC ID for both EC2 and GCE
- The network ID is reported as part of host metadata
- A follow up commit will include the network ID in the connections payload reported by the process-agent. Since both core and process agent need to be aware of this ID, the configuration option (network.id) is part of the core config package, and the detection code is in the shared util package.  
          

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
