### PR TITLE
[rtloader] Allow as_string to have encoded strings as input in Python 3

### DIFF
--- a/rtloader/common/stringutils.c
+++ b/rtloader/common/stringutils.c
@@ -150,9 +150,11 @@ done:
 char *as_yaml(PyObject *object) {
     char *retval = NULL;
     PyObject *dumped = NULL;
+    PyObject *encoding = Py_None;
 
     PyObject *args = PyTuple_New(0);
-    PyObject *kwargs = Py_BuildValue("{s:O, s:O}", "data", object, "Dumper", dumper);
+    PyObject *kwargs = Py_BuildValue("{s:O, s:O, s:O}", "data", object, "Dumper", dumper, "encoding", encoding);
+
     dumped = PyObject_Call(ydump, args, kwargs);
     if (dumped == NULL) {
         goto done;

--- a/rtloader/common/stringutils.c
+++ b/rtloader/common/stringutils.c
@@ -66,6 +66,7 @@ char *as_string(PyObject *object)
     }
 
     retval = strdupe(PyBytes_AS_STRING(temp_bytes));
+    Py_XDECREF(temp_bytes);
 #endif
 
     return retval;

--- a/rtloader/common/stringutils.c
+++ b/rtloader/common/stringutils.c
@@ -59,18 +59,13 @@ char *as_string(PyObject *object)
             // PyUnicode_AsEncodedString might raise an error if the codec raised an
             // exception
             PyErr_Clear();
-            retval = NULL;
-            goto done;
+            return NULL;
         }
     } else {
-        retval = NULL;
-        goto done;
+        return NULL;
     }
 
     retval = strdupe(PyBytes_AS_STRING(temp_bytes));
-
-done:
-    Py_XDECREF(temp_bytes);
 #endif
 
     return retval;

--- a/rtloader/common/stringutils.c
+++ b/rtloader/common/stringutils.c
@@ -46,11 +46,12 @@ char *as_string(PyObject *object)
     }
     retval = strdupe(tmp);
 #else
-    PyObject *temp_bytes;
+    PyObject *temp_bytes = NULL;
 
     if (PyBytes_Check(object)) {
         // We already have an encoded string, we suppose it has the correct encoding (UTF-8)
         temp_bytes = object;
+        Py_INCREF(temp_bytes);
     } else if (PyUnicode_Check(object)) {
         // Encode the Unicode string that was given
         temp_bytes = PyUnicode_AsEncodedString(object, "UTF-8", "strict");


### PR DESCRIPTION
### What does this PR do?

~Set the encoding to None when using `yaml.dump`, so that it returns a non-encoded string.~ Modify `as_string` so that it allows encoded strings as input.

### Motivation

In Python 3, within `rtloader`, `yaml.dump` has 'utf-8' as its default encoding, which results in an encoded string being returned (`b'<yaml>'`). ~When we convert it to a go string, we get `b'<yaml>'` which is not proper yaml, thus causing a yaml unmarshal error in Go.~ `as_string` doesn't recognise this to be either of string or unicode type, so it returns `NULL`, which triggers an error. This error prevents the "Add a check" list from being displayed in the GUI page where checks are managed.