### PR TITLE
Add a tag for kubernetes node role in host metadata

### DIFF
--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -39,16 +39,10 @@ func getDefaultLabelsToTags() map[string]string {
 func getLabelsToTags() map[string]string {
 	labelsToTags := getDefaultLabelsToTags()
 	for k, v := range config.Datadog.GetStringMapString("kubernetes_node_labels_as_tags") {
-		labelsToTags[k] = v
+		// viper lower-cases map keys from yaml, but not from envvars
+		labelsToTags[strings.ToLower(k)] = v
 	}
-	if len(labelsToTags) == 0 {
-		return nil
-	}
-	// viper lower-cases map keys from yaml, but not from envvars
-	for label, value := range labelsToTags {
-		delete(labelsToTags, label)
-		labelsToTags[strings.ToLower(label)] = value
-	}
+
 	return labelsToTags
 }
 

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -14,9 +14,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 )
 
+func getDefaultLabelsToTags() map[string]string {
+	return map[string]string{
+		"kubernetes.io/role": "kube_node_role",
+	}
+}
+
 // GetTags gets the tags from the kubernetes apiserver
 func GetTags() ([]string, error) {
-	labelsToTags := config.Datadog.GetStringMapString("kubernetes_node_labels_as_tags")
+	labelsToTags := getDefaultLabelsToTags()
+	for k, v := range config.Datadog.GetStringMapString("kubernetes_node_labels_as_tags") {
+		labelsToTags[k] = v
+	}
 
 	if len(labelsToTags) == 0 {
 		// Nothing to extract

--- a/releasenotes/notes/add-a-tag-for-kubernetes-node-role-in-host-metadata-8c426335a7732577.yaml
+++ b/releasenotes/notes/add-a-tag-for-kubernetes-node-role-in-host-metadata-8c426335a7732577.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add kube_node_role tag in host metadata for the node role based on the `kubernetes.io/role` label.


### PR DESCRIPTION
### What does this PR do?

Add `kube_node_role` tag in host metadata for the node role based on a well known label.

### Motivation

Users would like to differentiate nodes based on their role.
