### PR TITLE
Adding default for read timeout in the event collection

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -36,7 +36,7 @@ const (
 	eventTokenKey                 = "event"
 	maxEventCardinality           = 300
 	defaultResyncPeriodInSecond   = 300
-	defaultTimeoutEventCollection = 1000
+	defaultTimeoutEventCollection = 2000
 )
 
 // KubeASConfig is the config of the API server.

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -31,11 +31,12 @@ import (
 
 // Covers the Control Plane service check and the in memory pod metadata.
 const (
-	KubeControlPaneCheck         = "kube_apiserver_controlplane.up"
-	kubernetesAPIServerCheckName = "kubernetes_apiserver"
-	eventTokenKey                = "event"
-	maxEventCardinality          = 300
-	defaultResyncPeriodInSecond  = 300
+	KubeControlPaneCheck          = "kube_apiserver_controlplane.up"
+	kubernetesAPIServerCheckName  = "kubernetes_apiserver"
+	eventTokenKey                 = "event"
+	maxEventCardinality           = 300
+	defaultResyncPeriodInSecond   = 300
+	defaultTimeoutEventCollection = 1000
 )
 
 // KubeASConfig is the config of the API server.
@@ -70,7 +71,6 @@ func (c *KubeASConfig) parse(data []byte) error {
 	// default values
 	c.CollectEvent = config.Datadog.GetBool("collect_kubernetes_events")
 	c.CollectOShiftQuotas = true
-	c.EventCollectionTimeoutMs = config.Datadog.GetInt("kubernetes_event_collection_timeout")
 	c.ResyncPeriodEvents = defaultResyncPeriodInSecond
 
 	return yaml.Unmarshal(data, c)
@@ -89,6 +89,10 @@ func (k *KubeASCheck) Configure(config, initConfig integration.Data, source stri
 		log.Error("could not parse the config for the API server")
 		return err
 	}
+	if k.instance.EventCollectionTimeoutMs == 0 {
+		k.instance.EventCollectionTimeoutMs = defaultTimeoutEventCollection
+	}
+
 	if k.instance.MaxEventCollection == 0 {
 		k.instance.MaxEventCollection = maxEventCardinality
 	}

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -52,7 +52,7 @@ func (c *APIClient) RunEventCollection(resVer string, lastListTime time.Time, ev
 	defer evWatcher.Stop()
 	log.Debugf("Starting to watch from %s", resVer)
 	// watch during 2 * timeout maximum and store where we are at.
-	timeoutParse := time.NewTimer(time.Duration(eventReadTimeout*2) * time.Second)
+	timeoutParse := time.NewTimer(time.Duration(eventReadTimeout) * time.Second)
 	for {
 		select {
 		case rcv, ok := <-evWatcher.ResultChan():


### PR DESCRIPTION
### What does this PR do?

Event collection read timeout was parsed from the env/the datadog general config.
It should be in the yaml of the check.

This also defaults it at 1 second.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
