### PR TITLE
Adds a helper to get the Agent version.

### DIFF
--- a/cmd/agent/app/version.go
+++ b/cmd/agent/app/version.go
@@ -28,7 +28,7 @@ var versionCmd = &cobra.Command{
 		if flagNoColor {
 			color.NoColor = true
 		}
-		av, _ := version.New(version.AgentVersion, version.Commit)
+		av, _ := version.Agent()
 		meta := ""
 		if av.Meta != "" {
 			meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -64,7 +64,7 @@ func GetPythonPaths() []string {
 // GetVersion returns the version of the agent in a http response json
 func GetVersion(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	av, _ := version.New(version.AgentVersion, version.Commit)
+	av, _ := version.Agent()
 	j, _ := json.Marshal(av)
 	w.Write(j)
 }

--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -62,7 +62,7 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 
 // Sends the current agent version
 func getVersion(w http.ResponseWriter, r *http.Request) {
-	version, e := version.New(version.AgentVersion, version.Commit)
+	version, e := version.Agent()
 	if e != nil {
 		log.Errorf("Error getting version: " + e.Error())
 		w.Write([]byte("Error: " + e.Error()))

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
-	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1"
+	v1 "github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
@@ -73,7 +73,7 @@ func stopAgent(w http.ResponseWriter, r *http.Request) {
 
 func getVersion(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	av, err := version.New(version.AgentVersion, version.Commit)
+	av, err := version.Agent()
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
 		return

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -65,7 +65,7 @@ metadata for their metrics.`,
 			if flagNoColor {
 				color.NoColor = true
 			}
-			av, _ := version.New(version.AgentVersion, version.Commit)
+			av, _ := version.Agent()
 			meta := ""
 			if av.Meta != "" {
 				meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -57,7 +57,7 @@ extensions for special Datadog features.`,
 		Short: "Print the version number",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			av, _ := version.New(version.AgentVersion, version.Commit)
+			av, _ := version.Agent()
 			fmt.Println(fmt.Sprintf("DogStatsD from Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
 		},
 	}

--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func createMenuItems(notifyIcon *walk.NotifyIcon) []menuItem {
-	av, _ := version.New(version.AgentVersion, version.Commit)
+	av, _ := version.Agent()
 	verstring := av.GetNumberAndPre()
 
 	isAdmin, err := isUserAnAdmin()

--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -34,7 +34,7 @@ import (
 // GetVersion exposes the version of the agent to Python checks.
 //export GetVersion
 func GetVersion(agentVersion **C.char) {
-	av, _ := version.New(version.AgentVersion, version.Commit)
+	av, _ := version.Agent()
 	// version will be free by rtloader when it's done with it
 	*agentVersion = TrackedCString(av.GetNumber())
 }

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -204,7 +204,7 @@ func sendTelemetry(pythonVersion string) {
 	tags := []string{
 		fmt.Sprintf("python_version:%s", pythonVersion),
 	}
-	if agentVersion, err := version.New(version.AgentVersion, version.Commit); err == nil {
+	if agentVersion, err := version.Agent(); err == nil {
 		tags = append(tags,
 			fmt.Sprintf("agent_version_major:%d", agentVersion.Major),
 			fmt.Sprintf("agent_version_minor:%d", agentVersion.Minor),

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -64,7 +64,7 @@ func init() {
 	pyLoaderStats.Set("Py3Warnings", expvar.Func(expvarPy3Warnings))
 
 	agentVersionTags = []string{}
-	if agentVersion, err := version.New(version.AgentVersion, version.Commit); err == nil {
+	if agentVersion, err := version.Agent(); err == nil {
 		agentVersionTags = []string{
 			fmt.Sprintf("agent_version_major:%d", agentVersion.Major),
 			fmt.Sprintf("agent_version_minor:%d", agentVersion.Minor),

--- a/pkg/collector/python/test_datadog_agent.go
+++ b/pkg/collector/python/test_datadog_agent.go
@@ -27,7 +27,7 @@ func testGetVersion(t *testing.T) {
 	GetVersion(&v)
 	require.NotNil(t, v)
 
-	av, _ := version.New(version.AgentVersion, version.Commit)
+	av, _ := version.Agent()
 	assert.Equal(t, av.GetNumber(), C.GoString(v))
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -729,7 +729,7 @@ func GetMultipleEndpoints() (map[string][]string, error) {
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z
 func getDomainPrefix(app string) string {
-	v, _ := version.New(version.AgentVersion, version.Commit)
+	v, _ := version.Agent()
 	return fmt.Sprintf("%d-%d-%d-%s.agent", v.Major, v.Minor, v.Patch, app)
 }
 

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -72,7 +72,7 @@ func getFlareReader(multipartBoundary, archivePath, caseID, email, hostname stri
 			return
 		}
 
-		agentFullVersion, _ := version.New(version.AgentVersion, version.Commit)
+		agentFullVersion, _ := version.Agent()
 		writer.WriteField("agent_version", agentFullVersion.String())
 		writer.WriteField("hostname", hostname)
 

--- a/pkg/flare/flare_test.go
+++ b/pkg/flare/flare_test.go
@@ -59,7 +59,7 @@ func TestFlareHasRightForm(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	av, _ := version.New(version.AgentVersion, version.Commit)
+	av, _ := version.Agent()
 
 	assert.Equal(t, caseID, lastRequest.FormValue("case_id"))
 	assert.Equal(t, email, lastRequest.FormValue("email"))

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -100,7 +100,7 @@ func EnsureParentDirsExist(p string) error {
 
 // HTTPHeaders returns a http headers including various basic information (User-Agent, Content-Type...).
 func HTTPHeaders() map[string]string {
-	av, _ := version.New(version.AgentVersion, version.Commit)
+	av, _ := version.Agent()
 	return map[string]string{
 		"User-Agent":   fmt.Sprintf("Datadog Agent/%s", av.GetNumber()),
 		"Content-Type": "application/x-www-form-urlencoded",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,6 +22,10 @@ type Version struct {
 	Commit string
 }
 
+func Agent() (Version, error) {
+	return New(AgentVersion, Commit)
+}
+
 // New parses a version string like `0.0.0` and a commit identifier and returns a Version instance
 func New(version, commit string) (Version, error) {
 	re := regexp.MustCompile(`(\d+\.\d+\.\d+)(\-[^\+]+)*(\+.+)*`)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,6 +22,8 @@ type Version struct {
 	Commit string
 }
 
+var versionRx = regexp.MustCompile(`(\d+\.\d+\.\d+)(\-[^\+]+)*(\+.+)*`)
+
 // Agent returns the Datadog Agent version.
 func Agent() (Version, error) {
 	return New(AgentVersion, Commit)
@@ -29,8 +31,7 @@ func Agent() (Version, error) {
 
 // New parses a version string like `0.0.0` and a commit identifier and returns a Version instance
 func New(version, commit string) (Version, error) {
-	re := regexp.MustCompile(`(\d+\.\d+\.\d+)(\-[^\+]+)*(\+.+)*`)
-	toks := re.FindStringSubmatch(version)
+	toks := versionRx.FindStringSubmatch(version)
 	if len(toks) == 0 || toks[0] != version {
 		// if regex didn't match or partially matched, raise an error
 		return Version{}, fmt.Errorf("Version string has wrong format")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,6 +22,7 @@ type Version struct {
 	Commit string
 }
 
+// Agent returns the Datadog Agent version.
 func Agent() (Version, error) {
 	return New(AgentVersion, Commit)
 }


### PR DESCRIPTION
### What does this PR do?

Adds a helper method in the `version` pkg to get the Agent version.

### Motivation

Every calls to the function `version.New(string, string)` in the Agent are done to get the Agent version. We could even consider setting this method private, but it could be helpful someday so I've let it public.