### PR TITLE
Doc: add a mention to the DD_CLUSTER_AGENT_URL variable

### DIFF
--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -135,7 +135,8 @@ func (c *DCAClient) ClusterAgentAPIEndpoint() string {
 }
 
 // getClusterAgentEndpoint provides a validated https endpoint from configuration keys in datadog.yaml:
-// 1st. configuration key "cluster_agent.url", add the https prefix if the scheme isn't specified
+// 1st. configuration key "cluster_agent.url" (or the DD_CLUSTER_AGENT_URL environment variable),
+//      add the https prefix if the scheme isn't specified
 // 2nd. environment variables associated with "cluster_agent.kubernetes_service_name"
 //      ${dcaServiceName}_SERVICE_HOST and ${dcaServiceName}_SERVICE_PORT
 func getClusterAgentEndpoint() (string, error) {


### PR DESCRIPTION
### What does this PR do?

Adds a mention of the DD_CLUSTER_AGENT_URL variable in the comment to save time to people trying to change the url the clean way.

### Motivation

We had some issues with the cluster agent who couldn't reach himself on the service IP because we don't enable hairpin so I was looking for a way to overwrite easily the cluster agent url. As we only use environment variables to change our configuration, I thought it would be worth mentioning in this comment the corresponding environment variable to avoid the guess game.