### PR TITLE
pkg/trace/{obfuscate,agent}: remove obfuscator dependency on config package

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -445,7 +445,7 @@ type eventProcessorTestCase struct {
 
 func testEventProcessorFromConf(t *testing.T, conf *config.AgentConfig, testCase eventProcessorTestCase) {
 	t.Run(testCase.name, func(t *testing.T) {
-		processor := eventProcessorFromConf(conf)
+		processor := newEventProcessor(conf)
 		processor.Start()
 
 		actualEPS := generateTraffic(processor, testCase.serviceName, testCase.opName, testCase.extractionRate,

--- a/pkg/trace/obfuscate/http.go
+++ b/pkg/trace/obfuscate/http.go
@@ -18,7 +18,7 @@ func (o *Obfuscator) obfuscateHTTP(span *pb.Span) {
 	if span.Meta == nil {
 		return
 	}
-	if !o.opts.HTTP.RemoveQueryString && !o.opts.HTTP.RemovePathDigits {
+	if !o.opts.RemoveQueryString && !o.opts.RemovePathDigits {
 		// nothing to do
 		return
 	}
@@ -34,11 +34,11 @@ func (o *Obfuscator) obfuscateHTTP(span *pb.Span) {
 		span.Meta[k] = "?"
 		return
 	}
-	if o.opts.HTTP.RemoveQueryString && u.RawQuery != "" {
+	if o.opts.RemoveQueryString && u.RawQuery != "" {
 		u.ForceQuery = true // add the '?'
 		u.RawQuery = ""
 	}
-	if o.opts.HTTP.RemovePathDigits {
+	if o.opts.RemovePathDigits {
 		segs := strings.Split(u.Path, "/")
 		var changed bool
 		for i, seg := range segs {

--- a/pkg/trace/obfuscate/http_test.go
+++ b/pkg/trace/obfuscate/http_test.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,7 +26,7 @@ func TestObfuscateHTTP(t *testing.T) {
 	}, nil))
 
 	t.Run("query", func(t *testing.T) {
-		conf := &config.HTTPObfuscationConfig{RemoveQueryString: true}
+		conf := &Config{RemoveQueryString: true}
 		for ti, tt := range []inOutTest{
 			{
 				in:  "http://foo.com/",
@@ -58,7 +58,7 @@ func TestObfuscateHTTP(t *testing.T) {
 	})
 
 	t.Run("digits", func(t *testing.T) {
-		conf := &config.HTTPObfuscationConfig{RemovePathDigits: true}
+		conf := &Config{RemovePathDigits: true}
 		for ti, tt := range []inOutTest{
 			{
 				in:  "http://foo.com/",
@@ -102,7 +102,7 @@ func TestObfuscateHTTP(t *testing.T) {
 	})
 
 	t.Run("both", func(t *testing.T) {
-		conf := &config.HTTPObfuscationConfig{RemoveQueryString: true, RemovePathDigits: true}
+		conf := &Config{RemoveQueryString: true, RemovePathDigits: true}
 		for ti, tt := range []inOutTest{
 			{
 				in:  "http://foo.com/",
@@ -140,16 +140,18 @@ func TestObfuscateHTTP(t *testing.T) {
 	t.Run("wrong-type", func(t *testing.T) {
 		assert := assert.New(t)
 		span := pb.Span{Type: "web_server", Meta: map[string]string{"http.url": testURL}}
-		cfg := config.HTTPObfuscationConfig{RemoveQueryString: true, RemovePathDigits: true}
-		NewObfuscator(&config.ObfuscationConfig{HTTP: cfg}).Obfuscate(&span)
+		NewObfuscator(&Config{
+			RemoveQueryString: true,
+			RemovePathDigits:  true,
+		}).Obfuscate(&span)
 		assert.Equal(testURL, span.Meta["http.url"])
 	})
 }
 
 // testHTTPObfuscation tests that the given input results in the given output using the passed configuration.
-func testHTTPObfuscation(tt *inOutTest, conf *config.HTTPObfuscationConfig) func(t *testing.T) {
+func testHTTPObfuscation(tt *inOutTest, conf *Config) func(t *testing.T) {
 	return func(t *testing.T) {
-		var cfg config.HTTPObfuscationConfig
+		var cfg Config
 		if conf != nil {
 			cfg = *conf
 		}
@@ -158,7 +160,7 @@ func testHTTPObfuscation(tt *inOutTest, conf *config.HTTPObfuscationConfig) func
 			Type: "http",
 			Meta: map[string]string{"http.url": tt.in},
 		}
-		NewObfuscator(&config.ObfuscationConfig{HTTP: cfg}).Obfuscate(&span)
+		NewObfuscator(&cfg).Obfuscate(&span)
 		assert.Equal(tt.out, span.Meta["http.url"])
 	}
 }

--- a/pkg/trace/obfuscate/json.go
+++ b/pkg/trace/obfuscate/json.go
@@ -8,9 +8,17 @@ package obfuscate
 import (
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 )
+
+// JSONSettings specifies the behaviour of the JSON obfuscator.
+type JSONSettings struct {
+	// Enabled will specify whether obfuscation should be enabled.
+	Enabled bool
+
+	// KeepValues specifies a set of keys for which their values will not be obfuscated.
+	KeepValues []string
+}
 
 // obfuscateJSON obfuscates the given span's tag using the given obfuscator. If the obfuscator is
 // nil it is considered disabled.
@@ -37,7 +45,7 @@ type jsonObfuscator struct {
 	keepDepth int  // the depth at which we've stopped obfuscating
 }
 
-func newJSONObfuscator(cfg *config.JSONObfuscationConfig) *jsonObfuscator {
+func newJSONObfuscator(cfg *JSONSettings) *jsonObfuscator {
 	keepValue := make(map[string]bool, len(cfg.KeepValues))
 	for _, v := range cfg.KeepValues {
 		keepValue[v] = true

--- a/pkg/trace/obfuscate/json_test.go
+++ b/pkg/trace/obfuscate/json_test.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -80,7 +79,7 @@ func TestObfuscateJSON(t *testing.T) {
 	runTest := func(s *xmlObfuscateTest) func(*testing.T) {
 		return func(t *testing.T) {
 			assert := assert.New(t)
-			cfg := &config.JSONObfuscationConfig{KeepValues: s.KeepValues}
+			cfg := &JSONSettings{KeepValues: s.KeepValues}
 			out, err := newJSONObfuscator(cfg).obfuscate([]byte(s.In))
 			if !s.DontNormalize {
 				assert.NoError(err)
@@ -99,7 +98,7 @@ func TestObfuscateJSON(t *testing.T) {
 }
 
 func BenchmarkObfuscateJSON(b *testing.B) {
-	cfg := &config.JSONObfuscationConfig{KeepValues: []string{"highlight"}}
+	cfg := &JSONSettings{KeepValues: []string{"highlight"}}
 	if len(jsonSuite) == 0 {
 		b.Fatal("no test suite loaded")
 	}

--- a/pkg/trace/obfuscate/obfuscate_test.go
+++ b/pkg/trace/obfuscate/obfuscate_test.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+
 	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
@@ -47,16 +47,16 @@ func TestNewObfuscator(t *testing.T) {
 	assert.Nil(o.es)
 	assert.Nil(o.mongo)
 
-	o = NewObfuscator(&config.ObfuscationConfig{
-		ES:    config.JSONObfuscationConfig{},
-		Mongo: config.JSONObfuscationConfig{},
+	o = NewObfuscator(&Config{
+		ES:    JSONSettings{},
+		Mongo: JSONSettings{},
 	})
 	assert.Nil(o.es)
 	assert.Nil(o.mongo)
 
-	o = NewObfuscator(&config.ObfuscationConfig{
-		ES:    config.JSONObfuscationConfig{Enabled: true},
-		Mongo: config.JSONObfuscationConfig{Enabled: true},
+	o = NewObfuscator(&Config{
+		ES:    JSONSettings{Enabled: true},
+		Mongo: JSONSettings{Enabled: true},
 	})
 	assert.NotNil(o.es)
 	assert.NotNil(o.mongo)
@@ -124,7 +124,7 @@ func TestObfuscateConfig(t *testing.T) {
 	// configuration and asserts that the new tag value matches exp.
 	testConfig := func(
 		typ, key, val, exp string,
-		cfg *config.ObfuscationConfig,
+		cfg *Config,
 	) func(*testing.T) {
 		return func(t *testing.T) {
 			span := &pb.Span{Type: typ, Meta: map[string]string{key: val}}
@@ -138,9 +138,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"redis.raw_command",
 		"SET key val",
 		"SET key ?",
-		&config.ObfuscationConfig{
-			Redis: config.Enablable{Enabled: true},
-		},
+		&Config{Redis: true},
 	))
 
 	t.Run("redis/disabled", testConfig(
@@ -148,7 +146,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"redis.raw_command",
 		"SET key val",
 		"SET key val",
-		&config.ObfuscationConfig{},
+		&Config{},
 	))
 
 	t.Run("http/enabled", testConfig(
@@ -156,11 +154,9 @@ func TestObfuscateConfig(t *testing.T) {
 		"http.url",
 		"http://mysite.mydomain/1/2?q=asd",
 		"http://mysite.mydomain/?/??",
-		&config.ObfuscationConfig{
-			HTTP: config.HTTPObfuscationConfig{
-				RemovePathDigits:  true,
-				RemoveQueryString: true,
-			},
+		&Config{
+			RemovePathDigits:  true,
+			RemoveQueryString: true,
 		},
 	))
 
@@ -169,7 +165,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"http.url",
 		"http://mysite.mydomain/1/2?q=asd",
 		"http://mysite.mydomain/1/2?q=asd",
-		&config.ObfuscationConfig{},
+		&Config{},
 	))
 
 	t.Run("web/enabled", testConfig(
@@ -177,11 +173,9 @@ func TestObfuscateConfig(t *testing.T) {
 		"http.url",
 		"http://mysite.mydomain/1/2?q=asd",
 		"http://mysite.mydomain/?/??",
-		&config.ObfuscationConfig{
-			HTTP: config.HTTPObfuscationConfig{
-				RemovePathDigits:  true,
-				RemoveQueryString: true,
-			},
+		&Config{
+			RemovePathDigits:  true,
+			RemoveQueryString: true,
 		},
 	))
 
@@ -190,7 +184,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"http.url",
 		"http://mysite.mydomain/1/2?q=asd",
 		"http://mysite.mydomain/1/2?q=asd",
-		&config.ObfuscationConfig{},
+		&Config{},
 	))
 
 	t.Run("json/enabled", testConfig(
@@ -198,8 +192,8 @@ func TestObfuscateConfig(t *testing.T) {
 		"elasticsearch.body",
 		`{"role": "database"}`,
 		`{"role":"?"}`,
-		&config.ObfuscationConfig{
-			ES: config.JSONObfuscationConfig{Enabled: true},
+		&Config{
+			ES: JSONSettings{Enabled: true},
 		},
 	))
 
@@ -208,7 +202,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"elasticsearch.body",
 		`{"role": "database"}`,
 		`{"role": "database"}`,
-		&config.ObfuscationConfig{},
+		&Config{},
 	))
 
 	t.Run("memcached/enabled", testConfig(
@@ -216,9 +210,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"memcached.command",
 		"set key 0 0 0\r\nvalue",
 		"set key 0 0 0",
-		&config.ObfuscationConfig{
-			Memcached: config.Enablable{Enabled: true},
-		},
+		&Config{Memcached: true},
 	))
 
 	t.Run("memcached/disabled", testConfig(
@@ -226,7 +218,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"memcached.command",
 		"set key 0 0 0 noreply\r\nvalue",
 		"set key 0 0 0 noreply\r\nvalue",
-		&config.ObfuscationConfig{},
+		&Config{},
 	))
 }
 


### PR DESCRIPTION
This change removes the 'obfuscate' package's dependency on the 'config'
package in an attempt to reduce transitive dependency and make it more
accessible to outside users.

* Before: 176 transitive dependencies
* After: 106 transitive dependencies (87 standard library, 19 for models)

To view, use `go list -f '{{ join .Deps "\n" }}' ./pkg/trace/obfuscate`