### PR TITLE
[config] Support configuring additional_endpoints with env vars

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -254,6 +254,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("enable_payloads.json_to_v1_intake", true)
 
 	// Forwarder
+	config.BindEnvAndSetDefault("additional_endpoints", map[string][]string{})
 	config.BindEnvAndSetDefault("forwarder_timeout", 20)
 	config.BindEnvAndSetDefault("forwarder_retry_queue_max_size", 30)
 	config.BindEnvAndSetDefault("forwarder_num_workers", 1)
@@ -515,7 +516,6 @@ func initConfig(config Config) {
 	config.SetKnown("config_providers")
 	config.SetKnown("cluster_name")
 	config.SetKnown("listeners")
-	config.SetKnown("additional_endpoints.*")
 	config.SetKnown("proxy.http")
 	config.SetKnown("proxy.https")
 	config.SetKnown("proxy.no_proxy")
@@ -934,12 +934,7 @@ func getMultipleEndpointsWithConfig(config Config) (map[string][]string, error) 
 		},
 	}
 
-	var additionalEndpoints map[string][]string
-	err = config.UnmarshalKey("additional_endpoints", &additionalEndpoints)
-	if err != nil {
-		return keysPerDomain, err
-	}
-
+	additionalEndpoints := config.GetStringMapStringSlice("additional_endpoints")
 	// merge additional endpoints into keysPerDomain
 	for domain, apiKeys := range additionalEndpoints {
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -460,7 +460,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
 	config.BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
-	config.SetKnown("logs_config.additional_endpoints")
+	config.BindEnv("logs_config.additional_endpoints")
 
 	// The cardinality of tags to send for checks and dogstatsd respectively.
 	// Choices are: low, orchestrator, high.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -826,7 +826,6 @@ func trimTrailingSlashFromURLS(config Config) error {
 	var additionalEndpointSelectors = []string{
 		"additional_endpoints",
 		"apm_config.additional_endpoints",
-		"logs_config.additional_endpoints",
 		"process_config.additional_endpoints",
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -227,6 +227,29 @@ additional_endpoints:
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
+func TestGetMultipleEndpointsEnvVar(t *testing.T) {
+	os.Setenv("DD_API_KEY", "fakeapikey")
+	os.Setenv("DD_ADDITIONAL_ENDPOINTS", "{\"https://foo.datadoghq.com\": [\"someapikey\"]}")
+	defer os.Unsetenv("DD_API_KEY")
+	defer os.Unsetenv("DD_ADDITIONAL_ENDPOINTS")
+
+	testConfig := setupConf()
+
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
+
+	expectedMultipleEndpoints := map[string][]string{
+		"https://foo.datadoghq.com": {
+			"someapikey",
+		},
+		"https://app.datadoghq.com": {
+			"fakeapikey",
+		},
+	}
+
+	assert.Nil(t, err)
+	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
+}
+
 func TestGetMultipleEndpointsSite(t *testing.T) {
 	datadogYaml := `
 site: datadoghq.eu

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -649,7 +649,6 @@ func TestTrimTrailingSlashFromURLS(t *testing.T) {
 	var additionalEndpointSelectors = []string{
 		"additional_endpoints",
 		"apm_config.additional_endpoints",
-		"logs_config.additional_endpoints",
 		"process_config.additional_endpoints",
 	}
 	datadogYaml := `
@@ -666,12 +665,6 @@ apm_config:
     testingapm.com//:
     - fakekey
     test2apm.com/:
-    - fakekey
-logs_config:
-  additional_endpoints:
-    testinglogs.com///////:
-    - fakekey
-    test2logs.com/:
     - fakekey
 process_config:
   additional_endpoints:

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -123,7 +123,13 @@ func buildTCPEndpoints() (*Endpoints, error) {
 	}
 
 	var additionals []Endpoint
-	err := coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &additionals)
+	var err error
+	raw := coreConfig.Datadog.GetString("logs_config.additional_endpoints")
+	if raw != "" {
+		err = json.Unmarshal([]byte(raw), &additionals)
+	} else {
+		err = coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &additionals)
+	}
 	if err != nil {
 		log.Warnf("Could not parse additional_endpoints for logs: %v", err)
 	}
@@ -131,7 +137,6 @@ func buildTCPEndpoints() (*Endpoints, error) {
 		additionals[i].UseSSL = main.UseSSL
 		additionals[i].ProxyAddress = proxyAddress
 	}
-
 	return NewEndpoints(main, additionals, useProto, false, 0), nil
 }
 
