### PR TITLE
Update pipeline to independently build A6 or A7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,28 +151,6 @@ before_script:
       - $RELEASE_VERSION_7 == ""
 
 #
-# Job conditions
-#
-
-# run job when building Datadog Cluster Agent release tag
-
-.run_on_cluster_agent_tag: &run_on_cluster_agent_tag
-  only:
-    refs:
-      - tags
-    variables:
-      - $CI_COMMIT_TAG =~ /^dca-([\d.-]|rc)+$/
-
-# skip job when building Datadog Cluster Agent release tag
-
-.skip_on_cluster_agent_tag: &skip_on_cluster_agent_tag
-  except:
-    refs:
-      - tags
-    variables:
-      - $CI_COMMIT_TAG =~ /^dca-([\d.-]|rc)+$/
-
-#
 # source_test
 #
 #
@@ -2162,26 +2140,6 @@ latest_release_7:
     - if [[ -z "$IMAGE" ]]; then echo "Need an image"; exit 1; fi
     - if [[ -z "$TAG" ]]; then echo "Need a tag to delete"; exit 1; fi
     - inv -e docker.delete ${ORGANIZATION} ${IMAGE} ${TAG} ${DOCKER_TOKEN} &>/dev/null
-
-dca_tag_release:
-  <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag_7
-  stage: deploy
-  when: manual
-  variables:
-    <<: *docker_hub_variables
-  script:
-    - inv -e docker.publish --signed-push ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent:${CI_COMMIT_TAG#$(echo "dca-")}
-
-dca_latest_release:
-  <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag_7
-  stage: deploy
-  when: manual
-  variables:
-    <<: *docker_hub_variables
-  script:
-    - inv -e docker.publish --signed-push ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent:latest
 
 # invalidate cloudfront cache
 deploy_cloudfront_invalidate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -644,7 +644,8 @@ agent_suse-x64-a7:
     - mkdir .omnibus\pkg
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  timeout: 2h 00m
+  # Unavailable on gitlab < 12.3
+  # timeout: 2h 00m
   script:
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat --release-version %RELEASE_VERSION%
     - copy build-out\*.msi .omnibus\pkg

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2160,7 +2160,7 @@ latest_release_7:
 
 dca_tag_release:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_7
   stage: deploy
   when: manual
   variables:
@@ -2170,7 +2170,7 @@ dca_tag_release:
 
 dca_latest_release:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_7
   stage: deploy
   when: manual
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,19 @@ before_script:
     variables:
       - $RELEASE_VERSION == "nightly"
 
+# skip job only when triggered by an external tool (ex: Jenkins) and when
+# BUILD_AGENT_X is set to "no".
+
+.skip_when_unwanted_on_6: &skip_when_unwanted_on_6
+  except:
+    variables:
+      - $BUILD_AGENT_6 == "false"
+
+.skip_when_unwanted_on_7: &skip_when_unwanted_on_7
+  except:
+    variables:
+      - $BUILD_AGENT_7 == "false"
+
 #
 # Job conditions
 #
@@ -455,6 +468,7 @@ agent_deb-x64-a6:
     PYTHON_RUNTIMES: '2,3'
     DESTINATION_DEB: 'datadog-agent_6_amd64.deb'
     DESTINATION_DBG_DEB: 'datadog-agent-dbg_6_amd64.deb'
+  <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_deb
 
 agent_deb-x64-a7:
@@ -467,6 +481,7 @@ agent_deb-x64-a7:
     PYTHON_RUNTIMES: '3'
     DESTINATION_DEB: 'datadog-agent_7_amd64.deb'
     DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_amd64.deb'
+  <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_deb
 
 # build Agent package for deb-x64
@@ -541,6 +556,7 @@ agent_rpm-x64-a6:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PYTHON_RUNTIMES: '2,3'
     CONDA_ENV: ddpy3
+  <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_rpm
 
 # build Agent package for rpm-x64
@@ -552,6 +568,7 @@ agent_rpm-x64-a7:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
+  <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_rpm
 
 .agent_build_common_suse_rpm: &agent_build_common_suse_rpm
@@ -594,6 +611,7 @@ agent_suse-x64-a6:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PYTHON_RUNTIMES: '2,3'
+  <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_suse_rpm
 
 # build Agent package for suse-x64
@@ -604,6 +622,7 @@ agent_suse-x64-a7:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PYTHON_RUNTIMES: '3'
+  <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_suse_rpm
 
 
@@ -629,24 +648,28 @@ dockerbuild_windows_msi_x64-a7:
   variables:
     ARCH: "x64"
     PYTHON_RUNTIMES: '3'
+  <<: *skip_when_unwanted_on_7
 
 dockerbuild_windows_msi_x86-a7:
   extends: .dockerbuild_windows_msi_base
   variables:
     ARCH: "x86"
     PYTHON_RUNTIMES: '3'
+  <<: *skip_when_unwanted_on_7
 
 dockerbuild_windows_msi_x64-a6:
   extends: .dockerbuild_windows_msi_base
   variables:
     ARCH: "x64"
     PYTHON_RUNTIMES: '2,3'
+  <<: *skip_when_unwanted_on_6
 
 dockerbuild_windows_msi_x86-a6:
   extends: .dockerbuild_windows_msi_base
   variables:
     ARCH: "x86"
     PYTHON_RUNTIMES: '2,3'
+  <<: *skip_when_unwanted_on_6
 
 
 # build Agent package for android
@@ -789,6 +812,7 @@ deploy_deb_testing-a6:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -813,6 +837,7 @@ deploy_deb_testing-a7:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -835,6 +860,7 @@ deploy_deb_testing-a7:
 # deploy rpm packages to yum staging repo
 deploy_rpm_testing-a6:
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -851,6 +877,7 @@ deploy_rpm_testing-a6:
 
 deploy_rpm_testing-a7:
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -868,6 +895,7 @@ deploy_rpm_testing-a7:
 # deploy rpm packages to yum staging repo
 deploy_suse_rpm_testing-a6:
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -884,6 +912,7 @@ deploy_suse_rpm_testing-a6:
 
 deploy_suse_rpm_testing-a7:
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -901,6 +930,7 @@ deploy_suse_rpm_testing-a7:
 # deploy windows packages to our testing bucket
 deploy_windows_testing-a6:
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -911,6 +941,7 @@ deploy_windows_testing-a6:
 
 deploy_windows_testing-a7:
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -971,6 +1002,7 @@ kitchen_windows_upgrade5to6:
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   variables:
     PYTHON_RUNTIMES: '2,3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -990,6 +1022,7 @@ kitchen_windows_upgrade5to7:
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   variables:
     PYTHON_RUNTIMES: '3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -1010,6 +1043,7 @@ kitchen_windows-a6:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   variables:
     PYTHON_RUNTIMES: '2,3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -1029,6 +1063,7 @@ kitchen_windows-a7:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   variables:
     PYTHON_RUNTIMES: '3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -1047,6 +1082,7 @@ kitchen_windows-a7-2008:
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   variables:
     PYTHON_RUNTIMES: '3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -1063,6 +1099,7 @@ kitchen_windows_installer-a6:
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   variables:
     PYTHON_RUNTIMES: '2,3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -1078,6 +1115,7 @@ kitchen_windows_installer-a7:
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   variables:
     PYTHON_RUNTIMES: '3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -1095,6 +1133,7 @@ kitchen_centos-a6:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   variables:
     PYTHON_RUNTIMES: '2,3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -1111,6 +1150,7 @@ kitchen_centos-a7:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   variables:
     PYTHON_RUNTIMES: '3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -1129,6 +1169,7 @@ kitchen_ubuntu-a6:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   variables:
     PYTHON_RUNTIMES: '2,3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -1145,6 +1186,7 @@ kitchen_ubuntu-a7:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   variables:
     PYTHON_RUNTIMES: '3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -1162,6 +1204,7 @@ kitchen_suse-a6:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   variables:
     PYTHON_RUNTIMES: '2,3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -1177,6 +1220,7 @@ kitchen_suse-a7:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   variables:
     PYTHON_RUNTIMES: '3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -1194,6 +1238,7 @@ kitchen_debian-a6:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_6
   variables:
     PYTHON_RUNTIMES: '2,3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -1210,6 +1255,7 @@ kitchen_debian-a7:
   allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   <<: *run_when_testkitchen_triggered
+  <<: *skip_when_unwanted_on_7
   variables:
     PYTHON_RUNTIMES: '3'
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -1228,6 +1274,7 @@ kitchen_debian-a7:
 send_pkg_size-a6:
   stage: pkg_metrics
   <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   before_script:
     # tmp while we uppdate the base image
@@ -1279,6 +1326,7 @@ send_pkg_size-a6:
 send_pkg_size-a7:
   stage: pkg_metrics
   <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   before_script:
     # tmp while we uppdate the base image
@@ -1424,6 +1472,7 @@ testkitchen_cleanup_azure-a7:
 # build agent6 image
 build_agent6:
   <<: *docker_build_job_definition
+  <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -1434,6 +1483,7 @@ build_agent6:
 # build agent6 jmx image
 build_agent6_jmx:
   <<: *docker_build_job_definition
+  <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -1446,6 +1496,7 @@ build_agent6_jmx:
 # build agent6 jmx unified image (including python3)
 build_agent6_py2py3_jmx:
   <<: *docker_build_job_definition
+  <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -1456,6 +1507,7 @@ build_agent6_py2py3_jmx:
 # build agent7 image
 build_agent7:
   <<: *docker_build_job_definition
+  <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -1466,6 +1518,7 @@ build_agent7:
 # build agent7 jmx image
 build_agent7_jmx:
   <<: *docker_build_job_definition
+  <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -1619,15 +1672,27 @@ dev_nightly_docker_hub:
 # Check that the current version hasn't already been deployed (we don't want to
 # overwrite a public package). To update an erroneous package, first remove it
 # from our S3 bucket.
-check_already_deployed_version:
+check_already_deployed_version_6:
   <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_6
   stage: check_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
   script:
-    - cd $OMNIBUS_PACKAGE_DIR && /deploy_scripts/fail_deb_is_pkg_already_exists.sh
+    - cd $OMNIBUS_PACKAGE_DIR && /deploy_scripts/fail_deb_is_pkg_already_exists.sh datadog-agent_6*_amd64.deb
+
+check_already_deployed_version_7:
+  <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_7
+  stage: check_deploy
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - cd $OMNIBUS_PACKAGE_DIR && /deploy_scripts/fail_deb_is_pkg_already_exists.sh datadog-agent_7*_amd64.deb
 
 # If we trigger a build only pipeline we stop here.
 check_if_build_only:
@@ -1647,6 +1712,7 @@ check_if_build_only:
 # deploy debian packages to apt staging repo
 deploy_deb-6:
   <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_6
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -1678,6 +1744,7 @@ deploy_deb-6:
 
 deploy_deb-7:
   <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_7
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -1755,6 +1822,7 @@ deploy_windows_tags-latest-6:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   <<: *run_when_triggered_on_tag
+  <<: *skip_when_unwanted_on_6
   tags: [ "runner:main", "size:large" ]
   script:
     # By default we update the "latest" artifacts on our s3 bucket so the
@@ -1768,6 +1836,7 @@ deploy_windows_tags-latest-7:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   <<: *run_when_triggered_on_tag
+  <<: *skip_when_unwanted_on_7
   tags: [ "runner:main", "size:large" ]
   script:
     # By default we update the "latest" artifacts on our s3 bucket so the
@@ -1789,6 +1858,7 @@ deploy_android_tags:
 # deploy rpm packages to yum staging repo
 deploy_rpm-6:
   <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_6
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -1809,6 +1879,7 @@ deploy_rpm-6:
 
 deploy_rpm-7:
   <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_7
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -1830,6 +1901,7 @@ deploy_rpm-7:
 # deploy suse rpm packages to yum staging repo
 deploy_suse_rpm-6:
   <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_6
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -1850,6 +1922,7 @@ deploy_suse_rpm-6:
 
 deploy_suse_rpm-7:
   <<: *run_when_triggered
+  <<: *skip_when_unwanted_on_7
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -1919,12 +1992,14 @@ deploy_process_and_sysprobe:
 tag_release_6:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag
+  <<: *skip_when_unwanted_on_6
   stage: deploy
   when: manual
   variables:
+    PYTHON_RUNTIMES: '2,3'
     <<: *docker_hub_variables
   script:
-    - VERSION=`PYTHON_RUNTIMES=2,3 inv -e agent.version`
+    - VERSION=$(inv -e agent.version)
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py2 datadog/agent:${VERSION}
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py2-jmx datadog/agent:${VERSION}-jmx
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3 datadog/agent:${VERSION}-py3
@@ -1934,18 +2009,21 @@ tag_release_6:
 tag_release_7:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag
+  <<: *skip_when_unwanted_on_7
   stage: deploy
   when: manual
   variables:
+    PYTHON_RUNTIMES: '3'
     <<: *docker_hub_variables
   script:
-    - VERSION=`PYTHON_RUNTIMES=3 inv -e agent.version`
+    - VERSION=$(inv -e agent.version)
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3 datadog/agent:${VERSION}
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3-jmx datadog/agent:${VERSION}-jmx
 
 latest_release_6:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag
+  <<: *skip_when_unwanted_on_6
   stage: deploy
   when: manual
   variables:
@@ -1965,6 +2043,7 @@ latest_release_6:
 latest_release_7:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag
+  <<: *skip_when_unwanted_on_7
   stage: deploy
   when: manual
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -639,6 +639,7 @@ agent_suse-x64-a6:
     PYTHON_RUNTIMES: '2,3'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
+    - inv -e deps --verbose --dep-vendor-only
   <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_suse_rpm
 
@@ -652,6 +653,7 @@ agent_suse-x64-a7:
     PYTHON_RUNTIMES: '3'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
+    - inv -e deps --verbose --dep-vendor-only
   <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_suse_rpm
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -444,6 +444,7 @@ run_dogstatsd_size_test:
 #
 .agent_build_common_deb: &agent_build_common_deb
   script:
+    - echo "About to build for $RELEASE_VERSION"
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Retrieve the system-probe from S3
@@ -535,6 +536,7 @@ puppy_deb-x64:
 
 .agent_build_common_rpm: &agent_build_common_rpm
   script:
+    - echo "About to build for $RELEASE_VERSION"
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
@@ -596,6 +598,7 @@ agent_rpm-x64-a7:
 
 .agent_build_common_suse_rpm: &agent_build_common_suse_rpm
   script:
+    - echo "About to build for $RELEASE_VERSION"
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR_SUSE/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
@@ -635,7 +638,7 @@ agent_suse-x64-a6:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PYTHON_RUNTIMES: '2,3'
   before_script:
-    - export RELEASE_VERSION=$RELEASE_VERSION_7
+    - export RELEASE_VERSION=$RELEASE_VERSION_6
   <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_suse_rpm
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -646,6 +646,7 @@ agent_suse-x64-a7:
     - mkdir .omnibus\pkg
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
+  timeout: 2h 00m
   script:
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat --release-version %RELEASE_VERSION%
     - copy build-out\*.msi .omnibus\pkg

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -491,13 +491,14 @@ puppy_deb-x64:
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only --no-checks
+  <<: *skip_when_unwanted_on_6
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR --skip-deps
+    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION_6" --base-dir $OMNIBUS_BASE_DIR --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -name "datadog-puppy*_amd64.deb" -exec dpkg -c {} \;
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb $S3_ARTIFACTS_URI/datadog-puppy_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -697,6 +698,7 @@ agent_android_apk:
   tags: [ "runner:main", "size:large" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+  <<: *skip_when_unwanted_on_6
   before_script:
     - echo running android before_script
     - cd $SRC_PATH
@@ -727,7 +729,7 @@ dogstatsd_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  <<: *skip_when_unwanted_on_7
+  <<: *skip_when_unwanted_on_6
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
@@ -739,7 +741,7 @@ dogstatsd_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_6" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -name "datadog-dogstatsd*_amd64.deb" -exec dpkg -c {} \;
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb $S3_ARTIFACTS_URI/datadog-dogstatsd_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -759,7 +761,7 @@ dogstatsd_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  <<: *skip_when_unwanted_on_7
+  <<: *skip_when_unwanted_on_6
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
@@ -777,7 +779,7 @@ dogstatsd_rpm-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_6" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -type f -name '*.rpm' -print0 | sort -z | xargs -0 -I '{}' rpm -i '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -797,7 +799,7 @@ dogstatsd_suse-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:large" ]
-  <<: *skip_when_unwanted_on_7
+  <<: *skip_when_unwanted_on_6
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   script:
@@ -812,7 +814,7 @@ dogstatsd_suse-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_6" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache --skip-deps
     - find $OMNIBUS_BASE_DIR_SUSE/pkg -type f -name '*.rpm' -print0 | sort -z | xargs -0 -I '{}' rpm -i '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR_SUSE && cp $OMNIBUS_BASE_DIR_SUSE/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR_SUSE
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,8 @@ variables:
   S3_ARTIFACTS_URI: s3://dd-ci-artefacts-build-stable/$CI_PROJECT_NAME/$CI_PIPELINE_ID
   S3_OMNIBUS_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-cache-build-stable
   S3_DSD6_URI: s3://dsd6-staging/linux
-  RELEASE_VERSION: nightly
+  RELEASE_VERSION_6: nightly
+  RELEASE_VERSION_7: nightly
   DATADOG_AGENT_BUILDIMAGES: v1709713-2adac2a
   DATADOG_AGENT_BUILDERS: v1755190-c671974
   DATADOG_AGENT_WINBUILDIMAGES: v1782031-7bc5447
@@ -102,21 +103,30 @@ before_script:
     - web
 
 # run job only when triggered by an external tool (ex: Jenkins) and when
-# RELEASE_VERSION is NOT "nightly". In this setting we are building either a
+# RELEASE_VERSION_X is NOT "nightly". In this setting we are building either a
 # new tagged version of the agent (an RC for example). In both cases the
 # artifacts should be uploaded to our staging repository.
 
-.run_when_triggered_on_tag: &run_when_triggered_on_tag
+.run_when_triggered_on_tag_6: &run_when_triggered_on_tag_6
   only:
     refs:
       - triggers
   except: # we have to use except since gitlab doens't handle '!=' operator
     variables:
-      - $RELEASE_VERSION == "nightly"
-      - $RELEASE_VERSION == "" # no  RELEASE_VERSION means a nightly build for omnibus
+      - $RELEASE_VERSION_6 == "nightly"
+      - $RELEASE_VERSION_6 == "" # no  RELEASE_VERSION means a nightly build for omnibus
+
+.run_when_triggered_on_tag_7: &run_when_triggered_on_tag_7
+  only:
+    refs:
+      - triggers
+  except: # we have to use except since gitlab doens't handle '!=' operator
+    variables:
+      - $RELEASE_VERSION_7 == "nightly"
+      - $RELEASE_VERSION_7 == "" # no  RELEASE_VERSION means a nightly build for omnibus
 
 # run job only when triggered by an external tool (ex: Jenkins) and when
-# RELEASE_VERSION is "nightly". In this setting we build from master and update
+# RELEASE_VERSION_X is "nightly". In this setting we build from master and update
 # the nightly build for windows, linux and docker.
 
 .run_when_triggered_on_nightly: &run_when_triggered_on_nightly
@@ -124,7 +134,8 @@ before_script:
     refs:
       - triggers
     variables:
-      - $RELEASE_VERSION == "nightly"
+      - $RELEASE_VERSION_6 == "nightly"
+      - $RELEASE_VERSION_7 == "nightly"
 
 # skip job only when triggered by an external tool (ex: Jenkins) and when
 # BUILD_AGENT_X is set to "no".
@@ -132,12 +143,12 @@ before_script:
 .skip_when_unwanted_on_6: &skip_when_unwanted_on_6
   except:
     variables:
-      - $BUILD_AGENT_6 == "false"
+      - $RELEASE_VERSION_6 == ""
 
 .skip_when_unwanted_on_7: &skip_when_unwanted_on_7
   except:
     variables:
-      - $BUILD_AGENT_7 == "false"
+      - $RELEASE_VERSION_7 == ""
 
 #
 # Job conditions
@@ -174,7 +185,9 @@ before_script:
     - echo "Running windows source tests"
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat --release-version %RELEASE_VERSION% 
+    # can we not use RELEASE_VERSION here and just test on HEAD like the other platform's tests?
+    # TODO: verify --release-version must be set to `--release-version %RELEASE_VERSION%`
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat --release-version nightly
 
 run_tests_windows-x64:
   # temporarily allow failure for tests
@@ -182,7 +195,7 @@ run_tests_windows-x64:
   allow_failure: true
   variables:
     ARCH: "x64"
-  
+
 run_tests_windows-x86:
   # temporarily allow failure for tests
   extends: .run_tests_windows_base
@@ -430,9 +443,6 @@ run_dogstatsd_size_test:
 #
 #
 .agent_build_common_deb: &agent_build_common_deb
-  before_script:
-    - source /root/.bashrc && conda activate $CONDA_ENV
-    - inv -e deps --verbose --dep-vendor-only
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
@@ -468,6 +478,10 @@ agent_deb-x64-a6:
     PYTHON_RUNTIMES: '2,3'
     DESTINATION_DEB: 'datadog-agent_6_amd64.deb'
     DESTINATION_DBG_DEB: 'datadog-agent-dbg_6_amd64.deb'
+  before_script:
+    - source /root/.bashrc && conda activate $CONDA_ENV
+    - inv -e deps --verbose --dep-vendor-only
+    - export RELEASE_VERSION=$RELEASE_VERSION_6
   <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_deb
 
@@ -481,6 +495,10 @@ agent_deb-x64-a7:
     PYTHON_RUNTIMES: '3'
     DESTINATION_DEB: 'datadog-agent_7_amd64.deb'
     DESTINATION_DBG_DEB: 'datadog-agent-dbg_7_amd64.deb'
+  before_script:
+    - source /root/.bashrc && conda activate $CONDA_ENV
+    - inv -e deps --verbose --dep-vendor-only
+    - export RELEASE_VERSION=$RELEASE_VERSION_7
   <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_deb
 
@@ -500,7 +518,7 @@ puppy_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --skip-deps
+    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -name "datadog-puppy*_amd64.deb" -exec dpkg -c {} \;
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb $S3_ARTIFACTS_URI/datadog-puppy_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -516,9 +534,6 @@ puppy_deb-x64:
       - $OMNIBUS_PACKAGE_DIR
 
 .agent_build_common_rpm: &agent_build_common_rpm
-  before_script:
-    - source /root/.bashrc && conda activate $CONDA_ENV
-    - inv -e deps --verbose --dep-vendor-only
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
@@ -556,6 +571,10 @@ agent_rpm-x64-a6:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PYTHON_RUNTIMES: '2,3'
     CONDA_ENV: ddpy3
+  before_script:
+    - source /root/.bashrc && conda activate $CONDA_ENV
+    - inv -e deps --verbose --dep-vendor-only
+    - export RELEASE_VERSION=$RELEASE_VERSION_6
   <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_rpm
 
@@ -568,6 +587,10 @@ agent_rpm-x64-a7:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
+  before_script:
+    - source /root/.bashrc && conda activate $CONDA_ENV
+    - inv -e deps --verbose --dep-vendor-only
+    - export RELEASE_VERSION=$RELEASE_VERSION_7
   <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_rpm
 
@@ -611,6 +634,8 @@ agent_suse-x64-a6:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PYTHON_RUNTIMES: '2,3'
+  before_script:
+    - export RELEASE_VERSION=$RELEASE_VERSION_7
   <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_suse_rpm
 
@@ -622,6 +647,8 @@ agent_suse-x64-a7:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PYTHON_RUNTIMES: '3'
+  before_script:
+    - export RELEASE_VERSION=$RELEASE_VERSION_7
   <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_suse_rpm
 
@@ -648,6 +675,8 @@ dockerbuild_windows_msi_x64-a7:
   variables:
     ARCH: "x64"
     PYTHON_RUNTIMES: '3'
+  before_script:
+    - set RELEASE_VERSION %RELEASE_VERSION_7%
   <<: *skip_when_unwanted_on_7
 
 dockerbuild_windows_msi_x86-a7:
@@ -655,6 +684,8 @@ dockerbuild_windows_msi_x86-a7:
   variables:
     ARCH: "x86"
     PYTHON_RUNTIMES: '3'
+  before_script:
+    - set RELEASE_VERSION %RELEASE_VERSION_7%
   <<: *skip_when_unwanted_on_7
 
 dockerbuild_windows_msi_x64-a6:
@@ -662,6 +693,8 @@ dockerbuild_windows_msi_x64-a6:
   variables:
     ARCH: "x64"
     PYTHON_RUNTIMES: '2,3'
+  before_script:
+    - set RELEASE_VERSION %RELEASE_VERSION_6%
   <<: *skip_when_unwanted_on_6
 
 dockerbuild_windows_msi_x86-a6:
@@ -669,6 +702,8 @@ dockerbuild_windows_msi_x86-a6:
   variables:
     ARCH: "x86"
     PYTHON_RUNTIMES: '2,3'
+  before_script:
+    - set RELEASE_VERSION %RELEASE_VERSION_6%
   <<: *skip_when_unwanted_on_6
 
 
@@ -709,6 +744,7 @@ dogstatsd_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
+  <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
@@ -720,7 +756,7 @@ dogstatsd_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -name "datadog-dogstatsd*_amd64.deb" -exec dpkg -c {} \;
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb $S3_ARTIFACTS_URI/datadog-dogstatsd_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -740,6 +776,7 @@ dogstatsd_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
+  <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
@@ -757,7 +794,7 @@ dogstatsd_rpm-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -type f -name '*.rpm' -print0 | sort -z | xargs -0 -I '{}' rpm -i '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -777,6 +814,7 @@ dogstatsd_suse-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:large" ]
+  <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   script:
@@ -791,7 +829,7 @@ dogstatsd_suse-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache --skip-deps
     - find $OMNIBUS_BASE_DIR_SUSE/pkg -type f -name '*.rpm' -print0 | sort -z | xargs -0 -I '{}' rpm -i '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR_SUSE && cp $OMNIBUS_BASE_DIR_SUSE/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR_SUSE
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -1811,7 +1849,7 @@ deploy_windows_tags:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_6
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
@@ -1821,7 +1859,7 @@ deploy_windows_tags-latest-6:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_6
   <<: *skip_when_unwanted_on_6
   tags: [ "runner:main", "size:large" ]
   script:
@@ -1835,7 +1873,7 @@ deploy_windows_tags-latest-7:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_7
   <<: *skip_when_unwanted_on_7
   tags: [ "runner:main", "size:large" ]
   script:
@@ -1850,7 +1888,7 @@ deploy_android_tags:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_6
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.apk" $OMNIBUS_PACKAGE_DIR s3://$ANDROID_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
@@ -1991,7 +2029,7 @@ deploy_process_and_sysprobe:
 
 tag_release_6:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_6
   <<: *skip_when_unwanted_on_6
   stage: deploy
   when: manual
@@ -2008,7 +2046,7 @@ tag_release_6:
 
 tag_release_7:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_7
   <<: *skip_when_unwanted_on_7
   stage: deploy
   when: manual
@@ -2022,7 +2060,7 @@ tag_release_7:
 
 latest_release_6:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_6
   <<: *skip_when_unwanted_on_6
   stage: deploy
   when: manual
@@ -2042,7 +2080,7 @@ latest_release_6:
 
 latest_release_7:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_7
   <<: *skip_when_unwanted_on_7
   stage: deploy
   when: manual
@@ -2184,7 +2222,7 @@ pupernetes-master:
 
 pupernetes-tags:
   <<: *pupernetes_template
-  <<: *run_when_triggered_on_tag
+  <<: *run_when_triggered_on_tag_6
   when: manual
   script:
   # note: it's not the agent-dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,9 +163,7 @@ before_script:
     - echo "Running windows source tests"
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
-    # can we not use RELEASE_VERSION here and just test on HEAD like the other platform's tests?
-    # TODO: verify --release-version must be set to `--release-version %RELEASE_VERSION%`
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat --release-version nightly
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat
 
 run_tests_windows-x64:
   # temporarily allow failure for tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1924,11 +1924,12 @@ tag_release_6:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py2 datadog/agent:${CI_COMMIT_TAG}
-    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py2-jmx datadog/agent:${CI_COMMIT_TAG}-jmx
-    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3 datadog/agent:${CI_COMMIT_TAG}-py3
-    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3-jmx datadog/agent:${CI_COMMIT_TAG}-py3-jmx
-    - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd:${CI_COMMIT_TAG}
+    - VERSION=`PYTHON_RUNTIMES=2,3 inv -e agent.version`
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py2 datadog/agent:${VERSION}
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py2-jmx datadog/agent:${VERSION}-jmx
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3 datadog/agent:${VERSION}-py3
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3-jmx datadog/agent:${VERSION}-py3-jmx
+    - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd:${VERSION}
 
 tag_release_7:
   <<: *docker_tag_job_definition
@@ -1938,8 +1939,9 @@ tag_release_7:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3 datadog/agent:${CI_COMMIT_TAG}
-    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3-jmx datadog/agent:${CI_COMMIT_TAG}-jmx
+    - VERSION=`PYTHON_RUNTIMES=3 inv -e agent.version`
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3 datadog/agent:${VERSION}
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-py3-jmx datadog/agent:${VERSION}-jmx
 
 latest_release_6:
   <<: *docker_tag_job_definition

--- a/release.json
+++ b/release.json
@@ -4,8 +4,14 @@
 		"OMNIBUS_SOFTWARE_VERSION": "master",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
 		"JMXFETCH_VERSION": "0.33.0",
-		"JMXFETCH_HASH": "078011fbcca5e9beee2f041fefacbad824cff47e074b74a4674eb3efed8984b3",
-		"PYTHON_RUNTIMES": "3"
+		"JMXFETCH_HASH": "078011fbcca5e9beee2f041fefacbad824cff47e074b74a4674eb3efed8984b3"
+	},
+	"nightly-a7": {
+		"INTEGRATIONS_CORE_VERSION": "master",
+		"OMNIBUS_SOFTWARE_VERSION": "master",
+		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
+		"JMXFETCH_VERSION": "0.33.0",
+		"JMXFETCH_HASH": "078011fbcca5e9beee2f041fefacbad824cff47e074b74a4674eb3efed8984b3"
 	},
 	"6.14.0": {
 		"INTEGRATIONS_CORE_VERSION": "6.14.0",


### PR DESCRIPTION
### What does this PR do?

- Update container tagging strategy: provide hints to extract the correct git tag for the right agent (ie. A6 version should be 6.x.y, while A7 will be 7.x.y). The invoke scripts already support this with the `PYTHON_RUNTIMES` environment variable.   
- Skip A6 or A7 jobs if not building a package for a given version. This should apply to triggered builds only, otherwise all relevant jobs should run. When triggered, we will use two new environment variables `RELEASE_VERSION_6` and `RELEASE_VERSION_7`.
  - This is based off a new `except` gitlab YAML clause that should be typically paired with the `run_if_triggered` "family" conditional sections within the YAML job descriptions. 

### Motivation

Agent 6 & Agent 7 concurrent & independent builds.
