### PR TITLE
Fix crash caused by calling /config-check too early

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -236,6 +236,13 @@ func getCSRFToken(w http.ResponseWriter, r *http.Request) {
 func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 	var response response.ConfigCheckResponse
 
+	if common.AC == nil {
+		log.Errorf("Trying to use /config-check before the agent has been initialized.")
+		body, _ := json.Marshal(map[string]string{"error": "agent not initialized"})
+		http.Error(w, string(body), 503)
+		return
+	}
+
 	configs := common.AC.GetLoadedConfigs()
 	configSlice := make([]integration.Config, 0)
 	for _, config := range configs {

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -123,6 +123,13 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 	var response response.ConfigCheckResponse
 
+	if common.AC == nil {
+		log.Errorf("Trying to use /config-check before the agent has been initialized.")
+		body, _ := json.Marshal(map[string]string{"error": "agent not initialized"})
+		http.Error(w, string(body), 503)
+		return
+	}
+
 	configs := common.AC.GetLoadedConfigs()
 	configSlice := make([]integration.Config, 0)
 	for _, config := range configs {


### PR DESCRIPTION
### What does this PR do?

Check if `common.AC` has been initialized before trying to use it.

### Motivation

The fix done in https://github.com/DataDog/datadog-agent/commit/f4bd71fc62b3a5c74eedd0b127634758a8caa2dd wasn't enough, since `common.AC` is used further down in the same function.
