### PR TITLE
Consider only container services for logs AD

### DIFF
--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -59,7 +59,16 @@ func (s *Scheduler) Schedule(configs []integration.Config) {
 				s.sources.AddSource(source)
 			}
 		case s.newService(config):
-			log.Debugf("Received a new service: %v", config.Entity)
+			entityType, _, err := s.parseEntity(config.TaggerEntity)
+			if err != nil {
+				log.Warnf("Invalid service: %v", err)
+				continue
+			}
+			// logs only consider container services
+			if entityType != containers.ContainerEntityName {
+				continue
+			}
+			log.Infof("Received a new service: %v", config.Entity)
 			service, err := s.toService(config)
 			if err != nil {
 				log.Warnf("Invalid service: %v", err)
@@ -96,6 +105,15 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 			}
 		case s.newService(config):
 			// new service to remove
+			entityType, _, err := s.parseEntity(config.TaggerEntity)
+			if err != nil {
+				log.Warnf("Invalid service: %v", err)
+				continue
+			}
+			// logs only consider container services
+			if entityType != containers.ContainerEntityName {
+				continue
+			}
 			log.Infof("New service to remove: entity: %v", config.Entity)
 			service, err := s.toService(config)
 			if err != nil {

--- a/pkg/logs/scheduler/scheduler_test.go
+++ b/pkg/logs/scheduler/scheduler_test.go
@@ -26,6 +26,7 @@ func TestScheduleConfigCreatesNewSource(t *testing.T) {
 		LogsConfig:    []byte(`[{"service":"foo","source":"bar"}]`),
 		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
 		Provider:      providers.Kubernetes,
+		TaggerEntity:  "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		Entity:        "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		ClusterCheck:  false,
 		CreationTime:  0,
@@ -51,6 +52,7 @@ func TestScheduleConfigCreatesNewService(t *testing.T) {
 
 	configService := integration.Config{
 		LogsConfig:   []byte(""),
+		TaggerEntity: "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		Entity:       "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		ClusterCheck: false,
 		CreationTime: 0,
@@ -71,6 +73,7 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 		LogsConfig:    []byte(`[{"service":"foo","source":"bar"}]`),
 		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
 		Provider:      providers.Kubernetes,
+		TaggerEntity:  "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		Entity:        "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		ClusterCheck:  false,
 		CreationTime:  0,
@@ -99,6 +102,7 @@ func TestUnscheduleConfigRemovesService(t *testing.T) {
 
 	configService := integration.Config{
 		LogsConfig:   []byte(""),
+		TaggerEntity: "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		Entity:       "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		ClusterCheck: false,
 		CreationTime: 0,

--- a/pkg/logs/scheduler/scheduler_test.go
+++ b/pkg/logs/scheduler/scheduler_test.go
@@ -7,6 +7,7 @@ package scheduler
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
@@ -61,6 +62,22 @@ func TestScheduleConfigCreatesNewService(t *testing.T) {
 	go scheduler.Schedule([]integration.Config{configService})
 	svc := <-servicesStream
 	assert.Equal(t, configService.Entity, svc.GetEntityID())
+
+	// shouldn't consider pods
+	configService = integration.Config{
+		LogsConfig:   []byte(""),
+		TaggerEntity: "kubernetes_pod://ee9a4083-10fc-11ea-a545-02c6fa0ccfb0",
+		Entity:       "kubernetes_pod://ee9a4083-10fc-11ea-a545-02c6fa0ccfb0",
+		ClusterCheck: false,
+		CreationTime: 0,
+	}
+	go scheduler.Schedule([]integration.Config{configService})
+	select {
+	case <-servicesStream:
+		assert.Fail(t, "Pod should be ignored")
+	case <-time.After(100 * time.Millisecond):
+		break
+	}
 }
 
 func TestUnscheduleConfigRemovesSource(t *testing.T) {
@@ -111,4 +128,21 @@ func TestUnscheduleConfigRemovesService(t *testing.T) {
 	go scheduler.Unschedule([]integration.Config{configService})
 	svc := <-servicesStream
 	assert.Equal(t, configService.Entity, svc.GetEntityID())
+
+	// shouldn't consider pods
+	configService = integration.Config{
+		LogsConfig:   []byte(""),
+		TaggerEntity: "kubernetes_pod://ee9a4083-10fc-11ea-a545-02c6fa0ccfb0",
+		Entity:       "kubernetes_pod://ee9a4083-10fc-11ea-a545-02c6fa0ccfb0",
+		ClusterCheck: false,
+		CreationTime: 0,
+	}
+
+	go scheduler.Unschedule([]integration.Config{configService})
+	select {
+	case <-servicesStream:
+		assert.Fail(t, "Pod should be ignored")
+	case <-time.After(100 * time.Millisecond):
+		break
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Only consider container AD services for log scheduler (ignore pods & kube service)

### Motivation

Avoid
```
2019-11-27 10:14:19 UTC | CORE | WARN | (pkg/logs/input/kubernetes/launcher.go:127 in addSource) | Container kubernetes_pod://ead27058-10fc-11ea-a545-02c6fa0ccfb0 not found
2019-11-27 10:14:19 UTC | CORE | WARN | (pkg/logs/input/kubernetes/launcher.go:127 in addSource) | Container kubernetes_pod://ee9a4083-10fc-11ea-a545-02c6fa0ccfb0 not found
2019-11-27 10:14:19 UTC | CORE | WARN | (pkg/logs/input/kubernetes/launcher.go:127 in addSource) | Container kubernetes_pod://ef41d26e-10fc-11ea-a545-02c6fa0ccfb0 not found
2019-11-27 10:14:19 UTC | CORE | WARN | (pkg/logs/input/kubernetes/launcher.go:127 in addSource) | Container kubernetes_pod://ee7b0f3f-10fc-11ea-a545-02c6fa0ccfb0 not found
```

### Additional Notes

Anything else we should know when reviewing?
