### PR TITLE
Trim forward slashes from config urls

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -829,12 +829,17 @@ func trimTrailingSlashFromURLS(config Config) error {
 	}
 
 	for _, domain := range urls {
+		key := config.GetString(domain)
+		if len(key) == 0 {
+			continue
+		}
 		for {
-			if config.GetString(domain)[len(config.GetString(domain))-1:] != "/" {
+			if key[len(key)-1:] != "/" {
 				break
 			}
-			config.Set(domain, strings.TrimSuffix(config.GetString(domain), "/"))
+			key = strings.TrimSuffix(key, "/")
 		}
+		config.Set(domain, key)
 	}
 
 	for _, es := range additionalEndpointSelectors {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -767,8 +767,8 @@ func load(config Config, origin string, loadSecret bool) error {
 
 	loadProxyFromEnv(config)
 	sanitizeAPIKey(config)
-	trimTrailingSlashFromURLS(config)
 	applyOverrides(config)
+	trimTrailingSlashFromURLS(config)
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	setTracemallocEnabled(config)
 	setNumWorkers(config)
@@ -815,7 +815,7 @@ func sanitizeAPIKey(config Config) {
 	config.Set("api_key", strings.TrimSpace(config.GetString("api_key")))
 }
 
-//trims any forward slashes from the end of various config URL's (site, dd_url, and additional endpoints)
+//trimTrailingSlashFromURLS trims any forward slashes from the end of various config URL's (site, dd_url, and various additional endpoints)
 func trimTrailingSlashFromURLS(config Config) error {
 	var urls = []string{
 		"site",
@@ -846,7 +846,6 @@ func trimTrailingSlashFromURLS(config Config) error {
 			return err
 		}
 		for domain, keys := range additionalEndpoints {
-
 			if domain == "" {
 				continue
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -853,6 +853,9 @@ func trimTrailingSlashFromURLS(config Config) error {
 		}
 		for domain, key := range additionalEndpoints {
 			for {
+				if len(domain) == 0 {
+					continue
+				}
 				domain = strings.TrimSuffix(domain, "/")
 				if domain[len(domain)-1:] != "/" {
 					sanitizedAdditionalEndpoints[domain] = key

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -830,16 +830,10 @@ func trimTrailingSlashFromURLS(config Config) error {
 
 	for _, domain := range urls {
 		key := config.GetString(domain)
-		if len(key) == 0 {
+		if key == "" {
 			continue
 		}
-		for {
-			if key[len(key)-1:] != "/" {
-				break
-			}
-			key = strings.TrimSuffix(key, "/")
-		}
-		config.Set(domain, key)
+		config.Set(domain, strings.TrimRight(key, "/"))
 	}
 
 	for _, es := range additionalEndpointSelectors {
@@ -851,17 +845,13 @@ func trimTrailingSlashFromURLS(config Config) error {
 		if err != nil {
 			return err
 		}
-		for domain, key := range additionalEndpoints {
-			for {
-				if len(domain) == 0 {
-					continue
-				}
-				domain = strings.TrimSuffix(domain, "/")
-				if domain[len(domain)-1:] != "/" {
-					sanitizedAdditionalEndpoints[domain] = key
-					break
-				}
+		for domain, keys := range additionalEndpoints {
+
+			if domain == "" {
+				continue
 			}
+			domain = strings.TrimRight(domain, "/")
+			sanitizedAdditionalEndpoints[domain] = keys
 		}
 		config.Set(es, sanitizedAdditionalEndpoints)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -618,6 +618,69 @@ func TestSanitizeAPIKey(t *testing.T) {
 	assert.Equal(t, "foo", config.GetString("api_key"))
 }
 
+func TestTrimTrailingSlashFromURLS(t *testing.T) {
+	var urls = []string{
+		"site",
+		"dd_url",
+	}
+	var additionalEndpointSelectors = []string{
+		"additional_endpoints",
+		"apm_config.additional_endpoints",
+		"logs_config.additional_endpoints",
+		"process_config.additional_endpoints",
+	}
+	datadogYaml := `
+api_key: fakeapikey
+site: datadoghq.com/////
+dd_url: https://7-17-0-app.agent.datadoghq.com/
+additional_endpoints:
+  testing.com///:
+  - fakekey
+  test2.com/:
+  - fakekey
+apm_config:
+  additional_endpoints:
+    testingapm.com//:
+    - fakekey
+    test2apm.com/:
+    - fakekey
+logs_config:
+  additional_endpoints:
+    testinglogs.com///////:
+    - fakekey
+    test2logs.com/:
+    - fakekey
+process_config:
+  additional_endpoints:
+    testingproc.com/////:
+    - fakekey
+    test2proc.com/:
+    - fakekey
+`
+	testConfig := setupConfFromYAML(datadogYaml)
+	trimTrailingSlashFromURLS(testConfig)
+
+	for _, u := range urls {
+		testString := testConfig.GetString(u)
+		if testString[len(testString)-1:] == "/" {
+			t.Errorf("Error: The key %v: has a vlue of %v -- The trailing forward slash was not properly trimmed", u, testConfig.GetString(u))
+		}
+	}
+	for _, es := range additionalEndpointSelectors {
+		additionalEndpoints := make(map[string][]string)
+		err := testConfig.UnmarshalKey(es, &additionalEndpoints)
+		if err != nil {
+			t.Errorf("Error: %v", err)
+		}
+
+		for domain := range additionalEndpoints {
+			if domain[len(domain)-1:] == "/" {
+				t.Errorf("Error: The key %v: has a vlue of %v -- The trailing forward slash was not properly trimmed", es, domain)
+			}
+		}
+	}
+}
+
 // TestSecretBackendWithMultipleEndpoints tests an edge case of `viper.AllSettings()` when a config
 // key includes the key delimiter. Affects the config package when both secrets and multiple
 // endpoints are configured.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -632,7 +632,7 @@ func TestTrimTrailingSlashFromURLS(t *testing.T) {
 	datadogYaml := `
 api_key: fakeapikey
 site: datadoghq.com/////
-dd_url: https://7-17-0-app.agent.datadoghq.com/
+dd_url:
 additional_endpoints:
   testing.com///:
   - fakekey
@@ -662,6 +662,9 @@ process_config:
 
 	for _, u := range urls {
 		testString := testConfig.GetString(u)
+		if len(testString) == 0 {
+			continue
+		}
 		if testString[len(testString)-1:] == "/" {
 			t.Errorf("Error: The key %v: has a vlue of %v -- The trailing forward slash was not properly trimmed", u, testConfig.GetString(u))
 		}


### PR DESCRIPTION
### What does this PR do?
On agent configuration files, a trailing forward slash was causing URL's to have an unexpected '//' in the agent config object.  This PR adds a function that will trim extraneous forward slashes from the end of URL's to avoid scattered reports of this causing issues during runtime with submission.

It adds a function called trimTrailingSlashFromURLS in pkg/config/config.go and a corresponding test.  The function is called during creation of the global Datadog config object.

### Motivation
Issue here:  https://github.com/DataDog/datadog-agent/pull/4827

### Additional Notes

This PR addresses both dd_url and all additional_endpoints, including apm, process, and logs
