### PR TITLE
[system-probe] Tune conntrack expiration params

### DIFF
--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	// tcp_close is not intercepted for some reason.
 	TCPConnTimeout time.Duration
 
-	// MaxTrackedConnections specifies the maximum number of connections we can track, this will be the size of the eBPF + Conntrack.
+	// MaxTrackedConnections specifies the maximum number of connections we can track. This determines the size of the eBPF Maps
 	MaxTrackedConnections uint
 
 	// MaxClosedConnectionsBuffered represents the maximum number of closed connections we'll buffer in memory. These closed connections
@@ -55,6 +55,9 @@ type Config struct {
 
 	// EnableConntrack enables probing conntrack for network address translation via netlink
 	EnableConntrack bool
+
+	// ConntrackMaxStateSize specifies the maximum number of connections with NAT we can track
+	ConntrackMaxStateSize int
 
 	// ConntrackShortTermBufferSize is the maximum number of short term conntracked connections that will
 	// held in memory at once
@@ -84,6 +87,7 @@ func NewDefaultConfig() *Config {
 		UDPConnTimeout:        30 * time.Second,
 		TCPConnTimeout:        2 * time.Minute,
 		MaxTrackedConnections: 65536,
+		ConntrackMaxStateSize: 65536,
 		ProcRoot:              "/proc",
 		BPFDebug:              false,
 		EnableConntrack:       true,

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -20,7 +20,7 @@ import (
 const (
 	initializationTimeout = time.Second * 10
 
-	compactInterval = time.Minute * 4
+	compactInterval = time.Minute * 3
 
 	// generationLength must be greater than compactInterval to ensure we have  multiple compactions per generation
 	generationLength = compactInterval + time.Minute
@@ -239,7 +239,7 @@ func (ctr *realConntracker) loadInitialState(sessions []ct.Con) {
 // register is registered to be called whenever a conntrack update/create is called.
 // it will keep being called until it returns nonzero.
 func (ctr *realConntracker) register(c ct.Con) int {
-	// don't both storing if the connection is not NAT
+	// don't bother storing if the connection is not NAT
 	if !isNAT(c) {
 		return 0
 	}

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -172,7 +172,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 
 	conntracker := netlink.NewNoOpConntracker()
 	if config.EnableConntrack {
-		if c, err := netlink.NewConntracker(config.ProcRoot, config.ConntrackShortTermBufferSize, int(config.MaxTrackedConnections)); err != nil {
+		if c, err := netlink.NewConntracker(config.ProcRoot, config.ConntrackShortTermBufferSize, config.ConntrackMaxStateSize); err != nil {
 			log.Warnf("could not initialize conntrack, tracer will continue without NAT tracking: %s", err)
 		} else {
 			conntracker = c

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -88,6 +88,7 @@ type AgentConfig struct {
 	ExcludedDestinationConnections map[string][]string
 	EnableConntrack                bool
 	ConntrackShortTermBufferSize   int
+	ConntrackMaxStateSize          int
 	SystemProbeDebugPort           int
 	ClosedChannelSize              int
 	MaxClosedConnectionsBuffered   int
@@ -184,6 +185,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		EnableConntrack:              true,
 		ClosedChannelSize:            500,
 		ConntrackShortTermBufferSize: defaultConntrackShortTermBufferSize,
+		ConntrackMaxStateSize:        defaultMaxTrackedConnections,
 
 		// Check config
 		EnabledChecks: enabledChecks,

--- a/pkg/process/config/tracer_config.go
+++ b/pkg/process/config/tracer_config.go
@@ -52,6 +52,7 @@ func SysProbeConfigFromConfig(cfg *AgentConfig) *ebpf.Config {
 	tracerConfig.BPFDebug = cfg.SysProbeBPFDebug
 	tracerConfig.EnableConntrack = cfg.EnableConntrack
 	tracerConfig.ConntrackShortTermBufferSize = cfg.ConntrackShortTermBufferSize
+	tracerConfig.ConntrackMaxStateSize = cfg.ConntrackMaxStateSize
 	tracerConfig.DebugPort = cfg.SystemProbeDebugPort
 
 	if mccb := cfg.MaxClosedConnectionsBuffered; mccb > 0 {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -71,6 +71,9 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	if s := config.Datadog.GetInt(key(spNS, "conntrack_short_term_buffer_size")); s > 0 {
 		a.ConntrackShortTermBufferSize = s
 	}
+	if s := config.Datadog.GetInt(key(spNS, "conntrack_max_state_size")); s > 0 {
+		a.ConntrackMaxStateSize = s
+	}
 
 	if logFile := config.Datadog.GetString(key(spNS, "log_file")); logFile != "" {
 		a.LogFile = logFile


### PR DESCRIPTION
### What does this PR do?

* Tune `conntrack` expiration params (reducing TTL from 12 min to 9 min)
* Add dedicated configuration `ConntrackMaxStateSize` (though keeping the same default size for now);
* Add test for generating memory profile;