### PR TITLE
Log error when the base class can't be found or strings can't be initialized

### DIFF
--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -104,6 +104,7 @@ bool Two::init()
 
     // init custom builtins
     if (init_stringutils() != EXIT_SUCCESS) {
+        setError("error initializing string utils");
         goto done;
     }
     Py2_init_aggregator();
@@ -116,6 +117,9 @@ bool Two::init()
 
     // import the base class
     _baseClass = _importFrom("datadog_checks.checks", "AgentCheck");
+    if (_baseClass == NULL) {
+        setError("could not import base class");
+    }
 
 done:
     // save thread state and release the GIL


### PR DESCRIPTION
### What does this PR do?

Log error when the base class can't be found or strings can't be initialized.

This is to match the behavior or three in two