### PR TITLE
[kitchen] Revert use of a specific Agent 5 version in 5->6/7 tests

### DIFF
--- a/test/kitchen/kitchen-azure-upgrade5-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade5-test.yml
@@ -21,9 +21,6 @@ suites:
         enable: false
     dd-agent-5:
       api_key: <%= api_key %>
-      windows_agent_url: https://s3.amazonaws.com/ddagent-windows-unstable
-      # temporary, hand-rolled a5
-      windows_agent_filename: datadog-agent-5.32.3.git.1.53ce09c4-1-x86_64
     dd-agent-upgrade:
       add_new_repo: true
       <% dd_agent_config.each do |key, value| %>


### PR DESCRIPTION
### What does this PR do?

Reverts #4258, now that Agent 5 should uninstall correctly thanks to the trace-agent bugfix included in 5.32.5.

### Motivation

Kitchen tests cleanup.
