### PR TITLE
Fix regression when matching containerID to Pod due to runtime prefixes

### DIFF
--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -171,7 +171,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 			cLow, cOrch, cHigh := cTags.Compute()
 			entityID, err := kubelet.KubeContainerIDToTaggerEntityID(container.ID)
 			if err != nil {
-				log.Warnf("Unable to parse container: %s", err)
+				log.Warnf("Unable to parse container pName: %s / cName: %s / cId: %s / err: %s", pod.Metadata.Name, container.Name, container.ID, err)
 				continue
 			}
 			info := &TagInfo{

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -278,9 +278,13 @@ func (ku *KubeUtil) searchPodForContainerID(podList []*Pod, containerID string) 
 	if containerID == "" {
 		return nil, fmt.Errorf("containerID is empty")
 	}
+
+	// We will match only on the id itself, without runtime identifier, it should be quite unlikely on a Kube node
+	// to have a container in the runtime used by Kube to match a container in another runtime...
+	strippedContainerID := containers.ContainerIDForEntity(containerID)
 	for _, pod := range podList {
 		for _, container := range pod.Status.GetAllContainers() {
-			if container.ID == containerID {
+			if containers.ContainerIDForEntity(container.ID) == strippedContainerID {
 				return pod, nil
 			}
 		}

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -401,7 +401,7 @@ func (suite *KubeletTestSuite) TestGetPodForContainerID() {
 	require.True(suite.T(), errors.IsNotFound(err))
 
 	// Valid container ID
-	pod, err = kubeutil.GetPodForContainerID("docker://b3e4cd65204e04d1a2d4b7683cae2f59b2075700f033a6b09890bd0d3fecf6b6")
+	pod, err = kubeutil.GetPodForContainerID("container_id://b3e4cd65204e04d1a2d4b7683cae2f59b2075700f033a6b09890bd0d3fecf6b6")
 	// The /pods request is still cached
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), pod)

--- a/releasenotes/notes/fix-container-id-matching-tagging-b3e106aeee2a4bc0.yaml
+++ b/releasenotes/notes/fix-container-id-matching-tagging-b3e106aeee2a4bc0.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixes the matching of container id in Tagger (due to runtime prefix) by matching on the 'id' part only


### PR DESCRIPTION
### What does this PR do?

Currently due to the runtime prefix, we are never matching containers in the tagger's force refresh flow.
Issue was likely introduced by https://github.com/DataDog/datadog-agent/pull/3821

Proposed solution is to match only on container id (without runtime prefix).

### Motivation

Fixing the issue with missing tags on logs sent really quick by newly created containers.

### Additional Notes

Fix has been tested locally and on GKE, however it does not completely solve the issue we have internally.