### PR TITLE
[github] Fix CODEOWNERS default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # Rules are matched bottom-to-top, so one team can own subdirectories
 # and another the rest of the directory.
 
-/                                       @DataDog/agent-platform
+*                                       @DataDog/agent-platform
 
 /cmd/                                   @DataDog/agent-core
 /cmd/trace-agent/                       @DataDog/apm-agent


### PR DESCRIPTION
### What does this PR do?

Follow syntax given here to define the default code owner:
https://help.github.com/en/articles/about-code-owners#codeowners-syntax

### Motivation

Wrong default code owner on some PRs such as: https://github.com/DataDog/datadog-agent/pull/4279
