### PR TITLE
Dynamic buckets to batch queries to Datadog

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2215,6 +2215,7 @@
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/errors",
+    "k8s.io/apimachinery/pkg/util/rand",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",

--- a/pkg/util/kubernetes/apiserver/controller_util.go
+++ b/pkg/util/kubernetes/apiserver/controller_util.go
@@ -25,8 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/watermarkpodautoscaler/pkg/apis/datadoghq/v1alpha1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // NewAutoscalersController returns a new AutoscalersController
@@ -130,21 +128,6 @@ func (h *AutoscalersController) gc() {
 	}
 	h.deleteFromLocalStore(toDelete.External)
 	log.Debugf("Done GC run. Deleted %d metrics", len(toDelete.External))
-}
-
-// removeIgnoredAutoscaler is used in the gc to avoid considering the ignored Autoscalers
-func removeIgnoredAutoscaler(ignored map[types.UID]int, listCached []*autoscalingv2.HorizontalPodAutoscaler, listCachedWPA []*v1alpha1.WatermarkPodAutoscaler) (HPAToProcess []*autoscalingv2.HorizontalPodAutoscaler, WPAToProcess []*v1alpha1.WatermarkPodAutoscaler) {
-	for _, hpa := range listCached {
-		if _, ok := ignored[hpa.UID]; !ok {
-			HPAToProcess = append(HPAToProcess, hpa)
-		}
-	}
-	for _, wpa := range listCachedWPA {
-		if _, ok := ignored[wpa.UID]; !ok {
-			WPAToProcess = append(WPAToProcess, wpa)
-		}
-	}
-	return
 }
 
 func (h *AutoscalersController) deleteFromLocalStore(toDelete []custommetrics.ExternalMetricValue) {

--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -34,12 +34,6 @@ const (
 	maxCharactersPerChunk = 7000
 )
 
-type ByLen []string
-
-func (a ByLen) Len() int           { return len(a) }
-func (a ByLen) Less(i, j int) bool { return len(a[i]) > len(a[j]) }
-func (a ByLen) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-
 type DatadogClient interface {
 	QueryMetrics(from, to int64, query string) ([]datadog.Series, error)
 	GetRateLimitStats() map[string]datadog.RateLimit
@@ -158,9 +152,6 @@ func makeChunks(batch []string) (chunks [][]string) {
 	// uriLenght is used to avoid making a query that goes beyond the maximum URI size.
 	var uriLenght int
 	var tempBucket []string
-
-	// sort the batch by length of the element, from longest to shortest
-	sort.Sort(ByLen(batch))
 
 	for _, val := range batch {
 

--- a/pkg/util/kubernetes/autoscalers/processor_test.go
+++ b/pkg/util/kubernetes/autoscalers/processor_test.go
@@ -185,12 +185,12 @@ func TestProcessor_UpdateExternalMetrics(t *testing.T) {
 
 }
 
-var letterRunes = []rune("qwertyuiopasdfghjklzxcvbnm1234567890")
+var ASCIIRunes = []rune("qwertyuiopasdfghjklzxcvbnm1234567890")
 
 func randStringRune(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = ASCIIRunes[rand.Intn(len(ASCIIRunes))]
 	}
 	return string(b)
 }

--- a/pkg/util/kubernetes/autoscalers/processor_test.go
+++ b/pkg/util/kubernetes/autoscalers/processor_test.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/zorkian/go-datadog-api.v2"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 type fakeDatadogClient struct {
@@ -184,6 +185,16 @@ func TestProcessor_UpdateExternalMetrics(t *testing.T) {
 
 }
 
+var letterRunes = []rune("qwertyuiopasdfghjklzxcvbnm1234567890")
+
+func randStringRune(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
 func TestValidateExternalMetricsBatching(t *testing.T) {
 	metricName := "foo"
 	penTime := (int(time.Now().Unix()) - int(maxAge.Seconds()/2)) * 1000
@@ -231,7 +242,27 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 					Scope: makePtr("foo:bar"),
 				},
 			},
-			batchCalls: 4,
+			batchCalls: 5,
+			err:        nil,
+			timeout:    false,
+		},
+		{
+			desc: "Overspilling queries",
+			in: lambdaMakeChunks(20, custommetrics.ExternalMetricValue{
+				MetricName: randStringRune(4000),
+				Labels:     map[string]string{"foo": "bar"}}),
+			out: []datadog.Series{
+				{
+					Metric: &metricName,
+					Points: []datadog.DataPoint{
+						makePoints(1531492452000, 12),
+						makePoints(penTime, 14), // Force the penultimate point to be considered fresh at all time(< externalMaxAge)
+						makePoints(0, 27),
+					},
+					Scope: makePtr("foo:bar"),
+				},
+			},
+			batchCalls: 21,
 			err:        nil,
 			timeout:    false,
 		},
@@ -251,7 +282,7 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 					Scope: makePtr("foo:bar"),
 				},
 			},
-			batchCalls: 4,
+			batchCalls: 5,
 			err:        fmt.Errorf("Networking Error, timeout!!!"),
 			timeout:    true,
 		},


### PR DESCRIPTION
### What does this PR do?

One could create under 45 autoscalers (thus under the maximum number of supported autoscalers per batch call), with metric names and labels selectors such that the backend would return a 414 for an url too large (the CDN would return it actually).

This PR introduce a basic logic to avoid this pitfall. 
**Disclaimer:** We do not compute the optimal buckets (maximise the density of each chunk (to 7k characters) to minimise the number of calls) as we would be getting close to a [knapsack problem](https://en.wikipedia.org/wiki/Knapsack_problem). 
Secondly I chose not to sort the input by length of string for 2 reasons:
- Avoid the computation of the sorted slice
- While it would guarantee a consistency of # of calls (as the density of each chunk would be the same across calls), we maximise the likelihood of having more calls.
e.g. if the numbers represent the size of each query in the slice:
```
If we maximise each chunk to a len of 15 and 4 queries per batch, the sorted input:
10 | 9 | 3 | 2 | 1 | 1
yields:
[[10],[9,3,2,1],[1]] # 3 bucket, so 3 batch calls

While an unsorted one:
1 | 10 | 2 | 9 | 3 | 1
yields:
[[1,10,2],[9,3,1]] # 2 bucket, so 2 batch calls
```
This decision simply increases the likelihood of making fewer queries. Happy to revisit this (see the 1st commit, with the sort by length logic).

### Motivation

Improve the External Metrics Server.

### Additional Notes

Anything else we should know when reviewing?
