### PR TITLE
[backport to 7.17.x] Correct Python3 syntax in /readsecret.py (#4789)

### DIFF
--- a/Dockerfiles/agent/secrets-helper/readsecret.py
+++ b/Dockerfiles/agent/secrets-helper/readsecret.py
@@ -74,4 +74,4 @@ if __name__ == '__main__':
         except (ValueError, IOError) as e:
             output[s] = {"error": str(e)}
 
-    print json.dumps(output)
+    print(json.dumps(output))

--- a/Dockerfiles/agent/secrets-helper/test_readsecret.py
+++ b/Dockerfiles/agent/secrets-helper/test_readsecret.py
@@ -10,15 +10,17 @@ from readsecret import *
 
 class TestListSecretNames(unittest.TestCase):
     def test_invalid_output(self):
-        with self.assertRaisesRegexp(ValueError, "No JSON object could be decoded"):
+        with self.assertRaisesRegex(
+            ValueError, "Expecting value: line 1 column 1 \(char 0\)"
+        ):
             list_secret_names("")
 
     def test_invalid_version(self):
-        with self.assertRaisesRegexp(ValueError, "incompatible protocol version 2.0"):
+        with self.assertRaisesRegex(ValueError, "incompatible protocol version 2.0"):
             list_secret_names('{"version": "2.0"}')
 
     def test_not_list(self):
-        with self.assertRaisesRegexp(ValueError, "should be an array"):
+        with self.assertRaisesRegex(ValueError, "should be an array"):
             list_secret_names('{"version": "1.0", "secrets": "one"}')
 
     def test_valid(self):
@@ -35,7 +37,7 @@ class TestReadFile(unittest.TestCase):
         self.folder = None
 
     def test_path_escape(self):
-        with self.assertRaisesRegexp(ValueError, "outside of the specified folder"):
+        with self.assertRaisesRegex(ValueError, "outside of the specified folder"):
             read_file(self.folder, "a/../../outside/file")
 
     def test_path_escape_symlink(self):
@@ -52,11 +54,11 @@ class TestReadFile(unittest.TestCase):
             os.path.join(allowed_path, "target"),
         )
 
-        with self.assertRaisesRegexp(ValueError, "outside of the specified folder"):
+        with self.assertRaisesRegex(ValueError, "outside of the specified folder"):
             read_file(allowed_path, "target")
 
     def test_file_not_found(self):
-        with self.assertRaisesRegexp(IOError, "No such file or directory"):
+        with self.assertRaisesRegex(IOError, "No such file or directory"):
             read_file(self.folder, "file/not/found")
 
     def test_file_ok(self):
@@ -88,9 +90,9 @@ class TestIsValidFolder(unittest.TestCase):
 
     def test_nok(self):
         foldername = os.path.join(self.folder, "not_found")
-        with self.assertRaisesRegexp(argparse.ArgumentTypeError, "does not exist"):
+        with self.assertRaisesRegex(argparse.ArgumentTypeError, "does not exist"):
             is_valid_folder(foldername)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/releasenotes/notes/correct-python3-syntax-in-readsecret.py-e5c626675759797b.yaml
+++ b/releasenotes/notes/correct-python3-syntax-in-readsecret.py-e5c626675759797b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes #4650 [v7] Syntax in /readsecret.py for Py3

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -19,7 +19,7 @@ def test(ctx):
     """
     Run docker tests
     """
-    ctx.run("python ./Dockerfiles/agent/secrets-helper/test_readsecret.py")
+    ctx.run("python3 ./Dockerfiles/agent/secrets-helper/test_readsecret.py")
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Backport /readsecret.py change from master.

Fixes #4650 [v7] Syntax in /readsecret.py for Py3

- Correct syntax in /readsecret.py helper for DataDog Agent v7 (Python3).
- Fix test (different exception raised).
- Address minor deprecation warnings in tests.

