### PR TITLE
Grant CAP_NET_BIND_SERVICE capability to the cluster_agent

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -35,6 +35,17 @@ RUN apt-get update \
 
 COPY --from=builder /output /
 
+# We need to set the NET_BIND_SERVICE capability to allow the cluster-agent to bind
+# port 443 for metrics provider.
+# And we need to do it here because capabilities set in `builder` stage are not kept
+# by the `COPY --from=builder`.
+RUN apt-get update \
+ && apt-get install -y libcap2-bin \
+ && setcap cap_net_bind_service+ep /opt/datadog-agent/bin/datadog-cluster-agent \
+ && apt-get remove -y libcap2-bin \
+ && apt-get autoremove -y \
+ && apt-get clean
+
 # Allow running as an unprivileged user:
 # - General case is the dd-agent user
 # - OpenShift uses a random UID in the root group

--- a/releasenotes-dca/notes/allow-cluster-agent-to-bind-443-63f4ff578678ef42.yaml
+++ b/releasenotes-dca/notes/allow-cluster-agent-to-bind-443-63f4ff578678ef42.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix issue when the cluster-agent tries to bind the ``metricsProvider`` port (443) while it is not started as root.


### PR DESCRIPTION
to allow it to bind the 443 port for metrics provider.