### PR TITLE
[autodiscovery] Add `ignore_autodiscovery_tags` config parameter

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -104,7 +104,7 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		return resolvedConfig, fmt.Errorf("%s, skipping service %s", err, svc.GetEntity())
 	}
 
-	if !tpl.IgnoreListenerTags {
+	if !tpl.IgnoreAutodiscoveryTags {
 		if err := addServiceTags(&resolvedConfig, svc); err != nil {
 			return resolvedConfig, fmt.Errorf("unable to add tags for service '%s', err: %s", svc.GetEntity(), err)
 		}

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -95,9 +95,13 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		return resolvedConfig, errors.New("unable to resolve, service not ready")
 	}
 
-	tags, err := svc.GetTags()
-	if err != nil {
-		return resolvedConfig, err
+	tags := []string{}
+	var err error
+	if !tpl.IgnoreListenerTags {
+		tags, err = svc.GetTags()
+		if err != nil {
+			return resolvedConfig, err
+		}
 	}
 
 	err = SubstituteTemplateVariables(&resolvedConfig, templateVariables, svc)

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -422,7 +422,7 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("host: %%FOO%%")},
 			},
-			errorString: "yaml: found character that cannot start any token",
+			errorString: "unable to add tags for service 'a5901276aed1', err: yaml: found character that cannot start any token",
 		},
 	}
 	validTemplates := 0

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -38,19 +38,20 @@ const (
 
 // Config is a generic container for configuration files
 type Config struct {
-	Name          string       `json:"check_name"`     // the name of the check
-	Instances     []Data       `json:"instances"`      // array of Yaml configurations
-	InitConfig    Data         `json:"init_config"`    // the init_config in Yaml (python check only)
-	MetricConfig  Data         `json:"metric_config"`  // the metric config in Yaml (jmx check only)
-	LogsConfig    Data         `json:"logs"`           // the logs config in Yaml (logs-agent only)
-	ADIdentifiers []string     `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
-	Provider      string       `json:"provider"`       // the provider that issued the config
-	Entity        string       `json:"-"`              // the entity ID (optional)
-	TaggerEntity  string       `json:"-"`              // the tagger entity ID (optional)
-	ClusterCheck  bool         `json:"cluster_check"`  // cluster-check configuration flag
-	NodeName      string       `json:"node_name"`      // node name in case of an endpoint check backed by a pod
-	CreationTime  CreationTime `json:"-"`              // creation time of service
-	Source        string       `json:"source"`         // the source of the configuration
+	Name               string       `json:"check_name"`           // the name of the check
+	Instances          []Data       `json:"instances"`            // array of Yaml configurations
+	InitConfig         Data         `json:"init_config"`          // the init_config in Yaml (python check only)
+	MetricConfig       Data         `json:"metric_config"`        // the metric config in Yaml (jmx check only)
+	LogsConfig         Data         `json:"logs"`                 // the logs config in Yaml (logs-agent only)
+	ADIdentifiers      []string     `json:"ad_identifiers"`       // the list of AutoDiscovery identifiers (optional)
+	Provider           string       `json:"provider"`             // the provider that issued the config
+	Entity             string       `json:"-"`                    // the entity ID (optional)
+	TaggerEntity       string       `json:"-"`                    // the tagger entity ID (optional)
+	ClusterCheck       bool         `json:"cluster_check"`        // cluster-check configuration flag
+	NodeName           string       `json:"node_name"`            // node name in case of an endpoint check backed by a pod
+	CreationTime       CreationTime `json:"-"`                    // creation time of service
+	Source             string       `json:"source"`               // the source of the configuration
+	IgnoreListenerTags bool         `json:"ignore_listener_tags"` // Use to ignore tags coming from the listener
 }
 
 // CommonInstanceConfig holds the reserved fields for the yaml instance data

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	NodeName                string       `json:"node_name"`                 // node name in case of an endpoint check backed by a pod
 	CreationTime            CreationTime `json:"-"`                         // creation time of service
 	Source                  string       `json:"source"`                    // the source of the configuration
-	IgnoreAutodiscoveryTags bool         `json:"ignore_autodiscovery_tags"` // Use to ignore tags coming from the listener
+	IgnoreAutodiscoveryTags bool         `json:"ignore_autodiscovery_tags"` // Use to ignore tags coming from autodiscovery
 }
 
 // CommonInstanceConfig holds the reserved fields for the yaml instance data

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -38,20 +38,20 @@ const (
 
 // Config is a generic container for configuration files
 type Config struct {
-	Name               string       `json:"check_name"`           // the name of the check
-	Instances          []Data       `json:"instances"`            // array of Yaml configurations
-	InitConfig         Data         `json:"init_config"`          // the init_config in Yaml (python check only)
-	MetricConfig       Data         `json:"metric_config"`        // the metric config in Yaml (jmx check only)
-	LogsConfig         Data         `json:"logs"`                 // the logs config in Yaml (logs-agent only)
-	ADIdentifiers      []string     `json:"ad_identifiers"`       // the list of AutoDiscovery identifiers (optional)
-	Provider           string       `json:"provider"`             // the provider that issued the config
-	Entity             string       `json:"-"`                    // the entity ID (optional)
-	TaggerEntity       string       `json:"-"`                    // the tagger entity ID (optional)
-	ClusterCheck       bool         `json:"cluster_check"`        // cluster-check configuration flag
-	NodeName           string       `json:"node_name"`            // node name in case of an endpoint check backed by a pod
-	CreationTime       CreationTime `json:"-"`                    // creation time of service
-	Source             string       `json:"source"`               // the source of the configuration
-	IgnoreListenerTags bool         `json:"ignore_listener_tags"` // Use to ignore tags coming from the listener
+	Name                    string       `json:"check_name"`                // the name of the check
+	Instances               []Data       `json:"instances"`                 // array of Yaml configurations
+	InitConfig              Data         `json:"init_config"`               // the init_config in Yaml (python check only)
+	MetricConfig            Data         `json:"metric_config"`             // the metric config in Yaml (jmx check only)
+	LogsConfig              Data         `json:"logs"`                      // the logs config in Yaml (logs-agent only)
+	ADIdentifiers           []string     `json:"ad_identifiers"`            // the list of AutoDiscovery identifiers (optional)
+	Provider                string       `json:"provider"`                  // the provider that issued the config
+	Entity                  string       `json:"-"`                         // the entity ID (optional)
+	TaggerEntity            string       `json:"-"`                         // the tagger entity ID (optional)
+	ClusterCheck            bool         `json:"cluster_check"`             // cluster-check configuration flag
+	NodeName                string       `json:"node_name"`                 // node name in case of an endpoint check backed by a pod
+	CreationTime            CreationTime `json:"-"`                         // creation time of service
+	Source                  string       `json:"source"`                    // the source of the configuration
+	IgnoreAutodiscoveryTags bool         `json:"ignore_autodiscovery_tags"` // Use to ignore tags coming from the listener
 }
 
 // CommonInstanceConfig holds the reserved fields for the yaml instance data

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -21,13 +21,14 @@ import (
 )
 
 type configFormat struct {
-	ADIdentifiers []string    `yaml:"ad_identifiers"`
-	ClusterCheck  bool        `yaml:"cluster_check"`
-	InitConfig    interface{} `yaml:"init_config"`
-	MetricConfig  interface{} `yaml:"jmx_metrics"`
-	LogsConfig    interface{} `yaml:"logs"`
-	Instances     []integration.RawMap
-	DockerImages  []string `yaml:"docker_images"` // Only imported for deprecation warning
+	ADIdentifiers      []string    `yaml:"ad_identifiers"`
+	ClusterCheck       bool        `yaml:"cluster_check"`
+	InitConfig         interface{} `yaml:"init_config"`
+	MetricConfig       interface{} `yaml:"jmx_metrics"`
+	LogsConfig         interface{} `yaml:"logs"`
+	Instances          []integration.RawMap
+	DockerImages       []string `yaml:"docker_images"`        // Only imported for deprecation warning
+	IgnoreListenerTags bool     `yaml:"ignore_listener_tags"` // Use to ignore tags coming from the listener
 }
 
 type configPkg struct {
@@ -301,6 +302,9 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 
 	// Copy cluster_check status
 	config.ClusterCheck = cf.ClusterCheck
+
+	// Copy ignore_listener_tags parameter
+	config.IgnoreListenerTags = cf.IgnoreListenerTags
 
 	// DockerImages entry was found: we ignore it if no ADIdentifiers has been found
 	if len(cf.DockerImages) > 0 && len(cf.ADIdentifiers) == 0 {

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -21,14 +21,14 @@ import (
 )
 
 type configFormat struct {
-	ADIdentifiers      []string    `yaml:"ad_identifiers"`
-	ClusterCheck       bool        `yaml:"cluster_check"`
-	InitConfig         interface{} `yaml:"init_config"`
-	MetricConfig       interface{} `yaml:"jmx_metrics"`
-	LogsConfig         interface{} `yaml:"logs"`
-	Instances          []integration.RawMap
-	DockerImages       []string `yaml:"docker_images"`        // Only imported for deprecation warning
-	IgnoreListenerTags bool     `yaml:"ignore_listener_tags"` // Use to ignore tags coming from the listener
+	ADIdentifiers           []string    `yaml:"ad_identifiers"`
+	ClusterCheck            bool        `yaml:"cluster_check"`
+	InitConfig              interface{} `yaml:"init_config"`
+	MetricConfig            interface{} `yaml:"jmx_metrics"`
+	LogsConfig              interface{} `yaml:"logs"`
+	Instances               []integration.RawMap
+	DockerImages            []string `yaml:"docker_images"`             // Only imported for deprecation warning
+	IgnoreAutodiscoveryTags bool     `yaml:"ignore_autodiscovery_tags"` // Use to ignore tags coming from the listener
 }
 
 type configPkg struct {
@@ -303,8 +303,8 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 	// Copy cluster_check status
 	config.ClusterCheck = cf.ClusterCheck
 
-	// Copy ignore_listener_tags parameter
-	config.IgnoreListenerTags = cf.IgnoreListenerTags
+	// Copy ignore_autodiscovery_tags parameter
+	config.IgnoreAutodiscoveryTags = cf.IgnoreAutodiscoveryTags
 
 	// DockerImages entry was found: we ignore it if no ADIdentifiers has been found
 	if len(cf.DockerImages) > 0 && len(cf.ADIdentifiers) == 0 {

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -28,7 +28,7 @@ type configFormat struct {
 	LogsConfig              interface{} `yaml:"logs"`
 	Instances               []integration.RawMap
 	DockerImages            []string `yaml:"docker_images"`             // Only imported for deprecation warning
-	IgnoreAutodiscoveryTags bool     `yaml:"ignore_autodiscovery_tags"` // Use to ignore tags coming from the listener
+	IgnoreAutodiscoveryTags bool     `yaml:"ignore_autodiscovery_tags"` // Use to ignore tags coming from autodiscovery
 }
 
 type configPkg struct {

--- a/releasenotes/notes/autodiscovery-add-ignore_listener_tags-parameter-9968246cdad12bed.yaml
+++ b/releasenotes/notes/autodiscovery-add-ignore_listener_tags-parameter-9968246cdad12bed.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add `ignore_listener_tags` parameter config check.
+
+    In some cases, a check should not receive tags coming from the autodiscovery listeners.
+    By default `ignore_listener_tags` is set to false which doesn't change the behavior of the checks.
+    The first check that will use it is `kubernetes_state`.

--- a/releasenotes/notes/autodiscovery-add-ignore_listener_tags-parameter-9968246cdad12bed.yaml
+++ b/releasenotes/notes/autodiscovery-add-ignore_listener_tags-parameter-9968246cdad12bed.yaml
@@ -8,8 +8,8 @@
 ---
 enhancements:
   - |
-    Add `ignore_listener_tags` parameter config check.
+    Add `ignore_autodiscovery_tags` parameter config check.
 
     In some cases, a check should not receive tags coming from the autodiscovery listeners.
-    By default `ignore_listener_tags` is set to false which doesn't change the behavior of the checks.
+    By default `ignore_autodiscovery_tags` is set to false which doesn't change the behavior of the checks.
     The first check that will use it is `kubernetes_state`.


### PR DESCRIPTION
### What does this PR do?

Add `ignore_autodiscovery_tags` config parameter.

### Motivation

In some cases, a check should not receive tags coming from the autodiscovery listeners.
By default `ignore_autodiscovery_tags` is set to false which didn't change the behavior of the checks.
The first check that will use it is `kubernetes_state`.

### Additional Notes

link to this pr: https://github.com/DataDog/integrations-core/pull/5105
