### PR TITLE
Fix --incremental-build option for process-agent/system-probe

### DIFF
--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -86,7 +86,7 @@ def build(ctx, race=False, go_version=None, incremental_build=False, puppy=False
 
     args = {
         "race_opt": "-race" if race else "",
-        "build_type": "-i" if incremental_build else "-a",
+        "build_type": "" if incremental_build else "-a",
         "go_build_tags": " ".join(build_tags),
         "agent_bin": BIN_PATH,
         "gcflags": gcflags,

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -66,7 +66,7 @@ def build(ctx, race=False, go_version=None, incremental_build=False):
 
     args = {
         "race_opt": "-race" if race else "",
-        "build_type": "-i" if incremental_build else "-a",
+        "build_type": "" if incremental_build else "-a",
         "go_build_tags": " ".join(build_tags),
         "agent_bin": BIN_PATH,
         "gcflags": gcflags,


### PR DESCRIPTION

### What does this PR do?

We were using the `-i` flag to `go build` when passing
--incremental-build to the build system. `-i` causes the dependencies of
the build to be installed.

With inremental-build (system probe)
real	0m13.155s
user	0m3.032s
sys	0m6.796s

Without incremental build (system probe)
real	0m50.761s
user	0m32.740s
sys	0m12.024s

### QA/Testing

Not required; this is a change in the build command


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
