### PR TITLE
pkg/trace/api: clean up some test goroutines

### DIFF
--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -689,8 +689,7 @@ func TestWatchdog(t *testing.T) {
 		r.Start()
 		defer r.Stop()
 		go func() {
-			for {
-				<-r.out
+			for range r.out {
 			}
 		}()
 
@@ -771,8 +770,7 @@ func TestOOMKill(t *testing.T) {
 	r.Start()
 	defer r.Stop()
 	go func() {
-		for {
-			<-r.out
+		for range r.out {
 		}
 	}()
 


### PR DESCRIPTION
### What does this PR do?

Previously, these goroutines would run continue to run after the channel was drained. Now, they will stop when the channel becomes empty.

### Motivation

I was reading through the code and discovered these routines in the tests. This seemed like a small change good for a first PR

