### PR TITLE
Remove default log-level arg from jmx command

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -82,7 +82,7 @@ var (
 )
 
 func init() {
-	jmxCmd.PersistentFlags().StringVarP(&jmxLogLevel, "log-level", "l", "debug", "set the log level (default 'off') (deprecated, use the env var DD_LOG_LEVEL instead)")
+	jmxCmd.PersistentFlags().StringVarP(&jmxLogLevel, "log-level", "l", "", "set the log level (default 'debug') (deprecated, use the env var DD_LOG_LEVEL instead)")
 
 	// attach list and collect commands to jmx command
 	jmxCmd.AddCommand(jmxListCmd)
@@ -130,7 +130,7 @@ func runJmxCommand(command string) error {
 		overrides["log_level"] = jmxLogLevel
 		config.SetOverrides(overrides)
 	} else {
-		jmxLogLevel = config.GetEnv("DD_LOG_LEVEL", "off")
+		jmxLogLevel = config.GetEnv("DD_LOG_LEVEL", "debug")
 	}
 
 	overrides := make(map[string]interface{})


### PR DESCRIPTION
So the env var is used if the arg is not specified. Changed the default
to 'debug' to not change the behaviour of already installed agents.

Fixes PR: #3882