### PR TITLE
Add release note for Python 3 in Agent

### DIFF
--- a/releasenotes/notes/python3-in-agent-24f587f252391525.yaml
+++ b/releasenotes/notes/python3-in-agent-24f587f252391525.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The Agent now includes a Python 3 runtime to run checks.
+    By default, the Python 2 runtime is used. See the dedicated `Agent documentation page
+    <https://docs.datadoghq.com/agent/guide/python-3/>`_ for details on how to
+    configure the Agent to use the Python 3 runtime and how to migrate checks between
+    Python 2 and Python 3.

--- a/releasenotes/notes/python3-in-agent-24f587f252391525.yaml
+++ b/releasenotes/notes/python3-in-agent-24f587f252391525.yaml
@@ -11,5 +11,5 @@ features:
     The Agent now includes a Python 3 runtime to run checks.
     By default, the Python 2 runtime is used. See the dedicated `Agent documentation page
     <https://docs.datadoghq.com/agent/guide/python-3/>`_ for details on how to
-    configure the Agent to use the Python 3 runtime and how to migrate checks between
-    Python 2 and Python 3.
+    configure the Agent to use the Python 3 runtime and how to migrate checks from
+    Python 2 to Python 3.


### PR DESCRIPTION
### What does this PR do?

Add release note for Python 3 in Agent.

### Motivation

Python 3 will be included in the Agent in `6.14.0`. This needs to be documented in the changelog.

### Additional Notes

Open to ideas to improve wording and clarity.
The documentation PR linked has an [open PR](https://github.com/DataDog/documentation/pull/5334) to add instructions on how to enable Python 3 in the Agent.