### PR TITLE
[omnibus] cffi_backend stripping breaks SO on CentOS7

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -128,6 +128,7 @@ build do
             # Only affects psycopg2 - any binary whose path matches the pattern will be
             # skipped.
             strip_exclude("*psycopg2*")
+            strip_exclude("*cffi_backend*")
 
         elsif osx?
             # Remove linux specific configs


### PR DESCRIPTION
### What does this PR do?

Fixes a bug caused by stripping of altered ELF file (by manylinux scripts).
   

### Motivation

Unfortunately there's a bug potentially triggered by manylinux wheels where stripping might break some ELF files. See https://github.com/DataDog/omnibus-ruby/pull/94 and https://github.com/pypa/manylinux/issues/119. The issue stems from a problem on a tool used on some manylinux wheels. 