### PR TITLE
Leave debian testing repository to avoid conflicts in custom images

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -90,18 +90,6 @@ ENV DOCKER_DD_AGENT=true \
     # Allow readonlyrootfs
     S6_READ_ONLY_ROOT=1
 
-# Install openjdk-11-jre-headless on jmx flavor
-# Due to this bug https://bugs.openjdk.java.net/browse/JDK-8217766, we need to be able to
-# pull from testing since this is the only place for now where a version > 11.0.4 is available.
-# we leave testing in the sources to avoid dependencies conflict in custom images
-RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-11 from testing" \
- && echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list \
- && apt-get update \
- && mkdir /usr/share/man/man1 \
- && apt-get install --no-install-recommends -y openjdk-11-jre-headless \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; fi
-
 # make sure we have recent dependencies
 RUN apt-get update \
   # CVE-fixing time!
@@ -112,7 +100,18 @@ RUN apt-get update \
   && rm -f /usr/sbin/runuser \
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6954
   && rm -f /usr/lib/x86_64-linux-gnu/libdb-5.3.so \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install openjdk-11-jre-headless on jmx flavor
+# Due to this bug https://bugs.openjdk.java.net/browse/JDK-8217766, we need to be able to
+# pull from testing since this is the only place for now where a version > 11.0.4 is available.
+# we leave testing in the sources to avoid dependencies conflict in custom images
+RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-11 from testing" \
+ && echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list \
+ && apt-get update \
+ && mkdir /usr/share/man/man1 \
+ && apt-get install --no-install-recommends -y openjdk-11-jre-headless \
+ && apt-get clean; fi \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy agent from extract stage
 COPY --from=extract /output/ /

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -99,7 +99,7 @@ RUN apt-get update \
   # https://security-tracker.debian.org/tracker/CVE-2016-2779
   && rm -f /usr/sbin/runuser \
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6954
-  && rm -f /usr/lib/x86_64-linux-gnu/libdb-5.3.so \
+  && rm -f /usr/lib/x86_64-linux-gnu/libdb-5.3.so
 
 # Install openjdk-11-jre-headless on jmx flavor
 # Due to this bug https://bugs.openjdk.java.net/browse/JDK-8217766, we need to be able to
@@ -110,8 +110,10 @@ RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-11 from testing" \
  && apt-get update \
  && mkdir /usr/share/man/man1 \
  && apt-get install --no-install-recommends -y openjdk-11-jre-headless \
- && apt-get clean; fi \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ && apt-get clean; fi
+
+# cleaning up
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy agent from extract stage
 COPY --from=extract /output/ /

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -93,13 +93,13 @@ ENV DOCKER_DD_AGENT=true \
 # Install openjdk-11-jre-headless on jmx flavor
 # Due to this bug https://bugs.openjdk.java.net/browse/JDK-8217766, we need to be able to
 # pull from testing since this is the only place for now where a version > 11.0.4 is available.
+# we leave testing in the sources to avoid dependencies conflict in custom images
 RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-11 from testing" \
  && echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list \
  && apt-get update \
  && mkdir /usr/share/man/man1 \
  && apt-get install --no-install-recommends -y openjdk-11-jre-headless \
  && apt-get clean \
- && rm /etc/apt/sources.list.d/testing.list \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; fi
 
 # make sure we have recent dependencies


### PR DESCRIPTION
### What does this PR do?

Leave testing debian repository

### Motivation

Avoid dependencies conflict between what's installed via `openjdk` in `testing` and packages that would be installed later on in custom images

### Additional Notes

Anything else we should know when reviewing?
