### PR TITLE
pkg/trace/api: improve and instrument TCP connection rate limiter

### DIFF
--- a/releasenotes/notes/apm-tcp-connection-metrics-02e916ff1ba27fbb.yaml
+++ b/releasenotes/notes/apm-tcp-connection-metrics-02e916ff1ba27fbb.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Incoming TCP connections are now measured in the datadog.trace_agent.receiver.tcp_connections
+    metrics with a "status" tag having values: "accepted", "rejected", "timedout" and "errored".


### PR DESCRIPTION
This change simplifies the TCP connection rate limiter by removing the
unnecessary timeout and introducing metrics for incoming TCP connections
with a `status` tag having the potential values: `accepted`, `rejected`,
`timedout` and `errored`.

The timeout loop was removed because the HTTP server [already handles it
better internally](https://github.com/golang/go/blob/go1.12/src/net/http/server.go#L2858-L2877), along with the deadline, which introduced an unnecessary
repetitive loop. It might be that whoever implemented this a couple of years
ago misunderstood the use of SetDeadline for listeners.