### PR TITLE
Allow configurable GCE metadata tag exclusion

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -348,6 +348,7 @@ func initConfig(config Config) {
 
 	// GCE
 	config.BindEnvAndSetDefault("collect_gce_tags", true)
+	config.BindEnvAndSetDefault("exclude_gce_tags", []string{"kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings"})
 
 	// Cloud Foundry
 	config.BindEnvAndSetDefault("cloud_foundry", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -182,6 +182,26 @@ api_key:
 #
 # collect_gce_tags: true
 
+## @param exclude_gce_tags - list of strings - optional - default: ["kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings"]
+## Google Cloud Engine metadata attribute to exclude from being converted into
+## host tags -- only applicable when collect_gce_tags is true.
+#
+# exclude_gce_tags:
+#   - "kube-env"
+#   - "kubelet-config"
+#   - "containerd-configure-sh"
+#   - "startup-script"
+#   - "shutdown-script"
+#   - "configure-sh"
+#   - "sshKeys"
+#   - "ssh-keys"
+#   - "user-data"
+#   - "cli-cert"
+#   - "ipsec-cert"
+#   - "ssl-cert"
+#   - "google-container-manifest"
+#   - "bosh_settings"
+
 {{ end }}
 {{- if .Agent }}
 {{- if .BothPythonPresent -}}

--- a/pkg/util/gce/gce_tags.go
+++ b/pkg/util/gce/gce_tags.go
@@ -11,11 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-)
 
-// Slice of attributes to exclude from the tags (because they're too long, useless or sensitive)
-var excludedAttributes = []string{"kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script", "configure-sh",
-	"sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings"}
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
 
 // GetTags gets the tags from the GCE api
 func GetTags() ([]string, error) {
@@ -68,6 +66,8 @@ func GetTags() ([]string, error) {
 
 // isAttributeExcluded returns whether the attribute key should be excluded from the tags
 func isAttributeExcluded(attr string) bool {
+
+	excludedAttributes := config.Datadog.GetStringSlice("exclude_gce_tags")
 	for _, excluded := range excludedAttributes {
 		if attr == excluded {
 			return true

--- a/pkg/util/gce/gce_tags_test.go
+++ b/pkg/util/gce/gce_tags_test.go
@@ -15,11 +15,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetHostTags(t *testing.T) {
+func mockMetadataRequest(t *testing.T) *httptest.Server {
 	lastRequests := []*http.Request{}
 	content, err := ioutil.ReadFile("test/gce_metadata.json")
 	if err != nil {
@@ -32,9 +33,13 @@ func TestGetHostTags(t *testing.T) {
 		io.WriteString(w, string(content))
 		lastRequests = append(lastRequests, r)
 	}))
-	defer ts.Close()
 	metadataURL = ts.URL
+	return ts
+}
 
+func TestGetHostTags(t *testing.T) {
+	server := mockMetadataRequest(t)
+	defer server.Close()
 	tags, err := GetTags()
 	if err != nil {
 		assert.Fail(t, fmt.Sprintf("Error getting tags: %v", err))
@@ -50,6 +55,42 @@ func TestGetHostTags(t *testing.T) {
 		"numeric_project_id:111111111111",
 		"cluster-location:us-east1-b",
 		"cluster-name:test-cluster",
+		"created-by:projects/111111111111/zones/us-east1-b/instanceGroupManagers/gke-test-cluster-default-pool-0012834b-grp",
+		"gci-ensure-gke-docker:true",
+		"gci-update-strategy:update_disabled",
+		"google-compute-enable-pcid:true",
+		"instance-template:projects/111111111111/global/instanceTemplates/gke-test-cluster-default-pool-0012834b",
+	}
+	require.Len(t, tags, len(expectedTags))
+	for _, tag := range tags {
+		assert.Contains(t, expectedTags, tag)
+	}
+}
+
+func TestGetHostTagsWithNonDefaultTagFilters(t *testing.T) {
+	mockConfig := config.Mock()
+	defaultExclude := mockConfig.GetStringSlice("exclude_gce_tags")
+	defer mockConfig.Set("exclude_gce_tags", defaultExclude)
+
+	mockConfig.Set("exclude_gce_tags", append([]string{"cluster-name"}, defaultExclude...))
+
+	server := mockMetadataRequest(t)
+	defer server.Close()
+
+	tags, err := GetTags()
+	if err != nil {
+		assert.Fail(t, fmt.Sprintf("Error getting tags: %v", err))
+	}
+
+	expectedTags := []string{
+		"tag",
+		"zone:us-east1-b",
+		"instance-type:n1-standard-1",
+		"internal-hostname:dd-test.c.datadog-dd-test.internal",
+		"instance-id:1111111111111111111",
+		"project:test-project",
+		"numeric_project_id:111111111111",
+		"cluster-location:us-east1-b",
 		"created-by:projects/111111111111/zones/us-east1-b/instanceGroupManagers/gke-test-cluster-default-pool-0012834b-grp",
 		"gci-ensure-gke-docker:true",
 		"gci-update-strategy:update_disabled",

--- a/releasenotes/notes/configurable-gce-metadata-exclusion-99ae5728a430e037.yaml
+++ b/releasenotes/notes/configurable-gce-metadata-exclusion-99ae5728a430e037.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Adding a new config option "exclude_gce_tags", to configure which metadata
+    attribute from Google Cloud Engine to exclude from being converted into
+    host tags.


### PR DESCRIPTION
# This is a copy with some minor fix from: #4060

Comments from #4060:

### What does this PR do?

The GCE integration makes requests to the metadata endpoint of a node in order to gather some attribute information. It then adds some of this information as tags on a metric (things like `zone`, `project-name`, etc...). In that code is a hardcoded list of attributes which should be filtered out as they aren't particularly useful. This PR makes that list configurable by moving it into configuration rather than having it be hardcoded.

### Motivation

Some of our metrics have tags which aren't useful to us and they come from this integration. I'd like to filter them out to reduce the cardinality.
