### PR TITLE
SUSE sysvinit support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1069,7 +1069,8 @@ deploy_windows_testing-a7:
   <<: *kitchen_common
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
-    - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP4:2019.06.17"
+    - export TEST_PLATFORMS="sles-11,SUSE:SLES-BYOS:11-SP4:2019.07.01"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-12,SUSE:SLES:12-SP4:2019.06.17"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-15,SUSE:SLES-Standard:15:2019.06.17"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1069,8 +1069,7 @@ deploy_windows_testing-a7:
   <<: *kitchen_common
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
-    - export TEST_PLATFORMS="sles-11,SUSE:SLES-BYOS:11-SP4:2019.07.01"
-    - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-12,SUSE:SLES:12-SP4:2019.06.17"
+    - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP4:2019.06.17"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-15,SUSE:SLES-Standard:15:2019.06.17"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -183,6 +183,11 @@ if linux?
     extra_package_file "/etc/init.d/datadog-agent-process"
     extra_package_file "/etc/init.d/datadog-agent-trace"
   end
+  if suse?
+    extra_package_file "/etc/init.d/datadog-agent"
+    extra_package_file "/etc/init.d/datadog-agent-process"
+    extra_package_file "/etc/init.d/datadog-agent-trace"
+  end
   extra_package_file "#{systemd_directory}/datadog-agent.service"
   extra_package_file "#{systemd_directory}/datadog-agent-process.service"
   extra_package_file "#{systemd_directory}/datadog-agent-sysprobe.service"

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -76,6 +76,12 @@ build do
                 move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
                 move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
             end
+            if suse?
+                mkdir "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
+            end
             mkdir systemd_directory
             move "#{install_dir}/scripts/datadog-agent.service", systemd_directory
             move "#{install_dir}/scripts/datadog-agent-trace.service", systemd_directory

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -178,6 +178,20 @@ build do
           mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
     end
+    if suse?
+      erb source: "sysvinit_suse.erb",
+          dest: "#{install_dir}/scripts/datadog-agent",
+          mode: 0755,
+          vars: { install_dir: install_dir, etc_dir: etc_dir }
+      erb source: "sysvinit_suse.process.erb",
+          dest: "#{install_dir}/scripts/datadog-agent-process",
+          mode: 0755,
+          vars: { install_dir: install_dir, etc_dir: etc_dir }
+      erb source: "sysvinit_suse.trace.erb",
+          dest: "#{install_dir}/scripts/datadog-agent-trace",
+          mode: 0755,
+          vars: { install_dir: install_dir, etc_dir: etc_dir }
+    end
 
     erb source: "systemd.service.erb",
         dest: "#{install_dir}/scripts/datadog-agent.service",

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
@@ -75,8 +75,8 @@ do_start() {
 start_and_wait() {
   # Start the Agent
   do_start
-    case "$?" in
-    0) 
+  case "$?" in
+    0)
       # Wait until the Agent is running
       retries=5
       while [ $retries -gt 1 ]; do
