### PR TITLE
Document hostname_force_config_as_canonical

### DIFF
--- a/docs/agent/hostname_force_config_as_canonical.md
+++ b/docs/agent/hostname_force_config_as_canonical.md
@@ -1,0 +1,8 @@
+Agent hostname config as canonical 
+
+If `hostname` is set in `datadog.yaml` and the value starts with `ip-` or `domu`, this hostname is not used as a canonical hostname.
+More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).
+
+To use an hostname starting with `ip-` or `domu` as a canonical hostname, set the config `hostname_force_config_as_canonical` at `true` in datadog.yaml.
+It creates a new canonical hostname which receives new metrics. The old canonical hostname contains old metrics. 
+You may contact the support team if you want to have the old metrics in the new canonical hostname.

--- a/docs/agent/hostname_force_config_as_canonical.md
+++ b/docs/agent/hostname_force_config_as_canonical.md
@@ -1,15 +1,21 @@
-# Make config-provided hostname canonical
+# Config-provided hostname starting with `ip-` or `domu`
+
+## Description of the issue
 
 In v6 and v7 Agents, if `hostname` is set in `datadog.yaml` (or through the `DD_HOSTNAME` env var) and its value starts with `ip-` or `domu`, the hostname is not used in-app as the canonical hostname, even though it is a valid hostname.
 More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).
 
-Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` will be accepted as the canonical hostname in-app.
-
-Starting with v6.16.0 and v7.16.0, the Agent logs the following warning if it detects a situation where the config-provided hostname is a valid hostname but will not be accepted as the canonical hostname in-app:
+To know if your Agents are affected, starting with v6.16.0 and v7.16.0, the Agent logs the following warning if it detects a situation where the config-provided hostname is a valid hostname but will not be accepted as the canonical hostname in-app:
 `Hostname '<HOSTNAME>' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-config-as-canonical`
 
-## Impact of enabling hostname_force_config_as_canonical
+If this warning is logged, you can either:
 
-The hostname remains the same in-app until contacting the support team to runs the command that clears the existing host aliases.
-This command let the config-provided hostname be accepted as the canonical hostname in-app.
+* if you are satisfied with the in-app hostname: unset the configured `hostname` from `datadog.yaml` (or the `DD_HOSTNAME` env var) and restart the Agent; or
+* if you are not satisfied with the in-app hostname, and want the configured hostname to appear as the in-app hostname, follow the instructions below
 
+## Allowing Agent in-app hostnames to start with `ip-` or `domu`
+
+Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` will be accepted as the canonical hostname in-app:
+
+* for new hosts, enabling this option will work immediately
+* for hosts that already report to Datadog, after enabling this option, please contact our support team at support@datadoghq.com so that the in-app hostname can be changed to your configuration-provided hostname.

--- a/docs/agent/hostname_force_config_as_canonical.md
+++ b/docs/agent/hostname_force_config_as_canonical.md
@@ -1,6 +1,6 @@
 ## Make config-provided hostname canonical
 
-If `hostname` is set in `datadog.yaml` and the value starts with `ip-` or `domu`, this hostname is not used as a canonical hostname.
+In v6 and v7 Agents, if `hostname` is set in `datadog.yaml` (or through the `DD_HOSTNAME` env var) and its value starts with `ip-` or `domu`, the hostname is not used in-app as the canonical hostname, even though it is a valid hostname.
 More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).
 
 To use an hostname starting with `ip-` or `domu` as a canonical hostname, set the config `hostname_force_config_as_canonical` at `true` in datadog.yaml.

--- a/docs/agent/hostname_force_config_as_canonical.md
+++ b/docs/agent/hostname_force_config_as_canonical.md
@@ -1,8 +1,15 @@
-## Make config-provided hostname canonical
+# Make config-provided hostname canonical
 
 In v6 and v7 Agents, if `hostname` is set in `datadog.yaml` (or through the `DD_HOSTNAME` env var) and its value starts with `ip-` or `domu`, the hostname is not used in-app as the canonical hostname, even though it is a valid hostname.
 More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).
 
 Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` will be accepted as the canonical hostname in-app.
-It creates a new canonical hostname which receives new metrics. The old canonical hostname contains old metrics. 
-You may contact the support team if you want to have the old metrics in the new canonical hostname.
+
+Starting with v6.16.0 and v7.16.0, the Agent logs the following warning if it detects a situation where the config-provided hostname is a valid hostname but will not be accepted as the canonical hostname in-app:
+`Hostname '<HOSTNAME>' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-config-as-canonical`
+
+## Impact of enabling hostname_force_config_as_canonical
+
+The hostname remains the same in-app until contacting the support team to runs the command that clears the existing host aliases.
+This command let the config-provided hostname be accepted as the canonical hostname in-app.
+

--- a/docs/agent/hostname_force_config_as_canonical.md
+++ b/docs/agent/hostname_force_config_as_canonical.md
@@ -3,6 +3,6 @@
 In v6 and v7 Agents, if `hostname` is set in `datadog.yaml` (or through the `DD_HOSTNAME` env var) and its value starts with `ip-` or `domu`, the hostname is not used in-app as the canonical hostname, even though it is a valid hostname.
 More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).
 
-To use an hostname starting with `ip-` or `domu` as a canonical hostname, set the config `hostname_force_config_as_canonical` at `true` in datadog.yaml.
+Starting with Agent v6.16.0 and v7.16.0, the Agent supports the config option `hostname_force_config_as_canonical` (default: `false`). When set to `true`, a configuration-provided hostname starting with `ip-` or `domu` will be accepted as the canonical hostname in-app.
 It creates a new canonical hostname which receives new metrics. The old canonical hostname contains old metrics. 
 You may contact the support team if you want to have the old metrics in the new canonical hostname.

--- a/docs/agent/hostname_force_config_as_canonical.md
+++ b/docs/agent/hostname_force_config_as_canonical.md
@@ -1,4 +1,4 @@
-Agent hostname config as canonical 
+## Make config-provided hostname canonical
 
 If `hostname` is set in `datadog.yaml` and the value starts with `ip-` or `domu`, this hostname is not used as a canonical hostname.
 More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).


### PR DESCRIPTION
### What does this PR do?

Additional information about `hostname_force_config_as_canonical`.

https://github.com/DataDog/datadog-agent/pull/4504/files#diff-1d9d99d196299ff9a78c3e928058494aR153 defines a link to https://dtdg.co/agent-hostname-config-as-canonical which should point to this documentation.
