### PR TITLE
[dogstatsd] Include full metric message in error when invalid

### DIFF
--- a/pkg/dogstatsd/parse_events.go
+++ b/pkg/dogstatsd/parse_events.go
@@ -159,10 +159,10 @@ func parseEvent(message []byte) (dogstatsdEvent, error) {
 		return dogstatsdEvent{}, err
 	}
 	if len(rawEvent) < header.textLength+header.titleLength+1 {
-		return dogstatsdEvent{}, fmt.Errorf("invalid event: %q", message)
+		return dogstatsdEvent{}, fmt.Errorf("invalid event")
 	}
 	if header.titleLength == 0 || header.textLength == 0 {
-		return dogstatsdEvent{}, fmt.Errorf("invalid event, empty title or text: %q", message)
+		return dogstatsdEvent{}, fmt.Errorf("invalid event: empty title or text")
 	}
 	title := cleanEventText(rawEvent[:header.titleLength])
 	text := cleanEventText(rawEvent[header.titleLength+1 : header.titleLength+1+header.textLength])

--- a/pkg/dogstatsd/parse_metrics.go
+++ b/pkg/dogstatsd/parse_metrics.go
@@ -89,7 +89,7 @@ func parseMetricSample(message []byte) (dogstatsdMetricSample, error) {
 	// especially important here since all the unidentified garbage gets
 	// identified as metrics
 	if !hasMetricSampleFormat(message) {
-		return dogstatsdMetricSample{}, fmt.Errorf("invalid dogstatsd message format: %q", message)
+		return dogstatsdMetricSample{}, fmt.Errorf("invalid dogstatsd message format")
 	}
 
 	rawNameAndValue, message := nextField(message)

--- a/pkg/dogstatsd/parse_service_checks.go
+++ b/pkg/dogstatsd/parse_service_checks.go
@@ -99,7 +99,7 @@ func applyServiceCheckOptionalField(serviceCheck dogstatsdServiceCheck, optional
 
 func parseServiceCheck(message []byte) (dogstatsdServiceCheck, error) {
 	if !hasServiceCheckFormat(message) {
-		return dogstatsdServiceCheck{}, fmt.Errorf("invalid dogstatsd service check format: %q", message)
+		return dogstatsdServiceCheck{}, fmt.Errorf("invalid dogstatsd service check format")
 	}
 	// pop the _sc| header
 	message = message[4:]

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -290,7 +290,7 @@ func (s *Server) parsePackets(batcher *batcher, packets []*listeners.Packet) {
 			case serviceCheckType:
 				serviceCheck, err := s.parseServiceCheckMessage(message)
 				if err != nil {
-					log.Errorf("Dogstatsd: error parsing service check: %s", err)
+					log.Errorf("Dogstatsd: error parsing service check %q: %s", message, err)
 					continue
 				}
 				serviceCheck.Tags = append(serviceCheck.Tags, originTags...)
@@ -298,7 +298,7 @@ func (s *Server) parsePackets(batcher *batcher, packets []*listeners.Packet) {
 			case eventType:
 				event, err := s.parseEventMessage(message)
 				if err != nil {
-					log.Errorf("Dogstatsd: error parsing event: %s", err)
+					log.Errorf("Dogstatsd: error parsing event %q: %s", message, err)
 					continue
 				}
 				event.Tags = append(event.Tags, originTags...)
@@ -306,7 +306,7 @@ func (s *Server) parsePackets(batcher *batcher, packets []*listeners.Packet) {
 			case metricSampleType:
 				sample, err := s.parseMetricMessage(message)
 				if err != nil {
-					log.Errorf("Dogstatsd: error parsing metrics: %s", err)
+					log.Errorf("Dogstatsd: error parsing metric message %q: %s", message, err)
 					continue
 				}
 				if s.debugMetricsStats {


### PR DESCRIPTION
### What does this PR do?

* Includes the full metric message to the error when the message is invalid
* Normalizes how we log invalid events and service check messages as well

### Motivation

Ease troubleshooting.

### Additional Notes

Usability regression introduced by https://github.com/DataDog/datadog-agent/pull/4575