@@ -101,7 +101,7 @@ start_and_wait() {
       log_failure_msg
       return 1
       ;;
-    esac
+  esac
 }
 
 do_stop() {
@@ -110,6 +110,7 @@ do_stop() {
   if [ "$?" -eq "3" ]; then
     return 0
   fi
+
   killproc -TERM -p $PIDFILE $AGENTPATH
   RETVAL="$?"
   rm -f $PIDFILE
@@ -171,6 +172,7 @@ case "$1" in
     ;;
   status)
     echo -n "Checking for $DESC:"
+
     # Status codes are slightly different for the checkproc command:
     # 0 - service running
     # 1 - service dead, but /var/run/  pid  file exists

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
@@ -1,0 +1,191 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides: datadog-agent
+# Short-Description: Start and stop datadog agent
+# Description: Datadog Agent
+# Required-Start: $remote_fs
+# Required-Stop: $remote_fs
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+### END INIT INFO
+
+INSTALL_DIR="/opt/datadog-agent"
+AGENTPATH="$INSTALL_DIR/bin/agent/agent"
+PIDFILE="$INSTALL_DIR/run/agent.pid"
+AGENT_ARGS="run -p $PIDFILE"
+AGENT_USER="dd-agent"
+NAME="datadog-agent"
+DESC="Datadog Agent"
+
+# Shell functions sourced from /etc/rc.status (sourced by /lib/lsb/init-functions):
+#      rc_check         check and set local and overall rc status
+#      rc_status        check and set local and overall rc status
+#      rc_status -v     ditto but be verbose in local rc status
+#      rc_status -v -r  ditto and clear the local rc status
+#      rc_failed        set local and overall rc status to failed
+#      rc_failed <num>  set local and overall rc status to <num>
+#      rc_reset         clear local rc status (overall remains)
+#      rc_exit          exit appropriate to overall rc status
+
+# Shell functions sourced from /lib/lsb/init-functions:
+#      start_daemon
+#      killproc
+#      pidofproc
+#      log_success_msg
+#      log_failure_msg
+#      log_warning_msg
+. /lib/lsb/init-functions
+
+# Return values acc. to LSB for all commands but status:
+# 0 - success
+# 1 - generic or unspecified error
+# 2 - invalid or excess argument(s)
+# 3 - unimplemented feature (e.g. "reload")
+# 4 - insufficient privilege
+# 5 - program is not installed
+# 6 - program is not configured
+# 7 - program is not running
+#
+# Note that starting an already running service, stopping
+# or restarting a not-running service as well as the restart
+# with force-reload (in case signalling is not supported) are
+# considered a success.
+
+rc_reset
+
+if [ ! -x $AGENTPATH ]; then
+  echo "$AGENTPATH not found. Exiting."
+  exit 1
+fi
+
+if [ -r "/etc/default/${NAME}" ]; then
+  . "/etc/default/${NAME}"
+fi
+
+do_start() {
+  # If the Agent is already running, return success
+  checkproc $AGENTPATH
+  if [ "$?" -eq "0" ]; then
+    return 0
+  fi
+  startproc -f -q -p $PIDFILE $AGENTPATH $AGENT_ARGS
+}
+
+start_and_wait() {
+  # Start the Agent
+  do_start
+    case "$?" in
+    0) 
+      # Wait until the Agent is running
+      retries=5
+      while [ $retries -gt 1 ]; do
+        checkproc $AGENTPATH
+        if [ "$?" -eq "0" ]; then
+          # Successfully started. Start Process and Trace Agents
+          log_success_msg
+          service datadog-agent-process start
+          service datadog-agent-trace start
+          return 0
+        else
+          retries=$(($retries - 1))
+          sleep 1
+        fi
+      done
+      # Report an error if the Agent didn't start after 5 seconds
+      log_failure_msg
+      return 1
+      ;;
+    *)
+      # Report an error if the Agent didn't manage to start
+      log_failure_msg
+      return 1
+      ;;
+    esac
+}
+
+do_stop() {
+  checkproc $AGENTPATH
+  # If the Agent is not running, return success
+  if [ "$?" -eq "3" ]; then
+    return 0
+  fi
+  killproc -TERM -p $PIDFILE $AGENTPATH
+  RETVAL="$?"
+  rm -f $PIDFILE
+  return $RETVAL
+}
+
+stop_and_wait() {
+  # Stop the Agent
+  do_stop
+  case "$?" in
+    0)
+      # Successfully stopped. Stop Process and Trace Agents
+      log_success_msg
+      service datadog-agent-process stop
+      service datadog-agent-trace stop
+      return 0
+      ;;
+    *) 
+      # Report an error if the Agent didn't manage to stop
+      log_failure_msg 
+      return 1
+      ;;
+  esac
+}
+
+if [ ! -x $AGENTPATH ]; then
+  echo "$AGENTPATH not found. Exiting."
+  exit 1
+fi
+
+case "$1" in
+  start)
+    if [ "$DATADOG_ENABLED" = "no" ]; then
+      echo "Disabled via /etc/default/$NAME. Exiting."
+      exit 0
+    fi
+
+    echo -n "Starting $DESC"
+    start_and_wait
+    
+    # Remember error code for rc_exit
+    rc_status
+    ;;
+  stop)
+    echo -n "Shutting down $DESC"
+    stop_and_wait
+    
+    # Remember error code for rc_exit
+    rc_status
+    ;;
+  restart|reload)
+    ## Stop the service and regardless of whether it was
+    ## running or not, start it again.
+    $0 stop
+    $0 start
+
+    # Remember error code for rc_exit
+    rc_status
+    ;;
+  status)
+    echo -n "Checking for $DESC:"
+    # Status codes are slightly different for the checkproc command:
+    # 0 - service running
+    # 1 - service dead, but /var/run/  pid  file exists
+    # 2 - service dead, but /var/lock/ lock file exists
+    # 3 - service not running
+    checkproc $AGENTPATH
+
+    # Remember error code for rc_exit and print status
+    rc_status -v
+    ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start|stop|restart|reload|status}"
+    exit 1
+    ;;
+esac
+
+rc_exit

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
@@ -136,11 +136,6 @@ stop_and_wait() {
   esac
 }
 
