### PR TITLE
Don't use the default python version on Unix but the one specified in the configuration

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -252,7 +252,11 @@ func detectPythonLocation(pythonVersion string) {
 	if runtime.GOOS == "windows" {
 		pythonBinPath = filepath.Join(PythonHome, "python.exe")
 	} else {
-		pythonBinPath = filepath.Join(PythonHome, "bin", "python")
+		// On Unix both python are installed on the same embedded
+		// directory. We don't want to use the default version (aka
+		// "python") but either "python2" or "python3" based on the
+		// configuration.
+		pythonBinPath = filepath.Join(PythonHome, "bin", "python"+pythonVersion)
 	}
 }
 

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -19,11 +19,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	agentConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
-	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -259,7 +259,7 @@ func reportPy3Warnings(checkName string, checkFilePath string) {
 			checkFilePath = checkFilePath[:len(checkFilePath)-1]
 		}
 
-		if strings.HasPrefix(host.GetPythonVersion(), "3") {
+		if strings.TrimSpace(config.Datadog.GetString("python_version")) == "3" {
 			// the linter used by validatePython3 doesn't work when run from python3
 			status = a7TagPython3
 			metricValue = 1.0


### PR DESCRIPTION
### What does this PR do?

Don't use the default python version on Linux for the binary. This had no impact since `pythonBinPath` is only use right now for the a7 linter (which is only used when running with Python2). But It would have been an issue the day `pythonBinPath` is used for anything else.

Also, no need to use the `host` package to get the python version. We already depends on the config package, no need to import `metadata/host`.