### PR TITLE
Add EC2 IMDS v2 support

### DIFF
--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -151,11 +151,11 @@ func getResponse(url string, method string, headers map[string]string) (*http.Re
 	}
 
 	req, err := http.NewRequest(method, url, nil)
-	for header, value := range headers {
-		req.Header.Add(header, value)
-	}
 	if err != nil {
 		return nil, err
+	}
+	for header, value := range headers {
+		req.Header.Add(header, value)
 	}
 
 	res, err := client.Do(req)
@@ -167,7 +167,6 @@ func getResponse(url string, method string, headers map[string]string) (*http.Re
 		// Retry with a token
 		token, err := getToken()
 		if err != nil {
-			fmt.Println("3")
 			return nil, err
 		}
 		headers["X-aws-ec2-metadata-token"] = token
@@ -185,12 +184,11 @@ func getToken() (string, error) {
 	}
 
 	req, err := http.NewRequest(http.MethodPut, tokenURL, nil)
-	req.Header.Add("X-aws-ec2-metadata-token-ttl-seconds", "60")
-
 	if err != nil {
 		return "", err
 	}
 
+	req.Header.Add("X-aws-ec2-metadata-token-ttl-seconds", "60")
 	res, err := client.Do(req)
 	if err != nil {
 		return "", err

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -77,7 +78,7 @@ type ec2Identity struct {
 func getInstanceIdentity() (*ec2Identity, error) {
 	instanceIdentity := &ec2Identity{}
 
-	res, err := getResponse(instanceIdentityURL)
+	res, err := getResponse(instanceIdentityURL, http.MethodGet, map[string]string{})
 	if err != nil {
 		return instanceIdentity, fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}
@@ -110,7 +111,7 @@ func getSecurityCreds() (*ec2SecurityCred, error) {
 		return iamParams, err
 	}
 
-	res, err := getResponse(metadataURL + "/iam/security-credentials/" + iamRole)
+	res, err := getResponse(metadataURL+"/iam/security-credentials/"+iamRole, http.MethodGet, map[string]string{})
 	if err != nil {
 		return iamParams, fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}
@@ -129,7 +130,7 @@ func getSecurityCreds() (*ec2SecurityCred, error) {
 }
 
 func getIAMRole() (string, error) {
-	res, err := getResponse(metadataURL + "/iam/security-credentials/")
+	res, err := getResponse(metadataURL+"/iam/security-credentials/", http.MethodGet, map[string]string{})
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -78,7 +78,7 @@ type ec2Identity struct {
 func getInstanceIdentity() (*ec2Identity, error) {
 	instanceIdentity := &ec2Identity{}
 
-	res, err := getResponse(instanceIdentityURL, http.MethodGet, map[string]string{})
+	res, err := doHTTPRequest(instanceIdentityURL, http.MethodGet, map[string]string{}, true)
 	if err != nil {
 		return instanceIdentity, fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}
@@ -111,7 +111,7 @@ func getSecurityCreds() (*ec2SecurityCred, error) {
 		return iamParams, err
 	}
 
-	res, err := getResponse(metadataURL+"/iam/security-credentials/"+iamRole, http.MethodGet, map[string]string{})
+	res, err := doHTTPRequest(metadataURL+"/iam/security-credentials/"+iamRole, http.MethodGet, map[string]string{}, true)
 	if err != nil {
 		return iamParams, fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}
@@ -130,7 +130,7 @@ func getSecurityCreds() (*ec2SecurityCred, error) {
 }
 
 func getIAMRole() (string, error) {
-	res, err := getResponse(metadataURL+"/iam/security-credentials/", http.MethodGet, map[string]string{})
+	res, err := doHTTPRequest(metadataURL+"/iam/security-credentials/", http.MethodGet, map[string]string{}, true)
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -22,11 +22,13 @@ import (
 var (
 	initialTimeout     = timeout
 	initialMetadataURL = metadataURL
+	initialTokenURL    = tokenURL
 )
 
 func resetPackageVars() {
 	timeout = initialTimeout
 	metadataURL = initialMetadataURL
+	tokenURL = initialTokenURL
 }
 
 func TestIsDefaultHostname(t *testing.T) {
@@ -236,4 +238,96 @@ func TestGetLocalIPv4(t *testing.T) {
 	ips, err := GetLocalIPv4()
 	require.NoError(t, err)
 	assert.Equal(t, []string{ip}, ips)
+}
+
+func TestGetToken(t *testing.T) {
+	originalToken := "AQAAAFKw7LyqwVmmBMkqXHpDBuDWw2GnfGswTHi2yiIOGvzD7OMaWw=="
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		h := r.Header.Get("X-aws-ec2-metadata-token-ttl-seconds")
+		if h != "" && r.Method == http.MethodPut {
+			io.WriteString(w, originalToken)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	defer ts.Close()
+	tokenURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
+
+	token, err := getToken()
+	require.NoError(t, err)
+	assert.Equal(t, originalToken, token)
+}
+
+func TestMetedataRequestWithToken(t *testing.T) {
+	var requestWithoutToken *http.Request
+	var requestForToken *http.Request
+	var requestWithToken *http.Request
+	var seq int = 0
+
+	ipv4 := "198.51.100.1"
+	token := "AQAAAFKw7LyqwVmmBMkqXHpDBuDWw2GnfGswTHi2yiIOGvzD7OMaWw=="
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		switch r.Method {
+		case http.MethodPut:
+			// Should be a token request
+			h := r.Header.Get("X-aws-ec2-metadata-token-ttl-seconds")
+			if h == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+			r.Header.Add("X-sequence", fmt.Sprintf("%v", seq))
+			seq++
+			requestForToken = r
+			io.WriteString(w, token)
+		case http.MethodGet:
+			// Should be a metadata request
+			t := r.Header.Get("X-aws-ec2-metadata-token")
+			if t != token {
+				r.Header.Add("X-sequence", fmt.Sprintf("%v", seq))
+				seq++
+				requestWithoutToken = r
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			switch r.RequestURI {
+			case "/local-ipv4":
+				r.Header.Add("X-sequence", fmt.Sprintf("%v", seq))
+				seq++
+				requestWithToken = r
+				io.WriteString(w, ipv4)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		default:
+			fmt.Println("q")
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+	tokenURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
+
+	ips, err := GetLocalIPv4()
+	require.NoError(t, err)
+	assert.Equal(t, []string{ipv4}, ips)
+
+	assert.Equal(t, "0", requestWithoutToken.Header.Get("X-sequence"))
+	assert.Equal(t, "1", requestForToken.Header.Get("X-sequence"))
+	assert.Equal(t, "2", requestWithToken.Header.Get("X-sequence"))
+	assert.Equal(t, "", requestWithoutToken.Header.Get("X-aws-ec2-metadata-token"))
+	assert.Equal(t, "/local-ipv4", requestWithoutToken.RequestURI)
+	assert.Equal(t, http.MethodGet, requestWithoutToken.Method)
+	assert.Equal(t, "60", requestForToken.Header.Get("X-aws-ec2-metadata-token-ttl-seconds"))
+	assert.Equal(t, http.MethodPut, requestForToken.Method)
+	assert.Equal(t, "/", requestForToken.RequestURI)
+	assert.Equal(t, token, requestWithToken.Header.Get("X-aws-ec2-metadata-token"))
+	assert.Equal(t, "/local-ipv4", requestWithToken.RequestURI)
+	assert.Equal(t, http.MethodGet, requestWithToken.Method)
 }

--- a/releasenotes/notes/support-ec2-imds-v2-ce102fb61a1cdd45.yaml
+++ b/releasenotes/notes/support-ec2-imds-v2-ce102fb61a1cdd45.yaml
@@ -1,0 +1,8 @@
+enhancements:
+  - |
+    Add support for the EC2 instance metadata service
+    (IMDS) v2 that requires to get a token before any
+    metadata query. The agent will still issue
+    unauthenticated request first (IMDS v1) before
+    switching to token-based authentication (IMDS
+    v2) if it fails.


### PR DESCRIPTION
### What does this PR do?
Add instance metadata service v2 (IMDS v2) support.
AWS official documentation : https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
The agent will still rely on IMDS v1 first. It will do IMDS v2 request only if unauthenticated (IMDS v1) requests fail, thus the actual agent behaviour will only change if IMDS v1 is explicitly disabled, ensuring compatibility with existing deployments.

### Motivation
Properly support EC2 instances with IMDSv1 disabled.

### Additional Notes
Tests captured on an EC2 live instance with an agent development build : 
Request without token on an IMDSv2 only instance : 
```
GET /latest/meta-data/instance-id HTTP/1.1
Host: 169.254.169.254
User-Agent: Go-http-client/1.1
Accept-Encoding: gzip

HTTP/1.0 401 Unauthorized
Content-Length: 343
Content-Type: text/html
Date: Fri, 07 Feb 2020 13:31:39 GMT
Connection: close
Server: EC2ws

<?xml version="1.0" encoding="iso-8859-1"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
  <title>401 - Unauthorized</title>
 </head>
 <body>
  <h1>401 - Unauthorized</h1>
 </body>
</html>
```
Token request (PUT):
```
PUT /latest/api/token HTTP/1.1
Host: 169.254.169.254
User-Agent: Go-http-client/1.1
Content-Length: 0
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 60
Accept-Encoding: gzip

HTTP/1.0 200 OK
Content-Length: 56
Content-Type: text/plain
Date: Fri, 07 Feb 2020 13:31:39 GMT
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 60
Connection: close
Server: EC2ws

AQAAAFKw7LwD9Nn5LmMKwWMp9-xj2CI5EuASEmX6F3_g9F3iWvlFTQ==
````
Request to metadata with token:
```
GET /latest/meta-data/instance-id HTTP/1.1
Host: 169.254.169.254
User-Agent: Go-http-client/1.1
X-Aws-Ec2-Metadata-Token: AQAAAFKw7LwD9Nn5LmMKwWMp9-xj2CI5EuASEmX6F3_g9F3iWvlFTQ==
Accept-Encoding: gzip

HTTP/1.0 200 OK
Accept-Ranges: bytes
Content-Length: 19
Content-Type: text/plain
Date: Fri, 07 Feb 2020 13:31:39 GMT
Last-Modified: Fri, 07 Feb 2020 13:30:01 GMT
X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 60
Connection: close
Server: EC2ws

i-0c583456e1956d03e
```
