### PR TITLE
[logs] Expose compression metrics

### DIFF
--- a/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
+++ b/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
@@ -160,3 +160,7 @@ instances:
         type: rate
       - path: logs-agent/LogsSent
         type: rate
+      - path: logs-agent/BytesSent
+        type: rate
+      - path: logs-agent/EncodedBytesSent
+        type: rate

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -143,5 +143,7 @@ func (b *Builder) getMetricsStatus() map[string]int64 {
 	var metrics = make(map[string]int64, 2)
 	metrics["LogsProcessed"] = b.logsExpVars.Get("LogsProcessed").(*expvar.Int).Value()
 	metrics["LogsSent"] = b.logsExpVars.Get("LogsSent").(*expvar.Int).Value()
+	metrics["BytesSent"] = b.logsExpVars.Get("BytesSent").(*expvar.Int).Value()
+	metrics["EncodedBytesSent"] = b.logsExpVars.Get("EncodedBytesSent").(*expvar.Int).Value()
 	return metrics
 }

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -109,13 +109,19 @@ func TestStatusMetrics(t *testing.T) {
 	status := Get()
 	assert.Equal(t, int64(0), status.StatusMetrics["LogsProcessed"])
 	assert.Equal(t, int64(0), status.StatusMetrics["LogsSent"])
+	assert.Equal(t, int64(0), status.StatusMetrics["BytesSent"])
+	assert.Equal(t, int64(0), status.StatusMetrics["EncodedBytesSent"])
 
 	metrics.LogsProcessed.Set(5)
 	metrics.LogsSent.Set(3)
+	metrics.BytesSent.Set(42)
+	metrics.EncodedBytesSent.Set(21)
 	status = Get()
 
 	assert.Equal(t, int64(5), status.StatusMetrics["LogsProcessed"])
 	assert.Equal(t, int64(3), status.StatusMetrics["LogsSent"])
+	assert.Equal(t, int64(42), status.StatusMetrics["BytesSent"])
+	assert.Equal(t, int64(21), status.StatusMetrics["EncodedBytesSent"])
 
 	metrics.LogsProcessed.Set(math.MaxInt64)
 	metrics.LogsProcessed.Add(1)


### PR DESCRIPTION
### What does this PR do?

Expose compression metrics in the agent's status and in the agent_stats.yaml.example.

### Motivation

Have observability on the compression.

### Additional Notes

Anything else we should know when reviewing?
