### PR TITLE
[github] Change releasenotes and releasenotes-dca owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,6 +76,9 @@
 /pkg/procmatch/                         @DataDog/burrito
 /pkg/quantile                           @DataDog/metrics-aggregation
 
+/releasenotes/                          @DataDog/agent-all
+/releasenotes-dca/                      @DataDog/agent-all
+
 /rtloader/                              @DataDog/agent-core
 
 /tasks/                                 @DataDog/agent-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,7 +77,7 @@
 /pkg/quantile                           @DataDog/metrics-aggregation
 
 /releasenotes/                          @DataDog/agent-all
-/releasenotes-dca/                      @DataDog/agent-all
+/releasenotes-dca/                      @DataDog/container-integrations
 
 /rtloader/                              @DataDog/agent-core
 


### PR DESCRIPTION
### What does this PR do?

Changes code owner of `/releasenotes/` to `@DataDog/agent-all`, which contains all Agent teams.
Changes code owner of `/releasenotes-dca/` to `@DataDog/container-integrations`.

### Motivation

Release notes changes should not be blocked on a single team, any Agent team should be able to approve them.
