### PR TITLE
Verify check signature

### DIFF
--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -196,8 +196,8 @@ func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Da
 	defer C._free(unsafe.Pointer(cCheckName))
 
 	var check *C.rtloader_pyobject_t
-	verify := C.is_check_init_deprecated(rtloader, c.class)
-	if verify == 1 {
+	deprecated := C.is_check_init_deprecated(rtloader, c.class)
+	if deprecated == 1 {
 		log.Warnf("passing `agentConfig` to the constructor is deprecated, please use the `get_config` function from the 'datadog_agent' package (%s).", c.ModuleName)
 		allSettings := config.Datadog.AllSettings()
 		agentConfig, err := yaml.Marshal(allSettings)

--- a/pkg/collector/python/test_check.go
+++ b/pkg/collector/python/test_check.go
@@ -87,12 +87,17 @@ char *run_check(rtloader_t *s, rtloader_pyobject_t *check) {
 
 int get_check_return = 0;
 int get_check_calls = 0;
+int is_check_init_deprecated_return = 1;
 rtloader_pyobject_t *get_check_py_class = NULL;
 const char *get_check_init_config = NULL;
 const char *get_check_instance = NULL;
 const char *get_check_check_id = NULL;
 const char *get_check_check_name = NULL;
 rtloader_pyobject_t *get_check_check = NULL;
+
+int is_check_init_deprecated(rtloader_t *rtloader, rtloader_pyobject_t *py_class) {
+	return is_check_init_deprecated_return;
+}
 
 int get_check(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *init_config, const char *instance,
 const char *check_id, const char *check_name, rtloader_pyobject_t **check) {
@@ -149,7 +154,7 @@ void reset_check_mock() {
 	get_error_return = "";
 	rtloader_free_calls = 0;
 	run_check_calls = 0;
-	get_check_return = 0;
+	is_check_init_deprecated_return = 1;
 
 	get_check_return = 0;
 	get_check_calls = 0;
@@ -294,6 +299,7 @@ func testConfigure(t *testing.T) {
 	C.reset_check_mock()
 
 	C.get_check_return = 1
+	C.is_check_init_deprecated_return = 0
 	C.get_check_check = &C.rtloader_pyobject_t{}
 	err := c.Configure(integration.Data("{\"val\": 21}"), integration.Data("aaa"), "test")
 	assert.Nil(t, err)
@@ -321,17 +327,13 @@ func testConfigureDeprecated(t *testing.T) {
 	C.reset_check_mock()
 
 	C.get_check_return = 0
+	C.is_check_init_deprecated_return = 1
 	C.get_check_deprecated_check = &C.rtloader_pyobject_t{}
 	C.get_check_deprecated_return = 1
 	err := c.Configure(integration.Data("{\"val\": 21}"), integration.Data("aaa"), "test")
 	assert.Nil(t, err)
 
-	assert.Equal(t, c.class, C.get_check_py_class)
-	assert.Equal(t, "aaa", C.GoString(C.get_check_init_config))
-	assert.Equal(t, "{\"val\": 21}", C.GoString(C.get_check_instance))
-	assert.Equal(t, string(c.id), C.GoString(C.get_check_check_id))
-	assert.Equal(t, "fake_check", C.GoString(C.get_check_check_name))
-	assert.Nil(t, C.get_check_check)
+	assert.Nil(t, C.get_check_py_class)
 
 	assert.Equal(t, c.class, C.get_check_deprecated_py_class)
 	assert.Equal(t, "aaa", C.GoString(C.get_check_deprecated_init_config))

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -176,6 +176,17 @@ DATADOG_AGENT_RTLOADER_API int get_check_deprecated(rtloader_t *rtloader, rtload
                                                     const char *check_name, const char *agent_config,
                                                     rtloader_pyobject_t **check);
 
+/*! \fn int is_check_init_deprecated(rtloader_t *rtloader, rtloader_pyobject_t *py_class)
+    \brief Verify the signature of a check init method.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param py_class A rtloader_pyobject_t * pointer to the python check class we wish to instantiate.
+    \return 1 if it uses the old signature, 0 otherwise.
+    \sa rtloader_pyobject_t, rtloader_t, get_check
+
+    This function is deprecated in favor of `get_check()`.
+*/
+DATADOG_AGENT_RTLOADER_API int is_check_init_deprecated(rtloader_t *rtloader, rtloader_pyobject_t *py_class);
+
 /*! \fn char *run_check(rtloader_t *, rtloader_pyobject_t *check)
     \brief Runs a check instance.
     \param rtloader_t A rtloader_t * pointer to the RtLoader instance.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -108,6 +108,13 @@ public:
                           RtLoaderPyObject *&check)
         = 0;
 
+    //! Pure virtual isCheckInitDeprecated member.
+    /*!
+      \param py_class The python check class we wish to instantiate.
+      \return A boolean indicating the success or not of the operation.
+    */
+    virtual bool isCheckInitDeprecated(RtLoaderPyObject *py_class) = 0;
+
     //! Pure virtual runCheck member.
     /*!
       \param check The python object pointer to the check we wish to run.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -111,9 +111,9 @@ public:
     //! Pure virtual isCheckInitDeprecated member.
     /*!
       \param py_class The python check class we wish to instantiate.
-      \return A boolean indicating the success or not of the operation.
+      \return A int indicating the success or not of the operation.
     */
-    virtual bool isCheckInitDeprecated(RtLoaderPyObject *py_class) = 0;
+    virtual int isCheckInitDeprecated(RtLoaderPyObject *py_class) = 0;
 
     //! Pure virtual runCheck member.
     /*!

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -282,6 +282,11 @@ int get_check(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *i
         : 0;
 }
 
+int is_check_init_deprecated(rtloader_t *rtloader, rtloader_pyobject_t *py_class)
+{
+    return AS_TYPE(RtLoader, rtloader)->isCheckInitDeprecated(AS_TYPE(RtLoaderPyObject, py_class)) ? 1 : 0;
+}
+
 int get_check_deprecated(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *init_config,
                          const char *instance, const char *agent_config, const char *check_id, const char *check_name,
                          rtloader_pyobject_t **check)

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -284,7 +284,7 @@ int get_check(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *i
 
 int is_check_init_deprecated(rtloader_t *rtloader, rtloader_pyobject_t *py_class)
 {
-    return AS_TYPE(RtLoader, rtloader)->isCheckInitDeprecated(AS_TYPE(RtLoaderPyObject, py_class)) ? 1 : 0;
+    return AS_TYPE(RtLoader, rtloader)->isCheckInitDeprecated(AS_TYPE(RtLoaderPyObject, py_class));
 }
 
 int get_check_deprecated(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *init_config,

--- a/rtloader/test/python/deprecated_check/__init__.py
+++ b/rtloader/test/python/deprecated_check/__init__.py
@@ -1,0 +1,10 @@
+from datadog_checks.base.checks import AgentCheck
+
+
+class DeprecatedCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances=instances)
+
+
+__version__ = '0.0.1'

--- a/rtloader/test/python/test_check/__init__.py
+++ b/rtloader/test/python/test_check/__init__.py
@@ -1,0 +1,12 @@
+from datadog_checks.base.checks import AgentCheck
+
+
+class TestCheck(AgentCheck):
+
+    def __init__(self, name, init_config, instances):
+        AgentCheck.__init__(self, name, init_config, instances)
+        # Create a local variable to make sure we filter it
+        agentConfig = True
+
+
+__version__ = '0.0.1'

--- a/rtloader/test/python/test_check2/__init__.py
+++ b/rtloader/test/python/test_check2/__init__.py
@@ -1,0 +1,12 @@
+from datadog_checks.base.checks import AgentCheck
+
+
+class TestCheck2(AgentCheck):
+
+    def __init__(self, *args, **kwargs):
+        AgentCheck.__init__(self, *args, **kwargs)
+        # Create a local variable to make sure we filter it
+        agentConfig = True
+
+
+__version__ = '0.0.1'

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -211,6 +211,10 @@ func runFakeCheck() (string, error) {
 	classStr = (*C.char)(helpers.TrackedCString("fake_check"))
 	defer C._free(unsafe.Pointer(classStr))
 
+	ret := C.is_check_init_deprecated(rtloader, class)
+	if ret != 0 {
+		return "", fmt.Errorf(C.GoString(C.get_error(rtloader)))
+	}
 	C.get_check(rtloader, class, emptyStr, configStr, checkIdStr, classStr, &check)
 
 	checkResultStr := C.run_check(rtloader, check)

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -212,7 +212,7 @@ func runFakeCheck() (string, error) {
 	defer C._free(unsafe.Pointer(classStr))
 
 	ret := C.is_check_init_deprecated(rtloader, class)
-	if ret != 0 {
+	if ret != 1 {
 		return "", fmt.Errorf(C.GoString(C.get_error(rtloader)))
 	}
 	C.get_check(rtloader, class, emptyStr, configStr, checkIdStr, classStr, &check)
@@ -355,6 +355,27 @@ func runTestCheck() string {
 
 	ret := C.is_check_init_deprecated(rtloader, class)
 	if ret != 0 {
+		return "Failed to test check"
+	}
+	C.release_gil(rtloader, state)
+	runtime.UnlockOSThread()
+	return ""
+}
+
+func runTestCheck2() string {
+	var module *C.rtloader_pyobject_t
+	var class *C.rtloader_pyobject_t
+
+	runtime.LockOSThread()
+	state := C.ensure_gil(rtloader)
+
+	classStr := (*C.char)(helpers.TrackedCString("test_check2"))
+	defer C._free(unsafe.Pointer(classStr))
+
+	C.get_class(rtloader, classStr, &module, &class)
+
+	ret := C.is_check_init_deprecated(rtloader, class)
+	if ret != 1 {
 		return "Failed to test check"
 	}
 	C.release_gil(rtloader, state)

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -212,7 +212,7 @@ func runFakeCheck() (string, error) {
 	defer C._free(unsafe.Pointer(classStr))
 
 	ret := C.is_check_init_deprecated(rtloader, class)
-	if ret != 1 {
+	if ret != 2 {
 		return "", fmt.Errorf(C.GoString(C.get_error(rtloader)))
 	}
 	C.get_check(rtloader, class, emptyStr, configStr, checkIdStr, classStr, &check)
@@ -375,7 +375,7 @@ func runTestCheck2() string {
 	C.get_class(rtloader, classStr, &module, &class)
 
 	ret := C.is_check_init_deprecated(rtloader, class)
-	if ret != 1 {
+	if ret != 2 {
 		return "Failed to test check"
 	}
 	C.release_gil(rtloader, state)

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -319,3 +319,45 @@ func setModuleAttrString(module string, attr string, value string) {
 	C.release_gil(rtloader, state)
 	runtime.UnlockOSThread()
 }
+
+func runDeprecatedCheck() string {
+	var module *C.rtloader_pyobject_t
+	var class *C.rtloader_pyobject_t
+
+	runtime.LockOSThread()
+	state := C.ensure_gil(rtloader)
+
+	classStr := (*C.char)(helpers.TrackedCString("deprecated_check"))
+	defer C._free(unsafe.Pointer(classStr))
+
+	C.get_class(rtloader, classStr, &module, &class)
+
+	ret := C.is_check_init_deprecated(rtloader, class)
+	if ret != 1 {
+		return "Failed to test deprecated check"
+	}
+	C.release_gil(rtloader, state)
+	runtime.UnlockOSThread()
+	return ""
+}
+
+func runTestCheck() string {
+	var module *C.rtloader_pyobject_t
+	var class *C.rtloader_pyobject_t
+
+	runtime.LockOSThread()
+	state := C.ensure_gil(rtloader)
+
+	classStr := (*C.char)(helpers.TrackedCString("test_check"))
+	defer C._free(unsafe.Pointer(classStr))
+
+	C.get_class(rtloader, classStr, &module, &class)
+
+	ret := C.is_check_init_deprecated(rtloader, class)
+	if ret != 0 {
+		return "Failed to test check"
+	}
+	C.release_gil(rtloader, state)
+	runtime.UnlockOSThread()
+	return ""
+}

--- a/rtloader/test/rtloader/rtloader_test.go
+++ b/rtloader/test/rtloader/rtloader_test.go
@@ -196,3 +196,31 @@ with open(r'%s', 'w') as f:
 	// Check for leaks
 	helpers.AssertMemoryUsage(t)
 }
+
+func TestRunDeprecatedCheck(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	res := runDeprecatedCheck()
+
+	if res != "" {
+		t.Fatal(res)
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}
+
+func TestRunTestCheck(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	res := runTestCheck()
+
+	if res != "" {
+		t.Fatal(res)
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}

--- a/rtloader/test/rtloader/rtloader_test.go
+++ b/rtloader/test/rtloader/rtloader_test.go
@@ -224,3 +224,17 @@ func TestRunTestCheck(t *testing.T) {
 	// Check for leaks
 	helpers.AssertMemoryUsage(t)
 }
+
+func TestRunTestCheck2(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	res := runTestCheck2()
+
+	if res != "" {
+		t.Fatal(res)
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -395,6 +395,41 @@ done:
     return true;
 }
 
+bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
+{
+    PyObject *klass = reinterpret_cast<PyObject *>(py_class);
+    PyObject *init, *func_code, *co_varnames, *elt;
+    bool result = false;
+
+    // AgentCheck.__init__.__code__.co_varnames
+    //
+    init = PyObject_GetAttrString(klass, "__init__");
+    if (init == NULL) {
+        goto done;
+    }
+    func_code = PyObject_GetAttrString(init, "__code__");
+    if (func_code == NULL) {
+        goto done;
+    }
+    co_varnames = PyObject_GetAttrString(func_code, "co_varnames");
+    if (co_varnames == NULL) {
+        goto done;
+    }
+    elt = PyUnicode_FromString("agentConfig");
+    if (elt == NULL) {
+        goto done;
+    }
+    if (PySequence_Contains(co_varnames, elt) == 1) {
+        result = true;
+    }
+done:
+    Py_XDECREF(init);
+    Py_XDECREF(func_code);
+    Py_XDECREF(co_varnames);
+    Py_XDECREF(elt);
+    return result;
+}
+
 char *Three::runCheck(RtLoaderPyObject *check)
 {
     if (check == NULL) {

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -403,7 +403,6 @@ bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
     bool result = false;
 
     // AgentCheck.__init__.__code__.co_varnames[:AgentCheck.__init__.__code__.co_argcount]
-    //
     init = PyObject_GetAttrString(klass, "__init__");
     if (init == NULL) {
         goto done;
@@ -429,6 +428,7 @@ bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
         result = true;
     }
 done:
+    PyErr_Clear();
     Py_XDECREF(init);
     Py_XDECREF(func_code);
     Py_XDECREF(co_varnames);

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -395,13 +395,13 @@ done:
     return true;
 }
 
-bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
+int Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
 {
     PyObject *klass = reinterpret_cast<PyObject *>(py_class);
     PyObject *init, *func_code, *co_varnames, *co_argcount, *co_flags, *elt;
     init = func_code = co_varnames = co_argcount = co_flags = elt = NULL;
     Py_ssize_t idx = -1;
-    bool result = false;
+    int result = 0;
 
     // AgentCheck.__init__.__code__.co_varnames[:AgentCheck.__init__.__code__.co_argcount]
     init = PyObject_GetAttrString(klass, "__init__");
@@ -414,7 +414,7 @@ bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
     }
     co_flags = PyObject_GetAttrString(func_code, "co_flags");
     if (PyLong_AsSize_t(co_flags) & CO_VARKEYWORDS) {
-        result = true;
+        result = 2;
         goto done;
     }
     co_varnames = PyObject_GetAttrString(func_code, "co_varnames");
@@ -431,7 +431,7 @@ bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
     }
     idx = PySequence_Index(co_varnames, elt);
     if (idx != -1 && idx < PyLong_AsSize_t(co_argcount)) {
-        result = true;
+        result = 1;
     }
 done:
     PyErr_Clear();

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -398,8 +398,8 @@ done:
 bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
 {
     PyObject *klass = reinterpret_cast<PyObject *>(py_class);
-    PyObject *init, *func_code, *co_varnames, *co_argcount, *elt;
-    Py_ssize_t idx;
+    PyObject *init, *func_code, *co_varnames, *co_argcount, *elt = NULL;
+    Py_ssize_t idx = -1;
     bool result = false;
 
     // AgentCheck.__init__.__code__.co_varnames[:AgentCheck.__init__.__code__.co_argcount]

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -398,7 +398,8 @@ done:
 bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
 {
     PyObject *klass = reinterpret_cast<PyObject *>(py_class);
-    PyObject *init, *func_code, *co_varnames, *co_argcount, *elt = NULL;
+    PyObject *init, *func_code, *co_varnames, *co_argcount, *co_flags, *elt;
+    init = func_code = co_varnames = co_argcount = co_flags = elt = NULL;
     Py_ssize_t idx = -1;
     bool result = false;
 
@@ -409,6 +410,11 @@ bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
     }
     func_code = PyObject_GetAttrString(init, "__code__");
     if (func_code == NULL) {
+        goto done;
+    }
+    co_flags = PyObject_GetAttrString(func_code, "co_flags");
+    if (PyLong_AsSize_t(co_flags) & CO_VARKEYWORDS) {
+        result = true;
         goto done;
     }
     co_varnames = PyObject_GetAttrString(func_code, "co_varnames");
@@ -430,9 +436,10 @@ bool Three::isCheckInitDeprecated(RtLoaderPyObject *py_class)
 done:
     PyErr_Clear();
     Py_XDECREF(init);
-    Py_XDECREF(func_code);
+    Py_XDECREF(co_flags);
     Py_XDECREF(co_varnames);
     Py_XDECREF(co_argcount);
+    Py_XDECREF(func_code);
     Py_XDECREF(elt);
     return result;
 }

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -65,6 +65,7 @@ public:
     bool getCheck(RtLoaderPyObject *py_class, const char *init_config_str, const char *instance_str,
                   const char *check_id_str, const char *check_name, const char *agent_config_str,
                   RtLoaderPyObject *&check);
+    bool isCheckInitDeprecated(RtLoaderPyObject *py_class);
 
     char *runCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -65,7 +65,7 @@ public:
     bool getCheck(RtLoaderPyObject *py_class, const char *init_config_str, const char *instance_str,
                   const char *check_id_str, const char *check_name, const char *agent_config_str,
                   RtLoaderPyObject *&check);
-    bool isCheckInitDeprecated(RtLoaderPyObject *py_class);
+    int isCheckInitDeprecated(RtLoaderPyObject *py_class);
 
     char *runCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -396,6 +396,45 @@ done:
     return true;
 }
 
+bool Two::isCheckInitDeprecated(RtLoaderPyObject *py_class)
+{
+    PyObject *klass = reinterpret_cast<PyObject *>(py_class);
+    PyObject *init, *func, *func_code, *co_varnames, *elt;
+    bool result = false;
+
+    // AgentCheck.__init__.im_func.func_code.co_varnames
+    init = PyObject_GetAttrString(klass, "__init__");
+    if (init == NULL) {
+        goto done;
+    }
+    func = PyObject_GetAttrString(init, "im_func");
+    if (func == NULL) {
+        goto done;
+    }
+    func_code = PyObject_GetAttrString(func, "func_code");
+    if (func_code == NULL) {
+        goto done;
+    }
+    co_varnames = PyObject_GetAttrString(func_code, "co_varnames");
+    if (co_varnames == NULL) {
+        goto done;
+    }
+    elt = PyString_FromString("agentConfig");
+    if (elt == NULL) {
+        goto done;
+    }
+    if (PySequence_Contains(co_varnames, elt) == 1) {
+        result = true;
+    }
+done:
+    Py_XDECREF(init);
+    Py_XDECREF(func);
+    Py_XDECREF(func_code);
+    Py_XDECREF(co_varnames);
+    Py_XDECREF(elt);
+    return result;
+}
+
 char *Two::runCheck(RtLoaderPyObject *check)
 {
     if (check == NULL) {

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -403,7 +403,7 @@ bool Two::isCheckInitDeprecated(RtLoaderPyObject *py_class)
     Py_ssize_t idx;
     bool result = false;
 
-    // AgentCheck.__init__.im_func.func_code.co_varnames
+    // AgentCheck.__init__.__code__.co_varnames[:AgentCheck.__init__.__code__.co_argcount]
     init = PyObject_GetAttrString(klass, "__init__");
     if (init == NULL) {
         goto done;
@@ -433,6 +433,7 @@ bool Two::isCheckInitDeprecated(RtLoaderPyObject *py_class)
         result = true;
     }
 done:
+    PyErr_Clear();
     Py_XDECREF(init);
     Py_XDECREF(func);
     Py_XDECREF(func_code);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -400,7 +400,7 @@ bool Two::isCheckInitDeprecated(RtLoaderPyObject *py_class)
 {
     PyObject *klass = reinterpret_cast<PyObject *>(py_class);
     PyObject *init, *func, *func_code, *co_varnames, *co_argcount, *elt = NULL;
-    Py_ssize_t idx = -1;
+    long idx = -1;
     bool result = false;
 
     // AgentCheck.__init__.__code__.co_varnames[:AgentCheck.__init__.__code__.co_argcount]
@@ -429,7 +429,7 @@ bool Two::isCheckInitDeprecated(RtLoaderPyObject *py_class)
         goto done;
     }
     idx = PySequence_Index(co_varnames, elt);
-    if (idx != -1 && idx < PyLong_AsSsize_t(co_argcount)) {
+    if (idx != -1 && idx < PyLong_AsLong(co_argcount)) {
         result = true;
     }
 done:

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -399,8 +399,8 @@ done:
 bool Two::isCheckInitDeprecated(RtLoaderPyObject *py_class)
 {
     PyObject *klass = reinterpret_cast<PyObject *>(py_class);
-    PyObject *init, *func, *func_code, *co_varnames, *co_argcount, *elt;
-    Py_ssize_t idx;
+    PyObject *init, *func, *func_code, *co_varnames, *co_argcount, *elt = NULL;
+    Py_ssize_t idx = -1;
     bool result = false;
 
     // AgentCheck.__init__.__code__.co_varnames[:AgentCheck.__init__.__code__.co_argcount]

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -64,6 +64,7 @@ public:
     bool getCheck(RtLoaderPyObject *py_class, const char *init_config_str, const char *instance_str,
                   const char *check_id_str, const char *check_name, const char *agent_config_str,
                   RtLoaderPyObject *&check);
+    bool isCheckInitDeprecated(RtLoaderPyObject *py_class);
 
     char *runCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -64,7 +64,7 @@ public:
     bool getCheck(RtLoaderPyObject *py_class, const char *init_config_str, const char *instance_str,
                   const char *check_id_str, const char *check_name, const char *agent_config_str,
                   RtLoaderPyObject *&check);
-    bool isCheckInitDeprecated(RtLoaderPyObject *py_class);
+    int isCheckInitDeprecated(RtLoaderPyObject *py_class);
 
     char *runCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);


### PR DESCRIPTION
Instead of trying to call both check methods to see if one works, this inspect the class signature to look for the deprecated `agentConfig` parameter, and call the right init depending on the result.