### PR TITLE
Revert "[docker] allow user to add custom docker label for tagging"

### DIFF
--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -56,9 +56,9 @@ messages, the delete eventually wins.
 
 **TagInfo** accepts and store tags that have different cardinality. **TagCardinality** can be:
 
-* **LowCardinality**: in the host count order of magnitude
-* **OrchestratorCardinality**: tags that change value for each pod or task
-* **HighCardinality**: typically tags that change value for each web request, user agent, container, etc.
+* ***LowCardinality**: in the host count order of magnitude
+* ***OrchestratorCardinality**:tags that change value for each pod or task
+* ***HighCardinality**: typically tags that change value for each web request, user agent, container, etc.
 
 ## Tagger
 

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -8,7 +8,6 @@
 package collectors
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -72,8 +71,6 @@ func dockerExtractImage(tags *utils.TagList, co types.ContainerJSON, resolve res
 
 // dockerExtractLabels contain hard-coded labels from:
 // - Docker swarm
-// - Rancher
-// - Custom
 func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string, labelsAsTags map[string]string) {
 	for labelName, labelValue := range containerLabels {
 		switch labelName {
@@ -90,23 +87,6 @@ func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string,
 			tags.AddLow("rancher_stack", labelValue)
 		case "io.rancher.stack_service.name":
 			tags.AddLow("rancher_service", labelValue)
-
-		// Custom labels as tags
-		case "com.datadoghq.ad.tags":
-			tagNames := []string{}
-			err := json.Unmarshal([]byte(labelValue), &tagNames)
-			if err != nil {
-				log.Debugf("Cannot unmarshal AD tags: %s", err)
-			}
-			for _, tag := range tagNames {
-				tagParts := strings.Split(tag, ":")
-				// skip if tag is not in expected k:v format
-				if len(tagParts) != 2 {
-					log.Debugf("Tag '%s' is not in k:v format", tag)
-					continue
-				}
-				tags.AddHigh(tagParts[0], tagParts[1])
-			}
 
 		default:
 			if tagName, found := labelsAsTags[strings.ToLower(labelName)]; found {

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -228,22 +228,6 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 			expectedOrch: []string{},
 			expectedHigh: []string{},
 		},
-		{
-			testName: "extractCustomLabels",
-			co: &types.ContainerJSON{
-				Config: &container.Config{
-					Env: []string{"PATH=/bin"},
-					Labels: map[string]string{
-						"com.datadoghq.ad.tags": "[\"adTestKey:adTestVal1\", \"adTestKey:adTestVal2\"]",
-					},
-				},
-			},
-			toRecordEnvAsTags:    map[string]string{},
-			toRecordLabelsAsTags: map[string]string{},
-			expectedLow:          []string{},
-			expectedOrch:         []string{},
-			expectedHigh:         []string{"adTestKey:adTestVal1", "adTestKey:adTestVal2"},
-		},
 	}
 
 	dc := &DockerCollector{}

--- a/releasenotes/notes/add-support-for-ad-docker-label-tags-bc5e9908696d2b5b.yaml
+++ b/releasenotes/notes/add-support-for-ad-docker-label-tags-bc5e9908696d2b5b.yaml
@@ -1,5 +1,0 @@
----
-enhancements:
-  - |
-    Support custom tagging of docker container data via an autodiscovery "tags"
-    label key.


### PR DESCRIPTION
Reverts DataDog/datadog-agent#4648

Reverting as the feature was implemented incorrectly, and it is not urgent.