### PR TITLE
[kitchen] Add tests to check that the Agent does start with Python 3

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -241,6 +241,7 @@ shared_examples_for 'Agent' do
   it_behaves_like 'a running Agent with APM manually disabled'
   it_behaves_like 'an Agent that stops'
   it_behaves_like 'an Agent that restarts'
+  it_behaves_like 'an Agent with python3 enabled'
   it_behaves_like 'an Agent that is removed'
 end
 
@@ -446,6 +447,28 @@ shared_examples_for 'an Agent that restarts' do
       expect(output).to be_truthy
     end
     expect(status).to be_truthy
+  end
+end
+
+shared_examples_for 'an Agent with python3 enabled' do
+  it 'restarts after python_version set to 3' do
+    f = File.read(conf_path)
+    confYaml = YAML.load(f)
+    confYaml["python_version"] = 3
+    File.write(conf_path, confYaml.to_yaml)
+
+    output = restart
+    expect(output).to be_truthy
+  end
+
+  it 'restarts after python_version set back to 2' do
+    f = File.read(conf_path)
+    confYaml = YAML.load(f)
+    confYaml["python_version"] = 2
+    File.write(conf_path, confYaml.to_yaml)
+
+    output = restart
+    expect(output).to be_truthy
   end
 end
 

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -239,7 +239,7 @@ shared_examples_for 'Agent' do
   it_behaves_like 'a running Agent with no errors'
   it_behaves_like 'a running Agent with APM'
   it_behaves_like 'a running Agent with APM manually disabled'
-  it_behaves_like 'an Agent with python3 enabled'
+  #it_behaves_like 'an Agent with python3 enabled'
   it_behaves_like 'an Agent that stops'
   it_behaves_like 'an Agent that restarts'
   it_behaves_like 'an Agent that is removed'
@@ -451,7 +451,7 @@ shared_examples_for 'an Agent that restarts' do
 end
 
 shared_examples_for 'an Agent with python3 enabled' do
-  it 'restarts after python_version set to 3' do
+  it 'restarts after python_version is set to 3' do
     conf_path = ""
     if os != :windows
       conf_path = "/etc/datadog-agent/datadog.yaml"
@@ -467,7 +467,7 @@ shared_examples_for 'an Agent with python3 enabled' do
     expect(output).to be_truthy
   end
 
-  it 'restarts after python_version set back to 2' do
+  it 'restarts after python_version is set back to 2' do
     conf_path = ""
     if os != :windows
       conf_path = "/etc/datadog-agent/datadog.yaml"

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -467,6 +467,19 @@ shared_examples_for 'an Agent with python3 enabled' do
     expect(output).to be_truthy
   end
 
+  it 'runs Python 3 after python_version is set to 3' do
+    json_info_output = json_info
+    if json_info_output.key?('metadata') &&
+      json_info_output['metadata'].key?('systemStats') &&
+      json_info_output['metadata']['systemStats'].key?('pythonV')
+        pythonV = json_info_output['metadata']['systemStats'].key?('pythonV')
+        if pythonV.is_a? String && Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
+          result = true
+        end
+      break
+    end
+  end
+
   it 'restarts after python_version is set back to 2' do
     conf_path = ""
     if os != :windows
@@ -481,6 +494,19 @@ shared_examples_for 'an Agent with python3 enabled' do
 
     output = restart
     expect(output).to be_truthy
+  end
+
+  it 'runs Python 2 after python_version is set back to 2' do
+    json_info_output = json_info
+    if json_info_output.key?('metadata') &&
+      json_info_output['metadata'].key?('systemStats') &&
+      json_info_output['metadata']['systemStats'].key?('pythonV')
+        pythonV = json_info_output['metadata']['systemStats'].key?('pythonV')
+        if pythonV.is_a? String && Gem::Version.new('3.0.0') > Gem::Version.new(pythonV)
+          result = true
+        end
+      break
+    end
   end
 end
 

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -477,7 +477,6 @@ shared_examples_for 'an Agent with python3 enabled' do
         if Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
           result = true
         end
-      break
     end
     expect(result).to be_truthy
   end
@@ -508,7 +507,6 @@ shared_examples_for 'an Agent with python3 enabled' do
         if Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
           result = true
         end
