### PR TITLE
Fix installation problems for domain joined machines that aren't domain

### DIFF
--- a/omnibus/resources/agent/msi/cal/customaction.h
+++ b/omnibus/resources/agent/msi/cal/customaction.h
@@ -3,8 +3,8 @@
 #define MAX_PASS_LEN 18
 // usercreate.cpp
 bool generatePassword(wchar_t* passbuf, int passbuflen);
-int doCreateUser(const std::wstring& name, const wchar_t * domain, std::wstring& comment, const wchar_t* passbuf);
-int doSetUserPassword(const std::wstring& name, const wchar_t * domain, const wchar_t* passbuf);
+int doCreateUser(const std::wstring& name, std::wstring& comment, const wchar_t* passbuf);
+int doSetUserPassword(const std::wstring& name, const wchar_t* passbuf);
 DWORD changeRegistryAcls(CustomActionData& data, const wchar_t* name);
 DWORD addDdUserPermsToFile(CustomActionData& data, std::wstring &filename);
 bool isDomainController(MSIHANDLE hInstall);

--- a/omnibus/resources/agent/msi/cal/customactiondata.h
+++ b/omnibus/resources/agent/msi/cal/customactiondata.h
@@ -12,39 +12,34 @@ class CustomActionData
         bool present(const std::wstring& key) const;
         bool value( std::wstring& key, std::wstring &val) ;
 
-        const std::wstring& getUsername() const{
+        bool isUserDomainUser() const {
+            return domainUser;
+        }
+        bool isUserLocalUser() const {
+            return !domainUser;
+        }
+
+        const std::wstring& Username() const {
             return this->username;
         }
-        const std::wstring& getUserdomain() const{
-            return this->userdomain;
+        const std::wstring& UnqualifiedUsername() const {
+            return this->uqusername;
         }
-        const std::wstring& getFullUsername() const{
-            return this->fullusername;
+        const std::wstring& Domain() const {
+            return this->domain;
         }
-        const wchar_t* getDomainPtr() const{
-            return this->domainPtr;
-        }
-        const wchar_t* getUserPtr() const{
-            return this->userPtr;
-        }
-        const std::string& getFullUsernameMbcs() const {
-            return this->fullusermbcs;
-        }
-        const std::wstring& getQualifiedUsername() const {
-            return this->qualifieduser;
+        const std::wstring& Hostname() const {
+            return this->hostname;
         }
     private:
         MSIHANDLE hInstall;
+        bool domainUser;
         std::map< std::wstring, std::wstring> values;
-        std::wstring username; // unqualified
-        std::wstring userdomain;
-        std::wstring fullusername; // userdomain\username
-        std::string fullusermbcs;
-        // if it's a local account, it's just the username.
-        // otherwise, the full name.
-        std::wstring qualifieduser;
-        const wchar_t * domainPtr;
-        const wchar_t * userPtr;
+        std::wstring username; // qualified
+        std::wstring uqusername;// unqualified
+        std::wstring domain;
+        std::wstring hostname;
+
 
         bool parseUsernameData();
 };

--- a/omnibus/resources/agent/msi/cal/stopservices.cpp
+++ b/omnibus/resources/agent/msi/cal/stopservices.cpp
@@ -746,10 +746,10 @@ int installServices(MSIHANDLE hInstall, CustomActionData& data, const wchar_t *p
     serviceDef services[NUM_SERVICES] = {
         serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
                    agent_exe.c_str(),
-                   NULL, SERVICE_AUTO_START, data.getFullUsername().c_str(), password),
+                   NULL, SERVICE_AUTO_START, data.Username().c_str(), password),
         serviceDef(traceService.c_str(), L"DataDog Trace Agent", L"Send tracing metrics to DataDog",
                    trace_exe.c_str(),
-                   L"datadogagent\0\0", SERVICE_DEMAND_START, data.getFullUsername().c_str(), password),
+                   L"datadogagent\0\0", SERVICE_DEMAND_START, data.Username().c_str(), password),
         serviceDef(processService.c_str(), L"DataDog Process Agent", L"Send process metrics to DataDog",
                    process_exe.c_str(),
                    L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL)
@@ -809,10 +809,10 @@ int uninstallServices(MSIHANDLE hInstall, CustomActionData& data) {
     serviceDef services[NUM_SERVICES] = {
         serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
                    agent_exe.c_str(),
-                   L"winmgmt\0\0", SERVICE_AUTO_START, data.getFullUsername().c_str(), NULL),
+                   L"winmgmt\0\0", SERVICE_AUTO_START, data.Username().c_str(), NULL),
         serviceDef(traceService.c_str(), L"DataDog Trace Agent", L"Send tracing metrics to DataDog",
                    trace_exe.c_str(),
-                   L"datadogagent\0\0", SERVICE_DEMAND_START, data.getFullUsername().c_str(), NULL),
+                   L"datadogagent\0\0", SERVICE_DEMAND_START, data.Username().c_str(), NULL),
         serviceDef(processService.c_str(), L"DataDog Process Agent", L"Send process metrics to DataDog",
                    process_exe.c_str(),
                    L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL)
@@ -850,10 +850,10 @@ int verifyServices(MSIHANDLE hInstall, CustomActionData& data)
     serviceDef services[NUM_SERVICES] = {
         serviceDef(agentService.c_str(), L"DataDog Agent", L"Send metrics to DataDog",
                    agent_exe.c_str(),
-                   L"winmgmt\0\0", SERVICE_AUTO_START, data.getFullUsername().c_str(), NULL),
+                   L"winmgmt\0\0", SERVICE_AUTO_START, data.Username().c_str(), NULL),
         serviceDef(traceService.c_str(), L"DataDog Trace Agent", L"Send tracing metrics to DataDog",
                    trace_exe.c_str(),
-                   L"datadogagent\0\0", SERVICE_DEMAND_START, data.getFullUsername().c_str(), NULL),
+                   L"datadogagent\0\0", SERVICE_DEMAND_START, data.Username().c_str(), NULL),
         serviceDef(processService.c_str(), L"DataDog Process Agent", L"Send process metrics to DataDog",
                    process_exe.c_str(),
                    L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL)

