### PR TITLE
Hide sensitive data from `agent config` command output

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -275,7 +275,16 @@ func getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, string(body), 500)
 		return
 	}
-	w.Write(runtimeConfig)
+
+	scrubbed, err := log.CredentialsCleanerBytes(runtimeConfig)
+	if err != nil {
+		log.Errorf("Unable to scrub sensitive data from runtime config: %s", err)
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 500)
+		return
+	}
+
+	w.Write(scrubbed)
 }
 
 func getTaggerList(w http.ResponseWriter, r *http.Request) {

--- a/releasenotes/notes/scrub-sensitive-data-from-agent-config-output-2be5be4345370201.yaml
+++ b/releasenotes/notes/scrub-sensitive-data-from-agent-config-output-2be5be4345370201.yaml
@@ -1,5 +1,5 @@
 enhancements:
   - |
-    The agent config command output now scrub sensitive
+    The agent config command output now scrubs sensitive
     data and prevents API keys, password, token, etc. from
     appear in the console.

--- a/releasenotes/notes/scrub-sensitive-data-from-agent-config-output-2be5be4345370201.yaml
+++ b/releasenotes/notes/scrub-sensitive-data-from-agent-config-output-2be5be4345370201.yaml
@@ -2,4 +2,4 @@ enhancements:
   - |
     The agent config command output now scrubs sensitive
     data and prevents API keys, password, token, etc. from
-    appear in the console.
+    appearing in the console.

--- a/releasenotes/notes/scrub-sensitive-data-from-agent-config-output-2be5be4345370201.yaml
+++ b/releasenotes/notes/scrub-sensitive-data-from-agent-config-output-2be5be4345370201.yaml
@@ -1,5 +1,5 @@
 enhancements:
   - |
     The agent config command output now scrub sensitive
-    data and prevent API keys, password, token, etc. to
+    data and prevents API keys, password, token, etc. from
     appear in the console.

--- a/releasenotes/notes/scrub-sensitive-data-from-agent-config-output-2be5be4345370201.yaml
+++ b/releasenotes/notes/scrub-sensitive-data-from-agent-config-output-2be5be4345370201.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  - |
+    The agent config command output now scrub sensitive
+    data and prevent API keys, password, token, etc. to
+    appear in the console.


### PR DESCRIPTION
### What does this PR do?
The `agent config` command output now scrubs sensitive data.

### Motivation
Prevent sensitive data to appear in the console and/or being redirected and/or being written somewhere to limit the risk of credentials/passwords/API keys/Tokens/etc. leak. 

### Additional Notes
Reuse logic from ./pkg/util/log/strip.go
