### PR TITLE
[dogstatsd] Continue parsing packets with consecutive newlines

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -264,7 +264,7 @@ func nextMessage(packet *[]byte) (message []byte) {
 	}
 
 	advance, message, err := bufio.ScanLines(*packet, true)
-	if err != nil || len(message) == 0 {
+	if err != nil {
 		return nil
 	}
 
@@ -275,11 +275,14 @@ func nextMessage(packet *[]byte) (message []byte) {
 func (s *Server) parsePackets(batcher *batcher, packets []*listeners.Packet) {
 	for _, packet := range packets {
 		originTags := findOriginTags(packet.Origin)
-		log.Tracef("Dogstatsd receive: %s", packet.Contents)
+		log.Tracef("Dogstatsd receive: %q", packet.Contents)
 		for {
 			message := nextMessage(&packet.Contents)
 			if message == nil {
 				break
+			}
+			if len(message) == 0 {
+				continue
 			}
 			if s.Statistics != nil {
 				s.Statistics.StatEvent(1)

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -78,7 +78,7 @@ func TestStopServer(t *testing.T) {
 	require.NoError(t, err, "port is not available, it should be")
 }
 
-func TestUPDReceive(t *testing.T) {
+func TestUDPReceive(t *testing.T) {
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
@@ -161,6 +161,44 @@ func TestUPDReceive(t *testing.T) {
 		assert.Equal(t, sample.Name, "daemon_set")
 		assert.Equal(t, sample.RawValue, "abc")
 		assert.Equal(t, sample.Mtype, metrics.SetType)
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
+
+	// multi-metric packet
+	conn.Write([]byte("daemon1:666|c\ndaemon2:1000|c"))
+	select {
+	case res := <-metricOut:
+		assert.Equal(t, 2, len(res))
+		sample1 := res[0]
+		assert.NotNil(t, sample1)
+		assert.Equal(t, sample1.Name, "daemon1")
+		assert.EqualValues(t, sample1.Value, 666.0)
+		assert.Equal(t, sample1.Mtype, metrics.CounterType)
+		sample2 := res[1]
+		assert.NotNil(t, sample2)
+		assert.Equal(t, sample2.Name, "daemon2")
+		assert.EqualValues(t, sample2.Value, 1000.0)
+		assert.Equal(t, sample2.Mtype, metrics.CounterType)
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
+
+	// slightly malformed multi-metric packet, should still be parsed in whole
+	conn.Write([]byte("daemon1:666|c\n\ndaemon2:1000|c\n"))
+	select {
+	case res := <-metricOut:
+		assert.Equal(t, 2, len(res))
+		sample1 := res[0]
+		assert.NotNil(t, sample1)
+		assert.Equal(t, sample1.Name, "daemon1")
+		assert.EqualValues(t, sample1.Value, 666.0)
+		assert.Equal(t, sample1.Mtype, metrics.CounterType)
+		sample2 := res[1]
+		assert.NotNil(t, sample2)
+		assert.Equal(t, sample2.Name, "daemon2")
+		assert.EqualValues(t, sample2.Value, 1000.0)
+		assert.Equal(t, sample2.Mtype, metrics.CounterType)
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}


### PR DESCRIPTION
### What does this PR do?

When more than 1 consecutive newline was found in a packet, the dogstatsd parsing logic would ignore the rest of the packet (since #951 AFAIK). This worked fine so far probably because there is no dogstatsd datagram out there that is badly formatted enough to have 2 consecutive newlines in their contents.

That said, since the addition of the buffer of multiple packets in #4696, if a small datagram has a trailing newline, the next small datagram can end up appended to it with an additional newline separating the 2.  Example:

```
## UDP Datagram #1
"daemon1:666|c\n"
## UDP Datagram #2
"daemon2:666|c"
## Resulting packet contents parsed by the parser
"daemon1:666|c\n\ndaemon2:666|c"
```

In this case, the parser does see 2 consecutive newlines. If it stops parsing the packet at that point, it will have ignored all the messages in the second datagram.

Fix this by continuing to parse the packet even after 2 or more consecutive newlines are found.

An alternative solution would be to avoid adding an additional newline in the `packetsBuffer` when a datagram already has a trailing newline. Since there is no good justification for stopping parsing after 2 consecutive newlines I preferred to fix it here. Note that Agent v5 would continue parsing after 2 consecutive newlines.

### Motivation

Fix small regression introduced in #4696, and that caused a visible regression on one of our services which received dogstatsd datagrams with trailing newlines.

### Additional Notes

Also, changed the format specifier used to log dogstatsd packets at the debug level in order to ease troubleshooting (example: so that multiple newlines remain visible) and avoid logging multi-line log entries.
