### PR TITLE
Adding logic to show DCA status for Cluster Level Check feature only

### DIFF
--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -57,7 +57,7 @@ func FormatStatus(data []byte) (string, error) {
 	renderLogsStatus(b, logsStats)
 	renderAggregatorStatus(b, aggregatorStats)
 	renderDogstatsdStatus(b, dogstatsdStats)
-	if config.Datadog.GetBool("cluster_agent.enabled") {
+	if config.Datadog.GetBool("cluster_agent.enabled") || config.Datadog.GetBool("cluster_checks.enabled") {
 		renderDatadogClusterAgentStatus(b, dcaStats)
 	}
 


### PR DESCRIPTION
### What does this PR do?

The cluster level check feature does not require the `DD_CLUSTER_AGENT_ENABLED` (which will be fixed in the next release). 
If only the `DD_CLUTER_CHECKS_ENABLED` flag is used, the feature will work correctly but the Cluster Agent status will be missing from the `agent status` command of the node agent.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
