### PR TITLE
Adding User-Agent to the DCA client

### DIFF
--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -170,6 +170,7 @@ func NewDatadogClient() (*datadog.Client, error) {
 	client := datadog.NewClient(apiKey, appKey)
 	client.HttpClient.Transport = httputils.CreateHTTPTransport()
 	client.RetryTimeout = 3 * time.Second
+	client.ExtraHeader["User-Agent"] = "Datadog-Cluster-Agent"
 
 	return client, nil
 }


### PR DESCRIPTION
### What does this PR do?

For troubleshooting purposes: Having a User-Agent in the header of the calls made by the Cluster Agent will help identify queries faster.

### Motivation

Debugging.

### Additional Notes

Anything else we should know when reviewing?
