### PR TITLE
install_script changes for Agent 7 and ARM

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -88,6 +88,15 @@ if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
   dd_agent_major_version=$DD_AGENT_MAJOR_VERSION
 fi
 
+dd_agent_dist_channel=stable
+if [ -n "$DD_AGENT_DIST_CHANNEL" ]; then
+  if [ "$DD_AGENT_DIST_CHANNEL" != "stable" -a "$DD_AGENT_DIST_CHANNEL" != "beta" ]; then
+    echo "DD_AGENT_DIST_CHANNEL must be either 'stable' or 'beta'"
+    exit 1;
+  fi
+  dd_agent_dist_channel=$DD_AGENT_DIST_CHANNEL
+fi
+
 keyserver="hkp://keyserver.ubuntu.com:80"
 # use this env var to specify another key server, such as
 # hkp://p80.pool.sks-keyservers.net:80 for example.
@@ -149,7 +158,7 @@ if [ $OS = "RedHat" ]; then
         ARCHI="x86_64"
     fi
 
-    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.${repo_url}/stable/${dd_agent_major_version}/${ARCHI}/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\npriority=1\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog.repo"
+    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.${repo_url}/${dd_agent_dist_channel}/${dd_agent_major_version}/${ARCHI}/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\npriority=1\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog.repo"
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
     $sudo_cmd yum -y clean metadata
@@ -166,7 +175,7 @@ elif [ $OS = "Debian" ]; then
       $sudo_cmd apt-get install -y dirmngr
     fi
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
-    $sudo_cmd sh -c "echo 'deb https://apt.${repo_url}/ stable ${dd_agent_major_version}' > /etc/apt/sources.list.d/datadog.list"
+    $sudo_cmd sh -c "echo 'deb https://apt.${repo_url}/ ${dd_agent_dist_channel} ${dd_agent_major_version}' > /etc/apt/sources.list.d/datadog.list"
     $sudo_cmd apt-key adv --recv-keys --keyserver ${keyserver} A2923DFF56EDA6E76E55E492D3A80E30382E94DE
 
     printf "\033[34m\n* Installing the Datadog Agent package\n\033[0m\n"
@@ -200,7 +209,7 @@ elif [ $OS = "SUSE" ]; then
   fi
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"
-  $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.${repo_url}/suse/stable/${dd_agent_major_version}/${ARCHI}\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/zypp/repos.d/datadog.repo"
+  $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.${repo_url}/suse/${dd_agent_dist_channel}/${dd_agent_major_version}/${ARCHI}\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/zypp/repos.d/datadog.repo"
 
   echo -e "\033[34m\n* Importing the Datadog GPG Keys\n\033[0m"
   $sudo_cmd rpm --import https://yum.${repo_url}/DATADOG_RPM_KEY.public

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -79,6 +79,15 @@ if [ -n "$DD_UPGRADE" ]; then
   dd_upgrade=$DD_UPGRADE
 fi
 
+dd_agent_major_version=6
+if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
+  if [ "$DD_AGENT_MAJOR_VERSION" != "6" -a "$DD_AGENT_MAJOR_VERSION" != "7" ]; then
+    echo "DD_AGENT_MAJOR_VERSION must be either 6 or 7"
+    exit 1;
+  fi
+  dd_agent_major_version=$DD_AGENT_MAJOR_VERSION
+fi
+
 keyserver="hkp://keyserver.ubuntu.com:80"
 # use this env var to specify another key server, such as
 # hkp://p80.pool.sks-keyservers.net:80 for example.
@@ -134,11 +143,13 @@ if [ $OS = "RedHat" ]; then
     UNAME_M=$(uname -m)
     if [ "$UNAME_M"  == "i686" -o "$UNAME_M"  == "i386" -o "$UNAME_M"  == "x86" ]; then
         ARCHI="i386"
+    elif [ "$UNAME_M"  == "aarch64" ]; then
+        ARCHI="aarch64"
     else
         ARCHI="x86_64"
     fi
 
-    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.${repo_url}/stable/6/$ARCHI/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\npriority=1\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog.repo"
+    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.${repo_url}/stable/${dd_agent_major_version}/${ARCHI}/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\npriority=1\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog.repo"
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
     $sudo_cmd yum -y clean metadata
@@ -155,7 +166,7 @@ elif [ $OS = "Debian" ]; then
       $sudo_cmd apt-get install -y dirmngr
     fi
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
-    $sudo_cmd sh -c "echo 'deb https://apt.${repo_url}/ stable 6' > /etc/apt/sources.list.d/datadog.list"
+    $sudo_cmd sh -c "echo 'deb https://apt.${repo_url}/ stable ${dd_agent_major_version}' > /etc/apt/sources.list.d/datadog.list"
     $sudo_cmd apt-key adv --recv-keys --keyserver ${keyserver} A2923DFF56EDA6E76E55E492D3A80E30382E94DE
 
     printf "\033[34m\n* Installing the Datadog Agent package\n\033[0m\n"
@@ -182,10 +193,14 @@ elif [ $OS = "SUSE" ]; then
   if [ "$UNAME_M"  == "i686" -o "$UNAME_M"  == "i386" -o "$UNAME_M"  == "x86" ]; then
       printf "\033[31mThe Datadog Agent installer is only available for 64 bit SUSE Enterprise machines.\033[0m\n"
       exit;
+  elif [ "$UNAME_M"  == "aarch64" ]; then
+      ARCHI="aarch64"
+  else
+      ARCHI="x86_64"
   fi
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"
-  $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.${repo_url}/suse/stable/6/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/zypp/repos.d/datadog.repo"
+  $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.${repo_url}/suse/stable/${dd_agent_major_version}/${ARCHI}\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/zypp/repos.d/datadog.repo"
 
   echo -e "\033[34m\n* Importing the Datadog GPG Keys\n\033[0m"
   $sudo_cmd rpm --import https://yum.${repo_url}/DATADOG_RPM_KEY.public

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -82,7 +82,7 @@ fi
 dd_agent_major_version=6
 if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
   if [ "$DD_AGENT_MAJOR_VERSION" != "6" -a "$DD_AGENT_MAJOR_VERSION" != "7" ]; then
-    echo "DD_AGENT_MAJOR_VERSION must be either 6 or 7"
+    echo "DD_AGENT_MAJOR_VERSION must be either 6 or 7. Current value: $DD_AGENT_MAJOR_VERSION"
     exit 1;
   fi
   dd_agent_major_version=$DD_AGENT_MAJOR_VERSION
@@ -91,7 +91,7 @@ fi
 dd_agent_dist_channel=stable
 if [ -n "$DD_AGENT_DIST_CHANNEL" ]; then
   if [ "$DD_AGENT_DIST_CHANNEL" != "stable" -a "$DD_AGENT_DIST_CHANNEL" != "beta" ]; then
-    echo "DD_AGENT_DIST_CHANNEL must be either 'stable' or 'beta'"
+    echo "DD_AGENT_DIST_CHANNEL must be either 'stable' or 'beta'. Current value: $DD_AGENT_DIST_CHANNEL"
     exit 1;
   fi
   dd_agent_dist_channel=$DD_AGENT_DIST_CHANNEL


### PR DESCRIPTION
The env var DD_AGENT_MAJOR_VERSION can now be used to specify the agent
version (either 6 or 7). Default is 6 if not specified.

The env var DD_AGENT_DIST_CHANNEL lets you chose from stable (default) or beta, 
since we will be releasing Agent 7 in beta.

Also, places were x86_64 was hardcoded now can handle arm64 as well. The
installation still fails on ARM, since the agent isn't available yet.

