### PR TITLE
Allows install to proceed even if the default ddagentuser is present.

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -79,8 +79,8 @@ else
            :sha256 => "575093fd5748ccc22be6577fff15ae9ffe525b627888342bd43826053183e9da",
            :extract => :seven_zip
   else
-    source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-nopip-amd64.zip",
-         :sha256 => "b9878cf2e64084c35a98ae1acd68f93bd7bc36e232e01088cba7692153068f67",
+    source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-nopip-2-amd64.zip",
+         :sha256 => "0849a12f9a162636c1f4a561110ecb481cbb13bc54b558015b23559146bb5e26",
          :extract => :seven_zip
   end
   build do

--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -175,7 +175,7 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall) {
             }
         }
     }
-    hr = S_OK;
+    hr = -1;
     sid = GetSidForUser(NULL, data.getQualifiedUsername().c_str());
     if (!sid) {
         WcaLog(LOGMSG_STANDARD, "Failed to get SID for %s", data.getFullUsernameMbcs().c_str());
@@ -202,15 +202,21 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall) {
         WcaLog(LOGMSG_STANDARD, "failed to add service login right");
         goto LExit;
     }
-    nErr = AddUserToGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
-    if (nErr != NERR_Success) {
-        WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", nErr);
-        goto LExit;
-    }
-    nErr = AddUserToGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
-    if (nErr != NERR_Success) {
-        WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", nErr);
-        goto LExit;
+    hr = 0;
+    
+    if(!ddUserExists){
+        hr = -1;
+        nErr = AddUserToGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
+        if (nErr != NERR_Success) {
+            WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", nErr);
+            goto LExit;
+        }
+        nErr = AddUserToGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
+        if (nErr != NERR_Success) {
+            WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", nErr);
+            goto LExit;
+        }
+        hr = 0;
     }
     if (!ddServiceExists) {
         WcaLog(LOGMSG_STANDARD, "attempting to install services");

--- a/omnibus/resources/agent/msi/cal/customaction.h
+++ b/omnibus/resources/agent/msi/cal/customaction.h
@@ -4,6 +4,7 @@
 // usercreate.cpp
 bool generatePassword(wchar_t* passbuf, int passbuflen);
 int doCreateUser(const std::wstring& name, const wchar_t * domain, std::wstring& comment, const wchar_t* passbuf);
+int doSetUserPassword(const std::wstring& name, const wchar_t * domain, const wchar_t* passbuf);
 DWORD changeRegistryAcls(CustomActionData& data, const wchar_t* name);
 DWORD addDdUserPermsToFile(CustomActionData& data, std::wstring &filename);
 bool isDomainController(MSIHANDLE hInstall);

--- a/omnibus/resources/agent/msi/cal/stopservices.cpp
+++ b/omnibus/resources/agent/msi/cal/stopservices.cpp
@@ -97,7 +97,12 @@ VOID  DoStopSvc(MSIHANDLE hInstall, std::wstring &svcName)
 
     if (hService == NULL)
     {
-        WcaLog(LOGMSG_STANDARD, "OpenService failed (%d)\n", GetLastError());
+        DWORD err = GetLastError();
+        if(ERROR_SERVICE_DOES_NOT_EXIST == err) {
+            WcaLog(LOGMSG_STANDARD, "Didn't stop service: Service not found (this is expected on new installs)");
+        } else {
+            WcaLog(LOGMSG_STANDARD, "Didn't stop service: OpenService failed (%d)\n", err);
+        }
         CloseServiceHandle(hScManager);
         return;
     }

--- a/omnibus/resources/agent/msi/cal/usercreate.cpp
+++ b/omnibus/resources/agent/msi/cal/usercreate.cpp
@@ -250,8 +250,15 @@ int doCreateUser(const std::wstring& name, const wchar_t * domain, std::wstring&
 
 }
 
-
-
+int doSetUserPassword(const std::wstring& name, const wchar_t * domain, const wchar_t* passbuf)
+{
+    USER_INFO_1003 ui;
+    memset(&ui,0, sizeof(USER_INFO_1003));
+    ui.usri1003_password = (LPWSTR)passbuf;
+    DWORD ret = NetUserSetInfo(NULL, name.c_str(), 1003, (LPBYTE)&ui, NULL);
+    WcaLog(LOGMSG_STANDARD, "NetUserSetInfo Change Password %d", ret);
+    return ret;
+}
 DWORD DeleteUser(const wchar_t* host, const wchar_t* name){
     NET_API_STATUS ret = NetUserDel(NULL, name);
     return (DWORD)ret;

--- a/releasenotes/notes/ddau-password-reset-838235a000d992a6.yaml
+++ b/releasenotes/notes/ddau-password-reset-838235a000d992a6.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    In Windows, allows the install to succeed successfully even in the event
+    that the user was not cleaned up successfully from a previous install.


### PR DESCRIPTION
Fixes case where previous uninstall left the ddagentuser around.
In this case, will simply reset the password, and continue

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

Some uninstall scenarios leave us with the ddagentuser present Previous code (intentionally) failed in this case.  This made for some support escalations.

### Additional Notes

Anything else we should know when reviewing?
