### PR TITLE
Fix memory allocation/free & memtrack on windows

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -293,6 +293,7 @@ func Initialize(paths ...string) error {
 		}
 		return err
 	}
+	C.initMemoryModuleTracker(rtloader)
 
 	// Set the PYTHONPATH if needed.
 	for _, p := range paths {
@@ -305,7 +306,6 @@ func Initialize(paths ...string) error {
 		log.Warnf("unable to complete platform-specific initialization - should be non-fatal")
 	}
 
-	C.initMemoryModuleTracker(rtloader)
 	// Setup custom builtin before RtLoader initialization
 	C.initCgoFree(rtloader)
 	C.initLogger(rtloader)

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -50,6 +50,14 @@ void initMemoryTracker(void) {
 }
 
 //
+// init memory tracking facilities method
+//
+void initMemoryModuleTracker(rtloader_t *rtloader) {
+	set_rtloader_memory_tracker_cb(rtloader, MemoryTracker);
+}
+
+
+//
 // init free method
 //
 // On windows we need to free memory in the same DLL where it was allocated.
@@ -297,6 +305,7 @@ func Initialize(paths ...string) error {
 		log.Warnf("unable to complete platform-specific initialization - should be non-fatal")
 	}
 
+	C.initMemoryModuleTracker(rtloader)
 	// Setup custom builtin before RtLoader initialization
 	C.initCgoFree(rtloader)
 	C.initLogger(rtloader)

--- a/rtloader/common/rtloader_mem.c
+++ b/rtloader/common/rtloader_mem.c
@@ -6,6 +6,8 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
+#include <windows.h>
 
 // default memory management functions
 static rtloader_malloc_t rt_malloc = malloc;
@@ -27,7 +29,6 @@ void *_malloc(size_t sz) {
     if (ptr && cb_memory_tracker) {
         cb_memory_tracker(ptr, sz, DATADOG_AGENT_RTLOADER_ALLOCATION);
     }
-
     return ptr;
 }
 

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -55,7 +55,18 @@ DATADOG_AGENT_RTLOADER_API rtloader_t *make3(const char *pythonhome, char **erro
 
     The callback is expected to be provided by the rtloader caller - in go-context: CGO.
 */
+
+/*! \fn void set_memory_tracker_cb(cb_memory_tracker_t)
+    \brief Sets a callback to be used by rtloader for some memory allocation book-keeping.
+    \param rtloader pointer to the rtloader instance for which memory allocation tracking
+                    will be enabled
+    \param object A function pointer to the callback function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
 DATADOG_AGENT_RTLOADER_API void set_memory_tracker_cb(cb_memory_tracker_t);
+
+DATADOG_AGENT_RTLOADER_API void set_rtloader_memory_tracker_cb(rtloader_t *rtloader, cb_memory_tracker_t cb);
 
 // API
 /*! \fn void destroy(rtloader_t *rtloader)

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -46,6 +46,12 @@ public:
     */
     virtual bool init() = 0;
 
+    //! Pure virtual set_memory_tracker_db member.
+    /*!
+      This member sets the callback interface for memory allocation/deallocation
+      tracking
+      */
+    virtual void set_memory_tracker_cb(cb_memory_tracker_t cb) = 0;
     //! Pure virtual addPythonPath member.
     /*!
       This method adds a python path to the underlying python runtime.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -135,7 +135,7 @@ public:
       \param pointer the memory region on the heap we wish to free.
       Helper member to free heap memory.
     */
-    void free(void *);
+    virtual void free(void *) = 0;
 
     //! Pure virtual decref member.
     /*!

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -224,6 +224,11 @@ int init(rtloader_t *rtloader)
     return AS_TYPE(RtLoader, rtloader)->init() ? 1 : 0;
 }
 
+void set_rtloader_memory_tracker_cb(rtloader_t *rtloader, cb_memory_tracker_t cb)
+{
+    AS_TYPE(RtLoader, rtloader)->set_memory_tracker_cb(cb);
+}
+
 py_info_t *get_py_info(rtloader_t *rtloader)
 {
     return AS_TYPE(RtLoader, rtloader)->getPyInfo();

--- a/rtloader/rtloader/rtloader.cpp
+++ b/rtloader/rtloader/rtloader.cpp
@@ -134,10 +134,3 @@ void RtLoader::clearError()
     _errorFlag = false;
     _error = "";
 }
-
-void RtLoader::free(void *ptr)
-{
-    if (ptr != NULL) {
-        _free(ptr);
-    }
-}

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -124,6 +124,12 @@ done:
     return _baseClass != NULL;
 }
 
+void Three::set_memory_tracker_cb(cb_memory_tracker_t cb)
+{
+#ifdef _WIN32
+    ::_set_memory_tracker_cb(cb);
+#endif
+}
 /**
  * getPyInfo()
  */

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -756,6 +756,13 @@ bool Three::getAttrString(RtLoaderPyObject *obj, const char *attributeName, char
     return res;
 }
 
+void Three::free(void *ptr)
+{
+    if (ptr != NULL) {
+        _free(ptr);
+    }
+}
+
 void Three::decref(RtLoaderPyObject *obj)
 {
     Py_XDECREF(reinterpret_cast<PyObject *>(obj));

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -56,6 +56,7 @@ public:
     ~Three();
 
     bool init();
+    void set_memory_tracker_cb(cb_memory_tracker_t cb);
     bool addPythonPath(const char *path);
     rtloader_gilstate_t GILEnsure();
     void GILRelease(rtloader_gilstate_t);

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -69,6 +69,7 @@ public:
 
     char *runCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);
+    void free(void *ptr);
     void decref(RtLoaderPyObject *obj);
     void incref(RtLoaderPyObject *obj);
     void setModuleAttrString(char *module, char *attr, char *value);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -124,6 +124,12 @@ done:
     return _baseClass != NULL;
 }
 
+void Two::set_memory_tracker_cb(cb_memory_tracker_t cb)
+{
+#ifdef _WIN32
+    ::_set_memory_tracker_cb(cb);
+#endif
+}
 py_info_t *Two::getPyInfo()
 {
     PyObject *sys = NULL;

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -756,6 +756,12 @@ bool Two::getAttrString(RtLoaderPyObject *obj, const char *attributeName, char *
     Py_XDECREF(py_attr);
     return res;
 }
+void Two::free(void *ptr)
+{
+    if (ptr != NULL) {
+        _free(ptr);
+    }
+}
 
 void Two::decref(RtLoaderPyObject *obj)
 {

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -55,6 +55,7 @@ public:
     ~Two();
 
     bool init();
+    void set_memory_tracker_cb(cb_memory_tracker_t cb);
     bool addPythonPath(const char *path);
     rtloader_gilstate_t GILEnsure();
     void GILRelease(rtloader_gilstate_t);

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -68,6 +68,7 @@ public:
 
     char *runCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);
+    void free(void *ptr);
     void decref(RtLoaderPyObject *obj);
     void incref(RtLoaderPyObject *obj);
     void setModuleAttrString(char *module, char *attr, char *value);


### PR DESCRIPTION
### What does this PR do?

Modifies the supplied `free()` to track all the way through to the two/three implementation


### Motivation

Memory tracking wasn't working properly on Windows
Memory allocations/frees weren't being handled in same module, which could be a problem

### Additional Notes

Anything else we should know when reviewing?
