### PR TITLE
Adding extra logic for container restart

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -9,13 +9,14 @@ package listeners
 
 import (
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/go-connections/nat"
 	"io"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/go-connections/nat"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -173,9 +174,11 @@ func (l *DockerListener) init() {
 // figure out if the AutoConfig could be interested to inspect it.
 func (l *DockerListener) processEvent(e *docker.ContainerEvent) {
 	cID := e.ContainerID
+
 	l.m.RLock()
 	_, found := l.services[cID]
 	l.m.RUnlock()
+
 	if found {
 		if e.Action == "die" {
 			l.removeService(cID)

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -180,14 +180,15 @@ func (l *DockerListener) processEvent(e *docker.ContainerEvent) {
 	l.m.RUnlock()
 
 	if found {
-		if e.Action == "die" {
+		switch e.Action {
+		case "die":
 			l.removeService(cID)
-		} else if e.Action == "start" {
+		case "start":
 			// Container restarted with the same ID within 5 seconds.
 			time.AfterFunc(5*time.Second, func() {
 				l.createService(cID)
 			})
-		} else {
+		default:
 			// FIXME sometimes the agent's container's events are picked up twice at startup
 			log.Debugf("Expected die for container %s got %s: skipping event", cID[:12], e.Action)
 			return

--- a/releasenotes/notes/support-docker-restart-25e7560dc90dd699.yaml
+++ b/releasenotes/notes/support-docker-restart-25e7560dc90dd699.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Add logic to support docker restart of containers.


### PR DESCRIPTION
### What does this PR do?

When using the command `docker restart <container>` the new container spun up has the same container id.
In order to support short lived containers we introduced a delay to unschedule a check scheduled from the said container.

The issue with the restart is that we remove the check from the cache of known services and wait 5 seconds to unschedule the check. Because we receive an event for a container create and we don't know it, we schedule a check but soon the 5 seconds delay expires and unschedules the newly created check.

Moving the logic to remove the service from the map to the 5 second routine is not enough to solve the issue because when receiving the start event, we would find the container and just end up in [this part of the logic](https://github.com/DataDog/datadog-agent/blob/master/pkg/autodiscovery/listeners/docker.go#L187)

I could see only two solutions:
1/ Given that the methods are stateless, we would need to add logic to know if we are in a restart state instead of a start. This would mean a cache in the listener and then logic to cancel the removal of the check or ensure the subsequent creation of the check after the deletion. 
This felt like too big of a patch, not clean and would add potential leaking point or issues.
2/ Delay the creation of the check in the restart state. As we move the deletion of the service to the delayed routine if we receive the start event within 5 seconds (case of a normal restart) we delay the creation for 5 seconds and we have the check correctly unscheduled as a result of the `die` event and scheduled as a result of the `start` event.
If the restart takes more than 5 seconds, then the service will be removed by the removeservice and as we receive a start event, we will not find the service in the map and thus we follow the regular process.

This is not ideal, but is the least disruptive way I found to fix this issue. 

### Motivation

Customer issue

### Additional Notes

Anything else we should know when reviewing?
