### PR TITLE
pkg/trace/api: change default operation name to be compliant to normalization

### DIFF
--- a/pkg/trace/api/normalizer.go
+++ b/pkg/trace/api/normalizer.go
@@ -33,7 +33,7 @@ const (
 	// DefaultServiceName is the default name we assign a service if it's missing and we have no reasonable fallback
 	DefaultServiceName = "unnamed-service"
 	// DefaultSpanName is the default name we assign a span if it's missing and we have no reasonable fallback
-	DefaultSpanName = "unnamed-operation"
+	DefaultSpanName = "unnamed_operation"
 )
 
 var (

--- a/pkg/trace/api/normalizer_test.go
+++ b/pkg/trace/api/normalizer_test.go
@@ -116,7 +116,7 @@ func TestNormalizeEmptyName(t *testing.T) {
 	s := newTestSpan()
 	s.Name = ""
 	assert.NoError(t, normalize(ts, s))
-	assert.Equal(t, s.Name, strings.Replace(DefaultSpanName, "-", "_", -1))
+	assert.Equal(t, s.Name, DefaultSpanName)
 	assert.Equal(t, tsMalformed(&info.SpansMalformed{SpanNameEmpty: 1}), ts)
 }
 

--- a/releasenotes/notes/Change-default-span-name-9e0c381290830b98.yaml
+++ b/releasenotes/notes/Change-default-span-name-9e0c381290830b98.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    APM: Traces containing spans without an operation name will automatically
+    be assigned the "unnamed_span" name (previously "unnamed-span").


### PR DESCRIPTION
### What does this PR do?

In the case of no alphabetic character in a span name, the span name is replaced by the default span name. The thing is that the default is not compliant to normalization rules because it contains a dash. Normalization of span name replaces dashes by underscores.
