### PR TITLE
pkg/trace/stats: do not ignore single span sublayer metrics

### DIFF
--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -361,7 +361,6 @@ func TestConcentratorSublayersStatsCounts(t *testing.T) {
 		subtraceSublayers := ComputeSublayers(subtrace.Trace)
 		sublayers[subtrace.Root] = subtraceSublayers
 	}
-	assert.Equal(1, 2, "GOT %+v", subtraces)
 
 	testTrace := &Input{
 		Env:       "none",

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -361,6 +361,7 @@ func TestConcentratorSublayersStatsCounts(t *testing.T) {
 		subtraceSublayers := ComputeSublayers(subtrace.Trace)
 		sublayers[subtrace.Root] = subtraceSublayers
 	}
+	assert.Equal(1, 2, "GOT %+v", subtraces)
 
 	testTrace := &Input{
 		Env:       "none",
@@ -388,12 +389,18 @@ func TestConcentratorSublayersStatsCounts(t *testing.T) {
 		"query|_sublayers.duration.by_service|env:none,resource:resource4,service:A3,sublayer_service:A3": 340,
 		"query|_sublayers.duration.by_service|env:none,resource:resource2,service:A2,sublayer_service:A2": 1000,
 		"query|_sublayers.duration.by_service|env:none,resource:resource2,service:A2,sublayer_service:A3": 370,
+		"query|_sublayers.duration.by_service|env:none,resource:resource3,service:A2,sublayer_service:A2": 1000,
+		"query|_sublayers.duration.by_service|env:none,resource:resource6,service:A3,sublayer_service:A3": 30,
 		"query|_sublayers.duration.by_type|env:none,resource:resource1,service:A1,sublayer_type:db":       4370,
 		"query|_sublayers.duration.by_type|env:none,resource:resource2,service:A2,sublayer_type:db":       1370,
 		"query|_sublayers.duration.by_type|env:none,resource:resource4,service:A3,sublayer_type:db":       340,
+		"query|_sublayers.duration.by_type|env:none,resource:resource3,service:A2,sublayer_type:db":       1000,
+		"query|_sublayers.duration.by_type|env:none,resource:resource6,service:A3,sublayer_type:db":       30,
 		"query|_sublayers.span_count|env:none,resource:resource1,service:A1,:":                            6,
 		"query|_sublayers.span_count|env:none,resource:resource2,service:A2,:":                            4,
 		"query|_sublayers.span_count|env:none,resource:resource4,service:A3,:":                            2,
+		"query|_sublayers.span_count|env:none,resource:resource3,service:A2,:":                            1,
+		"query|_sublayers.span_count|env:none,resource:resource6,service:A3,:":                            1,
 		"query|duration|env:none,resource:resource1,service:A1":                                           2000,
 		"query|duration|env:none,resource:resource2,service:A2":                                           1000,
 		"query|duration|env:none,resource:resource3,service:A2":                                           1000,
@@ -412,7 +419,7 @@ func TestConcentratorSublayersStatsCounts(t *testing.T) {
 	}
 
 	// verify we got all counts
-	assert.Equal(len(expectedCountValByKey), len(receivedCounts), "GOT %v", receivedCounts)
+	assert.Equal(len(expectedCountValByKey), len(receivedCounts), "GOT %+v", receivedCounts)
 	// verify values
 	for key, val := range expectedCountValByKey {
 		count, ok := receivedCounts[key]

--- a/pkg/trace/stats/subtrace.go
+++ b/pkg/trace/stats/subtrace.go
@@ -68,8 +68,6 @@ func ExtractTopLevelSubtraces(t pb.Trace, root *pb.Span) []Subtrace {
 
 	// We do a DFS on the trace to record the toplevel ancesters of each span
 	for current := next.Pop(); current != nil; current = next.Pop() {
-		// We do not extract subtraces for toplevel spans that have no children
-		// since these are not interresting
 		if traceutil.HasTopLevel(current.Span) {
 			current.Ancestors = append(current.Ancestors, current.Span)
 		}

--- a/pkg/trace/stats/subtrace.go
+++ b/pkg/trace/stats/subtrace.go
@@ -70,7 +70,7 @@ func ExtractTopLevelSubtraces(t pb.Trace, root *pb.Span) []Subtrace {
 	for current := next.Pop(); current != nil; current = next.Pop() {
 		// We do not extract subtraces for toplevel spans that have no children
 		// since these are not interresting
-		if traceutil.HasTopLevel(current.Span) && len(childrenMap[current.Span.SpanID]) > 0 {
+		if traceutil.HasTopLevel(current.Span) {
 			current.Ancestors = append(current.Ancestors, current.Span)
 		}
 		visited[current.Span] = true

--- a/pkg/trace/stats/subtrace_test.go
+++ b/pkg/trace/stats/subtrace_test.go
@@ -44,7 +44,7 @@ func TestExtractTopLevelSubtracesWithSimpleTrace(t *testing.T) {
 	}
 }
 
-func TestExtractTopLevelSubtracesShouldIgnoreLeafTopLevel(t *testing.T) {
+func TestExtractTopLevelSubtracesShouldNotIgnoreLeafTopLevel(t *testing.T) {
 	assert := assert.New(t)
 
 	trace := pb.Trace{
@@ -57,6 +57,7 @@ func TestExtractTopLevelSubtracesShouldIgnoreLeafTopLevel(t *testing.T) {
 	expected := []Subtrace{
 		{trace[0], trace},
 		{trace[1], []*pb.Span{trace[1], trace[2]}},
+		{trace[2], []*pb.Span{}},
 	}
 
 	traceutil.ComputeTopLevel(trace)

--- a/releasenotes/notes/apm-count-single-span-subtrace-sublayers-c221b755688b2c7e.yaml
+++ b/releasenotes/notes/apm-count-single-span-subtrace-sublayers-c221b755688b2c7e.yaml
@@ -8,6 +8,6 @@
 ---
 fixes:
   - |
-    Stopped ignoring sublayer metrics for childless subtraces, since this
+    APM: Stopped ignoring sublayer metrics for childless subtraces, since this
     was throwing the metric count off in cases where subtraces for a service
     sometimes did have children and sometimes not.

--- a/releasenotes/notes/apm-count-single-span-subtrace-sublayers-c221b755688b2c7e.yaml
+++ b/releasenotes/notes/apm-count-single-span-subtrace-sublayers-c221b755688b2c7e.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Stopped ignoring sublayer metrics for childless subtraces, since this
+    was throwing the metric count off in cases where subtraces for a service
+    sometimes did have children and sometimes not.


### PR DESCRIPTION
### What does this PR do?
No longer ignoring childless spans for apm sublayer metrics and stats to fix inaccuracies in how sublayer metrics are sometimes reported.

It looks like this was done as an optimization since it makes sense if the service is always sending a single span, then the sublayer metrics are actually irrelevant. But in cases where the service sometimes has child spans and sometimes doesn't, this can cause the metric to simply be inaccurate since it doesn't take all metrics into account.


### Motivation

To fix a support ticket, described above.

### Additional Notes

This will probably cause some (unknown), increase in (sublayer) trace metrics being sent, i.e. now for all the single span traces (which shouldn't be a troublesome number I assume).
