### PR TITLE
Do not log an error if util.GetContainers() returns a detector error

### DIFF
--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -63,7 +63,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	start := time.Now()
 	ctrList, err := util.GetContainers()
 	if err != nil {
-		if err == containercollectors.ErrPermaFai || err == containercollectors.ErrNothingYet {
+		if err == containercollectors.ErrPermaFail || err == containercollectors.ErrNothingYet {
 			log.Debug("container collector was not detected, container check will not return any data")
 			return nil, nil
 		}

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -7,17 +7,17 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/tagger"
-	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
-	agentutil "github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
-	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	agentutil "github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	containercollectors "github.com/DataDog/datadog-agent/pkg/util/containers/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Container is a singleton ContainerCheck.
@@ -63,6 +63,10 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	start := time.Now()
 	ctrList, err := util.GetContainers()
 	if err != nil {
+		if err == containercollectors.ErrPermaFai || err == containercollectors.ErrNothingYet {
+			log.Debug("container collector was not detected, container check will not return any data")
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -68,7 +68,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	ctrList, err := util.GetContainers()
 	if err != nil {
 		if err == containercollectors.ErrPermaFail || err == containercollectors.ErrNothingYet && c.containerFailedLogLimit.ShouldLog() {
-			log.Debug("container collector was not detected, container check will not return any data. This message will logged for the first ten occurences, and then every ten minutes")
+			log.Debug("container collector was not detected, container check will not return any data. This message will logged for the first ten occurrences, and then every ten minutes")
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -43,7 +43,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	ctrList, err := util.GetContainers()
 
 	if err == containercollectors.ErrPermaFail || err == containercollectors.ErrNothingYet {
-		log.Debug("container collector was not detected, container check will not return any data")
+		log.Trace("container collector was not detected, container check will not return any data")
 		return nil, nil
 	}
 

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -42,7 +42,7 @@ func (r *RTContainerCheck) RealTime() bool { return true }
 func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
 	ctrList, err := util.GetContainers()
 
-	if err == containercollectors.ErrPermaFai || err == containercollectors.ErrNothingYet {
+	if err == containercollectors.ErrPermaFail || err == containercollectors.ErrNothingYet {
 		log.Debug("container collector was not detected, container check will not return any data")
 		return nil, nil
 	}

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	containercollectors "github.com/DataDog/datadog-agent/pkg/util/containers/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // RTContainer is a singleton RTContainerCheck.

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -6,11 +6,11 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
-
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	containercollectors "github.com/DataDog/datadog-agent/pkg/util/containers/collectors"
 )
 
 // RTContainer is a singleton RTContainerCheck.
@@ -40,6 +40,12 @@ func (r *RTContainerCheck) RealTime() bool { return true }
 // Run runs the real-time container check getting container-level stats from the Cgroups and Docker APIs.
 func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
 	ctrList, err := util.GetContainers()
+
+	if err == containercollectors.ErrPermaFai || err == containercollectors.ErrNothingYet {
+		log.Debug("container collector was not detected, container check will not return any data")
+		return nil, nil
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

We recently changed the container collector to be on, even if containers could not be detected at startup. The container check logs an error if container backends are not detected. Now that the container collector is enabled more frequently, we have seen the errors logged more frequently.

This PR changes both the container and container_rt check to detect and discard detector errors.
 
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
