### PR TITLE
[kitchen] Add tests to dd-agent-upgrade-agent7 scenario

### DIFF
--- a/test/kitchen/test/integration/dd-agent-upgrade-agent7/rspec/dd-agent-upgrade-agent7_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-upgrade-agent7/rspec/dd-agent-upgrade-agent7_spec.rb
@@ -1,0 +1,1 @@
+../../dd-agent-upgrade/rspec/dd-agent-upgrade_spec.rb

--- a/test/kitchen/test/integration/dd-agent-upgrade-agent7/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/dd-agent-upgrade-agent7/rspec/spec_helper.rb
@@ -1,0 +1,1 @@
+../../common/rspec/spec_helper.rb


### PR DESCRIPTION
### What does this PR do?

Adds tests for the verify step of the A7 -> A7 kitchen tests.

### Motivation

While it's good to have the scenario running to check that the install does not crash, it's better to actually test the result of the scenario...
