### PR TITLE
[windows] Add site parameter to GUI install

### DIFF
--- a/omnibus/resources/agent/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/agent/msi/assets/sitedlg.wxi
@@ -1,10 +1,10 @@
 <Include>
   <ComboBox Property="SITE">
-    <ListItem Text="Datadog US" Value="datadoghq.com"/>
-    <ListItem Text="Datadog EU" Value="datadoghq.eu"/>
+    <ListItem Text="Datadog US (datadoghq.com)" Value="datadoghq.com"/>
+    <ListItem Text="Datadog EU (datadoghq.eu)" Value="datadoghq.eu"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
-  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="yes" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
+  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
   <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
         Text="Back">
 

--- a/omnibus/resources/agent/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/agent/msi/assets/sitedlg.wxi
@@ -1,30 +1,31 @@
 <Include>
+  <ComboBox Property="SITE">
+    <ListItem Text="Datadog US" Value="datadoghq.com"/>
+    <ListItem Text="Datadog EU" Value="datadoghq.eu"/>
+  </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
-   
-   <Control Id="KeyFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="148"
-          Property="SITE" Text="datadoghq.com"
-         />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
-              Text="Back">
-          
-          <Publish Event="NewDialog" Value="ApiKeyDlg">1</Publish>
-        </Control>
-        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
-               Text="Next">
-          <Publish Event="NewDialog" Value="VerifyReadyDlg" />
-          
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
-               Text="Cancel">
-          <Publish Event="EndDialog" Value="Exit">1</Publish>
-        </Control>
+  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="yes" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
+  <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+        Text="Back">
+
+    <Publish Event="NewDialog" Value="ApiKeyDlg">1</Publish>
+  </Control>
+  <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
+          Text="Next">
+    <Publish Event="NewDialog" Value="VerifyReadyDlg" />
+
+  </Control>
+  <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
+          Text="Cancel">
+    <Publish Event="EndDialog" Value="Exit">1</Publish>
+  </Control>
 
    <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
    <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
    <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
    <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="32" 
             Transparent="yes" NoPrefix="yes" Text="!(loc.SiteDialogDescription)" />
-   
+
    <Control Id="EnterKey" Type="Text" Height="32" Width="320" X="25" Y="116"
                Text="!(loc.SiteDialogKeyLabel)" />
       </Dialog>

--- a/omnibus/resources/agent/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/agent/msi/assets/sitedlg.wxi
@@ -1,18 +1,17 @@
 <Include>
- <Dialog Id="ApiKeyDlg" Width="370" Height="270" Title="!(loc.ApiKeyDialogTitle)">
+ <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
    
    <Control Id="KeyFromDefault" Type="Edit" Height="15" Width="320" X="25" Y="148"
-          Property="APIKEY"
+          Property="SITE" Text="datadoghq.com"
          />
         <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
               Text="Back">
           
-          <Publish Event="NewDialog" Value="MaintenanceTypeDlg">WixUI_InstallMode = "Repair"</Publish>
-          <Publish Event="NewDialog" Value="LicenseAgreementDlg">NOT INSTALLED</Publish>
+          <Publish Event="NewDialog" Value="ApiKeyDlg">1</Publish>
         </Control>
         <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
                Text="Next">
-          <Publish Event="NewDialog" Value="SiteDlg" />
+          <Publish Event="NewDialog" Value="VerifyReadyDlg" />
           
         </Control>
         <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
@@ -24,9 +23,9 @@
    <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
    <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
    <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="32" 
-            Transparent="yes" NoPrefix="yes" Text="!(loc.ApiKeyDialogDescription)" />
+            Transparent="yes" NoPrefix="yes" Text="!(loc.SiteDialogDescription)" />
    
    <Control Id="EnterKey" Type="Text" Height="32" Width="320" X="25" Y="116"
-               Text="!(loc.ApiKeyDialogKeyLabel)" />
+               Text="!(loc.SiteDialogKeyLabel)" />
       </Dialog>
 </Include>

--- a/omnibus/resources/agent/msi/bundle.wxs.erb
+++ b/omnibus/resources/agent/msi/bundle.wxs.erb
@@ -22,6 +22,7 @@
     <WixVariable Id="WixUIBannerBmp" Value="Resources\assets\banner_background.bmp" />
 
     <Variable Name="APIKEY" bal:Overridable="yes"/>
