### PR TITLE
[DCA] [Fix] Get clc runner IPs from headers

### DIFF
--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -21,8 +21,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// clcRunnerIpHeader refers to the cluster level check runner ip passed in the request headers
-const clcRunnerIpHeader = "Clc-Runner-IP"
+// xForwardedForHeader refers to the cluster level check runner ip passed in the request headers
+const xForwardedForHeader = "X-Forwarded-For"
 
 // Install registers v1 API endpoints
 func installClusterCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
@@ -54,7 +54,7 @@ func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 			return
 		}
 
-		clientIP, err := validateClientIP(r.Header.Get(clcRunnerIpHeader))
+		clientIP, err := validateClientIP(r.Header.Get(xForwardedForHeader))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			incrementRequestMetric("postCheckStatus", http.StatusInternalServerError)

--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -174,7 +174,7 @@ func validateClientIP(addr string) (string, error) {
 	}
 
 	if addr == "" && config.Datadog.GetBool("cluster_checks.advanced_dispatching_enabled") {
-		log.Warn("Advanced dispatching error: cannot get runners IPs from http headers, make sure to upgrade cluster check runners")
+		log.Warn("Cluster check dispatching error: cannot get runner IP from http headers. advanced_dispatching_enabled requires agent 6.16 or above.")
 	}
 
 	return addr, nil

--- a/cmd/cluster-agent/api/v1/clusterchecks_test.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks_test.go
@@ -7,49 +7,63 @@
 
 package v1
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestParseClientIP(t *testing.T) {
+func Test_validateClientIP(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     string
-		expected string
+		name    string
+		addr    string
+		want    string
+		wantErr bool
 	}{
 		{
-			name:     "valid ipv4",
-			args:     "127.0.0.1:1337",
-			expected: "127.0.0.1",
+			name:    "valid ipv4",
+			addr:    "127.0.0.1",
+			want:    "127.0.0.1",
+			wantErr: false,
 		},
 		{
-			name:     "ipv4 no port",
-			args:     "127.0.0.1:",
-			expected: "127.0.0.1",
+			name:    "invalid ipv4",
+			addr:    "127.0.0.1.1",
+			want:    "",
+			wantErr: true,
 		},
 		{
-			name:     "ipv6",
-			args:     "[2001:db8:1f70::999:de8:7648:6e8]:1337",
-			expected: "2001:db8:1f70::999:de8:7648:6e8",
+			name:    "valid ipv6",
+			addr:    "2001:db8:1f70::999:de8:7648:6e8",
+			want:    "2001:db8:1f70::999:de8:7648:6e8",
+			wantErr: false,
 		},
 		{
-			name:     "valid ipv6 localhost",
-			args:     "[::1]:1337",
-			expected: "::1",
+			name:    "invalid ipv6",
+			addr:    "::1:",
+			want:    "",
+			wantErr: true,
 		},
 		{
-			name:     "ipv6 no port",
-			args:     "[::1]:",
-			expected: "::1",
+			name:    "invalidate localhost",
+			addr:    "localhost",
+			want:    "",
+			wantErr: true,
 		},
 		{
-			name:     "localhost",
-			args:     "localhost:1337",
-			expected: "localhost",
+			name:    "validate empty",
+			addr:    "",
+			want:    "",
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := parseClientIP(tt.args); got != tt.expected {
-				t.Errorf("parseClientIP() == %v, expected %v", got, tt.expected)
+			got, err := validateClientIP(tt.addr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateClientIP() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("validateClientIP() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Get cluster level check runner IPs from their request's headers instead of relying on `r.RemoteAddr`

### Motivation

Make the logic independent of the k8s network config

