### PR TITLE
Make agent version functions take an explicit major version parameter 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2500,7 +2500,7 @@ deploy_dsd:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTIFACTS_URI/dogstatsd/dogstatsd ./dogstatsd
-    - export PACKAGE_VERSION=$(inv agent.version --url-safe)
+    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version $AGENT_MAJOR_VERSION)
     - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy dsd binary to staging bucket
@@ -2515,7 +2515,7 @@ deploy_puppy:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTIFACTS_URI/puppy/agent ./agent
-    - export PACKAGE_VERSION=$(inv agent.version --url-safe)
+    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version $AGENT_MAJOR_VERSION)
     - aws s3 cp --region us-east-1 ./agent $S3_DSD6_URI/puppy/agent-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy process agent and system-probe to staging bucket
@@ -2551,7 +2551,7 @@ tag_release_6:
     AGENT_MAJOR_VERSION: 6
     <<: *docker_hub_variables
   script:
-    - VERSION=$(inv -e agent.version)
+    - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
     # Platform-specific agent images
     - inv -e docker.publish-bulk --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-py2-ARCH      --dst-template datadog/agent-ARCH:${VERSION}
     - inv -e docker.publish-bulk --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-py2-jmx-ARCH  --dst-template datadog/agent-ARCH:${VERSION}-jmx
@@ -2568,7 +2568,7 @@ tag_release_7:
     AGENT_MAJOR_VERSION: 7
     <<: *docker_hub_variables
   script:
-    - VERSION=$(inv -e agent.version)
+    - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
     # Images
     - inv -e docker.publish-bulk --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-py3-ARCH      --dst-template datadog/agent-ARCH:${VERSION}
     - inv -e docker.publish-bulk --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-py3-jmx-ARCH  --dst-template datadog/agent-ARCH:${VERSION}-jmx
@@ -2587,7 +2587,7 @@ latest_release_6:
     AGENT_MAJOR_VERSION: 6
     <<: *docker_hub_variables
   script:
-    - VERSION=$(inv -e agent.version)
+    - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag latest-py2        --template datadog/agent-ARCH:${VERSION}
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag latest-py2-jmx    --template datadog/agent-ARCH:${VERSION}-jmx
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag 6                 --template datadog/agent-ARCH:${VERSION}
@@ -2602,7 +2602,7 @@ latest_release_7:
     AGENT_MAJOR_VERSION: 7
     <<: *docker_hub_variables
   script:
-    - VERSION=$(inv -e agent.version)
+    - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag latest      --template datadog/agent-ARCH:${VERSION}
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag latest-jmx  --template datadog/agent-ARCH:${VERSION}-jmx
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag 7           --template datadog/agent-ARCH:${VERSION}
@@ -2730,20 +2730,20 @@ pupernetes-tags-6:
   <<: *pupernetes_template
   <<: *run_when_triggered_on_tag_6
   variables:
-    PYTHON_RUNTIMES: '2,3'
+    AGENT_MAJOR_VERSION: 6
   when: manual
   script:
-  - VERSION=$(inv -e agent.version)
+  - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
   - inv -e e2e-tests --image=datadog/agent:${VERSION}
 
 pupernetes-tags-7:
   <<: *pupernetes_template
   <<: *run_when_triggered_on_tag_7
   variables:
-    PYTHON_RUNTIMES: '3'
+    AGENT_MAJOR_VERSION: 7
   when: manual
   script:
-  - VERSION=$(inv -e agent.version)
+  - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
   - inv -e e2e-tests --image=datadog/agent:${VERSION}
 
 notify-on-failure:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -453,7 +453,7 @@ run_dogstatsd_size_test:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -name "datadog-agent*_${PACKAGE_ARCH}.deb" -exec dpkg -c {} \;
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-agent_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DEB
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-agent-dbg_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DBG_DEB
@@ -484,6 +484,7 @@ agent_deb-x64-a6:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     CONDA_ENV: ddpy3
+    AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: amd64
     DESTINATION_DEB: 'datadog-agent_6_amd64.deb'
@@ -503,6 +504,7 @@ agent_deb-x64-a7:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     CONDA_ENV: ddpy3
+    AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: amd64
     DESTINATION_DEB: 'datadog-agent_7_amd64.deb'
@@ -518,6 +520,7 @@ agent_deb-arm-a6:
   extends: .agent_build_common_arm
   variables:
     PKG_TARGET: deb_arm_x64
+    AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: arm64
     DESTINATION_DEB: 'datadog-agent_6_arm64.deb'
@@ -533,6 +536,7 @@ agent_deb-arm-a7:
   extends: .agent_build_common_arm
   variables:
     PKG_TARGET: deb_arm_x64
+    AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: arm64
     DESTINATION_DEB: 'datadog-agent_7_arm64.deb'
@@ -565,7 +569,7 @@ puppy_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR --skip-deps
+    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION_7" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -name "datadog-puppy*_amd64.deb" -exec dpkg -c {} \;
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb $S3_ARTIFACTS_URI/datadog-puppy_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -593,7 +597,7 @@ puppy_deb-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # use --skip-deps since the deps are installed by `before_script`
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR  ${USE_S3_CACHING} --skip-deps
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR  ${USE_S3_CACHING} --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -type f -name '*.rpm' ! -name '*dbg*.rpm' -print0 | xargs -0 -I '{}' rpm -i '{}'
     - find $OMNIBUS_BASE_DIR/pkg -type f -name '*dbg*.rpm' -print0 | xargs -0 -I '{}' rpm -i '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -615,6 +619,7 @@ agent_rpm-x64-a6:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+    AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
     CONDA_ENV: ddpy3
   before_script:
@@ -631,6 +636,7 @@ agent_rpm-x64-a7:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+    AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
   before_script:
@@ -645,6 +651,7 @@ agent_rpm-arm-a6:
   extends: .agent_build_common_arm
   variables:
     PKG_TARGET: rpm_arm_x64
+    AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
   before_script:
     - source /root/.bashrc
@@ -658,6 +665,7 @@ agent_rpm-arm-a7:
   extends: .agent_build_common_arm
   variables:
     PKG_TARGET: rpm_arm_x64
+    AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
   before_script:
     - source /root/.bashrc
@@ -680,7 +688,7 @@ agent_rpm-arm-a7:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # use --skip-deps since the deps are installed by `before_script`
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE ${USE_S3_CACHING} --skip-deps
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE ${USE_S3_CACHING} --skip-deps
     - find $OMNIBUS_BASE_DIR_SUSE/pkg -type f -name '*.rpm' ! -name '*dbg*.rpm' -print0 | xargs -0 -I '{}' zypper in '{}'
     - find $OMNIBUS_BASE_DIR_SUSE/pkg -type f -name '*dbg*.rpm' -print0 | xargs -0 -I '{}' zypper in '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR_SUSE && cp $OMNIBUS_BASE_DIR_SUSE/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR_SUSE
@@ -705,6 +713,7 @@ agent_suse-x64-a6:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+    AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
@@ -719,6 +728,7 @@ agent_suse-x64-a7:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+    AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
   before_script:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
@@ -741,7 +751,7 @@ agent_suse-x64-a7:
     - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir .omnibus\pkg
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat --release-version %RELEASE_VERSION%
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e AGENT_MAJOR_VERSION=${AGENT_MAJOR_VERSION} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat --release-version %RELEASE_VERSION%
     - copy build-out\*.msi .omnibus\pkg
   artifacts:
     expire_in: 2 weeks
@@ -752,6 +762,7 @@ dockerbuild_windows_msi_x64-a7:
   extends: .dockerbuild_windows_msi_base
   variables:
     ARCH: "x64"
+    AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
   before_script:
     - set RELEASE_VERSION %RELEASE_VERSION_7%
@@ -761,6 +772,7 @@ dockerbuild_windows_msi_x86-a7:
   extends: .dockerbuild_windows_msi_base
   variables:
     ARCH: "x86"
+    AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
   before_script:
     - set RELEASE_VERSION %RELEASE_VERSION_7%
