### PR TITLE
Add hostname sanity checks to prevent using POD name

### DIFF
--- a/pkg/util/containers/types.go
+++ b/pkg/util/containers/types.go
@@ -47,6 +47,16 @@ const (
 	UnknownNetworkMode        = "unknown"
 )
 
+// UTSMode is container UTS modes
+type UTSMode string
+
+// UTSMode is container UTS modes
+const (
+	DefaultUTSMode UTSMode = ""
+	HostUTSMode            = "host"
+	UnknownUTSMode         = "unknown"
+)
+
 // Container represents a single container on a machine
 // and includes Cgroup-level statistics about the container.
 type Container struct {

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -244,7 +244,7 @@ func (d *DockerUtil) Inspect(id string, withSize bool) (types.ContainerJSON, err
 
 // InspectSelf returns the inspect content of the container the current agent is running in
 func (d *DockerUtil) InspectSelf() (types.ContainerJSON, error) {
-	cID, err := d.GetAgentCID()
+	cID, err := GetAgentCID()
 	if err != nil {
 		return types.ContainerJSON{}, err
 	}
@@ -253,7 +253,7 @@ func (d *DockerUtil) InspectSelf() (types.ContainerJSON, error) {
 }
 
 // GetAgentCID returns the container ID where the current agent is running
-func (d *DockerUtil) GetAgentCID() (string, error) {
+func GetAgentCID() (string, error) {
 	prefix := config.Datadog.GetString("container_cgroup_prefix")
 	cID, _, err := metrics.ReadCgroupsForPath("/proc/self/cgroup", prefix)
 	if err != nil {

--- a/pkg/util/docker/network.go
+++ b/pkg/util/docker/network.go
@@ -142,11 +142,7 @@ func resolveDockerNetworks(containerNetworks map[string][]dockerNetwork) {
 // To get this info in an optimal way, consider calling util.GetAgentNetworkMode	func GetContainerNetworkMode(cid string) (string, error) {
 // instead to benefit from the cache
 func GetAgentContainerNetworkMode() (string, error) {
-	du, err := GetDockerUtil()
-	if err != nil {
-		return "", err
-	}
-	agentCID, _ := du.GetAgentCID()
+	agentCID, _ := GetAgentCID()
 	return GetContainerNetworkMode(agentCID)
 }
 

--- a/pkg/util/docker/uts.go
+++ b/pkg/util/docker/uts.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/docker/docker/api/types/container"
+)
+
+// GetAgentContainerUTSMode provides the UTS mode of the Agent container
+// To get this info in an optimal way, consider calling util.GetAgentUTSMode instead to benefit from the cache
+func GetAgentContainerUTSMode() (containers.UTSMode, error) {
+	agentCID, _ := GetAgentCID()
+	return GetContainerUTSMode(agentCID)
+}
+
+// GetContainerUTSMode returns the UTS mode of a container
+func GetContainerUTSMode(cid string) (containers.UTSMode, error) {
+	du, err := GetDockerUtil()
+	if err != nil {
+		return containers.UnknownUTSMode, err
+	}
+	container, err := du.Inspect(cid, false)
+	if err != nil {
+		return containers.UnknownUTSMode, err
+	}
+	return parseContainerUTSMode(container.HostConfig)
+}
+
+// parseContainerUTSMode returns the UTS mode of a container
+func parseContainerUTSMode(hostConfig *container.HostConfig) (containers.UTSMode, error) {
+	if hostConfig == nil {
+		return containers.UnknownUTSMode, errors.New("the HostConfig field is nil")
+	}
+	mode := containers.UTSMode(hostConfig.UTSMode)
+	switch mode {
+	case containers.DefaultUTSMode:
+		return containers.DefaultUTSMode, nil
+	case containers.HostUTSMode:
+		return containers.HostUTSMode, nil
+	}
+	if strings.HasPrefix(string(mode), containerModePrefix) {
+		return mode, nil
+	}
+	return containers.UnknownUTSMode, fmt.Errorf("unknown UTS mode: %s", mode)
+}

--- a/pkg/util/docker/uts_test.go
+++ b/pkg/util/docker/uts_test.go
@@ -1,0 +1,70 @@
+// +build docker
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/docker/docker/api/types/container"
+)
+
+func TestParseContainerUTSMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		hostConfig *container.HostConfig
+		want       containers.UTSMode
+		wantErr    bool
+	}{
+		{
+			name: "default",
+			hostConfig: &container.HostConfig{
+				UTSMode: "",
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "host",
+			hostConfig: &container.HostConfig{
+				UTSMode: "host",
+			},
+			want:    "host",
+			wantErr: false,
+		},
+		{
+			name: "attached to container",
+			hostConfig: &container.HostConfig{
+				UTSMode: "container:0a8f83f35f7d0161f29b819d9b533b57acade8d99609bba63664dd3326e4d301",
+			},
+			want:    "container:0a8f83f35f7d0161f29b819d9b533b57acade8d99609bba63664dd3326e4d301",
+			wantErr: false,
+		},
+		{
+			name: "unknown",
+			hostConfig: &container.HostConfig{
+				UTSMode: "Unexected unknown mode",
+			},
+			want:    "unknown",
+			wantErr: true,
+		},
+		{
+			name:       "nil hostConfig",
+			hostConfig: nil,
+			want:       "unknown",
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseContainerUTSMode(tt.hostConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseContainerUTSMode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseContainerUTSMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -216,7 +216,8 @@ func GetHostnameData() (HostnameData, error) {
 
 	// FQDN
 	var fqdn string
-	if isOSHostnameUsable() {
+	canUseOSHostname := isOSHostnameUsable()
+	if canUseOSHostname {
 		log.Debug("GetHostname trying FQDN/`hostname -f`...")
 		fqdn, err = getSystemFQDN()
 		if config.Datadog.GetBool("hostname_fqdn") && err == nil {
@@ -244,7 +245,7 @@ func GetHostnameData() (HostnameData, error) {
 		}
 	}
 
-	if isOSHostnameUsable() && hostName == "" {
+	if canUseOSHostname && hostName == "" {
 		// os
 		log.Debug("GetHostname trying os...")
 		systemName, err := os.Hostname()

--- a/pkg/util/kube_hostnetwork.go
+++ b/pkg/util/kube_hostnetwork.go
@@ -1,0 +1,16 @@
+// +build kubelet
+
+package util
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+func isAgentKubeHostNetwork() (bool, error) {
+	ku, err := kubelet.GetKubeUtil()
+	if err != nil {
+		return true, err
+	}
+
+	return ku.IsAgentHostNetwork()
+}

--- a/pkg/util/kube_hostnetwork_stub.go
+++ b/pkg/util/kube_hostnetwork_stub.go
@@ -1,0 +1,7 @@
+// +build !kubelet
+
+package util
+
+func isAgentKubeHostNetwork() (bool, error) {
+	return true, nil
+}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -500,6 +500,21 @@ func (ku *KubeUtil) GetRawMetrics() ([]byte, error) {
 	return data, nil
 }
 
+// IsAgentHostNetwork returns whether the agent is running inside a container with `hostNetwork` or not
+func (ku *KubeUtil) IsAgentHostNetwork() (bool, error) {
+	cid, err := docker.GetAgentCID()
+	if err != nil {
+		return false, err
+	}
+
+	pod, err := ku.GetPodForContainerID(cid)
+	if err != nil {
+		return false, err
+	}
+
+	return pod.Spec.HostNetwork, nil
+}
+
 func (ku *KubeUtil) setupKubeletApiEndpoint() error {
 	// HTTPS
 	ku.kubeletApiEndpoint = fmt.Sprintf("https://%s:%d", ku.kubeletHost, config.Datadog.GetInt("kubernetes_https_kubelet_port"))

--- a/pkg/util/uts_docker.go
+++ b/pkg/util/uts_docker.go
@@ -1,0 +1,29 @@
+// +build docker
+
+package util
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// GetAgentUTSMode retrieves from Docker the UTS mode of the Agent container
+func GetAgentUTSMode() (containers.UTSMode, error) {
+	cacheUTSModeKey := cache.BuildAgentKey("utsMode")
+	if cacheUTSMode, found := cache.Cache.Get(cacheUTSModeKey); found {
+		return cacheUTSMode.(containers.UTSMode), nil
+	}
+
+	log.Debugf("GetAgentUTSMode trying docker")
+	utsMode, err := docker.GetAgentContainerUTSMode()
+	cache.Cache.Set(cacheUTSModeKey, utsMode, cache.NoExpiration)
+	if err != nil {
+		return utsMode, fmt.Errorf("could not detect agent UTS mode: %v", err)
+	}
+	log.Debugf("GetAgentUTSMode: using UTS mode from Docker: %s", utsMode)
+	return utsMode, nil
+}

--- a/pkg/util/uts_nodocker.go
+++ b/pkg/util/uts_nodocker.go
@@ -1,0 +1,12 @@
+// +build !docker
+
+package util
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+// GetAgentUTSMode retrieves from Docker the UTS mode of the Agent container
+func GetAgentUTSMode() (containers.UTSMode, error) {
+	return containers.UnknownUTSMode, nil
+}

--- a/releasenotes/notes/check_hostname_is_usable-dc4b99e6f7242b34.yaml
+++ b/releasenotes/notes/check_hostname_is_usable-dc4b99e6f7242b34.yaml
@@ -1,0 +1,17 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Prevent a containerized agent from using the OS hostname as datadog agent hostname.
+    Datadog agent hostname should be stable and should reflect the identity of the host they are monitoring.
+    Container ID or kubernetes POD names are not suitable for that purpose.
+    That’s why the agent should avoid using the OS hostname when it is running in a dedicated UTS namespace.
+    Note that the agent is relying on many other smart ways of discovering the real hostname of the host
+    (EC2/AWS metadata server, docker daemon, kubernetes node names)
+    This change only acts as a safety belt when all those smart ways of discovering the hostname are not usable.

--- a/releasenotes/notes/check_hostname_is_usable-dc4b99e6f7242b34.yaml
+++ b/releasenotes/notes/check_hostname_is_usable-dc4b99e6f7242b34.yaml
@@ -8,10 +8,11 @@
 ---
 upgrade:
   - |
-    Prevent a containerized agent from using the OS hostname as datadog agent hostname.
-    Datadog agent hostname should be stable and should reflect the identity of the host they are monitoring.
-    Container ID or kubernetes POD names are not suitable for that purpose.
-    That’s why the agent should avoid using the OS hostname when it is running in a dedicated UTS namespace.
-    Note that the agent is relying on many other smart ways of discovering the real hostname of the host
-    (EC2/AWS metadata server, docker daemon, kubernetes node names)
-    This change only acts as a safety belt when all those smart ways of discovering the hostname are not usable.
+    Starting with this version, the containerized Agent never chooses the OS hostname as its hostname when it is running in a dedicated UTS namespace.
+    This is done in order to avoid picking container IDs or kubernetes POD names as hostnames, since these identifiers do not reflect the identity of the host they run on.
+
+    This change only affects you if your agent is currently using a container ID or a kubernetes POD name as hostname.
+    The hostname of the agent can be checked with ``agent hostname``.
+    If the output stays stable when the container or POD of the agent is destroyed and recreated, you’re not impacted by this change.
+    If the output changes, it means that the agent was unable to talk to EC2/GKE metadata server, it was unable to get the k8s node name from the kubelet, it was unable to get the hostname from the docker daemon and it is running in its dedicated UTS namespace.
+    Under those conditions, you should set explicitly define the host name to be used by the agent in its configuration file.


### PR DESCRIPTION
### What does this PR do?

Try to detect if the agent is running in a container with a UTS namespace which is not the root one.
In those cases, the output of `hostname -f` doesn’t reflect the identity of the host and shouldn’t be used.

### Motivation

In some very specific circonstances the agent might need to guess the `hostname` by just doing a `hostname -f` command inside a container.
Those circonstances are:
— the agent hasn’t access to the metadata server of the IaaS,
— the agent hasn’t access to the docker socket,
— the hostname constructed by the agent by concatenating the node name with the cluster name is not valid.

When the agent is running in a POD which has `hostNetwork: false` or, generally speaking, when the agent is running in a container with its dedicated UTS namespace, it shouldn’t use the hostname of the container because it doesn’t reflect the identity of the host and can change at each agent deployment.

### Additional Notes

Without #4492 and with an invalid cluster name (with an underscore),
**Before** this change:
```
$ kubectl get pods
NAME                                          READY   STATUS    RESTARTS   AGE
datadog-48qvg                                 3/3     Running   0          107s

$ kubectl exec datadog-48qvg -c agent agent hostname
Error: ValidHostname: gke-lenaic-pool-1-1c8b424c-spk1-lenaic_gke is not RFC1123 compliant
datadog-48qvg
```

**After** this change:
```
$ kubectl get pod
NAME                                          READY   STATUS             RESTARTS   AGE
datadog-5v98k                                 2/3     Error              0          9s

$ kubectl logs datadog-5v98k -c agent
[…]
2019-11-26 15:43:43 UTC | CORE | DEBUG | (pkg/util/hostname.go:181 in GetHostname) | agent is not running in the root UTS namespace. `hostname -f` cannot be used to detect hostname.
[…]
2019-11-26 15:43:43 UTC | CORE | INFO | (pkg/util/kubernetes/clustername/clustername.go:52 in getClusterName) | Got cluster name lenaic_gke from config
2019-11-26 15:43:43 UTC | CORE | ERROR | (pkg/util/hostname.go:61 in ValidHostname) | ValidHostname: gke-lenaic-pool-1-1c8b424c-wnkn-lenaic_gke is not RFC1123 compliant
[…]
2019-11-26 15:43:43 UTC | CORE | ERROR | (cmd/agent/app/run.go:204 in StartAgent) | Error while getting hostname, exiting: unable to reliably determine the host name. You can define one in the agent config file or in your hosts file
```