### PR TITLE
Container collectors: prioritize NodeOrchestrator over NodeRuntime

### DIFF
--- a/pkg/util/containers/collectors/detector_test.go
+++ b/pkg/util/containers/collectors/detector_test.go
@@ -135,13 +135,13 @@ func (suite *DetectorTestSuite) TestConfigureOneUnknown() {
 // TestConfigureOneRetry makes sure we retry collectors,
 // then select the new one based on higher priority
 func (suite *DetectorTestSuite) TestConfigureRetry() {
-	ok := registerMock("ok", NodeOrchestrator)
+	ok := registerMock("ok", NodeRuntime)
 	ok.On("Detect").Return(nil)
-	noRetry := registerMock("noretry", NodeOrchestrator)
+	noRetry := registerMock("noretry", NodeRuntime)
 	noRetry.On("Detect").Return(errors.New("retry not implemented"))
-	fail := registerMock("fail", NodeRuntime)
+	fail := registerMock("fail", NodeOrchestrator)
 	fail.On("Detect").Return(permaFailRetryError)
-	retry := registerMock("retry", NodeRuntime)
+	retry := registerMock("retry", NodeOrchestrator)
 	retry.On("Detect").Return(willRetryError).Once()
 	retry.On("Detect").Return(nil).Once()
 
@@ -214,9 +214,9 @@ func (suite *DetectorTestSuite) TestConfigureTwoByName() {
 // TestConfigureTwoByPrio autodetects between two valid collectors,
 // selected by priority
 func (suite *DetectorTestSuite) TestConfigureTwoByPrio() {
-	one := registerMock("one", NodeOrchestrator)
+	one := registerMock("one", NodeRuntime)
 	one.On("Detect").Return(nil).Once()
-	two := registerMock("two", NodeRuntime)
+	two := registerMock("two", NodeOrchestrator)
 	two.On("Detect").Return(nil).Once()
 
 	d := NewDetector("")

--- a/pkg/util/containers/collectors/types.go
+++ b/pkg/util/containers/collectors/types.go
@@ -18,8 +18,8 @@ type Collector interface {
 type CollectorPriority int
 
 // List of collector priorities
-// Order is reverse from the tagger: docker > kubelet
+// Same order as the tagger: docker < kubelet
 const (
-	NodeOrchestrator CollectorPriority = iota
-	NodeRuntime
+	NodeRuntime CollectorPriority = iota
+	NodeOrchestrator
 )


### PR DESCRIPTION
### What does this PR do?

Prioritize NodeOrchestrator collector (Kubelet) over NodeRuntime (Docker) when selecting a container collector from the available collectors.

### Motivation

- In k8s, the docker collector is unable to collect containers network info
- Same priority order used in the tagger

