### PR TITLE
[Scheduler] SendNow method to run a collector on demand

### DIFF
--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -111,7 +111,7 @@ func (c *Scheduler) SendNow(name string) {
 	sc, found := c.collectors[name]
 
 	if !found {
-		log.Errorf("Unable to find '" + name + "' metadata collector in the catalog!")
+		log.Errorf("Unable to find '" + name + "' in the running metadata collectors!")
 	}
 
 	if !sc.sendTimer.Stop() {

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -23,6 +23,7 @@ var catalog = make(map[string]Collector)
 var (
 	// For testing purposes
 	newTicker = time.NewTicker
+	firstRun  = true
 )
 
 type scheduledCollector struct {
@@ -48,9 +49,11 @@ func NewScheduler(s *serializer.Serializer) *Scheduler {
 		collectors: make(map[string]*scheduledCollector),
 	}
 
-	err := scheduler.firstRun()
-	if err != nil {
-		log.Errorf("Unable to send host metadata at first run: %v", err)
+	if firstRun {
+		err := scheduler.firstRun()
+		if err != nil {
+			log.Errorf("Unable to send host metadata at first run: %v", err)
+		}
 	}
 
 	scheduler.context, scheduler.contextCancel = context.WithCancel(context.Background())

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -22,8 +22,8 @@ var catalog = make(map[string]Collector)
 
 var (
 	// For testing purposes
-	newTimer = time.NewTimer
-	firstRun = true
+	newTimer                 = time.NewTimer
+	enableFirstRunCollection = true
 )
 
 type scheduledCollector struct {
@@ -47,7 +47,7 @@ func NewScheduler(s *serializer.Serializer) *Scheduler {
 		collectors: make(map[string]*scheduledCollector),
 	}
 
-	if firstRun {
+	if enableFirstRunCollection {
 		err := scheduler.firstRun()
 		if err != nil {
 			log.Errorf("Unable to send host metadata at first run: %v", err)

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -117,7 +117,10 @@ func (c *Scheduler) SendNow(name string) {
 	if !sc.sendTimer.Stop() {
 		// Drain the channel after stoping, as per Timer's documentation
 		// Explanation here: https://blogtitle.github.io/go-advanced-concurrency-patterns-part-2-timers/
-		<-sc.sendTimer.C
+		select {
+		case <-sc.sendTimer.C:
+		default: //So we don't block if the channel is empty
+		}
 	}
 
 	sc.sendTimer.Reset(0) // Fire immediately

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -37,8 +37,8 @@ func mockNewTimerNoTick(d time.Duration) *time.Timer {
 }
 
 func TestNewScheduler(t *testing.T) {
-	firstRun = false
-	defer func() { firstRun = true }()
+	enableFirstRunCollection = false
+	defer func() { enableFirstRunCollection = true }()
 
 	fwd := forwarder.NewDefaultForwarder(nil)
 	fwd.Start()
@@ -49,8 +49,8 @@ func TestNewScheduler(t *testing.T) {
 }
 
 func TestStopScheduler(t *testing.T) {
-	firstRun = false
-	defer func() { firstRun = true }()
+	enableFirstRunCollection = false
+	defer func() { enableFirstRunCollection = true }()
 
 	fwd := forwarder.NewDefaultForwarder(nil)
 	fwd.Start()
@@ -69,8 +69,8 @@ func TestStopScheduler(t *testing.T) {
 }
 
 func TestAddCollector(t *testing.T) {
-	firstRun = false
-	defer func() { firstRun = true }()
+	enableFirstRunCollection = false
+	defer func() { enableFirstRunCollection = true }()
 
 	newTimer = mockNewTimer
 	defer func() { newTimer = time.NewTimer }()
@@ -107,8 +107,8 @@ func TestAddCollector(t *testing.T) {
 }
 
 func TestSendNow(t *testing.T) {
-	firstRun = false
-	defer func() { firstRun = true }()
+	enableFirstRunCollection = false
+	defer func() { enableFirstRunCollection = true }()
 
 	newTimer = mockNewTimerNoTick
 	defer func() { newTimer = time.NewTimer }()

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -24,6 +24,18 @@ func (c MockCollector) Send(s *serializer.Serializer) error {
 	return nil
 }
 
+func mockNewTimer(d time.Duration) *time.Timer {
+	c := make(chan time.Time, 1)
+	timer := time.NewTimer(10 * time.Hour)
+	timer.C = c
+	c <- time.Now() // Ticks as soon as it's created
+	return timer
+}
+
+func mockNewTimerNoTick(d time.Duration) *time.Timer {
+	return time.NewTimer(10 * time.Hour)
+}
+
 func TestNewScheduler(t *testing.T) {
 	firstRun = false
 	defer func() { firstRun = true }()
@@ -54,18 +66,6 @@ func TestStopScheduler(t *testing.T) {
 	c.Stop()
 
 	assert.Equal(t, context.Canceled, c.context.Err())
-}
-
-func mockNewTimer(d time.Duration) *time.Timer {
-	c := make(chan time.Time, 1)
-	timer := time.NewTimer(10 * time.Hour)
-	timer.C = c
-	c <- time.Now() // Ticks as soon as it's created
-	return timer
-}
-
-func mockNewTimerNoTick(d time.Duration) *time.Timer {
-	return time.NewTimer(10 * time.Hour)
 }
 
 func TestAddCollector(t *testing.T) {

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -16,14 +16,21 @@ import (
 )
 
 func TestNewScheduler(t *testing.T) {
+	firstRun = false
+	defer func() { firstRun = true }()
+
 	fwd := forwarder.NewDefaultForwarder(nil)
 	fwd.Start()
 	s := serializer.NewSerializer(fwd)
 	c := NewScheduler(s)
+
 	assert.Equal(t, fwd, c.srl.Forwarder)
 }
 
 func TestStopScheduler(t *testing.T) {
+	firstRun = false
+	defer func() { firstRun = true }()
+
 	fwd := forwarder.NewDefaultForwarder(nil)
 	fwd.Start()
 	s := serializer.NewSerializer(fwd)
@@ -56,6 +63,9 @@ func (c MockCollector) Send(s *serializer.Serializer) error {
 }
 
 func TestCollectorSendLogic(t *testing.T) {
+	firstRun = false
+	defer func() { firstRun = true }()
+
 	newTicker = mockNewTicker
 	defer func() { newTicker = time.NewTicker }()
 


### PR DESCRIPTION
### What does this PR do?

Adds a `SendNow(collector)` method to `Scheduler` that triggers a `Send`
call on the given collector and restarts its regular collection timer. To do so,
the `time.Ticker` has been replaced by a `time.Timer`, that can be reset.
This has the implication that we now _must_ reset it each time after it fires.

Adds a tests that verifies both ways to call `Send`: at regular intervals
and via `SendNow`.

Also, it fixes the `Stop` test, which was trying to add inexistent collectors, and
makes tests faster by disabling the `firstRun` code that ran the host collector.

### Motivation

Until now, all our metadata collectors ran at regular intervals. For inventories,
we want to Send new data as soon as is available (within a threshold).
