### PR TITLE
[DCA] CLC dispatching telemetry

### DIFF
--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -34,11 +34,52 @@ var (
 		},
 		[]string{"node"},
 	)
+	rebalancingDecisions = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: "cluster_checks",
+			Name:      "rebalancing_decisions",
+			Help:      "Total number of check rebalancing decisions",
+		},
+	)
+	successfulRebalancing = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: "cluster_checks",
+			Name:      "successful_rebalancing_moves",
+			Help:      "Total number of successful check rebalancing decisions",
+		},
+	)
+	rebalancingDuration = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: "cluster_checks",
+			Name:      "rebalancing_duration_seconds",
+			Help:      "Duration of the check rebalancing algorithm last execution",
+		},
+	)
+	statsCollectionFails = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: "cluster_checks",
+			Name:      "failed_stats_collection",
+			Help:      "Total number of unsuccessful stats collection attempts",
+		},
+		[]string{"node"},
+	)
+	updateStatsDuration = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: "cluster_checks",
+			Name:      "updating_stats_duration_seconds",
+			Help:      "Duration of collecting stats from check runners and updating cache",
+		},
+	)
 
 	allMetrics = []prometheus.Collector{
 		nodeAgents,
 		danglingConfigs,
 		dispatchedConfigs,
+		rebalancingDecisions,
+		successfulRebalancing,
+		rebalancingDuration,
+		statsCollectionFails,
+		updateStatsDuration,
 	}
 )
 

--- a/releasenotes/notes/releasenotes-dca/-ee6b571da0daf3f8.yaml
+++ b/releasenotes/notes/releasenotes-dca/-ee6b571da0daf3f8.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Expose metrics for the cluster level checks advanced dispatching.


### PR DESCRIPTION
### What does this PR do?

Adds metrics to monitor the Cluster Agent's advanced dispatching logic for cluster checks:

- `cluster_checks_rebalancing_decisions`
- `cluster_checks_successful_rebalancing_moves`
- `cluster_checks_rebalancing_duration_seconds`
- `cluster_checks_failed_stats_collection`
- `cluster_checks_updating_stats_duration_seconds`

### Motivation

Improve the Cluster Agent's telemetry

### Additional Notes

Anything else we should know when reviewing?
