### PR TITLE
[kitchen] Workaround for Windows kitchen tests flakes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -726,6 +726,33 @@ kitchen_windows:
     paths:
       - $CI_PROJECT_DIR/kitchen_logs
 
+kitchen_windows_upgrade5to6:
+  stage: testkitchen_testing
+  allow_failure: true
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
+  <<: *run_when_testkitchen_triggered
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - cd $CI_PROJECT_DIR
+    - cd $DD_AGENT_TESTING_DIR
+    - rm -rf $CI_PROJECT_DIR/kitchen_logs
+    - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
+    - mkdir $CI_PROJECT_DIR/kitchen_logs
+    - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
+    - export TEST_PLATFORMS="win2008r2,MicrosoftWindowsServer:WindowsServer:2008-R2-SP1:2.127.20190603"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190603"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2012r2,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20190603"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2016,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:2016.127.20190603"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2019,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:2019.0.20190603"
+    - bash -l tasks/run-test-kitchen.sh windows-upgrade5-test
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - $CI_PROJECT_DIR/kitchen_logs
+
 kitchen_windows_installer:
   stage: testkitchen_testing
   allow_failure: false

--- a/test/kitchen/kitchen-azure-wupgrade5.yml
+++ b/test/kitchen/kitchen-azure-wupgrade5.yml
@@ -180,84 +180,11 @@ suites:
   }
 %>
 
-# Install the latest release candidate using Chef
-- name: dd-agent
-  run_list:
-    - "recipe[dd-agent-install]"
-  attributes:
-    apt:
-      unattended_upgrades:
-        enable: false
-    datadog:
-      <% dd_agent_config.each do |key, value| %>
-      <%= key %>: <%= value %>
-      <% end %>
-    dd-agent-install:
-      agent6: true
-      <% if ENV['AGENT_VERSION'] %>
-      windows_version: "<%= ENV['AGENT_VERSION'] %>"
-      <% end %>
-      windows_agent_url: <%= windows_agent_url %>
-      <% if ENV['WINDOWS_AGENT_FILE'] %>
-      windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
-      <% end %>
-    dd-agent-rspec:
-        skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
-
-# Installs the latest release Agent 6, then updates it to the latest release
-# candidate
-- name: dd-agent-upgrade-agent6
-  run_list:
-    - "recipe[dd-agent-install]"
-    - "recipe[dd-agent-upgrade]"
-  attributes:
-    apt:
-      unattended_upgrades:
-        enable: false
-    datadog:
-      <% dd_agent_config.each do |key, value| %>
-      <%= key %>: <%= value %>
-      <% end %>
-      # Get the latest release agents. The upgrade recipe will take care of
-      # adding the staging repo and upgrading to the latest candidate
-      agent6: true
-      agent6_aptrepo: http://apt.datadoghq.com/
-      agent6_aptrepo_dist: stable
-      agent6_yumrepo: http://yum.datadoghq.com/stable/6/x86_64/
-      agent6_yumrepo_suse: http://yum.datadoghq.com/suse/stable/6/x86_64/
-      windows_agent_url: https://s3.amazonaws.com/ddagent-windows-stable/
-    dd-agent-install:
-      agent6: true
-      windows_agent_url: https://s3.amazonaws.com/ddagent-windows-stable/
-      windows_agent_filename: datadog-agent-6-latest.amd64
-    dd-agent-upgrade:
-      add_new_repo: true
-      aptrepo: <%= aptrepo %>
-      aptrepo_dist: "pipeline-<%= ENV['CI_PIPELINE_ID'] %>"
-      yumrepo: http://yumtesting.datad0g.com/pipeline-<%= ENV['CI_PIPELINE_ID'] %>/x86_64/
-      yumrepo_suse: http://yumtesting.datad0g.com/suse/pipeline-<%= ENV['CI_PIPELINE_ID'] %>/x86_64/
-      windows_agent_url: <%= windows_agent_url %>
-      <% if ENV['AGENT_VERSION'] %>
-      windows_version: "<%= ENV['AGENT_VERSION'] %>"
-      <% end %>
-      <% if ENV['WINDOWS_AGENT_FILE'] %>
-      windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
-      <% end %>
-    dd-agent-upgrade-rspec:
-      # Used by the rspec test to know the version to which the agent should be upgraded
-      agent_expected_version: &agent_expected_version <%= ENV['DD_AGENT_EXPECTED_VERSION'] || "5.99.0" %>
-    dd-agent-rspec:
-        skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
-
-
 # Installs the latest release Agent 5, then updates it to the latest release
 # candidate
 - name: dd-agent-upgrade-agent5
