### PR TITLE
Disable windows unit tests on Gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,21 +161,22 @@ before_script:
     - echo "Running windows source tests"
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat --release-version %RELEASE_VERSION% 
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat --release-version %RELEASE_VERSION%
 
-run_tests_windows-x64:
-  # temporarily allow failure for tests
-  extends: .run_tests_windows_base
-  allow_failure: true
-  variables:
-    ARCH: "x64"
-  
-run_tests_windows-x86:
-  # temporarily allow failure for tests
-  extends: .run_tests_windows_base
-  allow_failure: true
-  variables:
-    ARCH: "x86"
+# TODO: disabled until slowness issues are solved
+# run_tests_windows-x64:
+#   # temporarily allow failure for tests
+#   extends: .run_tests_windows_base
+#   allow_failure: true
+#   variables:
+#     ARCH: "x64"
+
+# run_tests_windows-x86:
+#   # temporarily allow failure for tests
+#   extends: .run_tests_windows_base
+#   allow_failure: true
+#   variables:
+#     ARCH: "x86"
 
 
 .run_tests_preparation: &run_tests_preparation


### PR DESCRIPTION
### What does this PR do?

Disables windows unit tests on Gitlab until they can be made to run faster or they can run asynchronously.

### Motivation

They're currently very slow:
* the x64 ones take about 50min to complete, and fail
* the x86 ones take about 20min to complete, and fail at the start of the actual unit tests

This slowness is especially painful since the unit tests are the very first stage of the pipeline, and therefore slow down the entire pipeline.

### Additional Notes

Alternatively, we could move these tests at the very end of the pipeline to avoid blocking all the other stages.