### PR TITLE
[omnibus] provide chef-sugar manually, dep will be satisfied downstream

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 # Install omnibus
+gem 'chef-sugar', git: 'https://github.com/chef/chef-sugar.git', tag: 'v3.6.0'
 gem 'omnibus', git: 'https://github.com/DataDog/omnibus-ruby.git', branch: (ENV['OMNIBUS_RUBY_VERSION'] || 'datadog-5.5.0')
 
 # Use Chef's software definitions. It is recommended that you write your own


### PR DESCRIPTION
### What does this PR do?

Installs chef-sugar manually, the dependency is then satisfied downstream and not pulled from rubygems, thus avoiding the issue. Note that the problem stems from: https://github.com/chef/omnibus/issues/901

This should be a temporary fix until chef addresses the issue some other way or Seth Vargo restores the gem. 

### Motivation

Broken omnibus builds.
