### PR TITLE
[invoke] add golangci-lint to the bootstrappable deps

### DIFF
--- a/bootstrap.json
+++ b/bootstrap.json
@@ -9,7 +9,8 @@
             "golang.org/x/mobile/cmd/gomobile",
             "golang.org/x/tools/go/ast/astutil",
             "golang.org/x/tools/go/internal",
-            "golang.org/x/tools/go/gcexportdata"
+            "golang.org/x/tools/go/gcexportdata",
+            "github.com/golangci/golangci-lint"
         ],
         "golang.org/x/tools/go/ast/astutil": {
             "version": "release-branch.go1.10",
@@ -47,6 +48,11 @@
         "golang.org/x/mobile/cmd/gomobile": {
             "version": "8b05ea26b5669e5f52084ab001b8e49ec8877955",
             "type": "go"
+        },
+        "github.com/golangci/golangci-lint": {
+            "version": "v1.23.1",
+            "cmd": "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $BOOTSTRAPPED_VERSION",
+            "type": "shell"
         }
     }
 }

--- a/tasks/bootstrap.py
+++ b/tasks/bootstrap.py
@@ -3,13 +3,14 @@ Boostrapping related logic goes here
 """
 import os
 import json
+import sys
 
 from .utils import get_gopath
 
 # Bootstrap dependencies description
 BOOTSTRAP_DEPS = "bootstrap.json"
 BOOTSTRAP_ORDER_KEY = "order"
-BOOTSTRAP_SUPPORTED_KINDS = ["go", "python"]
+BOOTSTRAP_SUPPORTED_KINDS = ["go", "python", "shell"]
 BOOTSTRAP_SUPPORTED_STEPS = ["checkout", "install"]
 
 
@@ -23,7 +24,7 @@ def get_deps(key):
 
     return deps.get(key, {})
 
-def process_deps(ctx, target, version, kind, step, verbose=False):
+def process_deps(ctx, target, version, kind, step, cmd=None, verbose=False):
     """
     Process a dependency target.
 
@@ -58,3 +59,9 @@ def process_deps(ctx, target, version, kind, step, verbose=False):
         # no checkout needed for python deps
         if step == "install":
             ctx.run("pip install{} {}=={}".format(verbosity, target, version))
+    elif kind == "shell":
+        if step == "install":
+            if sys.platform == 'win32':
+                print("shell dependencies currently unsupported on windows please install manually")
+            else:
+                ctx.run("{}".format(cmd), env={'BOOTSTRAPPED_VERSION': version})

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -243,7 +243,7 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False, dep_
         tool = deps.get(dependency)
         if tool.get('install', True):
             print("processing get tool {}".format(dependency))
-            process_deps(ctx, dependency, tool.get('version'), tool.get('type'), 'install', verbose=verbose)
+            process_deps(ctx, dependency, tool.get('version'), tool.get('type'), 'install', cmd=tool.get('cmd'), verbose=verbose)
 
     if android:
         ndkhome = os.environ.get('ANDROID_NDK_HOME')


### PR DESCRIPTION
### What does this PR do?

Will help us bootstrap `golangci-lint` with the `inv deps` command. It adds support on macOS and linux (or rather non-windows systems) for a new class of bootstrap: shell deps. These are deps that would be installed via a shell command, as is the case with `golangci-lint`.

The version is passed as an environment variable names `BOOSTRAPPED_VERSION`, and the shell command should account for this. The reason being cleaner maintainability.

### Motivation

Improved developer experience on unix-based platforms.