### PR TITLE
Fix status page for the Cluster Agent

### DIFF
--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -35,10 +35,12 @@ Collector
       Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
       Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
       Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
+      {{- if $.CheckMetadata }}
       {{- if index $.CheckMetadata .CheckID }}
       metadata:
       {{- range $k, $v := index $.CheckMetadata .CheckID }}
         {{ $k }}: {{ $v }}
+      {{- end }}
       {{- end }}
       {{- end }}
       {{if .LastError -}}


### PR DESCRIPTION
Check if `CheckMetadata` exists before iterating over it in cluster agent status page.

### What does this PR do?

Fix the status to:
```
=========
Collector
=========

  Running Checks
  ==============

    kubernetes_apiserver
    --------------------
      Instance ID: kubernetes_apiserver [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
[...]
      Average Execution Time : 1.919s

=========
Forwarder
=========

  Transactions
  ============
    CheckRunsV1: 689
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
