### PR TITLE
[DCA] MetricServer generates k8s event on HPA|WPA

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1999,7 +1999,7 @@
   revision = "b3a7cee44a305be0a69e1b9ac03018307287e1b0"
 
 [[projects]]
-  digest = "0:"
+  digest = "1:f27698f7ae7864893ebcfb843e44d821263ac1dcf0ba1d5c2353f9d319a2f28d"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/kubelet/remote/fake",
@@ -2215,6 +2215,7 @@
     "k8s.io/client-go/informers/core/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
+    "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/listers/autoscaling/v2beta1",
     "k8s.io/client-go/listers/core/v1",

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -18,6 +18,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api"
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/custommetrics"
@@ -175,12 +179,18 @@ func start(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+
+		// Create event recorder
+		eventBroadcaster := record.NewBroadcaster()
+		eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "datadog-cluster-agent"})
+
 		stopCh := make(chan struct{})
 		ctx := apiserver.ControllerContext{
 			InformerFactory:    apiCl.InformerFactory,
 			WPAInformerFactory: apiCl.WPAInformerFactory,
 			Client:             apiCl.Cl,
 			LeaderElector:      le,
+			EventRecorder:      eventRecorder,
 			StopCh:             stopCh,
 		}
 

--- a/pkg/util/kubernetes/apiserver/controller_util.go
+++ b/pkg/util/kubernetes/apiserver/controller_util.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
@@ -29,13 +30,14 @@ import (
 )
 
 // NewAutoscalersController returns a new AutoscalersController
-func NewAutoscalersController(client kubernetes.Interface, le LeaderElectorInterface, dogCl autoscalers.DatadogClient) (*AutoscalersController, error) {
+func NewAutoscalersController(client kubernetes.Interface, eventRecorder record.EventRecorder, le LeaderElectorInterface, dogCl autoscalers.DatadogClient) (*AutoscalersController, error) {
 	var err error
 
 	h := &AutoscalersController{
-		clientSet: client,
-		le:        le, // only trigger GC and updateExternalMetrics by the Leader.
-		HPAqueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter(), "autoscalers"),
+		clientSet:     client,
+		le:            le, // only trigger GC and updateExternalMetrics by the Leader.
+		HPAqueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter(), "autoscalers"),
+		EventRecorder: eventRecorder,
 	}
 
 	h.toStore.data = make(map[string]custommetrics.ExternalMetricValue)

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/watermarkpodautoscaler/pkg/client/informers/externalversions"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 )
 
 type controllerFuncs struct {
@@ -42,6 +43,7 @@ type ControllerContext struct {
 	WPAInformerFactory externalversions.SharedInformerFactory
 	Client             kubernetes.Interface
 	LeaderElector      LeaderElectorInterface
+	EventRecorder      record.EventRecorder
 	StopCh             chan struct{}
 }
 
@@ -87,6 +89,7 @@ func startAutoscalersController(ctx ControllerContext) error {
 	}
 	autoscalersController, err := NewAutoscalersController(
 		ctx.Client,
+		ctx.EventRecorder,
 		ctx.LeaderElector,
 		dogCl,
 	)

--- a/pkg/util/kubernetes/apiserver/types.go
+++ b/pkg/util/kubernetes/apiserver/types.go
@@ -11,3 +11,9 @@ package apiserver
 type LeaderElectorInterface interface {
 	IsLeader() bool
 }
+
+const (
+	autoscalerNowHandleMsgEvent = "Autoscaler is now handle by the Cluster-Agent"
+	autoscalerIgnoreMsgEvent    = "Autoscaler is ignored, to many metrics already handled by the Cluster-Agent"
+	autoscalerUnIgnoreMsgEvent  = "Autoscaler will now be processed by the Cluster-Agent"
+)

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -44,6 +44,7 @@ func TestSuiteKube(t *testing.T) {
 	require.Nil(t, err)
 	output, err := compose.Start()
 	defer compose.Stop()
+	t.Logf("error: %v", err)
 	require.Nil(t, err, string(output))
 
 	// Init apiclient


### PR DESCRIPTION
### What does this PR do?

The Cluster-Agent will now generate kubernetes event attach to the HPA or WPA to reflect the metrics sink for the external-metrics-server.

### Motivation

Improve External metrics server user experience.

### Additional Notes

Anything else we should know when reviewing?
