### PR TITLE
[cmd/agent] Pass pointer to json.Unmarshal

### DIFF
--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -159,7 +159,7 @@ func makeRequest(url string) ([]byte, error) {
 	r, e := util.DoGet(c, url)
 	if e != nil {
 		var errMap = make(map[string]string)
-		json.Unmarshal(r, errMap)
+		json.Unmarshal(r, &errMap)
 		// If the error has been marshalled into a json object, check it and return it properly
 		if err, found := errMap["error"]; found {
 			e = fmt.Errorf(err)


### PR DESCRIPTION
### What does this PR do?

Pass a pointer to `json.Unmarshal` instead of a value in `makeRequest`.

### Motivation

Fix unit tests (`go vet` fails because of this).

