### PR TITLE
Multiple secret fetcher support

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -194,6 +194,9 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("secret_backend_output_max_size", secrets.SecretBackendOutputMaxSize)
 	config.BindEnvAndSetDefault("secret_backend_timeout", 5)
 
+	// multi secret backend
+	config.SetKnown("multi_secrets.*")
+
 	// Use to output logs in JSON format
 	config.BindEnvAndSetDefault("log_format_json", false)
 
@@ -804,6 +807,37 @@ func ResolveSecrets(config Config, origin string) error {
 		r := bytes.NewReader(finalYamlConf)
 		if err = config.MergeConfigOverride(r); err != nil {
 			return fmt.Errorf("could not update main configuration after decrypting secrets: %v", err)
+		}
+	}
+
+	for k, _ := range config.GetStringMapString("multi_secrets") {
+		secrets.InitMultipleSecrets(
+			config.GetString("multi_secrets."+k+".secret_backend_command"),
+			config.GetStringSlice("multi_secrets."+k+".secret_backend_arguments"),
+			config.GetInt("multi_secrets."+k+".secret_backend_timeout"),
+			config.GetInt("multi_secrets."+k+".secret_backend_output_max_size", secrets.SecretBackendOutputMaxSize),
+			config.GetString("multi_secrets."+k+".secret_backend_key_name"),
+		)
+
+		if config.GetString("multi_secrets."+k+".secret_backend_command") != "" {
+
+			// Viper doesn't expose the final location of the file it
+			// loads. Since we are searching for 'datadog.yaml' in multiple
+			// locations we let viper determine the one to use before
+			// updating it.
+			yamlConf, err := yaml.Marshal(config.AllSettings())
+			if err != nil {
+				return fmt.Errorf("unable to marshal configuration to YAML to decrypt secrets: %v", err)
+			}
+
+			finalYamlConf, err := secrets.Decrypt(yamlConf, origin)
+			if err != nil {
+				return fmt.Errorf("unable to decrypt secret from datadog.yaml: %v", err)
+			}
+			r := bytes.NewReader(finalYamlConf)
+			if err = config.MergeConfigOverride(r); err != nil {
+				return fmt.Errorf("could not update main configuration after decrypting secrets: %v", err)
+			}
 		}
 	}
 	return nil

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -7,7 +7,6 @@
 ## The Datadog API key to associate your Agent's data with your organization.
 ## Create a new API key here: https://app.datadoghq.com/account/settings
 #
-api_key:
 
 ## @param site - string - optional - default: datadoghq.com
 ## The site of the Datadog intake to send Agent data to.
@@ -889,11 +888,9 @@ api_key:
 ###########################
 
 ## @param log_level - string - optional - default: info
-## Minimum log level of the Datadog Agent.
-## Valid log levels are: trace, debug, info, warn, error, critical, and off.
-## Note: When using the 'off' log level, quotes are mandatory.
+## Minum log level of the Datadog Agent.
 #
-# log_level: 'info'
+# log_level: info
 
 ## @param log_file - string - optional
 ## Path of the log file for the Datadog Agent.
@@ -1443,5 +1440,24 @@ api_key:
 ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
 #
 # cluster_name: <CLUSTER_IDENTIFIER>
+log_file: /Users/thiago.frutuozo/workspace/merge-datadog-agent/datadog-my-fork/datadog.log
+multi_secrets:
+  database_secrets:
+    secret_backend_command: /Users/thiago.frutuozo/workspace/merge-datadog-agent/datadog-agent/tt.sh
+    secret_backend_timeout: 5
+    secret_backend_arguments:
+      - -param1
+      - -param2
+      - -param3
+    secret_backend_key_name: SECRET_KEY_NAME_1 # all secrets stated with SECRET_KEY_NAME will be sended to this backend
+  other_secrets:
+    secret_backend_command: /Users/thiago.frutuozo/workspace/merge-datadog-agent/datadog-agent/tt2.sh
+    secret_backend_timeout: 5
+    secret_backend_arguments:
+      - -param1
+      - -param2
+      - -param3
+    secret_backend_key_name: SECRET_KEY_NAME_2 # all secrets stated with SECRET_KEY_NAME will be sended to this backend
 
