### PR TITLE
Grant access to kubelet’s GET /stats/summary

### DIFF
--- a/Dockerfiles/manifests/rbac/clusterrole.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrole.yaml
@@ -50,5 +50,6 @@ rules:
   - nodes/metrics
   - nodes/spec
   - nodes/proxy
+  - nodes/stats
   verbs:
   - get


### PR DESCRIPTION
With DataDog/integrations-core#5052, the datadog agent starts monitoring the `/stats/summary/` endpoint of the kubelet.
So, we need to grant it a role that allows it.