### PR TITLE
[clcrunner] add pod ip to request header

### DIFF
--- a/cmd/agent/clcrunnerapi/v1/clcrunner.go
+++ b/cmd/agent/clcrunnerapi/v1/clcrunner.go
@@ -37,7 +37,6 @@ func SetupHandlers(r *mux.Router) {
 func getCLCRunnerStats(w http.ResponseWriter, r *http.Request) {
 	log.Info("Got a request for the runner stats. Making stats.")
 	w.Header().Set("Content-Type", "text/plain")
-
 	stats, err := status.GetExpvarRunnerStats()
 	if err != nil {
 		log.Errorf("Error getting exp var stats: %v", err)

--- a/cmd/agent/clcrunnerapi/v1/clcrunner.go
+++ b/cmd/agent/clcrunnerapi/v1/clcrunner.go
@@ -37,6 +37,7 @@ func SetupHandlers(r *mux.Router) {
 func getCLCRunnerStats(w http.ResponseWriter, r *http.Request) {
 	log.Info("Got a request for the runner stats. Making stats.")
 	w.Header().Set("Content-Type", "text/plain")
+
 	stats, err := status.GetExpvarRunnerStats()
 	if err != nil {
 		log.Errorf("Error getting exp var stats: %v", err)

--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -19,11 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 	cctypes "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	dcautil "github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-// realIPHeader refers to the cluster level check runner ip passed in the request headers
-const realIPHeader = "X-Real-Ip"
 
 // Install registers v1 API endpoints
 func installClusterCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
@@ -55,7 +53,7 @@ func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 			return
 		}
 
-		clientIP, err := validateClientIP(r.Header.Get(realIPHeader))
+		clientIP, err := validateClientIP(r.Header.Get(dcautil.RealIPHeader))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			incrementRequestMetric("postCheckStatus", http.StatusInternalServerError)

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -109,7 +109,7 @@ func (c *DCAClient) init() error {
 
 	c.clusterAgentAPIRequestHeaders = http.Header{}
 	c.clusterAgentAPIRequestHeaders.Set(authorizationHeaderKey, fmt.Sprintf("Bearer %s", authToken))
-	podIP := getLocalIP()
+	podIP := config.Datadog.GetString("clc_runner_host")
 	c.clusterAgentAPIRequestHeaders.Set(RealIPHeader, podIP)
 
 	// TODO remove insecure

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -375,19 +375,3 @@ func (c *DCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]
 
 	return metadataNames, nil
 }
-
-func getLocalIP() string {
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return ""
-	}
-	for _, address := range addrs {
-		// check the address type and if it is not a loopback the display it
-		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			if ipnet.IP.To4() != nil {
-				return ipnet.IP.String()
-			}
-		}
-	}
-	return ""
-}

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"os"

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -112,7 +112,7 @@ func (d *dummyClusterAgent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	podIP := r.Header.Get(RealIPHeader)
 	if podIP != clcRunnerIP {
-		log.Errorf("clc runner IP not provided")
+		log.Errorf("wrong clc runner IP: %s", podIP)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -110,6 +110,13 @@ func (d *dummyClusterAgent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	clcRunnerIP := r.Header.Get(RealIPHeader)
+	if clcRunnerIP == "" {
+		log.Errorf("clc runner IP not provided")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	// Handle http redirect
 	d.RLock()
 	redirectURL := d.redirectURL
@@ -228,6 +235,7 @@ const (
 	clusterAgentServiceHost = clusterAgentServiceName + "_SERVICE_HOST"
 	clusterAgentServicePort = clusterAgentServiceName + "_SERVICE_PORT"
 	clusterAgentTokenValue  = "01234567890123456789012345678901"
+	clcRunnerIP             = "10.92.1.39"
 )
 
 func (suite *clusterAgentSuite) SetupTest() {
@@ -235,6 +243,7 @@ func (suite *clusterAgentSuite) SetupTest() {
 	mockConfig.Set("cluster_agent.auth_token", clusterAgentTokenValue)
 	mockConfig.Set("cluster_agent.url", "")
 	mockConfig.Set("cluster_agent.kubernetes_service_name", "")
+	mockConfig.Set("clc_runner_host", clcRunnerIP)
 	os.Unsetenv(clusterAgentServiceHost)
 	os.Unsetenv(clusterAgentServicePort)
 }

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -110,8 +110,8 @@ func (d *dummyClusterAgent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clcRunnerIP := r.Header.Get(RealIPHeader)
-	if clcRunnerIP == "" {
+	podIP := r.Header.Get(RealIPHeader)
+	if podIP != clcRunnerIP {
 		log.Errorf("clc runner IP not provided")
 		w.WriteHeader(http.StatusBadRequest)
 		return


### PR DESCRIPTION
### What does this PR do?

Adds the CLC runner pod IP to the request header to avoid any confusion with the advanced dispatching logic and pod/node IPs.
 
### Motivation

Related to https://github.com/DataDog/datadog-agent/pull/4386

### Additional Notes

