### PR TITLE
Start system-probe before Datadog Agent

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
@@ -1,6 +1,7 @@
 [Unit]
 Description=Datadog System Probe
 Requires=sys-kernel-debug.mount
+Before=datadog-agent.service
 After=network.target sys-kernel-debug.mount
 
 [Service]


### PR DESCRIPTION
Make sure system-probe is started before the agent so it can  be detected, otherwise data will not be collected.