### PR TITLE
Fix tracer-ebpf compilation on Ubuntu 19.04 Disco

### DIFF
--- a/pkg/ebpf/c/tracer-ebpf.c
+++ b/pkg/ebpf/c/tracer-ebpf.c
@@ -1,5 +1,16 @@
 #include <linux/kconfig.h>
 
+/* clang does not support "asm volatile goto" yet.
+ * So redefine asm_volatile_goto to some invalid asm code.
+ * If asm_volatile_goto is actually used by the bpf program,
+ * a compilation error will appear.
+ */
+#ifdef asm_volatile_goto
+#undef asm_volatile_goto
+#endif
+#define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
+#pragma clang diagnostic ignored "-Wunused-label"
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
 #pragma clang diagnostic ignored "-Waddress-of-packed-member"

--- a/releasenotes/notes/fix_ebpf_compilation-3afacd5471cd37ec.yaml
+++ b/releasenotes/notes/fix_ebpf_compilation-3afacd5471cd37ec.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix eBPF code compilation errors about `asm goto` on Ubuntu 19.04 (Disco)
+    Fix eBPF code compilation errors about ``asm goto`` on Ubuntu 19.04 (Disco)

--- a/releasenotes/notes/fix_ebpf_compilation-3afacd5471cd37ec.yaml
+++ b/releasenotes/notes/fix_ebpf_compilation-3afacd5471cd37ec.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix eBPF code compilation errors about `asm goto` on Ubuntu 19.04 (Disco)


### PR DESCRIPTION
### What does this PR do?

Fix `tracer-ebpf` compilation on Ubuntu 19.04 Disco

### Motivation

Attempt to compile `system-probe` with Linux kernel headers 5.0 and LLVM 8
generates compilation errors due to `asm goto`:
```
vagrant@ci-lenaic:~/go/src/github.com/DataDog/datadog-agent$ inv system-probe.build
In file included from ./pkg/ebpf/c/tracer-ebpf.c:17:
In file included from /usr/src/linux-headers-5.0.0-36-generic/include/linux/ptrace.h:6:
In file included from /usr/src/linux-headers-5.0.0-36-generic/include/linux/sched.h:12:
In file included from /usr/src/linux-headers-5.0.0-36-generic/arch/x86/include/asm/current.h:6:
In file included from /usr/src/linux-headers-5.0.0-36-generic/arch/x86/include/asm/percpu.h:45:
In file included from /usr/src/linux-headers-5.0.0-36-generic/include/linux/kernel.h:11:
In file included from /usr/src/linux-headers-5.0.0-36-generic/include/linux/bitops.h:19:
/usr/src/linux-headers-5.0.0-36-generic/arch/x86/include/asm/bitops.h:209:9: error: 'asm goto' constructs are not supported yet
        return GEN_BINARY_RMWcc(LOCK_PREFIX __ASM_SIZE(bts), *addr, c, "Ir", nr);
               ^
/usr/src/linux-headers-5.0.0-36-generic/arch/x86/include/asm/rmwcc.h:60:32: note: expanded from macro 'GEN_BINARY_RMWcc'
                               ^
/usr/src/linux-headers-5.0.0-36-generic/arch/x86/include/asm/rmwcc.h:10:28: note: expanded from macro 'RMWcc_CONCAT'
                           ^
/usr/src/linux-headers-5.0.0-36-generic/arch/x86/include/asm/rmwcc.h:9:30: note: expanded from macro '__RMWcc_CONCAT'
                             ^
note: (skipping 2 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/usr/src/linux-headers-5.0.0-36-generic/arch/x86/include/asm/rmwcc.h:54:2: note: expanded from macro 'GEN_BINARY_RMWcc_6'
        __GEN_RMWcc(op " %[val], " arg0, var, cc,                       \
        ^
/usr/src/linux-headers-5.0.0-36-generic/arch/x86/include/asm/rmwcc.h:21:2: note: expanded from macro '__GEN_RMWcc'
        asm_volatile_goto (fullop "; j" #cc " %l[cc_label]"             \
        ^
/usr/src/linux-headers-5.0.0-36-generic/include/linux/compiler_types.h:188:37: note: expanded from macro 'asm_volatile_goto'
                                    ^
```

`asm goto` have been required for x86 since Linux 4.17 but their use is spreading over versions.
So, with old enough Linux kernel headers, we wouldn’t have the above mentioned errors.

And support for `asm goto` has been added in LLVM 9:
https://prereleases.llvm.org/9.0.0/rc3/tools/clang/docs/ReleaseNotes.html#c-language-changes-in-clang
So, the above mentioned errors don’t happen with LLVM 9 or above.

A discussion about these compilation errors can be found there:
https://github.com/iovisor/bcc/issues/2119

As a workaround, if we have the "bad" combination of Linux kernel headers and LLVM,
we can apply the same trick as the one described in https://github.com/iovisor/bcc/issues/2119
in order to make the `asm goto` block compile if not used but make the compilation abort if used.