### PR TITLE
[docs] Update link to 7.16 hostname config option docs

### DIFF
--- a/docs/agent/hostname_force_config_as_canonical.md
+++ b/docs/agent/hostname_force_config_as_canonical.md
@@ -6,7 +6,7 @@ In v6 and v7 Agents, if `hostname` is set in `datadog.yaml` (or through the `DD_
 More information about what a canonical hostname is can be found at [How does Datadog determine the Agent hostname?](https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#agent-versions).
 
 To know if your Agents are affected, starting with v6.16.0 and v7.16.0, the Agent logs the following warning if it detects a situation where the config-provided hostname is a valid hostname but will not be accepted as the canonical hostname in-app:
-`Hostname '<HOSTNAME>' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-config-as-canonical`
+`Hostname '<HOSTNAME>' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-force-config-as-canonical`
 
 If this warning is logged, you can either:
 

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -112,7 +112,7 @@ func GetHostnameData() (HostnameData, error) {
 	if err == nil {
 		hostnameData := saveHostnameData(cacheHostnameKey, configName, HostnameProviderConfiguration)
 		if !isHostnameCanonicalForIntake(configName) && !config.Datadog.GetBool("hostname_force_config_as_canonical") {
-			_ = log.Warnf("Hostname '%s' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-config-as-canonical", configName)
+			_ = log.Warnf("Hostname '%s' defined in configuration will not be used as the in-app hostname. For more information: https://dtdg.co/agent-hostname-force-config-as-canonical", configName)
 		}
 		return hostnameData, err
 	}


### PR DESCRIPTION
### What does this PR do?

Updates the link to the docs on the hostname config option that was added in 7.16.

### Motivation

At the moment we can't update the target of these links, and the current target is not valid. Will figure out a way we can update the targets later.
