### PR TITLE
pkg/config: add datadog.tracer to the list of StandardStatsdPrefixes for tracer health metrics.

### DIFF
--- a/pkg/config/standard_names.go
+++ b/pkg/config/standard_names.go
@@ -18,6 +18,7 @@ var StandardStatsdPrefixes = []string{
 	"datadog.dogstatsd",
 	"datadog.process",
 	"datadog.trace_agent",
+	"datadog.tracer",
 
 	"activemq",
 	"activemq_58",

--- a/releasenotes/notes/whitelist-tracer-metrics-82a29f90053042b8.yaml
+++ b/releasenotes/notes/whitelist-tracer-metrics-82a29f90053042b8.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add datadog.tracer to the list of standard statsd prefixes. Tracer metrics are published with this prefix.
+    Do not apply the metric namespace configured under `statsd_metric_namespace` to dogstatsd metrics prefixed with `datadog.tracer`. Tracer metrics are published with this prefix.

--- a/releasenotes/notes/whitelist-tracer-metrics-82a29f90053042b8.yaml
+++ b/releasenotes/notes/whitelist-tracer-metrics-82a29f90053042b8.yaml
@@ -6,5 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
+enhancements:
   - |
     Add datadog.tracer to the list of standard statsd prefixes. Tracer metrics are published with this prefix.

--- a/releasenotes/notes/whitelist-tracer-metrics-82a29f90053042b8.yaml
+++ b/releasenotes/notes/whitelist-tracer-metrics-82a29f90053042b8.yaml
@@ -1,0 +1,10 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+  - |
+    Add datadog.tracer to the list of standard statsd prefixes. Tracer metrics are published with this prefix.


### PR DESCRIPTION
We are adding health metrics to the tracers. (see: https://github.com/DataDog/dd-trace-go/pull/534)

We need to whitelist stats starting with `datadog.tracer`