### PR TITLE
[windows] adds missing system.mem.pagefile.* stats back

### DIFF
--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -572,6 +572,6 @@ will change from the GCE instance _name_ to the full GCE instance _hostname_ (wh
 
 _Only affects Windows Agents_
 
-When running the agent on Windows Agent 5, the metrics _system.mem.pagefile.*_ display inconsistent units (they're off by 10^6).
+When running the Windows Agent 5, the metrics _system.mem.pagefile.*_ display inconsistent units (they're off by 10^6).
 This problem has been fixed on Windows Agent6; however, the Agent 5 discrepancy remains for backwards compatibility.  Therefore,
 reported values (and associated monitors) will be different upon upgrade from Agent v5 to Agent v6.

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -23,7 +23,8 @@ open an issue or submit a Pull Request.
   * [Custom Checks](#custom-checks)
 * [JMX](#jmx)
 * [GCE hostname](#gce-hostname)
-
+* [System Metrics](#system-metrics)
+  
 ## Configuration Files
 
 Prior releases of Datadog Agent stored configuration files in `/etc/dd-agent`.
@@ -566,3 +567,11 @@ will change from the GCE instance _name_ to the full GCE instance _hostname_ (wh
 [python-dev]: https://github.com/DataDog/datadog-agent/tree/master/docs/dev/checks#python-checks
 [config]: config.md
 [integrations-core]: https://github.com/DataDog/integrations-core
+
+## System Metrics
+
+_Only affects Windows Agents_
+
+When running the agent on Windows Agent 5, the metrics _system.mem.pagefile.*_ display inconsistent units (they're off by 10^6).
+This problem has been fixed on Windows Agent6; however, the Agent 5 discrepancy remains for backwards compatibility.  Therefore,
+reported values (and associated monitors) will be different upon upgrade from Agent v5 to Agent v6.

--- a/pkg/collector/corechecks/system/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory_windows.go
@@ -123,6 +123,9 @@ func (c *MemoryCheck) Run() error {
 	p, errPage := pageMemory()
 	if errPage == nil {
 		sender.Gauge("system.mem.pagefile.pct_free", float64(100-p.UsedPercent)/100, "", nil)
+		sender.Gauge("system.mem.pagefile.total", float64(p.Total)/mbSize, "", nil)
+		sender.Gauge("system.mem.pagefile.free", float64(p.Available)/mbSize, "", nil)
+		sender.Gauge("system.mem.pagefile.used", float64(p.Used)/mbSize, "", nil)
 	} else {
 		log.Errorf("system.MemoryCheck: could not retrieve swap memory stats: %s", errSwap)
 	}

--- a/pkg/collector/corechecks/system/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory_windows_test.go
@@ -61,6 +61,9 @@ func TestMemoryCheckWindows(t *testing.T) {
 	mock.On("Gauge", "system.swap.pct_free", 0.6, "", []string(nil)).Return().Times(1)
 
 	mock.On("Gauge", "system.mem.pagefile.pct_free", 0.5, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.pagefile.total", 120000/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.pagefile.used", 30000/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.pagefile.free", 90000/mbSize, "", []string(nil)).Return().Times(1)
 
 	mock.On("Commit").Return().Times(1)
 
@@ -68,6 +71,6 @@ func TestMemoryCheckWindows(t *testing.T) {
 	require.Nil(t, err)
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 10)
+	mock.AssertNumberOfCalls(t, "Gauge", 13)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }

--- a/releasenotes/notes/syspagefile-18e12a984bfa51b6.yaml
+++ b/releasenotes/notes/syspagefile-18e12a984bfa51b6.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On Windows, adds system.mem.pagefile.* stats, previously available
+    only in Agent 5.


### PR DESCRIPTION
### What does this PR do?

Adds windows pagefile stats 