+    <Variable Name="SITE" bal:Overridable="yes"/>
     <Variable Name="TAGS" bal:Overridable="yes"/>
     <Variable Name="HOSTNAME" bal:Overridable="yes"/>
 		
@@ -43,6 +44,7 @@
       </ExePackage>
       <MsiPackage SourceFile="$(var.PackageMsi)">
         <MsiProperty Name="APIKEY" Value="[APIKEY]"/>
+        <MsiProperty Name="SITE" Value="[SITE]"/>
         <MsiProperty Name="TAGS" Value="[TAGS]"/>
         <MsiProperty Name="HOSTNAME" Value="[HOSTNAME]"/>
       </MsiPackage>

--- a/omnibus/resources/agent/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/agent/msi/localization-en-us.wxl.erb
@@ -44,9 +44,9 @@
 
   <!-- these strings for the site key dialog -->
   <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
-  <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Enter the [ShortCompanyName] Site</String>
-  <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Site </String>
-  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Please enter the [ShortCompanyName] Site</String>
+  <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
+  <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Where do you want the Agent to send data?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
   <String Id="Caption">[WixBundleName] Setup</String>

--- a/omnibus/resources/agent/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/agent/msi/localization-en-us.wxl.erb
@@ -46,7 +46,7 @@
   <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
   <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
   <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
-  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Where do you want the Agent to send data?</String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which Datadog region do you want the Agent to send data to?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
   <String Id="Caption">[WixBundleName] Setup</String>

--- a/omnibus/resources/agent/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/agent/msi/localization-en-us.wxl.erb
@@ -42,6 +42,13 @@
   <String Id ="ApiKeyDialogKeyLabel" Overridable="yes" Localizable="yes">Please enter the [ShortCompanyName] API Key</String>
   <String Id ="ApiKeySampleKey" Overridable="yes" Localizable="yes"></String>
 
+  <!-- these strings for the site key dialog -->
+  <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
+  <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Enter the [ShortCompanyName] Site</String>
+  <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Site </String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Please enter the [ShortCompanyName] Site</String>
+  <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
+
   <String Id="Caption">[WixBundleName] Setup</String>
   <String Id="Title">[WixBundleName]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>

--- a/omnibus/resources/agent/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/agent/msi/localization-en-us.wxl.erb
@@ -42,7 +42,7 @@
   <String Id ="ApiKeyDialogKeyLabel" Overridable="yes" Localizable="yes">Please enter the [ShortCompanyName] API Key</String>
   <String Id ="ApiKeySampleKey" Overridable="yes" Localizable="yes"></String>
 
-  <!-- these strings for the site key dialog -->
+  <!-- these strings for the site dialog -->
   <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
   <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
   <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>

--- a/omnibus/resources/agent/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/agent/msi/localization-en-us.wxl.erb
@@ -46,7 +46,7 @@
   <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
   <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
   <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
-  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which Datadog region do you want the Agent to send data to?</String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which [ShortCompanyName] region do you want the Agent to send data to?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
   <String Id="Caption">[WixBundleName] Setup</String>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -75,7 +75,7 @@
     <Property Id="DDAGENTUSER_NAME" />
     <Property Id="DDAGENTUSER_PASSWORD" Hidden="yes" />
     <Property Id="APIKEY" Hidden="yes" />
-    <Property Id="SITE" />
+    <Property Id="SITE" Value="datadoghq.com" />
     <Property Id="FinalizeInstall" Hidden="yes" />
      <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
      <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
@@ -586,7 +586,7 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">NOT APIKEY</Publish>
-      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="SiteDlg">NOT SITE</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">APIKEY AND (NOT SITE)</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY AND SITE</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -75,6 +75,7 @@
     <Property Id="DDAGENTUSER_NAME" />
     <Property Id="DDAGENTUSER_PASSWORD" Hidden="yes" />
     <Property Id="APIKEY" Hidden="yes" />
+    <Property Id="SITE" />
     <Property Id="FinalizeInstall" Hidden="yes" />
      <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
      <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
@@ -548,6 +549,7 @@
           WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed
       </Publish>
       <?include Resources\assets\apikeydlg.wxi ?>
+      <?include Resources\assets\sitedlg.wxi ?>
       <DialogRef Id="ErrorDlg" />
       <DialogRef Id="FatalError" />
       <DialogRef Id="FilesInUse" />
@@ -558,6 +560,7 @@
       <DialogRef Id="UserExit" />
       <DialogRef Id="WelcomeDlg" />
       <DialogRef Id="ApiKeyDlg"/>
