### PR TITLE
Re-include pylint in Agent packages

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -144,6 +144,7 @@ else
 end
 
 if with_python_runtime? "2"
+  dependency 'pylint2'
   dependency 'datadog-agent-integrations-py2'
 end
 

--- a/omnibus/config/software/pylint2.rb
+++ b/omnibus/config/software/pylint2.rb
@@ -1,0 +1,28 @@
+name "pylint2"
+# Ship 1.x as 2.x only supports python 3
+default_version "1.9.5"
+
+dependency "pip2"
+
+build do
+  # pylint is only called in a subprocess by the Agent, so the Agent doesn't have to be GPL as well
+  ship_license "GPLv2"
+
+  # aliases for the pips
+  if windows?
+    pip2 = "#{windows_safe_path(python_2_embedded)}\\Scripts\\pip.exe"
+    python2 = "#{windows_safe_path(python_2_embedded)}\\python.exe"
+  else
+    pip2 = "#{install_dir}/embedded/bin/pip2"
+    python2 = "#{install_dir}/embedded/bin/python2"
+  end
+
+  if windows?
+    # this pins a dependency of pylint, later versions (up to v3.7.1) are broken.
+    command "#{python2} -m pip install configparser==3.5.0"
+    command "#{python2} -m pip install pylint==#{version}"
+  else
+    command "#{pip2} install configparser==3.5.0"
+    command "#{pip2} install pylint==#{version}"
+  end
+end


### PR DESCRIPTION
### What does this PR do?

Re-include pylint in Agent packages (only when python 2 is included)

### Motivation

Was removed by mistake when removing 'a7' from the packages in https://github.com/DataDog/datadog-agent/pull/4224
