### PR TITLE
aggregator: make buffer size configurable.

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -207,18 +207,24 @@ type BufferedAggregator struct {
 
 // NewBufferedAggregator instantiates a BufferedAggregator
 func NewBufferedAggregator(s serializer.MetricSerializer, metricPool *metrics.MetricSamplePool, hostname, agentName string, flushInterval time.Duration) *BufferedAggregator {
+
+	bufferSize := config.Datadog.GetInt("aggregator_buffer_size")
+	if bufferSize == 0 {
+		bufferSize = 100
+	}
+
 	aggregator := &BufferedAggregator{
 		metricPool:             metricPool,
-		bufferedMetricIn:       make(chan []metrics.MetricSample, 100),  // TODO make buffer size configurable
-		bufferedServiceCheckIn: make(chan []*metrics.ServiceCheck, 100), // TODO make buffer size configurable
-		bufferedEventIn:        make(chan []*metrics.Event, 100),        // TODO make buffer size configurable
+		bufferedMetricIn:       make(chan []metrics.MetricSample, bufferSize),
+		bufferedServiceCheckIn: make(chan []*metrics.ServiceCheck, bufferSize),
+		bufferedEventIn:        make(chan []*metrics.Event, bufferSize),
 
-		metricIn:       make(chan *metrics.MetricSample, 100), // TODO make buffer size configurable
-		serviceCheckIn: make(chan metrics.ServiceCheck, 100),  // TODO make buffer size configurable
-		eventIn:        make(chan metrics.Event, 100),         // TODO make buffer size configurable
+		metricIn:       make(chan *metrics.MetricSample, bufferSize),
+		serviceCheckIn: make(chan metrics.ServiceCheck, bufferSize),
+		eventIn:        make(chan metrics.Event, bufferSize),
 
-		checkMetricIn:          make(chan senderMetricSample, 100),    // TODO make buffer size configurable
-		checkHistogramBucketIn: make(chan senderHistogramBucket, 100), // TODO make buffer size configurable
+		checkMetricIn:          make(chan senderMetricSample, bufferSize),
+		checkHistogramBucketIn: make(chan senderHistogramBucket, bufferSize),
 
 		statsdSampler:      *NewTimeSampler(bucketSize),
 		checkSamplers:      make(map[check.ID]*CheckSampler),

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -142,6 +142,13 @@ api_key:
 ## 'aggregator_stop_timeout' to 0.
 #
 # aggregator_stop_timeout: 2
+#
+# @param aggregator_buffer_size - unsigned int
+# The default buffer size for the aggregator use a sane value for most of the
+# use cases, however, it could be useful to manually set it in order to trade
+# RSS usage with better performances.
+#
+# aggregator_buffer_size: 100
 
 ## @param forwarder_timeout - integer - optional - default: 20
 ## Forwarder timeout in seconds

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -143,7 +143,7 @@ api_key:
 #
 # aggregator_stop_timeout: 2
 #
-# @param aggregator_buffer_size - unsigned int
+# @param aggregator_buffer_size - integer - optional - default: 100
 # The default buffer size for the aggregator use a sane value for most of the
 # use cases, however, it could be useful to manually set it in order to trade
 # RSS usage with better performances.


### PR DESCRIPTION
### What does this PR do?

Increasing the aggregator buffer size is a trade-off between RSS usage
and performance, let's make it configurable to be able to tweak that
using a configurable parameter.
