### PR TITLE
Adding batching logic to retrieve External Metrics values

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1999,7 +1999,7 @@
   revision = "b3a7cee44a305be0a69e1b9ac03018307287e1b0"
 
 [[projects]]
-  digest = "1:f27698f7ae7864893ebcfb843e44d821263ac1dcf0ba1d5c2353f9d319a2f28d"
+  digest = "0:"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/kubelet/remote/fake",
@@ -2205,6 +2205,7 @@
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/errors",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",

--- a/pkg/util/kubernetes/apiserver/controller_util.go
+++ b/pkg/util/kubernetes/apiserver/controller_util.go
@@ -100,24 +100,23 @@ func (h *AutoscalersController) gc() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	log.Infof("Starting garbage collection process on the Autoscalers")
-	rawListWPA := []*v1alpha1.WatermarkPodAutoscaler{}
+	wpaList := []*v1alpha1.WatermarkPodAutoscaler{}
 	var err error
 
 	if h.wpaEnabled {
-		rawListWPA, err = h.wpaLister.WatermarkPodAutoscalers(metav1.NamespaceAll).List(labels.Everything())
+		wpaList, err = h.wpaLister.WatermarkPodAutoscalers(metav1.NamespaceAll).List(labels.Everything())
 		if err != nil {
 			log.Errorf("Error listing the WatermarkPodAutoscalers %v", err)
 			return
 		}
 	}
 
-	rawListHPA, err := h.autoscalersLister.HorizontalPodAutoscalers(metav1.NamespaceAll).List(labels.Everything())
+	hpaList, err := h.autoscalersLister.HorizontalPodAutoscalers(metav1.NamespaceAll).List(labels.Everything())
 	if err != nil {
 		log.Errorf("Could not list hpas: %v", err)
 		return
 	}
 
