### PR TITLE
[kitchen] Add SUSE 11 kitchen tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1164,7 +1164,8 @@ deploy_windows_testing-a7:
   needs: ["deploy_suse_rpm_testing-a6", "deploy_suse_rpm_testing-a7"]
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
-    - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP4:2019.06.17"
+    - export TEST_PLATFORMS="sles-11,SUSE:SLES-BYOS:11-SP4:2019.07.01"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-12,SUSE:SLES:12-SP4:2019.06.17"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-15,SUSE:SLES-Standard:15:2019.06.17"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -293,22 +293,13 @@ else
   $sudo_cmd chmod 640 $CONF
 fi
 
-# On SUSE 11, sudo service datadog-agent start fails (seemingly because /sbin is not in a base user's path?)
+# On SUSE 11, sudo service datadog-agent start fails (because /sbin is not in a base user's path)
 # However, sudo /sbin/service datadog-agent does work.
 # Use which (from root user) to find the absolute path to service
 
-service_cmd="service"
-echo "sudo command:"
-echo $sudo_cmd
-echo "end sudo command"
-
 if [ "$SUSE11" == "yes" ]; then
-  service_cmd=`sudo which service`
+  service_cmd=`$sudo_cmd which service`
 fi
-
-echo "service command:"
-echo $service_cmd
-echo "end service command"
 
 # Use /usr/sbin/service by default.
 # Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -293,12 +293,20 @@ else
   $sudo_cmd chmod 640 $CONF
 fi
 
+# On SUSE 11, sudo service datadog-agent start fails (seemingly because /sbin is not in a base user's path?)
+# However, sudo /sbin/service datadog-agent does work.
+# Use which (from root user) to find the absolute path to service
+service_cmd="service"
+
+if [ "$SUSE11" == "yes" ]; then
+  service_cmd=`$sudo_cmd which service`
+fi
 
 # Use /usr/sbin/service by default.
 # Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`
-restart_cmd="$sudo_cmd service datadog-agent restart"
-stop_instructions="$sudo_cmd service datadog-agent stop"
-start_instructions="$sudo_cmd service datadog-agent start"
+restart_cmd="$sudo_cmd $service_cmd datadog-agent restart"
+stop_instructions="$sudo_cmd $service_cmd datadog-agent stop"
+start_instructions="$sudo_cmd $service_cmd datadog-agent start"
 
 if command -v systemctl 2>&1; then
   # Use systemd if systemctl binary exists

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -296,11 +296,19 @@ fi
 # On SUSE 11, sudo service datadog-agent start fails (seemingly because /sbin is not in a base user's path?)
 # However, sudo /sbin/service datadog-agent does work.
 # Use which (from root user) to find the absolute path to service
+
 service_cmd="service"
+echo "sudo command:"
+echo $sudo_cmd
+echo "end sudo command"
 
 if [ "$SUSE11" == "yes" ]; then
-  service_cmd=`$sudo_cmd which service`
+  service_cmd=`sudo which service`
 fi
+
+echo "service command:"
+echo $service_cmd
+echo "end service command"
 
 # Use /usr/sbin/service by default.
 # Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -24,7 +24,7 @@ if [ "$DISTRIBUTION_FAMILY" == "SUSE" ]; then
     # (even if they're not used) as it cannot process them (a package necessary to process them
     # was removed from the base distribution).
     if cat /etc/SuSE-release 2>/dev/null | grep VERSION | grep 11; then
-        SYSVINIT_SUPPORT="yes"
+        SUSE_SYSVINIT_SUPPORT="yes"
     else
         rm -f /etc/init.d/datadog-agent
         rm -f /etc/init.d/datadog-agent-process
@@ -41,10 +41,10 @@ if command -v systemctl >/dev/null 2>&1; then
 elif command -v initctl >/dev/null 2>&1; then
     # start/stop policy is already defined in the upstart job file
     :
