### PR TITLE
fix bug that uses the wrong socket parameter for ebpf API on RHEL/CentOS

### DIFF
--- a/pkg/ebpf/c/tracer-ebpf.c
+++ b/pkg/ebpf/c/tracer-ebpf.c
@@ -747,6 +747,7 @@ int kretprobe__udp_recvmsg(struct pt_regs* ctx) {
         return 0;
     }
 
+    log_debug("kretprobe/udp_recvmsg: pid_tgid: %d, return: %d\n", pid_tgid, copied);
     handle_message(&t, 0, copied);
 
     return 0;

--- a/pkg/ebpf/c/tracer-ebpf.c
+++ b/pkg/ebpf/c/tracer-ebpf.c
@@ -524,7 +524,7 @@ int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
 
 SEC("kprobe/tcp_sendmsg/rhel")
 int kprobe__tcp_sendmsg__rhel(struct pt_regs* ctx) {
-    struct sock* sk = (struct sock*)PT_REGS_PARM1(ctx);
+    struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
     size_t size = (size_t)PT_REGS_PARM4(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u64 zero = 0;
@@ -665,7 +665,7 @@ int kprobe__udp_sendmsg(struct pt_regs* ctx) {
 
 SEC("kprobe/udp_sendmsg/rhel")
 int kprobe__udp_sendmsg__rhel(struct pt_regs* ctx) {
-    struct sock* sk = (struct sock*)PT_REGS_PARM1(ctx);
+    struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
     size_t size = (size_t)PT_REGS_PARM4(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u64 zero = 0;
@@ -701,6 +701,18 @@ int kprobe__udp_recvmsg(struct pt_regs* ctx) {
     // Store pointer to the socket using the pid/tgid
     bpf_map_update_elem(&udp_recv_sock, &pid_tgid, &sk, BPF_ANY);
     log_debug("kprobe/udp_recvmsg: pid_tgid: %d\n", pid_tgid);
+
+    return 0;
+}
+
+SEC("kprobe/udp_recvmsg/rhel")
+int kprobe__udp_recvmsg_rhel(struct pt_regs* ctx) {
+    struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+
+    // Store pointer to the socket using the pid/tgid
+    bpf_map_update_elem(&udp_recv_sock, &pid_tgid, &sk, BPF_ANY);
+    log_debug("kprobe/udp_recvmsg/rhel: pid_tgid: %d\n", pid_tgid);
 
     return 0;
 }

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -97,11 +97,11 @@ func NewDefaultConfig() *Config {
 
 // EnabledKProbes returns a map of kprobes that are enabled per config settings.
 // This map does not include the probes used exclusively in the offset guessing process.
-func (c *Config) EnabledKProbes(isRHELOrCentos bool) map[KProbeName]struct{} {
+func (c *Config) EnabledKProbes(isRHELOrCentOS bool) map[KProbeName]struct{} {
 	enabled := make(map[KProbeName]struct{}, 0)
 
 	if c.CollectTCPConns {
-		if isRHELOrCentos {
+		if isRHELOrCentOS {
 			enabled[TCPSendMsgRHEL] = struct{}{}
 		} else {
 			enabled[TCPSendMsg] = struct{}{}
@@ -119,10 +119,11 @@ func (c *Config) EnabledKProbes(isRHELOrCentos bool) map[KProbeName]struct{} {
 
 	if c.CollectUDPConns {
 		enabled[UDPRecvMsgReturn] = struct{}{}
-		enabled[UDPRecvMsg] = struct{}{}
-		if isRHELOrCentos {
+		if isRHELOrCentOS {
 			enabled[UDPSendMsgRHEL] = struct{}{}
+			enabled[UDPRecvMsgRHEL] = struct{}{}
 		} else {
+			enabled[UDPRecvMsg] = struct{}{}
 			enabled[UDPSendMsg] = struct{}{}
 		}
 

--- a/pkg/ebpf/types.go
+++ b/pkg/ebpf/types.go
@@ -41,6 +41,8 @@ const (
 	UDPSendMsgRHEL KProbeName = "kprobe/udp_sendmsg/rhel"
 	// UDPRecvMsg traces the udp_recvmsg() system call
 	UDPRecvMsg KProbeName = "kprobe/udp_recvmsg"
+	// UDPRecvMsgRHEL traces the udp_recvmsg() system call on RHEL and CentOS.
+	UDPRecvMsgRHEL KProbeName = "kprobe/udp_recvmsg/rhel"
 	// UDPRecvMsgReturn traces the return value for the udp_recvmsg() system call
 	UDPRecvMsgReturn KProbeName = "kretprobe/udp_recvmsg"
 
@@ -75,5 +77,6 @@ var (
 	kprobeOverrides = map[KProbeName]KProbeName{
 		TCPSendMsgRHEL: TCPSendMsg,
 		UDPSendMsgRHEL: UDPSendMsg,
+		UDPRecvMsgRHEL: UDPRecvMsg,
 	}
 )


### PR DESCRIPTION
### What does this PR do?

This PR fixes the problem that we don't have a valid socket structure that causes parsing failure on ports and consequently don't record the bytes_sent successfully.

Last round of fix we only focused on position difference for the `size` parameter between old and new kernels, but ignored the fact that `sock` parameter also shifted. 

It's weird that we've been testing this local to local and it seem to work, probably a coincidence. 

cc: @DataDog/burrito 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