@@ -770,6 +782,7 @@ dockerbuild_windows_msi_x64-a6:
   extends: .dockerbuild_windows_msi_base
   variables:
     ARCH: "x64"
+    AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
   before_script:
     - set RELEASE_VERSION %RELEASE_VERSION_6%
@@ -779,6 +792,7 @@ dockerbuild_windows_msi_x86-a6:
   extends: .dockerbuild_windows_msi_base
   variables:
     ARCH: "x86"
+    AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
   before_script:
     - set RELEASE_VERSION %RELEASE_VERSION_6%
@@ -836,7 +850,7 @@ dogstatsd_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -name "datadog-dogstatsd*_amd64.deb" -exec dpkg -c {} \;
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb $S3_ARTIFACTS_URI/datadog-dogstatsd_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -875,7 +889,7 @@ dogstatsd_rpm-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -type f -name '*.rpm' -print0 | sort -z | xargs -0 -I '{}' rpm -i '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -321,7 +321,7 @@ build_dogstatsd_static-deb_x64:
     - source /root/.bashrc && conda activate ddpy3
     - inv deps --verbose --dep-vendor-only
   script:
-    - inv -e dogstatsd.build --static
+    - inv -e dogstatsd.build --static --major-version "$AGENT_MAJOR_VERSION"
     - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd
 
 # build puppy agent for deb-x64, to make sure the build is not broken because of build flags
@@ -335,7 +335,7 @@ build_puppy_agent-deb_x64:
     - source /root/.bashrc && conda activate ddpy3
     - inv deps --verbose --dep-vendor-only --no-checks
   script:
-    - inv -e agent.build --puppy
+    - inv -e agent.build --puppy --major-version "$AGENT_MAJOR_VERSION"
     - $S3_CP_CMD $SRC_PATH/$AGENT_BINARIES_DIR/agent $S3_ARTIFACTS_URI/puppy/agent
 
 # build puppy agent for ARM, to make sure the build is not broken because of build targets
@@ -349,7 +349,7 @@ build_puppy_agent-deb_x64_arm:
     - source /root/.bashrc && conda activate ddpy3
     - inv deps --verbose --dep-vendor-only --no-checks
   script:
-    - GOOS=linux GOARCH=arm inv -e agent.build --puppy
+    - GOOS=linux GOARCH=arm inv -e agent.build --puppy --major-version "$AGENT_MAJOR_VERSION"
 
 # build dogstatsd for deb-x64
 build_dogstatsd-deb_x64:
@@ -362,7 +362,7 @@ build_dogstatsd-deb_x64:
     - source /root/.bashrc && conda activate ddpy3
     - inv deps --verbose --dep-vendor-only
   script:
-    - inv -e dogstatsd.build
+    - inv -e dogstatsd.build --major-version "$AGENT_MAJOR_VERSION"
     - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/dogstatsd/dogstatsd
 
 
@@ -806,6 +806,7 @@ agent_android_apk:
   tags: [ "runner:main", "size:large" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+    AGENT_MAJOR_VERSION: 7
   <<: *skip_when_unwanted_on_6
   before_script:
     - echo running android before_script
@@ -824,7 +825,7 @@ agent_android_apk:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # for now do the steps manually.  Should eventually move this to an invoke
     # task
-    - inv -e android.build
+    - inv -e android.build --major-version "$AGENT_MAJOR_VERSION"
     - mkdir -p $OMNIBUS_PACKAGE_DIR
     - cp ./bin/agent/ddagent-*-unsigned.apk $OMNIBUS_PACKAGE_DIR
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -315,13 +315,11 @@ build_dogstatsd_static-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  variables:
-    AGENT_MAJOR_VERSION: 7
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only
   script:
-    - inv -e dogstatsd.build --static --major-version "$AGENT_MAJOR_VERSION"
+    - inv -e dogstatsd.build --static --major-version 7
     - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd
 
 # build dogstatsd for deb-x64
@@ -329,13 +327,11 @@ build_dogstatsd-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  variables:
-    AGENT_MAJOR_VERSION: 7
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only
   script:
-    - inv -e dogstatsd.build --major-version "$AGENT_MAJOR_VERSION"
+    - inv -e dogstatsd.build --major-version 7
     - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/dogstatsd/dogstatsd
 
 # build dogstatsd static for deb-arm
@@ -344,7 +340,6 @@ build_dogstatsd_static-deb_arm64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
-    AGENT_MAJOR_VERSION: 7
     ARCH: arm64
   before_script:
     - source /root/.bashrc
@@ -354,7 +349,7 @@ build_dogstatsd_static-deb_arm64:
     - cd $SRC_PATH
     - inv -e deps --verbose --dep-vendor-only
   script:
-    - inv -e dogstatsd.build --static --major-version "$AGENT_MAJOR_VERSION"
+    - inv -e dogstatsd.build --static --major-version 7
     - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd.$ARCH
 
 # build dogstatsd linked for deb-arm
@@ -363,7 +358,6 @@ build_dogstatsd-deb_arm64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
-    AGENT_MAJOR_VERSION: 7
     ARCH: arm64
   before_script:
     - source /root/.bashrc
@@ -373,7 +367,7 @@ build_dogstatsd-deb_arm64:
     - cd $SRC_PATH
     - inv -e deps --verbose --dep-vendor-only
   script:
-    - inv -e dogstatsd.build --major-version "$AGENT_MAJOR_VERSION"
+    - inv -e dogstatsd.build --major-version 7
     - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/dogstatsd/dogstatsd.$ARCH
 
 # build puppy agent for deb-x64, to make sure the build is not broken because of build flags
@@ -381,13 +375,11 @@ build_puppy_agent-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  variables:
-    AGENT_MAJOR_VERSION: 7
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only --no-checks
   script:
-    - inv -e agent.build --puppy --major-version "$AGENT_MAJOR_VERSION"
+    - inv -e agent.build --puppy --major-version 7
     - $S3_CP_CMD $SRC_PATH/$AGENT_BINARIES_DIR/agent $S3_ARTIFACTS_URI/puppy/agent
 
 # build puppy agent for ARM, to make sure the build is not broken because of build targets
@@ -396,7 +388,6 @@ build_puppy_agent-deb_arm64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
-    AGENT_MAJOR_VERSION: 7
     ARCH: arm64
   before_script:
     - source /root/.bashrc
@@ -406,7 +397,7 @@ build_puppy_agent-deb_arm64:
     - cd $SRC_PATH
     - inv -e deps --verbose --dep-vendor-only --no-checks
   script:
-    - GOOS=linux GOARCH=arm inv -e agent.build --puppy --major-version "$AGENT_MAJOR_VERSION"
+    - GOOS=linux GOARCH=arm inv -e agent.build --puppy --major-version 7
 
 .cluster_agent-build_common: &cluster_agent-build_common
   stage: binary_build
@@ -611,9 +602,6 @@ puppy_deb-x64:
   needs: ["build_puppy_agent-deb_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
-    AGENT_MAJOR_VERSION: 7
-    # FIXME: we set PYTHON_RUNTIMES to '3' here so that `inv agent.omnibus-build` picks up the v7 tag
-    PYTHON_RUNTIMES: '3'
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only --no-checks
@@ -624,7 +612,7 @@ puppy_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION_7" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR --skip-deps
+    - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -name "datadog-puppy*_amd64.deb" -exec dpkg -c {} \;
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb $S3_ARTIFACTS_URI/datadog-puppy_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-puppy*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -865,7 +853,6 @@ agent_android_apk:
   tags: [ "runner:main", "size:large" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
-    AGENT_MAJOR_VERSION: 7
   <<: *skip_when_unwanted_on_7
   before_script:
     - echo running android before_script
@@ -884,7 +871,7 @@ agent_android_apk:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # for now do the steps manually.  Should eventually move this to an invoke
     # task
-    - inv -e android.build --major-version "$AGENT_MAJOR_VERSION"
+    - inv -e android.build --major-version 7
     - mkdir -p $OMNIBUS_PACKAGE_DIR
     - cp ./bin/agent/ddagent-*-unsigned.apk $OMNIBUS_PACKAGE_DIR
   artifacts:
@@ -900,7 +887,6 @@ dogstatsd_deb-x64:
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
-    AGENT_MAJOR_VERSION: 7
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only
@@ -910,7 +896,7 @@ dogstatsd_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -name "datadog-dogstatsd*_amd64.deb" -exec dpkg -c {} \;
     - $S3_CP_CMD $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb $S3_ARTIFACTS_URI/datadog-dogstatsd_amd64.deb
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/datadog-dogstatsd*_amd64.deb{,.metadata.json} $OMNIBUS_PACKAGE_DIR
@@ -933,7 +919,6 @@ dogstatsd_rpm-x64:
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
-    AGENT_MAJOR_VERSION: 7
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only
@@ -949,7 +934,7 @@ dogstatsd_rpm-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps
     - find $OMNIBUS_BASE_DIR/pkg -type f -name '*.rpm' -print0 | sort -z | xargs -0 -I '{}' rpm -i '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR && cp $OMNIBUS_BASE_DIR/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -972,7 +957,6 @@ dogstatsd_suse-x64:
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
-    AGENT_MAJOR_VERSION: 7
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
@@ -985,7 +969,7 @@ dogstatsd_suse-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE ${USE_S3_CACHING} --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR_SUSE ${USE_S3_CACHING} --skip-deps
     - find $OMNIBUS_BASE_DIR_SUSE/pkg -type f -name '*.rpm' -print0 | sort -z | xargs -0 -I '{}' rpm -i '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR_SUSE && cp $OMNIBUS_BASE_DIR_SUSE/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR_SUSE
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -2567,14 +2551,12 @@ deploy_dsd:
   <<: *run_when_triggered
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
-  variables:
-    AGENT_MAJOR_VERSION: 7
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTIFACTS_URI/dogstatsd/dogstatsd ./dogstatsd
-    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version $AGENT_MAJOR_VERSION)
+    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)
     - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy dsd binary to staging bucket
@@ -2582,14 +2564,12 @@ deploy_puppy:
   <<: *run_when_triggered
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
-  variables:
-    AGENT_MAJOR_VERSION: 7
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTIFACTS_URI/puppy/agent ./agent
-    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version $AGENT_MAJOR_VERSION)
+    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)
     - aws s3 cp --region us-east-1 ./agent $S3_DSD6_URI/puppy/agent-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy process agent and system-probe to staging bucket
