### PR TITLE
Support sending a `service` tag for all integrations

### DIFF
--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -74,6 +74,16 @@ func (m *MockSender) SetCheckCustomTags(tags []string) {
 	m.Called(tags)
 }
 
+//SetCheckService enables the setting of check service mock call.
+func (m *MockSender) SetCheckService(service string) {
+	m.Called(service)
+}
+
+//FinalizeCheckServiceTag enables the sending of check service tag mock call.
+func (m *MockSender) FinalizeCheckServiceTag() {
+	m.Called()
+}
+
 //GetMetricStats enables the get metric stats mock call.
 func (m *MockSender) GetMetricStats() map[string]int64 {
 	m.Called()

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -20,9 +20,14 @@ func NewMockSender(id check.ID) *MockSender {
 	mockSender := new(MockSender)
 	// The MockSender will be injected in the corecheck via the aggregator
 	aggregator.InitAggregatorWithFlushInterval(nil, nil, "", "", 1*time.Hour)
-	aggregator.SetSender(mockSender, id)
+	SetSender(mockSender, id)
 
 	return mockSender
+}
+
+// SetSender sets passed sender with the passed ID.
+func SetSender(sender *MockSender, id check.ID) {
+	aggregator.SetSender(sender, id)
 }
 
 //MockSender allows mocking of the checks sender for unit testing

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -61,6 +61,8 @@ func (m *MockSender) SetupAcceptAll() {
 	m.On("GetMetricStats", mock.AnythingOfType("map[string]int64")).Return()
 	m.On("DisableDefaultHostname", mock.AnythingOfType("bool")).Return()
 	m.On("SetCheckCustomTags", mock.AnythingOfType("[]string")).Return()
+	m.On("SetCheckService", mock.AnythingOfType("string")).Return()
+	m.On("FinalizeCheckServiceTag").Return()
 	m.On("Commit").Return()
 }
 

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -59,8 +59,14 @@ type CommonInstanceConfig struct {
 	MinCollectionInterval int      `yaml:"min_collection_interval"`
 	EmptyDefaultHostname  bool     `yaml:"empty_default_hostname"`
 	Tags                  []string `yaml:"tags"`
+	Service               string   `yaml:"service"`
 	Name                  string   `yaml:"name"`
 	Namespace             string   `yaml:"namespace"`
+}
+
+// CommonGlobalConfig holds the reserved fields for the yaml init_config data
+type CommonGlobalConfig struct {
+	Service string `yaml:"service"`
 }
 
 // Equal determines whether the passed config is the same

--- a/pkg/collector/corechecks/system/file_handles_test.go
+++ b/pkg/collector/corechecks/system/file_handles_test.go
@@ -50,7 +50,7 @@ func TestFhCheckLinux(t *testing.T) {
 	// because the FinalizeCheckServiceTag is called in Configure.
 	// Hopefully, the check ID is an empty string while running unit tests;
 	mock := mocksender.NewMockSender("")
-	mock.SetupAcceptAll()
+	mock.On("FinalizeCheckServiceTag").Return()
 
 	fileHandleCheck := new(fhCheck)
 	fileHandleCheck.Configure(nil, nil, "test")

--- a/pkg/collector/corechecks/system/file_handles_test.go
+++ b/pkg/collector/corechecks/system/file_handles_test.go
@@ -46,10 +46,18 @@ func TestFhCheckLinux(t *testing.T) {
 	fileNrHandle = writeSampleFile(tmpFile, samplecontent1)
 	t.Logf("Testing from file %s", fileNrHandle) // To pass circle ci tests
 
+	// we have to init the mocked sender here before fileHandleCheck.Configure(...)
+	// (and append it to the aggregator, which is automatically done in NewMockSender)
+	// because the FinalizeCheckServiceTag is called in Configure.
+	// Hopefully, the check ID is an empty string while running unit tests;
+	mock := mocksender.NewMockSender("")
+	mock.On("FinalizeCheckServiceTag").Return()
+
 	fileHandleCheck := new(fhCheck)
 	fileHandleCheck.Configure(integration.Data("{\"val\": 42}"), integration.Data("{\"val\": 42}"), "test")
 
-	mock := mocksender.NewMockSender(fileHandleCheck.ID())
+	// it's not needed but we've better to recreate it with the check ID, for the sake of correctness
+	mock = mocksender.NewMockSender(fileHandleCheck.ID())
 
 	mock.On("Gauge", "system.fs.file_handles.allocated", 896.0, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.fs.file_handles.allocated_unused", 201.0, "", []string(nil)).Return().Times(1)

--- a/pkg/collector/corechecks/system/file_handles_test.go
+++ b/pkg/collector/corechecks/system/file_handles_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -54,7 +53,7 @@ func TestFhCheckLinux(t *testing.T) {
 	mock.On("FinalizeCheckServiceTag").Return()
 
 	fileHandleCheck := new(fhCheck)
-	fileHandleCheck.Configure(integration.Data("{\"val\": 42}"), integration.Data("{\"val\": 42}"), "test")
+	fileHandleCheck.Configure(nil, nil, "test")
 
 	// it's not needed but we've better to recreate it with the check ID, for the sake of correctness
 	mock = mocksender.NewMockSender(fileHandleCheck.ID())

--- a/pkg/collector/corechecks/system/file_handles_test.go
+++ b/pkg/collector/corechecks/system/file_handles_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -46,7 +47,7 @@ func TestFhCheckLinux(t *testing.T) {
 	t.Logf("Testing from file %s", fileNrHandle) // To pass circle ci tests
 
 	fileHandleCheck := new(fhCheck)
-	fileHandleCheck.Configure(nil, nil, "test")
+	fileHandleCheck.Configure(integration.Data("{\"val\": 42}"), integration.Data("{\"val\": 42}"), "test")
 
 	mock := mocksender.NewMockSender(fileHandleCheck.ID())
 

--- a/pkg/collector/corechecks/system/file_handles_test.go
+++ b/pkg/collector/corechecks/system/file_handles_test.go
@@ -50,13 +50,13 @@ func TestFhCheckLinux(t *testing.T) {
 	// because the FinalizeCheckServiceTag is called in Configure.
 	// Hopefully, the check ID is an empty string while running unit tests;
 	mock := mocksender.NewMockSender("")
-	mock.On("FinalizeCheckServiceTag").Return()
+	mock.SetupAcceptAll()
 
 	fileHandleCheck := new(fhCheck)
 	fileHandleCheck.Configure(nil, nil, "test")
 
-	// it's not needed but we've better to recreate it with the check ID, for the sake of correctness
-	mock = mocksender.NewMockSender(fileHandleCheck.ID())
+	// reset the check ID for the sake of correctness
+	mocksender.SetSender(mock, fileHandleCheck.ID())
 
 	mock.On("Gauge", "system.fs.file_handles.allocated", 896.0, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.fs.file_handles.allocated_unused", 201.0, "", []string(nil)).Return().Times(1)

--- a/pkg/collector/corechecks/system/uptime_test.go
+++ b/pkg/collector/corechecks/system/uptime_test.go
@@ -21,14 +21,14 @@ func TestUptimeCheckLinux(t *testing.T) {
 	// because the FinalizeCheckServiceTag is called in Configure.
 	// Hopefully, the check ID is an empty string while running unit tests;
 	mock := mocksender.NewMockSender("")
-	mock.On("FinalizeCheckServiceTag").Return()
+	mock.SetupAcceptAll()
 
 	uptime = uptimeSampler
 	uptimeCheck := new(UptimeCheck)
 	uptimeCheck.Configure(nil, nil, "test")
 
-	// it's not needed but we've better to recreate it with the check ID, for the sake of correctness
-	mock = mocksender.NewMockSender(uptimeCheck.ID())
+	// reset the check ID for the sake of correctness
+	mocksender.SetSender(mock, uptimeCheck.ID())
 
 	mock.On("Gauge", "system.uptime", 555.0, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)

--- a/pkg/collector/corechecks/system/uptime_test.go
+++ b/pkg/collector/corechecks/system/uptime_test.go
@@ -21,7 +21,7 @@ func TestUptimeCheckLinux(t *testing.T) {
 	// because the FinalizeCheckServiceTag is called in Configure.
 	// Hopefully, the check ID is an empty string while running unit tests;
 	mock := mocksender.NewMockSender("")
-	mock.SetupAcceptAll()
+	mock.On("FinalizeCheckServiceTag").Return()
 
 	uptime = uptimeSampler
 	uptimeCheck := new(UptimeCheck)

--- a/pkg/collector/corechecks/system/uptime_test.go
+++ b/pkg/collector/corechecks/system/uptime_test.go
@@ -16,11 +16,19 @@ func uptimeSampler() (uint64, error) {
 }
 
 func TestUptimeCheckLinux(t *testing.T) {
+	// we have to init the mocked sender here before fileHandleCheck.Configure(...)
+	// (and append it to the aggregator, which is automatically done in NewMockSender)
+	// because the FinalizeCheckServiceTag is called in Configure.
+	// Hopefully, the check ID is an empty string while running unit tests;
+	mock := mocksender.NewMockSender("")
+	mock.On("FinalizeCheckServiceTag").Return()
+
 	uptime = uptimeSampler
 	uptimeCheck := new(UptimeCheck)
 	uptimeCheck.Configure(nil, nil, "test")
 
-	mock := mocksender.NewMockSender(uptimeCheck.ID())
+	// it's not needed but we've better to recreate it with the check ID, for the sake of correctness
+	mock = mocksender.NewMockSender(uptimeCheck.ID())
 
 	mock.On("Gauge", "system.uptime", 555.0, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)

--- a/pkg/collector/python/test_check.go
+++ b/pkg/collector/python/test_check.go
@@ -295,11 +295,11 @@ func testConfigure(t *testing.T) {
 
 	C.get_check_return = 1
 	C.get_check_check = &C.rtloader_pyobject_t{}
-	err := c.Configure(integration.Data("{\"val\": 21}"), integration.Data("aaa"), "test")
+	err := c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
 	assert.Nil(t, err)
 
 	assert.Equal(t, c.class, C.get_check_py_class)
-	assert.Equal(t, "aaa", C.GoString(C.get_check_init_config))
+	assert.Equal(t, "{\"val\": 21}", C.GoString(C.get_check_init_config))
 	assert.Equal(t, "{\"val\": 21}", C.GoString(C.get_check_instance))
 	assert.Equal(t, string(c.id), C.GoString(C.get_check_check_id))
 	assert.Equal(t, "fake_check", C.GoString(C.get_check_check_name))
@@ -323,18 +323,18 @@ func testConfigureDeprecated(t *testing.T) {
 	C.get_check_return = 0
 	C.get_check_deprecated_check = &C.rtloader_pyobject_t{}
 	C.get_check_deprecated_return = 1
-	err := c.Configure(integration.Data("{\"val\": 21}"), integration.Data("aaa"), "test")
+	err := c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
 	assert.Nil(t, err)
 
 	assert.Equal(t, c.class, C.get_check_py_class)
-	assert.Equal(t, "aaa", C.GoString(C.get_check_init_config))
+	assert.Equal(t, "{\"val\": 21}", C.GoString(C.get_check_init_config))
 	assert.Equal(t, "{\"val\": 21}", C.GoString(C.get_check_instance))
 	assert.Equal(t, string(c.id), C.GoString(C.get_check_check_id))
 	assert.Equal(t, "fake_check", C.GoString(C.get_check_check_name))
 	assert.Nil(t, C.get_check_check)
 
 	assert.Equal(t, c.class, C.get_check_deprecated_py_class)
-	assert.Equal(t, "aaa", C.GoString(C.get_check_deprecated_init_config))
+	assert.Equal(t, "{\"val\": 21}", C.GoString(C.get_check_deprecated_init_config))
 	assert.Equal(t, "{\"val\": 21}", C.GoString(C.get_check_deprecated_instance))
 	assert.Equal(t, string(c.id), C.GoString(C.get_check_deprecated_check_id))
 	assert.Equal(t, "fake_check", C.GoString(C.get_check_deprecated_check_name))

--- a/releasenotes/notes/send-service-as-tag-b3ff43fc63b052bd.yaml
+++ b/releasenotes/notes/send-service-as-tag-b3ff43fc63b052bd.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Send a tag for any ``service`` defined in the ``init_config`` or
+    ``instances`` section of integration configuration, with the latter
+    taking precedence. This applies to metrics, events, and service checks.


### PR DESCRIPTION
### Motivation

We want to feature the notion of service more prominently for integrations so that we can correlate metrics with logs and traces