### PR TITLE
Add inventory metadata collection

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -29,6 +29,8 @@ var (
 	listenerCandidateIntl = 30 * time.Second
 	acErrors              *expvar.Map
 	errorStats            = newAcErrorStats()
+
+	currentAC *AutoConfig
 )
 
 func init() {
@@ -82,7 +84,13 @@ func NewAutoConfig(scheduler *scheduler.MetaScheduler) *AutoConfig {
 	}
 	// We need to listen to the service channels before anything is sent to them
 	go ac.serviceListening()
+	currentAC = ac
 	return ac
+}
+
+// GetCurrentAutoConfig returns the latest AutoConfig created (we should only ever create one).
+func GetCurrentAutoConfig() *AutoConfig {
+	return currentAC
 }
 
 // serviceListening is the main management goroutine for services.

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -34,6 +34,10 @@ type Collector struct {
 	m sync.RWMutex
 }
 
+var (
+	currentCollector *Collector
+)
+
 // NewCollector create a Collector instance and sets up the Python Environment
 func NewCollector(paths ...string) *Collector {
 	run := runner.NewRunner()
@@ -65,7 +69,13 @@ func NewCollector(paths ...string) *Collector {
 	}
 
 	log.Debug("Collector up and running!")
+	currentCollector = c
 	return c
+}
+
+// GetCurrentCollector returns the latest Collector created (we should only ever create one).
+func GetCurrentCollector() *Collector {
+	return currentCollector
 }
 
 // Stop halts any component involved in running a Check and shuts down

