### PR TITLE
[kubelet Collector] fix possible nil Pod in PodList

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -200,7 +200,7 @@ func (ku *KubeUtil) GetLocalPodList() ([]*Pod, error) {
 	}
 
 	// ensure we dont have nil pods
-	tmpSlice := make([]*Pod, 0, len(pods.Items))
+	tmpSlice := []*Pod{}
 	for _, pod := range pods.Items {
 		if pod != nil {
 			tmpSlice = append(tmpSlice, pod)

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -944,7 +944,7 @@ func (suite *KubeletTestSuite) TestPodListWithNullPod() {
 	pods, err := kubeutil.ForceGetLocalPodList()
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), pods)
-	require.Len(suite.T(), pods, 2)
+	require.Len(suite.T(), pods, 3)
 
 	for _, po := range pods {
 		require.NotNil(suite.T(), po)

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_null_pod.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_null_pod.json
@@ -3,8 +3,33 @@
     "apiVersion": "v1",
     "metadata": {},
     "items": [
-        {},
+        {
+            "metadata": {
+              "name": "dd-agent-ntepl",
+              "generateName": "dd-agent-",
+              "namespace": "default",
+              "selfLink": "/api/v1/namespaces/default/pods/dd-agent-ntepl",
+              "uid": "sdfsgdfgdfg"
+            },
+            "spec": {},
+            "status": {
+              "phase": "Running"
+            }
+        },
         null,
+        {
+            "metadata": {
+              "name": "dd-agent-barbbb",
+              "generateName": "dd-agent-",
+              "namespace": "default",
+              "selfLink": "/api/v1/namespaces/default/pods/dd-agent-barbbb",
+              "uid": "sdfsddsdsgdfgdfg"
+            },
+            "spec": {},
+            "status": {
+              "phase": "Running"
+            }
+        },
         {}
     ]
 }

--- a/releasenotes/notes/fix-kubeutil-GetLocalPodList-returning-nil-pod-be01bb72e6399d81.yaml
+++ b/releasenotes/notes/fix-kubeutil-GetLocalPodList-returning-nil-pod-be01bb72e6399d81.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Fix kubeutil.GetLocalPodList() that possibly returns nil pod(s) in the output slice.
+


### PR DESCRIPTION
### What does this PR do?

Remove a Slice pre-allocation for the "PodList" in the Kubelet Collector, this is not compatible with the Pod filtering done after. 

### Motivation

Fix a bug in the generation of the internal Kubelet collector `PodList`
The slice allocation before the pod filtering was not needed.

### Additional Notes

Anything else we should know when reviewing?
