### PR TITLE
[Fix][AutoConfig] update check in case of an empty tagger during the …

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -117,12 +117,12 @@ func (ac *AutoConfig) checkTagFreshness() {
 	for _, service := range ac.store.getServices() {
 		previousHash := ac.store.getTagsHashForService(service.GetTaggerEntity())
 		currentHash := tagger.GetEntityHash(service.GetTaggerEntity())
+		// Since an empty hash is a valid value, and we are not able to differentiate
+		// an empty tagger or store with an empty value.
+		// So we only look at the difference between current and previous
 		if currentHash != previousHash {
 			ac.store.setTagsHashForService(service.GetTaggerEntity(), currentHash)
-			if previousHash != "" {
-				// only refresh service if we already had a hash to avoid resetting it
-				servicesToRefresh = append(servicesToRefresh, service)
-			}
+			servicesToRefresh = append(servicesToRefresh, service)
 		}
 	}
 	for _, service := range servicesToRefresh {

--- a/releasenotes/notes/fix-autoconfig-refresh-from-tag-update-acb91d44ef1182ff.yaml
+++ b/releasenotes/notes/fix-autoconfig-refresh-from-tag-update-acb91d44ef1182ff.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug, when a check have its init configuration before that all the tagger collector report tags.


### PR DESCRIPTION
### What does this PR do?

Fix a bug, when a check have it init configuration before that all the tagger collector report tags.

### Motivation

The failure scenario here was:
1/ Some collector is slow to fill up their tags (kubelet takes some time to respond for instance)
2/ previousHash is “” as it is just init, currentHash is “” because the tagger is empty (and see the lookup function, it returns “” if the key is not found).
At this point, we just continue.
3/ Next refresh, previousHash is “”, currentHash has elements. They are different, so we set currentHash in the store but we do not consider this change as a candidate to trigger a rescheduling.
4/ previousHash gets the value of currentHash, if tags have not changed we consider that there is no change.
With the suggested change, we believe that every change ought to yield a refresh.

### Additional Notes

Anything else we should know when reviewing?
