### PR TITLE
[Fix] goroutine leak in the AD docker provider

### DIFF
--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -33,6 +33,7 @@ type DockerConfigProvider struct {
 	labelCache   map[string]map[string]string
 	syncInterval int
 	syncCounter  int
+	onceListen   sync.Once
 }
 
 // NewDockerConfigProvider returns a new ConfigProvider connected to docker.
@@ -79,7 +80,7 @@ func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 	d.Unlock()
 
 	// start listening after the first collection to avoid race in cache map init
-	go d.listen()
+	d.onceListen.Do(func() { go d.listen() })
 
 	return parseDockerLabels(containers)
 }


### PR DESCRIPTION
### What does this PR do?

Fix a goroutine leak in the autodiscovery docker provider

### Motivation

the leak was introduce in #4266. Thanks to the `sync.Once` we limit
the number of goroutine running `d.listen()` to one.

### Additional Notes

Anything else we should know when reviewing?
