### PR TITLE
Keep track of connection type in conntracker.go

### DIFF
--- a/pkg/ebpf/netlink/conntracker_test.go
+++ b/pkg/ebpf/netlink/conntracker_test.go
@@ -4,18 +4,86 @@ package netlink
 
 import (
 	"encoding/binary"
+	"io"
+	"io/ioutil"
 	"net"
+	"os/exec"
+	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-
 	ct "github.com/florianl/go-conntrack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWithIPTables(t *testing.T) {
+	assertRoot(t)
+
+	// run the teardown, just in case the last run did not exit cleanly
+	runScript(t, "teardown_dnat.sh")
+
+	// setup a dummy interface at 1.1.1.1 and a rule to DNAT 2.2.2.2 ->1.1.1.1
+	runScript(t, "setup_dnat.sh")
+	defer runScript(t, "teardown_dnat.sh")
+
+	ct, err := NewConntracker("/proc", 10, 1000)
+	require.NoError(t, err)
+	defer ct.Close()
+
+	// setup a listener on 1.1.1.1 (the real address of the dummy addr)
+	tcpListener, err := net.Listen("tcp", "1.1.1.1:8080")
+	require.NoError(t, err)
+	go func() {
+		tcpListener.Accept()
+	}()
+	defer tcpListener.Close()
+
+	udpListener, err := net.ListenUDP("udp", &net.UDPAddr{
+		IP:   net.ParseIP("1.1.1.1"),
+		Port: 8080,
+	})
+	defer udpListener.Close()
+
+	_, err = net.Dial("tcp", "2.2.2.2:8080")
+	require.NoError(t, err)
+
+	udpConn, err := net.Dial("udp", "2.2.2.2:8080")
+	require.NoError(t, err)
+	go func() {
+		udpConn.Write([]byte("hello"))
+	}()
+
+	timeout := time.After(time.Second * 5)
+	for {
+		select {
+		case <-timeout:
+			t.Errorf("missing entry")
+			t.Fail()
+			return
+		default:
+			var udpFound, tcpFound bool
+			for k, v := range ct.(*realConntracker).state {
+				if v.ReplSrcIP == util.AddressFromString("1.1.1.1") {
+					if k.proto == 0 { // ConnectionType_tcp
+						tcpFound = true
+					} else if k.proto == 1 { // ConnectionType_udp
+						udpFound = true
+					} else {
+						t.Errorf("unexpected proto: %v", k.proto)
+					}
+				}
+				if udpFound && tcpFound {
+					return
+				}
+			}
+		}
+	}
+}
 
 func TestIsNat(t *testing.T) {
 	c := map[ct.ConnAttrType][]byte{
@@ -33,7 +101,7 @@ func TestRegisterNonNat(t *testing.T) {
 	c := makeUntranslatedConn("10.0.0.0:8080", "50.30.40.10:12345")
 
 	rt.register(c)
-	translation := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 8080)
+	translation := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 8080, 0)
 	assert.Nil(t, translation)
 }
 
@@ -42,7 +110,7 @@ func TestRegisterNat(t *testing.T) {
 	c := makeTranslatedConn("10.0.0.0:12345", "50.30.40.10:80", "20.0.0.0:80")
 
 	rt.register(c)
-	translation := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345)
+	translation := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345, 0)
 	assert.NotNil(t, translation)
 	assert.Equal(t, &IPTranslation{
 		ReplSrcIP:   util.AddressFromString("20.0.0.0"),
@@ -53,14 +121,14 @@ func TestRegisterNat(t *testing.T) {
 
 	// even after unregistering, we should be able to access the conn
 	rt.unregister(c)
-	translation2 := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345)
+	translation2 := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345, 0)
 	assert.NotNil(t, translation2)
 
 	// double unregisters should never happen, though it will be treated as a no-op
 	rt.unregister(c)
 
 	rt.ClearShortLived()
-	translation3 := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345)
+	translation3 := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345, 0)
 	assert.Nil(t, translation3)
 
 	// triple unregisters should never happen, though it will be treated as a no-op
@@ -82,7 +150,7 @@ func TestGetUpdatesGen(t *testing.T) {
 		break // there is only one item in the map
 	}
 
