### PR TITLE
Add platform detection using uname command

### DIFF
--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -121,7 +121,7 @@ func GetPlatform() (string, error) {
 		return strings.ToLower(string(redhatRaw)), nil
 	}
 
-	return "", fmt.Errorf("error retrieving platform, with python: %s, with lsb_release: %s, reading redhat-release: %s", pyErr, lsbErr, redhatErr)
+	return "", fmt.Errorf("error retrieving platform, with python: %s, with uname: %s, with lsb_release: %s, reading redhat-release: %s", pyErr, unameErr, lsbErr, redhatErr)
 }
 
 // IsDebugfsMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs is mounted or not

--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -106,6 +106,11 @@ func GetPlatform() (string, error) {
 		return pyOut, nil
 	}
 
+	unameOut, unameErr := execCmd("uname -a")
+	if unameErr == nil {
+		return unameOut, nil
+	}
+
 	lsbOut, lsbErr := execCmd("lsb_release", "-a")
 	if lsbErr == nil {
 		return lsbOut, nil

--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -106,7 +106,7 @@ func GetPlatform() (string, error) {
 		return pyOut, nil
 	}
 
-	unameOut, unameErr := execCmd("uname -a")
+	unameOut, unameErr := execCmd("uname", "-a")
 	if unameErr == nil {
 		return unameOut, nil
 	}


### PR DESCRIPTION
### What does this PR do?

Our current platform detection failed to detect aws linux if python is not installed on the host. This PR adds another way so in case python check failed it'll fall back to `uname -a` command, which also provides similar info.

### Motivation

@DataDog/burrito 

### Additional Notes

Anything else we should know when reviewing?
