### PR TITLE
pkg/trace/flags: move flag.Parse to main.main

### DIFF
--- a/cmd/trace-agent/main_nix.go
+++ b/cmd/trace-agent/main_nix.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"flag"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
@@ -23,6 +24,8 @@ func main() {
 		defer watchdog.LogOnPanic()
 		handleSignal(cancelFunc)
 	}()
+
+	flag.Parse()
 
 	agent.Run(ctx)
 }

--- a/cmd/trace-agent/main_windows.go
+++ b/cmd/trace-agent/main_windows.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -93,6 +94,8 @@ func runService(isDebug bool) {
 
 // main is the main application entry point
 func main() {
+	flag.Parse()
+
 	isIntSess, err := svc.IsAnInteractiveSession()
 	if err != nil {
 		fmt.Printf("failed to determine if we are running in an interactive session: %v", err)

--- a/pkg/trace/flags/flags_z.go
+++ b/pkg/trace/flags/flags_z.go
@@ -51,6 +51,4 @@ func init() {
 	flag.StringVar(&MemProfile, "memprofile", "", "Write memory profile to `file`")
 
 	registerOSSpecificFlags()
-
-	flag.Parse()
 }


### PR DESCRIPTION
Due to a recent change in go1.13 (golang/go#21051), parsing of
flags inside `init` functions causes tests to fail. This change moves
`flag.Parse` inside `main.main`.

For more information see golang/go#33190