### PR TITLE
[system-probe] Improve DNS telemetry

### DIFF
--- a/pkg/ebpf/dns.go
+++ b/pkg/ebpf/dns.go
@@ -17,9 +17,12 @@ func (nullReverseDNS) Resolve(_ []ConnectionStats) map[util.Address][]string {
 
 func (nullReverseDNS) GetStats() map[string]int64 {
 	return map[string]int64{
-		"lookups":  0,
-		"resolved": 0,
-		"ips":      0,
+		"lookups":          0,
+		"resolved":         0,
+		"ips":              0,
+		"added":            0,
+		"expired":          0,
+		"packets_captured": 0,
 	}
 }
 

--- a/pkg/ebpf/dns_snooper_test.go
+++ b/pkg/ebpf/dns_snooper_test.go
@@ -63,6 +63,7 @@ Loop:
 	// Verify telemetry
 	stats := reverseDNS.GetStats()
 	assert.True(t, stats["ips"] >= 1)
+	assert.True(t, stats["packets_captured"] >= 1)
 	assert.Equal(t, int64(2), stats["lookups"])
 	assert.Equal(t, int64(1), stats["resolved"])
 }


### PR DESCRIPTION
### What does this PR do?

Improve DNS telemetry.

* Number of captured packets;
* Number of expired DNS entries;
* Number of added DNS entries;