+secret_backend_command: /Users/thiago.frutuozo/workspace/merge-datadog-agent/datadog-agent/tt2.sh
 {{ end -}}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1440,24 +1440,41 @@
 ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
 #
 # cluster_name: <CLUSTER_IDENTIFIER>
-log_file: /Users/thiago.frutuozo/workspace/merge-datadog-agent/datadog-my-fork/datadog.log
-multi_secrets:
-  database_secrets:
-    secret_backend_command: /Users/thiago.frutuozo/workspace/merge-datadog-agent/datadog-agent/tt.sh
-    secret_backend_timeout: 5
-    secret_backend_arguments:
-      - -param1
-      - -param2
-      - -param3
-    secret_backend_key_name: SECRET_KEY_NAME_1 # all secrets stated with SECRET_KEY_NAME will be sended to this backend
-  other_secrets:
-    secret_backend_command: /Users/thiago.frutuozo/workspace/merge-datadog-agent/datadog-agent/tt2.sh
-    secret_backend_timeout: 5
-    secret_backend_arguments:
-      - -param1
-      - -param2
-      - -param3
-    secret_backend_key_name: SECRET_KEY_NAME_2 # all secrets stated with SECRET_KEY_NAME will be sended to this backend
 
-secret_backend_command: /Users/thiago.frutuozo/workspace/merge-datadog-agent/datadog-agent/tt2.sh
+
+
+
+## @param multi_secrets - list of secrets - optional
+## `multi_secrets` allow multiple secrets configurations, 
+##
+#
+# multi_secrets: 
+#  - secret_backend_command: <COMMAND_PATH>
+#    secret_backend_arguments:
+#      - <ARGUMENT_1>
+#      - <ARGUMENT_2>
+#    secret_backend_key_name: <SECRET_KEY_NAME> # all secrets stated with SECRET_KEY_NAME will be send to this backend
+#  - secret_backend_command: <COMMAND_PATH>
+#    secret_backend_arguments:
+#      - <ARGUMENT_1>
+#      - <ARGUMENT_2>
+#    secret_backend_key_name: <SECRET_KEY_NAME> # all secrets stated with SECRET_KEY_NAME will be sent to this backend
+#
+## Configuration example:
+# 
+# multi_secrets: 
+#  - secret_backend_command: application_name
+#    secret_backend_arguments:
+#      - -param1
+#    secret_backend_key_name: SECRET1 # all secrets stated with SECRET_KEY_NAME will be send to this backend
+#  - secret_backend_command: application_name2
+#    secret_backend_arguments:
+#      - -param2
+#    secret_backend_key_name: SECRET2 # all secrets stated with SECRET_KEY_NAME will be sent to this backend
+#
+## Secrets configuration:
+#
+#     secret1: "SECRET1[my_key1]"
+#     secret2: "SECRET2[my_key2]"
+#     secret3: "ENC[my_key3]"
 {{ end -}}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1441,9 +1441,6 @@
 #
 # cluster_name: <CLUSTER_IDENTIFIER>
 
-
-
-
 ## @param multi_secrets - list of secrets - optional
 ## `multi_secrets` allow multiple secrets configurations, 
 ##

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -37,10 +37,10 @@ func (b *limitBuffer) Write(p []byte) (n int, err error) {
 
 func execCommand(inputPayload string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(),
-		time.Duration(secretBackendTimeout)*time.Second)
+		time.Duration(tmpSecretBackendTimeout)*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, secretBackendCommand, secretBackendArguments...)
+	cmd := exec.CommandContext(ctx, tmpSecretBackendCommand, tmpSecretBackendArguments...)
 	if err := checkRights(cmd.Path); err != nil {
 		return nil, err
 	}
