### PR TITLE
Make circleci look for release notes in releasenotes-dca/notes

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -217,7 +217,8 @@ def lint_releasenote(ctx):
         while True:
             res = requests.get(url)
             files = res.json()
-            if any([f['filename'].startswith("releasenotes/notes/") for f in files]):
+            if any([f['filename'].startswith("releasenotes/notes/") or \
+                    f['filename'].startswith("releasenotes-dca/notes/") for f in files]):
                 break
 
             if 'next' in res.links:
@@ -244,7 +245,8 @@ def lint_releasenote(ctx):
                 while True:
                     res = requests.get(url)
                     files = res.json().get("files", {})
-                    if any([f['filename'].startswith("releasenotes/notes/") for f in files]):
+                    if any([f['filename'].startswith("releasenotes/notes/") or \
+                            f['filename'].startswith("releasenotes-dca/notes/") for f in files]):
                         break
 
                     if 'next' in res.links:


### PR DESCRIPTION
so that cluster-agent specific PR don’t need to add the `no-changelog` tag.