### PR TITLE
Fix Kubernetes events collection

### DIFF
--- a/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -10,6 +10,9 @@ instances:
     # To deactivate the event collection, flip the collect_events option to false.
     # collect_events: false
     #
-    # You can specify a filter over the event types you want the check to ignore.
-    # See https://github.com/kubernetes/kubernetes/blob/638822fd0f30d9c78e78b91e918cb7364f86b8ab/pkg/kubelet/events/event.go#L20
-    # filtered_event_types: ["MissingClusterDNS"]
+    # Specify a list of exclusion filters over the event type, involvedObject.
+    #
+    # filtered_event_types: ["reason:FailedGetScale","kind:Pod","type:Normal"]
+    #
+    # Maximum number of events you wish to collect per check run.
+    # cardinality_limit: 300

--- a/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -16,3 +16,6 @@ instances:
     #
     # Maximum number of events you wish to collect per check run.
     # cardinality_limit: 300
+    #
+    # Parameter specified by the Cluster Agent when the event collection is configured as a cluster check.
+    # skip_leader_election: false

--- a/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -19,3 +19,7 @@ instances:
     #
     # Parameter specified by the Cluster Agent when the event collection is configured as a cluster check.
     # skip_leader_election: false
+    #
+    # Specify the frequency at which the Agent should list all events to re-sync following the informer pattern
+    #
+    # resync_period_kubernetes_events: 300

--- a/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -10,9 +10,9 @@ instances:
     # To deactivate the event collection, flip the collect_events option to false.
     # collect_events: false
     #
-    # Specify a list of exclusion filters over the event type, involvedObject.
+    # Specify a list of exclusion filters over the event type, involvedObject.kind, reason, following the Kubernetes field-selector format.
     #
-    # filtered_event_types: ["reason:FailedGetScale","kind:Pod","type:Normal"]
+    # filtered_event_types: ["reason!=FailedGetScale","involvedObject.kind==Pod","type==Normal"]
     #
     # Maximum number of events you wish to collect per check run.
     # max_events_per_run: 300

--- a/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/Dockerfiles/cluster-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -15,11 +15,11 @@ instances:
     # filtered_event_types: ["reason:FailedGetScale","kind:Pod","type:Normal"]
     #
     # Maximum number of events you wish to collect per check run.
-    # cardinality_limit: 300
+    # max_events_per_run: 300
     #
     # Parameter specified by the Cluster Agent when the event collection is configured as a cluster check.
     # skip_leader_election: false
     #
-    # Specify the frequency at which the Agent should list all events to re-sync following the informer pattern
+    # Specify the frequency in seconds at which the Agent should list all events to re-sync following the informer pattern
     #
-    # resync_period_kubernetes_events: 300
+    # kubernetes_event_resync_period_s: 300

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -17,9 +17,9 @@ instances:
     #
     # filtered_event_types: ["MissingClusterDNS","reason:FailedGetScale","kind:Pod","type:Normal"]
 
-    ## @param cardinality_limit - integer - optional - default: 300
+    ## @param max_events_per_run - integer - optional - default: 300
     ## Maximum number of events you wish to collect per check run.
-    # cardinality_limit: 300
+    # max_events_per_run: 300
 
     ## @param kubernetes_event_read_timeout_ms - integer - optional - default: 1000
     ## If the API Server is slow to respond under load, the event collection might fail. Increase the read timeout (in milliseconds).
@@ -31,7 +31,7 @@ instances:
     #
     # skip_leader_election: false
 
-    ## @param resync_period_kubernetes_events - integer - optional - default: 300
-    ## Specify the frequency at which the Agent should list all events to re-sync following the informer pattern
+    ## @param kubernetes_event_resync_period_s - integer - optional - default: 300
+    ## Specify the frequency in seconds at which the Agent should list all events to re-sync following the informer pattern
     #
-    # resync_period_kubernetes_events: 300
+    # kubernetes_event_resync_period_s: 300

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -13,9 +13,9 @@ instances:
     #   - <KEY_2>:<VALUE_2>
 
     ## @param filtered_event_types - array of strings - optional
-    ## Specify a list of exclusion filters over the event type, involvedObject.
+    ## Specify a list of exclusion filters over the event type, involvedObject.kind, reason, following the Kubernetes field-selector format.
     #
-    # filtered_event_types: ["MissingClusterDNS","reason:FailedGetScale","kind:Pod","type:Normal"]
+    # filtered_event_types: ["reason!=FailedGetScale","involvedObject.kind==Pod","type==Normal"]
 
     ## @param max_events_per_run - integer - optional - default: 300
     ## Maximum number of events you wish to collect per check run.

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -21,10 +21,10 @@ instances:
     ## Maximum number of events you wish to collect per check run.
     # cardinality_limit: 300
 
-    ## @param kubernetes_event_read_timeout_ms - integer - optional - default: 500
-    ## If the API Server is slow to respond under load, the event collection might fail. Increase the read timeout (in seconds).
+    ## @param kubernetes_event_read_timeout_ms - integer - optional - default: 1000
+    ## If the API Server is slow to respond under load, the event collection might fail. Increase the read timeout (in milliseconds).
     #
-    # kubernetes_event_read_timeout_ms: 500
+    # kubernetes_event_read_timeout_ms: 1000
 
     ## @param skip_leader_election - boolean - default: false
     ## Parameter specified by the Cluster Agent when the event collection is configured as a cluster check.

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -26,7 +26,12 @@ instances:
     #
     # kubernetes_event_read_timeout_ms: 1000
 
-    ## @param skip_leader_election - boolean - default: false
+    ## @param skip_leader_election - boolean - optional - default: false
     ## Parameter specified by the Cluster Agent when the event collection is configured as a cluster check.
     #
     # skip_leader_election: false
+
+    ## @param resync_period_kubernetes_events - integer - optional - default: 300
+    ## Specify the frequency at which the Agent should list all events to re-sync following the informer pattern
+    #
+    # resync_period_kubernetes_events: 300

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -13,13 +13,15 @@ instances:
     #   - <KEY_2>:<VALUE_2>
 
     ## @param filtered_event_types - array of strings - optional
-    ## Specify a filter over the event types you want the check to ignore.
-    ## See https://github.com/kubernetes/kubernetes/blob/638822fd0f30d9c78e78b91e918cb7364f86b8ab/pkg/kubelet/events/event.go#L20 for a full
-    ## list of events.
+    ## Specify a list of exclusion filters over the event type, involvedObject.
     #
-    # filtered_event_types: ["MissingClusterDNS"]
+    # filtered_event_types: ["MissingClusterDNS","reason:FailedGetScale","kind:Pod","type:Normal"]
 
-    ## @param kubernetes_event_read_timeout_ms - integer - optional - default: 100
+    ## @param cardinality_limit - integer - optional - default: 300
+    ## Maximum number of events you wish to collect per check run.
+    # cardinality_limit: 300
+
+    ## @param kubernetes_event_read_timeout_ms - integer - optional - default: 500
     ## If the API Server is slow to respond under load, the event collection might fail. Increase the read timeout (in seconds).
     #
-    # kubernetes_event_read_timeout_ms: 100
+    # kubernetes_event_read_timeout_ms: 500

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -25,3 +25,8 @@ instances:
     ## If the API Server is slow to respond under load, the event collection might fail. Increase the read timeout (in seconds).
     #
     # kubernetes_event_read_timeout_ms: 500
+
+    ## @param skip_leader_election - boolean - default: false
+    ## Parameter specified by the Cluster Agent when the event collection is configured as a cluster check.
+    #
+    # skip_leader_election: false

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -42,9 +42,9 @@ type KubeASConfig struct {
 	CollectOShiftQuotas      bool     `yaml:"collect_openshift_clusterquotas"`
 	FilteredEventTypes       []string `yaml:"filtered_event_types"`
 	EventCollectionTimeoutMs int      `yaml:"kubernetes_event_read_timeout_ms"`
-	CardinalityLimit         int      `yaml:"cardinality_limit"`
+	MaxEventCollection       int      `yaml:"max_events_per_run"`
 	LeaderSkip               bool     `yaml:"skip_leader_election"`
-	ResyncPeriodEvents       int      `yaml:"resync_period_kubernetes_events"`
+	ResyncPeriodEvents       int      `yaml:"kubernetes_event_resync_period_s"`
 }
 
 // EventC is the structure that holds the information pertaining to which event we collected last and when we last resynced.
@@ -86,8 +86,8 @@ func (k *KubeASCheck) Configure(config, initConfig integration.Data, source stri
 		log.Error("could not parse the config for the API server")
 		return err
 	}
