### PR TITLE
Reducing network connection payload sizes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,15 +10,14 @@
   source = "github.com/adjust/goautoneg"
 
 [[projects]]
-  digest = "1:80add72716890850681888ef2b2f9518f2459baa194ae8ece44aeaa140bf7945"
+  digest = "1:f8854a9233af0457591783788207552f6a6950521ce96e007382b1b506bfd5c6"
   name = "github.com/DataDog/agent-payload"
   packages = [
     "gogen",
     "process",
   ]
   pruneopts = ""
-  revision = "58cdf294cbf0f38873204da85cc91ec07f14b678"
-  version = "4.13.0"
+  revision = "cb184060464f95df4a0610585953eec30adf186d"
 
 [[projects]]
   digest = "1:e64fddc819e2abc68792a743dd857c379449a56f2b9eaf030c03fb0ec19de884"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/DataDog/agent-payload"
-  version = "4.13.0"
+  revision = "cb184060464f95df4a0610585953eec30adf186d"
 
 [[constraint]]
   name = "github.com/google/gopacket"

--- a/pkg/ebpf/encoding/format.go
+++ b/pkg/ebpf/encoding/format.go
@@ -8,47 +8,58 @@ import (
 )
 
 // FormatConnection converts a ConnectionStats into an model.Connection
