### PR TITLE
Fix linting

### DIFF
--- a/pkg/util/containers/metrics/proc.go
+++ b/pkg/util/containers/metrics/proc.go
@@ -13,7 +13,7 @@ import (
 )
 
 // hostProcFunc allows hostProc to be overridden for ease of mock testing
-var hostProcFunc func(...string) string = func(combineWith ...string) string {
+var hostProcFunc = func(combineWith ...string) string {
 	return hostProc(combineWith...)
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix linting when using `inv test`

### Motivation

```
pkg/util/containers/metrics/proc.go:16:18: should omit type func(...string) string from declaration of var hostProcFunc; it will be inferred from the right-hand side
Linting issues found in 1 files.
```

### Additional Notes

Anything else we should know when reviewing?
