### PR TITLE
Don't copy incomplete configuration specs for integrations

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -763,6 +763,9 @@ func moveConfigurationFiles(srcFolder string, dstFolder string) error {
 				continue
 			}
 			continue
+		// Skip incomplete configuration specs
+		} else if filename == "conf_spec.yaml" {
+			continue
 		}
 
 		// Replace existing file

--- a/releasenotes/notes/skip-incomplete-config-specs-integrations-863d1dd6d5c293a5.yaml
+++ b/releasenotes/notes/skip-incomplete-config-specs-integrations-863d1dd6d5c293a5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Don't copy incomplete configuration specs for the integration command.


### PR DESCRIPTION
### Motivation

The Agent tries to load them and they aren't the full spec anyway