### PR TITLE
Fix configcheck crash when agent not ready (again)

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -541,7 +541,7 @@ func (ac *AutoConfig) resolveTemplateForService(tpl integration.Config, svc list
 
 // GetLoadedConfigs returns configs loaded
 func (ac *AutoConfig) GetLoadedConfigs() map[string]integration.Config {
-	if ac.store == nil {
+	if ac == nil || ac.store == nil {
 		log.Error("Autoconfig store not initialized")
 		return map[string]integration.Config{}
 	}


### PR DESCRIPTION
We were already checking for `ac.store == nil`, but actually the `store`
field gets initialized as soon as the AutoConfig is created [1], so we should
really check for `ac` itself being null.

The original fix was added in #3602

[1] https://github.com/DataDog/datadog-agent/blob/master/pkg/autodiscovery/autoconfig.go#L80