### PR TITLE
[appveyor] Install deps before testing rtloader

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,11 +41,11 @@ cache:
 build: off
 
 test_script:
+  - inv -e deps --dep-vendor-only
   - inv -e rtloader.build --install-prefix=%APPVEYOR_BUILD_FOLDER%\dev --cmake-options="-G \"MSYS Makefiles\""
   - inv -e rtloader.install
   - inv -e rtloader.format --raise-if-changed
   - inv -e rtloader.test
-  - inv -e deps --dep-vendor-only
   - inv -e test --coverage --profile --fail-on-fmt --python-home-2=C:\Python27-x64 --python-home-3=C:\Python37-x64
   - codecov -f profile.cov -F windows
 


### PR DESCRIPTION
### What does this PR do?

Fix AppVeyor tests by installing Go deps before testing rtloader (since the rtloader tests include go tests that require some Go deps, for example `github.com\stretchr\testify\assert`.

### Additional Notes

To be honest I'm not sure how the AppVeyor tests passed before. I don't know how the Go deps that are needed to run the `rtloader` tests could already be there before this fix 🤔 