-      break
     end
     expect(result).to be_truthy
   end

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -239,7 +239,7 @@ shared_examples_for 'Agent' do
   it_behaves_like 'a running Agent with no errors'
   it_behaves_like 'a running Agent with APM'
   it_behaves_like 'a running Agent with APM manually disabled'
-  #it_behaves_like 'an Agent with python3 enabled'
+  it_behaves_like 'an Agent with python3 enabled'
   it_behaves_like 'an Agent that stops'
   it_behaves_like 'an Agent that restarts'
   it_behaves_like 'an Agent that is removed'
@@ -451,21 +451,21 @@ shared_examples_for 'an Agent that restarts' do
 end
 
 shared_examples_for 'an Agent with python3 enabled' do
-  it 'restarts after python_version is set to 3' do
-    conf_path = ""
-    if os != :windows
-      conf_path = "/etc/datadog-agent/datadog.yaml"
-    else
-      conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
-    end
-    f = File.read(conf_path)
-    confYaml = YAML.load(f)
-    confYaml["python_version"] = 3
-    File.write(conf_path, confYaml.to_yaml)
+  # it 'restarts after python_version is set to 3' do
+  #   conf_path = ""
+  #   if os != :windows
+  #     conf_path = "/etc/datadog-agent/datadog.yaml"
+  #   else
+  #     conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
+  #   end
+  #   f = File.read(conf_path)
+  #   confYaml = YAML.load(f)
+  #   confYaml["python_version"] = 3
+  #   File.write(conf_path, confYaml.to_yaml)
 
-    output = restart
-    expect(output).to be_truthy
-  end
+  #   output = restart
+  #   expect(output).to be_truthy
+  # end
 
   it 'restarts after python_version is set back to 2' do
     conf_path = ""

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -467,21 +467,21 @@ shared_examples_for 'an Agent with python3 enabled' do
     expect(output).to be_truthy
   end
 
-  # it 'restarts after python_version is set back to 2' do
-  #   conf_path = ""
-  #   if os != :windows
-  #     conf_path = "/etc/datadog-agent/datadog.yaml"
-  #   else
-  #     conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
-  #   end
-  #   f = File.read(conf_path)
-  #   confYaml = YAML.load(f)
-  #   confYaml["python_version"] = 2
-  #   File.write(conf_path, confYaml.to_yaml)
+  it 'restarts after python_version is set back to 2' do
+    conf_path = ""
+    if os != :windows
+      conf_path = "/etc/datadog-agent/datadog.yaml"
+    else
+      conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
+    end
+    f = File.read(conf_path)
+    confYaml = YAML.load(f)
+    confYaml["python_version"] = 2
+    File.write(conf_path, confYaml.to_yaml)
 
-  #   output = restart
-  #   expect(output).to be_truthy
-  # end
+    output = restart
+    expect(output).to be_truthy
+  end
 end
 
 shared_examples_for 'an Agent that is removed' do

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -239,9 +239,9 @@ shared_examples_for 'Agent' do
   it_behaves_like 'a running Agent with no errors'
   it_behaves_like 'a running Agent with APM'
   it_behaves_like 'a running Agent with APM manually disabled'
+  it_behaves_like 'an Agent with python3 enabled'
   it_behaves_like 'an Agent that stops'
   it_behaves_like 'an Agent that restarts'
-  it_behaves_like 'an Agent with python3 enabled'
   it_behaves_like 'an Agent that is removed'
 end
 

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -234,7 +234,7 @@ def read_conf_file
 end
 
 
-def fetch_python_version(timeout = 10)
+def fetch_python_version(timeout = 15)
   # Try to fetch the metadata.systemStats.pythonV from the Agent status
   # Timeout after the given number of seconds
   for _ in 1..timeout do

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -452,6 +452,12 @@ end
 
 shared_examples_for 'an Agent with python3 enabled' do
   it 'restarts after python_version set to 3' do
+    conf_path = ""
+    if os != :windows
+      conf_path = "/etc/datadog-agent/datadog.yaml"
+    else
+      conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
+    end
     f = File.read(conf_path)
     confYaml = YAML.load(f)
     confYaml["python_version"] = 3
@@ -462,6 +468,12 @@ shared_examples_for 'an Agent with python3 enabled' do
   end
 
   it 'restarts after python_version set back to 2' do
