### PR TITLE
Fix NTP check tagging

### DIFF
--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -127,12 +127,8 @@ func (c *ntpConfig) parse(data []byte, initData []byte, getLocalServers func() (
 
 // Configure configure the data from the yaml
 func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
-	err := c.CommonConfigure(data, source)
-	if err != nil {
-		return err
-	}
 	cfg := new(ntpConfig)
-	err = cfg.parse(data, initConfig, getLocalDefinedNTPServers)
+	err := cfg.parse(data, initConfig, getLocalDefinedNTPServers)
 	if err != nil {
 		log.Errorf("Error parsing configuration file: %s", err)
 		return err
@@ -140,6 +136,11 @@ func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data,
 
 	c.BuildID(data, initConfig)
 	c.cfg = cfg
+
+	err = c.CommonConfigure(data, source)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/releasenotes/notes/fix_ntp_tags_support-e28b551f2d2a2439.yaml
+++ b/releasenotes/notes/fix_ntp_tags_support-e28b551f2d2a2439.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix tag support for NTP check.


### PR DESCRIPTION
### What does this PR do?

This PR fixes the tagging feature for the NTP check.

### Motivation

Every check should [support the tagging feature from their configuration file](https://docs.datadoghq.com/tagging/assigning_tags/?tab=agentv6).

### Additional Notes

The base class for all the checks, `CheckBase`, implements tagging for all the checks. To actually send the specified tags, `CheckBase` sets the custom tags on a `Sender`.
The `Sender`s are issued from a `checkSenderPool` based on the check's ID.
If the check instance doesn't compute its ID before calling `commonConfigure`, then `CheckBase` cannot set the tags on the same sender as the check and tags are not sent correctly.

### Test plan

To test this feature, simply add some tags in the `ntp.yaml` configuration and ensure they can be seen in infrastructure map, under the NTP service.