-elif command -v update-rc.d >/dev/null 2>&1; then
-    update-rc.d $SERVICE_NAME defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with update-rc.d"
-    update-rc.d $SERVICE_NAME-process defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with update-rc.d"
-    update-rc.d $SERVICE_NAME-trace defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with update-rc.d"
+elif [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ] then
+    ln -s /etc/init.d/$SERVICE_NAME /etc/init.d/rc5.d/S95$SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME"
+    ln -s /etc/init.d/$SERVICE_NAME-process /etc/init.d/rc5.d/S95$SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process"
+    ln -s /etc/init.d/$SERVICE_NAME-trace /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace"
 else
     echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
 fi
@@ -57,7 +57,7 @@ if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
         systemctl restart $SERVICE_NAME || true
     elif command -v initctl >/dev/null 2>&1; then
         initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
-    elif [ "$SYSVINIT_SUPPORT" == "yes" ] && command -v service >/dev/null 2>&1; then
+    elif [ "$SUSE_SYSVINIT_SUPPORT" == "yes" ] && command -v service >/dev/null 2>&1; then
         service $SERVICE_NAME restart || true
     else
         echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -57,7 +57,7 @@ if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
         systemctl restart $SERVICE_NAME || true
     elif command -v initctl >/dev/null 2>&1; then
         initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
