### PR TITLE
Make the agent retrieve the cloud instance-id from the kubelet

### DIFF
--- a/pkg/util/kubernetes/kubelet/json.go
+++ b/pkg/util/kubernetes/kubelet/json.go
@@ -101,3 +101,18 @@ func (pu *podUnmarshaller) filteringDecoder(ptr unsafe.Pointer, iter *jsoniter.I
 		return true
 	})
 }
+
+type kubeletSpecUnmarshaller struct {
+	jsonConfig jsoniter.API
+}
+
+func newKubeletSpecUnmarshaller() *kubeletSpecUnmarshaller {
+	return &kubeletSpecUnmarshaller{
+		jsonConfig: jsonConfig.Froze(),
+	}
+}
+
+// unmarshal is a drop-in replacement for json.Unmarshall
+func (ksu *kubeletSpecUnmarshaller) unmarshal(data []byte, v interface{}) error {
+	return ksu.jsonConfig.Unmarshal(data, v)
+}

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -420,7 +420,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 func (suite *PodwatcherTestSuite) TestPullChanges() {
 	mockConfig := config.Mock()
 
-	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
+	kubelet, err := newDummyKubelet("testdata/podlist_1.8-2.json", "testdata/spec.json")
 	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.StartTLS()
 	defer ts.Close()

--- a/pkg/util/kubernetes/kubelet/testdata/spec.json
+++ b/pkg/util/kubernetes/kubelet/testdata/spec.json
@@ -1,0 +1,100 @@
+{
+  "num_cores": 2,
+  "cpu_frequency_khz": 2300098,
+  "memory_capacity": 8358805504,
+  "hugepages": [
+   {
+    "page_size": 1048576,
+    "num_pages": 0
+   },
+   {
+    "page_size": 2048,
+    "num_pages": 0
+   }
+  ],
+  "machine_id": "f3fa05a976504e8c8ffcb34a89916d90",
+  "system_uuid": "ec2856b5-7a2c-88e8-8e73-bcba2855ea4c",
+  "boot_id": "bdab808d-5d4f-416e-82d3-2abe8a2b9940",
+  "filesystems": [
+   {
+    "device": "tmpfs",
+    "capacity": 4179402752,
+    "type": "vfs",
+    "inodes": 1020362,
+    "has_inodes": true
+   },
+   {
+    "device": "/dev/xvda3",
+    "capacity": 127762673664,
+    "type": "vfs",
+    "inodes": 62389184,
+    "has_inodes": true
+   },
+   {
+    "device": "/dev/xvda2",
+    "capacity": 1023303680,
+    "type": "vfs",
+    "inodes": 65536,
+    "has_inodes": true
+   }
+  ],
+  "disk_map": {
+   "202:0": {
+    "name": "xvda",
+    "major": 202,
+    "minor": 0,
+    "size": 128849018880,
+    "scheduler": "mq-deadline"
+   }
+  },
+  "network_devices": [
+   {
+    "name": "ens3",
+    "mac_address": "02:d5:8f:10:a3:95",
+    "speed": 10000,
+    "mtu": 9001
+   }
+  ],
+  "topology": [
+   {
+    "node_id": 0,
+    "memory": 8358805504,
+    "cores": [
+     {
+      "core_id": 0,
+      "thread_ids": [
+       0,
+       1
+      ],
+      "caches": [
+       {
+        "size": 32768,
+        "type": "Data",
+        "level": 1
+       },
+       {
+        "size": 32768,
+        "type": "Instruction",
+        "level": 1
+       },
+       {
+        "size": 262144,
+        "type": "Unified",
+        "level": 2
+       }
+      ]
+     }
+    ],
+    "caches": [
+     {
+      "size": 47185920,
+      "type": "Unified",
+      "level": 3
+     }
+    ]
+   }
+  ],
+  "cloud_provider": "AWS",
+  "instance_type": "m4.large",
+  "instance_id": "i-0df70970cfb000872"
+ }

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -146,3 +146,10 @@ type ContainerStateTerminated struct {
 	StartedAt  time.Time `json:"startedAt"`
 	FinishedAt time.Time `json:"finishedAt"`
 }
+
+// KubeletSpec contains fields for unmarshalling a Kubelet Spec
+type KubeletSpec struct {
+	CloudProvider string `json:"cloud_provider"`
+	InstanceType  string `json:"instance_type"`
+	InstanceId    string `json:"instance_id"`
+}

--- a/releasenotes/notes/instance-id-from-kubelet-6b986f987cbac154.yaml
+++ b/releasenotes/notes/instance-id-from-kubelet-6b986f987cbac154.yaml
@@ -1,0 +1,24 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Make the agent able to find the instance-id of the node through the kubelet API when the metadata server is unreachable.
+    This is needed to allow the agent to run without ``hostNetwork: true`` on setups where the metadata server (http://169.254.169.254) is blocked from inside PODs.
+
+    This change addresses the issue only on AWS.
+
+    +=====+============================================================================================+=========================+
+    |     | Before the change                                                                          | After the change        |
+    |     +=================================================================+==========================+=========================+
+    |     | ``hostNetwork: true``                                           | ``hostNetwork: false``   | ``hostNetwork: false``  |
+    +-----+=================================================================+==========================+=========================+
+    | AWS | ``i-036684b9df3b1464f``                                         | ``datadog-884wv``        | ``i-036684b9df3b1464f`` |
+    +-----+-----------------------------------------------------------------+--------------------------+-------------------------+
+    | GCE | ``0gke-lenaic-pool-1-1c8b424c-v5tl.c.datadog-sandbox.internal`` | ``datadog-8ztnf``        | ``datadog-8ztnf``       |
+    +-----+-----------------------------------------------------------------+--------------------------+-------------------------+


### PR DESCRIPTION
When the agent is started with `hostNetwork: true`, it is able to find the AWS/GCE instance-id
from the metadata agent (169.254.169.254).
When the agent is started with `hostNetwork: false`, that metadata agent should become unreachable for security reasons.
In that case, the current kubelet hostname provider tries to concatenate the node name with the cluster name.
This change makes the kubelet hostname provider first try to get the instance-id from the kubelet.