### PR TITLE
Fix endpoints service generation from services annotated after creation of DCA

### DIFF
--- a/releasenotes-dca/notes/fix-ad-annotated-service-41807217fcb061f8.yaml
+++ b/releasenotes-dca/notes/fix-ad-annotated-service-41807217fcb061f8.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix issue preventing newly annotated services to be considered by autodiscovery in the cluster-agent


### PR DESCRIPTION
### What does this PR do?

Draft PR used as a discussion on the best way to fix the issue.

Currently if a Kube service is annotated with an endpoint check, for instance:
https://docs.datadoghq.com/integrations/kube_apiserver_metrics/

The provider will properly generate config templates but the `kube_endpoints.go` listener won't generate any service, for a very simple reason: the endpoints have not changed, only the service changed (added annotations).

I see 3 ways to fix this issue:
- Dumbest fix (current PR): Generate all endpoints service from the start, so they can be matched later when a service is annotated. Main issue is that we could have a LOT of endpoints that will be useless 99% of the time.

- Watching the Kube services in the `kube_endpoints.go` listener and trigger the process on all endpoints when we find changes on an annotated service.

- Get a Kube endpoints lister in the `kube_services.go` listener and generate the endpoints services when a service with annotation is modified/created.

I believe the 3# solution would be the easiest to understand, however I feel that it would break a bit the current separation we have between `kube_services.go` and `kube_endpoints.go`.

EDIT: Implemented solution 2# because there is some synchronisation happening in the `KubeEndpointsListener` on endpoints creation, and implementing solution 3# would require us to synchronise `KubeEndpointsListener` with `KubeServiceListener`, which is not desirable.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
