### PR TITLE
Log instead of error out when process-agent is not enabled in config in MacOS

### DIFF
--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -129,7 +129,8 @@ func (c *ProcessAgentCheck) run() error {
 func (c *ProcessAgentCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
 	// handle the case when the agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("process_config.enabled"); !enabled {
-		return fmt.Errorf("Process Agent disabled through main configuration file")
+		log.Info("Process Agent disabled through main configuration file")
+		return nil
 	}
 
 	var checkConf processAgentCheckConf

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -130,7 +130,6 @@ func (c *ProcessAgentCheck) Configure(data integration.Data, initConfig integrat
 	// handle the case when the agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("process_config.enabled"); !enabled {
 		log.Info("Process Agent disabled through main configuration file")
-		return nil
 	}
 
 	var checkConf processAgentCheckConf


### PR DESCRIPTION
### What does this PR do?

Currently the process corecheck returns an error when process-agent is disabled in the config. This results in process-agent showing up in error status in datadog-agent UI. The PR logs the message instead and return no error, so it shouldn't confuse customers anymore.

cc: @DataDog/burrito 

### Motivation

Confusing status page.

### Additional Notes

Anything else we should know when reviewing?
