### PR TITLE
[tasks/utils] Make get_version_numeric_only also use the AGENT_MAJOR_VERSION var

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -264,7 +264,7 @@ def get_version(ctx, include_git=False, url_safe=False, git_sha_length=7, prefix
 
 def get_version_numeric_only(ctx, env=os.environ):
     # we only need the git info for the non omnibus builds, omnibus includes all this information by default
-    version_hint = '7' if env.get('PYTHON_RUNTIMES', '') == '3' else '6'
+    version_hint = '7' if env.get('AGENT_MAJOR_VERSION', '') == '7' or env.get('PYTHON_RUNTIMES', '') == '3' else '6'
 
     version, _, _, _ = query_version(ctx, hint=version_hint)
     return version


### PR DESCRIPTION
### What does this PR do?

Fix `get_version_numeric_only` to accept `AGENT_MAJOR_VERSION` as a way to set the major version.

### Motivation

`get_version` got changed to use the `AGENT_MAJOR_VERSION` variable, but `get_version_numeric_only` did not. 
As `get_version_numeric_only` is used by `inv agent.build`, this meant that the puppy build (which does not set the alternative `PYTHON_RUNTIMES` variable, contrary to the full Agent build) had its version locked to 6.

