### PR TITLE
[Windows] Improve compilation experience

### DIFF
--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -241,7 +241,7 @@ func ConvertWindowsString(winput []uint8) string {
 // than 256kB when serialized and then dropped
 func LPWSTRToString(cwstr C.LPWSTR) string {
 	ptr := unsafe.Pointer(cwstr)
-	sz := C.wcslen((*C.wchar_t)(ptr))
+	sz := C.ULONGLONG(C.wcslen((*C.wchar_t)(ptr)))
 	sz = min(sz, maxRunes)
 	wstr := (*[maxRunes]uint16)(ptr)[:sz:sz]
 	return string(utf16.Decode(wstr))

--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -241,7 +241,7 @@ func ConvertWindowsString(winput []uint8) string {
 // than 256kB when serialized and then dropped
 func LPWSTRToString(cwstr C.LPWSTR) string {
 	ptr := unsafe.Pointer(cwstr)
-	sz := C.ULONGLONG(C.wcslen((*C.wchar_t)(ptr)))
+	sz := C.wcslen((*C.wchar_t)(ptr))
 	sz = min(sz, maxRunes)
 	wstr := (*[maxRunes]uint16)(ptr)[:sz:sz]
 	return string(utf16.Decode(wstr))

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -109,6 +109,10 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
 
     if sys.platform == 'win32':
         windres_target = "pe-x86-64"
+
+        # Important for x-compiling
+        env["CGO_ENABLED"] = "1"
+
         if arch == "x86":
             env["GOARCH"] = "386"
             windres_target = "pe-i386"

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -37,6 +37,9 @@ def build(ctx, install_prefix=None, python_runtimes=None, cmake_options='', arch
     here = os.path.abspath(os.path.dirname(__file__))
     dev_path = os.path.join(here, '..', 'dev')
 
+    if cmake_options.find("-G") == -1:
+        cmake_options += " -G \"Unix Makefiles\""
+
     cmake_args = cmake_options + " -DBUILD_DEMO:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH={}".format(install_prefix or dev_path)
 
     python_runtimes = python_runtimes or os.environ.get("PYTHON_RUNTIMES") or "2"


### PR DESCRIPTION
### What does this PR do?

This PR helps the agent to be built on Windows, and notably to cross compile a 32bit version of the agent.

### Motivation

A couple of pain points when building on Windows:

- By default CMake generates Visual Studio solution files for RTLoader, but we want "Unix Makefiles"
- When cross-compiling `cgo` is disabled, but we rely on it for our interop with C

### Test plan

## 64 bit

In a command prompt:

(Assuming Ruby 64bit with MSYS installed in `C:\Ruby24-x64`)
```
> C:\Ruby24-x64\bin\ridk.cmd enable
> rm -f rtloader\CMakeCache.txt
> inv rtloader.build
> inv rtloader.install
> rm -rf bin
> inv agent.build
```

## 32 bit

(Assuming Ruby 32bit with MSYS installed in `C:\Ruby24-x86`)
```
> C:\Ruby24-x86\bin\ridk.cmd enable
> rm -f rtloader\CMakeCache.txt
> inv rtloader.build --arch=x86
> inv rtloader.install
> rm -rf bin
> inv agent.build --arch=x86
```