### PR TITLE
Removes the trace & process agent from 32 bit windows builds

### DIFF
--- a/omnibus/resources/agent/msi/cal/stdafx.h
+++ b/omnibus/resources/agent/msi/cal/stdafx.h
@@ -39,3 +39,9 @@
 #include "ddreg.h"
 
 #include "resource.h"
+
+#ifdef _WIN64
+// define __REGISTER_ALL_SERVICES to have the custom action install APM & process
+// agent.  Otherwise, only the core service will be installed.
+#define __REGISTER_ALL_SERVICES
+#endif

--- a/omnibus/resources/agent/msi/cal/stopservices.cpp
+++ b/omnibus/resources/agent/msi/cal/stopservices.cpp
@@ -737,7 +737,8 @@ int installServices(MSIHANDLE hInstall, CustomActionData& data, const wchar_t *p
     SC_HANDLE hService = NULL;
     int retval = 0;
     // Get a handle to the SCM database. 
-#define NUM_SERVICES 3
+#ifdef __REGISTER_ALL_SERVICES
+  #define NUM_SERVICES 3
     serviceDef services[NUM_SERVICES] = {
         serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
                    agent_exe.c_str(),
@@ -750,6 +751,14 @@ int installServices(MSIHANDLE hInstall, CustomActionData& data, const wchar_t *p
                    L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL)
 
     };
+#else
+  #define NUM_SERVICES 1
+    serviceDef services[NUM_SERVICES] = {
+        serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
+                   agent_exe.c_str(),
+                   NULL, SERVICE_AUTO_START, data.getFullUsername().c_str(), password),
+    };
+#endif
     WcaLog(LOGMSG_STANDARD, "Installing services");
     hScManager = OpenSCManager(
         NULL,                    // local computer
@@ -800,7 +809,8 @@ int uninstallServices(MSIHANDLE hInstall, CustomActionData& data) {
     SC_HANDLE hService = NULL;
     int retval = 0;
     // Get a handle to the SCM database. 
-#define NUM_SERVICES 3
+#ifdef __REGISTER_ALL_SERVICES
+  #define NUM_SERVICES 3
     serviceDef services[NUM_SERVICES] = {
         serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
                    agent_exe.c_str(),
@@ -813,6 +823,14 @@ int uninstallServices(MSIHANDLE hInstall, CustomActionData& data) {
                    L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL)
 
     };
+#else 
+  #define NUM_SERVICES 1
+    serviceDef services[NUM_SERVICES] = {
+        serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
+                   agent_exe.c_str(),
+                   L"winmgmt\0\0", SERVICE_AUTO_START, data.getFullUsername().c_str(), NULL),
+    };
+#endif
     WcaLog(LOGMSG_STANDARD, "Installing services");
     hScManager = OpenSCManager(
         NULL,                    // local computer
@@ -841,7 +859,8 @@ int verifyServices(MSIHANDLE hInstall, CustomActionData& data)
     SC_HANDLE hService = NULL;
     int retval = 0;
     // Get a handle to the SCM database. 
-#define NUM_SERVICES 3
+#ifdef __REGISTER_ALL_SERVICES
+  #define NUM_SERVICES 3
     serviceDef services[NUM_SERVICES] = {
         serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
                    agent_exe.c_str(),
@@ -854,6 +873,14 @@ int verifyServices(MSIHANDLE hInstall, CustomActionData& data)
                    L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL)
 
     };
+#else
+  #define NUM_SERVICES 1
+    serviceDef services[NUM_SERVICES] = {
+        serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
+                   agent_exe.c_str(),
+                   L"winmgmt\0\0", SERVICE_AUTO_START, data.getFullUsername().c_str(), NULL),
+    };
+#endif
     WcaLog(LOGMSG_STANDARD, "Installing services");
     hScManager = OpenSCManager(
         NULL,                    // local computer

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -285,37 +285,40 @@
         
         </Component>
         <?endif ?>
+        
         <Directory Id="AGENT" Name="agent">
-          <!-- Windows service declaration for APM agent -->
-          <Component Id="DATADOGAPMSERVICE" Guid="a8e611fa-aedb-4c16-969c-bb827af0bd53">
-            <File Id="trace_agent.exe"
-                Name="trace-agent.exe"
-                Vital="yes"
-                KeyPath="yes"
-                DiskId="1"
-                Source="$(var.BinFiles)/trace-agent.exe"/>
-            <!-- The "Name" field must match the argument to eventlog.Open() -->
-            <util:EventSource Log="Application" Name="datadog-trace-agent"
-                    EventMessageFile="[AGENT]trace-agent.exe"
-                    SupportsErrors="yes"
-                    SupportsInformationals="yes"
-                    SupportsWarnings="yes"/>
-          </Component>
-          <!-- Windows service declaration for Process agent -->
-          <Component Id="DATADOGPROCESSSERVICE" Guid="3b119795-ddf8-44eb-9d53-301f7186e2f3">
-            <File Id="process_agent.exe"
-                Name="process-agent.exe"
-                Vital="yes"
-                KeyPath="yes"
-                DiskId="1"
-                Source="$(var.BinFiles)/process-agent.exe"/>
-            <!-- The "Name" field must match the argument to eventlog.Open() -->
-            <util:EventSource Log="Application" Name="datadog-process-agent"
-                    EventMessageFile="[AGENT]process-agent.exe"
-                    SupportsErrors="yes"
-                    SupportsInformationals="yes"
-                    SupportsWarnings="yes"/>
-          </Component>
+          <?if $(var.Platform) = x64 ?>
+            <!-- Windows service declaration for APM agent -->
+            <Component Id="DATADOGAPMSERVICE" Guid="a8e611fa-aedb-4c16-969c-bb827af0bd53">
+                <File Id="trace_agent.exe"
+                    Name="trace-agent.exe"
+                    Vital="yes"
+                    KeyPath="yes"
+                    DiskId="1"
+                    Source="$(var.BinFiles)/trace-agent.exe"/>
+                <!-- The "Name" field must match the argument to eventlog.Open() -->
+                <util:EventSource Log="Application" Name="datadog-trace-agent"
+                        EventMessageFile="[AGENT]trace-agent.exe"
+                        SupportsErrors="yes"
+                        SupportsInformationals="yes"
+                        SupportsWarnings="yes"/>
+            </Component>
+            <!-- Windows service declaration for Process agent -->
+            <Component Id="DATADOGPROCESSSERVICE" Guid="3b119795-ddf8-44eb-9d53-301f7186e2f3">
+                <File Id="process_agent.exe"
+                    Name="process-agent.exe"
+                    Vital="yes"
+                    KeyPath="yes"
+                    DiskId="1"
+                    Source="$(var.BinFiles)/process-agent.exe"/>
+                <!-- The "Name" field must match the argument to eventlog.Open() -->
+                <util:EventSource Log="Application" Name="datadog-process-agent"
+                        EventMessageFile="[AGENT]process-agent.exe"
+                        SupportsErrors="yes"
+                        SupportsInformationals="yes"
+                        SupportsWarnings="yes"/>
+            </Component>
+          <?endif ?>
         </Directory>
       </Directory>
     </DirectoryRef>
@@ -454,8 +457,10 @@
       <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="DATADOGAGENTSERVICE" />
       <ComponentRef Id="RTLOADERDLLS" />
-      <ComponentRef Id="DATADOGAPMSERVICE" />
-      <ComponentRef Id="DATADOGPROCESSSERVICE" />
+      <?if $(var.Platform) = x64 ?>
+        <ComponentRef Id="DATADOGAPMSERVICE" />
+        <ComponentRef Id="DATADOGPROCESSSERVICE" />
+      <?endif ?>
       <ComponentGroupRef Id="ExtraEXAMPLECONFSLOCATION" />
       <ComponentRef Id="CleanupMainApplicationFolder" />
       <ComponentRef Id="RegisterConfVariables" />

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -372,7 +373,13 @@ func initConfig(config Config) {
 	// Note that trace-agent environment variables are parsed in pkg/trace/config/env.go
 	// since some of them require custom parsing algorithms. DO NOT add environment variable
 	// bindings here, add them there instead.
-	config.BindEnvAndSetDefault("apm_config.enabled", true)
+	if runtime.GOARCH == "386" {
+		// on Windows-32 bit, the trace agent isn't installed.  Set the default to disabled
+		// so that there aren't messages in the log about failing to start.
+		config.BindEnvAndSetDefault("apm_config.enabled", false)
+	} else {
+		config.BindEnvAndSetDefault("apm_config.enabled", true)
+	}
 
 	// Process agent
 	config.SetDefault("process_config.enabled", "false")


### PR DESCRIPTION
### What does this PR do?

Removes the 32 bit process and trace from 32 bit builds
- the MSI won't install it
- the custom action won't register the service
- changes the default config when the architecture is 386 to be false for APM.

Note that means that if an agent were to be generated for 32 bit intel on linux,
the default would be changed in that environment, as well.
