### PR TITLE
Support dark mode for status bar menu on macOS

### DIFF
--- a/cmd/agent/gui/systray/Sources/gui.swift
+++ b/cmd/agent/gui/systray/Sources/gui.swift
@@ -64,6 +64,7 @@ class AgentGUI: NSObject {
         systemTrayItem.menu = ddMenu
         if ddImage!.isValid {
             ddImage!.size = NSMakeSize(15, 15)
+            ddImage!.isTemplate = true
             systemTrayItem.button!.image = ddImage
         } else {
             systemTrayItem.button!.title = "DD"

--- a/releasenotes/notes/dark-mode-macos-153b8aade595d749.yaml
+++ b/releasenotes/notes/dark-mode-macos-153b8aade595d749.yaml
@@ -1,0 +1,5 @@
+---
+
+fixes:
+  - |
+    Fix the appearrance of the status bar icon when using dark mode on macOS


### PR DESCRIPTION
### What does this PR do?

This PR fix the color of the bone icon of the status bar menu on macOS.

Before:
<img width="194" alt="Capture d’écran 2019-09-05 à 22 10 24" src="https://user-images.githubusercontent.com/715910/64377258-55e84500-d02a-11e9-8783-c4d9f1afd18c.png">

After:
<img width="188" alt="Capture d’écran 2019-09-05 à 22 10 58" src="https://user-images.githubusercontent.com/715910/64377266-5aacf900-d02a-11e9-8915-9f0529fa9dd4.png">

### Motivation

Will help users see the icon, as it was barely invisible in dark mode before
