### PR TITLE
Improve conntrack behavior when there are too many entries

### DIFF
--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -220,6 +220,7 @@ func (ctr *realConntracker) GetStats() map[string]int64 {
 
 func (ctr *realConntracker) Close() {
 	ctr.compactTicker.Stop()
+	ctr.exceededSizeLogLimit.Close()
 }
 
 func (ctr *realConntracker) loadInitialState(sessions []ct.Conn) {

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -257,8 +257,8 @@ func (ctr *realConntracker) register(c ct.Conn) int {
 	return 0
 }
 
-func (c *realConntracker) logExceededSize() {
-	if c.timesExceededSize < 10 || c.timesExceededSize%100 == 0 {
+func (ctr *realConntracker) logExceededSize() {
+	if ctr.timesExceededSize < 10 || ctr.timesExceededSize%100 == 0 {
 		log.Warnf("exceeded maximum conntrack state size: %d entries. You may need to increase system_probe_config.max_tracked_connections (will log first ten times, and then every 100th time)", ctr.maxStateSize)
 	}
 }

--- a/pkg/ebpf/netlink/conntracker_test.go
+++ b/pkg/ebpf/netlink/conntracker_test.go
@@ -91,13 +91,23 @@ func TestGetUpdatesGen(t *testing.T) {
 	}
 }
 
+func TestTooManyEntries(t *testing.T) {
+	rt := newConntracker()
+	rt.maxStateSize = 1
+
+	rt.register(makeTranslatedConn("10.0.0.0:12345", "50.30.40.10:80", "20.0.0.0:80"))
+	rt.register(makeTranslatedConn("10.0.0.1:12345", "50.30.40.10:80", "20.0.0.0:80"))
+	rt.register(makeTranslatedConn("10.0.0.2:12345", "50.30.40.10:80", "20.0.0.0:80"))
+}
+
 func newConntracker() *realConntracker {
 	return &realConntracker{
-		state:               make(map[connKey]*connValue),
-		shortLivedBuffer:    make(map[connKey]*IPTranslation),
-		maxShortLivedBuffer: 10000,
-		compactTicker:       time.NewTicker(time.Hour),
-		maxStateSize:        10000,
+		state:                make(map[connKey]*connValue),
+		shortLivedBuffer:     make(map[connKey]*IPTranslation),
+		maxShortLivedBuffer:  10000,
+		compactTicker:        time.NewTicker(time.Hour),
+		maxStateSize:         10000,
+		exceededSizeLogLimit: util.NewLogLimit(1, time.Minute),
 	}
 }
 

--- a/pkg/ebpf/tracer-ebpf.go
+++ b/pkg/ebpf/tracer-ebpf.go
@@ -161,7 +161,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"tracer-ebpf.o":       tracerEbpfO,
+	"tracer-ebpf.o": tracerEbpfO,
 	"tracer-ebpf-debug.o": tracerEbpfDebugO,
 }
 
@@ -204,10 +204,9 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
-	"tracer-ebpf-debug.o": {tracerEbpfDebugO, map[string]*bintree{}},
-	"tracer-ebpf.o":       {tracerEbpfO, map[string]*bintree{}},
+	"tracer-ebpf-debug.o": &bintree{tracerEbpfDebugO, map[string]*bintree{}},
+	"tracer-ebpf.o": &bintree{tracerEbpfO, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory
@@ -256,3 +255,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+

--- a/pkg/ebpf/tracer-ebpf.go
+++ b/pkg/ebpf/tracer-ebpf.go
@@ -161,7 +161,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"tracer-ebpf.o": tracerEbpfO,
+	"tracer-ebpf.o":       tracerEbpfO,
 	"tracer-ebpf-debug.o": tracerEbpfDebugO,
 }
 
@@ -204,9 +204,10 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"tracer-ebpf-debug.o": &bintree{tracerEbpfDebugO, map[string]*bintree{}},
-	"tracer-ebpf.o": &bintree{tracerEbpfO, map[string]*bintree{}},
+	"tracer-ebpf-debug.o": {tracerEbpfDebugO, map[string]*bintree{}},
+	"tracer-ebpf.o":       {tracerEbpfO, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory
@@ -255,4 +256,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -120,10 +120,10 @@ func (a AgentConfig) CheckInterval(checkName string) time.Duration {
 }
 
 const (
-	defaultEndpoint          = "https://process.datadoghq.com"
-	maxMessageBatch          = 100
-	maxConnsMessageBatch     = 1000
-	maxMaxTrackedConnections = 65536
+	defaultEndpoint              = "https://process.datadoghq.com"
+	maxMessageBatch              = 100
+	maxConnsMessageBatch         = 1000
+	defaultMaxTrackedConnections = 65536
 )
 
 // NewDefaultTransport provides a http transport configuration with sane default timeouts
@@ -185,7 +185,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		DisableIPv6Tracing:           false,
 		SystemProbeSocketPath:        defaultSystemProbeSocketPath,
 		SystemProbeLogFile:           defaultSystemProbeFilePath,
-		MaxTrackedConnections:        maxMaxTrackedConnections,
+		MaxTrackedConnections:        defaultMaxTrackedConnections,
 		EnableConntrack:              true,
 		ClosedChannelSize:            500,
 		ConntrackShortTermBufferSize: defaultConntrackShortTermBufferSize,

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -86,11 +86,7 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 
 	// The maximum number of connections the tracer can track
 	if mtc := config.Datadog.GetInt64(key(spNS, "max_tracked_connections")); mtc > 0 {
-		if mtc <= maxMaxTrackedConnections {
-			a.MaxTrackedConnections = uint(mtc)
-		} else {
-			log.Warnf("Overriding the configured max tracked connections limit because it exceeds maximum 65536, got: %v", mtc)
-		}
+		a.MaxTrackedConnections = uint(mtc)
 	}
 
 	// MaxClosedConnectionsBuffered represents the maximum number of closed connections we'll buffer in memory. These closed connections

--- a/pkg/process/util/log_limit.go
+++ b/pkg/process/util/log_limit.go
@@ -34,8 +34,9 @@ func NewLogLimit(n int, interval time.Duration) *LogLimit {
 
 // ShouldLog returns true if the caller should log
 func (l *LogLimit) ShouldLog() bool {
-	if l.n > 0 {
-		l.n--
+	n := atomic.LoadInt32(&l.n)
+	if n > 0 {
+		atomic.CompareAndSwapInt32(&l.n, n, n-1)
 		return true
 	}
 

--- a/pkg/process/util/log_limit.go
+++ b/pkg/process/util/log_limit.go
@@ -11,7 +11,9 @@ type LogLimit struct {
 	// we repeatedly add 1 to it.
 	n int32
 
-	// reset will be channel that belongs to the ticket
+	// exit and ticker must be different channels
+	// becaues Stopping a ticker will not close the ticker channel,
+	// and we will otherwise leak memory
 	ticker *time.Ticker
 	exit   chan struct{}
 }
@@ -21,11 +23,7 @@ type LogLimit struct {
 // interval thereafter.
 func NewLogLimit(n int, interval time.Duration) *LogLimit {
 	l := &LogLimit{
-		n: int32(n),
-
-		// exit and ticker must be different channels
-		// becaues Stopping a ticker will not close the ticker channel,
-		// and we will otherwise leak memory
+		n:      int32(n),
 		ticker: time.NewTicker(interval),
 		exit:   make(chan struct{}),
 	}

--- a/pkg/process/util/log_limit.go
+++ b/pkg/process/util/log_limit.go
@@ -1,43 +1,68 @@
 package util
 
 import (
+	"sync/atomic"
 	"time"
 )
 
 // LogLimit is a utility that can be used to avoid logging noisily
 type LogLimit struct {
-	firstN   int
-	interval time.Duration
-	next     time.Time
+	// n is the times remaining that the LogLimit will return true for ShouldLog.
+	// we repeatedly add 1 to it.
+	n int32
+
+	// reset will be channel that belongs to the ticket
+	ticker *time.Ticker
+	exit   chan struct{}
 }
 
 // NewLogLimit creates a LogLimit where shouldLog will return
 // true the first N times it is called, and will return true once every
 // interval thereafter.
 func NewLogLimit(n int, interval time.Duration) *LogLimit {
-	return &LogLimit{
-		firstN:   n,
-		interval: interval,
-		next:     time.Now().Add(interval),
+	l := &LogLimit{
+		n: int32(n),
+
+		// exit and ticker must be different channels
+		// becaues Stopping a ticker will not close the ticker channel,
+		// and we will otherwise leak memory
+		ticker: time.NewTicker(interval),
+		exit:   make(chan struct{}),
 	}
+
+	go l.resetLoop()
+	return l
 }
 
 // ShouldLog returns true if the caller should log
 func (l *LogLimit) ShouldLog() bool {
-	return l.shouldLogTime(time.Now())
-
-}
-
-func (l *LogLimit) shouldLogTime(now time.Time) bool {
-	if l.firstN > 0 {
-		l.firstN--
-		return true
-	}
-
-	if now.After(l.next) {
-		l.next = now.Add(l.interval)
+	if l.n > 0 {
+		l.n--
 		return true
 	}
 
 	return false
+}
+
+// Close will stop the underlying ticker
+func (l *LogLimit) Close() {
+	l.ticker.Stop()
+	close(l.exit)
+}
+
+func (l *LogLimit) resetLoop() {
+	for {
+		select {
+		case <-l.ticker.C:
+			l.resetCounter()
+		case <-l.exit:
+			return
+		}
+	}
+}
+
+func (l *LogLimit) resetCounter() {
+	// c.n == 0, it means we have gotten through the first few logs, and after ticker.T we should
+	// do another log
+	atomic.CompareAndSwapInt32(&l.n, 0, 1)
 }

--- a/pkg/process/util/log_limit.go
+++ b/pkg/process/util/log_limit.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"time"
+)
+
+// LogLimit is a utility that can be used to avoid logging noisily
+type LogLimit struct {
+	firstN   int
+	interval time.Duration
+	next     time.Time
+}
+
+// NewLogLimit creates a LogLimit where shouldLog will return
+// true the first N times it is called, and will return true once every
+// interval thereafter.
+func NewLogLimit(n int, interval time.Duration) *LogLimit {
+	return &LogLimit{
+		firstN:   n,
+		interval: interval,
+		next:     time.Now().Add(interval),
+	}
+}
+
+// ShouldLog returns true if the caller should log
+func (l *LogLimit) ShouldLog() bool {
+	return l.shouldLogTime(time.Now())
+
+}
+
+func (l *LogLimit) shouldLogTime(now time.Time) bool {
+	if l.firstN > 0 {
+		l.firstN--
+		return true
+	}
+
+	if now.After(l.next) {
+		l.next = now.Add(l.interval)
+		return true
+	}
+
+	return false
+}

--- a/pkg/process/util/log_limit_test.go
+++ b/pkg/process/util/log_limit_test.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogLimit(t *testing.T) {
+	l := NewLogLimit(10, time.Hour)
+
+	now := time.Now()
+
+	for i := 0; i < 10; i++ {
+		assert.True(t, l.shouldLogTime(now))
+	}
+
+	assert.False(t, l.shouldLogTime(now))
+	assert.False(t, l.shouldLogTime(now.Add(time.Minute*20)))
+
+	assert.True(t, l.shouldLogTime(now.Add(time.Minute*61)))
+	assert.False(t, l.shouldLogTime(now.Add(time.Minute*61)))
+}

--- a/pkg/process/util/log_limit_test.go
+++ b/pkg/process/util/log_limit_test.go
@@ -9,16 +9,18 @@ import (
 
 func TestLogLimit(t *testing.T) {
 	l := NewLogLimit(10, time.Hour)
-
-	now := time.Now()
+	defer l.Close()
 
 	for i := 0; i < 10; i++ {
-		assert.True(t, l.shouldLogTime(now))
+		// this reset will not have any effect because we haven't logged 10 times yet
+		l.resetCounter()
+		assert.True(t, l.ShouldLog())
 	}
 
-	assert.False(t, l.shouldLogTime(now))
-	assert.False(t, l.shouldLogTime(now.Add(time.Minute*20)))
+	assert.False(t, l.ShouldLog())
+	assert.False(t, l.ShouldLog())
 
-	assert.True(t, l.shouldLogTime(now.Add(time.Minute*61)))
-	assert.False(t, l.shouldLogTime(now.Add(time.Minute*61)))
+	l.resetCounter()
+	assert.True(t, l.ShouldLog())
+	assert.False(t, l.ShouldLog())
 }

--- a/releasenotes/notes/conntrack-improvements-b064980aa4daf198.yaml
+++ b/releasenotes/notes/conntrack-improvements-b064980aa4daf198.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The system-probe will no longer log excessively when its internal copy of the conntrack table
+    is full.  Furthermore, the artificial cap of 65536  on  ``system_probe_config.max_tracked_connections``,
+    which controlled the maximum number of conntrack entries seen by the system-probe has been lifted.


### PR DESCRIPTION
### What does this PR do?

- only log every 100th line after the first 10 
- life the cap on MaxTrackedConnections

### Motivation


### Additional Notes

Anything else we should know when reviewing?
