### PR TITLE
Bump embedded Python to 2.7.17 for windows

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -18,7 +18,7 @@
 name "python2"
 
 if ohai["platform"] != "windows"
-  default_version "2.7.16"
+  default_version "2.7.17"
 
   dependency "ncurses"
   dependency "zlib"
@@ -28,7 +28,7 @@ if ohai["platform"] != "windows"
   dependency "libyaml"
 
   source :url => "http://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-         :sha256 => "01da813a3600876f03f46db11cc5c408175e99f03af2ba942ef324389a83bad5"
+         :sha256 => "f22059d09cdf9625e0a7284d24a13062044f5bf59d93a7f3382190dfa94cecde"
 
   relative_path "Python-#{version}"
 
@@ -74,16 +74,16 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "2.7.16"
+  default_version "2.7.17"
   dependency "vc_redist"
 
   if windows_arch_i386?
     source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-x86.zip",
-           :sha256 => "575093fd5748ccc22be6577fff15ae9ffe525b627888342bd43826053183e9da",
+           :sha256 => "dda6107d08e228229d347feb9da6d491d44eb542c8c533d6d1e1d789a6838c76",
            :extract => :seven_zip
   else
     source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-nopip-2-amd64.zip",
-         :sha256 => "0849a12f9a162636c1f4a561110ecb481cbb13bc54b558015b23559146bb5e26",
+         :sha256 => "36673219e1e9d5d52645933b68f2e77c30199effb4d552ca7f84b36710e433e4",
          :extract => :seven_zip
   end
   build do

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -79,11 +79,11 @@ else
 
   if windows_arch_i386?
     source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-x86.zip",
-           :sha256 => "dda6107d08e228229d347feb9da6d491d44eb542c8c533d6d1e1d789a6838c76",
+           :sha256 => "a2c5c5736356f7264a7412cdca050cf2ae924c703c47a27b8f0d8f62ce2d6181",
            :extract => :seven_zip
   else
-    source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-nopip-2-amd64.zip",
-         :sha256 => "36673219e1e9d5d52645933b68f2e77c30199effb4d552ca7f84b36710e433e4",
+    source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-amd64.zip",
+         :sha256 => "557ea6690c5927360656c003d3114b73adbd755b712a2911975dde813d6d7afb",
          :extract => :seven_zip
   end
   build do

--- a/release.json
+++ b/release.json
@@ -13,7 +13,7 @@
 		"JMXFETCH_VERSION": "0.33.0",
 		"JMXFETCH_HASH": "078011fbcca5e9beee2f041fefacbad824cff47e074b74a4674eb3efed8984b3"
 	},
-	"7.15.0-beta": {
+	"7.15.0-beta.1": {
 		"INTEGRATIONS_CORE_VERSION": "6.15.0",
 		"OMNIBUS_SOFTWARE_VERSION": "6.15.0",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",

--- a/releasenotes/notes/python-2-7-17-abbfe429ee77680b.yaml
+++ b/releasenotes/notes/python-2-7-17-abbfe429ee77680b.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Bump embedded Python to 2.7.17.


### PR DESCRIPTION
### What does this PR do?

Bump embedded Python to 2.7.17.

### Motivation

2 fixed CVEs are mentioned there: https://github.com/python/cpython/blob/2.7/Misc/NEWS.d/2.7.17rc1.rst

### Additional Notes

@derekwbrown: Can you check the content of `https://s3.amazonaws.com/dd-agent-omnibus/python-windows-2.7.17-x86.zip` and `https://s3.amazonaws.com/dd-agent-omnibus/python-windows-2.7.17-nopip-2-amd64.zip`.

Here are the steps I used to create these 2 files:

For `https://s3.amazonaws.com/dd-agent-omnibus/python-windows-2.7.17-x86.zip`
1. Install https://www.python.org/ftp/python/2.7.17/python-2.7.17.msi with default settings to `C:\Python27`
2. Copy C:\Windows\SysWOW64\python27.dll to `C:\Python27` 
3. Copy `msvcr90.dll` and `Microsoft.VC90.CRT.manifest` from `https://s3.amazonaws.com/dd-agent-omnibus/python-windows-2.7.16-x86.zip` to `C:\Python27`
4. Remove `C:\Python27\Scripts` and `C:\Python27\Doc`
5. Remove `*.pyc` from `C:\Python27\Lib`
6. Create a zip from C:\Python27

For `https://s3.amazonaws.com/dd-agent-omnibus/python-windows-2.7.17-nopip-2-amd64.zip`
1. Install https://www.python.org/ftp/python/2.7.17/python-2.7.17.amd64.msi  with default settings to `C:\Python27`
2. Copy C:\Windows\System32\python27.dll to `C:\Python27` 
3. Nothing to do for `msvcr90.dll` and `Microsoft.VC90.CRT.manifest`
4. Same as before
5. Same as before
6. Same as before

I checked and we get the same result with the following steps:
Install https://www.python.org/ftp/python/2.7.17/python-2.7.17.amd64.msi  with default settings to `C:\Python27`  with the option `Install just for me`
Step 2 is not not needed anymore
Same as before

Tests performed on the agent installer built for this pipeline after commit `Update sha256 sums for new zips` https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/21427944:
- Windows 10: (x64/x86): Run a custom check with python 2. Python interpreter and `pip list` command can be run.
- Windows 2008: (x64 only): Run a custom check with python 2. Python interpreter command can be run. `pip list` **failed to create process.** but `python -m pip list` succeed.