### PR TITLE
Start system-probe unit with main Agent unit

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -1,7 +1,7 @@
 [Unit]
 Description=Datadog Agent
 After=network.target
-Wants=datadog-agent-trace.service datadog-agent-process.service
+Wants=datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service
 
 [Service]
 Type=simple

--- a/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
@@ -1,6 +1,7 @@
 [Unit]
 Description=Datadog System Probe
 Requires=sys-kernel-debug.mount
+Before=datadog-agent.service
 After=network.target sys-kernel-debug.mount
 
 [Service]

--- a/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
@@ -3,6 +3,8 @@ Description=Datadog System Probe
 Requires=sys-kernel-debug.mount
 Before=datadog-agent.service
 After=network.target sys-kernel-debug.mount
+BindsTo=datadog-agent.service
+ConditionPathExists=/etc/datadog-agent/system-probe.yaml
 
 [Service]
 Type=simple

--- a/releasenotes/notes/sysprobe-start-with-agent-c6283cc14717f265.yaml
+++ b/releasenotes/notes/sysprobe-start-with-agent-c6283cc14717f265.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    system-probe no longer needs to be enabled/started separately through systemctl


### PR DESCRIPTION
- system-probe no longer needs to be enabled/started separately
- When the Agent is started, system-probe will start before it
- system-probe won't start if config file is not present (see explanation below)
- If the system-probe doesn't start, Agent will still start without it
- If Agent starts, system-probe also restarts (due to `BindTo`)

Ideally we don't want to run system-probe if it's not enabled (which is not
by default), to avoid running anything as root in that scenario. This is hard
to achieve without adding some custom logic (that would also run as root).

The middle ground I found was to use `ConditionPathExists=` to check for
the system-probe config file. Since, by default, that file doesn't exist (we
provide a .example file for users to copy from), it means that by default we
will run nothing as root. If a user actually has a config file, they probably 
want to run system-probe and it makes sense to start it. It could happen 
that they create the file but set `enabled: false` there, in that case we will
start the system-probe (as root), do nothing and exit. I think it's still useful
to do so in this case, since it's most likely a configuration error and this
way we print a nice log saying "system probe not enabled. exiting." for them
to figure out.