-	if k.instance.CardinalityLimit == 0 {
-		k.instance.CardinalityLimit = 200
+	if k.instance.MaxEventCollection == 0 {
+		k.instance.MaxEventCollection = 200
 	}
 	k.ignoredEvents = convertFilter(k.instance.FilteredEventTypes)
 	return nil
@@ -235,7 +235,7 @@ func (k *KubeASCheck) eventCollectionCheck() (newEvents []*v1.Event, err error) 
 	}
 
 	timeout := int64(k.instance.EventCollectionTimeoutMs / 1000)
-	limit := int64(k.instance.CardinalityLimit)
+	limit := int64(k.instance.MaxEventCollection)
 	resync := int64(k.instance.ResyncPeriodEvents)
 	newEvents, k.eventCollection.LastResVer, k.eventCollection.LastTime, err = k.ac.RunEventCollection(resVer, lastTime, timeout, limit, resync, k.ignoredEvents)
 

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -124,8 +124,7 @@ func (k *KubeASCheck) Run() error {
 	if !k.instance.LeaderSkip {
 		// Only run if Leader Election is enabled.
 		if !config.Datadog.GetBool("leader_election") {
-			k.Warn("Leader Election not enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")
-			return nil
+			return log.Error("Leader Election not enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")
 		}
 		errLeader := k.runLeaderElection()
 		if errLeader != nil {

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -44,6 +44,7 @@ type KubeASConfig struct {
 	EventCollectionTimeoutMs int      `yaml:"kubernetes_event_read_timeout_ms"`
 	CardinalityLimit         int      `yaml:"cardinality_limit"`
 	LeaderSkip               bool     `yaml:"skip_leader_election"`
+	ResyncPeriodEvents       int      `yaml:"resync_period_kubernetes_events"`
 }
 
 // EventC is the structure that holds the information pertaining to which event we collected last and when we last resynced.
@@ -235,7 +236,8 @@ func (k *KubeASCheck) eventCollectionCheck() (newEvents []*v1.Event, err error) 
 
 	timeout := int64(k.instance.EventCollectionTimeoutMs / 1000)
 	limit := int64(k.instance.CardinalityLimit)
-	newEvents, k.eventCollection.LastResVer, k.eventCollection.LastTime, err = k.ac.RunEventCollection(resVer, lastTime, timeout, limit, k.ignoredEvents)
+	resync := int64(k.instance.ResyncPeriodEvents)
+	newEvents, k.eventCollection.LastResVer, k.eventCollection.LastTime, err = k.ac.RunEventCollection(resVer, lastTime, timeout, limit, resync, k.ignoredEvents)
 
 	if err != nil {
 		k.Warnf("Could not collect events from the api server: %s", err.Error())

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -10,6 +10,9 @@ package cluster
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"gopkg.in/yaml.v2"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -24,8 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"strings"
-	"time"
 )
 
 // Covers the Control Plane service check and the in memory pod metadata.
@@ -45,6 +46,7 @@ type KubeASConfig struct {
 	LeaderSkip               bool     `yaml:"skip_leader_election"`
 }
 
+// EventC is the structure that holds the information pertaining to which event we collected last and when we last resynced.
 type EventC struct {
 	ResVer   *string
 	LastTime *time.Time
@@ -103,7 +105,7 @@ func convertFilter(conf []string) string {
 		case f[0] == "kind" && len(f) == 2:
 			formatedFilters = append(formatedFilters, fmt.Sprintf("involvedObject.kind!=%s", f[1]))
 		case f[0] == "type" && len(f) == 2:
-			formatedFilters = append(formatedFilters, fmt.Sprintf("type=%s", f[1]))
+			formatedFilters = append(formatedFilters, fmt.Sprintf("type!=%s", f[1]))
 		default:
 			log.Error("Could not parse the fitler, only support kind, type and reason")
 		}

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -10,9 +10,7 @@ package cluster
 import (
 	"errors"
 	"fmt"
-	"time"
-
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"strings"
+	"time"
 )
 
 // Covers the Control Plane service check and the in memory pod metadata.
@@ -41,6 +41,13 @@ type KubeASConfig struct {
 	CollectOShiftQuotas      bool     `yaml:"collect_openshift_clusterquotas"`
 	FilteredEventType        []string `yaml:"filtered_event_types"`
 	EventCollectionTimeoutMs int      `yaml:"kubernetes_event_read_timeout_ms"`
+	CardinalityLimit         int      `yaml:"cardinality_limit"`
+	LeaderSkip               bool     `yaml:"skip_leader_election"`
+}
+
+type EventC struct {
+	ResVer   *string
+	LastTime *time.Time
 }
 
 // KubeASCheck grabs metrics and events from the API server.
@@ -48,8 +55,8 @@ type KubeASCheck struct {
 	core.CheckBase
 	instance              *KubeASConfig
 	KubeAPIServerHostname string
-	latestEventToken      string
-	configMapAvailable    bool
+	eventCollection       *EventC
+	ignoredEvents         string
 	ac                    *apiserver.APIClient
 	oshiftAPILevel        apiserver.OpenShiftAPILevel
 }
@@ -76,9 +83,32 @@ func (k *KubeASCheck) Configure(config, initConfig integration.Data, source stri
 		log.Error("could not parse the config for the API server")
 		return err
 	}
-
-	log.Debugf("Running config %s", config)
+	if k.instance.CardinalityLimit == 0 {
+		k.instance.CardinalityLimit = 200
+	}
+	k.ignoredEvents = convertFilter(k.instance.FilteredEventType)
 	return nil
+}
+
+func convertFilter(conf []string) string {
+	var formatedFilters []string
+	for _, filter := range conf {
+		f := strings.Split(filter, ":")
+		switch {
+		// Required to avoid introducing a breaking change.
+		case len(f) == 1:
+			formatedFilters = append(formatedFilters, fmt.Sprintf("reason!=%s", f[0]))
+		case f[0] == "reason" && len(f) == 2:
+			formatedFilters = append(formatedFilters, fmt.Sprintf("reason!=%s", f[1]))
+		case f[0] == "kind" && len(f) == 2:
+			formatedFilters = append(formatedFilters, fmt.Sprintf("involvedObject.kind!=%s", f[1]))
+		case f[0] == "type" && len(f) == 2:
+			formatedFilters = append(formatedFilters, fmt.Sprintf("type=%s", f[1]))
+		default:
+			log.Error("Could not parse the fitler, only support kind, type and reason")
+		}
+	}
+	return strings.Join(formatedFilters, ",")
 }
 
 // Run executes the check.
@@ -93,21 +123,22 @@ func (k *KubeASCheck) Run() error {
 		log.Debug("Cluster agent is enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")
 		return nil
 	}
-
-	// Only run if Leader Election is enabled.
-	if !config.Datadog.GetBool("leader_election") {
-		k.Warn("Leader Election not enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")
-		return nil
-	}
-	errLeader := k.runLeaderElection()
-	if errLeader != nil {
-		if errLeader == apiserver.ErrNotLeader {
-			// Only the leader can instantiate the apiserver client.
+	// Check is configured as a cluster check. The Cluster Agent passed in a config to skip the leader election.
+	if !k.instance.LeaderSkip {
+		// Only run if Leader Election is enabled.
+		if !config.Datadog.GetBool("leader_election") {
+			k.Warn("Leader Election not enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")
 			return nil
 		}
-		return err
+		errLeader := k.runLeaderElection()
+		if errLeader != nil {
+			if errLeader == apiserver.ErrNotLeader {
+				// Only the leader can instantiate the apiserver client.
+				return nil
+			}
+			return err
+		}
 	}
-
 	// API Server client initialisation on first run
 	if k.ac == nil {
 		// We start the API Server Client.
@@ -149,27 +180,16 @@ func (k *KubeASCheck) Run() error {
 		return nil
 	}
 
-	// Init of the resVersion token.
-	k.eventCollectionInit()
-
 	// Get the events from the API server
-	newEvents, modifiedEvents, err := k.eventCollectionCheck()
+	events, err := k.eventCollectionCheck()
 	if err != nil {
 		return err
 	}
 
 	// Process the events to have a Datadog format.
-	err = k.processEvents(sender, newEvents, false)
+	err = k.processEvents(sender, events)
 	if err != nil {
 		k.Warnf("Could not submit new event %s", err.Error())
-	}
-	// We send the events in 2 steps to make sure the new events are initializing the aggregation keys and as modified events have a different payload.
-	if len(modifiedEvents) == 0 {
-		return nil
-	}
-	err = k.processEvents(sender, modifiedEvents, true)
-	if err != nil {
-		k.Warnf("Could not submit modified event %s", err.Error())
 	}
 	return nil
 }
@@ -177,8 +197,9 @@ func (k *KubeASCheck) Run() error {
 // KubernetesASFactory is exported for integration testing.
 func KubernetesASFactory() check.Check {
 	return &KubeASCheck{
-		CheckBase: core.NewCheckBase(kubernetesAPIServerCheckName),
-		instance:  &KubeASConfig{},
+		CheckBase:       core.NewCheckBase(kubernetesAPIServerCheckName),
+		instance:        &KubeASConfig{},
+		eventCollection: &EventC{},
 	}
 }
 
@@ -203,69 +224,30 @@ func (k *KubeASCheck) runLeaderElection() error {
 	log.Tracef("Current leader: %q, running Kubernetes cluster related checks and collecting events", leaderEngine.GetLeader())
 	return nil
 }
-func (k *KubeASCheck) eventCollectionInit() {
-	if k.latestEventToken == "" {
-		// Initialization: Checking if we previously stored the latestEventToken in a configMap
-		tokenValue, found, err := k.ac.GetTokenFromConfigmap(eventTokenKey, 3600)
-		switch {
-		case err == apiserver.ErrOutdated:
-			k.configMapAvailable = found
-			k.latestEventToken = "0"
 
-		case err == apiserver.ErrNotFound:
-			k.latestEventToken = "0"
-
-		case err == nil:
-			k.configMapAvailable = found
-			k.latestEventToken = tokenValue
-
-		default:
-			log.Warnf("Cannot handle the tokenValue: %q, querying the kube-apiserver cache for events", tokenValue)
-			k.latestEventToken = "0"
-		}
+func (k *KubeASCheck) eventCollectionCheck() ([]*v1.Event, error) {
+	var err error
+	resVer, lastTime, err := k.ac.GetTokenFromConfigmap(eventTokenKey)
+	if err != nil {
+		return nil, err
 	}
-}
+	k.eventCollection.ResVer = &resVer
+	k.eventCollection.LastTime = &lastTime
 
-func (k *KubeASCheck) eventCollectionCheck() ([]*v1.Event, []*v1.Event, error) {
-	timeout := time.Duration(k.instance.EventCollectionTimeoutMs) * time.Millisecond
+	timeout := int64(k.instance.EventCollectionTimeoutMs / 1000)
+	limit := int64(k.instance.CardinalityLimit)
+	newEvents, err := k.ac.RunEventCollection(k.eventCollection.ResVer, k.eventCollection.LastTime, &timeout, limit, k.ignoredEvents)
 
-	newEvents, modifiedEvents, versionToken, err := k.ac.LatestEvents(k.latestEventToken, timeout)
 	if err != nil {
 		k.Warnf("Could not collect events from the api server: %s", err.Error())
-		return nil, nil, err
+		return nil, err
 	}
 
-	if versionToken == "0" {
-		// API server cache expired or no recent events to process. Resetting the Resversion token.
-		_, _, versionToken, err = k.ac.LatestEvents("0", timeout)
-		if err != nil {
-			k.Warnf("Could not collect cached events from the api server: %s", err.Error())
-			return nil, nil, err
-		}
-
-		if k.latestEventToken == versionToken {
-			log.Tracef("No new events collected")
-			// No new events but protobuf error was caught. Will retry at next run.
-			return nil, nil, nil
-		}
-		// There was a protobuf error and new events were submitted. Processing them and updating the resVersion.
-		k.latestEventToken = versionToken
+	configMapErr := k.ac.UpdateTokenInConfigmap(eventTokenKey, *k.eventCollection.ResVer, *k.eventCollection.LastTime)
+	if configMapErr != nil {
+		k.Warnf("Could not store the LastEventToken in the ConfigMap: %s", configMapErr.Error())
 	}
-
-	// We check that the resversion gotten from the API Server is more recent than the one cached in the util.
-	if len(newEvents)+len(modifiedEvents) == 0 {
-		return nil, nil, nil
-	}
-
-	k.latestEventToken = versionToken
-	if k.configMapAvailable {
-		configMapErr := k.ac.UpdateTokenInConfigmap(eventTokenKey, versionToken)
-		if configMapErr != nil {
-			k.Warnf("Could not store the LastEventToken in the ConfigMap: %s", configMapErr.Error())
-		}
-	}
-
-	return newEvents, modifiedEvents, nil
+	return newEvents, nil
 }
 
 func (k *KubeASCheck) parseComponentStatus(sender aggregator.Sender, componentsStatus *v1.ComponentStatusList) error {
@@ -305,19 +287,10 @@ func (k *KubeASCheck) parseComponentStatus(sender aggregator.Sender, componentsS
 // - iterates over the Kubernetes Events
 // - extracts some attributes and builds a structure ready to be submitted as a Datadog event (bundle)
 // - formats the bundle and submit the Datadog event
-func (k *KubeASCheck) processEvents(sender aggregator.Sender, events []*v1.Event, modified bool) error {
+func (k *KubeASCheck) processEvents(sender aggregator.Sender, events []*v1.Event) error {
 	eventsByObject := make(map[types.UID]*kubernetesEventBundle)
-	filteredByType := make(map[string]int)
 
-	// Only process the events which actions aren't part of the FilteredEventType list in the yaml config.
-ITER_EVENTS:
 	for _, event := range events {
-		for _, action := range k.instance.FilteredEventType {
-			if event.Reason == action {
-				filteredByType[action] = filteredByType[action] + 1
-				continue ITER_EVENTS
-			}
-		}
 		bundle, found := eventsByObject[event.InvolvedObject.UID]
 		if found == false {
 			bundle = newKubernetesEventBundler(event.InvolvedObject.UID, event.Source.Component)
@@ -327,15 +300,10 @@ ITER_EVENTS:
 		if err != nil {
 			k.Warnf("Error while bundling events, %s.", err.Error())
 		}
-
-		if len(filteredByType) > 0 {
-			log.Debugf("Filtered out the following events: %s", formatStringIntMap(filteredByType))
-		}
 	}
-
 	clusterName := clustername.GetClusterName()
 	for _, bundle := range eventsByObject {
-		datadogEv, err := bundle.formatEvents(modified, clusterName)
+		datadogEv, err := bundle.formatEvents(clusterName)
 		if err != nil {
 			k.Warnf("Error while formatting bundled events, %s. Not submitting", err.Error())
 			continue

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -287,12 +287,12 @@ func TestConvertFilter(t *testing.T) {
 		},
 		{
 			caseName: "exclude node and type",
-			filters:  []string{"kind:Node", "type:Normal"},
-			output:   "involvedObject.kind!=Node,type!=Normal",
+			filters:  []string{"involvedObject.kind!=Node", "type==Normal"},
+			output:   "involvedObject.kind!=Node,type==Normal",
 		},
 		{
 			caseName: "legacy support and exclude HorizontalPodAutoscaler",
-			filters:  []string{"kind:HorizontalPodAutoscaler", "type:Normal", "OOM"},
+			filters:  []string{"involvedObject.kind!=HorizontalPodAutoscaler", "type!=Normal", "OOM"},
 			output:   "involvedObject.kind!=HorizontalPodAutoscaler,type!=Normal,reason!=OOM",
 		},
 	} {

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -7,9 +7,9 @@
 package cluster
 
 import (
+	"fmt"
 	"testing"
 	"time"
-	"fmt"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -93,7 +93,9 @@ func (b *kubernetesEventBundle) formatEvents(clusterName string) (metrics.Event,
 		AggregationKey: fmt.Sprintf("kubernetes_apiserver:%s", b.objUid),
 	}
 	if b.namespace != "" {
+		// TODO remove the deprecated namespace tag, we should only rely on kube_namespace
 		output.Tags = append(output.Tags, fmt.Sprintf("namespace:%s", b.namespace))
+		output.Tags = append(output.Tags, fmt.Sprintf("kube_namespace:%s", b.namespace))
 	}
 	output.Text = "%%% \n" + fmt.Sprintf("%s \n _Events emitted by the %s seen at %s since %s_ \n", formatStringIntMap(b.countByAction), b.component, time.Unix(int64(b.lastTimestamp), 0), time.Unix(int64(b.timeStamp), 0)) + "\n %%%"
 	return output, nil

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -54,7 +54,7 @@ func (b *kubernetesEventBundle) addEvent(event *v1.Event) error {
 	b.namespace = event.InvolvedObject.Namespace
 
 	// We do not process the events in chronological order necessarily.
-	// We only care about the first time they occured, the last time and the count.
+	// We only care about the first time they occurred, the last time and the count.
 	b.timeStamp = float64(event.FirstTimestamp.Unix())
 	b.lastTimestamp = math.Max(b.lastTimestamp, float64(event.LastTimestamp.Unix()))
 

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -60,13 +60,13 @@ func (b *kubernetesEventBundle) addEvent(event *v1.Event) error {
 
 	b.countByAction[fmt.Sprintf("**%s**: %s\n", event.Reason, event.Message)] += int(event.Count)
 
-	switch event.InvolvedObject.Kind {
-	case "Node":
+	if event.InvolvedObject.Kind == "Pod" || event.InvolvedObject.Kind == "Node" {
+		b.nodename = event.Source.Host
+	}
+	if event.InvolvedObject.Namespace == "" {
 		b.readableKey = fmt.Sprintf("%s %s", event.InvolvedObject.Kind, event.InvolvedObject.Name)
-		b.nodename = event.Source.Host
-	case "Pod":
+	} else {
 		b.readableKey = fmt.Sprintf("%s %s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
-		b.nodename = event.Source.Host
 	}
 
 	return nil

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -57,9 +57,13 @@ func (b *kubernetesEventBundle) addEvent(event *v1.Event) error {
 	b.lastTimestamp = math.Max(b.lastTimestamp, float64(event.LastTimestamp.Unix()))
 
 	b.countByAction[fmt.Sprintf("**%s**: %s\n", event.Reason, event.Message)] += int(event.Count)
-	b.readableKey = fmt.Sprintf("%s %s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
 
-	if event.InvolvedObject.Kind == "Node" || event.InvolvedObject.Kind == "Pod" {
+	switch event.InvolvedObject.Kind {
+	case "Node":
+		b.readableKey = fmt.Sprintf("%s %s", event.InvolvedObject.Kind, event.InvolvedObject.Name)
+		b.nodename = event.Source.Host
+	case "Pod":
+		b.readableKey = fmt.Sprintf("%s %s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
 		b.nodename = event.Source.Host
 	}
 

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -53,6 +53,8 @@ func (b *kubernetesEventBundle) addEvent(event *v1.Event) error {
 	b.events = append(b.events, event)
 	b.namespace = event.InvolvedObject.Namespace
 
+	// We do not process the events in chronological order necessarily.
+	// We only care about the first time they occured, the last time and the count.
 	b.timeStamp = float64(event.FirstTimestamp.Unix())
 	b.lastTimestamp = math.Max(b.lastTimestamp, float64(event.LastTimestamp.Unix()))
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -210,62 +210,76 @@ func (c *APIClient) ComponentStatuses() (*v1.ComponentStatusList, error) {
 	return c.Cl.CoreV1().ComponentStatuses().List(metav1.ListOptions{TimeoutSeconds: &c.timeoutSeconds})
 }
 
-// GetTokenFromConfigmap returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap `configMapDCAToken` if its timestamp is less than tokenTimeout old.
-func (c *APIClient) GetTokenFromConfigmap(token string, tokenTimeout int64) (string, bool, error) {
-	namespace := common.GetResourcesNamespace()
-	tokenConfigMap, err := c.Cl.CoreV1().ConfigMaps(namespace).Get(configMapDCAToken, metav1.GetOptions{})
+func (c *APIClient) getOrCreateConfigMap(name, namespace string) (cmEvent *v1.ConfigMap, err error) {
+	cmEvent, err = c.Cl.CoreV1().ConfigMaps(namespace).Get(configMapDCAToken, metav1.GetOptions{})
 	if err != nil {
-		log.Debugf("Could not find the ConfigMap %s: %s", configMapDCAToken, err.Error())
-		return "", false, ErrNotFound
+		log.Debugf("Could not find the ConfigMap %s: %s, trying to create it.", configMapDCAToken, err.Error())
+		cmEvent, err = c.Cl.CoreV1().ConfigMaps(namespace).Create(&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapDCAToken,
+				Namespace: namespace,
+			},
+			Data: make(map[string]string),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("could not create the ConfigMap: %s", err.Error())
+		}
+		log.Infof("Created the ConfigMap %s", configMapDCAToken)
 	}
-	log.Infof("Found the ConfigMap %s", configMapDCAToken)
+	return cmEvent, nil
+}
 
-	eventTokenKey := fmt.Sprintf("%s.%s", token, tokenKey)
-	tokenValue, found := tokenConfigMap.Data[eventTokenKey]
-	if !found {
-		log.Errorf("%s was not found in the ConfigMap %s", eventTokenKey, configMapDCAToken)
-		return "", found, ErrNotFound
+// GetTokenFromConfigmap returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap `configMapDCAToken` if its timestamp is less than tokenTimeout old.
+func (c *APIClient) GetTokenFromConfigmap(token string) (string, time.Time, error) {
+	namespace := common.GetResourcesNamespace()
+	cmEvent, err := c.getOrCreateConfigMap(configMapDCAToken, namespace)
+	if err != nil {
+		// we will process things locally as we can't interact with the CM. Could be a RBAC issue.
+		return "", time.Now(), ErrNotFound
 	}
-	log.Infof("%s is %q", token, tokenValue)
+	nowTs := time.Now()
+	eventTokenKey := fmt.Sprintf("%s.%s", token, tokenKey)
+	tokenValue, found := cmEvent.Data[eventTokenKey]
+	if !found {
+		log.Debugf("%s was not found in the ConfigMap %s, updating it to resync.", eventTokenKey, configMapDCAToken)
+		err = c.UpdateTokenInConfigmap(configMapDCAToken, "", time.Now())
+		// we should try to set it.
+		if err != nil {
+			// we will process things locally as we can't interact with the CM
+			return "", time.Now(), ErrNotFound
+		}
+		return "", nowTs, nil
+	}
+	log.Tracef("%s is %q", token, tokenValue)
 
 	eventTokenTS := fmt.Sprintf("%s.%s", token, tokenTime)
-	tokenTimeStr, set := tokenConfigMap.Data[eventTokenTS] // This is so we can have one timestamp per token
-
+	tokenTimeStr, set := cmEvent.Data[eventTokenTS]
 	if !set {
 		log.Debugf("Could not find timestamp associated with %s in the ConfigMap %s. Refreshing.", eventTokenTS, configMapDCAToken)
 		// We return ErrOutdated to reset the tokenValue and its timestamp as token's timestamp was not found.
-		return tokenValue, found, ErrOutdated
+		return tokenValue, nowTs, ErrOutdated
 	}
 
 	tokenTime, err := time.Parse(time.RFC822, tokenTimeStr)
 	if err != nil {
-		return "", found, log.Errorf("could not convert the timestamp associated with %s from the ConfigMap %s", token, configMapDCAToken)
+		return "", nowTs, log.Errorf("could not convert the timestamp associated with %s from the ConfigMap %s", token, configMapDCAToken)
 	}
-	tokenAge := time.Now().Unix() - tokenTime.Unix()
-
-	if tokenAge > tokenTimeout {
-		log.Debugf("The tokenValue %s is outdated, refreshing the state", token)
-		return tokenValue, found, ErrOutdated
-	}
-	log.Debugf("Token %s was updated recently, using value to collect newer events.", token)
-	return tokenValue, found, nil
+	return tokenValue, tokenTime, err
 }
 
 // UpdateTokenInConfigmap updates the value of the `tokenValue` from the `tokenKey` and
 // sets its collected timestamp in the ConfigMap `configmaptokendca`
-func (c *APIClient) UpdateTokenInConfigmap(token, tokenValue string) error {
+func (c *APIClient) UpdateTokenInConfigmap(token, tokenValue string, timestamp time.Time) error {
 	namespace := common.GetResourcesNamespace()
-	tokenConfigMap, err := c.Cl.CoreV1().ConfigMaps(namespace).Get(configMapDCAToken, metav1.GetOptions{})
-	if err != nil {
+	tokenConfigMap, err := c.getOrCreateConfigMap(configMapDCAToken, namespace)
+	if err != nil && err != ErrOutdated {
 		return err
 	}
-
 	eventTokenKey := fmt.Sprintf("%s.%s", token, tokenKey)
 	tokenConfigMap.Data[eventTokenKey] = tokenValue
 
-	now := time.Now()
 	eventTokenTS := fmt.Sprintf("%s.%s", token, tokenTime)
-	tokenConfigMap.Data[eventTokenTS] = now.Format(time.RFC822) // Timestamps in the ConfigMap should all use the type int.
+	tokenConfigMap.Data[eventTokenTS] = timestamp.Format(time.RFC822) // Timestamps in the ConfigMap should all use the type int.
 
 	_, err = c.Cl.CoreV1().ConfigMaps(namespace).Update(tokenConfigMap)
 	if err != nil {

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -212,7 +212,7 @@ func (c *APIClient) ComponentStatuses() (*v1.ComponentStatusList, error) {
 func (c *APIClient) getOrCreateConfigMap(name, namespace string) (cmEvent *v1.ConfigMap, err error) {
 	cmEvent, err = c.Cl.CoreV1().ConfigMaps(namespace).Get(configMapDCAToken, metav1.GetOptions{})
 	if err != nil {
-		log.Debugf("Could not find the ConfigMap %s: %s, trying to create it.", configMapDCAToken, err.Error())
+		log.Errorf("Could not get the ConfigMap %s: %s, trying to create it.", configMapDCAToken, err.Error())
 		cmEvent, err = c.Cl.CoreV1().ConfigMaps(namespace).Create(&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configMapDCAToken,

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -232,12 +232,13 @@ func (c *APIClient) getOrCreateConfigMap(name, namespace string) (cmEvent *v1.Co
 // GetTokenFromConfigmap returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap `configMapDCAToken` if its timestamp is less than tokenTimeout old.
 func (c *APIClient) GetTokenFromConfigmap(token string) (string, time.Time, error) {
 	namespace := common.GetResourcesNamespace()
+	nowTs := time.Now()
+
 	cmEvent, err := c.getOrCreateConfigMap(configMapDCAToken, namespace)
 	if err != nil {
 		// we will process things locally as we can't interact with the CM. Could be a RBAC issue.
 		return "", time.Now(), ErrNotFound
 	}
-	nowTs := time.Now()
 	eventTokenKey := fmt.Sprintf("%s.%s", token, tokenKey)
 	tokenValue, found := cmEvent.Data[eventTokenKey]
 	if !found {

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -7,7 +7,7 @@
 
 package apiserver
 
-//// Covered by test/integration/util/kube_apiserver/events_test.go
+//// Covered by test/integration/util/kube_apiserver/apiserver_test.go
 
 import (
 	"fmt"

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -11,99 +11,128 @@ package apiserver
 
 import (
 	"fmt"
-	"strconv"
-	"time"
-
-	"github.com/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"strconv"
+	"time"
 )
 
-// LatestEvents retrieves all the cluster events happening after a given token.
-// First slice is the new events, second slice the modified events.
-// If the `since` parameter is empty, we query the apiserver's cache to avoid
-// overloading it.
-// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#watch-list-289
-func (c *APIClient) LatestEvents(since string, eventReadTimeout time.Duration) ([]*v1.Event, []*v1.Event, string, error) {
-	var added, modified []*v1.Event
-
-	// If `since` is "" strconv.Atoi(*latestResVersion) below will panic as we evaluate the error.
-	// One could chose to use "" instead of 0 to not query the API Server cache.
-	// We decide to only rely on the cache as it avoids crawling everything from the API Server at once.
-	resVersionInt, err := strconv.Atoi(since)
-	if err != nil {
-		log.Errorf("The cached resourceVersion token %s, could not be parsed with: %s", since, err)
-		since = "0"
+// RunEventCollection will return the most recent events emitted by the apiserver.
+func (c *APIClient) RunEventCollection(srv *string, st *time.Time, eventReadTimeout *int64, eventCardinalityLimit int64, filter string) ([]*v1.Event, error) {
+	var added []*v1.Event
+	nrv := srv
+	// list if latestResVer is "" or if lastListTS is > maxResync
+	if *srv == "" || time.Now().Second()-st.Second() > 300 {
+		evList, err := c.Cl.CoreV1().Events(metav1.NamespaceAll).List(metav1.ListOptions{
+			TimeoutSeconds:       eventReadTimeout,
+			Limit:                eventCardinalityLimit,
+			IncludeUninitialized: false,
+			FieldSelector:        filter,
+		})
+		if err != nil {
+			// TODO revisit error handling here
+			return nil, err
+		}
+		for _, e := range evList.Items {
+			// List call returns a different type than the Watch call.
+			added = append(added, &e)
+		}
+		if len(evList.Items) == int(eventCardinalityLimit) {
+			log.Infof("Limitted collection to the %d most recent events", eventCardinalityLimit)
+		}
+		*st = time.Now()
+		*srv = evList.ResourceVersion
 	}
 
-	log.Tracef("Starting watch of events with resourceVersion %s", since)
-
-	eventWatcher, err := c.Cl.CoreV1().Events(metav1.NamespaceAll).Watch(metav1.ListOptions{Watch: true, ResourceVersion: since})
+	// Start watcher with the most up to date RV
+	evWatcher, err := c.Cl.CoreV1().Events(metav1.NamespaceAll).Watch(metav1.ListOptions{
+		Watch:                true,
+		ResourceVersion:      *nrv,
+		Limit:                eventCardinalityLimit,
+		IncludeUninitialized: false,
+		FieldSelector:        filter,
+	})
 	if err != nil {
-		return nil, nil, "0", fmt.Errorf("Failed to watch events: %v", err)
+		return added, err
 	}
-	defer eventWatcher.Stop()
-
-	// To account for slow starts, wait longer for the first event
-	watcherTimeout := time.NewTimer(eventReadTimeout * 2)
+	defer evWatcher.Stop()
+	log.Debugf("Starting to watch from %s", *nrv)
+	// watch during 2 * timeout maximum and store where we are at.
+	timeoutParse := time.NewTimer(time.Duration(*eventReadTimeout*2) * time.Second)
 	for {
 		select {
-		case rcvdEv, ok := <-eventWatcher.ResultChan():
+		case rcv, ok := <-evWatcher.ResultChan():
 			if !ok {
-				log.Debugf("Unexpected watch close")
-				return added, modified, strconv.Itoa(resVersionInt), nil
+				log.Error("Unexpected watch close")
+				return added, fmt.Errorf("Unexpected watch close")
 			}
-			if rcvdEv.Type == watch.Error {
-				status, ok := rcvdEv.Object.(*metav1.Status)
+			if rcv.Type == watch.Error {
+				status, ok := rcv.Object.(*metav1.Status)
 				if !ok {
-					return nil, nil, "0", errors.New("could not parse status of error event from the API Server.") // TODO custom error
+					// TODO revisit error handling here.
+					return added, fmt.Errorf("Could not get status of ev ?")
 				}
 				if status.Reason == "Expired" {
-					// Known issue with ETCD https://github.com/kubernetes/kubernetes/issues/45506
-					// Once we have started the event watcher, we do not expect the resversion to be "0"
-					// Except when initializing. Forcing to 0 so we can keep on watching without hitting the cache.
-					log.Tracef("Resversion expired: %s", status.Message)
-					return added, modified, "0", nil
+					log.Debugf("RV is too old, using list and diffing to keep events more recent than the stored RV. \n")
+					evList, err := c.Cl.CoreV1().Events("").List(metav1.ListOptions{
+						//TimeoutSeconds: eventReadTimeout,
+						Limit:                eventCardinalityLimit,
+						IncludeUninitialized: false,
+						FieldSelector:        filter,
+					})
+					if err != nil {
+						return added, err
+					}
+					log.Infof("Listed %d events", len(evList.Items))
+					*st = time.Now()
+					i, _ := strconv.Atoi(*nrv)
+					ev := diffEvents(i, evList.Items)
+					*nrv = evList.ResourceVersion
+					// List, Do the diff, return delta ev, return newest RV from the List
+					// will return here
+					return ev, nil
 				}
-				// We continue here to avoid casting into a *v1.Event.
-				// In this case, the event is of type *metav1.Status.
-				log.Debugf("Unexpected watch error: %s", status.Message)
-				continue
-			}
+				// if other error, we return the err and RV "" to relist in the next run!, could be a network blip/.
 
-			currEvent, ok := rcvdEv.Object.(*v1.Event)
+			}
+			ev, ok := rcv.Object.(*v1.Event)
 			if !ok {
-				log.Debugf("The event object cannot be safely converted to event: %v", rcvdEv.Object)
+				// Could not cast the ev, might as well drop this ev, and continue.
+				log.Errorf("The event object for %v cannot be safely converted, skipping it.", rcv.Object)
 				continue
 			}
-
-			evResVer, err := strconv.Atoi(currEvent.ResourceVersion)
+			evResVer, err := strconv.Atoi(ev.ResourceVersion)
 			if err != nil {
 				// Could not convert the Resversion. Returning.
-				return added, modified, "0", err
+				// should not be happening, it means the object is not correctly formatted in etcd.
+				return added, err
 			}
-			if evResVer > resVersionInt {
-				resVersionInt = evResVer
+			added = append(added, ev)
+			i, err := strconv.Atoi(*nrv)
+			if evResVer > i {
+				// Events from the watch are not ordered necessarily, let's keep track of the newest RV.
+				*nrv = ev.ResourceVersion
 			}
 
-			if rcvdEv.Type == watch.Added {
-				added = append(added, currEvent)
-				resVersionInt = evResVer
-			}
-			if rcvdEv.Type == watch.Modified {
-				modified = append(modified, currEvent)
-				resVersionInt = evResVer
-			}
-			watcherTimeout.Reset(eventReadTimeout)
-
-		case <-watcherTimeout.C:
-			log.Debug("Timeout reached while collecting events")
+		case <-timeoutParse.C:
+			log.Debugf("Collected %d events, will resume watching from RV %s in 10 seconds", len(added), *nrv)
 			// No more events to read or the watch lasted more than `eventReadTimeout`.
 			// so return what was processed.
-			return added, modified, strconv.Itoa(resVersionInt), nil
+			return added, nil
 		}
 	}
+}
+
+func diffEvents(latestStoredRV int, fullList []v1.Event) []*v1.Event {
+	var diffEvents []*v1.Event
+	for _, ev := range fullList {
+		i, _ := strconv.Atoi(ev.ResourceVersion)
+		if i > latestStoredRV {
+			diffEvents = append(diffEvents, &ev)
+		}
+	}
+	log.Debugf("returning %d events that we have not collected", len(diffEvents))
+	return diffEvents
 }

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -22,10 +22,11 @@ import (
 )
 
 // RunEventCollection will return the most recent events emitted by the apiserver.
-func (c *APIClient) RunEventCollection(srv string, st time.Time, eventReadTimeout int64, eventCardinalityLimit int64, filter string) ([]*v1.Event, string, time.Time, error) {
+func (c *APIClient) RunEventCollection(srv string, st time.Time, eventReadTimeout int64, eventCardinalityLimit int64, resync int64, filter string) ([]*v1.Event, string, time.Time, error) {
 	var added []*v1.Event
-	// list if latestResVer is "" or if lastListTS is > maxResync
-	if srv == "" || time.Now().Sub(st) > 300*time.Second {
+	syncTimeout := time.Duration(resync) * time.Second
+	// list if latestResVer is "" or if lastListTS is > syncTimeout
+	if srv == "" || time.Now().Sub(st) > syncTimeout {
 		evList, err := c.Cl.CoreV1().Events(metav1.NamespaceAll).List(metav1.ListOptions{
 			TimeoutSeconds:       &eventReadTimeout,
 			Limit:                eventCardinalityLimit,

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -110,7 +110,12 @@ func (c *APIClient) RunEventCollection(srv *string, st *time.Time, eventReadTime
 				return added, err
 			}
 			added = append(added, ev)
+
 			i, err := strconv.Atoi(*nrv)
+			if err != nil {
+				log.Errorf("Could not cast %s into an integer: %s", *nrv, err.Error())
+				continue
+			}
 			if evResVer > i {
 				// Events from the watch are not ordered necessarily, let's keep track of the newest RV.
 				*nrv = ev.ResourceVersion

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -11,18 +11,19 @@ package apiserver
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"strconv"
+	"time"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	"strconv"
-	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // RunEventCollection will return the most recent events emitted by the apiserver.
 func (c *APIClient) RunEventCollection(srv *string, st *time.Time, eventReadTimeout *int64, eventCardinalityLimit int64, filter string) ([]*v1.Event, error) {
 	var added []*v1.Event
-	nrv := srv
 	// list if latestResVer is "" or if lastListTS is > maxResync
 	if *srv == "" || time.Now().Second()-st.Second() > 300 {
 		evList, err := c.Cl.CoreV1().Events(metav1.NamespaceAll).List(metav1.ListOptions{
@@ -32,24 +33,21 @@ func (c *APIClient) RunEventCollection(srv *string, st *time.Time, eventReadTime
 			FieldSelector:        filter,
 		})
 		if err != nil {
-			// TODO revisit error handling here
+			log.Errorf("Error Listing events: %s", err.Error())
 			return nil, err
 		}
 		for _, e := range evList.Items {
 			// List call returns a different type than the Watch call.
 			added = append(added, &e)
 		}
-		if len(evList.Items) == int(eventCardinalityLimit) {
-			log.Infof("Limitted collection to the %d most recent events", eventCardinalityLimit)
-		}
 		*st = time.Now()
 		*srv = evList.ResourceVersion
+		return added, nil
 	}
-
 	// Start watcher with the most up to date RV
 	evWatcher, err := c.Cl.CoreV1().Events(metav1.NamespaceAll).Watch(metav1.ListOptions{
 		Watch:                true,
-		ResourceVersion:      *nrv,
+		ResourceVersion:      *srv,
 		Limit:                eventCardinalityLimit,
 		IncludeUninitialized: false,
 		FieldSelector:        filter,
@@ -57,27 +55,28 @@ func (c *APIClient) RunEventCollection(srv *string, st *time.Time, eventReadTime
 	if err != nil {
 		return added, err
 	}
+
 	defer evWatcher.Stop()
-	log.Debugf("Starting to watch from %s", *nrv)
+	log.Debugf("Starting to watch from %s", *srv)
 	// watch during 2 * timeout maximum and store where we are at.
 	timeoutParse := time.NewTimer(time.Duration(*eventReadTimeout*2) * time.Second)
 	for {
 		select {
 		case rcv, ok := <-evWatcher.ResultChan():
 			if !ok {
-				log.Error("Unexpected watch close")
 				return added, fmt.Errorf("Unexpected watch close")
 			}
 			if rcv.Type == watch.Error {
 				status, ok := rcv.Object.(*metav1.Status)
 				if !ok {
-					// TODO revisit error handling here.
-					return added, fmt.Errorf("Could not get status of ev ?")
+					return added, fmt.Errorf("Could not unmarshall the status of the event")
 				}
-				if status.Reason == "Expired" {
-					log.Debugf("RV is too old, using list and diffing to keep events more recent than the stored RV. \n")
-					evList, err := c.Cl.CoreV1().Events("").List(metav1.ListOptions{
-						//TimeoutSeconds: eventReadTimeout,
+				switch status.Reason {
+				// Using a switch as there are a lot of different types and we might want to explore adapting the behaviour for certain ones in the future.
+				case "Expired":
+					log.Debugf("Resource Version is too old, listing all events and collecting only the new ones")
+					evList, err := c.Cl.CoreV1().Events(metav1.NamespaceAll).List(metav1.ListOptions{
+						TimeoutSeconds:       eventReadTimeout,
 						Limit:                eventCardinalityLimit,
 						IncludeUninitialized: false,
 						FieldSelector:        filter,
@@ -85,21 +84,24 @@ func (c *APIClient) RunEventCollection(srv *string, st *time.Time, eventReadTime
 					if err != nil {
 						return added, err
 					}
-					log.Infof("Listed %d events", len(evList.Items))
 					*st = time.Now()
-					i, _ := strconv.Atoi(*nrv)
+					i, err := strconv.Atoi(*srv)
+					if err != nil {
+						log.Errorf("Error converting the stored Resource Version: %s", err.Error())
+						continue
+					}
 					ev := diffEvents(i, evList.Items)
-					*nrv = evList.ResourceVersion
-					// List, Do the diff, return delta ev, return newest RV from the List
-					// will return here
+					*srv = evList.ResourceVersion
 					return ev, nil
+				default:
+					// see the different types: k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+					return added, fmt.Errorf("received an unexpected status while collecting the events: %s", status.Reason)
 				}
-				// if other error, we return the err and RV "" to relist in the next run!, could be a network blip/.
-
 			}
+
 			ev, ok := rcv.Object.(*v1.Event)
 			if !ok {
-				// Could not cast the ev, might as well drop this ev, and continue.
+				// Could not cast the ev, might as well drop this event, and continue.
 				log.Errorf("The event object for %v cannot be safely converted, skipping it.", rcv.Object)
 				continue
 			}
@@ -111,18 +113,18 @@ func (c *APIClient) RunEventCollection(srv *string, st *time.Time, eventReadTime
 			}
 			added = append(added, ev)
 
-			i, err := strconv.Atoi(*nrv)
+			i, err := strconv.Atoi(*srv)
 			if err != nil {
-				log.Errorf("Could not cast %s into an integer: %s", *nrv, err.Error())
+				log.Errorf("Could not cast %s into an integer: %s", *srv, err.Error())
 				continue
 			}
 			if evResVer > i {
 				// Events from the watch are not ordered necessarily, let's keep track of the newest RV.
-				*nrv = ev.ResourceVersion
+				*srv = ev.ResourceVersion
 			}
 
 		case <-timeoutParse.C:
-			log.Debugf("Collected %d events, will resume watching from RV %s in 10 seconds", len(added), *nrv)
+			log.Debugf("Collected %d events, will resume watching from RV %s", len(added), *srv)
 			// No more events to read or the watch lasted more than `eventReadTimeout`.
 			// so return what was processed.
 			return added, nil
@@ -133,11 +135,11 @@ func (c *APIClient) RunEventCollection(srv *string, st *time.Time, eventReadTime
 func diffEvents(latestStoredRV int, fullList []v1.Event) []*v1.Event {
 	var diffEvents []*v1.Event
 	for _, ev := range fullList {
-		i, _ := strconv.Atoi(ev.ResourceVersion)
-		if i > latestStoredRV {
+		erv, _ := strconv.Atoi(ev.ResourceVersion)
+		if erv > latestStoredRV {
 			diffEvents = append(diffEvents, &ev)
 		}
 	}
-	log.Debugf("returning %d events that we have not collected", len(diffEvents))
+	log.Debugf("Returning %d events that we have not collected", len(diffEvents))
 	return diffEvents
 }

--- a/pkg/util/kubernetes/apiserver/events_test.go
+++ b/pkg/util/kubernetes/apiserver/events_test.go
@@ -9,19 +9,17 @@ package apiserver
 
 import (
 	"fmt"
+	"testing"
+	
 	"github.com/magiconair/properties/assert"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestDiffEvents(t *testing.T) {
 	// This method is called when the RV used to watch is too old (server response)
 	// We List all events and only send the ones with a RV superior to the one we have (e.g. newer events).
 
-	// Case 1: List of 3 events from the APISever 2 of which have a RV superior to the one we have.
-	// Case 2: List of 3 events from the APISever all of which have a RV superior to the one we have.
-	// Case 3: List of 3 events from the APISever none of which have a RV superior to the one we have. (should not happen)
 	for n, tc := range []struct {
 		caseName   string
 		listEvents []v1.Event

--- a/pkg/util/kubernetes/apiserver/events_test.go
+++ b/pkg/util/kubernetes/apiserver/events_test.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/util/kubernetes/apiserver/events_test.go
+++ b/pkg/util/kubernetes/apiserver/events_test.go
@@ -22,14 +22,14 @@ func TestDiffEvents(t *testing.T) {
 
 	for n, tc := range []struct {
 		caseName   string
-		listEvents []v1.Event
+		listEvents []*v1.Event
 		resver     int
 		expected   []*v1.Event
 	}{
 
 		{
 			caseName: "2 new events",
-			listEvents: []v1.Event{{
+			listEvents: []*v1.Event{{
 				Reason: "OOM",
 				ObjectMeta: metav1.ObjectMeta{
 					ResourceVersion: "43",
@@ -65,7 +65,7 @@ func TestDiffEvents(t *testing.T) {
 		},
 		{
 			caseName: "all new events",
-			listEvents: []v1.Event{{
+			listEvents: []*v1.Event{{
 				Reason: "OOM",
 				ObjectMeta: metav1.ObjectMeta{
 					ResourceVersion: "43",
@@ -107,12 +107,13 @@ func TestDiffEvents(t *testing.T) {
 		},
 		{
 			caseName: "no new events",
-			listEvents: []v1.Event{{
-				Reason: "OOM",
-				ObjectMeta: metav1.ObjectMeta{
-					ResourceVersion: "43",
+			listEvents: []*v1.Event{
+				{
+					Reason: "OOM",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "43",
+					},
 				},
-			},
 				{
 					Reason: "Create",
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/util/kubernetes/apiserver/events_test.go
+++ b/pkg/util/kubernetes/apiserver/events_test.go
@@ -1,0 +1,140 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"fmt"
+	"github.com/magiconair/properties/assert"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestDiffEvents(t *testing.T) {
+	// This method is called when the RV used to watch is too old (server response)
+	// We List all events and only send the ones with a RV superior to the one we have (e.g. newer events).
+
+	// Case 1: List of 3 events from the APISever 2 of which have a RV superior to the one we have.
+	// Case 2: List of 3 events from the APISever all of which have a RV superior to the one we have.
+	// Case 3: List of 3 events from the APISever none of which have a RV superior to the one we have. (should not happen)
+	for n, tc := range []struct {
+		caseName   string
+		listEvents []v1.Event
+		resver     int
+		expected   []*v1.Event
+	}{
+
+		{
+			caseName: "2 new events",
+			listEvents: []v1.Event{{
+				Reason: "OOM",
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "43",
+				},
+			},
+				{
+					Reason: "Create",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "52",
+					},
+				},
+				{
+					Reason: "Scheduled",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "21",
+					},
+				},
+			},
+			resver: 22,
+			expected: []*v1.Event{{
+				Reason: "OOM",
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "43",
+				},
+			},
+				{
+					Reason: "Create",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "52",
+					},
+				},
+			},
+		},
+		{
+			caseName: "all new events",
+			listEvents: []v1.Event{{
+				Reason: "OOM",
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "43",
+				},
+			},
+				{
+					Reason: "Create",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "52",
+					},
+				},
+				{
+					Reason: "Scheduled",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "21",
+					},
+				},
+			},
+			resver: 15,
+			expected: []*v1.Event{{
+				Reason: "OOM",
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "43",
+				},
+			},
+				{
+					Reason: "Create",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "52",
+					},
+				},
+				{
+					Reason: "Scheduled",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "21",
+					},
+				},
+			},
+		},
+		{
+			caseName: "no new events",
+			listEvents: []v1.Event{{
+				Reason: "OOM",
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "43",
+				},
+			},
+				{
+					Reason: "Create",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "52",
+					},
+				},
+				{
+					Reason: "Scheduled",
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "21",
+					},
+				},
+			},
+			resver:   52,
+			expected: []*v1.Event{},
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", n, tc.caseName), func(t *testing.T) {
+			diffList := diffEvents(tc.resver, tc.listEvents)
+			assert.Equal(t, len(tc.expected), len(diffList))
+		})
+	}
+}

--- a/pkg/util/kubernetes/apiserver/events_test.go
+++ b/pkg/util/kubernetes/apiserver/events_test.go
@@ -10,7 +10,7 @@ package apiserver
 import (
 	"fmt"
 	"testing"
-	
+
 	"github.com/magiconair/properties/assert"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/releasenotes/notes/fix-kubernetes-events-078fc86a33a98255.yaml
+++ b/releasenotes/notes/fix-kubernetes-events-078fc86a33a98255.yaml
@@ -1,0 +1,16 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allow filtering of event types,reason and kind at query time.
+    Make the event limit configurable.
+    Improve the interaction with the ConfigMap to store the Resource Version.
+fixes:
+  - |
+    Do not permit sending events at their first timestamp.

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -77,7 +77,7 @@ func (suite *testSuite) SetupTest() {
 			}
 			// Confirm that we can query the kube-apiserver's resources
 			log.Debugf("trying to get LatestEvents")
-			_, err := suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
+			_, _, _, err := suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
 			if err == nil {
 				log.Debugf("successfully get LatestEvents: %s", resVer)
 				return
@@ -103,7 +103,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NotNil(suite.T(), core)
 
 	// Ignore potential startup events
-	_, err = suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
+	_, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 
 	// Create started event
@@ -113,7 +113,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the new started event
-	added, err := suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
+	added, resVer, lastList, err := suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 1)
 	assert.Equal(suite.T(), "started", added[0].Reason)
@@ -124,7 +124,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the new tick event
-	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
+	added, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 1)
 	assert.Equal(suite.T(), "tick", added[0].Reason)
@@ -143,7 +143,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the two modified test events
-	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
+	added, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 2)
 	assert.Equal(suite.T(), "tick", added[0].Reason)
@@ -152,7 +152,7 @@ func (suite *testSuite) TestKubeEvents() {
 	assert.EqualValues(suite.T(), 3, added[1].Count)
 
 	// We should get nothing new now
-	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
+	added, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 0)
 }

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -60,9 +60,9 @@ func TestSuiteKube(t *testing.T) {
 func (suite *testSuite) SetupTest() {
 	var err error
 	resVer := ""
-	eventReadTimeout := int64(5)
+	eventReadTimeout := int64(1)
 	lastList := time.Now()
-	tick := time.NewTicker(time.Millisecond * 500)
+	tick := time.NewTicker(time.Millisecond * 100)
 	timeout := time.NewTicker(setupTimeout)
 	for {
 		select {
@@ -90,7 +90,7 @@ func (suite *testSuite) SetupTest() {
 func (suite *testSuite) TestKubeEvents() {
 	mockConfig := config.Mock()
 	resVer := ""
-	eventReadTimeout := int64(5)
+	eventReadTimeout := int64(1)
 	lastList := time.Now()
 
 	// Init own client to write the events

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -77,7 +77,7 @@ func (suite *testSuite) SetupTest() {
 			}
 			// Confirm that we can query the kube-apiserver's resources
 			log.Debugf("trying to get LatestEvents")
-			_, _, _, err := suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
+			_, resVer, _, err := suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, 300, "")
 			if err == nil {
 				log.Debugf("successfully get LatestEvents: %s", resVer)
 				return
@@ -103,7 +103,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NotNil(suite.T(), core)
 
 	// Ignore potential startup events
-	_, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
+	_, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, 300, "")
 	require.NoError(suite.T(), err)
 
 	// Create started event
@@ -113,7 +113,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the new started event
-	added, resVer, lastList, err := suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
+	added, resVer, lastList, err := suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, 300, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 1)
 	assert.Equal(suite.T(), "started", added[0].Reason)
@@ -124,7 +124,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the new tick event
-	added, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
+	added, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, 300, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 1)
 	assert.Equal(suite.T(), "tick", added[0].Reason)
@@ -143,7 +143,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the two modified test events
-	added, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
+	added, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, 300, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 2)
 	assert.Equal(suite.T(), "tick", added[0].Reason)
@@ -152,7 +152,7 @@ func (suite *testSuite) TestKubeEvents() {
 	assert.EqualValues(suite.T(), 3, added[1].Count)
 
 	// We should get nothing new now
-	added, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, "")
+	added, resVer, lastList, err = suite.apiClient.RunEventCollection(resVer, lastList, eventReadTimeout, 100, 300, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 0)
 }

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	setupTimeout     = 10 * time.Second
-	eventReadTimeout = 500 * time.Millisecond
+	setupTimeout = 10 * time.Second
 )
 
 type testSuite struct {
@@ -60,7 +59,9 @@ func TestSuiteKube(t *testing.T) {
 
 func (suite *testSuite) SetupTest() {
 	var err error
-
+	resVer := ""
+	eventReadTimeout := int64(5)
+	lastList := time.Now()
 	tick := time.NewTicker(time.Millisecond * 500)
 	timeout := time.NewTicker(setupTimeout)
 	for {
@@ -76,9 +77,9 @@ func (suite *testSuite) SetupTest() {
 			}
 			// Confirm that we can query the kube-apiserver's resources
 			log.Debugf("trying to get LatestEvents")
-			_, _, resV, err := suite.apiClient.LatestEvents("0", eventReadTimeout)
+			_, err := suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
 			if err == nil {
-				log.Debugf("successfully get LatestEvents: %s", resV)
+				log.Debugf("successfully get LatestEvents: %s", resVer)
 				return
 			}
 			log.Debugf("cannot get LatestEvents: %s", err)
@@ -88,6 +89,9 @@ func (suite *testSuite) SetupTest() {
 
 func (suite *testSuite) TestKubeEvents() {
 	mockConfig := config.Mock()
+	resVer := ""
+	eventReadTimeout := int64(5)
+	lastList := time.Now()
 
 	// Init own client to write the events
 	mockConfig.Set("kubernetes_kubeconfig_path", suite.kubeConfigPath)
@@ -99,7 +103,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NotNil(suite.T(), core)
 
 	// Ignore potential startup events
-	_, _, initresversion, err := suite.apiClient.LatestEvents("0", eventReadTimeout)
+	_, err = suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 
 	// Create started event
@@ -109,10 +113,9 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the new started event
-	added, modified, resversion, err := suite.apiClient.LatestEvents(initresversion, eventReadTimeout)
+	added, err := suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 1)
-	assert.Len(suite.T(), modified, 0)
 	assert.Equal(suite.T(), "started", added[0].Reason)
 
 	// Create tick event
@@ -121,10 +124,9 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the new tick event
-	added, modified, resversion, err = suite.apiClient.LatestEvents(resversion, eventReadTimeout)
+	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 1)
-	assert.Len(suite.T(), modified, 0)
 	assert.Equal(suite.T(), "tick", added[0].Reason)
 
 	// Update tick event
@@ -141,28 +143,18 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the two modified test events
-	added, modified, resversion, err = suite.apiClient.LatestEvents(resversion, eventReadTimeout)
-	require.NoError(suite.T(), err)
-	assert.Len(suite.T(), added, 0)
-	assert.Len(suite.T(), modified, 2)
-	assert.Equal(suite.T(), "tick", modified[0].Reason)
-	assert.EqualValues(suite.T(), 2, modified[0].Count)
-	assert.Equal(suite.T(), "tick", modified[1].Reason)
-	assert.EqualValues(suite.T(), 3, modified[1].Count)
-	assert.EqualValues(suite.T(), modified[0].InvolvedObject.UID, modified[1].InvolvedObject.UID)
-
-	// We should get nothing new now
-	added, modified, resversion, err = suite.apiClient.LatestEvents(resversion, eventReadTimeout)
-	require.NoError(suite.T(), err)
-	assert.Len(suite.T(), added, 0)
-	assert.Len(suite.T(), modified, 0)
-
-	// We should get 2+0 events from initresversion
-	// apiserver does not send updates to objects if the add is in the same bucket
-	added, modified, _, err = suite.apiClient.LatestEvents(initresversion, eventReadTimeout)
+	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 2)
-	assert.Len(suite.T(), modified, 0)
+	assert.Equal(suite.T(), "tick", added[0].Reason)
+	assert.EqualValues(suite.T(), 2, added[0].Count)
+	assert.Equal(suite.T(), "tick", added[1].Reason)
+	assert.EqualValues(suite.T(), 3, added[1].Count)
+
+	// We should get nothing new now
+	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
+	require.NoError(suite.T(), err)
+	assert.Len(suite.T(), added, 0)
 }
 
 func (suite *testSuite) TestHostnameProvider() {

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -77,7 +77,7 @@ func (suite *testSuite) SetupTest() {
 			}
 			// Confirm that we can query the kube-apiserver's resources
 			log.Debugf("trying to get LatestEvents")
-			_, err := suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
+			_, err := suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
 			if err == nil {
 				log.Debugf("successfully get LatestEvents: %s", resVer)
 				return
@@ -103,7 +103,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NotNil(suite.T(), core)
 
 	// Ignore potential startup events
-	_, err = suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
+	_, err = suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 
 	// Create started event
@@ -113,7 +113,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the new started event
-	added, err := suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
+	added, err := suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 1)
 	assert.Equal(suite.T(), "started", added[0].Reason)
@@ -124,7 +124,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the new tick event
-	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
+	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 1)
 	assert.Equal(suite.T(), "tick", added[0].Reason)
@@ -143,7 +143,7 @@ func (suite *testSuite) TestKubeEvents() {
 	require.NoError(suite.T(), err)
 
 	// Test we get the two modified test events
-	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
+	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 2)
 	assert.Equal(suite.T(), "tick", added[0].Reason)
@@ -152,7 +152,7 @@ func (suite *testSuite) TestKubeEvents() {
 	assert.EqualValues(suite.T(), 3, added[1].Count)
 
 	// We should get nothing new now
-	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, &eventReadTimeout, 100, "")
+	added, err = suite.apiClient.RunEventCollection(&resVer, &lastList, eventReadTimeout, 100, "")
 	require.NoError(suite.T(), err)
 	assert.Len(suite.T(), added, 0)
 }


### PR DESCRIPTION
### What does this PR do?

This is the first large change to refactor and improve the Kubernetes Events collection.
As part of the kube_apiserver check, we collect kubernetes events.
The loop now is similar to the informer framework (we list and watch onwards using the resource version). We store the resource version in a configmap.

- [x] Add a flag to skip the leader election check, allowing this check to be scheduled as a Cluster Check
- [x] Use a List/Watch framework to resync and only collect what is new
- [x] Do not submit events with their firstTimestamp (initial goal of this PR)
- [x] Allow to getOrCreate the configmap (could cause issues if the CM is not created and the agent restart).
- [x] Clean up all the process (remove the GOTO, unecessary discrimination between Added and Modified events...)
- [x] Modify the filter_event option to filter at query time instead of post collection
- [x] Add an option to limit the cardinality of events collected for each check run.

### Motivation

Improve the Event Collection

### Additional Notes

Anything else we should know when reviewing?
