### PR TITLE
[DCA][Fix] Show endpoints check source

### DIFF
--- a/pkg/autodiscovery/providers/kube_endpoints.go
+++ b/pkg/autodiscovery/providers/kube_endpoints.go
@@ -144,11 +144,13 @@ func parseServiceAnnotationsForEndpoints(services []*v1.Service) []configInfo {
 			log.Debug("Ignoring a nil service")
 			continue
 		}
-		endptConf, errors := extractTemplatesFromMap(apiserver.EntityForEndpoints(svc.Namespace, svc.Name, ""), svc.Annotations, kubeEndpointAnnotationPrefix)
+		endpointsID := apiserver.EntityForEndpoints(svc.Namespace, svc.Name, "")
+		endptConf, errors := extractTemplatesFromMap(endpointsID, svc.Annotations, kubeEndpointAnnotationPrefix)
 		for _, err := range errors {
 			log.Errorf("Cannot parse endpoint template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 		}
 		for i := range endptConf {
+			endptConf[i].Source = "kube_endpoints:" + endpointsID
 			configsInfo = append(configsInfo, configInfo{
 				tpl:       endptConf[i],
 				namespace: svc.Namespace,

--- a/pkg/autodiscovery/providers/kube_endpoints_test.go
+++ b/pkg/autodiscovery/providers/kube_endpoints_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -55,6 +55,7 @@ func TestParseKubeServiceAnnotationsForEndpoints(t *testing.T) {
 						InitConfig:    integration.Data("{}"),
 						Instances:     []integration.Data{integration.Data("{\"name\":\"My endpoint\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 						ClusterCheck:  false,
+						Source:        "kube_endpoints:kube_endpoint_uid://default/myservice/",
 					},
 					namespace: "default",
 					name:      "myservice",


### PR DESCRIPTION
### What does this PR do?

Show endpoints check source in `configcheck` and `status` commands

### Motivation

```
=== kube_apiserver_metrics cluster check ===
Configuration provider: kubernetes-endpoints
Configuration source: Unknown configuration source
Instance ID: kube_apiserver_metrics:76c073f1747b2af3
...
```

### Additional Notes

Anything else we should know when reviewing?