+      <DialogRef Id="SiteDlg"/>
       <DialogRef Id="LicenseAgreementDlg"/>
 
       <DialogRef Id="MaintenanceWelcomeDlg"/>
@@ -574,7 +577,8 @@
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">NOT Installed</Publish>
 
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="3">1</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
+      <Publish Dialog="SiteDlg" Control="Back" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="SiteDlg">NOT PREVIOUSFOUND</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">PREVIOUSFOUND</Publish>
 
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
@@ -582,7 +586,8 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">NOT APIKEY</Publish>
-      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="SiteDlg">NOT SITE</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY AND SITE</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -586,7 +586,7 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">NOT APIKEY</Publish>
-      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">APIKEY AND (NOT SITE)</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="SiteDlg">APIKEY AND (NOT SITE)</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY AND SITE</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>

--- a/omnibus/resources/dogstatsd/msi/assets/apikeydlg.wxi
+++ b/omnibus/resources/dogstatsd/msi/assets/apikeydlg.wxi
@@ -12,7 +12,7 @@
         </Control>
         <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
                Text="Next">
-          <Publish Event="NewDialog" Value="VerifyReadyDlg" />
+          <Publish Event="NewDialog" Value="SiteDlg" />
           
         </Control>
         <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"

--- a/omnibus/resources/dogstatsd/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/dogstatsd/msi/assets/sitedlg.wxi
@@ -1,0 +1,32 @@
+<Include>
+  <ComboBox Property="SITE">
+    <ListItem Text="Datadog US" Value="datadoghq.com"/>
+    <ListItem Text="Datadog EU" Value="datadoghq.eu"/>
+  </ComboBox>
+ <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
+  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="yes" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
+  <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+        Text="Back">
+
+    <Publish Event="NewDialog" Value="ApiKeyDlg">1</Publish>
+  </Control>
+  <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
+          Text="Next">
+    <Publish Event="NewDialog" Value="VerifyReadyDlg" />
+
+  </Control>
+  <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
+          Text="Cancel">
+    <Publish Event="EndDialog" Value="Exit">1</Publish>
+  </Control>
+
+   <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
+   <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+   <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+   <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="32" 
+            Transparent="yes" NoPrefix="yes" Text="!(loc.SiteDialogDescription)" />
+
+   <Control Id="EnterKey" Type="Text" Height="32" Width="320" X="25" Y="116"
+               Text="!(loc.SiteDialogKeyLabel)" />
+      </Dialog>
+</Include>

--- a/omnibus/resources/dogstatsd/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/dogstatsd/msi/assets/sitedlg.wxi
@@ -1,10 +1,10 @@
 <Include>
   <ComboBox Property="SITE">
-    <ListItem Text="Datadog US" Value="datadoghq.com"/>
-    <ListItem Text="Datadog EU" Value="datadoghq.eu"/>
+    <ListItem Text="Datadog US (datadoghq.com)" Value="datadoghq.com"/>
+    <ListItem Text="Datadog EU (datadoghq.eu)" Value="datadoghq.eu"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
-  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="yes" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
+  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
   <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
         Text="Back">
 

--- a/omnibus/resources/dogstatsd/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/dogstatsd/msi/localization-en-us.wxl.erb
@@ -46,7 +46,7 @@
   <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
   <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
   <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
-  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Where do you want the Agent to send data?</String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which Datadog region do you want the Agent to send data to?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
   <String Id="Caption">[WixBundleName] Setup</String>

--- a/omnibus/resources/dogstatsd/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/dogstatsd/msi/localization-en-us.wxl.erb
@@ -46,7 +46,7 @@
   <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
   <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
   <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
-  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which Datadog region do you want the Agent to send data to?</String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which [ShortCompanyName] region do you want the Agent to send data to?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
   <String Id="Caption">[WixBundleName] Setup</String>

--- a/omnibus/resources/dogstatsd/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/dogstatsd/msi/localization-en-us.wxl.erb
@@ -42,6 +42,13 @@
   <String Id ="ApiKeyDialogKeyLabel" Overridable="yes" Localizable="yes">Please enter the [ShortCompanyName] API Key</String>
   <String Id ="ApiKeySampleKey" Overridable="yes" Localizable="yes"></String>
 
+  <!-- these strings for the site dialog -->
+  <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
+  <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
+  <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Where do you want the Agent to send data?</String>
+  <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
+
   <String Id="Caption">[WixBundleName] Setup</String>
   <String Id="Title">[WixBundleName]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>

