### PR TITLE
[system-probe] Disable DNS inspection by default

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -177,7 +177,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		DisableTCPTracing:            false,
 		DisableUDPTracing:            false,
 		DisableIPv6Tracing:           false,
-		DisableDNSInspection:         false,
+		DisableDNSInspection:         true,
 		SystemProbeSocketPath:        defaultSystemProbeSocketPath,
 		SystemProbeLogFile:           defaultSystemProbeFilePath,
 		MaxTrackedConnections:        defaultMaxTrackedConnections,

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -199,6 +199,7 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(false, agentConfig.Windows.AddNewArgs)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
 	assert.Equal(5065, agentConfig.ProcessExpVarPort)
+	assert.True(agentConfig.DisableDNSInspection)
 
 	agentConfig, err = NewAgentConfig(
 		"test",
@@ -226,6 +227,7 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.False(agentConfig.DisableTCPTracing)
 	assert.False(agentConfig.DisableUDPTracing)
 	assert.False(agentConfig.DisableIPv6Tracing)
+	assert.True(agentConfig.DisableDNSInspection)
 
 	agentConfig, err = NewAgentConfig(
 		"test",
@@ -252,7 +254,7 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.True(agentConfig.DisableTCPTracing)
 	assert.True(agentConfig.DisableUDPTracing)
 	assert.True(agentConfig.DisableIPv6Tracing)
-	assert.True(agentConfig.DisableDNSInspection)
+	assert.False(agentConfig.DisableDNSInspection)
 	assert.Equal(map[string][]string(map[string][]string{"172.0.0.1/20": {"*"}, "*": {"443"}, "127.0.0.1": {"5005"}}), agentConfig.ExcludedSourceConnections)
 	assert.Equal(map[string][]string(map[string][]string{"172.0.0.1/20": {"*"}, "*": {"*"}, "2001:db8::2:1": {"5005"}}), agentConfig.ExcludedDestinationConnections)
 }

--- a/pkg/process/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net-2.yaml
+++ b/pkg/process/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net-2.yaml
@@ -4,7 +4,7 @@ system_probe_config:
     disable_tcp: true
     disable_udp: true
     disable_ipv6: true
-    disable_dns_inspection: true
+    disable_dns_inspection: false
     excluded_linux_versions:
       - 5.5.0
       - 4.2.1

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -40,7 +40,9 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	a.DisableTCPTracing = config.Datadog.GetBool(key(spNS, "disable_tcp"))
 	a.DisableUDPTracing = config.Datadog.GetBool(key(spNS, "disable_udp"))
 	a.DisableIPv6Tracing = config.Datadog.GetBool(key(spNS, "disable_ipv6"))
-	a.DisableDNSInspection = config.Datadog.GetBool(key(spNS, "disable_dns_inspection"))
+	if config.Datadog.IsSet(key(spNS, "disable_dns_inspection")) {
+		a.DisableDNSInspection = config.Datadog.GetBool(key(spNS, "disable_dns_inspection"))
+	}
 
 	a.CollectLocalDNS = config.Datadog.GetBool(key(spNS, "collect_local_dns"))
 


### PR DESCRIPTION
### What does this PR do?

Disable DNS inspection by default.

### Motivation

This feature will be disabled by default until we have a more thorough assessment of its performance impact on hosts with a high number of DNS resolutions. 