### PR TITLE
Add agent hostname

### DIFF
--- a/pkg/collector/metadata/agentchecks/agentchecks.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks.go
@@ -20,7 +20,8 @@ import (
 // GetPayload builds a payload of all the agentchecks metadata
 func GetPayload() *Payload {
 	agentChecksPayload := ACPayload{}
-	hostname, _ := util.GetHostname()
+	hostnameData, _ := util.GetHostnameData()
+	hostname := hostnameData.Hostname
 	checkStats := runner.GetCheckStats()
 
 	for _, stats := range checkStats {
@@ -59,7 +60,7 @@ func GetPayload() *Payload {
 	}
 
 	// Grab the non agent checks information
-	metaPayload := host.GetMeta()
+	metaPayload := host.GetMeta(hostnameData)
 	metaPayload.Hostname = hostname
 	cp := common.GetPayload(hostname)
 	ehp := externalhost.GetPayload()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -166,6 +166,11 @@ func initConfig(config Config) {
 	// dependent; default should remain false on Windows to maintain backward
 	// compatibility with Agent5 behavior/win
 	config.BindEnvAndSetDefault("hostname_fqdn", false)
+
+	// When enabled, hostname defined in the configuration (datadog.yaml) and starting with `ip-` or `domu` on EC2 is used as
+	// canonical hostname, otherwise the instance-id is used as canonical hostname.
+	config.BindEnvAndSetDefault("hostname_force_config_as_canonical", false)
+
 	config.BindEnvAndSetDefault("cluster_name", "")
 
 	// secrets backend
@@ -333,10 +338,6 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("metrics_port", "5000")
 
 	// Metadata endpoints
-
-	// When enabled, hostname defined in the configuration (datadog.yaml) and starting with `ip-` or `domu` on EC2 is used as
-	// canonical hostname, otherwise the instance-id is used as canonical hostname.
-	config.BindEnvAndSetDefault("use_configuration_hostname_as_canonical_hostname", false)
 
 	// Defines the maximum size of hostame gathered from EC2, GCE, Azure and Alibabacloud metadata endpoints.
 	// Used internally to protect against configurations where metadata endpoints return incorrect values with 200 status codes.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -334,6 +334,10 @@ func initConfig(config Config) {
 
 	// Metadata endpoints
 
+	// When enabled, hostname defined in the configuration (datadog.yaml) and starting with `ip-` or `domu` on EC2 is used as
+	// canonical hostname, otherwise the instance-id is used as canonical hostname.
+	config.BindEnvAndSetDefault("use_configuration_hostname_as_canonical_hostname", false)
+
 	// Defines the maximum size of hostame gathered from EC2, GCE, Azure and Alibabacloud metadata endpoints.
 	// Used internally to protect against configurations where metadata endpoints return incorrect values with 200 status codes.
 	config.BindEnvAndSetDefault("metadata_endpoints_max_hostname_size", 255)

--- a/pkg/metadata/host.go
+++ b/pkg/metadata/host.go
@@ -8,7 +8,7 @@ package metadata
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/metadata/v5"
+	v5 "github.com/DataDog/datadog-agent/pkg/metadata/v5"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
@@ -19,9 +19,9 @@ type HostCollector struct{}
 
 // Send collects the data needed and submits the payload
 func (hp *HostCollector) Send(s *serializer.Serializer) error {
-	hostname, _ := util.GetHostname()
+	hostnameData, _ := util.GetHostnameData()
 
-	payload := v5.GetPayload(hostname)
+	payload := v5.GetPayload(hostnameData)
 	if err := s.SendMetadata(payload); err != nil {
 		return fmt.Errorf("unable to submit host metadata payload, %s", err)
 	}

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -133,7 +133,7 @@ func getMeta(hostnameData util.HostnameData) *Meta {
 
 	var agentHostname string
 
-	if config.Datadog.GetBool("use_configuration_hostname_as_canonical_hostname") &&
+	if config.Datadog.GetBool("hostname_force_config_as_canonical") &&
 		hostnameData.Provider == util.HostnameProviderConfiguration {
 		agentHostname = hostnameData.Hostname
 	}

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
@@ -19,7 +20,7 @@ import (
 )
 
 func TestGetPayload(t *testing.T) {
-	p := GetPayload("myhostname")
+	p := GetPayload(util.HostnameData{Hostname: "myhostname", Provider: ""})
 	assert.NotEmpty(t, p.Os)
 	assert.NotEmpty(t, p.PythonVersion)
 	assert.NotNil(t, p.SystemStats)
@@ -63,7 +64,7 @@ func TestGetHostInfo(t *testing.T) {
 }
 
 func TestGetMeta(t *testing.T) {
-	meta := getMeta()
+	meta := getMeta(util.HostnameData{})
 	assert.NotEmpty(t, meta.SocketHostname)
 	assert.NotEmpty(t, meta.Timezones)
 	assert.NotEmpty(t, meta.SocketFqdn)

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -26,6 +26,7 @@ type Meta struct {
 	Hostname       string   `json:"hostname"`
 	HostAliases    []string `json:"host_aliases"`
 	InstanceID     string   `json:"instance-id"`
+	AgentHostname  string   `json:"agent-hostname"`
 }
 
 // NetworkMeta is metadata about the host's network

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -26,7 +26,7 @@ type Meta struct {
 	Hostname       string   `json:"hostname"`
 	HostAliases    []string `json:"host_aliases"`
 	InstanceID     string   `json:"instance-id"`
-	AgentHostname  string   `json:"agent-hostname"`
+	AgentHostname  string   `json:"agent-hostname,omitempty"`
 }
 
 // NetworkMeta is metadata about the host's network

--- a/pkg/metadata/v5/v5.go
+++ b/pkg/metadata/v5/v5.go
@@ -13,13 +13,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 // GetPayload returns the complete metadata payload as seen in Agent v5
-func GetPayload(hostname string) *Payload {
-	cp := common.GetPayload(hostname)
-	hp := host.GetPayload(hostname)
-	rp := resources.GetPayload(hostname)
+func GetPayload(hostnameData util.HostnameData) *Payload {
+	cp := common.GetPayload(hostnameData.Hostname)
+	hp := host.GetPayload(hostnameData)
+	rp := resources.GetPayload(hostnameData.Hostname)
 
 	p := &Payload{
 		CommonPayload: CommonPayload{*cp},

--- a/pkg/metadata/v5/v5_test.go
+++ b/pkg/metadata/v5/v5_test.go
@@ -8,10 +8,11 @@ package v5
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetPayload(t *testing.T) {
-	pl := GetPayload("testhostname")
+	pl := GetPayload(util.HostnameData{Hostname: "testhostname", Provider: ""})
 	assert.NotNil(t, pl)
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -39,14 +39,14 @@ func GetStatus() (map[string]interface{}, error) {
 	}
 
 	stats["version"] = version.AgentVersion
-	hostname, err := util.GetHostname()
+	hostnameData, err := util.GetHostnameData()
 
 	var metadata *host.Payload
 	if err != nil {
 		log.Errorf("Error grabbing hostname for status: %v", err)
-		metadata = host.GetPayloadFromCache("unknown")
+		metadata = host.GetPayloadFromCache(util.HostnameData{Hostname: "unknown", Provider: "unknown"})
 	} else {
-		metadata = host.GetPayloadFromCache(hostname)
+		metadata = host.GetPayloadFromCache(hostnameData)
 	}
 	stats["metadata"] = metadata
 
@@ -149,12 +149,12 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	stats["conf_file"] = config.Datadog.ConfigFileUsed()
 	stats["version"] = version.AgentVersion
 	stats["pid"] = os.Getpid()
-	hostname, err := util.GetHostname()
+	hostnameData, err := util.GetHostnameData()
 	if err != nil {
 		log.Errorf("Error grabbing hostname for status: %v", err)
-		stats["metadata"] = host.GetPayloadFromCache("unknown")
+		stats["metadata"] = host.GetPayloadFromCache(util.HostnameData{Hostname: "unknown", Provider: "unknown"})
 	} else {
-		stats["metadata"] = host.GetPayloadFromCache(hostname)
+		stats["metadata"] = host.GetPayloadFromCache(hostnameData)
 	}
 	now := time.Now()
 	stats["time"] = now.Format(timeFormat)

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -169,12 +169,21 @@ func getResponse(url string) (*http.Response, error) {
 
 // IsDefaultHostname returns whether the given hostname is a default one for EC2
 func IsDefaultHostname(hostname string) bool {
+	return isDefaultHostname(hostname, config.Datadog.GetBool("ec2_use_windows_prefix_detection"))
+}
+
+// IsDefaultHostnameForSobotka returns whether the given hostname is a default one for EC2 for Sobotka
+func IsDefaultHostnameForSobotka(hostname string) bool {
+	return isDefaultHostname(hostname, false)
+}
+
+func isDefaultHostname(hostname string, useWindowsPrefix bool) bool {
 	hostname = strings.ToLower(hostname)
 	isDefault := false
 
 	var prefixes []string
 
-	if config.Datadog.GetBool("ec2_use_windows_prefix_detection") {
+	if useWindowsPrefix {
 		prefixes = defaultPrefixes
 	} else {
 		prefixes = oldDefaultPrefixes

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -172,8 +172,8 @@ func IsDefaultHostname(hostname string) bool {
 	return isDefaultHostname(hostname, config.Datadog.GetBool("ec2_use_windows_prefix_detection"))
 }
 
-// IsDefaultHostnameForSobotka returns whether the given hostname is a default one for EC2 for Sobotka
-func IsDefaultHostnameForSobotka(hostname string) bool {
+// IsDefaultHostnameForIntake returns whether the given hostname is a default one for EC2 for the intake
+func IsDefaultHostnameForIntake(hostname string) bool {
 	return isDefaultHostname(hostname, false)
 }
 

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -33,7 +33,7 @@ func TestIsDefaultHostname(t *testing.T) {
 	}
 }
 
-func TestIsDefaultHostnameForSobotka(t *testing.T) {
+func TestIsDefaultHostnameForIntake(t *testing.T) {
 	const key = "ec2_use_windows_prefix_detection"
 	prefixDetection := config.Datadog.GetBool(key)
 	config.Datadog.SetDefault(key, true)

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -39,9 +39,9 @@ func TestIsDefaultHostnameForSobotka(t *testing.T) {
 	config.Datadog.SetDefault(key, true)
 	defer config.Datadog.SetDefault(key, prefixDetection)
 
-	assert.True(t, IsDefaultHostnameForSobotka("IP-FOO"))
-	assert.True(t, IsDefaultHostnameForSobotka("domuarigato"))
-	assert.False(t, IsDefaultHostnameForSobotka("EC2AMAZ-FOO"))
+	assert.True(t, IsDefaultHostnameForIntake("IP-FOO"))
+	assert.True(t, IsDefaultHostnameForIntake("domuarigato"))
+	assert.False(t, IsDefaultHostnameForIntake("EC2AMAZ-FOO"))
 	assert.True(t, IsDefaultHostname("EC2AMAZ-FOO"))
 }
 

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -33,6 +33,18 @@ func TestIsDefaultHostname(t *testing.T) {
 	}
 }
 
+func TestIsDefaultHostnameForSobotka(t *testing.T) {
+	const key = "ec2_use_windows_prefix_detection"
+	prefixDetection := config.Datadog.GetBool(key)
+	config.Datadog.SetDefault(key, true)
+	defer config.Datadog.SetDefault(key, prefixDetection)
+
+	assert.True(t, IsDefaultHostnameForSobotka("IP-FOO"))
+	assert.True(t, IsDefaultHostnameForSobotka("domuarigato"))
+	assert.False(t, IsDefaultHostnameForSobotka("EC2AMAZ-FOO"))
+	assert.True(t, IsDefaultHostname("EC2AMAZ-FOO"))
+}
+
 func TestGetInstanceID(t *testing.T) {
 	expected := "i-0123456789abcdef0"
 	var lastRequest *http.Request

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -117,7 +117,7 @@ type HostnameData struct {
 }
 
 // saveHostnameData creates a HostnameData struct, saves it in the cache under cacheHostnameKey
-// and call setHostnameProvider with the provider if it is not empty.
+// and calls setHostnameProvider with the provider if it is not empty.
 func saveHostnameData(cacheHostnameKey string, hostname string, provider string) HostnameData {
 	hostnameData := HostnameData{Hostname: hostname, Provider: provider}
 	cache.Cache.Set(cacheHostnameKey, hostnameData, cache.NoExpiration)

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -142,7 +142,7 @@ func GetHostnameData() (HostnameData, error) {
 		cache.Cache.Set(cacheHostnameKey, hostnameData, cache.NoExpiration)
 		setHostnameProvider(provider)
 		if !checkIfHostnameUsedAsCanonicalHostname(configName) {
-			_ = log.Warnf("Hostname %s will not be used. Please see https://github.com/DataDog/documentation/blob/master/content/en/agent/faq/hostname-starting-with-ec2-default-prefix.md for more information", configName)
+			_ = log.Warnf("Hostname '%s' defined in configuration will not be used as the in-app hostname. https://dtdg.co/35FAVR7", configName)
 		}
 		return hostnameData, err
 	}

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -285,7 +285,7 @@ func GetHostnameData() (HostnameData, error) {
 
 func checkIfHostnameUsedAsCanonicalHostname(hostname string) bool {
 	// Sobotka uses instance id for ec2 default hostname except for Windows.
-	if ec2.IsDefaultHostnameForSobotka(hostname) {
+	if ec2.IsDefaultHostnameForIntake(hostname) {
 		if _, err := ec2.GetHostname(); err == nil {
 			return config.Datadog.GetBool("use_configuration_hostname_as_canonical_hostname")
 		}

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -287,7 +287,7 @@ func checkIfHostnameUsedAsCanonicalHostname(hostname string) bool {
 	// Sobotka uses instance id for ec2 default hostname except for Windows.
 	if ec2.IsDefaultHostnameForIntake(hostname) {
 		if _, err := ec2.GetHostname(); err == nil {
-			return config.Datadog.GetBool("use_configuration_hostname_as_canonical_hostname")
+			return config.Datadog.GetBool("hostname_force_config_as_canonical")
 		}
 	}
 	return true

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -149,7 +149,7 @@ func GetHostnameData() (HostnameData, error) {
 	err = ValidHostname(configName)
 	if err == nil {
 		hostnameData := saveHostnameData(cacheHostnameKey, configName, HostnameProviderConfiguration)
-		if !isHostnameCanonicalForIntake(configName) {
+		if !isHostnameCanonicalForIntake(configName) && !config.Datadog.GetBool("hostname_force_config_as_canonical") {
 			_ = log.Warnf("Hostname '%s' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-config-as-canonical", configName)
 		}
 		return hostnameData, err
@@ -289,9 +289,8 @@ func GetHostnameData() (HostnameData, error) {
 func isHostnameCanonicalForIntake(hostname string) bool {
 	// Intake uses instance id for ec2 default hostname except for Windows.
 	if ec2.IsDefaultHostnameForIntake(hostname) {
-		if _, err := ec2.GetInstanceID(); err == nil {
-			return config.Datadog.GetBool("hostname_force_config_as_canonical")
-		}
+		_, err := ec2.GetInstanceID()
+		return err != nil
 	}
 	return true
 }

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -142,7 +142,7 @@ func GetHostnameData() (HostnameData, error) {
 		cache.Cache.Set(cacheHostnameKey, hostnameData, cache.NoExpiration)
 		setHostnameProvider(provider)
 		if !checkIfHostnameUsedAsCanonicalHostname(configName) {
-			_ = log.Warnf("Hostname '%s' defined in configuration will not be used as the in-app hostname. https://dtdg.co/35FAVR7", configName)
+			_ = log.Warnf("Hostname '%s' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-config-as-canonical", configName)
 		}
 		return hostnameData, err
 	}

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -119,7 +119,9 @@ type HostnameData struct {
 func setHostnameData(cacheHostnameKey string, hostname string, provider string) HostnameData {
 	hostnameData := HostnameData{Hostname: hostname, Provider: provider}
 	cache.Cache.Set(cacheHostnameKey, hostnameData, cache.NoExpiration)
-	setHostnameProvider(provider)
+	if provider != "" {
+		setHostnameProvider(provider)
+	}
 	return hostnameData
 }
 
@@ -160,8 +162,7 @@ func GetHostnameData() (HostnameData, error) {
 
 	// if fargate we strip the hostname
 	if ecs.IsFargateInstance() {
-		hostnameData := HostnameData{}
-		cache.Cache.Set(cacheHostnameKey, hostnameData, cache.NoExpiration)
+		hostnameData := setHostnameData(cacheHostnameKey, "", "")
 		return hostnameData, nil
 	}
 

--- a/releasenotes/notes/add-warning-when-hostname-not-used-as-canonical-b520c6f13758e58e.yaml
+++ b/releasenotes/notes/add-warning-when-hostname-not-used-as-canonical-b520c6f13758e58e.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add a warning when the hostname defined in the configuration will not be used as a canonical hostname.
+    Log a warning when the hostname defined in the configuration will not be used as the in-app hostname.

--- a/releasenotes/notes/add-warning-when-hostname-not-used-as-canonical-b520c6f13758e58e.yaml
+++ b/releasenotes/notes/add-warning-when-hostname-not-used-as-canonical-b520c6f13758e58e.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add a warning when the hostname defined in the configuration will not be used as a canonical hostname.


### PR DESCRIPTION
### What does this PR do?

This PR sends `agent-hostname` in the metadata payload when the hostname is defined in the configuration file (datadog.yaml).

If you defined a hostname in the configuration starting with `ip-` or `domu` then sobotka will use the instance id as the canonical hostname. By sending `agent-hostname` we force sobotka to keep our hostname.

### Additional Notes

The release note description is short as our customer need to contact the support anyway.

Test performed:

* On EC2, start an agent with a hostname starting with `ip-` in the configuration with `use_configuration_hostname_as_canonical_hostname:true` => Canonical hostname start with `ip-`  

* On EC2, start an agent with a hostname starting with `ip-` in the configuration => Canonical hostname is the instance id (not starting with `ip-`). On this instance, set `use_configuration_hostname_as_canonical_hostname:true` => canonical hostname, stay the same.

**Please review carefully this PR as hostname logic can be tricky**.

**`GetStatus` and `getDCAStatus` will also return agent-hostname**.  `agent status` can display `agent-hostname` for example.