### PR TITLE
 Allow configurable GCE metadata tag exclusion

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -308,6 +308,7 @@ func initConfig(config Config) {
 
 	// GCE
 	config.BindEnvAndSetDefault("collect_gce_tags", true)
+	config.BindEnvAndSetDefault("exclude_gce_tags", []string{"kube-env", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings"})
 
 	// Cloud Foundry
 	config.BindEnvAndSetDefault("cloud_foundry", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -158,6 +158,24 @@ api_key:
 #
 # collect_gce_tags: true
 
+## @param exclude_gce_tags - list of strings - optional - default: ["kube-env", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings"]
+## Google Cloud Engine metadata attribute to exclude from being converted into host tags -- only applicable when collect_gce_tags is true
+#
+# exclude_gce_tags:
+#   - "kube-env"
+#   - "startup-script"
+#   - "shutdown-script"
+#   - "configure-sh"
+#   - "sshKeys"
+#   - "ssh-keys"
+#   - "user-data"
+#   - "cli-cert"
+#   - "ipsec-cert"
+#   - "ssl-cert"
+#   - "google-container-manifest"
+#   - "bosh_settings"
+ 
+
 {{ end }}
 {{- if .Agent }}
 

--- a/pkg/util/gce/gce_tags.go
+++ b/pkg/util/gce/gce_tags.go
@@ -11,11 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-)
 
-// Slice of attributes to exclude from the tags (because they're too long, useless or sensitive)
-var excludedAttributes = []string{"kube-env", "startup-script", "shutdown-script", "configure-sh",
-	"sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings"}
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
 
 // GetTags gets the tags from the GCE api
 func GetTags() ([]string, error) {
@@ -68,6 +66,8 @@ func GetTags() ([]string, error) {
 
 // isAttributeExcluded returns whether the attribute key should be excluded from the tags
 func isAttributeExcluded(attr string) bool {
+
+	excludedAttributes := config.Datadog.GetStringSlice("exclude_gce_tags")
 	for _, excluded := range excludedAttributes {
 		if attr == excluded {
 			return true


### PR DESCRIPTION
### What does this PR do?

The GCE integration makes requests to the metadata endpoint of a node in order to gather some attribute information. It then adds some of this information as tags on a metric (things like `zone`, `project-name`, etc...). In that code is a hardcoded list of attributes which should be filtered out as they aren't particularly useful. This PR makes that list configurable by moving it into configuration rather than having it be hardcoded.

### Motivation

Some of our metrics have tags which aren't useful to us and they come from this integration. I'd like to filter them out to reduce the cardinality.

### Additional Notes

I tried to write a test but it is currently failing. I can't seem to get the `config.Mock()` object to be used when trying to override the configurable value I added. I copied this logic from another test which works fine and after trying various things, I'm a little mystified. I don't write a lot of (read: any) Go, so I'm certainly at a disadvantage here. Hoping someone who is a bit more familiar with how this works can show me the right direction. I'm sure I'm just missing something silly.