### PR TITLE
[reno] Only look at tags starting with `6.`

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,7 +1,7 @@
 ---
 collapse_pre_releases: true
 no_show_source: true
-release_tag_re: '^([\d.-]|rc)+$'
+release_tag_re: '^6\.([\d.-]|rc)+$'
 pre_release_tag_re: '(?P<pre_release>-rc\.\d+)$'
 template: |
           # Each section from every releasenote are combined when the


### PR DESCRIPTION
### What does this PR do?

Configure reno so it only looks at tags starting with `6.`

### Motivation

Now that the repo in tagged with `7` tags, we have to tell reno to not
consider these tags as valid release tags, so that it can correctly
link RCs to their related release and generate the changelog successfully.

### Additional Notes

When we switch to v7 as the default, we should update this
pattern to 7. I'll make a card so we don't forget.