### PR TITLE
telemetry: do not set the namespace, the configuration check will take care of it

### DIFF
--- a/pkg/telemetry/counter.go
+++ b/pkg/telemetry/counter.go
@@ -26,19 +26,18 @@ type Counter interface {
 func NewCounter(subsystem, name string, tags []string, help string) Counter {
 	// subsystem is optional
 	if subsystem != "" {
-		subsystem = fmt.Sprintf("_%s", subsystem)
+		// Prefix metrics with a _, prometheus will add a second _
+		// It will create metrics with a custom separator and
+		// will let us replace it to a dot later in the process.
+		name = fmt.Sprintf("_%s", name)
 	}
 
 	c := &promCounter{
 		pc: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: namespace,
 				Subsystem: subsystem,
-				// Prefix metrics with a _, prometheus will add a second _
-				// It will create metrics with a custom separator and
-				// will let us replace it to a dot later in the process.
-				Name: fmt.Sprintf("_%s", name),
-				Help: help,
+				Name:      name,
+				Help:      help,
 			},
 			tags,
 		),

--- a/pkg/telemetry/gauge.go
+++ b/pkg/telemetry/gauge.go
@@ -32,19 +32,18 @@ type Gauge interface {
 func NewGauge(subsystem, name string, tags []string, help string) Gauge {
 	// subsystem is optional
 	if subsystem != "" {
-		subsystem = fmt.Sprintf("_%s", subsystem)
+		// Prefix metrics with a _, prometheus will add a second _
+		// It will create metrics with a custom separator and
+		// will let us replace it to a dot later in the process.
+		name = fmt.Sprintf("_%s", name)
 	}
 
 	g := &promGauge{
 		pg: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Namespace: namespace,
 				Subsystem: subsystem,
-				// Prefix metrics with a _, prometheus will add a second _
-				// It will create metrics with a custom separator and
-				// will let us replace it to a dot later in the process.
-				Name: fmt.Sprintf("_%s", name),
-				Help: help,
+				Name:      name,
+				Help:      help,
 			},
 			tags,
 		),

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,3 +1,5 @@
+// +build !clusterchecks
+
 package telemetry
 
 const (

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,7 +1,0 @@
-// +build !clusterchecks
-
-package telemetry
-
-const (
-	namespace = "agent"
-)

--- a/pkg/telemetry/telemetry_clusteragent.go
+++ b/pkg/telemetry/telemetry_clusteragent.go
@@ -1,0 +1,7 @@
+// +build clusterchecks
+
+package telemetry
+
+const (
+	namespace = "cluster_agent"
+)

--- a/pkg/telemetry/telemetry_clusteragent.go
+++ b/pkg/telemetry/telemetry_clusteragent.go
@@ -1,7 +1,0 @@
-// +build clusterchecks
-
-package telemetry
-
-const (
-	namespace = "cluster_agent"
-)


### PR DESCRIPTION
### What does this PR do?

Do not deal with the namespace of the metrics in the pkg, the configuration of the check will take care of it.