### PR TITLE
Add team Agent Core to the code owners of the Logs Agent.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,7 +71,7 @@
 /pkg/util/ecs/                          @DataDog/container-integrations @DataDog/burrito
 /pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/burrito
 /pkg/util/retry/                        @DataDog/container-integrations
-/pkg/logs/                              @DataDog/logs-intake
+/pkg/logs/                              @DataDog/logs-intake @DataDog/agent-core
 /pkg/metadata/ecs/                      @DataDog/burrito
 /pkg/metadata/kubernetes/               @DataDog/burrito
 /pkg/process/                           @DataDog/burrito


### PR DESCRIPTION
### What does this PR do?

Add team Agent Core to the code owners of the Logs Agent.

