### PR TITLE
Adds additional log_level documentation in config_template.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -889,9 +889,11 @@ api_key:
 ###########################
 
 ## @param log_level - string - optional - default: info
-## Minum log level of the Datadog Agent.
+## Minimum log level of the Datadog Agent.
+## Valid log levels are: trace, debug, info, warn, error, critical, and off.
+## Note: When using the 'off' log level, quotes are mandatory.
 #
-# log_level: info
+# log_level: 'info'
 
 ## @param log_file - string - optional
 ## Path of the log file for the Datadog Agent.


### PR DESCRIPTION
### What does this PR do?
Two additions, one listing all the valid log_level and a note
about mandatory quotes for the `off` log level.

### Motivation
If a non-existent log level is used the agent won't start. If the log level
is set to off, but unquoted in the datadog.yaml it will be parsed as a boolean
as per yaml specification 1.1 and the agent won't start either. 

### Additional Notes
N/A