--- a/pkg/metadata/helper.go
+++ b/pkg/metadata/helper.go
@@ -19,6 +19,10 @@ const (
 	agentChecksMetadataCollectorInterval = 600
 	// run the resources metadata collector every 300 seconds (5 minutes) by default, configurable
 	resourcesMetadataCollectorInterval = 300
+	// run the inventories metadata provider every 5 minutes
+	inventoriesMetadataCollectorInterval = 300
+	// run the inventories metadata collector interval minimum when configured through the configuration
+	inventoriesMetadataCollectorMinInterval = 300
 )
 
 type collector struct {
@@ -41,6 +45,11 @@ var (
 		"agent_checks": {os: "*", interval: agentChecksMetadataCollectorInterval * time.Second},
 		// We ignore resources error has it's not mandatory
 		"resources": {os: "linux", interval: resourcesMetadataCollectorInterval * time.Second, ignoreError: true},
+		"inventories": {
+			os:       "*",
+			interval: inventoriesMetadataCollectorInterval * time.Second,
+			min:      inventoriesMetadataCollectorMinInterval * time.Second,
+		},
 	}
 
 	// AllDefaultCollectors the names of all the available default collectors

--- a/pkg/metadata/host.go
+++ b/pkg/metadata/host.go
@@ -8,7 +8,7 @@ package metadata
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/metadata/v5"
+	v5 "github.com/DataDog/datadog-agent/pkg/metadata/v5"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
@@ -29,5 +29,5 @@ func (hp *HostCollector) Send(s *serializer.Serializer) error {
 }
 
 func init() {
-	catalog["host"] = new(HostCollector)
+	RegisterCollector("host", new(HostCollector))
 }

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -56,7 +56,7 @@ func TestGetPayload(t *testing.T) {
 	SetCheckMetadata("check1_instance1", "check_provided_key2", "Hi")
 	SetCheckMetadata("non_running_checkid", "check_provided_key1", "this should get deleted")
 
-	p := GetPayload(mockAutoConfig{}, mockCollector{})
+	p := GetPayload("testHostname", mockAutoConfig{}, mockCollector{})
 
 	assert.Equal(t, startNow, p.Timestamp)
 
@@ -91,7 +91,7 @@ func TestGetPayload(t *testing.T) {
 	startNow += 1000
 	SetCheckMetadata("check1_instance1", "check_provided_key1", 456)
 
-	p = GetPayload(mockAutoConfig{}, mockCollector{})
+	p = GetPayload("testHostname", mockAutoConfig{}, mockCollector{})
 
 	assert.Equal(t, startNow, p.Timestamp) //updated startNow is returned
 
@@ -124,6 +124,7 @@ func TestGetPayload(t *testing.T) {
 	assert.Nil(t, err)
 	jsonString := `
 	{
+		"hostname": "testHostname",
 		"timestamp": %v,
 		"check_metadata":
 		{

--- a/pkg/metadata/inventories/payload.go
+++ b/pkg/metadata/inventories/payload.go
@@ -25,6 +25,7 @@ type CheckInstanceMetadata map[string]interface{}
 
 // Payload handles the JSON unmarshalling of the metadata payload
 type Payload struct {
+	Hostname      string         `json:"hostname"`
 	Timestamp     int64          `json:"timestamp"`
 	CheckMetadata *CheckMetadata `json:"check_metadata"`
 	AgentMetadata *AgentMetadata `json:"agent_metadata"`

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package metadata
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
+	checkCollector "github.com/DataDog/datadog-agent/pkg/collector"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// InventoriesCollector fills and sends the inventory metadata payload
+type InventoriesCollector struct{}
+
+// Send collects the data needed and submits the payload
+func (hp *InventoriesCollector) Send(s *serializer.Serializer) error {
+	log.Errorf("Collecting inventories !")
+	ac := autodiscovery.GetCurrentAutoConfig()
+	coll := checkCollector.GetCurrentCollector()
+
+	hostname, err := util.GetHostname()
+	if err != nil {
+		return fmt.Errorf("unable to submit inventories metadata payload, no hostname: %s", err)
+	}
+
+	payload := inventories.GetPayload(hostname, ac, coll)
+	if err := s.SendMetadata(payload); err != nil {
+		return fmt.Errorf("unable to submit inventories metadata payload, %s", err)
+	}
+	return nil
+}
+
+func init() {
+	RegisterCollector("inventories", new(InventoriesCollector))
+}

--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -36,5 +36,5 @@ func (rp *ResourcesCollector) Send(s *serializer.Serializer) error {
 }
 
 func init() {
-	catalog["resources"] = new(ResourcesCollector)
+	RegisterCollector("resources", new(ResourcesCollector))
 }

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -270,7 +270,7 @@ func (s *Serializer) SendMetadata(m marshaler.Marshaler) error {
 		return fmt.Errorf("could not determine size of metadata payload: %s", err)
 	}
 
-	log.Debugf("Sending host metadata payload, content: %v", apiKeyRegExp.ReplaceAllString(string(payload), apiKeyReplacement))
+	log.Debugf("Sending metadata payload, content: %v", apiKeyRegExp.ReplaceAllString(string(payload), apiKeyReplacement))
 
 	if !smallEnough {
 		return fmt.Errorf("metadata payload was too big to send (%d bytes compressed), metadata payloads cannot be split", len(compressedPayload))
@@ -280,7 +280,7 @@ func (s *Serializer) SendMetadata(m marshaler.Marshaler) error {
 		return err
 	}
 
-	log.Infof("Sent host metadata payload, size (raw/compressed): %d/%d bytes.", len(payload), len(compressedPayload))
+	log.Infof("Sent metadata payload, size (raw/compressed): %d/%d bytes.", len(payload), len(compressedPayload))
 	return nil
 }
 

--- a/pkg/util/alibaba/alibaba.go
+++ b/pkg/util/alibaba/alibaba.go
@@ -12,12 +12,16 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 )
 
 // declare these as vars not const to ease testing
 var (
 	metadataURL = "http://100.100.100.200"
 	timeout     = 300 * time.Millisecond
+
+	// CloudProviderName contains the inventory name of for EC2
+	CloudProviderName = "Alibaba"
 )
 
 // GetHostAlias returns the VM ID from the Alibaba Metadata api
@@ -27,6 +31,9 @@ func GetHostAlias() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Alibaba HostAliases: unable to query metadata endpoint: %s", err)
 	}
+
+	// registering that we're running on alibaba
+	inventories.SetAgentMetadata(inventories.CloudProviderMetatadaName, CloudProviderName)
 	return res, err
 }
 

--- a/pkg/util/azure/azure.go
+++ b/pkg/util/azure/azure.go
@@ -14,12 +14,16 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 )
 
 // declare these as vars not const to ease testing
 var (
 	metadataURL = "http://169.254.169.254"
 	timeout     = 300 * time.Millisecond
+
+	// CloudProviderName contains the inventory name of for EC2
+	CloudProviderName = "Azure"
 )
 
 // GetHostAlias returns the VM ID from the Azure Metadata api
@@ -30,6 +34,8 @@ func GetHostAlias() (string, error) {
 		return "", fmt.Errorf("Azure HostAliases: unable to query metadata endpoint: %s", err)
 	}
 
+	// registering that we're running on Azure
+	inventories.SetAgentMetadata(inventories.CloudProviderMetatadaName, CloudProviderName)
 	return res, nil
 }
 

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 )
 
@@ -20,6 +21,9 @@ import (
 var (
 	metadataURL = "http://169.254.169.254/computeMetadata/v1"
 	timeout     = 300 * time.Millisecond
+
+	// CloudProviderName contains the inventory name of for EC2
+	CloudProviderName = "GCP"
 )
 
 type gceMetadata struct {
@@ -48,6 +52,9 @@ func GetHostname() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve hostname from GCE: %s", err)
 	}
+
+	// registering that we're running on GCP
+	inventories.SetAgentMetadata(inventories.CloudProviderMetatadaName, CloudProviderName)
 	return hostname, nil
 }
 

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -95,6 +96,11 @@ func Fqdn(hostname string) string {
 	return hostname
 }
 
+func setHostnameProvider(name string) {
+	hostnameProvider.Set(name)
+	inventories.SetAgentMetadata("hostname_source", name)
+}
+
 // GetHostname retrieve the host name for the Agent, trying to query these
 // environments/api, in order:
 // * GCE
@@ -117,7 +123,7 @@ func GetHostname() (string, error) {
 	err = ValidHostname(configName)
 	if err == nil {
 		cache.Cache.Set(cacheHostnameKey, configName, cache.NoExpiration)
-		hostnameProvider.Set("configuration")
+		setHostnameProvider("configuration")
 		return configName, err
 	}
 
@@ -140,7 +146,7 @@ func GetHostname() (string, error) {
 		gceName, err := getGCEHostname()
 		if err == nil {
 			cache.Cache.Set(cacheHostnameKey, gceName, cache.NoExpiration)
-			hostnameProvider.Set("gce")
+			setHostnameProvider("gce")
 			return gceName, err
 		}
 		expErr := new(expvar.String)
@@ -244,7 +250,7 @@ func GetHostname() (string, error) {
 	}
 
 	cache.Cache.Set(cacheHostnameKey, hostName, cache.NoExpiration)
-	hostnameProvider.Set(provider)
+	setHostnameProvider(provider)
 	if err != nil {
 		expErr := new(expvar.String)
 		expErr.Set(fmt.Sprintf(err.Error()))


### PR DESCRIPTION
### What does this PR do?

This PR send the inventory metadata payload every 5 minutes.

The paylaod now include checks information, `cloud_provider` and `hostname_source`.