### PR TITLE
APM: Allow overriding service name from container tags

### DIFF
--- a/pkg/trace/api/normalizer_test.go
+++ b/pkg/trace/api/normalizer_test.go
@@ -59,7 +59,8 @@ func tsDropped(td *info.TracesDropped) *info.TagStats {
 func TestNormalizeOK(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, newTagStats(), ts)
 }
 
@@ -67,7 +68,8 @@ func TestNormalizeServicePassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.Service
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.Service)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -76,7 +78,8 @@ func TestNormalizeEmptyServiceNoLang(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Service = ""
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, DefaultServiceName, s.Service)
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{ServiceEmpty: 1}), ts)
 }
@@ -86,7 +89,8 @@ func TestNormalizeEmptyServiceWithLang(t *testing.T) {
 	s := newTestSpan()
 	s.Service = ""
 	ts.Lang = "java"
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, s.Service, fmt.Sprintf("unnamed-%s-service", ts.Lang))
 	tsExpected := tsMalformed(&info.SpansMalformed{ServiceEmpty: 1})
 	tsExpected.Lang = ts.Lang
@@ -97,7 +101,8 @@ func TestNormalizeLongService(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Service = strings.Repeat("CAMEMBERT", 100)
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, s.Service, s.Service[:MaxServiceLen])
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{ServiceTruncate: 1}), ts)
 }
@@ -106,7 +111,8 @@ func TestNormalizeNamePassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.Name
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.Name)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -115,7 +121,8 @@ func TestNormalizeEmptyName(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Name = ""
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, s.Name, strings.Replace(DefaultSpanName, "-", "_", -1))
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameEmpty: 1}), ts)
 }
@@ -124,7 +131,8 @@ func TestNormalizeLongName(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Name = strings.Repeat("CAMEMBERT", 100)
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, s.Name, s.Name[:MaxNameLen])
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameTruncate: 1}), ts)
 }
@@ -133,7 +141,8 @@ func TestNormalizeNameNoAlphanumeric(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Name = "/"
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, s.Name, DefaultSpanName)
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameInvalid: 1}), ts)
 }
@@ -143,12 +152,12 @@ func TestNormalizeNameForMetrics(t *testing.T) {
 		"pylons.controller": "pylons.controller",
 		"trace-api.request": "trace_api.request",
 	}
-
+	overriddenServiceName := ""
 	ts := newTagStats()
 	s := newTestSpan()
 	for name, expName := range expNames {
 		s.Name = name
-		assert.NoError(t, normalize(ts, s))
+		assert.NoError(t, normalize(ts, s, overriddenServiceName))
 		assert.Equal(t, expName, s.Name)
 		assert.Equal(t, newTagStats(), ts)
 	}
@@ -158,7 +167,8 @@ func TestNormalizeResourcePassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.Resource
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.Resource)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -167,7 +177,8 @@ func TestNormalizeEmptyResource(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Resource = ""
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, s.Resource, s.Name)
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{ResourceEmpty: 1}), ts)
 }
@@ -176,7 +187,8 @@ func TestNormalizeTraceIDPassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.TraceID
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.TraceID)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -185,7 +197,8 @@ func TestNormalizeNoTraceID(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.TraceID = 0
-	assert.Error(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.Error(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, tsDropped(&info.TracesDropped{TraceIDZero: 1}), ts)
 }
 
@@ -193,7 +206,8 @@ func TestNormalizeSpanIDPassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.SpanID
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.SpanID)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -202,16 +216,19 @@ func TestNormalizeNoSpanID(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.SpanID = 0
-	assert.Error(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.Error(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, tsDropped(&info.TracesDropped{SpanIDZero: 1}), ts)
 }
 
 func TestNormalizeStart(t *testing.T) {
+
+	overriddenServiceName := ""
 	t.Run("pass-through", func(t *testing.T) {
 		ts := newTagStats()
 		s := newTestSpan()
 		before := s.Start
-		assert.NoError(t, normalize(ts, s))
+		assert.NoError(t, normalize(ts, s, overriddenServiceName))
 		assert.Equal(t, before, s.Start)
 		assert.Equal(t, newTagStats(), ts)
 	})
@@ -221,7 +238,7 @@ func TestNormalizeStart(t *testing.T) {
 		s := newTestSpan()
 		s.Start = 42
 		minStart := time.Now().UnixNano() - s.Duration
-		assert.NoError(t, normalize(ts, s))
+		assert.NoError(t, normalize(ts, s, overriddenServiceName))
 		assert.True(t, s.Start >= minStart)
 		assert.True(t, s.Start <= time.Now().UnixNano()-s.Duration)
 		assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidStartDate: 1}), ts)
