### PR TITLE
Allow long values in submit_histogram_bucket

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -23,7 +23,7 @@ type CheckSampler struct {
 	contextResolver *ContextResolver
 	metrics         metrics.ContextMetrics
 	sketchMap       sketchMap
-	lastBucketValue map[ckey.ContextKey]int
+	lastBucketValue map[ckey.ContextKey]int64
 	lastSeenBucket  map[ckey.ContextKey]time.Time
 	bucketExpiry    time.Duration
 }
@@ -36,7 +36,7 @@ func newCheckSampler() *CheckSampler {
 		contextResolver: newContextResolver(),
 		metrics:         metrics.MakeContextMetrics(),
 		sketchMap:       make(sketchMap),
-		lastBucketValue: make(map[ckey.ContextKey]int),
+		lastBucketValue: make(map[ckey.ContextKey]int64),
 		lastSeenBucket:  make(map[ckey.ContextKey]time.Time),
 		bucketExpiry:    1 * time.Minute,
 	}

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
-func benchmarkAddBucket(bucketValue int, b *testing.B) {
+func benchmarkAddBucket(bucketValue int64, b *testing.B) {
 	checkSampler := newCheckSampler()
 
 	bucket := &metrics.HistogramBucket{
@@ -28,12 +28,12 @@ func benchmarkAddBucket(bucketValue int, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		checkSampler.addBucket(bucket)
 		// reset bucket cache
-		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int)
+		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int64)
 		checkSampler.lastSeenBucket = make(map[ckey.ContextKey]time.Time)
 	}
 }
 
-func benchmarkAddBucketWideBounds(bucketValue int, b *testing.B) {
+func benchmarkAddBucketWideBounds(bucketValue int64, b *testing.B) {
 	checkSampler := newCheckSampler()
 
 	bounds := []float64{0, .0005, .001, .003, .005, .007, .01, .015, .02, .025, .03, .04, .05, .06, .07, .08, .09, .1, .5, 1, 5, 10}
@@ -54,7 +54,7 @@ func benchmarkAddBucketWideBounds(bucketValue int, b *testing.B) {
 			checkSampler.addBucket(bucket)
 		}
 		// reset bucket cache
-		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int)
+		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int64)
 		checkSampler.lastSeenBucket = make(map[ckey.ContextKey]time.Time)
 	}
 }

