### PR TITLE
Make Python 3 linter timeout configurable

### DIFF
--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -263,6 +263,10 @@ func reportPy3Warnings(checkName string, checkFilePath string) {
 			metricValue = 1.0
 		} else {
 			status = a7TagNotReady
+			log.Warnf("The Python 3 linter returned the following warnings for check '%s':", checkName)
+			for _, warning := range warnings {
+				log.Warn(warning)
+			}
 		}
 	}
 	py3Warnings[checkName] = status

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -257,6 +257,7 @@ func reportPy3Warnings(checkName string, checkFilePath string) {
 
 		if warnings, err := validatePython3(checkName, checkFilePath); err != nil {
 			status = a7TagUnknown
+			log.Errorf("Failed to validate Python 3 linting for check '%s': '%s'", checkName, err)
 		} else if len(warnings) == 0 {
 			status = a7TagReady
 			metricValue = 1.0

--- a/pkg/collector/python/py3_checker.go
+++ b/pkg/collector/python/py3_checker.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	linterTimeout = time.Duration(config.DataDog.GetInt("python3_linter_timeout")) * time.Second
+	linterTimeout = time.Duration(config.Datadog.GetInt("python3_linter_timeout")) * time.Second
 )
 
 func init() {

--- a/pkg/collector/python/py3_checker.go
+++ b/pkg/collector/python/py3_checker.go
@@ -16,11 +16,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
 var (
-	linterTimeout = 4 * time.Second
+	linterTimeout = config.DataDog.GetInt("python3_linter_timeout") * time.Second
 )
 
 func init() {

--- a/pkg/collector/python/py3_checker.go
+++ b/pkg/collector/python/py3_checker.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	linterTimeout = config.DataDog.GetInt("python3_linter_timeout") * time.Second
+	linterTimeout = time.Duration(config.DataDog.GetInt("python3_linter_timeout")) * time.Second
 )
 
 func init() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -130,6 +130,9 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("c_stacktrace_collection", false)
 	config.BindEnvAndSetDefault("c_core_dump", false)
 
+	// Python 3 linter timeout, in seconds
+	config.BindEnvAndSetDefault("python3_linter_timeout", 8)
+
 	// if/when the default is changed to true, make the default platform
 	// dependent; default should remain false on Windows to maintain backward
 	// compatibility with Agent5 behavior/win


### PR DESCRIPTION
### What does this PR do?

The Python 3 default linter timeout has been set to 8s, and the option is now configurable in the `datadog.yaml` configuration file.

### Motivation

The 4s timeout for the Python 3 linter is not enough for some custom checks which take a really long time to be linted.

### Additional Notes

Does this warrant a release note?
Should we advertise this option in the template `datadog.yaml` file?