### PR TITLE
[codeowners] Change ownership of config_template file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,6 +64,7 @@
 /pkg/collector/corechecks/net/          @DataDog/agent-platform
 /pkg/collector/corechecks/system/       @DataDog/agent-platform
 /pkg/collector/corechecks/systemd/      @DataDog/agent-integrations
+/pkg/config/config_template.yaml        @DataDog/agent-all @DataDog/baklava
 /pkg/tagger/                            @DataDog/container-integrations
 /pkg/util/clusteragent/                 @DataDog/container-integrations
 /pkg/util/containers/                   @DataDog/container-integrations
@@ -98,6 +99,3 @@
 /test/util                              @DataDog/agent-all
 
 /tools/ebpf/                            @DataDog/burrito
-
-# Match specific files first (at the bottom of the file to be matched first)
-config_template.yaml                    @DataDog/agent-all @DataDog/baklava

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,3 +98,6 @@
 /test/util                              @DataDog/agent-all
 
 /tools/ebpf/                            @DataDog/burrito
+
+# Match specific files first (at the bottom of the file to be matched first)
+config_template.yaml                    @DataDog/agent-all @DataDog/baklava


### PR DESCRIPTION
### What does this PR do?

Changes ownership of config_template file:
* Baklava since the config template is documentation
* Agent-all as any agent team has ownership to update this file

### Motivation

This file is mostly a documentation file, it's meant to be reflected on docs website at some point, changes to it should be reviewed by Baklava.