--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -32,7 +32,7 @@ func (m *MockSender) AssertMetric(t *testing.T, method string, metric string, va
 
 // AssertHistogramBucket allows to assert a histogram bucket was emitted with given parameters.
 // Additional tags over the ones specified don't make it fail
-func (m *MockSender) AssertHistogramBucket(t *testing.T, method string, metric string, value int, lowerBound float64, upperBound float64, monotonic bool, hostname string, tags []string) bool {
+func (m *MockSender) AssertHistogramBucket(t *testing.T, method string, metric string, value int64, lowerBound float64, upperBound float64, monotonic bool, hostname string, tags []string) bool {
 	return m.Mock.AssertCalled(t, method, metric, value, lowerBound, upperBound, monotonic, hostname, tags)
 }
 

--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -60,7 +60,7 @@ func (m *MockSender) Event(e metrics.Event) {
 }
 
 //HistogramBucket enables the histogram bucket mock call.
-func (m *MockSender) HistogramBucket(metric string, value int, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string) {
+func (m *MockSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string) {
 	m.Called(metric, value, lowerBound, upperBound, monotonic, hostname, tags)
 }
 

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -56,7 +56,7 @@ func (m *MockSender) SetupAcceptAll() {
 	m.On("Event", mock.AnythingOfType("metrics.Event")).Return()
 	m.On("HistogramBucket",
 		mock.AnythingOfType("string"),   // metric name
-		mock.AnythingOfType("int"),      // value
+		mock.AnythingOfType("int64"),    // value
 		mock.AnythingOfType("float64"),  // lower bound
 		mock.AnythingOfType("float64"),  // upper bound
 		mock.AnythingOfType("bool"),     // monotonic

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -32,7 +32,7 @@ type Sender interface {
 	Histogram(metric string, value float64, hostname string, tags []string)
 	Historate(metric string, value float64, hostname string, tags []string)
 	ServiceCheck(checkName string, status metrics.ServiceCheckStatus, hostname string, tags []string, message string)
-	HistogramBucket(metric string, value int, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string)
+	HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string)
 	Event(e metrics.Event)
 	GetMetricStats() map[string]int64
 	DisableDefaultHostname(disable bool)
@@ -287,7 +287,7 @@ func (s *checkSender) Histogram(metric string, value float64, hostname string, t
 }
 
 // HistogramBucket should be called to directly send raw buckets to be submitted as distribution metrics
-func (s *checkSender) HistogramBucket(metric string, value int, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string) {
+func (s *checkSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string) {
 	tags = append(tags, s.checkTags...)
 
 	log.Tracef(

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -462,7 +462,7 @@ func TestCheckSenderInterface(t *testing.T) {
 
 	histogramBucket := <-bucketChan
 	assert.Equal(t, "my.histogram_bucket", histogramBucket.bucket.Name)
-	assert.Equal(t, 42, histogramBucket.bucket.Value)
+	assert.Equal(t, int64(42), histogramBucket.bucket.Value)
 	assert.Equal(t, 1.0, histogramBucket.bucket.LowerBound)
 	assert.Equal(t, 2.0, histogramBucket.bucket.UpperBound)
 	assert.Equal(t, true, histogramBucket.bucket.Monotonic)

--- a/pkg/collector/python/aggregator.go
+++ b/pkg/collector/python/aggregator.go
@@ -112,7 +112,7 @@ func SubmitEvent(checkID *C.char, event *C.event_t) {
 
 // SubmitHistogramBucket is the method exposed to Python scripts to submit metrics
 //export SubmitHistogramBucket
-func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.long, lowerBound C.float, upperBound C.float, monotonic C.int, hostname *C.char, tags **C.char) {
+func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.longlong, lowerBound C.float, upperBound C.float, monotonic C.int, hostname *C.char, tags **C.char) {
 	goCheckID := C.GoString(checkID)
 	sender, err := aggregator.GetSender(chk.ID(goCheckID))
 	if err != nil || sender == nil {
@@ -121,7 +121,7 @@ func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.long, lo
 	}
 
 	_name := C.GoString(metricName)
-	_value := int(value)
+	_value := int64(value)
 	_lowerBound := float64(lowerBound)
 	_upperBound := float64(upperBound)
 	_monotonic := (monotonic != 0)

--- a/pkg/collector/python/aggregator.go
+++ b/pkg/collector/python/aggregator.go
@@ -112,7 +112,7 @@ func SubmitEvent(checkID *C.char, event *C.event_t) {
 
 // SubmitHistogramBucket is the method exposed to Python scripts to submit metrics
 //export SubmitHistogramBucket
-func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.int, lowerBound C.float, upperBound C.float, monotonic C.int, hostname *C.char, tags **C.char) {
+func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.long, lowerBound C.float, upperBound C.float, monotonic C.int, hostname *C.char, tags **C.char) {
 	goCheckID := C.GoString(checkID)
 	sender, err := aggregator.GetSender(chk.ID(goCheckID))
 	if err != nil || sender == nil {

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -107,7 +107,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 void SubmitMetric(char *, metric_type_t, char *, float, char **, int, char *);
 void SubmitServiceCheck(char *, char *, int, char **, int, char *, char *);
 void SubmitEvent(char *, event_t *, int);
-void SubmitHistogramBucket(char *, char *, int, float, float, int, char *, char **);
+void SubmitHistogramBucket(char *, char *, long, float, float, int, char *, char **);
 
 void initAggregatorModule(rtloader_t *rtloader) {
 	set_submit_metric_cb(rtloader, SubmitMetric);

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -107,7 +107,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 void SubmitMetric(char *, metric_type_t, char *, float, char **, int, char *);
 void SubmitServiceCheck(char *, char *, int, char **, int, char *, char *);
 void SubmitEvent(char *, event_t *, int);
-void SubmitHistogramBucket(char *, char *, long, float, float, int, char *, char **);
+void SubmitHistogramBucket(char *, char *, long long, float, float, int, char *, char **);
 
 void initAggregatorModule(rtloader_t *rtloader) {
 	set_submit_metric_cb(rtloader, SubmitMetric);

--- a/pkg/collector/python/test_aggregator.go
+++ b/pkg/collector/python/test_aggregator.go
@@ -191,7 +191,7 @@ func testSubmitHistogramBucket(t *testing.T) {
 	SubmitHistogramBucket(
 		C.CString("testID"),
 		C.CString("test_histogram"),
-		C.int(42),
+		C.long(42),
 		C.float(1.0),
 		C.float(2.0),
 		C.int(1),

--- a/pkg/collector/python/test_aggregator.go
+++ b/pkg/collector/python/test_aggregator.go
@@ -191,7 +191,7 @@ func testSubmitHistogramBucket(t *testing.T) {
 	SubmitHistogramBucket(
 		C.CString("testID"),
 		C.CString("test_histogram"),
-		C.long(42),
+		C.longlong(42),
 		C.float(1.0),
 		C.float(2.0),
 		C.int(1),

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -8,7 +8,7 @@ package metrics
 // HistogramBucket represents a prometheus/openmetrics histogram bucket
 type HistogramBucket struct {
 	Name       string
-	Value      int
+	Value      int64
 	LowerBound float64
 	UpperBound float64
 	Monotonic  bool

--- a/releasenotes/notes/allow-long-values-histogram-bucket-92dabc900d71d711.yaml
+++ b/releasenotes/notes/allow-long-values-histogram-bucket-92dabc900d71d711.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The `submit_histogram_bucket` API now accepts long integers as input values.

--- a/rtloader/common/builtins/aggregator.c
+++ b/rtloader/common/builtins/aggregator.c
@@ -377,7 +377,7 @@ static PyObject *submit_histogram_bucket(PyObject *self, PyObject *args)
     PyObject *py_tags = NULL; // borrowed
     char *check_id = NULL;
     char *name = NULL;
-    int value;
+    long value;
     float lower_bound;
     float upper_bound;
     int monotonic;
@@ -385,7 +385,7 @@ static PyObject *submit_histogram_bucket(PyObject *self, PyObject *args)
     char **tags = NULL;
 
     // Python call: aggregator.submit_histogram_bucket(self, metric string, value, lowerBound, upperBound, monotonic, hostname, tags)
-    if (!PyArg_ParseTuple(args, "OssiffisO", &check, &check_id, &name, &value, &lower_bound, &upper_bound, &monotonic, &hostname, &py_tags)) {
+    if (!PyArg_ParseTuple(args, "OsslffisO", &check, &check_id, &name, &value, &lower_bound, &upper_bound, &monotonic, &hostname, &py_tags)) {
         goto error;
     }
 

--- a/rtloader/common/builtins/aggregator.c
+++ b/rtloader/common/builtins/aggregator.c
@@ -377,7 +377,7 @@ static PyObject *submit_histogram_bucket(PyObject *self, PyObject *args)
     PyObject *py_tags = NULL; // borrowed
     char *check_id = NULL;
     char *name = NULL;
-    long value;
+    long long value;
     float lower_bound;
     float upper_bound;
     int monotonic;
@@ -385,7 +385,7 @@ static PyObject *submit_histogram_bucket(PyObject *self, PyObject *args)
     char **tags = NULL;
 
     // Python call: aggregator.submit_histogram_bucket(self, metric string, value, lowerBound, upperBound, monotonic, hostname, tags)
-    if (!PyArg_ParseTuple(args, "OsslffisO", &check, &check_id, &name, &value, &lower_bound, &upper_bound, &monotonic, &hostname, &py_tags)) {
+    if (!PyArg_ParseTuple(args, "OssLffisO", &check, &check_id, &name, &value, &lower_bound, &upper_bound, &monotonic, &hostname, &py_tags)) {
         goto error;
     }
 

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -99,7 +99,7 @@ typedef void (*cb_submit_service_check_t)(char *, char *, int, char **, char *, 
 // (id, event)
 typedef void (*cb_submit_event_t)(char *, event_t *);
 // (id, metric_name, value, lower_bound, upper_bound, monotonic, hostname, tags)
-typedef void (*cb_submit_histogram_bucket_t)(char *, char *, int, float, float, int, char *, char **);
+typedef void (*cb_submit_histogram_bucket_t)(char *, char *, long, float, float, int, char *, char **);
 
 // datadog_agent
 //

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -99,7 +99,7 @@ typedef void (*cb_submit_service_check_t)(char *, char *, int, char **, char *, 
 // (id, event)
 typedef void (*cb_submit_event_t)(char *, event_t *);
 // (id, metric_name, value, lower_bound, upper_bound, monotonic, hostname, tags)
-typedef void (*cb_submit_histogram_bucket_t)(char *, char *, long, float, float, int, char *, char **);
+typedef void (*cb_submit_histogram_bucket_t)(char *, char *, long long, float, float, int, char *, char **);
 
 // datadog_agent
 //


### PR DESCRIPTION
We're currently enforcing an integer, which obviously fails with bigger values.

Question: should it be `long long`?