### PR TITLE
Temporarily fix go dependencies

### DIFF
--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,15 +1,15 @@
 {
     "deps": {
         "order": [
-            "golang.org/x/tools/go/ast/astutil",
-            "golang.org/x/tools/go/internal",
-            "golang.org/x/tools/go/gcexportdata",
             "golang.org/x/lint/golint",
             "github.com/fzipp/gocyclo",
             "github.com/gordonklaus/ineffassign",
             "github.com/client9/misspell/cmd/misspell",
             "github.com/golang/dep/cmd/dep",
-            "golang.org/x/mobile/cmd/gomobile"
+            "golang.org/x/mobile/cmd/gomobile",
+            "golang.org/x/tools/go/ast/astutil",
+            "golang.org/x/tools/go/internal",
+            "golang.org/x/tools/go/gcexportdata"
         ],
         "golang.org/x/tools/go/ast/astutil": {
             "version": "release-branch.go1.10",


### PR DESCRIPTION
### What does this PR do?

Change dependency order so that the bootstrap script does not fail anymore.

### Motivation

`gomobile` changed their dependencies 3 days ago, and adds a dependency  (`x/tools/go/packages`) we can't satisfy due to the current dependency order (`x/tools` is checked out on `release-branch.go1.10` first, which doesn't contain `packages`, causing `go get -d golang.org/x/mobile/cmd/gomobile` to fail).
 

### Additional Notes

We need to rework how we pin & get dependencies.