### PR TITLE
[cluster-agent] Fix EventToken configmap update

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -245,7 +245,7 @@ func (c *APIClient) GetTokenFromConfigmap(token string) (string, time.Time, erro
 	if !found {
 		log.Debugf("%s was not found in the ConfigMap %s, updating it to resync.", eventTokenKey, configMapDCAToken)
 		// we should try to set it to "" .
-		err = c.UpdateTokenInConfigmap(eventTokenKey, "", time.Now())
+		err = c.UpdateTokenInConfigmap(token, "", time.Now())
 		return "", time.Now(), err
 	}
 	log.Tracef("%s is %q", token, tokenValue)


### PR DESCRIPTION
### What does this PR do?

call the method `apiserver.UpdateTokenInConfigmap()` with the correct "prefix token"

### Motivation

the Token configmap is not udpated properly 
```
$ k get cm datadogtoken -o yaml
apiVersion: v1
kind: ConfigMap
data:
  event.tokenKey: "304536335"
  event.tokenKey.tokenKey: ""
  event.tokenKey.tokenTimestamp: "2019-10-21T09:13:09Z"
  event.tokenTimestamp: "2019-10-21T09:13:09Z"

```

### Additional Notes

Anything else we should know when reviewing?
