### PR TITLE
ignore missing label com.datadoghq.ad.check_names

### DIFF
--- a/pkg/autodiscovery/listeners/common.go
+++ b/pkg/autodiscovery/listeners/common.go
@@ -16,7 +16,7 @@ import (
 const (
 	newIdentifierLabel         = "com.datadoghq.ad.check.id"
 	legacyIdentifierLabel      = "com.datadoghq.sd.check.id"
-	dockerADTemplateChechNames = "com.datadoghq.ad.check_names"
+	dockerADTemplateCheckNames = "com.datadoghq.ad.check_names"
 )
 
 // ComputeContainerServiceIDs takes an entity name, an image (resolved to an actual name) and labels
@@ -51,10 +51,13 @@ func ComputeContainerServiceIDs(entity string, image string, labels map[string]s
 // getCheckNamesFromLabels unmarshals the json string of check names
 // defined in docker labels and returns a slice of check names
 func getCheckNamesFromLabels(labels map[string]string) ([]string, error) {
-	checkNames := []string{}
-	err := json.Unmarshal([]byte(labels[dockerADTemplateChechNames]), &checkNames)
-	if err != nil {
-		return nil, fmt.Errorf("Cannot parse check names: %v", err)
+	if checkLabels, found := labels[dockerADTemplateCheckNames]; found {
+		checkNames := []string{}
+		err := json.Unmarshal([]byte(checkLabels), &checkNames)
+		if err != nil {
+			return nil, fmt.Errorf("Cannot parse check names: %v", err)
+		}
+		return checkNames, nil
 	}
-	return checkNames, nil
+	return nil, nil
 }

--- a/releasenotes/notes/ignore-missing-com.datadoghq.ad.check_names-01aa07d04a52f667.yaml
+++ b/releasenotes/notes/ignore-missing-com.datadoghq.ad.check_names-01aa07d04a52f667.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Ignore missing docker label com.datadoghq.ad.check_names instead of showing error logs.


### PR DESCRIPTION
### What does this PR do?

It does not fail parsing an empty string as json if no label com.datadoghq.ad.check_names is set for ecs tasks. Instead it just ignores it.

### Motivation

There are ERROR logs when starting the agent for each container in a task.
