### PR TITLE
Add python_version to template config file

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -5,7 +5,8 @@
 
 // +build !windows,!android
 
-//go:generate go run ../../pkg/config/render_config.go agent ../../pkg/config/config_template.yaml ./dist/datadog.yaml
+//go:generate go run ../../pkg/config/render_config.go agent-py2py3 ../../pkg/config/config_template.yaml ./dist/datadog.yaml
+//go:generate go run ../../pkg/config/render_config.go agent-py3 ../../pkg/config/config_template.yaml ./dist/datadog.yaml
 //go:generate go run ../../pkg/config/render_config.go system-probe ../../pkg/config/config_template.yaml ./dist/system-probe.yaml
 
 package main

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -5,10 +5,6 @@
 
 // +build !windows,!android
 
-//go:generate go run ../../pkg/config/render_config.go agent-py2py3 ../../pkg/config/config_template.yaml ./dist/datadog.yaml
-//go:generate go run ../../pkg/config/render_config.go agent-py3 ../../pkg/config/config_template.yaml ./dist/datadog.yaml
-//go:generate go run ../../pkg/config/render_config.go system-probe ../../pkg/config/config_template.yaml ./dist/system-probe.yaml
-
 package main
 
 import (

--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -4,8 +4,6 @@
 // Copyright 2016-2019 Datadog, Inc.
 
 // +build !android
-//go:generate go run ../../pkg/config/render_config.go agent-py2py3 ../../pkg/config/config_template.yaml ./dist/datadog.yaml
-//go:generate go run ../../pkg/config/render_config.go agent-py3 ../../pkg/config/config_template.yaml ./dist/datadog.yaml
 
 package main
 

--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -4,7 +4,8 @@
 // Copyright 2016-2019 Datadog, Inc.
 
 // +build !android
-//go:generate go run ../../pkg/config/render_config.go agent ../../pkg/config/config_template.yaml ./dist/datadog.yaml
+//go:generate go run ../../pkg/config/render_config.go agent-py2py3 ../../pkg/config/config_template.yaml ./dist/datadog.yaml
+//go:generate go run ../../pkg/config/render_config.go agent-py3 ../../pkg/config/config_template.yaml ./dist/datadog.yaml
 
 package main
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -53,6 +53,7 @@ build do
   with_both_python = ""
   if (with_python_runtime? "2") && (with_python_runtime? "3")
     with_both_python = "--with-both-python"
+  end
 
   # we assume the go deps are already installed before running omnibus
   if windows?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -51,7 +51,7 @@ build do
 
   # Flag to generate additional datadog.yaml options if we ship both python versions
   with_both_python = ""
-  if with_python_runtime? "2" && with_python_runtime? "3"
+  if (with_python_runtime? "2") && (with_python_runtime? "3")
     with_both_python = "--with-both-python"
 
   # we assume the go deps are already installed before running omnibus

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -49,17 +49,22 @@ build do
           :target => "#{gopath.to_path}/src/github.com/DataDog/datadog-agent/vendor/github.com/ianlancetaylor/cgosymbolizer/symbolizer.c"
   end
 
+  # Flag to generate additional datadog.yaml options if we ship both python versions
+  with_both_python = ""
+  if with_python_runtime? "2" && with_python_runtime? "3"
+    with_both_python = "--with-both-python"
+
   # we assume the go deps are already installed before running omnibus
   if windows?
     platform = windows_arch_i386? ? "x86" : "x64"
     command "inv -e rtloader.build --install-prefix \"#{windows_safe_path(python_2_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\"\" --arch #{platform}", :env => env
     command "mv rtloader/bin/*.dll  #{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent/"
-    command "inv -e agent.build --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded --arch #{platform}", env: env
+    command "inv -e agent.build --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded #{with_both_python} --arch #{platform}", env: env
     command "inv -e systray.build --rebuild --no-development --arch #{platform}", env: env
   else
     command "inv -e rtloader.build --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER'", :env => env
     command "inv -e rtloader.install"
-    command "inv -e agent.build --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded", env: env
+    command "inv -e agent.build --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded #{with_both_python}", env: env
   end
 
   if osx?

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -165,6 +165,12 @@ api_key:
 ## Advanced Configuration ##
 ############################
 
+## @param python_version - integer - optional - default: 2
+## The major version of Python used to run integrations and custom checks.
+## The only supported values are 2 (to use Python 2) or 3 (to use Python 3).
+#
+# python_version: 2
+
 ## @param confd_path - string - optional
 ## The path containing check configuration files. By default, uses the conf.d folder
 ## located in the Agent configuration folder.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -160,16 +160,18 @@ api_key:
 
 {{ end }}
 {{- if .Agent }}
-
-############################
-## Advanced Configuration ##
-############################
-
+{{- if .BothPythonPresent -}}
 ## @param python_version - integer - optional - default: 2
 ## The major version of Python used to run integrations and custom checks.
 ## The only supported values are 2 (to use Python 2) or 3 (to use Python 3).
 #
 # python_version: 2
+
+{{ end }}
+
+############################
+## Advanced Configuration ##
+############################
 
 ## @param confd_path - string - optional
 ## The path containing check configuration files. By default, uses the conf.d folder

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -164,6 +164,7 @@ api_key:
 ## @param python_version - integer - optional - default: 2
 ## The major version of Python used to run integrations and custom checks.
 ## The only supported values are 2 (to use Python 2) or 3 (to use Python 3).
+## Do not change this option when using the official Docker Agent images.
 #
 # python_version: 2
 

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -19,6 +19,7 @@ import (
 type context struct {
 	Common            bool
 	Agent             bool
+	BothPythonPresent bool
 	Metadata          bool
 	Dogstatsd         bool
 	LogsAgent         bool
@@ -43,10 +44,32 @@ func mkContext(buildType string) context {
 	buildType = strings.ToLower(buildType)
 
 	switch buildType {
-	case "agent":
+	case "agent-py3":
 		return context{
 			Common:            true,
 			Agent:             true,
+			Metadata:          true,
+			Dogstatsd:         true,
+			LogsAgent:         true,
+			JMX:               true,
+			Autoconfig:        true,
+			Logging:           true,
+			Autodiscovery:     true,
+			DockerTagging:     true,
+			KubernetesTagging: true,
+			ECS:               true,
+			Containerd:        true,
+			CRI:               true,
+			ProcessAgent:      true,
+			TraceAgent:        true,
+			Kubelet:           true,
+			KubeApiServer:     true, // TODO: remove when phasing out from node-agent
+		}
+	case "agent-py2py3":
+		return context{
+			Common:            true,
+			Agent:             true,
+			BothPythonPresent: true,
 			Metadata:          true,
 			Dogstatsd:         true,
 			LogsAgent:         true,

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -43,50 +43,33 @@ type context struct {
 func mkContext(buildType string) context {
 	buildType = strings.ToLower(buildType)
 
+	agentContext := context{
+		Common:            true,
+		Agent:             true,
+		Metadata:          true,
+		Dogstatsd:         true,
+		LogsAgent:         true,
+		JMX:               true,
+		Autoconfig:        true,
+		Logging:           true,
+		Autodiscovery:     true,
+		DockerTagging:     true,
+		KubernetesTagging: true,
+		ECS:               true,
+		Containerd:        true,
+		CRI:               true,
+		ProcessAgent:      true,
+		TraceAgent:        true,
+		Kubelet:           true,
+		KubeApiServer:     true, // TODO: remove when phasing out from node-agent
+	}
+
 	switch buildType {
 	case "agent-py3":
-		return context{
-			Common:            true,
-			Agent:             true,
-			Metadata:          true,
-			Dogstatsd:         true,
-			LogsAgent:         true,
-			JMX:               true,
-			Autoconfig:        true,
-			Logging:           true,
-			Autodiscovery:     true,
-			DockerTagging:     true,
-			KubernetesTagging: true,
-			ECS:               true,
-			Containerd:        true,
-			CRI:               true,
-			ProcessAgent:      true,
-			TraceAgent:        true,
-			Kubelet:           true,
-			KubeApiServer:     true, // TODO: remove when phasing out from node-agent
-		}
+		return agentContext
 	case "agent-py2py3":
-		return context{
-			Common:            true,
-			Agent:             true,
-			BothPythonPresent: true,
-			Metadata:          true,
-			Dogstatsd:         true,
-			LogsAgent:         true,
-			JMX:               true,
-			Autoconfig:        true,
-			Logging:           true,
-			Autodiscovery:     true,
-			DockerTagging:     true,
-			KubernetesTagging: true,
-			ECS:               true,
-			Containerd:        true,
-			CRI:               true,
-			ProcessAgent:      true,
-			TraceAgent:        true,
-			Kubelet:           true,
-			KubeApiServer:     true, // TODO: remove when phasing out from node-agent
-		}
+		agentContext.BothPythonPresent = true
+		return agentContext
 	case "system-probe":
 		return context{
 			SystemProbe: true,

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -152,6 +152,12 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     }
     ctx.run(cmd.format(**args), env=env)
 
+    # Remove cross-compiling bits to render config
+    env.update({
+        "GOOS": "",
+        "GOARCH": "",
+    })
+
     # Render the Agent configuration file template
     if with_both_python:
         cmd = "go run ./pkg/config/render_config.go agent-py2py3 ./pkg/config/config_template.yaml ./cmd/agent/dist/datadog.yaml"

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -159,12 +159,16 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     })
 
     # Render the Agent configuration file template
-    if with_both_python:
-        cmd = "go run ./pkg/config/render_config.go agent-py2py3 ./pkg/config/config_template.yaml ./cmd/agent/dist/datadog.yaml"
-    else:
-        cmd = "go run ./pkg/config/render_config.go agent-py3 ./pkg/config/config_template.yaml ./cmd/agent/dist/datadog.yaml"
+    cmd = "go run {go_file} {build_type} {template_file} {output_file}"
 
-    ctx.run(cmd, env=env)
+    args = {
+        "go_file": "./pkg/config/render_config.go",
+        "build_type": "agent-py2py3" if with_both_python else "agent-py3",
+        "template_file": "./pkg/config/config_template.yaml",
+        "output_file": "./cmd/agent/dist/datadog.yaml",
+    }
+
+    ctx.run(cmd.format(**args), env=env)
 
     # On Linux and MacOS, render the system-probe configuration file template
     if sys.platform != 'win32':

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -80,7 +80,7 @@ PUPPY_CORECHECKS = [
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
           puppy=False, development=True, precompile_only=False, skip_assets=False,
           embedded_path=None, rtloader_root=None, python_home_2=None, python_home_3=None,
-          arch='x64'):
+          with_both_python=False, arch='x64'):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -160,8 +160,16 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
         "GOOS": "",
         "GOARCH": "",
     })
-    cmd = "go generate {}/cmd/agent"
+
+    cmd = "go generate -x {}/cmd/agent"
     ctx.run(cmd.format(REPO_PATH), env=env)
+
+    if with_both_python:
+        cmd = "go generate -x --run=\"agent-py2py3\" {}/cmd/agent"
+        ctx.run(cmd.format(REPO_PATH), env=env)
+    else:
+        cmd = "go generate -x --run=\"agent-py3\" {}/cmd/agent"
+        ctx.run(cmd.format(REPO_PATH), env=env)
 
     if not skip_assets:
         refresh_assets(ctx, build_tags, development=development, puppy=puppy)


### PR DESCRIPTION
### What does this PR do?

Adds the `python_version` configuration option to the template configuration file.

### Motivation

Starting with 6.14, users will be able to switch python versions. The configuration file should show this option.

### Additional Notes

Open to any ideas to improve wording and / or placement in the file.
I put it in the "Agent" part of the file, which means it will only appear in the configuration file of the base Agent, not in the `DCA`'s nor `dogstatsd`'s config file.