### PR TITLE
Fix tagger warning when docker container not found

### DIFF
--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
@@ -119,8 +120,9 @@ func (c *DockerCollector) processEvent(e *docker.ContainerEvent) {
 func (c *DockerCollector) fetchForDockerID(cID string) ([]string, []string, []string, error) {
 	co, err := c.dockerUtil.Inspect(cID, false)
 	if err != nil {
-		// TODO separate "not found" and inspect error
-		log.Debugf("Failed to inspect container %s - %s", cID, err)
+		if !errors.IsNotFound(err) {
+			log.Debugf("Failed to inspect container %s - %s", cID, err)
+		}
 		return nil, nil, nil, err
 	}
 	return c.extractFromInspect(co)

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/client"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
@@ -225,6 +226,9 @@ func (d *DockerUtil) Inspect(id string, withSize bool) (types.ContainerJSON, err
 	ctx, cancel := context.WithTimeout(context.Background(), d.queryTimeout)
 	defer cancel()
 	container, _, err := d.cli.ContainerInspectWithRaw(ctx, id, withSize)
+	if client.IsErrNotFound(err) {
+		return container, dderrors.NewNotFound(fmt.Sprintf("docker container %s", id))
+	}
 	if err != nil {
 		return container, err
 	}

--- a/releasenotes/notes/Fix-tagger-warning-when-docker-container-not-found-ee755e2a2545e4f6.yaml
+++ b/releasenotes/notes/Fix-tagger-warning-when-docker-container-not-found-ee755e2a2545e4f6.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Avoid the tagger to log a warning when a docker container is not found.
+


### PR DESCRIPTION
### What does this PR do?

Add error conversion type between docker and datadog-agent error types.

### Motivation

Missing error conversion type between docker `not found` error and
datadog-agent error. The Tagger wasn't able to recognize the `not found`
error, and so enter into an error case that generates the Warning.

### Additional Notes

none
