### PR TITLE
[kitchen] Revert allow failure on Windows upgrade from Agent 6 jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1325,23 +1325,17 @@ kitchen_windows_upgrade5-a7:
   <<: *kitchen_windows_a7_common
   <<: *kitchen_upgrade5_common
 
-
-# Let these two jobs fail for now, as they have to fail
-# (they install latest, ie. 6.14.1, which is blacklisted)
-
 kitchen_windows_upgrade6-a6:
-  allow_failure: true
+  allow_failure: false
   <<: *skip_when_unwanted_on_6
   <<: *kitchen_windows_a6_common
   <<: *kitchen_upgrade6_common
-  retry: 0
 
 kitchen_windows_upgrade6-a7:
-  allow_failure: true
+  allow_failure: false
   <<: *skip_when_unwanted_on_7
   <<: *kitchen_windows_a7_common
   <<: *kitchen_upgrade6_common
-  retry: 0
 
 # run dd-agent-testing on centos
 kitchen_centos_chef-a6:


### PR DESCRIPTION
### What does this PR do?

Remove `allow_failure: true` from the Windows upgrade from Agent 6 jobs.

### Motivation

These tests should be working again, the latest Agent 6 version is 6.16.0 now.
