### PR TITLE
Fix registration of agent as event log source

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -274,7 +274,7 @@
           
           <!-- The "Name" field must match the argument to eventlog.Open() -->
           <util:EventSource Log="Application" Name="DatadogAgent"
-                EventMessageFile="[DIST]agent.exe"
+                EventMessageFile="[BIN]agent.exe"
                 SupportsErrors="yes"
                 SupportsInformationals="yes"
                 SupportsWarnings="yes"/>

--- a/releasenotes/notes/fixagenteventlogs-c7c2678d3d3b1fa4.yaml
+++ b/releasenotes/notes/fixagenteventlogs-c7c2678d3d3b1fa4.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, fixes registration of agent as event log source.  Allows
+    agent to correctly write to the Windows event log.


### PR DESCRIPTION
### What does this PR do?

Fixes agent regisration.

### Motivation

Agent event logs were coming out with the following message instead of the actual
message in the event log:

> The description for Event ID 4 from source DatadogAgent cannot be found. Either the component that raises this event is not installed on your local computer or the installation is corrupted. You can install or repair the component on the local computer.


### Additional Notes

Anything else we should know when reviewing?
