### PR TITLE
[gitlab] Do not trigger pipeline on tag creation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 include: 'https://gitlab-templates.ddbuild.io/slack-notifier/v1/template.yml'
 
 stages:
+  - fail_on_tag
   - source_test
   - binary_build
   - integration_test
@@ -156,6 +157,19 @@ before_script:
   except:
     variables:
       - $RELEASE_VERSION_7 == ""
+
+# Fail if we're running a pipeline on a non-triggered tag build
+fail_on_non_triggered_tag:
+  stage: fail_on_tag
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: [ "runner:main", "size:2xlarge" ]
+  only:
+    - tags
+  before_script:
+    - "# noop"
+  script:
+    - echo CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE
+    - '[ $CI_PIPELINE_SOURCE != "push" ]'
 
 #
 # source_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,6 +159,7 @@ before_script:
       - $RELEASE_VERSION_7 == ""
 
 # Fail if we're running a pipeline on a non-triggered tag build
+# NOTE: All jobs with 'needs' dependencies should also 'need' this to workaround a Gitlab issue: https://gitlab.com/gitlab-org/gitlab/issues/31526
 fail_on_non_triggered_tag:
   stage: fail_on_tag
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
@@ -327,7 +328,7 @@ build_dogstatsd_static-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "run_tests_deb-x64-py3" ]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only
@@ -340,7 +341,7 @@ build_dogstatsd-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "run_tests_deb-x64-py3" ]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only
@@ -353,7 +354,7 @@ build_dogstatsd_static-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: [ "run_tests_deb-x64-py3" ]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
   variables:
     ARCH: arm64
   before_script:
@@ -372,7 +373,7 @@ build_dogstatsd-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: [ "run_tests_deb-x64-py3" ]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
   variables:
     ARCH: arm64
   before_script:
@@ -391,7 +392,7 @@ build_puppy_agent-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "run_tests_deb-x64-py3" ]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only --no-checks
@@ -404,7 +405,7 @@ build_puppy_agent-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: [ "run_tests_deb-x64-py3" ]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
   variables:
     ARCH: arm64
   before_script:
@@ -419,7 +420,7 @@ build_puppy_agent-deb_arm64:
 
 .cluster_agent-build_common: &cluster_agent-build_common
   stage: binary_build
-  needs: [ "run_dep_check_lock" ]
+  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock" ]
   script:
     - inv -e cluster-agent.build
     - $S3_CP_CMD $SRC_PATH/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTIFACTS_URI/datadog-cluster-agent.$ARCH
@@ -483,7 +484,7 @@ cluster_agent-build_arm64:
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:
   stage: integration_test
