### PR TITLE
[logs] Make linger time configurable for HTTP endpoints

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,9 @@ const (
 	DefaultForwarderRecoveryInterval = 2
 
 	megaByte = 1024 * 1024
+
+	// DefaultBatchPeriodInS is the default HTTP batch period in second for logs
+	DefaultBatchPeriodInS = 5
 )
 
 var overrideVars = map[string]interface{}{}
@@ -398,6 +401,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.use_http", false)
 	config.BindEnvAndSetDefault("logs_config.use_compression", false)
 	config.BindEnvAndSetDefault("logs_config.compression_level", 6) // Default level for the gzip/deflate algorithm
+	config.BindEnvAndSetDefault("logs_config.batch_period_in_s", DefaultBatchPeriodInS)
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -87,7 +87,7 @@ func (suite *AgentTestSuite) TestAgent() {
 	defer l.Close()
 
 	endpoint := tcp.AddrToEndPoint(l.Addr())
-	endpoints := config.NewEndpoints(endpoint, nil, true, false)
+	endpoints := config.NewEndpoints(endpoint, nil, true, false, 0)
 
 	agent, sources, _ := createAgent(endpoints)
 
@@ -116,7 +116,7 @@ func (suite *AgentTestSuite) TestAgent() {
 
 func (suite *AgentTestSuite) TestAgentStopsWithWrongBackend() {
 	endpoint := config.Endpoint{Host: "fake:", Port: 0}
-	endpoints := config.NewEndpoints(endpoint, nil, true, false)
+	endpoints := config.NewEndpoints(endpoint, nil, true, false, 0)
 
 	agent, sources, _ := createAgent(endpoints)
 
@@ -140,7 +140,7 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongAdditionalBackend() {
 	endpoint := tcp.AddrToEndPoint(l.Addr())
 	additionalEndpoint := config.Endpoint{Host: "still_fake", Port: 0}
 
-	endpoints := config.NewEndpoints(endpoint, []config.Endpoint{additionalEndpoint}, true, false)
+	endpoints := config.NewEndpoints(endpoint, []config.Endpoint{additionalEndpoint}, true, false, 0)
 
 	agent, sources, _ := createAgent(endpoints)
 

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -5,6 +5,10 @@
 
 package config
 
+import (
+	"time"
+)
+
 // Endpoint holds all the organization and network parameters to send logs to Datadog.
 type Endpoint struct {
 	APIKey           string `mapstructure:"api_key"`
@@ -22,14 +26,16 @@ type Endpoints struct {
 	Additionals []Endpoint
 	UseProto    bool
 	UseHTTP     bool
+	BatchPeriod time.Duration
 }
 
 // NewEndpoints returns a new endpoints composite.
-func NewEndpoints(main Endpoint, additionals []Endpoint, useProto bool, useHTTP bool) *Endpoints {
+func NewEndpoints(main Endpoint, additionals []Endpoint, useProto bool, useHTTP bool, batchPeriod time.Duration) *Endpoints {
 	return &Endpoints{
 		Main:        main,
 		Additionals: additionals,
 		UseProto:    useProto,
 		UseHTTP:     useHTTP,
+		BatchPeriod: batchPeriod,
 	}
 }

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -123,6 +124,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	endpoints, err = BuildEndpoints()
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
+	suite.Equal(endpoints.BatchPeriod, 5*time.Second)
 
 	endpoint = endpoints.Main
 	suite.True(endpoint.UseSSL)
@@ -171,10 +173,12 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 
 	suite.config.Set("logs_config.use_http", true)
 	suite.config.Set("logs_config.dd_url", "foo")
+	suite.config.Set("logs_config.batch_period_in_s", 9)
 
 	endpoints, err = BuildEndpoints()
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
+	suite.Equal(endpoints.BatchPeriod, 9*time.Second)
 
 	endpoint = endpoints.Main
 	suite.True(endpoint.UseSSL)
@@ -214,11 +218,22 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFailWithInvalidOverride
 		"host:foo",
 		"host",
 	}
-
 	for _, url := range invalidURLs {
 		suite.config.Set("logs_config.logs_dd_url", url)
 		_, err := BuildEndpoints()
 		suite.NotNil(err)
+	}
+}
+
+func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFallbackOnDefaultWithInvalidBatchPeriod() {
+	suite.config.Set("logs_config.use_http", true)
+
+	invalidBatchPeriods := []int{-1, 0, 11}
+	for _, batchPeriod := range invalidBatchPeriods {
+		suite.config.Set("logs_config.batch_period_in_s", batchPeriod)
+		endpoints, err := BuildEndpoints()
+		suite.Nil(err)
+		suite.Equal(endpoints.BatchPeriod, coreConfig.DefaultBatchPeriodInS*time.Second)
 	}
 }
 

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -45,7 +45,7 @@ func NewPipeline(outputChan chan *message.Message, processingRules []*config.Pro
 
 	var strategy sender.Strategy
 	if endpoints.UseHTTP {
-		strategy = sender.NewBatchStrategy(sender.ArraySerializer)
+		strategy = sender.NewBatchStrategy(sender.ArraySerializer, endpoints.BatchPeriod)
 	} else {
 		strategy = sender.StreamStrategy
 	}

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -28,7 +28,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 		numberOfPipelines: 3,
 		auditor:           suite.a,
 		pipelines:         []*Pipeline{},
-		endpoints:         config.NewEndpoints(config.Endpoint{}, nil, true, false),
+		endpoints:         config.NewEndpoints(config.Endpoint{}, nil, true, false, 0),
 	}
 }
 

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -15,30 +15,29 @@ import (
 )
 
 const (
-	batchTimeout   = 5 * time.Second
 	maxBatchSize   = 200
 	maxContentSize = 1000000
 )
 
 // batchStrategy contains all the logic to send logs in batch.
 type batchStrategy struct {
-	buffer       *MessageBuffer
-	serializer   Serializer
-	batchTimeout time.Duration
+	buffer      *MessageBuffer
+	serializer  Serializer
+	batchPeriod time.Duration
 }
 
 // NewBatchStrategy returns a new batchStrategy.
-func NewBatchStrategy(serializer Serializer) Strategy {
+func NewBatchStrategy(serializer Serializer, batchPeriod time.Duration) Strategy {
 	return &batchStrategy{
-		buffer:       NewMessageBuffer(maxBatchSize, maxContentSize),
-		serializer:   serializer,
-		batchTimeout: batchTimeout,
+		buffer:      NewMessageBuffer(maxBatchSize, maxContentSize),
+		serializer:  serializer,
+		batchPeriod: batchPeriod,
 	}
 }
 
 // Send accumulates messages to a buffer and sends them when the buffer is full or outdated.
 func (s *batchStrategy) Send(inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error) {
-	flushTimer := time.NewTimer(s.batchTimeout)
+	flushTimer := time.NewTimer(s.batchPeriod)
 	defer func() {
 		flushTimer.Stop()
 	}()
@@ -63,7 +62,7 @@ func (s *batchStrategy) Send(inputChan chan *message.Message, outputChan chan *m
 					}
 				}
 				s.sendBuffer(outputChan, send)
-				flushTimer.Reset(s.batchTimeout)
+				flushTimer.Reset(s.batchPeriod)
 			}
 			if !added {
 				// it's possible that the message could not be added because the buffer was full
@@ -74,7 +73,7 @@ func (s *batchStrategy) Send(inputChan chan *message.Message, outputChan chan *m
 			// the first message that was added to the buffer has been here for too long,
 			// send the payload now
 			s.sendBuffer(outputChan, send)
-			flushTimer.Reset(s.batchTimeout)
+			flushTimer.Reset(s.batchPeriod)
 		}
 	}
 }

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 // newBatchStrategyWithLimits returns a new batchStrategy.
-func newBatchStrategyWithLimits(serializer Serializer, batchSize int, contentSize int, timeout time.Duration) Strategy {
+func newBatchStrategyWithLimits(serializer Serializer, batchSize int, contentSize int, batchPeriod time.Duration) Strategy {
 	return &batchStrategy{
-		buffer:       NewMessageBuffer(batchSize, contentSize),
-		serializer:   serializer,
-		batchTimeout: timeout,
+		buffer:      NewMessageBuffer(batchSize, contentSize),
+		serializer:  serializer,
+		batchPeriod: batchPeriod,
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Make linger time configurable for HTTP endpoints.
The value should be in [1s:10s].

### Motivation

The goal is to allow the user to tweak the tradeoff latency/efficiency.

### Additional Notes

Anything else we should know when reviewing?
