### PR TITLE
[logs] Support compression for HTTP endpoints

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -396,6 +396,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	config.BindEnv("logs_config.dd_url")
 	config.BindEnvAndSetDefault("logs_config.use_http", false)
+	config.BindEnvAndSetDefault("logs_config.use_compression", false)
+	config.BindEnvAndSetDefault("logs_config.compression_level", 6) // Default level for the gzip/deflate algorithm
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")

--- a/pkg/logs/client/http/content_encoding.go
+++ b/pkg/logs/client/http/content_encoding.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package http
+
+import (
+	"bytes"
+	"compress/gzip"
+)
+
+// ContentEncoding encodes the payload
+type ContentEncoding interface {
+	name() string
+	encode(payload []byte) ([]byte, error)
+}
+
+// IdentityContentType encodes the payload using the identity function
+var IdentityContentType ContentEncoding = &identityContentType{}
+
+type identityContentType struct{}
+
+func (c *identityContentType) name() string {
+	return "identity"
+}
+
+func (c *identityContentType) encode(payload []byte) ([]byte, error) {
+	return payload, nil
+}
+
+// GzipContentEncoding encodes the payload using gzip algorithm
+type GzipContentEncoding struct {
+	level int
+}
+
+// NewGzipContentEncoding creates a new Gzip content type
+func NewGzipContentEncoding(level int) *GzipContentEncoding {
+	if level < gzip.NoCompression {
+		level = gzip.NoCompression
+	} else if level > gzip.BestCompression {
+		level = gzip.BestCompression
+	}
+
+	return &GzipContentEncoding{
+		level,
+	}
+}
+
+func (c *GzipContentEncoding) name() string {
+	return "gzip"
+}
+
+func (c *GzipContentEncoding) encode(payload []byte) ([]byte, error) {
+	var compressedPayload bytes.Buffer
+	gzipWriter, err := gzip.NewWriterLevel(&compressedPayload, c.level)
+	if err != nil {
+		return nil, err
+	}
+	_, err = gzipWriter.Write(payload)
+	if err != nil {
+		return nil, err
+	}
+	err = gzipWriter.Flush()
+	if err != nil {
+		return nil, err
+	}
+	err = gzipWriter.Close()
+	if err != nil {
+		return nil, err
+	}
+	return compressedPayload.Bytes(), nil
+}