@@ -157,7 +162,13 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 	}
 
 	var additionals []Endpoint
-	err := coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &additionals)
+	var err error
+	raw := coreConfig.Datadog.GetString("logs_config.additional_endpoints")
+	if raw != "" {
+		err = json.Unmarshal([]byte(raw), &additionals)
+	} else {
+		err = coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &additionals)
+	}
 	if err != nil {
 		log.Warnf("Could not parse additional_endpoints for logs: %v", err)
 	}

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -122,17 +122,7 @@ func buildTCPEndpoints() (*Endpoints, error) {
 		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
 	}
 
-	var additionals []Endpoint
-	var err error
-	raw := coreConfig.Datadog.GetString("logs_config.additional_endpoints")
-	if raw != "" {
-		err = json.Unmarshal([]byte(raw), &additionals)
-	} else {
-		err = coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &additionals)
-	}
-	if err != nil {
-		log.Warnf("Could not parse additional_endpoints for logs: %v", err)
-	}
+	additionals := getAdditionalEndpoints()
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
 		additionals[i].ProxyAddress = proxyAddress
@@ -161,17 +151,7 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
 	}
 
-	var additionals []Endpoint
-	var err error
-	raw := coreConfig.Datadog.GetString("logs_config.additional_endpoints")
-	if raw != "" {
-		err = json.Unmarshal([]byte(raw), &additionals)
-	} else {
-		err = coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &additionals)
-	}
-	if err != nil {
-		log.Warnf("Could not parse additional_endpoints for logs: %v", err)
-	}
+	additionals := getAdditionalEndpoints()
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
 	}
