### PR TITLE
Fix SystemV init debian scripts for docker compatibility

### DIFF
--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
@@ -43,9 +43,9 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $AGENTPATH --test > /dev/null \
+	start-stop-daemon --start --test --quiet --pidfile $PIDFILE --startas $AGENTPATH > /dev/null \
 		|| return 1
-	start-stop-daemon --start --background --chuid $AGENT_USER --quiet --pidfile $PIDFILE --exec $AGENTPATH -- \
+	start-stop-daemon --start --background --chuid $AGENT_USER --quiet --pidfile $PIDFILE --startas $AGENTPATH -- \
 		$AGENT_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready
@@ -67,7 +67,7 @@ start_and_wait()
 			# check if the agent is running once per second for 5 seconds
 			retries=5
 			while [ $retries -gt 1 ]; do
-				start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $AGENTPATH --test
+				start-stop-daemon --start --test --quiet --pidfile $PIDFILE --startas $AGENTPATH
 				if [ "$?" -eq "1" ]; then
 					# We've started up successfully. Exit cleanly
 					log_end_msg 0
@@ -96,7 +96,7 @@ do_stop()
 	#   1 if daemon was already stopped
 	#   2 if daemon could not be stopped
 	#   other if a failure occurred
-	start-stop-daemon --stop --quiet --retry=30 --pidfile $PIDFILE --exec $AGENTPATH
+	start-stop-daemon --stop --quiet --retry=30 --pidfile $PIDFILE --startas $AGENTPATH
 	RETVAL="$?"
 	rm -f $PIDFILE
 	return $RETVAL

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.process.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.process.erb
@@ -42,9 +42,9 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $AGENTPATH --test > /dev/null \
+	start-stop-daemon --start --test --quiet --pidfile $PIDFILE --startas $AGENTPATH > /dev/null \
 		|| return 1
-	start-stop-daemon --start --background --chuid $AGENT_USER --quiet --pidfile $PIDFILE --exec $AGENTPATH -- \
+	start-stop-daemon --start --background --chuid $AGENT_USER --quiet --pidfile $PIDFILE --startas $AGENTPATH -- \
 		$AGENT_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready
@@ -67,7 +67,7 @@ start_and_wait()
 			# check if the agent is running once per second for 5 seconds
 			retries=5
 			while [ $retries -gt 1 ]; do
-				start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $AGENTPATH --test
+				start-stop-daemon --start --test --quiet --pidfile $PIDFILE --startas $AGENTPATH
 				if [ "$?" -eq "1" ]; then
 					# We've started up successfully. Exit cleanly
 					log_end_msg 0

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.trace.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.trace.erb
@@ -42,9 +42,9 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $AGENTPATH --test > /dev/null \
+	start-stop-daemon --start --test --quiet --pidfile $PIDFILE --startas $AGENTPATH > /dev/null \
 		|| return 1
-	start-stop-daemon --start --background --chuid $AGENT_USER --quiet --pidfile $PIDFILE --exec $AGENTPATH -- \
+	start-stop-daemon --start --background --chuid $AGENT_USER --quiet --pidfile $PIDFILE --startas $AGENTPATH -- \
 		$AGENT_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready
@@ -67,7 +67,7 @@ start_and_wait()
 			# check if the agent is running once per second for 5 seconds
 			retries=5
 			while [ $retries -gt 1 ]; do
-				start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $AGENTPATH --test
+				start-stop-daemon --start --test --quiet --pidfile $PIDFILE --startas $AGENTPATH
 				if [ "$?" -eq "1" ]; then
 					# We've started up successfully. Exit cleanly
 					log_end_msg 0
@@ -94,7 +94,7 @@ do_stop()
 	#   1 if daemon was already stopped
 	#   2 if daemon could not be stopped
 	#   other if a failure occurred
-	start-stop-daemon --stop --quiet --retry=30 --pidfile $PIDFILE --exec $AGENTPATH
+	start-stop-daemon --stop --quiet --retry=30 --pidfile $PIDFILE --startas $AGENTPATH
 	RETVAL="$?"
 	rm -f $PIDFILE
 	return $RETVAL


### PR DESCRIPTION
### What does this PR do?

Fix the template of debian init scripts created by the omnibus package as there they weren't correctly checking the daemon was running for every systems. 

### Motivation

On docker, the check as it was, was returning that the daemon was not running when it was.
With the `--startas` option, it skips the pid check in `/proc/$pid/exe` and thus, correctly find the daemon running with just checking the pidfile and the exec path. Which is enough for the agent.
