### PR TITLE
pkg/trace/obfuscate: fix bug with escape character in string

### DIFF
--- a/pkg/trace/obfuscate/obfuscate.go
+++ b/pkg/trace/obfuscate/obfuscate.go
@@ -46,25 +46,25 @@ type Config struct {
 	// Redis enables obfuscatiion of the "memcached.command" tag for spans of type "memcached".
 	Memcached bool
 
-	// literalEscapes reports whether we should treat escape characters literally or as escape characters.
+	// sqlLiteralEscapes reports whether we should treat escape characters literally or as escape characters.
 	// A non-zero value means 'yes'. Different SQL engines behave in different ways and the tokenizer needs
 	// to be generic.
 	// Not safe for concurrent use.
-	literalEscapes int32
+	sqlLiteralEscapes int32
 }
 
-// SetLiteralEscapes sets whether or not escape characters should be treated literally,
-func (o *Obfuscator) SetLiteralEscapes(ok bool) {
+// SetSQLLiteralEscapes sets whether or not escape characters should be treated literally by the SQL obfuscator.
+func (o *Obfuscator) SetSQLLiteralEscapes(ok bool) {
 	if ok {
-		atomic.StoreInt32(&o.opts.literalEscapes, 1)
+		atomic.StoreInt32(&o.opts.sqlLiteralEscapes, 1)
 	} else {
-		atomic.StoreInt32(&o.opts.literalEscapes, 0)
+		atomic.StoreInt32(&o.opts.sqlLiteralEscapes, 0)
 	}
 }
 
-// LiteralEscapes returns whether or not escape characters should be treated literally.
-func (o *Obfuscator) LiteralEscapes() bool {
-	return atomic.LoadInt32(&o.opts.literalEscapes) == 1
+// SQLLiteralEscapes returns whether or not escape characters should be treated literally by the SQL obfuscator.
+func (o *Obfuscator) SQLLiteralEscapes() bool {
+	return atomic.LoadInt32(&o.opts.sqlLiteralEscapes) == 1
 }
 
 // NewObfuscator creates a new Obfuscator.

--- a/pkg/trace/obfuscate/obfuscate_test.go
+++ b/pkg/trace/obfuscate/obfuscate_test.go
@@ -222,6 +222,24 @@ func TestObfuscateConfig(t *testing.T) {
 	))
 }
 
