### PR TITLE
Add container uptime metric

### DIFF
--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -211,6 +211,8 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 			continue
 		}
 
+		currentTime := time.Now()
+		computeUptime(sender, info, currentTime, tags)
 		computeMem(sender, metrics.Memory, tags)
 
 		if metrics.CPU.Throttling != nil && metrics.CPU.Usage != nil {
@@ -293,6 +295,13 @@ func computeHugetlb(sender aggregator.Sender, huge []*cgroups.HugetlbStat, tags 
 		sender.Gauge("containerd.hugetlb.max", float64(h.Max), "", tags)
 		sender.Gauge("containerd.hugetlb.failcount", float64(h.Failcnt), "", tags)
 		sender.Gauge("containerd.hugetlb.usage", float64(h.Usage), "", tags)
+	}
+}
+
+func computeUptime(sender aggregator.Sender, ctn containers.Container, currentTime time.Time, tags []string) {
+	uptime := currentTime.Sub(ctn.CreatedAt).Seconds()
+	if uptime > 0 {
+		sender.Gauge("containerd.uptime", uptime, "", tags)
 	}
 }
 

--- a/pkg/collector/corechecks/containers/cri.go
+++ b/pkg/collector/corechecks/containers/cri.go
@@ -8,6 +8,8 @@
 package containers
 
 import (
+	"time"
+
 	yaml "gopkg.in/yaml.v2"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
@@ -88,27 +90,49 @@ func (c *CRICheck) Run() error {
 		c.Warnf("Cannot get containers from the CRI: %s", err)
 		return err
 	}
-	c.processContainerStats(sender, util.Runtime, containerStats)
+	c.generateMetrics(sender, containerStats, util)
 
 	sender.Commit()
 	return nil
 }
 
