### PR TITLE
Use open source ARM images for building on CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -473,12 +473,6 @@ run_dogstatsd_size_test:
     paths:
       - $OMNIBUS_PACKAGE_DIR
 
-.agent_build_common_arm:
-  stage: package_build
-  needs: ["run_dep_check_lock"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/$PKG_TARGET:$DATADOG_AGENT_ARMBUILDIMAGES
-  tags: ["runner:docker-arm", "platform:arm64"]
-
 # build Agent package for deb-x64
 agent_deb-x64-a6:
   stage: package_build
@@ -519,9 +513,11 @@ agent_deb-x64-a7:
   <<: *agent_build_common_deb
 
 agent_deb-arm-a6:
-  extends: .agent_build_common_arm
+  stage: package_build
+  needs: ["run_dep_check_lock"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_arm_x64:$DATADOG_AGENT_ARMBUILDIMAGES
+  tags: ["runner:docker-arm", "platform:arm64"]
   variables:
-    PKG_TARGET: deb_arm_x64
     PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: arm64
     DESTINATION_DEB: 'datadog-agent_6_arm64.deb'
@@ -534,9 +530,11 @@ agent_deb-arm-a6:
   <<: *agent_build_common_deb
 
 agent_deb-arm-a7:
-  extends: .agent_build_common_arm
+  stage: package_build
+  needs: ["run_dep_check_lock"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_arm_x64:$DATADOG_AGENT_ARMBUILDIMAGES
+  tags: ["runner:docker-arm", "platform:arm64"]
   variables:
-    PKG_TARGET: deb_arm_x64
     PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: arm64
     DESTINATION_DEB: 'datadog-agent_7_arm64.deb'
@@ -646,9 +644,11 @@ agent_rpm-x64-a7:
 
   # build Agent package for rpm-x64
 agent_rpm-arm-a6:
-  extends: .agent_build_common_arm
+  stage: package_build
+  needs: ["run_dep_check_lock"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_arm_x64:$DATADOG_AGENT_ARMBUILDIMAGES
+  tags: ["runner:docker-arm", "platform:arm64"]
   variables:
-    PKG_TARGET: rpm_arm_x64
     PYTHON_RUNTIMES: '2,3'
   before_script:
     - source /root/.bashrc
@@ -659,9 +659,11 @@ agent_rpm-arm-a6:
 
 # build Agent package for rpm-x64
 agent_rpm-arm-a7:
-  extends: .agent_build_common_arm
+  stage: package_build
+  needs: ["run_dep_check_lock"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_arm_x64:$DATADOG_AGENT_ARMBUILDIMAGES
+  tags: ["runner:docker-arm", "platform:arm64"]
   variables:
-    PKG_TARGET: rpm_arm_x64
     PYTHON_RUNTIMES: '3'
   before_script:
     - source /root/.bashrc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -341,12 +341,17 @@ build_puppy_agent-deb_x64:
 # build puppy agent for ARM, to make sure the build is not broken because of build targets
 build_puppy_agent-deb_x64_arm:
   stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: [ "runner:main", "size:large" ]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:v1949502-eda0bce
+  tags: ["runner:docker-arm", "platform:arm64"]
   variables:
     AGENT_MAJOR_VERSION: 7
+    ARCH: arm64
   before_script:
-    - source /root/.bashrc && conda activate ddpy3
+    - source /root/.bashrc
+    # Hack to work around the cloning issue with arm runners
+    - mkdir -p $GOPATH/src/github.com/DataDog
+    - cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog
+    - cd $SRC_PATH
     - inv -e deps --verbose --dep-vendor-only --no-checks
   script:
     - GOOS=linux GOARCH=arm inv -e agent.build --puppy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ variables:
   DATADOG_AGENT_BUILDIMAGES: v1709713-2adac2a
   DATADOG_AGENT_BUILDERS: v1793959-4e4c346
   DATADOG_AGENT_WINBUILDIMAGES: v1876043-a759bdd
-  DATADOG_AGENT_ARMBUILDIMAGES: v1897460-9b1848b
+  DATADOG_AGENT_ARMBUILDIMAGES: v1949502-eda0bce
 
 
 # Default before_script for all the jobs. If you create a new job and don't want this to execute
@@ -393,7 +393,7 @@ cluster_agent-build_amd64:
 
 cluster_agent-build_arm64:
   <<: *cluster_agent-build_common
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_arm_x64:$DATADOG_AGENT_ARMBUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
     ARCH: arm64
@@ -515,7 +515,7 @@ agent_deb-x64-a7:
 agent_deb-arm-a6:
   stage: package_build
   needs: ["run_dep_check_lock"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_arm_x64:$DATADOG_AGENT_ARMBUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
     PYTHON_RUNTIMES: '2,3'
@@ -532,7 +532,7 @@ agent_deb-arm-a6:
 agent_deb-arm-a7:
   stage: package_build
   needs: ["run_dep_check_lock"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_arm_x64:$DATADOG_AGENT_ARMBUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
     PYTHON_RUNTIMES: '3'
@@ -646,7 +646,7 @@ agent_rpm-x64-a7:
 agent_rpm-arm-a6:
   stage: package_build
   needs: ["run_dep_check_lock"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_arm_x64:$DATADOG_AGENT_ARMBUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
     PYTHON_RUNTIMES: '2,3'
@@ -661,7 +661,7 @@ agent_rpm-arm-a6:
 agent_rpm-arm-a7:
   stage: package_build
   needs: ["run_dep_check_lock"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_arm_x64:$DATADOG_AGENT_ARMBUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
     PYTHON_RUNTIMES: '3'


### PR DESCRIPTION
### What does this PR do?

This PR makes the build of the ARM version of the puppy agent and all the other builds use open source images from https://github.com/DataDog/datadog-agent-buildimages.

### Motivation

Eat your own dogfood, the images were created for this purpose so let's use them.

### Additional Notes

This PR has to be considered in coordination with #4634 but might be considered independently.
