### PR TITLE
 pkg/trace/writer: add back trace level logging when bufferring traces and events

### DIFF
--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -132,7 +132,7 @@ func TestLegacyReceiver(t *testing.T) {
 		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
 			// start testing server
 			server := httptest.NewServer(
-				http.HandlerFunc(tc.r.httpHandleWithVersion(tc.apiVersion, tc.r.handleTraces)),
+				http.HandlerFunc(tc.r.handleWithVersion(tc.apiVersion, tc.r.handleTraces)),
 			)
 
 			// send traces to that endpoint without a content-type
@@ -195,7 +195,7 @@ func TestReceiverJSONDecoder(t *testing.T) {
 		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
 			// start testing server
 			server := httptest.NewServer(
-				http.HandlerFunc(tc.r.httpHandleWithVersion(tc.apiVersion, tc.r.handleTraces)),
+				http.HandlerFunc(tc.r.handleWithVersion(tc.apiVersion, tc.r.handleTraces)),
 			)
 
 			// send traces to that endpoint without a content-type
@@ -254,7 +254,7 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
 			// start testing server
 			server := httptest.NewServer(
-				http.HandlerFunc(tc.r.httpHandleWithVersion(tc.apiVersion, tc.r.handleTraces)),
+				http.HandlerFunc(tc.r.handleWithVersion(tc.apiVersion, tc.r.handleTraces)),
 			)
 
 			// send traces to that endpoint using the msgpack content-type
@@ -332,7 +332,7 @@ func TestReceiverDecodingError(t *testing.T) {
 	assert := assert.New(t)
 	conf := newTestReceiverConfig()
 	r := newTestReceiverFromConfig(conf)
-	server := httptest.NewServer(http.HandlerFunc(r.httpHandleWithVersion(v04, r.handleTraces)))
+	server := httptest.NewServer(http.HandlerFunc(r.handleWithVersion(v04, r.handleTraces)))
 	data := []byte("} invalid json")
 	client := &http.Client{}
 
@@ -375,7 +375,7 @@ func TestHandleTraces(t *testing.T) {
 	receiver := newTestReceiverFromConfig(conf)
 
 	// response recorder
-	handler := http.HandlerFunc(receiver.httpHandleWithVersion(v04, receiver.handleTraces))
+	handler := http.HandlerFunc(receiver.handleWithVersion(v04, receiver.handleTraces))
 
 	for n := 0; n < 10; n++ {
 		// consume the traces channel without doing anything
@@ -438,7 +438,7 @@ func TestReceiverRateLimiterCancel(t *testing.T) {
 	receiver := newTestReceiverFromConfig(conf)
 	receiver.RateLimiter.SetTargetRate(0.000001) // Make sure we sample aggressively
 
-	server := httptest.NewServer(http.HandlerFunc(receiver.httpHandleWithVersion(v04, receiver.handleTraces)))
+	server := httptest.NewServer(http.HandlerFunc(receiver.handleWithVersion(v04, receiver.handleTraces)))
 
 	defer server.Close()
 	url := server.URL + "/v0.4/traces"
@@ -493,7 +493,7 @@ func BenchmarkHandleTracesFromOneApp(b *testing.B) {
 	receiver := newTestReceiverFromConfig(conf)
 
 	// response recorder
-	handler := http.HandlerFunc(receiver.httpHandleWithVersion(v04, receiver.handleTraces))
+	handler := http.HandlerFunc(receiver.handleWithVersion(v04, receiver.handleTraces))
 
 	// benchmark
 	b.ResetTimer()
@@ -533,7 +533,7 @@ func BenchmarkHandleTracesFromMultipleApps(b *testing.B) {
 	receiver := newTestReceiverFromConfig(conf)
 
 	// response recorder
-	handler := http.HandlerFunc(receiver.httpHandleWithVersion(v04, receiver.handleTraces))
+	handler := http.HandlerFunc(receiver.handleWithVersion(v04, receiver.handleTraces))
 
 	// benchmark
 	b.ResetTimer()

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -150,9 +150,13 @@ func (w *TraceWriter) addSpans(pkg *SampledSpans) {
 		w.flush()
 	}
 	if len(pkg.Trace) > 0 {
+		log.Tracef("Handling new trace with %d spans: %v", len(pkg.Trace), pkg.Trace)
 		w.traces = append(w.traces, traceutil.APITrace(pkg.Trace))
 	}
-	w.events = append(w.events, pkg.Events...)
+	if len(pkg.Events) > 0 {
+		log.Tracef("Handling new APM events: %v", pkg.Events)
+		w.events = append(w.events, pkg.Events...)
+	}
 	w.bufferedSize += size
 }
 


### PR DESCRIPTION
#### Change 1

Renamed `httpHandleWithVersion` to `handleWithVersion` and merged it with `httpHandle` to simplify.

#### Change 2

Support has indicated that they were making use of these heavily in some testing environments, especially in .NET, so they were added back as part of that request. They were removed only in 6.13.0 as part of #3723.