### PR TITLE
pkg/trace/obfuscate: ensure double-quoted strings after assignments are obfuscated

### DIFF
--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -353,21 +353,33 @@ ORDER BY [b].[Name]`,
 		},
 		{
 			`SELECT * FROM users WHERE firstname=""`,
-			`SELECT * FROM users WHERE firstname = ""`,
+			`SELECT * FROM users WHERE firstname = ?`,
 		},
 		{
 			`SELECT * FROM users WHERE lastname=" "`,
-			`SELECT * FROM users WHERE lastname = ""`,
+			`SELECT * FROM users WHERE lastname = ?`,
 		},
 		{
 			`SELECT * FROM users WHERE lastname="	 "`,
-			`SELECT * FROM users WHERE lastname = ""`,
+			`SELECT * FROM users WHERE lastname = ?`,
 		},
 		{
 			`SELECT [b].[BlogId], [b].[Name]
 FROM [Blogs] AS [b
 ORDER BY [b].[Name]`,
 			`Non-parsable SQL query`,
+		},
+		{
+			`SELECT customer_item_list_id, customer_id FROM customer_item_list WHERE type = wishlist AND customer_id = ? AND visitor_id IS ? UNION SELECT customer_item_list_id, customer_id FROM customer_item_list WHERE type = wishlist AND customer_id IS ? AND visitor_id = "AA0DKTGEM6LRN3WWPZ01Q61E3J7ROX7O" ORDER BY customer_id DESC`,
+			"SELECT customer_item_list_id, customer_id FROM customer_item_list WHERE type = wishlist AND customer_id = ? AND visitor_id IS ? UNION SELECT customer_item_list_id, customer_id FROM customer_item_list WHERE type = wishlist AND customer_id IS ? AND visitor_id = ? ORDER BY customer_id DESC",
+		},
+		{
+			`update Orders set created = "2019-05-24 00:26:17", gross = 30.28, payment_type = "eventbrite", mg_fee = "3.28", fee_collected = "3.28", event = 59366262, status = "10", survey_type = 'direct', tx_time_limit = 480, invite = "", ip_address = "69.215.148.82", currency = 'USD', gross_USD = "30.28", tax_USD = 0.00, journal_activity_id = 4044659812798558774, eb_tax = 0.00, eb_tax_USD = 0.00, cart_uuid = "160b450e7df511e9810e0a0c06de92f8", changed = '2019-05-24 00:26:17' where id = ?`,
+			`update Orders set created = ? gross = ? payment_type = ? mg_fee = ? fee_collected = ? event = ? status = ? survey_type = ? tx_time_limit = ? invite = ? ip_address = ? currency = ? gross_USD = ? tax_USD = ? journal_activity_id = ? eb_tax = ? eb_tax_USD = ? cart_uuid = ? changed = ? where id = ?`,
+		},
+		{
+			`update Attendees set email = '626837270@qq.com', first_name = "贺新春送猪福加企鹅1054948000领98綵斤", last_name = '王子198442com体验猪多优惠', journal_activity_id = 4246684839261125564, changed = "2019-05-24 00:26:22" where id = 123`,
+			`update Attendees set email = ? first_name = ? last_name = ? journal_activity_id = ? changed = ? where id = ?`,
 		},
 	}
 

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -22,39 +22,41 @@ import (
 // list of available tokens; this list has been reduced because we don't
 // need a full-fledged tokenizer to implement a Lexer
 const (
-	EOFChar           = 0x100
-	LexError          = 57346
-	ID                = 57347
-	Limit             = 57348
-	Null              = 57349
-	String            = 57350
-	Number            = 57351
-	BooleanLiteral    = 57352
-	ValueArg          = 57353
-	ListArg           = 57354
-	Comment           = 57355
-	Variable          = 57356
-	Savepoint         = 57357
-	PreparedStatement = 57358
-	EscapeSequence    = 57359
-	NullSafeEqual     = 57360
-	LE                = 57361
-	GE                = 57362
-	NE                = 57363
-	As                = 57365
+	EOFChar  = 0x100
+	LexError = 57346 + iota
+	ID
+	Limit
+	Null
+	String
+	DoubleQuotedString
+	Number
+	BooleanLiteral
+	ValueArg
+	ListArg
+	Comment
+	Variable
+	Savepoint
+	PreparedStatement
+	EscapeSequence
+	NullSafeEqual
+	LE
+	GE
+	NE
+	As
 
-	// Filtered specifies that the given token has been discarded by one of the
-	// token filters.
-	Filtered = 57364
+	// FilteredGroupable specifies that the given token has been discarded by one of the
+	// token filters and that it is groupable together with consecutive FilteredGroupable
+	// tokens.
+	FilteredGroupable
 
-	// FilteredComma specifies that the token is a comma and was discarded by one
+	// Filtered specifies that the token is a comma and was discarded by one
 	// of the filters.
-	FilteredComma = 57366
+	Filtered
 
 	// FilteredBracketedIdentifier specifies that we are currently discarding
 	// a bracketed identifier (MSSQL).
 	// See issue https://github.com/DataDog/datadog-trace-agent/issues/475.
-	FilteredBracketedIdentifier = 57367
+	FilteredBracketedIdentifier
 )
 
 // Tokenizer is the struct used to generate SQL
@@ -173,7 +175,7 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 		case '\'':
 			return tkn.scanString(ch, String)
 		case '"':
-			return tkn.scanString(ch, ID)
+			return tkn.scanString(ch, DoubleQuotedString)
 		case '`':
 			return tkn.scanLiteralIdentifier('`')
 		case '%':

--- a/releasenotes/notes/apm-obfuscate-double-quotes-fd8c163f1c96404e.yaml
+++ b/releasenotes/notes/apm-obfuscate-double-quotes-fd8c163f1c96404e.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: double-quoted strings following assignments are now correctly obfuscated.


### PR DESCRIPTION
This change ensures that double-quoted strings after assignments get
obfuscated. In general, double-quoted strings can denote identifiers in
some cases, e.g.:

From https://dev.mysql.com/doc/refman/8.0/en/string-literals.html:
> If the ANSI_QUOTES SQL mode is enabled, string literals can be quoted only within single quotation marks because a string quoted within double quotation marks is interpreted as an identifier.

Using double quotes for strings is generally considered bad practice but
in some cases is omitted. It should be safe, until proven wrong, to
consider double quoted strings following an assignments to be a token
that needs to be obfuscated.

The change contains additional minor simplifications and clarifications to the overall algorithm:
* Rename `FilteredComma` to `Filtered`
* Rename `Filtered` to `FilteredGroupable`
