### PR TITLE
Prevent systemd security warnings in system journal

### DIFF
--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -233,9 +233,9 @@ func (c *SystemdCheck) getDbusConnection() (*dbus.Conn, error) {
 		if config.IsContainerized() {
 			conn, err = c.getPrivateSocketConnection("/host" + defaultPrivateSocket)
 		} else {
-			conn, err = c.getPrivateSocketConnection(defaultPrivateSocket)
+			conn, err = c.getSystemBusSocketConnection()
 			if err != nil {
-				conn, err = c.getSystemBusSocketConnection()
+				conn, err = c.getPrivateSocketConnection(defaultPrivateSocket)
 			}
 		}
 	}

--- a/releasenotes/notes/fix-reorder-systemd-integration-points-d193ae315a6fdd43.yaml
+++ b/releasenotes/notes/fix-reorder-systemd-integration-points-d193ae315a6fdd43.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Systemd integration points are re-ordered so that ``dbus`` is used in
+    preference to the systemd private API at ``/run/systemd/private``, as per
+    the systemd documentation. This prevents unnecessary logging to the system
+    journal when datadog-agent is run without root permissions.


### PR DESCRIPTION
### What does this PR do?

Re-orders two operations so that the one more likely to succeed, and that doesn't cause security warnings in the system journal is tried first.

### Motivation

The default systemd socket is a private API not intended for external use. For this reason, processes must be run as root to access them, and therefore this is typically very unlikely to work as the agent does not run as root by default. We re-order the checks to try dbus first which is far more likely to succeed.

This has the benefit of not causing extensive logging is syslog for failed connections due to insufficient permissions.

### Additional Notes

This was raised in https://github.com/DataDog/dd-agent/issues/3860

