### PR TITLE
Fix typo in process-agent cli

### DIFF
--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -118,10 +118,10 @@ func main() {
 	flag.StringVar(&opts.check, "check", "", "Run a specific check and print the results. Choose from: process, connections, realtime")
 
 	// windows-specific options for installing the service, uninstalling the service, etc.
-	flag.BoolVar(&winopts.installService, "install-service", false, "Install the trace agent to the Service Control Manager")
-	flag.BoolVar(&winopts.uninstallService, "uninstall-service", false, "Remove the trace agent from the Service Control Manager")
-	flag.BoolVar(&winopts.startService, "start-service", false, "Starts the trace agent service")
-	flag.BoolVar(&winopts.stopService, "stop-service", false, "Stops the trace agent service")
+	flag.BoolVar(&winopts.installService, "install-service", false, "Install the process agent to the Service Control Manager")
+	flag.BoolVar(&winopts.uninstallService, "uninstall-service", false, "Remove the process agent from the Service Control Manager")
+	flag.BoolVar(&winopts.startService, "start-service", false, "Starts the process agent service")
+	flag.BoolVar(&winopts.stopService, "stop-service", false, "Stops the process agent service")
 
 	flag.Parse()
 	isIntSess, err := svc.IsAnInteractiveSession()

--- a/releasenotes/notes/fix_typo_process_agent_cmd_help-298eeb13abdc3c22.yaml
+++ b/releasenotes/notes/fix_typo_process_agent_cmd_help-298eeb13abdc3c22.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a typo in the windows service related commands for the process agent CLI.
+    Was previously referencing `trace-agent`.


### PR DESCRIPTION
### What does this PR do?

The windows service based commands for the process agent CLI were referencing the trace agent. This fixes that help text. 