### PR TITLE
Use OpenJDK11 in the docker image

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -67,16 +67,11 @@ ENV DOCKER_DD_AGENT=true \
     # Allow readonlyrootfs
     S6_READ_ONLY_ROOT=1
 
-# Install openjdk-8-jre-headless on jmx flavor
-RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-8 from stable" \
- && echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/stretch.list \
- && echo "deb http://security.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list.d/stretch.list \
- && echo "deb http://deb.debian.org/debian stretch-updates main" >> /etc/apt/sources.list.d/stretch.list \
- && apt-get update \
+# Install openjdk-11-jre-headless on jmx flavor
+RUN if [ -n "$WITH_JMX" ]; then apt-get update \
  && mkdir /usr/share/man/man1 \
- && apt-get install --no-install-recommends -y openjdk-8-jre-headless \
+ && apt-get install --no-install-recommends -y openjdk-11-jre-headless \
  && apt-get clean \
- && rm /etc/apt/sources.list.d/stretch.list \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; fi
 
 # make sure we have recent dependencies

--- a/Dockerfiles/agent/datadog-docker.yaml
+++ b/Dockerfiles/agent/datadog-docker.yaml
@@ -13,5 +13,5 @@ apm_config:
   enabled: false
   apm_non_local_traffic: true
 
-# Use java cgroup memory awareness
-jmx_use_cgroup_memory_limit: true
+# Use java container support
+jmx_use_container_support: true

--- a/Dockerfiles/agent/datadog-ecs.yaml
+++ b/Dockerfiles/agent/datadog-ecs.yaml
@@ -13,5 +13,5 @@ apm_config:
   enabled: false
   apm_non_local_traffic: true
 
-# Use java cgroup memory awareness
-jmx_use_cgroup_memory_limit: true
+# Use java container support
+jmx_use_container_support: true

--- a/Dockerfiles/agent/datadog-k8s-docker.yaml
+++ b/Dockerfiles/agent/datadog-k8s-docker.yaml
@@ -17,5 +17,5 @@ apm_config:
   enabled: false
   apm_non_local_traffic: true
 
-# Use java cgroup memory awareness
-jmx_use_cgroup_memory_limit: true
+# Use java container support
+jmx_use_container_support: true

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -13,5 +13,5 @@ apm_config:
   enabled: false
   apm_non_local_traffic: true
 
-# Use java cgroup memory awareness
-jmx_use_cgroup_memory_limit: true
+# Use java container support
+jmx_use_container_support: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -317,6 +317,7 @@ func initConfig(config Config) {
 	// JMXFetch
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
+	config.BindEnvAndSetDefault("jmx_use_container_support", false)
 	config.BindEnvAndSetDefault("jmx_max_restarts", int64(3))
 	config.BindEnvAndSetDefault("jmx_restart_interval", int64(5))
 	config.BindEnvAndSetDefault("jmx_thread_pool_size", 3)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -690,9 +690,19 @@ api_key:
 ## When running in a memory cgroup, openjdk 8u131 and higher can automatically adjust
 ## its heap memory usage in accordance to the cgroup/container's memory limit.
 ## The Agent set a Xmx of 200MB if none is configured.
-## Note: older openjdk versions and other jvms might fail to start if this option is set
+## Note: older openjdk versions and openjdk 10 and higher as well as other
+## JVMs might fail to start if this option is set.
 #
 # jmx_use_cgroup_memory_limit: false
+
+## @param jmx_use_container_support - boolean - optional - default: false
+## When running in a container, openjdk 10 and higher can automatically detect
+## container specific configuration instead of querying the operating system
+## to adjust resources allotted to the JVM.
+## Note: openjdk versions prior to 10 and other JVMs might fail to start if
+## this option is set.
+#
+# jmx_use_container_support: false
 
 ## @param jmx_max_restarts - integer - optional - default: 3
 ## Number of JMX restarts allowed in the restart-interval before giving up.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -690,8 +690,8 @@ api_key:
 ## When running in a memory cgroup, openjdk 8u131 and higher can automatically adjust
 ## its heap memory usage in accordance to the cgroup/container's memory limit.
 ## The Agent set a Xmx of 200MB if none is configured.
-## Note: older openjdk versions and openjdk 10 and higher as well as other
-## JVMs might fail to start if this option is set.
+## Note: OpenJDK version < 8u131 or >= 10 as well as other JVMs might fail
+## to start if this option is set.
 #
 # jmx_use_cgroup_memory_limit: false
 

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -144,23 +144,11 @@ func (j *JMXFetch) Start(manage bool) error {
 	// Specify a maximum memory allocation pool for the JVM
 	javaOptions := j.JavaOptions
 
-	incompatibleOptions := false
 	useContainerSupport := config.Datadog.GetBool("jmx_use_container_support")
 	useCgroupMemoryLimit := config.Datadog.GetBool("jmx_use_cgroup_memory_limit")
 
 	if useContainerSupport && useCgroupMemoryLimit {
-		log.Warnf("Skipping incompatible options %q and %q, only one should be set at a time", jvmContainerSupport, jvmCgroupMemoryAwareness)
-		incompatibleOptions = true
-	}
-	if incompatibleOptions || !(useContainerSupport || useCgroupMemoryLimit) {
-		// Specify a maximum memory allocation pool for the JVM
-		if !strings.Contains(javaOptions, "Xmx") && !strings.Contains(javaOptions, "XX:MaxHeapSize") {
-			javaOptions += defaultJvmMaxMemoryAllocation
-		}
-		// Specify the initial memory allocation pool for the JVM
-		if !strings.Contains(javaOptions, "Xms") && !strings.Contains(javaOptions, "XX:InitialHeapSize") {
-			javaOptions += defaultJvmInitialMemoryAllocation
-		}
+		return fmt.Errorf("incompatible options %q and %q", jvmContainerSupport, jvmCgroupMemoryAwareness)
 	} else if useContainerSupport {
 		javaOptions += jvmContainerSupport
 	} else if useCgroupMemoryLimit {
@@ -174,6 +162,15 @@ func (j *JMXFetch) Start(manage bool) error {
 		}
 		if passOption {
 			javaOptions += jvmCgroupMemoryAwareness
+		}
+	} else {
+		// Specify a maximum memory allocation pool for the JVM
+		if !strings.Contains(javaOptions, "Xmx") && !strings.Contains(javaOptions, "XX:MaxHeapSize") {
+			javaOptions += defaultJvmMaxMemoryAllocation
+		}
+		// Specify the initial memory allocation pool for the JVM
+		if !strings.Contains(javaOptions, "Xms") && !strings.Contains(javaOptions, "XX:InitialHeapSize") {
+			javaOptions += defaultJvmInitialMemoryAllocation
 		}
 	}
 

--- a/releasenotes/notes/openjdk11-jvm-ece6b5cc12c86ff6.yaml
+++ b/releasenotes/notes/openjdk11-jvm-ece6b5cc12c86ff6.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for the `XX:+UseContainerSupport` JVM option through the
+    `jmx_use_container_support` configuration option.


### PR DESCRIPTION
### What does this PR do?

Since 6.11 we have been pulling OpenJDK8 from stretch (oldstable) as it was removed from buster that comes with OpenJDK11. This PR updates the docker image to use that latest version and enables using the JVM option `XX:+UseContainerSupport` that was introduced as a replacement of the deprecated `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap` with OpenJDK10+.

### Motivation

Update to OpenJDK11 so we don't use a deprecated package.
