### PR TITLE
Inventories: Add internal API to set metadata

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -215,8 +215,8 @@ func (c *Collector) started() bool {
 	return atomic.LoadUint32(&(c.state)) == started
 }
 
-// returns the ID's of all instances of a check
-func (c *Collector) getAllInstanceIDs(checkName string) []check.ID {
+// GetAllInstanceIDs returns the ID's of all instances of a check
+func (c *Collector) GetAllInstanceIDs(checkName string) []check.ID {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
@@ -237,7 +237,7 @@ func (c *Collector) ReloadAllCheckInstances(name string, newInstances []check.Ch
 	}
 
 	// Stop all the old instances
-	killed := c.getAllInstanceIDs(name)
+	killed := c.GetAllInstanceIDs(name)
 	for _, id := range killed {
 		e := c.StopCheck(id)
 		if e != nil {

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -176,7 +176,7 @@ func (suite *CollectorTestSuite) TestGetAllInstanceIDs() {
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), 3, len(suite.c.checks))
 
-	ids := suite.c.getAllInstanceIDs("TestCheck1")
+	ids := suite.c.GetAllInstanceIDs("TestCheck1")
 	assert.Equal(suite.T(), 2, len(ids))
 	sort.Sort(ChecksList(ids))
 	expected := []check.ID{"bar", "foo"}

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package inventories
+
+import (
+	"sync"
+	"time"
+)
+
+type checkMetadataCacheEntry struct {
+	LastUpdated           int64
+	CheckInstanceMetadata CheckInstanceMetadata
+}
+
+var (
+	checkMetadataCache = make(map[string]*checkMetadataCacheEntry) // by check ID
+	checkCacheMutex    = &sync.Mutex{}
+	agentMetadataCache = make(AgentMetadata)
+	agentCacheMutex    = &sync.Mutex{}
+)
+
+// SetAgentMetadata updates the agent metadata value in the cache
+func SetAgentMetadata(name string, value interface{}) {
+	agentCacheMutex.Lock()
+	defer agentCacheMutex.Unlock()
+
+	agentMetadataCache[name] = value
+}
+
+// SetCheckMetadata updates a metadata value for one check instance in the cache.
+func SetCheckMetadata(checkID, key string, value interface{}) {
+	checkCacheMutex.Lock()
+	defer checkCacheMutex.Unlock()
+
+	entry, found := checkMetadataCache[checkID]
+	if !found {
+		entry = &checkMetadataCacheEntry{
+			CheckInstanceMetadata: make(CheckInstanceMetadata),
+		}
+		checkMetadataCache[checkID] = entry
+	}
+
+	entry.LastUpdated = time.Now().UnixNano()
+	entry.CheckInstanceMetadata[key] = value
+}

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+// +build !windows
+
+package inventories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/stretchr/testify/assert"
+)
+
+func mockGetLoadedConfigs() map[string]integration.Config {
+	ret := make(map[string]integration.Config)
+	ret["check1_digest"] = integration.Config{
+		Name:     "check1",
+		Provider: "provider1",
+	}
+	ret["check2_digest"] = integration.Config{
+		Name:     "check2",
+		Provider: "provider2",
+	}
+	return ret
+}
+
+func mockGetAllInstanceIDs(checkName string) []check.ID {
+	if checkName == "check1" {
+		return []check.ID{"check1_instance1", "check1_instance2"}
+	} else if checkName == "check2" {
+		return []check.ID{"check2_instance1"}
+	}
+	return nil
+}
+
+func TestGetPayload(t *testing.T) {
+	getLoadedConfigs = mockGetLoadedConfigs
+	getAllInstanceIDs = mockGetAllInstanceIDs
+	startNow := time.Now().UnixNano()
+	nowNano = func() int64 { return startNow } // time of the first run
+	defer func() {
+		getLoadedConfigs = common.AC.GetLoadedConfigs
+		getAllInstanceIDs = common.Coll.GetAllInstanceIDs
+		nowNano = time.Now().UnixNano
+	}()
+
+	SetAgentMetadata("test", true)
+	SetCheckMetadata("check1_instance1", "check_provided_key1", 123)
+	SetCheckMetadata("check1_instance1", "check_provided_key2", "Hi")
+	SetCheckMetadata("non_running_checkid", "check_provided_key1", "this should get deleted")
+
+	p := GetPayload()
+
+	assert.Equal(t, startNow, p.Timestamp)
+
+	agentMetadata := *p.AgentMetadata
+	assert.Len(t, agentMetadata, 1)
+	assert.Equal(t, true, agentMetadata["test"])
+
+	checkMetadata := *p.CheckMetadata
+	assert.Len(t, checkMetadata, 2)           // non_running_checkid is not there
+	assert.Len(t, checkMetadata["check1"], 2) // check1 has two instances
+	check1Instance1 := *checkMetadata["check1"][0]
+	assert.Len(t, check1Instance1, 5)
+	assert.Equal(t, startNow, check1Instance1["last_updated"])
+	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
+	assert.Equal(t, "provider1", check1Instance1["config.provider"])
+	assert.Equal(t, 123, check1Instance1["check_provided_key1"])
+	assert.Equal(t, "Hi", check1Instance1["check_provided_key2"])
+	check1Instance2 := *checkMetadata["check1"][1]
+	assert.Len(t, check1Instance2, 3)
+	assert.Equal(t, agentStartupTime, check1Instance2["last_updated"])
+	assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
+	assert.Equal(t, "provider1", check1Instance2["config.provider"])
+	assert.Len(t, checkMetadata["check2"], 1) // check2 has one instance
+	check2Instance1 := *checkMetadata["check2"][0]
+	assert.Len(t, check2Instance1, 3)
+	assert.Equal(t, agentStartupTime, check2Instance1["last_updated"])
+	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
+	assert.Equal(t, "provider2", check2Instance1["config.provider"])
+
+	SetCheckMetadata("check2_instance1", "check_provided_key1", "hi")
+	originalStartNow := startNow
+	startNow += 1000
+	SetCheckMetadata("check1_instance1", "check_provided_key1", 456)
+
+	p = GetPayload()
+
+	assert.Equal(t, startNow, p.Timestamp) //updated startNow is returned
+
+	agentMetadata = *p.AgentMetadata
+	assert.Len(t, agentMetadata, 1)
+	assert.Equal(t, true, agentMetadata["test"])
+
+	checkMetadata = *p.CheckMetadata
+	assert.Len(t, checkMetadata, 2)
+	check1Instance1 = *checkMetadata["check1"][0]
+	assert.Len(t, check1Instance1, 5)
+	assert.Equal(t, startNow, check1Instance1["last_updated"]) // last_updated has changed
+	assert.Equal(t, "check1_instance1", check1Instance1["config.hash"])
+	assert.Equal(t, "provider1", check1Instance1["config.provider"])
+	assert.Equal(t, 456, check1Instance1["check_provided_key1"]) //Key has been updated
+	assert.Equal(t, "Hi", check1Instance1["check_provided_key2"])
+	check1Instance2 = *checkMetadata["check1"][1]
+	assert.Len(t, check1Instance2, 3)
+	assert.Equal(t, agentStartupTime, check1Instance2["last_updated"]) // last_updated still the same
+	assert.Equal(t, "check1_instance2", check1Instance2["config.hash"])
+	assert.Equal(t, "provider1", check1Instance2["config.provider"])
+	check2Instance1 = *checkMetadata["check2"][0]
+	assert.Len(t, check2Instance1, 4)
+	assert.Equal(t, originalStartNow, check2Instance1["last_updated"]) // reflects when check_provided_key1 was changed
+	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
+	assert.Equal(t, "provider2", check2Instance1["config.provider"])
+	assert.Equal(t, "hi", check2Instance1["check_provided_key1"]) // New key added
+
+}

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -7,6 +7,8 @@
 package inventories
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,5 +119,46 @@ func TestGetPayload(t *testing.T) {
 	assert.Equal(t, "check2_instance1", check2Instance1["config.hash"])
 	assert.Equal(t, "provider2", check2Instance1["config.provider"])
 	assert.Equal(t, "hi", check2Instance1["check_provided_key1"]) // New key added
+
+	marshaled, err := p.MarshalJSON()
+	assert.Nil(t, err)
+	jsonString := `
+	{
+		"timestamp": %v,
+		"check_metadata":
+		{
+			"check1":
+			[
+				{
+					"check_provided_key1": 456,
+					"check_provided_key2": "Hi",
+					"config.hash": "check1_instance1",
+					"config.provider": "provider1",
+					"last_updated": %v
+				},
+				{
+					"config.hash": "check1_instance2",
+					"config.provider": "provider1",
+					"last_updated": %v
+				}
+			],
+			"check2":
+			[
+				{
+					"check_provided_key1": "hi",
+					"config.hash": "check2_instance1",
+					"config.provider": "provider2",
+					"last_updated": %v
+				}
+			]
+		},
+		"agent_metadata":
+		{
+			"test": true
+		}
+	}`
+	jsonString = fmt.Sprintf(jsonString, startNow, startNow, agentStartupTime, originalStartNow)
+	jsonString = strings.Join(strings.Fields(jsonString), "") // Removes whitespaces and new lines
+	assert.Equal(t, jsonString, string(marshaled))
 
 }

--- a/pkg/metadata/inventories/payload.go
+++ b/pkg/metadata/inventories/payload.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package inventories
+
+// AgentMetadata contains metadata provided by the agent itself
+type AgentMetadata map[string]interface{}
+
+// CheckMetadata contains metadata provided by all integrations.
+// Each check has an entry in the top level map, each containing an array with
+// all its instances, each containing its metadata.
+type CheckMetadata map[string][]*CheckInstanceMetadata
+
+// CheckInstanceMetadata contains metadata provided by an instance of an integration.
+type CheckInstanceMetadata map[string]interface{}
+
+// Payload handles the JSON unmarshalling of the metadata payload
+type Payload struct {
+	Timestamp     int64          `json:"timestamp"`
+	CheckMetadata *CheckMetadata `json:"check_metadata"`
+	AgentMetadata *AgentMetadata `json:"agent_metadata"`
+}

--- a/pkg/metadata/inventories/payload.go
+++ b/pkg/metadata/inventories/payload.go
@@ -5,6 +5,13 @@
 
 package inventories
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+)
+
 // AgentMetadata contains metadata provided by the agent itself
 type AgentMetadata map[string]interface{}
 
@@ -21,4 +28,20 @@ type Payload struct {
 	Timestamp     int64          `json:"timestamp"`
 	CheckMetadata *CheckMetadata `json:"check_metadata"`
 	AgentMetadata *AgentMetadata `json:"agent_metadata"`
+}
+
+// MarshalJSON serialization a Payload to JSON
+func (p *Payload) MarshalJSON() ([]byte, error) {
+	type PayloadAlias Payload
+	return json.Marshal((*PayloadAlias)(p))
+}
+
+// Marshal not implemented
+func (p *Payload) Marshal() ([]byte, error) {
+	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
+}
+
+// SplitPayload breaks the payload into times number of pieces
+func (p *Payload) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+	return nil, fmt.Errorf("Inventories Payload splitting is not implemented")
 }


### PR DESCRIPTION
### What does this PR do?

- Adds the functions `SetAgentMetadata` and `SetCheckMetadata` to be used from the agent and the Python checks respectively.
- Also adds an initial version of the `GetPayload` function (still unused) together with the Payload type definition.
- A test ensures that `GetPayload` returns the metadata provided by `SetAgentMetadata` and `SetCheckMetadata` in the expected format.
