### PR TITLE
The system-probe should not try to access container APIs

### DIFF
--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUpdateRTStatus(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.NewDefaultAgentConfig()
+	cfg := config.NewDefaultAgentConfig(false)
 	c, err := NewCollector(cfg)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.
@@ -48,7 +48,7 @@ func TestUpdateRTStatus(t *testing.T) {
 
 func TestUpdateRTInterval(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.NewDefaultAgentConfig()
+	cfg := config.NewDefaultAgentConfig(false)
 	c, err := NewCollector(cfg)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.

--- a/cmd/process-agent/info_test.go
+++ b/cmd/process-agent/info_test.go
@@ -78,7 +78,7 @@ func testServer(t *testing.T) *httptest.Server {
 
 func TestInfo(t *testing.T) {
 	assert := assert.New(t)
-	conf := config.NewDefaultAgentConfig()
+	conf := config.NewDefaultAgentConfig(false)
 	server := testServer(t)
 	assert.NotNil(server)
 	defer server.Close()
@@ -95,7 +95,7 @@ func TestInfo(t *testing.T) {
 
 func TestNotRunning(t *testing.T) {
 	assert := assert.New(t)
-	conf := config.NewDefaultAgentConfig()
+	conf := config.NewDefaultAgentConfig(false)
 	server := testServer(t)
 	assert.NotNil(server)
 	defer server.Close()
@@ -122,7 +122,7 @@ func TestNotRunning(t *testing.T) {
 
 func TestError(t *testing.T) {
 	assert := assert.New(t)
-	conf := config.NewDefaultAgentConfig()
+	conf := config.NewDefaultAgentConfig(false)
 	server := testServer(t)
 	assert.NotNil(server)
 	defer server.Close()

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -29,7 +29,7 @@ func TestNetworkConnectionBatching(t *testing.T) {
 	// update lastRun to indicate that Process check is enabled and ran
 	Process.lastRun = time.Now()
 
-	cfg := config.NewDefaultAgentConfig()
+	cfg := config.NewDefaultAgentConfig(false)
 
 	for i, tc := range []struct {
 		cur, last      []*model.Connection

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -114,7 +114,7 @@ func TestProcessChunking(t *testing.T) {
 	containers := []*containers.Container{}
 	lastRun := time.Now().Add(-5 * time.Second)
 	syst1, syst2 := cpu.TimesStat{}, cpu.TimesStat{}
-	cfg := config.NewDefaultAgentConfig()
+	cfg := config.NewDefaultAgentConfig(false)
 
 	for i, tc := range []struct {
 		cur, last      []*process.FilledProcess

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -79,7 +79,7 @@ func TestRandomizeMessages(t *testing.T) {
 
 			lastRun := time.Now().Add(-5 * time.Second)
 			syst1, syst2 := cpu.TimesStat{}, cpu.TimesStat{}
-			cfg := config.NewDefaultAgentConfig()
+			cfg := config.NewDefaultAgentConfig(false)
 			sysInfo := &model.SystemInfo{}
 			lastCtrRates := util.ExtractContainerRateMetric(ctrs)
 
@@ -113,7 +113,7 @@ func TestBasicProcessMessages(t *testing.T) {
 	c[1].Pids = []int32{3}
 	lastRun := time.Now().Add(-5 * time.Second)
 	syst1, syst2 := cpu.TimesStat{}, cpu.TimesStat{}
-	cfg := config.NewDefaultAgentConfig()
+	cfg := config.NewDefaultAgentConfig(false)
 	sysInfo := &model.SystemInfo{}
 	lastCtrRates := util.ExtractContainerRateMetric(c)
 

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -148,7 +148,7 @@ func TestOnlyEnvConfigArgsScrubbingDisabled(t *testing.T) {
 }
 
 func TestGetHostname(t *testing.T) {
-	cfg := NewDefaultAgentConfig()
+	cfg := NewDefaultAgentConfig(false)
 	h, err := getHostname(cfg.DDAgentBin)
 	assert.Nil(t, err)
 	assert.NotEqual(t, "", h)
@@ -156,7 +156,7 @@ func TestGetHostname(t *testing.T) {
 
 func TestDefaultConfig(t *testing.T) {
 	assert := assert.New(t)
-	agentConfig := NewDefaultAgentConfig()
+	agentConfig := NewDefaultAgentConfig(false)
 
 	// assert that some sane defaults are set
 	assert.Equal("info", agentConfig.LogLevel)
@@ -164,7 +164,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(true, agentConfig.Scrubber.Enabled)
 
 	os.Setenv("DOCKER_DD_AGENT", "yes")
-	agentConfig = NewDefaultAgentConfig()
+	agentConfig = NewDefaultAgentConfig(false)
 	assert.Equal(os.Getenv("HOST_PROC"), "")
 	assert.Equal(os.Getenv("HOST_SYS"), "")
 	os.Setenv("DOCKER_DD_AGENT", "no")


### PR DESCRIPTION
### What does this PR do?

This will remove the following logs from system-probe startup, which are confusing because the system-probe does not even need access to the containers APIs

```
2019-09-17 19:54:13 UTC | SYS-PROBE | INFO | (pkg/util/containers/collectors/detector.go:122 in retryCandidates) | Collector docker successfully detected
2019-09-17 19:54:13 UTC | SYS-PROBE | INFO | (pkg/util/containers/collectors/detector.go:84 in GetPreferred) | Using collector docker
...
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