-if [ ! -x $AGENTPATH ]; then
-  echo "$AGENTPATH not found. Exiting."
-  exit 1
-fi
-
 case "$1" in
   start)
     if [ "$DATADOG_ENABLED" = "no" ]; then

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
@@ -1,0 +1,188 @@
+#!/bin/sh
+
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides: datadog-agent-process
+# Short-Description: Start and stop datadog process agent
+# Description: Datadog Process Agent
+# Required-Start: $remote_fs
+# Required-Stop: $remote_fs
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+### END INIT INFO
+
+ETC_DIR="/etc/datadog-agent"
+INSTALL_DIR="/opt/datadog-agent"
+AGENTPATH="$INSTALL_DIR/embedded/bin/process-agent"
+PIDFILE="$INSTALL_DIR/run/process-agent.pid"
+AGENT_ARGS="--config=$ETC_DIR/datadog.yaml --pid=$PIDFILE"
+AGENT_USER="dd-agent"
+NAME="datadog-agent-process"
+DESC="Datadog Process Agent"
+
+# Shell functions sourced from /etc/rc.status (sourced by /lib/lsb/init-functions):
+#      rc_check         check and set local and overall rc status
+#      rc_status        check and set local and overall rc status
+#      rc_status -v     ditto but be verbose in local rc status
+#      rc_status -v -r  ditto and clear the local rc status
+#      rc_failed        set local and overall rc status to failed
+#      rc_failed <num>  set local and overall rc status to <num>
+#      rc_reset         clear local rc status (overall remains)
+#      rc_exit          exit appropriate to overall rc status
+
+# Shell functions sourced from /lib/lsb/init-functions:
+#      start_daemon
+#      killproc
+#      pidofproc
+#      log_success_msg
+#      log_failure_msg
+#      log_warning_msg
+. /lib/lsb/init-functions
+
+# Return values acc. to LSB for all commands but status:
+# 0 - success
+# 1 - generic or unspecified error
+# 2 - invalid or excess argument(s)
+# 3 - unimplemented feature (e.g. "reload")
+# 4 - insufficient privilege
+# 5 - program is not installed
+# 6 - program is not configured
+# 7 - program is not running
+#
+# Note that starting an already running service, stopping
+# or restarting a not-running service as well as the restart
+# with force-reload (in case signalling is not supported) are
+# considered a success.
+
+rc_reset
+
+if [ ! -x $AGENTPATH ]; then
+  echo "$AGENTPATH not found. Exiting."
+  exit 1
+fi
+
+if [ -r "/etc/default/${NAME}" ]; then
+  . "/etc/default/${NAME}"
+fi
+
+do_start() {
+  # If the Agent is already running, return success
+  checkproc $AGENTPATH
+  if [ "$?" -eq "0" ]; then
+    return 0
+  fi
+  startproc -f -q -p $PIDFILE $AGENTPATH $AGENT_ARGS
+}
+
+start_and_wait() {
+  # Start the Agent
+  do_start
+  case "$?" in
+    0)
+      # Wait until the Agent is running
+      retries=5
+      while [ $retries -gt 1 ]; do
+        checkproc $AGENTPATH
+        if [ "$?" -eq "0" ]; then
+          # Successfully started.
+          log_success_msg
+          return 0
+        else
+          retries=$(($retries - 1))
+          sleep 1
+        fi
+      done
+      # Report an error if the Agent didn't start after 5 seconds
+      log_failure_msg
+      return 1
+      ;;
+    *) 
+    # Report an error if the Agent didn't manage to start
+    log_failure_msg
+    return 1 
+    ;;
+  esac
+}
+
+do_stop() {
+  checkproc $AGENTPATH
+  # If the Agent is not running, return success
+  if [ "$?" -eq "3" ]; then
+    return 0
+  fi
+
+  killproc -TERM -p $PIDFILE $AGENTPATH
+  RETVAL="$?"
+  rm -f $PIDFILE
+  return $RETVAL
+}
+
+stop_and_wait() {
+  # Stop the Agent
+  do_stop
+  case "$?" in
+    0) 
+      # Successfully stopped.
+      log_success_msg 
+      return 0
+      ;;
+    *) 
+      # Report an error if the Agent didn't manage to stop
+      log_failure_msg 
+      return 1
+      ;;
+  esac
+}
+
+case "$1" in
+  start)
+    if [ "$DATADOG_ENABLED" = "no" ]; then
+      echo "Disabled via /etc/default/$NAME. Exiting."
+      exit 0
+    fi
+
+    echo -n "Starting $DESC"
+    start_and_wait
+    
+    # Remember error code for rc_exit
+    rc_status
+    ;;
+  stop)
+    echo -n "Shutting down $DESC"
+    stop_and_wait
+    
+    # Remember error code for rc_exit
+    rc_status
+    ;;
+  restart|reload)
+    ## Stop the service and regardless of whether it was
+    ## running or not, start it again.
+    $0 stop
+    $0 start
+
+    # Remember error code for rc_exit
+    rc_status
+    ;;
+  status)
+    echo -n "Checking for $DESC:"
+
+    # Status codes are slightly different for the status command:
+    # 0 - service running
+    # 1 - service dead, but /var/run/  pid  file exists
+    # 2 - service dead, but /var/lock/ lock file exists
+    # 3 - service not running
+    checkproc $AGENTPATH
+
+    # Remember error code for rc_exit and print status
+    rc_status -v
+    ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start|stop|restart|reload|status}"
+    exit 1
+    ;;
+esac
+
+rc_exit
+

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-#!/bin/sh
-
 ### BEGIN INIT INFO
 # Provides: datadog-agent-process
 # Short-Description: Start and stop datadog process agent

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
@@ -97,11 +97,11 @@ start_and_wait() {
       log_failure_msg
       return 1
       ;;
-    *) 
-    # Report an error if the Agent didn't manage to start
-    log_failure_msg
-    return 1 
-    ;;
+    *)
+      # Report an error if the Agent didn't manage to start
+      log_failure_msg
+      return 1
+      ;;
   esac
 }
 
