### PR TITLE
pkg/trace/obfuscate: add a filter to extract table names from queries

### DIFF
--- a/pkg/trace/obfuscate/obfuscate.go
+++ b/pkg/trace/obfuscate/obfuscate.go
@@ -62,7 +62,7 @@ func (o *Obfuscator) SetSQLLiteralEscapes(ok bool) {
 	}
 }
 
-// SQLLiteralEscapes returns whether or not escape characters should be treated literally by the SQL obfuscator.
+// SQLLiteralEscapes reports whether escape characters should be treated literally by the SQL obfuscator.
 func (o *Obfuscator) SQLLiteralEscapes() bool {
 	return atomic.LoadInt32(&o.opts.sqlLiteralEscapes) == 1
 }

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -198,7 +198,6 @@ func (o *Obfuscator) obfuscateSQLString(in string) (*obfuscatedQuery, error) {
 type tableFinderFilter struct {
 	// seen keeps track of unique table names encountered by the filter.
 	seen map[string]struct{}
-
 	// csv specifies a comma-separated list of tables
 	csv strings.Builder
 }
@@ -261,8 +260,8 @@ type obfuscatedQuery struct {
 func attemptObfuscation(tokenizer *SQLTokenizer, filters []tokenFilter) (string, error) {
 	var (
 		out       bytes.Buffer
-		lastToken TokenKind
 		err       error
+		lastToken TokenKind
 	)
 	// call Scan() function until tokens are available or if a LEX_ERROR is raised. After
 	// retrieving a token, send it to the tokenFilter chains so that the token is discarded

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -9,9 +9,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -22,17 +25,26 @@ const nonParsableResource = "Non-parsable SQL query"
 // the Filter() function used to filter or replace given tokens.
 // A filter can be stateful and keep an internal state to apply the filter later;
 // this can be useful to prevent backtracking in some cases.
+
+// tokenFilter implementations process tokens in the order that they are found by the tokenizer
+// and respond as to how they should be interpreted in the result. For example: one token filter
+// may decide that a token should be hidden in the result, or that it should be transformed in
+// some way.
 type tokenFilter interface {
+	// Filter takes the current token kind, the last token kind and the token itself,
+	// returning the new token kind and the value that should be stored in the final query,
+	// along with an error.
 	Filter(token, lastToken TokenKind, buffer []byte) (TokenKind, []byte, error)
+
+	// Reset resets the filter.
 	Reset()
 }
 
-// discardFilter implements the tokenFilter interface so that the given
-// token is discarded or accepted.
+// discardFilter is a token filter which discards certain elements from a query, such as
+// comments and AS aliases by returning a nil buffer.
 type discardFilter struct{}
 
-// Filter the given token so that a `nil` slice is returned if the token
-// is in the token filtered list.
+// Filter the given token so that a `nil` slice is returned if the token is in the token filtered list.
 func (f *discardFilter) Filter(token, lastToken TokenKind, buffer []byte) (TokenKind, []byte, error) {
 	// filters based on previous token
 	switch lastToken {
@@ -69,11 +81,11 @@ func (f *discardFilter) Filter(token, lastToken TokenKind, buffer []byte) (Token
 	}
 }
 
-// Reset in a discardFilter is a noop action
+// Reset implements tokenFilter.
 func (f *discardFilter) Reset() {}
 
-// replaceFilter implements the tokenFilter interface so that the given
-// token is replaced with '?' or left unchanged.
+// replaceFilter is a token filter which obfuscates strings and numbers in queries by replacing them
+// with the "?" character.
 type replaceFilter struct{}
 
 // Filter the given token so that it will be replaced if in the token replacement list
@@ -96,11 +108,11 @@ func (f *replaceFilter) Filter(token, lastToken TokenKind, buffer []byte) (token
 	}
 }
 
-// Reset in a replaceFilter is a noop action
+// Reset implements tokenFilter.
 func (f *replaceFilter) Reset() {}
 
-// groupingFilter implements the tokenFilter interface so that when
-// a common pattern is identified, it's discarded to prevent duplicates
+// groupingFilter is a token filter which groups together items replaced by the replaceFilter. It is meant
+// to run immediately after it.
 type groupingFilter struct {
 	groupFilter int
 	groupMulti  int
@@ -142,8 +154,7 @@ func (f *groupingFilter) Filter(token, lastToken TokenKind, buffer []byte) (toke
 	return token, buffer, nil
 }
 
-// Reset in a groupingFilter restores variables used to count
-// escaped token that should be filtered
+// Reset resets the groupingFilter so that it may be used again.
 func (f *groupingFilter) Reset() {
 	f.groupFilter = 0
 	f.groupMulti = 0
@@ -152,11 +163,14 @@ func (f *groupingFilter) Reset() {
 // Process the given SQL or No-SQL string so that the resulting one is properly altered. This
 // function is generic and the behavior changes according to chosen tokenFilter implementations.
 // The process calls all filters inside the []tokenFilter.
-func (o *Obfuscator) obfuscateSQLString(in string) (string, error) {
+func (o *Obfuscator) obfuscateSQLString(in string) (*obfuscatedQuery, error) {
 	literalEscapes := o.SQLLiteralEscapes()
 	tokenizer := NewSQLTokenizer(in, literalEscapes)
 	filters := []tokenFilter{&discardFilter{}, &replaceFilter{}, &groupingFilter{}}
-
+	tableFinder := &tableFinderFilter{}
+	if config.HasFeature("table_names") {
+		filters = append(filters, tableFinder)
+	}
 	out, err := attemptObfuscation(tokenizer, filters)
 	if err != nil && tokenizer.SeenEscape() {
 		// If the tokenizer failed, but saw an escape character in the process,
@@ -165,17 +179,81 @@ func (o *Obfuscator) obfuscateSQLString(in string) (string, error) {
 		if out, err2 := attemptObfuscation(tokenizer, filters); err2 == nil {
 			// If the second attempt succeeded, change the default behavior
 			o.SetSQLLiteralEscapes(!literalEscapes)
-			return out, nil
+			return &obfuscatedQuery{
+				query:     out,
+				tablesCSV: tableFinder.CSV(),
+			}, nil
 		}
 	}
-	return out, err
+	return &obfuscatedQuery{
+		query:     out,
+		tablesCSV: tableFinder.CSV(),
+	}, err
 }
 
+// tableFinderFilter is a filter which attempts to identify the table name as it goes through each
+// token in a query.
+type tableFinderFilter struct {
+	// seen keeps track of unique table names encountered by the filter.
+	seen map[string]struct{}
+
+	// csv specifies a comma-separated list of tables
+	csv strings.Builder
+}
+
+// Filter implements tokenFilter.
+func (f *tableFinderFilter) Filter(token, lastToken TokenKind, buffer []byte) (TokenKind, []byte, error) {
+	switch lastToken {
+	case From, Update, Into, Join:
+		// SELECT ... FROM [tableName]
+		// DELETE FROM [tableName]
+		// UPDATE [tableName]
+		// INSERT INTO [tableName]
+		// ... JOIN [tableName]
+		f.storeName(string(buffer))
+	}
+	return token, buffer, nil
+}
+
+// storeName marks the given table name as seen in the internal storage.
+func (f *tableFinderFilter) storeName(name string) {
+	if _, ok := f.seen[name]; ok {
+		return
+	}
+	if f.seen == nil {
+		f.seen = make(map[string]struct{}, 1)
+	}
+	f.seen[name] = struct{}{}
+	if f.csv.Len() > 0 {
+		f.csv.WriteByte(',')
+	}
+	f.csv.WriteString(name)
+}
+
+// CSV returns a comma-separated list of the tables seen by the filter.
+func (f *tableFinderFilter) CSV() string { return f.csv.String() }
+
+// Reset implements tokenFilter.
+func (f *tableFinderFilter) Reset() {
+	for k := range f.seen {
+		delete(f.seen, k)
+	}
+	f.csv.Reset()
+}
+
+// obfuscatedQuery specifies information about an obfuscated SQL query.
+type obfuscatedQuery struct {
+	query     string // the obfuscated SQL query
+	tablesCSV string // comma-separated list of tables that the query addresses
+}
+
+// attemptObfuscation attempts to obfuscate the given SQL string, returning the final value, the table
+// names found in the query and any error.
 func attemptObfuscation(tokenizer *SQLTokenizer, filters []tokenFilter) (string, error) {
 	var (
 		out       bytes.Buffer
-		err       error
 		lastToken TokenKind
+		err       error
 	)
 	// call Scan() function until tokens are available or if a LEX_ERROR is raised. After
 	// retrieving a token, send it to the tokenFilter chains so that the token is discarded
@@ -186,9 +264,8 @@ func attemptObfuscation(tokenizer *SQLTokenizer, filters []tokenFilter) (string,
 			break
 		}
 		if token == LexError {
-			return "", tokenizer.Err()
+			return "", fmt.Errorf("%v", tokenizer.Err())
 		}
-
 		for _, f := range filters {
 			if token, buff, err = f.Filter(token, lastToken, buff); err != nil {
 				return "", err
@@ -200,6 +277,8 @@ func attemptObfuscation(tokenizer *SQLTokenizer, filters []tokenFilter) (string,
 				case ',':
 				case '=':
 					if lastToken == ':' {
+						// do not add a space before an equals if a colon was
+						// present before it.
 						break
 					}
 					fallthrough
@@ -217,7 +296,6 @@ func attemptObfuscation(tokenizer *SQLTokenizer, filters []tokenFilter) (string,
 	return out.String(), nil
 }
 
-// QuantizeSQL generates resource and sql.query meta for SQL spans
 func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
 	tags := []string{"type:sql"}
 	defer func() {
@@ -227,7 +305,7 @@ func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
 		tags = append(tags, "outcome:empty-resource")
 		return
 	}
-	result, err := o.obfuscateSQLString(span.Resource)
+	oq, err := o.obfuscateSQLString(span.Resource)
 	if err != nil {
 		// we have an error, discard the SQL to avoid polluting user resources.
 		log.Debugf("Error parsing SQL query: %v. Resource: %q", err, span.Resource)
@@ -243,14 +321,14 @@ func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
 	}
 
 	tags = append(tags, "outcome:success")
-	span.Resource = result
+	span.Resource = oq.query
 
+	if len(oq.tablesCSV) > 0 {
+		traceutil.SetMeta(span, "sql.tables", oq.tablesCSV)
+	}
 	if span.Meta != nil && span.Meta[sqlQueryTag] != "" {
 		// "sql.query" tag already set by user, do not change it.
 		return
 	}
-	if span.Meta == nil {
-		span.Meta = make(map[string]string)
-	}
-	span.Meta[sqlQueryTag] = result
+	traceutil.SetMeta(span, sqlQueryTag, oq.query)
 }

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -52,7 +52,7 @@ func TestSQLResourceQuery(t *testing.T) {
 	assert.Equal("SELECT * FROM users WHERE id = 42", span.Meta["sql.query"])
 }
 
-func TestSQLObfuscateTableNames(t *testing.T) {
+func TestSQLTableNames(t *testing.T) {
 	t.Run("on", func(t *testing.T) {
 		os.Setenv("DD_APM_FEATURES", "table_names")
 		defer os.Unsetenv("DD_APM_FEATURES")

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -142,8 +142,20 @@ func TestSQLTableFinder(t *testing.T) {
 			"users",
 		},
 		{
+			"select * from `backslashes` where id = 42",
+			"backslashes",
+		},
+		{
+			`select * from "double-quotes" where id = 42`,
+			"double-quotes",
+		},
+		{
 			"SELECT host, status FROM ec2_status WHERE org_id = 42",
 			"ec2_status",
+		},
+		{
+			"SELECT * FROM (SELECT * FROM nested_table)",
+			"nested_table",
 		},
 		{
 			"-- get user \n--\n select * \n   from users \n    where\n       id = 214325346",

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -52,6 +52,30 @@ func TestSQLResourceQuery(t *testing.T) {
 	assert.Equal("SELECT * FROM users WHERE id = 42", span.Meta["sql.query"])
 }
 
+func TestSQLObfuscateTableNames(t *testing.T) {
+	t.Run("on", func(t *testing.T) {
+		os.Setenv("DD_APM_FEATURES", "table_names")
+		defer os.Unsetenv("DD_APM_FEATURES")
+
+		span := &pb.Span{
+			Resource: "SELECT * FROM users WHERE id = 42",
+			Type:     "sql",
+		}
+		NewObfuscator(nil).Obfuscate(span)
+		assert.Equal(t, "users", span.Meta["sql.tables"])
+
+	})
+
+	t.Run("off", func(t *testing.T) {
+		span := &pb.Span{
+			Resource: "SELECT * FROM users WHERE id = 42",
+			Type:     "sql",
+		}
+		NewObfuscator(nil).Obfuscate(span)
+		assert.Empty(t, span.Meta["sql.tables"])
+	})
+}
+
 func TestSQLResourceWithoutQuery(t *testing.T) {
 	assert := assert.New(t)
 	span := &pb.Span{
@@ -130,69 +154,77 @@ func TestSQLUTF8(t *testing.T) {
 }
 
 func TestSQLTableFinder(t *testing.T) {
-	os.Setenv("DD_APM_FEATURES", "table_names")
-	defer os.Unsetenv("DD_APM_FEATURES")
+	t.Run("on", func(t *testing.T) {
+		os.Setenv("DD_APM_FEATURES", "table_names")
+		defer os.Unsetenv("DD_APM_FEATURES")
 
-	for _, tt := range []struct {
-		query  string
-		tables string
-	}{
-		{
-			"select * from users where id = 42",
-			"users",
-		},
-		{
-			"select * from `backslashes` where id = 42",
-			"backslashes",
-		},
-		{
-			`select * from "double-quotes" where id = 42`,
-			"double-quotes",
-		},
-		{
-			"SELECT host, status FROM ec2_status WHERE org_id = 42",
-			"ec2_status",
-		},
-		{
-			"SELECT * FROM (SELECT * FROM nested_table)",
-			"nested_table",
-		},
-		{
-			"-- get user \n--\n select * \n   from users \n    where\n       id = 214325346",
-			"users",
-		},
-		{
-			"SELECT articles.* FROM articles WHERE articles.id = 1 LIMIT 1, 20",
-			"articles",
-		},
-		{
-			"UPDATE user_dash_pref SET json_prefs = %(json_prefs)s, modified = '2015-08-27 22:10:32.492912' WHERE user_id = %(user_id)s AND url = %(url)s",
-			"user_dash_pref",
-		},
-		{
-			"SELECT DISTINCT host.id AS host_id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = %(org_id_1)s AND host.name NOT IN (%(name_1)s) AND host.name IN (%(name_2)s, %(name_3)s, %(name_4)s, %(name_5)s)",
-			"host,host_alias",
-		},
-		{
-			`update Orders set created = "2019-05-24 00:26:17", gross = 30.28, payment_type = "eventbrite", mg_fee = "3.28", fee_collected = "3.28", event = 59366262, status = "10", survey_type = 'direct', tx_time_limit = 480, invite = "", ip_address = "69.215.148.82", currency = 'USD', gross_USD = "30.28", tax_USD = 0.00, journal_activity_id = 4044659812798558774, eb_tax = 0.00, eb_tax_USD = 0.00, cart_uuid = "160b450e7df511e9810e0a0c06de92f8", changed = '2019-05-24 00:26:17' where id = ?`,
-			"Orders",
-		},
-		{
-			"SELECT * FROM clients WHERE (clients.first_name = 'Andy') LIMIT 1 BEGIN INSERT INTO owners (created_at, first_name, locked, orders_count, updated_at) VALUES ('2011-08-30 05:22:57', 'Andy', 1, NULL, '2011-08-30 05:22:57') COMMIT",
-			"clients,owners",
-		},
-		{
-			"DELETE FROM table WHERE table.a=1",
-			"table",
-		},
-	} {
-		t.Run("", func(t *testing.T) {
-			assert := assert.New(t)
-			oq, err := NewObfuscator(nil).obfuscateSQLString(tt.query)
-			assert.NoError(err)
-			assert.Equal(tt.tables, oq.tablesCSV)
-		})
-	}
+		for _, tt := range []struct {
+			query  string
+			tables string
+		}{
+			{
+				"select * from users where id = 42",
+				"users",
+			},
+			{
+				"select * from `backslashes` where id = 42",
+				"backslashes",
+			},
+			{
+				`select * from "double-quotes" where id = 42`,
+				"double-quotes",
+			},
+			{
+				"SELECT host, status FROM ec2_status WHERE org_id = 42",
+				"ec2_status",
+			},
+			{
+				"SELECT * FROM (SELECT * FROM nested_table)",
+				"nested_table",
+			},
+			{
+				"-- get user \n--\n select * \n   from users \n    where\n       id = 214325346",
+				"users",
+			},
+			{
+				"SELECT articles.* FROM articles WHERE articles.id = 1 LIMIT 1, 20",
+				"articles",
+			},
+			{
+				"UPDATE user_dash_pref SET json_prefs = %(json_prefs)s, modified = '2015-08-27 22:10:32.492912' WHERE user_id = %(user_id)s AND url = %(url)s",
+				"user_dash_pref",
+			},
+			{
+				"SELECT DISTINCT host.id AS host_id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = %(org_id_1)s AND host.name NOT IN (%(name_1)s) AND host.name IN (%(name_2)s, %(name_3)s, %(name_4)s, %(name_5)s)",
+				"host,host_alias",
+			},
+			{
+				`update Orders set created = "2019-05-24 00:26:17", gross = 30.28, payment_type = "eventbrite", mg_fee = "3.28", fee_collected = "3.28", event = 59366262, status = "10", survey_type = 'direct', tx_time_limit = 480, invite = "", ip_address = "69.215.148.82", currency = 'USD', gross_USD = "30.28", tax_USD = 0.00, journal_activity_id = 4044659812798558774, eb_tax = 0.00, eb_tax_USD = 0.00, cart_uuid = "160b450e7df511e9810e0a0c06de92f8", changed = '2019-05-24 00:26:17' where id = ?`,
+				"Orders",
+			},
+			{
+				"SELECT * FROM clients WHERE (clients.first_name = 'Andy') LIMIT 1 BEGIN INSERT INTO owners (created_at, first_name, locked, orders_count, updated_at) VALUES ('2011-08-30 05:22:57', 'Andy', 1, NULL, '2011-08-30 05:22:57') COMMIT",
+				"clients,owners",
+			},
+			{
+				"DELETE FROM table WHERE table.a=1",
+				"table",
+			},
+		} {
+			t.Run("", func(t *testing.T) {
+				assert := assert.New(t)
+				oq, err := NewObfuscator(nil).obfuscateSQLString(tt.query)
+				assert.NoError(err)
+				assert.Equal(tt.tables, oq.tablesCSV)
+			})
+		}
+	})
+
+	t.Run("off", func(t *testing.T) {
+		oq, err := NewObfuscator(nil).obfuscateSQLString("DELETE FROM table WHERE table.a=1")
+		assert.NoError(t, err)
+		assert.Empty(t, oq.tablesCSV)
+	})
 }
 
 func TestSQLQuantizer(t *testing.T) {

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -88,7 +88,8 @@ type SQLTokenizer struct {
 	seenEscape     bool // indicates whether this tokenizer has seen an escape character within a string
 }
 
-// NewSQLTokenizer creates a new SQLTokenizer for the given SQL string.
+// NewSQLTokenizer creates a new SQLTokenizer for the given SQL string. The literalEscapes argument specifies
+// whether escape characters should be treated literally or as such.
 func NewSQLTokenizer(sql string, literalEscapes bool) *SQLTokenizer {
 	return &SQLTokenizer{
 		rd:             strings.NewReader(sql),

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -33,6 +33,7 @@ const EOFChar = unicode.MaxRune + 1
 // need a full-fledged tokenizer to implement a Lexer
 const (
 	LexError = TokenKind(57346) + iota
+
 	ID
 	Limit
 	Null
@@ -52,6 +53,11 @@ const (
 	GE
 	NE
 	As
+	From
+	Update
+	Insert
+	Into
+	Join
 
 	// FilteredGroupable specifies that the given token has been discarded by one of the
 	// token filters and that it is groupable together with consecutive FilteredGroupable
@@ -106,6 +112,11 @@ var keywords = map[string]TokenKind{
 	"SAVEPOINT": Savepoint,
 	"LIMIT":     Limit,
 	"AS":        As,
+	"FROM":      From,
+	"UPDATE":    Update,
+	"INSERT":    Insert,
+	"INTO":      Into,
+	"JOIN":      Join,
 }
 
 // Err returns the last error that the tokenizer encountered, or nil.
@@ -242,7 +253,7 @@ func (tkn *SQLTokenizer) scanIdentifier() (TokenKind, []byte) {
 	}
 	upper := bytes.ToUpper(buffer.Bytes())
 	if keywordID, found := keywords[string(upper)]; found {
-		return keywordID, upper
+		return keywordID, buffer.Bytes()
 	}
 	return ID, buffer.Bytes()
 }


### PR DESCRIPTION
### Description

This change introduces a new tag called `sql.tables` which contains the tables that a query addresses as list of comma-separated values. To enable it, the feature flag `table_names` needs to be set using `DD_APM_FEATURES=table_names`. For example, given the query:

```
SELECT * FROM users JOIN friends
```

Will result in the tag `sql.tables` to contain the values `users,friends`

### Limitations

The current algorithm works agnostic of SQL engine. It simply takes the first word that follows any of the following keywords: `FROM`, `UPDATE`, `INTO` and `JOIN`. 

* Different SQL engines may have different syntax and could contain further keywords ([example](https://www.postgresql.org/docs/9.5/sql-select.html)) after these ones which are not table names. This case is not covered by the current implementation.

* If we later on decide to have the tracing clients mark the SQL engine as a tag, we could use it to further improve the processing.