### PR TITLE
[logs] Release file descriptor on file rotation when tailer is stuck

### DIFF
--- a/releasenotes/notes/logs-fix-file-descriptor-leak-on-file-rotation-97a86526151321fd.yaml
+++ b/releasenotes/notes/logs-fix-file-descriptor-leak-on-file-rotation-97a86526151321fd.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - | 
+    Fix files descriptor leak when tailing a logs file with file rotation and
+    the tailer is stuck for instance because of lost connectivity with the logs
+    intake endpoint.


### PR DESCRIPTION
### What does this PR do?

Close the tailer on file rotation even it is stuck to prevent file descriptor leak.

### Motivation

Some customers have been reporting to us cases where the agent keep file descriptors on rotated files causing disk space issue when the connectivity with the logs intake is lost. 

### Additional Notes

NA
