### PR TITLE
[entrypoint] ensure leader election only if DD_LEADER_ELECTION is true

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-kubernetes.sh
+++ b/Dockerfiles/agent/entrypoint/50-kubernetes.sh
@@ -23,7 +23,7 @@ if [[ ! -e /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default ]]; then
 fi
 
 # The apiserver check requires leader election to be enabled
-if [[ "$DD_LEADER_ELECTION" ]] && [[ ! -e /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default ]]; then
+if [[ "$DD_LEADER_ELECTION" == "true" ]] && [[ ! -e /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default ]]; then
     mv /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.example \
     /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
 else

--- a/releasenotes/notes/fix-leader-election-env-var-usage-7e9c38faa403a702.yaml
+++ b/releasenotes/notes/fix-leader-election-env-var-usage-7e9c38faa403a702.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Properly check for "true" value of env var DD_LEADER_ELECTION


### PR DESCRIPTION
### What does this PR do?

Currently any value for `DD_LEADER_ELECTION` would render the conditional true, including `"false"`. This makes it more explicit that the constant must be `"true"` to enter the block.

### Motivation

Accidental discovery that setting the constant to `"false"` did not have the intended effect.

### Additional Notes
