### PR TITLE
Amend env var - cloud launcher example

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,8 @@
 /docs/cluster-agent/                    @DataDog/baklava @DataDog/container-integrations
 /docs/dev/checks/                       @DataDog/baklava @DataDog/agent-core
 
+/google-marketplace                     @Datadog/container-integrations
+
 /Gopkg.lock                             @DataDog/agent-all
 /Gopkg.toml                             @DataDog/agent-all
 

--- a/google-marketplace/manifest/application.yaml.template
+++ b/google-marketplace/manifest/application.yaml.template
@@ -60,14 +60,14 @@ spec:
 
       ```
       env:
-      - name: DOGSTATSD_HOST_IP
+      - name: DD_AGENT_HOST
         valueFrom:
           fieldRef:
             fieldPath: status.hostIP
       ```
 
       Now any pod running the application will be able to send DogStatsD metrics
-      via port 8125 on $DOGSTATSD_HOST_IP.
+      via port 8125 on $DD_AGENT_HOST.
   selector:
     matchLabels:
       app.kubernetes.io/name: "$name"


### PR DESCRIPTION
### What does this PR do?

We use `DD_AGENT_HOST` as a "standard" env var to fetch the IP of the DogstatsD server.