### PR TITLE
remove exposing config content from expvar for process-agent

### DIFF
--- a/cmd/process-agent/info.go
+++ b/cmd/process-agent/info.go
@@ -235,13 +235,6 @@ func initInfo(conf *config.AgentConfig) error {
 		expvar.Publish("container_count", expvar.Func(publishContainerCount))
 		expvar.Publish("queue_size", expvar.Func(publishQueueSize))
 		expvar.Publish("container_id", expvar.Func(publishContainerID))
-		c := *conf
-		var buf []byte
-		buf, err = json.Marshal(&c)
-		if err != nil {
-			return
-		}
-		expvar.Publish("config", infoString(string(buf)))
 
 		infoTmpl, err = template.New("info").Funcs(funcMap).Parse(infoTmplSrc)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

A long time back we created the info command that exposes some information for process-agent to its expvar, including config information. This could leak critical info like APIKeys and other sensitive stuff, this PR removes it.

Also the info command that was used by the main agent to show each agent's detail info has been deprecated since agent 6. We'll need to create a new version of showing info. I created a card to track this work: https://datadoghq.atlassian.net/browse/PROC-101.

cc: @DataDog/burrito 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
