### PR TITLE
[Windows] Remove ddagentuser write access to binaries

### DIFF
--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -244,8 +244,6 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall) {
     }
     er = addDdUserPermsToFile(data, programdataroot);
     WcaLog(LOGMSG_STANDARD, "%d setting programdata dir perms", er);
-    er = addDdUserPermsToFile(data, installdir);
-    WcaLog(LOGMSG_STANDARD, "%d setting installdir dir perms", er);
 
     er = addDdUserPermsToFile(data, logfilename);
     WcaLog(LOGMSG_STANDARD, "%d setting log file perms", er);

--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -244,7 +244,10 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall) {
     }
     er = addDdUserPermsToFile(data, programdataroot);
     WcaLog(LOGMSG_STANDARD, "%d setting programdata dir perms", er);
-
+    er = addDdUserPermsToFile(data, embedded2Dir);
+    WcaLog(LOGMSG_STANDARD, "%d setting embedded2Dir dir perms", er);
+    er = addDdUserPermsToFile(data, embedded3Dir);
+    WcaLog(LOGMSG_STANDARD, "%d setting embedded3Dir dir perms", er);
     er = addDdUserPermsToFile(data, logfilename);
     WcaLog(LOGMSG_STANDARD, "%d setting log file perms", er);
     er = addDdUserPermsToFile(data, authtokenfilename);

--- a/omnibus/resources/agent/msi/cal/strings.cpp
+++ b/omnibus/resources/agent/msi/cal/strings.cpp
@@ -157,8 +157,8 @@ void getOsStrings()
     agent_exe = L"\"" + installdir + L"bin\\agent.exe\"";
     process_exe = L"\"" + installdir + L"bin\\agent\\process-agent.exe\" --config=\"" + programdataroot + L"datadog.yaml\"" ;
     trace_exe   = L"\"" + installdir + L"bin\\agent\\trace-agent.exe\" --config=\"" + programdataroot + L"datadog.yaml\"" ;
-    embedded2Dir = L"\"" + installdir + L"embedded2\"";
-    embedded3Dir = L"\"" + installdir + L"embedded3\"";
+    embedded2Dir = installdir + L"embedded2";
+    embedded3Dir = installdir + L"embedded3";
     datadog_acl_key_datadog = datadog_acl_key_datadog_base + datadog_path;
 
 }

--- a/omnibus/resources/agent/msi/cal/strings.cpp
+++ b/omnibus/resources/agent/msi/cal/strings.cpp
@@ -39,6 +39,8 @@ std::wstring datadogyamlfile;
 std::wstring confddir;
 std::wstring logdir;
 std::wstring installdir;
+std::wstring embedded2Dir;
+std::wstring embedded3Dir;
 
 std::wstring propertyCustomActionData(L"CustomActionData");
 std::wstring datadog_key_root;
@@ -155,7 +157,8 @@ void getOsStrings()
     agent_exe = L"\"" + installdir + L"bin\\agent.exe\"";
     process_exe = L"\"" + installdir + L"bin\\agent\\process-agent.exe\" --config=\"" + programdataroot + L"datadog.yaml\"" ;
     trace_exe   = L"\"" + installdir + L"bin\\agent\\trace-agent.exe\" --config=\"" + programdataroot + L"datadog.yaml\"" ;
-
+    embedded2Dir = L"\"" + installdir + L"embedded2\"";
+    embedded3Dir = L"\"" + installdir + L"embedded3\"";
     datadog_acl_key_datadog = datadog_acl_key_datadog_base + datadog_path;
 
 }

--- a/omnibus/resources/agent/msi/cal/strings.h
+++ b/omnibus/resources/agent/msi/cal/strings.h
@@ -29,6 +29,8 @@ extern std::wstring datadogyamlfile;
 extern std::wstring confddir;
 extern std::wstring logdir;
 extern std::wstring installdir;
+extern std::wstring embedded2Dir;
+extern std::wstring embedded3Dir;
 
 extern std::wstring strRollbackKeyName;
 extern std::wstring strUninstallKeyName;

--- a/releasenotes/notes/[Windows]-Remove-write-perm-to-ddagentuser-on-bin-ab4d5cc4f76e9369.yaml
+++ b/releasenotes/notes/[Windows]-Remove-write-perm-to-ddagentuser-on-bin-ab4d5cc4f76e9369.yaml
@@ -1,3 +1,3 @@
 security:
   - |
-    The ddagentuser no longer has write access to the bin folder on Windows
+    The ddagentuser no longer has write access to the process-agent binary on Windows

--- a/releasenotes/notes/[Windows]-Remove-write-perm-to-ddagentuser-on-bin-ab4d5cc4f76e9369.yaml
+++ b/releasenotes/notes/[Windows]-Remove-write-perm-to-ddagentuser-on-bin-ab4d5cc4f76e9369.yaml
@@ -1,0 +1,3 @@
+security:
+  - |
+    The ddagentuser no longer has write access to the bin folder on Windows


### PR DESCRIPTION
# What does this PR do?

This PR removes write access to `ddagentuser` on the bin folder on Windows.

# Motivation

The `ddagentuser` can overwrite its own binaries.

# Additional Notes