### PR TITLE
Fix inv make-kitchen-gitlab-yaml to correctly render python runtimes var

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -388,4 +388,4 @@ def make_kitchen_gitlab_yml(ctx):
             v['needs'] = new_needed
 
     with open('.gitlab-ci.yml', 'w') as f:
-        documents = yaml.dump(data, f)
+        documents = yaml.dump(data, f, default_style='"')


### PR DESCRIPTION
### What does this PR do?

Changes the default quote style so that the `PYTHON_RUNTIMES` definition is rendered as:
`PYTHON_RUNTIMES: "2,3"` instead of `PYTHON_RUNTIMES: 2,3` which broke the builds (neither Python 2 nor Python 3 were installed with the Agent).

### Motivation

Fix `inv make-kitchen-gitlab-yaml` command.

