### PR TITLE
Add Python 3 linter results to status page

### DIFF
--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -57,6 +57,21 @@
   </div>
 
   {{- with .pyLoaderStats }}
+    {{- if .Py3Warnings }}
+    <div class="stat">
+      <span class="stat_title">Python3 Linter Warnings</span>
+      <span class="stat_data">
+      {{ range $checkname, $warnings :=  .Py3Warnings }}
+          <span class="stat_subtitle">{{$checkname}}</span>
+          <span class="stat_subdata">
+            {{- range $idx, $warning := $warnings}}
+              {{pythonLoaderError $warning}}<br>
+            {{- end }}
+          </span>
+      {{- end}}
+      </span>
+    </div>
+    {{- end }}
     {{- if .ConfigureErrors }}
     <div class="stat">
       <span class="stat_title">Check Initialization Errors</span>

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -59,7 +59,7 @@
   {{- with .pyLoaderStats }}
     {{- if .Py3Warnings }}
     <div class="stat">
-      <span class="stat_title">Python3 Linter Warnings</span>
+      <span class="stat_title">Python 3 Linter Warnings</span>
       <span class="stat_data">
       {{ range $checkname, $warnings :=  .Py3Warnings }}
           <span class="stat_subtitle">{{$checkname}}</span>

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -38,7 +38,7 @@ import "C"
 var (
 	pyLoaderStats    *expvar.Map
 	configureErrors  map[string][]string
-	py3Warnings      map[string]string
+	py3Warnings      map[string][]string
 	statsLock        sync.RWMutex
 	agentVersionTags []string
 )
@@ -58,7 +58,7 @@ func init() {
 	loaders.RegisterLoader(10, factory)
 
 	configureErrors = map[string][]string{}
-	py3Warnings = map[string]string{}
+	py3Warnings = map[string][]string{}
 	pyLoaderStats = expvar.NewMap("pyLoader")
 	pyLoaderStats.Set("ConfigureErrors", expvar.Func(expvarConfigureErrors))
 	pyLoaderStats.Set("Py3Warnings", expvar.Func(expvarPy3Warnings))
@@ -274,10 +274,10 @@ func reportPy3Warnings(checkName string, checkFilePath string) {
 			log.Warnf("The Python 3 linter returned warnings for check '%s'. Set the log level to \"debug\" and restart the Agent to have the linter warnings logged.", checkName)
 			for _, warning := range warnings {
 				log.Debug(warning)
+				py3Warnings[checkName] = append(py3Warnings[checkName], warning)
 			}
 		}
 	}
-	py3Warnings[checkName] = status
 
 	// add a serie to the aggregator to be sent on every flush
 	tags := []string{

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -271,7 +271,7 @@ func reportPy3Warnings(checkName string, checkFilePath string) {
 			metricValue = 1.0
 		} else {
 			status = a7TagNotReady
-			log.Warnf("The Python 3 linter returned warnings for check '%s'. For more details, check the output of the "status" command or the status page of the Agent GUI).", checkName)
+			log.Warnf("The Python 3 linter returned warnings for check '%s'. For more details, check the output of the 'status' command or the status page of the Agent GUI).", checkName)
 			for _, warning := range warnings {
 				log.Debug(warning)
 				py3Warnings[checkName] = append(py3Warnings[checkName], warning)

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -271,7 +271,7 @@ func reportPy3Warnings(checkName string, checkFilePath string) {
 			metricValue = 1.0
 		} else {
 			status = a7TagNotReady
-			log.Warnf("The Python 3 linter returned warnings for check '%s'. Set the log level to \"debug\" and restart the Agent to have the linter warnings logged.", checkName)
+			log.Warnf("The Python 3 linter returned warnings for check '%s'. For more details, check the output of the "status" command or the status page of the Agent GUI).", checkName)
 			for _, warning := range warnings {
 				log.Debug(warning)
 				py3Warnings[checkName] = append(py3Warnings[checkName], warning)

--- a/pkg/collector/python/py3_checker.go
+++ b/pkg/collector/python/py3_checker.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -23,9 +24,12 @@ var (
 )
 
 type warning struct {
-	Line    int
-	Column  int
-	Message string
+	Line      int    `json:"line"`
+	Column    int    `json:"column"`
+	Message   string `json:"message"`
+	Path      string `json:"path"`
+	Symbol    string `json:"symbol"`
+	MessageId string `json:"message-id"`
 }
 
 // validatePython3 checks that a check can run on python 3.
@@ -57,7 +61,7 @@ func validatePython3(moduleName string, modulePath string) ([]string, error) {
 
 	// no post processing needed for now, we just retrieve every messages
 	for _, warn := range warnings {
-		message := fmt.Sprintf("Line %d, column %d: %s", warn.Line, warn.Column, warn.Message)
+		message := fmt.Sprintf("%s:%d:%d : %s (%s, %s)", filepath.Base(warn.Path), warn.Line, warn.Column, warn.Message, warn.Symbol, warn.MessageId)
 		res = append(res, message)
 	}
 

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -56,7 +56,7 @@ Collector
 
 {{- with .pyLoaderStats }}
   {{- if .Py3Warnings }}
-  Python3 Linter Warnings
+  Python 3 Linter Warnings
   =======================
     {{- range $CheckName, $warnings :=  .Py3Warnings }}
       {{ $CheckName }}

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -55,6 +55,17 @@ Collector
 {{- end }}
 
 {{- with .pyLoaderStats }}
+  {{- if .Py3Warnings }}
+  Python3 Linter Warnings
+  =======================
+    {{- range $CheckName, $warnings :=  .Py3Warnings }}
+      {{ $CheckName }}
+      {{printDashes $CheckName "-"}}
+      {{- range $idx, $warning := $warnings}}
+        {{ doNotEscape $warning }}
+      {{- end }}
+    {{end}}
+  {{- end }}
   {{- if .ConfigureErrors }}
   Check Initialization Errors
   ===========================

--- a/releasenotes/notes/add-py3-linter-to-status-99e0ec6da1d6e130.yaml
+++ b/releasenotes/notes/add-py3-linter-to-status-99e0ec6da1d6e130.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add Python 3 linter results to status page


### PR DESCRIPTION
### What does this PR do?

Add Python 3 Linter Results to Status

### Motivation

Will help users fix Python 3 compatibility issues.

### Additional Notes

Example output from `$ datadog-agent status`

```
  Python3 Linter Warnings
  =======================
      foo
      ---
        foo.py:17:8 : print statement used (print-statement, E1601)
        foo.py:18:8 : division w/o __future__ statement (old-division, W1619)

      hello
      -----
        hello.py:17:8 : print statement used (print-statement, E1601)
        hello.py:18:8 : division w/o __future__ statement (old-division, W1619)
```

Example output from GUI

![image](https://user-images.githubusercontent.com/49917914/69811972-9271aa00-11ef-11ea-94f8-254556ebf5f5.png)

