### PR TITLE
Add liveness and readiness probe to DCA manifest

### DIFF
--- a/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
+++ b/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
@@ -42,3 +42,13 @@ spec:
           #     secretKeyRef:
           #       name: datadog-auth-token
           #       key: token
+        livenessProbe:
+          httpGet:
+            port: 443
+            path: /healthz
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            port: 443
+            path: /healthz
+            scheme: HTTPS

--- a/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
+++ b/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
@@ -42,13 +42,14 @@ spec:
           #     secretKeyRef:
           #       name: datadog-auth-token
           #       key: token
-        livenessProbe:
-          httpGet:
-            port: 443
-            path: /healthz
-            scheme: HTTPS
-        readinessProbe:
-          httpGet:
-            port: 443
-            path: /healthz
-            scheme: HTTPS
+        # If you use the external metrics provider, use these liveness and readyness probes
+        # livenessProbe:
+        #   httpGet:
+        #     port: 443
+        #     path: /healthz
+        #     scheme: HTTPS
+        # readinessProbe:
+        #   httpGet:
+        #     port: 443
+        #     path: /healthz
+        #     scheme: HTTPS


### PR DESCRIPTION
### What does this PR do?

This PR adds a liveness and readiness probe to the DCA manifest as we have in the helm chart.

### Motivation

One customer asked about how to set a readiness probe on the DCA.
