### PR TITLE
[omnibus] Codesign binaries shipped in MacOS package

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -165,6 +165,10 @@ else
   dependency 'cacerts'
 end
 
+if osx?
+  dependency 'datadog-agent-mac-app'
+end
+
 if with_python_runtime? "2"
   dependency 'pylint2'
   dependency 'datadog-agent-integrations-py2'
@@ -172,10 +176,6 @@ end
 
 if with_python_runtime? "3"
   dependency 'datadog-agent-integrations-py3'
-end
-
-if osx?
-  dependency 'datadog-agent-mac-app'
 end
 
 # External agents

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -171,7 +171,11 @@ build do
             # remove windows specific configs
             delete "#{install_dir}/etc/conf.d/winproc.d"
 
-            # Nothing to move on osx, the confs already live in /opt/datadog-agent/etc/
+            # Codesign everything
+            command "find #{install_dir} -type f | grep -E '(\\.so|\\.dylib)' | xargs codesign --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)'"
+            command "find #{install_dir}/embedded/bin -perm +111 -type f | xargs codesign --force --timestamp  --deep -s 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)'"
+            command "find #{install_dir}/bin -perm +111 -type f | xargs codesign --force --timestamp  --deep -s 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)'"
+            command "codesign --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)' '#{install_dir}/Datadog Agent.app'"
         end
     end
 end


### PR DESCRIPTION
### What does this PR do?

Adds a code signing step when building on MacOS.

### Motivation

Required to notarize the MacOS package.

### Additional Notes

For now, the signing identity is directly defined and used in the software definition. A cleaner approach would be to define it at the project level, but that requires modifying `omnibus-ruby` code.

