### PR TITLE
[memtrack] performance optimization - dont get stack unless necessary

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -260,7 +260,9 @@ func Initialize(paths ...string) error {
 	pythonVersion := config.Datadog.GetString("python_version")
 
 	// memory related RTLoader-global initialization
-	C.initMemoryTracker()
+	if config.Datadog.GetBool("memtrack_enabled") {
+		C.initMemoryTracker()
+	}
 
 	detectPythonLocation(pythonVersion)
 

--- a/pkg/collector/python/memory.go
+++ b/pkg/collector/python/memory.go
@@ -68,7 +68,7 @@ func MemoryTracker(ptr unsafe.Pointer, sz C.size_t, op C.rtloader_mem_ops_t) {
 		bytes, ok := pointerCache.Load(ptr)
 		if !ok {
 			log.Debugf("untracked memory was attempted to be freed - set trace level for details")
-			lvl, err := log.GetCurrentLogLevel()
+			lvl, err := log.GetLogLevel()
 			if err == nil && lvl == seelog.TraceLvl {
 				stack := string(debug.Stack())
 				log.Tracef("Memory Tracker - stacktrace: \n%s", stack)

--- a/pkg/collector/python/memory.go
+++ b/pkg/collector/python/memory.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	_ "github.com/benesch/cgosymbolizer"
+	"github.com/cihub/seelog"
 )
 
 /*
@@ -68,7 +69,7 @@ func MemoryTracker(ptr unsafe.Pointer, sz C.size_t, op C.rtloader_mem_ops_t) {
 		if !ok {
 			log.Debugf("untracked memory was attempted to be freed - set trace level for details")
 			lvl, err := log.GetCurrentLogLevel()
-			if err == nil && lvl == "trace" {
+			if err == nil && lvl == seelog.TraceLvl {
 				stack := string(debug.Stack())
 				log.Tracef("Memory Tracker - stacktrace: \n%s", stack)
 			}

--- a/pkg/collector/python/memory.go
+++ b/pkg/collector/python/memory.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	_ "github.com/benesch/cgosymbolizer"
 )
@@ -54,7 +55,7 @@ func init() {
 //export MemoryTracker
 func MemoryTracker(ptr unsafe.Pointer, sz C.size_t, op C.rtloader_mem_ops_t) {
 	// run sync for reliability reasons
-	log.Debugf("Memory Tracker - ptr: %v, sz: %v, op: %v", ptr, sz, op)
+	log.Tracef("Memory Tracker - ptr: %v, sz: %v, op: %v", ptr, sz, op)
 	switch op {
 	case C.DATADOG_AGENT_RTLOADER_ALLOCATION:
 		pointerCache.Store(ptr, sz)
@@ -65,7 +66,7 @@ func MemoryTracker(ptr unsafe.Pointer, sz C.size_t, op C.rtloader_mem_ops_t) {
 	case C.DATADOG_AGENT_RTLOADER_FREE:
 		bytes, ok := pointerCache.Load(ptr)
 		if !ok {
-			log.Debugf("untracked memory was attempted to be freed")
+			log.Debugf("untracked memory was attempted to be freed - set trace level for details")
 			lvl, err := log.GetCurrentLogLevel()
 			if err == nil && lvl == "trace" {
 				stack := string(debug.Stack())
@@ -84,7 +85,10 @@ func MemoryTracker(ptr unsafe.Pointer, sz C.size_t, op C.rtloader_mem_ops_t) {
 
 func TrackedCString(str string) *C.char {
 	cstr := C.CString(str)
-	MemoryTracker(unsafe.Pointer(cstr), C.size_t(len(str)+1), C.DATADOG_AGENT_RTLOADER_ALLOCATION)
+
+	if config.Datadog.GetBool("memtrack_enabled") {
+		MemoryTracker(unsafe.Pointer(cstr), C.size_t(len(str)+1), C.DATADOG_AGENT_RTLOADER_ALLOCATION)
+	}
 
 	return cstr
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,6 +135,7 @@ func initConfig(config Config) {
 	// Debugging + C-land crash feature flags
 	config.BindEnvAndSetDefault("c_stacktrace_collection", false)
 	config.BindEnvAndSetDefault("c_core_dump", false)
+	config.BindEnvAndSetDefault("memtrack_enabled", true)
 	config.BindEnvAndSetDefault("tracemalloc_debug", false)
 
 	// Python 3 linter timeout, in seconds

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -255,9 +255,14 @@ api_key:
 #
 # disable_py3_validation: false
 #
+## @param memtrack_enabled - boolean - optional - default: true
+## Enables tracking of memory allocations made from the python runtime loader.
+#
+# memtrack_enabled: true
+
 ## @param tracemalloc_debug - boolean - optional - default: false
 ## Enables debugging with tracemalloc for python checks.
-## Please not that this option is only available when python_version is set to "3".
+## Please note that this option is only available when python_version is set to "3".
 ## Additionally when this option becomes effective the number of check runners is
 ## overridden to 1.
 #

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -329,6 +329,14 @@ func (sw *DatadogLogger) criticalf(format string, params ...interface{}) error {
 	return err
 }
 
+// getLogLevel returns the current log level
+func (sw *DatadogLogger) getLogLevel() seelog.LogLevel {
+	sw.l.RLock()
+	defer sw.l.RUnlock()
+
+	return sw.level
+}
+
 func buildLogEntry(v ...interface{}) string {
 	var fmtBuffer bytes.Buffer
 
@@ -538,11 +546,11 @@ func UnregisterAdditionalLogger(n string) error {
 	return errors.New("cannot unregister: logger not initialized")
 }
 
-// GetCurrentLogLevel returns a seelog native representation of the current
+// GetLogLevel returns a seelog native representation of the current
 // log level
-func GetCurrentLogLevel() (seelog.LogLevel, error) {
+func GetLogLevel() (seelog.LogLevel, error) {
 	if logger != nil && logger.inner != nil {
-		return logger.level, nil
+		return logger.getLogLevel(), nil
 	}
 
 	// need to return something, just set to Info (expected default)

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -538,9 +538,19 @@ func UnregisterAdditionalLogger(n string) error {
 	return errors.New("cannot unregister: logger not initialized")
 }
 
+// GetCurrentLogLevel returns a string representation of the current
+// log level
+func GetCurrentLogLevel() (string, error) {
+	if logger != nil && logger.inner != nil {
+		return logger.level.String(), nil
+	}
+
+	return "", errors.New("cannot get loglevel: logger not initialized")
+}
+
 func changeLogLevel(level string) error {
 	if logger == nil {
-		return errors.New("logger initialized, cant set log-level")
+		return errors.New("cannot set log-level: logger not initialized")
 	}
 
 	return logger.changeLogLevel(level)

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -538,14 +538,15 @@ func UnregisterAdditionalLogger(n string) error {
 	return errors.New("cannot unregister: logger not initialized")
 }
 
-// GetCurrentLogLevel returns a string representation of the current
+// GetCurrentLogLevel returns a seelog native representation of the current
 // log level
-func GetCurrentLogLevel() (string, error) {
+func GetCurrentLogLevel() (seelog.LogLevel, error) {
 	if logger != nil && logger.inner != nil {
-		return logger.level.String(), nil
+		return logger.level, nil
 	}
 
-	return "", errors.New("cannot get loglevel: logger not initialized")
+	// need to return something, just set to Info (expected default)
+	return seelog.InfoLvl, errors.New("cannot get loglevel: logger not initialized")
 }
 
 func changeLogLevel(level string) error {


### PR DESCRIPTION
### What does this PR do?

Performance improvement, only get the call stack if we're actually going to log it. Put the memory tracking behind a config flag, true for now, we can set to false if memory impact still considerable. 

### Motivation

After cleaning up the function, left the stack collecting call in the hot path, with a considerable increase in CPU utilization in certain scenarios.

