### PR TITLE
Fix race in docker config provider initialization

### DIFF
--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -57,7 +57,6 @@ func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 		if err != nil {
 			return []integration.Config{}, err
 		}
-		go d.listen()
 	}
 
 	var containers map[string]map[string]string
@@ -78,6 +77,9 @@ func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 	d.syncCounter += 1
 	d.upToDate = true
 	d.Unlock()
+
+	// start listening after the first collection to avoid race in cache map init
+	go d.listen()
 
 	return parseDockerLabels(containers)
 }

--- a/releasenotes/notes/fix-docker-crash-d18d71e7b79c34bd.yaml
+++ b/releasenotes/notes/fix-docker-crash-d18d71e7b79c34bd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug where the agent would crash when using the docker autodiscovery config provider.


### PR DESCRIPTION
### What does this PR do?

Fix a possible race between the first run and the goroutine in the docker config provider.

### Motivation

Fix #4236

### Additional Notes

Anything else we should know when reviewing?