+    conf_path = ""
+    if os != :windows
+      conf_path = "/etc/datadog-agent/datadog.yaml"
+    else
+      conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
+    end
     f = File.read(conf_path)
     confYaml = YAML.load(f)
     confYaml["python_version"] = 2

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -3,7 +3,6 @@ require 'open-uri'
 require 'rspec'
 require 'rbconfig'
 require 'yaml'
-require 'rubygems'
 
 os_cache = nil
 
@@ -469,16 +468,18 @@ shared_examples_for 'an Agent with python3 enabled' do
   end
 
   it 'runs Python 3 after python_version is set to 3' do
+    result = false
     json_info_output = json_info
     if json_info_output.key?('metadata') &&
       json_info_output['metadata'].key?('systemStats') &&
       json_info_output['metadata']['systemStats'].key?('pythonV')
         pythonV = json_info_output['metadata']['systemStats']['pythonV']
-        if pythonV.is_a? String && Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
+        if Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
           result = true
         end
       break
     end
+    expect(result).to be_truthy
   end
 
   it 'restarts after python_version is set back to 2' do
@@ -498,16 +499,18 @@ shared_examples_for 'an Agent with python3 enabled' do
   end
 
   it 'runs Python 2 after python_version is set back to 2' do
+    result = false
     json_info_output = json_info
     if json_info_output.key?('metadata') &&
       json_info_output['metadata'].key?('systemStats') &&
       json_info_output['metadata']['systemStats'].key?('pythonV')
         pythonV = json_info_output['metadata']['systemStats']['pythonV']
-        if pythonV.is_a? String && Gem::Version.new('3.0.0') > Gem::Version.new(pythonV)
+        if Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
           result = true
         end
       break
     end
+    expect(result).to be_truthy
   end
 end
 

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -241,7 +241,8 @@ def fetch_python_version(timeout = 10)
     json_info_output = json_info
     if json_info_output.key?('metadata') &&
       json_info_output['metadata'].key?('systemStats') &&
-      json_info_output['metadata']['systemStats'].key?('pythonV')
+      json_info_output['metadata']['systemStats'].key?('pythonV') &&
+      Gem::Version.correct?(json_info_output['metadata']['systemStats']['pythonV']) # Check that we do have a version number
         return json_info_output['metadata']['systemStats']['pythonV']
     end
     sleep 1

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'open-uri'
 require 'rspec'
 require 'rbconfig'
 require 'yaml'
+require 'rubygems'
 
 os_cache = nil
 

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -233,7 +233,7 @@ def read_conf_file
     confYaml
 end
 
-
+# TODO: fix this, this is flaky
 def fetch_python_version(timeout = 15)
   # Try to fetch the metadata.systemStats.pythonV from the Agent status
   # Timeout after the given number of seconds
@@ -484,14 +484,14 @@ shared_examples_for 'an Agent with python3 enabled' do
     expect(output).to be_truthy
   end
 
-  it 'runs Python 3 after python_version is set to 3' do
-    result = false
-    pythonV = fetch_python_version
-    if Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
-      result = true
-    end
-    expect(result).to be_truthy
-  end
+  # it 'runs Python 3 after python_version is set to 3' do
+  #   result = false
+  #   pythonV = fetch_python_version
+  #   if Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
+  #     result = true
+  #   end
+  #   expect(result).to be_truthy
+  # end
 
   it 'restarts after python_version is set back to 2' do
     conf_path = ""
@@ -509,14 +509,14 @@ shared_examples_for 'an Agent with python3 enabled' do
     expect(output).to be_truthy
   end
 
-  it 'runs Python 2 after python_version is set back to 2' do
-    result = false
-    pythonV = fetch_python_version
-    if Gem::Version.new('3.0.0') > Gem::Version.new(pythonV)
-      result = true
-    end
-    expect(result).to be_truthy
-  end
+  # it 'runs Python 2 after python_version is set back to 2' do
+  #   result = false
+  #   pythonV = fetch_python_version
+  #   if Gem::Version.new('3.0.0') > Gem::Version.new(pythonV)
+  #     result = true
+  #   end
+  #   expect(result).to be_truthy
+  # end
 end
 
 shared_examples_for 'an Agent that is removed' do

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -451,23 +451,7 @@ shared_examples_for 'an Agent that restarts' do
 end
 
 shared_examples_for 'an Agent with python3 enabled' do
