### PR TITLE
Don't check that laddr.Ip is in local net.Interfaces when determining direction

### DIFF
--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -659,7 +659,7 @@ func (t *Tracer) determineConnectionDirection(conn *ConnectionStats) ConnectionD
 		return LOCAL
 	}
 
-	if sourceLocal && t.portMapping.IsListening(conn.SPort) {
+	if t.portMapping.IsListening(conn.SPort) {
 		return INCOMING
 	}
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"expvar"
 	"fmt"
-	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/netlink"
-	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	bpflib "github.com/iovisor/gobpf/elf"
 )
@@ -37,9 +35,8 @@ type Tracer struct {
 
 	config *Config
 
-	state          NetworkState
-	portMapping    *PortMapping
-	localAddresses map[util.Address]struct{}
+	state       NetworkState
+	portMapping *PortMapping
 
 	conntracker netlink.Conntracker
 
@@ -187,7 +184,6 @@ func NewTracer(config *Config) (*Tracer, error) {
 		state:          state,
 		portMapping:    portMapping,
 		reverseDNS:     reverseDNS,
-		localAddresses: readLocalAddresses(),
 		buffer:         make([]ConnectionStats, 0, 512),
 		buf:            &bytes.Buffer{},
 		conntracker:    conntracker,
@@ -652,54 +648,12 @@ func (t *Tracer) determineConnectionDirection(conn *ConnectionStats) ConnectionD
 	if conn.Type == UDP {
 		return NONE
 	}
-	sourceLocal := t.isLocalAddress(conn.Source)
-	destLocal := t.isLocalAddress(conn.Dest)
-
-	if sourceLocal && destLocal {
-		return LOCAL
-	}
 
 	if t.portMapping.IsListening(conn.SPort) {
 		return INCOMING
 	}
 
 	return OUTGOING
-}
-
-func (t *Tracer) isLocalAddress(address util.Address) bool {
-	_, ok := t.localAddresses[address]
-	return ok
-}
-
-func readLocalAddresses() map[util.Address]struct{} {
-	addresses := make(map[util.Address]struct{}, 0)
-
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		_ = log.Errorf("error reading network interfaces: %s", err)
-		return addresses
-	}
-
-	for _, intf := range interfaces {
-		addrs, err := intf.Addrs()
-
-		if err != nil {
-			_ = log.Errorf("error reading interface %s addresses: %s", intf.Name, err)
-			continue
-		}
-
-		for _, addr := range addrs {
-			switch v := addr.(type) {
-			case *net.IPNet:
-				addresses[util.AddressFromNetIP(v.IP)] = struct{}{}
-			case *net.IPAddr:
-				addresses[util.AddressFromNetIP(v.IP)] = struct{}{}
-			}
-		}
-
-	}
-
-	return addresses
 }
 
 // SectionsFromConfig returns a map of string -> gobpf.SectionParams used to configure the way we load the BPF program (bpf map sizes)

--- a/releasenotes/notes/tcp-connection-direction-a951b372641cff06.yaml
+++ b/releasenotes/notes/tcp-connection-direction-a951b372641cff06.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fix a Network Performance Monitoring issue where TCP connection direction was incorrectly classified as ``outgoing`` containerized environments.
+    Fix a Network Performance Monitoring issue where TCP connection direction was incorrectly classified as ``outgoing`` in containerized environments.

--- a/releasenotes/notes/tcp-connection-direction-a951b372641cff06.yaml
+++ b/releasenotes/notes/tcp-connection-direction-a951b372641cff06.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix a Network Performance Monitoring issue where TCP connection direction was incorrectly classified as ``outgoing`` containerized environments.


### PR DESCRIPTION
### What does this PR do?

The system-probe was determining if a  connection was outgoing  if it met two criteria:

-  the source IP was "local" i.e. was one of the IPs reported by `net.Interfaces()`
- the source port was in the portMapping, which is populated by BPF the `inet_csk_accept` kprobe (which is only used for TCP)

The problem with this is that the list of interfaces seen by the agent often disagrees with local IPs seen by other containers.     

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