-	hpaList, wpaList := removeIgnoredAutoscaler(h.overFlowingAutoscalers, rawListHPA, rawListWPA)
 	emList, err := h.store.ListAllExternalMetricValues()
 	if err != nil {
 		log.Errorf("Could not list external metrics from store: %v", err)

--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -79,7 +79,6 @@ func newFakeAutoscalerController(t *testing.T, client kubernetes.Interface, itf 
 	ExtendToHPAController(autoscalerController, informerFactory.Autoscaling().V2beta1().HorizontalPodAutoscalers())
 
 	autoscalerController.autoscalersListerSynced = func() bool { return true }
-	autoscalerController.overFlowingAutoscalers = make(map[types.UID]int)
 
 	return autoscalerController, informerFactory
 }
@@ -315,7 +314,6 @@ func TestAutoscalerController(t *testing.T) {
 
 	c := client.AutoscalingV2beta1()
 	require.NotNil(t, c)
-	require.Equal(t, hctrl.metricsProcessedCount, 0)
 
 	mockedHPA := newFakeHorizontalPodAutoscaler(
 		"hpa_1",
@@ -346,7 +344,6 @@ func TestAutoscalerController(t *testing.T) {
 		hctrl.toStore.m.Unlock()
 		require.NotEmpty(t, st)
 		require.Len(t, st, 1)
-		require.Equal(t, hctrl.metricsProcessedCount, 1)
 
 	case <-timeout.C:
 		require.FailNow(t, "Timeout waiting for HPAs to update")
@@ -388,7 +385,6 @@ func TestAutoscalerController(t *testing.T) {
 	case <-timeout.C:
 		require.FailNow(t, "Timeout waiting for HPAs to update")
 	}
-	require.Equal(t, hctrl.metricsProcessedCount, 1)
 	storedHPA, err = hctrl.autoscalersLister.HorizontalPodAutoscalers(mockedHPA.Namespace).Get(mockedHPA.Name)
 	require.NoError(t, err)
 	require.Equal(t, storedHPA, mockedHPA)
@@ -434,11 +430,6 @@ func TestAutoscalerController(t *testing.T) {
 	)
 	mockedHPA.Annotations = makeAnnotations("foo", map[string]string{"foo": "bar"})
 
-	// fake the ignoring
-	hctrl.mu.Lock()
-	hctrl.metricsProcessedCount = 45
-	hctrl.mu.Unlock()
-
 	_, err = c.HorizontalPodAutoscalers("default").Create(newMockedHPA)
 	require.NoError(t, err)
 	select {
@@ -446,8 +437,6 @@ func TestAutoscalerController(t *testing.T) {
 	case <-timeout.C:
 		require.FailNow(t, "Timeout waiting for HPAs to update")
 	}
-	require.Equal(t, hctrl.metricsProcessedCount, 45)
-	require.Equal(t, hctrl.overFlowingAutoscalers[newMockedHPA.UID], 1)
 
 	// Verify that a Delete removes the Data from the Global Store and decreases metricsProcessdCount
 	err = c.HorizontalPodAutoscalers("default").Delete(newMockedHPA.Name, &metav1.DeleteOptions{})
@@ -458,11 +447,7 @@ func TestAutoscalerController(t *testing.T) {
 	case <-timeout.C:
 		require.FailNow(t, "Timeout waiting for HPAs to update")
 	}
-	hctrl.mu.Lock()
-	require.Equal(t, hctrl.metricsProcessedCount, 45)
-	require.Equal(t, len(hctrl.overFlowingAutoscalers), 0)
-	hctrl.mu.Unlock()
-	// Verify that a Delete removes the Data from the Global Store and decreases metricsProcessdCount at it was not ignored
+	// Verify that a Delete removes the Data from the Global Store
 	err = c.HorizontalPodAutoscalers("default").Delete(mockedHPA.Name, &metav1.DeleteOptions{})
 	require.NoError(t, err)
 	select {
@@ -477,19 +462,6 @@ func TestAutoscalerController(t *testing.T) {
 	case <-timeout.C:
 		require.FailNow(t, "Timeout waiting for HPAs to update")
 	}
-	hctrl.mu.Lock()
-	require.Equal(t, hctrl.metricsProcessedCount, 44)
-	hctrl.mu.Unlock()
-
-	_, err = c.HorizontalPodAutoscalers("default").Create(newMockedHPA)
-	require.NoError(t, err)
-	select {
-	case <-hctrl.autoscalers:
-	case <-timeout.C:
-		require.FailNow(t, "Timeout waiting for HPAs to update")
-	}
-	require.Equal(t, hctrl.metricsProcessedCount, 45)
-	require.Equal(t, len(hctrl.overFlowingAutoscalers), 0)
 }
 
 func TestAutoscalerSync(t *testing.T) {
@@ -513,62 +485,6 @@ func TestAutoscalerSync(t *testing.T) {
 	fakeKey := "default/prometheus"
 	err = hctrl.syncHPA(fakeKey)
 	require.Error(t, err, errors.IsNotFound)
-
-	require.Empty(t, hctrl.overFlowingAutoscalers)
-	hctrl.mu.Lock()
-	hctrl.metricsProcessedCount = 44
-	hctrl.mu.Unlock()
-	ignoredHPA := newFakeHorizontalPodAutoscaler(
-		"hpa_2",
-		"default",
-		"123",
-		"foo",
-		map[string]string{"foo": "bar"},
-	)
-	ignoredHPA.Spec.Metrics = append(ignoredHPA.Spec.Metrics, autoscalingv2.MetricSpec{
-		Type: v2beta1.ExternalMetricSourceType,
-		External: &v2beta1.ExternalMetricSource{
-			MetricName: "deadbeef",
-			MetricSelector: &metav1.LabelSelector{
-				MatchLabels: nil,
-			},
-		},
-	})
-	err = inf.Autoscaling().V2beta1().HorizontalPodAutoscalers().Informer().GetStore().Add(ignoredHPA)
-	require.NoError(t, err)
-	keyToIgnore := "default/hpa_2"
-	err = hctrl.syncHPA(keyToIgnore)
-	require.Nil(t, err)
-	require.NotEmpty(t, hctrl.overFlowingAutoscalers)
-	require.Equal(t, hctrl.overFlowingAutoscalers["123"], 2)
-	require.Equal(t, hctrl.metricsProcessedCount, 44)
-	hctrl.toStore.m.Lock()
-	require.Equal(t, len(hctrl.toStore.data), 1)
-	hctrl.toStore.m.Unlock()
-}
-
-func TestRemoveIgnoredHPAs(t *testing.T) {
-	listToIgnore := map[types.UID]int{
-		"aaa": 1,
-		"bbb": 2,
-	}
-	cachedHPAs := []*autoscalingv2.HorizontalPodAutoscaler{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				UID: "aaa",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				UID: "ccc",
-			},
-		},
-	}
-
-	e, _ := removeIgnoredAutoscaler(listToIgnore, cachedHPAs, nil)
-	require.Equal(t, len(e), 1)
-	require.Equal(t, e[0].UID, types.UID("ccc"))
-
 }
 
 // TestAutoscalerControllerGC tests the GC process of of the controller
@@ -577,7 +493,6 @@ func TestAutoscalerControllerGC(t *testing.T) {
 		caseName string
 		metrics  map[string]custommetrics.ExternalMetricValue
 		hpa      *v2beta1.HorizontalPodAutoscaler
-		ignored  map[types.UID]int
 		expected []custommetrics.ExternalMetricValue
 	}{
 		{
@@ -612,7 +527,6 @@ func TestAutoscalerControllerGC(t *testing.T) {
 					},
 				},
 			},
-			ignored: map[types.UID]int{},
 			expected: []custommetrics.ExternalMetricValue{ // skipped by gc
 				{
 					MetricName: "requests_per_s",
@@ -636,73 +550,6 @@ func TestAutoscalerControllerGC(t *testing.T) {
 					Valid:      false,
 				},
 			},
-			ignored:  map[types.UID]int{},
-			expected: []custommetrics.ExternalMetricValue{},
-		},
-		{
-			caseName: "hpa in global store but is ignored need to remove",
-			metrics: map[string]custommetrics.ExternalMetricValue{
-				"external_metric-horizontal-default-foo-requests_per_s": {
-					MetricName: "requests_per_s",
-					Labels:     map[string]string{"bar": "baz"},
-					Ref:        custommetrics.ObjectReference{Type: "horizontal", Name: "foo", Namespace: "default", UID: "1111"},
-					Timestamp:  12,
-					Value:      1,
-					Valid:      false,
-				},
-			},
-			hpa: &v2beta1.HorizontalPodAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "default",
-					UID:       "1111",
-				},
-				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-					Metrics: []autoscalingv2.MetricSpec{
-						{
-							Type: autoscalingv2.ExternalMetricSourceType,
-							External: &autoscalingv2.ExternalMetricSource{
-								MetricName: "requests_per_s",
-								MetricSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"bar": "baz"},
-								},
-							},
-						},
-					},
-				},
-			},
-			ignored: map[types.UID]int{
-				"1111": 1,
-			},
-			expected: []custommetrics.ExternalMetricValue{},
-		},
-		{
-			// For this test case, we don't see a difference, as the hpa is dropped before getting to DiffExternalMetrics
-			caseName: "hpa not in global store but ignored",
-			metrics:  map[string]custommetrics.ExternalMetricValue{},
-			hpa: &v2beta1.HorizontalPodAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "default",
-					UID:       "1111",
-				},
-				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-					Metrics: []autoscalingv2.MetricSpec{
-						{
-							Type: autoscalingv2.ExternalMetricSourceType,
-							External: &autoscalingv2.ExternalMetricSource{
-								MetricName: "requests_per_s",
-								MetricSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"bar": "baz"},
-								},
-							},
-						},
-					},
-				},
-			},
-			ignored: map[types.UID]int{
-				"1111": 1,
-			},
 			expected: []custommetrics.ExternalMetricValue{},
 		},
 	}
