### PR TITLE
Extract cloud provider detection outside of the hostname detection

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -273,6 +273,9 @@ func StartAgent() error {
 		log.Info("logs-agent disabled")
 	}
 
+	// Detect Cloud Provider
+	go util.DetectCloudProvider()
+
 	// create and setup the Autoconfig instance
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 	// start the autoconfig, this will immediately run any configured check

--- a/pkg/util/alibaba/alibaba.go
+++ b/pkg/util/alibaba/alibaba.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 )
 
 // declare these as vars not const to ease testing
@@ -24,6 +23,14 @@ var (
 	CloudProviderName = "Alibaba"
 )
 
+// IsRunningOn returns true if the agent is running on Alibaba
+func IsRunningOn() bool {
+	if _, err := GetHostAlias(); err == nil {
+		return true
+	}
+	return false
+}
+
 // GetHostAlias returns the VM ID from the Alibaba Metadata api
 func GetHostAlias() (string, error) {
 	res, err := getResponseWithMaxLength(metadataURL+"/latest/meta-data/instance-id",
@@ -31,9 +38,6 @@ func GetHostAlias() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Alibaba HostAliases: unable to query metadata endpoint: %s", err)
 	}
-
-	// registering that we're running on alibaba
-	inventories.SetAgentMetadata(inventories.CloudProviderMetatadaName, CloudProviderName)
 	return res, err
 }
 

--- a/pkg/util/azure/azure.go
+++ b/pkg/util/azure/azure.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 )
 
 // declare these as vars not const to ease testing
@@ -26,6 +25,14 @@ var (
 	CloudProviderName = "Azure"
 )
 
+// IsRunningOn returns true if the agent is running on Azure
+func IsRunningOn() bool {
+	if _, err := GetHostAlias(); err == nil {
+		return true
+	}
+	return false
+}
+
 // GetHostAlias returns the VM ID from the Azure Metadata api
 func GetHostAlias() (string, error) {
 	res, err := getResponseWithMaxLength(metadataURL+"/metadata/instance/compute/vmId?api-version=2017-04-02&format=text",
@@ -33,9 +40,6 @@ func GetHostAlias() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Azure HostAliases: unable to query metadata endpoint: %s", err)
 	}
-
-	// registering that we're running on Azure
-	inventories.SetAgentMetadata(inventories.CloudProviderMetatadaName, CloudProviderName)
 	return res, nil
 }
 

--- a/pkg/util/cloudprovider.go
+++ b/pkg/util/cloudprovider.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package util
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
+	"github.com/DataDog/datadog-agent/pkg/util/alibaba"
+	"github.com/DataDog/datadog-agent/pkg/util/azure"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs"
+	"github.com/DataDog/datadog-agent/pkg/util/gce"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type cloudProviderDetector struct {
+	name     string
+	callback func() bool
+}
+
+// DetectCloudProvider detects the cloud provider where the agent is running in order:
+// * AWS ECS/Fargate
+// * AWS EC2
+// * GCE
+// * Azure
+// * Alibaba
+func DetectCloudProvider() {
+	detectors := []cloudProviderDetector{
+		{name: ecs.CloudProviderName, callback: ecs.IsRunningOn},
+		{name: ec2.CloudProviderName, callback: ec2.IsRunningOn},
+		{name: gce.CloudProviderName, callback: gce.IsRunningOn},
+		{name: azure.CloudProviderName, callback: azure.IsRunningOn},
+		{name: alibaba.CloudProviderName, callback: alibaba.IsRunningOn},
+	}
+
+	for _, cloudDetector := range detectors {
+		if cloudDetector.callback() {
+			inventories.SetAgentMetadata(inventories.CloudProviderMetatadaName, cloudDetector.name)
+			log.Infof("Cloud provider %s detected", cloudDetector.name)
+			return
+		}
+	}
+	log.Info("No cloud provider detected")
+}

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -36,15 +35,17 @@ func GetInstanceID() (string, error) {
 	return getMetadataItemWithMaxLength("/instance-id", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 }
 
+// IsRunningOn returns true if the agent is running on AWS
+func IsRunningOn() bool {
+	if _, err := GetHostname(); err == nil {
+		return true
+	}
+	return false
+}
+
 // GetHostname fetches the hostname for current host from the EC2 metadata API
 func GetHostname() (string, error) {
-	hostname, err := getMetadataItemWithMaxLength("/hostname", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
-
-	// registering that we're running on AWS
-	if err == nil {
-		inventories.SetAgentMetadata(inventories.CloudProviderMetatadaName, CloudProviderName)
-	}
-	return hostname, err
+	return getMetadataItemWithMaxLength("/hostname", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 }
 
 // GetNetworkID retrieves the network ID using the EC2 metadata endpoint. For

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -29,6 +29,9 @@ const (
 	DefaultAgentPort = 51678
 	// Cache the fact we're running on ECS Fargate
 	isFargateInstanceCacheKey = "IsFargateInstanceCacheKey"
+
+	// CloudProviderName contains the inventory name of for ECS
+	CloudProviderName = "AWS"
 )
 
 type (
@@ -69,6 +72,11 @@ type (
 
 var globalUtil *Util
 var initOnce sync.Once
+
+// IsRunningOn returns true if the agent is running on ECS/Fargate
+func IsRunningOn() bool {
+	return IsECSInstance() || IsFargateInstance()
+}
 
 // GetUtil returns a ready to use ecs Util. It is backed by a shared singleton.
 func GetUtil() (*Util, error) {

--- a/pkg/util/ecs/ecs_nodocker.go
+++ b/pkg/util/ecs/ecs_nodocker.go
@@ -9,6 +9,16 @@ package ecs
 
 import "github.com/DataDog/datadog-agent/pkg/util/docker"
 
+const (
+	// CloudProviderName contains the inventory name of for ECS
+	CloudProviderName = "AWS"
+)
+
+// IsRunningOn returns true if the agent is running on ECS/Fargate
+func IsRunningOn() bool {
+	return false
+}
+
 // GetUtil returns an ECS util
 func GetUtil() (*Util, error) {
 	return nil, docker.ErrDockerNotCompiled

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 )
 
@@ -45,6 +44,14 @@ type gceProjectMetadata struct {
 	NumericProjectID int64
 }
 
+// IsRunningOn returns true if the agent is running on GCE
+func IsRunningOn() bool {
+	if _, err := GetHostname(); err == nil {
+		return true
+	}
+	return false
+}
+
 // GetHostname returns the hostname querying GCE Metadata api
 func GetHostname() (string, error) {
 	hostname, err := getResponseWithMaxLength(metadataURL+"/instance/hostname",
@@ -52,9 +59,6 @@ func GetHostname() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve hostname from GCE: %s", err)
 	}
-
-	// registering that we're running on GCP
-	inventories.SetAgentMetadata(inventories.CloudProviderMetatadaName, CloudProviderName)
 	return hostname, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Extract cloud provider detection outside of the hostname detection. Since hostname detection can be bypass by configuration or env variables.