### PR TITLE
Fix .pyc files clenaup

### DIFF
--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -161,8 +161,8 @@ else
 fi
 
 # Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs
-find $INSTALL_DIR/agent -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/agent"
-find $INSTALL_DIR/bin/agent/dist -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/bin/agent/dist"
-find $INSTALL_DIR/bin/agent/dist -name '__pycache__' -type d -delete || echo "Unable to delete __pycache__ directories in $INSTALL_DIR/bin/agent/dist"
+find $INSTALL_DIR/embedded/lib/python* -name '*.py[co]' -type f -delete || true
+find $INSTALL_DIR/bin/agent/dist -name '*.py[co]' -type f -delete || true
+find $INSTALL_DIR/bin/agent/dist -name '__pycache__' -type d -delete || true
 
 exit 0


### PR DESCRIPTION
### What does this PR do?

- `$INSTALL_DIR/agent` doesn't exist
- Instead, most `.pyc` files will be in `$INSTALL_DIR/embedded/lib/python*`
- We don't need to print an error if no `.pyc` files are found

### Motivation

The following error was appearing on uninstall:
```
find: `/opt/datadog-agent/agent': No such file or directory
Unable to delete .pyc files in /opt/datadog-agent/agent
```

