### PR TITLE
[docs] Redirect windows installer readme to docs website

### DIFF
--- a/omnibus/resources/agent/msi/README.md
+++ b/omnibus/resources/agent/msi/README.md
@@ -2,70 +2,16 @@
 
 Welcome to the Datadog installer for Windows.
 
-## Basic installation
+Installation instructions are available on the dedicated [docs website page](https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=agentv6#installation)
 
-The Datadog installer for Windows is a Microsoft Installer (MSI) package containing everything required to install the Datadog Agent.
+## Additional Configuration Options
 
-## Default installation
-
-The most basic installation is performed by downloading the installer and running the command
-
-* (cmd shell) `start /wait msiexec /q /i datadog-agent-6-latest.amd64.msi`
-* (powershell) `Start-Process msiexec -ArgumentList '/q /i datadog-agent-6-latest.amd64.msi'` -Wait
-
-This will result in all files being installed, but the agent will _not_ be functional.  This is because the agent won't run without an API_KEY.  This can be accomplished by editing the configuration file, `c:\programdata\datadog\datadog.yaml`.
-
-## Installation with options
-
-There are many items that can be preconfigured on the command line.  Each configuration item is added as an install property to the command line.  
-
-* (cmd shell) `msiexec /qn /i datadog-agent-6-latest.amd64.msi APIKEY="abcdefabcdefabcdefabcdefabcdefab" HOSTNAME="my_hostname" TAGS="mytag1,mytag2"`
-* (powershell) `Start-Process msiexec -ArgumentList 'datadog-agent-6-latest.amd64.msi APIKEY="abcdefabcdefabcdefabcdefabcdefab" HOSTNAME="my_hostname" TAGS="mytag1,mytag2"'`
-
-The above will install the agent, and preconfigure the configuration file with the APIKEY, as well as setting the hostname and tags.
-
-## Configuration Options
-
-The following configuration command line options are available when installing the agent.
-* APIKEY="_string_"
-  * Assigns the Datadog API KEY to string in the configuration file
-* TAGS="_string_"
-  * _string_ is a comma separated list of tags to assign in the configuration file
-* HOSTNAME="_string_"
-  * configures the hostname reported by the Datadog agent to _string_.  Overrides any hostname calculated at runtime.
-* LOGS_ENABLED="_string_"
-  * enables (_string_ is **true**) or explicitly disables (_string_ is **false**) the log collection feature in the configuration file.  Logs is disabled by default.
-* APM_ENABLED="_string_"
-  * explicitly enables (_string_ is **true**) or disables (_string_ is **false**) the APM agent in the configuration file.  APM is enabled by default
-* PROCESS_ENABLED="_string_"
-  * enables (_string_ is **true**) or explicitly disables (_string_ is **false**) the process agent in the configuration file.  The process agent is disabled by default.
-* CMD_PORT="_number_"
-  * Number is a valid port number between 0 and 65534.  The datadog agent uses port 5001 by default for it's control API.  If that port is already in use by another program, the default may be overridden here
-* PROXY_HOST="_string_"
-* PROXY_PORT="_number_"
-* PROXY_USER="_string_"
-* PROXY_PASSWORD="_string_"
-  * Takes the combination of the provided PROXY_* options, and creates the HTTP proxy configuration which the agent will use to report metrics back to the Datadog service.
-* SITE="_string_"
-  * Sets the **site** variable in datadog.yaml to _string_.
+Most command line options are documented on the [docs website](https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=agentv6#command-line). For completeness, the options that should only be used upon request from Datadog Support are listed below:
 * DD_URL="_string_"
-  * Sets the **dd_url** variable in datadog.yaml to _string_. 
+  * Sets the **dd_url** variable in datadog.yaml to _string_.
 * LOGS_DD_URL="_string_"
   * Sets the **logs_dd_url** variable in the **logs_config** section in datadog.yaml to _string_ . _string_ has to be of the form `<endpoint>:<format>`, for example `agent-intake.logs.datadoghq.com:443`.
 * PROCESS_DD_URL="_string_"
   * Sets the **process_dd_url** variable in the **process_config** section in datadog.yaml to _string_. 
 * TRACE_DD_URL="_string_"
   * Sets the **apm_dd_url** variable in the **apm_config** section in datadog.yaml to _string_. 
-* DDAGENTUSER_NAME="_username_"
-  * Creates/uses _username_ as user context for running the agent
-* DDAGENTUSER_PASSWORD="_password_"
-  * Specifies password to assign to ddagentuser, or use for existing ddagentuser
-  * Must be provided for domain server installs
-* APPLICATIONDATADIRECTORY="_path_"
-  * Specifies the directory to use for the configuration file directory tree
-  * Replaces default _c:\programdata\datadog_
-  * Must only be provided on initial install; not valid for upgrades
-* PROJECTLOCATION="_path_"
-  * Specifies the directory to use for the binary file directory tree
-  * Replaces default _c:\Program Files\Datadog\Datadog Agent_
-  * Must only be provided on initial install; not valid for upgrades


### PR DESCRIPTION
### What does this PR do?

Redirect to docs website for everything related to windows installer usage, except options that users should use in very specific cases, only after talking with the support team.
