### PR TITLE
Fixes rollback on Agent7; allows kitchen tests to pass as a result

### DIFF
--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -402,8 +402,11 @@ extern "C" UINT __stdcall DoRollback(MSIHANDLE hInstall) {
         DeleteFilesInDirectory(dir_to_delete.c_str(), L"*.pyc");
         dir_to_delete = installdir + L"embedded2";
         DeleteFilesInDirectory(dir_to_delete.c_str(), L"*.pyc");
+        // python 3, on startup, leaves a bunch of __pycache__ directories,
+        // so we have to be more aggressive.
         dir_to_delete = installdir + L"embedded3";
         DeleteFilesInDirectory(dir_to_delete.c_str(), L"*.pyc");
+        DeleteFilesInDirectory(dir_to_delete.c_str(), L"__pycache__", true);
     }
 LExit:
     er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;

--- a/omnibus/resources/agent/msi/cal/customaction.h
+++ b/omnibus/resources/agent/msi/cal/customaction.h
@@ -40,7 +40,7 @@ int uninstallServices(MSIHANDLE hInstall, CustomActionData& data);
 int verifyServices(MSIHANDLE hInstall, CustomActionData& data);
 
 //delfiles.cpp
-BOOL DeleteFilesInDirectory(const wchar_t* dirname, const wchar_t* ext);
+BOOL DeleteFilesInDirectory(const wchar_t* dirname, const wchar_t* ext, bool dirs = false);
 
 extern HMODULE hDllModule;
 // rights we might be interested in

--- a/omnibus/resources/agent/msi/cal/customaction.vcxproj
+++ b/omnibus/resources/agent/msi/cal/customaction.vcxproj
@@ -130,6 +130,7 @@
       <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PreprocessorDefinitions>_DEBUG;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>bcrypt.lib;version.lib;advapi32.lib;wcautil.lib;dutil.lib;netapi32.lib;msi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -142,6 +143,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>bcrypt.lib;version.lib;advapi32.lib;wcautil.lib;dutil.lib;netapi32.lib;msi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/omnibus/resources/agent/msi/cal/delfiles.cpp
+++ b/omnibus/resources/agent/msi/cal/delfiles.cpp
@@ -6,11 +6,24 @@ BOOL IsDots(const TCHAR* str) {
     }
     return TRUE;
 }
