### PR TITLE
Properly add the dirname tag to all log entries for files discovered through wild card configuration.

### DIFF
--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -152,9 +152,8 @@ func (p *Provider) searchFiles(pattern string, source *config.LogSource) ([]*Fil
 	sort.SliceStable(paths, func(i, j int) bool {
 		return filepath.Base(paths[i]) > filepath.Base(paths[j])
 	})
-	isWildcardPath := p.containsWildcard(pattern)
 	for _, path := range paths {
-		files = append(files, NewFile(path, source, isWildcardPath))
+		files = append(files, NewFile(path, source, true))
 	}
 	return files, nil
 }

--- a/pkg/logs/input/file/file_provider_test.go
+++ b/pkg/logs/input/file/file_provider_test.go
@@ -109,6 +109,30 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 	)
 }
 
+func (suite *ProviderTestSuite) TestCollectFilesWildcardFlag() {
+	// with wildcard
+
+	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
+	fileProvider := NewProvider(suite.filesLimit)
+	logSources := suite.newLogSources(path)
+	files, err := fileProvider.CollectFiles(logSources[0])
+	suite.NoError(err, "searching for files in this directory shouldn't fail")
+	for _, file := range files {
+		suite.True(file.IsWildcardPath, "this file has been found with a wildcard pattern.")
+	}
+
+	// without wildcard
+
+	path = fmt.Sprintf("%s/1/1.log", suite.testDir)
+	fileProvider = NewProvider(suite.filesLimit)
+	logSources = suite.newLogSources(path)
+	files, err = fileProvider.CollectFiles(logSources[0])
+	suite.NoError(err, "searching for files in this directory shouldn't fail")
+	for _, file := range files {
+		suite.False(file.IsWildcardPath, "this file has not been found using a wildcard pattern.")
+	}
+}
+
 func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWithRightPermissions() {
 	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
 	fileProvider := NewProvider(suite.filesLimit)

--- a/releasenotes/notes/logs-tag-dirname-at-creation-9da7c8f17a9b45bf.yaml
+++ b/releasenotes/notes/logs-tag-dirname-at-creation-9da7c8f17a9b45bf.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    logs agent - tailed files discovered through a configuration entry with
+    Logs: tailed files discovered through a configuration entry with
     wildcard will properly have the `dirname` tag on all log entries.

--- a/releasenotes/notes/logs-tag-dirname-at-creation-9da7c8f17a9b45bf.yaml
+++ b/releasenotes/notes/logs-tag-dirname-at-creation-9da7c8f17a9b45bf.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    logs agent - tailed files discovered through a configuration entry with
+    wildcard will properly have the `dirname` tag on all log entries.


### PR DESCRIPTION
### What does this PR do?

The `searchFiles` method which is looking for files to tail in a directory is aware if a file has been discovered through a wild card patter but it was not creating the `File` object with this info, this flag was instead set in the regularly called method `FilesToTail`.
This behavior could lead to `File` objects not having the flag appropriately set during a certain amount of time, sending logs without the `dirname` tag.

Basically, this PR changes the `File` constructor in order to store this info as soon as the File object is created, it also removes this responsability to `FilesToTail`.

### Motivation

Properly add the `dirname` tag to log entries for files discovered through wild card configuration.
