### PR TITLE
Don't print sensitive data in install logs

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -73,8 +73,10 @@
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
     <Property Id="DDAGENTUSER_NAME" />
-    <Property Id="DDAGENTUSER_PASSWORD"  />
-
+    <Property Id="DDAGENTUSER_PASSWORD" Hidden="yes" />
+    <Property Id="APIKEY" Hidden="yes" />
+    <Property Id="FinalizeInstall" Hidden="yes" />
+    
      <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
      <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
      <PropertyRef Id="WIX_ACCOUNT_USERS" />

--- a/releasenotes/notes/sanitizeinstalllogs-03275281c3e9e802.yaml
+++ b/releasenotes/notes/sanitizeinstalllogs-03275281c3e9e802.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, fixes installation logging to not include certain sensitive
+    data (specifically api key and the ddagentuser password)


### PR DESCRIPTION
### What does this PR do?

Marks specific properties as hidden, so they're not logged in the install log.
Allows customers to send logs w/o having to manually sanitize first.

Currently hidden keys are the DDAGENTUSER_PASSWORD and APIKEY (if provided).
FinalizeInstall key is also hidden, because that key includes the DDAGENTUSER_PASSWORD

### Motivation

allow customers to send logs more easily.

### Additional Notes

Anything else we should know when reviewing?