-// processContainerStats extracts metrics from the protobuf object
-func (c *CRICheck) processContainerStats(sender aggregator.Sender, runtime string, containerStats map[string]*pb.ContainerStats) {
+func (c *CRICheck) generateMetrics(sender aggregator.Sender, containerStats map[string]*pb.ContainerStats, criUtil cri.CRIClient) {
 	for cid, stats := range containerStats {
+		if stats == nil {
+			log.Warnf("Missing stats for container: %s", cid)
+			continue
+		}
+
 		entityID := containers.BuildTaggerEntityName(cid)
 		tags, err := tagger.Tag(entityID, collectors.HighCardinality)
 		if err != nil {
 			log.Errorf("Could not collect tags for container %s: %s", cid[:12], err)
 		}
-		tags = append(tags, "runtime:"+runtime)
-		sender.Gauge("cri.mem.rss", float64(stats.GetMemory().GetWorkingSetBytes().GetValue()), "", tags)
-		// Cumulative CPU usage (sum across all cores) since object creation.
-		sender.Rate("cri.cpu.usage", float64(stats.GetCpu().GetUsageCoreNanoSeconds().GetValue()), "", tags)
-		if c.instance.CollectDisk {
-			sender.Gauge("cri.disk.used", float64(stats.GetWritableLayer().GetUsedBytes().GetValue()), "", tags)
-			sender.Gauge("cri.disk.inodes", float64(stats.GetWritableLayer().GetInodesUsed().GetValue()), "", tags)
+		tags = append(tags, "runtime:"+criUtil.GetRuntime())
+
+		c.processContainerStats(sender, *stats, tags)
+
+		ctnStatus, err := criUtil.GetContainerStatus(cid)
+		if err == nil && ctnStatus != nil {
+			currentUnixTime := time.Now().UnixNano()
+			c.computeContainerUptime(sender, currentUnixTime, *ctnStatus, tags)
 		}
+	}
+}
+
+// processContainerStats extracts metrics from the protobuf object
+func (c *CRICheck) processContainerStats(sender aggregator.Sender, stats pb.ContainerStats, tags []string) {
+	sender.Gauge("cri.mem.rss", float64(stats.GetMemory().GetWorkingSetBytes().GetValue()), "", tags)
+	// Cumulative CPU usage (sum across all cores) since object creation.
+	sender.Rate("cri.cpu.usage", float64(stats.GetCpu().GetUsageCoreNanoSeconds().GetValue()), "", tags)
+	if c.instance.CollectDisk {
+		sender.Gauge("cri.disk.used", float64(stats.GetWritableLayer().GetUsedBytes().GetValue()), "", tags)
+		sender.Gauge("cri.disk.inodes", float64(stats.GetWritableLayer().GetInodesUsed().GetValue()), "", tags)
+	}
+}
+
+func (c *CRICheck) computeContainerUptime(sender aggregator.Sender, currentTime int64, ctnStatus pb.ContainerStatus, tags []string) {
+	if ctnStatus.StartedAt != 0 && currentTime-ctnStatus.StartedAt > 0 {
+		sender.Gauge("cri.uptime", float64((currentTime-ctnStatus.StartedAt)/int64(time.Second)), "", tags)
 	}
 }

--- a/pkg/collector/corechecks/containers/cri_test.go
+++ b/pkg/collector/corechecks/containers/cri_test.go
@@ -9,14 +9,17 @@ package containers
 
 import (
 	"testing"
+	"time"
 
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/cri/crimock"
+	"github.com/stretchr/testify/mock"
 )
 
-func TestCRIprocessContainerStats(t *testing.T) {
+func TestCriGenerateMetrics(t *testing.T) {
 	criCheck := &CRICheck{
 		CheckBase: core.NewCheckBase(criCheckName),
 		instance: &CRIConfig{
@@ -31,10 +34,15 @@ func TestCRIprocessContainerStats(t *testing.T) {
 		},
 	}
 
-	mocked := mocksender.NewMockSender(criCheck.ID())
-	mocked.On("Gauge", "cri.mem.rss", float64(0), "", []string{"runtime:fakeruntime"})
-	mocked.On("Rate", "cri.cpu.usage", float64(0), "", []string{"runtime:fakeruntime"})
-	mocked.On("Gauge", "cri.disk.used", float64(0), "", []string{"runtime:fakeruntime"})
-	mocked.On("Gauge", "cri.disk.inodes", float64(0), "", []string{"runtime:fakeruntime"})
-	criCheck.processContainerStats(mocked, "fakeruntime", stats)
+	mockedCriUtil := new(crimock.MockCRIClient)
+	mockedCriUtil.On("GetContainerStatus", "cri://foobar").Return(&pb.ContainerStatus{
+		StartedAt: time.Now().UnixNano() - int64(42*time.Second),
+	}, nil)
+	mockedSender := mocksender.NewMockSender(criCheck.ID())
+	mockedSender.On("Gauge", "cri.mem.rss", float64(0), "", []string{"runtime:fakeruntime"})
+	mockedSender.On("Rate", "cri.cpu.usage", float64(0), "", []string{"runtime:fakeruntime"})
+	mockedSender.On("Gauge", "cri.disk.used", float64(0), "", []string{"runtime:fakeruntime"})
+	mockedSender.On("Gauge", "cri.disk.inodes", float64(0), "", []string{"runtime:fakeruntime"})
+	mockedSender.On("Gauge", "cri.uptime", mock.MatchedBy(func(uptime float64) bool { return uptime >= 42.0 }), "", []string{"runtime:fakeruntime"})
+	criCheck.generateMetrics(mockedSender, stats, mockedCriUtil)
 }

--- a/pkg/collector/corechecks/containers/docker_test.go
+++ b/pkg/collector/corechecks/containers/docker_test.go
@@ -9,6 +9,7 @@ package containers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	cmetrics "github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
@@ -52,4 +53,19 @@ func TestReportIOMetrics(t *testing.T) {
 	mockSender.AssertMetric(t, "Rate", "docker.io.write_bytes", float64(671846400), "", sdaTags)
 	mockSender.AssertMetric(t, "Rate", "docker.io.read_bytes", float64(1130496), "", sdbTags)
 	mockSender.AssertMetric(t, "Rate", "docker.io.write_bytes", float64(0), "", sdbTags)
+}
+
+func TestReportUptime(t *testing.T) {
+	dockerCheck := &DockerCheck{
+		instance: &DockerConfig{},
+	}
+	mockSender := mocksender.NewMockSender(dockerCheck.ID())
+	mockSender.SetupAcceptAll()
+
+	tags := []string{"constant:tags", "container_name:dummy"}
+	currentTime := time.Now().Unix()
+
+	startTime := currentTime - 60
+	dockerCheck.reportUptime(startTime, currentTime, tags, mockSender)
+	mockSender.AssertMetric(t, "Gauge", "docker.uptime", 60.0, "", tags)
 }

--- a/pkg/util/containers/cri/crimock/criutil.go
+++ b/pkg/util/containers/cri/crimock/criutil.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build cri
+
+package crimock
+
+import (
+	"github.com/stretchr/testify/mock"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+// Mock
+type MockCRIClient struct {
+	mock.Mock
+}
+
+// ListContainerStats sends a ListContainerStatsRequest to the server, and parses the returned response
+func (m *MockCRIClient) ListContainerStats() (map[string]*pb.ContainerStats, error) {
+	args := m.Called()
+	return args.Get(0).(map[string]*pb.ContainerStats), args.Error(1)
+}
+
+// GetContainerStatus sends a ContainerStatusRequest to the server, and parses the returned response
+func (m *MockCRIClient) GetContainerStatus(containerID string) (*pb.ContainerStatus, error) {
+	args := m.Called(containerID)
+	return args.Get(0).(*pb.ContainerStatus), args.Error(1)
+}
+
+func (m *MockCRIClient) GetRuntime() string {
+	return "fakeruntime"
+}
+
+func (m *MockCRIClient) GetRuntimeVersion() string {
+	return "1.0"
+}

--- a/pkg/util/containers/cri/metadata.go
+++ b/pkg/util/containers/cri/metadata.go
@@ -21,8 +21,8 @@ func getMetadata() (map[string]string, error) {
 	if err != nil {
 		return metadata, err
 	}
-	metadata["cri_name"] = cu.Runtime
-	metadata["cri_version"] = cu.RuntimeVersion
+	metadata["cri_name"] = cu.GetRuntime()
+	metadata["cri_version"] = cu.GetRuntimeVersion()
 
 	return metadata, nil
 }

--- a/pkg/util/containers/cri/util_test.go
+++ b/pkg/util/containers/cri/util_test.go
@@ -31,8 +31,8 @@ func TestCRIUtilInit(t *testing.T) {
 	}
 	err = util.init()
 	require.NoError(t, err)
-	assert.Equal(t, "fakeRuntime", util.Runtime)
-	assert.Equal(t, "0.1.0", util.RuntimeVersion)
+	assert.Equal(t, "fakeRuntime", util.GetRuntime())
+	assert.Equal(t, "0.1.0", util.GetRuntimeVersion())
 }
 
 func TestCRIUtilListContainerStats(t *testing.T) {

--- a/releasenotes/notes/container-uptime-metrics-4f50973b086e74a3.yaml
+++ b/releasenotes/notes/container-uptime-metrics-4f50973b086e74a3.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Add docker.uptime, cri.uptime, and containerd.uptime metrics for all containers


### PR DESCRIPTION
### What does this PR do?

Add the `containerd.uptime` and `docker.uptime` metrics, two gauges that represents the uptime of a container (in seconds)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
