### PR TITLE
Bump Debian base image to current testing (bullseye)

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -2,7 +2,7 @@
 #  Preparation stage: extract and cleanup  #
 ############################################
 
-FROM debian:buster-slim AS extract
+FROM debian:bullseye-slim AS extract
 ARG WITH_JMX
 ARG PYTHON_VERSION
 ARG DD_AGENT_ARTIFACT=datadog-agent*_amd64.deb
@@ -73,7 +73,7 @@ COPY datadog*.yaml etc/datadog-agent/
 #  Actual docker image construction  #
 ######################################
 
-FROM debian:buster-slim AS release
+FROM debian:bullseye-slim AS release
 LABEL maintainer "Datadog <package@datadoghq.com>"
 ARG WITH_JMX
 ARG PYTHON_VERSION

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -2,7 +2,7 @@
 #  Preparation stage: extract and cleanup  #
 ############################################
 
-FROM debian:buster-slim AS extract
+FROM debian:bullseye-slim AS extract
 ARG WITH_JMX
 ARG PYTHON_VERSION
 ARG DD_AGENT_ARTIFACT=datadog-agent*_arm64.deb
@@ -73,7 +73,7 @@ COPY datadog*.yaml etc/datadog-agent/
 #  Actual docker image construction  #
 ######################################
 
-FROM debian:buster-slim AS release
+FROM debian:bullseye-slim AS release
 LABEL maintainer "Datadog <package@datadoghq.com>"
 ARG WITH_JMX
 ARG PYTHON_VERSION

--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -2,7 +2,7 @@
 # Preparation stage: layout and chmods #
 ########################################
 
-FROM debian:buster-slim as builder
+FROM debian:bullseye-slim as builder
 
 WORKDIR /output
 
@@ -21,7 +21,7 @@ RUN chmod 755 entrypoint.sh \
 # Actual docker image construction #
 ####################################
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -2,7 +2,7 @@
 # Preparation stage: layout and chmods #
 ########################################
 
-FROM debian:buster-slim as builder
+FROM debian:bullseye-slim as builder
 
 WORKDIR /output
 
@@ -21,7 +21,7 @@ RUN chmod 755 entrypoint.sh \
 # Actual docker image construction #
 ####################################
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 

--- a/releasenotes/notes/base-image-bullseye-e0266946db9d20a7.yaml
+++ b/releasenotes/notes/base-image-bullseye-e0266946db9d20a7.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Change agents base images to Debian bullseye


### PR DESCRIPTION
### What does this PR do?

Bump agent's base images to Debian testing (bullseye currently). It fixes some packages vulnerabilities seen by ECR scans (Clair/Klar). Check the relevant Google Doc for more information.

### Additional Notes

Tested locally and on GKE, does not seem to have any impact on agent performances.
