### PR TITLE
do not delete domain user on uninstall

### DIFF
--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -424,16 +424,20 @@ UINT doUninstallAs(MSIHANDLE hInstall, UNINSTALL_TYPE t)
     {
         std::string usershort;
         toMbcs(usershort, installedUser.c_str());
-        WcaLog(LOGMSG_STANDARD, "This install installed user %s, will remove", usershort.c_str());
+        WcaLog(LOGMSG_STANDARD, "This install installed user %s", usershort.c_str());
         installedUserPtr = installedUser.c_str();
         if (installState.getStringValue(installCreatedDDDomain.c_str(), installedDomain)) {
             installedDomainPtr = installedDomain.c_str();
             toMbcs(usershort, installedDomainPtr);
-            WcaLog(LOGMSG_STANDARD, "Removing user from domain %s", usershort);
+            WcaLog(LOGMSG_STANDARD, "NOT Removing user from domain %s", usershort);
+            WcaLog(LOGMSG_STANDARD, "Domain user can be removed.");
             installedComplete = installedDomain + L"\\";
+        } else {
+            WcaLog(LOGMSG_STANDARD, "Will delete user %s from local user store", usershort.c_str());
+            willDeleteUser = true;
         }
         installedComplete += installedUser;
-        willDeleteUser = true;
+        
     }
 
     if (willDeleteUser)

--- a/releasenotes/notes/nodeluser-cd95639a7760eb58.yaml
+++ b/releasenotes/notes/nodeluser-cd95639a7760eb58.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    On Windows, during an uninstall, if the user context for the datadog agent
+    is a domain user, the user will no longer be deleted even when the user 
+    was created by the corresponding install.


### PR DESCRIPTION
[windows] when uninstalling in an environment where a domain user was
used as the dd agent user context, do not attempt to delete the user


### Motivation

The original behavior created complexity with install/uninstall order across machines.
While this does leave an artifact of datadog after uninstall, it should overall have a better UX

### Additional Notes

Anything else we should know when reviewing?
