### PR TITLE
[kitchen] Split tests on multiple Azure regions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1174,23 +1174,23 @@ deploy_windows_testing-a7:
 
 .kitchen_chef_common: &kitchen_chef_common
   script:
-    - bash -l tasks/run-test-kitchen.sh chef-test $AGENT_MAJOR_VERSION
+    - AZURE_LOCATION='North Central US' bash -l tasks/run-test-kitchen.sh chef-test $AGENT_MAJOR_VERSION
 
 .kitchen_step_by_step_common: &kitchen_step_by_step_common
   script:
-    - bash -l tasks/run-test-kitchen.sh step-by-step-test $AGENT_MAJOR_VERSION
+    - AZURE_LOCATION='Central US' bash -l tasks/run-test-kitchen.sh step-by-step-test $AGENT_MAJOR_VERSION
 
 .kitchen_install_script_common: &kitchen_install_script_common
   script:
-    - bash -l tasks/run-test-kitchen.sh install-script-test $AGENT_MAJOR_VERSION
+    - AZURE_LOCATION='South Central US' bash -l tasks/run-test-kitchen.sh install-script-test $AGENT_MAJOR_VERSION
 
 .kitchen_upgrade5_common: &kitchen_upgrade5_common
   script:
-    - bash -l tasks/run-test-kitchen.sh upgrade5-test $AGENT_MAJOR_VERSION
+    - AZURE_LOCATION='Central US' bash -l tasks/run-test-kitchen.sh upgrade5-test $AGENT_MAJOR_VERSION
 
 .kitchen_upgrade6_common: &kitchen_upgrade6_common
   script:
-    - bash -l tasks/run-test-kitchen.sh upgrade6-test $AGENT_MAJOR_VERSION
+    - AZURE_LOCATION='South Central US' bash -l tasks/run-test-kitchen.sh upgrade6-test $AGENT_MAJOR_VERSION
 
 .kitchen_windows_installer_common: &kitchen_windows_installer_common
   <<: *kitchen_common
@@ -1199,7 +1199,7 @@ deploy_windows_testing-a7:
     - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190603"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
-    - bash -l tasks/run-test-kitchen.sh windows-install-test $AGENT_MAJOR_VERSION
+    - AZURE_LOCATION='North Central US' bash -l tasks/run-test-kitchen.sh windows-install-test $AGENT_MAJOR_VERSION
 
 .kitchen_windows_a6_common: &kitchen_windows_a6_common
   <<: *kitchen_common

--- a/test/kitchen/kitchen-azure-common.yml
+++ b/test/kitchen/kitchen-azure-common.yml
@@ -1,6 +1,7 @@
 ---
 <%
   ENV['AZURE_LOCATION'] ||= "North Central US"
+  location = ENV['AZURE_LOCATION']
 %>
 
 <%
@@ -51,7 +52,7 @@ driver:
 
 driver_config:
   subscription_id: <%= ENV['AZURE_SUBSCRIPTION_ID'] %>
-  location: <%= ENV['AZURE_LOCATION'] %>
+  location: <%= location %>
   <% if ENV['DD_PIPELINE_ID'] %>
   azure_resource_group_suffix: pl<%= ENV['DD_PIPELINE_ID'] %>
   <% else %>
@@ -77,8 +78,6 @@ platforms:
     windows_sizes = [
       "Standard_D2_v2"
     ]
-
-    location = "North Central US"
 
     windows_platforms = []
     sles11_platforms = []


### PR DESCRIPTION
### What does this PR do?

Splits the kitchen workload on three Azure regions: North Central US, Central US and South Central US.

### Motivation

Spread our resource usage.
Prevent kitchen failures due to exceeded quotas.
