### PR TITLE
Disable logs for the hostname command

### DIFF
--- a/cmd/agent/app/hostname.go
+++ b/cmd/agent/app/hostname.go
@@ -33,7 +33,8 @@ func doGetHostname(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
 
-	err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+	// log level is always off since this might be use by other agent to get the hostname
+	err = config.SetupLogger(loggerName, "off", "", "", false, true, false)
 	if err != nil {
 		fmt.Printf("Cannot setup logger, exiting: %v\n", err)
 		return err

--- a/releasenotes/notes/disable-log-hostname-cmd-940f6ee9c126a9f2.yaml
+++ b/releasenotes/notes/disable-log-hostname-cmd-940f6ee9c126a9f2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Disable debug log lines for the 'hostname' command since it's directly used
+    by other agents.


### PR DESCRIPTION
### What does this PR do?

This is needed since this is used by other agents to pull the hostname
(until they directly use the API)
