### PR TITLE
[gitlab] Fix the logic that checks existence of deb pkgs, for Agent 7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,7 +161,7 @@ before_script:
     - echo "Running windows source tests"
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat --release-version %RELEASE_VERSION% 
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat --release-version %RELEASE_VERSION%
 
 run_tests_windows-x64:
   # temporarily allow failure for tests
@@ -169,7 +169,7 @@ run_tests_windows-x64:
   allow_failure: true
   variables:
     ARCH: "x64"
-  
+
 run_tests_windows-x86:
   # temporarily allow failure for tests
   extends: .run_tests_windows_base
@@ -1653,10 +1653,12 @@ deploy_deb-6:
     - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
   script:
-    # We first check that the current version hasn't already been deployed
+    # We first check that the current v6 version hasn't already been deployed
     # (same as the check_already_deployed_version). We do this twice to mitigate
     # races and issues with retries while failing early if there is an issue.
     - pushd $OMNIBUS_PACKAGE_DIR
+    # remove v7 deb artifacts
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*_7.*amd64.deb
     - /deploy_scripts/fail_deb_is_pkg_already_exists.sh
     - popd
     - source /usr/local/rvm/scripts/rvm
@@ -1684,10 +1686,12 @@ deploy_deb-7:
     - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
   script:
-    # We first check that the current version hasn't already been deployed
+    # We first check that the current v7 version hasn't already been deployed
     # (same as the check_already_deployed_version). We do this twice to mitigate
     # races and issues with retries while failing early if there is an issue.
     - pushd $OMNIBUS_PACKAGE_DIR
+    # remove v6 deb artifacts
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*_6.*amd64.deb
     - /deploy_scripts/fail_deb_is_pkg_already_exists.sh
     - popd
     - source /usr/local/rvm/scripts/rvm


### PR DESCRIPTION
### What does this PR do?

Fix the logic that checks existence of deb pkgs in repo, was broken since the addition of Agent 7 in the pipeline.

### Motivation

Now that we release both Agent 6 and 7, the script that checks the existence of already-released deb packages matches all deb pkgs present locally.

Since we run this check on both `deploy_deb-6` and `deploy_deb-7`, make sure the check in these jobs only checks respectively the v6 and v7 packages, otherwise one of them may fail on a race condition. See https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/19779221 for an example.
