### PR TITLE
Make agent_log take a const string

### DIFF
--- a/rtloader/common/log.c
+++ b/rtloader/common/log.c
@@ -14,7 +14,7 @@ void _set_log_cb(cb_log_t cb)
 
 // Logs a message to the agent logger. Caller is in charge of freeing the
 // message if needed.
-void agent_log(log_level_t log_level, char *message) {
+void agent_log(log_level_t log_level, const char *message) {
     if (cb_log == NULL || message == NULL) {
         return;
     }

--- a/rtloader/common/log.h
+++ b/rtloader/common/log.h
@@ -27,12 +27,12 @@ extern "C" {
 */
 void _set_log_cb(cb_log_t);
 
-/*! \fn void agent_log( log_level_t, char *)
+/*! \fn void agent_log( log_level_t, const char *)
     \brief Logs the message to the agent loggers.
     \param log_level_t The log level to use to log the message.
-    \param char* A pointer to the message.
+    \param const char* A pointer to the message.
 */
-void agent_log(log_level_t, char *);
+void agent_log(log_level_t, const char *);
 
 #ifdef __cplusplus
 }

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -116,7 +116,7 @@ typedef void (*cb_get_clustername_t)(char **);
 // (tracemalloc_enabled)
 typedef bool (*cb_tracemalloc_enabled_t)(void);
 // (message, level)
-typedef void (*cb_log_t)(char *, int);
+typedef void (*cb_log_t)(const char *, int);
 // (hostname, source_type_name, list of tags)
 typedef void (*cb_set_external_tags_t)(char *, char *, char **);
 


### PR DESCRIPTION
So we can use it to log string literals.

Eg: `agent_log(DATADOG_AGENT_ERROR, "This is an error")` wouldn't compile before.
