### PR TITLE
Removing upgrade documentation

### DIFF
--- a/docs/agent/upgrade.md
+++ b/docs/agent/upgrade.md
@@ -1,5 +1,5 @@
 # Upgrade to Agent 6
 
-Instructions on how to upgrade your Agent from version 5 to version 6 can be found in [Datadog public documentation](https://docs.datadoghq.com/agent/guide/upgrade-to-agent-v6/).
+Instructions to upgrade your Agent from version 5 to version 6 can be found in [Datadog public documentation](https://docs.datadoghq.com/agent/guide/upgrade-to-agent-v6/).
 
 

--- a/docs/agent/upgrade.md
+++ b/docs/agent/upgrade.md
@@ -1,5 +1,3 @@
 # Upgrade to Agent 6
 
 Instructions to upgrade your Agent from version 5 to version 6 can be found in the [Datadog public documentation](https://docs.datadoghq.com/agent/guide/upgrade-to-agent-v6/).
-
-

--- a/docs/agent/upgrade.md
+++ b/docs/agent/upgrade.md
@@ -1,12 +1,5 @@
 # Upgrade to Agent 6
 
-Datadog Agent 6 has officially been released. Please use the in-application [install instructions](https://app.datadoghq.com/account/settings#agent) to install Agent 6 from scratch or upgrade from Agent 5.
+Instructions on how to upgrade your Agent from version 5 to version 6 can be found in [Datadog public documentation](https://docs.datadoghq.com/agent/guide/upgrade-to-agent-v6/).
 
-For a list of changes between Agent 5 and 6 that may affect you, please refer to:
-* [the doc on the general Agent changes][changes]
-* [the doc on the differences in the Agent config options][config]
-* [the list of Agent 5 features that are not ported to Agent 6][missing-features]
 
-[changes]: changes.md
-[config]: config.md
-[missing-features]: missing_features.md

--- a/docs/agent/upgrade.md
+++ b/docs/agent/upgrade.md
@@ -1,5 +1,5 @@
 # Upgrade to Agent 6
 
-Instructions to upgrade your Agent from version 5 to version 6 can be found in [Datadog public documentation](https://docs.datadoghq.com/agent/guide/upgrade-to-agent-v6/).
+Instructions to upgrade your Agent from version 5 to version 6 can be found in the [Datadog public documentation](https://docs.datadoghq.com/agent/guide/upgrade-to-agent-v6/).
 
 


### PR DESCRIPTION
Removing upgrade documentation from the repo, and leaving a placeholder to point to the public documentation page instead.
