### PR TITLE
Ensure that check is not JMX before running it

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -8,6 +8,7 @@ package app
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -244,7 +244,7 @@ var checkCmd = &cobra.Command{
 		for _, c := range cs {
 			for _, conf := range allConfigs {
 				if check.IsJMXConfig(conf.Name, conf.InitConfig) {
-					return fmt.Errorf("using the jmx option with the check command directly is deprecated, please use the jmx command instead")
+					return fmt.Errorf("using the jmx option with the check command directly is not supported, please use the jmx command instead")
 				}
 			}
 			s := runCheck(c, agg)

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -8,7 +8,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -245,12 +244,7 @@ var checkCmd = &cobra.Command{
 		for _, c := range cs {
 			for _, conf := range allConfigs {
 				if check.IsJMXConfig(conf.Name, conf.InitConfig) {
-					matchingChecks := collector.GetChecksByNameForConfigs(checkName, []integration.Config{conf})
-					for _, matchingCheck := range matchingChecks {
-						if c.ID() == matchingCheck.ID() {
-							return fmt.Errorf("using the jmx option with the check command directly is deprecated, please use the jmx command instead")
-						}
-					}
+					return fmt.Errorf("using the jmx option with the check command directly is deprecated, please use the jmx command instead")
 				}
 			}
 			s := runCheck(c, agg)

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -242,6 +242,16 @@ var checkCmd = &cobra.Command{
 		var instancesData []interface{}
 
 		for _, c := range cs {
+			for _, conf := range allConfigs {
+				if check.IsJMXConfig(conf.Name, conf.InitConfig) {
+					matchingChecks := collector.GetChecksByNameForConfigs(checkName, []integration.Config{conf})
+					for _, matchingCheck := range matchingChecks {
+						if c.ID() == matchingCheck.ID() {
+							return fmt.Errorf("using the jmx option with the check command directly is deprecated, please use the jmx command instead")
+						}
+					}
+				}
+			}
 			s := runCheck(c, agg)
 
 			// Sleep for a while to allow the aggregator to finish ingesting all the metrics/events/sc

--- a/releasenotes/notes/make_user_user_jmx_command_instead_of_check-e374f41fc5cdcddd.yaml
+++ b/releasenotes/notes/make_user_user_jmx_command_instead_of_check-e374f41fc5cdcddd.yaml
@@ -1,4 +1,4 @@
 fixes:
   - |
-    The parameter ``jmx`` is not supported with the command ``check``, it is replaced by the command ``jmx``.
+    The parameter ``jmx`` is not supported with the command ``check``, the ``jmx`` command should be used instead.
 

--- a/releasenotes/notes/make_user_user_jmx_command_instead_of_check-e374f41fc5cdcddd.yaml
+++ b/releasenotes/notes/make_user_user_jmx_command_instead_of_check-e374f41fc5cdcddd.yaml
@@ -1,0 +1,4 @@
+deprecations:
+  - |
+    The parameter ``jmx`` is deprecated on the command ``check``, it is replaced by the command ``jmx``.
+

--- a/releasenotes/notes/make_user_user_jmx_command_instead_of_check-e374f41fc5cdcddd.yaml
+++ b/releasenotes/notes/make_user_user_jmx_command_instead_of_check-e374f41fc5cdcddd.yaml
@@ -1,4 +1,4 @@
-deprecations:
+fixes:
   - |
     The parameter ``jmx`` is deprecated on the command ``check``, it is replaced by the command ``jmx``.
 

--- a/releasenotes/notes/make_user_user_jmx_command_instead_of_check-e374f41fc5cdcddd.yaml
+++ b/releasenotes/notes/make_user_user_jmx_command_instead_of_check-e374f41fc5cdcddd.yaml
@@ -1,4 +1,4 @@
 fixes:
   - |
-    The parameter ``jmx`` is deprecated on the command ``check``, it is replaced by the command ``jmx``.
+    The parameter ``jmx`` is not supported with the command ``check``, it is replaced by the command ``jmx``.
 


### PR DESCRIPTION
### What does this PR do?

Display an error message if a JMX check is invoked directly instead of using the `jmx` command.

### Motivation

The command `check` with the parameter `jmx` seems to hang and does not provide any feedback to the user. It is better to use the `jmx` command instead.

### Additional Notes

Anything else we should know when reviewing?
