### PR TITLE
Adding logic to skip old events

### DIFF
--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -99,6 +99,10 @@ func (c *APIClient) RunEventCollection(resVer string, lastListTime time.Time, ev
 				// should not be happening, it means the object is not correctly formatted in etcd.
 				return added, resVer, lastListTime, err
 			}
+			// in some cases events show up from the past, using 1 hour to be consistent with the APIServer
+			if float64(time.Now().Unix()-ev.LastTimestamp.Unix()) > 3600 {
+				continue
+			}
 			added = append(added, ev)
 			i, err := strconv.Atoi(resVer)
 			if err != nil {


### PR DESCRIPTION
### What does this PR do?

After letting the event collection run for some time, we noticed that even with the new logic, some events would still be submitted in the past.
As we migrate towards an informer for the events in the interim we need to make sure those old events are not submitted. 
In order to be consistent with teh APIServer's behavior, we use 1 hour:
```
NAMESPACE                               LAST SEEN   FIRST SEEN   COUNT   NAME                                                                               KIND                      SUBOBJECT                                               TYPE      REASON                         SOURCE                                    MESSAGE
process                                 1h          3h           39      XX-5d4444d5-m5qkf.15d27fCCC4                                   Pod                       spec.containers{process}                         Normal    P
ulled                         kubelet, ip-10-00000-72.ec2.internal    Container image "XX.dkr.ecr.us-east-1.amazonaws.com/image:latest" already present on machine
mortar                                  1h          3h           16      obj-runner-799CCC5f-l8b9c.15d2CCC553f2                              Pod                       spec.containers{obj-runner}                    Normal    S
tarted                        kubelet, ip-10-0000-82.ec2.internal    Started container
mortar                                  1h          3h           16      obj-runner-799XXf5f-l8b9c.15d2CCCC47                              Pod                       spec.containers{obj-runner}                    Normal    C
reated                        kubelet, ip-10-000002.ec2.internal    Created container
datadog
```
With this logic, we can see that we do not submit old events anymore:
<img width="1586" alt="Image 2019-10-30 at 6 30 12 PM" src="https://user-images.githubusercontent.com/7433560/67903965-57724d00-fb43-11e9-8880-d5cb9be89669.png">

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
