### PR TITLE
[Logs][Fix] Simplify logs tagging logic + add waiting for k8s tags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -419,6 +419,8 @@ func initConfig(config Config) {
 	config.BindEnv("logs_config.processing_rules")
 	// enforce the agent to use files to collect container logs on kubernetes environment
 	config.BindEnvAndSetDefault("logs_config.k8s_container_use_file", false)
+	// enforce waiting for kubelet tags on initial logs
+	config.BindEnvAndSetDefault("logs_config.k8s_wait_for_tags", false)
 
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
@@ -432,6 +434,9 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
 	config.BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
 	config.SetKnown("logs_config.additional_endpoints")
+	// Internal Use Only: additional config to ensure logs are tagged with kubelet tags
+	config.BindEnvAndSetDefault("logs_config.force_tagger_call_duration", 5) // Force calling the tagger for logs collected during the first 5s after discovering AD services
+	config.BindEnvAndSetDefault("logs_config.tagger_warmup_duration", 2)     // Wait for tagger before start fetching tags of new AD services
 
 	// The cardinality of tags to send for checks and dogstatsd respectively.
 	// Choices are: low, orchestrator, high.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -419,8 +419,9 @@ func initConfig(config Config) {
 	config.BindEnv("logs_config.processing_rules")
 	// enforce the agent to use files to collect container logs on kubernetes environment
 	config.BindEnvAndSetDefault("logs_config.k8s_container_use_file", false)
-	// enforce waiting for kubelet tags on initial logs
-	config.BindEnvAndSetDefault("logs_config.k8s_wait_for_tags", false)
+	// additional config to ensure initial logs are tagged with kubelet tags
+	// wait (seconds) for tagger before start fetching tags of new AD services
+	config.BindEnvAndSetDefault("logs_config.tagger_warmup_duration", 0) // Disabled by default (0 seconds)
 
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
@@ -434,9 +435,6 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
 	config.BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
 	config.SetKnown("logs_config.additional_endpoints")
-	// Internal Use Only: additional config to ensure logs are tagged with kubelet tags
-	config.BindEnvAndSetDefault("logs_config.force_tagger_call_duration", 5) // Force calling the tagger for logs collected during the first 5s after discovering AD services
-	config.BindEnvAndSetDefault("logs_config.tagger_warmup_duration", 2)     // Wait for tagger before start fetching tags of new AD services
 
 	// The cardinality of tags to send for checks and dogstatsd respectively.
 	// Choices are: low, orchestrator, high.

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -204,20 +204,7 @@ func batchWait(config coreConfig.Config) time.Duration {
 	return (time.Duration(batchWait) * time.Second)
 }
 
-// TagConfig contains the tag config used by tag providers
-type TagConfig struct {
-	ForceRefresh         bool
-	ForceRefreshDuration time.Duration
-	TaggerWarmupDuration time.Duration
-}
-
-// TagProviderConfig returns the config used by tag providers
-func TagProviderConfig() TagConfig {
-	tagProviderConfig := TagConfig{}
-	if coreConfig.Datadog.GetBool("logs_config.k8s_wait_for_tags") {
-		tagProviderConfig.ForceRefresh = true
-		tagProviderConfig.ForceRefreshDuration = coreConfig.Datadog.GetDuration("logs_config.force_tagger_call_duration") * time.Second
-		tagProviderConfig.TaggerWarmupDuration = coreConfig.Datadog.GetDuration("logs_config.tagger_warmup_duration") * time.Second
-	}
-	return tagProviderConfig
+// TaggerWarmupDuration is used to configure the tag providers
+func TaggerWarmupDuration() time.Duration {
+	return coreConfig.Datadog.GetDuration("logs_config.tagger_warmup_duration") * time.Second
 }

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -203,3 +203,21 @@ func batchWait(config coreConfig.Config) time.Duration {
 	}
 	return (time.Duration(batchWait) * time.Second)
 }
+
+// TagConfig contains the tag config used by tag providers
+type TagConfig struct {
+	ForceRefresh         bool
+	ForceRefreshDuration time.Duration
+	TaggerWarmupDuration time.Duration
+}
+
+// TagProviderConfig returns the config used by tag providers
+func TagProviderConfig() TagConfig {
+	tagProviderConfig := TagConfig{}
+	if coreConfig.Datadog.GetBool("logs_config.k8s_wait_for_tags") {
+		tagProviderConfig.ForceRefresh = true
+		tagProviderConfig.ForceRefreshDuration = coreConfig.Datadog.GetDuration("logs_config.force_tagger_call_duration") * time.Second
+		tagProviderConfig.TaggerWarmupDuration = coreConfig.Datadog.GetDuration("logs_config.tagger_warmup_duration") * time.Second
+	}
+	return tagProviderConfig
+}

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -123,6 +124,24 @@ func (suite *ConfigTestSuite) TestGlobalProcessingRulesShouldReturnRulesWithVali
 	suite.Equal("([A-Fa-f0-9]{28})", rule.Pattern)
 	suite.Equal("****************************", rule.ReplacePlaceholder)
 	suite.NotNil(rule.Regex)
+}
+
+func (suite *ConfigTestSuite) TestTagProviderConfig() {
+	var tagConfig TagConfig
+
+	// default config
+	tagConfig = TagProviderConfig()
+	suite.False(tagConfig.ForceRefresh)
+	suite.Equal(0*time.Second, tagConfig.TaggerWarmupDuration)
+	suite.Equal(0*time.Second, tagConfig.ForceRefreshDuration)
+
+	// k8s_wait_for_tags enabled config
+	suite.config.Set("logs_config.k8s_wait_for_tags", true)
+
+	tagConfig = TagProviderConfig()
+	suite.True(tagConfig.ForceRefresh)
+	suite.Equal(2*time.Second, tagConfig.TaggerWarmupDuration)
+	suite.Equal(5*time.Second, tagConfig.ForceRefreshDuration)
 }
 
 func TestConfigTestSuite(t *testing.T) {

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -126,22 +126,15 @@ func (suite *ConfigTestSuite) TestGlobalProcessingRulesShouldReturnRulesWithVali
 	suite.NotNil(rule.Regex)
 }
 