@@ -2622,10 +2602,9 @@ tag_release_6:
   stage: deploy6
   when: manual
   variables:
-    AGENT_MAJOR_VERSION: 6
     <<: *docker_hub_variables
   script:
-    - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
+    - VERSION=$(inv -e agent.version --major-version 6)
     # Platform-specific agent images
     - inv -e docker.publish-bulk --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-py2-ARCH      --dst-template datadog/agent-ARCH:${VERSION}
     - inv -e docker.publish-bulk --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-py2-jmx-ARCH  --dst-template datadog/agent-ARCH:${VERSION}-jmx
@@ -2639,10 +2618,9 @@ tag_release_7:
   stage: deploy7
   when: manual
   variables:
-    AGENT_MAJOR_VERSION: 7
     <<: *docker_hub_variables
   script:
-    - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
+    - VERSION=$(inv -e agent.version --major-version 7)
     # Images
     - inv -e docker.publish-bulk --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-py3-ARCH      --dst-template datadog/agent-ARCH:${VERSION}
     - inv -e docker.publish-bulk --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-py3-jmx-ARCH  --dst-template datadog/agent-ARCH:${VERSION}-jmx
@@ -2658,10 +2636,9 @@ latest_release_6:
   stage: deploy6
   when: manual
   variables:
-    AGENT_MAJOR_VERSION: 6
     <<: *docker_hub_variables
   script:
-    - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
+    - VERSION=$(inv -e agent.version --major-version 6)
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag latest-py2        --template datadog/agent-ARCH:${VERSION}
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag latest-py2-jmx    --template datadog/agent-ARCH:${VERSION}-jmx
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag 6                 --template datadog/agent-ARCH:${VERSION}
@@ -2673,10 +2650,9 @@ latest_release_7:
   stage: deploy7
   when: manual
   variables:
-    AGENT_MAJOR_VERSION: 7
     <<: *docker_hub_variables
   script:
-    - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
+    - VERSION=$(inv -e agent.version --major-version 7)
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag latest      --template datadog/agent-ARCH:${VERSION}
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag latest-jmx  --template datadog/agent-ARCH:${VERSION}-jmx
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent --tag 7           --template datadog/agent-ARCH:${VERSION}
@@ -2803,21 +2779,17 @@ pupernetes-master:
 pupernetes-tags-6:
   <<: *pupernetes_template
   <<: *run_when_triggered_on_tag_6
-  variables:
-    AGENT_MAJOR_VERSION: 6
   when: manual
   script:
-  - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
+  - VERSION=$(inv -e agent.version --major-version 6)
   - inv -e e2e-tests --image=datadog/agent:${VERSION}
 
 pupernetes-tags-7:
   <<: *pupernetes_template
   <<: *run_when_triggered_on_tag_7
-  variables:
-    AGENT_MAJOR_VERSION: 7
   when: manual
   script:
