### PR TITLE
[windows] Stop skipping flaky windows tests

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -409,7 +409,6 @@ end
 
 shared_examples_for 'an Agent that stops' do
   it 'stops' do
-    skip if os == :windows
     output = stop
     if os != :windows
       expect(output).to be_truthy
@@ -418,7 +417,6 @@ shared_examples_for 'an Agent that stops' do
   end
 
   it 'has connection refuse in the info command' do
-    skip if os == :windows
     if os == :windows
       expect(info).to include 'No connection could be made'
     else
@@ -427,12 +425,10 @@ shared_examples_for 'an Agent that stops' do
   end
 
   it 'is not running any agent processes' do
-    skip if os == :windows
     expect(agent_processes_running?).to be_falsey
   end
 
   it 'starts after being stopped' do
-    skip if os == :windows
     output = start
     if os != :windows
       expect(output).to be_truthy
@@ -467,7 +463,6 @@ end
 
 shared_examples_for 'an Agent with python3 enabled' do
   it 'restarts after python_version is set to 3' do
-    skip if os == :windows
     conf_path = ""
     if os != :windows
       conf_path = "/etc/datadog-agent/datadog.yaml"
@@ -484,7 +479,6 @@ shared_examples_for 'an Agent with python3 enabled' do
   end
 
   it 'runs Python 3 after python_version is set to 3' do
-    skip if os == :windows
     result = false
     python_version = fetch_python_version
     if ! python_version.nil? && Gem::Version.new('3.0.0') <= Gem::Version.new(python_version)
@@ -494,7 +488,6 @@ shared_examples_for 'an Agent with python3 enabled' do
   end
 
   it 'restarts after python_version is set back to 2' do
-    skip if os == :windows
     skip if info.include? "v7."
     conf_path = ""
     if os != :windows
@@ -512,7 +505,6 @@ shared_examples_for 'an Agent with python3 enabled' do
   end
 
   it 'runs Python 2 after python_version is set back to 2' do
-    skip if os == :windows
     skip if info.include? "v7."
     result = false
     python_version = fetch_python_version

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -56,6 +56,7 @@ def stop
   if os == :windows
     # forces the trace agent (and other dependent services) to stop
     result = system 'net stop /y datadogagent 2>&1'
+    sleep 5
   else
     if has_systemctl
       result = system 'sudo systemctl stop datadog-agent.service'
@@ -70,6 +71,7 @@ end
 def start
   if os == :windows
     result = system 'net start datadogagent 2>&1'
+    sleep 5
   else
     if has_systemctl
       result = system 'sudo systemctl start datadog-agent.service'
@@ -86,9 +88,11 @@ def restart
     # forces the trace agent (and other dependent services) to stop
     if is_running?
       result = system 'net stop /y datadogagent 2>&1'
+      sleep 5
       wait_until_stopped
     end
     result = system 'net start datadogagent 2>&1'
+    sleep 5
     wait_until_started
   else
     if has_systemctl


### PR DESCRIPTION
### What does this PR do?

Stops skipping some Windows tests because they were flaky during a release.
However, adds back some sleep on Windows starts / stops, it seems like the status can return that the process is started/stopped before it actually is.

### Motivation

Get back all kitchen tests in a running state.

### Additional notes

The fact that we still need sleeps may indicate that there is still a real problem with the Agent starts and stops from the service manager.