### PR TITLE
[gitlab] Add slack notifier

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,5 @@
+include: 'https://gitlab-templates.ddbuild.io/slack-notifier/v1/template.yml'
+
 stages:
   - source_test
   - binary_build
@@ -15,6 +17,7 @@ stages:
   - deploy_invalidate
   - e2e
   - testkitchen_cleanup
+  - notify
 
 variables:
   # The SRC_PATH is in the GOPATH of the builders which
@@ -2491,3 +2494,10 @@ pupernetes-tags:
   # note: it's not the agent-dev
   - inv -e e2e-tests --image=datadog/agent:$CI_COMMIT_TAG
   - inv -e e2e-tests --image=datadog/agent:${CI_COMMIT_TAG}-py3
+
+notify-on-failure:
+  extends: .slack-notifier.on-failure
+  script:
+    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME $CI_COMMIT_REF_NAME pipeline <$BUILD_URL|$CI_PIPELINE_ID> failed."'
+    - postmessage "#datadog-agent-pipelines" "$MESSAGE_TEXT"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2498,6 +2498,9 @@ pupernetes-tags:
 notify-on-failure:
   extends: .slack-notifier.on-failure
   before_script: ["# noop"]
+  only:
+    - master
+    - triggers
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME $CI_COMMIT_REF_NAME pipeline <$BUILD_URL|$CI_PIPELINE_ID> failed."'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2497,6 +2497,7 @@ pupernetes-tags:
 
 notify-on-failure:
   extends: .slack-notifier.on-failure
+  before_script: ["# noop"]
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME $CI_COMMIT_REF_NAME pipeline <$BUILD_URL|$CI_PIPELINE_ID> failed."'


### PR DESCRIPTION
### What does this PR do?

Sends a slack notification if a master or triggered pipeline fails.

### Motivation

It's nice to know when pipelines fail without having to go check every 10 minutes what's happening on gitlab. 