### PR TITLE
[macOS install script] Allow selecting major version to install

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -40,11 +40,11 @@ else
   echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing Agent version 6 by default.\033[0m"
 fi
 
-dmg_file="datadogagent.dmg"
+dmg_remote_file="datadogagent.dmg"
 if [ "$dd_agent_major_version" = "7" ]; then
-    dmg_file="datadog-agent-7-latest.dmg"
+    dmg_remote_file="datadog-agent-7-latest.dmg"
 fi
-dmg_url="$dmg_base_url/$dmg_file"
+dmg_url="$dmg_base_url/$dmg_remote_file"
 
 if [ $dd_upgrade ]; then
     if [ ! -f /opt/datadog-agent/etc/datadog.conf ]; then

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -126,7 +126,7 @@ function import_config() {
 # # Install the agent
 printf "\033[34m\n* Downloading datadog-agent\n\033[0m"
 rm -f $dmg_file
-curl --progress-bar $dmg_url > $dmg_file
+curl --fail --progress-bar $dmg_url > $dmg_file
 printf "\033[34m\n* Installing datadog-agent, you might be asked for your sudo password...\n\033[0m"
 $sudo_cmd hdiutil detach "/Volumes/datadog_agent" >/dev/null 2>&1 || true
 printf "\033[34m\n    - Mounting the DMG installer...\n\033[0m"

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -7,7 +7,7 @@
 set -e
 logfile=ddagent-install.log
 dmg_file=/tmp/datadog-agent.dmg
-dmg_url="https://s3.amazonaws.com/dd-agent/datadogagent.dmg"
+dmg_base_url="https://s3.amazonaws.com/dd-agent"
 
 dd_upgrade=
 if [ -n "$DD_UPGRADE" ]; then
@@ -28,6 +28,23 @@ fi
 if [ -n "$DD_SITE" ]; then
     site=$DD_SITE
 fi
+
+dd_agent_major_version=6
+if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
+  if [ "$DD_AGENT_MAJOR_VERSION" != "6" -a "$DD_AGENT_MAJOR_VERSION" != "7" ]; then
+    echo "DD_AGENT_MAJOR_VERSION must be either 6 or 7. Current value: $DD_AGENT_MAJOR_VERSION"
+    exit 1;
+  fi
+  dd_agent_major_version=$DD_AGENT_MAJOR_VERSION
+fi
+  echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing Agent version 6 by default.\033[0m"
+fi
+
+dmg_file="datadogagent.dmg"
+if [ "$dd_agent_major_version" = "7" ]; then
+    dmg_file="datadog-agent-7-latest.dmg"
+fi
+dmg_url="$dmg_base_url/$dmg_file"
 
 if [ $dd_upgrade ]; then
     if [ ! -f /opt/datadog-agent/etc/datadog.conf ]; then

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -36,7 +36,7 @@ if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
     exit 1;
   fi
   dd_agent_major_version=$DD_AGENT_MAJOR_VERSION
-fi
+else
   echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing Agent version 6 by default.\033[0m"
 fi
 


### PR DESCRIPTION
### What does this PR do?

Allow selecting the major DMG version to install, with the `DD_AGENT_MAJOR_VERSION` env var. Either 6 or 7. Defaults to 6.

Similar logic and code as the Linux install script. Behavior is similar to Linux to keep things consistent.

**DO NOT MERGE UNTIL 7.16 IS OUT**

### Motivation

Prepare for 7.16.

 We want users to be able to choose whether to install 6 or 7 because some users may want to install 6 to port some custom checks.