### PR TITLE
[github] Change ownership of Gopkg.lock and Gopkg.toml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,9 @@
 /docs/cluster-agent/                    @DataDog/baklava @DataDog/container-integrations
 /docs/dev/checks/                       @DataDog/baklava @DataDog/agent-core
 
+/Gopkg.lock                             @DataDog/agent-all
+/Gopkg.toml                             @DataDog/agent-all
+
 /Makefile.trace                         @DataDog/apm-agent
 
 /omnibus/                               @DataDog/agent-platform


### PR DESCRIPTION
### What does this PR do?

Changes ownership of `Gopkg.lock` and `Gopkg.toml` to @DataDog/agent-all.

### Motivation

Not blocking all PRs changing go packages on a single team.
