### PR TITLE
Build system-probe from the agent omnibus recipe

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -361,19 +361,6 @@ cluster_agent-build:
     - $S3_CP_CMD $SRC_PATH/Dockerfiles/cluster-agent/datadog-cluster.yaml $S3_ARTIFACTS_URI/datadog-cluster.yaml
     - $S3_CP_CMD --recursive $SRC_PATH/$CLUSTER_AGENT_BINARIES_DIR/dist/templates $S3_ARTIFACTS_URI/dist/templates
 
-# build system-probe bin
-system_probe-build:
-  stage: binary_build
-  # TODO(processes): change this to be ebpf:latest when we move to go1.12.x on the agent
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/ebpf:go1.10.1
-  before_script:
-    - cd $SRC_PATH
-    - inv -e deps --verbose --dep-vendor-only
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e system-probe.build
-    - $S3_CP_CMD $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe $S3_ARTIFACTS_URI/system-probe
-
 #
 # integration_test
 #
@@ -423,8 +410,6 @@ run_dogstatsd_size_test:
     - echo "About to build for $RELEASE_VERSION"
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
-    # Retrieve the system-probe from S3
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/system-probe $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
@@ -523,8 +508,6 @@ puppy_deb-x64:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    # Retrieve the system-probe from S3
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/system-probe $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe
     # use --skip-deps since the deps are installed by `before_script`
     - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -type f -name '*.rpm' ! -name '*dbg*.rpm' -print0 | xargs -0 -I '{}' rpm -i '{}'
@@ -585,8 +568,6 @@ agent_rpm-x64-a7:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    # Retrieve the system-probe from S3
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/system-probe $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe
     # use --skip-deps since the deps are installed by `before_script`
     - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache --skip-deps
     - find $OMNIBUS_BASE_DIR_SUSE/pkg -type f -name '*.rpm' ! -name '*dbg*.rpm' -print0 | xargs -0 -I '{}' zypper in '{}'

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -122,7 +122,7 @@ build do
 
   # Build the system-probe
   if linux?
-    command "invoke -e system-probe.build", :env => env
+    command "invoke -e system-probe.build --go-version=1.10.1", :env => env
     copy 'bin/system-probe/system-probe', "#{install_dir}/embedded/bin"
     block { File.chmod(0755, "#{install_dir}/embedded/bin/system-probe") }
   end

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -117,12 +117,16 @@ build do
     # TODO(processes): change this to be ebpf:latest when we move to go1.12.x on the agent
     command "invoke -e process-agent.build --go-version=1.10.1", :env => env
     copy 'bin/process-agent/process-agent', "#{install_dir}/embedded/bin"
-    # We don't use the system-probe in macOS builds
-    if !osx?
-      copy 'bin/system-probe/system-probe', "#{install_dir}/embedded/bin"
-      block { File.chmod(0755, "#{install_dir}/embedded/bin/system-probe") }
-    end
   end
+
+
+  # Build the system-probe
+  if linux?
+    command "invoke -e system-probe.build", :env => env
+    copy 'bin/system-probe/system-probe', "#{install_dir}/embedded/bin"
+    block { File.chmod(0755, "#{install_dir}/embedded/bin/system-probe") }
+  end
+
 
   if linux?
     if debian?

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -18,10 +18,11 @@ EBPF_BUILDER_IMAGE = 'datadog/tracer-bpf-builder'
 EBPF_BUILDER_FILE = os.path.join(".", "tools", "ebpf", "Dockerfiles", "Dockerfile-ebpf")
 
 BPF_TAG = "linux_bpf"
+GIMME_ENV_VARS = ['GOROOT', 'PATH']
 
 
 @task
-def build(ctx, race=False, incremental_build=False):
+def build(ctx, race=False, go_version=None, incremental_build=False):
     """
     Build the system_probe
     """
@@ -38,7 +39,22 @@ def build(ctx, race=False, incremental_build=False):
         "BuildDate": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
     }
 
+    goenv = {}
+    # TODO: this is a temporary workaround. system probe had issues when built with go 1.11 and 1.12
+    if go_version:
+        lines = ctx.run("gimme {version}".format(version=go_version)).stdout.split("\n")
+        for line in lines:
+            for env_var in GIMME_ENV_VARS:
+                if env_var in line:
+                    goenv[env_var] = line[line.find(env_var)+len(env_var)+1:-1].strip('\'\"')
+        ld_vars["GoVersion"] = go_version
+
     ldflags, gcflags, env = get_build_flags(ctx)
+
+    # extend PATH from gimme with the one from get_build_flags
+    if "PATH" in os.environ and "PATH" in goenv:
+        goenv["PATH"] += ":" + os.environ["PATH"]
+    env.update(goenv)
 
     # Add custom ld flags
     ldflags += ' '.join(["-X '{name}={value}'".format(name=main+key, value=value) for key, value in ld_vars.items()])

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -278,7 +278,7 @@ def build_object_files(ctx, install=True):
         # Now update the assets stored in the go code
         commands.append("go get -u github.com/jteeuwen/go-bindata/...")
 
-        assets_cmd = "go-bindata -pkg ebpf -prefix '{c_dir}' -modtime 1 -o '{go_file}' '{obj_file}' '{debug_obj_file}'"
+        assets_cmd = os.environ["GOPATH"]+"/bin/go-bindata -pkg ebpf -prefix '{c_dir}' -modtime 1 -o '{go_file}' '{obj_file}' '{debug_obj_file}'"
         commands.append(assets_cmd.format(
             c_dir=c_dir,
             go_file=os.path.join(bpf_dir, "tracer-ebpf.go"),


### PR DESCRIPTION
Use go 1.10 to build system-probe, since it had issues with 1.11 and 1.12.

Workaround copied from the process_agent [1] (which we should try to remove at some point).

[1] https://github.com/DataDog/datadog-agent/blob/master/tasks/process_agent.py#L61