+func TestLiteralEscapes(t *testing.T) {
+	o := NewObfuscator(nil)
+
+	t.Run("default", func(t *testing.T) {
+		assert.False(t, o.LiteralEscapes())
+	})
+
+	t.Run("setter true", func(t *testing.T) {
+		o.SetLiteralEscapes(true)
+		assert.True(t, o.LiteralEscapes())
+	})
+
+	t.Run("setter false", func(t *testing.T) {
+		o.SetLiteralEscapes(false)
+		assert.False(t, o.LiteralEscapes())
+	})
+}
+
 func BenchmarkCompactWhitespaces(b *testing.B) {
 	str := "a b       cde     fg       hi                     j  jk   lk lkjfdsalfd     afsd sfdafsd f"
 	for i := 0; i < b.N; i++ {

--- a/pkg/trace/obfuscate/obfuscate_test.go
+++ b/pkg/trace/obfuscate/obfuscate_test.go
@@ -226,17 +226,17 @@ func TestLiteralEscapes(t *testing.T) {
 	o := NewObfuscator(nil)
 
 	t.Run("default", func(t *testing.T) {
-		assert.False(t, o.LiteralEscapes())
+		assert.False(t, o.SQLLiteralEscapes())
 	})
 
-	t.Run("setter true", func(t *testing.T) {
-		o.SetLiteralEscapes(true)
-		assert.True(t, o.LiteralEscapes())
+	t.Run("true", func(t *testing.T) {
+		o.SetSQLLiteralEscapes(true)
+		assert.True(t, o.SQLLiteralEscapes())
 	})
 
-	t.Run("setter false", func(t *testing.T) {
-		o.SetLiteralEscapes(false)
-		assert.False(t, o.LiteralEscapes())
+	t.Run("false", func(t *testing.T) {
+		o.SetSQLLiteralEscapes(false)
+		assert.False(t, o.SQLLiteralEscapes())
 	})
 }
 

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -162,11 +162,10 @@ func (o *Obfuscator) obfuscateSQLString(in string) (string, error) {
 		// If the tokenizer failed, but saw an escape character in the process,
 		// try again treating escapes differently
 		tokenizer = NewSQLTokenizer(in, !literalEscapes)
-		var err2 error
-		if out, err2 = attemptObfuscation(tokenizer, filters); err2 == nil {
+		if out, err2 := attemptObfuscation(tokenizer, filters); err2 == nil {
 			// If the second attempt succeeded, change the default behavior
-			err = nil
 			o.SetLiteralEscapes(!literalEscapes)
+			return out, nil
 		}
 	}
 	return out, err

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -153,7 +153,7 @@ func (f *groupingFilter) Reset() {
 // function is generic and the behavior changes according to chosen tokenFilter implementations.
 // The process calls all filters inside the []tokenFilter.
 func (o *Obfuscator) obfuscateSQLString(in string) (string, error) {
-	literalEscapes := o.LiteralEscapes()
+	literalEscapes := o.SQLLiteralEscapes()
 	tokenizer := NewSQLTokenizer(in, literalEscapes)
 	filters := []tokenFilter{&discardFilter{}, &replaceFilter{}, &groupingFilter{}}
 
@@ -164,7 +164,7 @@ func (o *Obfuscator) obfuscateSQLString(in string) (string, error) {
 		tokenizer = NewSQLTokenizer(in, !literalEscapes)
 		if out, err2 := attemptObfuscation(tokenizer, filters); err2 == nil {
 			// If the second attempt succeeded, change the default behavior
-			o.SetLiteralEscapes(!literalEscapes)
+			o.SetSQLLiteralEscapes(!literalEscapes)
 			return out, nil
 		}
 	}

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -440,8 +440,8 @@ ORDER BY [b].[Name]`,
 		},
 	}
 
-	for i, c := range cases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
 			s := SQLSpan(c.query)
 			NewObfuscator(nil).Obfuscate(s)
 			assert.Equal(t, c.expected, s.Resource)
@@ -833,8 +833,8 @@ func TestSQLErrors(t *testing.T) {
 			`at position 69: unexpected EOF in string`,
 		},
 	}
-	for i, tc := range cases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
 			_, err := NewObfuscator(nil).obfuscateSQLString(tc.query)
 			assert.Error(t, err)
 			assert.Equal(t, tc.expected, err.Error())
@@ -896,14 +896,14 @@ func TestLiteralEscapesUpdates(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			o := NewObfuscator(nil)
-			o.SetLiteralEscapes(c.initial)
+			o.SetSQLLiteralEscapes(c.initial)
 			_, err := o.obfuscateSQLString(c.query)
 			if c.success {
 				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)
 			}
-			assert.Equal(t, c.expected, o.LiteralEscapes(), "Unexpected final value of LiteralEscapes")
+			assert.Equal(t, c.expected, o.SQLLiteralEscapes(), "Unexpected final value of SQLLiteralEscapes")
 		})
 	}
 }

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -461,32 +461,32 @@ func TestSQLTokenizerEscapeBackslashQuotes(t *testing.T) {
 		{
 			`'String with backslash-escaped quote at end \''`,
 			"String with backslash-escaped quote at end '",
-			String,
+			EscapedString,
 		},
 		{
 			`'String with backslash-escaped quote \' in middle'`,
 			"String with backslash-escaped quote ' in middle",
-			String,
+			EscapedString,
 		},
 		{
 			`'String with backslash-escaped embedded string \'foo\' in the middle'`,
 			"String with backslash-escaped embedded string 'foo' in the middle",
-			String,
+			EscapedString,
 		},
 		{
 			`'String with backslash-escaped embedded string at end \'foo\''`,
 			"String with backslash-escaped embedded string at end 'foo'",
-			String,
+			EscapedString,
 		},
 		{
 			`'String with backslash-escaped embedded string \'foo\' in the middle'`,
 			"String with backslash-escaped embedded string 'foo' in the middle",
-			String,
+			EscapedString,
 		},
 		{
 			`'String with double-backslash-escaped embedded string \\'foo\\' in the middle'`,
 			"String with double-backslash-escaped embedded string \\'foo\\' in the middle",
-			String,
+			EscapedString,
 		},
 		{
 			`'String with backslash-escaped embedded string \'foo\' in the middle followed by one at the end \'`,
@@ -670,7 +670,7 @@ in the middle'`,
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("tokenize_%s", c.str), func(t *testing.T) {
 			tokenizer := NewSQLTokenizer(c.str)
-			tokenizer.backslashQuote.ignoreEscape = true
+			tokenizer.ignoreEscape = true
 			kind, buffer := tokenizer.Scan()
 			assert.Equal(t, c.expectedKind, kind)
 			assert.Equal(t, c.expected, string(buffer))

--- a/releasenotes/notes/apm-fix-escapes-in-sql-bd7165f832a4172d.yaml
+++ b/releasenotes/notes/apm-fix-escapes-in-sql-bd7165f832a4172d.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Added a fallback into the SQL obfuscator to handle SQL engines that treat
+    backslashes literally.


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue, where our current SQL tokenizer assumes that a backslash within a string always acts as an escape character. In dialects such as MySQL, this turns out to be a good assumption, but in general, backslashes in SQL strings are treated literally.

The following query should be valid, but if we treat the backslash as an escape character, the tokenizer will fail to parse it.
```
SELECT * FROM foo WHERE name = 'backslash\' AND id ='1234';
```

This PR changes the behavior of the tokenizer to first assume that backlashes escape quotes, but if we eventually fail to parse the entire query, we will retry tokenization assuming that backslashes are treated literally. The big assumption here is that within a single query, backslashes will be treated consistently.

### Motivation

https://trello.com/c/4fUnQFso/2946-agent-obfuscation-problem

### Additional Notes

Anything else we should know when reviewing?