-func FormatConnection(conn ebpf.ConnectionStats) *model.Connection {
+func FormatConnection(conn ebpf.ConnectionStats, useAddrByteString bool) *model.Connection {
 	return &model.Connection{
-		Pid:                int32(conn.Pid),
-		Laddr:              formatAddr(conn.Source, conn.SPort),
-		Raddr:              formatAddr(conn.Dest, conn.DPort),
-		Family:             formatFamily(conn.Family),
-		Type:               formatType(conn.Type),
-		TotalBytesSent:     conn.MonotonicSentBytes,
-		TotalBytesReceived: conn.MonotonicRecvBytes,
-		TotalRetransmits:   conn.MonotonicRetransmits,
-		LastBytesSent:      conn.LastSentBytes,
-		LastBytesReceived:  conn.LastRecvBytes,
-		LastRetransmits:    conn.LastRetransmits,
-		Rtt:                conn.RTT,
-		RttVar:             conn.RTTVar,
-		Direction:          formatDirection(conn.Direction),
-		NetNS:              conn.NetNS,
-		IpTranslation:      formatIPTranslation(conn.IPTranslation),
+		Pid:               int32(conn.Pid),
+		Laddr:             formatAddr(conn.Source, conn.SPort, useAddrByteString),
+		Raddr:             formatAddr(conn.Dest, conn.DPort, useAddrByteString),
+		Family:            formatFamily(conn.Family),
+		Type:              formatType(conn.Type),
+		LastBytesSent:     conn.LastSentBytes,
+		LastBytesReceived: conn.LastRecvBytes,
+		LastRetransmits:   conn.LastRetransmits,
+		Rtt:               conn.RTT,
+		RttVar:            conn.RTTVar,
+		Direction:         formatDirection(conn.Direction),
+		NetNS:             conn.NetNS,
+		IpTranslation:     formatIPTranslation(conn.IPTranslation, useAddrByteString),
 	}
 }
 
-// FormatDNS converts a map[util.Address][]string to a map using IPs string representation
-func FormatDNS(dns map[util.Address][]string) map[string]*model.DNSEntry {
+// FormatDNS converts a map[util.Address][]string to a map using IPs byte string representation
+func FormatDNS(dns map[util.Address][]string, useAddrByteString bool) map[string]*model.DNSEntry {
 	if dns == nil {
 		return nil
 	}
 
 	ipToNames := make(map[string]*model.DNSEntry, len(dns))
 	for addr, names := range dns {
-		ipToNames[addr.String()] = &model.DNSEntry{Names: names}
+		if useAddrByteString {
+			ipToNames[addr.ByteString()] = &model.DNSEntry{Names: names}
+		} else {
+			ipToNames[addr.String()] = &model.DNSEntry{Names: names}
+		}
 	}
 
 	return ipToNames
 }
 
-func formatAddr(addr util.Address, port uint16) *model.Addr {
+func formatAddr(addr util.Address, port uint16, useAddrByteString bool) *model.Addr {
 	if addr == nil {
 		return nil
 	}
 
-	return &model.Addr{Ip: addr.String(), Port: int32(port)}
+	address := &model.Addr{
+		Port: int32(port),
+	}
+
+	if useAddrByteString {
+		address.IpByteString = addr.ByteString()
+	} else {
+		address.Ip = addr.String()
+	}
+
+	return address
 }
 
 func formatFamily(f ebpf.ConnectionFamily) model.ConnectionFamily {
@@ -86,15 +97,22 @@ func formatDirection(d ebpf.ConnectionDirection) model.ConnectionDirection {
 	}
 }
 
-func formatIPTranslation(ct *netlink.IPTranslation) *model.IPTranslation {
+func formatIPTranslation(ct *netlink.IPTranslation, useAddrByteString bool) *model.IPTranslation {
 	if ct == nil {
 		return nil
 	}
 
-	return &model.IPTranslation{
-		ReplSrcIP:   ct.ReplSrcIP.String(),
-		ReplDstIP:   ct.ReplDstIP.String(),
+	t := &model.IPTranslation{
 		ReplSrcPort: int32(ct.ReplSrcPort),
 		ReplDstPort: int32(ct.ReplDstPort),
 	}
+
+	if useAddrByteString {
+		t.ReplSrcIPByteString = ct.ReplSrcIP.ByteString()
+		t.ReplDstIPByteString = ct.ReplDstIP.ByteString()
+	} else {
+		t.ReplSrcIP = ct.ReplSrcIP.String()
+		t.ReplDstIP = ct.ReplDstIP.String()
+	}
+	return t
 }

--- a/pkg/ebpf/encoding/json.go
+++ b/pkg/ebpf/encoding/json.go
@@ -18,9 +18,11 @@ type jsonSerializer struct {
 func (j jsonSerializer) Marshal(conns *ebpf.Connections) ([]byte, error) {
 	agentConns := make([]*model.Connection, len(conns.Conns))
 	for i, conn := range conns.Conns {
-		agentConns[i] = FormatConnection(conn)
+		agentConns[i] = FormatConnection(conn, false)
 	}
-	payload := &model.Connections{Conns: agentConns, Dns: FormatDNS(conns.DNS)}
+
+	payload := &model.Connections{Conns: agentConns, Dns: FormatDNS(conns.DNS, false)}
+
 	writer := new(bytes.Buffer)
 	err := j.marshaller.Marshal(writer, payload)
 	return writer.Bytes(), err

--- a/pkg/ebpf/encoding/protobuf.go
+++ b/pkg/ebpf/encoding/protobuf.go
@@ -15,12 +15,12 @@ func (protoSerializer) Marshal(conns *ebpf.Connections) ([]byte, error) {
 	agentConns := make([]*model.Connection, len(conns.Conns))
 
 	for i, conn := range conns.Conns {
-		agentConns[i] = FormatConnection(conn)
+		agentConns[i] = FormatConnection(conn, true)
 	}
 
 	payload := &model.Connections{
 		Conns: agentConns,
-		Dns:   FormatDNS(conns.DNS),
+		Dns:   FormatDNS(conns.DNS, true),
 	}
 
 	return proto.Marshal(payload)

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -162,7 +162,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		LogToConsole:       false,
 		QueueSize:          20,
 		MaxPerMessage:      100,
-		MaxConnsPerMessage: 300,
+		MaxConnsPerMessage: 500,
 		AllowRealTime:      true,
 		HostName:           "",
 		Transport:          NewDefaultTransport(),

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -8,6 +8,7 @@ import (
 // Address is an IP abstraction that is family (v4/v6) agnostic
 type Address interface {
 	Bytes() []byte
+	ByteString() string
 	String() string
 }
 
@@ -24,9 +25,22 @@ func AddressFromNetIP(ip net.IP) Address {
 	return a
 }
 
-// AddressFromString creates an Address using the string representation of an v4 IP
+// AddressFromString creates an Address using the string representation of an IP
 func AddressFromString(ip string) Address {
 	return AddressFromNetIP(net.ParseIP(ip))
+}
+
+// AddressFromByteString creates an Address using the byte string representation of an IP
+func AddressFromByteString(ip string) Address {
+	if len(ip) == 16 {
+		return V6AddressFromBytes([]byte(ip))
+	}
+	return V4AddressFromBytes([]byte(ip))
+}
+
+// NetIPFromIPByteString returns a net.IP from an Address
+func NetIPFromIPByteString(ipBs string) net.IP {
+	return net.IP([]byte(ipBs))
 }
 
 // NetIPFromAddress returns a net.IP from an Address
@@ -58,6 +72,11 @@ func (a v4Address) Bytes() []byte {
 	return a[:]
 }
 
+// ByteString returns a byte representation of the underlying array as a string
+func (a v4Address) ByteString() string {
+	return string(a[:])
+}
+
 // String returns the human readable string representation of an IP
 func (a v4Address) String() string {
 	return net.IPv4(a[0], a[1], a[2], a[3]).String()
@@ -83,6 +102,11 @@ func V6AddressFromBytes(buf []byte) Address {
 // Bytes returns a byte array of the underlying array
 func (a v6Address) Bytes() []byte {
 	return a[:]
+}
+
+// ByteString returns a byte representation of the underlying array as a string
+func (a v6Address) ByteString() string {
+	return string(a[:])
 }
 
 // String returns the human readable string representation of an IP

--- a/pkg/process/util/address_test.go
+++ b/pkg/process/util/address_test.go
@@ -99,6 +99,9 @@ func TestAddressV4(t *testing.T) {
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("192.168.0.1"))
 	assert.Equal(t, "192.168.0.1", addr.String())
+	// Should be able to recreate addr from IP Byte string
+	assert.Equal(t, "\xc0\xa8\x00\x01", addr.ByteString())
+	assert.Equal(t, AddressFromByteString("\xc0\xa8\x00\x01"), addr)
 }
 
 func TestAddressV6(t *testing.T) {
@@ -129,4 +132,35 @@ func TestAddressV6(t *testing.T) {
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("2001:db8::2:1"))
 	assert.Equal(t, "2001:db8::2:1", addr.String())
+	// Should be able to recreate addr from IP Byte string
+	assert.Equal(t, " \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x01", addr.ByteString())
+	assert.Equal(t, AddressFromByteString(" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x01"), addr)
+}
+
+func TestAddressByteStrings(t *testing.T) {
+	// v4
+	addr := V4Address(16820416)
+	assert.Len(t, addr.ByteString(), 4) // Should only be 4 bytes
+	assert.Equal(t, "\xc0\xa8\x00\x01", addr.ByteString())
+	assert.Equal(t, addr, AddressFromByteString("\xc0\xa8\x00\x01"))
+	assert.Equal(t, NetIPFromAddress(addr), NetIPFromIPByteString("\xc0\xa8\x00\x01"))
+
+	addr = V4Address(0)
+	assert.Len(t, addr.ByteString(), 4) // Should only be 4 bytes
+	assert.Equal(t, "\x00\x00\x00\x00", addr.ByteString())
+	assert.Equal(t, addr, AddressFromByteString("\x00\x00\x00\x00"))
+	assert.Equal(t, NetIPFromAddress(addr), NetIPFromIPByteString("\x00\x00\x00\x00"))
+
+	// v6
+	addr = V6Address(72059793061183488, 3087860000)
+	assert.Len(t, addr.ByteString(), 16) // Should only be 16 bytes
+	assert.Equal(t, " \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x01", addr.ByteString())
+	assert.Equal(t, addr, AddressFromByteString(" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x01"))
+	assert.Equal(t, NetIPFromAddress(addr), NetIPFromIPByteString(" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x01"))
+
+	addr = V6Address(0, 0)
+	assert.Len(t, addr.ByteString(), 16) // Should only be 16 bytes
+	assert.Equal(t, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", addr.ByteString())
+	assert.Equal(t, addr, AddressFromByteString("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"))
+	assert.Equal(t, NetIPFromAddress(addr), NetIPFromIPByteString("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"))
 }

--- a/releasenotes/notes/enhancement-d9a106e0df9c1100.yaml
+++ b/releasenotes/notes/enhancement-d9a106e0df9c1100.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Reduce the wire size of messages for network connections, as well as increasing the batch size from 300 to 500


### PR DESCRIPTION
### What does this PR do?

Increase batch size from 300 to 500 messages per batch. Store byte representation of addresses over the wire to save bandwidth and overall reduce message sizes.

Changes from some production traffic payloads:
```
conns: 12522 (no conntrack)

pb size: 907559 bytes (current)
pb size: 618656 bytes (~32% drop) (base64 encoding of IP bytes + removing monotonic fields)
pb size: 565488 bytes (~38% drop) (string encoding of IP bytes + removing monotonic fields)
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
