### PR TITLE
use kernel version instead of RHEL OS to switch between kprobe calls

### DIFF
--- a/pkg/ebpf/c/tracer-ebpf.c
+++ b/pkg/ebpf/c/tracer-ebpf.c
@@ -522,8 +522,8 @@ int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     return handle_message(&t, size, 0);
 }
 
-SEC("kprobe/tcp_sendmsg/rhel")
-int kprobe__tcp_sendmsg__rhel(struct pt_regs* ctx) {
+SEC("kprobe/tcp_sendmsg/old")
+int kprobe__tcp_sendmsg__old(struct pt_regs* ctx) {
     struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
     size_t size = (size_t)PT_REGS_PARM4(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -533,7 +533,7 @@ int kprobe__tcp_sendmsg__rhel(struct pt_regs* ctx) {
     if (status == NULL) {
         return 0;
     }
-    log_debug("kprobe/tcp_sendmsg/rhel: pid_tgid: %d, size: %d\n", pid_tgid, size);
+    log_debug("kprobe/tcp_sendmsg/old: pid_tgid: %d, size: %d\n", pid_tgid, size);
 
     conn_tuple_t t = {};
     if (!read_conn_tuple(&t, status, sk, pid_tgid, CONN_TYPE_TCP)) {
@@ -663,8 +663,8 @@ int kprobe__udp_sendmsg(struct pt_regs* ctx) {
     return 0;
 }
 
-SEC("kprobe/udp_sendmsg/rhel")
-int kprobe__udp_sendmsg__rhel(struct pt_regs* ctx) {
+SEC("kprobe/udp_sendmsg/old")
+int kprobe__udp_sendmsg__old(struct pt_regs* ctx) {
     struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
     size_t size = (size_t)PT_REGS_PARM4(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -680,7 +680,7 @@ int kprobe__udp_sendmsg__rhel(struct pt_regs* ctx) {
         return 0;
     }
 
-    log_debug("kprobe/udp_sendmsg/rhel: pid_tgid: %d, size: %d\n", pid_tgid, size);
+    log_debug("kprobe/udp_sendmsg/old: pid_tgid: %d, size: %d\n", pid_tgid, size);
     handle_message(&t, size, 0);
 
     return 0;
@@ -705,14 +705,14 @@ int kprobe__udp_recvmsg(struct pt_regs* ctx) {
     return 0;
 }
 
-SEC("kprobe/udp_recvmsg/rhel")
-int kprobe__udp_recvmsg_rhel(struct pt_regs* ctx) {
+SEC("kprobe/udp_recvmsg/old")
+int kprobe__udp_recvmsg_old(struct pt_regs* ctx) {
     struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
 
     // Store pointer to the socket using the pid/tgid
     bpf_map_update_elem(&udp_recv_sock, &pid_tgid, &sk, BPF_ANY);
-    log_debug("kprobe/udp_recvmsg/rhel: pid_tgid: %d\n", pid_tgid);
+    log_debug("kprobe/udp_recvmsg/old: pid_tgid: %d\n", pid_tgid);
 
     return 0;
 }

--- a/pkg/ebpf/c/tracer-ebpf.c
+++ b/pkg/ebpf/c/tracer-ebpf.c
@@ -522,8 +522,8 @@ int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     return handle_message(&t, size, 0);
 }
 
-SEC("kprobe/tcp_sendmsg/old")
-int kprobe__tcp_sendmsg__old(struct pt_regs* ctx) {
+SEC("kprobe/tcp_sendmsg/pre_4_1_0")
+int kprobe__tcp_sendmsg__pre_4_1_0(struct pt_regs* ctx) {
     struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
     size_t size = (size_t)PT_REGS_PARM4(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -533,7 +533,7 @@ int kprobe__tcp_sendmsg__old(struct pt_regs* ctx) {
     if (status == NULL) {
         return 0;
     }
-    log_debug("kprobe/tcp_sendmsg/old: pid_tgid: %d, size: %d\n", pid_tgid, size);
+    log_debug("kprobe/tcp_sendmsg/pre_4_1_0: pid_tgid: %d, size: %d\n", pid_tgid, size);
 
     conn_tuple_t t = {};
     if (!read_conn_tuple(&t, status, sk, pid_tgid, CONN_TYPE_TCP)) {
@@ -663,8 +663,8 @@ int kprobe__udp_sendmsg(struct pt_regs* ctx) {
     return 0;
 }
 
-SEC("kprobe/udp_sendmsg/old")
-int kprobe__udp_sendmsg__old(struct pt_regs* ctx) {
+SEC("kprobe/udp_sendmsg/pre_4_1_0")
+int kprobe__udp_sendmsg__pre_4_1_0(struct pt_regs* ctx) {
     struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
     size_t size = (size_t)PT_REGS_PARM4(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -680,7 +680,7 @@ int kprobe__udp_sendmsg__old(struct pt_regs* ctx) {
         return 0;
     }
 
-    log_debug("kprobe/udp_sendmsg/old: pid_tgid: %d, size: %d\n", pid_tgid, size);
+    log_debug("kprobe/udp_sendmsg/pre_4_1_0: pid_tgid: %d, size: %d\n", pid_tgid, size);
     handle_message(&t, size, 0);
 
     return 0;
@@ -705,14 +705,14 @@ int kprobe__udp_recvmsg(struct pt_regs* ctx) {
     return 0;
 }
 
-SEC("kprobe/udp_recvmsg/old")
-int kprobe__udp_recvmsg_old(struct pt_regs* ctx) {
+SEC("kprobe/udp_recvmsg/pre_4_1_0")
+int kprobe__udp_recvmsg_pre_4_1_0(struct pt_regs* ctx) {
     struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
 
     // Store pointer to the socket using the pid/tgid
     bpf_map_update_elem(&udp_recv_sock, &pid_tgid, &sk, BPF_ANY);
-    log_debug("kprobe/udp_recvmsg/old: pid_tgid: %d\n", pid_tgid);
+    log_debug("kprobe/udp_recvmsg/pre_4_1_0: pid_tgid: %d\n", pid_tgid);
 
     return 0;
 }

--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -32,9 +32,6 @@ var (
 	ErrNotImplemented = errors.New("BPF-based system probe not implemented on non-linux systems")
 
 	nativeEndian binary.ByteOrder
-	// newAPIKernelVersion indicates the minimum version of kernel that uses the new API signature
-	// the affected APIs are kprobe/tcp_sendmsg, kprobe/udp_sendmsg, kprobe/udp_recvmsg
-	newAPIKernelVersion = "4.1.0"
 )
 
 func kernelCodeToString(code uint32) string {
@@ -185,8 +182,7 @@ func isRHELOrCentOS() (bool, error) {
 	return isCentOS(platform) || isRHEL(platform), nil
 }
 
-// hasOldKernelAPI compares current kernel version to the minimum kernel version that uses the new API
-func hasOldKernelAPI(currentKernelCode uint32) bool {
-	code := stringToKernelCode(newAPIKernelVersion)
-	return currentKernelCode < code
+// isPre410Kernel compares current kernel version to the minimum kernel version(4.1.0) and see if it's older
+func isPre410Kernel(currentKernelCode uint32) bool {
+	return currentKernelCode < stringToKernelCode("4.1.0")
 }

--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -32,6 +32,9 @@ var (
 	ErrNotImplemented = errors.New("BPF-based system probe not implemented on non-linux systems")
 
 	nativeEndian binary.ByteOrder
+	// newAPIKernelVersion indicates the minimum version of kernel that uses the new API signature
+	// the affected APIs are kprobe/tcp_sendmsg, kprobe/udp_sendmsg, kprobe/udp_recvmsg
+	newAPIKernelVersion = "4.1.0"
 )
 
 func kernelCodeToString(code uint32) string {
@@ -180,4 +183,10 @@ func isRHELOrCentOS() (bool, error) {
 		return false, err
 	}
 	return isCentOS(platform) || isRHEL(platform), nil
+}
+
+// hasOldKernelAPI compares current kernel version to the minimum kernel version that uses the new API
+func hasOldKernelAPI(currentKernelCode uint32) bool {
+	code := stringToKernelCode(newAPIKernelVersion)
+	return currentKernelCode < code
 }

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -85,6 +85,17 @@ func TestVerifyKernelFuncs(t *testing.T) {
 	assert.NotEmpty(t, err)
 }
 
+func TestHasOldKernelAPI(t *testing.T) {
+	oldKernels := []string{"3.10.0", "2.5.0", "4.0.10", "4.0"}
+	for _, kernel := range oldKernels {
+		assert.True(t, hasOldKernelAPI(stringToKernelCode(kernel)))
+	}
+	newKernels := []string{"4.1.0", "4.10.2", "4.1", "5.1"}
+	for _, kernel := range newKernels {
+		assert.False(t, hasOldKernelAPI(stringToKernelCode(kernel)))
+	}
+}
+
 func TestIsCentOS(t *testing.T) {
 	// python -m platform
 	assert.True(t, isCentOS("Linux-3.10.0-957.21.3.el7.x86_64-x86_64-with-centos-7.6.1810-Core"))

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -85,14 +85,14 @@ func TestVerifyKernelFuncs(t *testing.T) {
 	assert.NotEmpty(t, err)
 }
 
-func TestHasOldKernelAPI(t *testing.T) {
+func TestHasPre410Kernel(t *testing.T) {
 	oldKernels := []string{"3.10.0", "2.5.0", "4.0.10", "4.0"}
 	for _, kernel := range oldKernels {
-		assert.True(t, hasOldKernelAPI(stringToKernelCode(kernel)))
+		assert.True(t, isPre410Kernel(stringToKernelCode(kernel)))
 	}
 	newKernels := []string{"4.1.0", "4.10.2", "4.1", "5.1"}
 	for _, kernel := range newKernels {
-		assert.False(t, hasOldKernelAPI(stringToKernelCode(kernel)))
+		assert.False(t, isPre410Kernel(stringToKernelCode(kernel)))
 	}
 }
 

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -97,12 +97,12 @@ func NewDefaultConfig() *Config {
 
 // EnabledKProbes returns a map of kprobes that are enabled per config settings.
 // This map does not include the probes used exclusively in the offset guessing process.
-func (c *Config) EnabledKProbes(isRHELOrCentOS bool) map[KProbeName]struct{} {
+func (c *Config) EnabledKProbes(isOldKernel bool) map[KProbeName]struct{} {
 	enabled := make(map[KProbeName]struct{}, 0)
 
 	if c.CollectTCPConns {
-		if isRHELOrCentOS {
-			enabled[TCPSendMsgRHEL] = struct{}{}
+		if isOldKernel {
+			enabled[TCPSendMsgOld] = struct{}{}
 		} else {
 			enabled[TCPSendMsg] = struct{}{}
 		}
@@ -119,9 +119,9 @@ func (c *Config) EnabledKProbes(isRHELOrCentOS bool) map[KProbeName]struct{} {
 
 	if c.CollectUDPConns {
 		enabled[UDPRecvMsgReturn] = struct{}{}
-		if isRHELOrCentOS {
-			enabled[UDPSendMsgRHEL] = struct{}{}
-			enabled[UDPRecvMsgRHEL] = struct{}{}
+		if isOldKernel {
+			enabled[UDPSendMsgOld] = struct{}{}
+			enabled[UDPRecvMsgOld] = struct{}{}
 		} else {
 			enabled[UDPRecvMsg] = struct{}{}
 			enabled[UDPSendMsg] = struct{}{}

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -97,12 +97,12 @@ func NewDefaultConfig() *Config {
 
 // EnabledKProbes returns a map of kprobes that are enabled per config settings.
 // This map does not include the probes used exclusively in the offset guessing process.
-func (c *Config) EnabledKProbes(isOldKernel bool) map[KProbeName]struct{} {
+func (c *Config) EnabledKProbes(pre410Kernel bool) map[KProbeName]struct{} {
 	enabled := make(map[KProbeName]struct{}, 0)
 
 	if c.CollectTCPConns {
-		if isOldKernel {
-			enabled[TCPSendMsgOld] = struct{}{}
+		if pre410Kernel {
+			enabled[TCPSendMsgPre410] = struct{}{}
 		} else {
 			enabled[TCPSendMsg] = struct{}{}
 		}
@@ -119,9 +119,9 @@ func (c *Config) EnabledKProbes(isOldKernel bool) map[KProbeName]struct{} {
 
 	if c.CollectUDPConns {
 		enabled[UDPRecvMsgReturn] = struct{}{}
-		if isOldKernel {
-			enabled[UDPSendMsgOld] = struct{}{}
-			enabled[UDPRecvMsgOld] = struct{}{}
+		if pre410Kernel {
+			enabled[UDPSendMsgPre410] = struct{}{}
+			enabled[UDPRecvMsgPre410] = struct{}{}
 		} else {
 			enabled[UDPRecvMsg] = struct{}{}
 			enabled[UDPSendMsg] = struct{}{}

--- a/pkg/ebpf/types.go
+++ b/pkg/ebpf/types.go
@@ -17,9 +17,9 @@ const (
 	// TCPSendMsg traces the tcp_sendmsg() system call
 	TCPSendMsg KProbeName = "kprobe/tcp_sendmsg"
 
-	// TCPSendMsgRHEL traces the tcp_sendmsg() system call on CentOS and RHEL. This is created because
+	// TCPSendMsgOld traces the tcp_sendmsg() system call on kernels prior to 4.1. This is created because
 	// we need to load a different kprobe implementation
-	TCPSendMsgRHEL KProbeName = "kprobe/tcp_sendmsg/rhel"
+	TCPSendMsgOld KProbeName = "kprobe/tcp_sendmsg/old"
 
 	// TCPSendMsgReturn traces the return value for the tcp_sendmsg() system call
 	// XXX: This is only used for telemetry for now to count the number of errors returned
@@ -37,12 +37,12 @@ const (
 
 	// UDPSendMsg traces the udp_sendmsg() system call
 	UDPSendMsg KProbeName = "kprobe/udp_sendmsg"
-	// UDPSendMsgRHEL traces the udp_sendmsg() system call on RHEL and CentOS.
-	UDPSendMsgRHEL KProbeName = "kprobe/udp_sendmsg/rhel"
+	// UDPSendMsgOld traces the udp_sendmsg() system call on kernels prior to 4.1
+	UDPSendMsgOld KProbeName = "kprobe/udp_sendmsg/old"
 	// UDPRecvMsg traces the udp_recvmsg() system call
 	UDPRecvMsg KProbeName = "kprobe/udp_recvmsg"
-	// UDPRecvMsgRHEL traces the udp_recvmsg() system call on RHEL and CentOS.
-	UDPRecvMsgRHEL KProbeName = "kprobe/udp_recvmsg/rhel"
+	// UDPRecvMsgOld traces the udp_recvmsg() system call on kernels prior to 4.1
+	UDPRecvMsgOld KProbeName = "kprobe/udp_recvmsg/old"
 	// UDPRecvMsgReturn traces the return value for the udp_recvmsg() system call
 	UDPRecvMsgReturn KProbeName = "kretprobe/udp_recvmsg"
 
@@ -75,8 +75,8 @@ var (
 	// kprobeOverrides specifies a mapping between sections in our kprobe functions and
 	// the actual eBPF function that it should bind to
 	kprobeOverrides = map[KProbeName]KProbeName{
-		TCPSendMsgRHEL: TCPSendMsg,
-		UDPSendMsgRHEL: UDPSendMsg,
-		UDPRecvMsgRHEL: UDPRecvMsg,
+		TCPSendMsgOld: TCPSendMsg,
+		UDPSendMsgOld: UDPSendMsg,
+		UDPRecvMsgOld: UDPRecvMsg,
 	}
 )

--- a/pkg/ebpf/types.go
+++ b/pkg/ebpf/types.go
@@ -17,9 +17,9 @@ const (
 	// TCPSendMsg traces the tcp_sendmsg() system call
 	TCPSendMsg KProbeName = "kprobe/tcp_sendmsg"
 
-	// TCPSendMsgOld traces the tcp_sendmsg() system call on kernels prior to 4.1. This is created because
+	// TCPSendMsgPre410 traces the tcp_sendmsg() system call on kernels prior to 4.1.0. This is created because
 	// we need to load a different kprobe implementation
-	TCPSendMsgOld KProbeName = "kprobe/tcp_sendmsg/old"
+	TCPSendMsgPre410 KProbeName = "kprobe/tcp_sendmsg/pre_4_1_0"
 
 	// TCPSendMsgReturn traces the return value for the tcp_sendmsg() system call
 	// XXX: This is only used for telemetry for now to count the number of errors returned
@@ -37,12 +37,12 @@ const (
 
 	// UDPSendMsg traces the udp_sendmsg() system call
 	UDPSendMsg KProbeName = "kprobe/udp_sendmsg"
-	// UDPSendMsgOld traces the udp_sendmsg() system call on kernels prior to 4.1
-	UDPSendMsgOld KProbeName = "kprobe/udp_sendmsg/old"
+	// UDPSendMsgPre410 traces the udp_sendmsg() system call on kernels prior to 4.1.0
+	UDPSendMsgPre410 KProbeName = "kprobe/udp_sendmsg/pre_4_1_0"
 	// UDPRecvMsg traces the udp_recvmsg() system call
 	UDPRecvMsg KProbeName = "kprobe/udp_recvmsg"
-	// UDPRecvMsgOld traces the udp_recvmsg() system call on kernels prior to 4.1
-	UDPRecvMsgOld KProbeName = "kprobe/udp_recvmsg/old"
+	// UDPRecvMsgPre410 traces the udp_recvmsg() system call on kernels prior to 4.1.0
+	UDPRecvMsgPre410 KProbeName = "kprobe/udp_recvmsg/pre_4_1_0"
 	// UDPRecvMsgReturn traces the return value for the udp_recvmsg() system call
 	UDPRecvMsgReturn KProbeName = "kretprobe/udp_recvmsg"
 
@@ -75,8 +75,8 @@ var (
 	// kprobeOverrides specifies a mapping between sections in our kprobe functions and
 	// the actual eBPF function that it should bind to
 	kprobeOverrides = map[KProbeName]KProbeName{
-		TCPSendMsgOld: TCPSendMsg,
-		UDPSendMsgOld: UDPSendMsg,
-		UDPRecvMsgOld: UDPRecvMsg,
+		TCPSendMsgPre410: TCPSendMsg,
+		UDPSendMsgPre410: UDPSendMsg,
+		UDPRecvMsgPre410: UDPRecvMsg,
 	}
 )


### PR DESCRIPTION
### What does this PR do?

For CentOS 8 the kernel uses new API which breaks our previous check. This PR updates the check to not rely on OS distro but kernel version instead. 
cc: @DataDog/burrito 

### Motivation

CentOS 8 fix.

### Additional Notes

Anything else we should know when reviewing?
