### PR TITLE
pkg/trace/info: separate payload_too_large from decoding_error

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -370,7 +370,11 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	traces, err := r.decodeTraces(v, req)
 	if err != nil {
 		httpDecodingError(err, []string{tagTraceHandler, fmt.Sprintf("v:%s", v)}, w)
-		atomic.AddInt64(&ts.TracesDropped.DecodingError, traceCount)
+		if err == ErrLimitedReaderLimitReached {
+			atomic.AddInt64(&ts.TracesDropped.PayloadTooLarge, traceCount)
+		} else {
+			atomic.AddInt64(&ts.TracesDropped.DecodingError, traceCount)
+		}
 		log.Errorf("Cannot decode %s traces payload: %v", v, err)
 		return
 	}

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -191,6 +191,9 @@ func mapToString(m map[string]int64) string {
 type TracesDropped struct {
 	// DecodingError is when the agent fails to decode a trace payload
 	DecodingError int64
+	// PayloadTooLarge specifies the number of traces dropped due to the payload
+	// being too large to be accepted.
+	PayloadTooLarge int64
 	// EmptyTrace is when the trace contains no spans
 	EmptyTrace int64
 	// TraceIDZero is when any spans in a trace have TraceId=0
@@ -204,11 +207,12 @@ type TracesDropped struct {
 // tagValues converts TracesDropped into a map representation with keys matching standardized names for all reasons
 func (s *TracesDropped) tagValues() map[string]int64 {
 	return map[string]int64{
-		"decoding_error": atomic.LoadInt64(&s.DecodingError),
-		"empty_trace":    atomic.LoadInt64(&s.EmptyTrace),
-		"trace_id_zero":  atomic.LoadInt64(&s.TraceIDZero),
-		"span_id_zero":   atomic.LoadInt64(&s.SpanIDZero),
-		"foreign_span":   atomic.LoadInt64(&s.ForeignSpan),
+		"payload_too_large": atomic.LoadInt64(&s.PayloadTooLarge),
+		"decoding_error":    atomic.LoadInt64(&s.DecodingError),
+		"empty_trace":       atomic.LoadInt64(&s.EmptyTrace),
+		"trace_id_zero":     atomic.LoadInt64(&s.TraceIDZero),
+		"span_id_zero":      atomic.LoadInt64(&s.SpanIDZero),
+		"foreign_span":      atomic.LoadInt64(&s.ForeignSpan),
 	}
 }
 

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -21,11 +21,12 @@ func TestTracesDropped(t *testing.T) {
 
 	t.Run("tagValues", func(t *testing.T) {
 		assert.Equal(t, map[string]int64{
-			"empty_trace":    0,
-			"decoding_error": 1,
-			"foreign_span":   1,
-			"trace_id_zero":  1,
-			"span_id_zero":   1,
+			"empty_trace":       0,
+			"payload_too_large": 0,
+			"decoding_error":    1,
+			"foreign_span":      1,
+			"trace_id_zero":     1,
+			"span_id_zero":      1,
 		}, s.tagValues())
 	})
 

--- a/releasenotes/notes/apm-reason-payload-too-large-563bd2a463d41500.yaml
+++ b/releasenotes/notes/apm-reason-payload-too-large-563bd2a463d41500.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: The `datadog.trace_agent.normalizer.traces_dropped` metric now has a new
+    reason `payload_too_large` which was confusingly merged with `decoding_error`.


### PR DESCRIPTION
This change adds a new reason for dropped payloads: `payload_too_large`.
Previously, this reason was mashed together with `decoding_error` which
presented the risk of misleading viewers to believe that an invalid
payload was sent, when in fact a valid one might've been sent, but the
10M API limit was overflown.