### PR TITLE
[releasenotes] Remove dev-related release note

### DIFF
--- a/releasenotes/notes/rtloader-testing-accounting-and-fixes-41e46c6338c874fe.yaml
+++ b/releasenotes/notes/rtloader-testing-accounting-and-fixes-41e46c6338c874fe.yaml
@@ -9,8 +9,3 @@
 fixes:
   - |
     Minor memory leaks identified and fixed in RTLoader.
-other:
-  - |
-    RTLoader unit test memory accounting features to track correct
-    and expected memory usage.
-    Deprecation of direct use of malloc and free in RTLoader.


### PR DESCRIPTION
### What does this PR do?

Removes release note from #4134, as it's only relevant to developers.

### Motivation

Release notes are user-facing, doesn't make sense at the moment to add dev-related notes.

### Additional Notes

If we want dev-related notes, we could add a `development` section to the release notes maybe? But does it really make since since dev-related notes are not tied to releases?
