### PR TITLE
[rtloader] memory accounting on tests + associated fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,6 +159,7 @@ run_tests_deb-x64:
     - pip install wheel
     - pip install -r requirements.txt
     - go get gopkg.in/yaml.v2
+    - go get github.com/stretchr/testify
     - inv -e rtloader.build --install-prefix=$SRC_PATH/dev
     - inv -e rtloader.install
     - inv -e rtloader.format --raise-if-changed

--- a/releasenotes/notes/rtloader-testing-accounting-and-fixes-41e46c6338c874fe.yaml
+++ b/releasenotes/notes/rtloader-testing-accounting-and-fixes-41e46c6338c874fe.yaml
@@ -1,0 +1,16 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Minor memory leaks identified and fixed in RTLoader.
+other:
+  - |
+    RTLoader unit test memory accounting features to track correct
+    and expected memory usage.
+    Deprecation of direct use of malloc and free in RTLoader.

--- a/rtloader/CMakeLists.txt
+++ b/rtloader/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 
+## Project name
+project(RtLoader)
+
 ## Require C++11 with no extensions
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/rtloader/common/builtins/datadog_agent.c
+++ b/rtloader/common/builtins/datadog_agent.c
@@ -531,6 +531,15 @@ static PyObject *set_external_tags(PyObject *self, PyObject *args)
             _free(tags[j]);
         }
         _free(tags);
+
+        if (hostname) {
+            _free(hostname);
+            hostname = NULL;
+        }
+        if (source_type) {
+            _free(source_type);
+            source_type = NULL;
+        }
     }
 
 done:

--- a/rtloader/common/log.c
+++ b/rtloader/common/log.c
@@ -14,7 +14,7 @@ void _set_log_cb(cb_log_t cb)
 
 // Logs a message to the agent logger. Caller is in charge of freeing the
 // message if needed.
