### PR TITLE
[cmd/agent] Reintroduce legacy AgentCheck import path and fix uninstall cleanup

### DIFF
--- a/cmd/agent/dist/checks/__init__.py
+++ b/cmd/agent/dist/checks/__init__.py
@@ -2,5 +2,11 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-2019 Datadog, Inc.
+
+# NOTE: The files in this folder are needed for the legacy import path
+# (from checks import AgentCheck) to work.
+# As long as we do not properly deprecate the legacy import path, they
+# should not be removed. For more details, see #4032 and #4421.
+
 from datadog_checks.checks import AgentCheck
 from datadog_checks.errors import CheckException

--- a/cmd/agent/dist/checks/__init__.py
+++ b/cmd/agent/dist/checks/__init__.py
@@ -1,0 +1,6 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-2019 Datadog, Inc.
+from datadog_checks.checks import AgentCheck
+from datadog_checks.errors import CheckException

--- a/cmd/agent/dist/checks/libs/__init__.py
+++ b/cmd/agent/dist/checks/libs/__init__.py
@@ -1,0 +1,4 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-2019 Datadog, Inc.

--- a/cmd/agent/dist/checks/libs/wmi/__init__.py
+++ b/cmd/agent/dist/checks/libs/wmi/__init__.py
@@ -1,0 +1,4 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-2019 Datadog, Inc.

--- a/cmd/agent/dist/checks/libs/wmi/sampler.py
+++ b/cmd/agent/dist/checks/libs/wmi/sampler.py
@@ -1,0 +1,27 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-2019 Datadog, Inc.
+
+# pylint: disable=E0401
+
+"""
+A lightweight Python WMI module wrapper built on top of `pywin32` and `win32com` extensions.
+
+**Specifications**
+* Based on top of the `pywin32` and `win32com` third party extensions only
+* Compatible with `Raw`* and `Formatted` Performance Data classes
+    * Dynamically resolve properties' counter types
+    * Hold the previous/current `Raw` samples to compute/format new values*
+* Fast and lightweight
+    * Avoid queries overhead
+    * Cache connections and qualifiers
+    * Use `wbemFlagForwardOnly` flag to improve enumeration/memory performance
+
+*\\* `Raw` data formatting relies on the avaibility of the corresponding calculator.
+Please refer to `checks.lib.wmi.counter_type` for more information*
+
+Original discussion thread: https://github.com/DataDog/dd-agent/issues/1952
+Credits to @TheCloudlessSky (https://github.com/TheCloudlessSky)
+"""
+from datadog_checks.checks.win.wmi.sampler import WMISampler

--- a/cmd/agent/dist/checks/network_checks.py
+++ b/cmd/agent/dist/checks/network_checks.py
@@ -1,0 +1,5 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-2019 Datadog, Inc.
+from datadog_checks.checks import NetworkCheck, Status, EventType

--- a/cmd/agent/dist/checks/prometheus_check/__init__.py
+++ b/cmd/agent/dist/checks/prometheus_check/__init__.py
@@ -1,0 +1,6 @@
+# (C) Datadog, Inc. 2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from datadog_checks.checks.prometheus import (
+    PrometheusCheck, PrometheusFormat, UnknownFormatError
+)

--- a/cmd/agent/dist/checks/winwmi_check.py
+++ b/cmd/agent/dist/checks/winwmi_check.py
@@ -1,0 +1,7 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-2019 Datadog, Inc.
+from datadog_checks.checks.win.wmi import (
+    WinWMICheck, WMIMetric, MissingTagBy, from_time, to_time
+)

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -143,5 +143,6 @@ fi
 # Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs
 find $INSTALL_DIR/agent -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/agent"
 find $INSTALL_DIR/bin/agent/dist -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/bin/agent/dist"
+find $INSTALL_DIR/bin/agent/dist -name '__pycache__' -type d -delete || echo "Unable to delete __pycache__ directories in $INSTALL_DIR/bin/agent/dist"
 
 exit 0

--- a/releasenotes/notes/fix-agentcheck-import-5fd2e101c74f5311.yaml
+++ b/releasenotes/notes/fix-agentcheck-import-5fd2e101c74f5311.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Reintroduce legacy checks directory to make legacy AgentCheck import path
+    (``from checks import AgentCheck``) work again.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -207,7 +207,7 @@ def refresh_assets(ctx, build_tags, development=True, puppy=False):
     os.mkdir(dist_folder)
 
     if "python" in build_tags:
-        os.mkdir(os.path.join(dist_folder, "checks"))
+        copy_tree("./cmd/agent/dist/checks/", os.path.join(dist_folder, "checks"))
         copy_tree("./cmd/agent/dist/utils/", os.path.join(dist_folder, "utils"))
         shutil.copy("./cmd/agent/dist/config.py", os.path.join(dist_folder, "config.py"))
     if not puppy:


### PR DESCRIPTION
### What does this PR do?

Reverts #4032 (broke legacy import paths for `AgentCheck`) and fixes uninstall when Python 3 is used (removes `__pycache__` directories created by Python 3, which remained on uninstall).

### Motivation

Do not suddenly break legacy import paths without warnings.
