### PR TITLE
[system-probe] use IsLoopback instead of Direction=LOCAL to filter local DNS

### DIFF
--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -304,7 +304,7 @@ func (t *Tracer) initPerfPolling() (*bpflib.PerfMap, error) {
 //  • Local DNS (*:53) requests if configured (default: true)
 func (t *Tracer) shouldSkipConnection(conn *ConnectionStats) bool {
 	isDNSConnection := conn.DPort == 53 || conn.SPort == 53
-	if !t.config.CollectLocalDNS && isDNSConnection && conn.Direction == LOCAL {
+	if !t.config.CollectLocalDNS && isDNSConnection && conn.Dest.IsLoopback() {
 		return true
 	} else if IsBlacklistedConnection(t.sourceExcludes, t.destExcludes, conn) {
 		return true

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -951,42 +951,55 @@ func TestSkipConnectionDNS(t *testing.T) {
 		assert.True(t, tr.shouldSkipConnection(&ConnectionStats{
 			Source: util.AddressFromString("10.0.0.1"),
 			Dest:   util.AddressFromString("127.0.0.1"),
-			DPort:  53,
+			SPort:  1000, DPort: 53,
 		}))
 
 		assert.False(t, tr.shouldSkipConnection(&ConnectionStats{
 			Source: util.AddressFromString("10.0.0.1"),
 			Dest:   util.AddressFromString("127.0.0.1"),
-			DPort:  8080,
+			SPort:  1000, DPort: 8080,
 		}))
 
 		assert.True(t, tr.shouldSkipConnection(&ConnectionStats{
 			Source: util.AddressFromString("::3f::45"),
 			Dest:   util.AddressFromString("::1"),
-			DPort:  53,
+			SPort:  53, DPort: 1000,
 		}))
 
+		assert.True(t, tr.shouldSkipConnection(&ConnectionStats{
+			Source: util.AddressFromString("::3f::45"),
+			Dest:   util.AddressFromString("::1"),
+			SPort:  53, DPort: 1000,
+		}))
 	})
 
 	t.Run("CollectLocalDNS disabled", func(t *testing.T) {
 		tr := &Tracer{config: &Config{CollectLocalDNS: true}}
+
 		assert.False(t, tr.shouldSkipConnection(&ConnectionStats{
 			Source: util.AddressFromString("10.0.0.1"),
 			Dest:   util.AddressFromString("127.0.0.1"),
-			DPort:  53,
+			SPort:  1000, DPort: 53,
 		}))
 
 		assert.False(t, tr.shouldSkipConnection(&ConnectionStats{
 			Source: util.AddressFromString("10.0.0.1"),
 			Dest:   util.AddressFromString("127.0.0.1"),
-			DPort:  8080,
+			SPort:  1000, DPort: 8080,
 		}))
 
 		assert.False(t, tr.shouldSkipConnection(&ConnectionStats{
 			Source: util.AddressFromString("::3f::45"),
 			Dest:   util.AddressFromString("::1"),
-			DPort:  53,
+			SPort:  53, DPort: 1000,
 		}))
+
+		assert.False(t, tr.shouldSkipConnection(&ConnectionStats{
+			Source: util.AddressFromString("::3f::45"),
+			Dest:   util.AddressFromString("::1"),
+			SPort:  53, DPort: 1000,
+		}))
+
 	})
 }
 

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -941,6 +942,52 @@ func TestTCPMiscount(t *testing.T) {
 
 	tel := tr.getEbpfTelemetry()
 	assert.NotZero(t, tel["tcp_sent_miscounts"])
+}
+
+func TestSkipConnectionDNS(t *testing.T) {
+
+	t.Run("CollectLocalDNS disabled", func(t *testing.T) {
+		tr := &Tracer{config: &Config{CollectLocalDNS: false}}
+		assert.True(t, tr.shouldSkipConnection(&ConnectionStats{
+			Source: util.AddressFromString("10.0.0.1"),
+			Dest:   util.AddressFromString("127.0.0.1"),
+			DPort:  53,
+		}))
+
+		assert.False(t, tr.shouldSkipConnection(&ConnectionStats{
+			Source: util.AddressFromString("10.0.0.1"),
+			Dest:   util.AddressFromString("127.0.0.1"),
+			DPort:  8080,
+		}))
+
+		assert.True(t, tr.shouldSkipConnection(&ConnectionStats{
+			Source: util.AddressFromString("::3f::45"),
+			Dest:   util.AddressFromString("::1"),
+			DPort:  53,
+		}))
+
+	})
+
+	t.Run("CollectLocalDNS disabled", func(t *testing.T) {
+		tr := &Tracer{config: &Config{CollectLocalDNS: true}}
+		assert.False(t, tr.shouldSkipConnection(&ConnectionStats{
+			Source: util.AddressFromString("10.0.0.1"),
+			Dest:   util.AddressFromString("127.0.0.1"),
+			DPort:  53,
+		}))
+
+		assert.False(t, tr.shouldSkipConnection(&ConnectionStats{
+			Source: util.AddressFromString("10.0.0.1"),
+			Dest:   util.AddressFromString("127.0.0.1"),
+			DPort:  8080,
+		}))
+
+		assert.False(t, tr.shouldSkipConnection(&ConnectionStats{
+			Source: util.AddressFromString("::3f::45"),
+			Dest:   util.AddressFromString("::1"),
+			DPort:  53,
+		}))
+	})
 }
 
 func byAddress(l, r net.Addr) func(c ConnectionStats) bool {

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -9,6 +9,7 @@ import (
 type Address interface {
 	Bytes() []byte
 	String() string
+	IsLoopback() bool
 }
 
 // AddressFromNetIP returns an Address from a provided net.IP
@@ -63,6 +64,11 @@ func (a v4Address) String() string {
 	return net.IPv4(a[0], a[1], a[2], a[3]).String()
 }
 
+// IsLoopback returns true if this address is the loopback address
+func (a v4Address) IsLoopback() bool {
+	return net.IP(a[:]).IsLoopback()
+}
+
 type v6Address [16]byte
 
 // V6Address creates an Address using the uint128 representation of an v6 IP
@@ -88,4 +94,9 @@ func (a v6Address) Bytes() []byte {
 // String returns the human readable string representation of an IP
 func (a v6Address) String() string {
 	return net.IP(a[:]).String()
+}
+
+// IsLoopback returns true if this address is the loopback address
+func (a v6Address) IsLoopback() bool {
+	return net.IP(a[:]).IsLoopback()
 }

--- a/pkg/process/util/address_test.go
+++ b/pkg/process/util/address_test.go
@@ -32,10 +32,14 @@ func TestNetIPToAddress(t *testing.T) {
 	a = AddressFromNetIP(net.ParseIP("127.0.0.1"))
 	b = AddressFromNetIP(net.ParseIP("127.0.0.2"))
 	assert.NotEqual(t, a, b)
+	assert.True(t, a.IsLoopback())
+	assert.True(t, b.IsLoopback())
 
 	a = AddressFromNetIP(net.ParseIP("::7f00:35:0:1"))
 	b = AddressFromNetIP(net.ParseIP("::7f00:35:0:0"))
 	assert.NotEqual(t, a, b)
+	assert.False(t, a.IsLoopback())
+	assert.False(t, b.IsLoopback())
 }
 
 func TestNetIPFromAddress(t *testing.T) {
@@ -108,6 +112,7 @@ func TestAddressV6(t *testing.T) {
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("::7f00:35:0:0"))
 	assert.Equal(t, "::7f00:35:0:0", addr.String())
+	assert.False(t, addr.IsLoopback())
 
 	addr = V6Address(0, 0)
 	// Should be able to recreate addr from bytes alone
@@ -122,6 +127,7 @@ func TestAddressV6(t *testing.T) {
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("::1"))
 	assert.Equal(t, "::1", addr.String())
+	assert.True(t, addr.IsLoopback())
 
 	addr = V6Address(72059793061183488, 3087860000)
 	// Should be able to recreate addr from bytes alone
@@ -129,4 +135,5 @@ func TestAddressV6(t *testing.T) {
 	// Should be able to recreate addr from IP string
 	assert.Equal(t, addr, AddressFromString("2001:db8::2:1"))
 	assert.Equal(t, "2001:db8::2:1", addr.String())
+	assert.False(t, addr.IsLoopback())
 }


### PR DESCRIPTION

### What does this PR do?

github.com/DataDog/datadog-agent/pull/4628 got rid of the LOCAL
connection direction which had the unfortunate side effect of
breaking how we enforce the CollectLocalDNS flag.

We were using {s,d}port==53 && direction==LOCAL to filter DNS. Now we will use
{s,d}port==53 && dest.IsLoopback.

As part of this, add Address#IsLoopback uses net.IP#IsLoopback.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
