### PR TITLE
Automatically format tracer-ebpf.go

### DIFF
--- a/pkg/ebpf/tracer-ebpf.go
+++ b/pkg/ebpf/tracer-ebpf.go
@@ -206,8 +206,8 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"tracer-ebpf-debug.o": &bintree{tracerEbpfDebugO, map[string]*bintree{}},
-	"tracer-ebpf.o":       &bintree{tracerEbpfO, map[string]*bintree{}},
+	"tracer-ebpf-debug.o": {tracerEbpfDebugO, map[string]*bintree{}},
+	"tracer-ebpf.o":       {tracerEbpfO, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/pkg/ebpf/tracer-ebpf.go
+++ b/pkg/ebpf/tracer-ebpf.go
@@ -206,8 +206,8 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"tracer-ebpf-debug.o": {tracerEbpfDebugO, map[string]*bintree{}},
-	"tracer-ebpf.o":       {tracerEbpfO, map[string]*bintree{}},
+	"tracer-ebpf-debug.o": &bintree{tracerEbpfDebugO, map[string]*bintree{}},
+	"tracer-ebpf.o":       &bintree{tracerEbpfO, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -279,12 +279,15 @@ def build_object_files(ctx, install=True):
         commands.append("go get -u github.com/jteeuwen/go-bindata/...")
 
         assets_cmd = os.environ["GOPATH"]+"/bin/go-bindata -pkg ebpf -prefix '{c_dir}' -modtime 1 -o '{go_file}' '{obj_file}' '{debug_obj_file}'"
+        go_file = os.path.join(bpf_dir, "tracer-ebpf.go")
         commands.append(assets_cmd.format(
             c_dir=c_dir,
-            go_file=os.path.join(bpf_dir, "tracer-ebpf.go"),
+            go_file=go_file,
             obj_file=obj_file,
             debug_obj_file=debug_obj_file,
         ))
+
+        commands.append("gofmt -w {go_file}".format(go_file=go_file))
 
     for cmd in commands:
         ctx.run(cmd)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -287,7 +287,7 @@ def build_object_files(ctx, install=True):
             debug_obj_file=debug_obj_file,
         ))
 
-        commands.append("gofmt -w {go_file}".format(go_file=go_file))
+        commands.append("gofmt -w -s {go_file}".format(go_file=go_file))
 
     for cmd in commands:
         ctx.run(cmd)


### PR DESCRIPTION
### What does this PR do?

We've been checking in an incorrectly formatted version of tracer-ebpf.go for a while because go-bindata does not emit correctly formatted code. This  PR adds   a call to gofmt to the  build step which generates trace-ebpf.go

### Motivation

### Additional Notes

Anything else we should know when reviewing?