### PR TITLE
Explicitly pin to agent 7 in manifests

### DIFF
--- a/Dockerfiles/manifests/agent-clusterchecks-only.yaml
+++ b/Dockerfiles/manifests/agent-clusterchecks-only.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       serviceAccountName: datadog-agent
       containers:
-      - image: datadog/agent:latest
+      - image: datadog/agent:7
         imagePullPolicy: Always
         name: datadog-agent
         env:

--- a/Dockerfiles/manifests/agent-kubelet-only.yaml
+++ b/Dockerfiles/manifests/agent-kubelet-only.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: datadog-agent
       containers:
-      - image: datadog/agent:latest
+      - image: datadog/agent:7
         imagePullPolicy: Always
         name: datadog-agent
         env:

--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: datadog-agent
       containers:
-      - image: datadog/agent:latest
+      - image: datadog/agent:7
         imagePullPolicy: Always
         name: datadog-agent
         ports:


### PR DESCRIPTION
### What does this PR do?

Explicitly pin the image to `7` instead of `latest` in manifests.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
