### PR TITLE
[omnibus] Remove Python 3 integrations on upgrade/uninstall

### DIFF
--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -74,9 +74,14 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         # Starting with 6.10, integrations are also uninstalled on package removal
         # See https://github.com/DataDog/datadog-agent/pull/3066 for more details
         PIP_PATH=$INSTALL_DIR/embedded/bin/pip
+        PIP3_PATH=$INSTALL_DIR/embedded/bin/pip3
         if [ -x $PIP_PATH ]; then
-            echo "Uninstalling integrations..."
+            echo "Uninstalling Python 2 integrations..."
             $PIP_PATH freeze | grep ^datadog- | grep -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q --no-cache-dir || true
+        fi
+        if [ -x $PIP3_PATH ]; then
+            echo "Uninstalling Python 3 integrations..."
+            $PIP3_PATH freeze | grep ^datadog- | grep -v datadog-checks-base | xargs $PIP3_PATH uninstall -y -q --no-cache-dir || true
         fi
 
         # Delete all the .pyc/.pyo files in the embedded dir that are part of the old agent's package

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -96,9 +96,14 @@ uninstall_integrations()
     # Starting with 6.10, integrations are uninstalled on package removal
     # See https://github.com/DataDog/datadog-agent/pull/3066 for more details
     PIP_PATH=$INSTALL_DIR/embedded/bin/pip
+    PIP3_PATH=$INSTALL_DIR/embedded/bin/pip3
     if [ -x $PIP_PATH ]; then
-        echo "Uninstalling integrations..."
+        echo "Uninstalling Python 2 integrations..."
         $PIP_PATH freeze | grep ^datadog- | grep -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q --no-cache-dir || true
+    fi
+    if [ -x $PIP3_PATH ]; then
+        echo "Uninstalling Python 3 integrations..."
+        $PIP3_PATH freeze | grep ^datadog- | grep -v datadog-checks-base | xargs $PIP3_PATH uninstall -y -q --no-cache-dir || true
     fi
 }
 


### PR DESCRIPTION
### What does this PR do?

Removes the Python 3 integrations intalled in `embedded/lib/python3.7/site-packages` in addition to the Python 2 ones.

### Motivation

If someone updates an integration using the `integration` command, there could a scenario in which the `/opt/datadog-agent` folder is not empty after an Agent removal.
