### PR TITLE
Allow the agent to run even if we can't create auth_token

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -215,7 +215,7 @@ func StartAgent() error {
 	// start the cmd HTTP server
 	if runtime.GOOS != "android" {
 		if err = api.StartServer(); err != nil {
-			return log.Errorf("Error while starting api server, exiting: %v", err)
+			log.Errorf("Major error while starting api server (API will not be accessible): %v", err)
 		}
 	}
 

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -124,13 +124,13 @@ func FetchAuthToken() (string, error) {
 		key := make([]byte, authTokenMinimalLen)
 		_, e = rand.Read(key)
 		if e != nil {
-			return "", fmt.Errorf("error creating authentication token: %s", e)
+			return "", fmt.Errorf("error creating authentication token %s", e)
 		}
 
 		// Write the auth token to the auth token file (platform-specific)
 		e = saveAuthToken(hex.EncodeToString(key), authTokenFile)
 		if e != nil {
-			return "", fmt.Errorf("error creating authentication token: %s", e)
+			return "", fmt.Errorf("error creating authentication token %s", e)
 		}
 		log.Infof("Saved a new authentication token to %s", authTokenFile)
 	}
@@ -138,13 +138,13 @@ func FetchAuthToken() (string, error) {
 	// Read the token
 	authTokenRaw, e := ioutil.ReadFile(authTokenFile)
 	if e != nil {
-		return "", fmt.Errorf("unable to access authentication token: " + e.Error())
+		return "", fmt.Errorf("unable to access authentication token " + e.Error())
 	}
 
 	// Do some basic validation
 	authToken := string(authTokenRaw)
 	if len(authToken) < authTokenMinimalLen {
-		return "", fmt.Errorf("invalid authentication token: must be at least %d characters in length", authTokenMinimalLen)
+		return "", fmt.Errorf("invalid authentication token must be at least %d characters in length", authTokenMinimalLen)
 	}
 
 	return authToken, nil
@@ -177,13 +177,13 @@ func GetClusterAgentAuthToken() (string, error) {
 		key := make([]byte, authTokenMinimalLen)
 		_, e = rand.Read(key)
 		if e != nil {
-			return "", fmt.Errorf("error creating authentication token: %s", e)
+			return "", fmt.Errorf("error creating authentication token %s", e)
 		}
 
 		// Write the auth token to the auth token file (platform-specific)
 		e = saveAuthToken(hex.EncodeToString(key), tokenAbsPath)
 		if e != nil {
-			return "", fmt.Errorf("error creating authentication token: %s", e)
+			return "", fmt.Errorf("error creating authentication token %s", e)
 		}
 		log.Infof("Saved a new authentication token for the Cluster Agent at %s", tokenAbsPath)
 	}

--- a/releasenotes/notes/allow-agent-to-start-without-authtoken-e5af9c0133bdbd92.yaml
+++ b/releasenotes/notes/allow-agent-to-start-without-authtoken-e5af9c0133bdbd92.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Do not exit the agent if the 'auth_token' for the API can't be created. On
+    windows, if the agent doesn't have the right to create the file it would
+    trigger a rollback when installing/upgrading the agent.


### PR DESCRIPTION
### What does this PR do?

On Windows the agent might not have the right to create the auth_token
for the API. If we exit for this, it triggers a rollback when installing
the agent (since the msi check that the service is able to start).

We now let the agent start so the install is successful even if the API
will not work.

This commit also edit some error logs in order to remove the 'token:'
which trigger the log stripper to remove the error message.