### PR TITLE
Use new S3 URL format

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -7,7 +7,7 @@
 set -e
 logfile=ddagent-install.log
 dmg_file=/tmp/datadog-agent.dmg
-dmg_base_url="https://s3.amazonaws.com/dd-agent"
+dmg_base_url="https://dd-agent.s3.amazonaws.com"
 
 dd_upgrade=
 if [ -n "$DD_UPGRADE" ]; then

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -7,7 +7,7 @@
 set -e
 logfile=ddagent-install.log
 dmg_file=/tmp/datadog-agent.dmg
-dmg_base_url="https://dd-agent.s3.amazonaws.com"
+dmg_base_url="https://s3.amazonaws.com/dd-agent"
 
 dd_upgrade=
 if [ -n "$DD_UPGRADE" ]; then

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -78,11 +78,11 @@ else
   dependency "vc_redist"
 
   if windows_arch_i386?
-    source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-x86.zip",
+    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
            :sha256 => "a2c5c5736356f7264a7412cdca050cf2ae924c703c47a27b8f0d8f62ce2d6181",
            :extract => :seven_zip
   else
-    source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-amd64.zip",
+    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-amd64.zip",
          :sha256 => "557ea6690c5927360656c003d3114b73adbd755b712a2911975dde813d6d7afb",
          :extract => :seven_zip
   end

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -64,12 +64,12 @@ else
   if windows_arch_i386?
     dependency "vc_ucrt_redist"
 
-    source :url => "http://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-x86.zip",
+    source :url => "http://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
             :sha256 => "44f4a665392912fe172223c42c62dd193670392fee5010bc9f89c5cd2722964c"
   else
 
     # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
-    source :url => "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-#{version}-amd64.zip",
+    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-amd64.zip",
          :sha256 => "58563ca60891025923572107e02b8f07439928eb5222dd10466cc92089072c2a"
 
   end

--- a/omnibus/config/software/vc_redist.rb
+++ b/omnibus/config/software/vc_redist.rb
@@ -3,13 +3,13 @@
 name "vc_redist"
 default_version "90"
 
-# source :url => "https://s3.amazonaws.com/dd-agent-omnibus/msvcrntm_x64.tar.gz",
+# source :url => "https://dd-agent-omnibus.s3.amazonaws.com/msvcrntm_x64.tar.gz",
 if windows_arch_i386?
-  source :url => "https://s3.amazonaws.com/dd-agent-omnibus/msvc_runtime_x86.tgz",
+  source :url => "https://dd-agent-omnibus.s3.amazonaws.com/msvc_runtime_x86.tgz",
          :sha256 => "6fee9db533c6547648ea8423d9a0a281298586c3a0761d17ba3f36c5360c2434",
          :extract => :seven_zip
 else
-    source :url => "https://s3.amazonaws.com/dd-agent-omnibus/msvc_runtime_x64.tgz",
+    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/msvc_runtime_x64.tgz",
            :sha256 => "ee3d4be86e7a63a7a9f9f325962fcf62436ac234f1fd69919003463ffd43ee3f",
            :extract => :seven_zip
 

--- a/omnibus/config/software/vc_redist_14.rb
+++ b/omnibus/config/software/vc_redist_14.rb
@@ -4,11 +4,11 @@ name "vc_redist_140"
 default_version "140"
 
 if windows_arch_i386?
-  source :url => "https://s3.amazonaws.com/dd-agent-omnibus/Microsoft_VC141_CRT_x86.msm",
+  source :url => "https://dd-agent-omnibus.s3.amazonaws.com/Microsoft_VC141_CRT_x86.msm",
          :sha256 => "d582b8069174edaefb1fa04b84ebca375602655b5bdbb17aa15d61f43b25a67e",
          :target_filename => "Microsoft_VC141_CRT_x86.msm"
 else
-  source :url => "https://s3.amazonaws.com/dd-agent-omnibus/Microsoft_VC141_CRT_x64.msm",
+  source :url => "https://dd-agent-omnibus.s3.amazonaws.com/Microsoft_VC141_CRT_x64.msm",
          :sha256 => "102a2127f528865f6e462c5b28589a7249f70d0d4201676c3b2f2cc46f997b84",
          :target_filename => "Microsoft_VC141_CRT_x64.msm"
 end

--- a/omnibus/config/software/vc_ucrt_redist.rb
+++ b/omnibus/config/software/vc_ucrt_redist.rb
@@ -3,9 +3,9 @@
 name "vc_ucrt_redist"
 default_version "14"
 
-# source :url => "https://s3.amazonaws.com/dd-agent-omnibus/msvcrntm_x64.tar.gz",
+# source :url => "https://dd-agent-omnibus.s3.amazonaws.com/msvcrntm_x64.tar.gz",
 if windows_arch_i386?