-  - VERSION=$(inv -e agent.version --major-version $AGENT_MAJOR_VERSION)
+  - VERSION=$(inv -e agent.version --major-version 7)
   - inv -e e2e-tests --image=datadog/agent:${VERSION}
 
 notify-on-failure:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -798,7 +798,7 @@ agent_suse-x64-a7:
     - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir .omnibus\pkg
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat $RELEASE_VERSION $AGENT_MAJOR_VERSION
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\build-agent6.bat $RELEASE_VERSION $AGENT_MAJOR_VERSION
     - copy build-out\*.msi .omnibus\pkg
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -866,7 +866,7 @@ agent_android_apk:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 7
-  <<: *skip_when_unwanted_on_6
+  <<: *skip_when_unwanted_on_7
   before_script:
     - echo running android before_script
     - cd $SRC_PATH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -798,7 +798,7 @@ agent_suse-x64-a7:
     - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir .omnibus\pkg
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e AGENT_MAJOR_VERSION=${AGENT_MAJOR_VERSION} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\build-agent6.bat --release-version %RELEASE_VERSION%
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\build-agent6.bat --release-version %RELEASE_VERSION% --major-version %AGENT_MAJOR_VERSION%
     - copy build-out\*.msi .omnibus\pkg
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -926,7 +926,7 @@ dogstatsd_suse-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --base-dir $OMNIBUS_BASE_DIR_SUSE ${USE_S3_CACHING} --skip-deps
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version "$AGENT_MAJOR_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE ${USE_S3_CACHING} --skip-deps
     - find $OMNIBUS_BASE_DIR_SUSE/pkg -type f -name '*.rpm' -print0 | sort -z | xargs -0 -I '{}' rpm -i '{}'
     - mkdir -p $OMNIBUS_PACKAGE_DIR_SUSE && cp $OMNIBUS_BASE_DIR_SUSE/pkg/*.{rpm,metadata.json} $OMNIBUS_PACKAGE_DIR_SUSE
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1176,23 +1176,23 @@ deploy_windows_testing-a7:
 
 .kitchen_chef_common: &kitchen_chef_common
   script:
-    - bash -l tasks/run-test-kitchen.sh chef-test
+    - bash -l tasks/run-test-kitchen.sh chef-test $AGENT_MAJOR_VERSION
 
 .kitchen_step_by_step_common: &kitchen_step_by_step_common
   script:
-    - bash -l tasks/run-test-kitchen.sh step-by-step-test
+    - bash -l tasks/run-test-kitchen.sh step-by-step-test $AGENT_MAJOR_VERSION
 
 .kitchen_install_script_common: &kitchen_install_script_common
   script:
-    - bash -l tasks/run-test-kitchen.sh install-script-test
+    - bash -l tasks/run-test-kitchen.sh install-script-test $AGENT_MAJOR_VERSION
 
 .kitchen_upgrade5_common: &kitchen_upgrade5_common
   script:
-    - bash -l tasks/run-test-kitchen.sh upgrade5-test
+    - bash -l tasks/run-test-kitchen.sh upgrade5-test $AGENT_MAJOR_VERSION
 
 .kitchen_upgrade6_common: &kitchen_upgrade6_common
   script:
-    - bash -l tasks/run-test-kitchen.sh upgrade6-test
+    - bash -l tasks/run-test-kitchen.sh upgrade6-test $AGENT_MAJOR_VERSION
 
 .kitchen_windows_installer_common: &kitchen_windows_installer_common
   <<: *kitchen_common
@@ -1201,7 +1201,7 @@ deploy_windows_testing-a7:
     - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190603"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
-    - bash -l tasks/run-test-kitchen.sh windows-install-test
+    - bash -l tasks/run-test-kitchen.sh windows-install-test $AGENT_MAJOR_VERSION
 
 .kitchen_windows_a6_common: &kitchen_windows_a6_common
   <<: *kitchen_common

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -751,7 +751,7 @@ agent_suse-x64-a7:
     - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir .omnibus\pkg
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e AGENT_MAJOR_VERSION=${AGENT_MAJOR_VERSION} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES \build-agent6.bat --release-version %RELEASE_VERSION%
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e WINDOWS_BUILDER=true -e PYTHON_RUNTIMES=${PYTHON_RUNTIMES} -e AGENT_MAJOR_VERSION=${AGENT_MAJOR_VERSION} -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\build-agent6.bat --release-version %RELEASE_VERSION%
     - copy build-out\*.msi .omnibus\pkg
   artifacts:
     expire_in: 2 weeks

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -60,12 +60,12 @@ build do
     platform = windows_arch_i386? ? "x86" : "x64"
     command "inv -e rtloader.build --install-prefix \"#{windows_safe_path(python_2_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\"\" --arch #{platform}", :env => env
     command "mv rtloader/bin/*.dll  #{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent/"
-    command "inv -e agent.build --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded #{with_both_python} --arch #{platform}", env: env
-    command "inv -e systray.build --rebuild --no-development --arch #{platform}", env: env
+    command "inv -e agent.build --major-version $MAJOR_VERSION --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded #{with_both_python} --arch #{platform}", env: env
+    command "inv -e systray.build --major-version $MAJOR_VERSION --rebuild --no-development --arch #{platform}", env: env
   else
     command "inv -e rtloader.build --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER'", :env => env
     command "inv -e rtloader.install"
-    command "inv -e agent.build --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded #{with_both_python}", env: env
+    command "inv -e agent.build --major-version $MAJOR_VERSION --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded #{with_both_python}", env: env
   end
 
   if osx?
@@ -83,7 +83,7 @@ build do
   ## build the custom action library required for the install
   if windows?
     platform = windows_arch_i386? ? "x86" : "x64"
-    command "invoke customaction.build --arch=" + platform
+    command "invoke customaction.build --major-version $MAJOR_VERSION --arch=" + platform
   end
 
   # move around bin and config files
@@ -97,7 +97,7 @@ build do
     # only once the software that the project takes its version from (i.e. `datadog-agent`) has finished building
     env['TRACE_AGENT_VERSION'] = project.build_version.gsub(/[^0-9\.]/, '') # used by gorake.rb in the trace-agent, only keep digits and dots
     platform = windows_arch_i386? ? "x86" : "x64"
-    command "invoke trace-agent.build --arch #{platform}", :env => env
+    command "invoke trace-agent.build --major-version $MAJOR_VERSION --arch #{platform}", :env => env
 
     if windows?
       copy 'bin/trace-agent/trace-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
@@ -110,19 +110,19 @@ build do
   if windows?
     platform = windows_arch_i386? ? "x86" : "x64"
     # Build the process-agent with the correct go version for windows
-    command "invoke -e process-agent.build --arch #{platform}", :env => env
+    command "invoke -e process-agent.build --major-version $MAJOR_VERSION --arch #{platform}", :env => env
 
     copy 'bin/process-agent/process-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
   else
     # TODO(processes): change this to be ebpf:latest when we move to go1.12.x on the agent
-    command "invoke -e process-agent.build --go-version=1.10.1", :env => env
+    command "invoke -e process-agent.build --major-version $MAJOR_VERSION --go-version=1.10.1", :env => env
     copy 'bin/process-agent/process-agent', "#{install_dir}/embedded/bin"
   end
 
 
   # Build the system-probe
   if linux?
-    command "invoke -e system-probe.build --go-version=1.10.1", :env => env
+    command "invoke -e system-probe.build --major-version $MAJOR_VERSION --go-version=1.10.1", :env => env
     copy 'bin/system-probe/system-probe', "#{install_dir}/embedded/bin"
     block { File.chmod(0755, "#{install_dir}/embedded/bin/system-probe") }
   end

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -60,8 +60,8 @@ build do
     platform = windows_arch_i386? ? "x86" : "x64"
     command "inv -e rtloader.build --install-prefix \"#{windows_safe_path(python_2_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\"\" --arch #{platform}", :env => env
     command "mv rtloader/bin/*.dll  #{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent/"
-    command "inv -e agent.build --major-version $MAJOR_VERSION --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded #{with_both_python} --arch #{platform}", env: env
-    command "inv -e systray.build --major-version $MAJOR_VERSION --rebuild --no-development --arch #{platform}", env: env
+    command "inv -e agent.build --major-version %MAJOR_VERSION% --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded #{with_both_python} --arch #{platform}", env: env
+    command "inv -e systray.build --major-version %MAJOR_VERSION% --rebuild --no-development --arch #{platform}", env: env
   else
     command "inv -e rtloader.build --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER'", :env => env
     command "inv -e rtloader.install"
@@ -83,7 +83,7 @@ build do
   ## build the custom action library required for the install
   if windows?
     platform = windows_arch_i386? ? "x86" : "x64"
-    command "invoke customaction.build --major-version $MAJOR_VERSION --arch=" + platform
+    command "invoke customaction.build --major-version %MAJOR_VERSION% --arch=" + platform
   end
 
   # move around bin and config files
@@ -97,11 +97,12 @@ build do
     # only once the software that the project takes its version from (i.e. `datadog-agent`) has finished building
     env['TRACE_AGENT_VERSION'] = project.build_version.gsub(/[^0-9\.]/, '') # used by gorake.rb in the trace-agent, only keep digits and dots
     platform = windows_arch_i386? ? "x86" : "x64"
-    command "invoke trace-agent.build --major-version $MAJOR_VERSION --arch #{platform}", :env => env
 
     if windows?
+      command "invoke trace-agent.build --major-version %MAJOR_VERSION% --arch #{platform}", :env => env
       copy 'bin/trace-agent/trace-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
     else
+      command "invoke trace-agent.build --major-version $MAJOR_VERSION --arch #{platform}", :env => env
       copy 'bin/trace-agent/trace-agent', "#{install_dir}/embedded/bin"
     end
   end
@@ -110,7 +111,7 @@ build do
   if windows?
     platform = windows_arch_i386? ? "x86" : "x64"
     # Build the process-agent with the correct go version for windows
-    command "invoke -e process-agent.build --major-version $MAJOR_VERSION --arch #{platform}", :env => env
+    command "invoke -e process-agent.build --major-version %MAJOR_VERSION% --arch #{platform}", :env => env
 
     copy 'bin/process-agent/process-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
   else

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -29,6 +29,7 @@ build do
         "Python3_ROOT_DIR" => "#{windows_safe_path(python_3_embedded)}",
         "CMAKE_INSTALL_PREFIX" => "#{windows_safe_path(python_2_embedded)}",
     }
+    major_version_arg = "%MAJOR_VERSION%"
   else
     env = {
         'GOPATH' => gopath.to_path,
@@ -37,6 +38,7 @@ build do
         "Python3_ROOT_DIR" => "#{install_dir}/embedded",
         "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
     }
+    major_version_arg = "$MAJOR_VERSION"
   end
 
   # include embedded path (mostly for `pkg-config` binary)
@@ -60,12 +62,12 @@ build do
     platform = windows_arch_i386? ? "x86" : "x64"
     command "inv -e rtloader.build --install-prefix \"#{windows_safe_path(python_2_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\"\" --arch #{platform}", :env => env
     command "mv rtloader/bin/*.dll  #{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent/"
-    command "inv -e agent.build --major-version %MAJOR_VERSION% --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded #{with_both_python} --arch #{platform}", env: env
-    command "inv -e systray.build --major-version %MAJOR_VERSION% --rebuild --no-development --arch #{platform}", env: env
+    command "inv -e agent.build --major-version #{major_version_arg} --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded #{with_both_python} --arch #{platform}", env: env
+    command "inv -e systray.build --major-version #{major_version_arg} --rebuild --no-development --arch #{platform}", env: env
   else
     command "inv -e rtloader.build --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER'", :env => env
     command "inv -e rtloader.install"
-    command "inv -e agent.build --major-version $MAJOR_VERSION --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded #{with_both_python}", env: env
+    command "inv -e agent.build --major-version #{major_version_arg} --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded #{with_both_python}", env: env
   end
 
   if osx?
@@ -83,7 +85,7 @@ build do
   ## build the custom action library required for the install
   if windows?
     platform = windows_arch_i386? ? "x86" : "x64"
-    command "invoke customaction.build --major-version %MAJOR_VERSION% --arch=" + platform
+    command "invoke customaction.build --major-version #{major_version_arg} --arch=" + platform
   end
 
   # move around bin and config files
@@ -97,12 +99,11 @@ build do
     # only once the software that the project takes its version from (i.e. `datadog-agent`) has finished building
     env['TRACE_AGENT_VERSION'] = project.build_version.gsub(/[^0-9\.]/, '') # used by gorake.rb in the trace-agent, only keep digits and dots
     platform = windows_arch_i386? ? "x86" : "x64"
+    command "invoke trace-agent.build --major-version #{major_version_arg} --arch #{platform}", :env => env
 
     if windows?
-      command "invoke trace-agent.build --major-version %MAJOR_VERSION% --arch #{platform}", :env => env
       copy 'bin/trace-agent/trace-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
     else
-      command "invoke trace-agent.build --major-version $MAJOR_VERSION --arch #{platform}", :env => env
       copy 'bin/trace-agent/trace-agent', "#{install_dir}/embedded/bin"
     end
   end
@@ -111,19 +112,19 @@ build do
   if windows?
     platform = windows_arch_i386? ? "x86" : "x64"
     # Build the process-agent with the correct go version for windows
-    command "invoke -e process-agent.build --major-version %MAJOR_VERSION% --arch #{platform}", :env => env
+    command "invoke -e process-agent.build --major-version #{major_version_arg} --arch #{platform}", :env => env
 
     copy 'bin/process-agent/process-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
   else
     # TODO(processes): change this to be ebpf:latest when we move to go1.12.x on the agent
-    command "invoke -e process-agent.build --major-version $MAJOR_VERSION --go-version=1.10.1", :env => env
+    command "invoke -e process-agent.build --major-version #{major_version_arg} --go-version=1.10.1", :env => env
     copy 'bin/process-agent/process-agent', "#{install_dir}/embedded/bin"
   end
 
 
   # Build the system-probe
   if linux?
-    command "invoke -e system-probe.build --major-version $MAJOR_VERSION --go-version=1.10.1", :env => env
+    command "invoke -e system-probe.build --major-version #{major_version_arg} --go-version=1.10.1", :env => env
     copy 'bin/system-probe/system-probe', "#{install_dir}/embedded/bin"
     block { File.chmod(0755, "#{install_dir}/embedded/bin/system-probe") }
   end

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -22,7 +22,7 @@ build do
   }
 
   # we assume the go deps are already installed before running omnibus
-  command "invoke dogstatsd.build --rebuild", env: env
+  command "invoke dogstatsd.build --rebuild --major-version $MAJOR_VERSION", env: env
 
   mkdir "#{install_dir}/etc/datadog-dogstatsd"
   unless windows?

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -21,8 +21,14 @@ build do
     'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
   }
 
+  if windows?
+    major_version_arg = "%MAJOR_VERSION%"
+  else
+    major_version_arg = "$MAJOR_VERSION"
+  end
+
   # we assume the go deps are already installed before running omnibus
-  command "invoke dogstatsd.build --rebuild --major-version $MAJOR_VERSION", env: env
+  command "invoke dogstatsd.build --rebuild --major-version #{major_version_arg}", env: env
 
   mkdir "#{install_dir}/etc/datadog-dogstatsd"
   unless windows?

--- a/omnibus/config/software/datadog-puppy.rb
+++ b/omnibus/config/software/datadog-puppy.rb
@@ -25,7 +25,7 @@ build do
   # include embedded path (mostly for `pkg-config` binary)
   env = with_embedded_path(env)
 
-  command "invoke agent.build --puppy --rebuild --no-development", env: env
+  command "invoke agent.build --puppy --rebuild --no-development --major-version $MAJOR_VERSION", env: env
   copy('bin', install_dir)
 
   mkdir "#{install_dir}/run/"

--- a/omnibus/config/software/datadog-puppy.rb
+++ b/omnibus/config/software/datadog-puppy.rb
@@ -25,7 +25,13 @@ build do
   # include embedded path (mostly for `pkg-config` binary)
   env = with_embedded_path(env)
 
-  command "invoke agent.build --puppy --rebuild --no-development --major-version $MAJOR_VERSION", env: env
+  if windows?
+    major_version_arg = "%MAJOR_VERSION%"
+  else
+    major_version_arg = "$MAJOR_VERSION"
+  end
+
+  command "invoke agent.build --puppy --rebuild --no-development --major-version #{major_version_arg}", env: env
   copy('bin', install_dir)
 
   mkdir "#{install_dir}/run/"

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -81,7 +81,7 @@ PUPPY_CORECHECKS = [
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
           puppy=False, development=True, precompile_only=False, skip_assets=False,
           embedded_path=None, rtloader_root=None, python_home_2=None, python_home_3=None,
-          with_both_python=False, arch='x64'):
+          with_both_python=False, major_version='7', arch='x64'):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -95,7 +95,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
 
     ldflags, gcflags, env = get_build_flags(ctx, embedded_path=embedded_path,
             rtloader_root=rtloader_root, python_home_2=python_home_2, python_home_3=python_home_3,
-            with_both_python=with_both_python, arch=arch)
+            with_both_python=with_both_python, major_version=major_version, arch=arch)
 
     if not sys.platform.startswith('linux'):
         for ex in LINUX_ONLY_TAGS:
@@ -129,7 +129,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
         # This generates the manifest resource. The manifest resource is necessary for
         # being able to load the ancient C-runtime that comes along with Python 2.7
         # command = "rsrc -arch amd64 -manifest cmd/agent/agent.exe.manifest -o cmd/agent/rsrc.syso"
-        ver = get_version_numeric_only(ctx, env)
+        ver = get_version_numeric_only(ctx, env, major_version=major_version)
         build_maj, build_min, build_patch = ver.split(".")
 
         command = "windmc --target {target_arch} -r cmd/agent cmd/agent/agentmsg.mc ".format(target_arch=windres_target)
@@ -398,6 +398,7 @@ def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=No
                 env['SKIP_SIGN_MAC'] = 'true'
 
             env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, major_version=major_version, env=env)
+            env['MAJOR_VERSION'] = major_version
             omnibus_start = datetime.datetime.now()
             ctx.run(cmd.format(**args), env=env)
             omnibus_done = datetime.datetime.now()

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -434,7 +434,7 @@ def clean(ctx):
 
 
 @task
-def version(ctx, url_safe=False, git_sha_length=7):
+def version(ctx, url_safe=False, git_sha_length=7, major_version='7'):
     """
     Get the agent version.
     url_safe: get the version that is able to be addressed as a url
@@ -442,4 +442,4 @@ def version(ctx, url_safe=False, git_sha_length=7):
                     use this to explicitly set the version
                     (the windows builder and the default ubuntu version have such an incompatibility)
     """
-    print(get_version(ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length))
+    print(get_version(ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length, major_version=major_version))

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -329,7 +329,7 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
 
 @task(help={'skip-sign': "On macOS, use this option to build an unsigned package if you don't have Datadog's developer keys."})
 def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=None,
-                  skip_deps=False, skip_sign=False, release_version="nightly", omnibus_s3_cache=False):
+                  skip_deps=False, skip_sign=False, release_version="nightly", major_version='7', omnibus_s3_cache=False):
     """
     Build the Agent packages with Omnibus Installer.
     """
@@ -397,8 +397,7 @@ def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=No
             if skip_sign:
                 env['SKIP_SIGN_MAC'] = 'true'
 
-            env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, env=env)
-
+            env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, major_version=major_version, env=env)
             omnibus_start = datetime.datetime.now()
             ctx.run(cmd.format(**args), env=env)
             omnibus_done = datetime.datetime.now()

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -36,7 +36,7 @@ ANDROID_CORECHECKS = [
 CORECHECK_CONFS_DIR = "cmd/agent/android/app/src/main/assets/conf.d"
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
-        development=True, precompile_only=False, skip_assets=False):
+        development=True, precompile_only=False, skip_assets=False, major_version='7'):
     """
     Build the android apk. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -54,7 +54,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
 
-    ldflags, gcflags, env = get_build_flags(ctx)
+    ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version)
 
     if not sys.platform.startswith('linux'):
         for ex in LINUX_ONLY_TAGS:
@@ -93,7 +93,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
         cmd = "./gradlew --no-daemon build"
     ctx.run(cmd)
     os.chdir(pwd)
-    ver = get_version(ctx, include_git=True, git_sha_length=7)
+    ver = get_version(ctx, include_git=True, git_sha_length=7, major_version=major_version)
     outfile = "bin/agent/ddagent-{}-unsigned.apk".format(ver)
     shutil.copyfile("cmd/agent/android/app/build/outputs/apk/release/app-release-unsigned.apk", outfile)
 

--- a/tasks/customaction.py
+++ b/tasks/customaction.py
@@ -23,7 +23,7 @@ BIN_PATH = os.path.join(".", "bin", "agent")
 AGENT_TAG = "datadog/agent:master"
 
 @task
-def build(ctx, vstudio_root=None, arch="x64", debug=False):
+def build(ctx, vstudio_root=None, arch="x64", major_version='7', debug=False):
     """
     Build the custom action library for the agent
     """
@@ -32,7 +32,7 @@ def build(ctx, vstudio_root=None, arch="x64", debug=False):
         print("Custom action library is only for Win32")
         raise Exit(code=1)
 
-    ver = get_version_numeric_only(ctx, env=os.environ)
+    ver = get_version_numeric_only(ctx, env=os.environ, major_version=major_version)
     build_maj, build_min, build_patch = ver.split(".")
     verprops = " /p:MAJ_VER={build_maj} /p:MIN_VER={build_min} /p:PATCH_VER={build_patch} ".format(
             build_maj=build_maj,

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -33,14 +33,14 @@ DEFAULT_BUILD_TAGS = [
 
 @task
 def build(ctx, rebuild=False, race=False, static=False, build_include=None,
-          build_exclude=None):
+          build_exclude=None, major_version='7'):
     """
     Build Dogstatsd
     """
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     build_tags = get_build_tags(build_include, build_exclude)
-    ldflags, gcflags, env = get_build_flags(ctx, static=static)
+    ldflags, gcflags, env = get_build_flags(ctx, static=static, major_version=major_version)
     bin_path = DOGSTATSD_BIN_PATH
 
     if static:
@@ -158,7 +158,7 @@ def size_test(ctx, skip_build=False):
 
 @task
 def omnibus_build(ctx, log_level="info", base_dir=None, gem_path=None,
-                  skip_deps=False, release_version="nightly", omnibus_s3_cache=False):
+                  skip_deps=False, release_version="nightly", major_version='7', omnibus_s3_cache=False):
     """
     Build the Dogstatsd packages with Omnibus Installer.
     """
@@ -193,7 +193,8 @@ def omnibus_build(ctx, log_level="info", base_dir=None, gem_path=None,
         }
         if omnibus_s3_cache:
             args['populate_s3_cache'] = " --populate-s3-cache "
-        env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, git_sha_length=7)
+        env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, git_sha_length=7, major_version=major_version)
+        env['MAJOR_VERSION'] = major_version
         ctx.run(cmd.format(**args), env=env)
 
 

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -15,12 +15,12 @@ BIN_PATH = os.path.join(BIN_DIR, bin_name("process-agent", android=False))
 GIMME_ENV_VARS = ['GOROOT', 'PATH']
 
 @task
-def build(ctx, race=False, go_version=None, incremental_build=False, puppy=False, arch="x64"):
+def build(ctx, race=False, go_version=None, incremental_build=False, puppy=False, major_version='7', arch="x64"):
     """
     Build the process agent
     """
 
-    ldflags, gcflags, env = get_build_flags(ctx, arch=arch)
+    ldflags, gcflags, env = get_build_flags(ctx, arch=arch, major_version=major_version)
 
     # generate windows resources
     if sys.platform == 'win32':
@@ -29,7 +29,7 @@ def build(ctx, race=False, go_version=None, incremental_build=False, puppy=False
             env["GOARCH"] = "386"
             windres_target = "pe-i386"
 
-        ver = get_version_numeric_only(ctx, env)
+        ver = get_version_numeric_only(ctx, env, major_version=major_version)
         maj_ver, min_ver, patch_ver = ver.split(".")
         resdir = os.path.join(".", "cmd", "process-agent", "windows_resources")
 
@@ -48,7 +48,7 @@ def build(ctx, race=False, go_version=None, incremental_build=False, puppy=False
     # TODO use pkg/version for this
     main = "main."
     ld_vars = {
-        "Version": get_version(ctx),
+        "Version": get_version(ctx, major_version=major_version),
         "GoVersion": get_go_version(),
         "GitBranch": get_git_branch_name(),
         "GitCommit": get_git_commit(),

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -22,7 +22,7 @@ GIMME_ENV_VARS = ['GOROOT', 'PATH']
 
 
 @task
-def build(ctx, race=False, go_version=None, incremental_build=False):
+def build(ctx, race=False, go_version=None, incremental_build=False, major_version='7'):
     """
     Build the system_probe
     """
@@ -32,7 +32,7 @@ def build(ctx, race=False, go_version=None, incremental_build=False):
     # TODO use pkg/version for this
     main = "main."
     ld_vars = {
-        "Version": get_version(ctx),
+        "Version": get_version(ctx, major_version=major_version),
         "GoVersion": get_go_version(),
         "GitBranch": get_git_branch_name(),
         "GitCommit": get_git_commit(),
@@ -49,7 +49,7 @@ def build(ctx, race=False, go_version=None, incremental_build=False):
                     goenv[env_var] = line[line.find(env_var)+len(env_var)+1:-1].strip('\'\"')
         ld_vars["GoVersion"] = go_version
 
-    ldflags, gcflags, env = get_build_flags(ctx)
+    ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version)
 
     # extend PATH from gimme with the one from get_build_flags
     if "PATH" in os.environ and "PATH" in goenv:
@@ -78,7 +78,7 @@ def build(ctx, race=False, go_version=None, incremental_build=False):
 
 
 @task
-def build_in_docker(ctx, rebuild_ebpf_builder=False, race=False, incremental_build=False):
+def build_in_docker(ctx, rebuild_ebpf_builder=False, race=False, incremental_build=False, major_version='7'):
     """
     Build the system_probe using a container
     This can be used when the current OS don't have up to date linux headers
@@ -96,7 +96,7 @@ def build_in_docker(ctx, rebuild_ebpf_builder=False, race=False, incremental_bui
     if should_use_sudo(ctx):
         docker_cmd = "sudo " + docker_cmd
 
-    cmd = "invoke -e system-probe.build"
+    cmd = "invoke -e system-probe.build --major-version {}".format(major_version)
 
     if race:
         cmd += " --race"

--- a/tasks/systray.py
+++ b/tasks/systray.py
@@ -19,7 +19,7 @@ AGENT_TAG = "datadog/agent:master"
 
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
-          puppy=False, development=True, precompile_only=False, skip_assets=False, arch="x64"):
+          puppy=False, development=True, precompile_only=False, skip_assets=False, major_version='7', arch="x64"):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -35,7 +35,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     # This generates the manifest resource. The manifest resource is necessary for
     # being able to load the ancient C-runtime that comes along with Python 2.7
     # command = "rsrc -arch amd64 -manifest cmd/agent/agent.exe.manifest -o cmd/agent/rsrc.syso"
-    ver = get_version_numeric_only(ctx, env=os.environ)
+    ver = get_version_numeric_only(ctx, env=os.environ, major_version=major_version)
     build_maj, build_min, build_patch = ver.split(".")
     env = {}
     windres_target = "pe-x86-64"
@@ -51,7 +51,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     )
     command += "-i cmd/systray/systray.rc -O coff -o cmd/systray/rsrc.syso"
     ctx.run(command)
-    ldflags = get_version_ldflags(ctx)
+    ldflags = get_version_ldflags(ctx, major_version=major_version)
     ldflags += "-s -w -linkmode external -extldflags '-Wl,--subsystem,windows' "
     cmd = "go build {race_opt} {build_type} -o {agent_bin} -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/systray"
     args = {

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -44,7 +44,7 @@ DEFAULT_TEST_TARGETS = [
 @task()
 def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=None,
     verbose=False, race=False, profile=False, fail_on_fmt=False,
-    rtloader_root=None, python_home_2=None, python_home_3=None, cpus=0,
+    rtloader_root=None, python_home_2=None, python_home_3=None, cpus=0, major_version='7',
     timeout=120, arch="x64"):
     """
     Run all the tools and tests on the given targets. If targets are not specified,
@@ -87,7 +87,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
         f_cov.write("mode: count")
 
     ldflags, gcflags, env = get_build_flags(ctx, rtloader_root=rtloader_root,
-            python_home_2=python_home_2, python_home_3=python_home_3, arch=arch)
+            python_home_2=python_home_2, python_home_3=python_home_3, major_version=major_version, arch=arch)
 
     if sys.platform == 'win32':
         env['CGO_LDFLAGS'] += ' -Wl,--allow-multiple-definition'

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -22,13 +22,13 @@ DEFAULT_BUILD_TAGS = [
 
 @task
 def build(ctx, rebuild=False, race=False, precompile_only=False, build_include=None,
-          build_exclude=None, arch="x64"):
+          build_exclude=None, major_version='7', arch="x64"):
     """
     Build the trace agent.
     """
 
     # get env prior to windows sources so we only have to set the target architecture once
-    ldflags, gcflags, env = get_build_flags(ctx, arch=arch)
+    ldflags, gcflags, env = get_build_flags(ctx, arch=arch, major_version=major_version)
 
     # generate windows resources
     if sys.platform == 'win32':
@@ -37,7 +37,7 @@ def build(ctx, rebuild=False, race=False, precompile_only=False, build_include=N
             env["GOARCH"] = "386"
             windres_target = "pe-i386"
 
-        ver = get_version_numeric_only(ctx, env)
+        ver = get_version_numeric_only(ctx, env, major_version=major_version)
         maj_ver, min_ver, patch_ver = ver.split(".")
 
         ctx.run("windmc --target {target_arch}  -r cmd/trace-agent/windows_resources cmd/trace-agent/windows_resources/trace-agent-msg.mc".format(target_arch=windres_target))

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -198,15 +198,15 @@ def get_git_branch_name():
     return check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).decode('utf-8').strip()
 
 
-def query_version(ctx, git_sha_length=7, prefix=None, hint=None):
+def query_version(ctx, git_sha_length=7, prefix=None, major_version_hint=None):
     # The string that's passed in will look something like this: 6.0.0-beta.0-1-g4f19118
     # if the tag is 6.0.0-beta.0, it has been one commit since the tag and that commit hash is g4f19118
     cmd = "git describe --tags --candidates=50"
     if prefix and type(prefix) == str:
         cmd += " --match \"{}-*\"".format(prefix)
     else:
-        if hint:
-            cmd += " --match \"{}\.*\"".format(hint)
+        if major_version_hint:
+            cmd += " --match \"{}\.*\"".format(major_version_hint)
         else:
             cmd += " --match \"[0-9]*\""
     if git_sha_length and type(git_sha_length) == int:
@@ -245,12 +245,11 @@ def query_version(ctx, git_sha_length=7, prefix=None, hint=None):
     return version, pre, commit_number, git_sha
 
 
-def get_version(ctx, include_git=False, url_safe=False, git_sha_length=7, prefix=None, env=os.environ):
+def get_version(ctx, include_git=False, url_safe=False, git_sha_length=7, prefix=None, env=os.environ, major_version='7'):
     # we only need the git info for the non omnibus builds, omnibus includes all this information by default
-    version_hint = '7' if env.get('AGENT_MAJOR_VERSION', '') == '7' or env.get('PYTHON_RUNTIMES', '') == '3' else '6'
 
     version = ""
-    version, pre, commits_since_version, git_sha = query_version(ctx, git_sha_length, prefix, hint=version_hint)
+    version, pre, commits_since_version, git_sha = query_version(ctx, git_sha_length, prefix, major_version_hint=major_version)
     if pre:
         version = "{0}-{1}".format(version, pre)
     if commits_since_version and include_git:
@@ -262,11 +261,10 @@ def get_version(ctx, include_git=False, url_safe=False, git_sha_length=7, prefix
     # version could be unicode as it comes from `query_version`
     return str(version)
 
-def get_version_numeric_only(ctx, env=os.environ):
+def get_version_numeric_only(ctx, env=os.environ, major_version='7'):
     # we only need the git info for the non omnibus builds, omnibus includes all this information by default
-    version_hint = '7' if env.get('PYTHON_RUNTIMES', '') == '3' else '6'
 
-    version, _, _, _ = query_version(ctx, hint=version_hint)
+    version, _, _, _ = query_version(ctx, major_version_hint=major_version)
     return version
 
 def load_release_versions(ctx, target_version):

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -52,7 +52,7 @@ def get_multi_python_location(embedded_path=None, rtloader_root=None):
 
 def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
                     rtloader_root=None, python_home_2=None, python_home_3=None,
-                    with_both_python=False, arch="x64"):
+                    with_both_python=False, major_version='7', arch="x64"):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
 
@@ -60,7 +60,7 @@ def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
     Context object.
     """
     gcflags = ""
-    ldflags = get_version_ldflags(ctx, prefix)
+    ldflags = get_version_ldflags(ctx, prefix, major_version=major_version)
     env = {}
 
     # lets pass the build runtimes around with the env
@@ -148,7 +148,7 @@ def get_payload_version():
 
     return ""
 
-def get_version_ldflags(ctx, prefix=None):
+def get_version_ldflags(ctx, prefix=None, major_version='7'):
     """
     Compute the version from the git tags, and set the appropriate compiler
     flags
@@ -157,7 +157,7 @@ def get_version_ldflags(ctx, prefix=None):
     commit = get_git_commit()
 
     ldflags = "-X {}/pkg/version.Commit={} ".format(REPO_PATH, commit)
-    ldflags += "-X {}/pkg/version.AgentVersion={} ".format(REPO_PATH, get_version(ctx, include_git=True, prefix=prefix))
+    ldflags += "-X {}/pkg/version.AgentVersion={} ".format(REPO_PATH, get_version(ctx, include_git=True, prefix=prefix, major_version=major_version))
     ldflags += "-X {}/pkg/serializer.AgentPayloadVersion={} ".format(REPO_PATH, payload_v)
 
     return ldflags

--- a/tasks/winbuildscripts/build-agent6.bat
+++ b/tasks/winbuildscripts/build-agent6.bat
@@ -1,0 +1,29 @@
+if not exist c:\mnt\ goto nomntdir
+
+@echo c:\mnt found, continuing
+@echo PARAMS %*
+
+if NOT DEFINED RELEASE_VERSION set RELEASE_VERSION=nightly
+if NOT DEFINED AGENT_MAJOR_VERSION set AGENT_MAJOR_VERSION=7
+
+mkdir \dev\go\src\github.com\DataDog\datadog-agent 
+if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 1
+cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 2
+xcopy /e/s/h/q c:\mnt\*.* || exit /b 3
+inv -e deps --verbose --dep-vendor-only --no-checks || exit /b 4
+inv -e agent.omnibus-build --skip-deps --major-version %AGENT_MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 5
+
+dir \omnibus\pkg
+
+dir \omnibus-ruby\pkg\
+
+if not exist c:\mnt\build-out mkdir c:\mnt\build-out || exit /b 6
+copy \omnibus-ruby\pkg\*.msi c:\mnt\build-out || exit /b 7
+if exist \omnibus-ruby\pkg\*.zip copy \omnibus-ruby\pkg\*.zip c:\mnt\build-out || exit /b 7
+
+goto :EOF
+
+:nomntdir
+@echo directory not mounted, parameters incorrect
+exit /b 1
+goto :EOF

--- a/tasks/winbuildscripts/build-agent6.bat
+++ b/tasks/winbuildscripts/build-agent6.bat
@@ -4,14 +4,14 @@ if not exist c:\mnt\ goto nomntdir
 @echo PARAMS %*
 
 if NOT DEFINED RELEASE_VERSION set RELEASE_VERSION=nightly
-if NOT DEFINED AGENT_MAJOR_VERSION set AGENT_MAJOR_VERSION=7
+if NOT DEFINED MAJOR_VERSION set MAJOR_VERSION=7
 
 mkdir \dev\go\src\github.com\DataDog\datadog-agent 
 if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 1
 cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 2
 xcopy /e/s/h/q c:\mnt\*.* || exit /b 3
 inv -e deps --verbose --dep-vendor-only --no-checks || exit /b 4
-inv -e agent.omnibus-build --skip-deps --major-version %AGENT_MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 5
+inv -e agent.omnibus-build --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 5
 
 dir \omnibus\pkg
 

--- a/tasks/winbuildscripts/build-agent6.bat
+++ b/tasks/winbuildscripts/build-agent6.bat
@@ -19,7 +19,7 @@ dir \omnibus-ruby\pkg\
 
 if not exist c:\mnt\build-out mkdir c:\mnt\build-out || exit /b 6
 copy \omnibus-ruby\pkg\*.msi c:\mnt\build-out || exit /b 7
-if exist \omnibus-ruby\pkg\*.zip copy \omnibus-ruby\pkg\*.zip c:\mnt\build-out || exit /b 7
+if exist \omnibus-ruby\pkg\*.zip copy \omnibus-ruby\pkg\*.zip c:\mnt\build-out || exit /b 8
 
 goto :EOF
 

--- a/test/kitchen/kitchen-azure-common.yml
+++ b/test/kitchen/kitchen-azure-common.yml
@@ -171,9 +171,9 @@ platforms:
   url = "https://app.datad0g.com"
   aptrepo = "http://apttesting.datad0g.com/"
   aptrepo_dist = "pipeline-#{ENV['DD_PIPELINE_ID']}"
-  yumrepo = "http://yumtesting.datad0g.com/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['AGENT_MAJOR_VERSION']}/x86_64/"
-  yumrepo_suse = "http://yumtesting.datad0g.com/suse/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['AGENT_MAJOR_VERSION']}/x86_64/"
-  agent_major_version = "#{ENV['AGENT_MAJOR_VERSION']}"
+  yumrepo = "http://yumtesting.datad0g.com/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['MAJOR_VERSION']}/x86_64/"
+  yumrepo_suse = "http://yumtesting.datad0g.com/suse/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['MAJOR_VERSION']}/x86_64/"
+  agent_major_version = "#{ENV['MAJOR_VERSION']}"
   windows_agent_url = ENV['WINDOWS_AGENT_URL'] ? ENV['WINDOWS_AGENT_URL'] : "https://s3.amazonaws.com/#{ENV['WINDOWS_TESTING_S3_BUCKET']}/"
   dd_agent_config = {
     'agent_major_version': agent_major_version,

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -73,8 +73,8 @@ set -x
 # on linux it can just download the latest version from the package manager
 if [ -z ${AGENT_VERSION+x} ]; then
   pushd ../..
-    export AGENT_VERSION=`inv agent.version --url-safe --git-sha-length=7`
-    export DD_AGENT_EXPECTED_VERSION=`inv agent.version --url-safe --git-sha-length=7`
+    export AGENT_VERSION=`inv agent.version --url-safe --git-sha-length=7 --major-version $AGENT_MAJOR_VERSION`
+    export DD_AGENT_EXPECTED_VERSION=`inv agent.version --url-safe --git-sha-length=7 --major-version $AGENT_MAJOR_VERSION`
   popd
 fi
 

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -68,16 +68,6 @@ fi
 (echo "<% subscription_id=\"$AZURE_SUBSCRIPTION_ID\"; client_id=\"$AZURE_CLIENT_ID\"; client_secret=\"$AZURE_CLIENT_SECRET\"; tenant_id=\"$AZURE_TENANT_ID\"; %>" && cat azure-creds.erb) | erb > /root/.azure/credentials
 set -x
 
-# if the agent version isn't set, grab it
-# This is for the windows agent, as it needs to know the exact right version to grab
-# on linux it can just download the latest version from the package manager
-if [ -z ${AGENT_VERSION+x} ]; then
-  pushd ../..
-    export AGENT_VERSION=`inv agent.version --url-safe --git-sha-length=7 --major-version $AGENT_MAJOR_VERSION`
-    export DD_AGENT_EXPECTED_VERSION=`inv agent.version --url-safe --git-sha-length=7 --major-version $AGENT_MAJOR_VERSION`
-  popd
-fi
-
 # Generate a password to use for the windows servers
 if [ -z ${SERVER_PASSWORD+x} ]; then
   export SERVER_PASSWORD="$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)0aZ"
@@ -86,6 +76,23 @@ fi
 if [[ $# == 0 ]]; then
   echo "Missing run suite argument. Exiting."
   exit 1
+fi
+
+if [[ $# == 1 ]]; then
+  echo "Missing major version argument. Exiting."
+  exit 1
+fi
+
+export MAJOR_VERSION=$2
+
+# if the agent version isn't set, grab it
+# This is for the windows agent, as it needs to know the exact right version to grab
+# on linux it can just download the latest version from the package manager
+if [ -z ${AGENT_VERSION+x} ]; then
+  pushd ../..
+    export AGENT_VERSION=`inv agent.version --url-safe --git-sha-length=7 --major-version $MAJOR_VERSION`
+    export DD_AGENT_EXPECTED_VERSION=`inv agent.version --url-safe --git-sha-length=7 --major-version $MAJOR_VERSION`
+  popd
 fi
 
 cp kitchen-azure-common.yml kitchen.yml


### PR DESCRIPTION
### What does this PR do?

Make all invoke functions depending on the major version take the major version parameter explicitly, instead of relying on environment variables.

### Motivation

Having functions that depend on environment variables is not great, having the variables passed as parameters to the functions is way better.

### Additional Notes

Omnibus builds are somewhat trickier, as we can't pass parameters to `bundle exec omnibus ...`, only environment variables, and the omnibus builds do need the major version, as they call invoke functions. The way we're doing is thus as follows:
- inv agent.omnibus-build takes an explicit `--major-version` parameter,
- It injects this parameter to the omnibus env vars as `MAJOR_VERSION,
- the omnibus software definitions use the `MAJOR_VERSION` env var to call the other invoke functions (such as `inv agent.build`, `inv dogstatsd.build`, etc.) with the explicit `--major-version` parameter.

This PR creates a `tasks/winbuildscripts` folder containing the windows build scripts, as this will become the preferred way to package the build scripts once #4614 is merged (instead of baking the scripts in the build image directly, which is inconvenient).