### PR TITLE
Fixed a race condition for docker logs for short lived containers

### DIFF
--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -171,11 +171,8 @@ func (t *Tailer) readForever() {
 			if err != nil { // an error occurred, stop from reading new logs
 				switch {
 				case isReaderClosed(err):
-					// The reader has been closed during the shut down process of the tailer
-					// because as stated in the code base of docker:
-					// "It's up to the caller to close the stream.".
-					// See here for more information:
-					// https://github.com/moby/moby/blob/master/client/container_logs.go
+					// The reader has been closed during the shut down process
+					// of the tailer, stop reading
 					return
 				case isContextCanceled(err):
 					log.Debugf("Restarting reader for container %v after a read timeout", ShortContainerID(t.ContainerID))
@@ -275,7 +272,7 @@ func isContextCanceled(err error) bool {
 	return err == context.Canceled
 }
 
-// isReaderClosed returns true if the read has been closed.
+// isReaderClosed returns true if a reader has been closed.
 func isReaderClosed(err error) bool {
 	return strings.Contains(err.Error(), "http: read on closed response body")
 }


### PR DESCRIPTION
### What does this PR do?

* Fixed a race condition where docker logs would not be collected for short lived containers because the socket was returning `EOF` because no logs were outputted yet.

* Fixed another race condition which was making the tailer restart on a reader close error when the tailer was supposed to stop.

### Motivation

Make sure logs for short lived containers are properly collected.

### Additional Notes

Let's add end-to-end tests to make sure we don't have regression on this, we can't write a unit-test yet because we did not mock the docket client, e.g. https://github.com/DataDog/datadog-agent/pull/3981

This should fix https://github.com/DataDog/datadog-agent/issues/3955