### PR TITLE
clamp kernel blacklist for system-probe

### DIFF
--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -36,7 +36,7 @@ var (
 
 func kernelCodeToString(code uint32) string {
 	// Kernel "a.b.c", the version number will be (a<<16 + b<<8 + c)
-	a, b, c := code>>16, code>>8&0xf, code&0xf
+	a, b, c := code>>16, code>>8&0xff, code&0xff
 	return fmt.Sprintf("%d.%d.%d", a, b, c)
 }
 
@@ -85,13 +85,10 @@ func verifyOSVersion(kernelCode uint32, platform string, exclusionList []string)
 		return true, ""
 	}
 
-	if isLinuxAWSUbuntu(platform) {
-		if kernelCode < linuxKernelVersionCode(4, 4, 128) {
-			return false, fmt.Sprintf("Known bug on %s, see: \n- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454\n- https://launchpad.net/ubuntu/xenial/+source/linux-aws/+changelog#linux-aws_4.4.0-1060.69", platform)
-		}
-	} else if isUbuntu(platform) {
-		if kernelCode >= linuxKernelVersionCode(4, 4, 119) && kernelCode <= linuxKernelVersionCode(4, 4, 126) {
-			return false, fmt.Sprintf("got ubuntu kernel %s with known bug on platform: %s, see: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCodeToString(kernelCode), platform)
+	// using eBPF causes kernel panic for linux kernel version 4.4.114 ~ 4.4.127
+	if isLinuxAWSUbuntu(platform) || isUbuntu(platform) {
+		if kernelCode >= linuxKernelVersionCode(4, 4, 114) && kernelCode <= linuxKernelVersionCode(4, 4, 127) {
+			return false, fmt.Sprintf("Known bug for kernel %s on platform %s, see: \n- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCodeToString(kernelCode), platform)
 		}
 	}
 

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -22,10 +22,22 @@ func TestLinuxKernelVersionCode(t *testing.T) {
 }
 
 func TestUbuntuKernelsNotSupported(t *testing.T) {
-	for i := uint32(114); i < 128; i++ {
+	for i := uint32(114); i < uint32(128); i++ {
 		ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "linux-4.4-with-ubuntu", nil)
 		assert.False(t, ok)
 		assert.NotEmpty(t, msg)
+	}
+
+	for i := uint32(100); i < uint32(114); i++ {
+		ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "linux-4.4-with-ubuntu", nil)
+		assert.True(t, ok)
+		assert.Empty(t, msg)
+	}
+
+	for i := uint32(128); i < uint32(255); i++ {
+		ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "linux-4.4-with-ubuntu", nil)
+		assert.True(t, ok)
+		assert.Empty(t, msg)
 	}
 }
 

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -15,19 +15,15 @@ func TestLinuxKernelVersionCode(t *testing.T) {
 	assert.Equal(t, stringToKernelCode("2.6.9"), uint32(132617))
 	assert.Equal(t, stringToKernelCode("3.2.12"), uint32(197132))
 	assert.Equal(t, stringToKernelCode("4.4.0"), uint32(263168))
+
+	assert.Equal(t, kernelCodeToString(uint32(132617)), "2.6.9")
+	assert.Equal(t, kernelCodeToString(uint32(197132)), "3.2.12")
+	assert.Equal(t, kernelCodeToString(uint32(263168)), "4.4.0")
 }
 
-func TestUbuntu44119NotSupported(t *testing.T) {
-	for i := uint32(119); i < 127; i++ {
+func TestUbuntuKernelsNotSupported(t *testing.T) {
+	for i := uint32(114); i < 128; i++ {
 		ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "linux-4.4-with-ubuntu", nil)
-		assert.False(t, ok)
-		assert.NotEmpty(t, msg)
-	}
-}
-
-func TestLinuxAWSPreceding441060NotSupported(t *testing.T) {
-	for i := uint32(120); i < 128; i++ {
-		ok, msg := verifyOSVersion(linuxKernelVersionCode(4, 4, i), "Linux-4.4.0-1060-aws-x86_64-with-Ubuntu-16.04-xenial", nil)
 		assert.False(t, ok)
 		assert.NotEmpty(t, msg)
 	}

--- a/tools/ebpf/dev_setup.sh
+++ b/tools/ebpf/dev_setup.sh
@@ -25,10 +25,10 @@ EOD
 vagrant up
 
 
-echo "installing tools (invoke, clang format, jq, vim)"
+echo "installing tools (invoke, clang format, jq, vim, python3dev)"
 cat <<EOD | vagrant ssh
 sudo apt-get update
-sudo apt-get install -y python-pip unzip curl jq vim clang-format --fix-missing
+sudo apt-get install -y python-pip unzip curl jq vim clang-format python3-dev libsystemd-dev --fix-missing
 sudo pip install invoke pyyaml
 EOD
 


### PR DESCRIPTION
### What does this PR do?

For some kernel versions, using eBPF on it could cause kernel panic. After some testings seems like only the main stream kernel versions between 4.4.114 ~ 4.4.127 have this problem. Earlier version would most likely not have this bug introduced, and it is fixed in later versions. 

#### method for testing
For testing we created a vagrant box using xenial, then manually upgrade the kernel by installing kernel-image using `apt-get install linux-image-4.4.0-xxx` following a reboot. What we care about is the mainstream linux kernel version that these VMs based on, which can be found using `cat /proc/version_signature`. 

Note that there are several upstream versions that have no corresponding ubuntu kernels in the blacklist, but we block them for safety reason.

There's plenty of details in the content of this card: https://trello.com/c/zum0I49T/2381-narrow-down-incompatible-ubuntu-and-linux-aws-kernel-versions-with-system-probe

Also fixed a bug in function `kernelCodeToString`.

Also add some packages needed for dev environment.

cc: @DataDog/burrito 

### Motivation

Clamp the range so we don't over block versions.

### Additional Notes

Anything else we should know when reviewing?
