### PR TITLE
[kitchen] Fix windows upgrade tests not run in correct location

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -929,6 +929,21 @@ deploy_windows_testing-a7:
     paths:
       - $CI_PROJECT_DIR/kitchen_logs
 
+.kitchen_windows_upgrade_common: &kitchen_windows_upgrade_common
+  script:
+    - cd $CI_PROJECT_DIR
+    - cd $DD_AGENT_TESTING_DIR
+    - rm -rf $CI_PROJECT_DIR/kitchen_logs
+    - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
+    - mkdir $CI_PROJECT_DIR/kitchen_logs
+    - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
+    - bash -l tasks/run-test-kitchen.sh windows-upgrade5-test
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - $CI_PROJECT_DIR/kitchen_logs
+
 kitchen_windows_upgrade5to6:
   stage: testkitchen_testing
   allow_failure: true
@@ -945,8 +960,7 @@ kitchen_windows_upgrade5to6:
     - export TEST_PLATFORMS="$TEST_PLATFORMS|win2016,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:2016.127.20190603"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|win2019,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:2019.0.20190603"
   tags: [ "runner:main", "size:large" ]
-  script:
-    - bash -l tasks/run-test-kitchen.sh windows-upgrade5-test
+  <<: *kitchen_windows_upgrade_common
 
 kitchen_windows_upgrade5to7:
   stage: testkitchen_testing
@@ -964,8 +978,7 @@ kitchen_windows_upgrade5to7:
     - export TEST_PLATFORMS="$TEST_PLATFORMS|win2016,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:2016.127.20190603"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|win2019,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:2019.0.20190603"
   tags: [ "runner:main", "size:large" ]
-  script:
-    - bash -l tasks/run-test-kitchen.sh windows-upgrade5-test
+  <<: *kitchen_windows_upgrade_common
 
 # run dd-agent-testing on windows
 kitchen_windows-a6:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -901,7 +901,6 @@ deploy_windows_testing-a7:
 
 .kitchen_common: &kitchen_common
   script:
-    - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
     - rm -rf $CI_PROJECT_DIR/kitchen_logs
     - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
@@ -916,7 +915,6 @@ deploy_windows_testing-a7:
 
 .kitchen_windows_installer_common: &kitchen_windows_installer_common
   script:
-    - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
     - rm -rf $CI_PROJECT_DIR/kitchen_logs
     - rm -rf $DD_AGENT_TESTING_DIR/.kitchen
@@ -931,7 +929,6 @@ deploy_windows_testing-a7:
 
 .kitchen_windows_upgrade_common: &kitchen_windows_upgrade_common
   script:
-    - cd $CI_PROJECT_DIR
     - cd $DD_AGENT_TESTING_DIR
     - rm -rf $CI_PROJECT_DIR/kitchen_logs
     - rm -rf $DD_AGENT_TESTING_DIR/.kitchen

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -954,6 +954,7 @@ kitchen_windows_upgrade5to6:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
+    - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6
     - export TEST_PLATFORMS="win2008r2,MicrosoftWindowsServer:WindowsServer:2008-R2-SP1:2.127.20190603"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190603"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|win2012r2,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20190603"
@@ -972,6 +973,7 @@ kitchen_windows_upgrade5to7:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
+    - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7
     - export TEST_PLATFORMS="win2008r2,MicrosoftWindowsServer:WindowsServer:2008-R2-SP1:2.127.20190603"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190603"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|win2012r2,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20190603"


### PR DESCRIPTION
### What does this PR do?

Moves working folder of Windows upgrade tasks to the correct folder, initializes kitchen logs and adds them as artifacts.
Also adds the correct testing bucket environment variable for the upgrade tests, so that they know where to find the installer.

### Motivation

Broken Windows upgrade tests.

