### PR TITLE
Fix registering of the External Metrics Server's API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2108,6 +2108,7 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/sets",

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -18,6 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -102,6 +104,20 @@ func (o *DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
 
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
+
+	// we need to add the options to empty v1
+	// TODO fix the server code to avoid this
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+
+	// TODO: keep the generic API server from wanting this
+	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
+	scheme.AddUnversionedTypes(unversioned,
+		&metav1.Status{},
+		&metav1.APIVersions{},
+		&metav1.APIGroupList{},
+		&metav1.APIGroup{},
+		&metav1.APIResourceList{},
+	)
 	serverConfig := genericapiserver.NewConfig(codecs)
 
 	err := o.SecureServing.ApplyTo(serverConfig)

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -15,11 +15,11 @@ import (
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/apiserver"
 	basecmd "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd"
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/config"


### PR DESCRIPTION
### What does this PR do?

Some sub-resources were not registered in the scheme, as we were hidding the glog from the apiserver we did not see it but it was lacking.
This is just to have a cleaner implementation, no behavioural change.

### Motivation

Noticed as I was bumping to 1.15, b/c kubernetes moved away from glog to klog.

### Additional Notes

Anything else we should know when reviewing?
