### PR TITLE
[forwarder] full queues dont imply unhealthy forwarder

### DIFF
--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -39,7 +39,7 @@ func initForwarderHealthExpvars() {
 }
 
 // forwarderHealth report the health status of the Forwarder. A Forwarder is
-// unhealthy if the API keys are not longer valid or if to many transactions
+// unhealthy if the API keys are not longer valid or if too many transactions
 // were dropped
 type forwarderHealth struct {
 	health         *health.Handle
@@ -86,7 +86,7 @@ func (fh *forwarderHealth) healthCheckLoop() {
 	defer close(fh.stopped)
 
 	valid := fh.hasValidAPIKey()
-	// If no key is valid, no need to keep checking, they won't magicaly become valid
+	// If no key is valid, no need to keep checking, they won't magically become valid
 	if !valid {
 		log.Errorf("No valid api key found, reporting the forwarder as unhealthy.")
 		return
@@ -103,10 +103,7 @@ func (fh *forwarderHealth) healthCheckLoop() {
 				return
 			}
 		case <-fh.health.C:
-			if transactionsDroppedOnInput.Value() != 0 {
-				log.Errorf("Detected dropped transaction, reporting the forwarder as unhealthy: %v.", transactionsDroppedOnInput)
-				return
-			}
+			continue
 		}
 	}
 }

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -39,8 +39,7 @@ func initForwarderHealthExpvars() {
 }
 
 // forwarderHealth report the health status of the Forwarder. A Forwarder is
-// unhealthy if the API keys are not longer valid or if too many transactions
-// were dropped
+// unhealthy if the API keys are not longer valid
 type forwarderHealth struct {
 	health         *health.Handle
 	stop           chan bool
@@ -103,7 +102,6 @@ func (fh *forwarderHealth) healthCheckLoop() {
 				return
 			}
 		case <-fh.health.C:
-			continue
 		}
 	}
 }

--- a/releasenotes/notes/forwarder-healthcheck-behavior-change-cb1bd4918cfb711f.yaml
+++ b/releasenotes/notes/forwarder-healthcheck-behavior-change-cb1bd4918cfb711f.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Behavioral change on the forwarder healthcheck such that full queues
+    will not label the forwarder as unhealthy. Networking or endpoint issues
+    are not representative of an unhealthy agent or forwarder.


### PR DESCRIPTION
### What does this PR do?

This PR changes the behavior of the forwarder health check. The assumption that the forwarder is an unhealthy state because the queues are full is a bit of a stretch:
- queues could be full due to a network outage
- queues could be full due to an endpoint issue

In the case of a networking issue, outgoing attempts would not reach our endpoints, and thus it wouldn't help relief any back-pressure. We also have our back-off mechanisms to avoid being too aggressive. 
In the case of an endpoint issue, the problem is on our backend and does not indicate anything wrong with the agent or the forwarder.

Additionally, in neither of the cases above does restarting the agent add any value because a) we will reach the exact same state when the container is re-provisioned - typical K8s strategy and b) no customer action should be necessary on the pods  

### Motivation

Unexpected behavior on unavailable additional endpoint leading to a `crashloopbackoff` due to agent containers being flagged as unhealthy due to agent unrelated circumstances. 