-  needs: ["build_dogstatsd_static-deb_x64"]
+  needs: ["fail_on_non_triggered_tag", "build_dogstatsd_static-deb_x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
   before_script:
@@ -497,7 +498,7 @@ run_dogstatsd_size_test:
 # check the size of the static dogstatsd binary
 run_dogstatsd_arm_size_test:
   stage: integration_test
-  needs: ["build_dogstatsd_static-deb_arm64"]
+  needs: ["fail_on_non_triggered_tag", "build_dogstatsd_static-deb_arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -542,7 +543,7 @@ agent_deb-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["run_tests_deb-x64-py2", "run_tests_deb-x64-py3"]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py2", "run_tests_deb-x64-py3"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     CONDA_ENV: ddpy3
@@ -562,7 +563,7 @@ agent_deb-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["run_tests_deb-x64-py3"]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     CONDA_ENV: ddpy3
@@ -580,7 +581,7 @@ agent_deb-x64-a7:
 
 agent_deb-arm-a6:
   stage: package_build
-  needs: ["run_dep_check_lock"]
+  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -598,7 +599,7 @@ agent_deb-arm-a6:
 
 agent_deb-arm-a7:
   stage: package_build
-  needs: ["run_dep_check_lock"]
+  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -619,7 +620,7 @@ puppy_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["build_puppy_agent-deb_x64"]
+  needs: [ "fail_on_non_triggered_tag", "build_puppy_agent-deb_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
@@ -680,7 +681,7 @@ agent_rpm-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3"]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 6
@@ -698,7 +699,7 @@ agent_rpm-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["run_tests_rpm-x64-py3"]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_rpm-x64-py3"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 7
@@ -714,7 +715,7 @@ agent_rpm-x64-a7:
   # build Agent package for rpm-x64
 agent_rpm-arm-a6:
   stage: package_build
-  needs: ["run_dep_check_lock"]
+  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -730,7 +731,7 @@ agent_rpm-arm-a6:
 # build Agent package for rpm-x64
 agent_rpm-arm-a7:
   stage: package_build
-  needs: ["run_dep_check_lock"]
+  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -780,7 +781,7 @@ agent_suse-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3" ]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 6
@@ -796,7 +797,7 @@ agent_suse-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "run_tests_rpm-x64-py3" ]
+  needs: [ "fail_on_non_triggered_tag", "run_tests_rpm-x64-py3" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 7
@@ -811,7 +812,7 @@ agent_suse-x64-a7:
 cf_buildpack_windows:
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["run_dep_check_lock"]
+  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 7
@@ -835,7 +836,7 @@ cf_buildpack_windows:
 
 .windows_msi_base:
   stage: package_build
-  needs: ["run_dep_check_lock"]
+  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   # Unavailable on gitlab < 12.3
   # timeout: 2h 00m
@@ -974,7 +975,7 @@ dogstatsd_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "build_dogstatsd-deb_x64" ]
+  needs: [ "fail_on_non_triggered_tag", "build_dogstatsd-deb_x64" ]
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -1007,7 +1008,7 @@ dogstatsd_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "build_dogstatsd-deb_x64" ]
+  needs: [ "fail_on_non_triggered_tag", "build_dogstatsd-deb_x64" ]
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -1046,7 +1047,7 @@ dogstatsd_suse-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:large" ]
-  needs: [ "build_dogstatsd-deb_x64" ]
+  needs: [ "fail_on_non_triggered_tag", "build_dogstatsd-deb_x64" ]
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -1079,7 +1080,7 @@ dogstatsd_suse-x64:
 # deploy debian packages to apt staging repo
 deploy_deb_testing-a6:
   stage: testkitchen_deploy
-  needs: ["agent_deb-x64-a6"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1107,7 +1108,7 @@ deploy_deb_testing-a6:
 
 deploy_deb_testing-a7:
   stage: testkitchen_deploy
-  needs: ["agent_deb-x64-a7"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1139,7 +1140,7 @@ deploy_rpm_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: ["agent_rpm-x64-a6"]
+  needs: [ "fail_on_non_triggered_tag", "agent_rpm-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1159,7 +1160,7 @@ deploy_rpm_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: ["agent_rpm-x64-a7"]
+  needs: [ "fail_on_non_triggered_tag", "agent_rpm-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1180,7 +1181,7 @@ deploy_suse_rpm_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: ["agent_suse-x64-a6"]
+  needs: [ "fail_on_non_triggered_tag", "agent_suse-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1200,7 +1201,7 @@ deploy_suse_rpm_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: ["agent_suse-x64-a7"]
+  needs: [ "fail_on_non_triggered_tag", "agent_suse-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1221,7 +1222,7 @@ deploy_windows_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: ["windows_msi_x86-a6", "windows_msi_x64-a6"]
+  needs: [ "fail_on_non_triggered_tag", "windows_msi_x86-a6", "windows_msi_x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1233,7 +1234,7 @@ deploy_windows_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: ["windows_msi_x86-a7", "windows_msi_x64-a7"]
+  needs: [ "fail_on_non_triggered_tag", "windows_msi_x86-a7", "windows_msi_x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1369,52 +1370,52 @@ deploy_windows_testing-a7:
 .kitchen_scenario_windows_a6: &kitchen_scenario_windows_a6
   <<: *kitchen_os_windows
   <<: *kitchen_agent_a6
-  needs: ["deploy_windows_testing-a6"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_windows_testing-a6"]
 
 .kitchen_scenario_windows_a7: &kitchen_scenario_windows_a7
   <<: *kitchen_os_windows
   <<: *kitchen_agent_a7
-  needs: ["deploy_windows_testing-a7"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_windows_testing-a7"]
 
 .kitchen_scenario_centos_a6: &kitchen_scenario_centos_a6
   <<: *kitchen_os_centos
   <<: *kitchen_agent_a6
-  needs: ["deploy_rpm_testing-a6"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_a7: &kitchen_scenario_centos_a7
   <<: *kitchen_os_centos
   <<: *kitchen_agent_a7
-  needs: ["deploy_rpm_testing-a7"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_rpm_testing-a7"]
 
 .kitchen_scenario_ubuntu_a6: &kitchen_scenario_ubuntu_a6
   <<: *kitchen_os_ubuntu
   <<: *kitchen_agent_a6
-  needs: ["deploy_deb_testing-a6"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_deb_testing-a6"]
 
 .kitchen_scenario_ubuntu_a7: &kitchen_scenario_ubuntu_a7
   <<: *kitchen_os_ubuntu
   <<: *kitchen_agent_a7
-  needs: ["deploy_deb_testing-a7"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_deb_testing-a7"]
 
 .kitchen_scenario_suse_a6: &kitchen_scenario_suse_a6
   <<: *kitchen_os_suse
   <<: *kitchen_agent_a6
-  needs: ["deploy_suse_rpm_testing-a6"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_suse_rpm_testing-a6"]
 
 .kitchen_scenario_suse_a7: &kitchen_scenario_suse_a7
   <<: *kitchen_os_suse
   <<: *kitchen_agent_a6
-  needs: ["deploy_suse_rpm_testing-a7"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_suse_rpm_testing-a7"]
 
 .kitchen_scenario_debian_a6: &kitchen_scenario_debian_a6
   <<: *kitchen_os_debian
   <<: *kitchen_agent_a6
-  needs: ["deploy_deb_testing-a6"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_deb_testing-a6"]
 
 .kitchen_scenario_debian_a7: &kitchen_scenario_debian_a7
   <<: *kitchen_os_debian
   <<: *kitchen_agent_a7
-  needs: ["deploy_deb_testing-a7"]
+  needs: [ "fail_on_non_triggered_tag", "deploy_deb_testing-a7"]
 
 
 
@@ -1881,7 +1882,7 @@ testkitchen_cleanup_azure-a7:
 build_agent6:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: ["agent_deb-x64-a6"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1893,7 +1894,7 @@ build_agent6:
 build_agent6_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: ["agent_deb-arm-a6"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-arm-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1906,7 +1907,7 @@ build_agent6_arm64:
 build_agent6_jmx:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: ["agent_deb-x64-a6"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1920,7 +1921,7 @@ build_agent6_jmx:
 build_agent6_jmx_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: ["agent_deb-arm-a6"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-arm-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1935,7 +1936,7 @@ build_agent6_jmx_arm64:
 build_agent6_py2py3_jmx:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: ["agent_deb-x64-a6"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1948,7 +1949,7 @@ build_agent6_py2py3_jmx:
 build_agent7:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: ["agent_deb-x64-a7"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1960,7 +1961,7 @@ build_agent7:
 build_agent7_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: ["agent_deb-arm-a7"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-arm-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1973,7 +1974,7 @@ build_agent7_arm64:
 build_agent7_jmx:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: ["agent_deb-x64-a7"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1985,7 +1986,7 @@ build_agent7_jmx:
 build_agent7_jmx_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: ["agent_deb-arm-a7"]
+  needs: [ "fail_on_non_triggered_tag", "agent_deb-arm-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1998,7 +1999,7 @@ build_agent7_jmx_arm64:
 build_cluster_agent_amd64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: ["cluster_agent-build_amd64"]
+  needs: [ "fail_on_non_triggered_tag", "cluster_agent-build_amd64"]
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
@@ -2006,7 +2007,7 @@ build_cluster_agent_amd64:
 build_cluster_agent_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: ["cluster_agent-build_arm64"]
+  needs: [ "fail_on_non_triggered_tag", "cluster_agent-build_arm64"]
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
@@ -2015,7 +2016,7 @@ build_cluster_agent_arm64:
 build_dogstatsd_amd64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: ["build_dogstatsd_static-deb_x64"]
+  needs: [ "fail_on_non_triggered_tag", "build_dogstatsd_static-deb_x64"]
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
     BUILD_CONTEXT: Dockerfiles/dogstatsd/alpine
@@ -2103,6 +2104,7 @@ twistlock_scan-7:
 dev_branch_docker_hub:
   <<: *docker_tag_job_definition
   needs:
+    - fail_on_non_triggered_tag
     - build_agent6
     - build_agent6_jmx
     - build_agent6_py2py3_jmx
@@ -2127,6 +2129,7 @@ dev_branch_docker_hub:
 dev_branch_multiarch_docker_hub:
   <<: *docker_tag_job_definition
   needs:
+    - fail_on_non_triggered_tag
     - build_agent6
     - build_agent6_arm64
     - build_agent6_jmx
@@ -2164,6 +2167,7 @@ dev_branch_multiarch_docker_hub:
 dev_master_docker_hub:
   <<: *docker_tag_job_definition
   needs:
+    - fail_on_non_triggered_tag
     - build_agent6
     - build_agent6_jmx
     - build_agent6_py2py3_jmx
@@ -2185,7 +2189,7 @@ dev_master_docker_hub:
 
 dca_dev_branch_docker_hub:
   <<: *docker_tag_job_definition
-  needs: ["build_cluster_agent_amd64"]
+  needs: ["fail_on_non_triggered_tag", "build_cluster_agent_amd64"]
   when: manual
   except:
     - master
@@ -2196,7 +2200,7 @@ dca_dev_branch_docker_hub:
 
 dca_dev_branch_multiarch_docker_hub:
   <<: *docker_tag_job_definition
-  needs: ["build_cluster_agent_amd64", "build_cluster_agent_arm64"]
+  needs: ["fail_on_non_triggered_tag", "build_cluster_agent_amd64", "build_cluster_agent_arm64"]
   when: manual
   except:
     - master
@@ -2208,7 +2212,7 @@ dca_dev_branch_multiarch_docker_hub:
 
 dca_dev_master_docker_hub:
   <<: *docker_tag_job_definition
-  needs: ["build_cluster_agent_amd64"]
+  needs: ["fail_on_non_triggered_tag", "build_cluster_agent_amd64"]
   only:
     - master
   variables:
@@ -2221,6 +2225,7 @@ dev_nightly_docker_hub:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_nightly
   needs:
+    - fail_on_non_triggered_tag
     - build_agent6
     - build_agent6_jmx
     - build_agent6_py2py3_jmx


### PR DESCRIPTION
A bit of a hack. Make pipelines for tags fail automatically, since we don't want them but we can't `except` them out (otherwise, callback-triggered pipelines using a tag as git ref don't trigger).