### PR TITLE
cmd/jmx: properly pass the loglevel to the JMX runner.

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -173,6 +173,7 @@ func RunJmxCommand(command string, reporter jmxfetch.JMXReporter, output func(..
 	runner.Command = command
 	runner.IPCPort = api.ServerAddress().Port
 	runner.Output = log.Info
+	runner.LogLevel = jmxLogLevel
 	if output != nil {
 		runner.Output = output
 	}

--- a/releasenotes/notes/jmx-log-level-cli-81b4b78f813ca9a9.yaml
+++ b/releasenotes/notes/jmx-log-level-cli-81b4b78f813ca9a9.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The `jmx` and `check jmx` command will now properly use the loglevel provided
+    with the deprecated `--log-level` flag or the `DD_LOG_LEVEL` environment var if any.


### PR DESCRIPTION
### What does this PR do?

The `jmx` command (and the `check jmx` command which is actually calling the same methods) is not properly passing the log level to the runner.

### Motivation

Use the log level provided by the deprecated `-l` flag or the `DD_LOG_LEVEL` env var.

### Additional Notes

N/A