-func (suite *ConfigTestSuite) TestTagProviderConfig() {
-	var tagConfig TagConfig
+func (suite *ConfigTestSuite) TestTaggerWarmupDuration() {
+	// assert TaggerWarmupDuration is disabled by default
+	taggerWarmupDuration := TaggerWarmupDuration()
+	suite.Equal(0*time.Second, taggerWarmupDuration)
 
-	// default config
-	tagConfig = TagProviderConfig()
-	suite.False(tagConfig.ForceRefresh)
-	suite.Equal(0*time.Second, tagConfig.TaggerWarmupDuration)
-	suite.Equal(0*time.Second, tagConfig.ForceRefreshDuration)
-
-	// k8s_wait_for_tags enabled config
-	suite.config.Set("logs_config.k8s_wait_for_tags", true)
-
-	tagConfig = TagProviderConfig()
-	suite.True(tagConfig.ForceRefresh)
-	suite.Equal(2*time.Second, tagConfig.TaggerWarmupDuration)
-	suite.Equal(5*time.Second, tagConfig.ForceRefreshDuration)
+	// override
+	suite.config.Set("logs_config.tagger_warmup_duration", 5)
+	taggerWarmupDuration = TaggerWarmupDuration()
+	suite.Equal(5*time.Second, taggerWarmupDuration)
 }
 
 func TestConfigTestSuite(t *testing.T) {

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -80,7 +80,6 @@ func (t *Tailer) Stop() {
 	log.Infof("Stop tailing container: %v", ShortContainerID(t.ContainerID))
 	t.stop <- struct{}{}
 
-	t.tagProvider.Stop()
 	t.reader.Close()
 	// no-op if already closed because of a timeout
 	t.cancelFunc()
@@ -148,7 +147,6 @@ func (t *Tailer) tail(since string) error {
 	t.source.Status.Success()
 	t.source.AddInput(t.ContainerID)
 
-	t.tagProvider.Start()
 	go t.forwardMessages()
 	t.decoder.Start()
 	go t.readForever()

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -112,7 +112,6 @@ func (t *Tailer) Start(offset int64, whence int) error {
 	t.source.Status.Success()
 	t.source.AddInput(t.path)
 
-	t.tagProvider.Start()
 	go t.forwardMessages()
 	t.decoder.Start()
 	go t.readForever()
@@ -193,7 +192,6 @@ func (t *Tailer) StartFromBeginning() error {
 func (t *Tailer) Stop() {
 	atomic.StoreInt32(&t.didFileRotate, 0)
 	t.stop <- struct{}{}
-	t.tagProvider.Stop()
 	t.source.RemoveInput(t.path)
 	// wait for the decoder to be flushed
 	<-t.done

--- a/pkg/logs/tag/noop_provider.go
+++ b/pkg/logs/tag/noop_provider.go
@@ -13,9 +13,3 @@ type noopProvider struct {
 func (p *noopProvider) GetTags() []string {
 	return p.tags
 }
-
-// Start does nothing
-func (p *noopProvider) Start() {}
-
-// Stop does nothing
-func (p *noopProvider) Stop() {}

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -10,8 +10,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const refreshPeriod = 10 * time.Second
@@ -28,32 +30,77 @@ var NoopProvider Provider = &noopProvider{}
 
 // provider caches a list of up-to-date tags for a given entity polling periodically the tagger.
 type provider struct {
-	entityID string
-	tags     []string
-	done     chan struct{}
-	mu       sync.Mutex
+	entityID             string
+	tags                 []string
+	done                 chan struct{}
+	forceRefresh         bool
+	forceRefreshDuration time.Duration
+	taggerWarmupDuration time.Duration
+	mu                   sync.Mutex
+	sync.Once
 }
 
 // NewProvider returns a new Provider.
 func NewProvider(entityID string) Provider {
-	return &provider{
+	p := &provider{
 		entityID: entityID,
 		tags:     []string{},
 		done:     make(chan struct{}),
 	}
+	config := config.TagProviderConfig()
+	p.forceRefresh = config.ForceRefresh
+	p.forceRefreshDuration = config.ForceRefreshDuration
+	p.taggerWarmupDuration = config.TaggerWarmupDuration
+	return p
 }
 
 // GetTags returns the list of up-to-date tags.
+// if logs_config.k8s_wait_for_tags enabled:
+//   - GetTags waits on its first call before updating the local cache for 2 seconds (default)
+//   - GetTags forces updating the local cache for 5 seconds (default)
 func (p *provider) GetTags() []string {
+	p.Do(func() {
+		// Warmup duration
+		// Make sure the tagger collects all the service tags
+		<-time.After(p.taggerWarmupDuration)
+	})
+	if p.getForceRefresh() {
+		p.updateTags()
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.tags
 }
 
+// setForceRefresh udpates the forceRefresh attribute
+func (p *provider) setForceRefresh(b bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.forceRefresh = b
+}
+
+// getForceRefresh returns the forceRefresh attribute
+func (p *provider) getForceRefresh() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.forceRefresh
+}
+
 // Start starts the polling of new tags on another go routine.
+// Start calls the updateTags method before it returns to make sure
+// the local tag cache is populated when GetTags is called
 func (p *provider) Start() {
+	p.updateTags()
 	go func() {
-		p.updateTags()
+		select {
+		case <-p.done:
+			return
+		case <-time.After(p.forceRefreshDuration):
+			// Block updating tags cache
+			// during this time GetTags forces the update
+			p.setForceRefresh(false)
+			break
+		}
 		ticker := time.NewTicker(refreshPeriod)
 		defer ticker.Stop()
 		for {
@@ -77,7 +124,11 @@ func (p *provider) updateTags() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	tags, err := tagger.Tag(p.entityID, collectors.HighCardinality)
-	if err == nil && !reflect.DeepEqual(tags, p.tags) {
+	if err != nil {
+		log.Debugf("Cannot tag container %s: %v", p.entityID, err)
+		return
+	}
+	if !reflect.DeepEqual(tags, p.tags) {
 		p.tags = tags
 	}
 }

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -6,7 +6,6 @@
 package tag
 
 import (
-	"reflect"
 	"sync"
 	"time"
 
@@ -16,119 +15,41 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const refreshPeriod = 10 * time.Second
-
 // Provider returns a list of up-to-date tags for a given entity.
 type Provider interface {
 	GetTags() []string
-	Start()
-	Stop()
 }
 
 // NoopProvider does nothing
 var NoopProvider Provider = &noopProvider{}
 
-// provider caches a list of up-to-date tags for a given entity polling periodically the tagger.
+// provider provides a list of up-to-date tags for a given entity by calling the tagger.
 type provider struct {
 	entityID             string
-	tags                 []string
-	done                 chan struct{}
-	forceRefresh         bool
-	forceRefreshDuration time.Duration
 	taggerWarmupDuration time.Duration
-	mu                   sync.Mutex
 	sync.Once
 }
 
 // NewProvider returns a new Provider.
 func NewProvider(entityID string) Provider {
-	p := &provider{
-		entityID: entityID,
-		tags:     []string{},
-		done:     make(chan struct{}),
+	return &provider{
+		entityID:             entityID,
+		taggerWarmupDuration: config.TaggerWarmupDuration(),
 	}
-	config := config.TagProviderConfig()
-	p.forceRefresh = config.ForceRefresh
-	p.forceRefreshDuration = config.ForceRefreshDuration
-	p.taggerWarmupDuration = config.TaggerWarmupDuration
-	return p
 }
 
 // GetTags returns the list of up-to-date tags.
-// if logs_config.k8s_wait_for_tags enabled:
-//   - GetTags waits on its first call before updating the local cache for 2 seconds (default)
-//   - GetTags forces updating the local cache for 5 seconds (default)
 func (p *provider) GetTags() []string {
 	p.Do(func() {
 		// Warmup duration
 		// Make sure the tagger collects all the service tags
+		// TODO: remove this once AD and Tagger use the same PodWatcher instance
 		<-time.After(p.taggerWarmupDuration)
 	})
-	if p.getForceRefresh() {
-		p.updateTags()
-	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.tags
-}
-
-// setForceRefresh udpates the forceRefresh attribute
-func (p *provider) setForceRefresh(b bool) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.forceRefresh = b
-}
-
-// getForceRefresh returns the forceRefresh attribute
-func (p *provider) getForceRefresh() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.forceRefresh
-}
-
-// Start starts the polling of new tags on another go routine.
-// Start calls the updateTags method before it returns to make sure
-// the local tag cache is populated when GetTags is called
-func (p *provider) Start() {
-	p.updateTags()
-	go func() {
-		select {
-		case <-p.done:
-			return
-		case <-time.After(p.forceRefreshDuration):
-			// Block updating tags cache
-			// during this time GetTags forces the update
-			p.setForceRefresh(false)
-			break
-		}
-		ticker := time.NewTicker(refreshPeriod)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				p.updateTags()
-			case <-p.done:
-				return
-			}
-		}
-	}()
-}
-
-// Stop stops the polling of new tags.
-func (p *provider) Stop() {
-	p.done <- struct{}{}
-}
-
-// updateTags updates the list of tags using tagger.
-func (p *provider) updateTags() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	tags, err := tagger.Tag(p.entityID, collectors.HighCardinality)
 	if err != nil {
-		log.Debugf("Cannot tag container %s: %v", p.entityID, err)
-		return
+		log.Warnf("Cannot tag container %s: %v", p.entityID, err)
+		return []string{}
 	}
-	if !reflect.DeepEqual(tags, p.tags) {
-		p.tags = tags
-	}
+	return tags
 }

--- a/releasenotes/notes/fix-logs-tagging-350289df776b181f.yaml
+++ b/releasenotes/notes/fix-logs-tagging-350289df776b181f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    It's possible now to reduce the risk of missing kubernetes tags on initial logs by configuring "logs_config.tagger_warmup_duration".
+    Configuring "logs_config.tagger_warmup_duration" delays the send of the first logs of a container.
+    Default value 0 seconds, the fix is disabled by default.
+    Setting "logs_config.tagger_warmup_duration" to 5 (seconds) should be enough to retrieve all the tags.


### PR DESCRIPTION
### What does this PR do?

- Remove the local tag cache in the logs agent, rely on the tagger caching instead
- Resolve missing kubelet tags on initial logs caused by a race between AD and Tagger by introducing a warmup duration (disabled by default)

### Motivation

- Simplify the logs Tag Provider
- Ensure that first logs of a container are tagged with all kubernetes tags

### Additional Notes

- The logs agent calls the Tagger for each logs message now (similar to Dogstatsd)
- The tagger warmup duration fix is temporary, a planned PodWatcher revamp would resolve the race by design
- The tagger warmup duration wait is disabled by default
