### PR TITLE
[memtrack] two and three need to have their own references to callback

### DIFF
--- a/rtloader/common/rtloader_mem.c
+++ b/rtloader/common/rtloader_mem.c
@@ -16,23 +16,15 @@ static cb_memory_tracker_t cb_memory_tracker = NULL;
 
 void _set_memory_tracker_cb(cb_memory_tracker_t cb) {
 
-    // TODO: we build with gcc on windows so the __sync_synchronize
-    // builtin should work
-#ifndef _WIN32
     // Memory barrier for a little bit of safety on sets
     __sync_synchronize();
-#endif
     cb_memory_tracker = cb;
 }
 
 cb_memory_tracker_t _get_memory_tracker_cb(void) {
 
-    // TODO: we build with gcc on windows so the __sync_synchronize
-    // builtin should work
-#ifndef _WIN32
     // Memory barrier for a little bit of safety on gets
     __sync_synchronize();
-#endif
     return cb_memory_tracker;
 }
 

--- a/rtloader/common/rtloader_mem.c
+++ b/rtloader/common/rtloader_mem.c
@@ -15,10 +15,24 @@ static rtloader_free_t rt_free = free;
 static cb_memory_tracker_t cb_memory_tracker = NULL;
 
 void _set_memory_tracker_cb(cb_memory_tracker_t cb) {
+
+    // TODO: we build with gcc on windows so the __sync_synchronize
+    // builtin should work
+#ifndef _WIN32
+    // Memory barrier for a little bit of safety on sets
+    __sync_synchronize();
+#endif
     cb_memory_tracker = cb;
 }
 
 cb_memory_tracker_t _get_memory_tracker_cb(void) {
+
+    // TODO: we build with gcc on windows so the __sync_synchronize
+    // builtin should work
+#ifndef _WIN32
+    // Memory barrier for a little bit of safety on gets
+    __sync_synchronize();
+#endif
     return cb_memory_tracker;
 }
 

--- a/rtloader/common/rtloader_mem.c
+++ b/rtloader/common/rtloader_mem.c
@@ -18,6 +18,10 @@ void _set_memory_tracker_cb(cb_memory_tracker_t cb) {
     cb_memory_tracker = cb;
 }
 
