### PR TITLE
Always fallback to Host IP Provider

### DIFF
--- a/pkg/util/docker/host_ip_provider.go
+++ b/pkg/util/docker/host_ip_provider.go
@@ -41,16 +41,10 @@ type hostIPProvider struct {
 }
 
 func getDockerHostIPsUncached() []string {
-	var isHostMode bool
-	if mode, err := GetAgentContainerNetworkMode(); err == nil && mode == containers.HostNetworkMode {
-		isHostMode = true
-	}
-
-	var providers []hostIPProvider
-	providers = append(providers, hostIPProvider{"config", getHostIPsFromConfig})
-	providers = append(providers, hostIPProvider{"ec2 metadata endpoint", ec2.GetLocalIPv4})
-	if isHostMode {
-		providers = append(providers, hostIPProvider{"/proc/net/route", containers.DefaultHostIPs})
+	providers := []hostIPProvider{
+		{"config", getHostIPsFromConfig},
+		{"ec2 metadata endpoint", ec2.GetLocalIPv4},
+		{"/proc/net/route", containers.DefaultHostIPs},
 	}
 
 	return tryProviders(providers)


### PR DESCRIPTION
### What does this PR do?

Prior to this PR, we would only fallback to the host IP if the *agent container* was running on [host network mode](https://docs.docker.com/network/).
We now ensure that the container get's assigned to the Host IP if:
1) the container is running  on`host` network mode;
2) if we can't determine the container IP for some reason (as a fallback strategy);

#### How to test it

1. Run any container in host network mode: eg `docker run --network host redis:alpine`
2. Verify that the container is assigned to the Host IP address by inspecting `process-agent -check container`;

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
