### PR TITLE
pkg/trace/obfuscate: add detailed obfuscation errors and UTF-8 support

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -8,7 +8,9 @@ package obfuscate
 import (
 	"bytes"
 	"errors"
+	"fmt"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -20,7 +22,7 @@ const sqlQueryTag = "sql.query"
 // A filter can be stateful and keep an internal state to apply the filter later;
 // this can be useful to prevent backtracking in some cases.
 type tokenFilter interface {
-	Filter(token, lastToken int, buffer []byte) (int, []byte)
+	Filter(token, lastToken int, buffer []byte) (tokenType int, tokenBytes []byte, err error)
 	Reset()
 }
 
@@ -30,7 +32,7 @@ type discardFilter struct{}
 
 // Filter the given token so that a `nil` slice is returned if the token
 // is in the token filtered list.
-func (f *discardFilter) Filter(token, lastToken int, buffer []byte) (int, []byte) {
+func (f *discardFilter) Filter(token, lastToken int, buffer []byte) (tokenType int, tokenBytes []byte, err error) {
 	// filters based on previous token
 	switch lastToken {
 	case FilteredBracketedIdentifier:
@@ -39,9 +41,9 @@ func (f *discardFilter) Filter(token, lastToken int, buffer []byte) (int, []byte
 			if token != ID {
 				// the token between the brackets *must* be an identifier,
 				// otherwise the query is invalid.
-				return LexError, nil
+				return LexError, nil, fmt.Errorf("expected identifier in bracketed filter, got %d", token)
 			}
-			return FilteredBracketedIdentifier, nil
+			return FilteredBracketedIdentifier, nil, nil
 		}
 		fallthrough
 	case As:
@@ -49,20 +51,20 @@ func (f *discardFilter) Filter(token, lastToken int, buffer []byte) (int, []byte
 			// the identifier followed by AS is an MSSQL bracketed identifier
 			// and will continue to be discarded until we find the corresponding
 			// closing bracket counter-part. See GitHub issue DataDog/datadog-trace-agent#475.
-			return FilteredBracketedIdentifier, nil
+			return FilteredBracketedIdentifier, nil, nil
 		}
-		return Filtered, nil
+		return Filtered, nil, nil
 	}
 
 	// filters based on the current token; if the next token should be ignored,
 	// return the same token value (not FilteredGroupable) and nil
 	switch token {
 	case As:
-		return As, nil
+		return As, nil, nil
 	case Comment, ';':
-		return FilteredGroupable, nil
+		return FilteredGroupable, nil, nil
 	default:
-		return token, buffer
+		return token, buffer, nil
 	}
 }
 
@@ -74,22 +76,22 @@ func (f *discardFilter) Reset() {}
 type replaceFilter struct{}
 
 // Filter the given token so that it will be replaced if in the token replacement list
-func (f *replaceFilter) Filter(token, lastToken int, buffer []byte) (int, []byte) {
+func (f *replaceFilter) Filter(token, lastToken int, buffer []byte) (tokenType int, tokenBytes []byte, err error) {
 	switch lastToken {
 	case Savepoint:
-		return FilteredGroupable, []byte("?")
+		return FilteredGroupable, []byte("?"), nil
 	case '=':
 		switch token {
 		case DoubleQuotedString:
 			// double-quoted strings after assignments are eligible for obfuscation
-			return FilteredGroupable, []byte("?")
+			return FilteredGroupable, []byte("?"), nil
 		}
 	}
 	switch token {
 	case String, Number, Null, Variable, PreparedStatement, BooleanLiteral, EscapeSequence:
-		return FilteredGroupable, []byte("?")
+		return FilteredGroupable, []byte("?"), nil
 	default:
-		return token, buffer
+		return token, buffer, nil
 	}
 }
 
@@ -107,7 +109,7 @@ type groupingFilter struct {
 // has been recognized. A grouping is composed by items like:
 //   * '( ?, ?, ? )'
 //   * '( ?, ? ), ( ?, ? )'
-func (f *groupingFilter) Filter(token, lastToken int, buffer []byte) (int, []byte) {
+func (f *groupingFilter) Filter(token, lastToken int, buffer []byte) (tokenType int, tokenBytes []byte, err error) {
 	// increasing the number of groups means that we're filtering an entire group
 	// because it can be represented with a single '( ? )'
 	if (lastToken == '(' && token == FilteredGroupable) || (token == '(' && f.groupMulti > 0) {
@@ -122,21 +124,21 @@ func (f *groupingFilter) Filter(token, lastToken int, buffer []byte) (int, []byt
 		f.groupFilter++
 
 		if f.groupFilter > 1 {
-			return FilteredGroupable, nil
+			return FilteredGroupable, nil, nil
 		}
 	case f.groupFilter > 0 && (token == ',' || token == '?'):
 		// if we are in a group drop all commas
-		return FilteredGroupable, nil
+		return FilteredGroupable, nil, nil
 	case f.groupMulti > 1:
 		// drop all tokens since we're in a counting group
 		// and they're duplicated
-		return FilteredGroupable, nil
+		return FilteredGroupable, nil, nil
 	case token != ',' && token != '(' && token != ')' && token != FilteredGroupable:
 		// when we're out of a group reset the filter state
 		f.Reset()
 	}
 
-	return token, buffer
+	return token, buffer, nil
 }
 
 // Reset in a groupingFilter restores variables used to count
@@ -150,10 +152,11 @@ func (f *groupingFilter) Reset() {
 // function is generic and the behavior changes according to chosen tokenFilter implementations.
 // The process calls all filters inside the []tokenFilter.
 func obfuscateSQLString(in string) (string, error) {
-	tokenizer := NewStringTokenizer(in)
+	tokenizer := NewSQLTokenizer(in)
 	filters := []tokenFilter{&discardFilter{}, &replaceFilter{}, &groupingFilter{}}
 	var (
 		out       bytes.Buffer
+		err       error
 		lastToken int
 	)
 	// call Scan() function until tokens are available or if a LEX_ERROR is raised. After
@@ -162,11 +165,11 @@ func obfuscateSQLString(in string) (string, error) {
 	token, buff := tokenizer.Scan()
 	for ; token != EOFChar; token, buff = tokenizer.Scan() {
 		if token == LexError {
-			return "", errors.New("the tokenizer was unable to process the string")
+			return "", tokenizer.Err()
 		}
 		for _, f := range filters {
-			if token, buff = f.Filter(token, lastToken, buff); token == LexError {
-				return "", errors.New("the tokenizer was unable to process the string")
+			if token, buff, err = f.Filter(token, lastToken, buff); err != nil {
+				return "", err
 			}
 		}
 		if buff != nil {
@@ -186,18 +189,26 @@ func obfuscateSQLString(in string) (string, error) {
 		}
 		lastToken = token
 	}
+	if out.Len() == 0 {
+		return "", errors.New("result is empty")
+	}
 	return out.String(), nil
 }
 
 // QuantizeSQL generates resource and sql.query meta for SQL spans
 func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
+	tags := []string{"type:sql"}
+	defer func() {
+		metrics.Count("datadog.trace_agent.obfuscations", 1, tags, 1)
+	}()
 	if span.Resource == "" {
+		tags = append(tags, "outcome:empty-resource")
 		return
 	}
 	result, err := obfuscateSQLString(span.Resource)
-	if err != nil || result == "" {
+	if err != nil {
 		// we have an error, discard the SQL to avoid polluting user resources.
-		log.Debugf("Error parsing SQL query: %q", span.Resource)
+		log.Debugf("Error parsing SQL query: %v. Resource: %q", err, span.Resource)
 		if span.Meta == nil {
 			span.Meta = make(map[string]string, 1)
 		}
@@ -205,9 +216,11 @@ func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
 			span.Meta[sqlQueryTag] = span.Resource
 		}
 		span.Resource = "Non-parsable SQL query"
+		tags = append(tags, "outcome:error")
 		return
 	}
 
+	tags = append(tags, "outcome:success")
 	span.Resource = result
 
 	if span.Meta != nil && span.Meta[sqlQueryTag] != "" {

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -22,7 +22,7 @@ const sqlQueryTag = "sql.query"
 // A filter can be stateful and keep an internal state to apply the filter later;
 // this can be useful to prevent backtracking in some cases.
 type tokenFilter interface {
-	Filter(token, lastToken tokenKind, buffer []byte) (tokenKind, []byte, error)
+	Filter(token, lastToken TokenKind, buffer []byte) (TokenKind, []byte, error)
 	Reset()
 }
 
@@ -32,7 +32,7 @@ type discardFilter struct{}
 
 // Filter the given token so that a `nil` slice is returned if the token
 // is in the token filtered list.
-func (f *discardFilter) Filter(token, lastToken tokenKind, buffer []byte) (tokenKind, []byte, error) {
+func (f *discardFilter) Filter(token, lastToken TokenKind, buffer []byte) (TokenKind, []byte, error) {
 	// filters based on previous token
 	switch lastToken {
 	case FilteredBracketedIdentifier:
@@ -76,7 +76,7 @@ func (f *discardFilter) Reset() {}
 type replaceFilter struct{}
 
 // Filter the given token so that it will be replaced if in the token replacement list
-func (f *replaceFilter) Filter(token, lastToken tokenKind, buffer []byte) (tokenType tokenKind, tokenBytes []byte, err error) {
+func (f *replaceFilter) Filter(token, lastToken TokenKind, buffer []byte) (tokenType TokenKind, tokenBytes []byte, err error) {
 	switch lastToken {
 	case Savepoint:
 		return FilteredGroupable, []byte("?"), nil
@@ -109,7 +109,7 @@ type groupingFilter struct {
 // has been recognized. A grouping is composed by items like:
 //   * '( ?, ?, ? )'
 //   * '( ?, ? ), ( ?, ? )'
-func (f *groupingFilter) Filter(token, lastToken tokenKind, buffer []byte) (tokenType tokenKind, tokenBytes []byte, err error) {
+func (f *groupingFilter) Filter(token, lastToken TokenKind, buffer []byte) (tokenType TokenKind, tokenBytes []byte, err error) {
 	// increasing the number of groups means that we're filtering an entire group
 	// because it can be represented with a single '( ? )'
 	if (lastToken == '(' && token == FilteredGroupable) || (token == '(' && f.groupMulti > 0) {
@@ -157,7 +157,7 @@ func obfuscateSQLString(in string) (string, error) {
 	var (
 		out       bytes.Buffer
 		err       error
-		lastToken tokenKind
+		lastToken TokenKind
 	)
 	// call Scan() function until tokens are available or if a LEX_ERROR is raised. After
 	// retrieving a token, send it to the tokenFilter chains so that the token is discarded

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -22,7 +22,7 @@ const sqlQueryTag = "sql.query"
 // A filter can be stateful and keep an internal state to apply the filter later;
 // this can be useful to prevent backtracking in some cases.
 type tokenFilter interface {
-	Filter(token, lastToken int, buffer []byte) (tokenType int, tokenBytes []byte, err error)
+	Filter(token, lastToken rune, buffer []byte) (tokenType rune, tokenBytes []byte, err error)
 	Reset()
 }
 
@@ -32,7 +32,7 @@ type discardFilter struct{}
 
 // Filter the given token so that a `nil` slice is returned if the token
 // is in the token filtered list.
-func (f *discardFilter) Filter(token, lastToken int, buffer []byte) (tokenType int, tokenBytes []byte, err error) {
+func (f *discardFilter) Filter(token, lastToken rune, buffer []byte) (tokenType rune, tokenBytes []byte, err error) {
 	// filters based on previous token
 	switch lastToken {
 	case FilteredBracketedIdentifier:
@@ -76,7 +76,7 @@ func (f *discardFilter) Reset() {}
 type replaceFilter struct{}
 
 // Filter the given token so that it will be replaced if in the token replacement list
-func (f *replaceFilter) Filter(token, lastToken int, buffer []byte) (tokenType int, tokenBytes []byte, err error) {
+func (f *replaceFilter) Filter(token, lastToken rune, buffer []byte) (tokenType rune, tokenBytes []byte, err error) {
 	switch lastToken {
 	case Savepoint:
 		return FilteredGroupable, []byte("?"), nil
@@ -109,7 +109,7 @@ type groupingFilter struct {
 // has been recognized. A grouping is composed by items like:
 //   * '( ?, ?, ? )'
 //   * '( ?, ? ), ( ?, ? )'
-func (f *groupingFilter) Filter(token, lastToken int, buffer []byte) (tokenType int, tokenBytes []byte, err error) {
+func (f *groupingFilter) Filter(token, lastToken rune, buffer []byte) (tokenType rune, tokenBytes []byte, err error) {
 	// increasing the number of groups means that we're filtering an entire group
 	// because it can be represented with a single '( ? )'
 	if (lastToken == '(' && token == FilteredGroupable) || (token == '(' && f.groupMulti > 0) {
@@ -157,7 +157,7 @@ func obfuscateSQLString(in string) (string, error) {
 	var (
 		out       bytes.Buffer
 		err       error
-		lastToken int
+		lastToken rune
 	)
 	// call Scan() function until tokens are available or if a LEX_ERROR is raised. After
 	// retrieving a token, send it to the tokenFilter chains so that the token is discarded

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -90,6 +90,36 @@ func TestSQLResourceWithError(t *testing.T) {
 	}
 }
 
+func TestSQLUTF8(t *testing.T) {
+	assert := assert.New(t)
+	for _, tt := range []struct{ in, out string }{
+		{
+			"SELECT Codi , Nom_CA AS Nom, Descripció_CAT AS Descripció FROM ProtValAptitud WHERE Vigent=1 ORDER BY Ordre, Codi",
+			"SELECT Codi, Nom_CA, Descripció_CAT FROM ProtValAptitud WHERE Vigent = ? ORDER BY Ordre, Codi",
+		},
+		{
+			" SELECT  dbo.Treballadors_ProtCIE_AntecedentsPatologics.IdTreballadorsProtCIE_AntecedentsPatologics,   dbo.ProtCIE.Codi As CodiProtCIE, Treballadors_ProtCIE_AntecedentsPatologics.Año,                              dbo.ProtCIE.Nom_ES, dbo.ProtCIE.Nom_CA  FROM         dbo.Treballadors_ProtCIE_AntecedentsPatologics  WITH (NOLOCK)  INNER JOIN                       dbo.ProtCIE  WITH (NOLOCK)  ON dbo.Treballadors_ProtCIE_AntecedentsPatologics.CodiProtCIE = dbo.ProtCIE.Codi  WHERE Treballadors_ProtCIE_AntecedentsPatologics.IdTreballador =  12345 ORDER BY   Treballadors_ProtCIE_AntecedentsPatologics.Año DESC, dbo.ProtCIE.Codi ",
+			"SELECT dbo.Treballadors_ProtCIE_AntecedentsPatologics.IdTreballadorsProtCIE_AntecedentsPatologics, dbo.ProtCIE.Codi, Treballadors_ProtCIE_AntecedentsPatologics.Año, dbo.ProtCIE.Nom_ES, dbo.ProtCIE.Nom_CA FROM dbo.Treballadors_ProtCIE_AntecedentsPatologics WITH ( NOLOCK ) INNER JOIN dbo.ProtCIE WITH ( NOLOCK ) ON dbo.Treballadors_ProtCIE_AntecedentsPatologics.CodiProtCIE = dbo.ProtCIE.Codi WHERE Treballadors_ProtCIE_AntecedentsPatologics.IdTreballador = ? ORDER BY Treballadors_ProtCIE_AntecedentsPatologics.Año DESC, dbo.ProtCIE.Codi",
+		},
+		{
+			"select  top 100 percent  IdTrebEmpresa as [IdTrebEmpresa], CodCli as [Client], NOMEMP as [Nom Client], Baixa as [Baixa], CASE WHEN IdCentreTreball IS NULL THEN '-' ELSE  CONVERT(VARCHAR(8),IdCentreTreball) END as [Id Centre],  CASE WHEN NOMESTAB IS NULL THEN '-' ELSE NOMESTAB END  as [Nom Centre],  TIPUS as [Tipus Lloc], CASE WHEN IdLloc IS NULL THEN '-' ELSE  CONVERT(VARCHAR(8),IdLloc) END  as [Id Lloc],  CASE WHEN NomLlocComplert IS NULL THEN '-' ELSE NomLlocComplert END  as [Lloc Treball],  CASE WHEN DesLloc IS NULL THEN '-' ELSE DesLloc END  as [Descripció], IdLlocTreballUnic as [Id Únic]  From ( SELECT    '-' AS TIPUS,  dbo.Treb_Empresa.IdTrebEmpresa, dbo.Treb_Empresa.IdTreballador, dbo.Treb_Empresa.CodCli, dbo.Clients.NOMEMP,   dbo.Treb_Empresa.Baixa,                      dbo.Treb_Empresa.IdCentreTreball, dbo.Cli_Establiments.NOMESTAB, null AS IdLloc,                        null AS NomLlocComplert, dbo.Treb_Empresa.DataInici,                        dbo.Treb_Empresa.DataFi, CASE WHEN dbo.Treb_Empresa.DesLloc IS NULL THEN '' ELSE dbo.Treb_Empresa.DesLloc END DesLloc, dbo.Treb_Empresa.IdLlocTreballUnic FROM         dbo.Clients  WITH (NOLOCK) INNER JOIN                       dbo.Treb_Empresa  WITH (NOLOCK) ON dbo.Clients.CODCLI = dbo.Treb_Empresa.CodCli LEFT OUTER JOIN                       dbo.Cli_Establiments  WITH (NOLOCK) ON dbo.Cli_Establiments.Id_ESTAB_CLI = dbo.Treb_Empresa.IdCentreTreball AND                        dbo.Cli_Establiments.CODCLI = dbo.Treb_Empresa.CodCli WHERE     dbo.Treb_Empresa.IdTreballador = 64376 AND Treb_Empresa.IdTecEIRLLlocTreball IS NULL AND IdMedEIRLLlocTreball IS NULL AND IdLlocTreballTemporal IS NULL  UNION ALL SELECT    'AV. RIESGO' AS TIPUS,  dbo.Treb_Empresa.IdTrebEmpresa, dbo.Treb_Empresa.IdTreballador, dbo.Treb_Empresa.CodCli, dbo.Clients.NOMEMP, dbo.Treb_Empresa.Baixa,                       dbo.Treb_Empresa.IdCentreTreball, dbo.Cli_Establiments.NOMESTAB, dbo.Treb_Empresa.IdTecEIRLLlocTreball AS IdLloc,                        dbo.fn_NomLlocComposat(dbo.Treb_Empresa.IdTecEIRLLlocTreball) AS NomLlocComplert, dbo.Treb_Empresa.DataInici,                        dbo.Treb_Empresa.DataFi, CASE WHEN dbo.Treb_Empresa.DesLloc IS NULL THEN '' ELSE dbo.Treb_Empresa.DesLloc END DesLloc, dbo.Treb_Empresa.IdLlocTreballUnic FROM         dbo.Clients  WITH (NOLOCK) INNER JOIN                       dbo.Treb_Empresa  WITH (NOLOCK) ON dbo.Clients.CODCLI = dbo.Treb_Empresa.CodCli LEFT OUTER JOIN                       dbo.Cli_Establiments  WITH (NOLOCK) ON dbo.Cli_Establiments.Id_ESTAB_CLI = dbo.Treb_Empresa.IdCentreTreball AND                        dbo.Cli_Establiments.CODCLI = dbo.Treb_Empresa.CodCli WHERE     (dbo.Treb_Empresa.IdTreballador = 64376) AND (NOT (dbo.Treb_Empresa.IdTecEIRLLlocTreball IS NULL))  UNION ALL SELECT     'EXTERNA' AS TIPUS,  dbo.Treb_Empresa.IdTrebEmpresa, dbo.Treb_Empresa.IdTreballador, dbo.Treb_Empresa.CodCli, dbo.Clients.NOMEMP,  dbo.Treb_Empresa.Baixa,                      dbo.Treb_Empresa.IdCentreTreball, dbo.Cli_Establiments.NOMESTAB, dbo.Treb_Empresa.IdMedEIRLLlocTreball AS IdLloc,                        dbo.fn_NomMedEIRLLlocComposat(dbo.Treb_Empresa.IdMedEIRLLlocTreball) AS NomLlocComplert,  dbo.Treb_Empresa.DataInici,                        dbo.Treb_Empresa.DataFi, CASE WHEN dbo.Treb_Empresa.DesLloc IS NULL THEN '' ELSE dbo.Treb_Empresa.DesLloc END DesLloc, dbo.Treb_Empresa.IdLlocTreballUnic FROM         dbo.Clients  WITH (NOLOCK) INNER JOIN                       dbo.Treb_Empresa  WITH (NOLOCK) ON dbo.Clients.CODCLI = dbo.Treb_Empresa.CodCli LEFT OUTER JOIN                       dbo.Cli_Establiments  WITH (NOLOCK) ON dbo.Cli_Establiments.Id_ESTAB_CLI = dbo.Treb_Empresa.IdCentreTreball AND                        dbo.Cli_Establiments.CODCLI = dbo.Treb_Empresa.CodCli WHERE     (dbo.Treb_Empresa.IdTreballador = 64376) AND (Treb_Empresa.IdTecEIRLLlocTreball IS NULL) AND (NOT (dbo.Treb_Empresa.IdMedEIRLLlocTreball IS NULL))  UNION ALL SELECT     'TEMPORAL' AS TIPUS,  dbo.Treb_Empresa.IdTrebEmpresa, dbo.Treb_Empresa.IdTreballador, dbo.Treb_Empresa.CodCli, dbo.Clients.NOMEMP, dbo.Treb_Empresa.Baixa,                       dbo.Treb_Empresa.IdCentreTreball, dbo.Cli_Establiments.NOMESTAB, dbo.Treb_Empresa.IdLlocTreballTemporal AS IdLloc,                       dbo.Lloc_Treball_Temporal.NomLlocTreball AS NomLlocComplert,  dbo.Treb_Empresa.DataInici,                        dbo.Treb_Empresa.DataFi, CASE WHEN dbo.Treb_Empresa.DesLloc IS NULL THEN '' ELSE dbo.Treb_Empresa.DesLloc END DesLloc, dbo.Treb_Empresa.IdLlocTreballUnic FROM         dbo.Clients  WITH (NOLOCK) INNER JOIN                       dbo.Treb_Empresa  WITH (NOLOCK) ON dbo.Clients.CODCLI = dbo.Treb_Empresa.CodCli INNER JOIN                       dbo.Lloc_Treball_Temporal  WITH (NOLOCK) ON dbo.Treb_Empresa.IdLlocTreballTemporal = dbo.Lloc_Treball_Temporal.IdLlocTreballTemporal LEFT OUTER JOIN                       dbo.Cli_Establiments  WITH (NOLOCK) ON dbo.Cli_Establiments.Id_ESTAB_CLI = dbo.Treb_Empresa.IdCentreTreball AND                        dbo.Cli_Establiments.CODCLI = dbo.Treb_Empresa.CodCli WHERE     dbo.Treb_Empresa.IdTreballador = 64376 AND Treb_Empresa.IdTecEIRLLlocTreball IS NULL AND IdMedEIRLLlocTreball IS NULL ) as taula  Where 1=0 ",
+			"select top ? percent IdTrebEmpresa, CodCli, NOMEMP, Baixa, CASE WHEN IdCentreTreball IS ? THEN ? ELSE CONVERT ( VARCHAR ( ? ) IdCentreTreball ) END, CASE WHEN NOMESTAB IS ? THEN ? ELSE NOMESTAB END, TIPUS, CASE WHEN IdLloc IS ? THEN ? ELSE CONVERT ( VARCHAR ( ? ) IdLloc ) END, CASE WHEN NomLlocComplert IS ? THEN ? ELSE NomLlocComplert END, CASE WHEN DesLloc IS ? THEN ? ELSE DesLloc END, IdLlocTreballUnic From ( SELECT ?, dbo.Treb_Empresa.IdTrebEmpresa, dbo.Treb_Empresa.IdTreballador, dbo.Treb_Empresa.CodCli, dbo.Clients.NOMEMP, dbo.Treb_Empresa.Baixa, dbo.Treb_Empresa.IdCentreTreball, dbo.Cli_Establiments.NOMESTAB, ?, ?, dbo.Treb_Empresa.DataInici, dbo.Treb_Empresa.DataFi, CASE WHEN dbo.Treb_Empresa.DesLloc IS ? THEN ? ELSE dbo.Treb_Empresa.DesLloc END DesLloc, dbo.Treb_Empresa.IdLlocTreballUnic FROM dbo.Clients WITH ( NOLOCK ) INNER JOIN dbo.Treb_Empresa WITH ( NOLOCK ) ON dbo.Clients.CODCLI = dbo.Treb_Empresa.CodCli LEFT OUTER JOIN dbo.Cli_Establiments WITH ( NOLOCK ) ON dbo.Cli_Establiments.Id_ESTAB_CLI = dbo.Treb_Empresa.IdCentreTreball AND dbo.Cli_Establiments.CODCLI = dbo.Treb_Empresa.CodCli WHERE dbo.Treb_Empresa.IdTreballador = ? AND Treb_Empresa.IdTecEIRLLlocTreball IS ? AND IdMedEIRLLlocTreball IS ? AND IdLlocTreballTemporal IS ? UNION ALL SELECT ?, dbo.Treb_Empresa.IdTrebEmpresa, dbo.Treb_Empresa.IdTreballador, dbo.Treb_Empresa.CodCli, dbo.Clients.NOMEMP, dbo.Treb_Empresa.Baixa, dbo.Treb_Empresa.IdCentreTreball, dbo.Cli_Establiments.NOMESTAB, dbo.Treb_Empresa.IdTecEIRLLlocTreball, dbo.fn_NomLlocComposat ( dbo.Treb_Empresa.IdTecEIRLLlocTreball ), dbo.Treb_Empresa.DataInici, dbo.Treb_Empresa.DataFi, CASE WHEN dbo.Treb_Empresa.DesLloc IS ? THEN ? ELSE dbo.Treb_Empresa.DesLloc END DesLloc, dbo.Treb_Empresa.IdLlocTreballUnic FROM dbo.Clients WITH ( NOLOCK ) INNER JOIN dbo.Treb_Empresa WITH ( NOLOCK ) ON dbo.Clients.CODCLI = dbo.Treb_Empresa.CodCli LEFT OUTER JOIN dbo.Cli_Establiments WITH ( NOLOCK ) ON dbo.Cli_Establiments.Id_ESTAB_CLI = dbo.Treb_Empresa.IdCentreTreball AND dbo.Cli_Establiments.CODCLI = dbo.Treb_Empresa.CodCli WHERE ( dbo.Treb_Empresa.IdTreballador = ? ) AND ( NOT ( dbo.Treb_Empresa.IdTecEIRLLlocTreball IS ? ) ) UNION ALL SELECT ?, dbo.Treb_Empresa.IdTrebEmpresa, dbo.Treb_Empresa.IdTreballador, dbo.Treb_Empresa.CodCli, dbo.Clients.NOMEMP, dbo.Treb_Empresa.Baixa, dbo.Treb_Empresa.IdCentreTreball, dbo.Cli_Establiments.NOMESTAB, dbo.Treb_Empresa.IdMedEIRLLlocTreball, dbo.fn_NomMedEIRLLlocComposat ( dbo.Treb_Empresa.IdMedEIRLLlocTreball ), dbo.Treb_Empresa.DataInici, dbo.Treb_Empresa.DataFi, CASE WHEN dbo.Treb_Empresa.DesLloc IS ? THEN ? ELSE dbo.Treb_Empresa.DesLloc END DesLloc, dbo.Treb_Empresa.IdLlocTreballUnic FROM dbo.Clients WITH ( NOLOCK ) INNER JOIN dbo.Treb_Empresa WITH ( NOLOCK ) ON dbo.Clients.CODCLI = dbo.Treb_Empresa.CodCli LEFT OUTER JOIN dbo.Cli_Establiments WITH ( NOLOCK ) ON dbo.Cli_Establiments.Id_ESTAB_CLI = dbo.Treb_Empresa.IdCentreTreball AND dbo.Cli_Establiments.CODCLI = dbo.Treb_Empresa.CodCli WHERE ( dbo.Treb_Empresa.IdTreballador = ? ) AND ( Treb_Empresa.IdTecEIRLLlocTreball IS ? ) AND ( NOT ( dbo.Treb_Empresa.IdMedEIRLLlocTreball IS ? ) ) UNION ALL SELECT ?, dbo.Treb_Empresa.IdTrebEmpresa, dbo.Treb_Empresa.IdTreballador, dbo.Treb_Empresa.CodCli, dbo.Clients.NOMEMP, dbo.Treb_Empresa.Baixa, dbo.Treb_Empresa.IdCentreTreball, dbo.Cli_Establiments.NOMESTAB, dbo.Treb_Empresa.IdLlocTreballTemporal, dbo.Lloc_Treball_Temporal.NomLlocTreball, dbo.Treb_Empresa.DataInici, dbo.Treb_Empresa.DataFi, CASE WHEN dbo.Treb_Empresa.DesLloc IS ? THEN ? ELSE dbo.Treb_Empresa.DesLloc END DesLloc, dbo.Treb_Empresa.IdLlocTreballUnic FROM dbo.Clients WITH ( NOLOCK ) INNER JOIN dbo.Treb_Empresa WITH ( NOLOCK ) ON dbo.Clients.CODCLI = dbo.Treb_Empresa.CodCli INNER JOIN dbo.Lloc_Treball_Temporal WITH ( NOLOCK ) ON dbo.Treb_Empresa.IdLlocTreballTemporal = dbo.Lloc_Treball_Temporal.IdLlocTreballTemporal LEFT OUTER JOIN dbo.Cli_Establiments WITH ( NOLOCK ) ON dbo.Cli_Establiments.Id_ESTAB_CLI = dbo.Treb_Empresa.IdCentreTreball AND dbo.Cli_Establiments.CODCLI = dbo.Treb_Empresa.CodCli WHERE dbo.Treb_Empresa.IdTreballador = ? AND Treb_Empresa.IdTecEIRLLlocTreball IS ? AND IdMedEIRLLlocTreball IS ? ) Where ? = ?",
+		},
+		{
+			"select  IdHistLabAnt as [IdHistLabAnt], IdTreballador as [IdTreballador], Empresa as [Professió], Anys as [Anys],  Riscs as [Riscos], Nom_CA AS [Prot CNO], Nom_ES as [Prot CNO Altre Idioma]   From ( SELECT     dbo.Treb_HistAnt.IdHistLabAnt, dbo.Treb_HistAnt.IdTreballador,           dbo.Treb_HistAnt.Empresa, dbo.Treb_HistAnt.Anys, dbo.Treb_HistAnt.Riscs, dbo.Treb_HistAnt.CodiProtCNO,           dbo.ProtCNO.Nom_ES, dbo.ProtCNO.Nom_CA  FROM     dbo.Treb_HistAnt  WITH (NOLOCK) LEFT OUTER JOIN                       dbo.ProtCNO  WITH (NOLOCK) ON dbo.Treb_HistAnt.CodiProtCNO = dbo.ProtCNO.Codi  Where  dbo.Treb_HistAnt.IdTreballador = 12345 ) as taula ",
+			"select IdHistLabAnt, IdTreballador, Empresa, Anys, Riscs, Nom_CA, Nom_ES From ( SELECT dbo.Treb_HistAnt.IdHistLabAnt, dbo.Treb_HistAnt.IdTreballador, dbo.Treb_HistAnt.Empresa, dbo.Treb_HistAnt.Anys, dbo.Treb_HistAnt.Riscs, dbo.Treb_HistAnt.CodiProtCNO, dbo.ProtCNO.Nom_ES, dbo.ProtCNO.Nom_CA FROM dbo.Treb_HistAnt WITH ( NOLOCK ) LEFT OUTER JOIN dbo.ProtCNO WITH ( NOLOCK ) ON dbo.Treb_HistAnt.CodiProtCNO = dbo.ProtCNO.Codi Where dbo.Treb_HistAnt.IdTreballador = ? )",
+		},
+		{
+			"SELECT     Cli_Establiments.CODCLI, Cli_Establiments.Id_ESTAB_CLI As [Código Centro Trabajo], Cli_Establiments.CODIGO_CENTRO_AXAPTA As [Código C. Axapta],  Cli_Establiments.NOMESTAB As [Nombre],                                 Cli_Establiments.ADRECA As [Dirección], Cli_Establiments.CodPostal As [Código Postal], Cli_Establiments.Poblacio as [Población], Cli_Establiments.Provincia,                                Cli_Establiments.TEL As [Tel],  Cli_Establiments.EMAIL As [EMAIL],                                Cli_Establiments.PERS_CONTACTE As [Contacto], Cli_Establiments.PERS_CONTACTE_CARREC As [Cargo Contacto], Cli_Establiments.NumTreb As [Plantilla],                                Cli_Establiments.Localitzacio As [Localización], Tipus_Activitat.CNAE, Tipus_Activitat.Nom_ES As [Nombre Actividad], ACTIVO AS [Activo]                        FROM         Cli_Establiments LEFT OUTER JOIN                                    Tipus_Activitat ON Cli_Establiments.Id_ACTIVITAT = Tipus_Activitat.IdActivitat                        Where CODCLI = '01234' AND CENTRE_CORRECTE = 3 AND ACTIVO = 5                        ORDER BY Cli_Establiments.CODIGO_CENTRO_AXAPTA ",
+			"SELECT Cli_Establiments.CODCLI, Cli_Establiments.Id_ESTAB_CLI, Cli_Establiments.CODIGO_CENTRO_AXAPTA, Cli_Establiments.NOMESTAB, Cli_Establiments.ADRECA, Cli_Establiments.CodPostal, Cli_Establiments.Poblacio, Cli_Establiments.Provincia, Cli_Establiments.TEL, Cli_Establiments.EMAIL, Cli_Establiments.PERS_CONTACTE, Cli_Establiments.PERS_CONTACTE_CARREC, Cli_Establiments.NumTreb, Cli_Establiments.Localitzacio, Tipus_Activitat.CNAE, Tipus_Activitat.Nom_ES, ACTIVO FROM Cli_Establiments LEFT OUTER JOIN Tipus_Activitat ON Cli_Establiments.Id_ACTIVITAT = Tipus_Activitat.IdActivitat Where CODCLI = ? AND CENTRE_CORRECTE = ? AND ACTIVO = ? ORDER BY Cli_Establiments.CODIGO_CENTRO_AXAPTA",
+		},
+	} {
+		out, err := obfuscateSQLString(tt.in)
+		assert.NoError(err)
+		assert.Equal(tt.out, out)
+	}
+}
+
 func TestSQLQuantizer(t *testing.T) {
 	cases := []sqlTestCase{
 		{
@@ -450,51 +480,51 @@ func TestSQLErrors(t *testing.T) {
 
 	_, err = obfuscateSQLString("SELECT a FROM b WHERE a.x !* 2")
 	assert.Error(err)
-	assert.Equal(`at position 28: expected "=" after "!", got "*" (42)`, err.Error())
+	assert.Equal(`at position 27: expected "=" after "!", got "*" (42)`, err.Error())
 
-	_, err = obfuscateSQLString("SELECT ԫ")
+	_, err = obfuscateSQLString("SELECT 🥒")
 	assert.Error(err)
-	assert.Equal(`at position 9: unexpected byte 212`, err.Error())
+	assert.Equal(`at position 11: unexpected byte 129362`, err.Error())
 
 	_, err = obfuscateSQLString("SELECT name, `1a` FROM profile")
 	assert.Error(err)
-	assert.Equal(`at position 15: unexpected character "1" (49) in literal identifier`, err.Error())
+	assert.Equal(`at position 14: unexpected character "1" (49) in literal identifier`, err.Error())
 
 	_, err = obfuscateSQLString("SELECT name, `age}` FROM profile")
 	assert.Error(err)
-	assert.Equal(`at position 18: literal identifiers must end in "`+"`"+`", got "}" (125)`, err.Error())
+	assert.Equal(`at position 17: literal identifiers must end in "`+"`"+`", got "}" (125)`, err.Error())
 
 	_, err = obfuscateSQLString("SELECT %(asd)| FROM profile")
 	assert.Error(err)
-	assert.Equal(`at position 14: invalid character after variable identifier: "|" (124)`, err.Error())
+	assert.Equal(`at position 13: invalid character after variable identifier: "|" (124)`, err.Error())
 
 	_, err = obfuscateSQLString("USING $A FROM users")
 	assert.Error(err)
-	assert.Equal(`at position 8: prepared statements must start with digits, got "A" (65)`, err.Error())
+	assert.Equal(`at position 7: prepared statements must start with digits, got "A" (65)`, err.Error())
 
 	_, err = obfuscateSQLString("USING $09 SELECT")
 	assert.Error(err)
-	assert.Equal(`at position 10: invalid number`, err.Error())
+	assert.Equal(`at position 9: invalid number`, err.Error())
 
 	_, err = obfuscateSQLString("INSERT VALUES (1, 2) INTO {ABC")
 	assert.Error(err)
-	assert.Equal(`at position 31: unexpected EOF in escape sequence`, err.Error())
+	assert.Equal(`at position 30: unexpected EOF in escape sequence`, err.Error())
 
 	_, err = obfuscateSQLString("SELECT one, :2two FROM profile")
 	assert.Error(err)
-	assert.Equal(`at position 14: bind variables should start with letters, got "2" (50)`, err.Error())
+	assert.Equal(`at position 13: bind variables should start with letters, got "2" (50)`, err.Error())
 
 	_, err = obfuscateSQLString("SELECT age FROM profile WHERE name='John \\")
 	assert.Error(err)
-	assert.Equal(`at position 43: unexpected EOF after escape character in string`, err.Error())
+	assert.Equal(`at position 42: unexpected EOF after escape character in string`, err.Error())
 
 	_, err = obfuscateSQLString("SELECT age FROM profile WHERE name='John")
 	assert.Error(err)
-	assert.Equal(`at position 42: unexpected EOF in string`, err.Error())
+	assert.Equal(`at position 41: unexpected EOF in string`, err.Error())
 
 	_, err = obfuscateSQLString("/* abcd")
 	assert.Error(err)
-	assert.Equal(`at position 8: unexpected EOF in comment`, err.Error())
+	assert.Equal(`at position 7: unexpected EOF in comment`, err.Error())
 }
 
 // Benchmark the Tokenizer using a SQL statement

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -87,6 +87,7 @@ func (tkn *SQLTokenizer) Reset(in string) {
 	tkn.rd.Reset(in)
 	tkn.pos = 0
 	tkn.lastChar = 0
+	tkn.err = nil
 }
 
 // keywords used to recognize string tokens

--- a/releasenotes/notes/apm-detailed-sql-obfuscation-err-028377160c2f73f7.yaml
+++ b/releasenotes/notes/apm-detailed-sql-obfuscation-err-028377160c2f73f7.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: On SQL obfuscation errors, a detailed explanation is presented when DEBUG logging
+    level is enabled.

--- a/releasenotes/notes/apm-obfuscate-sql-utf8-5483752f9bb518c9.yaml
+++ b/releasenotes/notes/apm-obfuscate-sql-utf8-5483752f9bb518c9.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: SQL obfuscation now supports queries with UTF-8 characters.


### PR DESCRIPTION
This change modifies the internal API of the obfuscator such that it
displays details error when SQL obfuscation errors occur, including the
character position at which the error happened.

Example:
```
2019-09-30 11:54:17 CEST | TRACE | DEBUG | (pkg/trace/obfuscate/sql.go:205 in obfuscateSQL) | Error parsing SQL query: at position 18: literal identifiers must end in "`", got "}" (125). Query: "SELECT name, `age}` FROM profile"
```

A new metric `datadog.trace_agent.obfuscations` has been added which contains a `type` tag, signifying the type of obfuscation occurring (e.g. `sql`) and an `outcome` tag signifying the outcome (e.g. `error`, `success`, etc.)