@@ -233,7 +250,7 @@ func TestNormalizeStart(t *testing.T) {
 		s.Start = 42
 		s.Duration = time.Now().UnixNano() * 2
 		minStart := time.Now().UnixNano()
-		assert.NoError(t, normalize(ts, s))
+		assert.NoError(t, normalize(ts, s, overriddenServiceName))
 		assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidStartDate: 1}), ts)
 		assert.True(t, s.Start >= minStart, "start should have been reset to current time")
 		assert.True(t, s.Start <= time.Now().UnixNano(), "start should have been reset to current time")
@@ -244,7 +261,8 @@ func TestNormalizeDurationPassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.Duration
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.Duration)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -253,7 +271,8 @@ func TestNormalizeEmptyDuration(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Duration = 0
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.EqualValues(t, s.Duration, 0)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -262,7 +281,8 @@ func TestNormalizeNegativeDuration(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Duration = -50
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.EqualValues(t, s.Duration, 0)
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidDuration: 1}), ts)
 }
@@ -271,7 +291,8 @@ func TestNormalizeLargeDuration(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Duration = int64(math.MaxInt64)
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.EqualValues(t, s.Duration, 0)
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{InvalidDuration: 1}), ts)
 }
@@ -280,7 +301,8 @@ func TestNormalizeErrorPassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.Error
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.Error)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -289,7 +311,8 @@ func TestNormalizeMetricsPassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.Metrics
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.Metrics)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -298,7 +321,8 @@ func TestNormalizeMetaPassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.Meta
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.Meta)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -307,7 +331,8 @@ func TestNormalizeParentIDPassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.ParentID
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.ParentID)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -316,7 +341,8 @@ func TestNormalizeTypePassThru(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	before := s.Type
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, before, s.Type)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -325,7 +351,8 @@ func TestNormalizeTypeTooLong(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Type = strings.Repeat("sql", 1000)
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{TypeTruncate: 1}), ts)
 }
 
@@ -333,7 +360,8 @@ func TestNormalizeServiceTag(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Service = "retargeting(api-Staging "
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, "retargeting_api-staging", s.Service)
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -342,7 +370,8 @@ func TestNormalizeEnv(t *testing.T) {
 	ts := newTagStats()
 	s := newTestSpan()
 	s.Meta["env"] = "DEVELOPMENT"
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, "development", s.Meta["env"])
 	assert.Equal(t, newTagStats(), ts)
 }
@@ -355,16 +384,38 @@ func TestSpecialZipkinRootSpan(t *testing.T) {
 	s.SpanID = 42
 	beforeTraceID := s.TraceID
 	beforeSpanID := s.SpanID
-	assert.NoError(t, normalize(ts, s))
+	overriddenServiceName := ""
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
 	assert.Equal(t, uint64(0), s.ParentID)
 	assert.Equal(t, beforeTraceID, s.TraceID)
 	assert.Equal(t, beforeSpanID, s.SpanID)
 	assert.Equal(t, newTagStats(), ts)
 }
 
