### PR TITLE
Fixing status of DCA if the EMP is not enabled

### DIFF
--- a/pkg/clusteragent/custommetrics/status.go
+++ b/pkg/clusteragent/custommetrics/status.go
@@ -20,7 +20,7 @@ import (
 func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 	status := make(map[string]interface{})
 	if !config.Datadog.GetBool("external_metrics_provider.enabled") {
-		status["Disabled"] = "The external metrics provider is not enabled on the cluster-agent"
+		status["Disabled"] = "The external metrics provider is not enabled on the Cluster Agent"
 		return status
 	}
 	configMapName := GetConfigmapName()

--- a/pkg/status/dist/templates/custommetricsprovider.tmpl
+++ b/pkg/status/dist/templates/custommetricsprovider.tmpl
@@ -1,35 +1,34 @@
 Custom Metrics Server
 =====================
-  {{- if .custommetrics.Error }}
-  Error: {{ .custommetrics.Error }}
-  {{ else }}
   {{- if .custommetrics.Disabled }}
-  Disabled: {{ .custommetrics.Disabled }}
-  {{ else }}
-  ConfigMap name: {{ .custommetrics.Cmname }}
-  {{ if .custommetrics.StoreError }}
-  Error: {{ .custommetrics.StoreError }}
-  {{ else }}
-  External Metrics
-  ----------------
-    {{- if .custommetrics.External.ListError }}
-    Error: {{ .custommetrics.External.ListError }}
+    Status: {{ .custommetrics.Disabled }}
+    {{- if .custommetrics.Error }}
+    Error: {{ .custommetrics.Error }}
     {{ else }}
-    Total: {{ .custommetrics.External.Total }}
-    Valid: {{ .custommetrics.External.Valid }}
-    {{ range $metric := .custommetrics.External.Metrics }}
-    {{- range $name, $value := $metric }}
-    {{- if or (eq $name "hpa") (eq $name "labels") }}
-    {{$name}}:
-    {{- range $k, $v := $value }}
-    - {{$k}}: {{$v}}
-    {{- end -}}
-    {{else}}
-    {{$name}}: {{$value}}
+    ConfigMap name: {{ .custommetrics.Cmname }}
+    {{ if .custommetrics.StoreError }}
+    Error: {{ .custommetrics.StoreError }}
+    {{ else }}
+    External Metrics
+    ----------------
+      {{- if .custommetrics.External.ListError }}
+      Error: {{ .custommetrics.External.ListError }}
+      {{ else }}
+      Total: {{ .custommetrics.External.Total }}
+      Valid: {{ .custommetrics.External.Valid }}
+      {{- range $metric := .custommetrics.External.Metrics }}
+      {{- range $name, $value := $metric }}
+      {{- if or (eq $name "hpa") (eq $name "labels") }}
+      {{$name}}:
+      {{- range $k, $v := $value }}
+      - {{$k}}: {{$v}}
+      {{- end -}}
+      {{- else}}
+      {{$name}}: {{$value}}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
     {{- end }}
     {{- end }}
-    {{ end }}
-    {{- end }}
-  {{- end }}
-  {{- end }}
   {{- end }}

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -94,6 +94,8 @@ NOTE: Changes made to this template should be reflected on the following templat
 
   Custom Metrics Server
   =====================
+  {{- if .custommetrics.Disabled }}
+    Status: {{ .custommetrics.Disabled }}
     {{- if .custommetrics.Error }}
     Error: {{ .custommetrics.Error }}
     {{ else }}
@@ -123,6 +125,7 @@ NOTE: Changes made to this template should be reflected on the following templat
       {{- end }}
     {{- end }}
     {{- end }}
+  {{- end }}
 {{- end }}
 
 {{- if .clusterchecks }}


### PR DESCRIPTION
### What does this PR do?

If the External Metrics Provider is deactivated, the `agent status` page of the Cluster Agent will print:
```
  Custom Metrics Server
  =====================
    External Metrics
    ----------------
      Total:
      Valid:
```
This prints:
```
  Custom Metrics Server
  =====================
    Status: The external metrics provider is not enabled on the Cluster Agent
```

The status file in the flare was already correct.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
