### PR TITLE
Be more resilient to strange kubelet json

### DIFF
--- a/pkg/util/kubernetes/kubelet/json.go
+++ b/pkg/util/kubernetes/kubelet/json.go
@@ -90,9 +90,8 @@ func (pu *podUnmarshaller) filteringDecoder(ptr unsafe.Pointer, iter *jsoniter.I
 
 	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
 		if field == "items" {
-			itemsVal := iter.WhatIsNext()
 			// consider null pod list as an error
-			if itemsVal == jsoniter.NilValue {
+			if iter.WhatIsNext() == jsoniter.NilValue {
 				return false
 			}
 			iter.ReadArrayCB(podCallback)

--- a/pkg/util/kubernetes/kubelet/json.go
+++ b/pkg/util/kubernetes/kubelet/json.go
@@ -90,6 +90,11 @@ func (pu *podUnmarshaller) filteringDecoder(ptr unsafe.Pointer, iter *jsoniter.I
 
 	iter.ReadObjectCB(func(iter *jsoniter.Iterator, field string) bool {
 		if field == "items" {
+			itemsVal := iter.WhatIsNext()
+			// consider null pod list as an error
+			if itemsVal == jsoniter.NilValue {
+				return false
+			}
 			iter.ReadArrayCB(podCallback)
 		} else {
 			iter.Skip()

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -196,7 +196,7 @@ func (ku *KubeUtil) GetLocalPodList() ([]*Pod, error) {
 
 	err = ku.podUnmarshaller.unmarshal(data, &pods)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to unmarshal podlist, invalid or null: %s", err)
 	}
 
 	// ensure we dont have nil pods

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_null_pod.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_null_pod.json
@@ -3,8 +3,156 @@
     "apiVersion": "v1",
     "metadata": {},
     "items": [
-        {},
         null,
+        {
+            "metadata": {
+                "name": "nginx-99d8b564-4r4vq",
+                "generateName": "nginx-99d8b564-",
+                "namespace": "default",
+                "selfLink": "/api/v1/namespaces/default/pods/nginx-99d8b564-4r4vq",
+                "uid": "7979cfcd-0751-11e8-a2b8-000c29dea4f6",
+                "resourceVersion": "4001",
+                "creationTimestamp": "2018-02-01T13:11:54Z",
+                "labels": {
+                    "app": "nginx",
+                    "pod-template-hash": "55846120"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2018-02-01T14:11:54.674242999+01:00",
+                    "kubernetes.io/config.source": "api",
+                    "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"nginx-99d8b564\",\"uid\":\"7977f3ec-0751-11e8-a2b8-000c29dea4f6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"3995\"}}\n"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "name": "nginx-99d8b564",
+                        "uid": "7977f3ec-0751-11e8-a2b8-000c29dea4f6",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-pkh77",
+                        "secret": {
+                            "secretName": "default-token-pkh77",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "nginx",
+                        "image": "nginx:latest",
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-pkh77",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/",
+                                "port": 80,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 30,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/",
+                                "port": 80,
+                                "host": "127.0.0.1",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 20,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent",
+                        "ports": [
+                            {
+                                "hostPort": 80,
+                                "containerPort": 80,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "hostPort": 443,
+                                "containerPort": 443,
+                                "protocol": "TCP"
+                            }
+                        ]
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "my-node-name",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2018-02-01T13:11:54Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "False",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2018-02-01T13:11:54Z",
+                        "reason": "ContainersNotReady",
+                        "message": "containers with unready status: [nginx]"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2018-02-01T13:11:54Z"
+                    }
+                ],
+                "hostIP": "192.168.128.141",
+                "podIP": "192.168.128.141",
+                "startTime": "2018-02-01T13:11:54Z",
+                "containerStatuses": [
+                    {
+                        "name": "nginx",
+                        "state": {
+                            "running": {
+                                "startedAt": "2018-02-01T13:11:55Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": false,
+                        "restartCount": 0,
+                        "image": "nginx:latest",
+                        "imageID": "docker-pullable://nginx@sha256:285b49d42c703fdf257d1e2422765c4ba9d3e37768d6ea83d7fe2043dad6e63d",
+                        "containerID": "docker://61e83ec5ce7af1c134c159bac1bf94d3413486ba655e5ebd6231e0a92a1c7b54"
+                    }
+                ],
+                "qosClass": "BestEffort"
+            }
+        },
         {}
     ]
 }

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_startup.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_startup.json
@@ -1,0 +1,6 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": null
+}

--- a/releasenotes/notes/kubelet-json-34a7c8b2f1a3ceee.yaml
+++ b/releasenotes/notes/kubelet-json-34a7c8b2f1a3ceee.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The agent is now more resilient to incomplete responses from the kubelet

--- a/test/integration/util/kubelet/insecurekubelet_test.go
+++ b/test/integration/util/kubelet/insecurekubelet_test.go
@@ -54,8 +54,9 @@ func (suite *InsecureTestSuite) TestHTTP() {
 	assert.Equal(suite.T(), emptyPodList, string(b))
 
 	podList, err := ku.GetLocalPodList()
-	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), 0, len(podList))
+	// we don't consider null podlist as valid
+	require.Error(suite.T(), err)
+	assert.Nil(suite.T(), podList)
 
 	require.EqualValues(suite.T(),
 		map[string]string{
@@ -86,8 +87,9 @@ func (suite *InsecureTestSuite) TestInsecureHTTPS() {
 	assert.Equal(suite.T(), emptyPodList, string(b))
 
 	podList, err := ku.GetLocalPodList()
-	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), 0, len(podList))
+	// we don't consider null podlist as valid
+	require.Error(suite.T(), err)
+	assert.Nil(suite.T(), podList)
 
 	require.EqualValues(suite.T(),
 		map[string]string{

--- a/test/integration/util/kubelet/securekubelet_test.go
+++ b/test/integration/util/kubelet/securekubelet_test.go
@@ -59,8 +59,9 @@ func (suite *SecureTestSuite) TestWithTLSCA() {
 	assert.Equal(suite.T(), emptyPodList, string(b))
 
 	podList, err := ku.GetLocalPodList()
-	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), 0, len(podList))
+	// we don't consider null podlist as valid
+	require.Error(suite.T(), err)
+	assert.Nil(suite.T(), podList)
 
 	require.EqualValues(suite.T(),
 		map[string]string{
@@ -123,8 +124,9 @@ func (suite *SecureTestSuite) TestTLSWithCACertificate() {
 	assert.Equal(suite.T(), emptyPodList, string(b))
 
 	podList, err := ku.GetLocalPodList()
-	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), 0, len(podList))
+	// we don't consider null podlist as valid
+	require.Error(suite.T(), err)
+	assert.Nil(suite.T(), podList)
 
 	require.EqualValues(suite.T(),
 		map[string]string{


### PR DESCRIPTION
### What does this PR do?

Be more resilient to `null` items in the podlist, consider `null` pod list as an error

### Motivation

Separate a null pod list from an empty pod list.

### Additional Notes

e2e ✅ 
