### PR TITLE
Fixed a bug where the logs-agent could not start new tcp tailers because of a lock

### DIFF
--- a/pkg/logs/input/listener/tailer.go
+++ b/pkg/logs/input/listener/tailer.go
@@ -62,10 +62,7 @@ func (t *Tailer) forwardMessages() {
 		t.done <- struct{}{}
 	}()
 	for output := range t.decoder.OutputChan {
-		t.outputChan <- message.NewMessageWithSource(
-			output.Content,
-			message.StatusInfo,
-			t.source)
+		t.outputChan <- message.NewMessageWithSource(output.Content, message.StatusInfo, t.source)
 	}
 }
 

--- a/pkg/logs/input/listener/tcp.go
+++ b/pkg/logs/input/listener/tcp.go
@@ -96,7 +96,7 @@ func (l *TCPListener) run() {
 				l.source.Status.Success()
 				continue
 			default:
-				l.startNewTailer(conn)
+				l.startTailer(conn)
 				l.source.Status.Success()
 			}
 		}
@@ -126,8 +126,8 @@ func (l *TCPListener) read(tailer *Tailer) ([]byte, error) {
 	return frame[:n], nil
 }
 
-// startNewTailer creates and starts a new tailer that reads from the connection.
-func (l *TCPListener) startNewTailer(conn net.Conn) {
+// startTailer creates and starts a new tailer that reads from the connection.
+func (l *TCPListener) startTailer(conn net.Conn) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	tailer := NewTailer(l.source, conn, l.pipelineProvider.NextPipelineChan(), l.read)
@@ -137,9 +137,9 @@ func (l *TCPListener) startNewTailer(conn net.Conn) {
 
 // stopTailer stops the tailer.
 func (l *TCPListener) stopTailer(tailer *Tailer) {
+	tailer.Stop()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	tailer.Stop()
 	for i, t := range l.tailers {
 		if t == tailer {
 			l.tailers = append(l.tailers[:i], l.tailers[i+1:]...)


### PR DESCRIPTION
### What does this PR do?

Make sure the critical section does not depend on `tailer.Stop()` which can be blocking when the buffers are not flushed yet. In the past, `tailer.Stop()` could hang forever because of an issue in the go TLS handshake but we fixed this bug since the `6.13.x`, cc https://github.com/DataDog/datadog-agent/pull/3851

### Motivation

As `tailers` can be modified concurrently, we use a `lock` to prevent concurrent writes so a tailer can't be created when another one is deleted. Thus if the deletion hangs forever, the agent won't start new tailers.

### Additional Notes

We fixed a lock contention, the deadlock should not happen anymore.
