### PR TITLE
Add release note for RPM key rotation

### DIFF
--- a/releasenotes/notes/change-rpm-gpg-signing-key-63afbb232393823f.yaml
+++ b/releasenotes/notes/change-rpm-gpg-signing-key-63afbb232393823f.yaml
@@ -10,6 +10,6 @@ upgrade:
   - |
     The GPG key used to sign the Agent RPM packages has been rotated.
     See the dedicated `Agent documentation page
-    <https://docs.datadoghq.com/agent/guide/python-3/>`_ to know how
-    to make sure that the new Agent RPM packages can be installed on
+    <https://docs.datadoghq.com/agent/faq/rpm-gpg-key-rotation-agent-6/>`_
+    to know how to make sure that the new Agent RPM packages can be installed on
     hosts.

--- a/releasenotes/notes/change-rpm-gpg-signing-key-63afbb232393823f.yaml
+++ b/releasenotes/notes/change-rpm-gpg-signing-key-63afbb232393823f.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    The GPG key used to sign the Agent RPM packages has been rotated.
+    See the dedicated `Agent documentation page
+    <https://docs.datadoghq.com/agent/guide/python-3/>`_ to know how
+    to make sure that the new Agent RPM packages can be installed on
+    hosts.


### PR DESCRIPTION
### What does this PR do?

Add release note for the RPM key rotation in Agent.

### Motivation

The RPM key used to sign our RPM packages has been rotated. This is a potentially breaking change (can prevent install of Agent packages) which needs to be added to the changelog.

### Additional Notes

Open to ideas to improve wording.