### PR TITLE
Prevent deb-s3 from running at the same time for 6 and 7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1745,7 +1745,7 @@ deploy_deb-6:
     # (same as the check_already_deployed_version). We do this twice to mitigate
     # races and issues with retries while failing early if there is an issue.
     - pushd $OMNIBUS_PACKAGE_DIR
-    - /deploy_scripts/fail_deb_is_pkg_already_exists.sh *_7.*amd64.deb
+    - /deploy_scripts/fail_deb_is_pkg_already_exists.sh *_6.*amd64.deb
     - popd
     - source /usr/local/rvm/scripts/rvm
     - rvm use 2.4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,8 @@ stages:
   - pkg_metrics
   - image_build
   - image_deploy
-  - deploy
+  - deploy6
+  - deploy7
   - deploy_invalidate
   - e2e
   - testkitchen_cleanup
@@ -62,7 +63,7 @@ variables:
   RELEASE_VERSION_6: nightly
   RELEASE_VERSION_7: nightly
   DATADOG_AGENT_BUILDIMAGES: v1709713-2adac2a
-  DATADOG_AGENT_BUILDERS: v1755190-c671974
+  DATADOG_AGENT_BUILDERS: v1790442-01a4d70
   DATADOG_AGENT_WINBUILDIMAGES: v1782031-7bc5447
 
 
@@ -1734,7 +1735,7 @@ check_if_build_only:
 deploy_deb-6:
   <<: *run_when_triggered
   <<: *skip_when_unwanted_on_6
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1744,7 +1745,7 @@ deploy_deb-6:
     # (same as the check_already_deployed_version). We do this twice to mitigate
     # races and issues with retries while failing early if there is an issue.
     - pushd $OMNIBUS_PACKAGE_DIR
-    - /deploy_scripts/fail_deb_is_pkg_already_exists.sh
+    - /deploy_scripts/fail_deb_is_pkg_already_exists.sh *_7.*amd64.deb
     - popd
     - source /usr/local/rvm/scripts/rvm
     - rvm use 2.4
@@ -1766,7 +1767,7 @@ deploy_deb-6:
 deploy_deb-7:
   <<: *run_when_triggered
   <<: *skip_when_unwanted_on_7
-  stage: deploy
+  stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1776,7 +1777,7 @@ deploy_deb-7:
     # (same as the check_already_deployed_version). We do this twice to mitigate
     # races and issues with retries while failing early if there is an issue.
     - pushd $OMNIBUS_PACKAGE_DIR
-    - /deploy_scripts/fail_deb_is_pkg_already_exists.sh
+    - /deploy_scripts/fail_deb_is_pkg_already_exists.sh *_7.*amd64.deb
     - popd
     - source /usr/local/rvm/scripts/rvm
     - rvm use 2.4
@@ -1797,7 +1798,7 @@ deploy_deb-7:
 
 # deploy windows packages to a public s3 bucket when pushed on master
 deploy_windows_master:
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1807,7 +1808,7 @@ deploy_windows_master:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_windows_master-latest-6:
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1817,7 +1818,7 @@ deploy_windows_master-latest-6:
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-6*-x86_64.msi "s3://$WINDOWS_BUILDS_S3_BUCKET/master/datadog-agent-6-latest.amd64.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_windows_master-latest-7:
-  stage: deploy
+  stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1828,7 +1829,7 @@ deploy_windows_master-latest-7:
 
 # deploy windows packages to a public s3 bucket when tagged
 deploy_windows_tags:
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1838,7 +1839,7 @@ deploy_windows_tags:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_windows_tags-latest-6:
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1852,7 +1853,7 @@ deploy_windows_tags-latest-6:
     - if [ "WINDOWS_DO_NOT_UPDATE_LATEST" != "true" ]; then $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-6*-x86_64.msi s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/datadog-agent-6-latest.amd64.msi --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732; fi
 
 deploy_windows_tags-latest-7:
-  stage: deploy
+  stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1867,7 +1868,7 @@ deploy_windows_tags-latest-7:
 
 # deploy android packages to a public s3 bucket when tagged
 deploy_android_tags:
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1880,7 +1881,7 @@ deploy_android_tags:
 deploy_rpm-6:
   <<: *run_when_triggered
   <<: *skip_when_unwanted_on_6
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1901,7 +1902,7 @@ deploy_rpm-6:
 deploy_rpm-7:
   <<: *run_when_triggered
   <<: *skip_when_unwanted_on_7
-  stage: deploy
+  stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1923,7 +1924,7 @@ deploy_rpm-7:
 deploy_suse_rpm-6:
   <<: *run_when_triggered
   <<: *skip_when_unwanted_on_6
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1944,7 +1945,7 @@ deploy_suse_rpm-6:
 deploy_suse_rpm-7:
   <<: *run_when_triggered
   <<: *skip_when_unwanted_on_7
-  stage: deploy
+  stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1965,7 +1966,7 @@ deploy_suse_rpm-7:
 # deploy dsd binary to staging bucket
 deploy_dsd:
   <<: *run_when_triggered
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1978,7 +1979,7 @@ deploy_dsd:
 # deploy dsd binary to staging bucket
 deploy_puppy:
   <<: *run_when_triggered
-  stage: deploy
+  stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -2014,7 +2015,7 @@ tag_release_6:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag_6
   <<: *skip_when_unwanted_on_6
-  stage: deploy
+  stage: deploy6
   when: manual
   variables:
     PYTHON_RUNTIMES: '2,3'
@@ -2031,7 +2032,7 @@ tag_release_7:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag_7
   <<: *skip_when_unwanted_on_7
-  stage: deploy
+  stage: deploy7
   when: manual
   variables:
     PYTHON_RUNTIMES: '3'
@@ -2045,7 +2046,7 @@ latest_release_6:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag_6
   <<: *skip_when_unwanted_on_6
-  stage: deploy
+  stage: deploy6
   when: manual
   variables:
     <<: *docker_hub_variables
@@ -2065,7 +2066,7 @@ latest_release_7:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag_7
   <<: *skip_when_unwanted_on_7
-  stage: deploy
+  stage: deploy7
   when: manual
   variables:
     <<: *docker_hub_variables


### PR DESCRIPTION
Potential race condition if both scripts try to write common files in the repo (eg: Release file) at the same time.

Also updates de builders to use the new `fail_deb_is_pkg_already_exists` script that only checks the files specified.
