### PR TITLE
Relocate min_collection_interval settings during A5->A6/7 config conversion

### DIFF
--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -9,7 +9,6 @@ package common
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -23,6 +22,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/legacy"
 )
+
+// TransformationFunc type represents transformation applicable to byte slices
+type TransformationFunc func(rawData []byte) ([]byte, error)
 
 // ImportConfig imports the agent5 configuration into the agent6 yaml config
 func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
@@ -111,6 +113,8 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 		}
 	}
 
+	tr := []TransformationFunc{relocateMinCollectionInterval}
+
 	for _, f := range files {
 		if f.IsDir() || filepath.Ext(f.Name()) != cfgExt {
 			continue
@@ -141,11 +145,8 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 			continue
 		}
 
-		if err := copyFile(src, dst, force); err != nil {
+		if err := copyFile(src, dst, force, tr); err != nil {
 			return fmt.Errorf("unable to copy %s to %s: %v", src, dst, err)
-		}
-		if err := relocateMinCollectionIntervalInFile(dst); err != nil {
-			return fmt.Errorf("error %v", err)
 		}
 
 		fmt.Fprintln(
@@ -179,7 +180,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 		src := filepath.Join(oldConfigDir, "conf.d", "auto_conf", f.Name())
 		dst := filepath.Join(newConfigDir, "conf.d", checkName+dirExt, "auto_conf"+cfgExt)
 
-		if err := copyFile(src, dst, force); err != nil {
+		if err := copyFile(src, dst, force, tr); err != nil {
 			fmt.Fprintf(os.Stderr, "unable to copy %s to %s: %v\n", src, dst, err)
 			continue
 		}
@@ -218,8 +219,8 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	return nil
 }
 
-// Copy the src file to dst. File attributes won't be copied.
-func copyFile(src, dst string, overwrite bool) error {
+// Copy the src file to dst. File attributes won't be copied. Apply all TransformationFunc while copying.
+func copyFile(src, dst string, overwrite bool, transformations []TransformationFunc) error {
 	// if the file exists check whether we can overwrite
 	if _, err := os.Stat(dst); !os.IsNotExist(err) {
 		if overwrite {
@@ -233,28 +234,25 @@ func copyFile(src, dst string, overwrite bool) error {
 		}
 	}
 
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
 	// Create necessary destination directories
-	err = os.MkdirAll(filepath.Dir(dst), 0750)
+	err := os.MkdirAll(filepath.Dir(dst), 0750)
 	if err != nil {
 		return err
 	}
 
-	out, err := os.Create(dst)
+	data, err := ioutil.ReadFile(src)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to read file %s : %s", src, err)
 	}
-	defer out.Close()
 
-	_, err = io.Copy(out, in)
-	if err != nil {
-		return err
+	for _, transformation := range transformations {
+		data, err = transformation(data)
+		if err != nil {
+			return fmt.Errorf("unable to convert file %s : %s", src, err)
+		}
 	}
+
+	ioutil.WriteFile(dst, data, 0640)
 
 	ddGroup, errGroup := user.LookupGroup("dd-agent")
 	ddUser, errUser := user.LookupId("dd-agent")
@@ -272,18 +270,18 @@ func copyFile(src, dst string, overwrite bool) error {
 			return fmt.Errorf("Couldn't convert dd-agent user ID: %s into an int: %s", ddUser.Uid, err)
 		}
 
-		err = out.Chown(ddUID, ddGID)
+		err = os.Chown(dst, ddUID, ddGID)
 		if err != nil {
 			return fmt.Errorf("Couldn't change the file permissions for this check. Error: %s", err)
 		}
 	}
 
-	err = out.Chmod(0640)
+	err = os.Chmod(dst, 0640)
 	if err != nil {
 		return err
 	}
 
-	return out.Close()
+	return nil
 }
 
 // configTraceAgent extracts trace-agent specific info and dump to its own config file
@@ -302,18 +300,6 @@ func configTraceAgent(datadogConfPath, traceAgentConfPath string, overwrite bool
 	}
 
 	return legacy.ImportTraceAgentConfig(datadogConfPath, traceAgentConfPath)
-}
-
-func relocateMinCollectionIntervalInFile(file string) error {
-	data, err := ioutil.ReadFile(file)
-	if err != nil {
-		return err
-	}
-	output, err := relocateMinCollectionInterval(data)
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(file, output, 0640)
 }
 
 func relocateMinCollectionInterval(rawData []byte) ([]byte, error) {

--- a/cmd/agent/common/import_test.go
+++ b/cmd/agent/common/import_test.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestBasicMinCollectionIntervalRelocation(t *testing.T) {
+	input := `
+init_config:
+   min_collection_interval: 30
+instances: [{}, {}]`
+	output := `
+init_config: {}
+instances:
+  - min_collection_interval: 30
+  - min_collection_interval: 30`
+	assertRelocation(t, input, output)
+}
+
+func TestEmptyInstances(t *testing.T) {
+	input := `
+init_config:
+   min_collection_interval: 30
+instances:`
+	output := `
+init_config: {}
+instances:`
+	assertRelocation(t, input, output)
+}
+
+func TestEmptyYaml(t *testing.T) {
+	assertRelocation(t, "", "")
+}
+func TestUntouchedYaml(t *testing.T) {
+	input := `
+instances:
+  - host: localhost
+    port: 7199
+    cassandra_aliasing: true
+init_config:
+  is_jmx: true
+  collect_default_metrics: true`
+	assertRelocation(t, input, input)
+}
+
+func assertRelocation(t *testing.T, input, expectedOutput string) {
+	output, _ := relocateMinCollectionInterval([]byte(input))
+	expectedYamlOuput := make(map[interface{}]interface{})
+	yamlOutput := make(map[interface{}]interface{})
+	yaml.Unmarshal(output, &yamlOutput)
+	yaml.Unmarshal([]byte(expectedOutput), &expectedYamlOuput)
+	assert.Equal(t, yamlOutput, expectedYamlOuput)
+}

--- a/releasenotes/notes/a5-a6-migration-includes-min_collection_interva-5bdafec51d7e0a88.yaml
+++ b/releasenotes/notes/a5-a6-migration-includes-min_collection_interva-5bdafec51d7e0a88.yaml
@@ -1,0 +1,6 @@
+enhancements:
+  - |
+    The min_collection_interval check setting has been
+    relocated since Agent 6/7 release. The agent import
+    command now include in the right section this setting
+    when importing configuration from Agent 5.   


### PR DESCRIPTION
### What does this PR do?
min_collection_interval settings has been relocated in A6/7 (cf. https://docs.datadoghq.com/developers/write_agent_check/?tab=agentv6v7#collection-interval vs. https://docs.datadoghq.com/developers/write_agent_check/?tab=agentv5#collection-interval) and this PR implement the relocation during the `agent import` command. 

### Motivation
Improve the A5->A6/7 upgrade path

### Additional Notes
N/A