### PR TITLE
Remove setcap NET_BIND_SERVICE as we cannot make it work with user namespaces used in the CI

### DIFF
--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -38,17 +38,6 @@ RUN apt-get update \
 
 COPY --from=builder /output /
 
-# We need to set the NET_BIND_SERVICE capability to allow the cluster-agent to bind
-# port 443 for metrics provider.
-# And we need to do it here because capabilities set in `builder` stage are not kept
-# by the `COPY --from=builder`.
-RUN apt-get update \
-    && apt-get install -y libcap2-bin \
-    && setcap cap_net_bind_service+ep /opt/datadog-agent/bin/datadog-cluster-agent \
-    && apt-get remove -y libcap2-bin \
-    && apt-get autoremove -y \
-    && apt-get clean
-
 # Allow running as an unprivileged user:
 # - General case is the dd-agent user
 # - OpenShift uses a random UID in the root group

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -38,17 +38,6 @@ RUN apt-get update \
 
 COPY --from=builder /output /
 
-# We need to set the NET_BIND_SERVICE capability to allow the cluster-agent to bind
-# port 443 for metrics provider.
-# And we need to do it here because capabilities set in `builder` stage are not kept
-# by the `COPY --from=builder`.
-RUN apt-get update \
-    && apt-get install -y libcap2-bin \
-    && setcap cap_net_bind_service+ep /opt/datadog-agent/bin/datadog-cluster-agent \
-    && apt-get remove -y libcap2-bin \
-    && apt-get autoremove -y \
-    && apt-get clean
-
 # Allow running as an unprivileged user:
 # - General case is the dd-agent user
 # - OpenShift uses a random UID in the root group


### PR DESCRIPTION
### What does this PR do?

Going back to previous state. For non root we need to document usage of port != 443.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
