### PR TITLE
Make NTPCheck use CheckBase's MinCollectionInterval

### DIFF
--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -46,10 +46,15 @@ type CheckBase struct {
 
 // NewCheckBase returns a check base struct with a given check name
 func NewCheckBase(name string) CheckBase {
+	return NewCheckBaseWithInterval(name, defaults.DefaultCheckInterval)
+}
+
+// NewCheckBase returns a check base struct with a given check name and interval
+func NewCheckBaseWithInterval(name string, defaultInterval time.Duration) CheckBase {
 	return CheckBase{
 		checkName:     name,
 		checkID:       check.ID(name),
-		checkInterval: defaults.DefaultCheckInterval,
+		checkInterval: defaultInterval,
 	}
 }
 

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -49,7 +49,7 @@ func NewCheckBase(name string) CheckBase {
 	return NewCheckBaseWithInterval(name, defaults.DefaultCheckInterval)
 }
 
-// NewCheckBase returns a check base struct with a given check name and interval
+// NewCheckBaseWithInterval returns a check base struct with a given check name and interval
 func NewCheckBaseWithInterval(name string, defaultInterval time.Duration) CheckBase {
 	return CheckBase{
 		checkName:     name,

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -24,12 +24,12 @@ import (
 )
 
 const ntpCheckName = "ntp"
+const defaultMinCollectionInterval = 900 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
 
 var (
 	ntpExpVar = expvar.NewFloat("ntpOffset")
 	// for testing purpose
-	ntpQuery                     = ntp.QueryWithOptions
-	defaultMinCollectionInterval = 900 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
+	ntpQuery = ntp.QueryWithOptions
 )
 
 // NTPCheck only has sender and config
@@ -59,16 +59,6 @@ type ntpConfig struct {
 
 func (c *NTPCheck) String() string {
 	return "ntp"
-}
-
-// Interval returns the scheduling time for the check.
-// Override the CheckBase.Interval() method to return a default collection interval of 15min if none is specified
-// in the config file.
-func (c *NTPCheck) Interval() time.Duration {
-	if c.CheckBase.Interval() == 0 {
-		return time.Second * time.Duration(defaultMinCollectionInterval)
-	}
-	return c.CheckBase.Interval()
 }
 
 func (c *ntpConfig) parse(data []byte, initData []byte, getLocalServers func() ([]string, error)) error {
@@ -230,7 +220,7 @@ func (c *NTPCheck) queryOffset() (float64, error) {
 
 func ntpFactory() check.Check {
 	return &NTPCheck{
-		CheckBase: core.NewCheckBase(ntpCheckName),
+		CheckBase: core.NewCheckBaseWithInterval(ntpCheckName, time.Duration(defaultMinCollectionInterval)*time.Second),
 	}
 }
 

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -61,6 +61,9 @@ func (c *NTPCheck) String() string {
 	return "ntp"
 }
 
+// Interval returns the scheduling time for the check.
+// Override the CheckBase.Interval() method to return a default collection interval of 15min if none is specified
+// in the config file.
 func (c *NTPCheck) Interval() time.Duration {
 	if c.CheckBase.Interval() == 0 {
 		return time.Second * time.Duration(defaultMinCollectionInterval)

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -28,7 +28,7 @@ const ntpCheckName = "ntp"
 var (
 	ntpExpVar = expvar.NewFloat("ntpOffset")
 	// for testing purpose
-	ntpQuery = ntp.QueryWithOptions
+	ntpQuery                     = ntp.QueryWithOptions
 	defaultMinCollectionInterval = 900 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
 )
 


### PR DESCRIPTION
### What does this PR do?

This PR makes `NTPCheck` use `CheckBase`'s `MinCollectionInterval`

### Motivation

The property was duplicated in the `NTPCheck`'s config. Every time the check ran with the default interval of 15s, the `Run` method would check if it was time to run or not.

### Additional Notes

The property `MinCollectionInterval` was already defined in `CommonInstanceConfig`, and so it was duplicated in the `NTPInstanceConfig`. This PR aims to remove that duplicated property.