### PR TITLE
[reno] Update inv release.update-changelog for new release process

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,7 +1,7 @@
 ---
 collapse_pre_releases: true
 no_show_source: true
-release_tag_re: '^[67]\.([\d.-]|rc)+$'
+release_tag_re: '^[67]\.([\d.-]|rc|devel)+$'
 pre_release_tag_re: '(?P<pre_release>-rc\.\d+)$'
 template: |
           # Each section from every releasenote are combined when the

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -60,11 +60,12 @@ def update_changelog(ctx, new_version):
         raise
 
     # removing releasenotes from bugfix on the old minor.
+    branching_point = "{}.{}.0-devel".format(new_version_int[0], new_version_int[1])
     previous_minor = "%s.%s" % (new_version_int[0], new_version_int[1] - 1)
     if previous_minor == "7.15":
         previous_minor = "6.15" # 7.15 is the first release in the 7.x series
-    log_result = ctx.run("git log {}.0...remotes/origin/{}.x --name-only | \
-            grep releasenotes/notes/ || true".format(previous_minor, previous_minor))
+    log_result = ctx.run("git log {}...remotes/origin/{}.x --name-only --oneline | \
+            grep releasenotes/notes/ || true".format(branching_point, previous_minor))
     log_result = log_result.stdout.replace('\n', ' ').strip()
     if len(log_result) > 0:
         ctx.run("git rm --ignore-unmatch {}".format(log_result))
@@ -72,9 +73,9 @@ def update_changelog(ctx, new_version):
     # generate the new changelog
     ctx.run("reno report \
             --ignore-cache \
-            --earliest-version {}.0 \
+            --earliest-version {} \
             --version {} \
-            --no-show-source > /tmp/new_changelog.rst".format(previous_minor, new_version))
+            --no-show-source > /tmp/new_changelog.rst".format(branching_point, new_version))
 
     # reseting git
     ctx.run("git reset --hard HEAD")

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -61,7 +61,7 @@ def update_changelog(ctx, new_version):
 
     # removing releasenotes from bugfix on the old minor.
     branching_point = "{}.{}.0-devel".format(new_version_int[0], new_version_int[1])
-    previous_minor = "%s.%s" % (new_version_int[0], new_version_int[1] - 1)
+    previous_minor = "{}.{}".format(new_version_int[0], new_version_int[1] - 1)
     if previous_minor == "7.15":
         previous_minor = "6.15" # 7.15 is the first release in the 7.x series
     log_result = ctx.run("git log {}...remotes/origin/{}.x --name-only --oneline | \


### PR DESCRIPTION
### What does this PR do?

Starts checking the release notes from `7.x.0-devel` instead of `7.{x-1}.0` because of our new release process.
Uses shorter `--oneline` version of git log to avoid catching commit message lines with `*` in them which are then fed to `git rm`.

### Motivation

Make the changelog invoke task work with the new release process.
