### PR TITLE
Remove symbols from go build

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -85,7 +85,7 @@ def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "
     else:
-        ldflags += "-r {}/lib ".format(embedded_path)
+        ldflags += "-s -w -r {}/lib ".format(embedded_path)
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"


### PR DESCRIPTION
Try to reduce go binaries size.