### PR TITLE
API validation on api instead of app endpoint

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,9 +27,8 @@ import (
 
 const (
 	// DefaultSite is the default site the Agent sends data to.
-	DefaultSite         = "datadoghq.com"
-	infraURLPrefix      = "https://app."
-	apiValidationPrefix = "https://api."
+	DefaultSite    = "datadoghq.com"
+	infraURLPrefix = "https://app."
 
 	// DefaultNumWorkers default number of workers for our check runner
 	DefaultNumWorkers = 4
@@ -857,16 +856,6 @@ func AddAgentVersionToDomain(DDURL string, app string) (string, error) {
 
 func getMainInfraEndpointWithConfig(config Config) string {
 	return GetMainEndpointWithConfig(config, infraURLPrefix, "dd_url")
-}
-
-//WORKING
-func getAPIValidationEndpoint(config Config) string {
-	//should I add api_validation_endpoint to global config here?
-	//how can I forward or save this value so that forwarderhealth can use it to validate the apikey
-	//does forwarder health have access to the Datadog config type when it runs?
-	apiEndpoint := GetMainEndpointWithConfig(config, apiValidationPrefix, "dd_url")
-	return apiEndpoint
-
 }
 
 // GetMainEndpointWithConfig implements the logic to extract the DD URL from a config, based on `site` and ddURLKey

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,8 +27,9 @@ import (
 
 const (
 	// DefaultSite is the default site the Agent sends data to.
-	DefaultSite    = "datadoghq.com"
-	infraURLPrefix = "https://app."
+	DefaultSite         = "datadoghq.com"
+	infraURLPrefix      = "https://app."
+	apiValidationPrefix = "https://api."
 
 	// DefaultNumWorkers default number of workers for our check runner
 	DefaultNumWorkers = 4
@@ -856,6 +857,16 @@ func AddAgentVersionToDomain(DDURL string, app string) (string, error) {
 
 func getMainInfraEndpointWithConfig(config Config) string {
 	return GetMainEndpointWithConfig(config, infraURLPrefix, "dd_url")
+}
+
+//WORKING
+func getAPIValidationEndpoint(config Config) string {
+	//should I add api_validation_endpoint to global config here?
+	//how can I forward or save this value so that forwarderhealth can use it to validate the apikey
+	//does forwarder health have access to the Datadog config type when it runs?
+	apiEndpoint := GetMainEndpointWithConfig(config, apiValidationPrefix, "dd_url")
+	return apiEndpoint
+
 }
 
 // GetMainEndpointWithConfig implements the logic to extract the DD URL from a config, based on `site` and ddURLKey

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -111,7 +111,7 @@ func (fh *forwarderHealth) healthCheckLoop() {
 	}
 }
 
-//computeDomainsURL populates a map containing API Endpoints per API keys that belongs to the forwarderHealth struct
+// computeDomainsURL populates a map containing API Endpoints per API keys that belongs to the forwarderHealth struct
 func (fh *forwarderHealth) computeDomainsURL() {
 	for domain, apiKeys := range fh.keysPerDomains {
 		apiDomain := ""

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -55,12 +55,12 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 	defer ts1.Close()
 	defer ts2.Close()
 
-	keysPerDomains := map[string][]string{
+	keysPerAPIEndpoint := map[string][]string{
 		ts1.URL: {"api_key1", "api_key2"},
 		ts2.URL: {"key3"},
 	}
 
-	fh := forwarderHealth{keysPerDomains: keysPerDomains}
+	fh := forwarderHealth{keysPerAPIEndpoint: keysPerAPIEndpoint}
 	fh.init()
 	assert.True(t, fh.hasValidAPIKey())
 

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -43,12 +43,14 @@ func TestComputeDomainsURL(t *testing.T) {
 		"https://app.datadoghq.com": {"api_key1"},
 	}
 
+	testMap := map[string][]string{
+		"https://api.datadoghq.com": {"api_key1"},
+	}
+
 	fh := forwarderHealth{keysPerDomains: keysPerDomains}
 	fh.init()
 
-	_, ok := fh.keysPerAPIEndpoint["https://api.datadoghq.com"]
-
-	assert.True(t, ok)
+	assert.Equal(t, fh.keysPerAPIEndpoint, testMap)
 }
 
 func TestHasValidAPIKeyErrors(t *testing.T) {

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -60,8 +60,9 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 		ts2.URL: {"key3"},
 	}
 
-	fh := forwarderHealth{keysPerAPIEndpoint: keysPerAPIEndpoint}
+	fh := forwarderHealth{}
 	fh.init()
+	fh.keysPerAPIEndpoint = keysPerAPIEndpoint
 	assert.True(t, fh.hasValidAPIKey())
 
 	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending with _key1"))

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -38,6 +38,19 @@ func TestHasValidAPIKey(t *testing.T) {
 	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with key3"))
 }
 
+func TestComputeDomainsURL(t *testing.T) {
+	keysPerDomains := map[string][]string{
+		"https://app.datadoghq.com": {"api_key1"},
+	}
+
+	fh := forwarderHealth{keysPerDomains: keysPerDomains}
+	fh.init()
+
+	_, ok := fh.keysPerAPIEndpoint["https://api.datadoghq.com"]
+
+	assert.True(t, ok)
+}
+
 func TestHasValidAPIKeyErrors(t *testing.T) {
 	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()


### PR DESCRIPTION
### What does this PR do?

This PR makes sure that endpoints used for api validation us the api domain space rather than the app domain space

### Motivation


### Additional Notes

The PR uses the .com or .eu suffix to decide which instance to send api validation to
