### PR TITLE
telemetry: avoid using the `type` tag.

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -102,9 +102,9 @@ var (
 	aggregatorHostnameUpdate                   = expvar.Int{}
 
 	tlmFlush = telemetry.NewCounter("aggregator", "flush",
-		[]string{"metric_type", "state"}, "Count of flush")
+		[]string{"data_type", "state"}, "Count of flush")
 	tlmProcessed = telemetry.NewCounter("aggregator", "processed",
-		[]string{"metric_type"}, "Amount of metrics/services_checks/events processed by the aggregator")
+		[]string{"data_type"}, "Amount of metrics/services_checks/events processed by the aggregator")
 	tlmHostnameUpdate = telemetry.NewCounter("aggregator", "hostname_update",
 		nil, "Count of hostname update")
 

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -102,9 +102,9 @@ var (
 	aggregatorHostnameUpdate                   = expvar.Int{}
 
 	tlmFlush = telemetry.NewCounter("aggregator", "flush",
-		[]string{"type", "state"}, "Count of flush")
+		[]string{"metric_type", "state"}, "Count of flush")
 	tlmProcessed = telemetry.NewCounter("aggregator", "processed",
-		[]string{"type"}, "Amount of metrics/services_checks/events processed by the aggregator")
+		[]string{"metric_type"}, "Amount of metrics/services_checks/events processed by the aggregator")
 	tlmHostnameUpdate = telemetry.NewCounter("aggregator", "hostname_update",
 		nil, "Count of hostname update")
 

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -40,7 +40,7 @@ var (
 	dogstatsdPacketsLastSec          = expvar.Int{}
 
 	tlmProcessed = telemetry.NewCounter("dogstatsd", "processed",
-		[]string{"metric_type", "state"}, "Count of service checks/events/metrics processed by dogstatsd")
+		[]string{"message_type", "state"}, "Count of service checks/events/metrics processed by dogstatsd")
 )
 
 func init() {

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -40,7 +40,7 @@ var (
 	dogstatsdPacketsLastSec          = expvar.Int{}
 
 	tlmProcessed = telemetry.NewCounter("dogstatsd", "processed",
-		[]string{"type", "state"}, "Count of service checks/events/metrics processed by dogstatsd")
+		[]string{"metric_type", "state"}, "Count of service checks/events/metrics processed by dogstatsd")
 )
 
 func init() {

--- a/pkg/forwarder/transaction.go
+++ b/pkg/forwarder/transaction.go
@@ -44,7 +44,7 @@ var (
 	tlmTxDroppedOnInput = telemetry.NewCounter("transactions", "dropped_on_input",
 		[]string{"domain"}, "Count of transactions dropped on input")
 	tlmTxErrors = telemetry.NewCounter("transactions", "errors",
-		[]string{"domain", "type"}, "Count of transactions errored grouped by type of error")
+		[]string{"domain", "error_type"}, "Count of transactions errored grouped by type of error")
 	tlmTxHTTPErrors = telemetry.NewCounter("transactions", "http_errors",
 		[]string{"domain", "code"}, "Count of transactions http errors per http code")
 )


### PR DESCRIPTION
### What does this PR do?

Changes the use of the `type` tag to something more specific, avoiding collision with existing `type` tag.
