### PR TITLE
Do not try to stop nil forwarder on exit

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -325,7 +325,9 @@ func StopAgent() {
 	clcrunnerapi.StopCLCRunnerServer()
 	jmx.StopJmxfetch()
 	aggregator.StopDefaultAggregator()
-	common.Forwarder.Stop()
+	if common.Forwarder != nil {
+		common.Forwarder.Stop()
+	}
 	logs.Stop()
 	gui.StopGUIServer()
 	os.Remove(pidfilePath)


### PR DESCRIPTION
### What does this PR do?

Add nil check before stopping the forwarder

### Motivation

Avoid panic when stopping the agent before the forwarder is created

### Additional Notes

Anything else we should know when reviewing?