+func TestNormalizeOverrideServiceWhenEmpty(t *testing.T) {
+	ts := newTagStats()
+	s := newTestSpan()
+	s.Service = ""
+	overriddenServiceName := "overridden-service-name"
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
+	assert.Equal(t, "overridden-service-name", s.Service)
+	assert.Equal(t, newTagStats(), ts)
+}
+
+func TestNormalizeRetainServiceWhenNotEmpty(t *testing.T) {
+	ts := newTagStats()
+	s := newTestSpan()
+	s.Service = "service-name"
+	overriddenServiceName := "overridden-service-name"
+	assert.NoError(t, normalize(ts, s, overriddenServiceName))
+	assert.Equal(t, "service-name", s.Service)
+	assert.Equal(t, newTagStats(), ts)
+}
+
 func TestNormalizeTraceEmpty(t *testing.T) {
 	ts, trace := newTagStats(), pb.Trace{}
-	err := normalizeTrace(ts, trace)
+	overriddenServiceName := ""
+	err := normalizeTrace(ts, trace, overriddenServiceName)
 	assert.Error(t, err)
 	assert.Equal(t, tsDropped(&info.TracesDropped{EmptyTrace: 1}), ts)
 }
@@ -376,7 +427,8 @@ func TestNormalizeTraceTraceIdMismatch(t *testing.T) {
 	span1.TraceID = 1
 	span2.TraceID = 2
 	trace := pb.Trace{span1, span2}
-	err := normalizeTrace(ts, trace)
+	overriddenServiceName := ""
+	err := normalizeTrace(ts, trace, overriddenServiceName)
 	assert.Error(t, err)
 	assert.Equal(t, tsDropped(&info.TracesDropped{ForeignSpan: 1}), ts)
 }
@@ -387,7 +439,8 @@ func TestNormalizeTraceInvalidSpan(t *testing.T) {
 
 	span2.Name = "" // invalid
 	trace := pb.Trace{span1, span2}
-	err := normalizeTrace(ts, trace)
+	overriddenServiceName := ""
+	err := normalizeTrace(ts, trace, overriddenServiceName)
 	assert.NoError(t, err)
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameEmpty: 1}), ts)
 }
@@ -398,7 +451,8 @@ func TestNormalizeTraceDuplicateSpanID(t *testing.T) {
 
 	span2.SpanID = span1.SpanID
 	trace := pb.Trace{span1, span2}
-	err := normalizeTrace(ts, trace)
+	overriddenServiceName := ""
+	err := normalizeTrace(ts, trace, overriddenServiceName)
 	assert.NoError(t, err)
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{DuplicateSpanID: 1}), ts)
 }
@@ -409,7 +463,8 @@ func TestNormalizeTrace(t *testing.T) {
 
 	span2.SpanID++
 	trace := pb.Trace{span1, span2}
-	err := normalizeTrace(ts, trace)
+	overriddenServiceName := ""
+	err := normalizeTrace(ts, trace, overriddenServiceName)
 	assert.NoError(t, err)
 }
 
