### PR TITLE
pkg/trace/api: add language tags to payload_refused metric

### DIFF
--- a/releasenotes/notes/apm-payload-refused-lang-tags-b5c797cfa88bdc21.yaml
+++ b/releasenotes/notes/apm-payload-refused-lang-tags-b5c797cfa88bdc21.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: The `datadog.trace_agent.receiver.payload_refused` metric now has language tags
+    like its peer metrics.


### PR DESCRIPTION
This change adds the previously missing language tags to the
`datadog.trace_agent.receiver.payload_refused` metric.