### PR TITLE
streamline build pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -698,6 +698,7 @@ agent_suse-x64-a7:
 ##
 .dockerbuild_windows_msi_base:
   stage: package_build
+  needs: ["run_dep_check_lock"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   # Unavailable on gitlab < 12.3
   # timeout: 2h 00m
@@ -889,6 +890,7 @@ dogstatsd_suse-x64:
 # deploy debian packages to apt staging repo
 deploy_deb_testing-a6:
   stage: testkitchen_deploy
+  needs: ["agent_deb-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -914,6 +916,7 @@ deploy_deb_testing-a6:
 
 deploy_deb_testing-a7:
   stage: testkitchen_deploy
+  needs: ["agent_deb-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -943,6 +946,7 @@ deploy_rpm_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
+  needs: ["agent_rpm-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -960,6 +964,7 @@ deploy_rpm_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
+  needs: ["agent_rpm-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -978,6 +983,7 @@ deploy_suse_rpm_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
+  needs: ["agent_suse-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -995,6 +1001,7 @@ deploy_suse_rpm_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
+  needs: ["agent_suse-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1013,6 +1020,7 @@ deploy_windows_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
+  needs: ["dockerbuild_windows_msi_x86-a6", "dockerbuild_windows_msi_x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1024,6 +1032,7 @@ deploy_windows_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
+  needs: ["dockerbuild_windows_msi_x86-a7", "dockerbuild_windows_msi_x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1089,6 +1098,7 @@ deploy_windows_testing-a7:
 .kitchen_windows_a6_common: &kitchen_windows_a6_common
   <<: *kitchen_common
   <<: *kitchen_a6_common
+  needs: ["deploy_windows_testing-a6"]
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6
@@ -1103,6 +1113,7 @@ deploy_windows_testing-a7:
 .kitchen_windows_a7_common: &kitchen_windows_a7_common
   <<: *kitchen_common
   <<: *kitchen_a7_common
+  needs: ["deploy_windows_testing-a7"]
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7
@@ -1116,6 +1127,7 @@ deploy_windows_testing-a7:
 
 .kitchen_centos_common: &kitchen_centos_common
   <<: *kitchen_common
+  needs: ["deploy_rpm_testing-a6", "deploy_rpm_testing-a7"]
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export TEST_PLATFORMS="centos-69,OpenLogic:CentOS:6.9:6.9.20180530"
@@ -1126,6 +1138,7 @@ deploy_windows_testing-a7:
 
 .kitchen_ubuntu_common: &kitchen_ubuntu_common
   <<: *kitchen_common
+  needs: ["deploy_deb_testing-a6", "deploy_deb_testing-a7"]
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export TEST_PLATFORMS="ubuntu-14-04,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140"
@@ -1136,6 +1149,7 @@ deploy_windows_testing-a7:
 
 .kitchen_suse_common: &kitchen_suse_common
   <<: *kitchen_common
+  needs: ["deploy_suse_rpm_testing-a6", "deploy_suse_rpm_testing-a7"]
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP4:2019.06.17"
@@ -1145,6 +1159,7 @@ deploy_windows_testing-a7:
 
 .kitchen_debian_common: &kitchen_debian_common
   <<: *kitchen_common
+  needs: ["deploy_deb_testing-a6", "deploy_deb_testing-a7"]
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export TEST_PLATFORMS="debian-8,credativ:Debian:8:8.20190313.0"
@@ -1159,6 +1174,7 @@ kitchen_windows_installer-a6:
   <<: *skip_when_unwanted_on_6
   <<: *kitchen_windows_installer_common
   <<: *kitchen_a6_common
+  needs: ["deploy_windows_testing-a6"]
   before_script:
     - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6
   retry: 0
@@ -1168,6 +1184,7 @@ kitchen_windows_installer-a7:
   <<: *skip_when_unwanted_on_7
   <<: *kitchen_windows_installer_common
   <<: *kitchen_a7_common
+  needs: ["deploy_windows_testing-a7"]
   before_script:
     - export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7
   retry: 0


### PR DESCRIPTION
### What does this PR do?

Using dag feature:
individual package_builds are started as soon as possible
builds are deployed to kitchen repo as available, rather than waiting for all packages to be done
kitchen tests are run as available (when kitchen is run)

### Motivation

Speeds total pipeline execution.
LInux builds (including kitchen) will complete sooner
Linux and windows builds start testing before arm builds (the slowest package builds) complete.

