### PR TITLE
Fix upstart scripts to not stop the system-probe when agent stops

### DIFF
--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -1,7 +1,6 @@
 description "Datadog System Probe"
 
-start on started datadog-agent
-stop on (runlevel [!2345] or stopping datadog-agent)
+stop on (runlevel [!2345])
 
 respawn
 respawn limit 10 5

--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -1,5 +1,6 @@
 description "Datadog System Probe"
 
+start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -1,7 +1,6 @@
 description "Datadog System Probe"
 
-start on started datadog-agent
-stop on (runlevel [!2345] or stopping datadog-agent)
+stop on (runlevel [!2345])
 
 respawn
 respawn limit 10 5

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -1,5 +1,6 @@
 description "Datadog System Probe"
 
+start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn


### PR DESCRIPTION
### What does this PR do?

Fixes a bug with upstart based systems where restarting the agent killed the system-probe process but did not restart it.

### Motivation


### Additional Notes

