### PR TITLE
Fix diagnose config setup

### DIFF
--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -25,23 +24,21 @@ var diagnoseCommand = &cobra.Command{
 	Use:   "diagnose",
 	Short: "Execute some connectivity diagnosis on your system",
 	Long:  ``,
-	Run:   doDiagnose,
+	RunE:  doDiagnose,
 }
 
-func doDiagnose(cmd *cobra.Command, args []string) {
+func doDiagnose(cmd *cobra.Command, args []string) error {
 	// Global config setup
-	if confFilePath != "" {
-		if err := common.SetupConfig(confFilePath); err != nil {
-			fmt.Println("Cannot setup config, exiting:", err)
-			panic(err)
-		}
+	err := common.SetupConfig(confFilePath)
+	if err != nil {
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
 
 	if flagNoColor {
 		color.NoColor = true
 	}
 
-	err := config.SetupLogger(
+	err = config.SetupLogger(
 		loggerName,
 		config.Datadog.GetString("log_level"),
 		common.DefaultLogFile,
@@ -51,12 +48,8 @@ func doDiagnose(cmd *cobra.Command, args []string) {
 		config.Datadog.GetBool("log_format_json"),
 	)
 	if err != nil {
-		log.Errorf("Error while setting up logging, exiting: %v", err)
-		panic(err)
+		return fmt.Errorf("Error while setting up logging, exiting: %v", err)
 	}
 
-	err = diagnose.RunAll(color.Output)
-	if err != nil {
-		panic(err)
-	}
+	return diagnose.RunAll(color.Output)
 }

--- a/cmd/cluster-agent/app/diagnose.go
+++ b/cmd/cluster-agent/app/diagnose.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -27,23 +26,21 @@ var diagnoseCommand = &cobra.Command{
 	Use:   "diagnose",
 	Short: "Execute some connectivity diagnosis on your system",
 	Long:  ``,
-	Run:   doDiagnose,
+	RunE:  doDiagnose,
 }
 
-func doDiagnose(cmd *cobra.Command, args []string) {
+func doDiagnose(cmd *cobra.Command, args []string) error {
 	// Global config setup
-	if confPath != "" {
-		if err := common.SetupConfig(confPath); err != nil {
-			fmt.Println("Cannot setup config, exiting:", err)
-			panic(err)
-		}
+	err := common.SetupConfig(confPath)
+	if err != nil {
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
 
 	if flagNoColor {
 		color.NoColor = true
 	}
 
-	err := config.SetupLogger(
+	err = config.SetupLogger(
 		loggerName,
 		config.Datadog.GetString("log_level"),
 		common.DefaultLogFile,
@@ -53,12 +50,8 @@ func doDiagnose(cmd *cobra.Command, args []string) {
 		config.Datadog.GetBool("log_format_json"),
 	)
 	if err != nil {
-		log.Errorf("Error while setting up logging, exiting: %v", err)
-		panic(err)
+		return fmt.Errorf("Error while setting up logging, exiting: %v", err)
 	}
 
-	err = diagnose.RunAll(color.Output)
-	if err != nil {
-		panic(err)
-	}
+	return diagnose.RunAll(color.Output)
 }

--- a/releasenotes/notes/fix-diagnose-config-2f8f2f95ced4fd9e.yaml
+++ b/releasenotes/notes/fix-diagnose-config-2f8f2f95ced4fd9e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the behavior of the diagnose command that would not consider default configuration location
+    when run independently


### PR DESCRIPTION
### What does this PR do?

Fix `diagnose` config setup

### Motivation

The current configuration setup would not look for the default config location

### Additional Notes

Not affecting the `diagnose` in the `flare` as the agent config is already setup
