### PR TITLE
pkg/trace/traceutil: fix earliest date when encoding wire trace

### DIFF
--- a/pkg/trace/traceutil/trace.go
+++ b/pkg/trace/traceutil/trace.go
@@ -6,6 +6,8 @@
 package traceutil
 
 import (
+	"math"
+
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -67,7 +69,7 @@ func GetRoot(t pb.Trace) *pb.Span {
 // APITrace returns an APITrace from t, as required by the Datadog API.
 // It also returns an estimated size in bytes.
 func APITrace(t pb.Trace) *pb.APITrace {
-	var earliest, latest int64
+	earliest, latest := int64(math.MaxInt64), int64(0)
 	for _, s := range t {
 		start := s.Start
 		if start < earliest {


### PR DESCRIPTION
This change fixes a problem in the outgoing trace structure where the
earliest date was wrongly computed. It does not seem to affect anyone.