### PR TITLE
[POC] Add dogstatsd metric cache

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,14 +2,6 @@
 
 
 [[projects]]
-  digest = "1:db5c4e7a9516334fb1e9d5951fb9943d0f13e4f415a77c22b97e60f4d10a62a7"
-  name = "bitbucket.org/ww/goautoneg"
-  packages = ["."]
-  pruneopts = ""
-  revision = "d788f35a0315672bc90f50a6145d1252a230ee0d"
-  source = "github.com/adjust/goautoneg"
-
-[[projects]]
   digest = "1:c4e071eb2f960b14286f0fe2057d4f87dfd83c840c059377f01c37b5112595ed"
   name = "github.com/DataDog/agent-payload"
   packages = [
@@ -2007,7 +1999,7 @@
   revision = "b3a7cee44a305be0a69e1b9ac03018307287e1b0"
 
 [[projects]]
-  digest = "0:"
+  digest = "1:f27698f7ae7864893ebcfb843e44d821263ac1dcf0ba1d5c2353f9d319a2f28d"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/kubelet/remote/fake",
@@ -2154,6 +2146,7 @@
     "github.com/google/gopacket/layers",
     "github.com/gorilla/mux",
     "github.com/hashicorp/consul/api",
+    "github.com/hashicorp/golang-lru",
     "github.com/hectane/go-acl",
     "github.com/iovisor/gobpf/elf",
     "github.com/json-iterator/go",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -268,6 +268,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("statsd_forward_port", 0)
 	config.BindEnvAndSetDefault("statsd_metric_namespace", "")
 	config.BindEnvAndSetDefault("statsd_metric_namespace_blacklist", StandardStatsdPrefixes)
+	config.BindEnvAndSetDefault("dogstatsd_metric_cache_size", 2000)
 	// Autoconfig
 	config.BindEnvAndSetDefault("autoconf_template_dir", "/datadog/check_configs")
 	config.BindEnvAndSetDefault("exclude_pause_container", true)

--- a/pkg/dogstatsd/metric_cache.go
+++ b/pkg/dogstatsd/metric_cache.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package dogstatsd
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/hashicorp/golang-lru"
+)
+
+type MetricCacheItem struct {
+	Name       string
+	Mtype      metrics.MetricType
+	Tags       []string
+	Host       string
+	SampleRate float64
+}
+
+type metricCache struct {
+	cache *lru.Cache
+}
+
+func newMetricCache(size int) (*metricCache, error) {
+	cache, err := lru.New(size)
+	if err != nil {
+		return &metricCache{}, err
+	}
+	return &metricCache{cache: cache}, nil
+}
+
+func (m *metricCache) get(metricName string) (*MetricCacheItem) {
+	if result, ok := m.cache.Get(metricName); ok {
+		return result.(*MetricCacheItem)
+	}
+	return nil
+}
+
+func (m *metricCache) add(metricName string, sample *MetricCacheItem) {
+	m.cache.Add(metricName, sample)
+}