@@ -424,6 +479,7 @@ func TestIsValidStatusCode(t *testing.T) {
 
 func TestNormalizeInvalidUTF8(t *testing.T) {
 	invalidUTF8 := "test\x99\x8f"
+	overriddenServiceName := ""
 
 	t.Run("service", func(t *testing.T) {
 		assert := assert.New(t)
@@ -433,7 +489,7 @@ func TestNormalizeInvalidUTF8(t *testing.T) {
 
 		span.Service = invalidUTF8
 
-		err := normalize(ts, span)
+		err := normalize(ts, span, overriddenServiceName)
 
 		assert.Nil(err)
 		assert.Equal("test", span.Service)
@@ -447,7 +503,7 @@ func TestNormalizeInvalidUTF8(t *testing.T) {
 
 		span.Resource = invalidUTF8
 
-		err := normalize(ts, span)
+		err := normalize(ts, span, overriddenServiceName)
 
 		assert.Nil(err)
 		assert.Equal("test��", span.Resource)
@@ -461,7 +517,7 @@ func TestNormalizeInvalidUTF8(t *testing.T) {
 
 		span.Name = invalidUTF8
 
-		err := normalize(ts, span)
+		err := normalize(ts, span, overriddenServiceName)
 
 		assert.Nil(err)
 		assert.Equal("test", span.Name)
@@ -475,7 +531,7 @@ func TestNormalizeInvalidUTF8(t *testing.T) {
 
 		span.Type = invalidUTF8
 
-		err := normalize(ts, span)
+		err := normalize(ts, span, overriddenServiceName)
 
 		assert.Nil(err)
 		assert.Equal("test��", span.Type)
@@ -492,7 +548,7 @@ func TestNormalizeInvalidUTF8(t *testing.T) {
 			"test2":     invalidUTF8,
 		}
 
-		err := normalize(ts, span)
+		err := normalize(ts, span, overriddenServiceName)
 
 		assert.Nil(err)
 		assert.EqualValues(map[string]string{
@@ -505,11 +561,12 @@ func TestNormalizeInvalidUTF8(t *testing.T) {
 func BenchmarkNormalization(b *testing.B) {
 	b.ReportAllocs()
 
+	overriddenServiceName := ""
 	for i := 0; i < b.N; i++ {
 		ts := newTagStats()
 		span := newTestSpan()
 
-		normalize(ts, span)
+		normalize(ts, span, overriddenServiceName)
 	}
 }
 

--- a/releasenotes/notes/apm-override-service-name-1c407133d3ded26d.yaml
+++ b/releasenotes/notes/apm-override-service-name-1c407133d3ded26d.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - | 
+    Allow propagating the service name set in container tags down to the spans,
+    but only if the original span(s) contain it as empty value indicating the
+    override is required


### PR DESCRIPTION
### What does this PR do?
The PR allows APM to propagate the service name as set in container tags down to the spans, but only if the original span(s) contain it as empty value indicating the override is required. The latter is specified either as empty service name in APM agent configuration (e.g -Ddd.service.name=) or programmatically with service name for a span being empty string. Non-empty values for the service are retained (not getting overridden from the labels), in case there are additional services APM agent discovers (e.g. HSQLDB being explicitly named as a different service).

### Behaviour 
#### Observed
Setting service name via tag extraction for Docker compose (docker_labels_as_tags ->com.docker.compose.service: service_name) leaves traces under 'unnamed-java-app' (Java APM agent's default).

#### Expected
Setting service name via tag extraction for Docker compose (docker_labels_as_tags ->com.docker.compose.service: service_name) groups traces under the service name in Docker-compose configuration.

### Motivation
To keep the service naming in a single place decided I should use Docker labels (or K8S annotations though didn't test that) to specify it, and then rely on tag extraction in auto-discovery (https://docs.datadoghq.com/agent/autodiscovery/tag/?tab=agent). Later I found the extraction does work (e.g. Docker-compose service gets propagated as 'container.service_name' on the root span level) though all traces are grouped under 'unnamed-java-app' service (Java APM is used for the experimentation hence the default service name it provides). Ultimately I want to avoid specifying the service name in Java properties (dd.service.name) since that'd be a duplication. 

It might be possible that the DataDog backend is expected to use the container.service_name tag from the root span to set proper service name, however it currently doesn't work.

### Additional Notes
Spring Framework PetClient (microservices variant) has been adapted to embed DataDog agents and has been used for the experimentation (https://github.com/hostcc/spring-petclinic-microservices#datadog-integration).
DataDog agent version: v6.14.0-devel+git.54.6b078c8 (build from current master), 6.13.0 (from datadog/agent:latest Docker image)
DataDog APM version: 0.31.0~e9872762
CI status: [![CircleCI](https://circleci.com/gh/hostcc/datadog-agent/tree/master.svg?style=svg)](https://circleci.com/gh/hostcc/datadog-agent/tree/master) 
