### PR TITLE
Patch jaydebeapy

### DIFF
--- a/omnibus/config/patches/datadog-agent-integrations-py2/jpype_0_7.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py2/jpype_0_7.patch
@@ -1,0 +1,23 @@
+--- a/__init__.py
++++ b/__init__.py
+@@ -173,7 +173,19 @@ def _jdbc_connect_jpype(jclassname, url, driver_args, jars, libs):
+         # jvm_path = ('/usr/lib/jvm/java-6-openjdk'
+         #             '/jre/lib/i386/client/libjvm.so')
+         jvm_path = jpype.getDefaultJVMPath()
+-        jpype.startJVM(jvm_path, *args)
++        jpype_ver = 0.
++        if hasattr(jpype, '__version__'):
++            try:
++                ver_match = re.match('\d+\.\d+', jpype.__version__)
++                if ver_match:
++                    jpype_ver = float(ver_match.group(0))
++            except ValueError:
++                pass
++        if jpype_ver < 0.7:
++            jpype.startJVM(jvm_path, *args)
++        else:
++            jpype.startJVM(jvm_path, *args, ignoreUnrecognized=True,
++                           convertStrings=True)
+     if not jpype.isThreadAttachedToJVM():
+         jpype.attachThreadToJVM()
+     if _jdbc_name_to_const is None:

--- a/omnibus/config/patches/datadog-agent-integrations-py3/jpype_0_7.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py3/jpype_0_7.patch
@@ -1,0 +1,23 @@
+--- a/__init__.py
++++ b/__init__.py
+@@ -173,7 +173,19 @@ def _jdbc_connect_jpype(jclassname, url, driver_args, jars, libs):
+         # jvm_path = ('/usr/lib/jvm/java-6-openjdk'
+         #             '/jre/lib/i386/client/libjvm.so')
+         jvm_path = jpype.getDefaultJVMPath()
+-        jpype.startJVM(jvm_path, *args)
++        jpype_ver = 0.
++        if hasattr(jpype, '__version__'):
++            try:
++                ver_match = re.match('\d+\.\d+', jpype.__version__)
++                if ver_match:
++                    jpype_ver = float(ver_match.group(0))
++            except ValueError:
++                pass
++        if jpype_ver < 0.7:
++            jpype.startJVM(jvm_path, *args)
++        else:
++            jpype.startJVM(jvm_path, *args, ignoreUnrecognized=True,
++                           convertStrings=True)
+     if not jpype.isThreadAttachedToJVM():
+         jpype.attachThreadToJVM()
+     if _jdbc_name_to_const is None:

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -257,8 +257,10 @@ build do
     # Patch applies to only one file: set it explicitly as a target, no need for -p
     if windows?
       patch :source => "create-regex-at-runtime.patch", :target => "#{python_2_embedded}/Lib/site-packages/yaml/reader.py"
+      patch :source => "jpype_0_7.patch", :target => "#{python_2_embedded}/Lib/site-packages/jaydebeapi/__init__.py"
     else
       patch :source => "create-regex-at-runtime.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/yaml/reader.py"
+      patch :source => "jpype_0_7.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/jaydebeapi/__init__.py"
     end
 
   end

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -254,6 +254,14 @@ build do
         command "#{pip} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
       end
     end
+
+    # Patch applies to only one file: set it explicitly as a target, no need for -p
+    if windows?
+      patch :source => "jpype_0_7.patch", :target => "#{python_3_embedded}/Lib/site-packages/jaydebeapi/__init__.py"
+    else
+      patch :source => "jpype_0_7.patch", :target => "#{install_dir}/embedded/lib/python3.7/site-packages/jaydebeapi/__init__.py"
+    end
+
   end
 
   # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible

--- a/releasenotes/notes/patch-jaydebeapi-for-new-jpype-23b8199845e669d7.yaml
+++ b/releasenotes/notes/patch-jaydebeapi-for-new-jpype-23b8199845e669d7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Carry a custom patch for jaydebeapi to support latest jpype.


### PR DESCRIPTION
We need to carry a custom patch for jaydebeapi as it doesn't support latest
jpype currently and no release is happening.

See https://github.com/baztian/jaydebeapi/pull/107.

Originally submitted as #4402.