### PR TITLE
Push "datadog/dogstatsd:7" tag as well when releasing latest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2608,6 +2608,7 @@ latest_release_7:
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag 7           --template datadog/agent-ARCH:${VERSION}
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag 7-jmx       --template datadog/agent-ARCH:${VERSION}-jmx
     - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG}-amd64 datadog/dogstatsd:latest
+    - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG}-amd64 datadog/dogstatsd:7
 
 #
 # Use these steps to revert the latest tags to a previous release


### PR DESCRIPTION
### What does this PR do?

Push "datadog/dogstatsd:7" tag as well when releasing latest

### Motivation

Allow users to pull a major version of the image instead of "latest"
