### PR TITLE
[ebpf] Fix connection expiration race condition

### DIFF
--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -5,6 +5,7 @@ package ebpf
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1069,6 +1070,81 @@ func TestSkipConnectionDNS(t *testing.T) {
 		}))
 
 	})
+}
+
+func TestConnectionExpirationRegression(t *testing.T) {
+	tr, err := NewTracer(NewDefaultConfig())
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	// Create TCP Server that simply "drains" connection until receiving an EOF
+	connClosed := make(chan struct{})
+	server := NewTCPServer(func(c net.Conn) {
+		io.Copy(ioutil.Discard, c)
+		c.Close()
+		connClosed <- struct{}{}
+	})
+	doneChan := make(chan struct{})
+	server.Run(doneChan)
+	defer func() { doneChan <- struct{}{} }()
+
+	c, err := net.DialTimeout("tcp", server.address, time.Second)
+	require.NoError(t, err)
+
+	// Warm up state
+	_ = getConnections(t, tr)
+
+	// Write 5 bytes to TCP socket
+	payload := []byte("12345")
+	_, err = c.Write(payload)
+	require.NoError(t, err)
+
+	// Fetch connection matching source and target address
+	// This will make sure to populate the state for this particular client
+	allConnections := getConnections(t, tr)
+	connectionStats, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), allConnections)
+	require.True(t, ok)
+	assert.Equal(t, uint64(len(payload)), connectionStats.LastSentBytes)
+
+	// This emulates the race condition, a `tcp_close` followed by a call to `Tracer.removeConnections()`
+	// It's unfortunate we're relying here on private methods, but there isn't much we can do to avoid that.
+	c.Close()
+	<-connClosed
+	time.Sleep(100 * time.Millisecond)
+	removeConnection(t, tr, connectionStats)
+
+	// Since no bytes were send or received after we obtained the connectionStats, we should have 0 LastBytesSent
+	allConnections = getConnections(t, tr)
+	connectionStats, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), allConnections)
+	require.True(t, ok)
+	assert.Equal(t, uint64(0), connectionStats.LastSentBytes)
+
+	// Finally, this connection should have been expired from the state
+	allConnections = getConnections(t, tr)
+	_, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), allConnections)
+	require.False(t, ok)
+}
+
+func removeConnection(t *testing.T, tr *Tracer, c *ConnectionStats) {
+	mp, err := tr.getMap(connMap)
+	require.NoError(t, err)
+
+	tcpMp, err := tr.getMap(tcpStatsMap)
+	require.NoError(t, err)
+
+	tuple := []*ConnTuple{
+		&ConnTuple{
+			pid:      _Ctype_uint(c.Pid),
+			saddr_l:  _Ctype_ulonglong(binary.LittleEndian.Uint32(c.Source.Bytes())),
+			daddr_l:  _Ctype_ulonglong(binary.LittleEndian.Uint32(c.Dest.Bytes())),
+			sport:    _Ctype_ushort(c.SPort),
+			dport:    _Ctype_ushort(c.DPort),
+			netns:    _Ctype_uint(c.NetNS),
+			metadata: 1, // TCP/IPv4
+		},
+	}
+
+	tr.removeEntries(mp, tcpMp, tuple)
 }
 
 func byAddress(l, r net.Addr) func(c ConnectionStats) bool {

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -1133,7 +1133,7 @@ func removeConnection(t *testing.T, tr *Tracer, c *ConnectionStats) {
 	require.NoError(t, err)
 
 	tuple := []*ConnTuple{
-		&ConnTuple{
+		{
 			pid:      _Ctype_uint(c.Pid),
 			saddr_l:  _Ctype_ulonglong(binary.LittleEndian.Uint32(c.Source.Bytes())),
 			daddr_l:  _Ctype_ulonglong(binary.LittleEndian.Uint32(c.Dest.Bytes())),


### PR DESCRIPTION
### What does this PR do?

This PR fixes a connection expiration data race that was causing network metrics to be over-reported in some cases.

Basically the data race arises in the following scenario:
1. Connection check is executed (`Tracer.GetActiveConnections()`)
2. One of the connections (let's call it *c* ) hasn't been updated in the eBPF map for for longer than ` TCPConnTimeout` and it's "marked" as expired (`Tracer.getConnections`);
3. At the same time the connection *c* is closed and `kprobe/tcp_close` is executed;
4. The closed connection is written to the perf ring buffer. Once user space reads it, it calls `state.StoreClosedConnection` (from `Tracer.initPerfPooling`);
5. Now the function call initiated in **2.** calls `Tracer.removeEntries` with connection *c* as an argument;
6. The state associated to *c* is removed;
7. Client calls again `Tracer.GetActiveConnections()`; Since there is no state associated to *c* but just the `closedConnection` entry, the user gets back `Monotonic{Sent,Recv}Bytes` as if it was `Last{Sent,Recv}Bytes`

#### Note about the test

The testing code is unfortunately too tied to the private API of the tracer, so I'm not sure if it's totally worth it. Another way to test this would be setting a small number to `TCPConnTimeout`, opening a bunch of connections and then closing them and calling `GetActiveConnections` after `TCPConnTimeout` seconds. That would potentially trigger the race condition without relying on the private API, but the test could become too flaky so 🤷‍♂ 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?