### PR TITLE
Adding logic to avoid processing too many HPAs

### DIFF
--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -374,11 +374,12 @@ func (h *AutoscalersController) updateAutoscaler(old, obj interface{}) {
 	toDelete := hpa.Inspect(oldAutoscaler)
 	h.deleteFromLocalStore(toDelete)
 	// We re-evaluate if the HPA can be processed in syncAutoscaler, subsequently to the enqueue.
+	h.mu.Lock()
 	if _, ok := h.overFlowingHPAs[oldAutoscaler.UID]; !ok {
 		h.metricsProcessedCount -= len(toDelete)
 	}
 	delete(h.overFlowingHPAs, oldAutoscaler.UID)
-
+	h.mu.Unlock()
 	log.Tracef("Processing update event for autoscaler %s/%s with configuration: %s", newAutoscaler.Namespace, newAutoscaler.Name, newAutoscaler.Annotations)
 	h.enqueue(newAutoscaler)
 }

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -16,6 +16,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	autoscalersinformer "k8s.io/client-go/informers/autoscaling/v2beta1"
 	"k8s.io/client-go/kubernetes"
@@ -29,7 +30,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hpa"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -352,6 +352,7 @@ func (h *AutoscalersController) addAutoscaler(obj interface{}) {
 // Adding the new obj and dropping the previous one is sufficient.
 // FIXME if the metric name or scope is changed in the HPA manifest we should propagate the change
 // to the Global store here
