### PR TITLE
[docker] allow user to add custom docker label for tagging

### DIFF
--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -56,9 +56,9 @@ messages, the delete eventually wins.
 
 **TagInfo** accepts and store tags that have different cardinality. **TagCardinality** can be:
 
-* ***LowCardinality**: in the host count order of magnitude
-* ***OrchestratorCardinality**:tags that change value for each pod or task
-* ***HighCardinality**: typically tags that change value for each web request, user agent, container, etc.
+* **LowCardinality**: in the host count order of magnitude
+* **OrchestratorCardinality**: tags that change value for each pod or task
+* **HighCardinality**: typically tags that change value for each web request, user agent, container, etc.
 
 ## Tagger
 

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -102,7 +102,7 @@ func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string,
 				tagParts := strings.Split(tag, ":")
 				// skip if tag is not in expected k:v format
 				if len(tagParts) != 2 {
-					log.Debugf("Tag %s is not in k:v format", strings.Join(tagParts, ", "))
+					log.Debugf("Tag '%s' is not in k:v format", tag)
 					continue
 				}
 				tags.AddHigh(tagParts[0], tagParts[1])

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -234,7 +234,7 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 				Config: &container.Config{
 					Env: []string{"PATH=/bin"},
 					Labels: map[string]string{
-						"com.datadoghq.ad.tags": "adTestKey:adTestVal1 adTestKey:adTestVal2",
+						"com.datadoghq.ad.tags": "[\"adTestKey:adTestVal1\", \"adTestKey:adTestVal2\"]",
 					},
 				},
 			},

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -228,6 +228,22 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 			expectedOrch: []string{},
 			expectedHigh: []string{},
 		},
+		{
+			testName: "extractCustomLabels",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{"PATH=/bin"},
+					Labels: map[string]string{
+						"com.datadoghq.ad.tags": "adTestKey:adTestVal1 adTestKey:adTestVal2",
+					},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow:          []string{},
+			expectedOrch:         []string{},
+			expectedHigh:         []string{"adTestKey:adTestVal1", "adTestKey:adTestVal2"},
+		},
 	}
 
 	dc := &DockerCollector{}

--- a/releasenotes/notes/add-support-for-ad-docker-label-tags-bc5e9908696d2b5b.yaml
+++ b/releasenotes/notes/add-support-for-ad-docker-label-tags-bc5e9908696d2b5b.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Support custom tagging of docker container data via an autodiscovery "tags"
+    label key.


### PR DESCRIPTION
### What does this PR do?

Supports the use of a docker label with key `"com.datadoghq.ad.tags"` that will be converted to tags associated with container data.

### Motivation

Flexibility to add tagging outside of datadog.yaml file

### Additional Notes

