### PR TITLE
Copy SNMP profiles during installation

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -240,6 +240,12 @@ build do
         end
       end
 
+      # Copy SNMP profiles
+      profiles = "#{check_dir}/datadog_checks/#{check}/data/profiles"
+      if File.exist? profiles
+        copy profile, "#{check_conf_dir}/"
+      end
+
       File.file?("#{check_dir}/setup.py") || next
       if windows?
         command "#{python} -m pip install --no-deps #{windows_safe_path(project_dir)}\\#{check}"

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -243,7 +243,7 @@ build do
       # Copy SNMP profiles
       profiles = "#{check_dir}/datadog_checks/#{check}/data/profiles"
       if File.exist? profiles
-        copy profile, "#{check_conf_dir}/"
+        copy profiles, "#{check_conf_dir}/"
       end
 
       File.file?("#{check_dir}/setup.py") || next

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -254,7 +254,7 @@ build do
       # Copy SNMP profiles
       profiles = "#{check_dir}/datadog_checks/#{check}/data/profiles"
       if File.exist? profiles
-        copy profile, "#{check_conf_dir}/"
+        copy profiles, "#{check_conf_dir}/"
       end
 
       File.file?("#{check_dir}/setup.py") || next

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -251,6 +251,12 @@ build do
         end
       end
 
+      # Copy SNMP profiles
+      profiles = "#{check_dir}/datadog_checks/#{check}/data/profiles"
+      if File.exist? profiles
+        copy profile, "#{check_conf_dir}/"
+      end
+
       File.file?("#{check_dir}/setup.py") || next
       if windows?
         command "#{python} -m pip install --no-deps #{windows_safe_path(project_dir)}\\#{check}"

--- a/releasenotes/notes/snmp-profiles-9711c7d2307e9362.yaml
+++ b/releasenotes/notes/snmp-profiles-9711c7d2307e9362.yaml
@@ -1,4 +1,4 @@
 ---
-features:
+other:
   - |
     Copy SNMP profiles shipped by the integration during installation.

--- a/releasenotes/notes/snmp-profiles-9711c7d2307e9362.yaml
+++ b/releasenotes/notes/snmp-profiles-9711c7d2307e9362.yaml
@@ -1,4 +1,0 @@
----
-other:
-  - |
-    Copy SNMP profiles shipped by the integration during installation.

--- a/releasenotes/notes/snmp-profiles-9711c7d2307e9362.yaml
+++ b/releasenotes/notes/snmp-profiles-9711c7d2307e9362.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Copy SNMP profiles shipped by the integration during installation.


### PR DESCRIPTION
SNMP profiles are extra configuration files, we need to copy them during
installation.