### PR TITLE
[loader] python: synchronous-serial linting/validation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -139,7 +139,9 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("tracemalloc_debug", false)
 
 	// Python 3 linter timeout, in seconds
-	config.BindEnvAndSetDefault("python3_linter_timeout", 8)
+	// NOTE: linter is notoriously slow, in the absence of a better solution we
+	//       can only increase this timeout value. Linting operation is async.
+	config.BindEnvAndSetDefault("python3_linter_timeout", 120)
 
 	// if/when the default is changed to true, make the default platform
 	// dependent; default should remain false on Windows to maintain backward

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -256,7 +256,7 @@ api_key:
 # disable_py3_validation: false
 #
 ## @param python3_linter_timeout - integer - optional - default: 120
-## Timeout value in seconds for validation of python checks.
+## Timeout in seconds for validation of compatibility with python 3 when running python 2.
 #
 # python3_linter_timeout: 120
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -255,6 +255,11 @@ api_key:
 #
 # disable_py3_validation: false
 #
+## @param disable_py3_validation - integer - optional - default: 120
+## Timeout value in seconds for validation of python checks.
+#
+# python3_linter_timeout: 120
+
 ## @param memtrack_enabled - boolean - optional - default: true
 ## Enables tracking of memory allocations made from the python runtime loader.
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -255,7 +255,7 @@ api_key:
 #
 # disable_py3_validation: false
 #
-## @param disable_py3_validation - integer - optional - default: 120
+## @param python3_linter_timeout - integer - optional - default: 120
 ## Timeout value in seconds for validation of python checks.
 #
 # python3_linter_timeout: 120


### PR DESCRIPTION
### What does this PR do?

This PR makes the python3 validation/linting asynchronous. Because we hold a mutex all through the validation operation, validation should still be serial. This is something we definitely want to keep CPU usage under control. 

### Motivation

Some checks are taking the order of minutes to validate, which is quite considerable. Any alternative will require setting a high value for the linting timeout, if this operation remains synchronous, this would result in the agent stalling at startup until said timeout expired or the linting completed.... venturing into delays measured in the order of minutes not and seconds isn't really acceptable. 