### PR TITLE
[omnibus] Use code_signing_identity and skip signing if skip-sign is provided

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -23,6 +23,13 @@ else
   else
     maintainer 'Datadog Packages <package@datadoghq.com>'
   end
+
+  if osx?
+    unless ENV['SKIP_SIGN_MAC'] == 'true'
+      code_signing_identity 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)'
+    end
+  end
+
   install_dir '/opt/datadog-agent'
 end
 

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -171,11 +171,13 @@ build do
             # remove windows specific configs
             delete "#{install_dir}/etc/conf.d/winproc.d"
 
-            # Codesign everything
-            command "find #{install_dir} -type f | grep -E '(\\.so|\\.dylib)' | xargs codesign --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)'"
-            command "find #{install_dir}/embedded/bin -perm +111 -type f | xargs codesign --force --timestamp  --deep -s 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)'"
-            command "find #{install_dir}/bin -perm +111 -type f | xargs codesign --force --timestamp  --deep -s 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)'"
-            command "codesign --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)' '#{install_dir}/Datadog Agent.app'"
+            if code_signing_identity
+                # Codesign everything
+                command "find #{install_dir} -type f | grep -E '(\\.so|\\.dylib)' | xargs codesign --force --timestamp --deep -s '#{code_signing_identity}'"
+                command "find #{install_dir}/embedded/bin -perm +111 -type f | xargs codesign --force --timestamp  --deep -s '#{code_signing_identity}'"
+                command "find #{install_dir}/bin -perm +111 -type f | xargs codesign --force --timestamp  --deep -s '#{code_signing_identity}'"
+                command "codesign --force --timestamp --deep -s '#{code_signing_identity}' '#{install_dir}/Datadog Agent.app'"
+            end
         end
     end
 end


### PR DESCRIPTION
### What does this PR do?

Uses `code_signing_identity` added in https://github.com/DataDog/omnibus-ruby/pull/102
Skips code signing if `--skip-sign` is given to `inv agent.omnibus-build`.

### Motivation

Make the omnibus build still work without the signing keys when the `--skip-sign` option is provided.