@@ -179,6 +159,21 @@ func buildHTTPEndpoints() (*Endpoints, error) {
 	batchWait := batchWait(coreConfig.Datadog)
 
 	return NewEndpoints(main, additionals, false, true, batchWait), nil
+}
+
+func getAdditionalEndpoints() []Endpoint {
+	var endpoints []Endpoint
+	var err error
+	raw := coreConfig.Datadog.GetString("logs_config.additional_endpoints")
+	if raw != "" {
+		err = json.Unmarshal([]byte(raw), &endpoints)
+	} else {
+		err = coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &endpoints)
+	}
+	if err != nil {
+		log.Warnf("Could not parse additional_endpoints for logs: %v", err)
+	}
+	return endpoints
 }
 
 func isSetAndNotEmpty(config coreConfig.Config, key string) bool {

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -139,4 +140,80 @@ func (suite *ConfigTestSuite) TestTaggerWarmupDuration() {
 
 func TestConfigTestSuite(t *testing.T) {
 	suite.Run(t, new(ConfigTestSuite))
+}
+
+func (suite *ConfigTestSuite) TestMultipleHttpEndpointsEnvVar() {
+	suite.config.Set("api_key", "123")
+	suite.config.Set("logs_config.batch_wait", 1)
+	suite.config.Set("logs_config.logs_dd_url", "agent-http-intake.logs.datadoghq.com:443")
+	suite.config.Set("logs_config.use_compression", true)
+	suite.config.Set("logs_config.compression_level", 6)
+	suite.config.Set("logs_config.logs_no_ssl", false)
+
+	os.Setenv("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS", `[
+	{"api_key": "456", "host": "additional.endpoint.1", "port": 1234, "use_compression": true, "compression_level": 2},
+	{"api_key": "789", "host": "additional.endpoint.2", "port": 1234, "use_compression": true, "compression_level": 2}]`)
+	defer os.Unsetenv("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS")
+
+	expectedMainEndpoint := Endpoint{
+		APIKey:           "123",
+		Host:             "agent-http-intake.logs.datadoghq.com",
+		Port:             443,
+		UseSSL:           true,
+		UseCompression:   true,
+		CompressionLevel: 6}
+	expectedAdditionalEndpoint1 := Endpoint{
+		APIKey:           "456",
+		Host:             "additional.endpoint.1",
+		Port:             1234,
+		UseSSL:           true,
+		UseCompression:   true,
+		CompressionLevel: 2}
+	expectedAdditionalEndpoint2 := Endpoint{
+		APIKey:           "789",
+		Host:             "additional.endpoint.2",
+		Port:             1234,
+		UseSSL:           true,
+		UseCompression:   true,
+		CompressionLevel: 2}
+
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true, time.Second)
+	endpoints, err := buildHTTPEndpoints()
+
+	suite.Nil(err)
+	suite.Equal(expectedEndpoints, endpoints)
+}
+
+func (suite *ConfigTestSuite) TestMultipleTCPEndpointsEnvVar() {
+	suite.config.Set("api_key", "123")
+	suite.config.Set("logs_config.logs_dd_url", "agent-http-intake.logs.datadoghq.com:443")
+	suite.config.Set("logs_config.logs_no_ssl", false)
+	suite.config.Set("logs_config.socks5_proxy_address", "proxy.test:3128")
+	suite.config.Set("logs_config.dev_mode_use_proto", true)
+
+	os.Setenv("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS", `[{"api_key": "456", "host": "additional.endpoint", "port": 1234}]`)
+	defer os.Unsetenv("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS")
+
+	expectedMainEndpoint := Endpoint{
+		APIKey:           "123",
+		Host:             "agent-http-intake.logs.datadoghq.com",
+		Port:             443,
+		UseSSL:           true,
+		UseCompression:   false,
+		CompressionLevel: 0,
+		ProxyAddress:     "proxy.test:3128"}
+	expectedAdditionalEndpoint := Endpoint{
+		APIKey:           "456",
+		Host:             "additional.endpoint",
+		Port:             1234,
+		UseSSL:           true,
+		UseCompression:   false,
+		CompressionLevel: 0,
+		ProxyAddress:     "proxy.test:3128"}
+
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false, 0)
+	endpoints, err := buildTCPEndpoints()
+
+	suite.Nil(err)
+	suite.Equal(expectedEndpoints, endpoints)
 }

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -226,13 +226,13 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig() {
 	suite.config.Set("logs_config.compression_level", 6)
 	suite.config.Set("logs_config.logs_no_ssl", false)
 	endpointsInConfig := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"api_key":           "456",
 			"host":              "additional.endpoint.1",
 			"port":              1234,
 			"use_compression":   true,
 			"compression_level": 2},
