### PR TITLE
[omnibus] fix distutils in RHEL builds for binary compilation

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -52,7 +52,7 @@ build do
         elsif linux?
             # Fix pip after building on extended toolchain in CentOS builder
             if redhat?
-              command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec sed -i 's/\/opt\/centos\/devtoolset\-1\.1\/root//g' {} \;"
+              command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec sed -i 's/\\/opt\\/centos\\/devtoolset\\-1\\.1\\/root//g' {} \\;"
             end
 
             # Move system service files

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -50,6 +50,11 @@ build do
             delete "#{install_dir}/bin/agent/dist/*.yaml"
             command "del /q /s #{windows_safe_path(install_dir)}\\*.pyc"
         elsif linux?
+            # Fix pip after building on extended toolchain in CentOS builder
+            if redhat?
+              command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec sed -i 's/\/opt\/centos\/devtoolset\-1\.1\/root//g' {} \;"
+            end
+
             # Move system service files
             mkdir "/etc/init"
             move "#{install_dir}/scripts/datadog-agent.conf", "/etc/init"

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -52,7 +52,11 @@ build do
         elsif linux?
             # Fix pip after building on extended toolchain in CentOS builder
             if redhat?
-              command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec sed -i 's/\\/opt\\/centos\\/devtoolset\\-1\\.1\\/root//g' {} \\;"
+              rhel_toolchain_root = "/opt/centos/devtoolset-1.1/root"
+              # lets be cautious - we first search for the expected toolchain path, if its not there, bail out
+              command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec grep -inH '#{rhel_toolchain_root}' {} \\; |  egrep '.*'"
+              # replace paths with expected target toolchain location
+              command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec sed -i 's##{rhel_toolchain_root}##g' {} \\;"
             end
 
             # Move system service files


### PR DESCRIPTION
### What does this PR do?

This PR patches distutils `_sysconfigdata.py` (or relevant variant), to ensure the build environment variables used by it meet the typical expected locations, most typically `/usr/bin`. 

Our builder ships its compiler toolchain root in  `/opt/centos/devtoolset-1.1` as opposed to `/` - remaining paths are the same. For instance:
`/opt/centos/devtoolset-1.1/usr/bin/gcc` -> `/usr/bin/gcc`

Stripping the leading part of the path is enough to re-standardize the locations to what would be expected on a standard target with a build toolchain installed in the standard location.

### Motivation

This PR should fix an issue that would arise during compilation of binary wheels given the use `distutils` makes of `_sysconfigdata.py`. That file contains the locations for compiler, linker, etc as found on the build machine, not the target. Our RHEL/CentOS builder does not have the gcc toolchain in the expected location - because the default toolchain is a little old and we want to use similar compiler toolchain versions in both our deb and rpm (centos, suse) builds. 

### Additional Notes

Should maybe make sure this fails if no matches are found....
