### PR TITLE
[DCA] Add toleration margin for clc advanced dispatching

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -15,6 +15,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const tolerationMargin float64 = 0.9
+
 type Weight struct {
 	nodeName string
 	busyness int
@@ -182,7 +184,7 @@ func (d *dispatcher) rebalance() {
 			}
 
 			pickedNodeName := pickNode(diffMap, sourceNodeName)
-			if diffMap[pickedNodeName]+checkWeight < diffMap[sourceNodeName] {
+			if diffMap[pickedNodeName]+checkWeight < int(float64(diffMap[sourceNodeName])*tolerationMargin) {
 				// move a check to a new node only if it keeps the busyness of the new node
 				// lower than the original node's busyness
 				rebalancingDecisions.Inc()

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -123,7 +123,7 @@ func TestRebalance(t *testing.T) {
 							MetricSamples:        10,
 						},
 						"checkA3": types.CLCRunnerStats{
-							AverageExecutionTime: 300,
+							AverageExecutionTime: 200,
 							MetricSamples:        10,
 						},
 					},
@@ -162,15 +162,15 @@ func TestRebalance(t *testing.T) {
 							AverageExecutionTime: 100,
 							MetricSamples:        10,
 						},
-						"checkA3": types.CLCRunnerStats{
-							AverageExecutionTime: 300,
-							MetricSamples:        10,
-						},
 					},
 				},
 				"B": {
 					name: "B",
 					clcRunnerStats: types.CLCRunnersStats{
+						"checkA3": types.CLCRunnerStats{
+							AverageExecutionTime: 200,
+							MetricSamples:        10,
+						},
 						"checkB0": types.CLCRunnerStats{
 							AverageExecutionTime: 20,
 							MetricSamples:        10,
@@ -357,7 +357,7 @@ func TestRebalance(t *testing.T) {
 							MetricSamples:        10,
 						},
 						"checkB3": types.CLCRunnerStats{
-							AverageExecutionTime: 300,
+							AverageExecutionTime: 200,
 							MetricSamples:        10,
 						},
 						"checkB4": types.CLCRunnerStats{
@@ -442,10 +442,6 @@ func TestRebalance(t *testing.T) {
 							AverageExecutionTime: 100,
 							MetricSamples:        10,
 						},
-						"checkB3": types.CLCRunnerStats{
-							AverageExecutionTime: 300,
-							MetricSamples:        10,
-						},
 					},
 				},
 				"C": {
@@ -460,6 +456,10 @@ func TestRebalance(t *testing.T) {
 						},
 						"checkC2": types.CLCRunnerStats{
 							AverageExecutionTime: 100,
+							MetricSamples:        10,
+						},
+						"checkB3": types.CLCRunnerStats{
+							AverageExecutionTime: 200,
 							MetricSamples:        10,
 						},
 					},

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -162,15 +162,15 @@ func TestRebalance(t *testing.T) {
 							AverageExecutionTime: 100,
 							MetricSamples:        10,
 						},
+						"checkA3": types.CLCRunnerStats{
+							AverageExecutionTime: 300,
+							MetricSamples:        10,
+						},
 					},
 				},
 				"B": {
 					name: "B",
 					clcRunnerStats: types.CLCRunnersStats{
-						"checkA3": types.CLCRunnerStats{
-							AverageExecutionTime: 300,
-							MetricSamples:        10,
-						},
 						"checkB0": types.CLCRunnerStats{
 							AverageExecutionTime: 20,
 							MetricSamples:        10,
@@ -442,6 +442,10 @@ func TestRebalance(t *testing.T) {
 							AverageExecutionTime: 100,
 							MetricSamples:        10,
 						},
+						"checkB3": types.CLCRunnerStats{
+							AverageExecutionTime: 300,
+							MetricSamples:        10,
+						},
 					},
 				},
 				"C": {
@@ -456,10 +460,6 @@ func TestRebalance(t *testing.T) {
 						},
 						"checkC2": types.CLCRunnerStats{
 							AverageExecutionTime: 100,
-							MetricSamples:        10,
-						},
-						"checkB3": types.CLCRunnerStats{
-							AverageExecutionTime: 300,
 							MetricSamples:        10,
 						},
 					},
@@ -699,12 +699,7 @@ func TestRebalance(t *testing.T) {
 			},
 			out: map[string]*nodeStore{
 				"A": {
-					clcRunnerStats: types.CLCRunnersStats{
-						"checkC1": types.CLCRunnerStats{
-							AverageExecutionTime: 500,
-							MetricSamples:        10,
-						},
-					},
+					clcRunnerStats: types.CLCRunnersStats{},
 				},
 				"B": {
 					clcRunnerStats: types.CLCRunnersStats{},
@@ -713,6 +708,10 @@ func TestRebalance(t *testing.T) {
 					clcRunnerStats: types.CLCRunnersStats{
 						"checkC0": types.CLCRunnerStats{
 							AverageExecutionTime: 20,
+							MetricSamples:        10,
+						},
+						"checkC1": types.CLCRunnerStats{
+							AverageExecutionTime: 500,
 							MetricSamples:        10,
 						},
 					},
@@ -935,10 +934,6 @@ func TestRebalance(t *testing.T) {
 							AverageExecutionTime: 100,
 							MetricSamples:        20,
 						},
-						"checkD2": types.CLCRunnerStats{
-							AverageExecutionTime: 300,
-							MetricSamples:        600,
-						},
 					},
 				},
 				"D": {
@@ -950,6 +945,10 @@ func TestRebalance(t *testing.T) {
 						"checkD1": types.CLCRunnerStats{
 							AverageExecutionTime: 100,
 							MetricSamples:        50,
+						},
+						"checkD2": types.CLCRunnerStats{
+							AverageExecutionTime: 300,
+							MetricSamples:        600,
 						},
 					},
 				},


### PR DESCRIPTION
### What does this PR do?

Adds a toleration margin to avoid "unnecessary" check rebalancing

### Motivation

Make dispatching more stable
