### PR TITLE
[kitchen] Add A7->A7 upgrade tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1351,6 +1351,10 @@ deploy_windows_testing-a7:
   script:
     - AZURE_LOCATION='South Central US' bash -l tasks/run-test-kitchen.sh upgrade6-test $AGENT_MAJOR_VERSION
 
+.kitchen_test_upgrade7: &kitchen_test_upgrade7
+  script:
+    - AZURE_LOCATION='North Central US' bash -l tasks/run-test-kitchen.sh upgrade7-test $AGENT_MAJOR_VERSION
+
 .kitchen_test_windows_installer: &kitchen_test_windows_installer
   before_script: [ "# noop" ] # Override kitchen_os_windows default
   script:
@@ -1464,6 +1468,11 @@ kitchen_windows_upgrade6-a7:
   <<: *kitchen_scenario_windows_a7
   <<: *kitchen_test_upgrade6
 
+kitchen_windows_upgrade7-a7:
+  allow_failure: false
+  <<: *kitchen_scenario_windows_a7
+  <<: *kitchen_test_upgrade7
+
 # run dd-agent-testing on centos
 kitchen_centos_chef-a6:
   allow_failure: false
@@ -1514,6 +1523,11 @@ kitchen_centos_upgrade6-a7:
   allow_failure: false
   <<: *kitchen_scenario_centos_a7
   <<: *kitchen_test_upgrade6
+
+kitchen_centos_upgrade7-a7:
+  allow_failure: false
+  <<: *kitchen_scenario_centos_a7
+  <<: *kitchen_test_upgrade7
 
 # run dd-agent-testing on ubuntu
 # Could fail if we encounter the issue with apt locks/azure agent, but should be investigated if that's the case
@@ -1567,6 +1581,11 @@ kitchen_ubuntu_upgrade6-a7:
   <<: *kitchen_scenario_ubuntu_a7
   <<: *kitchen_test_upgrade6
 
+kitchen_ubuntu_upgrade7-a7:
+  allow_failure: false
+  <<: *kitchen_scenario_ubuntu_a7
+  <<: *kitchen_test_upgrade7
+
 # run dd-agent-testing on suse
 kitchen_suse_chef-a6:
   allow_failure: false
@@ -1617,6 +1636,11 @@ kitchen_suse_upgrade6-a7:
   allow_failure: false
   <<: *kitchen_scenario_suse_a7
   <<: *kitchen_test_upgrade6
+
+kitchen_suse_upgrade7-a7:
+  allow_failure: false
+  <<: *kitchen_scenario_suse_a7
+  <<: *kitchen_test_upgrade7
 
 # run dd-agent-testing on debian
 # Could fail if we encounter the issue with apt locks/azure agent, but should be investigated if that's the case
@@ -1670,6 +1694,10 @@ kitchen_debian_upgrade6-a7:
   <<: *kitchen_scenario_debian_a7
   <<: *kitchen_test_upgrade6
 
+kitchen_debian_upgrade7-a7:
+  allow_failure: false
+  <<: *kitchen_scenario_debian_a7
+  <<: *kitchen_test_upgrade7
 
 
 #

--- a/test/kitchen/kitchen-azure-upgrade7-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade7-test.yml
@@ -1,6 +1,6 @@
 suites:
 
-# Installs the latest release Agent 6, then updates it to the latest release
+# Installs the latest release Agent 7, then updates it to the latest release
 # candidate
 - name: dd-agent-upgrade-agent7
   run_list:

--- a/test/kitchen/kitchen-azure-upgrade7-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade7-test.yml
@@ -1,0 +1,36 @@
+suites:
+
+# Installs the latest release Agent 6, then updates it to the latest release
+# candidate
+- name: dd-agent-upgrade-agent7
+  run_list:
+    - "recipe[dd-agent-install]"
+    - "recipe[dd-agent-upgrade]"
+  attributes:
+    apt:
+      unattended_upgrades:
+        enable: false
+    datadog:
+      agent_major_version: 7
+      api_key: <%= api_key %>
+    dd-agent-install:
+      windows_agent_url: https://s3.amazonaws.com/ddagent-windows-stable/
+      windows_agent_filename: datadog-agent-7-latest.amd64
+    dd-agent-upgrade:
+      add_new_repo: true
+      <% dd_agent_config.each do |key, value| %>
+      <%= key %>: <%= value %>
+      <% end %>
+      <% if ENV['AGENT_VERSION'] %>
+      windows_version: "<%= ENV['AGENT_VERSION'] %>"
+      <% end %>
+      <% if ENV['WINDOWS_AGENT_FILE'] %>
+      windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
+      <% end %>
+    dd-agent-import-conf:
+      api_key: <%= api_key %>
+    dd-agent-upgrade-rspec:
+      # Used by the rspec test to know the version to which the agent should be upgraded
+      agent_expected_version: &agent_expected_version <%= ENV['DD_AGENT_EXPECTED_VERSION'] || "5.99.0" %>
+    dd-agent-rspec:
+      skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -122,6 +122,10 @@ if [[ $1 == "upgrade6-test" ]]; then
   cat kitchen-azure-upgrade6-test.yml >> kitchen.yml
 fi
 
+if [[ $1 == "upgrade7-test" ]]; then
+  cat kitchen-azure-upgrade7-test.yml >> kitchen.yml
+fi
+
 bundle exec kitchen diagnose --no-instances --loader
 
 rm -rf cookbooks


### PR DESCRIPTION
### What does this PR do?

Adds Agent 7 to Agent 7 upgrade scenario to kitchen tests.

### Motivation

Test all possible upgrade paths to the tested Agent 7 version.
