### PR TITLE
Add make-kitchen-gitlab-yml invoke task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1872,7 +1872,7 @@ build_agent6:
   needs: ["agent_deb-x64-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
-    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -6
     BUILD_ARG: --target release --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*_amd64.deb
@@ -1884,7 +1884,7 @@ build_agent6_arm64:
   needs: ["agent_deb-arm-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
-    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -6
     BUILD_ARG: --target release --build-arg PYTHON_VERSION=2 --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*arm64.deb
@@ -1897,7 +1897,7 @@ build_agent6_jmx:
   needs: ["agent_deb-x64-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
-    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     BUILD_ARTIFACT_GLOB: datadog-agent_6*_amd64.deb
     TAG_SUFFIX: -6-jmx
@@ -1911,7 +1911,7 @@ build_agent6_jmx_arm64:
   needs: ["agent_deb-arm-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
-    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     BUILD_ARTIFACT_GLOB: datadog-agent_6*arm64.deb
     TAG_SUFFIX: -6-jmx
@@ -1926,7 +1926,7 @@ build_agent6_py2py3_jmx:
   needs: ["agent_deb-x64-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
-    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -6-py2py3-jmx
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent_6*_amd64.deb
@@ -1939,7 +1939,7 @@ build_agent7:
   needs: ["agent_deb-x64-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
-    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
     BUILD_ARG: --target release --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
@@ -1951,7 +1951,7 @@ build_agent7_arm64:
   needs: ["agent_deb-arm-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
-    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
     BUILD_ARG: --target release --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
@@ -1964,7 +1964,7 @@ build_agent7_jmx:
   needs: ["agent_deb-x64-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
-    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
@@ -1976,7 +1976,7 @@ build_agent7_jmx_arm64:
   needs: ["agent_deb-arm-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
-    IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
@@ -1988,7 +1988,7 @@ build_cluster_agent_amd64:
   extends: .docker_build_job_definition_amd64
   needs: ["cluster_agent-build_amd64"]
   variables:
-    IMAGE: &cluster-agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
 
 build_cluster_agent_arm64:
@@ -1996,7 +1996,7 @@ build_cluster_agent_arm64:
   extends: .docker_build_job_definition_arm64
   needs: ["cluster_agent-build_arm64"]
   variables:
-    IMAGE: &cluster-agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
 
 # build the dogstatsd image
@@ -2005,7 +2005,7 @@ build_dogstatsd_amd64:
   extends: .docker_build_job_definition_amd64
   needs: ["build_dogstatsd_static-deb_x64"]
   variables:
-    IMAGE: &dogstatsd_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
     BUILD_CONTEXT: Dockerfiles/dogstatsd/alpine
 
 #
@@ -2020,9 +2020,9 @@ twistlock_scan-6:
   dependencies: [] # Don't download Gitlab artefacts
   allow_failure: true # Don't block the pipeline
   variables:
-    SRC_AGENT: *agent_ecr
-    SRC_DSD: *dogstatsd_ecr
-    SRC_DCA: *cluster-agent_ecr
+    SRC_AGENT: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    SRC_DSD: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
+    SRC_DCA: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
   before_script:
     - export SRC_TAG=v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
     - export DOCKER_CLIENT_ADDRESS=$DOCKER_HOST
@@ -2042,9 +2042,9 @@ twistlock_scan-7:
   dependencies: [] # Don't download Gitlab artefacts
   allow_failure: true # Don't block the pipeline
   variables:
-    SRC_AGENT: *agent_ecr
-    SRC_DSD: *dogstatsd_ecr
-    SRC_DCA: *cluster-agent_ecr
+    SRC_AGENT: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    SRC_DSD: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
+    SRC_DCA: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
   before_script:
     - export SRC_TAG=v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
     - export DOCKER_CLIENT_ADDRESS=$DOCKER_HOST
@@ -2078,9 +2078,9 @@ twistlock_scan-7:
   DELEGATION_KEY_SSM_KEY: docker_hub_signing_key
   DELEGATION_PASS_SSM_KEY: docker_hub_signing_pass
   DOCKER_REGISTRY_URL: docker.io
-  SRC_AGENT: *agent_ecr
-  SRC_DSD: *dogstatsd_ecr
-  SRC_DCA: *cluster-agent_ecr
+  SRC_AGENT: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+  SRC_DSD: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
+  SRC_DCA: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
 
 .quay_variables: &quay_variables
   <<: *docker_hub_variables

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -4,26 +4,26 @@ Invoke entrypoint, import here all the tasks we want to make available
 import os
 from invoke import Collection
 
-from . import (agent, 
-    android, 
-    bench, 
+from . import (agent,
+    android,
+    bench,
     cluster_agent,
-    customaction, 
-    docker, 
-    dogstatsd, 
-    installcmd, 
+    customaction,
+    docker,
+    dogstatsd,
+    installcmd,
     process_agent,
-    pylauncher, 
-    release, 
-    rtloader, 
-    system_probe, 
-    systray, 
+    pylauncher,
+    release,
+    rtloader,
+    system_probe,
+    systray,
     trace_agent
 )
 
 
 from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, lint_licenses, reset
-from .test import test, integration_tests, lint_teamassignment, lint_releasenote, lint_milestone, lint_filenames, e2e_tests
+from .test import test, integration_tests, lint_teamassignment, lint_releasenote, lint_milestone, lint_filenames, e2e_tests, make_kitchen_gitlab_yml
 from .build_tags import audit_tag_impact
 
 # the root namespace
@@ -47,6 +47,7 @@ ns.add_task(lint_milestone)
 ns.add_task(lint_filenames)
 ns.add_task(audit_tag_impact)
 ns.add_task(e2e_tests)
+ns.add_task(make_kitchen_gitlab_yml)
 
 # add namespaced tasks to the root
 ns.add_collection(agent)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -8,6 +8,7 @@ import fnmatch
 import re
 import operator
 import sys
+import yaml
 
 import invoke
 from invoke import task
@@ -353,3 +354,38 @@ class TestProfiler:
                 sorted_times = sorted_times[:limit]
             for pkg, time in sorted_times:
                 print("{}s\t{}".format(time, pkg))
+
+@task
+def make_kitchen_gitlab_yml(ctx):
+    """
+    Replaces .gitlab-ci.yml with one containing only the steps needed to run kitchen-tests
+    """
+    with open('.gitlab-ci.yml') as f:
+        data = yaml.load(f, Loader=yaml.FullLoader)
+
+    data['stages'] = ['package_build', 'testkitchen_deploy', 'testkitchen_testing', 'testkitchen_cleanup']
+    for k,v in data.items():
+        if isinstance(v, dict) and v.get('stage', None) not in [None, 'package_build', 'testkitchen_deploy', 'testkitchen_testing', 'testkitchen_cleanup']:
+            del data[k]
+        if 'except' in v:
+            del v['except']
+        if 'only' in v:
+            del v['only']
+        if len(v) == 0:
+            del data[k]
+
+    for k,v in data.items():
+        if 'extends' in v:
+            extended = v['extends']
+            if extended not in data:
+                del data[k]
+        if 'needs' in v:
+            needed = v['needs']
+            new_needed = []
+            for n in needed:
+                if n in data:
+                   new_needed.append(n)
+            v['needs'] = new_needed
+
+    with open('.gitlab-ci.yml', 'w') as f:
+        documents = yaml.dump(data, f)


### PR DESCRIPTION
Removes every entry in `.gitlab-ci.yml` except those used for kitchen tests, so testing a change in kitchen is faster.
