### PR TITLE
Revert "[gitlab] Do not trigger pipeline on tag creation (#4758)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 include: 'https://gitlab-templates.ddbuild.io/slack-notifier/v1/template.yml'
 
 stages:
-  - fail_on_tag
   - source_test
   - binary_build
   - integration_test
@@ -157,20 +156,6 @@ before_script:
   except:
     variables:
       - $RELEASE_VERSION_7 == ""
-
-# Fail if we're running a pipeline on a non-triggered tag build
-# NOTE: All jobs with 'needs' dependencies should also 'need' this to workaround a Gitlab issue: https://gitlab.com/gitlab-org/gitlab/issues/31526
-fail_on_non_triggered_tag:
-  stage: fail_on_tag
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: [ "runner:main", "size:2xlarge" ]
-  only:
-    - tags
-  before_script:
-    - "# noop"
-  script:
-    - echo CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE
-    - '[ $CI_PIPELINE_SOURCE != "push" ]'
 
 #
 # source_test
@@ -328,7 +313,7 @@ build_dogstatsd_static-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
+  needs: [ "run_tests_deb-x64-py3" ]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only
@@ -341,7 +326,7 @@ build_dogstatsd-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
+  needs: [ "run_tests_deb-x64-py3" ]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only
@@ -354,7 +339,7 @@ build_dogstatsd_static-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
+  needs: [ "run_tests_deb-x64-py3" ]
   variables:
     ARCH: arm64
   before_script:
@@ -373,7 +358,7 @@ build_dogstatsd-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
+  needs: [ "run_tests_deb-x64-py3" ]
   variables:
     ARCH: arm64
   before_script:
@@ -392,7 +377,7 @@ build_puppy_agent-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
+  needs: [ "run_tests_deb-x64-py3" ]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only --no-checks
@@ -405,7 +390,7 @@ build_puppy_agent-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3" ]
+  needs: [ "run_tests_deb-x64-py3" ]
   variables:
     ARCH: arm64
   before_script:
@@ -420,7 +405,7 @@ build_puppy_agent-deb_arm64:
 
 .cluster_agent-build_common: &cluster_agent-build_common
   stage: binary_build
-  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock" ]
+  needs: [ "run_dep_check_lock" ]
   script:
     - inv -e cluster-agent.build
     - $S3_CP_CMD $SRC_PATH/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTIFACTS_URI/datadog-cluster-agent.$ARCH
@@ -484,7 +469,7 @@ cluster_agent-build_arm64:
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:
   stage: integration_test
