### PR TITLE
[invoke] Only add rtloader ldflags if rtloader_lib is nonempty

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -95,6 +95,7 @@ def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + " -L{}".format(' -L '.join(rtloader_lib))
     env['CGO_CFLAGS'] = os.environ.get('CGO_CFLAGS', '') + " -w -I{} -I{}".format(rtloader_headers,
                                                                                   rtloader_common_headers)
+
     # if `static` was passed ignore setting rpath, even if `embedded_path` was passed as well
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -95,11 +95,10 @@ def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + " -L{}".format(' -L '.join(rtloader_lib))
     env['CGO_CFLAGS'] = os.environ.get('CGO_CFLAGS', '') + " -w -I{} -I{}".format(rtloader_headers,
                                                                                   rtloader_common_headers)
-
     # if `static` was passed ignore setting rpath, even if `embedded_path` was passed as well
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "
-    else:
+    elif rtloader_lib:
         ldflags += "-r {} ".format(':'.join(rtloader_lib))
 
     if os.environ.get("DELVE"):


### PR DESCRIPTION
### What does this PR do?

The system-probe build is broken due to 9e1ecd80c6f6419a21c32bc470acdfe1cc5c2f04 

This should fix it

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