-void agent_log(log_level_t log_level, const char *message) {
+void agent_log(log_level_t log_level, char *message) {
     if (cb_log == NULL || message == NULL) {
         return;
     }

--- a/rtloader/common/log.h
+++ b/rtloader/common/log.h
@@ -32,7 +32,7 @@ void _set_log_cb(cb_log_t);
     \param log_level_t The log level to use to log the message.
     \param const char* A pointer to the message.
 */
-void agent_log(log_level_t, const char *);
+void agent_log(log_level_t, char *);
 
 #ifdef __cplusplus
 }

--- a/rtloader/common/rtloader_mem.c
+++ b/rtloader/common/rtloader_mem.c
@@ -7,9 +7,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 // default memory management functions
 static rtloader_malloc_t rt_malloc = malloc;
 static rtloader_free_t rt_free = free;
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 // these must be set by the Agent
 static cb_memory_tracker_t cb_memory_tracker = NULL;

--- a/rtloader/common/rtloader_mem.h
+++ b/rtloader/common/rtloader_mem.h
@@ -16,15 +16,16 @@
 
 #include <stdlib.h>
 
-#define MEM_DEPRECATION_MSG "raw primitives should not be used in the context"\
-                            "of the rtloader"
+#define MEM_DEPRECATION_MSG                                                                                            \
+    "raw primitives should not be used in the context"                                                                 \
+    "of the rtloader"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern void *malloc (size_t size) __attribute__((deprecated(MEM_DEPRECATION_MSG)));
-extern void free (void *ptr) __attribute__((deprecated(MEM_DEPRECATION_MSG)));
+extern void *malloc(size_t size) __attribute__((deprecated(MEM_DEPRECATION_MSG)));
+extern void free(void *ptr) __attribute__((deprecated(MEM_DEPRECATION_MSG)));
 
 /*! \fn void _set_memory_tracker_cb(cb_memory_tracker_t cb)
     \brief Sets a callback to be used by rtloader to add memory tracking stats.

--- a/rtloader/common/rtloader_mem.h
+++ b/rtloader/common/rtloader_mem.h
@@ -16,9 +16,15 @@
 
 #include <stdlib.h>
 
+#define MEM_DEPRECATION_MSG "raw primitives should not be used in the context"\
+                            "of the rtloader"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+extern void *malloc (size_t size) __attribute__((deprecated(MEM_DEPRECATION_MSG)));
+extern void free (void *ptr) __attribute__((deprecated(MEM_DEPRECATION_MSG)));
 
 /*! \fn void _set_memory_tracker_cb(cb_memory_tracker_t cb)
     \brief Sets a callback to be used by rtloader to add memory tracking stats.

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -116,7 +116,7 @@ typedef void (*cb_get_clustername_t)(char **);
 // (tracemalloc_enabled)
 typedef bool (*cb_tracemalloc_enabled_t)(void);
 // (message, level)
-typedef void (*cb_log_t)(const char *, int);
+typedef void (*cb_log_t)(char *, int);
 // (check_id, name, value)
 typedef void (*cb_set_check_metadata_t)(char *, char *, char *);
 // (hostname, source_type_name, list of tags)

--- a/rtloader/test/aggregator/aggregator.go
+++ b/rtloader/test/aggregator/aggregator.go
@@ -13,24 +13,26 @@ import (
 	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
-// #cgo CFLAGS: -I../../include
-// #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
-// #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
-//
-// #include <stdlib.h>
-// #include <datadog_agent_rtloader.h>
-//
-// extern void submitMetric(char *, metric_type_t, char *, float, char **, char *);
-// extern void submitServiceCheck(char *, char *, int, char **, char *, char *);
-// extern void submitEvent(char*, event_t*);
-// extern void submitHistogramBucket(char *, char *, int, float, float, int, char *, char **);
-//
-// static void initAggregatorTests(rtloader_t *rtloader) {
-//    set_submit_metric_cb(rtloader, submitMetric);
-//    set_submit_service_check_cb(rtloader, submitServiceCheck);
-//    set_submit_event_cb(rtloader, submitEvent);
-//    set_submit_histogram_bucket_cb(rtloader, submitHistogramBucket);
-// }
+/*
+#cgo CFLAGS: -I../../include -I../../common
+#cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
+#cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
+
+#include "rtloader_mem.h"
+#include "datadog_agent_rtloader.h"
+
+extern void submitMetric(char *, metric_type_t, char *, float, char **, char *);
+extern void submitServiceCheck(char *, char *, int, char **, char *, char *);
+extern void submitEvent(char*, event_t*);
+extern void submitHistogramBucket(char *, char *, int, float, float, int, char *, char **);
+
+static void initAggregatorTests(rtloader_t *rtloader) {
+   set_submit_metric_cb(rtloader, submitMetric);
+   set_submit_service_check_cb(rtloader, submitServiceCheck);
+   set_submit_event_cb(rtloader, submitEvent);
+   set_submit_histogram_bucket_cb(rtloader, submitHistogramBucket);
+}
+*/
 import "C"
 
 var (
@@ -110,20 +112,20 @@ func run(call string) (string, error) {
 	}
 	defer os.Remove(tmpfile.Name())
 
-	code := C.CString(fmt.Sprintf(`
+	code := (*C.char)(helpers.TrackedCString(fmt.Sprintf(`
 try:
 	import aggregator
 	%s
 except Exception as e:
 	with open(r'%s', 'w') as f:
 		f.write("{}: {}\n".format(type(e).__name__, e))
-`, call, tmpfile.Name()))
+`, call, tmpfile.Name())))
+	defer C._free(unsafe.Pointer(code))
 
 	runtime.LockOSThread()
 	state := C.ensure_gil(rtloader)
 
 	ret := C.run_simple_string(rtloader, code) == 1
-	C.free(unsafe.Pointer(code))
 
 	C.release_gil(rtloader, state)
 	runtime.UnlockOSThread()

--- a/rtloader/test/aggregator/aggregator.go
+++ b/rtloader/test/aggregator/aggregator.go
@@ -84,13 +84,13 @@ func resetOuputValues() {
 }
 
 func setUp() error {
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
+
 	rtloader = (*C.rtloader_t)(common.GetRtLoader())
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
-
-	// Initialize memory tracking
-	helpers.InitMemoryTracker()
 
 	C.initAggregatorTests(rtloader)
 

--- a/rtloader/test/aggregator/aggregator.go
+++ b/rtloader/test/aggregator/aggregator.go
@@ -10,6 +10,7 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -85,6 +86,9 @@ func setUp() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	C.initAggregatorTests(rtloader)
 

--- a/rtloader/test/aggregator/aggregator.go
+++ b/rtloader/test/aggregator/aggregator.go
@@ -14,7 +14,7 @@ import (
 )
 
 /*
-#cgo CFLAGS: -I../../include -I../../common
+#cgo CFLAGS: -I../../include -I../../common -Wno-deprecated-declarations
 #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
 #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
 

--- a/rtloader/test/aggregator/aggregator_test.go
+++ b/rtloader/test/aggregator/aggregator_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 func TestMain(m *testing.M) {
@@ -18,6 +20,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestSubmitMetric(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`aggregator.submit_metric(None, 'id', aggregator.GAUGE, 'name', -99.0, ['foo', 21, 'bar', ["hey"]], 'myhost')`)
 
 	if err != nil {
@@ -47,9 +52,15 @@ func TestSubmitMetric(t *testing.T) {
 	if tags[0] != "foo" || tags[1] != "bar" {
 		t.Fatalf("Unexpected tags: %v", tags)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubmitMetricParsingError(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`
 	aggregator.submit_metric(None, 21, aggregator.GAUGE, 'name', -99.0, ['foo', 21, 'bar', ["hey"]], 'myhost')
 	`)
@@ -60,9 +71,15 @@ func TestSubmitMetricParsingError(t *testing.T) {
 	if matched, err := regexp.Match("TypeError: argument 2 must be (str|string), not int", []byte(out)); err != nil && !matched {
 		t.Errorf("wrong printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubmitMetricTagsError(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`
 	aggregator.submit_metric(None, 'id', aggregator.GAUGE, 'name', -99.0, 123, 'myhost')
 	`)
@@ -73,9 +90,15 @@ func TestSubmitMetricTagsError(t *testing.T) {
 	if out != "TypeError: tags must be a sequence" {
 		t.Errorf("wrong printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubmitServiceCheck(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`aggregator.submit_service_check(None, 'id', 'my.service.check', 1, ['foo', 21, 'bar', ["hey"]], 'myhost', 'A message!')`)
 
 	if err != nil {
@@ -105,9 +128,15 @@ func TestSubmitServiceCheck(t *testing.T) {
 	if scMessage != "A message!" {
 		t.Fatalf("Unexpected name value: %s", scMessage)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubmitServiceCheckParsingError(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`aggregator.submit_service_check(None, 123, 'my.service.check', 1, ['foo', 21, 'bar', ["hey"]], 'myhost', 'A message!')`)
 
 	if err != nil {
@@ -116,9 +145,15 @@ func TestSubmitServiceCheckParsingError(t *testing.T) {
 	if matched, err := regexp.Match("TypeError: argument 1 must be (str|string), not int", []byte(out)); err != nil && !matched {
 		t.Errorf("wrong printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubmitServiceCheckTagsError(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`aggregator.submit_service_check(None, 'id', 'my.service.check', 1, 123, 'myhost', 'A message!')`)
 
 	if err != nil {
@@ -127,9 +162,15 @@ func TestSubmitServiceCheckTagsError(t *testing.T) {
 	if out != "TypeError: tags must be a sequence" {
 		t.Errorf("wrong printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubmitEvent(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	ev = {
 		'timestamp': 123456,
@@ -189,9 +230,15 @@ func TestSubmitEvent(t *testing.T) {
 	if _event.tags[0] != "foo" || _event.tags[1] != "bar" {
 		t.Fatalf("Unexpected tags: %v", _event.tags)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubmitEventMissingFields(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	ev = {
 		'msg_text': 'Event message',
@@ -238,9 +285,15 @@ func TestSubmitEventMissingFields(t *testing.T) {
 	if _event.tags != nil {
 		t.Fatal("Tags should be nil")
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestEventCheckEventNotDict(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	aggregator.submit_event(None, 'id', "I should be a dict")
 	`
@@ -252,9 +305,15 @@ func TestEventCheckEventNotDict(t *testing.T) {
 	if out != "TypeError: event must be a dict" {
 		t.Errorf("wrong printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestEventCheckParsingError(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	aggregator.submit_event(None, 21, {})
 	`
@@ -266,9 +325,15 @@ func TestEventCheckParsingError(t *testing.T) {
 	if matched, err := regexp.Match("TypeError: argument 2 must be (str|string), not int", []byte(out)); err != nil && !matched {
 		t.Errorf("wrong printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestEventCheckTagsError(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	ev = {
 		'timestamp': 123456,
@@ -293,9 +358,15 @@ func TestEventCheckTagsError(t *testing.T) {
 	if out != "TypeError: tags must be a sequence" {
 		t.Errorf("wrong printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubmitHistogramBucket(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`aggregator.submit_histogram_bucket(None, 'id', 'name', 42, 1.0, 2.0, 1, 'myhost', ['foo', 21, 'bar', ["hey"]])`)
 	if err != nil {
 		t.Fatal(err)
@@ -331,4 +402,7 @@ func TestSubmitHistogramBucket(t *testing.T) {
 	if tags[0] != "foo" || tags[1] != "bar" {
 		t.Fatalf("Unexpected tags: %v", tags)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/test/common/cgo_free.go
+++ b/rtloader/test/common/cgo_free.go
@@ -3,6 +3,8 @@ package testcommon
 import (
 	"fmt"
 	"unsafe"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 /*
@@ -21,7 +23,7 @@ static void initCgoFreeTests(rtloader_t *rtloader) {
 import "C"
 
 var (
-	rtloader           *C.rtloader_t
+	rtloader      *C.rtloader_t
 	cgoFreeCalled bool
 	latestFreePtr unsafe.Pointer
 )
@@ -31,6 +33,9 @@ func setUp() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	C.initCgoFreeTests(rtloader)
 

--- a/rtloader/test/common/cgo_free_test.go
+++ b/rtloader/test/common/cgo_free_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 	"unsafe"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 func TestMain(m *testing.M) {
@@ -19,6 +21,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestCgoFree(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	callCgoFree(nil)
 	if cgoFreeCalled != false {
 		t.Errorf("freeing NULL should not haved called the cgoFree callback")
@@ -32,4 +37,7 @@ func TestCgoFree(t *testing.T) {
 	if unsafe.Pointer(&v) != latestFreePtr {
 		t.Errorf("Freed pointer was not the same as the one given to the callback")
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/test/containers/containers.go
+++ b/rtloader/test/containers/containers.go
@@ -13,7 +13,7 @@ import (
 )
 
 /*
-#cgo CFLAGS: -I../../include -I../../common
+#cgo CFLAGS: -I../../include -I../../common -Wno-deprecated-declarations
 #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
 #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
 

--- a/rtloader/test/containers/containers.go
+++ b/rtloader/test/containers/containers.go
@@ -12,18 +12,20 @@ import (
 	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
-// #cgo CFLAGS: -I../../include
-// #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
-// #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
-//
-// #include <stdlib.h>
-// #include <datadog_agent_rtloader.h>
-//
-// extern int is_excluded(char *, char*);
-//
-// static void initContainersTests(rtloader_t *rtloader) {
-//    set_is_excluded_cb(rtloader, is_excluded);
-// }
+/*
+#cgo CFLAGS: -I../../include -I../../common
+#cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
+#cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
+
+#include "rtloader_mem.h"
+#include "datadog_agent_rtloader.h"
+
+extern int is_excluded(char *, char*);
+
+static void initContainersTests(rtloader_t *rtloader) {
+   set_is_excluded_cb(rtloader, is_excluded);
+}
+*/
 import "C"
 
 var (
@@ -70,20 +72,20 @@ func tearDown() {
 
 func run(call string) (string, error) {
 	tmpfile.Truncate(0)
-	code := C.CString(fmt.Sprintf(`
+	code := (*C.char)(helpers.TrackedCString(fmt.Sprintf(`
 try:
 	import containers
 	%s
 except Exception as e:
 	with open(r'%s', 'w') as f:
 		f.write("{}: {}\n".format(type(e).__name__, e))
-`, call, tmpfile.Name()))
+`, call, tmpfile.Name())))
+	defer C._free(unsafe.Pointer(code))
 
 	runtime.LockOSThread()
 	state := C.ensure_gil(rtloader)
 
 	ret := C.run_simple_string(rtloader, code) == 1
-	C.free(unsafe.Pointer(code))
 
 	C.release_gil(rtloader, state)
 	runtime.UnlockOSThread()

--- a/rtloader/test/containers/containers.go
+++ b/rtloader/test/containers/containers.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -26,8 +27,8 @@ import (
 import "C"
 
 var (
-	rtloader     *C.rtloader_t
-	tmpfile *os.File
+	rtloader *C.rtloader_t
+	tmpfile  *os.File
 )
 
 type message struct {
@@ -41,6 +42,9 @@ func setUp() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/containers/containers.go
+++ b/rtloader/test/containers/containers.go
@@ -40,13 +40,13 @@ type message struct {
 }
 
 func setUp() error {
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
+
 	rtloader = (*C.rtloader_t)(common.GetRtLoader())
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
-
-	// Initialize memory tracking
-	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/containers/containers_test.go
+++ b/rtloader/test/containers/containers_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 func TestMain(m *testing.M) {
@@ -18,6 +20,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIsExcluded(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		f.write("{},{}".format(
@@ -32,9 +37,15 @@ func TestIsExcluded(t *testing.T) {
 	if out != "True,False" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestIsExcludedErrorTypeName(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		f.write("{},{}".format(
@@ -49,9 +60,15 @@ func TestIsExcludedErrorTypeName(t *testing.T) {
 	if matched, err := regexp.Match("TypeError: argument 1 must be (str|string), not int", []byte(out)); err != nil && !matched {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestIsExcludedErrorTypeImage(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		f.write("{},{}".format(
@@ -65,4 +82,7 @@ func TestIsExcludedErrorTypeImage(t *testing.T) {
 	if matched, err := regexp.Match("TypeError: argument 2 must be (str|string), not int", []byte(out)); err != nil && !matched {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -31,6 +31,7 @@ extern void headers(char **);
 extern void setCheckMetadata(char*, char*, char*);
 extern void setExternalHostTags(char*, char*, char**);
 
+
 static void initDatadogAgentTests(rtloader_t *rtloader) {
    set_cgo_free_cb(rtloader, _free);
    set_get_clustername_cb(rtloader, getClustername);

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -58,6 +59,9 @@ func setUp() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -59,13 +59,13 @@ type message struct {
 }
 
 func setUp() error {
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
+
 	rtloader = (*C.rtloader_t)(common.GetRtLoader())
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
-
-	// Initialize memory tracking
-	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -13,34 +13,37 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// #cgo CFLAGS: -I../../include
-// #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
-// #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
-//
-// #include <stdlib.h>
-// #include <datadog_agent_rtloader.h>
-//
-// extern void doLog(char*, int);
-// extern void getClustername(char **);
-// extern void getConfig(char *, char **);
-// extern void getHostname(char **);
-// extern bool getTracemallocEnabled();
-// extern void getVersion(char **);
-// extern void headers(char **);
-// extern void setCheckMetadata(char*, char*, char*);
-// extern void setExternalHostTags(char*, char*, char**);
-//
-// static void initDatadogAgentTests(rtloader_t *rtloader) {
-//    set_get_clustername_cb(rtloader, getClustername);
-//    set_get_config_cb(rtloader, getConfig);
-//    set_get_hostname_cb(rtloader, getHostname);
-//    set_tracemalloc_enabled_cb(rtloader, getTracemallocEnabled);
-//    set_get_version_cb(rtloader, getVersion);
-//    set_headers_cb(rtloader, headers);
-//    set_log_cb(rtloader, doLog);
-//    set_set_check_metadata_cb(rtloader, setCheckMetadata);
-//    set_set_external_tags_cb(rtloader, setExternalHostTags);
-// }
+/*
+#cgo CFLAGS: -I../../include -I../../common
+#cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
+#cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
+
+#include "rtloader_mem.h"
+#include "datadog_agent_rtloader.h"
+
+extern void doLog(char*, int);
+extern void getClustername(char **);
+extern void getConfig(char *, char **);
+extern void getHostname(char **);
+extern bool getTracemallocEnabled();
+extern void getVersion(char **);
+extern void headers(char **);
+extern void setCheckMetadata(char*, char*, char*);
+extern void setExternalHostTags(char*, char*, char**);
+
+static void initDatadogAgentTests(rtloader_t *rtloader) {
+   set_cgo_free_cb(rtloader, _free);
+   set_get_clustername_cb(rtloader, getClustername);
+   set_get_config_cb(rtloader, getConfig);
+   set_get_hostname_cb(rtloader, getHostname);
+   set_tracemalloc_enabled_cb(rtloader, getTracemallocEnabled);
+   set_get_version_cb(rtloader, getVersion);
+   set_headers_cb(rtloader, headers);
+   set_log_cb(rtloader, doLog);
+   set_set_check_metadata_cb(rtloader, setCheckMetadata);
+   set_set_external_tags_cb(rtloader, setExternalHostTags);
+}
+*/
 import "C"
 
 var (
@@ -87,7 +90,7 @@ func tearDown() {
 
 func run(call string) (string, error) {
 	tmpfile.Truncate(0)
-	code := C.CString(fmt.Sprintf(`
+	code := (*C.char)(helpers.TrackedCString(fmt.Sprintf(`
 import sys
 try:
 	import datadog_agent
@@ -95,13 +98,13 @@ try:
 except Exception as e:
 	with open(r'%s', 'w') as f:
 		f.write("{}: {}\n".format(type(e).__name__, e))
-`, call, tmpfile.Name()))
+`, call, tmpfile.Name())))
+	defer C._free(unsafe.Pointer(code))
 
 	runtime.LockOSThread()
 	state := C.ensure_gil(rtloader)
 
 	ret := C.run_simple_string(rtloader, code) == 1
-	C.free(unsafe.Pointer(code))
 
 	C.release_gil(rtloader, state)
 	runtime.UnlockOSThread()
@@ -117,7 +120,7 @@ except Exception as e:
 
 //export getVersion
 func getVersion(in **C.char) {
-	*in = C.CString("1.2.3")
+	*in = (*C.char)(helpers.TrackedCString("1.2.3"))
 }
 
 //export getConfig
@@ -126,13 +129,13 @@ func getConfig(key *C.char, in **C.char) {
 	goKey := C.GoString(key)
 	switch goKey {
 	case "log_level":
-		*in = C.CString("\"warning\"")
+		*in = (*C.char)(helpers.TrackedCString("\"warning\""))
 	case "foo":
 		m := message{C.GoString(key), "Hello", 123456}
 		b, _ := yaml.Marshal(m)
-		*in = C.CString(string(b))
+		*in = (*C.char)(helpers.TrackedCString(string(b)))
 	default:
-		*in = C.CString("null")
+		*in = (*C.char)(helpers.TrackedCString("null"))
 	}
 }
 
@@ -145,17 +148,17 @@ func headers(in **C.char) {
 	}
 	retval, _ := yaml.Marshal(h)
 
-	*in = C.CString(string(retval))
+	*in = (*C.char)(helpers.TrackedCString(string(retval)))
 }
 
 //export getHostname
 func getHostname(in **C.char) {
-	*in = C.CString("localfoobar")
+	*in = (*C.char)(helpers.TrackedCString("localfoobar"))
 }
 
 //export getClustername
 func getClustername(in **C.char) {
-	*in = C.CString("the-cluster")
+	*in = (*C.char)(helpers.TrackedCString("the-cluster"))
 }
 
 //export getTracemallocEnabled

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -14,7 +14,7 @@ import (
 )
 
 /*
-#cgo CFLAGS: -I../../include -I../../common
+#cgo CFLAGS: -I../../include -I../../common -Wno-deprecated-declarations
 #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
 #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
 

--- a/rtloader/test/datadog_agent/datadog_agent_test.go
+++ b/rtloader/test/datadog_agent/datadog_agent_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 func TestMain(m *testing.M) {
@@ -20,6 +22,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetVersion(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		version = datadog_agent.get_version()
@@ -36,9 +41,15 @@ func TestGetVersion(t *testing.T) {
 	if out != "1.2.3" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetConfig(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	d = datadog_agent.get_config("foo")
 	with open(r'%s', 'w') as f:
@@ -51,9 +62,15 @@ func TestGetConfig(t *testing.T) {
 	if out != "foo:Hello:123456" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestHeaders(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	d = datadog_agent.headers(http_host="myhost", ignore_me="snafu")
 	with open(r'%s', 'w') as f:
@@ -66,9 +83,15 @@ func TestHeaders(t *testing.T) {
 	if out != "Accept,Content-Type,Host,User-Agent" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetHostname(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		name = datadog_agent.get_hostname()
@@ -85,9 +108,15 @@ func TestGetHostname(t *testing.T) {
 	if out != "localfoobar" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetClustername(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		name = datadog_agent.get_clustername()
@@ -105,17 +134,29 @@ func TestGetClustername(t *testing.T) {
 	if out != "the-cluster" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetTracemallocEnabled(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `assert datadog_agent.tracemalloc_enabled()`
 	_, err := run(code)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestLog(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	datadog_agent.log("foo message", 99)
 	`
@@ -126,6 +167,9 @@ func TestLog(t *testing.T) {
 	if out != "[99]foo message" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetCheckMetadata(t *testing.T) {
@@ -142,6 +186,9 @@ func TestSetCheckMetadata(t *testing.T) {
 }
 
 func TestSetExternalTags(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	tags = [
 		('hostname', {'source_type': ['tag1', 'tag2']}),
@@ -156,9 +203,15 @@ func TestSetExternalTags(t *testing.T) {
 	if out != "hostname,source_type,tag1,tag2\nhostname2,source_type2,tag3,tag4" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetExternalTagsIgnoreNonString(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	tags = [
 		('hostname', {'source_type': ['tag1', 123, 'tag2']}),
@@ -173,9 +226,15 @@ func TestSetExternalTagsIgnoreNonString(t *testing.T) {
 	if out != "hostname,source_type,tag1,tag2\nhostname2,source_type2,tag3,tag4" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetExternalTagsUnicode(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	tags = [
 		('hostname', {'source_type': [u'tag1', 123, u'tag2']}),
@@ -190,9 +249,15 @@ func TestSetExternalTagsUnicode(t *testing.T) {
 	if out != "hostname,source_type,tag1,tag2\nhostname2,source_type2,tag3,tag4" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetExternalTagsNotList(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	datadog_agent.set_external_tags({})
 	`
@@ -203,9 +268,15 @@ func TestSetExternalTagsNotList(t *testing.T) {
 	if out != "TypeError: tags must be a list" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetExternalTagsNotTuple(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	datadog_agent.set_external_tags([{}, {}])
 	`
@@ -216,9 +287,15 @@ func TestSetExternalTagsNotTuple(t *testing.T) {
 	if out != "TypeError: external host tags list must contain only tuples" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetExternalTagsInvalidHostname(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	tags = [
 		(123, {'source_type': ['tag1', 'tag2']}),
@@ -233,9 +310,15 @@ func TestSetExternalTagsInvalidHostname(t *testing.T) {
 	if out != "TypeError: hostname is not a valid string" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetExternalTagsNotDict(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	tags = [
 		("hostname", ('source_type', ['tag1', 'tag2'])),
@@ -250,9 +333,15 @@ func TestSetExternalTagsNotDict(t *testing.T) {
 	if out != "TypeError: second elem of the host tags tuple must be a dict" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetExternalTagInvalidSourceType(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	tags = [
 		('hostname', {'source_type': ['tag1', 'tag2']}),
@@ -267,9 +356,15 @@ func TestSetExternalTagInvalidSourceType(t *testing.T) {
 	if out != "TypeError: source_type is not a valid string" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetExternalTagInvalidTagsList(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := `
 	tags = [
 		('hostname', {'source_type': {'tag1': 'tag2'}}),
@@ -284,4 +379,7 @@ func TestSetExternalTagInvalidTagsList(t *testing.T) {
 	if out != "TypeError: dict value must be a list of tags" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/test/helpers/helpers.go
+++ b/rtloader/test/helpers/helpers.go
@@ -1,0 +1,32 @@
+package helpers
+
+import (
+	"expvar"
+	"unsafe"
+)
+
+/*
+#cgo CFLAGS: -I../../include -I../../common
+#cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
+#cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
+
+#include "datadog_agent_rtloader.h"
+
+*/
+import "C"
+
+var (
+	Allocations = expvar.Int{}
+	Frees       = expvar.Int{}
+)
+
+// TestMemoryTracker is the method exposed to the RTLoader for memory tracking
+//export TestMemoryTracker
+func TestMemoryTracker(ptr unsafe.Pointer, sz C.size_t, op C.rtloader_mem_ops_t) {
+	switch op {
+	case C.DATADOG_AGENT_RTLOADER_ALLOCATION:
+		Allocations.Add(1)
+	case C.DATADOG_AGENT_RTLOADER_FREE:
+		Frees.Add(1)
+	}
+}

--- a/rtloader/test/helpers/helpers_native.go
+++ b/rtloader/test/helpers/helpers_native.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"expvar"
 	"testing"
 	"unsafe"
 
@@ -46,4 +47,11 @@ func ResetMemoryStats() {
 func AssertMemoryUsage(t *testing.T) {
 	assert.Equal(t, Allocations.Value(), Frees.Value(),
 		"Number of allocations doesn't match number of frees")
+}
+
+// AssertMemoryAllocations makes sure the allocations match the
+// provided value
+func AssertMemoryExpectation(t *testing.T, counter expvar.Int, expected int64) {
+	assert.Equal(t, expected, counter.Value(),
+		"Memory statistic doesn't match the expected value")
 }

--- a/rtloader/test/helpers/helpers_native.go
+++ b/rtloader/test/helpers/helpers_native.go
@@ -1,5 +1,12 @@
 package helpers
 
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
 /*
 #cgo CFLAGS: -I../../include -I../../common
 #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
@@ -19,4 +26,24 @@ import "C"
 // InitMemoryTracker initializes RTLoader memory tracking
 func InitMemoryTracker() {
 	C.initTestMemoryTracker()
+}
+
+// ResetMemoryStats resets allocations and frees counters to zero
+func TrackedCString(str string) unsafe.Pointer {
+	cstr := C.CString(str)
+	Allocations.Add(1)
+
+	return unsafe.Pointer(cstr)
+}
+
+// ResetMemoryStats resets allocations and frees counters to zero
+func ResetMemoryStats() {
+	Allocations.Set(0)
+	Frees.Set(0)
+}
+
+// AssertMemoryUsage makes sure the allocations and frees match
+func AssertMemoryUsage(t *testing.T) {
+	assert.Equal(t, Allocations.Value(), Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }

--- a/rtloader/test/helpers/helpers_native.go
+++ b/rtloader/test/helpers/helpers_native.go
@@ -1,0 +1,22 @@
+package helpers
+
+/*
+#cgo CFLAGS: -I../../include -I../../common
+#cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
+#cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
+
+#include "datadog_agent_rtloader.h"
+#include "rtloader_mem.h"
+
+void TestMemoryTracker(void *, size_t, rtloader_mem_ops_t);
+void initTestMemoryTracker(void) {
+	set_memory_tracker_cb(TestMemoryTracker);
+}
+
+*/
+import "C"
+
+// InitMemoryTracker initializes RTLoader memory tracking
+func InitMemoryTracker() {
+	C.initTestMemoryTracker()
+}

--- a/rtloader/test/init/init.go
+++ b/rtloader/test/init/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -18,6 +19,9 @@ func runInit() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	// Updates sys.path so testing Check can be found
 	C.add_python_path(rtloader, C.CString("../python"))

--- a/rtloader/test/init/init.go
+++ b/rtloader/test/init/init.go
@@ -15,13 +15,13 @@ import (
 import "C"
 
 func runInit() error {
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
+
 	rtloader := (*C.rtloader_t)(common.GetRtLoader())
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
-
-	// Initialize memory tracking
-	helpers.InitMemoryTracker()
 
 	// Updates sys.path so testing Check can be found
 	C.add_python_path(rtloader, C.CString("../python"))

--- a/rtloader/test/init/init_test.go
+++ b/rtloader/test/init/init_test.go
@@ -7,10 +7,13 @@ import (
 )
 
 func TestInit(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	if err := runInit(); err != nil {
 		t.Errorf("Expected nil, got: %v", err)
 	}
 
-	// Check for leaks
-	helpers.AssertMemoryUsage(t)
+	// Check for expected allocations
+	helpers.AssertMemoryExpectation(t, helpers.Allocations, 1)
 }

--- a/rtloader/test/init/init_test.go
+++ b/rtloader/test/init/init_test.go
@@ -2,10 +2,15 @@ package testinit
 
 import (
 	"testing"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 func TestInit(t *testing.T) {
 	if err := runInit(); err != nil {
 		t.Errorf("Expected nil, got: %v", err)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/test/kubeutil/kubeutil.go
+++ b/rtloader/test/kubeutil/kubeutil.go
@@ -13,7 +13,7 @@ import (
 )
 
 /*
-#cgo CFLAGS: -I../../include -I../../common
+#cgo CFLAGS: -I../../include -I../../common -Wno-deprecated-declarations
 #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
 #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
 

--- a/rtloader/test/kubeutil/kubeutil.go
+++ b/rtloader/test/kubeutil/kubeutil.go
@@ -12,18 +12,21 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// #cgo CFLAGS: -I../../include
-// #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
-// #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
-//
-// #include <stdlib.h>
-// #include <datadog_agent_rtloader.h>
-//
-// extern void getConnectionInfo(char **);
-//
-// static void initKubeUtilTests(rtloader_t *rtloader) {
-//    set_get_connection_info_cb(rtloader, getConnectionInfo);
-// }
+/*
+#cgo CFLAGS: -I../../include -I../../common
+#cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
+#cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
+
+#include "rtloader_mem.h"
+#include "datadog_agent_rtloader.h"
+
+extern void getConnectionInfo(char **);
+
+static void initKubeUtilTests(rtloader_t *rtloader) {
+   set_cgo_free_cb(rtloader, _free);
+   set_get_connection_info_cb(rtloader, getConnectionInfo);
+}
+*/
 import "C"
 
 var (
@@ -65,20 +68,20 @@ func tearDown() {
 
 func run(call string) (string, error) {
 	tmpfile.Truncate(0)
-	code := C.CString(fmt.Sprintf(`
+	code := (*C.char)(helpers.TrackedCString(fmt.Sprintf(`
 try:
 	import kubeutil
 	%s
 except Exception as e:
 	with open(r'%s', 'w') as f:
 		f.write("{}\n".format(e))
-`, call, tmpfile.Name()))
+`, call, tmpfile.Name())))
+	defer C._free(unsafe.Pointer(code))
 
 	runtime.LockOSThread()
 	state := C.ensure_gil(rtloader)
 
 	ret := C.run_simple_string(rtloader, code) == 1
-	C.free(unsafe.Pointer(code))
 
 	C.release_gil(rtloader, state)
 	runtime.UnlockOSThread()
@@ -104,5 +107,5 @@ func getConnectionInfo(in **C.char) {
 	}
 	retval, _ := yaml.Marshal(h)
 
-	*in = C.CString(string(retval))
+	*in = (*C.char)(helpers.TrackedCString(string(retval)))
 }

--- a/rtloader/test/kubeutil/kubeutil.go
+++ b/rtloader/test/kubeutil/kubeutil.go
@@ -36,13 +36,13 @@ var (
 )
 
 func setUp() error {
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
+
 	rtloader = (*C.rtloader_t)(common.GetRtLoader())
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
-
-	// Initialize memory tracking
-	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/kubeutil/kubeutil.go
+++ b/rtloader/test/kubeutil/kubeutil.go
@@ -8,6 +8,7 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -26,7 +27,7 @@ import (
 import "C"
 
 var (
-	rtloader        *C.rtloader_t
+	rtloader   *C.rtloader_t
 	tmpfile    *os.File
 	returnNull bool
 )
@@ -36,6 +37,9 @@ func setUp() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/kubeutil/kubeutil_test.go
+++ b/rtloader/test/kubeutil/kubeutil_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 func TestMain(m *testing.M) {
@@ -20,6 +22,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetConnectionInfo(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	d = kubeutil.get_connection_info()
 	with open(r'%s', 'w') as f:
@@ -34,9 +39,15 @@ func TestGetConnectionInfo(t *testing.T) {
 	if out != "BarKey,FooKey-BarValue,FooValue" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetConnectionInfoNoKubeutil(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	returnNull = true
 	defer func() { returnNull = false }()
 
@@ -52,4 +63,7 @@ func TestGetConnectionInfoNoKubeutil(t *testing.T) {
 	if out != "{}" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -5,8 +5,8 @@ package testrtloader
 #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl -lstdc++
 #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
 
-#include <datadog_agent_rtloader.h>
 #include "rtloader_mem.h"
+#include "datadog_agent_rtloader.h"
 */
 import "C"
 

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -17,6 +17,7 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -30,6 +31,9 @@ func setUp() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -29,13 +29,13 @@ var (
 )
 
 func setUp() error {
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
+
 	rtloader = (*C.rtloader_t)(common.GetRtLoader())
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
-
-	// Initialize memory tracking
-	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/rtloader/rtloader_test.go
+++ b/rtloader/test/rtloader/rtloader_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 func TestMain(m *testing.M) {
@@ -25,6 +26,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetPyInfo(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	ver, path := getPyInfo()
 	prefix := "3."
 	if common.UsingTwo {
@@ -38,9 +42,15 @@ func TestGetPyInfo(t *testing.T) {
 	if path == "" {
 		t.Errorf("Python path is null")
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestRunSimpleString(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 with open(r'%s', 'w') as f:
 	f.write('Hello, World!')`, tmpfile.Name())
@@ -54,9 +64,15 @@ with open(r'%s', 'w') as f:
 	if output != "Hello, World!" {
 		t.Errorf("Unexpected printed value: '%s'", output)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetError(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	errorStr := getError()
 	expected := "unable to import module 'foo': No module named 'foo'"
 	if common.UsingTwo {
@@ -65,15 +81,27 @@ func TestGetError(t *testing.T) {
 	if errorStr != expected {
 		t.Fatalf("Wrong error string returned: %s", errorStr)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestHasError(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	if !hasError() {
 		t.Fatal("has_error should return true, got false")
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetCheck(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	version, err := getFakeCheck()
 
 	if err != nil {
@@ -83,9 +111,15 @@ func TestGetCheck(t *testing.T) {
 	if version != "0.4.2" {
 		t.Fatalf("expected version '0.4.2', found '%s'", version)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestRunCheck(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	res, err := runFakeCheck()
 
 	if err != nil {
@@ -95,9 +129,15 @@ func TestRunCheck(t *testing.T) {
 	if res != "" {
 		t.Fatal(res)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetCheckWarnings(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	res, err := runFakeGetWarnings()
 
 	if err != nil {
@@ -107,9 +147,15 @@ func TestGetCheckWarnings(t *testing.T) {
 	if res[0] != "warning 1" || res[1] != "warning 2" || res[2] != "warning 3" {
 		t.Fatal(res)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetIntegrationsList(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	res, err := getIntegrationList()
 
 	if err != nil {
@@ -121,9 +167,15 @@ func TestGetIntegrationsList(t *testing.T) {
 	if !reflect.DeepEqual(expected, res) {
 		t.Fatalf("Expected %v, got %v", expected, res)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSetModuleAttrString(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	setModuleAttrString("sys", "test", "hello")
 
 	code := fmt.Sprintf(`
@@ -140,4 +192,7 @@ with open(r'%s', 'w') as f:
 	if output != "hello" {
 		t.Errorf("Unexpected printed value: '%s'", output)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/test/tagger/tagger.go
+++ b/rtloader/test/tagger/tagger.go
@@ -13,7 +13,7 @@ import (
 )
 
 /*
-#cgo CFLAGS: -I../../include -I../../common
+#cgo CFLAGS: -I../../include -I../../common -Wno-deprecated-declarations
 #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
 #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
 

--- a/rtloader/test/tagger/tagger.go
+++ b/rtloader/test/tagger/tagger.go
@@ -36,13 +36,13 @@ var (
 )
 
 func setUp() error {
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
+
 	rtloader = (*C.rtloader_t)(common.GetRtLoader())
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
-
-	// Initialize memory tracking
-	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/tagger/tagger.go
+++ b/rtloader/test/tagger/tagger.go
@@ -23,8 +23,8 @@ import (
 extern char **Tags(char*, int);
 
 static void initTaggerTests(rtloader_t *rtloader) {
-   set_tags_cb(rtloader, Tags);
    set_cgo_free_cb(rtloader, _free);
+   set_tags_cb(rtloader, Tags);
 }
 
 */

--- a/rtloader/test/tagger/tagger.go
+++ b/rtloader/test/tagger/tagger.go
@@ -9,22 +9,25 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
-// #cgo CFLAGS: -I../../include -I../../common
-// #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
-// #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
-//
-// #include "datadog_agent_rtloader.h"
-// #include "rtloader_mem.h"
-//
-// #include <stdlib.h>
-//
-// extern char **Tags(char*, int);
-//
-// static void initTaggerTests(rtloader_t *rtloader) {
-//    set_tags_cb(rtloader, Tags);
-// }
+/*
+#cgo CFLAGS: -I../../include -I../../common
+#cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
+#cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
+
+#include "datadog_agent_rtloader.h"
+#include "rtloader_mem.h"
+
+#include <stdlib.h>
+
+extern char **Tags(char*, int);
+
+static void initTaggerTests(rtloader_t *rtloader) {
+   set_tags_cb(rtloader, Tags);
+}
+*/
 import "C"
 
 var (
@@ -37,6 +40,9 @@ func setUp() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/tagger/tagger_test.go
+++ b/rtloader/test/tagger/tagger_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -37,8 +36,8 @@ func TestGetTags(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetTagsHighCard(t *testing.T) {
@@ -55,8 +54,8 @@ func TestGetTagsHighCard(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetTagsUnknown(t *testing.T) {
@@ -73,8 +72,8 @@ func TestGetTagsUnknown(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetTagsErrorType(t *testing.T) {
@@ -87,8 +86,8 @@ func TestGetTagsErrorType(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestTagsLow(t *testing.T) {
@@ -105,8 +104,8 @@ func TestTagsLow(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestTagsHigh(t *testing.T) {
@@ -123,8 +122,8 @@ func TestTagsHigh(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestTagsOrchestrator(t *testing.T) {
@@ -141,8 +140,8 @@ func TestTagsOrchestrator(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestTagsInvalidCardinality(t *testing.T) {
@@ -159,8 +158,8 @@ func TestTagsInvalidCardinality(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestTagsUnknown(t *testing.T) {
@@ -177,8 +176,8 @@ func TestTagsUnknown(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestTagsErrorType(t *testing.T) {
@@ -191,6 +190,6 @@ func TestTagsErrorType(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 
-	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
-		"Number of allocations doesn't match number of frees")
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/test/tagger/tagger_test.go
+++ b/rtloader/test/tagger/tagger_test.go
@@ -23,6 +23,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetTags(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	import json
 	with open(r'%s', 'w') as f:
@@ -41,6 +44,9 @@ func TestGetTags(t *testing.T) {
 }
 
 func TestGetTagsHighCard(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	import json
 	with open(r'%s', 'w') as f:
@@ -59,6 +65,9 @@ func TestGetTagsHighCard(t *testing.T) {
 }
 
 func TestGetTagsUnknown(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	import json
 	with open(r'%s', 'w') as f:
@@ -77,6 +86,9 @@ func TestGetTagsUnknown(t *testing.T) {
 }
 
 func TestGetTagsErrorType(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`tagger.get_tags(1234, True)`)
 	out, err := run(code)
 	if err != nil {
@@ -91,6 +103,9 @@ func TestGetTagsErrorType(t *testing.T) {
 }
 
 func TestTagsLow(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	import json
 	with open(r'%s', 'w') as f:
@@ -109,6 +124,9 @@ func TestTagsLow(t *testing.T) {
 }
 
 func TestTagsHigh(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	import json
 	with open(r'%s', 'w') as f:
@@ -127,6 +145,9 @@ func TestTagsHigh(t *testing.T) {
 }
 
 func TestTagsOrchestrator(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	import json
 	with open(r'%s', 'w') as f:
@@ -145,6 +166,9 @@ func TestTagsOrchestrator(t *testing.T) {
 }
 
 func TestTagsInvalidCardinality(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	import json
 	with open(r'%s', 'w') as f:
@@ -163,6 +187,9 @@ func TestTagsInvalidCardinality(t *testing.T) {
 }
 
 func TestTagsUnknown(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	import json
 	with open(r'%s', 'w') as f:
@@ -181,6 +208,9 @@ func TestTagsUnknown(t *testing.T) {
 }
 
 func TestTagsErrorType(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`tagger.tag(1234, tagger.LOW)`)
 	out, err := run(code)
 	if err != nil {

--- a/rtloader/test/tagger/tagger_test.go
+++ b/rtloader/test/tagger/tagger_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -33,6 +36,9 @@ func TestGetTags(t *testing.T) {
 	if out != "[\"a\", \"b\", \"c\"]" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }
 
 func TestGetTagsHighCard(t *testing.T) {
@@ -48,6 +54,9 @@ func TestGetTagsHighCard(t *testing.T) {
 	if out != "[\"A\", \"B\", \"C\"]" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }
 
 func TestGetTagsUnknown(t *testing.T) {
@@ -63,6 +72,9 @@ func TestGetTagsUnknown(t *testing.T) {
 	if out != "[]" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }
 
 func TestGetTagsErrorType(t *testing.T) {
@@ -74,6 +86,9 @@ func TestGetTagsErrorType(t *testing.T) {
 	if matched, err := regexp.Match("TypeError: argument 1 must be (str|string), not int", []byte(out)); err != nil && !matched {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }
 
 func TestTagsLow(t *testing.T) {
@@ -89,6 +104,9 @@ func TestTagsLow(t *testing.T) {
 	if out != "[\"a\", \"b\", \"c\"]" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }
 
 func TestTagsHigh(t *testing.T) {
@@ -104,6 +122,9 @@ func TestTagsHigh(t *testing.T) {
 	if out != "[\"A\", \"B\", \"C\"]" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }
 
 func TestTagsOrchestrator(t *testing.T) {
@@ -119,6 +140,9 @@ func TestTagsOrchestrator(t *testing.T) {
 	if out != "[\"1\", \"2\", \"3\"]" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }
 
 func TestTagsInvalidCardinality(t *testing.T) {
@@ -134,6 +158,9 @@ func TestTagsInvalidCardinality(t *testing.T) {
 	if out != "TypeError: Invalid cardinality" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }
 
 func TestTagsUnknown(t *testing.T) {
@@ -149,6 +176,9 @@ func TestTagsUnknown(t *testing.T) {
 	if out != "[]" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }
 
 func TestTagsErrorType(t *testing.T) {
@@ -160,4 +190,7 @@ func TestTagsErrorType(t *testing.T) {
 	if matched, err := regexp.Match("TypeError: argument 1 must be (str|string), not int", []byte(out)); err != nil && !matched {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	assert.Equal(t, helpers.Allocations.Value(), helpers.Frees.Value(),
+		"Number of allocations doesn't match number of frees")
 }

--- a/rtloader/test/util/util.go
+++ b/rtloader/test/util/util.go
@@ -13,7 +13,7 @@ import (
 )
 
 /*
-#cgo CFLAGS: -I../../include -I../../common
+#cgo CFLAGS: -I../../include -I../../common -Wno-deprecated-declarations
 #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
 #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
 

--- a/rtloader/test/util/util.go
+++ b/rtloader/test/util/util.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -23,8 +24,8 @@ import (
 import "C"
 
 var (
-	rtloader     *C.rtloader_t
-	tmpfile *os.File
+	rtloader *C.rtloader_t
+	tmpfile  *os.File
 )
 
 type message struct {
@@ -38,6 +39,9 @@ func setUp() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/util/util.go
+++ b/rtloader/test/util/util.go
@@ -41,13 +41,13 @@ type message struct {
 }
 
 func setUp() error {
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
+
 	rtloader = (*C.rtloader_t)(common.GetRtLoader())
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
-
-	// Initialize memory tracking
-	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/util/util_test.go
+++ b/rtloader/test/util/util_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 func TestMain(m *testing.M) {
@@ -17,6 +19,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestHeaders(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`
 	d = util.headers(http_host="myhost", ignore_me="snafu")
 	with open(r'%s', 'w') as f:
@@ -29,4 +34,7 @@ func TestHeaders(t *testing.T) {
 	if out != "Accept,Content-Type,Host,User-Agent" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/test/uutil/uutil.go
+++ b/rtloader/test/uutil/uutil.go
@@ -35,13 +35,13 @@ var (
 )
 
 func setUp() error {
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
+
 	rtloader = (*C.rtloader_t)(common.GetRtLoader())
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
-
-	// Initialize memory tracking
-	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/uutil/uutil.go
+++ b/rtloader/test/uutil/uutil.go
@@ -13,7 +13,7 @@ import (
 )
 
 /*
-#cgo CFLAGS: -I../../include -I../../common
+#cgo CFLAGS: -I../../include -I../../common -Wno-deprecated-declarations
 #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
 #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
 

--- a/rtloader/test/uutil/uutil.go
+++ b/rtloader/test/uutil/uutil.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/rtloader/test/common"
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -24,8 +25,8 @@ import (
 import "C"
 
 var (
-	rtloader     *C.rtloader_t
-	tmpfile *os.File
+	rtloader *C.rtloader_t
+	tmpfile  *os.File
 )
 
 func setUp() error {
@@ -33,6 +34,9 @@ func setUp() error {
 	if rtloader == nil {
 		return fmt.Errorf("make failed")
 	}
+
+	// Initialize memory tracking
+	helpers.InitMemoryTracker()
 
 	var err error
 	tmpfile, err = ioutil.TempFile("", "testout")

--- a/rtloader/test/uutil/uutil.go
+++ b/rtloader/test/uutil/uutil.go
@@ -12,16 +12,21 @@ import (
 	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
-// #cgo CFLAGS: -I../../include
-// #cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
-// #cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
-// #include <datadog_agent_rtloader.h>
-//
-// extern void getSubprocessOutput(char **, char **, char **, int*, char **);
-//
-// static void init_utilTests(rtloader_t *rtloader) {
-//    set_get_subprocess_output_cb(rtloader, getSubprocessOutput);
-// }
+/*
+#cgo CFLAGS: -I../../include -I../../common
+#cgo !windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -ldl
+#cgo windows LDFLAGS: -L../../rtloader/ -ldatadog-agent-rtloader -lstdc++ -static
+
+#include "rtloader_mem.h"
+#include "datadog_agent_rtloader.h"
+
+extern void getSubprocessOutput(char **, char **, char **, int*, char **);
+
+static void init_utilTests(rtloader_t *rtloader) {
+   set_cgo_free_cb(rtloader, _free);
+   set_get_subprocess_output_cb(rtloader, getSubprocessOutput);
+}
+*/
 import "C"
 
 var (
@@ -62,7 +67,7 @@ func tearDown() {
 
 func run(call string) (string, error) {
 	tmpfile.Truncate(0)
-	code := C.CString(fmt.Sprintf(`
+	code := (*C.char)(helpers.TrackedCString(fmt.Sprintf(`
 try:
 	import _util
 	import sys
@@ -70,7 +75,8 @@ try:
 except Exception as e:
 	with open(r'%s', 'w') as f:
 		f.write("{}: {}\n".format(type(e).__name__, e))
-`, call, tmpfile.Name()))
+`, call, tmpfile.Name())))
+	defer C._free(unsafe.Pointer(code))
 
 	runtime.LockOSThread()
 	state := C.ensure_gil(rtloader)
@@ -107,10 +113,10 @@ func charArrayToSlice(array **C.char) (res []string) {
 //export getSubprocessOutput
 func getSubprocessOutput(cargs **C.char, cstdout **C.char, cstderr **C.char, cretCode *C.int, cexception **C.char) {
 	args = charArrayToSlice(cargs)
-	*cstdout = C.CString(stdout)
-	*cstderr = C.CString(stderr)
+	*cstdout = (*C.char)(helpers.TrackedCString(stdout))
+	*cstderr = (*C.char)(helpers.TrackedCString(stderr))
 	*cretCode = C.int(retCode)
 	if setException {
-		*cexception = C.CString(exception)
+		*cexception = (*C.char)(helpers.TrackedCString(exception))
 	}
 }

--- a/rtloader/test/uutil/uutil_test.go
+++ b/rtloader/test/uutil/uutil_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/rtloader/test/helpers"
 )
 
 var (
@@ -35,6 +37,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestSubprocessOutputWrongArg(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`_util.subprocess_output()`)
 	out, err := run(code)
 	if err != nil {
@@ -43,9 +48,15 @@ func TestSubprocessOutputWrongArg(t *testing.T) {
 	if out != "TypeError: get_subprocess_output() takes at least 1 argument (0 given)" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubprocessOutputEmptyList(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	code := fmt.Sprintf(`_util.subprocess_output([])`)
 	out, err := run(code)
 	if err != nil {
@@ -54,9 +65,15 @@ func TestSubprocessOutputEmptyList(t *testing.T) {
 	if out != "TypeError: invalid command: empty list" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubprocessOutput(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	stdout = "/tmp"
 	code := fmt.Sprintf(`
 	stdout, stderr, ret = _util.subprocess_output(["ls"], False)
@@ -70,9 +87,15 @@ func TestSubprocessOutput(t *testing.T) {
 	if out != "/tmp |  | 0" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetSubprocessOutput(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	stdout = "/tmp"
 	code := fmt.Sprintf(`
 	stdout, stderr, ret = _util.get_subprocess_output(["ls"], False)
@@ -86,9 +109,15 @@ func TestGetSubprocessOutput(t *testing.T) {
 	if out != "/tmp |  | 0" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetSubprocessOutputStderr(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	stdout = "/tmp"
 	stderr = "some error"
 	code := fmt.Sprintf(`
@@ -103,9 +132,15 @@ func TestGetSubprocessOutputStderr(t *testing.T) {
 	if out != "/tmp | some error | 0" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetSubprocessOutputRetCode(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	stdout = "/tmp"
 	retCode = 21
 	code := fmt.Sprintf(`
@@ -120,9 +155,15 @@ func TestGetSubprocessOutputRetCode(t *testing.T) {
 	if out != "/tmp |  | 21" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetSubprocessOutputStderrRetCode(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	stdout = "/tmp"
 	stderr = "some error"
 	retCode = 21
@@ -138,9 +179,15 @@ func TestGetSubprocessOutputStderrRetCode(t *testing.T) {
 	if out != "/tmp | some error | 21" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetSubprocessOutputErrorNotList(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`_util.get_subprocess_output("ls", False)`)
 
 	if err != nil {
@@ -149,9 +196,15 @@ func TestGetSubprocessOutputErrorNotList(t *testing.T) {
 	if out != "TypeError: command args not a list" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetSubprocessOutputErrorNotBool(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`_util.get_subprocess_output(["ls"], 1)`)
 
 	if err != nil {
@@ -160,9 +213,15 @@ func TestGetSubprocessOutputErrorNotBool(t *testing.T) {
 	if out != "TypeError: bad raise_on_empty argument: should be bool" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestGetSubprocessOutputErrorCommandArgsNotString(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	out, err := run(`_util.get_subprocess_output(["ls", 123], False)`)
 
 	if err != nil {
@@ -171,9 +230,15 @@ func TestGetSubprocessOutputErrorCommandArgsNotString(t *testing.T) {
 	if out != "TypeError: command argument must be valid strings" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubprocessOutputRaiseEmptyStdout(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	stdout = "" // setting empty output
 	code := fmt.Sprintf(`_util.subprocess_output(["ls"], True)`)
 	out, err := run(code)
@@ -183,9 +248,15 @@ func TestSubprocessOutputRaiseEmptyStdout(t *testing.T) {
 	if out != "SubprocessOutputEmptyError: get_subprocess_output expected output but had none." {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubprocessOutputRaiseException(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	setException = true
 	exception = "THIS IS AN ERROR FROM GO"
 	code := fmt.Sprintf(`_util.subprocess_output(["ls"], False)`)
@@ -196,9 +267,15 @@ func TestSubprocessOutputRaiseException(t *testing.T) {
 	if out != "Exception: THIS IS AN ERROR FROM GO" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }
 
 func TestSubprocessOutputRaiseEmptyException(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
 	setException = true
 	exception = ""
 	code := fmt.Sprintf(`_util.subprocess_output(["ls"], False)`)
@@ -209,4 +286,7 @@ func TestSubprocessOutputRaiseEmptyException(t *testing.T) {
 	if out != "Exception:" {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
 }

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -175,10 +175,10 @@ void Three::freePyInfo(py_info_t *info)
 {
     info->version = NULL;
     if (info->path) {
-        free(info->path);
+        _free(info->path);
         info->version = NULL;
     }
-    free(info);
+    _free(info);
     return;
 }
 bool Three::runSimpleString(const char *code) const

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -176,9 +176,9 @@ void Two::freePyInfo(py_info_t *info)
 {
     info->version = NULL;
     if (info->path) {
-        free(info->path);
+        _free(info->path);
     }
-    free(info);
+    _free(info);
     return;
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR mainly adds memory accounting to our unit tests, ensuring all tests have a net allocation/free count of 0 at the end of each test.  

The PR also introduces a few fixes identified in the process, including a couple of small leaks.

Finally, it deprecates the use of `malloc` and `free` directly in the C rtloader code. This might not currently be offering full coverage in the C++ code, but new and malloc shouldn't typically used in C++ by convention anyway. 

### Motivation

The goal of this PR is to help us identify leaks within the CI as a product of changes to code in the RTLoader. 

### Additional Notes

Finally, the rtloader deprecation warning for `malloc` and `free` is currently triggering as a result of importing `stdlib.h`, I will try to address this before the PR is merged.
