### PR TITLE
Fix kube node roles to host tags feature (handles multiple roles / node)

### DIFF
--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -50,6 +50,8 @@ func extractTags(nodeLabels, labelsToTags map[string]string) []string {
 	tagList := utils.NewTagList()
 
 	for labelName, labelValue := range nodeLabels {
+		labelName, labelValue := labelPreprocessor(labelName, labelValue)
+
 		if tagName, found := labelsToTags[strings.ToLower(labelName)]; found {
 			tagList.AddLow(tagName, labelValue)
 		}
@@ -57,4 +59,15 @@ func extractTags(nodeLabels, labelsToTags map[string]string) []string {
 
 	tags, _, _ := tagList.Compute()
 	return tags
+}
+
+func labelPreprocessor(labelName string, labelValue string) (string, string) {
+	switch {
+	// Kube label syntax guarantees that a valid name is present after /
+	// Label value is not used by Kube in this case
+	case strings.HasPrefix(labelName, "node-role.kubernetes.io/"):
+		return "kubernetes.io/role", labelName[24:]
+	}
+
+	return labelName, labelValue
 }

--- a/pkg/util/kubernetes/hostinfo/tags_test.go
+++ b/pkg/util/kubernetes/hostinfo/tags_test.go
@@ -22,6 +22,14 @@ func TestExtractTags(t *testing.T) {
 		"kubernetes.io/hostname":        "gke-dummy-18-default-pool-6888842e-hcv0",
 	}
 
+	roleLabels := map[string]string{
+		"kubernetes.io/role":                   "compute-node2",
+		"node-role.kubernetes.io":              "foo",
+		"node-role.kubernetes.io/9090-090-9":   "bar",
+		"node-role.kubernetes.io/compute-node": "",
+		"node-role.kubernetes.io/foo":          "bar",
+	}
+
 	for _, tc := range []struct {
 		nodeLabels   map[string]string
 		labelsToTags map[string]string
@@ -66,6 +74,16 @@ func TestExtractTags(t *testing.T) {
 			nodeLabels:   gkeLabels,
 			labelsToTags: map[string]string{},
 			expectedTags: nil,
+		},
+		{
+			nodeLabels:   roleLabels,
+			labelsToTags: getDefaultLabelsToTags(),
+			expectedTags: []string{
+				"kube_node_role:compute-node2",
+				"kube_node_role:9090-090-9",
+				"kube_node_role:compute-node",
+				"kube_node_role:foo",
+			},
 		},
 	} {
 		t.Run("", func(t *testing.T) {

--- a/releasenotes/notes/fix-kube-node-role-tag-9c29a785c79b3c50.yaml
+++ b/releasenotes/notes/fix-kube-node-role-tag-9c29a785c79b3c50.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the node roles to host tags feature by handling the other official Kube way to setting node roles (when multiple roles are required)


### PR DESCRIPTION
### What does this PR do?

Linked to QA Card:
https://trello.com/c/sdWNXzVB/3785-add-a-tag-for-kubernetes-node-role-in-host-metadata

Handles the 2 ways of setting node roles in Kube (the other one is required if a node has multiple roles):
```
kubernetes.io/role=compute-node2
role.kubernetes.io/compute-node=compute-node
role.kubernetes.io/compute-node=""
```
I've tried to implement something not too ugly that could serve other purposes but as we need to parse the labelName to get the value (...), we still need to add logic in there.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