-	iptr := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345)
+	iptr := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345, 0)
 	require.NotNil(t, iptr)
 
 	for _, v := range rt.state {
@@ -145,4 +213,37 @@ func parts(p string) ([]byte, []byte) {
 	ip := net.ParseIP(segments[0]).To4()
 
 	return ip, b
+}
+
+func assertRoot(t *testing.T) {
+	user, err := user.Current()
+	if err != nil {
+		t.Skipf("cannot detect user, will skip test %v", err)
+	}
+
+	if user.Username != "root" {
+		t.Skipf("skipping test because username is not root, but %v", user.Username)
+	}
+}
+
+func runScript(t *testing.T, fname string) {
+	path := filepath.Join("testdata", fname)
+	cmd := exec.Command("/bin/bash", path)
+	stdErr, err := cmd.StderrPipe()
+	assert.NoError(t, err)
+
+	stdOut, err := cmd.StdoutPipe()
+	assert.NoError(t, err)
+
+	cmdOut := io.MultiReader(stdErr, stdOut)
+	err = cmd.Start()
+	assert.NoError(t, err)
+
+	message, err := ioutil.ReadAll(cmdOut)
+	assert.NoError(t, err)
+
+	if err := cmd.Wait(); err != nil {
+		t.Errorf("failed with stderr: %v", string(message))
+		t.Errorf("failed with error %v", err)
+	}
 }

--- a/pkg/ebpf/netlink/conntracker_test.go
+++ b/pkg/ebpf/netlink/conntracker_test.go
@@ -4,12 +4,7 @@ package netlink
 
 import (
 	"encoding/binary"
-	"io"
-	"io/ioutil"
 	"net"
-	"os/exec"
-	"os/user"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,71 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestWithIPTables(t *testing.T) {
-	assertRoot(t)
-
-	// run the teardown, just in case the last run did not exit cleanly
-	runScript(t, "teardown_dnat.sh")
-
-	// setup a dummy interface at 1.1.1.1 and a rule to DNAT 2.2.2.2 ->1.1.1.1
-	runScript(t, "setup_dnat.sh")
-	defer runScript(t, "teardown_dnat.sh")
-
-	ct, err := NewConntracker("/proc", 10, 1000)
-	require.NoError(t, err)
-	defer ct.Close()
-
-	// setup a listener on 1.1.1.1 (the real address of the dummy addr)
-	tcpListener, err := net.Listen("tcp", "1.1.1.1:8080")
-	require.NoError(t, err)
-	go func() {
-		tcpListener.Accept()
-	}()
-	defer tcpListener.Close()
-
-	udpListener, err := net.ListenUDP("udp", &net.UDPAddr{
-		IP:   net.ParseIP("1.1.1.1"),
-		Port: 8080,
-	})
-	require.NoError(t, err)
-	defer udpListener.Close()
-
-	_, err = net.Dial("tcp", "2.2.2.2:8080")
-	require.NoError(t, err)
-
-	udpConn, err := net.Dial("udp", "2.2.2.2:8080")
-	require.NoError(t, err)
-	go func() {
-		udpConn.Write([]byte("hello"))
-	}()
-
-	timeout := time.After(time.Second * 5)
-	for {
-		select {
-		case <-timeout:
-			t.Errorf("missing entry")
-			t.Fail()
-			return
-		default:
-			var udpFound, tcpFound bool
-			for k, v := range ct.(*realConntracker).state {
-				if v.ReplSrcIP == util.AddressFromString("1.1.1.1") {
-					if k.proto == 0 { // ConnectionType_tcp
-						tcpFound = true
-					} else if k.proto == 1 { // ConnectionType_udp
-						udpFound = true
-					} else {
-						t.Errorf("unexpected proto: %v", k.proto)
-					}
-				}
-				if udpFound && tcpFound {
-					return
-				}
-			}
-		}
-	}
-}
 
 func TestIsNat(t *testing.T) {
 	c := map[ct.ConnAttrType][]byte{
@@ -236,37 +166,4 @@ func parts(p string) ([]byte, []byte) {
 	ip := net.ParseIP(segments[0]).To4()
 
 	return ip, b
-}
-
-func assertRoot(t *testing.T) {
-	user, err := user.Current()
-	if err != nil {
-		t.Skipf("cannot detect user, will skip test %v", err)
-	}
-
-	if user.Username != "root" {
-		t.Skipf("skipping test because username is not root, but %v", user.Username)
-	}
-}
-
-func runScript(t *testing.T, fname string) {
-	path := filepath.Join("testdata", fname)
-	cmd := exec.Command("/bin/bash", path)
-	stdErr, err := cmd.StderrPipe()
-	assert.NoError(t, err)
-
-	stdOut, err := cmd.StdoutPipe()
-	assert.NoError(t, err)
-
-	cmdOut := io.MultiReader(stdErr, stdOut)
-	err = cmd.Start()
-	assert.NoError(t, err)
-
-	message, err := ioutil.ReadAll(cmdOut)
-	assert.NoError(t, err)
-
-	if err := cmd.Wait(); err != nil {
-		t.Errorf("failed with stderr: %v", string(message))
-		t.Errorf("failed with error %v", err)
-	}
 }

--- a/pkg/ebpf/netlink/conntracker_test.go
+++ b/pkg/ebpf/netlink/conntracker_test.go
@@ -47,6 +47,7 @@ func TestWithIPTables(t *testing.T) {
 		IP:   net.ParseIP("1.1.1.1"),
 		Port: 8080,
 	})
+	require.NoError(t, err)
 	defer udpListener.Close()
 
 	_, err = net.Dial("tcp", "2.2.2.2:8080")

--- a/pkg/ebpf/netlink/noop.go
+++ b/pkg/ebpf/netlink/noop.go
@@ -2,7 +2,10 @@
 
 package netlink
 
-import "github.com/DataDog/datadog-agent/pkg/process/util"
+import (
+	"github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
 
 type noOpConntracker struct{}
 
@@ -11,7 +14,7 @@ func NewNoOpConntracker() Conntracker {
 	return &noOpConntracker{}
 }
 
-func (*noOpConntracker) GetTranslationForConn(ip util.Address, port uint16, proto uint8) *IPTranslation {
+func (*noOpConntracker) GetTranslationForConn(ip util.Address, port uint16, transport process.ConnectionType) *IPTranslation {
 	return nil
 }
 

--- a/pkg/ebpf/netlink/noop.go
+++ b/pkg/ebpf/netlink/noop.go
@@ -11,7 +11,7 @@ func NewNoOpConntracker() Conntracker {
 	return &noOpConntracker{}
 }
 
-func (*noOpConntracker) GetTranslationForConn(ip util.Address, port uint16) *IPTranslation {
+func (*noOpConntracker) GetTranslationForConn(ip util.Address, port uint16, proto uint8) *IPTranslation {
 	return nil
 }
 

--- a/pkg/ebpf/netlink/testdata/setup_dnat.sh
+++ b/pkg/ebpf/netlink/testdata/setup_dnat.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+ip link add dummy0 type dummy
+ip address add  1.1.1.1 broadcast + dev dummy0
+ip link set dummy0 up
+iptables -t nat -A OUTPUT  --dest 2.2.2.2 -j DNAT --to-destination 1.1.1.1

--- a/pkg/ebpf/netlink/testdata/teardown_dnat.sh
+++ b/pkg/ebpf/netlink/testdata/teardown_dnat.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -x
+
+# tear down the testing interface, and iptables rule
+ip link del dummy0
+iptables -t nat -D OUTPUT    -d 2.2.2.2  -j DNAT --to-destination 1.1.1.1
+
+# clear out the conntrack table
+conntrack -F

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -277,7 +277,7 @@ func (t *Tracer) initPerfPolling() (*bpflib.PerfMap, error) {
 				if t.shouldSkipConnection(&cs) {
 					atomic.AddInt64(&t.skippedConns, 1)
 				} else {
-					cs.IPTranslation = t.conntracker.GetTranslationForConn(cs.Source, cs.SPort)
+					cs.IPTranslation = t.conntracker.GetTranslationForConn(cs.Source, cs.SPort, uint8(cs.Type))
 					t.state.StoreClosedConnection(cs)
 				}
 			case lostCount, ok := <-lostChannel:
@@ -393,7 +393,7 @@ func (t *Tracer) getConnections(active []ConnectionStats) ([]ConnectionStats, ui
 				atomic.AddInt64(&t.skippedConns, 1)
 			} else {
 				// lookup conntrack in for active
-				conn.IPTranslation = t.conntracker.GetTranslationForConn(conn.Source, conn.SPort)
+				conn.IPTranslation = t.conntracker.GetTranslationForConn(conn.Source, conn.SPort, uint8(conn.Type))
 				active = append(active, conn)
 			}
 		}

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/netlink"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -277,7 +278,7 @@ func (t *Tracer) initPerfPolling() (*bpflib.PerfMap, error) {
 				if t.shouldSkipConnection(&cs) {
 					atomic.AddInt64(&t.skippedConns, 1)
 				} else {
-					cs.IPTranslation = t.conntracker.GetTranslationForConn(cs.Source, cs.SPort, uint8(cs.Type))
+					cs.IPTranslation = t.conntracker.GetTranslationForConn(cs.Source, cs.SPort, process.ConnectionType(cs.Type))
 					t.state.StoreClosedConnection(cs)
 				}
 			case lostCount, ok := <-lostChannel:
@@ -393,7 +394,7 @@ func (t *Tracer) getConnections(active []ConnectionStats) ([]ConnectionStats, ui
 				atomic.AddInt64(&t.skippedConns, 1)
 			} else {
 				// lookup conntrack in for active
-				conn.IPTranslation = t.conntracker.GetTranslationForConn(conn.Source, conn.SPort, uint8(conn.Type))
+				conn.IPTranslation = t.conntracker.GetTranslationForConn(conn.Source, conn.SPort, process.ConnectionType(conn.Type))
 				active = append(active, conn)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Include L4 proto in the connection key used by conntracker.go

### Motivation

the old key for each conntrack entry was `(sourceIP, sourcePort)`.  Because it's possible to use have UDP and TCP  connections have the same sourceIP/sourcePort, a bunch of TCP connections were incorrectly . attached to UDP translations.

Also includes an integration test which uses IP tables to simulate a DNAT-ed connection. The integration test needs to be run as root, and will not run otherwise.

### Additional Notes

Anything else we should know when reviewing?
