### PR TITLE
Remove spammy log when we fail formatting windows events

### DIFF
--- a/pkg/logs/input/windowsevent/eventlog.c
+++ b/pkg/logs/input/windowsevent/eventlog.c
@@ -309,7 +309,10 @@ LPWSTR FormatEvtField(EVT_HANDLE hMetadata, EVT_HANDLE hEvent, EVT_FORMAT_MESSAG
             ;
         else
         {
-            wprintf(L"EvtFormatMessage failed with %u\n", status);
+        // Remove this log because it can get very spammy. It should be using
+        // a function that will send logs to DD agent in debug / trace mode
+        // TODO(achntrl): Replace the wprintf with DD agent logger
+        //     wprintf(L"EvtFormatMessage failed with %u\n", status);
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Remove spammy log when we fail formatting windows events

### Motivation

This log is very spammy and is mostly invisible because it's not reported by the agent. We are going make it a debug log in the future

### Additional Notes

Anything else we should know when reviewing?
