### PR TITLE
[rpm deploy] Replace --no-progress with --only-show-errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2171,7 +2171,7 @@ deploy_rpm-6:
     - rvm use 2.4
     - mkdir -p ./rpmrepo/6/x86_64/
     - mkdir -p ./rpmrepo/6/aarch64/
-    - aws s3 sync --no-progress s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ ./rpmrepo/6/
+    - aws s3 sync --only-show-errors s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ ./rpmrepo/6/
 
     # add RPMs to new "6" branch
     - cp $OMNIBUS_PACKAGE_DIR/*-6.*x86_64.rpm ./rpmrepo/6/x86_64/
@@ -2180,7 +2180,7 @@ deploy_rpm-6:
     - createrepo --update -v --checksum sha ./rpmrepo/6/aarch64
 
     # sync to S3
-    - aws s3 sync --no-progress --delete ./rpmrepo/6/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - aws s3 sync --only-show-errors --delete ./rpmrepo/6/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_rpm-7:
   <<: *run_when_triggered
@@ -2195,7 +2195,7 @@ deploy_rpm-7:
     - rvm use 2.4
     - mkdir -p ./rpmrepo/7/x86_64/
     - mkdir -p ./rpmrepo/7/aarch64/
-    - aws s3 sync --no-progress s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/7/ ./rpmrepo/7/
+    - aws s3 sync --only-show-errors s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/7/ ./rpmrepo/7/
 
     # add RPMs to new "7" branch
     - cp $OMNIBUS_PACKAGE_DIR/*-7.*x86_64.rpm ./rpmrepo/7/x86_64/
@@ -2204,7 +2204,7 @@ deploy_rpm-7:
     - createrepo --update -v --checksum sha ./rpmrepo/7/aarch64
 
     # sync to S3
-    - aws s3 sync --no-progress --delete ./rpmrepo/7/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/7/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - aws s3 sync --only-show-errors --delete ./rpmrepo/7/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/7/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy suse rpm packages to yum staging repo
 # NOTE: no SuSE ARM builds currently.
@@ -2220,14 +2220,14 @@ deploy_suse_rpm-6:
     - source /usr/local/rvm/scripts/rvm
     - rvm use 2.4
     - mkdir -p ./rpmrepo/6/x86_64/
-    - aws s3 sync --no-progress s3://$RPM_S3_BUCKET/suse/$DEB_RPM_BUCKET_BRANCH/6/ ./rpmrepo/6/
+    - aws s3 sync --only-show-errors s3://$RPM_S3_BUCKET/suse/$DEB_RPM_BUCKET_BRANCH/6/ ./rpmrepo/6/
 
     # add RPMs to new "6" branch
     - cp $OMNIBUS_PACKAGE_DIR_SUSE/*-6.*x86_64.rpm ./rpmrepo/6/x86_64/
     - createrepo --update -v --checksum sha ./rpmrepo/6/x86_64
 
     # sync to S3
-    - aws s3 sync --no-progress --delete ./rpmrepo/6/ s3://$RPM_S3_BUCKET/suse/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - aws s3 sync --only-show-errors --delete ./rpmrepo/6/ s3://$RPM_S3_BUCKET/suse/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_suse_rpm-7:
   <<: *run_when_triggered
@@ -2241,14 +2241,14 @@ deploy_suse_rpm-7:
     - source /usr/local/rvm/scripts/rvm
     - rvm use 2.4
     - mkdir -p ./rpmrepo/7/x86_64/
-    - aws s3 sync --no-progress s3://$RPM_S3_BUCKET/suse/$DEB_RPM_BUCKET_BRANCH/7/ ./rpmrepo/7/
+    - aws s3 sync --only-show-errors s3://$RPM_S3_BUCKET/suse/$DEB_RPM_BUCKET_BRANCH/7/ ./rpmrepo/7/
 
     # add RPMs to new "7" branch
     - cp $OMNIBUS_PACKAGE_DIR_SUSE/*-7.*x86_64.rpm ./rpmrepo/7/x86_64/
     - createrepo --update -v --checksum sha ./rpmrepo/7/x86_64
 
     # sync to S3
-    - aws s3 sync --no-progress --delete ./rpmrepo/7/ s3://$RPM_S3_BUCKET/suse/$DEB_RPM_BUCKET_BRANCH/7/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - aws s3 sync --only-show-errors --delete ./rpmrepo/7/ s3://$RPM_S3_BUCKET/suse/$DEB_RPM_BUCKET_BRANCH/7/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy dsd binary to staging bucket
 deploy_dsd:


### PR DESCRIPTION
### What does this PR do?

Follow-up of #4516.
`--no-progress` doesn't exist yet in the version of `awscli` (1.11.152) we install in our builders.

### Motivation

Broken nightly pipeline.
