### PR TITLE
[ebpf] Disable socket filter for CentOS

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -828,7 +828,7 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:3e7518df4c30983b334eeefd02d4c8a97788a1ea44c48e44eacd509b1623af7e"
+  digest = "1:1b6f213327a9343809b0328f41d7f2835a8750438292ab0898dbff1d6a60b7ad"
   name = "github.com/iovisor/gobpf"
   packages = [
     "elf",
@@ -836,7 +836,7 @@
     "pkg/cpuonline",
   ]
   pruneopts = ""
-  revision = "42285a7409f87cb399476b132e726aacfc63fbdc"
+  revision = "a14c39bf99c7539b5578baf2449ff2e37dd35901"
   source = "github.com/DataDog/gobpf"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -192,7 +192,7 @@
 [[constraint]]
   name = "github.com/iovisor/gobpf"
   source = "github.com/DataDog/gobpf"
-  revision = "42285a7409f87cb399476b132e726aacfc63fbdc"
+  revision = "a14c39bf99c7539b5578baf2449ff2e37dd35901"
 
 [[constraint]]
   name = "github.com/florianl/go-conntrack"

--- a/pkg/ebpf/dns_snooper_test.go
+++ b/pkg/ebpf/dns_snooper_test.go
@@ -19,7 +19,7 @@ func TestDNSSnooping(t *testing.T) {
 
 	// Load socket filter
 	cfg := NewDefaultConfig()
-	err = m.Load(SectionsFromConfig(cfg))
+	err = m.Load(SectionsFromConfig(cfg, true))
 	require.NoError(t, err)
 
 	filter := m.SocketFilter("socket/dns_filter")

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -96,7 +96,19 @@ func NewTracer(config *Config) (*Tracer, error) {
 		return nil, fmt.Errorf("could not read bpf module: %s", err)
 	}
 
-	err = m.Load(SectionsFromConfig(config))
+	// check if current platform is RHEL or CentOS because it affects what kprobe are we going to enable
+	isRHELOrCentos, err := isRHELOrCentOS()
+	if err != nil {
+		// if the platform couldn't be determined, treat it as non RHEL case
+		log.Warn("could not detect the platform, will use kprobes from kernel version > 4.1.x")
+	}
+
+	if isRHELOrCentos {
+		log.Info("detected platform as RHEL/CentOS, switch to use kprobes from kernel version 3.3.x")
+	}
+
+	enableSocketFilter := config.DNSInspection && !isRHELOrCentos
+	err = m.Load(SectionsFromConfig(config, enableSocketFilter))
 	if err != nil {
 		return nil, fmt.Errorf("could not load bpf module: %s", err)
 	}
@@ -119,17 +131,6 @@ func NewTracer(config *Config) (*Tracer, error) {
 	}
 	log.Infof("socket struct offset guessing complete (took %v)", time.Since(start))
 
-	// check if current platform is RHEL or CentOS because it affects what kprobe are we going to enable
-	isRHELOrCentos, err := isRHELOrCentOS()
-	if err != nil {
-		// if the platform couldn't be determined, treat it as non RHEL case
-		log.Warn("could not detect the platform, will use kprobes from kernel version > 4.1.x")
-	}
-
-	if isRHELOrCentos {
-		log.Info("detected platform as RHEL/CentOS, switch to use kprobes from kernel version 3.3.x")
-	}
-
 	// Use the config to determine what kernel probes should be enabled
 	enabledProbes := config.EnabledKProbes(isRHELOrCentos)
 
@@ -149,7 +150,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 	}
 
 	var reverseDNS ReverseDNS = nullReverseDNS{}
-	if shouldEnableSocketFilter(config) {
+	if enableSocketFilter {
 		filter := m.SocketFilter("socket/dns_filter")
 		if filter == nil {
 			return nil, fmt.Errorf("error retrieving socket filter")
@@ -697,7 +698,7 @@ func readLocalAddresses() map[util.Address]struct{} {
 }
 
 // SectionsFromConfig returns a map of string -> gobpf.SectionParams used to configure the way we load the BPF program (bpf map sizes)
-func SectionsFromConfig(c *Config) map[string]bpflib.SectionParams {
+func SectionsFromConfig(c *Config, enableSocketFilter bool) map[string]bpflib.SectionParams {
 	return map[string]bpflib.SectionParams{
 		connMap.sectionName(): {
 			MapMaxEntries: int(c.MaxTrackedConnections),
@@ -712,12 +713,7 @@ func SectionsFromConfig(c *Config) map[string]bpflib.SectionParams {
 			MapMaxEntries: 1024,
 		},
 		"socket/dns_filter": {
-			Disabled: !shouldEnableSocketFilter(c),
+			Disabled: !enableSocketFilter,
 		},
 	}
-}
-
-func shouldEnableSocketFilter(c *Config) bool {
-	isRHELOrCentos, _ := isRHELOrCentOS()
-	return c.DNSInspection && !isRHELOrCentos
 }

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -149,7 +149,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 	}
 
 	var reverseDNS ReverseDNS = nullReverseDNS{}
-	if config.DNSInspection {
+	if shouldEnableSocketFilter(config) {
 		filter := m.SocketFilter("socket/dns_filter")
 		if filter == nil {
 			return nil, fmt.Errorf("error retrieving socket filter")
@@ -711,6 +711,13 @@ func SectionsFromConfig(c *Config) map[string]bpflib.SectionParams {
 		tcpCloseEventMap.sectionName(): {
 			MapMaxEntries: 1024,
 		},
-		"socket/dns_filter": {},
+		"socket/dns_filter": {
+			Disabled: !shouldEnableSocketFilter(c),
+		},
 	}
+}
+
+func shouldEnableSocketFilter(c *Config) bool {
+	isRHELOrCentos, _ := isRHELOrCentOS()
+	return c.DNSInspection && !isRHELOrCentos
 }


### PR DESCRIPTION
### What does this PR do?

Disable socket filter loading process (feeding bytecode to the eBPF VM) in certain cases.

### Motivation

Certain kernels/distros (RedHat and CentOS) don't support eBPF socket filter programs.
