### PR TITLE
Disallow binary/conf directory changes on upgrade

### DIFF
--- a/omnibus/resources/agent/msi/localbuild/parameters.wxi
+++ b/omnibus/resources/agent/msi/localbuild/parameters.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
-  <?define VersionNumber="6.12.0.1" ?>
-  <?define DisplayVersionNumber="6.12.0" ?>
+  <?define VersionNumber="6.17.0.1" ?>
+  <?define DisplayVersionNumber="6.17.0" ?>
   <?define UpgradeCode="0c50421b-aefb-4f15-a809-7af256d608a5" ?>
   <?define InstallDir="C:/opt/datadog-agent" ?>
   <?define InstallFiles="C:/omnibus-ruby/src/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files" ?>

--- a/omnibus/resources/agent/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/agent/msi/localization-en-us.wxl.erb
@@ -86,6 +86,9 @@
   <String Id="WillInstall">[WixBundleName] will be installed on your device</String>
   <String Id="InstallLicenseLinkText">By installing you accept these &lt;a href="#"&gt;license terms&lt;/a&gt;</String>
 
+  <String Id="NoMoveInstallDir">The installation directory cannot be changed on an upgrade.</String>
+  <String Id="NoMoveConfDir">The configuration file directory cannot be changed on an upgrade.</String>
+
   
   <!-- Bitmap filenames -->
   <String Id ="LicenseAgreementDlgBannerBitmap" Overridable="yes" Localizable="no">BannerBmp</String>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -76,10 +76,46 @@
     <Property Id="DDAGENTUSER_PASSWORD" Hidden="yes" />
     <Property Id="APIKEY" Hidden="yes" />
     <Property Id="FinalizeInstall" Hidden="yes" />
-    
      <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
      <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
      <PropertyRef Id="WIX_ACCOUNT_USERS" />
+
+    <!--
+      The following four properties are set to see if the user specified the binary dir or config dir on
+      the command line. These properties are loaded before the property is loaded from the registry (below)
+      so we can tell if it was actually supplied on the command line.
+
+      The second of each pair is because the directory can be stored with a trailing "\", but it's the same
+      directory.  Makes the comparison (below) easier.
+    -->
+    <SetProperty Id="PROJECTLOCATIONONCMDLINE" Value="[PROJECTLOCATION]" Before="AppSearch">PROJECTLOCATION </SetProperty>
+    <SetProperty Id="PROJECTLOCATIONONCMDLINESLASH" Value="[PROJECTLOCATION]\" Before="AppSearch">PROJECTLOCATION </SetProperty> 
+    <SetProperty Id="CONFDIRONCOMMANDLINE" Value="[APPLICATIONDATADIRECTORY]" Before="AppSearch">APPLICATIONDATADIRECTORY </SetProperty>
+    <SetProperty Id="CONFDIRONCOMMANDLINESLASH" Value="[APPLICATIONDATADIRECTORY]\" Before="AppSearch">APPLICATIONDATADIRECTORY </SetProperty> 
+
+    <!-- This condition allows the install if
+        1) the user didn't supply the binary directory on the command line
+        2) this is NOT an upgrade
+        3) it is an upgrade, but the supplied directory is the same as the originally installed one. 
+        
+      Case (3) is to allow automation tools to supply the same arguments regardless of whether it's an install or
+      upgrade.-->
+    <Condition
+      Message="!(loc.NoMoveInstallDir)">
+      <!-- Inside of conditional must be TRUE to meet the condition (to NOT fail the install) -->
+      <![CDATA[(NOT PROJECTLOCATIONONCMDLINE) OR (NOT PREVIOUSFOUND) 
+              OR ((PROJECTLOCATIONONCMDLINE~=PROJECTLOCATION) OR
+                  (PROJECTLOCATIONONCMDLINESLASH~=PROJECTLOCATION))]]>
+    </Condition>
+
+    <!-- Same as above, but for the configuration directory. -->
+    <Condition
+      Message="!(loc.NoMoveConfDir)">
+      <!-- Inside of conditional must be TRUE to meet the condition (to NOT fail the install) -->
+      <![CDATA[(NOT CONFDIRONCOMMANDLINE) OR (NOT PREVIOUSFOUND) 
+              OR ((CONFDIRONCOMMANDLINE~=APPLICATIONDATADIRECTORY) OR
+                  (CONFDIRONCOMMANDLINESLASH~=APPLICATIONDATADIRECTORY))]]>
+    </Condition>
     <Media Id="1" Cabinet="agent.cab" EmbedCab="yes" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
@@ -123,6 +159,13 @@
                       Type="raw"
                       Id="APPLICATIONROOTDIRECTORY_REGSEARCH"
                       Name="InstallPath" />
+    </Property>
+    <Property Id="APPLICATIONDATADIRECTORY" Secure="yes">
+      <RegistrySearch Key="SOFTWARE\Datadog\Datadog Agent"
+                      Root="HKLM"
+                      Type="raw"
+                      Id="APPLICATIONDATADIRECTORY_REGSEARCH"
+                      Name="ConfigRoot" />
     </Property>
 
     <DirectoryRef Id="PROJECTLOCATION">

--- a/releasenotes/notes/nochangedirs-3a59b0abb8caa529.yaml
+++ b/releasenotes/notes/nochangedirs-3a59b0abb8caa529.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, when upgrading, installer will fail if the user attempts 
+    to assign a configuration file directory or binary directory that is 
+    different from the original.


### PR DESCRIPTION
On Windows, when upgrading, installer will fail if the user attempts
    to assign a configuration file directory or binary directory that is
        different from the original.

### What does this PR do?

Prevents upgrades if user attempts to assign a different directory for the binary dir/conf dir.

### Motivation

Prevent user administration error.

### Additional Notes

Testing should include the following cases:
- Clean install, installer should still honor PROJECTLOCATION and APPLICATIONDATADIRECTORY as documented here https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=agentv6v7#command-line
- On upgrade, installer should succeed if neither PROJECTLOCATION or APPLICATIONDATADIRECTORY is supplied on command line
- On upgrade, installer should succeed if either or both PROJECTLOCATION or APPLICATIONDATADIRECTORY is supplied on command line, and is the same as the original install.

- On upgrade, installer should fail if either or both PROJECTLOCATION or APPLICATIONDATADIRECTORY is supplied on command line, and is different
