### PR TITLE
[Logs]: Increase the HTTP batch size to provide larger logging throughput

### DIFF
--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	batchTimeout   = 5 * time.Second
-	maxBatchSize   = 20
+	maxBatchSize   = 200
 	maxContentSize = 1000000
 )
 


### PR DESCRIPTION
### What does this PR do?

Increase the HTTP batch size to provide larger logging throughput

### Motivation

The per channel throughput of the HTTP transport is decided by size of the request and request's round-trip-time. To cope with potential large RTT, we increase the log batch size (and hence the request size) to maintain the throughput

### Additional Notes

Anything else we should know when reviewing?
