### PR TITLE
log.Debug -> log.Debugf

### DIFF
--- a/pkg/logs/client/tcp/connection_manager.go
+++ b/pkg/logs/client/tcp/connection_manager.go
@@ -104,7 +104,7 @@ func (cm *ConnectionManager) NewConnection(ctx context.Context) (net.Conn, error
 			log.Warn(err)
 			continue
 		}
-		log.Debug("connected to %v", cm.address())
+		log.Debugf("connected to %v", cm.address())
 
 		if cm.endpoint.UseSSL {
 			sslConn := tls.Client(conn, &tls.Config{


### PR DESCRIPTION
### What does this PR do?

log.Debug -> log.Debugf

### Motivation

I saw the following log in my environment. It think it's just a typo:)
```
2019-10-23 04:34:44 UTC | CORE | DEBUG | (pkg/logs/client/tcp/connection_manager.go:107 in NewConnection) | connected to %v agent-intake.logs.datadoghq.com:10516
```

### Additional Notes

nothing.
