### PR TITLE
Split A6/A7 pipelines for Windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1877,7 +1877,6 @@ deploy_windows_tags-latest-7:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   <<: *run_when_triggered_on_tag_7
-  <<: *skip_when_unwanted_on_7
   tags: [ "runner:main", "size:large" ]
   script:
     # By default we update the "latest" artifacts on our s3 bucket so the
@@ -2035,7 +2034,6 @@ deploy_process_and_sysprobe:
 tag_release_6:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag_6
-  <<: *skip_when_unwanted_on_6
   stage: deploy6
   when: manual
   variables:
@@ -2052,7 +2050,6 @@ tag_release_6:
 tag_release_7:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag_7
-  <<: *skip_when_unwanted_on_7
   stage: deploy7
   when: manual
   variables:
@@ -2066,7 +2063,6 @@ tag_release_7:
 latest_release_6:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag_6
-  <<: *skip_when_unwanted_on_6
   stage: deploy6
   when: manual
   variables:
@@ -2086,7 +2082,6 @@ latest_release_6:
 latest_release_7:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag_7
-  <<: *skip_when_unwanted_on_7
   stage: deploy7
   when: manual
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1581,7 +1581,8 @@ build_dogstatsd:
 # Docker dev image deployments
 #
 
-twistlock_scan:
+twistlock_scan-6:
+  <<: *skip_when_unwanted_on_6
   stage: image_deploy
   tags: [ "runner:docker", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/twistlock-cli:2.5.121
@@ -1603,6 +1604,26 @@ twistlock_scan:
     - scan ${SRC_AGENT}:${SRC_TAG}-py3-jmx
     - scan ${SRC_DSD}:${SRC_TAG}
     - scan ${SRC_DCA}:${SRC_TAG}
+
+twistlock_scan-7:
+  <<: *skip_when_unwanted_on_7
+  stage: image_deploy
+  tags: [ "runner:docker", "size:large" ]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/twistlock-cli:2.5.121
+  dependencies: [] # Don't download Gitlab artefacts
+  allow_failure: true # Don't block the pipeline
+  variables:
+    SRC_AGENT: *agent_ecr
+    SRC_DSD: *dogstatsd_ecr
+    SRC_DCA: *cluster-agent_ecr
+  before_script:
+    - export SRC_TAG=v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - export DOCKER_CLIENT_ADDRESS=$DOCKER_HOST
+    - TWISTLOCK_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.twistlock_password --with-decryption --query "Parameter.Value" --out text)
+    - scan () { echo -e "\n==== Scanning $1 ====\n"; docker pull $1 > /dev/null; /twistcli images scan --address="$TWISTLOCK_URL" --user="$TWISTLOCK_USER" --password="$TWISTLOCK_PASS" --vulnerability-threshold=$THRESHOLD --details $1; }
+  script:
+    - scan ${SRC_AGENT}:${SRC_TAG}-7-py3
+    - scan ${SRC_AGENT}:${SRC_TAG}-7-py3-jmx
 
 .docker_tag_job_definition: &docker_tag_job_definition
   stage: image_deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1811,7 +1811,7 @@ deploy_deb-7:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $DEB_RPM_BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*amd64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $DEB_RPM_BUCKET_BRANCH -m 7 -b $DEB_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_7.*amd64.deb
 
-# deploy windows packages to a public s3 bucket when pushed on master
+# nightlies (6 and 7), deployed to bucket/master
 deploy_windows_master:
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -1822,7 +1822,8 @@ deploy_windows_master:
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-deploy_windows_master-latest-6:
+# nightlies latest (6 and 7, x64 only), deployed to bucket/master
+deploy_windows_master-latest:
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -1831,19 +1832,10 @@ deploy_windows_master-latest-6:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-6*-x86_64.msi "s3://$WINDOWS_BUILDS_S3_BUCKET/master/datadog-agent-6-latest.amd64.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-
-deploy_windows_master-latest-7:
-  stage: deploy7
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_nightly
-  tags: [ "runner:main", "size:large" ]
-  script:
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-7*-x86_64.msi "s3://$WINDOWS_BUILDS_S3_BUCKET/master/datadog-agent-7-latest.amd64.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-# deploy windows packages to a public s3 bucket when tagged
-deploy_windows_tags:
+# triggered builds (6), deployed to bucket/tagged
+deploy_windows_tags-a6:
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -1851,15 +1843,26 @@ deploy_windows_tags:
   <<: *run_when_triggered_on_tag_6
   tags: [ "runner:main", "size:large" ]
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
+# triggered builds (7), deployed to bucket/tagged
+deploy_windows_tags-a7:
+  stage: deploy7
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
+  <<: *run_when_triggered_on_tag_7
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+
+# triggered builds latest (6, x64 only), deployed to bucket/tagged
 deploy_windows_tags-latest-6:
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   <<: *run_when_triggered_on_tag_6
-  <<: *skip_when_unwanted_on_6
   tags: [ "runner:main", "size:large" ]
   script:
     # By default we update the "latest" artifacts on our s3 bucket so the
@@ -1867,6 +1870,7 @@ deploy_windows_tags-latest-6:
     # (when building a custom beta for example).
     - if [ "WINDOWS_DO_NOT_UPDATE_LATEST" != "true" ]; then $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-6*-x86_64.msi s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/datadog-agent-6-latest.amd64.msi --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732; fi
 
+# triggered builds latest (7, x64 only), deployed to bucket/tagged
 deploy_windows_tags-latest-7:
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS


### PR DESCRIPTION
We had a single stage to upload to the `tagged` directory in the bucket, that only run on `deploy6`. On split pipelines the A7 artifacts wouldn't be uploaded. Split in two stages, one for each agent.

Also splits twistlock scan.