### PR TITLE
Stop HTML-escaping on agent status output

### DIFF
--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -8,9 +8,10 @@ package status
 import (
 	"encoding/json"
 	"fmt"
-	"html/template"
+	htemplate "html/template"
 	"strconv"
 	"strings"
+	ttemplate "text/template"
 	"time"
 	"unicode"
 
@@ -20,13 +21,13 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-// Fmap return a fresh copy of a map of utility functions for templating
-func Fmap() template.FuncMap {
-	return template.FuncMap{
+// Fmap return a fresh copy of a map of utility functions for HTML templating
+func Fmap() htemplate.FuncMap {
+	return htemplate.FuncMap{
 		"doNotEscape":        doNotEscape,
 		"lastError":          lastError,
-		"lastErrorTraceback": lastErrorTraceback,
-		"lastErrorMessage":   lastErrorMessage,
+		"lastErrorTraceback": func(s string) htemplate.HTML { return doNotEscape(lastErrorTraceback(s)) },
+		"lastErrorMessage":   func(s string) htemplate.HTML { return doNotEscape(lastErrorMessage(s)) },
 		"configError":        configError,
 		"printDashes":        printDashes,
 		"formatUnixTime":     formatUnixTime,
@@ -44,40 +45,61 @@ func Fmap() template.FuncMap {
 	}
 }
 
-func doNotEscape(value string) template.HTML {
-	return template.HTML(value)
+// Textfmap return a fresh copy of a map of utility functions for text templating
+func Textfmap() ttemplate.FuncMap {
+	return ttemplate.FuncMap{
+		"lastErrorTraceback": lastErrorTraceback,
+		"lastErrorMessage":   lastErrorMessage,
+		"printDashes":        printDashes,
+		"formatUnixTime":     formatUnixTime,
+		"humanize":           mkHuman,
+		"humanizeDuration":   mkHumanDuration,
+		"toUnsortedList":     toUnsortedList,
+		"formatTitle":        formatTitle,
+		"add":                add,
+		"status":             status,
+		"redText":            redText,
+		"yellowText":         yellowText,
+		"greenText":          greenText,
+		"ntpWarning":         ntpWarning,
+		"version":            getVersion,
+	}
 }
 
-func configError(value string) template.HTML {
-	return template.HTML(value + "\n")
+func doNotEscape(value string) htemplate.HTML {
+	return htemplate.HTML(value)
 }
 
-func lastError(value string) template.HTML {
-	return template.HTML(value)
+func configError(value string) htemplate.HTML {
+	return htemplate.HTML(value + "\n")
 }
 
-func lastErrorTraceback(value string) template.HTML {
+func lastError(value string) htemplate.HTML {
+	return htemplate.HTML(value)
+}
+
+func lastErrorTraceback(value string) string {
 	var lastErrorArray []map[string]string
 
 	err := json.Unmarshal([]byte(value), &lastErrorArray)
 	if err != nil || len(lastErrorArray) == 0 {
-		return template.HTML("No traceback")
+		return "No traceback"
 	}
 	lastErrorArray[0]["traceback"] = strings.Replace(lastErrorArray[0]["traceback"], "\n", "\n      ", -1)
 	lastErrorArray[0]["traceback"] = strings.TrimRight(lastErrorArray[0]["traceback"], "\n\t ")
-	return template.HTML(lastErrorArray[0]["traceback"])
+	return lastErrorArray[0]["traceback"]
 }
 
 // lastErrorMessage converts the last error message to html
-func lastErrorMessage(value string) template.HTML {
+func lastErrorMessage(value string) string {
 	var lastErrorArray []map[string]string
 	err := json.Unmarshal([]byte(value), &lastErrorArray)
 	if err == nil && len(lastErrorArray) > 0 {
 		if msg, ok := lastErrorArray[0]["message"]; ok {
-			return template.HTML(msg)
+			return msg
 		}
 	}
-	return template.HTML(value)
+	return value
 }
 
 // formatUnixTime formats the unix time to make it more readable

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -12,15 +12,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"io"
+	"text/template"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-var (
-	fmap = Fmap()
-)
+var fmap = Textfmap()
 
 // FormatStatus takes a json bytestring and prints out the formatted statuspage
 func FormatStatus(data []byte) (string, error) {

--- a/pkg/status/templates/collector.tmpl
+++ b/pkg/status/templates/collector.tmpl
@@ -66,7 +66,7 @@ Collector
       {{ $CheckName }}
       {{printDashes $CheckName "-"}}
       {{- range $idx, $warning := $warnings}}
-        {{ doNotEscape $warning }}
+        {{$warning}}
       {{- end }}
     {{end}}
   {{- end }}
@@ -81,7 +81,7 @@ Collector
 
       instance {{$idx}}:
 
-        {{ doNotEscape $err }}
+        {{$err}}
       {{- end }}
     {{- end}}
   {{- end }}
@@ -94,7 +94,7 @@ Collector
     {{- range $checkname, $error := .ConfigErrors }}
     {{$checkname}}
     {{printDashes $checkname "-"}}
-      {{ configError $error }}
+      {{$error}}
     {{- end }}
   {{- end}}
 {{- end }}
@@ -109,10 +109,10 @@ Collector
       {{- range $kind, $err := $errors -}}
         {{- if eq $kind "Python Check Loader" }}
       {{$kind}}:
-        {{ doNotEscape $err }}
+        {{$err}}
         {{ else }}
       {{$kind}}:
-        {{ doNotEscape $err }}
+        {{$err}}
         {{ end }}
       {{- end }}
     {{- end }}

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -2,7 +2,7 @@
 NOTE: Changes made to this template should be reflected on the following templates, if applicable:
 * cmd/agent/gui/views/templates/generalStatus.tmpl
 */}}{{printDashes .title "="}}
-{{doNotEscape .title}}
+{{.title}}
 {{printDashes .title "="}}
 
   Status date: {{.time}}

--- a/releasenotes/notes/no-more-escaping-agent-status-output-d0ca597cfe38fa85.yaml
+++ b/releasenotes/notes/no-more-escaping-agent-status-output-d0ca597cfe38fa85.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  - |
+    Stop doing HTML escaping on agent status command output
+    in order to properly display all non-alphanumeric
+    characters.


### PR DESCRIPTION
### What does this PR do?
It stops using html/template to render `agent status` output and it switches to text/template thus it the text is now rendered without doing HTML escaping. 

### Motivation
Makes the `agent status` output more readable.

### Additional Notes
N/A