+cb_memory_tracker_t _get_memory_tracker_cb(void) {
+    return cb_memory_tracker;
+}
+
 void *_malloc(size_t sz) {
     void *ptr = NULL;
     ptr = rt_malloc(sz);

--- a/rtloader/common/rtloader_mem.h
+++ b/rtloader/common/rtloader_mem.h
@@ -30,6 +30,15 @@ extern "C" {
 */
 void _set_memory_tracker_cb(cb_memory_tracker_t);
 
+/*! \fn cb_memory_tracker_t _set_memory_tracker_cb(void)
+    \brief Returns the callback used by rtloader for memory tracking stats.
+    \return object A function pointer to the callback function.
+
+    This function is thread unsafe, be sure to call it early on before multiple threads
+    may start using the allocator.
+*/
+cb_memory_tracker_t _get_memory_tracker_cb(void);
+
 /*! \fn void *_malloc(size_t sz)
     \brief Basic malloc wrapper that will also keep memory stats if enabled.
     \param sz the number of bytes to allocate.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -6,8 +6,8 @@
 #ifndef DATADOG_AGENT_RTLOADER_RTLOADER_H
 #define DATADOG_AGENT_RTLOADER_RTLOADER_H
 
-#include "rtloader_types.h"
 #include "rtloader_mem.h"
+#include "rtloader_types.h"
 
 #include <map>
 #include <mutex>

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -7,6 +7,7 @@
 #define DATADOG_AGENT_RTLOADER_RTLOADER_H
 
 #include "rtloader_types.h"
+#include "rtloader_mem.h"
 
 #include <map>
 #include <mutex>
@@ -32,9 +33,12 @@ class RtLoader
 {
 public:
     //! Constructor.
-    RtLoader()
+    RtLoader(cb_memory_tracker_t memtrack_cb)
         : _error()
-        , _errorFlag(false){};
+        , _errorFlag(false)
+    {
+        _set_memory_tracker_cb(memtrack_cb);
+    };
 
     //! Destructor.
     virtual ~RtLoader(){};
@@ -407,7 +411,7 @@ private:
   \param python_home A C-string path to the python home for the target python runtime.
   \return A pointer to the RtLoader instance created by the implementing function.
 */
-typedef RtLoader *(create_t)(const char *python_home);
+typedef RtLoader *(create_t)(const char *python_home, cb_memory_tracker_t memtrack_cb);
 
 /*! destroy_t function prototype
   \typedef destroy_t defines the destructor function prototype to destroy existing RtLoader instances.

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -95,7 +95,7 @@ rtloader_t *make2(const char *python_home, char **error)
     if (!create) {
         return NULL;
     }
-    return AS_TYPE(rtloader_t, create(python_home));
+    return AS_TYPE(rtloader_t, create(python_home, _get_memory_tracker_cb()));
 }
 
 rtloader_t *make3(const char *python_home, char **error)
@@ -109,7 +109,7 @@ rtloader_t *make3(const char *python_home, char **error)
     if (!create_three) {
         return NULL;
     }
-    return AS_TYPE(rtloader_t, create_three(python_home));
+    return AS_TYPE(rtloader_t, create_three(python_home, memtrack_cb));
 }
 
 /*! \fn void destroy(rtloader_t *rtloader)
@@ -162,7 +162,7 @@ rtloader_t *make2(const char *python_home, char **error)
         return NULL;
     }
 
-    return AS_TYPE(rtloader_t, create(python_home));
+    return AS_TYPE(rtloader_t, create(python_home, _get_memory_tracker_cb()));
 }
 
 rtloader_t *make3(const char *python_home, char **error)
@@ -195,7 +195,7 @@ rtloader_t *make3(const char *python_home, char **error)
         return NULL;
     }
 
-    return AS_TYPE(rtloader_t, create_three(python_home));
+    return AS_TYPE(rtloader_t, create_three(python_home, _get_memory_tracker_cb()));
 }
 
 void destroy(rtloader_t *rtloader)

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -109,7 +109,7 @@ rtloader_t *make3(const char *python_home, char **error)
     if (!create_three) {
         return NULL;
     }
-    return AS_TYPE(rtloader_t, create_three(python_home, memtrack_cb));
+    return AS_TYPE(rtloader_t, create_three(python_home, _get_memory_tracker_cb()));
 }
 
 /*! \fn void destroy(rtloader_t *rtloader)

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -21,9 +21,9 @@
 #include <algorithm>
 #include <sstream>
 
-extern "C" DATADOG_AGENT_RTLOADER_API RtLoader *create(const char *pythonHome)
+extern "C" DATADOG_AGENT_RTLOADER_API RtLoader *create(const char *pythonHome, cb_memory_tracker_t memtrack_cb)
 {
-    return new Three(pythonHome);
+    return new Three(pythonHome, memtrack_cb);
 }
 
 extern "C" DATADOG_AGENT_RTLOADER_API void destroy(RtLoader *p)
@@ -31,8 +31,8 @@ extern "C" DATADOG_AGENT_RTLOADER_API void destroy(RtLoader *p)
     delete p;
 }
 
-Three::Three(const char *python_home)
-    : RtLoader()
+Three::Three(const char *python_home, cb_memory_tracker_t memtrack_cb)
+    : RtLoader(memtrack_cb)
     , _pythonHome(NULL)
     , _baseClass(NULL)
     , _pythonPaths()

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -32,7 +32,7 @@ public:
       Basic constructor, initializes the _error string to an empty string and
       errorFlag to false and set the supplied PYTHONHOME.
     */
-    Three(const char *python_home);
+    Three(const char *python_home, cb_memory_tracker_t memtrack_cb);
 
     //! Destructor.
     /*!

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -23,9 +23,9 @@
 #include <cstdlib>
 #include <sstream>
 
-extern "C" DATADOG_AGENT_RTLOADER_API RtLoader *create(const char *pythonHome)
+extern "C" DATADOG_AGENT_RTLOADER_API RtLoader *create(const char *pythonHome, cb_memory_tracker_t memtrack_cb)
 {
-    return new Two(pythonHome);
+    return new Two(pythonHome, memtrack_cb);
 }
 
 extern "C" DATADOG_AGENT_RTLOADER_API void destroy(RtLoader *p)
@@ -33,8 +33,8 @@ extern "C" DATADOG_AGENT_RTLOADER_API void destroy(RtLoader *p)
     delete p;
 }
 
-Two::Two(const char *python_home)
-    : RtLoader()
+Two::Two(const char *python_home, cb_memory_tracker_t memtrack_cb)
+    : RtLoader(memtrack_cb)
     , _pythonHome(NULL)
     , _baseClass(NULL)
     , _pythonPaths()

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -31,7 +31,7 @@ public:
       Basic constructor, initializes the _error string to an empty string and
       errorFlag to false and set the supplied PYTHONHOME.
     */
-    Two(const char *python_home);
+    Two(const char *python_home, cb_memory_tracker_t memtrack_cb);
 
     //! Destructor.
     /*!


### PR DESCRIPTION
### What does this PR do?

This PR addresses a lingering issue in the RTLoader. `Two` and `Three` are built as shared objects and have their own copies of the memory management callback (`static`, not `extern`). This PR introduces the easy fix: at instantiation register the references to the callback logic in these copies of the callback pointer.

The better fix, possibly and time-permitting, would be to expose the callback pointer as an extern and then the shared objects might grab a reference to that extern variable. This would probably require some compiler changes and so it might not be worth for the current release.   

### Motivation

Memory tracking from `Two` or `Three` was not going to go through the tracker due to the uninitialized callback in their static copy of the variable. 
