### PR TITLE
Remove unused log build tag

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -20,7 +20,6 @@ ALL_TAGS = set([
     "jmx",
     "kubeapiserver",
     "kubelet",
-    "log",
     "netcgo", # Force the use of the CGO resolver. This will also have the effect of making the binary non-static
     "process",
     "systemd",


### PR DESCRIPTION
### What does this PR do?

Removes the `log` build tag

### Motivation

Looks unused no match when searching for `/{2} \+build \w*,?log`

### Additional Notes

Anything else we should know when reviewing?