+
+/**
+ * This function recursively deletes all files in a given tree that match a given
+ * extension.  It will only accept an absolute path.
+ * 
+ * @param dirname  The root path to start the deletion
+ * 
+ * @param ext   the filename and/or extension to delete.  Can be a fixed name or wildcard
+ * 
+ * @param dirs  If true, will delete directories which match the ext parameter, if the
+ *              directory is empty. If false (the default), will delete files
+ */
 BOOL DeleteFilesInDirectory(const wchar_t* dirname, const wchar_t* ext, bool dirs) {
     HANDLE hFind;
     WIN32_FIND_DATA FindFileData;
 
-    if(!isPathAbsolute(dirname)){
+    std::filesystem::path checkpath(dirname);
+    if(!checkpath.is_absolute()){
         // don't allow this.   If the path is not absolute, assume we didn't mean
         // to delete it
         WcaLog(LOGMSG_STANDARD, "Not deleting directory %S, not absolute", dirname);

--- a/omnibus/resources/agent/msi/cal/stdafx.h
+++ b/omnibus/resources/agent/msi/cal/stdafx.h
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <map>
 #include <sstream>
+#include <filesystem>
 
 // WiX Header Files:
 #include <wcautil.h>

--- a/omnibus/resources/agent/msi/cal/strings.cpp
+++ b/omnibus/resources/agent/msi/cal/strings.cpp
@@ -241,3 +241,30 @@ bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, wchar_t **dst,
 bool loadDdAgentPassword(MSIHANDLE hInstall, wchar_t **pass, DWORD *len) {
     return loadPropertyString(hInstall, propertyDDAgentUserPassword.c_str(), pass, len);
 }
+
+
+bool isPathAbsolute(const wchar_t * path) {
+    // path is absolute if it's <driveletter>:\ or
+    // \\.\<driveletter>:\ or
+    // \\?\<driveletter>:\
+
+    if(wcslen(path) <= 7) {
+        // can't fit anything in there 
+        // theoretically, the path could be absolute in 7 chars.  But 
+        // it's so short for our purposes that it's not a valid path.
+        return false;
+    }
+    if(path[1] == L':') {
+        // could be standard DOS path
+        if(path[2] == L'\\') {
+            // looks good
+            return true;
+        }
+    }
+    if(path[2] == L'.' || path[2] == L'?'){
+        if(path[5] == L':' && path[6] == L'\\'){
+            return true;
+        }
+    }
+    return false;
+}

--- a/omnibus/resources/agent/msi/cal/strings.cpp
+++ b/omnibus/resources/agent/msi/cal/strings.cpp
@@ -243,28 +243,3 @@ bool loadDdAgentPassword(MSIHANDLE hInstall, wchar_t **pass, DWORD *len) {
 }
 
 
-bool isPathAbsolute(const wchar_t * path) {
-    // path is absolute if it's <driveletter>:\ or
-    // \\.\<driveletter>:\ or
-    // \\?\<driveletter>:\
-
-    if(wcslen(path) <= 7) {
-        // can't fit anything in there 
-        // theoretically, the path could be absolute in 7 chars.  But 
-        // it's so short for our purposes that it's not a valid path.
-        return false;
-    }
-    if(path[1] == L':') {
-        // could be standard DOS path
-        if(path[2] == L'\\') {
-            // looks good
-            return true;
-        }
-    }
-    if(path[2] == L'.' || path[2] == L'?'){
-        if(path[5] == L':' && path[6] == L'\\'){
-            return true;
-        }
-    }
-    return false;
-}

--- a/omnibus/resources/agent/msi/cal/strings.h
+++ b/omnibus/resources/agent/msi/cal/strings.h
@@ -53,5 +53,4 @@ bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, std::wstring& 
 bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, wchar_t **dst, DWORD *len);
 bool loadDdAgentPassword(MSIHANDLE hInstall, wchar_t **dst, DWORD *len);
 
-bool isPathAbsolute(const wchar_t * path) ;
 #define MAX_CUSTOM_PROPERTY_SIZE        128

--- a/omnibus/resources/agent/msi/cal/strings.h
+++ b/omnibus/resources/agent/msi/cal/strings.h
@@ -53,4 +53,5 @@ bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, std::wstring& 
 bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, wchar_t **dst, DWORD *len);
 bool loadDdAgentPassword(MSIHANDLE hInstall, wchar_t **dst, DWORD *len);
 
+bool isPathAbsolute(const wchar_t * path) ;
 #define MAX_CUSTOM_PROPERTY_SIZE        128

--- a/releasenotes/notes/fixpy3rollback-2f8b4e7fab0f48d2.yaml
+++ b/releasenotes/notes/fixpy3rollback-2f8b4e7fab0f48d2.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On windows, correctly deletes python 3 precompiled files (py3) in
+    the event of an installation failure and rollback
+

--- a/tasks/customaction.py
+++ b/tasks/customaction.py
@@ -23,7 +23,7 @@ BIN_PATH = os.path.join(".", "bin", "agent")
 AGENT_TAG = "datadog/agent:master"
 
 @task
-def build(ctx, vstudio_root=None, arch="x64", debug=None):
+def build(ctx, vstudio_root=None, arch="x64", debug=False):
     """
     Build the custom action library for the agent
     """


### PR DESCRIPTION
### What does this PR do?

Make sure all files are cleaned up on rollback.

Existing code for python2 walks directory tree, and deletes `.pyc` files left behind (MSI only cleans up files that we explicitly install; pyc files are left behind when the interpreter starts).

Python 3 puts those files in the `__pycache__` directory, so the files were being removed, but
the directories were being left behind.  Cleans out the directories, too.

Added check for a fully qualified path, to prevent deleting the wrong directory in the case of a relative path.
### Motivation

Be a good citizen (clean up if install fails).
Allows testing to pass.

### Additional Notes

Anything else we should know when reviewing?