--- a/pkg/dogstatsd/metric_cache_test.go
+++ b/pkg/dogstatsd/metric_cache_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package dogstatsd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMetricCache(t *testing.T) {
+	c, err := newMetricCache(3)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, c.cache.Len())
+
+	// add to cache
+	metric1 := &MetricCacheItem{
+		Name: "my.metric.1",
+	}
+	metric2 := &MetricCacheItem{
+		Name: "my.metric.2",
+	}
+	metric3 := &MetricCacheItem{
+		Name: "my.metric.3",
+	}
+	c.add("metric1", metric1)
+	c.add("metric2", metric2)
+	c.add("metric3", metric3)
+	assert.Equal(t, 3, c.cache.Len())
+
+	// adding more metric than max size of the cache will flush the oldest one
+	metric4 := &MetricCacheItem{
+		Name: "my.metric.4",
+	}
+	c.add("metric4", metric4)
+
+	assert.Equal(t, 3, c.cache.Len())
+	assert.Equal(t, metric2, c.get("metric2"))
+	assert.Equal(t, metric3, c.get("metric3"))
+	assert.Equal(t, metric4, c.get("metric4"))
+	assert.Equal(t, (*MetricCacheItem)(nil), c.get("metric1")) // metric1, the oldest metric has been removed
+}

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -65,7 +65,7 @@ func TestGaugePacketCounter(t *testing.T) {
 }
 
 func TestParseGauge(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -78,7 +78,7 @@ func TestParseGauge(t *testing.T) {
 }
 
 func TestParseCounter(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|c"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:21|c"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -91,7 +91,7 @@ func TestParseCounter(t *testing.T) {
 }
 
 func TestParseCounterWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -106,7 +106,7 @@ func TestParseCounterWithTags(t *testing.T) {
 }
 
 func TestParseHistogram(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|h"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:21|h"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -119,7 +119,7 @@ func TestParseHistogram(t *testing.T) {
 }
 
 func TestParseTimer(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -132,7 +132,7 @@ func TestParseTimer(t *testing.T) {
 }
 
 func TestParseSet(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:abc|s"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:abc|s"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -145,7 +145,7 @@ func TestParseSet(t *testing.T) {
 }
 
 func TestParseDistribution(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -157,7 +157,7 @@ func TestParseDistribution(t *testing.T) {
 }
 
 func TestParseSetUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -170,7 +170,7 @@ func TestParseSetUnicode(t *testing.T) {
 }
 
 func TestParseGaugeWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -185,7 +185,7 @@ func TestParseGaugeWithTags(t *testing.T) {
 }
 
 func TestParseGaugeWithHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "", nil, "default-hostname", nil, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -199,7 +199,7 @@ func TestParseGaugeWithHostTag(t *testing.T) {
 }
 
 func TestParseGaugeWithEmptyHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "", nil, "default-hostname", nil, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -213,7 +213,7 @@ func TestParseGaugeWithEmptyHostTag(t *testing.T) {
 }
 
 func TestParseGaugeWithNoTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname", nil, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -225,7 +225,7 @@ func TestParseGaugeWithNoTags(t *testing.T) {
 }
 
 func TestParseGaugeWithSampleRate(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -238,7 +238,7 @@ func TestParseGaugeWithSampleRate(t *testing.T) {
 }
 
 func TestParseGaugeWithPoundOnly(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -251,7 +251,7 @@ func TestParseGaugeWithPoundOnly(t *testing.T) {
 }
 
 func TestParseGaugeWithUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"), "", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -266,36 +266,36 @@ func TestParseGaugeWithUnicode(t *testing.T) {
 
 func TestParseMetricError(t *testing.T) {
 	// not enough information
-	_, err := parseMetricMessage([]byte("daemon:666"), "", nil, "default-hostname")
+	_, err := parseMetricMessage([]byte("daemon:666"), "", nil, "default-hostname", nil, nil)
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:666|"), "", nil, "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666|"), "", nil, "default-hostname", nil, nil)
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:|g"), "", nil, "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:|g"), "", nil, "default-hostname", nil, nil)
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte(":666|g"), "", nil, "default-hostname")
+	_, err = parseMetricMessage([]byte(":666|g"), "", nil, "default-hostname", nil, nil)
 	assert.Error(t, err)
 
 	// too many value
-	_, err = parseMetricMessage([]byte("daemon:666:777|g"), "", nil, "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666:777|g"), "", nil, "default-hostname", nil, nil)
 	assert.Error(t, err)
 
 	// unknown metadata prefix
-	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"), "", nil, "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"), "", nil, "default-hostname", nil, nil)
 	assert.NoError(t, err)
 
 	// invalid value
-	_, err = parseMetricMessage([]byte("daemon:abc|g"), "", nil, "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:abc|g"), "", nil, "default-hostname", nil, nil)
 	assert.Error(t, err)
 
 	// invalid metric type
-	_, err = parseMetricMessage([]byte("daemon:666|unknown"), "", nil, "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666|unknown"), "", nil, "default-hostname", nil, nil)
 	assert.Error(t, err)
 
 	// invalid sample rate
-	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"), "", nil, "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"), "", nil, "default-hostname", nil, nil)
 	assert.Error(t, err)
 }
 
@@ -725,7 +725,7 @@ func TestEventMetadataMultiple(t *testing.T) {
 }
 
 func TestNamespace(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "testNamespace.", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "testNamespace.", nil, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -734,7 +734,7 @@ func TestNamespace(t *testing.T) {
 }
 
 func TestNamespaceBlacklist(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("datadog.agent.daemon:21|ms"), "testNamespace.", []string{"datadog.agent"}, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("datadog.agent.daemon:21|ms"), "testNamespace.", []string{"datadog.agent"}, "default-hostname", nil, nil)
 
 	assert.NoError(t, err)
 
@@ -750,7 +750,7 @@ func TestEntityOriginDetectionNoTags(t *testing.T) {
 		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname", nil, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -771,7 +771,7 @@ func TestEntityOriginDetectionTags(t *testing.T) {
 		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname", nil, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -791,7 +791,7 @@ func TestEntityOriginDetectionTagsError(t *testing.T) {
 		return nil, errors.New("cannot get tags")
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname", nil, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)


### PR DESCRIPTION
### What does this PR do?

Add LRU cache to reduce time spent by `dogstatsd` in parsing metrics. It also reduce the allocation.

With LRU cache:

- 21% reduction in time per op
- 25% reduction in allocs/op

```
# Benchmark before (master branch)
BenchmarkParsePacket1-8      2000000           873 ns/op         431 B/op         12 allocs/op
BenchmarkParsePacket2-8      2000000           825 ns/op         425 B/op         12 allocs/op
BenchmarkParsePacket3-8      2000000           837 ns/op         445 B/op         12 allocs/op

Average ns/op: 2535
Average allocs/op: 12


# Benchmark with cache (this PR)
BenchmarkParsePacketWithCache1-8     2000000           663 ns/op         397 B/op          9 allocs/op
BenchmarkParsePacketWithCache2-8     2000000           646 ns/op         416 B/op          9 allocs/op
BenchmarkParsePacketWithCache3-8     2000000           687 ns/op         429 B/op          9 allocs/op

Average ns/op: 1996
Average allocs/op: 9


(1996-2535)/2535 = -0,2126
```

## Further optimisation: Share MetricSample fields

We can make `MetricCacheItem` a subset of `metrics.MetricSample`, but that will lead to more changes across the code base since `metrics.MetricSample` is widely used.

`MetricCacheItem` can be cached (LRU) and shared for all metrics with same characteristics.

Probably 10-20% reduction in ns/op and allocs/op.

```
type MetricSample struct {
	CacheSample *MetricCacheItem
	Value      float64
	RawValue   string
	Timestamp  float64
}

type MetricCacheItem struct {
	Name       string
	Mtype      metrics.MetricType
	Tags       []string
	Host       string
	SampleRate float64
}
```

Note:
- There is probably a better name for `MetricCacheItem`
- MetricCacheItem is a bit different than the concept MetricSampleContext. SampleRate and Mtype are also in MetricCacheItem.


### Motivation

Performance & Memory.

### Additional Notes
