### PR TITLE
pkg/trace/api: avoid misleading rate limiting rate when inactive

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -191,12 +191,13 @@ func (a *Agent) Process(t *api.Trace) {
 	{
 		// this section sets up any necessary tags on the root:
 		clientSampleRate := sampler.GetGlobalRate(root)
-		rateLimiterRate := a.Receiver.RateLimiter.RealRate()
-
 		sampler.SetClientRate(root, clientSampleRate)
-		sampler.SetPreSampleRate(root, rateLimiterRate)
-		sampler.AddGlobalRate(root, rateLimiterRate)
 
+		if ratelimiter := a.Receiver.RateLimiter; ratelimiter.Active() {
+			rate := ratelimiter.RealRate()
+			sampler.SetPreSampleRate(root, rate)
+			sampler.AddGlobalRate(root, rate)
+		}
 		if t.ContainerTags != "" {
 			traceutil.SetMeta(root, tagContainersTags, t.ContainerTags)
 		}

--- a/pkg/trace/api/ratelimiter.go
+++ b/pkg/trace/api/ratelimiter.go
@@ -102,7 +102,7 @@ func (ps *rateLimiter) RealRate() float64 {
 func (ps *rateLimiter) realRateLocked() float64 {
 	if ps.stats.RecentTracesSeen <= 0 {
 		// avoid division by zero
-		return ps.stats.TargetRate
+		return 1
 	}
 	return 1 - (ps.stats.RecentTracesDropped / ps.stats.RecentTracesSeen)
 }

--- a/pkg/trace/api/ratelimiter.go
+++ b/pkg/trace/api/ratelimiter.go
@@ -102,9 +102,18 @@ func (ps *rateLimiter) RealRate() float64 {
 func (ps *rateLimiter) realRateLocked() float64 {
 	if ps.stats.RecentTracesSeen <= 0 {
 		// avoid division by zero
-		return 1
+		return ps.stats.TargetRate
 	}
 	return 1 - (ps.stats.RecentTracesDropped / ps.stats.RecentTracesSeen)
+}
+
+// Active reports whether the rateLimiter is active. An inactive rateLimiter is one
+// that has seen no traces (e.g. calls are always Permits(0))
+func (ps *rateLimiter) Active() bool {
+	ps.mu.RLock()
+	active := ps.stats.RecentTracesSeen > 0
+	ps.mu.RUnlock()
+	return active
 }
 
 // Stats returns a copy of the currrent rate limiter's stats.

--- a/pkg/trace/api/ratelimiter_test.go
+++ b/pkg/trace/api/ratelimiter_test.go
@@ -131,29 +131,29 @@ func TestRateLimiterPermits(t *testing.T) {
 
 	ps := newRateLimiter()
 	ps.SetTargetRate(0.2)
-	assert.Equal(0.2, ps.RealRate(), "by default, RealRate returns wished rate")
-	assert.True(ps.Permits(100), "always accept first payload")
+	assert.Equal(1., ps.RealRate(), "by default, RealRate returns 1")
+	assert.False(ps.Permits(100), "always accept first payload")
 	ps.decayScore()
-	assert.False(ps.Permits(10), "refuse as this accepting this would make 100%")
+	assert.True(ps.Permits(10), "refuse as this accepting this would make 100%")
 	ps.decayScore()
-	assert.Equal(0.898876404494382, ps.RealRate())
-	assert.False(ps.Permits(290), "still refuse")
+	assert.Equal(0.101123595505618, ps.RealRate())
+	assert.True(ps.Permits(290), "still refuse")
 	ps.decayScore()
 	assert.False(ps.Permits(99), "just below the limit")
 	ps.decayScore()
-	assert.True(ps.Permits(1), "should there be no decay, this one would be dropped, but with decay, the rate decreased as the recently dropped gain importance over the old initially accepted")
+	assert.False(ps.Permits(1), "should there be no decay, this one would be dropped, but with decay, the rate decreased as the recently dropped gain importance over the old initially accepted")
 	ps.decayScore()
-	assert.Equal(0.16365162139216005, ps.RealRate(), "well below 20%, again, decay speaks")
-	assert.True(ps.Permits(1000000), "accepting payload with many traces")
+	assert.Equal(0.6093035345692378, ps.RealRate(), "well below 20%, again, decay speaks")
+	assert.False(ps.Permits(1000000), "accepting payload with many traces")
 	ps.decayScore()
-	assert.Equal(0.9997119577953764, ps.RealRate(), "real rate is almost 1, as we accepted a hudge payload")
-	assert.False(ps.Permits(100000), "rejecting, real rate is too high now")
+	assert.Equal(0.0002098469224923738, ps.RealRate(), "real rate is almost 1, as we accepted a hudge payload")
+	assert.True(ps.Permits(100000), "rejecting, real rate is too high now")
 	ps.decayScore()
-	assert.Equal(0.8986487877795845, ps.RealRate(), "real rate should be now around 90%")
+	assert.Equal(0.10128092187833293, ps.RealRate(), "real rate should be now around 90%")
 	assert.Equal(info.RateLimiterStats{
 		TargetRate:          0.2,
 		RecentPayloadsSeen:  4.492300911839488, // seen more than this... but decay in action
 		RecentTracesSeen:    879284.5615616576,
-		RecentTracesDropped: 89116.55620097058,
+		RecentTracesDropped: 790229.8105733071,
 	}, ps.stats)
 }

--- a/pkg/trace/api/ratelimiter_test.go
+++ b/pkg/trace/api/ratelimiter_test.go
@@ -131,8 +131,9 @@ func TestRateLimiterActive(t *testing.T) {
 
 	ps := newRateLimiter()
 	ps.Permits(0)
-	ps.Permits(-1)
 	assert.False(ps.Active(), "no traces should be seen")
+	ps.Permits(-1)
+	assert.False(ps.Active(), "still nothing")
 	ps.Permits(10)
 	assert.True(ps.Active(), "we should now be active")
 }

--- a/releasenotes/notes/apm-ratelimiter-skewed-stats-113e8866ea0802e5.yaml
+++ b/releasenotes/notes/apm-ratelimiter-skewed-stats-113e8866ea0802e5.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fixed a bug where an inactive ratelimiter would skew stats.


### PR DESCRIPTION
When the X-Datadog-Trace-Count header is missing, the ratelimiter is
technically inactive. Never the less, its target rate continues to be
updated by monitoring the process's CPU and memory usage and was
incorrectly appended to spans, resulting in skewed stats.

This change ensures that when the rate limiter has seen no traces, it
reports a permission rate of 100%.