### PR TITLE
[omnibus] Preserve the python2-versioned 2to3 script

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -110,10 +110,13 @@ build do
             delete "#{install_dir}/embedded/share/aclocal"
             delete "#{install_dir}/embedded/share/examples"
 
-            # Setup pip aliases: `/opt/datadog-agent/embedded/bin/pip` will default to `pip2`
+            # Setup script aliases, e.g. `/opt/datadog-agent/embedded/bin/pip` will default to `pip2`
             if with_python_runtime? "2"
                 delete "#{install_dir}/embedded/bin/pip"
                 link "#{install_dir}/embedded/bin/pip2", "#{install_dir}/embedded/bin/pip"
+
+                delete "#{install_dir}/embedded/bin/2to3"
+                link "#{install_dir}/embedded/bin/2to3-2.7", "#{install_dir}/embedded/bin/2to3"
             end
 
             # removing the man pages from the embedded folder to reduce package size by ~4MB

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -63,6 +63,8 @@ if ohai["platform"] != "windows"
     command "make install", :env => env
     delete "#{install_dir}/embedded/lib/python2.7/test"
 
+    move "#{install_dir}/embedded/bin/2to3", "#{install_dir}/embedded/bin/2to3-2.7"
+
     block do
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/lib-dynload/readline.*"))
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/lib-dynload/gdbm.so"))

--- a/releasenotes/notes/preserve-2to3-py2-f03fe4686c4786a1.yaml
+++ b/releasenotes/notes/preserve-2to3-py2-f03fe4686c4786a1.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    On Linux, preserve the script `/opt/datadog-agent/embedded/bin/2to3`
+    that relies on the python 2 interpreter, alongside the python 3 one.


### PR DESCRIPTION
### What does this PR do?

Preserve the python2-versioned 2to3 script on Linux:
* the new `2to3-2.7` file now contains the python 2 version of the script
* in packages that include python 2 (i.e. Agent 6), `2to3` now points to `2to3-2.7`
* in packages that only include python 3 (i.e. Agent 7), `2to3` still points to `2to3-3.7` (symlink created by python3 compilation)
* the existing `2to3-3.7` file is unchanged

### Motivation

Since 6.14.0, the 2to3 script would only be shipped in its py3 version.

Let's ship the py2 version of the script as well, by prefixing it correctly. This is useful:

* for the container image, since the py2 container image does not contain python 3 but we still want users to be able to run 2to3 there
* to reduce confusion overall on what version of python the 2to3 script uses
