### PR TITLE
Enhance short lived container autodiscovery

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -101,7 +101,10 @@ func (ac *AutoConfig) serviceListening() {
 		case svc := <-ac.newService:
 			ac.processNewService(svc)
 		case svc := <-ac.delService:
-			ac.processDelService(svc)
+			// delay service removal for short lived service detection
+			time.AfterFunc(5*time.Second, func() {
+				ac.processDelService(svc)
+			})
 		case <-tagFreshnessTicker.C:
 			ac.checkTagFreshness()
 		}

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -39,7 +39,7 @@ type DockerConfigProvider struct {
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
 func NewDockerConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
 	return &DockerConfigProvider{
-		// periodically resync if we're missing events
+		// periodically resync every 30 runs if we're missing events
 		syncInterval: 30,
 	}, nil
 }
@@ -61,7 +61,8 @@ func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 	}
 
 	var containers map[string]map[string]string
-	// on the first run we collect all labels, then rely on events
+	// on the first run we collect all labels, then rely on individual events to
+	// avoid listing all containers too often
 	if d.labelCache == nil || d.syncCounter == d.syncInterval {
 		containers, err = d.dockerUtil.AllContainerLabels()
 		if err != nil {

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -9,6 +9,7 @@ package providers
 
 import (
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -25,16 +26,22 @@ const (
 // DockerConfigProvider implements the ConfigProvider interface for the docker labels.
 type DockerConfigProvider struct {
 	sync.RWMutex
-	dockerUtil *docker.DockerUtil
-	upToDate   bool
-	streaming  bool
-	health     *health.Handle
+	dockerUtil   *docker.DockerUtil
+	upToDate     bool
+	streaming    bool
+	health       *health.Handle
+	labelCache   map[string]map[string]string
+	syncInterval int
+	syncCounter  int
 }
 
 // NewDockerConfigProvider returns a new ConfigProvider connected to docker.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
 func NewDockerConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
-	return &DockerConfigProvider{}, nil
+	return &DockerConfigProvider{
+		// periodically resync if we're missing events
+		syncInterval: 30,
+	}, nil
 }
 
 // String returns a string representation of the DockerConfigProvider
@@ -53,12 +60,21 @@ func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 		go d.listen()
 	}
 
-	containers, err := d.dockerUtil.AllContainerLabels()
-	if err != nil {
-		return []integration.Config{}, err
+	var containers map[string]map[string]string
+	// on the first run we collect all labels, then rely on events
+	if d.labelCache == nil || d.syncCounter == d.syncInterval {
+		containers, err = d.dockerUtil.AllContainerLabels()
+		if err != nil {
+			return []integration.Config{}, err
+		}
+		d.labelCache = containers
+		d.syncCounter = 0
+	} else {
+		containers = d.labelCache
 	}
 
 	d.Lock()
+	d.syncCounter += 1
 	d.upToDate = true
 	d.Unlock()
 
@@ -88,13 +104,27 @@ CONNECT:
 				// only these two event types will change what containers appear.
 				// Container labels cannot change once they are created, so we don't need to react on
 				// other lifecycle events.
-				if ev.Action == "start" || ev.Action == "die" {
-					d.Lock()
-					d.upToDate = false
-					d.Unlock()
+				if ev.Action == "start" {
+					container, err := d.dockerUtil.Inspect(ev.ContainerID, false)
+					if err != nil {
+						log.Warnf("Error inspecting container: %s", err)
+					} else {
+						d.Lock()
+						d.labelCache[ev.ContainerID] = container.Config.Labels
+						d.upToDate = false
+						d.Unlock()
+					}
+				} else if ev.Action == "die" {
+					// delay for short lived detection
+					time.AfterFunc(5*time.Second, func() {
+						d.Lock()
+						delete(d.labelCache, ev.ContainerID)
+						d.upToDate = false
+						d.Unlock()
+					})
 				}
 			case err := <-errChan:
-				log.Warnf("error getting docker events: %s", err)
+				log.Warnf("Error getting docker events: %s", err)
 				d.Lock()
 				d.upToDate = false
 				d.Unlock()

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const unreadinessTimeout = 30 * time.Second
+const unreadinessTimeout = 25 * time.Second
 
 // PodWatcher regularly pools the kubelet for new/changed/removed containers.
 // It keeps an internal state to only send the updated pods.
@@ -163,7 +163,7 @@ func (w *PodWatcher) Expire() ([]string, error) {
 		}
 	}
 	for id, lastSeenReady := range w.lastSeenReady {
-		// we keep pods gone unready for 30 seconds and then force removal
+		// we keep pods gone unready for 25 seconds and then force removal
 		if now.Sub(lastSeenReady) > unreadinessTimeout {
 			delete(w.lastSeenReady, id)
 			expiredContainers = append(expiredContainers, id)


### PR DESCRIPTION
### What does this PR do?

* Rework the docker config provider to avoid listing all containers too often
* Add delay in service & docker config removal for better short-lived container detection

### Motivation

What inspired you to submit this pull request?

### Additional Notes

e2e ✅ 