-		map[string]interface{}{
+		{
 			"api_key":           "789",
 			"host":              "additional.endpoint.2",
 			"port":              1234,
@@ -278,7 +278,7 @@ func (suite *ConfigTestSuite) TestMultipleTCPEndpointsInConf() {
 	suite.config.Set("logs_config.dev_mode_use_proto", true)
 	suite.config.Set("logs_config.dev_mode_use_proto", true)
 	endpointsInConfig := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"api_key": "456",
 			"host":    "additional.endpoint",
 			"port":    1234},

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -217,3 +217,94 @@ func (suite *ConfigTestSuite) TestMultipleTCPEndpointsEnvVar() {
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
 }
+
+func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig() {
+	suite.config.Set("api_key", "123")
+	suite.config.Set("logs_config.batch_wait", 1)
+	suite.config.Set("logs_config.logs_dd_url", "agent-http-intake.logs.datadoghq.com:443")
+	suite.config.Set("logs_config.use_compression", true)
+	suite.config.Set("logs_config.compression_level", 6)
+	suite.config.Set("logs_config.logs_no_ssl", false)
+	endpointsInConfig := []map[string]interface{}{
+		map[string]interface{}{
+			"api_key":           "456",
+			"host":              "additional.endpoint.1",
+			"port":              1234,
+			"use_compression":   true,
+			"compression_level": 2},
+		map[string]interface{}{
+			"api_key":           "789",
+			"host":              "additional.endpoint.2",
+			"port":              1234,
+			"use_compression":   true,
+			"compression_level": 2},
+	}
+	suite.config.Set("logs_config.additional_endpoints", endpointsInConfig)
+
+	expectedMainEndpoint := Endpoint{
+		APIKey:           "123",
+		Host:             "agent-http-intake.logs.datadoghq.com",
+		Port:             443,
+		UseSSL:           true,
+		UseCompression:   true,
+		CompressionLevel: 6}
+	expectedAdditionalEndpoint1 := Endpoint{
+		APIKey:           "456",
+		Host:             "additional.endpoint.1",
+		Port:             1234,
+		UseSSL:           true,
+		UseCompression:   true,
+		CompressionLevel: 2}
+	expectedAdditionalEndpoint2 := Endpoint{
+		APIKey:           "789",
+		Host:             "additional.endpoint.2",
+		Port:             1234,
+		UseSSL:           true,
+		UseCompression:   true,
+		CompressionLevel: 2}
+
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true, time.Second)
+	endpoints, err := buildHTTPEndpoints()
+
+	suite.Nil(err)
+	suite.Equal(expectedEndpoints, endpoints)
+}
+
+func (suite *ConfigTestSuite) TestMultipleTCPEndpointsInConf() {
+	suite.config.Set("api_key", "123")
+	suite.config.Set("logs_config.logs_dd_url", "agent-http-intake.logs.datadoghq.com:443")
+	suite.config.Set("logs_config.logs_no_ssl", false)
+	suite.config.Set("logs_config.socks5_proxy_address", "proxy.test:3128")
+	suite.config.Set("logs_config.dev_mode_use_proto", true)
+	suite.config.Set("logs_config.dev_mode_use_proto", true)
+	endpointsInConfig := []map[string]interface{}{
+		map[string]interface{}{
+			"api_key": "456",
+			"host":    "additional.endpoint",
+			"port":    1234},
+	}
+	suite.config.Set("logs_config.additional_endpoints", endpointsInConfig)
+
+	expectedMainEndpoint := Endpoint{
+		APIKey:           "123",
+		Host:             "agent-http-intake.logs.datadoghq.com",
+		Port:             443,
+		UseSSL:           true,
+		UseCompression:   false,
+		CompressionLevel: 0,
+		ProxyAddress:     "proxy.test:3128"}
+	expectedAdditionalEndpoint := Endpoint{
+		APIKey:           "456",
+		Host:             "additional.endpoint",
+		Port:             1234,
+		UseSSL:           true,
+		UseCompression:   false,
+		CompressionLevel: 0,
+		ProxyAddress:     "proxy.test:3128"}
+
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false, 0)
+	endpoints, err := buildTCPEndpoints()
+
+	suite.Nil(err)
+	suite.Equal(expectedEndpoints, endpoints)
+}

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -11,12 +11,12 @@ import (
 
 // Endpoint holds all the organization and network parameters to send logs to Datadog.
 type Endpoint struct {
-	APIKey           string `mapstructure:"api_key"`
+	APIKey           string `mapstructure:"api_key" json:"api_key"`
 	Host             string
 	Port             int
 	UseSSL           bool
-	UseCompression   bool `mapstructure:"use_compression"`
-	CompressionLevel int  `mapstructure:"compression_level"`
+	UseCompression   bool `mapstructure:"use_compression" json:"use_compression"`
+	CompressionLevel int  `mapstructure:"compression_level" json:"compression_level"`
 	ProxyAddress     string
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds support for configuring `additional_endpoints` & `logs_config.additional_endpoints` with env vars.

### Additional Notes

This only applies to the infra & log agent for now.

TODO: extend this to the other agents (apm & process)
