### PR TITLE
Process agent & system-probe ignores sigpipe signals

### DIFF
--- a/pkg/process/util/signal_nowindows.go
+++ b/pkg/process/util/signal_nowindows.go
@@ -14,7 +14,7 @@ import (
 func HandleSignals(exit chan bool) {
 	sigIn := make(chan os.Signal, 100)
 	signal.Notify(sigIn)
-	// unix only in all likelihood;  but we don't care.
+	// unix only in all likelihood; but we don't care.
 	for sig := range sigIn {
 		switch sig {
 		case syscall.SIGINT, syscall.SIGTERM:
@@ -22,6 +22,11 @@ func HandleSignals(exit chan bool) {
 			close(exit)
 		case syscall.SIGCHLD:
 			// Running docker.GetDockerStat() spins up / kills a new process
+			continue
+		case syscall.SIGPIPE:
+			// By default systemd redirects the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal.
+			// Go ignores SIGPIPE signals unless it is when stdout or stdout is closed, in this case the agent is stopped.
+			// We never want the agent to stop upon receiving SIGPIPE, so we intercept the SIGPIPE signals and just discard them.
 			continue
 		default:
 			log.Debugf("Caught signal %s; continuing/ignoring.", sig)

--- a/releasenotes/notes/fix-05e775eee53f78d3.yaml
+++ b/releasenotes/notes/fix-05e775eee53f78d3.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The process-agent and system-probe agents should ignore SIGPIPE signals.


### PR DESCRIPTION
### What does this PR do?

I think we're receiving a ton of these signals and that the extremely excessive logging is causing high CPU performance.

Looks like both the main agent and trace agent ignores these signals, so copying the logic:
- https://github.com/DataDog/datadog-agent/blob/master/cmd/trace-agent/main.go#L26-L29
- https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/app/run.go#L75-L84

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
