### PR TITLE
[SUSE] Enable init scripts with chkconfig

### DIFF
--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -46,10 +46,10 @@ elif [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
         update-rc.d $SERVICE_NAME defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with update-rc.d"
         update-rc.d $SERVICE_NAME-process defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with update-rc.d"
         update-rc.d $SERVICE_NAME-trace defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with update-rc.d"
-    else
-        ln -s /etc/init.d/$SERVICE_NAME /etc/init.d/rc5.d/S95$SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME"
-        ln -s /etc/init.d/$SERVICE_NAME-process /etc/init.d/rc5.d/S95$SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process"
-        ln -s /etc/init.d/$SERVICE_NAME-trace /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace"
+    elif command -v chkconfig >/dev/null 2>&1; then
+        chkconfig --set $SERVICE_NAME on || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with chkconfig"
+        chkconfig --set $SERVICE_NAME-process on || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with chkconfig"
+        chkconfig --set $SERVICE_NAME-trace on || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with chkconfig"
     fi
 else
     echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -80,10 +80,10 @@ deregister_agent()
             update-rc.d -f $SERVICE_NAME-process remove || true
             update-rc.d -f $SERVICE_NAME-trace remove || true
             update-rc.d -f $SERVICE_NAME remove || true
-        else
-            rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-process || true
-            rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME-trace || true
-            rm -f /etc/init.d/rc5.d/S95$SERVICE_NAME || true
+        elif command -v chkconfig >/dev/null 2>&1; then
+            chkconfig --set $SERVICE_NAME off || true
+            chkconfig --set $SERVICE_NAME-process off || true
+            chkconfig --set $SERVICE_NAME-trace off || true
         fi
     else
         echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."


### PR DESCRIPTION
### What does this PR do?

Uses `chkconfig` to enable and disable the Agent at startup.
Fixes init script not being present on all expected runlevels (2 to 5).

### Motivation

SUSE 11 testing.