--- a/pkg/logs/client/http/content_encoding_test.go
+++ b/pkg/logs/client/http/content_encoding_test.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package http
+
+import (
+	"bytes"
+	"compress/gzip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdentityContentType(t *testing.T) {
+	payload := []byte("my payload")
+
+	encodedPayload, err := IdentityContentType.encode(payload)
+	assert.Nil(t, err)
+
+	assert.Equal(t, payload, encodedPayload)
+}
+
+func TestIdentityContentTypeName(t *testing.T) {
+	assert.Equal(t, IdentityContentType.name(), "identity")
+}
+
+func TestGzipContentEncoding(t *testing.T) {
+	payload := []byte("my payload")
+
+	encodedPayload, err := NewGzipContentEncoding(gzip.BestCompression).encode(payload)
+	assert.Nil(t, err)
+
+	decompressedPayload, err := decompress(encodedPayload)
+	assert.Nil(t, err)
+
+	assert.Equal(t, payload, decompressedPayload)
+}
+
+func TestGzipContentEncodingName(t *testing.T) {
+	assert.Equal(t, NewGzipContentEncoding(gzip.BestCompression).name(), "gzip")
+}
+
+func decompress(payload []byte) ([]byte, error) {
+	reader, err := gzip.NewReader(bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	var buffer bytes.Buffer
+	_, err = buffer.ReadFrom(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}

--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -58,6 +58,9 @@ func (d *Destination) Send(payload []byte) error {
 		}
 	}
 
+	metrics.BytesSent.Add(int64(len(payload)))
+	metrics.EncodedBytesSent.Add(int64(len(payload)))
+
 	content := d.prefixer.apply(payload)
 	frame, err := d.delimiter.delimit(content)
 	if err != nil {

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -136,7 +136,9 @@ func buildTCPEndpoints() (*Endpoints, error) {
 
 func buildHTTPEndpoints() (*Endpoints, error) {
 	main := Endpoint{
-		APIKey: getLogsAPIKey(coreConfig.Datadog),
+		APIKey:           getLogsAPIKey(coreConfig.Datadog),
+		UseCompression:   coreConfig.Datadog.GetBool("logs_config.use_compression"),
+		CompressionLevel: coreConfig.Datadog.GetInt("logs_config.compression_level"),
 	}
 
 	switch {

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -7,11 +7,13 @@ package config
 
 // Endpoint holds all the organization and network parameters to send logs to Datadog.
 type Endpoint struct {
-	APIKey       string `mapstructure:"api_key"`
-	Host         string
-	Port         int
-	UseSSL       bool
-	ProxyAddress string
+	APIKey           string `mapstructure:"api_key"`
+	Host             string
+	Port             int
+	UseSSL           bool
+	UseCompression   bool
+	CompressionLevel int
+	ProxyAddress     string
 }
 
 // Endpoints holds the main endpoint and additional ones to dualship logs.

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -129,6 +129,41 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	suite.Equal("agent-http-intake.logs.datadoghq.com", endpoint.Host)
 }
 
+func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPConfigAndCompression() {
+	var endpoints *Endpoints
+	var endpoint Endpoint
+	var err error
+
+	suite.config.Set("logs_config.use_http", true)
+	suite.config.Set("logs_config.use_compression", true)
+
+	endpoints, err = BuildEndpoints()
+	suite.Nil(err)
+	suite.True(endpoints.UseHTTP)
+
+	endpoint = endpoints.Main
+	suite.True(endpoint.UseCompression)
+	suite.Equal(endpoint.CompressionLevel, 6)
+}
+
+func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPConfigAndCompressionAndOverride() {
+	var endpoints *Endpoints
+	var endpoint Endpoint
+	var err error
+
+	suite.config.Set("logs_config.use_http", true)
+	suite.config.Set("logs_config.use_compression", true)
+	suite.config.Set("logs_config.compression_level", 1)
+
+	endpoints, err = BuildEndpoints()
+	suite.Nil(err)
+	suite.True(endpoints.UseHTTP)
+
+	endpoint = endpoints.Main
+	suite.True(endpoint.UseCompression)
+	suite.Equal(endpoint.CompressionLevel, 1)
+}
+
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPConfigAndOverride() {
 	var endpoints *Endpoints
 	var endpoint Endpoint

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -22,6 +22,10 @@ var (
 	DestinationErrors = expvar.Int{}
 	// DestinationLogsDropped is the total number of logs dropped per Destination
 	DestinationLogsDropped = expvar.Map{}
+	// BytesSent is the total number of sent bytes before encoding if any
+	BytesSent = expvar.Int{}
+	// EncodedBytesSent is the total number of sent bytes after encoding if any
+	EncodedBytesSent = expvar.Int{}
 	// TODO: Add LogsCollected for the total number of collected logs.
 )
 
@@ -32,4 +36,6 @@ func init() {
 	LogsExpvars.Set("LogsSent", &LogsSent)
 	LogsExpvars.Set("DestinationErrors", &DestinationErrors)
 	LogsExpvars.Set("DestinationLogsDropped", &DestinationLogsDropped)
+	LogsExpvars.Set("BytesSent", &BytesSent)
+	LogsExpvars.Set("EncodedBytesSent", &EncodedBytesSent)
 }

--- a/pkg/logs/metrics/metrics_test.go
+++ b/pkg/logs/metrics/metrics_test.go
@@ -12,5 +12,5 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	assert.Equal(t, LogsExpvars.String(), `{"DestinationErrors": 0, "DestinationLogsDropped": {}, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0}`)
+	assert.Equal(t, LogsExpvars.String(), `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0}`)
 }

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -92,13 +92,13 @@ func TestStatusDeduplicateErrorsAndWarnings(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	defer Clear()
 	Clear()
-	var expected = `{"DestinationErrors": 0, "DestinationLogsDropped": {}, "Errors": "", "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": ""}`
+	var expected = `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "", "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": ""}`
 	assert.Equal(t, expected, metrics.LogsExpvars.String())
 
 	createSources()
 	AddGlobalWarning("bar", "Unique Warning")
 	AddGlobalError("bar", "I am an error")
-	expected = `{"DestinationErrors": 0, "DestinationLogsDropped": {}, "Errors": "I am an error", "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": "Unique Warning"}`
+	expected = `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "I am an error", "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": "Unique Warning"}`
 	assert.Equal(t, expected, metrics.LogsExpvars.String())
 }
 


### PR DESCRIPTION
### What does this PR do?

Support compression for logs HTTP endpoints

### Motivation

Reduce bandwidth consumption to reduce ingress costs

### Additional Notes

Anything else we should know when reviewing?
