### PR TITLE
Escape message when using JSON format for the logs

### DIFF
--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -32,9 +32,16 @@ func BuildCommonFormat(loggerName LoggerName) string {
 	return fmt.Sprintf("%%Date(%s) | %s | %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%Msg%%n", logDateFormat, loggerName)
 }
 
+func createQuoteMsgFormatter(params string) seelog.FormatterFunc {
+	return func(message string, level seelog.LogLevel, context seelog.LogContextInterface) interface{} {
+		return strconv.Quote(message)
+	}
+}
+
 // BuildJSONFormat returns the log JSON format seelog string
 func BuildJSONFormat(loggerName LoggerName) string {
-	return fmt.Sprintf("{&quot;agent&quot;:&quot;%s&quot;,&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%ShortFilePath&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n", strings.ToLower(string(loggerName)), logDateFormat)
+	seelog.RegisterCustomFormatter("QuoteMsg", createQuoteMsgFormatter)
+	return fmt.Sprintf("{&quot;agent&quot;:&quot;%s&quot;,&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%ShortFilePath&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:%%QuoteMsg}%%n", strings.ToLower(string(loggerName)), logDateFormat)
 }
 
 func getSyslogTLSKeyPair() (*tls.Certificate, error) {

--- a/releasenotes/notes/escape-json-log-def2b8976376ad65.yaml
+++ b/releasenotes/notes/escape-json-log-def2b8976376ad65.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Escape message when using JSON log format. This, for example, fixes
+    multiline JSON payload when logging a Exception from Python.


### PR DESCRIPTION
### What does this PR do?

Escape message when using JSON format for the logs

This fix broken JSON output like:
```
{"agent":"core","time":"2019-08-12 16:58:46 MDT","level":"ERROR","file":"pkg/collector/runner/runner.go","line":"298","func":"work","msg":"Error running check max: [{"message": "ERROR", "traceback": "Traceback (most recent call last):
  File \"/home/maxime/dev/go/src/github.com/DataDog/datadog-agent/venv/local/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 532, in run
    self.check(instance)
  File \"/home/maxime/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/max.py\", line 8, in check
    raise Exception(\"ERROR\")
Exception: ERROR
"}]"}
```

to:
```
{"agent":"core","time":"2019-08-12 17:04:25 MDT","level":"ERROR","file":"pkg/collector/runner/runner.go","line":"298","func":"work","msg":"Error running check max: [{\"message\": \"ERROR\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/home/maxime/dev/go/src/github.com/DataDog/datadog-agent/venv/local/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\\\", line 532, in run\\n    self.check(instance)\\n  File \\\"/home/maxime/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/max.py\\\", line 8, in check\\n    raise Exception(\\\"ERROR\\\")\\nException: ERROR\\n\"}]"}
```