### PR TITLE
[omnibus] Upgrade packaged python 3 on Linux/macOS to 3.7.4

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -12,10 +12,6 @@ if ohai["platform"] != "windows"
   dependency "liblzma"
   dependency "libyaml"
 
-  version "3.6.7" do
-    source :sha256 => "b7c36f7ed8f7143b2c46153b7332db2227669f583ea0cce753facf549d1a4239"
-  end
-
   version "3.7.4" do
     source :sha256 => "d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3"
   end

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -12,11 +12,8 @@ if ohai["platform"] != "windows"
   dependency "liblzma"
   dependency "libyaml"
 
-  version "3.7.4" do
-    source :sha256 => "d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3"
-  end
-
-  source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz"
+  source :sha256 => "d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3",
+         :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz"
 
   relative_path "Python-#{version}"
 

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,6 +1,6 @@
 name "python3"
 
-default_version "3.7.1"
+default_version "3.7.4"
 
 if ohai["platform"] != "windows"
   dependency "libffi"
@@ -16,8 +16,8 @@ if ohai["platform"] != "windows"
     source :sha256 => "b7c36f7ed8f7143b2c46153b7332db2227669f583ea0cce753facf549d1a4239"
   end
 
-  version "3.7.1" do
-    source :sha256 => "36c1b81ac29d0f8341f727ef40864d99d8206897be96be73dc34d4739c9c9f06"
+  version "3.7.4" do
+    source :sha256 => "d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3"
   end
 
   source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz"
@@ -66,7 +66,6 @@ if ohai["platform"] != "windows"
 
 else
   dependency "vc_redist_14"
-  default_version "3.7.4"
 
   if windows_arch_i386?
     dependency "vc_ucrt_redist"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -12,8 +12,8 @@ if ohai["platform"] != "windows"
   dependency "liblzma"
   dependency "libyaml"
 
-  source :sha256 => "d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3",
-         :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz"
+  source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
+         :sha256 => "d63e63e14e6d29e17490abbe6f7d17afb3db182dbd801229f14e55f4157c4ba3"
 
   relative_path "Python-#{version}"
 


### PR DESCRIPTION
### What does this PR do?

Upgrades packaged python 3 on Linux/macOS to latest 3.7.4

### Motivation

Ship the latest python 3. Includes the latest security fixes. See https://docs.python.org/3.7/whatsnew/changelog.html#python-3-7-4-final for details.

Also, brings the version on Linux/macOS in line with packaged python 3 version on
Windows.