### PR TITLE
dsd: return packets to their pool

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -320,6 +320,7 @@ func (s *Server) parsePackets(batcher *batcher, packets []*listeners.Packet) {
 				}
 			}
 		}
+		s.packetPool.Put(packet)
 	}
 	batcher.flush()
 }


### PR DESCRIPTION
### What does this PR do?

Return packets back to their pool. Regression introduced in https://github.com/DataDog/datadog-agent/pull/4630.

Impact was not pooling incoming packets

### Notes

🤦‍♂ 