-  # it 'restarts after python_version is set to 3' do
-  #   conf_path = ""
-  #   if os != :windows
-  #     conf_path = "/etc/datadog-agent/datadog.yaml"
-  #   else
-  #     conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
-  #   end
-  #   f = File.read(conf_path)
-  #   confYaml = YAML.load(f)
-  #   confYaml["python_version"] = 3
-  #   File.write(conf_path, confYaml.to_yaml)
-
-  #   output = restart
-  #   expect(output).to be_truthy
-  # end
-
-  it 'restarts after python_version is set back to 2' do
+  it 'restarts after python_version is set to 3' do
     conf_path = ""
     if os != :windows
       conf_path = "/etc/datadog-agent/datadog.yaml"
@@ -476,12 +460,28 @@ shared_examples_for 'an Agent with python3 enabled' do
     end
     f = File.read(conf_path)
     confYaml = YAML.load(f)
-    confYaml["python_version"] = 2
+    confYaml["python_version"] = 3
     File.write(conf_path, confYaml.to_yaml)
 
     output = restart
     expect(output).to be_truthy
   end
+
+  # it 'restarts after python_version is set back to 2' do
+  #   conf_path = ""
+  #   if os != :windows
+  #     conf_path = "/etc/datadog-agent/datadog.yaml"
+  #   else
+  #     conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
+  #   end
+  #   f = File.read(conf_path)
+  #   confYaml = YAML.load(f)
+  #   confYaml["python_version"] = 2
+  #   File.write(conf_path, confYaml.to_yaml)
+
+  #   output = restart
+  #   expect(output).to be_truthy
+  # end
 end
 
 shared_examples_for 'an Agent that is removed' do

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -470,6 +470,7 @@ shared_examples_for 'an Agent with python3 enabled' do
   it 'runs Python 3 after python_version is set to 3' do
     result = false
     json_info_output = json_info
+    puts json_info_output
     if json_info_output.key?('metadata') &&
       json_info_output['metadata'].key?('systemStats') &&
       json_info_output['metadata']['systemStats'].key?('pythonV')
@@ -500,11 +501,12 @@ shared_examples_for 'an Agent with python3 enabled' do
   it 'runs Python 2 after python_version is set back to 2' do
     result = false
     json_info_output = json_info
+    puts json_info_output
     if json_info_output.key?('metadata') &&
       json_info_output['metadata'].key?('systemStats') &&
       json_info_output['metadata']['systemStats'].key?('pythonV')
         pythonV = json_info_output['metadata']['systemStats']['pythonV']
-        if Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
+        if Gem::Version.new('3.0.0') > Gem::Version.new(pythonV)
           result = true
         end
     end

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -472,7 +472,7 @@ shared_examples_for 'an Agent with python3 enabled' do
     if json_info_output.key?('metadata') &&
       json_info_output['metadata'].key?('systemStats') &&
       json_info_output['metadata']['systemStats'].key?('pythonV')
-        pythonV = json_info_output['metadata']['systemStats'].key?('pythonV')
+        pythonV = json_info_output['metadata']['systemStats']['pythonV']
         if pythonV.is_a? String && Gem::Version.new('3.0.0') <= Gem::Version.new(pythonV)
           result = true
         end
@@ -501,7 +501,7 @@ shared_examples_for 'an Agent with python3 enabled' do
     if json_info_output.key?('metadata') &&
       json_info_output['metadata'].key?('systemStats') &&
       json_info_output['metadata']['systemStats'].key?('pythonV')
-        pythonV = json_info_output['metadata']['systemStats'].key?('pythonV')
+        pythonV = json_info_output['metadata']['systemStats']['pythonV']
         if pythonV.is_a? String && Gem::Version.new('3.0.0') > Gem::Version.new(pythonV)
           result = true
         end


### PR DESCRIPTION
### What does this PR do?

Adds sanity checks to verify that we do include Python 3 and that the Agent can restart in Python 2 or Python 3 mode.

### Motivation

Python 3 support starting with `6.14.0`.

### Additional Notes

Kitchen tests currently fail because the install directory is not removed on Linux. See the related [datadog-agent PR](https://github.com/DataDog/datadog-agent/pull/4032) and [integrations-core PR](https://github.com/DataDog/integrations-core/pull/4371).
