### PR TITLE
Display distribution metrics in agent check command

### DIFF
--- a/pkg/quantile/sparse.go
+++ b/pkg/quantile/sparse.go
@@ -9,10 +9,12 @@ import (
 )
 
 // A Sketch for tracking quantiles
+// The serialized JSON of Sketch contains the summary only
+// Bins are not included.
 type Sketch struct {
 	sparseStore
 
-	Basic summary.Summary
+	Basic summary.Summary `json:"summary"`
 }
 
 func (s *Sketch) String() string {

--- a/pkg/status/dist/templates/aggregator.tmpl
+++ b/pkg/status/dist/templates/aggregator.tmpl
@@ -43,6 +43,9 @@ Aggregator
 {{- if .SketchesFlushErrors}}
   Sketches Flush Errors: {{humanize .SketchesFlushErrors}}
 {{- end }}
+{{- if .ChecksHistogramBucketMetricSample }}
+  Checks Histogram Bucket Metric Sample: {{humanize .ChecksHistogramBucketMetricSample}}
+{{- end }}
 {{- if .HostnameUpdate}}
   Hostname Update: {{humanize .HostnameUpdate}}
 {{- end }}

--- a/releasenotes/notes/display-distribution-metrics-bcde80bb9e08fa0e.yaml
+++ b/releasenotes/notes/display-distribution-metrics-bcde80bb9e08fa0e.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Agent check command displays the distribution metrics.
+    The Agent status command displays histogram bucket samples.


### PR DESCRIPTION
### What does this PR do?

- implements the `MarshalJSON` method for `SketchSeriesList` to display sketches in `agent check` command
- display `ChecksHistogramBucketMetricSample` in `agent status` command

### Motivation

Facilitate debugging distribution metrics in the Agent

### Additional Notes

- [This line](https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/app/check.go#L415) was returning a non-nil error

- example output 
```
$ agent check openmetrics -r
...
=== Sketches ===
{
  "sketches": [
    {
      "metric": "openmetrics_gen.http_response_time_seconds_histogram",
      "tags": [
        "docker_image:mfpierre/prometheus-generator:latest",
        "image_name:mfpierre/prometheus-generator",
        "image_tag:latest",
        "kube_container_name:openmetrics-generator",
        "kube_deployment:openmetrics-generator",
        "kube_namespace:default",
        "lower_bound:0.1",
        "pod_phase:running",
        "short_image:prometheus-generator",
        "upper_bound:0.25"
      ],
      "host": "ci-ahmed",
      "interval": 0,
      "points": [
        {
          "sketch": {
            "summary": {
              "Min": 0.10000000149011612,
              "Max": 0.2461538461920539,
              "Sum": 6.750000029802317,
              "Avg": 0.17307692384108503,
              "Cnt": 39
            }
          },
          "ts": 1578488618
        }
      ]
    },
...
```

```
$ agent status
...
=========
Aggregator
=========
...
  Sketches Flushed: 8
  Checks Histogram Bucket Metric Sample: 24
...
```