+// When the maxMetricsCount is reached concurrent ADD and UPDATE events can race.
 func (h *AutoscalersController) updateAutoscaler(old, obj interface{}) {
 	newAutoscaler, ok := obj.(*autoscalingv2.HorizontalPodAutoscaler)
 	if !ok {

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -29,11 +29,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hpa"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
 	// maxRetries is the maximum number of times we try to process an autoscaler before it is dropped out of the queue.
 	maxRetries = 10
+	// maxMetricsCount is the maximum number of metrics we can query from the backend.
+	maxMetricsCount = 40
 )
 
 type PollerConfig struct {
@@ -62,6 +65,11 @@ type AutoscalersController struct {
 	// used in unit tests to wait until hpas are synced
 	autoscalers chan interface{}
 
+	// metricsProcessedCount keeps track of the number of metrics queried per batch to avoid going over the backend limitation
+	metricsProcessedCount int
+	// overFlowingHPAs keeps a map of the HPA to the number of metrics in their specs that were ignored as there are already too many metrics being processed.
+	overFlowingHPAs map[types.UID]int
+
 	toStore   metricsBatch
 	hpaProc   hpa.ProcessorInterface
 	store     custommetrics.Store
@@ -80,6 +88,7 @@ func NewAutoscalersController(client kubernetes.Interface, le LeaderElectorInter
 	}
 
 	h.toStore.data = make(map[string]custommetrics.ExternalMetricValue)
+	h.overFlowingHPAs = make(map[types.UID]int)
 
 	gcPeriodSeconds := config.Datadog.GetInt("hpa_watcher_gc_period")
 	refreshPeriod := config.Datadog.GetInt("external_metrics_provider.refresh_period")
@@ -215,20 +224,29 @@ func (h *AutoscalersController) gc() {
 		log.Errorf("Could not list hpas: %v", err)
 		return
 	}
-
+	processedList := removeIgnoredHPAs(h.overFlowingHPAs, list)
 	emList, err := h.store.ListAllExternalMetricValues()
 	if err != nil {
 		log.Errorf("Could not list external metrics from store: %v", err)
 		return
 	}
-
-	deleted := hpa.DiffExternalMetrics(list, emList)
+	deleted := hpa.DiffExternalMetrics(processedList, emList)
 	if err = h.store.DeleteExternalMetricValues(deleted); err != nil {
 		log.Errorf("Could not delete the external metrics in the store: %v", err)
 		return
 	}
 	h.deleteFromLocalStore(deleted)
 	log.Debugf("Done GC run. Deleted %d metrics", len(deleted))
+}
+
+// removeIgnoredHPAs is used in the gc to avoid considering the ignored HPAs
+func removeIgnoredHPAs(ignored map[types.UID]int, listCached []*autoscalingv2.HorizontalPodAutoscaler) (toProcess []*autoscalingv2.HorizontalPodAutoscaler) {
+	for _, hpa := range listCached {
+		if _, ok := ignored[hpa.UID]; !ok {
+			toProcess = append(toProcess, hpa)
+		}
+	}
+	return
 }
 
 func (h *AutoscalersController) worker() {
@@ -298,13 +316,19 @@ func (h *AutoscalersController) syncAutoscalers(key interface{}) error {
 			return ErrIsEmpty
 		}
 		new := h.hpaProc.ProcessHPAs(hpa)
+		if len(new)+h.metricsProcessedCount > maxMetricsCount {
+			log.Warnf("Currently processing %d metrics, skipping %s/%s as we can't process more than %d metrics",
+				h.metricsProcessedCount, hpa.Namespace, hpa.Name, maxMetricsCount)
+			h.overFlowingHPAs[hpa.UID] = len(new)
+			return nil
+		}
 		h.toStore.m.Lock()
 		for metric, value := range new {
 			// We should only insert placeholders in the local cache.
 			h.toStore.data[metric] = value
 		}
 		h.toStore.m.Unlock()
-
+		h.metricsProcessedCount += len(new)
 		log.Tracef("Local batch cache of HPA is %v", h.toStore.data)
 	}
 	return err
@@ -341,7 +365,8 @@ func (h *AutoscalersController) updateAutoscaler(old, obj interface{}) {
 		log.Tracef("Update received for the %s/%s, without a relevant change to the configuration", newAutoscaler.Namespace, newAutoscaler.Name)
 		return
 	}
-	// Need to delete the old object from the local cache. If the labels have changed, the syncAutoscaler would not override the old key.
+	// Need to delete the old object from the local cache. If the labels (tags) have changed, the syncAutoscaler would not override the old key.
+	// If the oldAutoscaler is behind a HPA in the queue that maximises processedMetricsCount, it will be added to overFlowingHPAs and garbage collected.
 	toDelete := hpa.Inspect(oldAutoscaler)
 	h.deleteFromLocalStore(toDelete)
 
@@ -370,6 +395,11 @@ func (h *AutoscalersController) deleteAutoscaler(obj interface{}) {
 			h.enqueue(deletedHPA)
 			return
 		}
+		// Only decrease the count of processed metrics if we are able to successfully remove them from the global store.
+		// TODO pop HPAs from h.overFlowingHPAs and start processing the one(s) we have been ignoring up to the maxMetricsCount
+		// Current behavior: HPA will be evaluated next resync and processed if it does not have too many metrics.
+		h.metricsProcessedCount -= len(toDelete)
+		delete(h.overFlowingHPAs, deletedHPA.UID)
 		return
 	}
 
@@ -393,6 +423,10 @@ func (h *AutoscalersController) deleteAutoscaler(obj interface{}) {
 		h.enqueue(deletedHPA)
 		return
 	}
+	// Only decrease the count of processed metrics if we are able to successfully remove them from the global store.
+	// TODO pop HPAs from h.overFlowingHPAs and start processing the one(s) we have been ignoring, up to the maxMetricsCount
+	h.metricsProcessedCount -= len(toDelete)
+	delete(h.overFlowingHPAs, deletedHPA.UID)
 }
 
 func (h *AutoscalersController) enqueue(obj interface{}) {

--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -13,20 +13,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 	"k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hpa"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/informers"
 )
 
 func newFakeConfigMapStore(t *testing.T, ns, name string, metrics map[string]custommetrics.ExternalMetricValue) (custommetrics.Store, kubernetes.Interface) {


### PR DESCRIPTION
### What does this PR do?

In some environments with many HPAs it is was previously possible to trigger a situation where HPAs were invalidated.  This PR adds better error handling to prevent the condition. This change adds logic to keep track of the HPAs that we attempted to process but would have included too many metrics  at the controller level.

We are further working on additional batching calls, but in the interim we this error handling will help ensure existing HPAs are not invalidated. 

Added tests to cover the Resync, the deletion, the update ...

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
