### PR TITLE
[logs/registry] Do not log error if registry does not exist

### DIFF
--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -156,7 +156,11 @@ func (a *Auditor) run() {
 func (a *Auditor) recoverRegistry() map[string]*RegistryEntry {
 	mr, err := ioutil.ReadFile(a.registryPath)
 	if err != nil {
-		log.Error(err)
+		if os.IsNotExist(err) {
+			log.Debugf("Could not find state file at %q, will start with default offsets", a.registryPath)
+		} else {
+			log.Error(err)
+		}
 		return make(map[string]*RegistryEntry)
 	}
 	r, err := a.unmarshalRegistry(mr)


### PR DESCRIPTION
# What does this PR do?

Do not log error if registry does not exist.

It's expected for the registry to not exist when the agent starts for
the first time, so only log at the debug level when that happens.

### Motivation

Avoid noisy log entries/misleading log levels