### PR TITLE
Update datadog-agent RBAC in DCA folder

### DIFF
--- a/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml
+++ b/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml
@@ -12,6 +12,8 @@ rules:
   verbs:
   - get
 - nonResourceURLs:
+  - "/version"
+  - "/healthz"
   - "/metrics"
   verbs:
   - get

--- a/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml
+++ b/Dockerfiles/manifests/cluster-agent/rbac/rbac-agent.yaml
@@ -11,6 +11,10 @@ rules:
   - nodes/proxy # Required to get /pods
   verbs:
   - get
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
 ---
 kind: ServiceAccount
 apiVersion: v1


### PR DESCRIPTION
### What does this PR do?

Update the `Clusterrole` for `serviceaccount:datadog-agent ` in DCA manifest folder to include permission to apiserver's "/metrics" endpoint.

This is already added to the standalone agent's RBAC: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/rbac/clusterrole.yaml#L44

This permission is needed for Kubernetes apiserver integrations, `kube_apiserver_metrics`, in particular.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
