### PR TITLE
Make inventory intervals configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -565,7 +565,10 @@ func initConfig(config Config) {
 	config.SetKnown("apm_config.receiver_timeout")
 	config.SetKnown("apm_config.watchdog_check_delay")
 
+	// inventories
 	config.BindEnvAndSetDefault("inventories_enabled", true)
+	config.BindEnvAndSetDefault("inventories_max_interval", 600) // 10min
+	config.BindEnvAndSetDefault("inventories_min_interval", 300) // 5min
 
 	setAssetFs(config)
 }

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -5,16 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
-)
-
-const (
-	minSendInterval = 5 * time.Minute
-	maxSendInterval = 10 * time.Minute
 )
 
 type inventoriesCollector struct {
@@ -51,7 +47,7 @@ func (c inventoriesCollector) Send(s *serializer.Serializer) error {
 
 // Init initializes the inventory metadata collection
 func (c inventoriesCollector) Init() error {
-	return inventories.StartMetadataUpdatedGoroutine(c.sc, minSendInterval)
+	return inventories.StartMetadataUpdatedGoroutine(c.sc, config.Datadog.GetDuration("inventories_min_interval")*time.Second)
 }
 
 // SetupInventories registers the inventories collector into the Scheduler and, if configured, schedules it
@@ -63,7 +59,7 @@ func SetupInventories(sc *Scheduler, ac inventories.AutoConfigInterface, coll in
 	}
 	RegisterCollector("inventories", ic)
 
-	if err := sc.AddCollector("inventories", maxSendInterval); err != nil {
+	if err := sc.AddCollector("inventories", config.Datadog.GetDuration("inventories_max_interval")*time.Second); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?

Inventory metadata collection doesn't use fix interval to collect and
send data.
Instead inventory send data as soon as possible on update with at least
'inventories_min_interval' seconds between 2 push. The collector will
also resent data every 'inventories_max_interval' if the metadata hasn't
changed.