### PR TITLE
[kitchen] Force generated kitchen windows password to comply with Azure restrictions

### DIFF
--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -80,7 +80,7 @@ fi
 
 # Generate a password to use for the windows servers
 if [ -z ${SERVER_PASSWORD+x} ]; then
-  export SERVER_PASSWORD=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)
+  export SERVER_PASSWORD="$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)0aZ"
 fi
 
 cp kitchen-azure.yml kitchen.yml


### PR DESCRIPTION
### What does this PR do?

Generates a password which always complies with Azure / Windows requirements.
Azure requires Windows passwords to not contain special characters, and to contain at least a numeric digit, a lowercase letter and an uppercase letter.

### Motivation

Lesser pipeline-related frustration: this removes a kitchen error which may make a pipeline fail if a bad password is generated.