--- a/omnibus/resources/agent/msi/cal/strings.h
+++ b/omnibus/resources/agent/msi/cal/strings.h
@@ -37,6 +37,10 @@ extern std::wstring agent_exe;
 extern std::wstring trace_exe;
 extern std::wstring process_exe;
 
+extern std::wstring computername;
+extern std::wstring domainname; // if domain joined, workgroup name otherwise
+extern bool isDomainJoined;
+
 // installation steps
 extern std::wstring installCreatedDDUser;
 extern std::wstring installCreatedDDDomain;
@@ -46,6 +50,8 @@ void initializeStringsFromStringTable();
 
 
 void toMbcs(std::string& target, LPCWSTR src);
+void toMbcs(std::string& target, std::wstring& src);
+
 bool loadDdAgentUserName(MSIHANDLE hInstall, LPCWSTR propertyName = NULL);
 bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, std::wstring& dst);
 bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, wchar_t **dst, DWORD *len);

--- a/omnibus/resources/agent/msi/cal/usercreate.cpp
+++ b/omnibus/resources/agent/msi/cal/usercreate.cpp
@@ -86,7 +86,7 @@ DWORD changeRegistryAcls(CustomActionData& data, const wchar_t* name) {
     //ExplicitAccess suser;
     //suser.BuildGrantUser(secretUserUsername.c_str(), GENERIC_READ | GENERIC_EXECUTE | READ_CONTROL | KEY_READ);
 
-    PSID  usersid = GetSidForUser(NULL, data.getQualifiedUsername().c_str());
+    PSID  usersid = GetSidForUser(NULL, data.Username().c_str());
     ExplicitAccess dduser;
     dduser.BuildGrantUser((SID *)usersid, GENERIC_ALL | KEY_ALL_ACCESS,
         SUB_CONTAINERS_AND_OBJECTS_INHERIT);
@@ -118,17 +118,15 @@ DWORD changeRegistryAcls(CustomActionData& data, const wchar_t* name) {
 
 DWORD addDdUserPermsToFile(CustomActionData& data, std::wstring &filename)
 {
-    std::string shortfile;
-    toMbcs(shortfile, (LPCWSTR)filename.c_str());
 
     if(!PathFileExistsW((LPCWSTR) filename.c_str()))
     {
         // return success; we don't need to do anything
-        WcaLog(LOGMSG_STANDARD, "file %s doesn't exist, not doing anything", shortfile.c_str());
+        WcaLog(LOGMSG_STANDARD, "file %S doesn't exist, not doing anything", filename.c_str());
         return 0;
     }
-    WcaLog(LOGMSG_STANDARD, "Changing file permissions on %s", shortfile.c_str());
-    PSID  usersid = GetSidForUser(NULL, data.getQualifiedUsername().c_str());
+    WcaLog(LOGMSG_STANDARD, "Changing file permissions on %S", filename.c_str());
+    PSID  usersid = GetSidForUser(NULL, data.Username().c_str());
     ExplicitAccess dduser;
     dduser.BuildGrantUser((SID *)usersid, FILE_ALL_ACCESS,
                           SUB_CONTAINERS_AND_OBJECTS_INHERIT);
@@ -226,7 +224,7 @@ doneRemove:
     return ;
 }
 
-int doCreateUser(const std::wstring& name, const wchar_t * domain, std::wstring& comment, const wchar_t* passbuf)
+int doCreateUser(const std::wstring& name, std::wstring& comment, const wchar_t* passbuf)
 {
     
     USER_INFO_1 ui;
@@ -250,7 +248,7 @@ int doCreateUser(const std::wstring& name, const wchar_t * domain, std::wstring&
 
 }
 
-int doSetUserPassword(const std::wstring& name, const wchar_t * domain, const wchar_t* passbuf)
+int doSetUserPassword(const std::wstring& name,  const wchar_t* passbuf)
 {
     USER_INFO_1003 ui;
     memset(&ui,0, sizeof(USER_INFO_1003));
@@ -306,9 +304,9 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data, bool isDC)
     LPWSTR refDomain = NULL;
     DWORD cchRefDomain = 0;
     SID_NAME_USE use;
-    std::string narrowdomain;
     DWORD err = 0;
-    const wchar_t * userToTry = data.getQualifiedUsername().c_str();
+    const wchar_t * userToTry = data.Username().c_str();
+    const wchar_t * hostToTry = NULL;
 
     BOOL bRet = LookupAccountName(NULL, userToTry, newsid, &cbSid, refDomain, &cchRefDomain, &use);
     if (bRet) {
@@ -331,9 +329,9 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data, bool isDC)
                 WcaLog(LOGMSG_STANDARD, "Can't reach domain controller %d", err);
                 // if the user specified a domain, then also must be able to contact
                 // the domain authority
-                if (data.getDomainPtr() == NULL) {
+                if (data.isUserLocalUser() == NULL) {
                     WcaLog(LOGMSG_STANDARD, "trying fully qualified local account");
-                    bRet = LookupAccountName(NULL, data.getFullUsername().c_str(), newsid, &cbSid, refDomain, &cchRefDomain, &use);
+                    bRet = LookupAccountName(computername.c_str(), data.Username().c_str(), newsid, &cbSid, refDomain, &cchRefDomain, &use);
                     if (bRet) {
                         // this should *never* happen, because we didn't pass in a buffer large enough for
                         // the sid or the domain name.
@@ -360,7 +358,7 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data, bool isDC)
                 WcaLog(LOGMSG_STANDARD, "doesUserExist: Lookup Account Name: Unexpected error %d 0x%x", err, err);
                 return -1;
             }
-            userToTry = data.getFullUsername().c_str();
+            hostToTry = computername.c_str();
 
         }
         else {        // we don't know what happened
@@ -376,7 +374,7 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data, bool isDC)
     ZeroMemory(refDomain, (cchRefDomain + 1) * sizeof(wchar_t));
 
     // try it again
-    bRet = LookupAccountName(NULL, userToTry, newsid, &cbSid, refDomain, &cchRefDomain, &use);
+    bRet = LookupAccountName(hostToTry, userToTry, newsid, &cbSid, refDomain, &cchRefDomain, &use);
     if (!bRet) {
         err = GetLastError();
         WcaLog(LOGMSG_STANDARD, "Failed to lookup account name %d", GetLastError());
@@ -389,8 +387,7 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data, bool isDC)
         goto cleanAndFail;
     }
     retval = 1;
-    toMbcs(narrowdomain, refDomain);
-    WcaLog(LOGMSG_STANDARD, "Got SID from %s", narrowdomain.c_str());
+    WcaLog(LOGMSG_STANDARD, "Got SID from %S", refDomain);
 
 cleanAndFail:
     if (newsid) {

--- a/omnibus/resources/agent/msi/cal/userrights.cpp
+++ b/omnibus/resources/agent/msi/cal/userrights.cpp
@@ -271,7 +271,7 @@ int EnableServiceForUser(CustomActionData& data, const std::wstring& service)
 		WcaLog(LOGMSG_STANDARD,"Failed to query security info %d\n", GetLastError());
 		goto cleanAndReturn;
 	}
-	if ((sid = GetSidForUser(NULL, data.getQualifiedUsername().c_str())) == NULL) {
+	if ((sid = GetSidForUser(NULL, data.Username().c_str())) == NULL) {
 		WcaLog(LOGMSG_STANDARD,"Failed to get sid\n");
 		goto cleanAndReturn;
 	}

--- a/releasenotes/notes/domain-install-fix-060a624e7b91341d.yaml
+++ b/releasenotes/notes/domain-install-fix-060a624e7b91341d.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On windows, fixes problem where Agent would intermittently fail to install
+    on domain-joined machine, when another Agent was already installed on the
+    DC.


### PR DESCRIPTION
controllers.


### What does this PR do?

Fixes problem with windows installer in which installs would mysteriously fail on domain joined machines.

Problem would manifest when
1) Datadog agent was (properly) installed on a domain controller, and the username used to install was <domain>\ddagentuser

2) Datatog agent was installed on domain joined (but not DC) machine, using defaults (as in, not specifying <domain>\ddagentuser.  This is also proper, and as instructed.

When checking to see if the ddagentuser exists, the API in question checks the local database and then any trusted domain servers (as documented). Therefore, the domain controller would respond that the user exists (because it does in the domain), even though our intent was to install into the local security database.

new changes include

- Computing the hostname of the machine that we're installing on, and comparing that to the <domain> field that's passed in (<host>\<username>, while redundant, is legal.
 - Computing whether the machine is domain-joined, and if so....
 - Computing the domain name to which the machine is joined
 - using the fully qualified user (i.e. <authority>\<username> (where <authority> == host|domain) when checking for pre-existence of the user.
 - checking that the domain supplied as the authority is the domain to which the machine is joined (and log if is not, but continue installation)
 - new log messages, and cleanup of some existing log messages, for easier field debugging.

### Motivation

Customer install fails.
