### PR TITLE
Add inventory info to the status page and check command

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -129,6 +130,10 @@ var checkCmd = &cobra.Command{
 		s := serializer.NewSerializer(common.Forwarder)
 		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, "agent", checkCmdFlushInterval)
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
+
+		if config.Datadog.GetBool("inventories_enabled") {
+			metadata.SetupInventoriesExpvar(common.AC, common.Coll)
+		}
 
 		allConfigs := common.AC.GetAllConfigs()
 
@@ -285,8 +290,9 @@ var checkCmd = &cobra.Command{
 				}
 
 				instanceData := map[string]interface{}{
-					"aggregator": aggregatorData,
-					"runner":     runnerData,
+					"aggregator":  aggregatorData,
+					"runner":      runnerData,
+					"inventories": collectorData["inventories"],
 				}
 				instancesData = append(instancesData, instanceData)
 			} else if profileMemory {

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -32,6 +32,14 @@
                 Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
                 Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
                 Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}<br>
+                {{- if index $.Stats.inventories .CheckID }}
+                Metadata:<br>
+                <span class="stat_subdata">
+                  {{- range $k, $v := index $.Stats.inventories .CheckID }}
+                    {{ $k }}: {{ $v }}<br>
+                  {{- end }}
+                </span>
+                {{- end }}
               {{- if .LastError}}
                 <span class="error">Error</span>: {{lastErrorMessage .LastError}}<br>
                       {{lastErrorTraceback .LastError -}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -92,6 +92,15 @@
   </div>
 
   <div class="stat">
+    <span class="stat_title">Metadata</span>
+    <span class="stat_data">
+    {{- range $key, $value := .agent_metadata }}
+      {{ $key }}: {{ $value }}
+    {{- end }}
+    </span>
+  </div>
+
+  <div class="stat">
     <span class="stat_title">JMX Status</span>
     <span class="stat_data">
       {{- with .JMXStatus -}}

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -95,7 +95,7 @@ func TestGetPayload(t *testing.T) {
 	SetAgentMetadata("test", true)
 	SetCheckMetadata("check1_instance1", "check_provided_key1", 123)
 	SetCheckMetadata("check1_instance1", "check_provided_key2", "Hi")
-	SetCheckMetadata("non_running_checkid", "check_provided_key1", "this should get deleted")
+	SetCheckMetadata("non_running_checkid", "check_provided_key1", "this_should_be_kept")
 
 	p := GetPayload("testHostname", &mockAutoConfig{}, &mockCollector{})
 
@@ -106,7 +106,7 @@ func TestGetPayload(t *testing.T) {
 	assert.Equal(t, true, agentMetadata["test"])
 
 	checkMetadata := *p.CheckMetadata
-	assert.Len(t, checkMetadata, 2)           // non_running_checkid is not there
+	assert.Len(t, checkMetadata, 3)
 	assert.Len(t, checkMetadata["check1"], 2) // check1 has two instances
 	check1Instance1 := *checkMetadata["check1"][0]
 	assert.Len(t, check1Instance1, 5)
@@ -141,7 +141,7 @@ func TestGetPayload(t *testing.T) {
 	assert.Equal(t, true, agentMetadata["test"])
 
 	checkMetadata = *p.CheckMetadata
-	assert.Len(t, checkMetadata, 2)
+	assert.Len(t, checkMetadata, 3)
 	check1Instance1 = *checkMetadata["check1"][0]
 	assert.Len(t, check1Instance1, 5)
 	assert.Equal(t, startNow.UnixNano(), check1Instance1["last_updated"]) // last_updated has changed
@@ -192,6 +192,15 @@ func TestGetPayload(t *testing.T) {
 					"config.provider": "provider2",
 					"last_updated": %v
 				}
+			],
+			"non_running_checkid":
+			[
+				{
+					"check_provided_key1": "this_should_be_kept",
+					"config.hash": "non_running_checkid",
+					"config.provider": "",
+					"last_updated": %v
+				}
 			]
 		},
 		"agent_metadata":
@@ -199,7 +208,7 @@ func TestGetPayload(t *testing.T) {
 			"test": true
 		}
 	}`
-	jsonString = fmt.Sprintf(jsonString, startNow.UnixNano(), startNow.UnixNano(), agentStartupTime.UnixNano(), originalStartNow.UnixNano())
+	jsonString = fmt.Sprintf(jsonString, startNow.UnixNano(), startNow.UnixNano(), agentStartupTime.UnixNano(), originalStartNow.UnixNano(), originalStartNow.UnixNano())
 	jsonString = strings.Join(strings.Fields(jsonString), "") // Removes whitespaces and new lines
 	assert.Equal(t, jsonString, string(marshaled))
 

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -35,6 +35,12 @@ Collector
       Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
       Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
       Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
+      {{- if index $.CheckMetadata .CheckID }}
+      metadata:
+      {{- range $k, $v := index $.CheckMetadata .CheckID }}
+        {{ $k }}: {{ $v }}
+      {{- end }}
+      {{- end }}
       {{if .LastError -}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -77,6 +77,12 @@ NOTE: Changes made to this template should be reflected on the following templat
     error: {{.hostnameStats.errors.all}}
   {{- end }}
 
+  Metadata
+  ========
+  {{- range $key, $value := .agent_metadata }}
+    {{ $key }}: {{ $value }}
+  {{- end }}
+
 {{- if .leaderelection}}
 
 Leader Election

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -46,10 +46,11 @@ func FormatStatus(data []byte) (string, error) {
 	logsStats := stats["logsStats"]
 	dcaStats := stats["clusterAgentStatus"]
 	endpointsInfos := stats["endpointsInfos"]
+	inventoriesStats := stats["inventories"]
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
-	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, "")
+	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, inventoriesStats, "")
 	renderJMXFetchStatus(b, jmxStats)
 	renderForwarderStatus(b, forwarderStats)
 	renderEndpointsInfos(b, endpointsInfos)
@@ -77,7 +78,7 @@ func FormatDCAStatus(data []byte) (string, error) {
 	title := fmt.Sprintf("Datadog Cluster Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
-	renderChecksStats(b, runnerStats, nil, nil, autoConfigStats, checkSchedulerStats, "")
+	renderChecksStats(b, runnerStats, nil, nil, autoConfigStats, checkSchedulerStats, nil, "")
 	renderForwarderStatus(b, forwarderStats)
 	renderEndpointsInfos(b, endpointsInfos)
 
@@ -164,7 +165,7 @@ func renderHPAStats(w io.Writer, hpaStats interface{}) {
 	}
 }
 
-func renderChecksStats(w io.Writer, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats interface{}, onlyCheck string) {
+func renderChecksStats(w io.Writer, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, inventoriesStats interface{}, onlyCheck string) {
 	checkStats := make(map[string]interface{})
 	checkStats["RunnerStats"] = runnerStats
 	checkStats["pyLoaderStats"] = pyLoaderStats
@@ -172,6 +173,7 @@ func renderChecksStats(w io.Writer, runnerStats, pyLoaderStats, pythonInit, auto
 	checkStats["AutoConfigStats"] = autoConfigStats
 	checkStats["CheckSchedulerStats"] = checkSchedulerStats
 	checkStats["OnlyCheck"] = onlyCheck
+	checkStats["CheckMetadata"] = inventoriesStats
 	t := template.Must(template.New("collector.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "collector.tmpl")))
 
 	err := t.Execute(w, checkStats)
@@ -190,7 +192,8 @@ func renderCheckStats(data []byte, checkName string) (string, error) {
 	pythonInit := stats["pythonInit"]
 	autoConfigStats := stats["autoConfigStats"]
 	checkSchedulerStats := stats["checkSchedulerStats"]
-	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, checkName)
+	inventoriesStats := stats["inventories"]
+	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, inventoriesStats, checkName)
 
 	return b.String(), nil
 }


### PR DESCRIPTION
### What does this PR do?

This add the inventory metadata (both check and agent metadata) to the status page (text, GUI and JSON) and the check command (text and JSON).

here is an example:
```
    redisdb (1.13.0)
    ----------------
      Instance ID: redisdb:fbcb8b58205c97ee [OK]
      Configuration Source: file:/home/maxime/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/conf.d/redisdb.yaml
      Total Runs: 1
      Metric Samples: Last Run: 33, Total: 33
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 6ms
      metadata:
        version.major: 5
        version.minor: 0
        version.patch: 6
        version.raw: 5.0.6
        version.scheme: semver
```

In the JSON output the metadata are not merged with the check but in there own section `inventories` and `agent_metadata`.