### PR TITLE
[system-probe] Allow system-probe `systemd` unit to be enabled

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
@@ -12,3 +12,6 @@ ExecStart=<%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/s
 # it is also supported to have it here.
 StartLimitInterval=10
 StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

Currently `system-probe` cannot be auto initialized via `systemd` by running
```
$ sudo systemctl enable datadog-agent-sysprobe
```
since `datadog-agent-sysprobe.service` unit file doesn't contain a `[Install]` section.

Worth noting that this PR will *not* change the current behavior, which is leaving system-probe disabled by default.

In the meantime system-probe users can run the following command to enable the service:
```
$ sudo systemctl add-wants multi-user.target datadog-agent-sysprobe.service
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
