### PR TITLE
Implement Python API for setting check metadata

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -149,4 +150,15 @@ func SetExternalTags(hostname *C.char, sourceType *C.char, tags **C.char) {
 	}
 
 	externalhost.SetExternalTags(hname, stype, tagsStrings)
+}
+
+// SetCheckMetadata updates a metadata value for one check instance in the cache.
+// Indirectly used by the C function `set_check_metadata` that's mapped to `datadog_agent.set_check_metadata`.
+//export SetCheckMetadata
+func SetCheckMetadata(checkID, name, value *C.char) {
+	cid := C.GoString(checkID)
+	key := C.GoString(name)
+	val := C.GoString(value)
+
+	inventories.SetCheckMetadata(cid, key, val)
 }

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -81,6 +81,7 @@ void GetConfig(char*, char **);
 void GetHostname(char **);
 void GetVersion(char **);
 void Headers(char **);
+void SetCheckMetadata(char *, char *, char *);
 void SetExternalTags(char *, char *, char **);
 bool TracemallocEnabled();
 
@@ -90,6 +91,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 	set_get_hostname_cb(rtloader, GetHostname);
 	set_get_version_cb(rtloader, GetVersion);
 	set_headers_cb(rtloader, Headers);
+	set_set_check_metadata_cb(rtloader, SetCheckMetadata);
 	set_set_external_tags_cb(rtloader, SetExternalTags);
 	set_tracemalloc_enabled_cb(rtloader, TracemallocEnabled);
 }

--- a/releasenotes/notes/rtloader-api-for-check-metadata-bfa94b82c27d782d.yaml
+++ b/releasenotes/notes/rtloader-api-for-check-metadata-bfa94b82c27d782d.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Implement API that allows Python checks to send metadata using
+    the ``inventories`` provider.

--- a/rtloader/common/builtins/datadog_agent.h
+++ b/rtloader/common/builtins/datadog_agent.h
@@ -74,6 +74,14 @@
 
     The callback is expected to be provided by the rtloader caller - in go-context: CGO.
 */
+/*! \fn void _set_set_check_metadata_cb(cb_set_check_metadata_t)
+    \brief Sets a callback to be used by rtloader to allow setting metadata for a given
+    check instance.
+    \param object A function pointer with cb_set_check_metadata_t prototype to the callback
+    function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
 /*! \fn void _set_set_external_tags_cb(cb_set_external_tags_t)
     \brief Sets a callback to be used by rtloader to allow setting external tags for a given
     hostname.
@@ -118,6 +126,7 @@ void _set_tracemalloc_enabled_cb(cb_tracemalloc_enabled_t);
 void _set_get_version_cb(cb_get_version_t);
 void _set_headers_cb(cb_headers_t);
 void _set_log_cb(cb_log_t);
+void _set_set_check_metadata_cb(cb_set_check_metadata_t);
 void _set_set_external_tags_cb(cb_set_external_tags_t);
 
 PyObject *_public_headers(PyObject *self, PyObject *args, PyObject *kwargs);

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -461,6 +461,17 @@ DATADOG_AGENT_RTLOADER_API void set_tracemalloc_enabled_cb(rtloader_t *, cb_trac
 */
 DATADOG_AGENT_RTLOADER_API void set_log_cb(rtloader_t *, cb_log_t);
 
+/*! \fn void set_set_check_metadata_cb(rtloader_t *, cb_set_check_metadata_t)
+    \brief Sets a callback to be used by rtloader to allow setting metadata for a given
+    check instance.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param object A function pointer with cb_set_check_metadata_t prototype to the callback
+    function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
+DATADOG_AGENT_RTLOADER_API void set_set_check_metadata_cb(rtloader_t *, cb_set_check_metadata_t);
+
 /*! \fn void set_set_external_tags_cb(rtloader_t *, cb_set_external_tags_t)
     \brief Sets a callback to be used by rtloader to allow setting external tags for a given
     hostname.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -339,6 +339,15 @@ public:
     */
     virtual void setLogCb(cb_log_t) = 0;
 
