### PR TITLE
[rtloader] Fix small mem leak in set_external_tags

### DIFF
--- a/releasenotes/notes/memleak-set-external-tags-empty-dict-36d4a20308c3d8a2.yaml
+++ b/releasenotes/notes/memleak-set-external-tags-empty-dict-36d4a20308c3d8a2.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix small memory leak in ``datadog_agent.set_external_tags`` when an empty
+    source_type dict is passed for a given hostname.

--- a/rtloader/common/builtins/datadog_agent.c
+++ b/rtloader/common/builtins/datadog_agent.c
@@ -570,6 +570,7 @@ static PyObject *set_external_tags(PyObject *self, PyObject *args)
         Py_ssize_t pos = 0;
         PyObject *key = NULL, *value = NULL;
         if (!PyDict_Next(dict, &pos, &key, &value)) {
+            _free(hostname);
             continue;
         }
 

--- a/rtloader/test/datadog_agent/datadog_agent_test.go
+++ b/rtloader/test/datadog_agent/datadog_agent_test.go
@@ -384,6 +384,29 @@ func TestSetExternalTagInvalidTagsList(t *testing.T) {
 	helpers.AssertMemoryUsage(t)
 }
 
+func TestSetExternalTagEmptyDict(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	code := `
+	tags = [
+		('hostname', {}),
+		('hostname2', {'source_type2': ['tag3', 'tag4']}),
+	]
+	datadog_agent.set_external_tags(tags)
+	`
+	out, err := run(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "hostname2,source_type2,tag3,tag4" {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}
+
 func TestWritePersistentCache(t *testing.T) {
 	code := `
 	datadog_agent.write_persistent_cache("12345", "someothervalue")


### PR DESCRIPTION
### What does this PR do?

Fix small mem leak in `set_external_tags`. Only happens when an empty dict is passed for a given hostname.

Added test that demonstrates the leak.

### Motivation

💅 

### Additional Notes

Was easy to find and fix thanks to the very useful mem tracking facilities that were added in #4134!