### PR TITLE
Use modulo to compute the group size

### DIFF
--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -75,7 +75,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	}
 
 	groupSize := len(ctrList) / cfg.MaxPerMessage
-	if len(ctrList) != cfg.MaxPerMessage*groupSize {
+	if len(ctrList)%cfg.MaxPerMessage != 0 {
 		groupSize++
 	}
 	chunked := chunkContainers(ctrList, c.lastRates, c.lastRun, groupSize, cfg.MaxPerMessage)

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -52,7 +52,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	}
 
 	groupSize := len(ctrList) / cfg.MaxPerMessage
-	if len(ctrList) != cfg.MaxPerMessage {
+	if len(ctrList)%cfg.MaxPerMessage != 0 {
 		groupSize++
 	}
 	chunked := fmtContainerStats(ctrList, r.lastRates, r.lastRun, groupSize)


### PR DESCRIPTION
### What does this PR do?

Consistent condition for `groupSize` computation

### Motivation

Using `len(ctrList) != cfg.MaxPerMessage` would increase the `groupSize` even if it's an exact multiple of the max size

### Additional Notes

Anything else we should know when reviewing?
