### PR TITLE
Properly install latest available versions of the Agent with install script on Fedora 

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -164,7 +164,7 @@ if [ $OS = "RedHat" ]; then
     $sudo_cmd yum -y clean metadata
 
     dnf_flag=""
-    if [ -f "/etc/fedora-release" ]; then
+    if [ -f "/etc/fedora-release" ] && [ -f "/usr/bin/dnf" ]; then
       # On Fedora, yum is an alias of dnf, dnf install doesn't
       # upgrade a package if a newer version is available, until
       # the --best flag is set

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -162,7 +162,17 @@ if [ $OS = "RedHat" ]; then
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
     $sudo_cmd yum -y clean metadata
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install datadog-agent || $sudo_cmd yum -y install datadog-agent
+
+    dnf_flag=""
+    if [ -f "/etc/fedora-release" ]; then
+      # On Fedora, yum is an alias of dnf, dnf install doesn't
+      # upgrade a package if a newer version is available, until
+      # the --best flag is set
+      dnf_flag="--best"
+    fi
+
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install $dnf_flag datadog-agent || $sudo_cmd yum -y install $dnf_flag datadog-agent
+
 elif [ $OS = "Debian" ]; then
 
     printf "\033[34m\n* Installing apt-transport-https\n\033[0m\n"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -166,7 +166,7 @@ if [ $OS = "RedHat" ]; then
     dnf_flag=""
     if [ -f "/etc/fedora-release" ] && [ -f "/usr/bin/dnf" ]; then
       # On Fedora, yum is an alias of dnf, dnf install doesn't
-      # upgrade a package if a newer version is available, until
+      # upgrade a package if a newer version is available, unless
       # the --best flag is set
       dnf_flag="--best"
     fi


### PR DESCRIPTION
### What does this PR do?

On Fedora, adds the `--best` flag while calling `yum install` in order to properly update the Agent version if a newer is available.

### Motivation

`yum` on Fedora >= 22 is an alias to `dnf` which doesn't update a package with `yum install` if a newer version is available.
Thus, the upgrade instructions v5 → v6 → v7 were not working properly on Fedora.

### Additional Notes

Bug found while testing the install instructions of Agent v7.
Tested with Fedora 30, an update from v5 to v6 was not working either.