### PR TITLE
[ebpf] Use root network namespace when creating DNS socket filter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1333,6 +1333,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:0b30de1a6957125af05f8dbe7dfe8843fb4aa0d87d803d3ebd83f39aed113c9a"
+  name = "github.com/vishvananda/netns"
+  packages = ["."]
+  pruneopts = ""
+  revision = "0a2b9b5464df8343199164a0321edf3313202f7e"
+
+[[projects]]
+  branch = "master"
   digest = "1:4a4c4edf69b61bf98e98d22696aa80c4059384895920de4d5e2fe696068d5f13"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
@@ -2188,6 +2196,7 @@
     "github.com/tinylib/msgp/msgp",
     "github.com/twmb/murmur3",
     "github.com/urfave/negroni",
+    "github.com/vishvananda/netns",
     "golang.org/x/mobile/asset",
     "golang.org/x/net/context",
     "golang.org/x/net/proxy",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -263,3 +263,7 @@
 [[constraint]]
   name = "github.com/cenkalti/backoff"
   version = "v3.0.0"
+
+[[constraint]]
+  name = "github.com/vishvananda/netns"
+  revision = "0a2b9b5464df8343199164a0321edf3313202f7e"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -164,3 +164,4 @@ network,github.com/florianl/go-conntrack,MIT
 network,github.com/mdlayher/netlink,MIT
 network,github.com/google/gopacket,BSD-3-Clause
 network,github.com/DataDog/mmh3,MIT
+network,github.com/vishvananda/netns,Apache-2.0

--- a/pkg/ebpf/dns_snooper.go
+++ b/pkg/ebpf/dns_snooper.go
@@ -5,6 +5,7 @@ package ebpf
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -14,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/google/gopacket/afpacket"
 	bpflib "github.com/iovisor/gobpf/elf"
+	"github.com/vishvananda/netns"
 )
 
 const (
@@ -44,10 +46,21 @@ type SocketFilterSnooper struct {
 }
 
 // NewSocketFilterSnooper returns a new SocketFilterSnooper
-func NewSocketFilterSnooper(filter *bpflib.SocketFilter) (*SocketFilterSnooper, error) {
-	packetSrc, err := newPacketSource(filter)
-	if err != nil {
-		return nil, err
+func NewSocketFilterSnooper(rootPath string, filter *bpflib.SocketFilter) (*SocketFilterSnooper, error) {
+	var (
+		packetSrc *packetSource
+		srcErr    error
+	)
+
+	// Create the RAW_SOCKET inside the root network namespace
+	nsErr := WithRootNS(rootPath, func() {
+		packetSrc, srcErr = newPacketSource(filter)
+	})
+	if nsErr != nil {
+		return nil, nsErr
+	}
+	if srcErr != nil {
+		return nil, srcErr
 	}
 
 	cache := newReverseDNSCache(dnsCacheSize, dnsCacheTTL, dnsCacheExpirationPeriod)
@@ -229,4 +242,34 @@ func (p *packetSource) Close() {
 	}
 
 	p.TPacket.Close()
+}
+
+// WithRootNS executes a function within root network namespace and then switch back
+// to the previous namespace. If the thread is already in the root network namespace,
+// the function is executed without calling SYS_SETNS.
+func WithRootNS(procRoot string, fn func()) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	prevNS, err := netns.Get()
+	if err != nil {
+		return err
+	}
+
+	rootNS, err := netns.GetFromPath(fmt.Sprintf("%s/1/ns/net", procRoot))
+	if err != nil {
+		return err
+	}
+
+	if rootNS.Equal(prevNS) {
+		fn()
+		return nil
+	}
+
+	if err := netns.Set(rootNS); err != nil {
+		return err
+	}
+
+	fn()
+	return netns.Set(prevNS)
 }

--- a/pkg/ebpf/dns_snooper_test.go
+++ b/pkg/ebpf/dns_snooper_test.go
@@ -25,7 +25,7 @@ func TestDNSSnooping(t *testing.T) {
 	filter := m.SocketFilter("socket/dns_filter")
 	require.NotNil(t, filter)
 
-	reverseDNS, err := NewSocketFilterSnooper(filter)
+	reverseDNS, err := NewSocketFilterSnooper("/proc", filter)
 	require.NoError(t, err)
 	defer reverseDNS.Close()
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -156,7 +156,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 			return nil, fmt.Errorf("error retrieving socket filter")
 		}
 
-		if snooper, err := NewSocketFilterSnooper(filter); err == nil {
+		if snooper, err := NewSocketFilterSnooper(config.ProcRoot, filter); err == nil {
 			reverseDNS = snooper
 		} else {
 			fmt.Errorf("error enabling DNS traffic inspection: %s", err)


### PR DESCRIPTION
### What does this PR do?

Add support for DNS resolution in Network Performance Monitoring when system-probe is not running on the root network namespace.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
