### PR TITLE
Pin golang.org/x/tools

### DIFF
--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,6 +1,9 @@
 {
     "deps": {
         "order": [
+            "golang.org/x/tools/go/ast/astutil",
+            "golang.org/x/tools/go/internal",
+            "golang.org/x/tools/go/gcexportdata",
             "golang.org/x/lint/golint",
             "github.com/fzipp/gocyclo",
             "github.com/gordonklaus/ineffassign",
@@ -8,6 +11,19 @@
             "github.com/golang/dep/cmd/dep",
             "golang.org/x/mobile/cmd/gomobile"
         ],
+        "golang.org/x/tools/go/ast/astutil": {
+            "version": "release-branch.go1.10",
+            "type": "go"
+        },
+        "golang.org/x/tools/go/internal": {
+            "version": "release-branch.go1.10",
+            "type": "go",
+            "install": false
+        },
+        "golang.org/x/tools/go/gcexportdata": {
+            "version": "release-branch.go1.10",
+            "type": "go"
+        },
         "github.com/golang/dep/cmd/dep": {
             "version": "v0.5.0",
             "type": "go"

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -217,8 +217,9 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False, dep_
     order = deps.get("order", deps.keys())
     for dependency in order:
         tool = deps.get(dependency)
-        print("processing get tool {}".format(dependency))
-        process_deps(ctx, dependency, tool.get('version'), tool.get('type'), 'install', verbose=verbose)
+        if tool.get('install', True):
+            print("processing get tool {}".format(dependency))
+            process_deps(ctx, dependency, tool.get('version'), tool.get('type'), 'install', verbose=verbose)
 
     if android:
         ndkhome = os.environ.get('ANDROID_NDK_HOME')


### PR DESCRIPTION
### What does this PR do?

Pin all `golang.org/x/tools` we use so that they don't break with go 1.10.
Doing `go get -d golang.org/x/tools` is not possible, it results in an error as there are no go files in the root folder.
Installing `golang.org/x/tools/go/internal` is also not possible (same "no Go files" error), but it can be `go get` for some reason.


### Motivation

Fix Gitlab pipeline.

### Additional Notes

Is this really a maintainable way of doing things?