### PR TITLE
[config_template] Document new flare_stripped_keys option

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -212,6 +212,16 @@ api_key:
 #
 # python_version: 2
 
+## @param flare_stripped_keys - list of strings - optional
+## By default, the Agent removes known sensitive keys from Agent and Integrations yaml configs before
+## including them in the flare.
+## Use this parameter to define additional sensitive keys that the Agent should scrub from
+## the yaml files included in the flare.
+#
+# flare_stripped_keys:
+#   - "sensitive_key_1"
+#   - "sensitive_key_2"
+
 {{ end }}
 
 ############################

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -202,16 +202,6 @@ api_key:
 #   - "google-container-manifest"
 #   - "bosh_settings"
 
-{{ end }}
-{{- if .Agent }}
-{{- if .BothPythonPresent -}}
-## @param python_version - integer - optional - default: 2
-## The major version of Python used to run integrations and custom checks.
-## The only supported values are 2 (to use Python 2) or 3 (to use Python 3).
-## Do not change this option when using the official Docker Agent images.
-#
-# python_version: 2
-
 ## @param flare_stripped_keys - list of strings - optional
 ## By default, the Agent removes known sensitive keys from Agent and Integrations yaml configs before
 ## including them in the flare.
@@ -221,6 +211,16 @@ api_key:
 # flare_stripped_keys:
 #   - "sensitive_key_1"
 #   - "sensitive_key_2"
+
+{{ end }}
+{{- if .Agent }}
+{{- if .BothPythonPresent -}}
+## @param python_version - integer - optional - default: 2
+## The major version of Python used to run integrations and custom checks.
+## The only supported values are 2 (to use Python 2) or 3 (to use Python 3).
+## Do not change this option when using the official Docker Agent images.
+#
+# python_version: 2
 
 {{ end }}
 


### PR DESCRIPTION
### What does this PR do?

Documents the new `flare_stripped_keys` option

### Motivation

Document an option that was added in https://github.com/DataDog/datadog-agent/pull/4412, so that it's clear what it should be used for.
