### PR TITLE
[process-agent] Fix behavior when custom endpoint has a path specified

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -277,8 +277,7 @@ func errResponse(format string, a ...interface{}) postResponse {
 }
 
 func (l *Collector) postToAPI(endpoint config.APIEndpoint, checkPath string, body []byte, responses chan postResponse, containerCount int) {
-	endpoint.Endpoint.Path = checkPath
-	url := endpoint.Endpoint.String()
+	url := endpoint.GetCheckURL(checkPath)
 	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
 	if err != nil {
 		responses <- errResponse("could not create request to %s: %s", url, err)


### PR DESCRIPTION
### What does this PR do?

Properly handle process-agent setups where `process_dd_url` points to something like a NGINX server configured to proxy process-agent requests like the following:

```
location /dd-process/ {
  proxy_pass https://process.datadoghq.com/;
}
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?