### PR TITLE
dsd: remove one alloc by sample linked to telemetry

### DIFF
--- a/pkg/telemetry/utils.go
+++ b/pkg/telemetry/utils.go
@@ -8,8 +8,7 @@ import (
 // Returns true if a * is present in the telemetry.checks list.
 func IsCheckEnabled(checkName string) bool {
 	// false if telemetry is disabled
-	if !config.Datadog.IsSet("telemetry.enabled") ||
-		config.Datadog.GetBool("telemetry.enabled") == false {
+	if !IsEnabled() {
 		return false
 	}
 
@@ -24,4 +23,9 @@ func IsCheckEnabled(checkName string) bool {
 		}
 	}
 	return false
+}
+
+// IsEnabled returns whether or not telemetry is enabled
+func IsEnabled() bool {
+	return config.Datadog.IsSet("telemetry.enabled") && config.Datadog.GetBool("telemetry.enabled")
 }


### PR DESCRIPTION
### What does this PR do?

Remove one alloc by sample as this has some impact on drop rate. 

### Note

This is a temporary solution for 6.17 to avoid adding a small regression. IMO we should not use tags here as they have a static list of values. Metric names would be a better fit to separate errors, samples, service checks and events.