### PR TITLE
Add a flag (IGNORESVCSTATUS) to allow the installation to succeed even if

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -435,8 +435,8 @@
       <Custom Action='FinalizeInstall' After='InstallServices'>      <![CDATA[Installed="" ]]> </Custom>
 
       <!-- Same deal here -->
-      <Custom Action='StartDDServices' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL" AND ALLOWSTARTFAIL="" ]]></Custom>
-      <Custom Action='StartDDServicesAllowStartFail' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL" AND ALLOWSTARTFAIL<>"" ]]></Custom>
+      <Custom Action='StartDDServices' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL" AND IGNORESVCSTATUS="" ]]></Custom>
+      <Custom Action='StartDDServicesAllowStartFail' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL" AND IGNORESVCSTATUS<>"" ]]></Custom>
       
       <!-- only do the uninstall (which removes the user state and file perms) 
            on a full uninstall -->

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -435,7 +435,8 @@
       <Custom Action='FinalizeInstall' After='InstallServices'>      <![CDATA[Installed="" ]]> </Custom>
 
       <!-- Same deal here -->
-      <Custom Action='StartDDServices' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL" ]]></Custom>
+      <Custom Action='StartDDServices' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL" AND ALLOWSTARTFAIL="" ]]></Custom>
+      <Custom Action='StartDDServicesAllowStartFail' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL" AND ALLOWSTARTFAIL<>"" ]]></Custom>
       
       <!-- only do the uninstall (which removes the user state and file perms) 
            on a full uninstall -->
@@ -579,6 +580,7 @@
     <CustomAction Id='FinalizeInstall' BinaryKey='wixcadll' DllEntry='FinalizeInstall' Execute='deferred' Return='check' Impersonate='no'/>
     <CustomAction Id='StopDDServices' BinaryKey='wixcadll' DllEntry='PreStopServices' Execute='deferred' Return='check' Impersonate='no'/>
     <CustomAction Id='StartDDServices' BinaryKey='wixcadll' DllEntry='PostStartServices' Execute='deferred' Return='check' Impersonate='no'/>
+    <CustomAction Id='StartDDServicesAllowStartFail' BinaryKey='wixcadll' DllEntry='PostStartServices' Execute='deferred' Return='ignore' Impersonate='no'/>
 
     <CustomAction Id='SetUninstallProperty' Return='check' Property='DoUninstall' 
         Value='PROJECTLOCATION=[PROJECTLOCATION];DDAGENTUSER_NAME=[DDAGENTUSER_NAME];DDAGENTUSER_PASSWORD=[DDAGENTUSER_PASSWORD];' />


### PR DESCRIPTION
the service start fails.  Provides a better path for troubleshooting
installation failures when the service fails to start

### What does this PR do?

Provides an additional tool for troubleshooting.  When the installation fails due the service failing to start, gives an option to allow the installation to succeed, anyway.

Makes it easier to troubleshoot why the service start is failing

### Motivation

Multiple customer support issues.

### Additional Notes

Anything else we should know when reviewing?
