### PR TITLE
Remove symlink to terminfo

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -114,6 +114,8 @@ build do
 
             # removing the terminfo db from the embedded folder to reduce package size by ~7MB
             delete "#{install_dir}/embedded/share/terminfo"
+            # removing the symlink too
+            delete "#{install_dir}/embedded/lib/terminfo"
 
             # removing useless folder
             delete "#{install_dir}/embedded/share/aclocal"


### PR DESCRIPTION
### What does this PR do?

Removes the dead symlink to terminfo. It was breaking cloudfoundry agent bosh release

### Motivation

```
vagrant@ubuntu-xenial:/opt/datadog-agent/embedded$ find . -xtype l
./lib/terminfo
```
