### PR TITLE
Add tag hash for all services

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -571,6 +571,10 @@ func GetResolveWarnings() map[string][]string {
 func (ac *AutoConfig) processNewService(svc listeners.Service) {
 	// in any case, register the service and store its tag hash
 	ac.store.setServiceForEntity(svc, svc.GetEntity())
+	ac.store.setTagsHashForService(
+		svc.GetTaggerEntity(),
+		tagger.GetEntityHash(svc.GetTaggerEntity()),
+	)
 
 	// get all the templates matching service identifiers
 	var templates []integration.Config


### PR DESCRIPTION
### What does this PR do?

Fixing a regression introduced by #4127 :
All containers that don't have AD annotations won't get their tagger hash set via https://github.com/DataDog/datadog-agent/blob/11f49b5eeca0f1f86f3de494b4235594349bb582/pkg/autodiscovery/autoconfig.go#L527
the following loop will happen, causing unecessary logs and operations in autoconfig:
-> new service with empty hash
-> getting non empty hash from tagger causing rescheduling
-> hash is removed with rescheduling via https://github.com/DataDog/datadog-agent/blob/master/pkg/autodiscovery/autoconfig.go#L620
-> new service with empty hash
... 🔁 

This PR sets the tag hash directly when we receive a new service and not only when we have an AD template, breaking effectively the above loop