### PR TITLE
Add networkID to process-agent checks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,15 +10,15 @@
   source = "github.com/adjust/goautoneg"
 
 [[projects]]
-  digest = "1:4d058d0c70c840a711bc07a754f8585fd7a4d7fe4f17b5291daa94efb8fd8e63"
+  digest = "1:dfa126c123ce1bef1328b4d5b025ca5f0bb72a4ceebf2da1da680058f0ea276c"
   name = "github.com/DataDog/agent-payload"
   packages = [
     "gogen",
     "process",
   ]
   pruneopts = ""
-  revision = "289e8fe7ace0255e45ff2e87704a39dc103b2f86"
-  version = "4.9.1"
+  revision = "bd00819f7e33ddcf00a0fdc4f71847229e5c2998"
+  version = "4.11.0"
 
 [[projects]]
   digest = "1:e64fddc819e2abc68792a743dd857c379449a56f2b9eaf030c03fb0ec19de884"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/DataDog/agent-payload"
-  version = "4.9.1"
+  version = "4.11.0"
 
 [[constraint]]
   name = "github.com/DataDog/gohai"

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -31,11 +31,18 @@ type ContainerCheck struct {
 	lastRates       map[string]util.ContainerRateMetrics
 	lastRun         time.Time
 	lastCtrIDForPID map[int32]string
+	networkID       string
 }
 
 // Init initializes a ContainerCheck instance.
 func (c *ContainerCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
 	c.sysInfo = info
+
+	networkID, err := agentutil.GetNetworkID()
+	if err != nil {
+		log.Infof("no network ID detected: %s", err)
+	}
+	c.networkID = networkID
 }
 
 // Name returns the name of the ProcessCheck.
@@ -59,11 +66,6 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 		return nil, err
 	}
 
-	networkID, err := util.GetNetworkID()
-	if err != nil {
-		log.Debugf("could not get networkID: %s", err)
-	}
-
 	// End check early if this is our first run.
 	if c.lastRates == nil {
 		c.lastRates = util.ExtractContainerRateMetric(ctrList)
@@ -83,7 +85,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 		totalContainers += float64(len(chunked[i]))
 		messages = append(messages, &model.CollectorContainer{
 			HostName:   cfg.HostName,
-			NetworkId:  networkID,
+			NetworkId:  c.networkID,
 			Info:       c.sysInfo,
 			Containers: chunked[i],
 			GroupId:    groupID,

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	agentutil "github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -58,6 +59,11 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 		return nil, err
 	}
 
+	networkID, err := util.GetNetworkID()
+	if err != nil {
+		log.Debugf("could not get networkID: %s", err)
+	}
+
 	// End check early if this is our first run.
 	if c.lastRates == nil {
 		c.lastRates = util.ExtractContainerRateMetric(ctrList)
@@ -77,6 +83,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 		totalContainers += float64(len(chunked[i]))
 		messages = append(messages, &model.CollectorContainer{
 			HostName:   cfg.HostName,
+			NetworkId:  networkID,
 			Info:       c.sysInfo,
 			Containers: chunked[i],
 			GroupId:    groupID,

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -96,7 +96,7 @@ func (c *ConnectionsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 
 	networkID, err := util.GetNetworkID()
 	if err != nil {
-		log.Debugf("could not detect networkID, will continue with empty string")
+		log.Debugf("could not detect networkID: %s", err)
 	}
 
 	log.Debugf("collected connections in %s", time.Since(start))

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -69,7 +69,7 @@ func TestNetworkConnectionBatching(t *testing.T) {
 		},
 	} {
 		cfg.MaxConnsPerMessage = tc.maxSize
-		chunks := batchConnections(cfg, 0, tc.cur)
+		chunks := batchConnections(cfg, 0, tc.cur, "nid")
 
 		assert.Len(t, chunks, tc.expectedChunks, "len %d", i)
 		total := 0
@@ -80,6 +80,7 @@ func TestNetworkConnectionBatching(t *testing.T) {
 
 			// make sure we could get container and pid mapping for connections
 			assert.Equal(t, len(connections.Connections), len(connections.ContainerForPid))
+			assert.Equal(t, "nid", connections.NetworkId)
 			for _, conn := range connections.Connections {
 				assert.Contains(t, connections.ContainerForPid, conn.Pid)
 				assert.Equal(t, fmt.Sprintf("%d", conn.Pid), connections.ContainerForPid[conn.Pid])

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -86,7 +86,7 @@ func TestRandomizeMessages(t *testing.T) {
 			cfg.MaxPerMessage = tc.maxSize
 			processes := fmtProcesses(cfg, procsByPid, procsByPid, ctrs, syst2, syst1, lastRun)
 			containers := fmtContainers(ctrs, lastCtrRates, lastRun)
-			messages, totalProcs, totalContainers := createProcCtrMessages(processes, containers, cfg, sysInfo, int32(i))
+			messages, totalProcs, totalContainers := createProcCtrMessages(processes, containers, cfg, sysInfo, int32(i), "nid")
 
 			assert.Equal(t, totalProcs, tc.pCount)
 			assert.Equal(t, totalContainers, tc.cCount)
@@ -204,7 +204,7 @@ func TestBasicProcessMessages(t *testing.T) {
 
 			procs := fmtProcesses(cfg, tc.cur, tc.last, tc.containers, syst2, syst1, lastRun)
 			containers := fmtContainers(tc.containers, lastCtrRates, lastRun)
-			messages, totalProcs, totalContainers := createProcCtrMessages(procs, containers, cfg, sysInfo, int32(i))
+			messages, totalProcs, totalContainers := createProcCtrMessages(procs, containers, cfg, sysInfo, int32(i), "nid")
 
 			assert.Equal(t, tc.expectedChunks, len(messages))
 			assert.Equal(t, tc.totalProcs, totalProcs)


### PR DESCRIPTION
### What does this PR do?
Include networkId in process/container/connection check.

Depends on https://github.com/DataDog/agent-payload/pull/23

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
