### PR TITLE
[omnibus] python2 shared-libs (again) w/ new builders

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ variables:
   S3_OMNIBUS_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-cache-build-stable
   S3_DSD6_URI: s3://dsd6-staging/linux
   RELEASE_VERSION: nightly
-  DATADOG_AGENT_BUILDIMAGES: v1614107-913f0a9
+  DATADOG_AGENT_BUILDIMAGES: v1631023-f2ae59b
   DATADOG_AGENT_BUILDERS: v1613952-f072482
 
 

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -48,7 +48,8 @@ if ohai["platform"] != "windows"
                           "CC=clang",
                           "MACOSX_DEPLOYMENT_TARGET=10.12")
   elsif linux?
-    python_configure.push("--enable-unicode=ucs4")
+    python_configure.push("--enable-unicode=ucs4",
+                          "--enable-shared")
   end
 
   build do


### PR DESCRIPTION
### What does this PR do?

Build python2 in shared lib mode again (after reverting), requires new builders.

### Motivation

We want a shared build.