### PR TITLE
Validate cluster-name provided by file

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -205,7 +205,7 @@ func TestProcessBundledEvents(t *testing.T) {
 	mocked.AssertExpectations(t)
 
 	// Test the hostname change when a cluster name is set
-	var testClusterName = "Laika"
+	var testClusterName = "laika"
 	mockConfig := config.Mock()
 	mockConfig.Set("cluster_name", testClusterName)
 	clustername.ResetClusterName() // reset state as clustername was already read

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -470,7 +470,7 @@ func initConfig(config Config) {
 	// Mostly, keys we use IsSet() on, because IsSet always returns true if a key has a default.
 	config.SetKnown("metadata_providers")
 	config.SetKnown("config_providers")
-	config.SetKnown("clustername")
+	config.SetKnown("cluster_name")
 	config.SetKnown("listeners")
 	config.SetKnown("additional_endpoints.*")
 	config.SetKnown("proxy.http")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1361,6 +1361,6 @@ api_key:
 ## These are the same rules as the ones enforced by GKE:
 ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
 #
-# clustername: <CLUSTER_IDENTIFIER>
+# cluster_name: <CLUSTER_IDENTIFIER>
 
 {{ end -}}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1353,6 +1353,13 @@ api_key:
 
 ## @param clustername - string - optional
 ## Set a custom kubernetes cluster identifier to avoid host alias collisions.
+## The cluster name can be up to 40 characters with the following restrictions:
+## * Lowercase letters, numbers, and hyphens only.
+## * Must start with a letter.
+## * Must end with a number or a letter.
+##
+## These are the same rules as the ones enforced by GKE:
+## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
 #
 # clustername: <CLUSTER_IDENTIFIER>
 

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -18,6 +18,12 @@ import (
 )
 
 var (
+	// validClusterName matches exactly the same naming rule as the one enforced by GKE:
+	// https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
+	// The cluster name can be up to 40 characters with the following restrictions:
+	// * Lowercase letters, numbers, and hyphens only.
+	// * Must start with a letter.
+	// * Must end with a number or a letter.
 	validClusterName = regexp.MustCompile(`^[a-z]([a-z0-9\-]{0,38}[a-z0-9])?$`)
 )
 

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -6,6 +6,8 @@
 package clustername
 
 import (
+	"fmt"
+	"regexp"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -13,6 +15,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	validClusterName = regexp.MustCompile(`^[a-z]([a-z0-9\-]{0,38}[a-z0-9])?$`)
 )
 
 type clusterNameData struct {
@@ -50,6 +56,11 @@ func getClusterName(data *clusterNameData) string {
 		data.clusterName = config.Datadog.GetString("cluster_name")
 		if data.clusterName != "" {
 			log.Infof("Got cluster name %s from config", data.clusterName)
+			if !validClusterName.MatchString(data.clusterName) {
+				panic(fmt.Sprintf("\"%s\" isn’t a valid cluster name. It must start with a lowercase "+
+					"letter followed by up to 39 lowercase letters, numbers, or hyphens, and "+
+					"cannot end with a hyphen.", data.clusterName))
+			}
 		}
 
 		// autodiscover clustername through k8s providers' API

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -17,7 +17,7 @@ func TestGetClusterName(t *testing.T) {
 	mockConfig := config.Mock()
 	data := newClusterNameData()
 
-	var testClusterName = "Laika"
+	var testClusterName = "laika"
 	mockConfig.Set("cluster_name", testClusterName)
 	defer mockConfig.Set("cluster_name", nil)
 

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -24,7 +24,7 @@ func TestGetClusterName(t *testing.T) {
 	assert.Equal(t, testClusterName, getClusterName(data))
 
 	// Test caching and reset
-	var newClusterName = "Youri"
+	var newClusterName = "youri"
 	mockConfig.Set("cluster_name", newClusterName)
 	assert.Equal(t, testClusterName, getClusterName(data))
 	freshData := newClusterNameData()

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -29,4 +29,15 @@ func TestGetClusterName(t *testing.T) {
 	assert.Equal(t, testClusterName, getClusterName(data))
 	freshData := newClusterNameData()
 	assert.Equal(t, newClusterName, getClusterName(freshData))
+
+	// Test invalid cluster names
+	for _, invalidClusterName := range []string{
+		"Capital",
+		"with_underscore",
+		"toolongtoolongtoolongtoolongtoolongtoolong"} {
+		mockConfig.Set("cluster_name", invalidClusterName)
+		freshData = newClusterNameData()
+		assert.Panics(t, func() { getClusterName(freshData) },
+			"getClusterName(…) should panic when the cluster-name is invalid")
+	}
 }

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -322,7 +322,7 @@ func (suite *KubeletTestSuite) TestGetHostname() {
 	require.Equal(suite.T(), "my-node-name", hostname)
 
 	// Testing hostname when a cluster name is set
-	var testClusterName = "Laika"
+	var testClusterName = "laika"
 	mockConfig.Set("cluster_name", testClusterName)
 	clustername.ResetClusterName() // reset state as clustername was already read
 

--- a/releasenotes/notes/validate-cluster-name-06ce2c1e32f5ffc0.yaml
+++ b/releasenotes/notes/validate-cluster-name-06ce2c1e32f5ffc0.yaml
@@ -1,0 +1,10 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - Add a validation check on cluster-name that enforces the same rule as on GKE

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -184,12 +184,12 @@ func (suite *testSuite) TestHostnameProvider() {
 	assert.Equal(suite.T(), "target.host", foundHost)
 
 	// Testing hostname when a cluster name is set
-	var testClusterName = "Laika"
+	var testClusterName = "laika"
 	mockConfig.Set("cluster_name", testClusterName)
 	clustername.ResetClusterName()
 	defer mockConfig.Set("cluster_name", "")
 	defer clustername.ResetClusterName()
 
 	foundHost, err = apiserver.HostnameProvider()
-	assert.Equal(suite.T(), "target.host-Laika", foundHost)
+	assert.Equal(suite.T(), "target.host-laika", foundHost)
 }


### PR DESCRIPTION
### What does this PR do?

Validate the cluster-name provided by file so that the kubelet hostname provider built by concatenating the node name with the cluster name doesn’t result in a non-RFC1123 name.

The rule enforced by this change is exactly the same as the one enforced by GKE.

### Motivation

If somebody tries to put an underscore in the cluster_name, the hostname built by the kubelet hostname provider is not RFC1123 valid and, as such, is rejected as a potential hostname.
If, in addition, the agent is running inside a kubernetes POD which hasn’t access to the IaaS metadata server, the agent will default to using the hostname seen from inside its POD, which happens to be the POD name.

Using the POD name as agent hostname is an issue because is changes at each redeployment of the agent.