### PR TITLE
Bump embedded Python to 2.7.17 for Linux only

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -18,7 +18,7 @@
 name "python2"
 
 if ohai["platform"] != "windows"
-  default_version "2.7.16"
+  default_version "2.7.17"
 
   dependency "ncurses"
   dependency "zlib"
@@ -28,7 +28,7 @@ if ohai["platform"] != "windows"
   dependency "libyaml"
 
   source :url => "http://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-         :sha256 => "01da813a3600876f03f46db11cc5c408175e99f03af2ba942ef324389a83bad5"
+         :sha256 => "f22059d09cdf9625e0a7284d24a13062044f5bf59d93a7f3382190dfa94cecde"
 
   relative_path "Python-#{version}"
 

--- a/releasenotes/notes/python-2-7-17-abbfe429ee77680b.yaml
+++ b/releasenotes/notes/python-2-7-17-abbfe429ee77680b.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Bump embedded Python to 2.7.17.


### PR DESCRIPTION
### What does this PR do?

Bump embedded Python to 2.7.17 for Linux.