@@ -49,11 +49,11 @@ func execCommand(inputPayload string) ([]byte, error) {
 
 	stdout := limitBuffer{
 		buf: &bytes.Buffer{},
-		max: SecretBackendOutputMaxSize,
+		max: tmpSecretBackendOutputMaxSize,
 	}
 	stderr := limitBuffer{
 		buf: &bytes.Buffer{},
-		max: SecretBackendOutputMaxSize,
+		max: tmpSecretBackendOutputMaxSize,
 	}
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -63,9 +63,9 @@ func execCommand(inputPayload string) ([]byte, error) {
 		log.Errorf("secret_backend_command stderr: %s", stderr.buf.String())
 
 		if ctx.Err() == context.DeadlineExceeded {
-			return nil, fmt.Errorf("error while running '%s': command timeout", secretBackendCommand)
+			return nil, fmt.Errorf("error while running '%s': command timeout", tmpSecretBackendCommand)
 		}
-		return nil, fmt.Errorf("error while running '%s': %s", secretBackendCommand, err)
+		return nil, fmt.Errorf("error while running '%s': %s", tmpSecretBackendCommand, err)
 	}
 	return stdout.buf.Bytes(), nil
 }

--- a/pkg/secrets/fetch_secret_test.go
+++ b/pkg/secrets/fetch_secret_test.go
@@ -83,61 +83,61 @@ func TestLimitBuffer(t *testing.T) {
 
 func TestExecCommandError(t *testing.T) {
 	defer func() {
-		secretBackendCommand = ""
-		secretBackendArguments = []string{}
-		secretBackendTimeout = 0
+		tmpSecretBackendCommand = ""
+		tmpSecretBackendArguments = []string{}
+		tmpSecretBackendTimeout = 0
 	}()
 
 	inputPayload := "{\"version\": \"" + PayloadVersion + "\" , \"secrets\": [\"sec1\", \"sec2\"]}"
 
 	// empty secretBackendCommand
-	secretBackendCommand = ""
+	tmpSecretBackendCommand = ""
 	_, err := execCommand(inputPayload)
 	require.NotNil(t, err)
 
 	// test timeout
-	secretBackendCommand = "./test/timeout/timeout" + binExtension
-	setCorrectRight(secretBackendCommand)
-	secretBackendTimeout = 2
+	tmpSecretBackendCommand = "./test/timeout/timeout" + binExtension
+	setCorrectRight(tmpSecretBackendCommand)
+	tmpSecretBackendTimeout = 2
 	_, err = execCommand(inputPayload)
 	require.NotNil(t, err)
 	require.Equal(t, "error while running './test/timeout/timeout"+binExtension+"': command timeout", err.Error())
 
 	// test simple (no error)
-	secretBackendCommand = "./test/simple/simple" + binExtension
-	setCorrectRight(secretBackendCommand)
+	tmpSecretBackendCommand = "./test/simple/simple" + binExtension
+	setCorrectRight(tmpSecretBackendCommand)
 	resp, err := execCommand(inputPayload)
 	require.Nil(t, err)
 	require.Equal(t, []byte("{\"handle1\":{\"value\":\"simple_password\"}}"), resp)
 
 	// test error
-	secretBackendCommand = "./test/error/error" + binExtension
-	setCorrectRight(secretBackendCommand)
+	tmpSecretBackendCommand = "./test/error/error" + binExtension
+	setCorrectRight(tmpSecretBackendCommand)
 	_, err = execCommand(inputPayload)
 	require.NotNil(t, err)
 
 	// test arguments
-	secretBackendCommand = "./test/argument/argument" + binExtension
-	setCorrectRight(secretBackendCommand)
-	secretBackendArguments = []string{"arg1"}
+	tmpSecretBackendCommand = "./test/argument/argument" + binExtension
+	setCorrectRight(tmpSecretBackendCommand)
+	tmpSecretBackendArguments = []string{"arg1"}
 	_, err = execCommand(inputPayload)
 	require.NotNil(t, err)
-	secretBackendArguments = []string{"arg1", "arg2"}
+	tmpSecretBackendArguments = []string{"arg1", "arg2"}
 	resp, err = execCommand(inputPayload)
 	require.Nil(t, err)
 	require.Equal(t, []byte("{\"handle1\":{\"value\":\"arg_password\"}}"), resp)
 
 	// test input
-	secretBackendCommand = "./test/input/input" + binExtension
-	setCorrectRight(secretBackendCommand)
+	tmpSecretBackendCommand = "./test/input/input" + binExtension
+	setCorrectRight(tmpSecretBackendCommand)
 	resp, err = execCommand(inputPayload)
 	require.Nil(t, err)
 	require.Equal(t, []byte("{\"handle1\":{\"value\":\"input_password\"}}"), resp)
 
 	// test buffer limit
-	secretBackendCommand = "./test/response_too_long/response_too_long" + binExtension
-	setCorrectRight(secretBackendCommand)
-	SecretBackendOutputMaxSize = 20
+	tmpSecretBackendCommand = "./test/response_too_long/response_too_long" + binExtension
+	setCorrectRight(tmpSecretBackendCommand)
+	tmpSecretBackendOutputMaxSize = 20
 	_, err = execCommand(inputPayload)
 	require.NotNil(t, err)
 	assert.Equal(t, "error while running './test/response_too_long/response_too_long"+binExtension+"': command output was too long: exceeded 20 bytes", err.Error())

--- a/pkg/secrets/info.go
+++ b/pkg/secrets/info.go
@@ -14,27 +14,32 @@ import (
 
 // SecretInfo export troubleshooting information about the decrypted secrets
 type SecretInfo struct {
-	ExecutablePath string
-	Rights         string
-	RightDetails   string
-	UnixOwner      string
-	UnixGroup      string
+	ExecutablePath []string
+	Rights         []string
+	RightDetails   []string
+	UnixOwner      []string
+	UnixGroup      []string
 	SecretsHandles map[string][]string
 }
 
 // Print output a SecretInfo to a io.Writer
 func (si *SecretInfo) Print(w io.Writer) {
-	fmt.Fprintf(w, "=== Checking executable rights ===\n")
-	fmt.Fprintf(w, "Executable path: %s\n", si.ExecutablePath)
 
-	fmt.Fprintf(w, "Check Rights: %s\n", si.Rights)
+	for x := 0; x < len(si.ExecutablePath); x++ {
 
-	fmt.Fprintf(w, "\nRights Detail:\n")
-	fmt.Fprintf(w, "%s\n", si.RightDetails)
+		fmt.Fprintf(w, "=== Checking executable rights ===\n")
+		fmt.Fprintf(w, "Executable path: %s\n", si.ExecutablePath[x])
 
-	if runtime.GOOS != "windows" {
-		fmt.Fprintf(w, "Owner username: %s\n", si.UnixOwner)
-		fmt.Fprintf(w, "Group name: %s\n", si.UnixGroup)
+		fmt.Fprintf(w, "Check Rights: %s\n", si.Rights[x])
+
+		fmt.Fprintf(w, "\nRights Detail:\n")
+		fmt.Fprintf(w, "%s\n", si.RightDetails[x])
+
+		if runtime.GOOS != "windows" {
+			fmt.Fprintf(w, "Owner username: %s\n", si.UnixOwner[x])
+			fmt.Fprintf(w, "Group name: %s\n", si.UnixGroup[x])
+		}
+		fmt.Fprintf(w, "\n")
 	}
 
 	fmt.Fprintf(w, "\n=== Secrets stats ===\n")

--- a/pkg/secrets/info_nix.go
+++ b/pkg/secrets/info_nix.go
@@ -15,31 +15,33 @@ import (
 )
 
 func (info *SecretInfo) populateRights() {
-	err := checkRights(info.ExecutablePath)
-	if err != nil {
-		info.Rights = fmt.Sprintf("Error: %s", err)
-	} else {
-		info.Rights = fmt.Sprintf("OK, the executable has the correct rights")
-	}
+	for x := 0; x < len(info.ExecutablePath); x++ {
+		err := checkRights(info.ExecutablePath[x])
+		if err != nil {
+			info.Rights = append(info.Rights, fmt.Sprintf("Error: %s", err))
+		} else {
+			info.Rights = append(info.Rights, fmt.Sprintf("OK, the executable has the correct rights"))
+		}
 
-	var stat syscall.Stat_t
-	if err := syscall.Stat(secretBackendCommand, &stat); err != nil {
-		info.RightDetails = fmt.Sprintf("Could not stat %s: %s", secretBackendCommand, err)
-	} else {
-		info.RightDetails = fmt.Sprintf("file mode: %o", stat.Mode)
-	}
+		var stat syscall.Stat_t
+		if err := syscall.Stat(info.ExecutablePath[x], &stat); err != nil {
+			info.RightDetails = append(info.RightDetails, fmt.Sprintf("Could not stat %s: %s", info.ExecutablePath[x], err))
+		} else {
+			info.RightDetails = append(info.RightDetails, fmt.Sprintf("file mode: %o", stat.Mode))
+		}
 
-	owner, err := user.LookupId(strconv.Itoa(int(stat.Uid)))
-	if err != nil {
-		info.UnixOwner = fmt.Sprintf("could not fetch name for UID %d: %s", stat.Uid, err)
-	} else {
-		info.UnixOwner = owner.Username
-	}
+		owner, err := user.LookupId(strconv.Itoa(int(stat.Uid)))
+		if err != nil {
+			info.UnixOwner = append(info.UnixOwner, fmt.Sprintf("could not fetch name for UID %d: %s", stat.Uid, err))
+		} else {
+			info.UnixOwner = append(info.UnixOwner, owner.Username)
+		}
 
-	group, err := user.LookupGroupId(strconv.Itoa(int(stat.Gid)))
-	if err != nil {
-		info.UnixGroup = fmt.Sprintf("could not fetch name for GID %d: %s", stat.Gid, err)
-	} else {
-		info.UnixGroup = group.Name
+		group, err := user.LookupGroupId(strconv.Itoa(int(stat.Gid)))
+		if err != nil {
+			info.UnixGroup = append(info.UnixGroup, fmt.Sprintf("could not fetch name for GID %d: %s", stat.Gid, err))
+		} else {
+			info.UnixGroup = append(info.UnixGroup, group.Name)
+		}
 	}
 }

--- a/pkg/secrets/info_windows.go
+++ b/pkg/secrets/info_windows.go
@@ -14,34 +14,40 @@ import (
 )
 
 func (info *SecretInfo) populateRights() {
-	err := checkRights(info.ExecutablePath)
-	if err != nil {
-		info.Rights = fmt.Sprintf("Error: %s", err)
-	} else {
-		info.Rights = fmt.Sprintf("OK, the executable has the correct rights")
-	}
+	for x := 0; x < len(info.ExecutablePath); x++ {
+		err := checkRights(info.ExecutablePath[x])
+		if err != nil {
+			info.Rights = append(info.Rights, fmt.Sprintf("Error: %s", err))
+		} else {
+			info.Rights = append(info.Rights, fmt.Sprintf("OK, the executable has the correct rights"))
+		}
 
-	ps, err := exec.LookPath("powershell.exe")
-	if err != nil {
-		info.RightDetails = fmt.Sprintf("Could not find executable powershell.exe: %s", err)
-		return
-	}
+		ps, err := exec.LookPath("powershell.exe")
+		if err != nil {
+			info.RightDetails = append(info.Rights, fmt.Sprintf("Could not find executable powershell.exe: %s", err))
+			return
+		}
 
-	cmd := exec.Command(ps, "get-acl", "-Path", info.ExecutablePath, "|", "format-list")
+		cmd := exec.Command(ps, "get-acl", "-Path", info.ExecutablePath, "|", "format-list")
 
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+		stdout := bytes.Buffer{}
+		stderr := bytes.Buffer{}
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
 
-	err = cmd.Run()
-	if err != nil {
-		info.RightDetails += fmt.Sprintf("Error calling 'get-acl': %s\n", err)
-	} else {
-		info.RightDetails += fmt.Sprintf("Acl list:\n")
-	}
-	info.RightDetails += fmt.Sprintf("stdout:\n %s\n", stdout.String())
-	if stderr.Len() != 0 {
-		info.RightDetails += fmt.Sprintf("stderr:\n %s\n", stderr.String())
+		err = cmd.Run()
+		var tmp = ""
+		if err != nil {
+			tmp += fmt.Sprintf("Error calling 'get-acl': %s\n", err)
+		} else {
+			tmp += fmt.Sprintf("Acl list:\n")
+		}
+		tmp += fmt.Sprintf("stdout:\n %s\n", stdout.String())
+		if stderr.Len() != 0 {
+			tmp += fmt.Sprintf("stderr:\n %s\n", stderr.String())
+		}
+
+		info.RightDetails = append(info.RightDetails, tmp)
+
 	}
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -17,6 +17,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+type secretProvider struct {
+	secretCache map[string]string
+	// list of handles and where they were found
+	secretOrigin map[string]common.StringSet
+
+	secretBackendCommand   string
+	secretBackendArguments []string
+	secretBackendTimeout   int
+	secretBackendKeyName   string //used for multiples secrets feature
+
+	// SecretBackendOutputMaxSize defines max size of the JSON output from a secrets reader backend
+	secretBackendOutputMaxSize int
+}
+
 var (
 	secretCache map[string]string
 	// list of handles and where they were found
@@ -28,6 +42,13 @@ var (
 
 	// SecretBackendOutputMaxSize defines max size of the JSON output from a secrets reader backend
 	SecretBackendOutputMaxSize = 1024 * 1024
+
+	secretProviders []secretProvider
+
+	tmpSecretBackendCommand       string
+	tmpSecretBackendArguments     []string
+	tmpSecretBackendTimeout       int
+	tmpSecretBackendOutputMaxSize = SecretBackendOutputMaxSize
 )
 
 func init() {
@@ -43,6 +64,30 @@ func Init(command string, arguments []string, timeout int, maxSize int) {
 	secretBackendArguments = arguments
 	secretBackendTimeout = timeout
 	SecretBackendOutputMaxSize = maxSize
+}
+
+// Init initializes the command and other options of the secrets package when using multiples secrets. Since
+// this package is used by the 'config' package to decrypt itself we can't
+// directly use it.
+func InitMultipleSecrets(command string, arguments []string, timeout int, maxSize int, keyName string) {
+	if maxSize == 0 {
+		secretProviders = append(secretProviders, secretProvider{
+			secretBackendCommand:       command,
+			secretBackendArguments:     arguments,
+			secretBackendTimeout:       timeout,
+			secretBackendOutputMaxSize: SecretBackendOutputMaxSize,
+			secretBackendKeyName:       strings.Trim(keyName, " "),
+		})
+	} else {
+		secretProviders = append(secretProviders, secretProvider{
+			secretBackendCommand:       command,
+			secretBackendArguments:     arguments,
+			secretBackendTimeout:       timeout,
+			secretBackendOutputMaxSize: maxSize,
+			secretBackendKeyName:       strings.Trim(keyName, " "),
+		})
+	}
+
 }
 
 type walkerCallback func(string) (string, error)
@@ -118,86 +163,191 @@ func isEnc(str string) (bool, string) {
 	return false, ""
 }
 
+func isKey(str string, keyName string) (bool, string) {
+	// trimming space and tabs
+	str = strings.Trim(str, " 	")
+	if strings.HasPrefix(str, keyName+"[") && strings.HasSuffix(str, "]") {
+		return true, str[strings.Index(str, "[")+1 : len(str)-1]
+	}
+	return false, ""
+}
+
 // testing purpose
 var secretFetcher = fetchSecret
 
 // Decrypt replaces all encrypted secrets in data by executing
 // "secret_backend_command" once if all secrets aren't present in the cache.
 func Decrypt(data []byte, origin string) ([]byte, error) {
-	if data == nil || secretBackendCommand == "" {
+	var config interface{}
+	if data == nil || (secretBackendCommand == "" && len(secretProviders) == 0) {
 		return data, nil
 	}
 
-	var config interface{}
+	anySecret := false
 	err := yaml.Unmarshal(data, &config)
 	if err != nil {
 		return nil, fmt.Errorf("could not Unmarshal config: %s", err)
 	}
 
-	// First we collect all new handles in the config
-	newHandles := []string{}
-	haveSecret := false
-	err = walk(&config, func(str string) (string, error) {
-		if ok, handle := isEnc(str); ok {
-			haveSecret = true
-			// Check if we already know this secret
-			if secret, ok := secretCache[handle]; ok {
-				log.Debugf("Secret '%s' was retrieved from cache", handle)
-				// keep track of place where a handle was found
-				secretOrigin[handle].Add(origin)
-				return secret, nil
-			}
-			newHandles = append(newHandles, handle)
-		}
-		return str, nil
-	})
-	if err != nil {
-		return nil, err
-	}
+	if secretBackendCommand != "" {
 
-	// the configuration does not contain any secrets
-	if !haveSecret {
-		return data, nil
-	}
-
-	// check if any new secrets need to be fetch
-	if len(newHandles) != 0 {
-		secrets, err := secretFetcher(newHandles, origin)
-		if err != nil {
-			return nil, err
-		}
-
-		// Replace all new encrypted secrets in the config
+		// First we collect all new handles in the config
+		newHandles := []string{}
+		haveSecret := false
 		err = walk(&config, func(str string) (string, error) {
 			if ok, handle := isEnc(str); ok {
-				if secret, ok := secrets[handle]; ok {
-					log.Debugf("Secret '%s' was retrieved from executable", handle)
+				haveSecret = true
+				// Check if we already know this secret
+				if secret, ok := secretCache[handle]; ok {
+					log.Debugf("Secret '%s' was retrieved from cache", handle)
+					// keep track of place where a handle was found
+					secretOrigin[handle].Add(origin)
 					return secret, nil
 				}
-				// This should never happen since fetchSecret will return an error
-				// if not every handles have been fetched.
-				return str, fmt.Errorf("unknown secret '%s'", handle)
+				newHandles = append(newHandles, handle)
 			}
 			return str, nil
 		})
 		if err != nil {
 			return nil, err
 		}
+
+		// the configuration does not contain any secrets
+		/*
+		   if !haveSecret {
+		           return data, nil
+		   }
+		*/
+
+		if haveSecret {
+			anySecret = true
+			// check if any new secrets need to be fetch
+			if len(newHandles) != 0 {
+				tmpSecretBackendCommand = secretBackendCommand
+				tmpSecretBackendArguments = secretBackendArguments
+				tmpSecretBackendTimeout = secretBackendTimeout
+				tmpSecretBackendOutputMaxSize = SecretBackendOutputMaxSize
+
+				secrets, err := secretFetcher(newHandles, origin)
+				if err != nil {
+					return nil, err
+				}
+
+				// Replace all new encrypted secrets in the config
+				err = walk(&config, func(str string) (string, error) {
+					if ok, handle := isEnc(str); ok {
+						if secret, ok := secrets[handle]; ok {
+							log.Debugf("Secret '%s' was retrieved from executable", handle)
+							return secret, nil
+						}
+						// This should never happen since fetchSecret will return an error
+						// if not every handles have been fetched.
+						return str, fmt.Errorf("unknown secret '%s'", handle)
+					}
+					return str, nil
+				})
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
 	}
 
-	finalConfig, err := yaml.Marshal(config)
-	if err != nil {
-		return nil, fmt.Errorf("could not Marshal config after replacing encrypted secrets: %s", err)
+	if len(secretProviders) > 0 {
+		for x := 0; x < len(secretProviders); x++ {
+			if secretProviders[x].secretBackendCommand == "" {
+				continue
+				//return data, nil
+			}
+
+			// First we collect all new handles in the config
+			newHandles := []string{}
+			haveSecret := false
+			err = walk(&config, func(str string) (string, error) {
+				if ok, handle := isKey(str, secretProviders[x].secretBackendKeyName); ok {
+					haveSecret = true
+					// Check if we already know this secret
+					//if secret, ok := secretCache[handle]; ok {
+					//      log.Debugf("Secret '%s' was retrieved from cache", handle)
+					// keep track of place where a handle was found
+					//      secretOrigin[handle].Add(origin)
+					//      return secret, nil
+					//}
+					newHandles = append(newHandles, handle)
+				}
+				return str, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			// the configuration does not contain any secrets
+			if !haveSecret {
+				continue
+				//return data, nil
+			}
+
+			anySecret = true
+
+			// check if any new secrets need to be fetch
+			if len(newHandles) > 0 {
+				tmpSecretBackendCommand = secretProviders[x].secretBackendCommand
+				tmpSecretBackendArguments = secretProviders[x].secretBackendArguments
+				tmpSecretBackendTimeout = secretProviders[x].secretBackendTimeout
+				tmpSecretBackendOutputMaxSize = secretProviders[x].secretBackendOutputMaxSize
+
+				secrets, err := secretFetcher(newHandles, origin)
+				if err != nil {
+					return nil, err
+				}
+
+				// Replace all new encrypted secrets in the config
+				err = walk(&config, func(str string) (string, error) {
+					if ok, handle := isKey(str, secretProviders[x].secretBackendKeyName); ok {
+						if secret, ok := secrets[handle]; ok {
+							log.Debugf("Secret '%s' was retrieved from executable", handle)
+							return secret, nil
+						}
+						// This should never happen since fetchSecret will return an error
+						// if not every handles have been fetched.
+						return str, fmt.Errorf("unknown secret '%s'", handle)
+					}
+					return str, nil
+				})
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
 	}
-	return finalConfig, nil
+
+	if !anySecret {
+		return data, nil
+	} else {
+		finalConfig, err := yaml.Marshal(config)
+		if err != nil {
+			return nil, fmt.Errorf("could not Marshal config after replacing encrypted secrets: %s", err)
+		}
+		return finalConfig, nil
+	}
 }
 
 // GetDebugInfo exposes debug informations about secrets to be included in a flare
 func GetDebugInfo() (*SecretInfo, error) {
-	if secretBackendCommand == "" {
+	if secretBackendCommand == "" && len(secretProviders) == 0 {
 		return nil, fmt.Errorf("No secret_backend_command set: secrets feature is not enabled")
 	}
-	info := &SecretInfo{ExecutablePath: secretBackendCommand}
+
+	var allSecretBackendCommand []string
+	for x := 0; x < len(secretProviders); x++ {
+		allSecretBackendCommand = append(allSecretBackendCommand, secretProviders[x].secretBackendCommand)
+	}
+
+	if secretBackendCommand != "" {
+		allSecretBackendCommand = append(allSecretBackendCommand, secretBackendCommand)
+	}
+
+	info := &SecretInfo{ExecutablePath: allSecretBackendCommand}
 	info.populateRights()
 
 	info.SecretsHandles = map[string][]string{}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -70,24 +70,13 @@ func Init(command string, arguments []string, timeout int, maxSize int) {
 // this package is used by the 'config' package to decrypt itself we can't
 // directly use it.
 func InitMultipleSecrets(command string, arguments []string, timeout int, maxSize int, keyName string) {
-	if maxSize == 0 {
-		secretProviders = append(secretProviders, secretProvider{
-			secretBackendCommand:       command,
-			secretBackendArguments:     arguments,
-			secretBackendTimeout:       timeout,
-			secretBackendOutputMaxSize: SecretBackendOutputMaxSize,
-			secretBackendKeyName:       strings.Trim(keyName, " "),
-		})
-	} else {
-		secretProviders = append(secretProviders, secretProvider{
-			secretBackendCommand:       command,
-			secretBackendArguments:     arguments,
-			secretBackendTimeout:       timeout,
-			secretBackendOutputMaxSize: maxSize,
-			secretBackendKeyName:       strings.Trim(keyName, " "),
-		})
-	}
-
+	secretProviders = append(secretProviders, secretProvider{
+		secretBackendCommand:       command,
+		secretBackendArguments:     arguments,
+		secretBackendTimeout:       timeout,
+		secretBackendOutputMaxSize: SecretBackendOutputMaxSize,
+		secretBackendKeyName:       strings.Trim(keyName, " "),
+	})
 }
 
 type walkerCallback func(string) (string, error)

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -286,7 +286,7 @@ func TestDebugInfo(t *testing.T) {
 	info, err := GetDebugInfo()
 	require.Nil(t, err)
 
-	assert.Equal(t, "some_command", info.ExecutablePath)
+	assert.Equal(t, "some_command", info.ExecutablePath[0])
 
 	// sort handle first. The only handle with multiple location is "pass2".
 	handles := info.SecretsHandles


### PR DESCRIPTION
### What does this PR do?

multiples secret fetcher at the same time

### Motivation

In some situations is necessary to use more than one secret fetcher. For example, to fetch api_key we could use Vault, but to fetch database secrets we could use AWS Secrets Manager. Also, one team will provide the application to fetch api_key, and another will provide the application to fetch database secrets.

Based on that, multiple secret fetcher support will help to achieve this goal.

### Additional Notes

This change does not change the current secret fetcher functionality.