### PR TITLE
Switch windows builds to docker builders

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -249,6 +249,7 @@ run_tests_rpm-x64-py3:
 
 # run tests for eBPF code
 run_tests_ebpf:
+  allow_failure: true
   stage: source_test
   # TODO(processes): change this to be ebpf:latest when we move to go1.12.x on the agent
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/ebpf:go1.10.1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,7 +155,7 @@ before_script:
 
 
 # run tests for windows-64
-run_tests_windows-x64:
+.run_tests_windows_base:
   # temporarily allow failure for tests
   allow_failure: false
   stage: source_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,7 @@ variables:
   RELEASE_VERSION: nightly
   DATADOG_AGENT_BUILDIMAGES: v1709713-2adac2a
   DATADOG_AGENT_BUILDERS: v1755190-c671974
+  DATADOG_AGENT_WINBUILDIMAGES: v1748171-a0bc272
 
 
 # Default before_script for all the jobs. If you create a new job and don't want this to execute
@@ -151,6 +152,35 @@ before_script:
 # source_test
 #
 #
+
+
+# run tests for windows-64
+run_tests_windows-x64:
+  # temporarily allow failure for tests
+  allow_failure: false
+  stage: source_test
+  before_script:
+    - echo "Running windows source tests"
+  variables:
+    WINDOWS_BUILDER: 'true'
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  script:
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat --release-version %RELEASE_VERSION% 
+
+run_tests_windows-x64:
+  # temporarily allow failure for tests
+  extends: .run_tests_windows_base
+  allow_failure: true
+  variables:
+    ARCH: "x64"
+  
+run_tests_windows-x86:
+  # temporarily allow failure for tests
+  extends: .run_tests_windows_base
+  allow_failure: true
+  variables:
+    ARCH: "x86"
+
 
 .run_tests_preparation: &run_tests_preparation
   before_script:
@@ -604,10 +634,14 @@ agent_suse-x64-a7:
     - inv agent.omnibus-build --release-version %RELEASE_VERSION% --omnibus-s3-cache --base-dir %OMNIBUS_BASE_DIR_WIN_OMNIBUS% --skip-deps
     # copy the results from the build dir to here, because artifacts must be relative to the project directory
     - copy %OMNIBUS_BASE_DIR_WIN%\pkg\* %WIN_CI_PROJECT_DIR%\.omnibus\pkg
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - .omnibus/pkg
+  # remove artifacts (for now) so they don't collide with the docker-generated artifacts
+  # artifacts:
+  #   expire_in: 2 weeks
+  #   paths:
+  #    - .omnibus/pkg
+
+
+
 
 # build Agent package for Windows
 build_windows_msi_x64-a6:
@@ -623,6 +657,49 @@ build_windows_msi_x64-a7:
     CREDENTIALS_FILE_PATH: 'c:\users\gitlab\.aws\config'
     PYTHON_RUNTIMES: '3'
   <<: *agent_build_common_windows
+
+##
+## windows dockerized builds
+##
+.dockerbuild_windows_msi_base:
+  before_script:
+    - mkdir .omnibus\pkg
+  stage: package_build
+  variables:
+    WINDOWS_BUILDER: 'true'
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  script:
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat --release-version %RELEASE_VERSION%
+    - copy build-out\*.msi .omnibus\pkg
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - .omnibus/pkg
+
+dockerbuild_windows_msi_x64-a7:
+  extends: .dockerbuild_windows_msi_base
+  variables:
+    ARCH: "x64"
+    PYTHON_RUNTIMES: '3'
+
+dockerbuild_windows_msi_x86-a7:
+  extends: .dockerbuild_windows_msi_base
+  variables:
+    ARCH: "x86"
+    PYTHON_RUNTIMES: '3'
+
+dockerbuild_windows_msi_x64-a6:
+  extends: .dockerbuild_windows_msi_base
+  variables:
+    ARCH: "x64"
+    PYTHON_RUNTIMES: '2,3'
+
+dockerbuild_windows_msi_x86-a6:
+  extends: .dockerbuild_windows_msi_base
+  variables:
+    ARCH: "x86"
+    PYTHON_RUNTIMES: '2,3'
+
 
 # build Agent package for android
 agent_android_apk:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,13 +156,9 @@ before_script:
 
 # run tests for windows-64
 .run_tests_windows_base:
-  # temporarily allow failure for tests
-  allow_failure: false
   stage: source_test
   before_script:
     - echo "Running windows source tests"
-  variables:
-    WINDOWS_BUILDER: 'true'
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat --release-version %RELEASE_VERSION% 
@@ -611,53 +607,6 @@ agent_suse-x64-a7:
   <<: *agent_build_common_suse_rpm
 
 
