### PR TITLE
Add checks last execution date in status output

### DIFF
--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -32,6 +32,8 @@
                 Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
                 Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
                 Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}<br>
+                Last Execution Date : {{formatUnixTime .UpdateTimestamp}}<br>
+                Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}<br>
                 {{- if index $.Stats.inventories .CheckID }}
                 Metadata:<br>
                 <span class="stat_subdata">

--- a/cmd/agent/gui/views/templates/singleCheck.tmpl
+++ b/cmd/agent/gui/views/templates/singleCheck.tmpl
@@ -8,6 +8,8 @@
         Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
         Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
         Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
+        Last Execution Date : {{formatUnixTime .UpdateTimestamp}}<br>
+        Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}<br>
       {{- if .LastError}}
         <span class="error">Error</span>: {{lastErrorMessage .LastError}}<br>
               {{lastErrorTraceback .LastError -}}

--- a/pkg/collector/check/stats.go
+++ b/pkg/collector/check/stats.go
@@ -45,6 +45,7 @@ type Stats struct {
 	ExecutionTimes       [32]int64 // circular buffer of recent run durations, most recent at [(TotalRuns+31) % 32]
 	AverageExecutionTime int64     // average run duration
 	LastExecutionTime    int64     // most recent run duration, provided for convenience
+	LastSuccessDate      int64     // most recent successful execution date, unix timestamp in seconds
 	LastError            string    // error that occurred in the last run, if any
 	LastWarnings         []string  // warnings that occurred in the last run, if any
 	UpdateTimestamp      int64     // latest update to this instance, unix timestamp in seconds
@@ -96,6 +97,7 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats m
 			tlmRuns.Inc(cs.CheckName, "ok")
 		}
 		cs.LastError = ""
+		cs.LastSuccessDate = time.Now().Unix()
 	}
 	cs.LastWarnings = []string{}
 	if len(warnings) != 0 {

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -35,6 +35,8 @@ Collector
       Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
       Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
       Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
+      Last Execution Date : {{formatUnixTime .UpdateTimestamp}}
+      Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}
       {{- if $.CheckMetadata }}
       {{- if index $.CheckMetadata .CheckID }}
       metadata:

--- a/releasenotes/notes/add-execution-date-in-status-cmd-b2205885b86153e8.yaml
+++ b/releasenotes/notes/add-execution-date-in-status-cmd-b2205885b86153e8.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  - |
+    The status output now shows checks' last execution date
+    and the last successful one.


### PR DESCRIPTION
### What does this PR do?
Add the last execution date & the last successful execution date for all checks in status output.

### Motivation
It may help while troubleshoot checks behaviour to known when a check was executed last time as well as the last time it was successfully executed.

### Additional Notes
N/A