### PR TITLE
[process-agent] [system-probe] Remove initial logger from startup

### DIFF
--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -5,8 +5,6 @@ package main
 import (
 	"flag"
 	_ "net/http/pprof"
-
-	"github.com/DataDog/datadog-agent/pkg/process/config"
 )
 
 func main() {
@@ -19,12 +17,6 @@ func main() {
 	flag.BoolVar(&opts.version, "version", false, "Print the version and exit")
 	flag.StringVar(&opts.check, "check", "", "Run a specific check and print the results. Choose from: process, connections, realtime")
 	flag.Parse()
-
-	// Set up a default config before parsing config so we log errors nicely.
-	// The default will be stdout since we can't assume any file is writable.
-	if err := config.SetupInitialLogger(loggerName); err != nil {
-		panic(err)
-	}
 
 	exit := make(chan bool)
 

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -47,13 +47,6 @@ func main() {
 	flag.BoolVar(&opts.version, "version", false, "Print the version and exit")
 	flag.Parse()
 
-	// Set up a default config before parsing config so we log errors nicely.
-	// The default will be stdout since we can't assume any file is writable.
-	if err := config.SetupInitialLogger(loggerName); err != nil {
-		panic(err)
-	}
-	defer log.Flush()
-
 	// --version
 	if opts.version {
 		fmt.Println(versionString("\n"))

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -544,20 +544,6 @@ func constructProxy(host, scheme string, port int, user, password string) (proxy
 	return http.ProxyURL(u), nil
 }
 
-// SetupInitialLogger will set up a default logger before parsing config so we log errors nicely.
-// The default will be stdout since we can't assume any file is writable.
-func SetupInitialLogger(loggerName config.LoggerName) error {
-	return config.SetupLogger(
-		loggerName,
-		"info",
-		"",
-		"",
-		false,
-		true, // logToConsole
-		false,
-	)
-}
-
 func setupLogger(loggerName config.LoggerName, logFile string, cfg *AgentConfig) error {
 	return config.SetupLogger(
 		loggerName,

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -379,36 +379,36 @@ func NewSystemProbeConfig(loggerName config.LoggerName, yamlPath string) (*Agent
 }
 
 func loadEnvVariables() {
-	for envKey, cfgKey := range map[string]string{
-		"DD_PROCESS_AGENT_CONTAINER_SOURCE": "process_config.container_source",
-		"DD_SCRUB_ARGS":                     "process_config.scrub_args",
-		"DD_STRIP_PROCESS_ARGS":             "process_config.strip_proc_arguments",
-		"DD_PROCESS_AGENT_URL":              "process_config.process_dd_url",
-		"DD_ORCHESTRATOR_URL":               "process_config.orchestrator_dd_url",
+	for _, variable := range []struct{ env, cfg string }{
+		{"DD_PROCESS_AGENT_CONTAINER_SOURCE", "process_config.container_source"},
+		{"DD_SCRUB_ARGS", "process_config.scrub_args"},
+		{"DD_STRIP_PROCESS_ARGS", "process_config.strip_proc_arguments"},
+		{"DD_PROCESS_AGENT_URL", "process_config.process_dd_url"},
+		{"DD_ORCHESTRATOR_URL", "process_config.orchestrator_dd_url"},
 
 		// System probe specific configuration (Beta)
-		"DD_SYSTEM_PROBE_ENABLED":   "system_probe_config.enabled",
-		"DD_SYSPROBE_SOCKET":        "system_probe_config.sysprobe_socket",
-		"DD_DISABLE_TCP_TRACING":    "system_probe_config.disable_tcp",
-		"DD_DISABLE_UDP_TRACING":    "system_probe_config.disable_udp",
-		"DD_DISABLE_IPV6_TRACING":   "system_probe_config.disable_ipv6",
-		"DD_DISABLE_DNS_INSPECTION": "system_probe_config.disable_dns_inspection",
-		"DD_COLLECT_LOCAL_DNS":      "system_probe_config.collect_local_dns",
+		{"DD_SYSTEM_PROBE_ENABLED", "system_probe_config.enabled"},
+		{"DD_SYSPROBE_SOCKET", "system_probe_config.sysprobe_socket"},
+		{"DD_DISABLE_TCP_TRACING", "system_probe_config.disable_tcp"},
+		{"DD_DISABLE_UDP_TRACING", "system_probe_config.disable_udp"},
+		{"DD_DISABLE_IPV6_TRACING", "system_probe_config.disable_ipv6"},
+		{"DD_DISABLE_DNS_INSPECTION", "system_probe_config.disable_dns_inspection"},
+		{"DD_COLLECT_LOCAL_DNS", "system_probe_config.collect_local_dns"},
 
-		"DD_HOSTNAME":       "hostname",
-		"DD_DOGSTATSD_PORT": "dogstatsd_port",
-		"DD_BIND_HOST":      "bind_host",
-		"HTTPS_PROXY":       "proxy.https",
-		"DD_PROXY_HTTPS":    "proxy.https",
+		{"DD_HOSTNAME", "hostname"},
+		{"DD_DOGSTATSD_PORT", "dogstatsd_port"},
+		{"DD_BIND_HOST", "bind_host"},
+		{"HTTPS_PROXY", "proxy.https"},
+		{"DD_PROXY_HTTPS", "proxy.https"},
 
-		"DD_LOGS_STDOUT":    "log_to_console",
-		"LOG_TO_CONSOLE":    "log_to_console",
-		"DD_LOG_TO_CONSOLE": "log_to_console",
-		"LOG_LEVEL":         "log_level", // Support LOG_LEVEL and DD_LOG_LEVEL but prefer DD_LOG_LEVEL
-		"DD_LOG_LEVEL":      "log_level",
+		{"DD_LOGS_STDOUT", "log_to_console"},
+		{"LOG_TO_CONSOLE", "log_to_console"},
+		{"DD_LOG_TO_CONSOLE", "log_to_console"},
+		{"LOG_LEVEL", "log_level"}, // Support LOG_LEVEL and DD_LOG_LEVEL but prefer DD_LOG_LEVEL
+		{"DD_LOG_LEVEL", "log_level"},
 	} {
-		if v, ok := os.LookupEnv(envKey); ok {
-			config.Datadog.Set(cfgKey, v)
+		if v, ok := os.LookupEnv(variable.env); ok {
+			config.Datadog.Set(variable.cfg, v)
 		}
 	}
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -379,6 +379,8 @@ func NewSystemProbeConfig(loggerName config.LoggerName, yamlPath string) (*Agent
 }
 
 func loadEnvVariables() {
+	// The following environment variables will be loaded in the order listed, meaning variables
+	// further down the list may override prior variables.
 	for _, variable := range []struct{ env, cfg string }{
 		{"DD_PROCESS_AGENT_CONTAINER_SOURCE", "process_config.container_source"},
 		{"DD_SCRUB_ARGS", "process_config.scrub_args"},

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -148,6 +148,19 @@ func TestOnlyEnvConfigArgsScrubbingDisabled(t *testing.T) {
 	}
 }
 
+func TestOnlyEnvConfigLogLevelOverride(t *testing.T) {
+	config.Datadog = config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	defer restoreGlobalConfig()
+
+	os.Setenv("DD_LOG_LEVEL", "error")
+	defer os.Unsetenv("DD_LOG_LEVEL")
+	os.Setenv("LOG_LEVEL", "debug")
+	defer os.Unsetenv("LOG_LEVEL")
+
+	agentConfig, _ := NewAgentConfig("test", "", "")
+	assert.Equal(t, "error", agentConfig.LogLevel)
+}
+
 func TestDisablingDNSInspection(t *testing.T) {
 	config.Datadog = config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	defer restoreGlobalConfig()

--- a/releasenotes/notes/process-remove-initial-logger-2b926bf5653e609f.yaml
+++ b/releasenotes/notes/process-remove-initial-logger-2b926bf5653e609f.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix process-agent not respecting logger configuration during startup.


### PR DESCRIPTION
### What does this PR do?

This PR removes the initial logger from startup. The initial logger is not necessary because the log package buffers logs that are written before the logger is initialized, so no logs will be lost. In the case of error logs, these are automatically written to stdout as well, so they can be captured if the application quits before the log is flushed. This initial logger does not respect any logging config variables, which was the underlying issue behind https://github.com/DataDog/datadog-agent/issues/4300.

This PR also changes the map of environment variable and config variable names to a slice. Because we explicitly intend for certain variables to override others (e.g. `DD_LOG_LEVEL` is preferred over `LOG_LEVEL`), we must iterate through these variables in order, and a map does not guarantee iteration order.

### Motivation

[PROC-24](https://datadoghq.atlassian.net/browse/PROC-24)
Fixes https://github.com/DataDog/datadog-agent/issues/4300

### Additional Notes

@DataDog/processes 
@DataDog/networks 