### PR TITLE
[kitchen] Fix install script kitchen test not finding apt/yum repo

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -41,6 +41,8 @@ execute 'update Agent install script repository' do
     sed -i 's~stable main~#{node['dd-agent-install-script']['candidate_repo_branch']} main~' install-script
     sed -i 's~stable 6~#{node['dd-agent-install-script']['candidate_repo_branch']} main~' install-script
     sed -i 's~stable/6~#{node['dd-agent-install-script']['candidate_repo_branch']}~' install-script
+    sed -i 's~${dd_agent_dist_channel} ${dd_agent_major_version}~#{node['dd-agent-install-script']['candidate_repo_branch']} main~' install-script
+    sed -i 's~${dd_agent_dist_channel}/${dd_agent_major_version}~#{node['dd-agent-install-script']['candidate_repo_branch']}~' install-script
   EOF
 
   only_if { node['dd-agent-install-script']['install_candidate'] }


### PR DESCRIPTION
### What does this PR do?

Makes the chef recipe used by kitchen to launch the install script work again, following a change in the install script.

### Motivation

We modified our install script to make it work for any release branch and component.
However this broke the kitchen tests, which use sed to replace parts of the install script to make it work with the testing repository.

A more durable solution would be to use the new environment variables provided (which would require more work on the chef recipe used in the kitchen test), but this should be enough to unblock the pipeline for now.

### Additional Notes

Only merge this once the kitchen tests are OK.