### PR TITLE
add connection blacklisting

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1226,6 +1226,14 @@
   version = "v0.1.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:227a91986ac2522b2ecc9cfafed7451037efbf01de54eb6c3d0c9f876b279d55"
+  name = "github.com/stretchr/stew"
+  packages = ["slice"]
+  pruneopts = ""
+  revision = "80ef0842b48b329a6120607c817a85aff5a2ec71"
+
+[[projects]]
   digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = [
@@ -2048,6 +2056,7 @@
     "github.com/spf13/afero",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
+    "github.com/stretchr/stew/slice",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1226,14 +1226,6 @@
   version = "v0.1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:227a91986ac2522b2ecc9cfafed7451037efbf01de54eb6c3d0c9f876b279d55"
-  name = "github.com/stretchr/stew"
-  packages = ["slice"]
-  pruneopts = ""
-  revision = "80ef0842b48b329a6120607c817a85aff5a2ec71"
-
-[[projects]]
   digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = [
@@ -2056,7 +2048,6 @@
     "github.com/spf13/afero",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
-    "github.com/stretchr/stew/slice",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -455,6 +455,8 @@ func initConfig(config Config) {
 	config.SetKnown("system_probe_config.max_closed_connections_buffered")
 	config.SetKnown("system_probe_config.max_connection_state_buffered")
 	config.SetKnown("system_probe_config.excluded_linux_versions")
+	config.SetKnown("system_probe_config.excluded_source_connections")
+	config.SetKnown("system_probe_config.excluded_destination_connections")
 	config.SetKnown("system_probe_config.closed_channel_size")
 
 	// APM

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -455,8 +455,8 @@ func initConfig(config Config) {
 	config.SetKnown("system_probe_config.max_closed_connections_buffered")
 	config.SetKnown("system_probe_config.max_connection_state_buffered")
 	config.SetKnown("system_probe_config.excluded_linux_versions")
-	config.SetKnown("system_probe_config.excluded_source_connections")
-	config.SetKnown("system_probe_config.excluded_destination_connections")
+	config.SetKnown("system_probe_config.source_excludes")
+	config.SetKnown("system_probe_config.dest_excludes")
 	config.SetKnown("system_probe_config.closed_channel_size")
 
 	// APM

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -61,6 +61,12 @@ type Config struct {
 
 	// ClosedChannelSize specifies the size for closed channel for the tracer
 	ClosedChannelSize int
+
+	// ExcludedSourceConnections is a map of source connections to blacklist
+	ExcludedSourceConnections map[string][]string
+
+	// ExcludedDestinationConnections is a map of destination connections to blacklist
+	ExcludedDestinationConnections map[string][]string
 }
 
 // NewDefaultConfig enables traffic collection for all connection types

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -252,10 +252,8 @@ func (t *Tracer) shouldSkipConnection(conn *ConnectionStats) bool {
 	switch {
 	case !t.config.CollectLocalDNS && isDNSConnection && conn.Direction == LOCAL:
 		return true
-	case conn.Direction == LOCAL || INCOMING:
-		return util2.IsBlacklistedConnection("source", conn.Source, conn.SPort)
-	case conn.Direction == OUTGOING:
-		return util2.IsBlacklistedConnection("destination", conn.Source, conn.SPort)
+	case util.IsBlacklistedConnection("source", conn.Source, conn.SPort) || util.IsBlacklistedConnection("destination", conn.Dest, conn.DPort):
+		return true
 	}
 	return false
 }

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/netlink"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -68,6 +69,15 @@ type Tracer struct {
 
 	// Internal buffer used to compute bytekeys
 	buf *bytes.Buffer
+
+	// Connections for the tracer to blacklist
+	connectionBlacklist *ConnectionBlacklist
+}
+
+// ConnectionBlacklist stores the agent's blacklist configuration for source and destination to be called by the tracer
+type ConnectionBlacklist struct {
+	SourceBlacklist      []*util.ConnectionFilter
+	DestinationBlacklist []*util.ConnectionFilter
 }
 
 const (
@@ -126,14 +136,15 @@ func NewTracer(config *Config) (*Tracer, error) {
 	state := NewNetworkState(config.ClientStateExpiry, config.MaxClosedConnectionsBuffered, config.MaxConnectionsStateBuffered)
 
 	tr := &Tracer{
-		m:              m,
-		config:         config,
-		state:          state,
-		portMapping:    portMapping,
-		localAddresses: readLocalAddresses(),
-		buffer:         make([]ConnectionStats, 0, 512),
-		buf:            &bytes.Buffer{},
-		conntracker:    conntracker,
+		m:                   m,
+		config:              config,
+		state:               state,
+		portMapping:         portMapping,
+		localAddresses:      readLocalAddresses(),
+		buffer:              make([]ConnectionStats, 0, 512),
+		buf:                 &bytes.Buffer{},
+		conntracker:         conntracker,
+		connectionBlacklist: getNetworkBlacklists(),
 	}
 
 	tr.perfMap, err = tr.initPerfPolling()
@@ -252,7 +263,7 @@ func (t *Tracer) shouldSkipConnection(conn *ConnectionStats) bool {
 	switch {
 	case !t.config.CollectLocalDNS && isDNSConnection && conn.Direction == LOCAL:
 		return true
-	case util.IsBlacklistedConnection("source", conn.Source, conn.SPort) || util.IsBlacklistedConnection("destination", conn.Dest, conn.DPort):
+	case util.IsBlacklistedConnection(t.connectionBlacklist.SourceBlacklist, conn.Source, conn.SPort) || util.IsBlacklistedConnection(t.connectionBlacklist.DestinationBlacklist, conn.Dest, conn.DPort):
 		return true
 	}
 	return false
@@ -636,6 +647,16 @@ func readLocalAddresses() map[util.Address]struct{} {
 	}
 
 	return addresses
+}
+
+// getNetworkBlacklists retrieves the blacklists set in the agent config
+func getNetworkBlacklists() *ConnectionBlacklist {
+	s := util.ParseBlacklist(config.Datadog.GetStringMapStringSlice("system_probe_config.excluded_source_connections"))
+	d := util.ParseBlacklist(config.Datadog.GetStringMapStringSlice("system_probe_config.excluded_destination_connections"))
+	return &ConnectionBlacklist{
+		SourceBlacklist:      s,
+		DestinationBlacklist: d,
+	}
 }
 
 // SectionsFromConfig returns a map of string -> gobpf.SectionParams used to configure the way we load the BPF program (bpf map sizes)

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -255,10 +255,9 @@ func (t *Tracer) initPerfPolling() (*bpflib.PerfMap, error) {
 //  • Local DNS (*:53) requests if configured (default: true)
 func (t *Tracer) shouldSkipConnection(conn *ConnectionStats) bool {
 	isDNSConnection := conn.DPort == 53 || conn.SPort == 53
-	switch {
-	case !t.config.CollectLocalDNS && isDNSConnection && conn.Direction == LOCAL:
+	if !t.config.CollectLocalDNS && isDNSConnection && conn.Direction == LOCAL {
 		return true
-	case util.IsBlacklistedConnection(t.sourceExcludes, conn.Source, conn.SPort) || util.IsBlacklistedConnection(t.destExcludes, conn.Dest, conn.DPort):
+	} else if util.IsBlacklistedConnection(t.sourceExcludes, conn.Source, conn.SPort) || util.IsBlacklistedConnection(t.destExcludes, conn.Dest, conn.DPort) {
 		return true
 	}
 	return false

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -738,7 +738,7 @@ func isLocalDNS(c ConnectionStats) bool {
 
 func TestShouldSkipBlacklistedConnection(t *testing.T) {
 	// exclude connections from 127.0.0.1:80
-	config.Datadog.SetDefaultSetDefault("system_probe_config.excluded_source_connections", map[string][]string{"127.0.0.1": {"80"}})
+	config.Datadog.SetDefault("system_probe_config.excluded_source_connections", map[string][]string{"127.0.0.1": {"80"}})
 	config := NewDefaultConfig()
 	tr, err := NewTracer(config)
 	if err != nil {

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -5,7 +5,7 @@ package ebpf
 import (
 	"bufio"
 	"bytes"
-	json "encoding/json"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -23,7 +23,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -738,8 +737,9 @@ func isLocalDNS(c ConnectionStats) bool {
 
 func TestShouldSkipBlacklistedConnection(t *testing.T) {
 	// exclude connections from 127.0.0.1:80
-	config.Datadog.SetDefault("system_probe_config.excluded_source_connections", map[string][]string{"127.0.0.1": {"80"}})
 	config := NewDefaultConfig()
+	config.ExcludedSourceConnections = map[string][]string{"127.0.0.1": {"80"}}
+	config.ExcludedDestinationConnections = map[string][]string{"127.0.0.1": {"80"}}
 	tr, err := NewTracer(config)
 	if err != nil {
 		t.Fatal(err)
@@ -761,6 +761,7 @@ func TestShouldSkipBlacklistedConnection(t *testing.T) {
 	// Make sure we're not picking up 127.0.0.1:80
 	for _, c := range getConnections(t, tr).Conns {
 		assert.False(t, c.Source.String() == "127.0.0.1" && c.SPort == 80)
+		assert.False(t, c.Dest.String() == "127.0.0.1" && c.DPort == 80)
 	}
 }
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -84,6 +84,8 @@ type AgentConfig struct {
 	MaxTrackedConnections        uint
 	SysProbeBPFDebug             bool
 	ExcludedBPFLinuxVersions     []string
+	ExcludedInboundConnections   map[string][]string
+	ExcludedOutboundConnections  map[string][]string
 	EnableConntrack              bool
 	ConntrackShortTermBufferSize int
 	SystemProbeDebugPort         int

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -73,25 +73,25 @@ type AgentConfig struct {
 	ProcessExpVarPort  int
 
 	// System probe collection configuration
-	EnableSystemProbe            bool
-	EnableLocalSystemProbe       bool // To have the system probe embedded in the process-agent
-	DisableTCPTracing            bool
-	DisableUDPTracing            bool
-	DisableIPv6Tracing           bool
-	CollectLocalDNS              bool
-	SystemProbeSocketPath        string
-	SystemProbeLogFile           string
-	MaxTrackedConnections        uint
-	SysProbeBPFDebug             bool
-	ExcludedBPFLinuxVersions     []string
-	ExcludedInboundConnections   map[string][]string
-	ExcludedOutboundConnections  map[string][]string
-	EnableConntrack              bool
-	ConntrackShortTermBufferSize int
-	SystemProbeDebugPort         int
-	ClosedChannelSize            int
-	MaxClosedConnectionsBuffered int
-	MaxConnectionsStateBuffered  int
+	EnableSystemProbe              bool
+	EnableLocalSystemProbe         bool // To have the system probe embedded in the process-agent
+	DisableTCPTracing              bool
+	DisableUDPTracing              bool
+	DisableIPv6Tracing             bool
+	CollectLocalDNS                bool
+	SystemProbeSocketPath          string
+	SystemProbeLogFile             string
+	MaxTrackedConnections          uint
+	SysProbeBPFDebug               bool
+	ExcludedBPFLinuxVersions       []string
+	ExcludedSourceConnections      map[string][]string
+	ExcludedDestinationConnections map[string][]string
+	EnableConntrack                bool
+	ConntrackShortTermBufferSize   int
+	SystemProbeDebugPort           int
+	ClosedChannelSize              int
+	MaxClosedConnectionsBuffered   int
+	MaxConnectionsStateBuffered    int
 
 	// Check config
 	EnabledChecks  []string

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -254,8 +254,8 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.True(agentConfig.DisableTCPTracing)
 	assert.True(agentConfig.DisableUDPTracing)
 	assert.True(agentConfig.DisableIPv6Tracing)
-	assert.Equal(map[string][]string(map[string][]string{"172.0.0.1/20": []string{"*"}, "*": []string{"443"}, "127.0.0.1": []string{"5005"}}), agentConfig.ExcludedSourceConnections)
-	assert.Equal(map[string][]string(map[string][]string{"172.0.0.1/20": []string{"*"}, "*": []string{"*"}, "2001:db8::2:1": []string{"5005"}}), agentConfig.ExcludedDestinationConnections)
+	assert.Equal(map[string][]string(map[string][]string{"172.0.0.1/20": {"*"}, "*": {"443"}, "127.0.0.1": {"5005"}}), agentConfig.ExcludedSourceConnections)
+	assert.Equal(map[string][]string(map[string][]string{"172.0.0.1/20": {"*"}, "*": {"*"}, "2001:db8::2:1": {"5005"}}), agentConfig.ExcludedDestinationConnections)
 }
 
 func TestProxyEnv(t *testing.T) {

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -254,6 +254,8 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.True(agentConfig.DisableTCPTracing)
 	assert.True(agentConfig.DisableUDPTracing)
 	assert.True(agentConfig.DisableIPv6Tracing)
+	assert.Equal(map[string][]string(map[string][]string{"172.0.0.1/20": []string{"*"}, "*": []string{"443"}, "127.0.0.1": []string{"5005"}}), agentConfig.ExcludedSourceConnections)
+	assert.Equal(map[string][]string(map[string][]string{"172.0.0.1/20": []string{"*"}, "*": []string{"*"}, "2001:db8::2:1": []string{"5005"}}), agentConfig.ExcludedDestinationConnections)
 }
 
 func TestProxyEnv(t *testing.T) {

--- a/pkg/process/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net-2.yaml
+++ b/pkg/process/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net-2.yaml
@@ -8,3 +8,17 @@ system_probe_config:
       - 5.5.0
       - 4.2.1
     closed_channel_size: 1000
+    source_excludes:
+      127.0.0.1:
+        - "5005"
+      172.0.0.1/20:
+        - "*"
+      "*":
+        - "443"
+    dest_excludes:
+      2001:db8::2:1:
+        - "5005"
+      172.0.0.1/20:
+        - "*"
+      "*":
+        - "*"

--- a/pkg/process/config/tracer_config.go
+++ b/pkg/process/config/tracer_config.go
@@ -32,6 +32,14 @@ func SysProbeConfigFromConfig(cfg *AgentConfig) *ebpf.Config {
 		log.Info("system probe TCP tracing disabled by configuration")
 	}
 
+	if len(cfg.ExcludedSourceConnections) > 0 {
+		tracerConfig.ExcludedSourceConnections = cfg.ExcludedSourceConnections
+	}
+
+	if len(cfg.ExcludedDestinationConnections) > 0 {
+		tracerConfig.ExcludedDestinationConnections = cfg.ExcludedDestinationConnections
+	}
+
 	tracerConfig.CollectLocalDNS = cfg.CollectLocalDNS
 
 	tracerConfig.MaxTrackedConnections = cfg.MaxTrackedConnections

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -118,11 +118,11 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		a.SystemProbeDebugPort = debugPort
 	}
 
-	if sourceExclude := key(spNS, "excluded_source_connections"); config.Datadog.IsSet(sourceExclude) {
+	if sourceExclude := key(spNS, "source_excludes"); config.Datadog.IsSet(sourceExclude) {
 		a.ExcludedSourceConnections = config.Datadog.GetStringMapStringSlice(sourceExclude)
 	}
 
-	if destinationExclude := key(spNS, "excluded_destination_connections"); config.Datadog.IsSet(destinationExclude) {
+	if destinationExclude := key(spNS, "dest_excludes"); config.Datadog.IsSet(destinationExclude) {
 		a.ExcludedDestinationConnections = config.Datadog.GetStringMapStringSlice(destinationExclude)
 	}
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -118,6 +118,14 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		a.SystemProbeDebugPort = debugPort
 	}
 
+	if sourceExclude := key(spNS, "excluded_source_connections"); config.Datadog.IsSet(sourceExclude) {
+		a.ExcludedInboundConnections = config.Datadog.GetStringMapStringSlice(sourceExclude)
+	}
+
+	if destinationExclude := key(spNS, "excluded_destination_connections"); config.Datadog.IsSet(destinationExclude) {
+		a.ExcludedOutboundConnections = config.Datadog.GetStringMapStringSlice(destinationExclude)
+	}
+
 	return nil
 }
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -119,11 +119,11 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	}
 
 	if sourceExclude := key(spNS, "excluded_source_connections"); config.Datadog.IsSet(sourceExclude) {
-		a.ExcludedInboundConnections = config.Datadog.GetStringMapStringSlice(sourceExclude)
+		a.ExcludedSourceConnections = config.Datadog.GetStringMapStringSlice(sourceExclude)
 	}
 
 	if destinationExclude := key(spNS, "excluded_destination_connections"); config.Datadog.IsSet(destinationExclude) {
-		a.ExcludedOutboundConnections = config.Datadog.GetStringMapStringSlice(destinationExclude)
+		a.ExcludedDestinationConnections = config.Datadog.GetStringMapStringSlice(destinationExclude)
 	}
 
 	return nil

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -29,6 +29,11 @@ func AddressFromString(ip string) Address {
 	return AddressFromNetIP(net.ParseIP(ip))
 }
 
+// NetIPFromAddress returns a net.IP from an Address
+func NetIPFromAddress(addr Address) net.IP {
+	return net.IP(addr.Bytes())
+}
+
 type v4Address [4]byte
 
 // V4Address creates an Address using the uint32 representation of an v4 IP

--- a/pkg/process/util/address_test.go
+++ b/pkg/process/util/address_test.go
@@ -38,6 +38,26 @@ func TestNetIPToAddress(t *testing.T) {
 	assert.NotEqual(t, a, b)
 }
 
+func TestNetIPFromAddress(t *testing.T) {
+	// v4
+	addr := V4Address(889192575)
+	ip := net.ParseIP("127.0.0.53").To4()
+	ipFromAddr := NetIPFromAddress(addr)
+	assert.Equal(t, ip, ipFromAddr)
+
+	// v6
+	addr = V6Address(889192575, 0)
+	ip = net.ParseIP("::7f00:35:0:0")
+	ipFromAddr = NetIPFromAddress(addr)
+	assert.Equal(t, ip, ipFromAddr)
+
+	// v4 + v6 mismatched
+	addr = V4Address(889192575)
+	ip = net.ParseIP("::7f00:35:0:0")
+	ipFromAddr = NetIPFromAddress(addr)
+	assert.NotEqual(t, ip, ipFromAddr)
+}
+
 func TestAddressUsageInMaps(t *testing.T) {
 	addrMap := make(map[Address]struct{})
 

--- a/pkg/process/util/network_filter.go
+++ b/pkg/process/util/network_filter.go
@@ -5,68 +5,67 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/stretchr/stew/slice"
 )
 
-// Connection holds a user-defined blacklisted IP, CIDR, and ports
-type Connection struct {
-	IP    string
-	CIDR  *net.IPNet
-	Ports []string
+// ConnectionFilter holds a user-defined blacklisted IP/CIDR, and ports
+type ConnectionFilter struct {
+	IP    *net.IPNet
+	Ports map[uint16]struct{}
 }
 
-// takes the user defined blacklist and returns a slice of Connections
-func parseBlacklist(filters map[string][]string) (blacklist []*Connection) {
+// takes the user defined blacklist and returns a slice of ConnectionFilters
+func ParseBlacklist(filters map[string][]string) (blacklist []*ConnectionFilter) {
 	for ip, ports := range filters {
-		conn := &Connection{
-			IP:    ip,
-			Ports: ports,
-		}
+		conn := &ConnectionFilter{Ports: map[uint16]struct{}{}}
 
+		// retrieve valid IPs
 		if strings.Contains(ip, "/") {
-			ipv4, subnet, err := net.ParseCIDR(ip)
+			_, subnet, err := net.ParseCIDR(ip)
 			if err != nil {
 				log.Debugf("Could not parse %s", err)
 			}
-			conn.IP, conn.CIDR = ipv4.String(), subnet
+			conn.IP = subnet
+		} else if strings.Contains(ip, ":") {
+			_, subnet, err := net.ParseCIDR(ip + "/64") // if given ipv6, prefix length of 64
+			if err != nil {
+				log.Debugf("Could not parse %s", err)
+			}
+			conn.IP = subnet
+
+		} else {
+			_, subnet, err := net.ParseCIDR(ip + "/32") // if given ipv4, prefix length of 32
+			if err != nil {
+				log.Debugf("Could not parse given IPs: %s", err)
+			}
+			conn.IP = subnet
+		}
+
+		// convert and store given ports
+		for _, v := range ports {
+			k, err := strconv.ParseUint(v, 10, 16)
+			if err != nil {
+				log.Debugf("Could not parse given ports: %s", err)
+				continue
+			}
+			conn.Ports[uint16(k)] = struct{}{}
 		}
 		blacklist = append(blacklist, conn)
 	}
 	return blacklist
 }
 
-// determine whether we should be excluding a source or destination connection
-func newNetworkFilter(direction string) (networkFilter []*Connection) {
-	if direction == "source" {
-		networkFilter = parseBlacklist(config.Datadog.GetStringMapStringSlice("system_probe_config.excluded_source_connections"))
-	} else if direction == "destination" {
-		networkFilter = parseBlacklist(config.Datadog.GetStringMapStringSlice("system_probe_config.excluded_destination_connections"))
-	}
-	return networkFilter
-}
-
 // IsBlacklistedConnection returns true if a given connection should be excluded
 // by the tracer based on user defined filters
-func IsBlacklistedConnection(dir string, addrIP Address, addrPort uint16) bool {
+func IsBlacklistedConnection(c []*ConnectionFilter, addrIP Address, addrPort uint16) bool {
 	ip := NetIPFromAddress(addrIP)
-	port := strconv.Itoa(int(addrPort))
 
-	if nf := newNetworkFilter(dir); len(nf) > 0 {
-		for _, conn := range nf {
-			// see if we should exclude this IP
-			if conn.CIDR != nil && conn.CIDR.Contains(ip) || conn.IP == ip.String() {
-				switch {
-				case slice.ContainsString(conn.Ports, "*") || len(conn.Ports) == 0:
-					return true
-				case slice.ContainsString(conn.Ports, port):
+	if len(c) > 0 {
+		for _, conn := range c {
+			if conn.IP != nil && conn.IP.Contains(ip) {
+				if _, ok := conn.Ports[addrPort]; ok {
 					return true
 				}
-			}
-			// see if we should exclude this port across all connections
-			if (strings.Contains(conn.IP, "*") || len(conn.IP) == 0) && slice.ContainsString(conn.Ports, port) {
-				return true
 			}
 		}
 	}

--- a/pkg/process/util/network_filter.go
+++ b/pkg/process/util/network_filter.go
@@ -10,81 +10,93 @@ import (
 
 // ConnectionFilter holds a user-defined blacklisted IP/CIDR, and ports
 type ConnectionFilter struct {
-	IP    *net.IPNet
-	Ports map[uint16]struct{}
+	IP       *net.IPNet
+	Ports    map[uint16]struct{}
+	AllPorts bool
 }
 
 // ParseConnectionFilters takes the user defined blacklist and returns a slice of ConnectionFilters
 func ParseConnectionFilters(filters map[string][]string) (blacklist []*ConnectionFilter) {
-out:
 	for ip, ports := range filters {
-		conn := &ConnectionFilter{Ports: map[uint16]struct{}{}}
+		filter := &ConnectionFilter{Ports: map[uint16]struct{}{}}
 		var subnet *net.IPNet
 		var err error
-		var ignorePorts bool
 
 		// retrieve valid IPs
-		if strings.ContainsRune(ip, 42) {
+		if strings.ContainsRune(ip, '*') {
 			subnet = nil // use for wildcard
-		} else if strings.ContainsRune(ip, 47) {
+		} else if strings.ContainsRune(ip, '/') {
 			_, subnet, err = net.ParseCIDR(ip)
-		} else if strings.ContainsRune(ip, 58) {
+		} else if strings.ContainsRune(ip, '.') {
+			_, subnet, err = net.ParseCIDR(ip + "/32") // if given ipv4, prefix length of 32
+		} else if strings.Contains(ip, "::") {
 			_, subnet, err = net.ParseCIDR(ip + "/64") // if given ipv6, prefix length of 64
 		} else {
-			_, subnet, err = net.ParseCIDR(ip + "/32") // if given ipv4, prefix length of 32
+			log.Debugf("Invalid IP/CIDR/* defined for connection filter: %s", err)
+			continue
 		}
 
 		if err != nil {
 			log.Debugf("Could not parse given IPs: %s", err)
 			continue
 		}
-		conn.IP = subnet
+		filter.IP = subnet
 
-		// convert and store given ports
+		validFilter := true
 		for _, v := range ports {
-			// look for wildcard
-			if strings.ContainsRune(v, 42) {
-				ignorePorts = true
+			if v == "*" {
+				// This means that IP + port are both *, which effectively blacklists all conns, which is invalid.
+				if subnet == nil {
+					log.Debugf("Invalid filter with IP/CIDR as * and port as *: %s", err)
+					validFilter = false
+					break
+				}
+
+				filter.AllPorts = true
 				continue
 			}
 
+			// The defined port is an integer, lets handle that
 			k, err := strconv.ParseUint(v, 10, 16)
 			if err != nil {
 				log.Debugf("Could not parse list of ports: %s", err)
-				continue out
+				validFilter = false
 			}
-			conn.Ports[uint16(k)] = struct{}{}
+			filter.Ports[uint16(k)] = struct{}{}
 		}
 
-		// declare empty ports if wildcard is found
-		if ignorePorts {
-			conn.Ports = map[uint16]struct{}{}
+		if validFilter {
+			blacklist = append(blacklist, filter)
 		}
-		blacklist = append(blacklist, conn)
 	}
 	return blacklist
 }
 
 // IsBlacklistedConnection returns true if a given connection should be excluded
 // by the tracer based on user defined filters
-func IsBlacklistedConnection(c []*ConnectionFilter, addrIP Address, addrPort uint16) bool {
+func IsBlacklistedConnection(cf []*ConnectionFilter, addrIP Address, addrPort uint16) bool {
 	ip := NetIPFromAddress(addrIP)
 
-	if len(c) > 0 {
-		for _, conn := range c {
-			switch {
-			case conn.IP == nil:
-				if _, ok := conn.Ports[addrPort]; ok {
-					return true
-				}
-			case conn.IP.Contains(ip):
-				if _, ok := conn.Ports[addrPort]; ok {
-					return true
-				} else if len(conn.Ports) == 0 {
-					return true
-				}
+	// No filters so short-circuit
+	if len(cf) == 0 {
+		return false
+	}
+
+	// Iterate through filters to see if this connection matches any defined filter.
+	for _, filter := range cf {
+		// IP is wildcard (*) so only ports are defined
+		if filter.IP == nil {
+			if _, ok := filter.Ports[addrPort]; ok {
+				return true
+			}
+		} else if filter.IP.Contains(ip) {
+			if filter.AllPorts {
+				return true
+			} else if _, ok := filter.Ports[addrPort]; ok {
+				return true
 			}
 		}
 	}
+
 	return false
 }

--- a/pkg/process/util/network_filter.go
+++ b/pkg/process/util/network_filter.go
@@ -14,7 +14,7 @@ type ConnectionFilter struct {
 	Ports map[uint16]struct{}
 }
 
-// takes the user defined blacklist and returns a slice of ConnectionFilters
+// ParseBlacklist takes the user defined blacklist and returns a slice of ConnectionFilters
 func ParseBlacklist(filters map[string][]string) (blacklist []*ConnectionFilter) {
 	for ip, ports := range filters {
 		conn := &ConnectionFilter{Ports: map[uint16]struct{}{}}

--- a/pkg/process/util/network_filter.go
+++ b/pkg/process/util/network_filter.go
@@ -37,7 +37,7 @@ func ParseConnectionFilters(filters map[string][]string) (blacklist []*Connectio
 		}
 
 		if err != nil {
-			log.Debugf("Could not parse given IPs: %s", err)
+			log.Errorf("Given filter will not be respected. Could not parse given IPs: %s", err)
 			continue
 		}
 		filter.IP = subnet
@@ -47,7 +47,7 @@ func ParseConnectionFilters(filters map[string][]string) (blacklist []*Connectio
 			if v == "*" {
 				// This means that IP + port are both *, which effectively blacklists all conns, which is invalid.
 				if subnet == nil {
-					log.Debugf("Invalid filter with IP/CIDR as * and port as *: %s", err)
+					log.Errorf("Given rule will not be respected. Invalid filter with IP/CIDR as * and port as *: %s", err)
 					validFilter = false
 					break
 				}

--- a/pkg/process/util/network_filter.go
+++ b/pkg/process/util/network_filter.go
@@ -49,19 +49,22 @@ func newNetworkFilter(direction string) (networkFilter []*Connection) {
 // IsBlacklistedConnection returns true if a given connection should be excluded
 // by the tracer based on user defined filters
 func IsBlacklistedConnection(dir string, addrIP Address, addrPort uint16) bool {
+	ip := NetIPFromAddress(addrIP)
+	port := strconv.Itoa(int(addrPort))
+
 	if nf := newNetworkFilter(dir); len(nf) > 0 {
 		for _, conn := range nf {
 			// see if we should exclude this IP
-			if conn.CIDR != nil && conn.CIDR.Contains(net.ParseIP(addrIP.String())) || conn.IP == addrIP.String() {
+			if conn.CIDR != nil && conn.CIDR.Contains(ip) || conn.IP == ip.String() {
 				switch {
 				case slice.ContainsString(conn.Ports, "*") || len(conn.Ports) == 0:
 					return true
-				case slice.ContainsString(conn.Ports, strconv.Itoa(int(addrPort))):
+				case slice.ContainsString(conn.Ports, port):
 					return true
 				}
 			}
 			// see if we should exclude this port across all connections
-			if (strings.Contains(conn.IP, "*") || len(conn.IP) == 0) && slice.ContainsString(conn.Ports, strconv.Itoa(int(addrPort))) {
+			if (strings.Contains(conn.IP, "*") || len(conn.IP) == 0) && slice.ContainsString(conn.Ports, port) {
 				return true
 			}
 		}

--- a/pkg/process/util/network_filter.go
+++ b/pkg/process/util/network_filter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/stew/slice"
 )
 
+// Connection holds a user-defined blacklisted IP, CIDR, and ports
 type Connection struct {
 	IP    string
 	CIDR  *net.IPNet

--- a/pkg/process/util/network_filter.go
+++ b/pkg/process/util/network_filter.go
@@ -14,41 +14,51 @@ type ConnectionFilter struct {
 	Ports map[uint16]struct{}
 }
 
-// ParseBlacklist takes the user defined blacklist and returns a slice of ConnectionFilters
-func ParseBlacklist(filters map[string][]string) (blacklist []*ConnectionFilter) {
+// ParseConnectionFilters takes the user defined blacklist and returns a slice of ConnectionFilters
+func ParseConnectionFilters(filters map[string][]string) (blacklist []*ConnectionFilter) {
+out:
 	for ip, ports := range filters {
 		conn := &ConnectionFilter{Ports: map[uint16]struct{}{}}
+		var subnet *net.IPNet
+		var err error
+		var ignorePorts bool
 
 		// retrieve valid IPs
-		if strings.Contains(ip, "/") {
-			_, subnet, err := net.ParseCIDR(ip)
-			if err != nil {
-				log.Debugf("Could not parse %s", err)
-			}
-			conn.IP = subnet
-		} else if strings.Contains(ip, ":") {
-			_, subnet, err := net.ParseCIDR(ip + "/64") // if given ipv6, prefix length of 64
-			if err != nil {
-				log.Debugf("Could not parse %s", err)
-			}
-			conn.IP = subnet
-
+		if strings.ContainsRune(ip, 42) {
+			subnet = nil // use for wildcard
+		} else if strings.ContainsRune(ip, 47) {
+			_, subnet, err = net.ParseCIDR(ip)
+		} else if strings.ContainsRune(ip, 58) {
+			_, subnet, err = net.ParseCIDR(ip + "/64") // if given ipv6, prefix length of 64
 		} else {
-			_, subnet, err := net.ParseCIDR(ip + "/32") // if given ipv4, prefix length of 32
-			if err != nil {
-				log.Debugf("Could not parse given IPs: %s", err)
-			}
-			conn.IP = subnet
+			_, subnet, err = net.ParseCIDR(ip + "/32") // if given ipv4, prefix length of 32
 		}
+
+		if err != nil {
+			log.Debugf("Could not parse given IPs: %s", err)
+			continue
+		}
+		conn.IP = subnet
 
 		// convert and store given ports
 		for _, v := range ports {
-			k, err := strconv.ParseUint(v, 10, 16)
-			if err != nil {
-				log.Debugf("Could not parse given ports: %s", err)
+			// look for wildcard
+			if strings.ContainsRune(v, 42) {
+				ignorePorts = true
 				continue
 			}
+
+			k, err := strconv.ParseUint(v, 10, 16)
+			if err != nil {
+				log.Debugf("Could not parse list of ports: %s", err)
+				continue out
+			}
 			conn.Ports[uint16(k)] = struct{}{}
+		}
+
+		// declare empty ports if wildcard is found
+		if ignorePorts {
+			conn.Ports = map[uint16]struct{}{}
 		}
 		blacklist = append(blacklist, conn)
 	}
@@ -62,8 +72,15 @@ func IsBlacklistedConnection(c []*ConnectionFilter, addrIP Address, addrPort uin
 
 	if len(c) > 0 {
 		for _, conn := range c {
-			if conn.IP != nil && conn.IP.Contains(ip) {
+			switch {
+			case conn.IP == nil:
 				if _, ok := conn.Ports[addrPort]; ok {
+					return true
+				}
+			case conn.IP.Contains(ip):
+				if _, ok := conn.Ports[addrPort]; ok {
+					return true
+				} else if len(conn.Ports) == 0 {
 					return true
 				}
 			}

--- a/pkg/process/util/network_filter.go
+++ b/pkg/process/util/network_filter.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/stretchr/stew/slice"
+)
+
+type Connection struct {
+	IP    string
+	CIDR  *net.IPNet
+	Ports []string
+}
+
+// takes the user defined blacklist and returns a slice of Connections
+func parseBlacklist(filters map[string][]string) (blacklist []*Connection) {
+	for ip, ports := range filters {
+		conn := &Connection{
+			IP:    ip,
+			Ports: ports,
+		}
+
+		if strings.Contains(ip, "/") {
+			ipv4, subnet, err := net.ParseCIDR(ip)
+			if err != nil {
+				log.Debugf("Could not parse %s", err)
+			}
+			conn.IP, conn.CIDR = ipv4.String(), subnet
+		}
+		blacklist = append(blacklist, conn)
+	}
+	return blacklist
+}
+
+// determine whether we should be excluding a source or destination connection
+func newNetworkFilter(direction string) (networkFilter []*Connection) {
+	if direction == "source" {
+		networkFilter = parseBlacklist(config.Datadog.GetStringMapStringSlice("system_probe_config.excluded_source_connections"))
+	} else if direction == "destination" {
+		networkFilter = parseBlacklist(config.Datadog.GetStringMapStringSlice("system_probe_config.excluded_destination_connections"))
+	}
+	return networkFilter
+}
+
+// IsBlacklistedConnection returns true if a given connection should be excluded
+// by the tracer based on user defined filters
+func IsBlacklistedConnection(dir string, addrIP Address, addrPort uint16) bool {
+	if nf := newNetworkFilter(dir); len(nf) > 0 {
+		for _, conn := range nf {
+			// see if we should exclude this IP
+			if conn.CIDR != nil && conn.CIDR.Contains(net.ParseIP(addrIP.String())) || conn.IP == addrIP.String() {
+				switch {
+				case slice.ContainsString(conn.Ports, "*") || len(conn.Ports) == 0:
+					return true
+				case slice.ContainsString(conn.Ports, strconv.Itoa(int(addrPort))):
+					return true
+				}
+			}
+			// see if we should exclude this port across all connections
+			if (strings.Contains(conn.IP, "*") || len(conn.IP) == 0) && slice.ContainsString(conn.Ports, strconv.Itoa(int(addrPort))) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/process/util/network_filter_test.go
+++ b/pkg/process/util/network_filter_test.go
@@ -13,6 +13,7 @@ var testSourceFilters = map[string][]string{
 	"::7f00:35:0:0": {"443"},  // ipv6
 	"10.0.0.10":     {"3333", "*"},
 	"10.0.0.25":     {"30", "ABCD"}, // invalid config
+	"123.ABCD":      {"*"},          // invalid config
 }
 
 var testDestinationFilters = map[string][]string{
@@ -35,6 +36,7 @@ func TestParseConnectionFilters(t *testing.T) {
 	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("10.0.0.10"), uint16(6666)))    // port wildcard
 	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("10.0.0.10"), uint16(33)))
 	assert.False(t, IsBlacklistedConnection(sourceList, AddressFromString("10.0.0.25"), uint16(30))) // bad port config
+	assert.False(t, IsBlacklistedConnection(sourceList, AddressFromString("123.ABCD"), uint16(30)))  // bad IP config
 
 	// destination
 	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("10.0.0.5"), uint16(8080)))

--- a/pkg/process/util/network_filter_test.go
+++ b/pkg/process/util/network_filter_test.go
@@ -9,19 +9,18 @@ import (
 
 var testSourceFilters = map[string][]string{
 	"172.0.0.1":     {"80", "10", "443"},
-	"172.0.1.2":     {"*"},
-	"*":             {"9000"},
-	"::7f00:35:0:0": {"443"},
-	"10.0.0.10":     {"3333", "bad-port@#!"},
+	"*":             {"9000"}, // only port 9000
+	"::7f00:35:0:0": {"443"},  // ipv6
+	"10.0.0.10":     {"3333", "*"},
+	"10.0.0.25":     {"30", "ABCD"}, // invalid config
 }
 
 var testDestinationFilters = map[string][]string{
 	"10.0.0.0/24":      {"8080", "8081", "10255"},
-	"169.254.170.2":    {"5005"},
-	"":                 {"1234"},
+	"":                 {"1234"}, // invalid config
 	"2001:db8::2:1":    {"5001"},
 	"2001:db8::2:1/55": {"80"},
-	"*":                {"9000"},
+	"*":                {"*"}, // invalid config
 }
 
 func TestParseConnectionFilters(t *testing.T) {
@@ -29,28 +28,46 @@ func TestParseConnectionFilters(t *testing.T) {
 	destList := ParseConnectionFilters(testDestinationFilters)
 
 	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("172.0.0.1"), uint16(10)))
-	assert.False(t, IsBlacklistedConnection(sourceList, AddressFromString("172.0.0.2"), uint16(10)))
-	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("172.0.1.2"), uint16(10001)))
-	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("*"), uint16(9000)))
+	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("*"), uint16(9000))) // only port 9000
+	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("10.0.1.24"), uint16(9000)))
 	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("::7f00:35:0:0"), uint16(443))) // ipv6
-	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("0"), uint16(443)))             // == ::7f00:35:0:0
-	assert.False(t, IsBlacklistedConnection(sourceList, AddressFromString("10.0.0.10"), uint16(3333)))   // bad port
+	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("0"), uint16(443)))             // 0 == ::7f00:35:0:0
+	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("10.0.0.10"), uint16(6666)))    // port wildcard
+	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("10.0.0.10"), uint16(33)))
+	assert.False(t, IsBlacklistedConnection(sourceList, AddressFromString("10.0.0.25"), uint16(30))) // bad port config
 
 	// destination
 	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("10.0.0.5"), uint16(8080)))
-	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("169.254.170.2"), uint16(5005)))
+	assert.False(t, IsBlacklistedConnection(destList, AddressFromString("10.0.0.5"), uint16(80)))
 	assert.False(t, IsBlacklistedConnection(destList, AddressFromString(""), uint16(1234)))
-	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("2001:db8::2:1"), uint16(5001)))
-	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("2001:db8::5:1"), uint16(80)))
-	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("123.4.5.6"), uint16(9000)))
+	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("2001:db8::2:1"), uint16(5001))) // ipv6
+	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("2001:db8::5:1"), uint16(80)))   // ipv6 CIDR
+	assert.False(t, IsBlacklistedConnection(destList, AddressFromString("*"), uint16(30)))
+
 }
 
 var sink bool
 
-func BenchmarkIsBlacklistedConnection(b *testing.B) {
+func BenchmarkIsBlacklistedConnectionIPv4(b *testing.B) {
 	sourceList := ParseConnectionFilters(testSourceFilters)
 	destList := ParseConnectionFilters(testDestinationFilters)
 	addrs := randIPv4(6)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, addr := range addrs {
+			sink = IsBlacklistedConnection(sourceList, addr, uint16(rand.Intn(9999)))
+			sink = IsBlacklistedConnection(destList, addr, uint16(rand.Intn(9999)))
+		}
+	}
+
+}
+
+func BenchmarkIsBlacklistedConnectionIPv6(b *testing.B) {
+	sourceList := ParseConnectionFilters(testSourceFilters)
+	destList := ParseConnectionFilters(testDestinationFilters)
+	addrs := randIPv6(6)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/pkg/process/util/network_filter_test.go
+++ b/pkg/process/util/network_filter_test.go
@@ -8,28 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var filters = map[string][]string{
-	"172.0.0.1": []string{
-		"80",
-		"10",
-		"443",
-	},
-	"172.0.1.2": []string{},
-	"10.0.0.0/24": []string{
-		"8080",
-		"8081",
-		"10255",
-	},
-	"*": []string{
-		"9000",
-	},
-	"169.254.170.2": []string{
-		"*",
-	},
+var testFilters = map[string][]string{
+	"172.0.0.1":     {"80", "10", "443"},
+	"172.0.1.2":     {},
+	"10.0.0.0/24":   {"8080", "8081", "10255"},
+	"*":             {"9000"},
+	"169.254.170.2": {"*"},
 }
 
 func TestParseBlacklist(t *testing.T) {
-	config.Datadog.SetDefault("system_probe_config.excluded_source_connections", filters)
+	config.Datadog.SetDefault("system_probe_config.excluded_source_connections", testFilters)
 	parseBlacklist(config.Datadog.GetStringMapStringSlice("system_probe_config.excluded_source_connections"))
 
 	assert.True(t, IsBlacklistedConnection("source", AddressFromString("172.0.0.1"), uint16(10)))
@@ -76,11 +64,11 @@ func TestNewNetworkFilter(t *testing.T) {
 	s = newNetworkFilter("invalid")
 	assert.Empty(t, s)
 
-	config.Datadog.SetDefault("system_probe_config.excluded_source_connections", filters)
+	config.Datadog.SetDefault("system_probe_config.excluded_source_connections", testFilters)
 	s = newNetworkFilter("source")
 	assert.Equal(t, len(s), len(connections))
 
-	config.Datadog.SetDefault("system_probe_config.excluded_destination_connections", filters)
+	config.Datadog.SetDefault("system_probe_config.excluded_destination_connections", testFilters)
 	d := newNetworkFilter("destination")
 	assert.Equal(t, len(d), len(connections))
 }

--- a/pkg/process/util/network_filter_test.go
+++ b/pkg/process/util/network_filter_test.go
@@ -1,0 +1,86 @@
+package util
+
+import (
+	"net"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+var filters = map[string][]string{
+	"172.0.0.1": []string{
+		"80",
+		"10",
+		"443",
+	},
+	"172.0.1.2": []string{},
+	"10.0.0.0/24": []string{
+		"8080",
+		"8081",
+		"10255",
+	},
+	"*": []string{
+		"9000",
+	},
+	"169.254.170.2": []string{
+		"*",
+	},
+}
+
+func TestParseBlacklist(t *testing.T) {
+	config.Datadog.SetDefault("system_probe_config.excluded_source_connections", filters)
+	parseBlacklist(config.Datadog.GetStringMapStringSlice("system_probe_config.excluded_source_connections"))
+
+	assert.True(t, IsBlacklistedConnection("source", AddressFromString("172.0.0.1"), uint16(10)))
+	assert.True(t, IsBlacklistedConnection("source", AddressFromString("172.0.1.2"), uint16(8080)))
+	assert.True(t, IsBlacklistedConnection("source", AddressFromString("10.0.0.5"), uint16(8080)))
+	assert.True(t, IsBlacklistedConnection("source", AddressFromString("169.254.170.2"), uint16(5005)))
+	assert.True(t, IsBlacklistedConnection("source", AddressFromString("125.0.0.3"), uint16(9000)))
+
+	assert.False(t, IsBlacklistedConnection("source", AddressFromString("10.0.0.256"), uint16(8081)))
+	assert.False(t, IsBlacklistedConnection("source", AddressFromString("127.0.0.1"), uint16(443)))
+	assert.False(t, IsBlacklistedConnection("invalid", AddressFromString("localhost"), uint16(3333)))
+}
+
+func TestNewNetworkFilter(t *testing.T) {
+	_, subnet, _ := net.ParseCIDR("10.0.0.0/24")
+	connections := []*Connection{
+		{
+			IP:    "172.0.0.1",
+			CIDR:  nil,
+			Ports: []string{"80", "10", "443"},
+		}, {
+			IP:    "172.0.1.2",
+			CIDR:  nil,
+			Ports: []string{}, // what if nil?
+		}, {
+			IP:    "10.0.0.0",
+			CIDR:  subnet,
+			Ports: []string{"8080", "8081", "10255"},
+		}, {
+			IP:    "",
+			CIDR:  nil,
+			Ports: []string{"9000"},
+		}, {
+			IP:    "169.254.170.2",
+			CIDR:  nil,
+			Ports: []string{"*"},
+		},
+	}
+
+	config.Datadog.SetDefault("system_probe_config.excluded_source_connections", map[string][]string{})
+	s := newNetworkFilter("source")
+	assert.Empty(t, s)
+
+	s = newNetworkFilter("invalid")
+	assert.Empty(t, s)
+
+	config.Datadog.SetDefault("system_probe_config.excluded_source_connections", filters)
+	s = newNetworkFilter("source")
+	assert.Equal(t, len(s), len(connections))
+
+	config.Datadog.SetDefault("system_probe_config.excluded_destination_connections", filters)
+	d := newNetworkFilter("destination")
+	assert.Equal(t, len(d), len(connections))
+}

--- a/pkg/process/util/network_filter_test.go
+++ b/pkg/process/util/network_filter_test.go
@@ -28,7 +28,6 @@ func TestParseConnectionFilters(t *testing.T) {
 	sourceList := ParseConnectionFilters(testSourceFilters)
 	destList := ParseConnectionFilters(testDestinationFilters)
 
-	// source
 	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("172.0.0.1"), uint16(10)))
 	assert.False(t, IsBlacklistedConnection(sourceList, AddressFromString("172.0.0.2"), uint16(10)))
 	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("172.0.1.2"), uint16(10001)))

--- a/pkg/process/util/network_filter_test.go
+++ b/pkg/process/util/network_filter_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,9 +9,10 @@ import (
 
 var testSourceFilters = map[string][]string{
 	"172.0.0.1":     {"80", "10", "443"},
-	"172.0.1.2":     {},
+	"172.0.1.2":     {"*"},
 	"*":             {"9000"},
 	"::7f00:35:0:0": {"443"},
+	"10.0.0.10":     {"3333", "bad-port@#!"},
 }
 
 var testDestinationFilters = map[string][]string{
@@ -19,18 +21,21 @@ var testDestinationFilters = map[string][]string{
 	"":                 {"1234"},
 	"2001:db8::2:1":    {"5001"},
 	"2001:db8::2:1/55": {"80"},
+	"*":                {"9000"},
 }
 
-func TestParseBlacklist(t *testing.T) {
-	sourceList := ParseBlacklist(testSourceFilters)
-	destList := ParseBlacklist(testDestinationFilters)
+func TestParseConnectionFilters(t *testing.T) {
+	sourceList := ParseConnectionFilters(testSourceFilters)
+	destList := ParseConnectionFilters(testDestinationFilters)
 
 	// source
 	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("172.0.0.1"), uint16(10)))
 	assert.False(t, IsBlacklistedConnection(sourceList, AddressFromString("172.0.0.2"), uint16(10)))
-	assert.False(t, IsBlacklistedConnection(sourceList, AddressFromString("*"), uint16(9000)))
+	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("172.0.1.2"), uint16(10001)))
+	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("*"), uint16(9000)))
 	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("::7f00:35:0:0"), uint16(443))) // ipv6
 	assert.True(t, IsBlacklistedConnection(sourceList, AddressFromString("0"), uint16(443)))             // == ::7f00:35:0:0
+	assert.False(t, IsBlacklistedConnection(sourceList, AddressFromString("10.0.0.10"), uint16(3333)))   // bad port
 
 	// destination
 	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("10.0.0.5"), uint16(8080)))
@@ -38,4 +43,38 @@ func TestParseBlacklist(t *testing.T) {
 	assert.False(t, IsBlacklistedConnection(destList, AddressFromString(""), uint16(1234)))
 	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("2001:db8::2:1"), uint16(5001)))
 	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("2001:db8::5:1"), uint16(80)))
+	assert.True(t, IsBlacklistedConnection(destList, AddressFromString("123.4.5.6"), uint16(9000)))
+}
+
+var sink bool
+
+func BenchmarkIsBlacklistedConnection(b *testing.B) {
+	sourceList := ParseConnectionFilters(testSourceFilters)
+	destList := ParseConnectionFilters(testDestinationFilters)
+	addrs := randIPv4(6)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, addr := range addrs {
+			sink = IsBlacklistedConnection(sourceList, addr, uint16(rand.Intn(9999)))
+			sink = IsBlacklistedConnection(destList, addr, uint16(rand.Intn(9999)))
+		}
+	}
+}
+
+func randIPv4(count int) (addrs []Address) {
+	for i := 0; i < count; i++ {
+		r := rand.Intn(999999999) + 999999
+		addrs = append(addrs, V4Address(uint32(r)))
+	}
+	return addrs
+}
+
+func randIPv6(count int) (addrs []Address) {
+	for i := 0; i < count; i++ {
+		r := rand.Intn(999999999) + 999999
+		addrs = append(addrs, V6Address(uint64(r), uint64(r)))
+	}
+	return addrs
 }

--- a/releasenotes/notes/blacklist-connections-12e099d3647b69f0.yaml
+++ b/releasenotes/notes/blacklist-connections-12e099d3647b69f0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Allows the user to blacklist source and destination connections by passing IPs or CIDRs as well as port numbers.


### PR DESCRIPTION
### What does this PR do?

Allows a user to blacklist connections (via IPs, CIDR, and ports) on the system-probe. 

Example user config: 
```yaml
system_probe_config.source_excludes: 
  127.0.0.1:
    - 5005
    - 8126
  172.0.0.1/20:
    - "*"
  "*":
    - 4003
system_probe_config.dest_excludes: 
  2001:db8::2:1:
    - 443
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
