### PR TITLE
Fix set_external_tags: two calls of _free(hostname)

### DIFF
--- a/rtloader/common/builtins/datadog_agent.c
+++ b/rtloader/common/builtins/datadog_agent.c
@@ -571,6 +571,7 @@ static PyObject *set_external_tags(PyObject *self, PyObject *args)
         PyObject *key = NULL, *value = NULL;
         if (!PyDict_Next(dict, &pos, &key, &value)) {
             _free(hostname);
+            hostname = NULL;
             continue;
         }
 

--- a/rtloader/test/datadog_agent/datadog_agent_test.go
+++ b/rtloader/test/datadog_agent/datadog_agent_test.go
@@ -391,7 +391,8 @@ func TestSetExternalTagEmptyDict(t *testing.T) {
 	code := `
 	tags = [
 		('hostname', {}),
-		('hostname2', {'source_type2': ['tag3', 'tag4']}),
+		('hostname2', {'source_type2': ['tag3', 'tag4']}),		
+		('hostname', {}),
 	]
 	datadog_agent.set_external_tags(tags)
 	`

--- a/rtloader/test/datadog_agent/datadog_agent_test.go
+++ b/rtloader/test/datadog_agent/datadog_agent_test.go
@@ -391,7 +391,7 @@ func TestSetExternalTagEmptyDict(t *testing.T) {
 	code := `
 	tags = [
 		('hostname', {}),
-		('hostname2', {'source_type2': ['tag3', 'tag4']}),		
+		('hostname2', {'source_type2': ['tag3', 'tag4']}),
 		('hostname', {}),
 	]
 	datadog_agent.set_external_tags(tags)


### PR DESCRIPTION
### What does this PR do?

Do not call `_free(hostname)` twice in `datadog_agent.set_external_tags` when an empty source_type dict is passed for the last hostname.

### Motivation

### Additional Notes

If `_free(hostname)` is called from https://github.com/DataDog/datadog-agent/compare/ogaca/Fixset_external_tagsDoubleFree?expand=1#diff-5d5e1b75394a1b5c0e3c0df4374cf193R573 on the last iteration of the `for` https://github.com/DataDog/datadog-agent/compare/ogaca/Fixset_external_tagsDoubleFree?expand=1#diff-5d5e1b75394a1b5c0e3c0df4374cf193R543 then we call  `_free(hostname)`https://github.com/DataDog/datadog-agent/compare/ogaca/Fixset_external_tagsDoubleFree?expand=1#diff-5d5e1b75394a1b5c0e3c0df4374cf193R642.