### PR TITLE
Fix process agent to just send empty usernames when can't get username

### DIFF
--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -282,7 +282,7 @@ func getUsernameForProcess(h windows.Handle) (name string, err error) {
 	tokenUser, err := t.GetTokenUser()
 
 	user, domain, _, err := tokenUser.User.Sid.LookupAccount("")
-	if(nil == err){
+	if nil == err {
 		return domain + "\\" + user, err
 	}
 	return "", err

--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -181,7 +181,7 @@ func getAllProcesses(cfg *config.AgentConfig) (map[int32]*process.FilledProcess,
 				}
 
 				if err = cp.fill(&proc); err != nil {
-					log.Debugf("could not fill WMI process information for pid %v %v", pid, err)
+					log.Debugf("could not fill Win32 process information for pid %v %v", pid, err)
 					continue
 				}
 			} else {
@@ -282,7 +282,10 @@ func getUsernameForProcess(h windows.Handle) (name string, err error) {
 	tokenUser, err := t.GetTokenUser()
 
 	user, domain, _, err := tokenUser.User.Sid.LookupAccount("")
-	return domain + "\\" + user, err
+	if(nil == err){
+		return domain + "\\" + user, err
+	}
+	return "", err
 }
 
 func convertWindowsString(winput []uint16) string {
@@ -387,10 +390,12 @@ func (cp *cachedProcess) fill(proc *Win32_Process) (err error) {
 		log.Debugf("Couldn't open process %v %v", proc.ProcessID, err)
 		return err
 	}
-	cp.userName, err = getUsernameForProcess(cp.procHandle)
-	if err != nil {
+	var usererr error
+	cp.userName, usererr = getUsernameForProcess(cp.procHandle)
+	if usererr != nil {
 		log.Debugf("Couldn't get process username %v %v", proc.ProcessID, err)
 	}
+
 	cp.executablePath = *proc.ExecutablePath
 	if len(cp.executablePath) == 0 {
 		// some system processes don't give us the executable path variable.  Just
@@ -417,10 +422,10 @@ func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error)
 		log.Infof("Couldn't open process %v %v", pe32.Th32ProcessID, err)
 		return err
 	}
-	cp.userName, err = getUsernameForProcess(cp.procHandle)
-	if err != nil {
-		log.Infof("Couldn't get process username %v %v", pe32.Th32ProcessID, err)
-		return err
+	var usererr error
+	cp.userName, usererr = getUsernameForProcess(cp.procHandle)
+	if usererr != nil {
+		log.Debugf("Couldn't get process username %v %v", pe32.Th32ProcessID, err)
 	}
 	cp.commandLine = convertWindowsString(pe32.SzExeFile[:])
 	cp.executablePath = cp.commandLine

--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -282,10 +282,10 @@ func getUsernameForProcess(h windows.Handle) (name string, err error) {
 	tokenUser, err := t.GetTokenUser()
 
 	user, domain, _, err := tokenUser.User.Sid.LookupAccount("")
-	if nil == err {
-		return domain + "\\" + user, err
+	if nil != err {
+		return "", err
 	}
-	return "", err
+	return domain + "\\" + user, err
 }
 
 func convertWindowsString(winput []uint16) string {

--- a/releasenotes/notes/fixprocessuser-4aec145e005a5caa.yaml
+++ b/releasenotes/notes/fixprocessuser-4aec145e005a5caa.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows process agent, fix problem wherein if the agent is unable
+    to figure out the process' user name, the process info/stats were not
+    sent at all.  Now sends all relevant stats without the username


### PR DESCRIPTION
### What does this PR do?

On windows, still report the process even when we can't compute the username.


### Motivation

Customer issue; there's no username associated with a process in a windows container using process isolation.

### Additional Notes

Anything else we should know when reviewing?
