### PR TITLE
Allow ref to capture groups in mask replacement

### DIFF
--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -84,7 +84,7 @@ func (p *Processor) applyRedactingRules(msg *message.Message) (bool, []byte) {
 				return false, nil
 			}
 		case config.MaskSequences:
-			content = rule.Regex.ReplaceAllLiteral(content, rule.Placeholder)
+			content = rule.Regex.ReplaceAll(content, rule.Placeholder)
 		}
 	}
 	return true, content

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -113,6 +113,15 @@ func TestMask(t *testing.T) {
 	shouldProcess, redactedMessage = p.applyRedactingRules(newMessage([]byte("The credit card 4323124312341234 was used to buy some time"), &source, ""))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("The credit card [masked_credit_card] was used to buy some time"), redactedMessage)
+
+	source = newSource("mask_sequences", "${1}[masked_value]", "([Dd]ata_?values=)\\S+")
+	shouldProcess, redactedMessage = p.applyRedactingRules(newMessage([]byte("New data added to Datavalues=123456 on prod"), &source, ""))
+	assert.Equal(t, true, shouldProcess)
+	assert.Equal(t, []byte("New data added to Datavalues=[masked_value] on prod"), redactedMessage)
+
+	shouldProcess, redactedMessage = p.applyRedactingRules(newMessage([]byte("New data added to data_values=123456 on prod"), &source, ""))
+	assert.Equal(t, true, shouldProcess)
+	assert.Equal(t, []byte("New data added to data_values=[masked_value] on prod"), redactedMessage)
 }
 
 func TestTruncate(t *testing.T) {

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -122,6 +122,10 @@ func TestMask(t *testing.T) {
 	shouldProcess, redactedMessage = p.applyRedactingRules(newMessage([]byte("New data added to data_values=123456 on prod"), &source, ""))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("New data added to data_values=[masked_value] on prod"), redactedMessage)
+
+	shouldProcess, redactedMessage = p.applyRedactingRules(newMessage([]byte("New data added to data_values= on prod"), &source, ""))
+	assert.Equal(t, true, shouldProcess)
+	assert.Equal(t, []byte("New data added to data_values= on prod"), redactedMessage)
 }
 
 func TestTruncate(t *testing.T) {

--- a/releasenotes/notes/use-capture-groups-in-mask-sequences-4acbb79ab6a7f7b5.yaml
+++ b/releasenotes/notes/use-capture-groups-in-mask-sequences-4acbb79ab6a7f7b5.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Users can now use references to capture groups
+    in mask sequence replacement_placeholder strings


### PR DESCRIPTION
### What does this PR do?

Changes the replace function in logs mask sequences to expand references to capture groups (`$1`, `$2`, `${1}` etc.) allowing users to insert part of the matched content back into the replacement string.

### Motivation

Some customers have reached out recently asking for the ability to use backreferences to capture groups in the regex they specify for logs mask sequences. The use cases are generally as follows:
- user wants to use a certain string in a regex as a reference to the part they want to replace
- user wants to keep the reference string in the original log

Currently we only support inserting a raw string so customers have to hardcode the reference back in as in:

```
pattern: User=\w+
replace_placeholder: "User=[masked_user]"
```

However, sometimes the reference can be something variable as in:

```
Customer ID=1234
customer ID=1234
customer_id=1234
CustomerId=1234
```

In this case, customers are looking for something like:

```
pattern: ([^=]*=)\S+
replace_placeholder: "${1}[masked_id]"
```

### Additional Notes

Anything else we should know when reviewing?
