### PR TITLE
Avoid panic in conntracker#isNAT

### DIFF
--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -333,6 +333,16 @@ func (ctr *realConntracker) compact() {
 }
 
 func isNAT(c ct.Con) bool {
+	if c.Origin == nil ||
+		c.Reply == nil ||
+		c.Origin.Proto == nil ||
+		c.Reply.Proto == nil ||
+		c.Origin.Proto.SrcPort == nil ||
+		c.Origin.Proto.DstPort == nil ||
+		c.Reply.Proto.SrcPort == nil ||
+		c.Reply.Proto.DstPort == nil {
+		return false
+	}
 
 	return !(*c.Origin.Src).Equal(*c.Reply.Dst) ||
 		!(*c.Origin.Dst).Equal(*c.Reply.Src) ||


### PR DESCRIPTION
On our test environment we were seeing panics on this line in
conntracker.go:

```
func isNAT(c ct.Con) bool {
  ...
  *c.Origin.Proto.SrcPort != *c.Reply.Proto.DstPort
}
```

My theory for why this happens is not all conntrack entries will have
port information. The type of Reply.Proto has both TCP/UDP fields like
port and ICMP fields. ICMP is a portless protocol, so this code would
have crashed on ICMP entries.

Since we don't handle ICMP connections, I believe it is safe to assume
that if any of the port information is nil, we can safely assume that
the connection is not NATed
