### PR TITLE
Fix typo in writeEvent

### DIFF
--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -276,7 +276,7 @@ func writeEvent(event *Event, writer *utiljson.RawObjectWriter) error {
 
 	if len(event.Tags) != 0 {
 		if err := writer.StartArrayField("tags"); err != nil {
-			return nil
+			return err
 		}
 		for _, tag := range event.Tags {
 			writer.AddStringValue(tag)


### PR DESCRIPTION
### What does this PR do?

Handle the error returned by `utiljson.RawObjectWriter.StartArrayField` in `Event.writeEvent`. This kind of error is unexpected.