@@ -715,7 +562,6 @@ func TestAutoscalerControllerGC(t *testing.T) {
 			hctrl, inf := newFakeAutoscalerController(t, client, i, d)
 
 			hctrl.store = store
-			hctrl.overFlowingAutoscalers = testCase.ignored
 
 			if testCase.hpa != nil {
 				err := inf.

--- a/pkg/util/kubernetes/apiserver/wpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/wpa_controller_test.go
@@ -389,37 +389,12 @@ func TestWPASync(t *testing.T) {
 
 }
 
-func TestRemoveIgnoredWPAs(t *testing.T) {
-	listToIgnore := map[types.UID]int{
-		"aaa": 1,
-		"bbb": 2,
-	}
-	cachedWPAs := []*v1alpha1.WatermarkPodAutoscaler{
-		{
-			ObjectMeta: v1.ObjectMeta{
-				UID: "aaa",
-			},
-		},
-		{
-			ObjectMeta: v1.ObjectMeta{
-				UID: "ccc",
-			},
-		},
-	}
-
-	_, e := removeIgnoredAutoscaler(listToIgnore, nil, cachedWPAs)
-	require.Equal(t, len(e), 1)
-	require.Equal(t, e[0].UID, types.UID("ccc"))
-
-}
-
 // TestAutoscalerControllerGC tests the GC process of of the controller
 func TestWPAGC(t *testing.T) {
 	testCases := []struct {
 		caseName string
 		metrics  map[string]custommetrics.ExternalMetricValue
 		wpa      *v1alpha1.WatermarkPodAutoscaler
-		ignored  map[types.UID]int
 		expected []custommetrics.ExternalMetricValue
 	}{
 		{
@@ -511,9 +486,6 @@ func TestWPAGC(t *testing.T) {
 					},
 				},
 			},
-			ignored: map[types.UID]int{
-				"1111": 1,
-			},
 			expected: []custommetrics.ExternalMetricValue{},
 		},
 	}
@@ -531,7 +503,6 @@ func TestWPAGC(t *testing.T) {
 			ExtendToWPAController(hctrl, inf.Datadoghq().V1alpha1().WatermarkPodAutoscalers())
 
 			hctrl.store = store
-			hctrl.overFlowingAutoscalers = testCase.ignored
 
 			if testCase.wpa != nil {
 				err := inf.Datadoghq().

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -63,7 +63,6 @@ const (
 // queryDatadogExternal converts the metric name and labels from the Ref format into a Datadog metric.
 // It returns the last value for a bucket of 5 minutes,
 func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point, error) {
-	log.Infof("DEV Querying %s", metricNames)
 	if metricNames == nil {
 		log.Tracef("No processed external metrics to query")
 		return nil, nil

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -63,6 +63,7 @@ const (
 // queryDatadogExternal converts the metric name and labels from the Ref format into a Datadog metric.
 // It returns the last value for a bucket of 5 minutes,
 func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point, error) {
+	log.Infof("DEV Querying %s", metricNames)
 	if metricNames == nil {
 		log.Tracef("No processed external metrics to query")
 		return nil, nil

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -154,6 +154,7 @@ func NewDatadogClient() (*datadog.Client, error) {
 
 	client := datadog.NewClient(apiKey, appKey)
 	client.HttpClient.Transport = httputils.CreateHTTPTransport()
+	client.RetryTimeout = 3 * time.Second
 
 	return client, nil
 }

--- a/pkg/util/kubernetes/autoscalers/processor_test.go
+++ b/pkg/util/kubernetes/autoscalers/processor_test.go
@@ -274,7 +274,7 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 			p := &Processor{datadogClient: datadogClient}
 
 			_, err := p.validateExternalMetric(tt.in)
-			if err != nil {
+			if err != nil || tt.err != nil {
 				assert.Contains(t, err.Error(), tt.err.Error())
 			}
 			assert.Equal(t, tt.batchCalls, res.bc)


### PR DESCRIPTION
### What does this PR do?

This change introduces a batching logic to query Datadog for values configured in Autoscalers using External Metrics.
Removes the logic to limit the number of autoscalers to 45 and the event emission to best track this limit.
Also adds a timeout on the client side to avoid blocking if there is a network issue.

### Motivation

Prior to this change, we would limit the number of supported Autoscalers to 45.
We are now introducing logic to lift this limit.

Because we batch 45 metrics per call, this means that the rate limit can be hit much more quickly.
As a reminder, the default rate limit is at 300 queries/hour. By default we do 1 query every 30s, hence the default rate limiting will not allow for more than 90 Autoscalers. Reach out to our Solution team to increase it. We will now make 2* Ceil( #Autoscalers / 45) calls per minute.

We are going to add logic to better surface how many queries are left before hitting the rate limit.