### PR TITLE
Fix API endpoint

### DIFF
--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -88,7 +88,7 @@ type Point struct {
 const (
 	value         = 1
 	timestamp     = 0
-	queryEndpoint = "/v1/query"
+	queryEndpoint = "/api/v1/query"
 )
 
 // queryDatadogExternal converts the metric name and labels from the Ref format into a Datadog metric.

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -184,14 +184,13 @@ func setPrometheusMetric(val string, metric *prometheus.GaugeVec) error {
 func (p *Processor) updateRateLimitingMetrics() error {
 	updateMap := p.datadogClient.GetRateLimitStats()
 	queryLimits := updateMap[queryEndpoint]
-	var errors []error
 
-	errors = append(errors,
+	errors := []error{
 		setPrometheusMetric(queryLimits.Limit, rateLimitsLimit),
 		setPrometheusMetric(queryLimits.Remaining, rateLimitsRemaining),
 		setPrometheusMetric(queryLimits.Period, rateLimitsPeriod),
 		setPrometheusMetric(queryLimits.Reset, rateLimitsReset),
-	)
+	}
 
 	return utilserror.NewAggregate(errors)
 }

--- a/pkg/util/kubernetes/autoscalers/processor_test.go
+++ b/pkg/util/kubernetes/autoscalers/processor_test.go
@@ -270,7 +270,7 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 			datadogClient := &fakeDatadogClient{
 				getRateLimitsFunc: func() map[string]datadog.RateLimit {
 					return map[string]datadog.RateLimit{
-						"/v1/query": {
+						queryEndpoint: {
 							Limit:     "12",
 							Period:    "10",
 							Remaining: "200",
@@ -512,7 +512,7 @@ func TestUpdateRateLimiting(t *testing.T) {
 		{
 			desc: "Nominal case",
 			rateLimits: map[string]datadog.RateLimit{
-				"/v1/query": {
+				queryEndpoint: {
 					Limit:     "12",
 					Period:    "3600",
 					Reset:     "11",
@@ -530,7 +530,7 @@ func TestUpdateRateLimiting(t *testing.T) {
 		{
 			desc: "Missing header case",
 			rateLimits: map[string]datadog.RateLimit{
-				"/v1/query": {
+				queryEndpoint: {
 					Limit:  "12",
 					Period: "3600",
 					Reset:  "11",
@@ -546,7 +546,7 @@ func TestUpdateRateLimiting(t *testing.T) {
 		{
 			desc: "Missing headers case",
 			rateLimits: map[string]datadog.RateLimit{
-				"/v1/query": {
+				queryEndpoint: {
 					Limit:  "12",
 					Period: "3600",
 				},


### PR DESCRIPTION
### What does this PR do?

Using url.Parse in the upstream we get the `/api` prepended in the api endpoint identifier.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