@@ -167,7 +167,7 @@ case "$1" in
   status)
     echo -n "Checking for $DESC:"
 
-    # Status codes are slightly different for the status command:
+    # Status codes are slightly different for the checkproc command:
     # 0 - service running
     # 1 - service dead, but /var/run/  pid  file exists
     # 2 - service dead, but /var/lock/ lock file exists

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
@@ -95,11 +95,11 @@ start_and_wait() {
       log_failure_msg
       return 1
       ;;
-    *) 
-    # Report an error if the Agent didn't manage to start
-    log_failure_msg
-    return 1 
-    ;;
+    *)
+      # Report an error if the Agent didn't manage to start
+      log_failure_msg
+      return 1
+      ;;
   esac
 }
 
@@ -165,7 +165,7 @@ case "$1" in
   status)
     echo -n "Checking for $DESC:"
 
-    # Status codes are slightly different for the status command:
+    # Status codes are slightly different for the checkproc command:
     # 0 - service running
     # 1 - service dead, but /var/run/  pid  file exists
     # 2 - service dead, but /var/lock/ lock file exists

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
@@ -1,0 +1,185 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides: datadog-agent-trace
+# Short-Description: Start and stop datadog trace agent
+# Description: Datadog Trace Agent (APM)
+# Required-Start: $remote_fs
+# Required-Stop: $remote_fs
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+### END INIT INFO
+
+ETC_DIR="/etc/datadog-agent"
+INSTALL_DIR="/opt/datadog-agent"
+AGENTPATH="$INSTALL_DIR/embedded/bin/trace-agent"
+PIDFILE="$INSTALL_DIR/run/trace-agent.pid"
+AGENT_ARGS="--config=$ETC_DIR/datadog.yaml --pid=$PIDFILE"
+AGENT_USER="dd-agent"
+NAME="datadog-agent-trace"
+DESC="Datadog Trace Agent (APM)"
+
+# Shell functions sourced from /etc/rc.status (sourced by /lib/lsb/init-functions):
+#      rc_check         check and set local and overall rc status
+#      rc_status        check and set local and overall rc status
+#      rc_status -v     ditto but be verbose in local rc status
+#      rc_status -v -r  ditto and clear the local rc status
+#      rc_failed        set local and overall rc status to failed
+#      rc_failed <num>  set local and overall rc status to <num>
+#      rc_reset         clear local rc status (overall remains)
+#      rc_exit          exit appropriate to overall rc status
+
+# Shell functions sourced from /lib/lsb/init-functions:
+#      start_daemon
+#      killproc
+#      pidofproc
+#      log_success_msg
+#      log_failure_msg
+#      log_warning_msg
+. /lib/lsb/init-functions
+
+# Return values acc. to LSB for all commands but status:
+# 0 - success
+# 1 - generic or unspecified error
+# 2 - invalid or excess argument(s)
+# 3 - unimplemented feature (e.g. "reload")
+# 4 - insufficient privilege
+# 5 - program is not installed
+# 6 - program is not configured
+# 7 - program is not running
+#
+# Note that starting an already running service, stopping
+# or restarting a not-running service as well as the restart
+# with force-reload (in case signalling is not supported) are
+# considered a success.
+
+rc_reset
+
+if [ ! -x $AGENTPATH ]; then
+  echo "$AGENTPATH not found. Exiting."
+  exit 1
+fi
+
+if [ -r "/etc/default/${NAME}" ]; then
+  . "/etc/default/${NAME}"
+fi
+
+do_start() {
+  # If the Agent is already running, return success
+  checkproc $AGENTPATH
+  if [ "$?" -eq "0" ]; then
+    return 0
+  fi
+  startproc -f -q -p $PIDFILE $AGENTPATH $AGENT_ARGS
+}
+
+start_and_wait() {
+  # Start the Agent
+  do_start
+  case "$?" in
+    0)
+      # Wait until the Agent is running
+      retries=5
+      while [ $retries -gt 1 ]; do
+        checkproc $AGENTPATH
+        if [ "$?" -eq "0" ]; then
+          # Successfully started.
+          log_success_msg
+          return 0
+        else
+          retries=$(($retries - 1))
+          sleep 1
+        fi
+      done
+      # Report an error if the Agent didn't start after 5 seconds
+      log_failure_msg
+      return 1
+      ;;
+    *) 
+    # Report an error if the Agent didn't manage to start
+    log_failure_msg
+    return 1 
+    ;;
+  esac
+}
+
+do_stop() {
+  checkproc $AGENTPATH
+  # If the Agent is not running, return success
+  if [ "$?" -eq "3" ]; then
+    return 0
+  fi
+
+  killproc -TERM -p $PIDFILE $AGENTPATH
+  RETVAL="$?"
+  rm -f $PIDFILE
+  return $RETVAL
+}
+
+stop_and_wait() {
+  # Stop the Agent
+  do_stop
+  case "$?" in
+    0) 
+      # Successfully stopped.
+      log_success_msg 
+      return 0
+      ;;
+    *) 
+      # Report an error if the Agent didn't manage to stop
+      log_failure_msg 
+      return 1
+      ;;
+  esac
+}
+
+case "$1" in
+  start)
+    if [ "$DATADOG_ENABLED" = "no" ]; then
+      echo "Disabled via /etc/default/$NAME. Exiting."
+      exit 0
+    fi
+
+    echo -n "Starting $DESC"
+    start_and_wait
+    
+    # Remember error code for rc_exit
+    rc_status
+    ;;
+  stop)
+    echo -n "Shutting down $DESC"
+    stop_and_wait
+    
+    # Remember error code for rc_exit
+    rc_status
+    ;;
+  restart|reload)
+    ## Stop the service and regardless of whether it was
+    ## running or not, start it again.
+    $0 stop
+    $0 start
+
+    # Remember error code for rc_exit
+    rc_status
+    ;;
+  status)
+    echo -n "Checking for $DESC:"
+
+    # Status codes are slightly different for the status command:
+    # 0 - service running
+    # 1 - service dead, but /var/run/  pid  file exists
+    # 2 - service dead, but /var/lock/ lock file exists
+    # 3 - service not running
+    checkproc $AGENTPATH
+
+    # Remember error code for rc_exit and print status
+    rc_status -v
+    ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start|stop|restart|reload|status}"
+    exit 1
+    ;;
+esac
+
+rc_exit

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -11,6 +11,18 @@ INSTALL_DIR=/opt/datadog-agent
 CONFIG_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
 
+KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || grep -m1 -Eo $KNOWN_DISTRIBUTION /etc/os-release 2>/dev/null || uname -s)
+if [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "SUSE" ]; then
+    DISTRIBUTION_FAMILY="SUSE"
+fi
+
+if [ "$DISTRIBUTION_FAMILY" == "SUSE" ] && ! cat /etc/SuSE-release 2>/dev/null | grep VERSION | grep 11; then
+    rm -f /etc/init.d/datadog-agent*
+else
+    SYSVINIT_SUPPORT="yes"
+fi
+
 # Create a symlink to the agent's binary
 ln -sf $INSTALL_DIR/bin/agent/agent /usr/bin/datadog-agent
 
@@ -20,6 +32,10 @@ if command -v systemctl >/dev/null 2>&1; then
 elif command -v initctl >/dev/null 2>&1; then
     # start/stop policy is already defined in the upstart job file
     :
+elif command -v update-rc.d >/dev/null 2>&1; then
+    update-rc.d $SERVICE_NAME defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with update-rc.d"
+    update-rc.d $SERVICE_NAME-process defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with update-rc.d"
+    update-rc.d $SERVICE_NAME-trace defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with update-rc.d"
 else
     echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
 fi
@@ -32,6 +48,8 @@ if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
         systemctl restart $SERVICE_NAME || true
     elif command -v initctl >/dev/null 2>&1; then
         initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
