### PR TITLE
Fix create-new-version not picking up highest tag correctly

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -135,6 +135,8 @@ def _is_version_higher(version_1, version_2):
         return False
     if version_1["rc"] == 0:
         return True
+    if version_2["rc"] == 0:
+        return False
     if version_1["rc"] < version_2["rc"]:
         return False
     return True

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -133,6 +133,8 @@ def _is_version_higher(version_1, version_2):
         return False
     if version_1["patch"] < version_2["patch"]:
         return False
+    if version_1["rc"] == 0:
+        return True
     if version_1["rc"] < version_2["rc"]:
         return False
     return True


### PR DESCRIPTION
### What does this PR do?

Fix an issue with the `create-new-version` command where it picks up a version with an RC as higher than a version without (e.g. `7.17.0-rc8` should not be greater than `7.17.0`).
