### PR TITLE
Use the current import paths for legacy redirects

### DIFF
--- a/cmd/agent/dist/checks/__init__.py
+++ b/cmd/agent/dist/checks/__init__.py
@@ -8,5 +8,5 @@
 # As long as we do not properly deprecate the legacy import path, they
 # should not be removed. For more details, see #4032 and #4421.
 
-from datadog_checks.checks import AgentCheck
-from datadog_checks.errors import CheckException
+from datadog_checks.base.checks import AgentCheck
+from datadog_checks.base.errors import CheckException

--- a/cmd/agent/dist/checks/libs/wmi/sampler.py
+++ b/cmd/agent/dist/checks/libs/wmi/sampler.py
@@ -24,4 +24,4 @@ Please refer to `checks.lib.wmi.counter_type` for more information*
 Original discussion thread: https://github.com/DataDog/dd-agent/issues/1952
 Credits to @TheCloudlessSky (https://github.com/TheCloudlessSky)
 """
-from datadog_checks.checks.win.wmi.sampler import WMISampler
+from datadog_checks.base.checks.win.wmi.sampler import WMISampler

--- a/cmd/agent/dist/checks/network_checks.py
+++ b/cmd/agent/dist/checks/network_checks.py
@@ -2,4 +2,4 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-2019 Datadog, Inc.
-from datadog_checks.checks import NetworkCheck, Status, EventType
+from datadog_checks.base.checks import NetworkCheck, Status, EventType

--- a/cmd/agent/dist/checks/prometheus_check/__init__.py
+++ b/cmd/agent/dist/checks/prometheus_check/__init__.py
@@ -1,6 +1,6 @@
 # (C) Datadog, Inc. 2016
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from datadog_checks.checks.prometheus import (
+from datadog_checks.base.checks.prometheus import (
     PrometheusCheck, PrometheusFormat, UnknownFormatError
 )

--- a/cmd/agent/dist/checks/winwmi_check.py
+++ b/cmd/agent/dist/checks/winwmi_check.py
@@ -2,6 +2,6 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-2019 Datadog, Inc.
-from datadog_checks.checks.win.wmi import (
+from datadog_checks.base.checks.win.wmi import (
     WinWMICheck, WMIMetric, MissingTagBy, from_time, to_time
 )

--- a/cmd/agent/dist/utils/containers.py
+++ b/cmd/agent/dist/utils/containers.py
@@ -2,4 +2,4 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-2019 Datadog, Inc.
-from datadog_checks.utils.containers import hash_mutable
+from datadog_checks.base.utils.containers import hash_mutable

--- a/cmd/agent/dist/utils/platform.py
+++ b/cmd/agent/dist/utils/platform.py
@@ -2,4 +2,4 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-2019 Datadog, Inc.
-from datadog_checks.utils.platform import Platform
+from datadog_checks.base.utils.platform import Platform

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -3,4 +3,4 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-2019 Datadog, Inc.
 
-from datadog_checks.utils.subprocess_output import get_subprocess_output
+from datadog_checks.base.utils.subprocess_output import get_subprocess_output

--- a/cmd/agent/dist/utils/tailfile.py
+++ b/cmd/agent/dist/utils/tailfile.py
@@ -2,4 +2,4 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-2019 Datadog, Inc.
-from datadog_checks.utils.tailfile import TailFile
+from datadog_checks.base.utils.tailfile import TailFile

--- a/cmd/agent/dist/utils/timeout.py
+++ b/cmd/agent/dist/utils/timeout.py
@@ -2,4 +2,4 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-2019 Datadog, Inc.
-from datadog_checks.utils.timeout import TimeoutException, timeout
+from datadog_checks.base.utils.timeout import TimeoutException, timeout


### PR DESCRIPTION
### Motivation

https://docs.datadoghq.com/agent/guide/python-3/#package-imports