### PR TITLE
Allow Empty docker.d Directory to disable Docker Check

### DIFF
--- a/Dockerfiles/agent/entrypoint/51-docker.sh
+++ b/Dockerfiles/agent/entrypoint/51-docker.sh
@@ -19,7 +19,7 @@ if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
 fi
 
 # Enable the docker corecheck
-if [[ ! -e /etc/datadog-agent/conf.d/docker.d/conf.yaml.default ]]; then
+if [[ ! -e /etc/datadog-agent/conf.d/docker.d/conf.yaml.default && -e /etc/datadog-agent/conf.d/docker.d/conf.yaml.example ]]; then
     mv /etc/datadog-agent/conf.d/docker.d/conf.yaml.example \
     /etc/datadog-agent/conf.d/docker.d/conf.yaml.default
 fi

--- a/releasenotes/notes/entrypoint-fix-issue-mounting-empty-docker.d-directory
+++ b/releasenotes/notes/entrypoint-fix-issue-mounting-empty-docker.d-directory
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue in Docker where mounting empty directories to disable docker check encounters an error:
+    "mv: cannot stat '/etc/datadog-agent/conf.d/docker.d/conf.yaml.example': No such file or directory"


### PR DESCRIPTION
https://trello.com/c/RNaIRN3H/926-fix-the-docker-entrypoint-file-to-check-if-example-exists-before-moving-it

### What does this PR do?

Fixes an issue in Docker where mounting empty directories to disable docker check encounters an error:

Command:

```
DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent \
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /root/emptydirectory/:/etc/datadog-agent/conf.d/ \
-e DD_API_KEY=xxx datadog/agent:latest
```

Logs

```
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] 01-check-apikey.sh: executing...
[cont-init.d] 01-check-apikey.sh: exited 0.
[cont-init.d] 50-cri.sh: executing...
[cont-init.d] 50-cri.sh: exited 0.
[cont-init.d] 50-ecs.sh: executing...
[cont-init.d] 50-ecs.sh: exited 0.
[cont-init.d] 50-kubernetes.sh: executing...
[cont-init.d] 50-kubernetes.sh: exited 0.
[cont-init.d] 50-mesos.sh: executing...
[cont-init.d] 50-mesos.sh: exited 0.
[cont-init.d] 51-docker.sh: executing...
mv: cannot stat '/etc/datadog-agent/conf.d/docker.d/conf.yaml.example': No such file or directory
[cont-init.d] 51-docker.sh: exited 1.
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
