### PR TITLE
[omnibus] Use erb template vars in SysVInit scripts

### DIFF
--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
@@ -14,7 +14,7 @@
 
 . /lib/lsb/init-functions
 
-INSTALL_DIR="/opt/datadog-agent"
+INSTALL_DIR="<%= install_dir %>"
 AGENTPATH="$INSTALL_DIR/bin/agent/agent"
 PIDFILE="$INSTALL_DIR/run/agent.pid"
 AGENT_ARGS="run -p $PIDFILE"

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.process.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.process.erb
@@ -12,8 +12,8 @@
 
 . /lib/lsb/init-functions
 
-ETC_DIR="/etc/datadog-agent"
-INSTALL_DIR="/opt/datadog-agent"
+ETC_DIR="<%= etc_dir %>"
+INSTALL_DIR="<%= install_dir %>"
 AGENTPATH="$INSTALL_DIR/embedded/bin/process-agent"
 PIDFILE="$INSTALL_DIR/run/process-agent.pid"
 AGENT_ARGS="--config=$ETC_DIR/datadog.yaml --pid=$PIDFILE"

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.trace.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.trace.erb
@@ -12,8 +12,8 @@
 
 . /lib/lsb/init-functions
 
-ETC_DIR="/etc/datadog-agent"
-INSTALL_DIR="/opt/datadog-agent"
+ETC_DIR="<%= etc_dir %>"
+INSTALL_DIR="<%= install_dir %>"
 AGENTPATH="$INSTALL_DIR/embedded/bin/trace-agent"
 PIDFILE="$INSTALL_DIR/run/trace-agent.pid"
 AGENT_ARGS="--config=$ETC_DIR/datadog.yaml --pid=$PIDFILE"

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
@@ -10,7 +10,7 @@
 # Default-Stop: 0 1 6
 ### END INIT INFO
 
-INSTALL_DIR="/opt/datadog-agent"
+INSTALL_DIR="<%= install_dir %>"
 AGENTPATH="$INSTALL_DIR/bin/agent/agent"
 PIDFILE="$INSTALL_DIR/run/agent.pid"
 AGENT_ARGS="run -p $PIDFILE"

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
@@ -10,8 +10,8 @@
 # Default-Stop: 0 1 6
 ### END INIT INFO
 
-ETC_DIR="/etc/datadog-agent"
-INSTALL_DIR="/opt/datadog-agent"
+ETC_DIR="<%= etc_dir %>"
+INSTALL_DIR="<%= install_dir %>"
 AGENTPATH="$INSTALL_DIR/embedded/bin/process-agent"
 PIDFILE="$INSTALL_DIR/run/process-agent.pid"
 AGENT_ARGS="--config=$ETC_DIR/datadog.yaml --pid=$PIDFILE"

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
@@ -10,8 +10,8 @@
 # Default-Stop: 0 1 6
 ### END INIT INFO
 
-ETC_DIR="/etc/datadog-agent"
-INSTALL_DIR="/opt/datadog-agent"
+ETC_DIR="<%= etc_dir %>"
+INSTALL_DIR="<%= install_dir %>"
 AGENTPATH="$INSTALL_DIR/embedded/bin/trace-agent"
 PIDFILE="$INSTALL_DIR/run/trace-agent.pid"
 AGENT_ARGS="--config=$ETC_DIR/datadog.yaml --pid=$PIDFILE"


### PR DESCRIPTION

### What does this PR do?

Make use of the `etc_dir` and `install_dir` template variables provided to the service template files.

### Motivation

We use erb templates for our service scripts, and we provide two vars (`etc_dir` and `install_dir`), which are useful if we want to change the installation or config directories and still have working scripts.
However, we didn't use them in the SysVInit scripts (the etc and install directories were hardcoded in the service files).

