### PR TITLE
Set UDP connection direction to NONE

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,15 +10,15 @@
   source = "github.com/adjust/goautoneg"
 
 [[projects]]
-  digest = "1:a6fa96ada3d26514dfee37255ba66f99160993f2c3eaede0c6f1b19fba6e7ad7"
+  digest = "1:c4e071eb2f960b14286f0fe2057d4f87dfd83c840c059377f01c37b5112595ed"
   name = "github.com/DataDog/agent-payload"
   packages = [
     "gogen",
     "process",
   ]
   pruneopts = ""
-  revision = "2904bbe1a881e01d78a287a2a8027ce157776116"
-  version = "4.14.0"
+  revision = "8cebd5a06a08dc27a4d822940f5275b0fa41aa34"
+  version = "4.15.0"
 
 [[projects]]
   digest = "1:e64fddc819e2abc68792a743dd857c379449a56f2b9eaf030c03fb0ec19de884"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/DataDog/agent-payload"
-  version = "4.14.0"
+  version = "4.15.0"
 
 [[constraint]]
   name = "github.com/google/gopacket"

--- a/pkg/ebpf/encoding/format.go
+++ b/pkg/ebpf/encoding/format.go
@@ -78,6 +78,8 @@ func formatDirection(d ebpf.ConnectionDirection) model.ConnectionDirection {
 		return model.ConnectionDirection_outgoing
 	case ebpf.LOCAL:
 		return model.ConnectionDirection_local
+	case ebpf.NONE:
+		return model.ConnectionDirection_none
 	default:
 		return model.ConnectionDirection_unspecified
 	}

--- a/pkg/ebpf/event_common.go
+++ b/pkg/ebpf/event_common.go
@@ -53,6 +53,9 @@ const (
 
 	// LOCAL represents connections that don't leave the host
 	LOCAL ConnectionDirection = 3
+
+	// NONE represents connections that have no direction (udp, for example)
+	NONE ConnectionDirection = 4
 )
 
 func (d ConnectionDirection) String() string {
@@ -61,6 +64,8 @@ func (d ConnectionDirection) String() string {
 		return "outgoing"
 	case LOCAL:
 		return "local"
+	case NONE:
+		return "none"
 	default:
 		return "incoming"
 	}

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -647,6 +647,9 @@ func (t *Tracer) populatePortMapping(mp *bpflib.Map) ([]uint16, error) {
 }
 
 func (t *Tracer) determineConnectionDirection(conn *ConnectionStats) ConnectionDirection {
+	if conn.Type == UDP {
+		return NONE
+	}
 	sourceLocal := t.isLocalAddress(conn.Source)
 	destLocal := t.isLocalAddress(conn.Dest)
 

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -670,6 +670,7 @@ func TestUDPSendAndReceive(t *testing.T) {
 	assert.Equal(t, serverMessageSize, int(conn.MonotonicRecvBytes))
 	assert.Equal(t, os.Getpid(), int(conn.Pid))
 	assert.Equal(t, addrPort(server.address), int(conn.DPort))
+	assert.Equal(t, NONE, conn.Direction)
 
 	doneChan <- struct{}{}
 }


### PR DESCRIPTION
### What does this PR do?

Sets the UDP connection direction to NONE

### Motivation

UDP connections have no direction so we should explicitly say so

### Additional Notes

Anything else we should know when reviewing?
