### PR TITLE
Fix retry + optional fallback logic for cluster tagging

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -310,6 +310,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_agent.auth_token", "")
 	config.BindEnvAndSetDefault("cluster_agent.url", "")
 	config.BindEnvAndSetDefault("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
+	config.BindEnvAndSetDefault("cluster_agent.tagging_fallback", false)
 	config.BindEnvAndSetDefault("metrics_port", "5000")
 
 	// Metadata endpoints

--- a/releasenotes/notes/clustert-agent-fallback-04bc5ce81848036f.yaml
+++ b/releasenotes/notes/clustert-agent-fallback-04bc5ce81848036f.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add an option to disable the cluster agent local fallback for tag collection (disabled by default).
+fixes:
+  - |
+    Fix an issue where the node agent would not retry to connect to the cluster agent for tag collection.


### PR DESCRIPTION
### What does this PR do?

* Fix a bug where the tagger will not retry to connect to the cluster agent on the first failure
* Disable the fallback logic by default if the cluster-agent

without fallback (default):
```
2019-09-26 12:42:52 UTC | CORE | ERROR | (pkg/tagger/collectors/kubernetes_main.go:57 in Detect) | Could not initialise the communication with the cluster agent: permanent failure in clusterAgentClient: Get https://charlyDCA.fr/version: dial tcp: lookup charlyDCA.fr: no such host
2019-09-26 12:42:52 UTC | CORE | DEBUG | (pkg/tagger/tagger.go:150 in tryCollectors) | kube-metadata-collector tag collector cannot start: permanent failure in clusterAgentClient: Get https://charlyDCA.fr/version: dial tcp: lookup charlyDCA.fr: no such host
```

with fallback enabled:
```
2019-09-26 12:30:14 UTC | CORE | DEBUG | (pkg/tagger/tagger.go:146 in tryCollectors) | will retry kube-metadata-collector later: temporary failure in clusterAgentClient, will retry later: Get https://charlyDCA.fr/version: dial tcp: lookup charlyDCA.fr: no such host
2019-09-26 12:30:44 UTC | CORE | DEBUG | (pkg/util/clusteragent/clusteragent.go:88 in GetClusterAgentClient) | Cluster Agent init error: permanent failure in clusterAgentClient: Get https://charlyDCA.fr/version: dial tcp: lookup charlyDCA.fr: no such host
2019-09-26 12:30:44 UTC | CORE | ERROR | (pkg/tagger/collectors/kubernetes_main.go:57 in Detect) | Could not initialise the communication with the cluster agent: permanent failure in clusterAgentClient: Get https://charlyDCA.fr/version: dial tcp: lookup charlyDCA.fr: no such host
2019-09-26 12:30:44 UTC | CORE | ERROR | (pkg/tagger/collectors/kubernetes_main.go:65 in Detect) | Permanent failure in communication with the cluster agent, will fallback to local service mapper
```

### Motivation

Do not overload the API server if the cluster agent is missconfigured/unavailable.

### Additional Notes

Anything else we should know when reviewing?