--- a/omnibus/resources/dogstatsd/msi/source.wxs.erb
+++ b/omnibus/resources/dogstatsd/msi/source.wxs.erb
@@ -64,7 +64,7 @@
 
     <Property Id="APIKEY" Hidden="yes" />
     <Property Id="FinalizeInstall" Hidden="yes" />
-    
+    <Property Id="SITE" Value="datadoghq.com" />
      <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
      <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
      <PropertyRef Id="WIX_ACCOUNT_LOCALSERVICE" />
@@ -300,6 +300,7 @@
 
 
       <?include Resources\assets\apikeydlg.wxi ?>
+      <?include Resources\assets\sitedlg.wxi ?>
       <DialogRef Id="ErrorDlg" />
       <DialogRef Id="FatalError" />
       <DialogRef Id="FilesInUse" />
@@ -310,6 +311,7 @@
       <DialogRef Id="UserExit" />
       <DialogRef Id="WelcomeDlg" />
       <DialogRef Id="ApiKeyDlg"/>
+      <DialogRef Id="SiteDlg"/>
       <DialogRef Id="LicenseAgreementDlg"/>
 
       <DialogRef Id="MaintenanceWelcomeDlg"/>
@@ -326,7 +328,8 @@
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">NOT Installed</Publish>
 
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="3">1</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
+      <Publish Dialog="SiteDlg" Control="Back" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="SiteDlg">NOT PREVIOUSFOUND</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">PREVIOUSFOUND</Publish>
 
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
@@ -334,7 +337,8 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">NOT APIKEY</Publish>
-      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="SiteDlg">APIKEY AND (NOT SITE)</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY AND SITE</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 

--- a/omnibus/resources/puppy/msi/assets/apikeydlg.wxi
+++ b/omnibus/resources/puppy/msi/assets/apikeydlg.wxi
@@ -12,7 +12,7 @@
         </Control>
         <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
                Text="Next">
-          <Publish Event="NewDialog" Value="VerifyReadyDlg" />
+          <Publish Event="NewDialog" Value="SiteDlg" />
           
         </Control>
         <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"

--- a/omnibus/resources/puppy/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/puppy/msi/assets/sitedlg.wxi
@@ -1,0 +1,32 @@
+<Include>
+  <ComboBox Property="SITE">
+    <ListItem Text="Datadog US" Value="datadoghq.com"/>
+    <ListItem Text="Datadog EU" Value="datadoghq.eu"/>
+  </ComboBox>
+ <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
+  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="yes" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
+  <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+        Text="Back">
+
+    <Publish Event="NewDialog" Value="ApiKeyDlg">1</Publish>
+  </Control>
+  <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes"
+          Text="Next">
+    <Publish Event="NewDialog" Value="VerifyReadyDlg" />
+
+  </Control>
+  <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes"
+          Text="Cancel">
+    <Publish Event="EndDialog" Value="Exit">1</Publish>
+  </Control>
+
+   <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
+   <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+   <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+   <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="32" 
+            Transparent="yes" NoPrefix="yes" Text="!(loc.SiteDialogDescription)" />
+
+   <Control Id="EnterKey" Type="Text" Height="32" Width="320" X="25" Y="116"
+               Text="!(loc.SiteDialogKeyLabel)" />
+      </Dialog>
+</Include>

--- a/omnibus/resources/puppy/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/puppy/msi/assets/sitedlg.wxi
@@ -1,10 +1,10 @@
 <Include>
   <ComboBox Property="SITE">
-    <ListItem Text="Datadog US" Value="datadoghq.com"/>
-    <ListItem Text="Datadog EU" Value="datadoghq.eu"/>
+    <ListItem Text="Datadog US (datadoghq.com)" Value="datadoghq.com"/>
+    <ListItem Text="Datadog EU (datadoghq.eu)" Value="datadoghq.eu"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
-  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="yes" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
+  <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>
   <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
         Text="Back">
 

--- a/omnibus/resources/puppy/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/puppy/msi/localization-en-us.wxl.erb
@@ -46,7 +46,7 @@
   <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
   <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
   <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
-  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Where do you want the Agent to send data?</String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which Datadog region do you want the Agent to send data to?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
   <String Id="Caption">[WixBundleName] Setup</String>

--- a/omnibus/resources/puppy/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/puppy/msi/localization-en-us.wxl.erb
@@ -46,7 +46,7 @@
   <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
   <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
   <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
