### PR TITLE
Fix launching multiple times the docker provider

### DIFF
--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -52,11 +52,13 @@ func (d *DockerConfigProvider) String() string {
 // Collect retrieves all running containers and extract AD templates from their labels.
 func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 	var err error
+	firstCollection := false
 	if d.dockerUtil == nil {
 		d.dockerUtil, err = docker.GetDockerUtil()
 		if err != nil {
 			return []integration.Config{}, err
 		}
+		firstCollection = true
 	}
 
 	var containers map[string]map[string]string
@@ -79,7 +81,9 @@ func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 	d.Unlock()
 
 	// start listening after the first collection to avoid race in cache map init
-	go d.listen()
+	if firstCollection {
+		go d.listen()
+	}
 
 	return parseDockerLabels(containers)
 }

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -53,9 +53,12 @@ func (d *DockerConfigProvider) String() string {
 func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 	var err error
 	firstCollection := false
+
+	d.Lock()
 	if d.dockerUtil == nil {
 		d.dockerUtil, err = docker.GetDockerUtil()
 		if err != nil {
+			d.Unlock()
 			return []integration.Config{}, err
 		}
 		firstCollection = true
@@ -67,6 +70,7 @@ func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 	if d.labelCache == nil || d.syncCounter == d.syncInterval {
 		containers, err = d.dockerUtil.AllContainerLabels()
 		if err != nil {
+			d.Unlock()
 			return []integration.Config{}, err
 		}
 		d.labelCache = containers
@@ -75,7 +79,6 @@ func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 		containers = d.labelCache
 	}
 
-	d.Lock()
 	d.syncCounter += 1
 	d.upToDate = true
 	d.Unlock()


### PR DESCRIPTION
### What does this PR do?

Fix a bug introduced by https://github.com/DataDog/datadog-agent/pull/4266 which would start multiple times the docker config provider, leading into an unhealthy agent 

### Motivation

Fix leak + crashes

### Additional Notes

Anything else we should know when reviewing?
