### PR TITLE
Do not panic when the cluster-name is invalid

### DIFF
--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -6,7 +6,6 @@
 package clustername
 
 import (
-	"fmt"
 	"regexp"
 	"sync"
 
@@ -63,9 +62,11 @@ func getClusterName(data *clusterNameData) string {
 		if data.clusterName != "" {
 			log.Infof("Got cluster name %s from config", data.clusterName)
 			if !validClusterName.MatchString(data.clusterName) {
-				panic(fmt.Sprintf("\"%s\" isn’t a valid cluster name. It must start with a lowercase "+
+				log.Errorf("\"%s\" isn’t a valid cluster name. It must start with a lowercase "+
 					"letter followed by up to 39 lowercase letters, numbers, or hyphens, and "+
-					"cannot end with a hyphen.", data.clusterName))
+					"cannot end with a hyphen.", data.clusterName)
+				log.Errorf("As a consequence, the cluster name provided by the config will be ignored")
+				data.clusterName = ""
 			}
 		}
 

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -37,7 +37,6 @@ func TestGetClusterName(t *testing.T) {
 		"toolongtoolongtoolongtoolongtoolongtoolong"} {
 		mockConfig.Set("cluster_name", invalidClusterName)
 		freshData = newClusterNameData()
-		assert.Panics(t, func() { getClusterName(freshData) },
-			"getClusterName(…) should panic when the cluster-name is invalid")
+		assert.Equal(t, "", getClusterName(freshData))
 	}
 }

--- a/releasenotes/notes/validate-cluster-name-06ce2c1e32f5ffc0.yaml
+++ b/releasenotes/notes/validate-cluster-name-06ce2c1e32f5ffc0.yaml
@@ -7,4 +7,4 @@
 # Each section note must be formatted as reStructuredText.
 ---
 fixes:
-  - Add a validation check on cluster-name that enforces the same rule as on GKE
+  - Check that cluster-name provided by configuraiton file are compliant with the same rule as on GKE. Logs an error and ignore it otherwise.


### PR DESCRIPTION
### What does this PR do?

Do not panic when the cluster-name is invalid.
Just log an error.

### Motivation

Not breaking existing deployments with invalid cluster names.