### PR TITLE
[ebpf] Fix nil pointer dereference bug for malformed DNS packets

### DIFF
--- a/pkg/ebpf/dns_snooper.go
+++ b/pkg/ebpf/dns_snooper.go
@@ -101,7 +101,7 @@ func (s *SocketFilterSnooper) Close() {
 func (s *SocketFilterSnooper) run(packets <-chan gopacket.Packet) {
 	for packet := range packets {
 		layer := packet.Layer(layers.LayerTypeDNS)
-		if layer.LayerType() != layers.LayerTypeDNS {
+		if layer == nil {
 			continue
 		}
 		dns, ok := layer.(*layers.DNS)


### PR DESCRIPTION
### What does this PR do?

Fix nil pointer dereference bug for malformed DNS packets. This can happen when a UDP datagram doesn't enclose a DNS payload.

### Motivation

Bug is causing intermittent crashes on staging environment.
