### PR TITLE
Update update_changelog to use 7.x tags

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,7 +1,7 @@
 ---
 collapse_pre_releases: true
 no_show_source: true
-release_tag_re: '^6\.([\d.-]|rc)+$'
+release_tag_re: '^[67]\.([\d.-]|rc)+$'
 pre_release_tag_re: '(?P<pre_release>-rc\.\d+)$'
 template: |
           # Each section from every releasenote are combined when the

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -56,6 +56,8 @@ def update_changelog(ctx, new_version):
 
     # removing releasenotes from bugfix on the old minor.
     previous_minor = "%s.%s" % (new_version_int[0], new_version_int[1] - 1)
+    if previous_minor == "7.15":
+        previous_minor = "6.15" # 7.15 is the first release in the 7.x series
     log_result = ctx.run("git log {}.0...remotes/origin/{}.x --name-only | \
             grep releasenotes/notes/ || true".format(previous_minor, previous_minor))
     log_result = log_result.stdout.replace('\n', ' ').strip()


### PR DESCRIPTION
Running `inv release.update-changelog 7.16.0` now does the right thing.