### PR TITLE
Log issues with networkID at Info level

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -149,7 +149,7 @@ func getMeta() *Meta {
 func getNetworkMeta() *NetworkMeta {
 	nid, err := util.GetNetworkID()
 	if err != nil {
-		log.Errorf("could not get network metadata: %s", err)
+		log.Infof("could not get network metadata: %s", err)
 		return nil
 	}
 	return &NetworkMeta{ID: nid}


### PR DESCRIPTION
# What does this PR do?

The networkID flag is optional, and it's okay if not detected. We should not log at such a scary level.


### Motivation

### Additional Notes
