### PR TITLE
Clean out artifact directories prior to each build to ensure there's no

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -626,6 +626,8 @@ agent_suse-x64-a7:
   # Unavailable on gitlab < 12.3
   # timeout: 2h 00m
   script:
+    - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
+    - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir .omnibus\pkg
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat --release-version %RELEASE_VERSION%
     - copy build-out\*.msi .omnibus\pkg


### PR DESCRIPTION
carry over from one build to the other