-  needs: ["fail_on_non_triggered_tag", "build_dogstatsd_static-deb_x64"]
+  needs: ["build_dogstatsd_static-deb_x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
   before_script:
@@ -498,7 +483,7 @@ run_dogstatsd_size_test:
 # check the size of the static dogstatsd binary
 run_dogstatsd_arm_size_test:
   stage: integration_test
-  needs: ["fail_on_non_triggered_tag", "build_dogstatsd_static-deb_arm64"]
+  needs: ["build_dogstatsd_static-deb_arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -543,7 +528,7 @@ agent_deb-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py2", "run_tests_deb-x64-py3"]
+  needs: ["run_tests_deb-x64-py2", "run_tests_deb-x64-py3"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     CONDA_ENV: ddpy3
@@ -563,7 +548,7 @@ agent_deb-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_deb-x64-py3"]
+  needs: ["run_tests_deb-x64-py3"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     CONDA_ENV: ddpy3
@@ -581,7 +566,7 @@ agent_deb-x64-a7:
 
 agent_deb-arm-a6:
   stage: package_build
-  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
+  needs: ["run_dep_check_lock"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -599,7 +584,7 @@ agent_deb-arm-a6:
 
 agent_deb-arm-a7:
   stage: package_build
-  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
+  needs: ["run_dep_check_lock"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -620,7 +605,7 @@ puppy_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "fail_on_non_triggered_tag", "build_puppy_agent-deb_x64"]
+  needs: ["build_puppy_agent-deb_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
@@ -681,7 +666,7 @@ agent_rpm-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3"]
+  needs: ["run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 6
@@ -699,7 +684,7 @@ agent_rpm-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_rpm-x64-py3"]
+  needs: ["run_tests_rpm-x64-py3"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 7
@@ -715,7 +700,7 @@ agent_rpm-x64-a7:
   # build Agent package for rpm-x64
 agent_rpm-arm-a6:
   stage: package_build
-  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
+  needs: ["run_dep_check_lock"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -731,7 +716,7 @@ agent_rpm-arm-a6:
 # build Agent package for rpm-x64
 agent_rpm-arm-a7:
   stage: package_build
-  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
+  needs: ["run_dep_check_lock"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -781,7 +766,7 @@ agent_suse-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3" ]
+  needs: [ "run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 6
@@ -797,7 +782,7 @@ agent_suse-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "fail_on_non_triggered_tag", "run_tests_rpm-x64-py3" ]
+  needs: [ "run_tests_rpm-x64-py3" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 7
@@ -812,7 +797,7 @@ agent_suse-x64-a7:
 cf_buildpack_windows:
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
+  needs: ["run_dep_check_lock"]
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 7
@@ -836,7 +821,7 @@ cf_buildpack_windows:
 
 .windows_msi_base:
   stage: package_build
-  needs: [ "fail_on_non_triggered_tag", "run_dep_check_lock"]
+  needs: ["run_dep_check_lock"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   # Unavailable on gitlab < 12.3
   # timeout: 2h 00m
@@ -975,7 +960,7 @@ dogstatsd_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "fail_on_non_triggered_tag", "build_dogstatsd-deb_x64" ]
+  needs: [ "build_dogstatsd-deb_x64" ]
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -1008,7 +993,7 @@ dogstatsd_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: [ "fail_on_non_triggered_tag", "build_dogstatsd-deb_x64" ]
+  needs: [ "build_dogstatsd-deb_x64" ]
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -1047,7 +1032,7 @@ dogstatsd_suse-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:large" ]
-  needs: [ "fail_on_non_triggered_tag", "build_dogstatsd-deb_x64" ]
+  needs: [ "build_dogstatsd-deb_x64" ]
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -1080,7 +1065,7 @@ dogstatsd_suse-x64:
 # deploy debian packages to apt staging repo
 deploy_deb_testing-a6:
   stage: testkitchen_deploy
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a6"]
+  needs: ["agent_deb-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1108,7 +1093,7 @@ deploy_deb_testing-a6:
 
 deploy_deb_testing-a7:
   stage: testkitchen_deploy
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a7"]
+  needs: ["agent_deb-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1140,7 +1125,7 @@ deploy_rpm_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: [ "fail_on_non_triggered_tag", "agent_rpm-x64-a6"]
+  needs: ["agent_rpm-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1160,7 +1145,7 @@ deploy_rpm_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: [ "fail_on_non_triggered_tag", "agent_rpm-x64-a7"]
+  needs: ["agent_rpm-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1181,7 +1166,7 @@ deploy_suse_rpm_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: [ "fail_on_non_triggered_tag", "agent_suse-x64-a6"]
+  needs: ["agent_suse-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1201,7 +1186,7 @@ deploy_suse_rpm_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: [ "fail_on_non_triggered_tag", "agent_suse-x64-a7"]
+  needs: ["agent_suse-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1222,7 +1207,7 @@ deploy_windows_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: [ "fail_on_non_triggered_tag", "windows_msi_x86-a6", "windows_msi_x64-a6"]
+  needs: ["windows_msi_x86-a6", "windows_msi_x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1234,7 +1219,7 @@ deploy_windows_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: [ "fail_on_non_triggered_tag", "windows_msi_x86-a7", "windows_msi_x64-a7"]
+  needs: ["windows_msi_x86-a7", "windows_msi_x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1370,52 +1355,52 @@ deploy_windows_testing-a7:
 .kitchen_scenario_windows_a6: &kitchen_scenario_windows_a6
   <<: *kitchen_os_windows
   <<: *kitchen_agent_a6
-  needs: [ "fail_on_non_triggered_tag", "deploy_windows_testing-a6"]
+  needs: ["deploy_windows_testing-a6"]
 
 .kitchen_scenario_windows_a7: &kitchen_scenario_windows_a7
   <<: *kitchen_os_windows
   <<: *kitchen_agent_a7
-  needs: [ "fail_on_non_triggered_tag", "deploy_windows_testing-a7"]
+  needs: ["deploy_windows_testing-a7"]
 
 .kitchen_scenario_centos_a6: &kitchen_scenario_centos_a6
   <<: *kitchen_os_centos
   <<: *kitchen_agent_a6
-  needs: [ "fail_on_non_triggered_tag", "deploy_rpm_testing-a6"]
+  needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_a7: &kitchen_scenario_centos_a7
   <<: *kitchen_os_centos
   <<: *kitchen_agent_a7
-  needs: [ "fail_on_non_triggered_tag", "deploy_rpm_testing-a7"]
+  needs: ["deploy_rpm_testing-a7"]
 
 .kitchen_scenario_ubuntu_a6: &kitchen_scenario_ubuntu_a6
   <<: *kitchen_os_ubuntu
   <<: *kitchen_agent_a6
-  needs: [ "fail_on_non_triggered_tag", "deploy_deb_testing-a6"]
+  needs: ["deploy_deb_testing-a6"]
 
 .kitchen_scenario_ubuntu_a7: &kitchen_scenario_ubuntu_a7
   <<: *kitchen_os_ubuntu
   <<: *kitchen_agent_a7
-  needs: [ "fail_on_non_triggered_tag", "deploy_deb_testing-a7"]
+  needs: ["deploy_deb_testing-a7"]
 
 .kitchen_scenario_suse_a6: &kitchen_scenario_suse_a6
   <<: *kitchen_os_suse
   <<: *kitchen_agent_a6
-  needs: [ "fail_on_non_triggered_tag", "deploy_suse_rpm_testing-a6"]
+  needs: ["deploy_suse_rpm_testing-a6"]
 
 .kitchen_scenario_suse_a7: &kitchen_scenario_suse_a7
   <<: *kitchen_os_suse
   <<: *kitchen_agent_a6
-  needs: [ "fail_on_non_triggered_tag", "deploy_suse_rpm_testing-a7"]
+  needs: ["deploy_suse_rpm_testing-a7"]
 
 .kitchen_scenario_debian_a6: &kitchen_scenario_debian_a6
   <<: *kitchen_os_debian
   <<: *kitchen_agent_a6
-  needs: [ "fail_on_non_triggered_tag", "deploy_deb_testing-a6"]
+  needs: ["deploy_deb_testing-a6"]
 
 .kitchen_scenario_debian_a7: &kitchen_scenario_debian_a7
   <<: *kitchen_os_debian
   <<: *kitchen_agent_a7
-  needs: [ "fail_on_non_triggered_tag", "deploy_deb_testing-a7"]
+  needs: ["deploy_deb_testing-a7"]
 
 
 
@@ -1882,7 +1867,7 @@ testkitchen_cleanup_azure-a7:
 build_agent6:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a6"]
+  needs: ["agent_deb-x64-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1894,7 +1879,7 @@ build_agent6:
 build_agent6_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-arm-a6"]
+  needs: ["agent_deb-arm-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1907,7 +1892,7 @@ build_agent6_arm64:
 build_agent6_jmx:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a6"]
+  needs: ["agent_deb-x64-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1921,7 +1906,7 @@ build_agent6_jmx:
 build_agent6_jmx_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-arm-a6"]
+  needs: ["agent_deb-arm-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1936,7 +1921,7 @@ build_agent6_jmx_arm64:
 build_agent6_py2py3_jmx:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a6"]
+  needs: ["agent_deb-x64-a6"]
   <<: *skip_when_unwanted_on_6
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1949,7 +1934,7 @@ build_agent6_py2py3_jmx:
 build_agent7:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a7"]
+  needs: ["agent_deb-x64-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1961,7 +1946,7 @@ build_agent7:
 build_agent7_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-arm-a7"]
+  needs: ["agent_deb-arm-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1974,7 +1959,7 @@ build_agent7_arm64:
 build_agent7_jmx:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-x64-a7"]
+  needs: ["agent_deb-x64-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1986,7 +1971,7 @@ build_agent7_jmx:
 build_agent7_jmx_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: [ "fail_on_non_triggered_tag", "agent_deb-arm-a7"]
+  needs: ["agent_deb-arm-a7"]
   <<: *skip_when_unwanted_on_7
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -1999,7 +1984,7 @@ build_agent7_jmx_arm64:
 build_cluster_agent_amd64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: [ "fail_on_non_triggered_tag", "cluster_agent-build_amd64"]
+  needs: ["cluster_agent-build_amd64"]
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
@@ -2007,7 +1992,7 @@ build_cluster_agent_amd64:
 build_cluster_agent_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
-  needs: [ "fail_on_non_triggered_tag", "cluster_agent-build_arm64"]
+  needs: ["cluster_agent-build_arm64"]
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
@@ -2016,7 +2001,7 @@ build_cluster_agent_arm64:
 build_dogstatsd_amd64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
-  needs: [ "fail_on_non_triggered_tag", "build_dogstatsd_static-deb_x64"]
+  needs: ["build_dogstatsd_static-deb_x64"]
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
     BUILD_CONTEXT: Dockerfiles/dogstatsd/alpine
@@ -2104,7 +2089,6 @@ twistlock_scan-7:
 dev_branch_docker_hub:
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - build_agent6
     - build_agent6_jmx
     - build_agent6_py2py3_jmx
@@ -2129,7 +2113,6 @@ dev_branch_docker_hub:
 dev_branch_multiarch_docker_hub:
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - build_agent6
     - build_agent6_arm64
     - build_agent6_jmx
@@ -2167,7 +2150,6 @@ dev_branch_multiarch_docker_hub:
 dev_master_docker_hub:
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - build_agent6
     - build_agent6_jmx
     - build_agent6_py2py3_jmx
@@ -2189,7 +2171,7 @@ dev_master_docker_hub:
 
 dca_dev_branch_docker_hub:
   <<: *docker_tag_job_definition
-  needs: ["fail_on_non_triggered_tag", "build_cluster_agent_amd64"]
+  needs: ["build_cluster_agent_amd64"]
   when: manual
   except:
     - master
@@ -2200,7 +2182,7 @@ dca_dev_branch_docker_hub:
 
 dca_dev_branch_multiarch_docker_hub:
   <<: *docker_tag_job_definition
-  needs: ["fail_on_non_triggered_tag", "build_cluster_agent_amd64", "build_cluster_agent_arm64"]
+  needs: ["build_cluster_agent_amd64", "build_cluster_agent_arm64"]
   when: manual
   except:
     - master
@@ -2212,7 +2194,7 @@ dca_dev_branch_multiarch_docker_hub:
 
 dca_dev_master_docker_hub:
   <<: *docker_tag_job_definition
-  needs: ["fail_on_non_triggered_tag", "build_cluster_agent_amd64"]
+  needs: ["build_cluster_agent_amd64"]
   only:
     - master
   variables:
@@ -2225,7 +2207,6 @@ dev_nightly_docker_hub:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_nightly
   needs:
-    - fail_on_non_triggered_tag
     - build_agent6
     - build_agent6_jmx
     - build_agent6_py2py3_jmx


### PR DESCRIPTION

### What does this PR do?

This reverts commit 7c25c2ed8484397e2c8b787ceb88d8c8c9a110a7.
The workaround we used (adding a `needs` on the `fail_on_non_triggered_tag` job) makes the whole pipeline disappear on a regular branch pipeline (and makes web pipelines crash), because:
- `fail_on_non_triggered_tag` is skipped, thus the whole `fail_on_tag` stage is skipped. As a consequence, the stage is removed from the pipeline,
- then, the jobs which need `fail_on_non_triggered_tag` error out, since the needed job does not exist.

### Motivation

Make pipelines work once again.

