### PR TITLE
dsd parsing: remove allocations during int and float parsing

### DIFF
--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -361,10 +361,18 @@ func parseMetricMessage(message []byte, namespace string, namespaceBlacklist []s
 	return sample, nil
 }
 
+// the std API does not have methods to do []byte => float parsing
+// we use this unsafe trick to avoid having to allocate one string for
+// every parsed float
+// see https://github.com/golang/go/issues/2632
 func parseFloat64(rawFloat []byte) (float64, error) {
 	return strconv.ParseFloat(*(*string)(unsafe.Pointer(&rawFloat)), 64)
 }
 
+// the std API does not have methods to do []byte => float parsing
+// we use this unsafe trick to avoid having to allocate one string for
+// every parsed float
+// see https://github.com/golang/go/issues/2632
 func parseInt64(rawInt []byte) (int64, error) {
 	return strconv.ParseInt(*(*string)(unsafe.Pointer(&rawInt)), 10, 64)
 }


### PR DESCRIPTION
### What does this PR do?

Remove a few useless allocations in the dogstatsd parsing logic.

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkParseMetric-4     472           430           -8.90%

benchmark                  old allocs     new allocs     delta
BenchmarkParseMetric-4     7              5              -28.57%

benchmark                  old bytes     new bytes     delta
BenchmarkParseMetric-4     224           216           -3.57%
```
Unfortunately `strconv.Parse* `only accepts strings as parameters. 
This issue was reported at https://github.com/golang/go/issues/2632 but it does not seem that the Go team has a concrete plan to deal with it.
    
We have two options to remove those allocs:
1. clone their parsing code or import a dependency that does that for us
2. a dirty trick commonly used to temporarily convert []byte to string without allocs

This PR implements 2. This is safe as long as nothing concurrently changes the underlying bytes but that's probably also true of the `string(...)` conversion.

### Motivation

Working towards less than one alloc for each dogstatsd metric sample to reduce GC overhead.