### PR TITLE
Remove Windows executables in Linux packages

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -271,5 +271,4 @@ build do
   # Used by the `datadog-agent integration` command to prevent downgrading a check to a version
   # older than the one shipped in the agent
   copy "#{project_dir}/requirements-agent-release.txt", "#{install_dir}/"
-
 end

--- a/omnibus/config/software/pip2.rb
+++ b/omnibus/config/software/pip2.rb
@@ -24,4 +24,10 @@ build do
   end
 
   command "#{python_bin} setup.py install --prefix=#{python_prefix}"
+
+  if ohai["platform"] != "windows"
+    block do
+      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/site-packages/pip-19.0.3-py2.7.egg/pip/_vendor/distlib/*.exe"))
+    end
+  end
 end

--- a/omnibus/config/software/pip2.rb
+++ b/omnibus/config/software/pip2.rb
@@ -27,7 +27,7 @@ build do
 
   if ohai["platform"] != "windows"
     block do
-      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/site-packages/pip-19.0.3-py2.7.egg/pip/_vendor/distlib/*.exe"))
+      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/site-packages/pip-*-py2.7.egg/pip/_vendor/distlib/*.exe"))
     end
   end
 end

--- a/omnibus/config/software/pip3.rb
+++ b/omnibus/config/software/pip3.rb
@@ -22,4 +22,11 @@ build do
   end
 
   command "#{python_bin} setup.py install --prefix=#{python_prefix}"
+
+  if ohai["platform"] != "windows"
+    block do
+      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python3.*/site-packages/pip-19.0.3-py3.*.egg/pip/_vendor/distlib/*.exe"))
+      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python3.*/site-packages/pip/_vendor/distlib/*.exe"))
+    end
+  end
 end

--- a/omnibus/config/software/pip3.rb
+++ b/omnibus/config/software/pip3.rb
@@ -25,7 +25,7 @@ build do
 
   if ohai["platform"] != "windows"
     block do
-      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python3.*/site-packages/pip-19.0.3-py3.*.egg/pip/_vendor/distlib/*.exe"))
+      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python3.*/site-packages/pip-*-py3.*.egg/pip/_vendor/distlib/*.exe"))
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python3.*/site-packages/pip/_vendor/distlib/*.exe"))
     end
   end

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -67,6 +67,7 @@ if ohai["platform"] != "windows"
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/lib-dynload/readline.*"))
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/lib-dynload/gdbm.so"))
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/lib-dynload/dbm.so"))
+      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/distutils/command/wininst-*.exe"))
     end
   end
 

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -54,6 +54,7 @@ if ohai["platform"] != "windows"
     major, minor, bugfix = version.split(".")
     block do
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python#{major}.#{minor}/lib-dynload/readline.*"))
+      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python#{major}.#{minor}/distutils/command/wininst-*.exe"))
     end
   end
 

--- a/omnibus/config/software/setuptools3.rb
+++ b/omnibus/config/software/setuptools3.rb
@@ -22,4 +22,10 @@ build do
   ship_license "PSFL"
   command "#{python_bin} bootstrap.py"
   command "#{python_bin} setup.py install --prefix=#{python_prefix}"
+
+  if ohai["platform"] != "windows"
+    block do
+      FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python3.*/site-packages/setuptools/*.exe"))
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?

On Linux, removes `.exe` files shipped by default by some dependencies.

### Motivation

Package cleanup.

### Additional Notes

Cleanup was done at the software definition level, not at the project level, because each software definition should clean up its own artifacts.