### PR TITLE
[system-probe] Improve DNS memory usage

### DIFF
--- a/pkg/ebpf/dns.go
+++ b/pkg/ebpf/dns.go
@@ -23,6 +23,7 @@ func (nullReverseDNS) GetStats() map[string]int64 {
 		"added":            0,
 		"expired":          0,
 		"packets_captured": 0,
+		"decoding_errors":  0,
 	}
 }
 

--- a/pkg/ebpf/dns.go
+++ b/pkg/ebpf/dns.go
@@ -17,13 +17,16 @@ func (nullReverseDNS) Resolve(_ []ConnectionStats) map[util.Address][]string {
 
 func (nullReverseDNS) GetStats() map[string]int64 {
 	return map[string]int64{
-		"lookups":          0,
-		"resolved":         0,
-		"ips":              0,
-		"added":            0,
-		"expired":          0,
-		"packets_captured": 0,
-		"decoding_errors":  0,
+		"lookups":           0,
+		"resolved":          0,
+		"ips":               0,
+		"added":             0,
+		"expired":           0,
+		"packets_received":  0,
+		"packets_processed": 0,
+		"packets_dropped":   0,
+		"socket_polls":      0,
+		"decoding_errors":   0,
 	}
 }
 

--- a/pkg/ebpf/dns_cache.go
+++ b/pkg/ebpf/dns_cache.go
@@ -207,7 +207,7 @@ type translation struct {
 func newTranslation(domain []byte) *translation {
 	return &translation{
 		dns: string(domain),
-		ips: make([]util.Address, 0),
+		ips: nil,
 	}
 }
 

--- a/pkg/ebpf/dns_cache.go
+++ b/pkg/ebpf/dns_cache.go
@@ -59,16 +59,16 @@ func (c *reverseDNSCache) Add(translation *translation, now time.Time) bool {
 	}
 
 	exp := now.Add(c.ttl).UnixNano()
-	for addr := range translation.ips {
+	for _, addr := range translation.ips {
 		val, ok := c.data[addr]
 		if ok {
 			val.expiration = exp
-			val.merge(translation.name)
+			val.merge(translation.dns)
 			continue
 		}
 
 		atomic.AddInt64(&c.added, 1)
-		c.data[addr] = &dnsCacheVal{names: []string{translation.name}, expiration: exp}
+		c.data[addr] = &dnsCacheVal{names: []string{translation.dns}, expiration: exp}
 	}
 
 	// Update cache length for telemetry purposes
@@ -200,17 +200,23 @@ func (v *dnsCacheVal) copy() []string {
 }
 
 type translation struct {
-	name string
-	ips  map[util.Address]struct{}
+	dns string
+	ips []util.Address
 }
 
 func newTranslation(domain []byte) *translation {
 	return &translation{
-		name: string(domain),
-		ips:  make(map[util.Address]struct{}),
+		dns: string(domain),
+		ips: make([]util.Address, 0),
 	}
 }
 
 func (t *translation) add(addr util.Address) {
-	t.ips[addr] = struct{}{}
+	for _, other := range t.ips {
+		if other == addr {
+			return
+		}
+	}
+
+	t.ips = append(t.ips, addr)
 }

--- a/pkg/ebpf/dns_parser.go
+++ b/pkg/ebpf/dns_parser.go
@@ -1,0 +1,87 @@
+package ebpf
+
+import (
+	"bytes"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+type dnsParser struct {
+	decoder *gopacket.DecodingLayerParser
+	layers  []gopacket.LayerType
+	payload *layers.DNS
+}
+
+func newDNSParser() *dnsParser {
+	payload := &layers.DNS{}
+
+	stack := []gopacket.DecodingLayer{
+		&layers.Ethernet{},
+		&layers.IPv4{},
+		&layers.IPv6{},
+		&layers.UDP{},
+		payload,
+	}
+
+	return &dnsParser{
+		decoder: gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, stack...),
+		payload: payload,
+	}
+}
+
+func (p *dnsParser) Parse(data []byte) *translation {
+	err := p.decoder.DecodeLayers(data, &p.layers)
+	if err != nil || p.decoder.Truncated {
+		return nil
+	}
+
+	for _, layer := range p.layers {
+		if layer == layers.LayerTypeDNS {
+			return p.parseAnswer(p.payload)
+		}
+	}
+
+	return nil
+}
+
+// source: https://github.com/weaveworks/scope
+// every value should be *copied* to translation since the layer object gets re-used by gopacket
+func (*dnsParser) parseAnswer(dns *layers.DNS) *translation {
+	// Only consider responses to singleton, A-record questions
+	if !dns.QR || dns.ResponseCode != 0 || len(dns.Questions) != 1 {
+		return nil
+	}
+	question := dns.Questions[0]
+	if question.Type != layers.DNSTypeA || question.Class != layers.DNSClassIN {
+		return nil
+	}
+
+	var (
+		domainQueried = question.Name
+		records       = append(dns.Answers, dns.Additionals...)
+		translation   = newTranslation(domainQueried)
+		alias         []byte
+	)
+
+	// Retrieve the CNAME record, if available.
+	for _, record := range records {
+		if record.Type == layers.DNSTypeCNAME && record.Class == layers.DNSClassIN && bytes.Equal(domainQueried, record.Name) {
+			alias = record.CNAME
+			break
+		}
+	}
+
+	// Get IPs
+	for _, record := range records {
+		if record.Type != layers.DNSTypeA || record.Class != layers.DNSClassIN {
+			continue
+		}
+		if bytes.Equal(domainQueried, record.Name) || (alias != nil && bytes.Equal(alias, record.Name)) {
+			translation.add(util.AddressFromNetIP(record.IP))
+		}
+	}
+
+	return translation
+}

--- a/pkg/ebpf/dns_snooper.go
+++ b/pkg/ebpf/dns_snooper.go
@@ -46,7 +46,14 @@ type SocketFilterSnooper struct {
 
 // NewSocketFilterSnooper returns a new SocketFilterSnooper
 func NewSocketFilterSnooper(filter *bpflib.SocketFilter) (*SocketFilterSnooper, error) {
-	packetSrc, err := afpacket.NewTPacket(afpacket.OptPollTimeout(1 * time.Second))
+	packetSrc, err := afpacket.NewTPacket(
+		afpacket.OptPollTimeout(1*time.Second),
+		// This setup will require ~4Mb that is mmap'd into the process virtual space
+		// More information here: https://www.kernel.org/doc/Documentation/networking/packet_mmap.txt
+		afpacket.OptFrameSize(4096),
+		afpacket.OptBlockSize(4096*128),
+		afpacket.OptNumBlocks(8),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating raw socket: %s", err)
 	}

--- a/pkg/ebpf/dns_snooper.go
+++ b/pkg/ebpf/dns_snooper.go
@@ -115,16 +115,17 @@ func (s *SocketFilterSnooper) processPacket(data []byte) {
 func (s *SocketFilterSnooper) pollPackets() {
 	for {
 		data, _, err := s.source.ZeroCopyReadPacketData()
-		if err == nil {
-			s.processPacket(data)
-			continue
-		}
 
 		// Properly synchronizes termination process
 		select {
 		case <-s.exit:
 			return
 		default:
+		}
+
+		if err == nil {
+			s.processPacket(data)
+			continue
 		}
 
 		// Immediately retry for temporary network errors

--- a/pkg/ebpf/dns_snooper.go
+++ b/pkg/ebpf/dns_snooper.go
@@ -4,10 +4,7 @@ package ebpf
 
 import (
 	"fmt"
-	"io"
-	"net"
 	"reflect"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -128,21 +125,9 @@ func (s *SocketFilterSnooper) pollPackets() {
 			continue
 		}
 
-		// Immediately retry for temporary network errors
-		if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
-			continue
-		}
-
 		// Immediately retry for EAGAIN
 		if err == syscall.EAGAIN {
 			continue
-		}
-
-		// Immediately break for known unrecoverable errors
-		if err == io.EOF || err == io.ErrUnexpectedEOF || err == io.ErrNoProgress ||
-			err == io.ErrClosedPipe || err == io.ErrShortBuffer || err == syscall.EBADF ||
-			strings.Contains(err.Error(), "use of closed file") {
-			return
 		}
 
 		// Sleep briefly and try again

--- a/pkg/ebpf/dns_snooper_test.go
+++ b/pkg/ebpf/dns_snooper_test.go
@@ -64,6 +64,7 @@ Loop:
 	stats := reverseDNS.GetStats()
 	assert.True(t, stats["ips"] >= 1)
 	assert.True(t, stats["packets_captured"] >= 1)
+	assert.True(t, stats["socket_polls"] >= 1)
 	assert.Equal(t, int64(2), stats["lookups"])
 	assert.Equal(t, int64(1), stats["resolved"])
 }

--- a/pkg/ebpf/dns_snooper_test.go
+++ b/pkg/ebpf/dns_snooper_test.go
@@ -63,8 +63,6 @@ Loop:
 	// Verify telemetry
 	stats := reverseDNS.GetStats()
 	assert.True(t, stats["ips"] >= 1)
-	assert.True(t, stats["packets_captured"] >= 1)
-	assert.True(t, stats["socket_polls"] >= 1)
 	assert.Equal(t, int64(2), stats["lookups"])
 	assert.Equal(t, int64(1), stats["resolved"])
 }

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -64,6 +64,13 @@ func TestTracerExpvar(t *testing.T) {
 			"Lookups",
 			"Resolved",
 			"Ips",
+			"Added",
+			"Expired",
+			"PacketsCaptured",
+			"PacketsProcessed",
+			"PacketsDropped",
+			"SocketPolls",
+			"DecodingErrors",
 		},
 		"kprobes": {
 			"PtcpCleanupRbufHits",


### PR DESCRIPTION
### What does this PR do?

* Tune `RAW_SOCKET` ring buffer size (previously ~64Mb now ~4Mb).
  * More information here: https://www.kernel.org/doc/Documentation/networking/packet_mmap.txt
* Reduce DNS decoding allocations by re-using decoding objects and using a pre-defined protocol stack. 
  * More information here: https://godoc.org/github.com/google/gopacket#hdr-Fast_Decoding_With_DecodingLayerParser;
* Use zero-copy functionality from `gopacket` for polling and decoding packet data;
  * More information here: https://godoc.org/github.com/google/gopacket/afpacket#TPacket.ZeroCopyReadPacketData
* Fix DNS snooper termination (this was only affecting nodes with high DNS traffic);
* Create `packetSource` abstraction (code refactoring);
* Add more DNS telemetry (packets dropped, socket polls, packets received, packets processed);
* Cache `*translation*` object and use `[]util.Address` instead of `map[util.Address]struct{}` to reduce memory allocations;

Memory profile taken from one of our busiest servers (in terms of DNS traffic):

**Before** (DNS code path accounting for ~40% of allocations)
![-alloc_objects (before)](https://user-images.githubusercontent.com/692520/69742007-0afe3b00-110a-11ea-8c08-7ae87c33a68c.png)

**After** (DNS code path accounting for ~2% of allocations)
![-alloc_objects (after](https://user-images.githubusercontent.com/692520/69742006-0afe3b00-110a-11ea-8440-f209e7d2fd1d.png)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
