### PR TITLE
Include CPU arch in host info

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -32,6 +32,7 @@
       {{end}}
       <br>Go Version: {{.go_version}}
       <br>Python Version: {{.python_version}}
+      <br>Build arch: {{.build_arch}}
     </span>
   </div>
 

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -12,6 +12,7 @@ NOTE: Changes made to this template should be reflected on the following templat
   {{- if .python_version }}
   Python Version: {{.python_version}}
   {{- end }}
+  Build arch: {{.build_arch}}
   {{- if .runnerStats.Workers}}
   Check Runners: {{.runnerStats.Workers}}
   {{end -}}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -64,6 +64,7 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["python_version"] = strings.Split(pythonVersion, " ")[0]
 	stats["agent_start"] = startTime.Format(timeFormat)
 	stats["hostinfo"] = host.GetStatusInformation()
+	stats["build_arch"] = runtime.GOARCH
 	now := time.Now()
 	stats["time"] = now.Format(timeFormat)
 


### PR DESCRIPTION
To distinguish x64 and ARM machines.

Eg:
```
  Status date: 2019-11-29 13:06:00.610181 CET
  Agent start: 2019-11-29 13:05:33.240144 CET
  Pid: 78434
  Go Version: go1.13
  Python Version: 3.7.4
  Build arch: amd64
  Check Runners: 4
  Log Level: info
```