### PR TITLE
[NTP] Use the timeout from the config

### DIFF
--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -63,7 +63,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 	var instance ntpInstanceConfig
 	var initConf ntpInitConfig
 	defaultVersion := 3
-	defaultTimeout := 1
+	defaultTimeout := 5
 	defaultPort := 123
 	defaultOffsetThreshold := 60
 	defaultMinCollectionInterval := 900 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
@@ -175,7 +175,7 @@ func (c *NTPCheck) queryOffset() (float64, error) {
 	offsets := []float64{}
 
 	for _, host := range c.cfg.instance.Hosts {
-		response, err := ntpQuery(host, ntp.QueryOptions{Version: c.cfg.instance.Version, Port: c.cfg.instance.Port})
+		response, err := ntpQuery(host, ntp.QueryOptions{Version: c.cfg.instance.Version, Port: c.cfg.instance.Port, Timeout: time.Duration(c.cfg.instance.Timeout) * time.Second})
 		if err != nil {
 			log.Infof("There was an error querying the ntp host %s: %s", host, err)
 			continue

--- a/releasenotes/notes/ntp-timeout-unused-e431a5aa3f7d6c70.yaml
+++ b/releasenotes/notes/ntp-timeout-unused-e431a5aa3f7d6c70.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed NTP timeout not being used from the configuration.


### PR DESCRIPTION
### What does this PR do?

The timeout wasn't being passed to the NTP client, so the default timeout of the client (5s) was always used regardless of whatever is configured.

This also changes our default to match the default from the NTP client so that we don't change the behaviour of existing agents.