-  excludes: <% if (sles15_platforms.nil? || sles15_platforms.empty?) && (windows_platforms.nil? || windows_platforms.empty?) %>[]<% end %> # Agent 5 package doesn't work on SLES 15
+  excludes: <% if sles15_platforms.nil? || sles15_platforms.empty? %>[]<% end %> # Agent 5 package doesn't work on SLES 15
     <% sles15_platforms.each do |p| %>
-    - <%= p %>
-    <% end %>
-    <% windows_platforms.each do |p| %>
     - <%= p %>
     <% end %>
   run_list:
@@ -299,52 +226,5 @@ suites:
     dd-agent-upgrade-rspec:
       # Used by the rspec test to know the version to which the agent should be upgraded
       agent_expected_version: &agent_expected_version <%= ENV['DD_AGENT_EXPECTED_VERSION'] || "5.99.0" %>
-    dd-agent-rspec:
-        skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
-
-
-# Installs the latest release candidate using the install script
-- name: dd-agent-install-script
-  excludes: <% if windows_platforms.nil? || windows_platforms.empty? %>[]<% end %>
-    <% windows_platforms.each do |p| %>
-    - <%= p %>
-    <% end %>
-  run_list:
-    - "recipe[dd-agent-install-script]"
-  attributes:
-    apt:
-      unattended_upgrades:
-        enable: false
-    dd-agent-install-script:
-      api_key: <%= api_key %>
-      candidate_repo_branch: pipeline-<%= ENV['CI_PIPELINE_ID'] %>
-      install_script_url: https://raw.githubusercontent.com/DataDog/datadog-agent/<%= ENV['CI_COMMIT_SHA'] %>/cmd/agent/install_script.sh
-      install_candidate: true
-    dd-agent-rspec:
-        skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
-
-# Installs the latest release candidate using the step-by-step instructions (on dogweb)
-- name: dd-agent-step-by-step
-  run_list:
-    - "recipe[dd-agent-step-by-step]"
-  excludes: <% if windows_platforms.nil? || windows_platforms.empty? %>[]<% end %>
-    <% windows_platforms.each do |p| %>
-    - <%= p %>
-    <% end %>
-  attributes:
-    apt:
-      unattended_upgrades:
-        enable: false
-    datadog:
-      agent6: true
-    dd-agent-step-by-step:
-      <% dd_agent_config.each do |key, value| %>
-      <%= key %>: <%= value %>
-      <% end %>
-      api_key: <%= api_key %>
-      repo_branch_apt: pipeline-<%= ENV['CI_PIPELINE_ID'] %>
-      repo_branch_yum: pipeline-<%= ENV['CI_PIPELINE_ID'] %>
-      candidate_repo_branch: pipeline-<%= ENV['CI_PIPELINE_ID'] %>
-      install_candidate: true
     dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -90,6 +90,10 @@ if [[ $#  != 0 && $1 == "windows-install-test" ]]; then
   cp kitchen-azure-winstall.yml kitchen.yml
 fi
 
+if [[ $#  != 0 && $1 == "windows-upgrade5-test" ]]; then
+  cp kitchen-azure-wupgrade5.yml kitchen.yml
+fi
+
 kitchen diagnose --no-instances --loader
 
 rm -rf cookbooks

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -415,6 +415,7 @@ end
 
 shared_examples_for 'an Agent that stops' do
   it 'stops' do
+    skip if os == :windows
     output = stop
     if os != :windows
       expect(output).to be_truthy
@@ -423,6 +424,7 @@ shared_examples_for 'an Agent that stops' do
   end
 
   it 'has connection refuse in the info command' do
+    skip if os == :windows
     if os == :windows
       expect(info).to include 'No connection could be made'
     else
@@ -431,10 +433,12 @@ shared_examples_for 'an Agent that stops' do
   end
 
   it 'is not running any agent processes' do
+    skip if os == :windows
     expect(agent_processes_running?).to be_falsey
   end
 
   it 'starts after being stopped' do
+    skip if os == :windows
     output = start
     if os != :windows
       expect(output).to be_truthy
@@ -469,6 +473,7 @@ end
 
 shared_examples_for 'an Agent with python3 enabled' do
   it 'restarts after python_version is set to 3' do
+    skip if os == :windows
     conf_path = ""
     if os != :windows
       conf_path = "/etc/datadog-agent/datadog.yaml"
@@ -494,6 +499,7 @@ shared_examples_for 'an Agent with python3 enabled' do
   # end
 
   it 'restarts after python_version is set back to 2' do
+    skip if os == :windows
     conf_path = ""
     if os != :windows
       conf_path = "/etc/datadog-agent/datadog.yaml"


### PR DESCRIPTION
### What does this PR do?

Separates A5->A6 Windows upgrade tests in their own gitlab job, allowed to fail.
Skips stop tests on Windows, since they're flaky.

### Motivation

Prevent gitlab pipelines from failing because of flakes, until we get a working solution for those flakes.

