### PR TITLE
[DCA][Fix] Invalidate changed Endpoints config

### DIFF
--- a/pkg/autodiscovery/providers/kube_endpoints.go
+++ b/pkg/autodiscovery/providers/kube_endpoints.go
@@ -32,11 +32,11 @@ const (
 
 // kubeEndpointsConfigProvider implements the ConfigProvider interface for the apiserver.
 type kubeEndpointsConfigProvider struct {
+	sync.RWMutex
 	serviceLister      listersv1.ServiceLister
 	endpointsLister    listersv1.EndpointsLister
 	upToDate           bool
 	monitoredEndpoints map[string]bool
-	sync.RWMutex
 }
 
 // configInfo contains an endpoint check config template with its name and namespace

--- a/pkg/autodiscovery/providers/kube_endpoints_test.go
+++ b/pkg/autodiscovery/providers/kube_endpoints_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
 
 var (
@@ -195,7 +196,7 @@ func TestGenerateConfigs(t *testing.T) {
 	}
 }
 
-func TestInvalidateIfChangedForEndpoints(t *testing.T) {
+func TestInvalidateIfChangedService(t *testing.T) {
 	s88 := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: "88",
@@ -278,11 +279,336 @@ func TestInvalidateIfChangedForEndpoints(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf(""), func(t *testing.T) {
 			provider := &KubeEndpointsConfigProvider{upToDate: true}
-			provider.invalidateIfChanged(tc.old, tc.obj)
+			provider.invalidateIfChangedService(tc.old, tc.obj)
 
 			upToDate, err := provider.IsUpToDate()
 			assert.NoError(t, err)
 			assert.Equal(t, !tc.invalidate, upToDate)
+		})
+	}
+}
+
+func TestInvalidateIfChangedEndpoints(t *testing.T) {
+	for name, tc := range map[string]struct {
+		first    *v1.Endpoints
+		second   *v1.Endpoints
+		upToDate bool
+	}{
+		"Same resversion": {
+			first: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+			},
+			second: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+			},
+			upToDate: true,
+		},
+		"Change resversion, same subsets": {
+			first: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 126},
+						},
+					},
+				},
+			},
+			second: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "124",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 126},
+						},
+					},
+				},
+			},
+			upToDate: true,
+		},
+		"Change IP": {
+			first: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 126},
+						},
+					},
+				},
+			},
+			second: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "124",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.3", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 126},
+						},
+					},
+				},
+			},
+			upToDate: false,
+		},
+		"Change IP for not monitored Endpoints": {
+			first: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Namespace:       "default",
+					Name:            "notmonitored",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 126},
+						},
+					},
+				},
+			},
+			second: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "124",
+					Namespace:       "default",
+					Name:            "notmonitored",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.3", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 126},
+						},
+					},
+				},
+			},
+			upToDate: true,
+		},
+		"Change Hostname": {
+			first: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 126},
+						},
+					},
+				},
+			},
+			second: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "124",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.3", Hostname: "host3"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 126},
+						},
+					},
+				},
+			},
+			upToDate: false,
+		},
+		"Change port number": {
+			first: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 126},
+						},
+					},
+				},
+			},
+			second: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "124",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 124},
+						},
+					},
+				},
+			},
+			upToDate: false,
+		},
+		"Remove IP": {
+			first: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 124},
+						},
+					},
+				},
+			},
+			second: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "124",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 124},
+						},
+					},
+				},
+			},
+			upToDate: false,
+		},
+		"Remove port": {
+			first: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+							{Name: "port2", Port: 124},
+						},
+					},
+				},
+			},
+			second: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "124",
+					Namespace:       "default",
+					Name:            "myservice",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "host1"},
+							{IP: "10.0.0.2", Hostname: "host2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port1", Port: 123},
+						},
+					},
+				},
+			},
+			upToDate: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			provider := &KubeEndpointsConfigProvider{
+				upToDate: true,
+				monitoredEndpoints: map[string]bool{
+					apiserver.EntityForEndpoints("default", "myservice", ""): true,
+				},
+			}
+			provider.invalidateIfChangedEndpoints(tc.first, tc.second)
+
+			upToDate, err := provider.IsUpToDate()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.upToDate, upToDate)
 		})
 	}
 }

--- a/pkg/autodiscovery/providers/kube_endpoints_test.go
+++ b/pkg/autodiscovery/providers/kube_endpoints_test.go
@@ -278,7 +278,7 @@ func TestInvalidateIfChangedService(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf(""), func(t *testing.T) {
-			provider := &KubeEndpointsConfigProvider{upToDate: true}
+			provider := &kubeEndpointsConfigProvider{upToDate: true}
 			provider.invalidateIfChangedService(tc.old, tc.obj)
 
 			upToDate, err := provider.IsUpToDate()
@@ -598,7 +598,7 @@ func TestInvalidateIfChangedEndpoints(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			provider := &KubeEndpointsConfigProvider{
+			provider := &kubeEndpointsConfigProvider{
 				upToDate: true,
 				monitoredEndpoints: map[string]bool{
 					apiserver.EntityForEndpoints("default", "myservice", ""): true,


### PR DESCRIPTION
### What does this PR do?

Watch endpoint objects changes in the `kube_endpoints` config provider

### Motivation

Autodiscover endpoint changes and update check config to match AD service created by the `kube_endpoints` AD listener

### Additional Notes

Anything else we should know when reviewing?