+    elif [ "$SYSVINIT_SUPPORT" == "yes" ] && command -v service >/dev/null 2>&1; then
+        service $SERVICE_NAME restart || true
     else
         echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
     fi

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -17,10 +17,19 @@ if [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIB
     DISTRIBUTION_FAMILY="SUSE"
 fi
 
-if [ "$DISTRIBUTION_FAMILY" == "SUSE" ] && ! cat /etc/SuSE-release 2>/dev/null | grep VERSION | grep 11; then
-    rm -f /etc/init.d/datadog-agent*
-else
-    SYSVINIT_SUPPORT="yes"
+if [ "$DISTRIBUTION_FAMILY" == "SUSE" ]; then
+    # HACK: Check if we're running on SUSE 11. In that case, we support SysVInit scripts.
+    # Otherwise, remove the SysVInit files.
+    # This is necessary because, at least on SLES 15, the presence of these files makes systemd crash
+    # (even if they're not used) as it cannot process them (a package necessary to process them
+    # was removed from the base distribution).
+    if cat /etc/SuSE-release 2>/dev/null | grep VERSION | grep 11; then
+        SYSVINIT_SUPPORT="yes"
+    else
+        rm -f /etc/init.d/datadog-agent
+        rm -f /etc/init.d/datadog-agent-process
+        rm -f /etc/init.d/datadog-agent-trace
+    fi
 fi
 
 # Create a symlink to the agent's binary

--- a/releasenotes/notes/add-suse-sysvinit-support-b1d022717baf122f.yaml
+++ b/releasenotes/notes/add-suse-sysvinit-support-b1d022717baf122f.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for SysVInit on SUSE 11.


### PR DESCRIPTION
### What does this PR do?

Add SysVInit scripts for the SUSE Agent package.
[Hack] On SUSE 12+, these scripts are removed right after the package is installed, as on later systems (and in particular SUSE 15), the presence of these scripts make the `systemctl enable` step fail.

### Motivation

Support SysVInit on SUSE 11.

### Additional Notes

Not ready yet. Kitchen tests pass, but we don't have tests for SUSE 11.