### PR TITLE
Stop shipping tokumx on Python 3

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -51,6 +51,8 @@ blacklist_folders = [
   'docker_daemon',
   'kubernetes',
   'ntp',                           # provided as a go check by the core agent
+  # Python 2-only
+  'tokumx',
 ]
 
 # package names of dependencies that won't be added to the Agent Python environment
@@ -70,7 +72,7 @@ if arm?
 end
 
 if windows? && windows_arch_i386?
-  blacklist_folders.push('oracle') 
+  blacklist_folders.push('oracle')
   blacklist_packages.push(/^cx-Oracle==/)
   blacklist_packages.push(/^jpype1==/)
   blacklist_packages.push(/^Jpype1==/)


### PR DESCRIPTION
### Motivation

Tokumx does not support Python 3 as it requires an old version of the dependency, see https://github.com/DataDog/integrations-core/pull/3001