### PR TITLE
[reno] Change title of security-related section

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -50,6 +50,6 @@ sections:
   - [enhancements, Enhancement Notes]
   - [issues, Known Issues]
   - [deprecations, Deprecation Notes]
-  - [security, Security Issues]
+  - [security, Security Notes]
   - [fixes, Bug Fixes]
   - [other, Other Notes]


### PR DESCRIPTION
### What does this PR do?

Switch from "security issues" to the more neutral "security notes", makes it clear they're not "known issues" but similar to other notes.
