### PR TITLE
add logic to include system-probe.yaml into flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -400,7 +400,7 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths, perms
 		// and use best effort to include system-probe.yaml to the flare
 		systemProbePath := getSystemProbePath(filePath)
 		if systemErr := createConfigFiles(systemProbePath, tempDir, hostname, permsInfos); systemErr != nil {
-			log.Errorf("error happened while zipping system-probe.yaml: %s", systemErr)
+			log.Warnf("could not zip system-probe.yaml: %s", systemErr)
 		}
 	}
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -400,7 +400,7 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths, perms
 		// and use best effort to include system-probe.yaml to the flare
 		systemProbePath := getSystemProbePath(filePath)
 		if systemErr := createConfigFiles(systemProbePath, tempDir, hostname, permsInfos); systemErr != nil {
-			log.Warnf("could not zip system-probe.yaml: %s", systemErr)
+			log.Warnf("could not zip system-probe.yaml, system-probe might not be configured, or is in a different directory with datadog.yaml: %s", systemErr)
 		}
 	}
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -407,34 +407,6 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths, perms
 	return err
 }
 
-func createConfigFiles(filePath, tempDir, hostname string, permsInfos permissionsInfos) error {
-	// Check if the file exists
-	_, err := os.Stat(filePath)
-	if err == nil {
-		f := filepath.Join(tempDir, hostname, "etc", filepath.Base(filePath))
-		err := ensureParentDirsExist(f)
-		if err != nil {
-			return err
-		}
-
-		w, err := newRedactingWriter(f, os.ModePerm, true)
-		if err != nil {
-			return err
-		}
-		defer w.Close()
-
-		_, err = w.WriteFromFile(filePath)
-		if err != nil {
-			return err
-		}
-
-		if permsInfos != nil {
-			permsInfos.add(filePath)
-		}
-	}
-	return nil
-}
-
 func zipSecrets(tempDir, hostname string) error {
 	var b bytes.Buffer
 
@@ -670,8 +642,38 @@ func cleanDirectoryName(name string) string {
 	return filteredName
 }
 
-// getSystemProbePath would take the path to datadog-agent.yaml and replace the file name with system-probe.yaml
-func getSystemProbePath(filePath string) string {
-	path := filepath.Dir(filePath)
+// createConfigFiles takes the content of config files that need to be included in the flare and
+// put them in the directory waiting to be archived
+func createConfigFiles(filePath, tempDir, hostname string, permsInfos permissionsInfos) error {
+	// Check if the file exists
+	_, err := os.Stat(filePath)
+	if err == nil {
+		f := filepath.Join(tempDir, hostname, "etc", filepath.Base(filePath))
+		err := ensureParentDirsExist(f)
+		if err != nil {
+			return err
+		}
+
+		w, err := newRedactingWriter(f, os.ModePerm, true)
+		if err != nil {
+			return err
+		}
+		defer w.Close()
+
+		_, err = w.WriteFromFile(filePath)
+		if err != nil {
+			return err
+		}
+
+		if permsInfos != nil {
+			permsInfos.add(filePath)
+		}
+	}
+	return nil
+}
+
+// getSystemProbePath would take the path to datadog.yaml and replace the file name with system-probe.yaml
+func getSystemProbePath(ddCfgFilePath string) string {
+	path := filepath.Dir(ddCfgFilePath)
 	return filepath.Join(path, "system-probe.yaml")
 }

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -148,6 +148,11 @@ func TestZipConfigCheck(t *testing.T) {
 func TestIncludeSystemProbeConfig(t *testing.T) {
 	assert := assert.New(t)
 	common.SetupConfig("./test/datadog-agent.yaml")
+	// create system-probe.yaml file because it's in .gitignore
+	_, err := os.Create("./test/system-probe.yaml")
+	assert.NoError(err, "couldn't create system-probe.yaml")
+	defer os.Remove("./test/system-probe.yaml")
+
 	zipFilePath := getArchivePath()
 	filePath, err := createArchive(zipFilePath, true, SearchPaths{"": "./test/confd"}, "")
 	assert.NoError(err)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -145,6 +145,33 @@ func TestZipConfigCheck(t *testing.T) {
 	assert.NotContains(t, string(content), "MySecurePass")
 }
 
+func TestIncludeSystemProbeConfig(t *testing.T) {
+	assert := assert.New(t)
+	common.SetupConfig("./test/datadog-agent.yaml")
+	zipFilePath := getArchivePath()
+	filePath, err := createArchive(zipFilePath, true, SearchPaths{"": "./test/confd"}, "")
+	assert.NoError(err)
+	assert.Equal(zipFilePath, filePath)
+
+	defer os.Remove(zipFilePath)
+
+	z, err := zip.OpenReader(zipFilePath)
+	assert.NoError(err, "opening the zip shouldn't pop an error")
+
+	var hasDDConfig, hasSysProbeConfig bool
+	for _, f := range z.File {
+		if strings.HasSuffix(f.Name, "datadog-agent.yaml") {
+			hasDDConfig = true
+		}
+		if strings.HasSuffix(f.Name, "system-probe.yaml") {
+			hasSysProbeConfig = true
+		}
+	}
+
+	assert.True(hasDDConfig, "datadog-agent.yaml should've been included")
+	assert.True(hasSysProbeConfig, "system-probe.yaml should've been included")
+}
+
 func TestIncludeConfigFiles(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
### What does this PR do?

For current datadog-agent flare we don't get `system-probe.yaml` file. This PR adds the logic to do "best effort" to include the config file. The process assumes that `system-probe.yaml` lives side by side with `datadog.yaml`, which is already the default setup. 

The "best effort" is used because the main agent is not aware of the existence of `system-probe.yaml`, so there's no way to take the content programatically. I made it so that if we failed to detect system-probe.yaml file, just log a warning and move on without returning the error.

cc: @DataDog/burrito 

### Motivation

system-probe.yaml file missing in flare.

### Additional Notes

Anything else we should know when reviewing?
