### PR TITLE
[kitchen] Use different test names depending on the agent version

### DIFF
--- a/test/kitchen/kitchen-apt-check-azure.yml
+++ b/test/kitchen/kitchen-apt-check-azure.yml
@@ -66,7 +66,7 @@ platforms:
 
 suites:
 
-- name: dd-test-install
+- name: dd-test-install-<%=ENV['AGENT_VERSION']%>
   includes:
     <% platforms_x64.each do |platform| %>
     - <%= platform %>

--- a/test/kitchen/kitchen-azure-winstall.yml
+++ b/test/kitchen/kitchen-azure-winstall.yml
@@ -163,7 +163,7 @@ suites:
   }
 %>
 
-  - name: dd-agent-installopts
+  - name: dd-agent-installopts-<%=ENV['AGENT_VERSION']%>
     run_list:
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
@@ -200,7 +200,7 @@ suites:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
 
-  - name: dd-agent-all-subservices
+  - name: dd-agent-all-subservices-<%=ENV['AGENT_VERSION']%>
     run_list:
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
@@ -229,7 +229,7 @@ suites:
       dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
-  - name: dd-agent-no-subservices
+  - name: dd-agent-no-subservices-<%=ENV['AGENT_VERSION']%>
     run_list:
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
@@ -258,7 +258,7 @@ suites:
       dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
-  - name: dd-agent-user-win
+  - name: dd-agent-user-win-<%=ENV['AGENT_VERSION']%>
     run_list:
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
@@ -286,7 +286,7 @@ suites:
       dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
-  - name: dd-agent-install-fail
+  - name: dd-agent-install-fail-<%=ENV['AGENT_VERSION']%>
     run_list:
         - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
@@ -315,7 +315,7 @@ suites:
       dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
-  - name: dd-agent-alt-dir
+  - name: dd-agent-alt-dir-<%=ENV['AGENT_VERSION']%>
     run_list:
         - "recipe[dd-agent-install::_install_windows_base]"
     attributes:

--- a/test/kitchen/kitchen-azure-wupgrade5.yml
+++ b/test/kitchen/kitchen-azure-wupgrade5.yml
@@ -182,7 +182,7 @@ suites:
 
 # Installs the latest release Agent 5, then updates it to the latest release
 # candidate
-- name: dd-agent-upgrade-agent5
+- name: dd-agent-upgrade-agent5-<%=ENV['AGENT_VERSION']%>
   excludes: <% if sles15_platforms.nil? || sles15_platforms.empty? %>[]<% end %> # Agent 5 package doesn't work on SLES 15
     <% sles15_platforms.each do |p| %>
     - <%= p %>

--- a/test/kitchen/kitchen-azure.yml
+++ b/test/kitchen/kitchen-azure.yml
@@ -184,7 +184,7 @@ suites:
 %>
 
 # Install the latest release candidate using Chef
-- name: dd-agent
+- name: dd-agent-<%=ENV['AGENT_VERSION']%>
   run_list:
     - "recipe[dd-agent-install]"
   attributes:
@@ -209,7 +209,7 @@ suites:
 
 # Installs the latest release Agent 6, then updates it to the latest release
 # candidate
-- name: dd-agent-upgrade-agent6
+- name: dd-agent-upgrade-agent6-<%=ENV['AGENT_VERSION']%>
   run_list:
     - "recipe[dd-agent-install]"
     - "recipe[dd-agent-upgrade]"
@@ -255,7 +255,7 @@ suites:
 
 # Installs the latest release Agent 5, then updates it to the latest release
 # candidate
-- name: dd-agent-upgrade-agent5
+- name: dd-agent-upgrade-agent5-<%=ENV['AGENT_VERSION']%>
   excludes: <% if (sles15_platforms.nil? || sles15_platforms.empty?) && (windows_platforms.nil? || windows_platforms.empty?) %>[]<% end %> # Agent 5 package doesn't work on SLES 15
     <% sles15_platforms.each do |p| %>
     - <%= p %>
@@ -310,7 +310,7 @@ suites:
 
 
 # Installs the latest release candidate using the install script
-- name: dd-agent-install-script
+- name: dd-agent-install-script-<%=ENV['AGENT_VERSION']%>
   excludes: <% if windows_platforms.nil? || windows_platforms.empty? %>[]<% end %>
     <% windows_platforms.each do |p| %>
     - <%= p %>
@@ -330,7 +330,7 @@ suites:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
 # Installs the latest release candidate using the step-by-step instructions (on dogweb)
-- name: dd-agent-step-by-step
+- name: dd-agent-step-by-step-<%=ENV['AGENT_VERSION']%>
   run_list:
     - "recipe[dd-agent-step-by-step]"
   excludes: <% if windows_platforms.nil? || windows_platforms.empty? %>[]<% end %>


### PR DESCRIPTION
Since both try to create the same VMs, I would expect this to create conflicts.