### PR TITLE
Remove explicit check of sketch Memsize to 32 Bytes 

### DIFF
--- a/pkg/quantile/store_test.go
+++ b/pkg/quantile/store_test.go
@@ -26,26 +26,6 @@ func buildStore(t *testing.T, dsl string) *sparseStore {
 }
 
 func TestStore(t *testing.T) {
-	t.Run("MemSize", func(t *testing.T) {
-		// empty store
-		const (
-			emptySize = 32
-			binSize   = 4
-		)
-		s := buildStore(t, "")
-		s.bins = nil
-
-		used, allocated := s.MemSize()
-		require.Equal(t, emptySize, used)
-		require.Equal(t, emptySize, allocated)
-
-		s.bins = make([]bin, 1, 2)
-		used, allocated = s.MemSize()
-
-		require.Equal(t, emptySize+binSize, used)
-		require.Equal(t, emptySize+2*binSize, allocated)
-	})
-
 	t.Run("merge", func(t *testing.T) {
 		type mt struct {
 			s, o, exp string


### PR DESCRIPTION


### What does this PR do?

Remove the explicit check of sketch MemSize to 32 Bytes. The underlying memory size depends on how go slices are represented under the hood. e.g On a 32-bit arch, go slices are 12 Bytes and on a 64-bit arch, go slices are 24 Bytes.
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
