### PR TITLE
Set enable_events_stream_payload_serialization at True

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -237,7 +237,7 @@ func initConfig(config Config) {
 	// Serializer
 	config.BindEnvAndSetDefault("enable_stream_payload_serialization", true)
 	config.BindEnvAndSetDefault("enable_service_checks_stream_payload_serialization", true)
-	config.BindEnvAndSetDefault("enable_events_stream_payload_serialization", false)
+	config.BindEnvAndSetDefault("enable_events_stream_payload_serialization", true)
 
 	// Warning: do not change the two following values. Your payloads will get dropped by Datadog's intake.
 	config.BindEnvAndSetDefault("serializer_max_payload_size", 2*megaByte+megaByte/2)


### PR DESCRIPTION
### What does this PR do?

Change the default value of enable_events_stream_payload_serialization.

### Motivation

Dev was testing on stating.

### Additional Notes

Follow-up to https://github.com/DataDog/datadog-agent/pull/4184

How to test this card:
- Make sure we have the same number of events as before
- Setting `enable_events_stream_payload_serialization` at `false` disable the new serialization 
- The event serialization logic has 3 cases to check (*) (Expvar `SendEventsErrItemTooBigs` and `SendEventsErrItemTooBigsFallback` helps to identify the 3 cases):
   - If the number of events with the same source type is low.
   - If the number of source type is low
   - fallback   

(*) As events are gathered by SourceType, the serialization logic is more complex than for the other serializations.
1. We first try to use PayloadBuilder where a single item is the list of all events for the same source type. This method may lead to item than can be too big to be serialized. In this case we try the following method.
 2. If the count of source type is less than maxItemCountForCreateMarshalersBySourceType then we use a of PayloadBuilder for each source type where an item is a single event. We limit to maxItemCountForCreateMarshalersBySourceType for performance reasons.
 3. If none of the previous methods work, we fallback to the old serialization method (Serializer.serializePayload).
