### PR TITLE
Address vulnerabilities in the dogstatsd image

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 


### PR DESCRIPTION
### What does this PR do?

Pull fixes for the following CVEs:
- CVE-2019-14697
- CVE-2018-20679
- CVE-2019-5747

This implies the following version bumps:
- musl `1.1.19-r10` -> `1.1.22-r3`
- busybox `1.28.4-r3` -> `1.30.1-r2`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
