### PR TITLE
[gitlab] Ensure cloudfront invalidation runs after successful deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2659,19 +2659,31 @@ latest_release_7:
     - if [[ -z "$TAG" ]]; then echo "Need a tag to delete"; exit 1; fi
     - inv -e docker.delete ${ORGANIZATION} ${IMAGE} ${TAG} ${DOCKER_TOKEN} &>/dev/null
 
-# invalidate cloudfront cache
-deploy_cloudfront_invalidate:
+#
+# Cloudfront cache invalidation:
+# Duplicated in 2 jobs: one that runs "on success" of the previous stage, and one that runs "on failure" of previous stages.
+# Compared to having 1 single job that runs "always", this setup guarantees that if earlier stages first failed and were
+# then retried successfully, the cloudfront invalidation will also run after the successful retry.
+#
+.deploy_cloudfront_invalidate: &deploy_cloudfront_invalidate
   <<: *run_when_triggered
   stage: deploy_invalidate
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
-  when: always
   script:
     - cd /deploy_scripts/cloudfront-invalidation
     - "REPO=apt PATTERN_SUBSTRING=/$DEB_RPM_BUCKET_BRANCH/ ./invalidate.sh"
     - "REPO=yum PATTERN_SUBSTRING=/$DEB_RPM_BUCKET_BRANCH/ ./invalidate.sh"
+
+deploy_cloudfront_invalidate_on_success:
+  <<: *deploy_cloudfront_invalidate
+  when: on_success
+
+deploy_cloudfront_invalidate_on_failure:
+  <<: *deploy_cloudfront_invalidate
+  when: on_failure
 
 #
 # end to end


### PR DESCRIPTION
### What does this PR do?

Ensures that cloudfront invalidation runs after successful deploy.

### Motivation

See inline comment. This solves a case that often happened when building RCs.

### Additional Notes

There is still an edge that's not covered: if there are more than 1 failure of the previous stages, the cloudfront invalidation will be run after the 1st failure, it will **not** be run after the subsequent failures, and it will be run after the (eventual) success of the previous stage (if it happens). So if the failures after the 1st one do modify the repos, the repos could end up in an inconsistent state until the invalidation is run manually or is run automatically after a successful retry.

Still, the behavior introduced by this PR is much better, and in most cases should not require a human to re-run the invalidation step manually anymore.