+    //! setCheckMetadataCb member.
+    /*!
+      \param A cb_set_check_metadata_t function pointer to the CGO callback.
+
+      This allows us to set the relevant CGO callback that will allow adding metadata for
+      specific check instances to the go-land Inventories metadata provider cache.
+    */
+    virtual void setSetCheckMetadataCb(cb_set_check_metadata_t) = 0;
+
     //! setExternalTagsCb member.
     /*!
       \param A cb_set_external_tags_t function pointer to the CGO callback.

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -117,6 +117,8 @@ typedef void (*cb_get_clustername_t)(char **);
 typedef bool (*cb_tracemalloc_enabled_t)(void);
 // (message, level)
 typedef void (*cb_log_t)(const char *, int);
+// (check_id, name, value)
+typedef void (*cb_set_check_metadata_t)(char *, char *, char *);
 // (hostname, source_type_name, list of tags)
 typedef void (*cb_set_external_tags_t)(char *, char *, char **);
 

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -421,6 +421,11 @@ void set_log_cb(rtloader_t *rtloader, cb_log_t cb)
     AS_TYPE(RtLoader, rtloader)->setLogCb(cb);
 }
 
+void set_set_check_metadata_cb(rtloader_t *rtloader, cb_set_check_metadata_t cb)
+{
+    AS_TYPE(RtLoader, rtloader)->setSetCheckMetadataCb(cb);
+}
+
 void set_set_external_tags_cb(rtloader_t *rtloader, cb_set_external_tags_t cb)
 {
     AS_TYPE(RtLoader, rtloader)->setSetExternalTagsCb(cb);

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -26,6 +26,7 @@ import (
 // extern bool getTracemallocEnabled();
 // extern void getVersion(char **);
 // extern void headers(char **);
+// extern void setCheckMetadata(char*, char*, char*);
 // extern void setExternalHostTags(char*, char*, char**);
 //
 // static void initDatadogAgentTests(rtloader_t *rtloader) {
@@ -36,6 +37,7 @@ import (
 //    set_get_version_cb(rtloader, getVersion);
 //    set_headers_cb(rtloader, headers);
 //    set_log_cb(rtloader, doLog);
+//    set_set_check_metadata_cb(rtloader, setCheckMetadata);
 //    set_set_external_tags_cb(rtloader, setExternalHostTags);
 // }
 import "C"
@@ -161,6 +163,18 @@ func getTracemallocEnabled() C.bool {
 func doLog(msg *C.char, level C.int) {
 	data := []byte(fmt.Sprintf("[%d]%s", int(level), C.GoString(msg)))
 	ioutil.WriteFile(tmpfile.Name(), data, 0644)
+}
+
+//export setCheckMetadata
+func setCheckMetadata(checkID, name, value *C.char) {
+	cid := C.GoString(checkID)
+	key := C.GoString(name)
+	val := C.GoString(value)
+
+	f, _ := os.OpenFile(tmpfile.Name(), os.O_APPEND|os.O_RDWR|os.O_CREATE, 0666)
+	defer f.Close()
+
+	f.WriteString(strings.Join([]string{cid, key, val}, ","))
 }
 
 //export setExternalHostTags

--- a/rtloader/test/datadog_agent/datadog_agent_test.go
+++ b/rtloader/test/datadog_agent/datadog_agent_test.go
@@ -128,6 +128,19 @@ func TestLog(t *testing.T) {
 	}
 }
 
+func TestSetCheckMetadata(t *testing.T) {
+	code := `
+	datadog_agent.set_check_metadata("redis:test:12345", "version.raw", "5.0.6")
+	`
+	out, err := run(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "redis:test:12345,version.raw,5.0.6" {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+}
+
 func TestSetExternalTags(t *testing.T) {
 	code := `
 	tags = [

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -833,6 +833,11 @@ void Three::setLogCb(cb_log_t cb)
     _set_log_cb(cb);
 }
 
+void Three::setSetCheckMetadataCb(cb_set_check_metadata_t cb)
+{
+    _set_set_check_metadata_cb(cb);
+}
+
 void Three::setSetExternalTagsCb(cb_set_external_tags_t cb)
 {
     _set_set_external_tags_cb(cb);

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -99,6 +99,7 @@ public:
     void setGetClusternameCb(cb_get_clustername_t);
     void setGetTracemallocEnabledCb(cb_tracemalloc_enabled_t);
     void setLogCb(cb_log_t);
+    void setSetCheckMetadataCb(cb_set_check_metadata_t);
     void setSetExternalTagsCb(cb_set_external_tags_t);
 
     // _util API

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -838,6 +838,11 @@ void Two::setLogCb(cb_log_t cb)
     _set_log_cb(cb);
 }
 
+void Two::setSetCheckMetadataCb(cb_set_check_metadata_t cb)
+{
+    _set_set_check_metadata_cb(cb);
+}
+
 void Two::setSetExternalTagsCb(cb_set_external_tags_t cb)
 {
     _set_set_external_tags_cb(cb);

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -98,6 +98,7 @@ public:
     void setGetClusternameCb(cb_get_clustername_t);
     void setGetTracemallocEnabledCb(cb_tracemalloc_enabled_t);
     void setLogCb(cb_log_t);
+    void setSetCheckMetadataCb(cb_set_check_metadata_t);
     void setSetExternalTagsCb(cb_set_external_tags_t);
 
     // _util API


### PR DESCRIPTION
### What does this PR do?

Allows Python checks to send metadata using the `inventories` provider introduced in https://github.com/DataDog/datadog-agent/pull/4158