### PR TITLE
[ebpf] Add log entry when system-probe isn't running on root netns

### DIFF
--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/netlink"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	bpflib "github.com/iovisor/gobpf/elf"
 )
@@ -159,6 +160,11 @@ func NewTracer(config *Config) (*Tracer, error) {
 			reverseDNS = snooper
 		} else {
 			fmt.Errorf("error enabling DNS traffic inspection: %s", err)
+		}
+
+		if !util.IsRootNS(config.ProcRoot) {
+			log.Warn("system-probe is not running on the root network namespace, which is usually caused by running the " +
+				"system-probe in a container without using the host network. in this mode, you may see partial DNS resolution.")
 		}
 	}
 

--- a/pkg/process/util/netns.go
+++ b/pkg/process/util/netns.go
@@ -1,0 +1,35 @@
+// +build linux
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// IsRootNS determines whether the current thread is attached to the root network namespace
+func IsRootNS(procRoot string) bool {
+	rootPath := fmt.Sprintf("%s/1/ns/net", procRoot)
+	rootNS, err := os.Open(rootPath)
+	if err != nil {
+		return false
+	}
+	defer rootNS.Close()
+
+	currentPath := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), syscall.Gettid())
+	currentNS, err := os.Open(currentPath)
+	if err != nil {
+		return false
+	}
+	defer currentNS.Close()
+
+	var s1, s2 syscall.Stat_t
+	if err := syscall.Fstat(int(rootNS.Fd()), &s1); err != nil {
+		return false
+	}
+	if err := syscall.Fstat(int(currentNS.Fd()), &s2); err != nil {
+		return false
+	}
+	return s1.Dev == s2.Dev && s1.Ino == s2.Ino
+}


### PR DESCRIPTION
### What does this PR do?

Back porting this https://github.com/DataDog/datadog-agent/pull/4790 (already merged on master) to **release 7.17**.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