-    elif [ "$SUSE_SYSVINIT_SUPPORT" == "yes" ] && command -v service >/dev/null 2>&1; then
+    elif [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ] && command -v service >/dev/null 2>&1; then
         service $SERVICE_NAME restart || true
     else
         echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -42,9 +42,15 @@ elif command -v initctl >/dev/null 2>&1; then
     # start/stop policy is already defined in the upstart job file
     :
 elif [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
-    ln -s /etc/init.d/$SERVICE_NAME /etc/init.d/rc5.d/S95$SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME"
-    ln -s /etc/init.d/$SERVICE_NAME-process /etc/init.d/rc5.d/S95$SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process"
-    ln -s /etc/init.d/$SERVICE_NAME-trace /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace"
+    if command -v update-rc.d >/dev/null 2>&1; then
+        update-rc.d $SERVICE_NAME defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with update-rc.d"
+        update-rc.d $SERVICE_NAME-process defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with update-rc.d"
+        update-rc.d $SERVICE_NAME-trace defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with update-rc.d"
+    else
+        ln -s /etc/init.d/$SERVICE_NAME /etc/init.d/rc5.d/S95$SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME"
+        ln -s /etc/init.d/$SERVICE_NAME-process /etc/init.d/rc5.d/S95$SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process"
+        ln -s /etc/init.d/$SERVICE_NAME-trace /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace"
+    fi
 else
     echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
 fi

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -41,7 +41,7 @@ if command -v systemctl >/dev/null 2>&1; then
 elif command -v initctl >/dev/null 2>&1; then
     # start/stop policy is already defined in the upstart job file
     :
-elif [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ] then
+elif [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
     ln -s /etc/init.d/$SERVICE_NAME /etc/init.d/rc5.d/S95$SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME"
     ln -s /etc/init.d/$SERVICE_NAME-process /etc/init.d/rc5.d/S95$SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process"
     ln -s /etc/init.d/$SERVICE_NAME-trace /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace"

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -17,10 +17,14 @@ elif [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTR
     DISTRIBUTION_FAMILY="SUSE"
 fi
 
+if [ "$DISTRIBUTION_FAMILY" == "SUSE" ] && cat /etc/SuSE-release 2>/dev/null | grep VERSION | grep 11; then
+    SUSE_SYSVINIT_SUPPORT="yes"
+fi
+
 stop_agent()
 {
     # Stop an already running agent
-    # Only supports systemd and upstart
+    # Only supports systemd and upstart (sysvinit is supported on Debian and SUSE 11)
     if command -v systemctl >/dev/null 2>&1; then
         systemctl stop $SERVICE_NAME-process || true
         systemctl stop $SERVICE_NAME-sysprobe || true
@@ -57,7 +61,7 @@ deregister_agent()
     elif command -v initctl >/dev/null 2>&1; then
         # Nothing to do, this is defined directly in the upstart job file
         :
-    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$DISTRIBUTION_FAMILY"="SUSE" ]; then
+    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
         if command -v update-rc.d >/dev/null 2>&1; then
             update-rc.d -f $SERVICE_NAME-process remove || true
             update-rc.d -f $SERVICE_NAME-trace remove || true
@@ -65,6 +69,10 @@ deregister_agent()
         else
             echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
         fi
+    elif [ "$SUSE_SYSVINIT_SUPPORT"="yes" ]; then
+        rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME || true
+        rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-process || true
+        rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || true
     else
         echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
     fi

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -17,7 +17,7 @@ elif [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTR
     DISTRIBUTION_FAMILY="SUSE"
 fi
 
-if [ "$DISTRIBUTION_FAMILY" == "SUSE" ] && cat /etc/SuSE-release 2>/dev/null | grep VERSION | grep 11; then
+if [ "$DISTRIBUTION_FAMILY" = "SUSE" ] && cat /etc/SuSE-release 2>/dev/null | grep VERSION | grep 11; then
     SUSE_SYSVINIT_SUPPORT="yes"
 fi
 
@@ -35,7 +35,7 @@ stop_agent()
         initctl stop $SERVICE_NAME-sysprobe || true
         initctl stop $SERVICE_NAME-trace || true
         initctl stop $SERVICE_NAME || true
-    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$SUSE_SYSVINIT_SUPPORT"="yes" ]; then
+    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
         if command -v service >/dev/null 2>&1; then
             service $SERVICE_NAME-process stop || true
             service $SERVICE_NAME-trace stop || true
@@ -69,7 +69,7 @@ deregister_agent()
         else
             echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
         fi
-    elif [ "$SUSE_SYSVINIT_SUPPORT"="yes" ]; then
+    elif [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
         rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME || true
         rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-process || true
         rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || true

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -31,7 +31,7 @@ stop_agent()
         initctl stop $SERVICE_NAME-sysprobe || true
         initctl stop $SERVICE_NAME-trace || true
         initctl stop $SERVICE_NAME || true
-    elif [ "$DISTRIBUTION_FAMILY" = "Debian" || "$DISTRIBUTION_FAMILY"="SUSE" ]; then
+    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$DISTRIBUTION_FAMILY"="SUSE" ]; then
         if command -v service >/dev/null 2>&1; then
             service $SERVICE_NAME-process stop || true
             service $SERVICE_NAME-trace stop || true
@@ -57,10 +57,9 @@ deregister_agent()
     elif command -v initctl >/dev/null 2>&1; then
         # Nothing to do, this is defined directly in the upstart job file
         :
-    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
+    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$DISTRIBUTION_FAMILY"="SUSE" ]; then
         if command -v update-rc.d >/dev/null 2>&1; then
             update-rc.d -f $SERVICE_NAME-process remove || true
-            update-rc.d -f $SERVICE_NAME-sysprobe remove || true
             update-rc.d -f $SERVICE_NAME-trace remove || true
             update-rc.d -f $SERVICE_NAME remove || true
         else

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -38,6 +38,7 @@ stop_agent()
     elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
         if command -v service >/dev/null 2>&1; then
             service $SERVICE_NAME-process stop || true
+            service $SERVICE_NAME-sysprobe stop || true
             service $SERVICE_NAME-trace stop || true
             service $SERVICE_NAME stop || true
         else
@@ -64,15 +65,22 @@ deregister_agent()
     elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
         if command -v update-rc.d >/dev/null 2>&1; then
             update-rc.d -f $SERVICE_NAME-process remove || true
+            update-rc.d -f $SERVICE_NAME-sysprobe remove || true
             update-rc.d -f $SERVICE_NAME-trace remove || true
             update-rc.d -f $SERVICE_NAME remove || true
         else
             echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
         fi
     elif [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
-        rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME || true
-        rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-process || true
-        rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || true
+        if command -v update-rc.d >/dev/null 2>&1; then
+            update-rc.d -f $SERVICE_NAME-process remove || true
+            update-rc.d -f $SERVICE_NAME-trace remove || true
+            update-rc.d -f $SERVICE_NAME remove || true
+        else
+            rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-process || true
+            rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || true
+            rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME || true
+        fi
     else
         echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
     fi

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -13,6 +13,8 @@ SERVICE_NAME=datadog-agent
 
 if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
     DISTRIBUTION_FAMILY="Debian"
+elif [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "SUSE" ]; then
+    DISTRIBUTION_FAMILY="SUSE"
 fi
 
 stop_agent()
@@ -29,10 +31,9 @@ stop_agent()
         initctl stop $SERVICE_NAME-sysprobe || true
         initctl stop $SERVICE_NAME-trace || true
         initctl stop $SERVICE_NAME || true
-    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
+    elif [ "$DISTRIBUTION_FAMILY" = "Debian" || "$DISTRIBUTION_FAMILY"="SUSE" ]; then
         if command -v service >/dev/null 2>&1; then
             service $SERVICE_NAME-process stop || true
-            service $SERVICE_NAME-sysprobe stop || true
             service $SERVICE_NAME-trace stop || true
             service $SERVICE_NAME stop || true
         else

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -38,6 +38,8 @@ stop_agent()
     elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
         if command -v service >/dev/null 2>&1; then
             service $SERVICE_NAME-process stop || true
+            # TODO: investigate if the following line could be used in other cases than with sysvinit systems (which don't support sysprobe).
+            # If not, remove it.
             service $SERVICE_NAME-sysprobe stop || true
             service $SERVICE_NAME-trace stop || true
             service $SERVICE_NAME stop || true
@@ -65,6 +67,8 @@ deregister_agent()
     elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
         if command -v update-rc.d >/dev/null 2>&1; then
             update-rc.d -f $SERVICE_NAME-process remove || true
+            # TODO: investigate if the following line could be used in other cases than with sysvinit systems (which don't support sysprobe).
+            # If not, remove it.
             update-rc.d -f $SERVICE_NAME-sysprobe remove || true
             update-rc.d -f $SERVICE_NAME-trace remove || true
             update-rc.d -f $SERVICE_NAME remove || true

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -35,7 +35,7 @@ stop_agent()
         initctl stop $SERVICE_NAME-sysprobe || true
         initctl stop $SERVICE_NAME-trace || true
         initctl stop $SERVICE_NAME || true
-    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$DISTRIBUTION_FAMILY"="SUSE" ]; then
+    elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$SUSE_SYSVINIT_SUPPORT"="yes" ]; then
         if command -v service >/dev/null 2>&1; then
             service $SERVICE_NAME-process stop || true
             service $SERVICE_NAME-trace stop || true

--- a/test/kitchen/kitchen-azure-common.yml
+++ b/test/kitchen/kitchen-azure-common.yml
@@ -81,6 +81,7 @@ platforms:
     location = "North Central US"
 
     windows_platforms = []
+    sles11_platforms = []
     sles15_platforms = []
 
     idx = 0
@@ -94,6 +95,7 @@ platforms:
     platform_name = platform[0] + "-#{host}"
 
     windows = platform_name.include?("win")
+    sles11 = platform_name.include?("sles-11")
     sles15 = platform_name.include?("sles-15")
     windows2008 = windows && platform_name.include?("2008")
 
@@ -103,6 +105,9 @@ platforms:
     else
       if sles15
         sles15_platforms << platform_name
+      end
+      if sles11
+        sles11_platforms << platform_name
       end
       size = sizes[idx % sizes.length]
     end

--- a/test/kitchen/kitchen-azure-upgrade5-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade5-test.yml
@@ -3,8 +3,11 @@ suites:
 # Installs the latest release Agent 5, then updates it to the latest release
 # candidate
 - name: dd-agent-upgrade-agent5
-  excludes: <% if sles15_platforms.nil? || sles15_platforms.empty? %>[]<% end %> # Agent 5 package doesn't work on SLES 15
+  excludes: <% if (sles15_platforms.nil? || sles15_platforms.empty?) && (sles11_platforms.nil? || sles11_platforms.empty?) %>[]<% end %> # Agent 5 package doesn't work on SLES 15, Agent 5 install script doesn't work on SLES 11
     <% sles15_platforms.each do |p| %>
+    - <%= p %>
+    <% end %>
+    <% sles11_platforms.each do |p| %>
     - <%= p %>
     <% end %>
   run_list:

--- a/test/kitchen/kitchen-azure-upgrade6-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade6-test.yml
@@ -3,6 +3,10 @@ suites:
 # Installs the latest release Agent 6, then updates it to the latest release
 # candidate
 - name: dd-agent-upgrade-agent6
+  excludes: <% if sles11_platforms.nil? || sles11_platforms.empty? %>[]<% end %> # No stable Agent 6 SUSE 11 package yet
+    <% sles11_platforms.each do |p| %>
+    - <%= p %>
+    <% end %>
   run_list:
     - "recipe[dd-agent-install]"
     - "recipe[dd-agent-upgrade]"

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -43,6 +43,7 @@ execute 'update Agent install script repository' do
     sed -i 's~stable/6~#{node['dd-agent-install-script']['repo_branch_yum']}~' install-script
     sed -i 's~${dd_agent_dist_channel} ${dd_agent_major_version}~#{node['dd-agent-install-script']['repo_branch_apt']} #{node['dd-agent-install-script']['repo_component_apt']}~' install-script
     sed -i 's~${dd_agent_dist_channel}/${dd_agent_major_version}~#{node['dd-agent-install-script']['repo_branch_yum']}~' install-script
+    sed -i 's~$sudo_cmd which service~sudo which service~' install-script
   EOF
 
   only_if { node['dd-agent-install-script']['install_candidate'] }

--- a/test/kitchen/site-cookbooks/dd-agent-install/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/attributes/default.rb
@@ -5,6 +5,11 @@
 default['datadog']['agent_start'] = true
 default['datadog']['agent_enable'] = true
 
+# On SUSE 11, skip system-probe management since it's not shipped with the Agent.
+if node['platform_family'] == 'suse' && node['platform_version'].to_i <= 11
+  default['datadog']['system_probe']['manage_config'] = false
+end
+
 # All other options use the defaults set in the official cookbook,
 # or the options set in the kitchen job (eg. aptrepo, yumrepo, etc.)
 

--- a/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
@@ -67,9 +67,13 @@ when 'suse'
 
   execute 'install suse' do
     command <<-EOF
+      sudo curl -o /tmp/DATADOG_RPM_KEY.public https://yum.${repo_url}/DATADOG_RPM_KEY.public
+      sudo rpm --import /tmp/DATADOG_RPM_KEY.public
+      sudo curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public
+      sudo rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public
       sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
       sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-      sudo zypper --non-interactive refresh datadog
+      sudo zypper --non-interactive --no-gpg-check refresh datadog
       sudo zypper --non-interactive install #{node['dd-agent-step-by-step']['package_name']}
     EOF
   end

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -35,7 +35,7 @@ def agent_command
 end
 
 def service_command
-  `sudo which service`
+  "/sbin/service"
 end
 
 def wait_until_stopped(timeout = 60)
@@ -93,7 +93,7 @@ def stop
     elsif has_upstart
       result = system 'sudo initctl stop datadog-agent'
     else
-      result = system `sudo #{service} datadog-agent stop`
+      result = system "sudo #{service_command} datadog-agent stop"
     end
   end
   wait_until_stopped
@@ -110,7 +110,7 @@ def start
     elsif has_upstart
       result = system 'sudo initctl start datadog-agent'
     else
-      result = system "sudo #{service} datadog-agent start"
+      result = system "sudo #{service_command} datadog-agent start"
     end
   end
   wait_until_started
@@ -141,7 +141,7 @@ def restart
       wait_until_stopped 5
       wait_until_started 5
     else
-      result = system "sudo #{service} datadog-agent restart"
+      result = system "sudo #{service_command} datadog-agent restart"
       wait_until_stopped 5
       wait_until_started 5
     end
@@ -182,7 +182,7 @@ def status
     elsif has_upstart
       system('sudo initctl status datadog-agent')
     else
-      system("sudo #{service} datadog-agent status")
+      system("sudo #{service_command} datadog-agent status")
     end
   end
 end
@@ -197,7 +197,7 @@ def is_service_running?(svcname)
       status = `sudo initctl status #{svcname}`
       status.include?('start/running')
     else
-      status = `sudo #{service} #{svcname} status`
+      status = `sudo #{service_command} #{svcname} status`
       status.include?('running')
     end
   end

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -34,6 +34,10 @@ def agent_command
   end
 end
 
+def service_command
+  `sudo which service`
+end
+
 def wait_until_stopped(timeout = 60)
   # Check if the agent has stopped every second
   # Timeout after the given number of seconds
@@ -89,7 +93,7 @@ def stop
     elsif has_upstart
       result = system 'sudo initctl stop datadog-agent'
     else
-      result = system 'sudo service datadog-agent stop'
+      result = system `sudo #{service} datadog-agent stop`
     end
   end
   wait_until_stopped
@@ -106,7 +110,7 @@ def start
     elsif has_upstart
       result = system 'sudo initctl start datadog-agent'
     else
-      result = system 'sudo service datadog-agent start'
+      result = system "sudo #{service} datadog-agent start"
     end
   end
   wait_until_started
@@ -137,7 +141,7 @@ def restart
       wait_until_stopped 5
       wait_until_started 5
     else
-      result = system 'sudo service datadog-agent restart'
+      result = system "sudo #{service} datadog-agent restart"
       wait_until_stopped 5
       wait_until_started 5
     end
@@ -178,7 +182,7 @@ def status
     elsif has_upstart
       system('sudo initctl status datadog-agent')
     else
-      system('sudo service datadog-agent status')
+      system("sudo #{service} datadog-agent status")
     end
   end
 end
@@ -193,7 +197,7 @@ def is_service_running?(svcname)
       status = `sudo initctl status #{svcname}`
       status.include?('start/running')
     else
-      status = `sudo service #{svcname} status`
+      status = `sudo #{service} #{svcname} status`
       status.include?('running')
     end
   end

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -34,10 +34,6 @@ def agent_command
   end
 end
 
-def service_command
-  "/sbin/service"
-end
-
 def wait_until_stopped(timeout = 60)
   # Check if the agent has stopped every second
   # Timeout after the given number of seconds
@@ -93,7 +89,7 @@ def stop
     elsif has_upstart
       result = system 'sudo initctl stop datadog-agent'
     else
-      result = system "sudo #{service_command} datadog-agent stop"
+      result = system "sudo /sbin/service datadog-agent stop"
     end
   end
   wait_until_stopped
@@ -110,7 +106,7 @@ def start
     elsif has_upstart
       result = system 'sudo initctl start datadog-agent'
     else
-      result = system "sudo #{service_command} datadog-agent start"
+      result = system "sudo /sbin/service datadog-agent start"
     end
   end
   wait_until_started
@@ -141,7 +137,7 @@ def restart
       wait_until_stopped 5
       wait_until_started 5
     else
-      result = system "sudo #{service_command} datadog-agent restart"
+      result = system "sudo /sbin/service datadog-agent restart"
       wait_until_stopped 5
       wait_until_started 5
     end
@@ -182,7 +178,7 @@ def status
     elsif has_upstart
       system('sudo initctl status datadog-agent')
     else
-      system("sudo #{service_command} datadog-agent status")
+      system("sudo /sbin/service datadog-agent status")
     end
   end
 end
@@ -197,7 +193,7 @@ def is_service_running?(svcname)
       status = `sudo initctl status #{svcname}`
       status.include?('start/running')
     else
-      status = `sudo #{service_command} #{svcname} status`
+      status = `sudo /sbin/service #{svcname} status`
       status.include?('running')
     end
   end


### PR DESCRIPTION
### What does this PR do?

Adds kitchen tests for SUSE 11 with sysvinit.
Fixes problems with said sysvinit scripts.

### Motivation

Check that the sysvinit scripts we created do work correctly.

### Additional Notes

A5 upgrade tests are disabled for now because the A5 install-script does not work on SUSE 11.
A6 upgrade tests are disabled for now as we don't have a stable A6 version supporting SUSE 11 yet.
