### PR TITLE
Update config.go

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -871,6 +871,7 @@ func GetMainEndpointWithConfig(config Config, prefix string, ddURLKey string) (r
 	} else {
 		resolvedDDURL = prefix + DefaultSite
 	}
+	resolvedDDURL = strings.TrimSuffix(resolvedDDURL, "/")
 	return
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds a TrimSuffix() function to the GetMainEndpointWithConfig function in config.go to trim trailing '/'s from dd_url and site parameters in base agent config:
### Motivation

https://trello.com/c/jU06Pend/1487-handle-trailing-in-ddurl-and-site

### Additional Notes

I have tested this locally with both dd_url and site, with a trailing '/' attached to that value
