### PR TITLE
Add message from ComponentStatus condition to service check

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -268,6 +268,7 @@ func (k *KubeASCheck) parseComponentStatus(sender aggregator.Sender, componentsS
 		tagComp := []string{fmt.Sprintf("component:%s", component.Name)}
 		for _, condition := range component.Conditions {
 			statusCheck := metrics.ServiceCheckUnknown
+			message := ""
 
 			// We only expect the Healthy condition. May change in the future. https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 			if condition.Type != "Healthy" {
@@ -278,11 +279,12 @@ func (k *KubeASCheck) parseComponentStatus(sender aggregator.Sender, componentsS
 			switch condition.Status {
 			case "True":
 				statusCheck = metrics.ServiceCheckOK
-
+				message = condition.Message
 			case "False":
 				statusCheck = metrics.ServiceCheckCritical
+				message = condition.Error
 			}
-			sender.ServiceCheck(KubeControlPaneCheck, statusCheck, k.KubeAPIServerHostname, tagComp, "")
+			sender.ServiceCheck(KubeControlPaneCheck, statusCheck, k.KubeAPIServerHostname, tagComp, message)
 		}
 	}
 	return nil

--- a/releasenotes/notes/dca-componentstatus-check-add-message-cee694ed9eeb5a69.yaml
+++ b/releasenotes/notes/dca-componentstatus-check-add-message-cee694ed9eeb5a69.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adds message field to the ComponentStatus check of kube_apiserver_controlplane.up
+    service check.


### PR DESCRIPTION
### What does this PR do?
Adds the message field from ComponentCondition to the Kube Apiserver Control Plane service check.
### Motivation
Aids debugging issues when a component status is reported as unhealthy as the message can be templated in Datadog monitor notifications.
### Additional Notes
Which ComponentCondition field is used for the message is based on the `kubectl get componentstatuses` behavior defined in the following code:
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go#L63