### PR TITLE
telemetry: support options while creating telemetry metrics.

### DIFF
--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	apiRequests = telemetry.NewCounter("", "api_requests",
-		[]string{"handler", "status"}, "Counter of requests made to the cluster agent API.")
+	apiRequests = telemetry.NewCounterWithOpts("", "api_requests",
+		[]string{"handler", "status"}, "Counter of requests made to the cluster agent API.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 )
 
 func incrementRequestMetric(handler string, status int) {

--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -12,20 +12,28 @@ import (
 )
 
 var (
-	nodeAgents = telemetry.NewGauge("cluster_checks", "nodes_reporting",
-		nil, "Number of node agents reporting.")
-	danglingConfigs = telemetry.NewGauge("cluster_checks", "configs_dangling",
-		nil, "Number of check configurations not dispatched.")
-	dispatchedConfigs = telemetry.NewGauge("cluster_checks", "configs_dispatched",
-		[]string{"node"}, "Number of check configurations dispatched, by node.")
-	rebalancingDecisions = telemetry.NewCounter("cluster_checks", "rebalancing_decisions",
-		nil, "Total number of check rebalancing decisions")
-	successfulRebalancing = telemetry.NewCounter("cluster_checks", "successful_rebalancing_moves",
-		nil, "Total number of successful check rebalancing decisions")
-	rebalancingDuration = telemetry.NewGauge("cluster_checks", "rebalancing_duration_seconds",
-		nil, "Duration of the check rebalancing algorithm last execution")
-	statsCollectionFails = telemetry.NewCounter("cluster_checks", "failed_stats_collection",
-		[]string{"node"}, "Total number of unsuccessful stats collection attempts")
-	updateStatsDuration = telemetry.NewGauge("cluster_checks", "updating_stats_duration_seconds",
-		nil, "Duration of collecting stats from check runners and updating cache")
+	nodeAgents = telemetry.NewGaugeWithOpts("cluster_checks", "nodes_reporting",
+		nil, "Number of node agents reporting.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	danglingConfigs = telemetry.NewGaugeWithOpts("cluster_checks", "configs_dangling",
+		nil, "Number of check configurations not dispatched.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	dispatchedConfigs = telemetry.NewGaugeWithOpts("cluster_checks", "configs_dispatched",
+		[]string{"node"}, "Number of check configurations dispatched, by node.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	rebalancingDecisions = telemetry.NewCounterWithOpts("cluster_checks", "rebalancing_decisions",
+		nil, "Total number of check rebalancing decisions",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	successfulRebalancing = telemetry.NewCounterWithOpts("cluster_checks", "successful_rebalancing_moves",
+		nil, "Total number of successful check rebalancing decisions",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	rebalancingDuration = telemetry.NewGaugeWithOpts("cluster_checks", "rebalancing_duration_seconds",
+		nil, "Duration of the check rebalancing algorithm last execution",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	statsCollectionFails = telemetry.NewCounterWithOpts("cluster_checks", "failed_stats_collection",
+		[]string{"node"}, "Total number of unsuccessful stats collection attempts",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	updateStatsDuration = telemetry.NewGaugeWithOpts("cluster_checks", "updating_stats_duration_seconds",
+		nil, "Duration of collecting stats from check runners and updating cache",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 )

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -31,8 +31,9 @@ const (
 )
 
 var (
-	externalTotal = telemetry.NewGauge("external_metrics", "",
-		[]string{"valid"}, "Number of external metrics tagged.")
+	externalTotal = telemetry.NewGaugeWithOpts("", "external_metrics",
+		[]string{"valid"}, "Number of external metrics tagged.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	errNotInitialized = fmt.Errorf("configmap not initialized")
 )

--- a/pkg/telemetry/counter.go
+++ b/pkg/telemetry/counter.go
@@ -22,7 +22,7 @@ type Counter interface {
 }
 
 // NewCounter creates a Counter with default options for telemetry purpose.
-// Current implementation used: Prometheus Ounter
+// Current implementation used: Prometheus Counter
 func NewCounter(subsystem, name string, tags []string, help string) Counter {
 	return NewCounterWithOpts(subsystem, name, tags, help, DefaultOptions)
 }

--- a/pkg/telemetry/counter.go
+++ b/pkg/telemetry/counter.go
@@ -21,11 +21,17 @@ type Counter interface {
 	Delete(tagsValue ...string)
 }
 
-// NewCounter creates a Counter for telemetry purpose.
-// Current implementation used: Prometheus Counter.
+// NewCounter creates a Counter with default options for telemetry purpose.
+// Current implementation used: Prometheus Ounter
 func NewCounter(subsystem, name string, tags []string, help string) Counter {
+	return NewCounterWithOpts(subsystem, name, tags, help, DefaultOptions)
+}
+
+// NewCounterWithOpts creates a Counter with the given options for telemetry purpose.
+// See NewCounter()
+func NewCounterWithOpts(subsystem, name string, tags []string, help string, opts Options) Counter {
 	// subsystem is optional
-	if subsystem != "" {
+	if subsystem != "" && !opts.NoDoubleUnderscoreSep {
 		// Prefix metrics with a _, prometheus will add a second _
 		// It will create metrics with a custom separator and
 		// will let us replace it to a dot later in the process.

--- a/pkg/telemetry/gauge.go
+++ b/pkg/telemetry/gauge.go
@@ -27,11 +27,17 @@ type Gauge interface {
 	Delete(tagsValue ...string)
 }
 
-// NewGauge creates a Gauge for telemetry purpose.
+// NewGauge creates a Gauge with default options for telemetry purpose.
 // Current implementation used: Prometheus Gauge
 func NewGauge(subsystem, name string, tags []string, help string) Gauge {
+	return NewGaugeWithOpts(subsystem, name, tags, help, DefaultOptions)
+}
+
+// NewGaugeWithOpts creates a Gauge with the given options for telemetry purpose.
+// See NewGauge()
+func NewGaugeWithOpts(subsystem, name string, tags []string, help string, opts Options) Gauge {
 	// subsystem is optional
-	if subsystem != "" {
+	if subsystem != "" && !opts.NoDoubleUnderscoreSep {
 		// Prefix metrics with a _, prometheus will add a second _
 		// It will create metrics with a custom separator and
 		// will let us replace it to a dot later in the process.

--- a/pkg/telemetry/options.go
+++ b/pkg/telemetry/options.go
@@ -1,6 +1,6 @@
 package telemetry
 
-// Telemetry metric options.
+// Options for telemetry metrics.
 // Creating an Options struct without specifying any of its fields should be the
 // equivalent of using the DefaultOptions var.
 type Options struct {

--- a/pkg/telemetry/options.go
+++ b/pkg/telemetry/options.go
@@ -1,0 +1,17 @@
+package telemetry
+
+// Telemetry metric options.
+// Creating an Options struct without specifying any of its fields should be the
+// equivalent of using the DefaultOptions var.
+type Options struct {
+	// NoDoubleUnderscoreSep is set to true when you don't want to
+	// separate the subsystem and the name with a double underscore separator.
+	NoDoubleUnderscoreSep bool
+}
+
+// DefaultOptions for telemetry metrics which don't need to specify any option.
+var DefaultOptions = Options{
+	// By default, we want to separate the subsystem and the metric name with a
+	// double underscore to be able to replace it later in the process.
+	NoDoubleUnderscoreSep: false,
+}

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -24,20 +24,27 @@ import (
 )
 
 var (
-	ddRequests = telemetry.NewCounter("", "datadog_requests",
-		[]string{"status"}, "Counter of requests made to Datadog")
-	metricsEval = telemetry.NewGauge("", "external_metrics_processed_value",
-		[]string{"metric"}, "value processed from querying Datadog")
-	metricsDelay = telemetry.NewGauge("", "external_metrics_delay_seconds",
-		[]string{"metric"}, "freshness of the metric evaluated from querying Datadog")
-	rateLimitsRemaining = telemetry.NewGauge("", "rate_limit_queries_remaining",
-		[]string{"endpoint"}, "number of queries remaining before next reset")
-	rateLimitsReset = telemetry.NewGauge("", "rate_limit_queries_reset",
-		[]string{"endpoint"}, "number of seconds before next reset")
-	rateLimitsPeriod = telemetry.NewGauge("", "rate_limit_queries_period",
-		[]string{"endpoint"}, "period of rate limiting")
-	rateLimitsLimit = telemetry.NewGauge("", "rate_limit_queries_limit",
-		[]string{"endpoint"}, "maximum number of queries allowed in the period")
+	ddRequests = telemetry.NewCounterWithOpts("", "datadog_requests",
+		[]string{"status"}, "Counter of requests made to Datadog",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	metricsEval = telemetry.NewGaugeWithOpts("", "external_metrics_processed_value",
+		[]string{"metric"}, "value processed from querying Datadog",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	metricsDelay = telemetry.NewGaugeWithOpts("", "external_metrics_delay_seconds",
+		[]string{"metric"}, "freshness of the metric evaluated from querying Datadog",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	rateLimitsRemaining = telemetry.NewGaugeWithOpts("", "rate_limit_queries_remaining",
+		[]string{"endpoint"}, "number of queries remaining before next reset",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	rateLimitsReset = telemetry.NewGaugeWithOpts("", "rate_limit_queries_reset",
+		[]string{"endpoint"}, "number of seconds before next reset",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	rateLimitsPeriod = telemetry.NewGaugeWithOpts("", "rate_limit_queries_period",
+		[]string{"endpoint"}, "period of rate limiting",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	rateLimitsLimit = telemetry.NewGaugeWithOpts("", "rate_limit_queries_limit",
+		[]string{"endpoint"}, "maximum number of queries allowed in the period",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 )
 
 type Point struct {


### PR DESCRIPTION
### What does this PR do?

This PR adds support of Options while creating Gauge / Counter telemetry metrics.

### Motivation

Stick with the original metrics produced by the Cluster Agent.

### Additional Notes

All metrics that were already produced before `7.17.0` use the option `NoDoubleUnderscoreSep` introduced by this PR to keep the same name.