### PR TITLE
[invoke] rpath should only require using the one location lib/lib64

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -100,7 +100,7 @@ def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "
     else:
-        ldflags += "-r {}/lib:{}/lib64 ".format(embedded_path, embedded_path)
+        ldflags += "-r {} ".format(':'.join(rtloader_lib))
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"


### PR DESCRIPTION
### What does this PR do?

We now only pass the expected location to the rpath. Passing both lib/lib64 was apparently acting up on some environments. 

### Motivation

Some issues reported on users running tests on macOS. I presume it might've affected the build as well. This should help fix the rpath search problem. 
