### PR TITLE
Add function for getting Host IP when running in host network mode

### DIFF
--- a/pkg/util/docker/network.go
+++ b/pkg/util/docker/network.go
@@ -151,10 +151,10 @@ func DefaultGateway() (net.IP, error) {
 	return ip, nil
 }
 
-// DefaultHostAddrs returns the IP addresses bound to the default network interface.
+// DefaultHostIPs returns the IP addresses bound to the default network interface.
 // The default network interface is the one connected to the network gateway, and it is determined
 // by parsing the routing table file in the proc file system.
-func DefaultHostAddrs() ([]net.Addr, error) {
+func DefaultHostIPs() ([]string, error) {
 	fields, err := defaultGatewayFields()
 	if err != nil {
 		return nil, err
@@ -167,7 +167,18 @@ func DefaultHostAddrs() ([]net.Addr, error) {
 		return nil, err
 	}
 
-	return iface.Addrs()
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+
+	ips := make([]string, len(addrs))
+	for i, addr := range addrs {
+		// Translate CIDR blocks into IPs, if necessary
+		ips[i] = strings.Split(addr.String(), "/")[0]
+	}
+
+	return ips, nil
 }
 
 // defaultGatewayFields extracts the fields associated to the interface connected

--- a/pkg/util/docker/network.go
+++ b/pkg/util/docker/network.go
@@ -137,6 +137,49 @@ func resolveDockerNetworks(containerNetworks map[string][]dockerNetwork) {
 
 // DefaultGateway returns the default Docker gateway.
 func DefaultGateway() (net.IP, error) {
+	fields, err := defaultGatewayFields()
+	if err != nil || len(fields) < 3 {
+		return nil, err
+	}
+
+	ipInt, err := strconv.ParseUint(fields[2], 16, 32)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse ip %s from route file: %s", fields[2], err)
+	}
+	ip := make(net.IP, 4)
+	binary.LittleEndian.PutUint32(ip, uint32(ipInt))
+	return ip, nil
+}
+
+// DefaultHostAddrs returns the IP addresses bound to the default network interface.
+// The default network interface is the one connected to the network gateway, and it is determined
+// by parsing the routing table file in the proc file system.
+func DefaultHostAddrs() ([]net.Addr, error) {
+	fields, err := defaultGatewayFields()
+	if err != nil {
+		return nil, err
+	}
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("missing interface information from routing file")
+	}
+	iface, err := net.InterfaceByName(fields[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return iface.Addrs()
+}
+
+// defaultGatewayFields extracts the fields associated to the interface connected
+// to the network gateway from the linux routing table. As an example, for the given file in /proc/net/routes:
+//
+// Iface   Destination  Gateway   Flags  RefCnt  Use  Metric  Mask      MTU  Window  IRTT
+// enp0s3  00000000     0202000A  0003   0       0    0       00000000  0    0       0
+// enp0s3  0002000A     00000000  0001   0       0    0       00FFFFFF  0    0       0
+//
+// The returned value would be ["enp0s3","00000000","0202000A","0003","0","0","0","00000000","0","0","0"]
+//
+func defaultGatewayFields() ([]string, error) {
 	procRoot := config.Datadog.GetString("proc_root")
 	netRouteFile := filepath.Join(procRoot, "net", "route")
 	f, err := os.Open(netRouteFile)
@@ -150,18 +193,13 @@ func DefaultGateway() (net.IP, error) {
 	}
 	defer f.Close()
 
-	ip := make(net.IP, 4)
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
-		if len(fields) >= 3 && fields[1] == "00000000" {
-			ipInt, err := strconv.ParseUint(fields[2], 16, 32)
-			if err != nil {
-				return nil, fmt.Errorf("unable to parse ip %s, from %s: %s", fields[2], netRouteFile, err)
-			}
-			binary.LittleEndian.PutUint32(ip, uint32(ipInt))
-			break
+		if len(fields) >= 1 && fields[1] == "00000000" {
+			return fields, nil
 		}
 	}
-	return ip, nil
+
+	return nil, fmt.Errorf("couldn't retrieve default gateway information")
 }

--- a/pkg/util/docker/network_test.go
+++ b/pkg/util/docker/network_test.go
@@ -9,10 +9,12 @@ package docker
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -68,6 +70,51 @@ ens33	00000000	FEFEA8C0	0003	0	0	100	00000000	0	0	0
 			require.Nil(t, ip)
 		})
 	}
+}
+
+func TestDefaulHostAddrs(t *testing.T) {
+	dummyProcDir, err := newTempFolder("test-default-host-addrs")
+	require.Nil(t, err)
+	defer dummyProcDir.removeAll()
+	config.Datadog.SetDefault("proc_root", dummyProcDir.RootPath)
+
+	t.Run("routing table contains a gateway entry", func(t *testing.T) {
+		routes := `
+		    Iface    Destination Gateway  Flags RefCnt Use Metric Mask     MTU Window IRTT
+		    default  00000000    010011AC 0003  0      0   0      00000000 0   0      0
+		    default  000011AC    00000000 0001  0      0   0      0000FFFF 0   0      0
+		    eth1     000012AC    00000000 0001  0      0   0      0000FFFF 0   0      0 `
+
+		// Pick an existing device and replace the "default" placeholder by its name
+		interfaces, err := net.Interfaces()
+		require.NoError(t, err)
+		require.NotEmpty(t, interfaces)
+
+		netInterface := interfaces[0]
+		netAddrs, err := netInterface.Addrs()
+		require.NoError(t, err)
+		routes = strings.ReplaceAll(routes, "default", netInterface.Name)
+
+		// Populate routing table file
+		err = dummyProcDir.add(filepath.Join("net", "route"), routes)
+		require.NoError(t, err)
+
+		addrs, err := DefaultHostAddrs()
+		assert.Nil(t, err)
+		assert.Equal(t, netAddrs, addrs)
+	})
+
+	t.Run("routing table missing a gateway entry", func(t *testing.T) {
+		routes := `
+	        Iface    Destination Gateway  Flags RefCnt Use Metric Mask     MTU Window IRTT
+	        eth0     000011AC    00000000 0001  0      0   0      0000FFFF 0   0      0
+	        eth1     000012AC    00000000 0001  0      0   0      0000FFFF 0   0      0 `
+
+		err = dummyProcDir.add(filepath.Join("net", "route"), routes)
+		require.NoError(t, err)
+		_, err := DefaultHostAddrs()
+		assert.NotNil(t, err)
+	})
 }
 
 func TestFindDockerNetworks(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Provides an utility function to retrieve the IPs bound to the default network interface.
The default interface is determined heuristically by parsing the routing table and getting the interface routing to the default network gateway.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