-  source :url => "https://s3.amazonaws.com/dd-agent-omnibus/msvc_ucrt_runtime_x86.zip",
+  source :url => "https://dd-agent-omnibus.s3.amazonaws.com/msvc_ucrt_runtime_x86.zip",
          :sha256 => "7f93f888b3f99f890557a7361381b10552022744422e482510c24f25cf09191d",
          :extract => :seven_zip
 

--- a/test/kitchen/kitchen-azure-common.yml
+++ b/test/kitchen/kitchen-azure-common.yml
@@ -177,7 +177,7 @@ platforms:
   yumrepo = "http://yumtesting.datad0g.com/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['MAJOR_VERSION']}/x86_64/"
   yumrepo_suse = "http://yumtesting.datad0g.com/suse/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['MAJOR_VERSION']}/x86_64/"
   agent_major_version = "#{ENV['MAJOR_VERSION']}"
-  windows_agent_url = ENV['WINDOWS_AGENT_URL'] ? ENV['WINDOWS_AGENT_URL'] : "https://s3.amazonaws.com/#{ENV['WINDOWS_TESTING_S3_BUCKET']}/"
+  windows_agent_url = ENV['WINDOWS_AGENT_URL'] ? ENV['WINDOWS_AGENT_URL'] : "https://#{ENV['WINDOWS_TESTING_S3_BUCKET']}.s3.amazonaws.com/"
   dd_agent_config = {
     'agent_major_version': agent_major_version,
     'api_key': api_key,

--- a/test/kitchen/kitchen-azure-upgrade6-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade6-test.yml
@@ -18,7 +18,7 @@ suites:
       agent_major_version: 6
       api_key: <%= api_key %>
     dd-agent-install:
-      windows_agent_url: https://s3.amazonaws.com/ddagent-windows-stable/
+      windows_agent_url: https://ddagent-windows-stable.s3.amazonaws.com/
       windows_agent_filename: datadog-agent-6-latest.amd64
     dd-agent-upgrade:
       add_new_repo: true

--- a/test/kitchen/kitchen-azure-upgrade7-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade7-test.yml
@@ -14,7 +14,7 @@ suites:
       agent_major_version: 7
       api_key: <%= api_key %>
     dd-agent-install:
-      windows_agent_url: https://s3.amazonaws.com/ddagent-windows-stable/
+      windows_agent_url: https://ddagent-windows-stable.s3.amazonaws.com/
       windows_agent_filename: datadog-agent-7-latest.amd64
     dd-agent-upgrade:
       add_new_repo: true

--- a/test/kitchen/site-cookbooks/dd-agent-5/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-5/attributes/default.rb
@@ -7,7 +7,7 @@ if node['platform_family'] == 'windows'
   default['dd-agent-5']['windows_agent_checksum'] = nil
   default['dd-agent-5']['windows_version'] = nil
   default['dd-agent-5']['windows_agent_filename'] = "ddagent-cli-latest"
-  default['dd-agent-5']['windows_agent_url'] = 'https://s3.amazonaws.com/ddagent-windows-stable/'
+  default['dd-agent-5']['windows_agent_url'] = 'https://ddagent-windows-stable.s3.amazonaws.com/'
   default['dd-agent-5']['agent_install_options'] = nil
   default['dd-agent-5']['config_dir'] = "#{ENV['ProgramData']}/Datadog"
   default['dd-agent-5']['agent_name'] = 'DatadogAgent'

--- a/test/kitchen/site-cookbooks/dd-agent-install/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/attributes/default.rb
@@ -28,7 +28,7 @@ default['dd-agent-install']['api_key'] = nil
 default['dd-agent-install']['agent_major_version'] = nil
 default['dd-agent-install']['windows_version'] = nil # => install the latest available version
 default['dd-agent-install']['windows_agent_checksum'] = nil
-default['dd-agent-install']['windows_agent_url'] = 'https://s3.amazonaws.com/ddagent-windows-stable/'
+default['dd-agent-install']['windows_agent_url'] = 'https://ddagent-windows-stable.s3.amazonaws.com/'
 
 default['dd-agent-install']['agent_package_retries'] = nil
 default['dd-agent-install']['agent_package_retry_delay'] = nil

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/attributes/default.rb
@@ -11,7 +11,7 @@ default['dd-agent-upgrade']['package_name'] = 'datadog-agent'
 
 default['dd-agent-upgrade']['windows_version'] = nil # => install the latest available version
 default['dd-agent-upgrade']['windows_agent_checksum'] = nil
-default['dd-agent-upgrade']['windows_agent_url'] = 'https://s3.amazonaws.com/ddagent-windows-stable/'
+default['dd-agent-upgrade']['windows_agent_url'] = 'https://ddagent-windows-stable.s3.amazonaws.com/'
 
 default['dd-agent-upgrade']['agent_package_retries'] = nil
 default['dd-agent-upgrade']['agent_package_retry_delay'] = nil


### PR DESCRIPTION
### What does this PR do?

Switch S3 URLs to virtual-hosted style.

### Motivation

Comply with the new standard. Even if old buckets should not be affected, let's be consistent in the path style we use.
