### PR TITLE
Set explicit patch target

### DIFF
--- a/omnibus/config/software/pip2.rb
+++ b/omnibus/config/software/pip2.rb
@@ -13,7 +13,7 @@ relative_path "pip-#{version}"
 build do
   ship_license "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
 
-  patch :source => "remove-python27-deprecation-warning.patch"
+  patch :source => "remove-python27-deprecation-warning.patch", :target => "src/pip/_internal/cli/base_command.py"
 
   if ohai["platform"] == "windows"
     python_bin = "#{windows_safe_path(python_2_embedded)}\\python.exe"


### PR DESCRIPTION
### What does this PR do?

Like https://github.com/DataDog/datadog-agent/blob/ac5bcc66b122b15753212bda505b63e74551e1d1/omnibus/config/software/datadog-agent-integrations-py2.rb#L248-L253

### Motivation

```
          [Builder: pip2] I | 2019-08-19T21:26:36-04:00 | Build pip2: 0.3438s
The following shell command exited with status 3:
    $ bash -c 'patch -p1 -i ../../../../dev/go/src/github.com/DataDog/datadog-agent/omnibus/config/patches/pip2/remove-python27-deprecation-warning.patch'
Output:
    patching file src/pip/_internal/cli/base_command.py
Error:
    Assertion failed: hunk, file ../patch-2.5.9-src/patch.c, line 354
```