### PR TITLE
blacklist linux-aws versions prior to 4.4.0-1060

### DIFF
--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -89,6 +89,10 @@ func verifyOSVersion(kernelCode uint32, platform string, exclusionList []string)
 		if kernelCode >= linuxKernelVersionCode(4, 4, 119) && kernelCode <= linuxKernelVersionCode(4, 4, 126) {
 			return false, fmt.Sprintf("got ubuntu kernel %s with known bug on platform: %s, see: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCodeToString(kernelCode), platform)
 		}
+	} else if isLinuxAWS(platform) {
+		if kernelCode < linuxKernelVersionCode(4, 4, 128) {
+			return false, fmt.Sprintf("Known bug on %s, see: \n- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454\n- https://launchpad.net/ubuntu/xenial/+source/linux-aws/+changelog#linux-aws_4.4.0-1060.69", platform)
+		}
 	}
 
 	missing, err := verifyKernelFuncs(path.Join(util.GetProcRoot(), "kallsyms"))
@@ -158,4 +162,8 @@ func init() {
 
 func isUbuntu(platform string) bool {
 	return strings.Contains(platform, "ubuntu")
+}
+
+func isLinuxAWS(platform string) bool {
+	return strings.Contains(platform, "aws")
 }

--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -85,13 +85,13 @@ func verifyOSVersion(kernelCode uint32, platform string, exclusionList []string)
 		return true, ""
 	}
 
-	if isUbuntu(platform) {
-		if kernelCode >= linuxKernelVersionCode(4, 4, 119) && kernelCode <= linuxKernelVersionCode(4, 4, 126) {
-			return false, fmt.Sprintf("got ubuntu kernel %s with known bug on platform: %s, see: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCodeToString(kernelCode), platform)
-		}
-	} else if isLinuxAWS(platform) {
+	if isLinuxAWSUbuntu(platform) {
 		if kernelCode < linuxKernelVersionCode(4, 4, 128) {
 			return false, fmt.Sprintf("Known bug on %s, see: \n- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454\n- https://launchpad.net/ubuntu/xenial/+source/linux-aws/+changelog#linux-aws_4.4.0-1060.69", platform)
+		}
+	} else if isUbuntu(platform) {
+		if kernelCode >= linuxKernelVersionCode(4, 4, 119) && kernelCode <= linuxKernelVersionCode(4, 4, 126) {
+			return false, fmt.Sprintf("got ubuntu kernel %s with known bug on platform: %s, see: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCodeToString(kernelCode), platform)
 		}
 	}
 
@@ -161,9 +161,9 @@ func init() {
 }
 
 func isUbuntu(platform string) bool {
-	return strings.Contains(platform, "ubuntu")
+	return strings.Contains(strings.ToLower(platform), "ubuntu")
 }
 
-func isLinuxAWS(platform string) bool {
-	return strings.Contains(platform, "aws")
+func isLinuxAWSUbuntu(platform string) bool {
+	return strings.Contains(strings.ToLower(platform), "aws") && isUbuntu(platform)
 }

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -27,7 +27,7 @@ func TestUbuntu44119NotSupported(t *testing.T) {
 
 func TestLinuxAWSPreceding441060NotSupported(t *testing.T) {
 	for i := uint32(120); i < 128; i++ {
-		ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "Linux-4.4.0-1060-aws", nil)
+		ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "Linux-4.4.0-1060-aws-x86_64-with-Ubuntu-16.04-xenial", nil)
 		assert.False(t, ok)
 		assert.NotEmpty(t, msg)
 	}

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -25,6 +25,14 @@ func TestUbuntu44119NotSupported(t *testing.T) {
 	}
 }
 
+func TestLinuxAWSPreceding441060NotSupported(t *testing.T) {
+	for i := uint32(120); i < 128; i++ {
+		ok, err := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "Linux-4.4.0-1060-aws", nil)
+		assert.False(t, ok)
+		assert.NotEmpty(t, err)
+	}
+}
+
 func TestExcludedKernelVersion(t *testing.T) {
 	exclusionList := []string{"5.5.1", "6.3.2"}
 	ok, err := verifyOSVersion(linuxKernelVersionCode(4, 4, 121), "ubuntu", exclusionList)

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -19,45 +19,45 @@ func TestLinuxKernelVersionCode(t *testing.T) {
 
 func TestUbuntu44119NotSupported(t *testing.T) {
 	for i := uint32(119); i < 127; i++ {
-		ok, err := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "linux-4.4-with-ubuntu", nil)
+		ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "linux-4.4-with-ubuntu", nil)
 		assert.False(t, ok)
-		assert.NotEmpty(t, err)
+		assert.NotEmpty(t, msg)
 	}
 }
 
 func TestLinuxAWSPreceding441060NotSupported(t *testing.T) {
 	for i := uint32(120); i < 128; i++ {
-		ok, err := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "Linux-4.4.0-1060-aws", nil)
+		ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "Linux-4.4.0-1060-aws", nil)
 		assert.False(t, ok)
-		assert.NotEmpty(t, err)
+		assert.NotEmpty(t, msg)
 	}
 }
 
 func TestExcludedKernelVersion(t *testing.T) {
 	exclusionList := []string{"5.5.1", "6.3.2"}
-	ok, err := verifyOSVersion(linuxKernelVersionCode(4, 4, 121), "ubuntu", exclusionList)
+	ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, 121), "ubuntu", exclusionList)
 	assert.False(t, ok)
