### PR TITLE
[dogstatsd] ignore origin tags if entityID is present

### DIFF
--- a/pkg/dogstatsd/enrich_test.go
+++ b/pkg/dogstatsd/enrich_test.go
@@ -16,7 +16,7 @@ func parseAndEnrichMetricMessage(message []byte, namespace string, namespaceBlac
 	if err != nil {
 		return metrics.MetricSample{}, err
 	}
-	return enrichMetricSample(parsed, namespace, namespaceBlacklist, defaultHostname), nil
+	return enrichMetricSample(parsed, namespace, namespaceBlacklist, defaultHostname, ""), nil
 }
 
 func parseAndEnrichServiceCheckMessage(message []byte, defaultHostname string) (*metrics.ServiceCheck, error) {
@@ -25,7 +25,7 @@ func parseAndEnrichServiceCheckMessage(message []byte, defaultHostname string) (
 	if err != nil {
 		return nil, err
 	}
-	return enrichServiceCheck(parsed, defaultHostname), nil
+	return enrichServiceCheck(parsed, defaultHostname, ""), nil
 }
 
 func parseAndEnrichEventMessage(message []byte, defaultHostname string) (*metrics.Event, error) {
@@ -34,7 +34,7 @@ func parseAndEnrichEventMessage(message []byte, defaultHostname string) (*metric
 	if err != nil {
 		return nil, err
 	}
-	return enrichEvent(parsed, defaultHostname), nil
+	return enrichEvent(parsed, defaultHostname, ""), nil
 }
 
 func TestConvertParseGauge(t *testing.T) {

--- a/pkg/dogstatsd/enrich_test.go
+++ b/pkg/dogstatsd/enrich_test.go
@@ -2,6 +2,8 @@ package dogstatsd
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -10,13 +12,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func returnEmptyTags() []string {
+	return []string{}
+}
+
 func parseAndEnrichMetricMessage(message []byte, namespace string, namespaceBlacklist []string, defaultHostname string) (metrics.MetricSample, error) {
 	parser := newParser()
 	parsed, err := parser.parseMetricSample(message)
 	if err != nil {
 		return metrics.MetricSample{}, err
 	}
-	return enrichMetricSample(parsed, namespace, namespaceBlacklist, defaultHostname, ""), nil
+	return enrichMetricSample(parsed, namespace, namespaceBlacklist, defaultHostname, returnEmptyTags), nil
 }
 
 func parseAndEnrichServiceCheckMessage(message []byte, defaultHostname string) (*metrics.ServiceCheck, error) {
@@ -25,7 +31,7 @@ func parseAndEnrichServiceCheckMessage(message []byte, defaultHostname string) (
 	if err != nil {
 		return nil, err
 	}
-	return enrichServiceCheck(parsed, defaultHostname, ""), nil
+	return enrichServiceCheck(parsed, defaultHostname, returnEmptyTags), nil
 }
 
 func parseAndEnrichEventMessage(message []byte, defaultHostname string) (*metrics.Event, error) {
@@ -34,7 +40,7 @@ func parseAndEnrichEventMessage(message []byte, defaultHostname string) (*metric
 	if err != nil {
 		return nil, err
 	}
-	return enrichEvent(parsed, defaultHostname, ""), nil
+	return enrichEvent(parsed, defaultHostname, returnEmptyTags), nil
 }
 
 func TestConvertParseGauge(t *testing.T) {
@@ -772,4 +778,71 @@ func TestConvertEntityOriginDetectionTagsError(t *testing.T) {
 	assert.Equal(t, "sometag2:somevalue2", parsed.Tags[1])
 	assert.Equal(t, "my-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
+}
+
+func Test_enrichTags(t *testing.T) {
+	emptyTagsList := func() []string { return []string{} }
+
+	type args struct {
+		tags            []string
+		defaultHostname string
+		originTagsFunc  func() []string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  []string
+		want1 string
+	}{
+		{
+			name: "empty tags, host=foo",
+			args: args{
+				defaultHostname: "foo",
+				originTagsFunc:  emptyTagsList,
+			},
+			want:  nil,
+			want1: "foo",
+		},
+		{
+			name: "entityId not present, host=foo, should return origin tags",
+			args: args{
+				tags:            []string{"env:prod"},
+				defaultHostname: "foo",
+				originTagsFunc:  func() []string { return []string{"mytag:bar"} },
+			},
+			want:  []string{"env:prod", "mytag:bar"},
+			want1: "foo",
+		},
+		{
+			name: "entityId present, host=foo, should not return origin tags",
+			args: args{
+				tags:            []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "my-id")},
+				defaultHostname: "foo",
+				originTagsFunc:  func() []string { return []string{"mytag:bar"} },
+			},
+			want:  []string{"env:prod"},
+			want1: "foo",
+		},
+		{
+			name: "entityId=none present, host=foo, should not call the originTagsFunc()",
+			args: args{
+				tags:            []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "none")},
+				defaultHostname: "foo",
+				originTagsFunc:  func() []string { panic("oups") },
+			},
+			want:  []string{"env:prod"},
+			want1: "foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := enrichTags(tt.args.tags, tt.args.defaultHostname, tt.args.originTagsFunc)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("enrichTags() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("enrichTags() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
 }

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/mapper"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -274,6 +275,7 @@ func nextMessage(packet *[]byte) (message []byte) {
 
 func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*listeners.Packet) {
 	for _, packet := range packets {
+		originTagger := originTags{origin: packet.Origin}
 		log.Tracef("Dogstatsd receive: %q", packet.Contents)
 		for {
 			message := nextMessage(&packet.Contents)
@@ -290,21 +292,21 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*liste
 
 			switch messageType {
 			case serviceCheckType:
-				serviceCheck, err := s.parseServiceCheckMessage(parser, message, packet.Origin)
+				serviceCheck, err := s.parseServiceCheckMessage(parser, message, originTagger.getTags)
 				if err != nil {
 					log.Errorf("Dogstatsd: error parsing service check %q: %s", message, err)
 					continue
 				}
 				batcher.appendServiceCheck(serviceCheck)
 			case eventType:
-				event, err := s.parseEventMessage(parser, message, packet.Origin)
+				event, err := s.parseEventMessage(parser, message, originTagger.getTags)
 				if err != nil {
 					log.Errorf("Dogstatsd: error parsing event %q: %s", message, err)
 					continue
 				}
 				batcher.appendEvent(event)
 			case metricSampleType:
-				sample, err := s.parseMetricMessage(parser, message, packet.Origin)
+				sample, err := s.parseMetricMessage(parser, message, originTagger.getTags)
 				if err != nil {
 					log.Errorf("Dogstatsd: error parsing metric message %q: %s", message, err)
 					continue
@@ -326,7 +328,7 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*liste
 	batcher.flush()
 }
 
-func (s *Server) parseMetricMessage(parser *parser, message []byte, originID string) (metrics.MetricSample, error) {
+func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFunc func() []string) (metrics.MetricSample, error) {
 	sample, err := parser.parseMetricSample(message)
 	if err != nil {
 		dogstatsdMetricParseErrors.Add(1)
@@ -340,7 +342,7 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originID str
 			sample.tags = append(sample.tags, mapResult.Tags...)
 		}
 	}
-	metricSample := enrichMetricSample(sample, s.metricPrefix, s.metricPrefixBlacklist, s.defaultHostname, originID)
+	metricSample := enrichMetricSample(sample, s.metricPrefix, s.metricPrefixBlacklist, s.defaultHostname, originTagsFunc)
 	metricSample.Tags = append(metricSample.Tags, s.extraTags...)
 	dogstatsdMetricPackets.Add(1)
 	// FIXME (arthur): remove this check and s.telemetryEnabled once we don't
@@ -351,28 +353,28 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originID str
 	return metricSample, nil
 }
 
-func (s *Server) parseEventMessage(parser *parser, message []byte, originID string) (*metrics.Event, error) {
+func (s *Server) parseEventMessage(parser *parser, message []byte, originTagsFunc func() []string) (*metrics.Event, error) {
 	sample, err := parser.parseEvent(message)
 	if err != nil {
 		dogstatsdEventParseErrors.Add(1)
 		tlmProcessed.Inc("events", "error")
 		return nil, err
 	}
-	event := enrichEvent(sample, s.defaultHostname, originID)
+	event := enrichEvent(sample, s.defaultHostname, originTagsFunc)
 	event.Tags = append(event.Tags, s.extraTags...)
 	tlmProcessed.Inc("events", "ok")
 	dogstatsdEventPackets.Add(1)
 	return event, nil
 }
 
-func (s *Server) parseServiceCheckMessage(parser *parser, message []byte, originID string) (*metrics.ServiceCheck, error) {
+func (s *Server) parseServiceCheckMessage(parser *parser, message []byte, originTagsFunc func() []string) (*metrics.ServiceCheck, error) {
 	sample, err := parser.parseServiceCheck(message)
 	if err != nil {
 		dogstatsdServiceCheckParseErrors.Add(1)
 		tlmProcessed.Inc("service_checks", "error")
 		return nil, err
 	}
-	serviceCheck := enrichServiceCheck(sample, s.defaultHostname, originID)
+	serviceCheck := enrichServiceCheck(sample, s.defaultHostname, originTagsFunc)
 	serviceCheck.Tags = append(serviceCheck.Tags, s.extraTags...)
 	dogstatsdServiceCheckPackets.Add(1)
 	tlmProcessed.Inc("service_checks", "ok")
@@ -445,4 +447,32 @@ func FormatDebugStats(stats []byte) (string, error) {
 	}
 
 	return buf.String(), nil
+}
+
+func findOriginTags(origin string) []string {
+	var tags []string
+	if origin != listeners.NoOrigin {
+		originTags, err := tagger.Tag(origin, tagger.DogstatsdCardinality)
+		if err != nil {
+			log.Errorf(err.Error())
+		} else {
+			tags = append(tags, originTags...)
+		}
+	}
+	return tags
+}
+
+type originTags struct {
+	origin string
+	tags   []string
+	// we don't use "sync.Once" here because we know only on one goroutine can call the function `getTags()`
+	alreadyRun bool
+}
+
+func (o *originTags) getTags() []string {
+	if !o.alreadyRun {
+		o.tags = findOriginTags(o.origin)
+		o.alreadyRun = true
+	}
+	return o.tags
 }

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -23,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/mapper"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
-	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -275,7 +274,6 @@ func nextMessage(packet *[]byte) (message []byte) {
 
 func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*listeners.Packet) {
 	for _, packet := range packets {
-		originTags := findOriginTags(packet.Origin)
 		log.Tracef("Dogstatsd receive: %q", packet.Contents)
 		for {
 			message := nextMessage(&packet.Contents)
@@ -292,23 +290,21 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*liste
 
 			switch messageType {
 			case serviceCheckType:
-				serviceCheck, err := s.parseServiceCheckMessage(parser, message)
+				serviceCheck, err := s.parseServiceCheckMessage(parser, message, packet.Origin)
 				if err != nil {
 					log.Errorf("Dogstatsd: error parsing service check %q: %s", message, err)
 					continue
 				}
-				serviceCheck.Tags = append(serviceCheck.Tags, originTags...)
 				batcher.appendServiceCheck(serviceCheck)
 			case eventType:
-				event, err := s.parseEventMessage(parser, message)
+				event, err := s.parseEventMessage(parser, message, packet.Origin)
 				if err != nil {
 					log.Errorf("Dogstatsd: error parsing event %q: %s", message, err)
 					continue
 				}
-				event.Tags = append(event.Tags, originTags...)
 				batcher.appendEvent(event)
 			case metricSampleType:
-				sample, err := s.parseMetricMessage(parser, message)
+				sample, err := s.parseMetricMessage(parser, message, packet.Origin)
 				if err != nil {
 					log.Errorf("Dogstatsd: error parsing metric message %q: %s", message, err)
 					continue
@@ -316,7 +312,6 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*liste
 				if s.debugMetricsStats {
 					s.storeMetricStats(sample.Name)
 				}
-				sample.Tags = append(sample.Tags, originTags...)
 				batcher.appendSample(sample)
 				if s.histToDist && sample.Mtype == metrics.HistogramType {
 					distSample := sample.Copy()
@@ -331,7 +326,7 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*liste
 	batcher.flush()
 }
 
-func (s *Server) parseMetricMessage(parser *parser, message []byte) (metrics.MetricSample, error) {
+func (s *Server) parseMetricMessage(parser *parser, message []byte, originID string) (metrics.MetricSample, error) {
 	sample, err := parser.parseMetricSample(message)
 	if err != nil {
 		dogstatsdMetricParseErrors.Add(1)
@@ -345,7 +340,7 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte) (metrics.Met
 			sample.tags = append(sample.tags, mapResult.Tags...)
 		}
 	}
-	metricSample := enrichMetricSample(sample, s.metricPrefix, s.metricPrefixBlacklist, s.defaultHostname)
+	metricSample := enrichMetricSample(sample, s.metricPrefix, s.metricPrefixBlacklist, s.defaultHostname, originID)
 	metricSample.Tags = append(metricSample.Tags, s.extraTags...)
 	dogstatsdMetricPackets.Add(1)
 	// FIXME (arthur): remove this check and s.telemetryEnabled once we don't
@@ -356,45 +351,32 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte) (metrics.Met
 	return metricSample, nil
 }
 
-func (s *Server) parseEventMessage(parser *parser, message []byte) (*metrics.Event, error) {
+func (s *Server) parseEventMessage(parser *parser, message []byte, originID string) (*metrics.Event, error) {
 	sample, err := parser.parseEvent(message)
 	if err != nil {
 		dogstatsdEventParseErrors.Add(1)
 		tlmProcessed.Inc("events", "error")
 		return nil, err
 	}
-	event := enrichEvent(sample, s.defaultHostname)
+	event := enrichEvent(sample, s.defaultHostname, originID)
 	event.Tags = append(event.Tags, s.extraTags...)
 	tlmProcessed.Inc("events", "ok")
 	dogstatsdEventPackets.Add(1)
 	return event, nil
 }
 
-func (s *Server) parseServiceCheckMessage(parser *parser, message []byte) (*metrics.ServiceCheck, error) {
+func (s *Server) parseServiceCheckMessage(parser *parser, message []byte, originID string) (*metrics.ServiceCheck, error) {
 	sample, err := parser.parseServiceCheck(message)
 	if err != nil {
 		dogstatsdServiceCheckParseErrors.Add(1)
 		tlmProcessed.Inc("service_checks", "error")
 		return nil, err
 	}
-	serviceCheck := enrichServiceCheck(sample, s.defaultHostname)
+	serviceCheck := enrichServiceCheck(sample, s.defaultHostname, originID)
 	serviceCheck.Tags = append(serviceCheck.Tags, s.extraTags...)
 	dogstatsdServiceCheckPackets.Add(1)
 	tlmProcessed.Inc("service_checks", "ok")
 	return serviceCheck, nil
-}
-
-func findOriginTags(origin string) []string {
-	var tags []string
-	if origin != listeners.NoOrigin {
-		originTags, err := tagger.Tag(origin, tagger.DogstatsdCardinality)
-		if err != nil {
-			log.Errorf(err.Error())
-		} else {
-			tags = append(tags, originTags...)
-		}
-	}
-	return tags
 }
 
 // Stop stops a running Dogstatsd server

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -433,6 +433,7 @@ func TestDebugStats(t *testing.T) {
 
 func TestNoMappingsConfig(t *testing.T) {
 	datadogYaml := ``
+	getOriginTags := func() []string { return []string{} }
 
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
@@ -448,7 +449,7 @@ func TestNoMappingsConfig(t *testing.T) {
 	assert.Nil(t, s.mapper)
 
 	parser := newParser()
-	_, err = s.parseMetricMessage(parser, []byte("test.metric:666|g"), "")
+	_, err = s.parseMetricMessage(parser, []byte("test.metric:666|g"), getOriginTags)
 	assert.NoError(t, err)
 }
 
@@ -460,6 +461,7 @@ type MetricSample struct {
 }
 
 func TestMappingCases(t *testing.T) {
+	getOriginTags := func() []string { return []string{} }
 	scenarios := []struct {
 		name              string
 		config            string
@@ -546,22 +548,22 @@ dogstatsd_mapper_profiles:
 		t.Run(scenario.name, func(t *testing.T) {
 			config.Datadog.SetConfigType("yaml")
 			err := config.Datadog.ReadConfig(strings.NewReader(scenario.config))
-			assert.NoError(t, err)
+			assert.NoError(t, err, "Case `%s` failed. ReadConfig should not return error %v", scenario.name, err)
 
 			port, err := getAvailableUDPPort()
-			require.NoError(t, err)
+			require.NoError(t, err, "Case `%s` failed. getAvailableUDPPort should not return error %v", scenario.name, err)
 			config.Datadog.SetDefault("dogstatsd_port", port)
 
 			s, err := NewServer(nil, nil, nil, nil)
-			require.NoError(t, err)
+			require.NoError(t, err, "Case `%s` failed. NewServer should not return error %v", scenario.name, err)
 
-			assert.Equal(t, config.Datadog.Get("dogstatsd_mapper_cache_size"), scenario.expectedCacheSize)
+			assert.Equal(t, config.Datadog.Get("dogstatsd_mapper_cache_size"), scenario.expectedCacheSize, "Case `%s` failed. cache_size `%s` should be `%s`", scenario.name, config.Datadog.Get("dogstatsd_mapper_cache_size"), scenario.expectedCacheSize)
 
 			var actualSamples []MetricSample
 			for _, p := range scenario.packets {
 				parser := newParser()
-				sample, err := s.parseMetricMessage(parser, []byte(p), "")
-				assert.NoError(t, err)
+				sample, err := s.parseMetricMessage(parser, []byte(p), getOriginTags)
+				assert.NoError(t, err, "Case `%s` failed. parseMetricMessage should not return error %v", err)
 				actualSamples = append(actualSamples, MetricSample{Name: sample.Name, Tags: sample.Tags, Mtype: sample.Mtype, Value: sample.Value})
 			}
 			for _, sample := range scenario.expectedSamples {

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -448,7 +448,7 @@ func TestNoMappingsConfig(t *testing.T) {
 	assert.Nil(t, s.mapper)
 
 	parser := newParser()
-	_, err = s.parseMetricMessage(parser, []byte("test.metric:666|g"))
+	_, err = s.parseMetricMessage(parser, []byte("test.metric:666|g"), "")
 	assert.NoError(t, err)
 }
 
@@ -560,7 +560,7 @@ dogstatsd_mapper_profiles:
 			var actualSamples []MetricSample
 			for _, p := range scenario.packets {
 				parser := newParser()
-				sample, err := s.parseMetricMessage(parser, []byte(p))
+				sample, err := s.parseMetricMessage(parser, []byte(p), "")
 				assert.NoError(t, err)
 				actualSamples = append(actualSamples, MetricSample{Name: sample.Name, Tags: sample.Tags, Mtype: sample.Mtype, Value: sample.Value})
 			}

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -272,7 +272,7 @@ func (j *JMXFetch) Start(manage bool) error {
 
 	err = j.cmd.Start()
 
-	// start syncrhonization channels
+	// start synchronization channels
 	if err == nil && manage {
 		j.managed = true
 		j.shutdown = make(chan struct{})

--- a/releasenotes/notes/dogstatsd-ignore-origintags-when-entityid-is-present-399d0317a3d30f30.yaml
+++ b/releasenotes/notes/dogstatsd-ignore-origintags-when-entityid-is-present-399d0317a3d30f30.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    ignore "origin" tags if the 'dd.internal.entity_id' tag is present in dogstatsd metrics.


### PR DESCRIPTION
### What does this PR do?

refactor the originTags detection in dogstatsd server:
* ignore originTags if the entityID tags is present
* ignore entityID value equal to "none"

### Motivation

avoid having the origin tags if the entity ID tag is present in the metrics.

### Additional Notes

this PR is linked to: https://github.com/DataDog/jmxfetch/pull/264