### PR TITLE
Allow using tracemalloc only for specific checks

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,6 +137,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("c_core_dump", false)
 	config.BindEnvAndSetDefault("memtrack_enabled", true)
 	config.BindEnvAndSetDefault("tracemalloc_debug", false)
+	config.BindEnvAndSetDefault("tracemalloc_whitelist", "")
+	config.BindEnvAndSetDefault("tracemalloc_blacklist", "")
 
 	// Python 3 linter timeout, in seconds
 	// NOTE: linter is notoriously slow, in the absence of a better solution we

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -273,6 +273,18 @@ api_key:
 #
 # tracemalloc_debug: false
 
+## @param tracemalloc_whitelist - string - optional
+## Comma-separated list of Python checks to enable tracemalloc for when `tracemalloc_debug` is true.
+## By default, all Python checks are enabled.
+#
+# tracemalloc_whitelist: <TRACEMALLOC_WHITELIST>
+
+## @param tracemalloc_blacklist - string - optional
+## Comma-separated list of Python checks to disable tracemalloc for when `tracemalloc_debug` is true.
+## By default, all Python checks are enabled. This setting takes precedence over `tracemalloc_whitelist`.
+#
+# tracemalloc_blacklist: <TRACEMALLOC_BLACKLIST>
+
 ## @param secret_backend_command - string - optional
 ## `secret_backend_command` is the path to the script to execute to fetch secrets.
 ## The executable must have specific rights that differ on Windows and Linux.

--- a/releasenotes/notes/allow-tracemalloc-for-specific-checks-46fbe672b9b62eb1.yaml
+++ b/releasenotes/notes/allow-tracemalloc-for-specific-checks-46fbe672b9b62eb1.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add options ``tracemalloc_whitelist`` and ``tracemalloc_blacklist`` for
+    allowing the use of tracemalloc only for specific checks.


### PR DESCRIPTION
### Motivation

This is generally useful, but in particular we are trying to send metrics from isolated environments where we only want to trace one check at a time. Without this the default checks like `network` clutter the dashboard query.

### Additional Notes

The actual logic will be implemented in a PR to `integrations-core`.