### PR TITLE
Fix system-probe internal deployment task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1991,7 +1991,7 @@ deploy_process_and_sysprobe:
     - ls
   tags: [ "runner:main", "size:large" ]
   script:
-    - dpkg -x datadog-agent_*_amd64.deb ./out
+    - dpkg -x $(ls -1 datadog-agent_*_amd64.deb | sort -V | head -n 1) ./out
     # Use tag or shortened branch with short commit hash to identify the binary
     - export SHORT_REF=$(echo $CI_COMMIT_REF_NAME | cut -d'/' -f2- | cut -c -10 | sed -E 's/[^[:alnum:]]+/-/g')
     - export NAME="${CI_COMMIT_TAG:-$SHORT_REF}-${CI_COMMIT_SHA:0:7}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1991,6 +1991,8 @@ deploy_process_and_sysprobe:
     - ls
   tags: [ "runner:main", "size:large" ]
   script:
+    # The shell expansion `datadog-agent_*_amd64.deb` might return multiple
+    # entries, so we sort them and get the first one.
     - dpkg -x $(ls -1 datadog-agent_*_amd64.deb | sort -V | head -n 1) ./out
     # Use tag or shortened branch with short commit hash to identify the binary
     - export SHORT_REF=$(echo $CI_COMMIT_REF_NAME | cut -d'/' -f2- | cut -c -10 | sed -E 's/[^[:alnum:]]+/-/g')


### PR DESCRIPTION
### What does this PR do?

Fixes internal deployment task (process-agent and system-probe only).

The current version is no longer working now that `datadog-agent_*_amd64.deb` expansion is returning multiple entries (eg. `datadog-agent_6.15.0~rc.2-1_amd64.deb` and `datadog-agent_7.15.0~rc.2-1_amd64.deb`)
