### PR TITLE
dsd: pool metrics.MetricSample

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -128,7 +128,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		s := serializer.NewSerializer(common.Forwarder)
-		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, "agent", checkCmdFlushInterval)
+		agg := aggregator.InitAggregatorWithFlushInterval(s, nil, hostname, "agent", checkCmdFlushInterval)
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 
 		if config.Datadog.GetBool("inventories_enabled") {

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -250,7 +250,7 @@ func StartAgent() error {
 	// setup the aggregator
 	s := serializer.NewSerializer(common.Forwarder)
 	metricSamplePool := metrics.NewMetricSamplePool(32)
-	agg := aggregator.InitAggregator(s, hostname, "agent")
+	agg := aggregator.InitAggregator(s, metricSamplePool, hostname, "agent")
 	agg.AddAgentStartupTelemetry(version.AgentVersion)
 
 	// start dogstatsd

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -166,7 +166,7 @@ func start(cmd *cobra.Command, args []string) error {
 	f.Start()
 	s := serializer.NewSerializer(f)
 
-	aggregatorInstance := aggregator.InitAggregator(s, hostname, "cluster_agent")
+	aggregatorInstance := aggregator.InitAggregator(s, nil, hostname, "cluster_agent")
 	aggregatorInstance.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Cluster Agent", version.AgentVersion))
 
 	log.Infof("Datadog Cluster Agent is now running.")

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -185,7 +185,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	metricSamplePool := metrics.NewMetricSamplePool(32)
-	aggregatorInstance := aggregator.InitAggregator(s, hname, "agent")
+	aggregatorInstance := aggregator.InitAggregator(s, metricSamplePool, hname, "agent")
 	sampleC, eventC, serviceCheckC := aggregatorInstance.GetBufferedChannels()
 	statsd, err := dogstatsd.NewServer(metricSamplePool, sampleC, eventC, serviceCheckC)
 	if err != nil {

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -27,7 +27,7 @@ var checkID2 check.ID = "2"
 func TestRegisterCheckSampler(t *testing.T) {
 	resetAggregator()
 
-	agg := InitAggregator(nil, "", "agent")
+	agg := InitAggregator(nil, nil, "", "agent")
 	err := agg.registerSender(checkID1)
 	assert.Nil(t, err)
 	assert.Len(t, aggregatorInstance.checkSamplers, 1)
@@ -44,7 +44,7 @@ func TestRegisterCheckSampler(t *testing.T) {
 func TestDeregisterCheckSampler(t *testing.T) {
 	resetAggregator()
 
-	agg := InitAggregator(nil, "", "agent")
+	agg := InitAggregator(nil, nil, "", "agent")
 	agg.registerSender(checkID1)
 	agg.registerSender(checkID2)
 	assert.Len(t, aggregatorInstance.checkSamplers, 2)
@@ -59,7 +59,7 @@ func TestDeregisterCheckSampler(t *testing.T) {
 
 func TestAddServiceCheckDefaultValues(t *testing.T) {
 	resetAggregator()
-	agg := InitAggregator(nil, "resolved-hostname", "agent")
+	agg := InitAggregator(nil, nil, "resolved-hostname", "agent")
 
 	agg.addServiceCheck(metrics.ServiceCheck{
 		// leave Host and Ts fields blank
@@ -88,7 +88,7 @@ func TestAddServiceCheckDefaultValues(t *testing.T) {
 
 func TestAddEventDefaultValues(t *testing.T) {
 	resetAggregator()
-	agg := InitAggregator(nil, "resolved-hostname", "agent")
+	agg := InitAggregator(nil, nil, "resolved-hostname", "agent")
 
 	agg.addEvent(metrics.Event{
 		// only populate required fields
@@ -134,7 +134,7 @@ func TestAddEventDefaultValues(t *testing.T) {
 
 func TestSetHostname(t *testing.T) {
 	resetAggregator()
-	agg := InitAggregator(nil, "hostname", "agent")
+	agg := InitAggregator(nil, nil, "hostname", "agent")
 	assert.Equal(t, "hostname", agg.hostname)
 	sender, err := GetSender(checkID1)
 	require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestSetHostname(t *testing.T) {
 func TestDefaultData(t *testing.T) {
 	resetAggregator()
 	s := &serializer.MockSerializer{}
-	agg := InitAggregator(s, "hostname", "agent")
+	agg := InitAggregator(s, nil, "hostname", "agent")
 	start := time.Now()
 
 	s.On("SendServiceChecks", metrics.ServiceChecks{{
@@ -185,7 +185,7 @@ func TestDefaultData(t *testing.T) {
 func TestRecurentSeries(t *testing.T) {
 	resetAggregator()
 	s := &serializer.MockSerializer{}
-	agg := NewBufferedAggregator(s, "hostname", "agent", DefaultFlushInterval)
+	agg := NewBufferedAggregator(s, nil, "hostname", "agent", DefaultFlushInterval)
 
 	// Add two recurrentSeries
 	AddRecurrentSeries(&metrics.Serie{

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -19,7 +19,7 @@ import (
 func NewMockSender(id check.ID) *MockSender {
 	mockSender := new(MockSender)
 	// The MockSender will be injected in the corecheck via the aggregator
-	aggregator.InitAggregatorWithFlushInterval(nil, "", "", 1*time.Hour)
+	aggregator.InitAggregatorWithFlushInterval(nil, nil, "", "", 1*time.Hour)
 	aggregator.SetSender(mockSender, id)
 
 	return mockSender

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -37,7 +37,7 @@ func resetAggregator() {
 
 func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "", "")
+	InitAggregator(nil, nil, "", "")
 
 	s, err := GetDefaultSender()
 	assert.Nil(t, err)
@@ -53,7 +53,7 @@ func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 
 func TestGetSenderWithDifferentIDsReturnsDifferentCheckSamplers(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "", "")
+	InitAggregator(nil, nil, "", "")
 
 	s, err := GetSender(checkID1)
 	assert.Nil(t, err)
@@ -76,7 +76,7 @@ func TestGetSenderWithDifferentIDsReturnsDifferentCheckSamplers(t *testing.T) {
 
 func TestGetSenderWithSameIDsReturnsSameSender(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "", "")
+	InitAggregator(nil, nil, "", "")
 
 	sender1, err := GetSender(checkID1)
 	assert.Nil(t, err)
@@ -93,7 +93,7 @@ func TestGetSenderWithSameIDsReturnsSameSender(t *testing.T) {
 
 func TestDestroySender(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "", "")
+	InitAggregator(nil, nil, "", "")
 
 	_, err := GetSender(checkID1)
 	assert.Nil(t, err)
@@ -109,7 +109,7 @@ func TestDestroySender(t *testing.T) {
 
 func TestGetAndSetSender(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "", "")
+	InitAggregator(nil, nil, "", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
@@ -127,7 +127,7 @@ func TestGetAndSetSender(t *testing.T) {
 
 func TestGetSenderDefaultHostname(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "testhostname", "")
+	InitAggregator(nil, nil, "testhostname", "")
 
 	sender, err := GetSender(checkID1)
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestGetSenderDefaultHostname(t *testing.T) {
 
 func TestGetSenderAddCheckCustomTagsMetrics(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "testhostname", "")
+	InitAggregator(nil, nil, "testhostname", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
@@ -178,7 +178,7 @@ func TestGetSenderAddCheckCustomTagsMetrics(t *testing.T) {
 
 func TestGetSenderAddCheckCustomTagsService(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "testhostname", "")
+	InitAggregator(nil, nil, "testhostname", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
@@ -215,7 +215,7 @@ func TestGetSenderAddCheckCustomTagsService(t *testing.T) {
 
 func TestGetSenderAddCheckCustomTagsEvent(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "testhostname", "")
+	InitAggregator(nil, nil, "testhostname", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
@@ -263,7 +263,7 @@ func TestGetSenderAddCheckCustomTagsEvent(t *testing.T) {
 
 func TestGetSenderAddCheckCustomTagsHistogramBucket(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "testhostname", "")
+	InitAggregator(nil, nil, "testhostname", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -475,3 +475,18 @@ func TestBucketSamplingWithSketchAndSeries(t *testing.T) {
 		ContextKey: generateContextKey(&dSample1),
 	}, sketches[0])
 }
+
+func BenchmarkTimeSampler(b *testing.B) {
+	sampler := NewTimeSampler(10)
+	sample := metrics.MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      metrics.GaugeType,
+		Tags:       []string{"foo", "bar"},
+		SampleRate: 1,
+		Timestamp:  12345.0,
+	}
+	for n := 0; n < b.N; n++ {
+		sampler.addSample(&sample, 12345.0)
+	}
+}

--- a/pkg/dogstatsd/batch.go
+++ b/pkg/dogstatsd/batch.go
@@ -1,0 +1,65 @@
+package dogstatsd
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// batcher batchs multiple metrics before submission
+// this struct is not safe for concurent use
+type batcher struct {
+	samples       []metrics.MetricSample
+	samplesCount  int
+	events        []*metrics.Event
+	serviceChecks []*metrics.ServiceCheck
+
+	samplePool      *metrics.MetricSamplePool
+	sampleOut       chan<- []metrics.MetricSample
+	eventOut        chan<- []*metrics.Event
+	serviceCheckOut chan<- []*metrics.ServiceCheck
+}
+
+func newBatcher(samplePool *metrics.MetricSamplePool, sampleOut chan<- []metrics.MetricSample, eventOut chan<- []*metrics.Event, serviceCheckOut chan<- []*metrics.ServiceCheck) *batcher {
+	return &batcher{
+		samples:         samplePool.GetBatch(),
+		samplePool:      samplePool,
+		sampleOut:       sampleOut,
+		eventOut:        eventOut,
+		serviceCheckOut: serviceCheckOut,
+	}
+}
+
+func (b *batcher) appendSample(sample metrics.MetricSample) {
+	if b.samplesCount == len(b.samples) {
+		b.flushSamples()
+	}
+	b.samples[b.samplesCount] = sample
+	b.samplesCount++
+}
+
+func (b *batcher) appendEvent(event *metrics.Event) {
+	b.events = append(b.events, event)
+}
+
+func (b *batcher) appendServiceCheck(serviceCheck *metrics.ServiceCheck) {
+	b.serviceChecks = append(b.serviceChecks, serviceCheck)
+}
+
+func (b *batcher) flushSamples() {
+	if b.samplesCount > 0 {
+		b.sampleOut <- b.samples[:b.samplesCount]
+		b.samplesCount = 0
+		b.samples = b.samplePool.GetBatch()
+	}
+}
+
+func (b *batcher) flush() {
+	b.flushSamples()
+	if len(b.events) > 0 {
+		b.eventOut <- b.events
+		b.events = []*metrics.Event{}
+	}
+	if len(b.serviceChecks) > 0 {
+		b.serviceCheckOut <- b.serviceChecks
+		b.serviceChecks = []*metrics.ServiceCheck{}
+	}
+}

--- a/pkg/dogstatsd/batch.go
+++ b/pkg/dogstatsd/batch.go
@@ -4,8 +4,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
-// batcher batchs multiple metrics before submission
-// this struct is not safe for concurent use
+// batcher batches multiple metrics before submission
+// this struct is not safe for concurrent use
 type batcher struct {
 	samples       []metrics.MetricSample
 	samplesCount  int

--- a/pkg/dogstatsd/convert_bench_test.go
+++ b/pkg/dogstatsd/convert_bench_test.go
@@ -17,7 +17,7 @@ func buildRawSample(tagCount int) []byte {
 }
 
 // used to store the result and avoid optimizations
-var sample *metrics.MetricSample
+var sample metrics.MetricSample
 
 func BenchmarkParseMetric(b *testing.B) {
 	for i := 1; i < 1000; i *= 4 {

--- a/pkg/dogstatsd/convert_bench_test.go
+++ b/pkg/dogstatsd/convert_bench_test.go
@@ -26,7 +26,7 @@ func BenchmarkParseMetric(b *testing.B) {
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				sample, _ = parseMetricMessage(rawSample, "", []string{}, "default-hostname")
+				sample, _ = parseAndEnrichMetricMessage(rawSample, "", []string{}, "default-hostname")
 			}
 		})
 	}

--- a/pkg/dogstatsd/enrich.go
+++ b/pkg/dogstatsd/enrich.go
@@ -19,30 +19,6 @@ var (
 	getTags tagRetriever = tagger.Tag
 )
 
-func parseMetricMessage(message []byte, namespace string, namespaceBlacklist []string, defaultHostname string) (*metrics.MetricSample, error) {
-	sample, err := parseMetricSample(message)
-	if err != nil {
-		return nil, err
-	}
-	return enrichMetricSample(sample, namespace, namespaceBlacklist, defaultHostname), nil
-}
-
-func parseEventMessage(message []byte, defaultHostname string) (*metrics.Event, error) {
-	sample, err := parseEvent(message)
-	if err != nil {
-		return nil, err
-	}
-	return enrichEvent(sample, defaultHostname), nil
-}
-
-func parseServiceCheckMessage(message []byte, defaultHostname string) (*metrics.ServiceCheck, error) {
-	sample, err := parseServiceCheck(message)
-	if err != nil {
-		return nil, err
-	}
-	return enrichServiceCheck(sample, defaultHostname), nil
-}
-
 func enrichTags(tags []string, defaultHostname string) ([]string, string) {
 	if len(tags) == 0 {
 		return nil, defaultHostname

--- a/pkg/dogstatsd/enrich.go
+++ b/pkg/dogstatsd/enrich.go
@@ -68,7 +68,7 @@ func enrichMetricType(dogstatsdMetricType metricType) metrics.MetricType {
 	return metrics.GaugeType
 }
 
-func enrichMetricSample(metricSample dogstatsdMetricSample, namespace string, namespaceBlacklist []string, defaultHostname string) *metrics.MetricSample {
+func enrichMetricSample(metricSample dogstatsdMetricSample, namespace string, namespaceBlacklist []string, defaultHostname string) metrics.MetricSample {
 	metricName := metricSample.name
 	if namespace != "" {
 		blacklisted := false
@@ -84,7 +84,7 @@ func enrichMetricSample(metricSample dogstatsdMetricSample, namespace string, na
 
 	tags, hostname := enrichTags(metricSample.tags, defaultHostname)
 
-	return &metrics.MetricSample{
+	return metrics.MetricSample{
 		Host:       hostname,
 		Name:       metricName,
 		Tags:       tags,

--- a/pkg/dogstatsd/enrich_test.go
+++ b/pkg/dogstatsd/enrich_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func parseAndEnrichMetricMessage(message []byte, namespace string, namespaceBlacklist []string, defaultHostname string) (*metrics.MetricSample, error) {
+func parseAndEnrichMetricMessage(message []byte, namespace string, namespaceBlacklist []string, defaultHostname string) (metrics.MetricSample, error) {
 	parsed, err := parseMetricSample(message)
 	if err != nil {
-		return nil, err
+		return metrics.MetricSample{}, err
 	}
 	return enrichMetricSample(parsed, namespace, namespaceBlacklist, defaultHostname), nil
 }

--- a/pkg/dogstatsd/enrich_test.go
+++ b/pkg/dogstatsd/enrich_test.go
@@ -10,8 +10,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func parseAndEnrichMetricMessage(message []byte, namespace string, namespaceBlacklist []string, defaultHostname string) (*metrics.MetricSample, error) {
+	parsed, err := parseMetricSample(message)
+	if err != nil {
+		return nil, err
+	}
+	return enrichMetricSample(parsed, namespace, namespaceBlacklist, defaultHostname), nil
+}
+
+func parseAndEnrichServiceCheckMessage(message []byte, defaultHostname string) (*metrics.ServiceCheck, error) {
+	parsed, err := parseServiceCheck(message)
+	if err != nil {
+		return nil, err
+	}
+	return enrichServiceCheck(parsed, defaultHostname), nil
+}
+
+func parseAndEnrichEventMessage(message []byte, defaultHostname string) (*metrics.Event, error) {
+	parsed, err := parseEvent(message)
+	if err != nil {
+		return nil, err
+	}
+	return enrichEvent(parsed, defaultHostname), nil
+}
+
 func TestConvertParseGauge(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -24,7 +48,7 @@ func TestConvertParseGauge(t *testing.T) {
 }
 
 func TestConvertParseCounter(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|c"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:21|c"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -37,7 +61,7 @@ func TestConvertParseCounter(t *testing.T) {
 }
 
 func TestConvertParseCounterWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -52,7 +76,7 @@ func TestConvertParseCounterWithTags(t *testing.T) {
 }
 
 func TestConvertParseHistogram(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|h"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:21|h"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -65,7 +89,7 @@ func TestConvertParseHistogram(t *testing.T) {
 }
 
 func TestConvertParseTimer(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:21|ms"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -78,7 +102,7 @@ func TestConvertParseTimer(t *testing.T) {
 }
 
 func TestConvertParseSet(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:abc|s"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:abc|s"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -91,7 +115,7 @@ func TestConvertParseSet(t *testing.T) {
 }
 
 func TestConvertParseDistribution(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:3.5|d"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -103,7 +127,7 @@ func TestConvertParseDistribution(t *testing.T) {
 }
 
 func TestConvertParseSetUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -116,7 +140,7 @@ func TestConvertParseSetUnicode(t *testing.T) {
 }
 
 func TestConvertParseGaugeWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -131,7 +155,7 @@ func TestConvertParseGaugeWithTags(t *testing.T) {
 }
 
 func TestConvertParseGaugeWithHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -145,7 +169,7 @@ func TestConvertParseGaugeWithHostTag(t *testing.T) {
 }
 
 func TestConvertParseGaugeWithEmptyHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -159,7 +183,7 @@ func TestConvertParseGaugeWithEmptyHostTag(t *testing.T) {
 }
 
 func TestConvertParseGaugeWithNoTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -171,7 +195,7 @@ func TestConvertParseGaugeWithNoTags(t *testing.T) {
 }
 
 func TestConvertParseGaugeWithSampleRate(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g|@0.21"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -184,7 +208,7 @@ func TestConvertParseGaugeWithSampleRate(t *testing.T) {
 }
 
 func TestConvertParseGaugeWithPoundOnly(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g|#"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -197,7 +221,7 @@ func TestConvertParseGaugeWithPoundOnly(t *testing.T) {
 }
 
 func TestConvertParseGaugeWithUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -212,42 +236,42 @@ func TestConvertParseGaugeWithUnicode(t *testing.T) {
 
 func TestConvertParseMetricError(t *testing.T) {
 	// not enough information
-	_, err := parseMetricMessage([]byte("daemon:666"), "", nil, "default-hostname")
+	_, err := parseAndEnrichMetricMessage([]byte("daemon:666"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:666|"), "", nil, "default-hostname")
+	_, err = parseAndEnrichMetricMessage([]byte("daemon:666|"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:|g"), "", nil, "default-hostname")
+	_, err = parseAndEnrichMetricMessage([]byte("daemon:|g"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte(":666|g"), "", nil, "default-hostname")
+	_, err = parseAndEnrichMetricMessage([]byte(":666|g"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
 	// too many value
-	_, err = parseMetricMessage([]byte("daemon:666:777|g"), "", nil, "default-hostname")
+	_, err = parseAndEnrichMetricMessage([]byte("daemon:666:777|g"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
 	// unknown metadata prefix
-	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"), "", nil, "default-hostname")
+	_, err = parseAndEnrichMetricMessage([]byte("daemon:666|g|m:test"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	// invalid value
-	_, err = parseMetricMessage([]byte("daemon:abc|g"), "", nil, "default-hostname")
+	_, err = parseAndEnrichMetricMessage([]byte("daemon:abc|g"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
 	// invalid metric type
-	_, err = parseMetricMessage([]byte("daemon:666|unknown"), "", nil, "default-hostname")
+	_, err = parseAndEnrichMetricMessage([]byte("daemon:666|unknown"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
 	// invalid sample rate
-	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"), "", nil, "default-hostname")
+	_, err = parseAndEnrichMetricMessage([]byte("daemon:666|g|@abc"), "", nil, "default-hostname")
 	assert.Error(t, err)
 }
 
 func TestConvertParseMonokeyBatching(t *testing.T) {
 	// TODO: not implemented
-	// parsed, err := parseMetricMessage([]byte("test_gauge:1.5|g|#tag1:one,tag2:two:2.3|g|#tag3:three:3|g"), "default-hostname")
+	// parsed, err := parseAndEnrichMetricMessage([]byte("test_gauge:1.5|g|#tag1:one,tag2:two:2.3|g|#tag3:three:3|g"), "default-hostname")
 }
 
 func TestConvertEnsureUTF8(t *testing.T) {
@@ -267,7 +291,7 @@ func TestConvertPacketStringEndings(t *testing.T) {
 }
 
 func TestConvertServiceCheckMinimal(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0"), "default-hostname")
+	sc, err := parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0"), "default-hostname")
 
 	assert.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -280,31 +304,31 @@ func TestConvertServiceCheckMinimal(t *testing.T) {
 
 func TestConvertServiceCheckError(t *testing.T) {
 	// not enough information
-	_, err := parseServiceCheckMessage([]byte("_sc|agent.up"), "default-hostname")
+	_, err := parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up"), "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|"), "default-hostname")
+	_, err = parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|"), "default-hostname")
 	assert.Error(t, err)
 
 	// not invalid status
-	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|OK"), "default-hostname")
+	_, err = parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|OK"), "default-hostname")
 	assert.Error(t, err)
 
 	// not unknown status
-	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|21"), "default-hostname")
+	_, err = parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|21"), "default-hostname")
 	assert.Error(t, err)
 
 	// invalid timestamp
-	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|0|d:some_time"), "default-hostname")
+	_, err = parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|d:some_time"), "default-hostname")
 	assert.NoError(t, err)
 
 	// unknown metadata
-	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|0|u:unknown"), "default-hostname")
+	_, err = parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|u:unknown"), "default-hostname")
 	assert.NoError(t, err)
 }
 
 func TestConvertServiceCheckMetadataTimestamp(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|d:21"), "default-hostname")
+	sc, err := parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|d:21"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -316,7 +340,7 @@ func TestConvertServiceCheckMetadataTimestamp(t *testing.T) {
 }
 
 func TestConvertServiceCheckMetadataHostname(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|h:localhost"), "default-hostname")
+	sc, err := parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|h:localhost"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -328,7 +352,7 @@ func TestConvertServiceCheckMetadataHostname(t *testing.T) {
 }
 
 func TestConvertServiceCheckMetadataHostnameInTag(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#host:localhost"), "default-hostname")
+	sc, err := parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|#host:localhost"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -340,7 +364,7 @@ func TestConvertServiceCheckMetadataHostnameInTag(t *testing.T) {
 }
 
 func TestConvertServiceCheckMetadataEmptyHostTag(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#host:,other:tag"), "default-hostname")
+	sc, err := parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|#host:,other:tag"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -352,7 +376,7 @@ func TestConvertServiceCheckMetadataEmptyHostTag(t *testing.T) {
 }
 
 func TestConvertServiceCheckMetadataTags(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"), "default-hostname")
+	sc, err := parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -364,7 +388,7 @@ func TestConvertServiceCheckMetadataTags(t *testing.T) {
 }
 
 func TestConvertServiceCheckMetadataMessage(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|m:this is fine"), "default-hostname")
+	sc, err := parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|m:this is fine"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -377,7 +401,7 @@ func TestConvertServiceCheckMetadataMessage(t *testing.T) {
 
 func TestConvertServiceCheckMetadataMultiple(t *testing.T) {
 	// all type
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|d:21|h:localhost|#tag1:test,tag2|m:this is fine"), "default-hostname")
+	sc, err := parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|d:21|h:localhost|#tag1:test,tag2|m:this is fine"), "default-hostname")
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
 	assert.Equal(t, "localhost", sc.Host)
@@ -387,7 +411,7 @@ func TestConvertServiceCheckMetadataMultiple(t *testing.T) {
 	assert.Equal(t, []string{"tag1:test", "tag2"}, sc.Tags)
 
 	// multiple time the same tag
-	sc, err = parseServiceCheckMessage([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"), "default-hostname")
+	sc, err = parseAndEnrichServiceCheckMessage([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"), "default-hostname")
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
 	assert.Equal(t, "localhost2", sc.Host)
@@ -398,7 +422,7 @@ func TestConvertServiceCheckMetadataMultiple(t *testing.T) {
 }
 
 func TestConvertEventMinimal(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -414,7 +438,7 @@ func TestConvertEventMinimal(t *testing.T) {
 }
 
 func TestConvertEventMultilinesText(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,24}:test title|test\\line1\\nline2\\nline3"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,24}:test title|test\\line1\\nline2\\nline3"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -430,7 +454,7 @@ func TestConvertEventMultilinesText(t *testing.T) {
 }
 
 func TestConvertEventPipeInTitle(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,24}:test|title|test\\line1\\nline2\\nline3"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,24}:test|title|test\\line1\\nline2\\nline3"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test|title", e.Title)
@@ -447,71 +471,71 @@ func TestConvertEventPipeInTitle(t *testing.T) {
 
 func TestConvertEventError(t *testing.T) {
 	// missing length header
-	_, err := parseEventMessage([]byte("_e:title|text"), "default-hostname")
+	_, err := parseAndEnrichEventMessage([]byte("_e:title|text"), "default-hostname")
 	assert.Error(t, err)
 
 	// greater length than packet
-	_, err = parseEventMessage([]byte("_e{10,10}:title|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{10,10}:title|text"), "default-hostname")
 	assert.Error(t, err)
 
 	// zero length
-	_, err = parseEventMessage([]byte("_e{0,0}:a|a"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{0,0}:a|a"), "default-hostname")
 	assert.Error(t, err)
 
 	// missing title or text length
-	_, err = parseEventMessage([]byte("_e{5555:title|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{5555:title|text"), "default-hostname")
 	assert.Error(t, err)
 
 	// missing wrong len format
-	_, err = parseEventMessage([]byte("_e{a,1}:title|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{a,1}:title|text"), "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseEventMessage([]byte("_e{1,a}:title|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{1,a}:title|text"), "default-hostname")
 	assert.Error(t, err)
 
 	// missing title or text length
-	_, err = parseEventMessage([]byte("_e{5,}:title|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{5,}:title|text"), "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseEventMessage([]byte("_e{,4}:title|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{,4}:title|text"), "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseEventMessage([]byte("_e{}:title|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{}:title|text"), "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseEventMessage([]byte("_e{,}:title|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{,}:title|text"), "default-hostname")
 	assert.Error(t, err)
 
 	// not enough information
-	_, err = parseEventMessage([]byte("_e|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e|text"), "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseEventMessage([]byte("_e:|text"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e:|text"), "default-hostname")
 	assert.Error(t, err)
 
 	// invalid timestamp
-	_, err = parseEventMessage([]byte("_e{5,4}:title|text|d:abc"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{5,4}:title|text|d:abc"), "default-hostname")
 	assert.NoError(t, err)
 
 	// invalid priority
-	_, err = parseEventMessage([]byte("_e{5,4}:title|text|p:urgent"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{5,4}:title|text|p:urgent"), "default-hostname")
 	assert.NoError(t, err)
 
 	// invalid priority
-	_, err = parseEventMessage([]byte("_e{5,4}:title|text|p:urgent"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{5,4}:title|text|p:urgent"), "default-hostname")
 	assert.NoError(t, err)
 
 	// invalid alert type
-	_, err = parseEventMessage([]byte("_e{5,4}:title|text|t:test"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{5,4}:title|text|t:test"), "default-hostname")
 	assert.NoError(t, err)
 
 	// unknown metadata
-	_, err = parseEventMessage([]byte("_e{5,4}:title|text|x:1234"), "default-hostname")
+	_, err = parseAndEnrichEventMessage([]byte("_e{5,4}:title|text|x:1234"), "default-hostname")
 	assert.NoError(t, err)
 }
 
 func TestConvertEventMetadataTimestamp(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|d:21"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|d:21"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -527,7 +551,7 @@ func TestConvertEventMetadataTimestamp(t *testing.T) {
 }
 
 func TestConvertEventMetadataPriority(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|p:low"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|p:low"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -543,7 +567,7 @@ func TestConvertEventMetadataPriority(t *testing.T) {
 }
 
 func TestConvertEventMetadataHostname(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|h:localhost"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|h:localhost"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -559,7 +583,7 @@ func TestConvertEventMetadataHostname(t *testing.T) {
 }
 
 func TestConvertEventMetadataHostnameInTag(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#host:localhost"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|#host:localhost"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -575,7 +599,7 @@ func TestConvertEventMetadataHostnameInTag(t *testing.T) {
 }
 
 func TestConvertEventMetadataEmptyHostTag(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#host:,other:tag"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|#host:,other:tag"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -591,7 +615,7 @@ func TestConvertEventMetadataEmptyHostTag(t *testing.T) {
 }
 
 func TestConvertEventMetadataAlertType(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|t:warning"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|t:warning"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -607,7 +631,7 @@ func TestConvertEventMetadataAlertType(t *testing.T) {
 }
 
 func TestConvertEventMetadataAggregatioKey(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|k:some aggregation key"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|k:some aggregation key"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -623,7 +647,7 @@ func TestConvertEventMetadataAggregatioKey(t *testing.T) {
 }
 
 func TestConvertEventMetadataSourceType(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|s:this is the source"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|s:this is the source"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -639,7 +663,7 @@ func TestConvertEventMetadataSourceType(t *testing.T) {
 }
 
 func TestConvertEventMetadataTags(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#tag1,tag2:test"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|#tag1,tag2:test"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -655,7 +679,7 @@ func TestConvertEventMetadataTags(t *testing.T) {
 }
 
 func TestConvertEventMetadataMultiple(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"), "default-hostname")
+	e, err := parseAndEnrichEventMessage([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -671,7 +695,7 @@ func TestConvertEventMetadataMultiple(t *testing.T) {
 }
 
 func TestConvertNamespace(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "testNamespace.", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:21|ms"), "testNamespace.", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -680,7 +704,7 @@ func TestConvertNamespace(t *testing.T) {
 }
 
 func TestConvertNamespaceBlacklist(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("datadog.agent.daemon:21|ms"), "testNamespace.", []string{"datadog.agent"}, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("datadog.agent.daemon:21|ms"), "testNamespace.", []string{"datadog.agent"}, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -696,7 +720,7 @@ func TestConvertEntityOriginDetectionNoTags(t *testing.T) {
 		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -717,7 +741,7 @@ func TestConvertEntityOriginDetectionTags(t *testing.T) {
 		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -734,7 +758,7 @@ func TestConvertEntityOriginDetectionTagsError(t *testing.T) {
 		return nil, errors.New("cannot get tags")
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
+	parsed, err := parseAndEnrichMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -52,6 +52,7 @@ func init() {
 type Server struct {
 	listeners             []listeners.StatsdListener
 	packetsIn             chan listeners.Packets
+	samplePool            *metrics.MetricSamplePool
 	Statistics            *util.Stats
 	Started               bool
 	packetPool            *listeners.PacketPool
@@ -76,7 +77,7 @@ type metricStat struct {
 }
 
 // NewServer returns a running Dogstatsd server
-func NewServer(metricOut chan<- []*metrics.MetricSample, eventOut chan<- []*metrics.Event, serviceCheckOut chan<- []*metrics.ServiceCheck) (*Server, error) {
+func NewServer(samplePool *metrics.MetricSamplePool, metricOut chan<- []*metrics.MetricSample, eventOut chan<- []*metrics.Event, serviceCheckOut chan<- []*metrics.ServiceCheck) (*Server, error) {
 	var stats *util.Stats
 	if config.Datadog.GetBool("dogstatsd_stats_enable") == true {
 		buff := config.Datadog.GetInt("dogstatsd_stats_buffer")
@@ -140,6 +141,7 @@ func NewServer(metricOut chan<- []*metrics.MetricSample, eventOut chan<- []*metr
 	s := &Server{
 		Started:               true,
 		Statistics:            stats,
+		samplePool:            samplePool,
 		packetsIn:             packetsChannel,
 		listeners:             tmpListeners,
 		packetPool:            packetPool,

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -254,7 +254,7 @@ func nextMessage(packet *[]byte) (message []byte) {
 func (s *Server) parsePackets(batcher *batcher, packets []*listeners.Packet) {
 	for _, packet := range packets {
 		originTags := findOriginTags(packet.Origin)
-		//log.Tracef("Dogstatsd receive: %s", packet.Contents)
+		log.Tracef("Dogstatsd receive: %s", packet.Contents)
 		for {
 			message := nextMessage(&packet.Contents)
 			if message == nil {

--- a/pkg/dogstatsd/server_bench_test.go
+++ b/pkg/dogstatsd/server_bench_test.go
@@ -43,7 +43,7 @@ func buildPacketConent(numberOfMetrics int) []byte {
 	return []byte(rawPacket)
 }
 
-func BenchmarkParsePacket(b *testing.B) {
+func BenchmarkParsePackets(b *testing.B) {
 	// our logger will log dogstatsd packet by default if nothing is setup
 	config.SetupLogger("", "off", "", "", false, true, false)
 
@@ -54,7 +54,8 @@ func BenchmarkParsePacket(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		batcher := newBatcher(pool, sampleOut, eventOut, scOut)
-		rawPacket := buildPacketConent(25)
+		// 32 packets of 20 samples
+		rawPacket := buildPacketConent(20 * 32)
 		packet := listeners.Packet{
 			Contents: rawPacket,
 			Origin:   listeners.NoOrigin,

--- a/pkg/dogstatsd/server_bench_test.go
+++ b/pkg/dogstatsd/server_bench_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func BenchmarkParsePacket(b *testing.B) {
-	s, _ := NewServer(nil, nil, nil)
+	s, _ := NewServer(metrics.NewMetricSamplePool(16), nil, nil, nil)
 	defer s.Stop()
 
 	for n := 0; n < b.N; n++ {
@@ -21,6 +21,6 @@ func BenchmarkParsePacket(b *testing.B) {
 			Contents: []byte("daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2"),
 			Origin:   listeners.NoOrigin,
 		}
-		s.parsePacket(&packet, []*metrics.MetricSample{}, []*metrics.Event{}, []*metrics.ServiceCheck{})
+		s.parsePackets(listeners.Packets{&packet})
 	}
 }

--- a/pkg/dogstatsd/server_bench_test.go
+++ b/pkg/dogstatsd/server_bench_test.go
@@ -8,19 +8,61 @@ package dogstatsd
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
+
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
+func mockAggregator(pool *metrics.MetricSamplePool) (chan []metrics.MetricSample, chan []*metrics.Event, chan []*metrics.ServiceCheck) {
+	bufferedMetricIn := make(chan []metrics.MetricSample, 100)
+	bufferedServiceCheckIn := make(chan []*metrics.ServiceCheck, 100)
+	bufferedEventIn := make(chan []*metrics.Event, 100)
+
+	go func() {
+		for {
+			select {
+			case _ = <-bufferedServiceCheckIn:
+				break
+			case _ = <-bufferedEventIn:
+				break
+			case sampleBatch := <-bufferedMetricIn:
+				pool.PutBatch(sampleBatch)
+			}
+		}
+	}()
+
+	return bufferedMetricIn, bufferedEventIn, bufferedServiceCheckIn
+}
+
+func buildPacketConent(numberOfMetrics int) []byte {
+	rawPacket := "daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2"
+	for i := 1; i < numberOfMetrics; i++ {
+		rawPacket += "\ndaemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2"
+	}
+	return []byte(rawPacket)
+}
+
 func BenchmarkParsePacket(b *testing.B) {
-	s, _ := NewServer(metrics.NewMetricSamplePool(16), nil, nil, nil)
+	// our logger will log dogstatsd packet by default if nothing is setup
+	config.SetupLogger("", "off", "", "", false, true, false)
+
+	pool := metrics.NewMetricSamplePool(16)
+	sampleOut, eventOut, scOut := mockAggregator(pool)
+	s, _ := NewServer(pool, sampleOut, eventOut, scOut)
 	defer s.Stop()
 
-	for n := 0; n < b.N; n++ {
+	b.RunParallel(func(pb *testing.PB) {
+		batcher := newBatcher(pool, sampleOut, eventOut, scOut)
+		rawPacket := buildPacketConent(25)
 		packet := listeners.Packet{
-			Contents: []byte("daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2"),
+			Contents: rawPacket,
 			Origin:   listeners.NoOrigin,
 		}
-		s.parsePackets(listeners.Packets{&packet})
-	}
+		packets := listeners.Packets{&packet}
+		for pb.Next() {
+			packet.Contents = rawPacket
+			s.parsePackets(batcher, packets)
+		}
+	})
 }

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -45,7 +45,7 @@ func TestNewServer(t *testing.T) {
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	s, err := NewServer(nil, nil, nil)
+	s, err := NewServer(metrics.NewMetricSamplePool(16), nil, nil, nil)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
 	assert.NotNil(t, s)
@@ -57,7 +57,7 @@ func TestStopServer(t *testing.T) {
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	s, err := NewServer(nil, nil, nil)
+	s, err := NewServer(metrics.NewMetricSamplePool(16), nil, nil, nil)
 	require.NoError(t, err, "cannot start DSD")
 	s.Stop()
 
@@ -84,7 +84,7 @@ func TestUPDReceive(t *testing.T) {
 	metricOut := make(chan []*metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
-	s, err := NewServer(metricOut, eventOut, serviceOut)
+	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
 
@@ -243,7 +243,7 @@ func TestUDPForward(t *testing.T) {
 	metricOut := make(chan []*metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
-	s, err := NewServer(metricOut, eventOut, serviceOut)
+	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
 
@@ -280,7 +280,7 @@ func TestHistToDist(t *testing.T) {
 	metricOut := make(chan []*metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
-	s, err := NewServer(metricOut, eventOut, serviceOut)
+	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
 
@@ -320,7 +320,7 @@ func TestExtraTags(t *testing.T) {
 	metricOut := make(chan []*metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
-	s, err := NewServer(metricOut, eventOut, serviceOut)
+	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
 
@@ -349,7 +349,7 @@ func TestDebugStats(t *testing.T) {
 	metricOut := make(chan []*metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
-	s, err := NewServer(metricOut, eventOut, serviceOut)
+	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
 

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -81,7 +81,7 @@ func TestUPDReceive(t *testing.T) {
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	metricOut := make(chan []*metrics.MetricSample)
+	metricOut := make(chan []metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
 	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)
@@ -240,7 +240,7 @@ func TestUDPForward(t *testing.T) {
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	metricOut := make(chan []*metrics.MetricSample)
+	metricOut := make(chan []metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
 	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)
@@ -277,7 +277,7 @@ func TestHistToDist(t *testing.T) {
 	config.Datadog.SetDefault("histogram_copy_to_distribution_prefix", "dist.")
 	defer config.Datadog.SetDefault("histogram_copy_to_distribution_prefix", "")
 
-	metricOut := make(chan []*metrics.MetricSample)
+	metricOut := make(chan []metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
 	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)
@@ -317,7 +317,7 @@ func TestExtraTags(t *testing.T) {
 	config.Datadog.SetDefault("dogstatsd_tags", []string{"sometag3:somevalue3"})
 	defer config.Datadog.SetDefault("dogstatsd_tags", []string{})
 
-	metricOut := make(chan []*metrics.MetricSample)
+	metricOut := make(chan []metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
 	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)
@@ -346,7 +346,7 @@ func TestExtraTags(t *testing.T) {
 }
 
 func TestDebugStats(t *testing.T) {
-	metricOut := make(chan []*metrics.MetricSample)
+	metricOut := make(chan []metrics.MetricSample)
 	eventOut := make(chan []*metrics.Event)
 	serviceOut := make(chan []*metrics.ServiceCheck)
 	s, err := NewServer(metrics.NewMetricSamplePool(16), metricOut, eventOut, serviceOut)

--- a/pkg/metrics/metric_sample_pool.go
+++ b/pkg/metrics/metric_sample_pool.go
@@ -22,10 +22,16 @@ func NewMetricSamplePool(batchSize int) *MetricSamplePool {
 
 // GetBatch gets a batch of metric samples from the pool
 func (m *MetricSamplePool) GetBatch() []MetricSample {
+	if m == nil {
+		return nil
+	}
 	return m.pool.Get().([]MetricSample)
 }
 
 // PutBatch puts a batch back into the pool
 func (m *MetricSamplePool) PutBatch(batch []MetricSample) {
+	if m == nil {
+		return
+	}
 	m.pool.Put(batch[:cap(batch)])
 }

--- a/pkg/metrics/metric_sample_pool.go
+++ b/pkg/metrics/metric_sample_pool.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"sync"
+)
+
+// MetricSamplePool is a pool of metrics sample
+type MetricSamplePool struct {
+	pool *sync.Pool
+}
+
+// NewMetricSamplePool creates a new MetricSamplePool
+func NewMetricSamplePool(batchSize int) *MetricSamplePool {
+	return &MetricSamplePool{
+		pool: &sync.Pool{
+			New: func() interface{} {
+				batch := make([]MetricSample, 0, batchSize)
+				return &batch
+			},
+		},
+	}
+}
+
+// GetBatch gets a batch of metric samples from the pool
+func (m *MetricSamplePool) GetBatch() []MetricSample {
+	return m.pool.Get().([]MetricSample)
+}
+
+// PutBatch puts a batch back into the pool
+func (m *MetricSamplePool) PutBatch(batch []MetricSample) {
+	m.pool.Put(batch[:0])
+}

--- a/pkg/metrics/metric_sample_pool.go
+++ b/pkg/metrics/metric_sample_pool.go
@@ -14,8 +14,7 @@ func NewMetricSamplePool(batchSize int) *MetricSamplePool {
 	return &MetricSamplePool{
 		pool: &sync.Pool{
 			New: func() interface{} {
-				batch := make([]MetricSample, 0, batchSize)
-				return &batch
+				return make([]MetricSample, batchSize)
 			},
 		},
 	}
@@ -28,5 +27,5 @@ func (m *MetricSamplePool) GetBatch() []MetricSample {
 
 // PutBatch puts a batch back into the pool
 func (m *MetricSamplePool) PutBatch(batch []MetricSample) {
-	m.pool.Put(batch[:0])
+	m.pool.Put(batch[:cap(batch)])
 }

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -211,7 +211,7 @@ func main() {
 	f := &forwarderBenchStub{}
 	s := serializer.NewSerializer(f)
 
-	agg = aggregator.InitAggregatorWithFlushInterval(s, "hostname", time.Duration(*flushIval)*time.Second)
+	agg = aggregator.InitAggregatorWithFlushInterval(s, nil, "hostname", time.Duration(*flushIval)*time.Second)
 
 	aggregator.SetDefaultAggregator(agg)
 	sender, err := aggregator.GetSender(check.ID("benchmark check"))


### PR DESCRIPTION
### What does this PR do?

Create pool of `metrics.MetricSample` batches shared between dogstatsd parsers and the aggregator. 

### Motivation

It's currently expensive to store one object on the heap for each incoming sample. This PR brings two benefits:

1. Reduce the number of pointers the GC has to keep track of by allocating slices of samples instead of slice of pointers to samples.
2. Re-use the number and size of allocations by using a `sync.Pool`

### Benchmark

Parsing 640 sample:

```
benchmark                   old ns/op     new ns/op     delta
BenchmarkParsePackets-4     246904        192589        -22.00%

benchmark                   old allocs     new allocs     delta
BenchmarkParsePackets-4     4495           3243           -27.85%

benchmark                   old bytes     new bytes     delta
BenchmarkParsePackets-4     170349        70636         -58.53%
```

### Notes

This PR targets https://github.com/DataDog/datadog-agent/pull/4575