### PR TITLE
[ec2/test] Increase timeout on unit tests of ec2 util

### DIFF
--- a/pkg/util/ec2/ec2_tags_test.go
+++ b/pkg/util/ec2/ec2_tags_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,8 @@ func TestGetIAMRole(t *testing.T) {
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
 
 	val, err := getIAMRole()
 	require.Nil(t, err)
@@ -54,6 +57,8 @@ func TestGetSecurityCreds(t *testing.T) {
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
 
 	cred, err := getSecurityCreds()
 	require.Nil(t, err)
@@ -71,6 +76,8 @@ func TestGetInstanceIdentity(t *testing.T) {
 	}))
 	defer ts.Close()
 	instanceIdentityURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
 
 	val, err := getInstanceIdentity()
 	require.Nil(t, err)

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -12,11 +12,22 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var (
+	initialTimeout     = timeout
+	initialMetadataURL = metadataURL
+)
+
+func resetPackageVars() {
+	timeout = initialTimeout
+	metadataURL = initialMetadataURL
+}
 
 func TestIsDefaultHostname(t *testing.T) {
 	const key = "ec2_use_windows_prefix_detection"
@@ -55,6 +66,8 @@ func TestGetInstanceID(t *testing.T) {
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
 
 	val, err := GetInstanceID()
 	assert.Nil(t, err)
@@ -72,6 +85,8 @@ func TestGetHostname(t *testing.T) {
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
 
 	val, err := GetHostname()
 	assert.Nil(t, err)
@@ -148,6 +163,8 @@ func TestGetNetworkID(t *testing.T) {
 
 	defer ts.Close()
 	metadataURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
 
 	val, err := GetNetworkID()
 	assert.NoError(t, err)
@@ -161,6 +178,8 @@ func TestGetInstanceIDNoMac(t *testing.T) {
 
 	defer ts.Close()
 	metadataURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
 
 	_, err := GetNetworkID()
 	require.Error(t, err)
@@ -189,6 +208,8 @@ func TestGetInstanceIDMultipleVPC(t *testing.T) {
 
 	defer ts.Close()
 	metadataURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
 
 	_, err := GetNetworkID()
 	require.Error(t, err)
@@ -209,6 +230,8 @@ func TestGetLocalIPv4(t *testing.T) {
 
 	defer ts.Close()
 	metadataURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
 
 	ips, err := GetLocalIPv4()
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Increases timeout on unit tests of ec2 util.

### Motivation

Try to avoid flakes on appveyor, see https://ci.appveyor.com/project/Datadog/datadog-agent/builds/30486255 for example.