-.agent_build_common_windows: &agent_build_common_windows
-  stage: package_build
-  tags: ["runner:windows-agent6"]
-  ## this is a weird workaround. Can't use the built-in CI_PROJECT_DIR because the path separators
-  ## are wrong.  Record the PROJECT dir with the correct path separators to be used later
-  before_script:
-    - set WIN_CI_PROJECT_DIR=%CD%
-    - if exist .omnibus rd /s/q .omnibus
-    - mkdir .omnibus\pkg
-    - if exist \omnibus-ruby rd /s/q \omnibus-ruby
-    - if exist %OMNIBUS_BASE_DIR_WIN% rd /s/q %OMNIBUS_BASE_DIR_WIN%
-    - if exist \opt\datadog-agent rd /s/q \opt\datadog-agent
-    - if exist %GOPATH%\src rd /s/q %GOPATH%\src
-    - mkdir %GOPATH%\src\github.com\DataDog\datadog-agent
-    - xcopy /q/h/e/s * %GOPATH%\src\github.com\DataDog\datadog-agent
-    - cd %GOPATH%\src\github.com\DataDog\datadog-agent
-    - inv -e deps --verbose --dep-vendor-only --no-checks
-  script:
-    # remove artifacts from previous pipelines that may come from the cache
-    - cd %GOPATH%\src\github.com\DataDog\datadog-agent
-    # use --skip-deps since the deps are installed by `before_script`
-    - inv agent.omnibus-build --release-version %RELEASE_VERSION% --omnibus-s3-cache --base-dir %OMNIBUS_BASE_DIR_WIN_OMNIBUS% --skip-deps
-    # copy the results from the build dir to here, because artifacts must be relative to the project directory
-    - copy %OMNIBUS_BASE_DIR_WIN%\pkg\* %WIN_CI_PROJECT_DIR%\.omnibus\pkg
-  # remove artifacts (for now) so they don't collide with the docker-generated artifacts
-  # artifacts:
-  #   expire_in: 2 weeks
-  #   paths:
-  #    - .omnibus/pkg
-
-
-
-
-# build Agent package for Windows
-# build_windows_msi_x64-a6:
-#  variables:
-#    WINDOWS_BUILDER: 'true'
-#    CREDENTIALS_FILE_PATH: 'c:\users\gitlab\.aws\config'
-#    PYTHON_RUNTIMES: '2,3'
-#  <<: *agent_build_common_windows
-
-# build_windows_msi_x64-a7:
-#  variables:
-#     WINDOWS_BUILDER: 'true'
-#    CREDENTIALS_FILE_PATH: 'c:\users\gitlab\.aws\config'
-#    PYTHON_RUNTIMES: '3'
-#  <<: *agent_build_common_windows
 
 ##
 ## windows dockerized builds
@@ -666,11 +615,9 @@ agent_suse-x64-a7:
   before_script:
     - mkdir .omnibus\pkg
   stage: package_build
-  variables:
-    WINDOWS_BUILDER: 'true'
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat --release-version %RELEASE_VERSION%
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat --release-version %RELEASE_VERSION%
     - copy build-out\*.msi .omnibus\pkg
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -645,19 +645,19 @@ agent_suse-x64-a7:
 
 
 # build Agent package for Windows
-build_windows_msi_x64-a6:
-  variables:
-    WINDOWS_BUILDER: 'true'
-    CREDENTIALS_FILE_PATH: 'c:\users\gitlab\.aws\config'
-    PYTHON_RUNTIMES: '2,3'
-  <<: *agent_build_common_windows
+# build_windows_msi_x64-a6:
+#  variables:
+#    WINDOWS_BUILDER: 'true'
+#    CREDENTIALS_FILE_PATH: 'c:\users\gitlab\.aws\config'
+#    PYTHON_RUNTIMES: '2,3'
+#  <<: *agent_build_common_windows
 
-build_windows_msi_x64-a7:
-  variables:
-    WINDOWS_BUILDER: 'true'
-    CREDENTIALS_FILE_PATH: 'c:\users\gitlab\.aws\config'
-    PYTHON_RUNTIMES: '3'
-  <<: *agent_build_common_windows
+# build_windows_msi_x64-a7:
+#  variables:
+#     WINDOWS_BUILDER: 'true'
+#    CREDENTIALS_FILE_PATH: 'c:\users\gitlab\.aws\config'
+#    PYTHON_RUNTIMES: '3'
+#  <<: *agent_build_common_windows
 
 ##
 ## windows dockerized builds

--- a/tasks/ssm.py
+++ b/tasks/ssm.py
@@ -11,7 +11,7 @@ from invoke.exceptions import Exit
 
 
 
-ssm_command = "aws.exe ssm get-parameter --name {} --region us-east-1 --with-decryption"
+ssm_command = "aws.exe ssm get-parameter --name {} --with-decryption --region us-east-1"
 ssm_param_password = "keygen.dd_win_agent_codesign.password"
 ssm_param_pfx_part1 = "keygen.dd_win_agent_codesign.pfx_b64_0"
 ssm_param_pfx_part2 = "keygen.dd_win_agent_codesign.pfx_b64_1"

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -45,7 +45,7 @@ DEFAULT_TEST_TARGETS = [
 def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=None,
     verbose=False, race=False, profile=False, fail_on_fmt=False,
     rtloader_root=None, python_home_2=None, python_home_3=None, cpus=0,
-    timeout=120):
+    timeout=120, arch="x64"):
     """
     Run all the tools and tests on the given targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -87,7 +87,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
         f_cov.write("mode: count")
 
     ldflags, gcflags, env = get_build_flags(ctx, rtloader_root=rtloader_root,
-            python_home_2=python_home_2, python_home_3=python_home_3)
+            python_home_2=python_home_2, python_home_3=python_home_3, arch=arch)
 
     if sys.platform == 'win32':
         env['CGO_LDFLAGS'] += ' -Wl,--allow-multiple-definition'


### PR DESCRIPTION
### What does this PR do?

Moves builds to windows container builds, off of single-use runners

### Motivation

Ability to manage & scale

### Additional Notes

Includes 32 bit builds
Includes source test (32 and 64) on windows now
Builds will take longer.
