### PR TITLE
Re-add windows source tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ trace-agent-msg.h
 cmd/process-agent/windows_resources/process-agent-msg.rc
 cmd/process-agent/windows_resources/*.bin
 process-agent-msg.h
+# process agent test artifacts
+pkg/process/config/logs
 
 #visual studio files
 *.aps
@@ -104,4 +106,7 @@ devenv/packer_cache
 
 # doxygen doc & error log
 rtloader/doc
-rtlodaer/doxygen/errors.log
+rtloader/doxygen/errors.log
+
+# integrations-core when checked out for unit tests
+integrations-core/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,20 +171,19 @@ before_script:
   script:
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \unittests.bat
 
-# TODO: disabled until slowness issues are solved
-# run_tests_windows-x64:
-#   # temporarily allow failure for tests
-#   extends: .run_tests_windows_base
-#   allow_failure: true
-#   variables:
-#     ARCH: "x64"
+run_tests_windows-x64:
+  # temporarily allow failure for tests
+  extends: .run_tests_windows_base
+  allow_failure: true
+  variables:
+    ARCH: "x64"
 
-# run_tests_windows-x86:
-#   # temporarily allow failure for tests
-#   extends: .run_tests_windows_base
-#   allow_failure: true
-#   variables:
-#     ARCH: "x86"
+run_tests_windows-x86:
+  # temporarily allow failure for tests
+  extends: .run_tests_windows_base
+  allow_failure: true
+  variables:
+    ARCH: "x86"
 
 .run_tests_preparation: &run_tests_preparation
   before_script:

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -152,8 +152,10 @@ func TestInfo(t *testing.T) {
 	assert.NotEmpty(info)
 	t.Logf("Info:\n%s\n", info)
 	expectedInfo, err := ioutil.ReadFile("./testdata/okay.info")
+	re := regexp.MustCompile(`\r\n`)
+	expectedInfoString := re.ReplaceAllString(string(expectedInfo), "\n")
 	assert.NoError(err)
-	assert.Equal(string(expectedInfo), info)
+	assert.Equal(expectedInfoString, info)
 }
 
 func TestHideAPIKeys(t *testing.T) {
@@ -194,8 +196,10 @@ func TestWarning(t *testing.T) {
 	info := buf.String()
 
 	expectedWarning, err := ioutil.ReadFile("./testdata/warning.info")
+	re := regexp.MustCompile(`\r\n`)
+	expectedWarningString := re.ReplaceAllString(string(expectedWarning), "\n")
 	assert.NoError(err)
-	assert.Equal(string(expectedWarning), info)
+	assert.Equal(expectedWarningString, info)
 
 	t.Logf("Info:\n%s\n", info)
 }

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -103,7 +103,12 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
     if cpus:
         build_cpus_opt = "-p {}".format(cpus)
     if race:
-        race_opt = "-race"
+        # race doesn't appear to be supported on non-x64 platforms
+        if arch == "x86":
+            print("\n -- Warning... disabling race test, not supported on this platform --\n")
+        else:
+            race_opt = "-race"
+
     if coverage:
         if race:
             # atomic is quite expensive but it's the only way to run


### PR DESCRIPTION
Tests were removed because they're slow; however, with DAG feature
they won't block other stages

