### PR TITLE
[omnibus][python3] Remove embedded Python 3 test directory

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -48,7 +48,7 @@ if ohai["platform"] != "windows"
     command python_configure.join(" "), :env => env
     command "make -j #{workers}", :env => env
     command "make install", :env => env
-    # delete "#{install_dir}/embedded/lib/python2.7/test"
+    delete "#{install_dir}/embedded/lib/python3.7/test"
 
     # There exists no configure flag to tell Python to not compile readline support :(
     major, minor, bugfix = version.split(".")


### PR DESCRIPTION
### What does this PR do?

The `embedded/lib/python3.7/test` folder contains source files and compiled files for
core Python libraries' tests. We remove them for Python 2, and we should
do the same for Python 3 (installed size decreases by 60MB for the MacOS dmgs, 20MB for the deb and rpm packages).

### Motivation

Shrink Agent installed size.

