### PR TITLE
Logic to fully support AWS Fargate on Amazon EKS

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-eks.sh
+++ b/Dockerfiles/agent/entrypoint/50-eks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -z "${EKS_FARGATE}" ]]; then
+if [[ -z "${DD_EKS_FARGATE}" ]]; then
     exit 0
 fi
 

--- a/Dockerfiles/agent/entrypoint/50-eks.sh
+++ b/Dockerfiles/agent/entrypoint/50-eks.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [[ -z "${EKS_FARGATE}" ]]; then
+    exit 0
+fi
+
+# Set a default config for EKS Fargate if found
+# Don't override /etc/datadog-agent/datadog.yaml if it exists
+if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
+    ln -s  /etc/datadog-agent/datadog-kubernetes.yaml \
+           /etc/datadog-agent/datadog.yaml
+fi
+
+# Remove all default cheks & enable kubelet check
+if [[ ! -e /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default ]]; then
+    find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete
+    mv /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.example \
+    /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
+fi

--- a/Dockerfiles/agent/entrypoint/50-eks.sh
+++ b/Dockerfiles/agent/entrypoint/50-eks.sh
@@ -11,9 +11,15 @@ if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
            /etc/datadog-agent/datadog.yaml
 fi
 
-# Remove all default checks & enable kubelet and eks_fargate checks
+# Remove all default checks & enable kubelet check
 if [[ ! -e /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default ]]; then
     find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete
+    mv /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.example \
+     /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
+fi
+
+# Enable eks_fargate check
+if [[ ! -e /etc/datadog-agent/conf.d/eks_fargate.d/conf.yaml.default ]]; then
     mv /etc/datadog-agent/conf.d/eks_fargate.d/conf.yaml.example \
      /etc/datadog-agent/conf.d/eks_fargate.d/conf.yaml.default
 fi

--- a/Dockerfiles/agent/entrypoint/50-eks.sh
+++ b/Dockerfiles/agent/entrypoint/50-eks.sh
@@ -11,9 +11,11 @@ if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
            /etc/datadog-agent/datadog.yaml
 fi
 
-# Remove all default cheks & enable kubelet check
+# Remove all default checks & enable kubelet and eks_fargate checks
 if [[ ! -e /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default ]]; then
     find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete
     mv /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.example \
     /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
+    mv /etc/datadog-agent/conf.d/eks_fargate.d/conf.yaml.example \
+     /etc/datadog-agent/conf.d/eks_fargate.d/conf.yaml.default
 fi

--- a/Dockerfiles/agent/entrypoint/50-eks.sh
+++ b/Dockerfiles/agent/entrypoint/50-eks.sh
@@ -14,8 +14,6 @@ fi
 # Remove all default checks & enable kubelet and eks_fargate checks
 if [[ ! -e /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default ]]; then
     find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete
-    mv /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.example \
-    /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
     mv /etc/datadog-agent/conf.d/eks_fargate.d/conf.yaml.example \
      /etc/datadog-agent/conf.d/eks_fargate.d/conf.yaml.default
 fi

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -324,6 +324,8 @@ func initConfig(config Config) {
 
 	// Kubernetes
 	config.BindEnvAndSetDefault("kubernetes_kubelet_host", "")
+	config.BindEnvAndSetDefault("kubernetes_kubelet_nodename", "")
+	config.BindEnvAndSetDefault("eks_fargate", false)
 	config.BindEnvAndSetDefault("kubernetes_http_kubelet_port", 10255)
 	config.BindEnvAndSetDefault("kubernetes_https_kubelet_port", 10250)
 

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -701,7 +701,7 @@ func (ku *KubeUtil) setKubeletHost(hosts *connectionInfo, httpsPort, httpPort in
 	var connectionErrors []error
 	log.Debugf("Trying several connection methods to locate the kubelet...")
 	if ku.kubeletProxiedEndpoint && config.Datadog.Get("kubernetes_kubelet_nodename") != "" {
-		ku.kubeletApiEndpoint = fmt.Sprintf("https://%s:%s/api/v1/nodes/%s/proxy", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"), config.Datadog.Get("kubernetes_kubelet_nodename"))
+		ku.kubeletApiEndpoint = fmt.Sprintf("https://%s:%s/api/v1/nodes/%s/proxy/", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"), config.Datadog.Get("kubernetes_kubelet_nodename"))
 		log.Infof("EKS on Fargate mode detected, will proxy calls to the Kubelet through the APIServer at %s", ku.kubeletApiEndpoint)
 		return nil
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -28,7 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
-	"os"
 )
 
 const (
@@ -331,7 +331,6 @@ func (ku *KubeUtil) GetPodForEntityID(entityID string) (*Pod, error) {
 //  - HTTPS w/ service account token
 //  - HTTP (unauthenticated)
 func (ku *KubeUtil) setupKubeletApiClient() error {
-	// TODO configure the TLS for the APIServer in EKS Fargate mode. Bearer Token config will be needed too.
 	transport := &http.Transport{}
 	err := ku.setupTLS(
 		config.Datadog.GetBool("kubelet_tls_verify"),

--- a/release.json
+++ b/release.json
@@ -1,13 +1,13 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "ahmed-mez/kubelet-dev",
+		"INTEGRATIONS_CORE_VERSION": "master",
 		"OMNIBUS_SOFTWARE_VERSION": "master",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
 		"JMXFETCH_VERSION": "0.33.1",
 		"JMXFETCH_HASH": "140dd8568b78f5a616da8664f34bb37397c3d3ed87af106d632714f7218e8e88"
 	},
 	"nightly-a7": {
-		"INTEGRATIONS_CORE_VERSION": "ahmed-mez/kubelet-dev",
+		"INTEGRATIONS_CORE_VERSION": "master",
 		"OMNIBUS_SOFTWARE_VERSION": "master",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
 		"JMXFETCH_VERSION": "0.33.1",

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "master",
+		"INTEGRATIONS_CORE_VERSION": "ahmed-mez/kubelet-dev",
 		"OMNIBUS_SOFTWARE_VERSION": "master",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
 		"JMXFETCH_VERSION": "0.33.1",

--- a/release.json
+++ b/release.json
@@ -7,7 +7,7 @@
 		"JMXFETCH_HASH": "140dd8568b78f5a616da8664f34bb37397c3d3ed87af106d632714f7218e8e88"
 	},
 	"nightly-a7": {
-		"INTEGRATIONS_CORE_VERSION": "master",
+		"INTEGRATIONS_CORE_VERSION": "ahmed-mez/kubelet-dev",
 		"OMNIBUS_SOFTWARE_VERSION": "master",
 		"OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
 		"JMXFETCH_VERSION": "0.33.1",

--- a/releasenotes/notes/aws-fargate-amazon-eks-support-9a194a9f6c022062.yaml
+++ b/releasenotes/notes/aws-fargate-amazon-eks-support-9a194a9f6c022062.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Add logic to support querying the kubelet through the APIServer to monitor AWS Fargate on Amazon EKS.


### PR DESCRIPTION
### What does this PR do?

This adds logic to remove the default checks and configure the kubelet check to be proxied through the APIServer.
Also enabled the new `eks_fargate` check to report the number of pods backed by the AWS Fargate runtime.

### Motivation
Official image to support AWS Fargate on Amazon EKS

### Additional Notes

Anything else we should know when reviewing?
