### PR TITLE
Reset error code to zero, so that uninstall won't fail if deleting

### DIFF
--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -543,7 +543,7 @@ UINT doUninstallAs(MSIHANDLE hInstall, UNINSTALL_TYPE t)
     if (hLsa) {
         LsaClose(hLsa);
     }
-    return er;
+    return 0;
 
 }
 HMODULE hDllModule;

--- a/releasenotes/notes/allowuserfail-37c0eaca34275c7f.yaml
+++ b/releasenotes/notes/allowuserfail-37c0eaca34275c7f.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+
+fixes:
+  - |
+    On Windows, allow the uninstall to succeed even if the removal of
+    the `ddagentuser` fails for some reason.


### PR DESCRIPTION
the ddagentuser fails

### What does this PR do?

Sets the error code back to zero after logging the failure if the attempt to remove
the ddagentuser fails for some reason

### Motivation

The user is trying to uninstall.  While we're making best effort to clean everything up,
we shouldn't ever fail the uninstall.  Just leads to increased frustration


### Additional Notes

Anything else we should know when reviewing?
