### PR TITLE
[gitlab] Fix version that's pulled in latest_release_7 job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2566,6 +2566,7 @@ latest_release_6:
   stage: deploy6
   when: manual
   variables:
+    AGENT_MAJOR_VERSION: 6
     <<: *docker_hub_variables
   script:
     - VERSION=$(inv -e agent.version)
@@ -2581,6 +2582,7 @@ latest_release_7:
   stage: deploy7
   when: manual
   variables:
+    AGENT_MAJOR_VERSION: 7
     <<: *docker_hub_variables
   script:
     - VERSION=$(inv -e agent.version)


### PR DESCRIPTION
### What does this PR do?

Fix version that's pulled in `latest_release_7` jobs.

It requires `MAJOR_AGENT_VERSION` to be set to 7 to pick up the right tag.

Note: in the future I think we should pass this major version parameter as an argument of `inv agent.version`, so that this logic is more explicit. Should be cleaned up after 7.16 of course :)