### PR TITLE
[logs] user is aware of the transport used by looking at the agent status

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -206,6 +206,12 @@
 
         Logs Agent is not running </br>
       {{- end }}
+      {{- if .endpoints }}
+
+        {{- range $endpoint := .endpoints }}
+          {{ $endpoint }}
+        {{- end }}
+      {{- end }}
       {{- if .metrics }}
 
         {{- range $metric_name, $metric_value := .metrics }}

--- a/pkg/logs/client/tcp/connection_manager_test.go
+++ b/pkg/logs/client/tcp/connection_manager_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
-	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
 func newConnectionManagerForAddr(addr net.Addr) *ConnectionManager {
@@ -36,7 +35,7 @@ func TestAddress(t *testing.T) {
 func TestNewConnection(t *testing.T) {
 	l := mock.NewMockLogsIntake(t)
 	defer l.Close()
-	status.CreateSources([]*config.LogSource{})
+	config.CreateSources([]*config.LogSource{})
 	destinationsCtx := client.NewDestinationsContext()
 
 	connManager := newConnectionManagerForAddr(l.Addr())

--- a/pkg/logs/config/test_utils.go
+++ b/pkg/logs/config/test_utils.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package config
+
+// ConsumeSources ensures that another component is consuming the channel to prevent
+// the producer to get stuck.
+func consumeSources(sources *LogSources) {
+	go func() {
+		sources := sources.GetAddedForType("foo")
+		for range sources {
+		}
+	}()
+}
+
+// CreateSources creates sources
+func CreateSources(sourcesArray []*LogSource) *LogSources {
+	logSources := NewLogSources()
+	for _, source := range sourcesArray {
+		logSources.AddSource(source)
+	}
+	consumeSources(logSources)
+	return logSources
+}

--- a/pkg/logs/input/file/file_provider_test.go
+++ b/pkg/logs/input/file/file_provider_test.go
@@ -77,7 +77,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 	path := fmt.Sprintf("%s/1/1.log", suite.testDir)
 	fileProvider := NewProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	status.CreateSources(logSources)
+	config.CreateSources(logSources)
 	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(1, len(files))
@@ -90,7 +90,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
 	fileProvider := NewProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	status.CreateSources(logSources)
+	status.InitStatus(config.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(3, len(files))
@@ -137,7 +137,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWi
 	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
 	fileProvider := NewProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	status.CreateSources(logSources)
+	config.CreateSources(logSources)
 	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(2, len(files))
@@ -152,7 +152,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard()
 	path := fmt.Sprintf("%s/1/?.log", suite.testDir)
 	fileProvider := NewProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	status.CreateSources(logSources)
+	status.InitStatus(config.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(3, len(files))
@@ -192,7 +192,7 @@ func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
 	fileProvider := NewProvider(suite.filesLimit)
 	logSources := suite.newLogSources(path)
-	status.CreateSources(logSources)
+	status.InitStatus(config.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
 	suite.Equal(suite.filesLimit, len(files))
 	suite.Equal([]string{"3 files tailed out of 5 files matching"}, logSources[0].Messages.GetMessages())
@@ -211,7 +211,7 @@ func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 		config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/1/*.log", suite.testDir)}),
 		config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: fmt.Sprintf("%s/2/*.log", suite.testDir)}),
 	}
-	status.CreateSources(logSources)
+	status.InitStatus(config.CreateSources(logSources))
 	files := fileProvider.FilesToTail(logSources)
 	suite.Equal(2, len(files))
 	suite.Equal([]string{"2 files tailed out of 3 files matching"}, logSources[0].Messages.GetMessages())

--- a/pkg/logs/input/file/scanner_test.go
+++ b/pkg/logs/input/file/scanner_test.go
@@ -63,7 +63,7 @@ func (suite *ScannerTestSuite) SetupTest() {
 	sleepDuration := 20 * time.Millisecond
 	suite.s = NewScanner(config.NewLogSources(), suite.openFilesLimit, suite.pipelineProvider, auditor.NewRegistry(), sleepDuration)
 	suite.s.activeSources = append(suite.s.activeSources, suite.source)
-	status.CreateSources([]*config.LogSource{suite.source})
+	status.InitStatus(config.CreateSources([]*config.LogSource{suite.source}))
 	suite.s.scan()
 }
 
@@ -216,7 +216,7 @@ func TestScannerScanStartNewTailer(t *testing.T) {
 	source := config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})
 	scanner.activeSources = append(scanner.activeSources, source)
 	status.Clear()
-	status.CreateSources([]*config.LogSource{source})
+	status.InitStatus(config.CreateSources([]*config.LogSource{source}))
 	defer status.Clear()
 
 	// create file
@@ -268,7 +268,7 @@ func TestScannerScanWithTooManyFiles(t *testing.T) {
 	source := config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})
 	scanner.activeSources = append(scanner.activeSources, source)
 	status.Clear()
-	status.CreateSources([]*config.LogSource{source})
+	status.InitStatus(config.CreateSources([]*config.LogSource{source}))
 	defer status.Clear()
 
 	// test at scan

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -8,8 +8,9 @@ package logs
 import (
 	"errors"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"sync/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -48,9 +49,6 @@ func Start() error {
 	// setup the config scheduler
 	adScheduler = scheduler.NewScheduler(sources, services)
 
-	// setup the status
-	status.Init(&isRunning, sources, metrics.LogsExpvars)
-
 	// setup the server config
 	endpoints, err := config.BuildEndpoints()
 	if err != nil {
@@ -58,6 +56,9 @@ func Start() error {
 		status.AddGlobalError(invalidEndpoints, message)
 		return errors.New(message)
 	}
+
+	// setup the status
+	status.Init(&isRunning, endpoints, sources, metrics.LogsExpvars)
 
 	// setup global processing rules
 	processingRules, err := config.GlobalProcessingRules()

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -37,6 +37,7 @@ type Integration struct {
 // Status provides some information about logs-agent.
 type Status struct {
 	IsRunning     bool             `json:"is_running"`
+	Endpoints     []string         `json:"endpoints"`
 	StatusMetrics map[string]int64 `json:"metrics"`
 	Integrations  []Integration    `json:"integrations"`
 	Errors        []string         `json:"errors"`
@@ -44,10 +45,10 @@ type Status struct {
 }
 
 // Init instantiates the builder that builds the status on the fly.
-func Init(isRunning *int32, sources *config.LogSources, logExpVars *expvar.Map) {
+func Init(isRunning *int32, endpoints *config.Endpoints, sources *config.LogSources, logExpVars *expvar.Map) {
 	warnings = config.NewMessages()
 	errors = config.NewMessages()
-	builder = NewBuilder(isRunning, sources, warnings, errors, logExpVars)
+	builder = NewBuilder(isRunning, endpoints, sources, warnings, errors, logExpVars)
 }
 
 // Clear clears the status which means it needs to be initialized again to be used.

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -16,17 +16,17 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
-func createSources() *config.LogSources {
-	return CreateSources([]*config.LogSource{
+func initStatus() {
+	InitStatus(config.CreateSources([]*config.LogSource{
 		config.NewLogSource("foo", &config.LogsConfig{Type: "foo"}),
 		config.NewLogSource("bar", &config.LogsConfig{Type: "foo"}),
 		config.NewLogSource("foo", &config.LogsConfig{Type: "foo"}),
-	})
+	}))
 }
 
 func TestSourceAreGroupedByIntegrations(t *testing.T) {
 	defer Clear()
-	createSources()
+	initStatus()
 
 	status := Get()
 	assert.Equal(t, true, status.IsRunning)
@@ -46,7 +46,7 @@ func TestSourceAreGroupedByIntegrations(t *testing.T) {
 
 func TestStatusDeduplicateWarnings(t *testing.T) {
 	defer Clear()
-	createSources()
+	initStatus()
 
 	AddGlobalWarning("bar", "Unique Warning")
 	AddGlobalWarning("foo", "Identical Warning")
@@ -63,7 +63,7 @@ func TestStatusDeduplicateWarnings(t *testing.T) {
 
 func TestStatusDeduplicateErrors(t *testing.T) {
 	defer Clear()
-	createSources()
+	initStatus()
 
 	AddGlobalError("bar", "Unique Error")
 	AddGlobalError("foo", "Identical Error")
@@ -75,7 +75,7 @@ func TestStatusDeduplicateErrors(t *testing.T) {
 
 func TestStatusDeduplicateErrorsAndWarnings(t *testing.T) {
 	defer Clear()
-	createSources()
+	initStatus()
 
 	AddGlobalWarning("bar", "Unique Warning")
 	AddGlobalWarning("foo", "Identical Warning")
@@ -95,7 +95,7 @@ func TestMetrics(t *testing.T) {
 	var expected = `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "", "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": ""}`
 	assert.Equal(t, expected, metrics.LogsExpvars.String())
 
-	createSources()
+	initStatus()
 	AddGlobalWarning("bar", "Unique Warning")
 	AddGlobalError("bar", "I am an error")
 	expected = `{"BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "I am an error", "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": "Unique Warning"}`
@@ -104,7 +104,7 @@ func TestMetrics(t *testing.T) {
 
 func TestStatusMetrics(t *testing.T) {
 	defer Clear()
-	createSources()
+	initStatus()
 
 	status := Get()
 	assert.Equal(t, int64(0), status.StatusMetrics["LogsProcessed"])

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -128,3 +128,11 @@ func TestStatusMetrics(t *testing.T) {
 	status = Get()
 	assert.Equal(t, int64(math.MinInt64), status.StatusMetrics["LogsProcessed"])
 }
+
+func TestStatusEndpoints(t *testing.T) {
+	defer Clear()
+	initStatus()
+
+	status := Get()
+	assert.Equal(t, "Sending uncompressed logs in SSL encrypted TCP to agent-intake.logs.datadoghq.com on port 10516", status.Endpoints[0])
+}

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -13,5 +13,6 @@ import (
 // InitStatus initialize a status builder
 func InitStatus(sources *config.LogSources) {
 	var isRunning int32 = 1
-	Init(&isRunning, sources, metrics.LogsExpvars)
+	endpoints, _ := config.BuildEndpoints()
+	Init(&isRunning, endpoints, sources, metrics.LogsExpvars)
 }

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -10,25 +10,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
-// ConsumeSources ensures that another component is consuming the channel to prevent
-// the producer to get stuck.
-func ConsumeSources(sources *config.LogSources) {
-	go func() {
-		sources := sources.GetAddedForType("foo")
-		for range sources {
-		}
-	}()
-}
-
-// CreateSources creates sources and initialize a status builder
-func CreateSources(sourcesArray []*config.LogSource) *config.LogSources {
-	logSources := config.NewLogSources()
-	for _, source := range sourcesArray {
-		logSources.AddSource(source)
-	}
-	ConsumeSources(logSources)
+// InitStatus initialize a status builder
+func InitStatus(sources *config.LogSources) {
 	var isRunning int32 = 1
-	Init(&isRunning, logSources, metrics.LogsExpvars)
-
-	return logSources
+	Init(&isRunning, sources, metrics.LogsExpvars)
 }

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -10,6 +10,13 @@ Logs Agent
   Logs Agent is not running
 {{- end }}
 
+{{- if .endpoints }}
+
+  {{- range $endpoint := .endpoints }}
+    {{ $endpoint }}
+  {{- end }}
+{{- end }}
+
 {{- if .metrics }}
 
   {{- range $metric_name, $metric_value := .metrics }}

--- a/releasenotes/notes/logs-add-endpoints-information-in-the-agent-status-6b2029d38e35c0c7.yaml
+++ b/releasenotes/notes/logs-add-endpoints-information-in-the-agent-status-6b2029d38e35c0c7.yaml
@@ -1,0 +1,5 @@
+
+---
+features:
+  - |
+    Add information on endpoints inside the logs-agent section of the agent status.


### PR DESCRIPTION
### What does this PR do?

When running the Agent status we should have the following:
```
==========
Logs Agent
==========
    Sending <COMPRESSION_MODE> logs in <PROTOCOL> to <ENDPOINT> on port <PORT>
    
    LogsProcessed: 310804
    LogsSent: 310788
```

With:
`<COMPRESSION_MODE>`: compressed or uncompressed
`<PROTOCOL>`: SSL encrypted TCP or HTTPS
`<ENDPOINT>`: endpoint
`<PORT>`: Port used

### Motivation

Better visibility on the logs configuration for the user

### Additional Notes

Anything else we should know when reviewing?
