### PR TITLE
pkg/trace/{api,agent}: merge all container tags into _dd.tags.container

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -26,7 +26,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const processStatsInterval = time.Minute
+// tagContainersTags specifies the name of the tag which holds key/value
+// pairs representing information about the container (Docker, EC2, etc).
+const tagContainersTags = "_dd.tags.container"
 
 // Agent struct holds all the sub-routines structs and make the data flow between them
 type Agent struct {
@@ -195,8 +197,8 @@ func (a *Agent) Process(t *api.Trace) {
 		sampler.SetPreSampleRate(root, rateLimiterRate)
 		sampler.AddGlobalRate(root, rateLimiterRate)
 
-		for k, v := range t.ContainerTags {
-			root.Meta[k] = v
+		if t.ContainerTags != "" {
+			root.Meta[tagContainersTags] = t.ContainerTags
 		}
 	}
 

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -159,16 +159,12 @@ func TestProcess(t *testing.T) {
 		}
 
 		agnt.Process(&api.Trace{
-			Spans:  pb.Trace{span},
-			Source: &info.Tags{},
-			ContainerTags: map[string]string{
-				"A": "B",
-				"C": "",
-			},
+			Spans:         pb.Trace{span},
+			Source:        &info.Tags{},
+			ContainerTags: "A:B,C",
 		})
 
-		assert.Equal(t, "B", span.Meta["A"])
-		assert.Equal(t, "", span.Meta["C"])
+		assert.Equal(t, "A:B,C", span.Meta[tagContainersTags])
 	})
 
 	t.Run("Stats/Priority", func(t *testing.T) {


### PR DESCRIPTION
This change puts all container tags concatenated using the comma
separator into the a single tag called `_dd.tags.container`.