### PR TITLE
[GUI] Remove "6" version from page title

### DIFF
--- a/cmd/agent/gui/views/templates/index.tmpl
+++ b/cmd/agent/gui/views/templates/index.tmpl
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title> Datadog Agent </title>
+    <title> Datadog Agent</title>
     <link rel="stylesheet" href="view/css/font-awesome.min.css">
     <link rel="stylesheet" href="view/css/codemirror.css">
     <link rel="stylesheet" href="view/css/stylesheet.css">

--- a/cmd/agent/gui/views/templates/index.tmpl
+++ b/cmd/agent/gui/views/templates/index.tmpl
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title> Datadog Agent</title>
+    <title>Datadog Agent</title>
     <link rel="stylesheet" href="view/css/font-awesome.min.css">
     <link rel="stylesheet" href="view/css/codemirror.css">
     <link rel="stylesheet" href="view/css/stylesheet.css">

--- a/cmd/agent/gui/views/templates/index.tmpl
+++ b/cmd/agent/gui/views/templates/index.tmpl
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title> DataDog Agent 6 </title>
+    <title> Datadog Agent </title>
     <link rel="stylesheet" href="view/css/font-awesome.min.css">
     <link rel="stylesheet" href="view/css/codemirror.css">
     <link rel="stylesheet" href="view/css/stylesheet.css">


### PR DESCRIPTION
### What does this PR do?

Removes mention of "6" from GUI page header.

Before: 
![Screen Shot 2019-12-04 at 3 28 10 PM](https://user-images.githubusercontent.com/4912500/70179454-61591400-16de-11ea-93ef-105eff8f2f7d.png)

Also, fix case of `DataDog` -> `Datadog`.

### Motivation

Doesn't make sense for Agent 7. We can remove the major version here altogether since the full (correct) version is displayed next to it.