-  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which Datadog region do you want the Agent to send data to?</String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Which [ShortCompanyName] region do you want the Agent to send data to?</String>
   <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
 
   <String Id="Caption">[WixBundleName] Setup</String>

--- a/omnibus/resources/puppy/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/puppy/msi/localization-en-us.wxl.erb
@@ -42,6 +42,13 @@
   <String Id ="ApiKeyDialogKeyLabel" Overridable="yes" Localizable="yes">Please enter the [ShortCompanyName] API Key</String>
   <String Id ="ApiKeySampleKey" Overridable="yes" Localizable="yes"></String>
 
+  <!-- these strings for the site dialog -->
+  <String Id ="SiteDialogTitle" Overridable="yes" Localizable="yes">[ProductName] Setup</String>
+  <String Id ="SiteDialogDescription" Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}Select the [ShortCompanyName] Region</String>
+  <String Id ="SiteDialogBannerTitle"  Overridable="yes" Localizable="yes">{\WixUI_Font_Normal_White}[ShortCompanyName] Region </String>
+  <String Id ="SiteDialogKeyLabel" Overridable="yes" Localizable="yes">Where do you want the Agent to send data?</String>
+  <String Id ="SiteSampleKey" Overridable="yes" Localizable="yes"></String>
+
   <String Id="Caption">[WixBundleName] Setup</String>
   <String Id="Title">[WixBundleName]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>

--- a/omnibus/resources/puppy/msi/source.wxs.erb
+++ b/omnibus/resources/puppy/msi/source.wxs.erb
@@ -75,8 +75,8 @@
     <Property Id="DDAGENTUSER_NAME" />
     <Property Id="DDAGENTUSER_PASSWORD" Hidden="yes" />
     <Property Id="APIKEY" Hidden="yes" />
+    <Property Id="SITE" Value="datadoghq.com" />
     <Property Id="FinalizeInstall" Hidden="yes" />
-    
      <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
      <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
      <PropertyRef Id="WIX_ACCOUNT_USERS" />
@@ -441,6 +441,7 @@
           WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed
       </Publish>
       <?include Resources\assets\apikeydlg.wxi ?>
+      <?include Resources\assets\sitedlg.wxi ?>
       <DialogRef Id="ErrorDlg" />
       <DialogRef Id="FatalError" />
       <DialogRef Id="FilesInUse" />
@@ -451,6 +452,7 @@
       <DialogRef Id="UserExit" />
       <DialogRef Id="WelcomeDlg" />
       <DialogRef Id="ApiKeyDlg"/>
+      <DialogRef Id="SiteDlg"/>
       <DialogRef Id="LicenseAgreementDlg"/>
 
       <DialogRef Id="MaintenanceWelcomeDlg"/>
@@ -467,7 +469,8 @@
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">NOT Installed</Publish>
 
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="3">1</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
+      <Publish Dialog="SiteDlg" Control="Back" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="SiteDlg">NOT PREVIOUSFOUND</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">PREVIOUSFOUND</Publish>
 
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
@@ -475,7 +478,8 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">NOT APIKEY</Publish>
-      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="SiteDlg">APIKEY AND (NOT SITE)</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY AND SITE</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 

--- a/releasenotes/notes/add-site-windows-gui-install-b838e8b6c0874804.yaml
+++ b/releasenotes/notes/add-site-windows-gui-install-b838e8b6c0874804.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On Windows, a step to set the ``site`` parameter has been added
+    to the graphical installer.


### PR DESCRIPTION
### What does this PR do?

Adds a dialog box to specify the `site` parameter in Agent, DogStatsD and Puppy GUI installers, between the API key box and the confirmation box.
The site can be chosen with a combo box, with two preset options: Datadog US and Datadog EU (which are translated into `site: datadoghq.com` and `site: datadoghq.eu`, respectively) which defaults to `Datadog US`. Custom site parameters can also be given.

![image](https://user-images.githubusercontent.com/26872252/74306653-692ed780-4d63-11ea-9dd8-63985bf168b1.png)
![image](https://user-images.githubusercontent.com/26872252/74306679-82d01f00-4d63-11ea-9917-1c4edee9c820.png)
![image](https://user-images.githubusercontent.com/26872252/74306695-8e234a80-4d63-11ea-9b11-489a574c85db.png)


### Motivation

Allow users to set the `site` parameter during install.
