### PR TITLE
sort uniq: benchmark fix

### DIFF
--- a/pkg/util/sort_uniq_test.go
+++ b/pkg/util/sort_uniq_test.go
@@ -34,6 +34,7 @@ func benchmarkDeduplicateTags(b *testing.B, numberOfTags int) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
+		copy(tempTags, tags)
 		SortUniqInPlace(tempTags)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

We were sorting an already sorted slice, fix that by reseting the slice every-time.

This adds an unrealistic overhead but there isn't a much better solution.

```
goos: darwin
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/util
BenchmarkDeduplicateTags/deduplicate-1-tags-in-place-4         	200000000	         7.98 ns/op	       0 B/op	       0 allocs/op
BenchmarkDeduplicateTags/deduplicate-2-tags-in-place-4         	50000000	        30.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkDeduplicateTags/deduplicate-4-tags-in-place-4         	20000000	        88.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkDeduplicateTags/deduplicate-8-tags-in-place-4         	 5000000	       307 ns/op	       0 B/op	       0 allocs/op
BenchmarkDeduplicateTags/deduplicate-16-tags-in-place-4        	 1000000	      1166 ns/op	       0 B/op	       0 allocs/op
BenchmarkDeduplicateTags/deduplicate-32-tags-in-place-4        	 1000000	      2192 ns/op	      32 B/op	       1 allocs/op
BenchmarkDeduplicateTags/deduplicate-64-tags-in-place-4        	  300000	      5585 ns/op	      32 B/op	       1 allocs/op
BenchmarkDeduplicateTags/deduplicate-128-tags-in-place-4       	  200000	     13047 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/DataDog/datadog-agent/pkg/util	15.550s
Success: Benchmarks passed.
```