-	assert.NotEmpty(t, err)
+	assert.NotEmpty(t, msg)
 
-	ok, err = verifyOSVersion(linuxKernelVersionCode(5, 5, 1), "debian", exclusionList)
+	ok, msg = verifyOSVersion(linuxKernelVersionCode(5, 5, 1), "debian", exclusionList)
 	assert.False(t, ok)
-	assert.NotEmpty(t, err)
+	assert.NotEmpty(t, msg)
 
-	ok, err = verifyOSVersion(linuxKernelVersionCode(6, 3, 2), "debian", exclusionList)
+	ok, msg = verifyOSVersion(linuxKernelVersionCode(6, 3, 2), "debian", exclusionList)
 	assert.False(t, ok)
-	assert.NotEmpty(t, err)
+	assert.NotEmpty(t, msg)
 
-	ok, err = verifyOSVersion(linuxKernelVersionCode(6, 3, 1), "debian", exclusionList)
+	ok, msg = verifyOSVersion(linuxKernelVersionCode(6, 3, 1), "debian", exclusionList)
 	assert.True(t, ok)
-	assert.Empty(t, err)
+	assert.Empty(t, msg)
 
-	ok, err = verifyOSVersion(linuxKernelVersionCode(5, 5, 2), "debian", exclusionList)
+	ok, msg = verifyOSVersion(linuxKernelVersionCode(5, 5, 2), "debian", exclusionList)
 	assert.True(t, ok)
-	assert.Empty(t, err)
+	assert.Empty(t, msg)
 
-	ok, err = verifyOSVersion(linuxKernelVersionCode(3, 10, 0), "Linux-3.10.0-957.5.1.el7.x86_64-x86_64-with-centos-7.6.1810-Core", exclusionList)
+	ok, msg = verifyOSVersion(linuxKernelVersionCode(3, 10, 0), "Linux-3.10.0-957.5.1.el7.x86_64-x86_64-with-centos-7.6.1810-Core", exclusionList)
 	assert.True(t, ok)
-	assert.Empty(t, err)
+	assert.Empty(t, msg)
 }
 
 func TestVerifyKernelFuncs(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

linux-aws kernel 4.4.0-1060.69 holds the patch for this bug: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454. Any linux-aws kernel version that precedes will not be supported.

### Motivation

This was brought to our attention by a customer.

### Additional Notes

Anything else we should know when reviewing?
