### PR TITLE
Use OpenJDK11 in the docker image

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -68,10 +68,15 @@ ENV DOCKER_DD_AGENT=true \
     S6_READ_ONLY_ROOT=1
 
 # Install openjdk-11-jre-headless on jmx flavor
-RUN if [ -n "$WITH_JMX" ]; then apt-get update \
+# Due to this bug https://bugs.openjdk.java.net/browse/JDK-8217766, we need to be able to
+# pull from testing since this is the only place for now where a version > 11.0.4 is available.
+RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-11 from testing" \
+ && echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list \
+ && apt-get update \
  && mkdir /usr/share/man/man1 \
  && apt-get install --no-install-recommends -y openjdk-11-jre-headless \
  && apt-get clean \
+ && rm /etc/apt/sources.list.d/testing.list \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; fi
 
 # make sure we have recent dependencies

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -67,16 +67,11 @@ ENV DOCKER_DD_AGENT=true \
     # Allow readonlyrootfs
     S6_READ_ONLY_ROOT=1
 
-# Install openjdk-8-jre-headless on jmx flavor
-RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-8 from stable" \
- && echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/stretch.list \
- && echo "deb http://security.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list.d/stretch.list \
- && echo "deb http://deb.debian.org/debian stretch-updates main" >> /etc/apt/sources.list.d/stretch.list \
- && apt-get update \
+# Install openjdk-11-jre-headless on jmx flavor
+RUN if [ -n "$WITH_JMX" ]; then apt-get update \
  && mkdir /usr/share/man/man1 \
- && apt-get install --no-install-recommends -y openjdk-8-jre-headless \
+ && apt-get install --no-install-recommends -y openjdk-11-jre-headless \
  && apt-get clean \
- && rm /etc/apt/sources.list.d/stretch.list \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; fi
 
 # make sure we have recent dependencies

--- a/Dockerfiles/agent/datadog-docker.yaml
+++ b/Dockerfiles/agent/datadog-docker.yaml
@@ -14,5 +14,5 @@ apm_config:
   enabled: false
   apm_non_local_traffic: true
 
-# Use java cgroup memory awareness
-jmx_use_cgroup_memory_limit: true
+# Use java container support
+jmx_use_container_support: true

--- a/Dockerfiles/agent/datadog-ecs.yaml
+++ b/Dockerfiles/agent/datadog-ecs.yaml
@@ -13,5 +13,5 @@ apm_config:
   enabled: false
   apm_non_local_traffic: true
 
-# Use java cgroup memory awareness
-jmx_use_cgroup_memory_limit: true
+# Use java container support
+jmx_use_container_support: true

--- a/Dockerfiles/agent/datadog-k8s-docker.yaml
+++ b/Dockerfiles/agent/datadog-k8s-docker.yaml
@@ -18,5 +18,5 @@ apm_config:
   enabled: false
   apm_non_local_traffic: true
 
-# Use java cgroup memory awareness
-jmx_use_cgroup_memory_limit: true
+# Use java container support
+jmx_use_container_support: true

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -13,5 +13,5 @@ apm_config:
   enabled: false
   apm_non_local_traffic: true
 
-# Use java cgroup memory awareness
-jmx_use_cgroup_memory_limit: true
+# Use java container support
+jmx_use_container_support: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -334,6 +334,7 @@ func initConfig(config Config) {
 	// JMXFetch
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
+	config.BindEnvAndSetDefault("jmx_use_container_support", false)
 	config.BindEnvAndSetDefault("jmx_max_restarts", int64(3))
 	config.BindEnvAndSetDefault("jmx_restart_interval", int64(5))
 	config.BindEnvAndSetDefault("jmx_thread_pool_size", 3)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -729,9 +729,19 @@ api_key:
 ## When running in a memory cgroup, openjdk 8u131 and higher can automatically adjust
 ## its heap memory usage in accordance to the cgroup/container's memory limit.
 ## The Agent set a Xmx of 200MB if none is configured.
-## Note: older openjdk versions and other jvms might fail to start if this option is set
+## Note: OpenJDK version < 8u131 or >= 10 as well as other JVMs might fail
+## to start if this option is set.
 #
 # jmx_use_cgroup_memory_limit: false
+
+## @param jmx_use_container_support - boolean - optional - default: false
+## When running in a container, openjdk 10 and higher can automatically detect
+## container specific configuration instead of querying the operating system
+## to adjust resources allotted to the JVM.
+## Note: openjdk versions prior to 10 and other JVMs might fail to start if
+## this option is set.
+#
+# jmx_use_container_support: false
 
 ## @param jmx_max_restarts - integer - optional - default: 3
 ## Number of JMX restarts allowed in the restart-interval before giving up.

--- a/releasenotes/notes/openjdk11-jvm-ece6b5cc12c86ff6.yaml
+++ b/releasenotes/notes/openjdk11-jvm-ece6b5cc12c86ff6.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for the `XX:+UseContainerSupport` JVM option through the
+    `jmx_use_container_support` configuration option.


### PR DESCRIPTION
### What does this PR do?

This is the follow-up of #4034 and #4105.

After testing this update we found out that a bug in the cgroup detection logic inside the JVM was triggered leading to invalid memory sizing (https://bugs.openjdk.java.net/browse/JDK-8217766). This bug was fixed in OpenJDK 13 and backported to OpenJDK 11.0.5 which is only available from debian's testing distribution for now.
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
