### PR TITLE
dogstatsd: add go version in the version command.

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -14,6 +14,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -59,7 +60,8 @@ extensions for special Datadog features.`,
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			av, _ := version.Agent()
-			fmt.Println(fmt.Sprintf("DogStatsD from Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
+			fmt.Println(fmt.Sprintf("DogStatsD from Agent %s - Codename: %s - Commit: %s - Serialization version: %s - Go version: %s",
+				av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion, runtime.Version()))
 		},
 	}
 

--- a/releasenotes/notes/dogstatsd-go-version-732dac5b9d8ed5a7.yaml
+++ b/releasenotes/notes/dogstatsd-go-version-732dac5b9d8ed5a7.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Add the Go version used to build Dogstatsd in its `version` command.


### PR DESCRIPTION
### What does this PR do?

Add Go version used to build Dogstatsd in its version command.

### Motivation

Useful while working on dogstatsd.
