### PR TITLE
[sketch] Better interpolation of buckets and uint32 counts 

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -18,29 +18,27 @@ const checksSourceTypeName = "System"
 
 // CheckSampler aggregates metrics from one Check instance
 type CheckSampler struct {
-	series                   []*metrics.Serie
-	sketches                 []metrics.SketchSeries
-	contextResolver          *ContextResolver
-	metrics                  metrics.ContextMetrics
-	sketchMap                sketchMap
-	lastBucketValue          map[ckey.ContextKey]int
-	lastSeenBucket           map[ckey.ContextKey]time.Time
-	bucketExpiry             time.Duration
-	interpolationGranularity int
+	series          []*metrics.Serie
+	sketches        []metrics.SketchSeries
+	contextResolver *ContextResolver
+	metrics         metrics.ContextMetrics
+	sketchMap       sketchMap
+	lastBucketValue map[ckey.ContextKey]int
+	lastSeenBucket  map[ckey.ContextKey]time.Time
+	bucketExpiry    time.Duration
 }
 
 // newCheckSampler returns a newly initialized CheckSampler
 func newCheckSampler() *CheckSampler {
 	return &CheckSampler{
-		series:                   make([]*metrics.Serie, 0),
-		sketches:                 make([]metrics.SketchSeries, 0),
-		contextResolver:          newContextResolver(),
-		metrics:                  metrics.MakeContextMetrics(),
-		sketchMap:                make(sketchMap),
-		lastBucketValue:          make(map[ckey.ContextKey]int),
-		lastSeenBucket:           make(map[ckey.ContextKey]time.Time),
-		bucketExpiry:             1 * time.Minute,
-		interpolationGranularity: 1000,
+		series:          make([]*metrics.Serie, 0),
+		sketches:        make([]metrics.SketchSeries, 0),
+		contextResolver: newContextResolver(),
+		metrics:         metrics.MakeContextMetrics(),
+		sketchMap:       make(sketchMap),
+		lastBucketValue: make(map[ckey.ContextKey]int),
+		lastSeenBucket:  make(map[ckey.ContextKey]time.Time),
+		bucketExpiry:    1 * time.Minute,
 	}
 }
 

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -6,7 +6,6 @@
 package aggregator
 
 import (
-	"math"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
@@ -108,34 +107,11 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
 		return
 	}
 
-	// simple linear interpolation, TODO: optimize
-	var linearIncr float64
-	var incrCount int
-	var countPerIncr uint
-	if bucket.Value > cs.interpolationGranularity {
-		linearIncr = bucketRange / float64(cs.interpolationGranularity)
-		countPerIncr = uint(bucket.Value / cs.interpolationGranularity)
-		incrCount = cs.interpolationGranularity
-	} else {
-		linearIncr = bucketRange / float64(bucket.Value)
-		countPerIncr = 1
-		incrCount = bucket.Value
-	}
-	if math.IsInf(bucket.UpperBound, 1) {
-		// We simulate the behavior of promQL for the infinity bucket:
-		// "if the quantile falls into the highest bucket, the upper bound of the 2nd highest bucket is returned"
-		incrCount = 1
-		countPerIncr = uint(bucket.Value)
-	}
-	currentVal := bucket.LowerBound
 	log.Tracef(
-		"Interpolating %d values by group of %d over the [%f-%f] bucket with %f increment",
-		bucket.Value, countPerIncr, bucket.LowerBound, bucket.UpperBound, linearIncr,
+		"Interpolating %d values over the [%f-%f] bucket",
+		bucket.Value, bucket.LowerBound, bucket.UpperBound,
 	)
-	for i := 0; i < incrCount; i++ {
-		cs.sketchMap.insertN(int64(bucket.Timestamp), contextKey, currentVal, countPerIncr)
-		currentVal += linearIncr
-	}
+	cs.sketchMap.insertInterp(int64(bucket.Timestamp), contextKey, bucket.LowerBound, bucket.UpperBound, uint(bucket.Value))
 }
 
 func (cs *CheckSampler) commitSeries(timestamp float64) {

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -6,6 +6,7 @@
 package aggregator
 
 import (
+	"math"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
@@ -104,6 +105,10 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
 	}
 	if bucket.Value == 0 {
 		// noop
+		return
+	}
+	if math.IsInf(bucket.UpperBound, 1) {
+		cs.sketchMap.insertInterp(int64(bucket.Timestamp), contextKey, bucket.LowerBound, bucket.LowerBound, uint(bucket.Value))
 		return
 	}
 

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -31,7 +31,6 @@ func benchmarkAddBucket(bucketValue int, b *testing.B) {
 		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int)
 		checkSampler.lastSeenBucket = make(map[ckey.ContextKey]time.Time)
 	}
-	b.Logf("Sketch size: %d", checkSampler.sketchMap.Len())
 }
 
 func benchmarkAddBucketWideBounds(bucketValue int, b *testing.B) {
@@ -58,8 +57,6 @@ func benchmarkAddBucketWideBounds(bucketValue int, b *testing.B) {
 		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int)
 		checkSampler.lastSeenBucket = make(map[ckey.ContextKey]time.Time)
 	}
-	b.Logf("Sketch size: %d", checkSampler.sketchMap.Len())
-
 }
 
 func BenchmarkAddBucket1(b *testing.B)        { benchmarkAddBucket(1, b) }

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -31,6 +31,35 @@ func benchmarkAddBucket(bucketValue int, b *testing.B) {
 		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int)
 		checkSampler.lastSeenBucket = make(map[ckey.ContextKey]time.Time)
 	}
+	b.Logf("Sketch size: %d", checkSampler.sketchMap.Len())
+}
+
+func benchmarkAddBucketWideBounds(bucketValue int, b *testing.B) {
+	checkSampler := newCheckSampler()
+
+	bounds := []float64{0, .0005, .001, .003, .005, .007, .01, .015, .02, .025, .03, .04, .05, .06, .07, .08, .09, .1, .5, 1, 5, 10}
+	bucket := &metrics.HistogramBucket{
+		Name:      "my.histogram",
+		Value:     bucketValue,
+		Tags:      []string{"foo", "bar"},
+		Timestamp: 12345.0,
+	}
+
+	for n := 0; n < b.N; n++ {
+		for i := range bounds {
+			if i == 0 {
+				continue
+			}
+			bucket.LowerBound = bounds[i-1]
+			bucket.UpperBound = bounds[i]
+			checkSampler.addBucket(bucket)
+		}
+		// reset bucket cache
+		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int)
+		checkSampler.lastSeenBucket = make(map[ckey.ContextKey]time.Time)
+	}
+	b.Logf("Sketch size: %d", checkSampler.sketchMap.Len())
+
 }
 
 func BenchmarkAddBucket1(b *testing.B)        { benchmarkAddBucket(1, b) }
@@ -40,3 +69,5 @@ func BenchmarkAddBucket1000(b *testing.B)     { benchmarkAddBucket(1000, b) }
 func BenchmarkAddBucket10000(b *testing.B)    { benchmarkAddBucket(10000, b) }
 func BenchmarkAddBucket1000000(b *testing.B)  { benchmarkAddBucket(1000000, b) }
 func BenchmarkAddBucket10000000(b *testing.B) { benchmarkAddBucket(10000000, b) }
+
+func BenchmarkAddBucketWide1e10(b *testing.B) { benchmarkAddBucketWideBounds(1e10, b) }

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -278,11 +278,11 @@ func TestCheckHistogramBucketInfinityBucket(t *testing.T) {
 
 	checkSampler.commit(12349.0)
 	_, flushed := checkSampler.flush()
+	assert.Equal(t, 1, len(flushed))
 
 	expSketch := &quantile.Sketch{}
 	expSketch.InsertMany(quantile.Default(), []float64{9000.0, 9000.0, 9000.0, 9000.0})
 
-	assert.Equal(t, 1, len(flushed))
 	metrics.AssertSketchSeriesEqual(t, metrics.SketchSeries{
 		Name: "my.histogram",
 		Tags: []string{"foo", "bar"},

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -210,12 +210,12 @@ func TestCheckHistogramBucketSampling(t *testing.T) {
 
 	checkSampler.commit(12349.0)
 	_, flushed := checkSampler.flush()
+	assert.Equal(t, 1, len(flushed))
 
 	expSketch := &quantile.Sketch{}
 	// linear interpolated values
 	expSketch.Insert(quantile.Default(), 10.0, 12.5, 15.0, 17.5)
 
-	assert.Equal(t, 1, len(flushed))
 	metrics.AssertSketchSeriesEqual(t, metrics.SketchSeries{
 		Name: "my.histogram",
 		Tags: []string{"foo", "bar"},

--- a/pkg/aggregator/sketch_map.go
+++ b/pkg/aggregator/sketch_map.go
@@ -39,15 +39,6 @@ func (m sketchMap) insert(ts int64, ck ckey.ContextKey, v float64) bool {
 	return true
 }
 
-func (m sketchMap) insertN(ts int64, ck ckey.ContextKey, v float64, n uint) bool {
-	if math.IsInf(v, 0) || math.IsNaN(v) {
-		return false
-	}
-
-	m.getOrCreate(ts, ck).InsertN(v, n)
-	return true
-}
-
 func (m sketchMap) insertInterp(ts int64, ck ckey.ContextKey, l float64, u float64, n uint) bool {
 	if math.IsInf(l, 0) || math.IsNaN(l) {
 		return false

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -68,12 +68,14 @@ func (a *Agent) InsertInterpolate(l float64, u float64, n uint) {
 		keys = append(keys, k)
 	}
 	whatsLeft := n
+	distance := u - l
 	kStartIdx := 0
 	lowerB := agentConfig.f64(keys[kStartIdx])
 	kEndIdx := 1
 	for kEndIdx < len(keys) {
 		upperB := agentConfig.f64(keys[kEndIdx])
-		distance := u - l
+		// ((upperB - lowerB) / distance) is the ratio of the distance between the current buckets to the total distance
+		// which tells us how much of the remaining value to put in this bucket
 		kn := uint(((upperB - lowerB) / distance) * float64(whatsLeft))
 		if kn > 0 {
 			a.Sketch.Basic.InsertN(lowerB, kn)

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -69,17 +69,18 @@ func (a *Agent) InsertInterpolate(l float64, u float64, n uint) {
 	}
 	whatsLeft := n
 	kStartIdx := 0
+	lowerB := agentConfig.f64(keys[kStartIdx])
 	kEndIdx := 1
 	for kEndIdx < len(keys) {
-		distance := u - l
-		lowerB := agentConfig.f64(keys[kStartIdx])
 		upperB := agentConfig.f64(keys[kEndIdx])
+		distance := u - l
 		kn := uint(((upperB - lowerB) / distance) * float64(whatsLeft))
 		if kn > 0 {
 			a.Sketch.Basic.InsertN(lowerB, kn)
 			a.CountBuf = append(a.CountBuf, KeyCount{k: keys[kStartIdx], n: kn})
 			whatsLeft -= kn
 			kStartIdx = kEndIdx
+			lowerB = upperB
 		}
 		kEndIdx++
 	}

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -70,13 +70,13 @@ func (a *Agent) InsertInterpolate(l float64, u float64, n uint) {
 	whatsLeft := n
 	distance := u - l
 	kStartIdx := 0
-	lowerB := agentConfig.f64(keys[kStartIdx])
+	lowerB := agentConfig.binLow(keys[kStartIdx])
 	kEndIdx := 1
 	for kEndIdx < len(keys) {
-		upperB := agentConfig.f64(keys[kEndIdx])
+		upperB := agentConfig.binLow(keys[kEndIdx])
 		// ((upperB - lowerB) / distance) is the ratio of the distance between the current buckets to the total distance
 		// which tells us how much of the remaining value to put in this bucket
-		kn := uint(((upperB - lowerB) / distance) * float64(whatsLeft))
+		kn := uint(((upperB - lowerB) / distance) * float64(n))
 		if kn > 0 {
 			a.Sketch.Basic.InsertN(lowerB, kn)
 			a.CountBuf = append(a.CountBuf, KeyCount{k: keys[kStartIdx], n: kn})
@@ -86,7 +86,7 @@ func (a *Agent) InsertInterpolate(l float64, u float64, n uint) {
 		}
 		kEndIdx++
 	}
-	a.Sketch.Basic.InsertN(agentConfig.f64(keys[len(keys)-1]), whatsLeft)
-	a.CountBuf = append(a.CountBuf, KeyCount{k: keys[len(keys)-1], n: whatsLeft})
+	a.Sketch.Basic.InsertN(agentConfig.binLow(keys[kStartIdx]), whatsLeft)
+	a.CountBuf = append(a.CountBuf, KeyCount{k: keys[kStartIdx], n: whatsLeft})
 	a.flush()
 }

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -61,12 +61,6 @@ func (a *Agent) Insert(v float64) {
 	a.flush()
 }
 
-// InsertN inserts v, n times into the sketch.
-func (a *Agent) InsertN(v float64, n uint) {
-	a.Sketch.Basic.InsertN(v, n)
-	a.CountBuf = append(a.CountBuf, KeyCount{k: agentConfig.key(v), n: n})
-}
-
 // InsertInterpolate linearly interpolates counts from lower (l) to upper (u)
 func (a *Agent) InsertInterpolate(l float64, u float64, n uint) {
 	keys := make([]Key, 0)
@@ -80,6 +74,8 @@ func (a *Agent) InsertInterpolate(l float64, u float64, n uint) {
 		a.Sketch.Basic.InsertN(agentConfig.f64(k), each)
 		a.CountBuf = append(a.CountBuf, KeyCount{k: k, n: each})
 	}
-	a.CountBuf = append(a.CountBuf, KeyCount{k: keys[len(keys)-1], n: leftover})
+	lastk := keys[len(keys)-1]
+	a.Sketch.Basic.InsertN(agentConfig.f64(lastk), leftover)
+	a.CountBuf = append(a.CountBuf, KeyCount{k: lastk, n: leftover})
 	a.flush()
 }

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -30,11 +30,6 @@ func (a *Agent) Finish() *Sketch {
 	return a.Sketch.Copy()
 }
 
-// Flush flushes any pending inserts.
-func (a *Agent) Flush() {
-	a.flush()
-}
-
 // flush buffered values into the sketch.
 func (a *Agent) flush() {
 	if len(a.Buf) != 0 {
@@ -78,7 +73,7 @@ func (a *Agent) InsertInterpolate(l float64, u float64, n uint) {
 	for k := agentConfig.key(l); k <= agentConfig.key(u); k++ {
 		keys = append(keys, k)
 	}
-	// non-linear interpolation
+	// @TODO[jtb] this is non-linear interpolation, make it linear
 	each := n / uint(len(keys))
 	leftover := n - (each * uint(len(keys)))
 	for _, k := range keys {

--- a/pkg/quantile/bin.go
+++ b/pkg/quantile/bin.go
@@ -6,12 +6,12 @@ import (
 )
 
 const (
-	maxBinWidth = math.MaxUint16
+	maxBinWidth = math.MaxUint32
 )
 
 type bin struct {
 	k Key
-	n uint16
+	n uint32
 }
 
 // incrSafe performs `b.n += by` safely handling overflows. When an overflow
@@ -24,7 +24,7 @@ func (b *bin) incrSafe(by int) int {
 		return next - maxBinWidth
 	}
 
-	b.n = uint16(next)
+	b.n = uint32(next)
 	return 0
 }
 
@@ -34,14 +34,14 @@ func (b *bin) incrSafe(by int) int {
 //   (2) n > maxBinWidth  : >1 bin
 func appendSafe(bins []bin, k Key, n int) []bin {
 	if n <= maxBinWidth {
-		return append(bins, bin{k: k, n: uint16(n)})
+		return append(bins, bin{k: k, n: uint32(n)})
 	}
 
 	// on overflow, insert multiple bins with the same key.
 	// put full bins at end
 
 	// TODO|PROD: Add validation func that sorts by key and then n (smaller bin first).
-	r := uint16(n % maxBinWidth)
+	r := uint32(n % maxBinWidth)
 	if r != 0 {
 		bins = append(bins, bin{k: k, n: r})
 	}

--- a/pkg/quantile/bin_test.go
+++ b/pkg/quantile/bin_test.go
@@ -9,9 +9,9 @@ import (
 func TestBin_incrSafe(t *testing.T) {
 	const maxn = maxBinWidth
 	tests := []struct {
-		n            uint16
+		n            uint32
 		by           int
-		wantN        uint16
+		wantN        uint32
 		wantOverflow int
 		name         string
 	}{

--- a/pkg/quantile/config.go
+++ b/pkg/quantile/config.go
@@ -40,9 +40,9 @@ type Config struct {
 }
 
 // MaxCount returns the max number of values you can insert.
-// This is limited by using a uint16 for bin.n
+// This is limited by using a uint32 for bin.n
 func (c *Config) MaxCount() int {
-	return c.binLimit * math.MaxUint16
+	return c.binLimit * math.MaxUint32
 }
 
 // f64 returns the lower bound for the given key: γ^k

--- a/pkg/quantile/key.go
+++ b/pkg/quantile/key.go
@@ -16,6 +16,12 @@ const (
 // A Key represents a quantized version of a float64. See Config for more details
 type Key int16
 
+// A KeyCount represents a Key and an associated count
+type KeyCount struct {
+	k Key
+	n uint
+}
+
 // IsInf returns true if the key represents +/-Inf
 func (k Key) IsInf() bool {
 	// TODO: bench http://graphics.stanford.edu/~seander/bithacks.html#IntegerAbs

--- a/pkg/quantile/main_test.go
+++ b/pkg/quantile/main_test.go
@@ -45,7 +45,7 @@ func ParseSketch(t *testing.T, dsl string) *Sketch {
 		}
 
 		s.count += int(n)
-		s.bins = append(s.bins, bin{k: k, n: uint16(n)})
+		s.bins = append(s.bins, bin{k: k, n: uint32(n)})
 		s.Basic.InsertN(c.f64(k), uint(n))
 	})
 

--- a/pkg/quantile/main_test.go
+++ b/pkg/quantile/main_test.go
@@ -74,7 +74,7 @@ func parseN(t *testing.T, s string) uint64 {
 	}
 
 	// <k>:max case
-	n := uint64(math.MaxUint16)
+	n := uint64(math.MaxUint32)
 	switch {
 	case s == "max":
 		return n

--- a/pkg/quantile/store.go
+++ b/pkg/quantile/store.go
@@ -130,6 +130,61 @@ func (s *sparseStore) merge(c *Config, o *sparseStore) {
 	putBinList(tmp)
 }
 
+func (s *sparseStore) insertCounts(c *Config, kcs []KeyCount) {
+
+	// TODO|PERF: A custom uint16 sort should easily beat sort.Sort.
+	// TODO|PERF: Would it be cheaper to sort float64s and then convert to keys?
+	sort.Slice(kcs, func(i, j int) bool {
+		return kcs[i].k < kcs[j].k
+	})
+
+	// TODO|PERF: Add a non-allocating fast path. When every key is already contained
+	// in the sketch (and no overflow happens) we can just directly update.
+	tmp := getBinList()
+
+	var (
+		sIdx, keyIdx int
+	)
+
+	for sIdx < len(s.bins) && keyIdx < len(kcs) {
+		b := s.bins[sIdx]
+		vk := kcs[keyIdx].k
+		kn := int(kcs[keyIdx].n)
+
+		switch {
+		case b.k < vk:
+			tmp = append(tmp, b)
+			sIdx++
+		case b.k > vk:
+			// When vk[i] == vk[i+1] we need to make sure they go in the same bucket.
+			tmp = appendSafe(tmp, vk, kn)
+			s.count += kn
+			keyIdx++
+		default:
+			tmp = appendSafe(tmp, b.k, int(b.n+uint32(kn)))
+			s.count += kn
+			sIdx++
+			keyIdx++
+		}
+	}
+
+	tmp = append(tmp, s.bins[sIdx:]...)
+
+	for keyIdx < len(kcs) {
+		kn := int(kcs[keyIdx].n)
+		tmp = appendSafe(tmp, kcs[keyIdx].k, int(kn))
+		s.count += kn
+		keyIdx++
+	}
+
+	tmp = trimLeft(tmp, c.binLimit)
+
+	// TODO|PERF: reallocate if cap(s.bins) >> len(s.bins)
+	s.bins = s.bins.ensureLen(len(tmp))
+	copy(s.bins, tmp)
+	putBinList(tmp)
+}
+
 func (s *sparseStore) insert(c *Config, keys []Key) {
 	s.count += len(keys)
 

--- a/pkg/quantile/store_test.go
+++ b/pkg/quantile/store_test.go
@@ -19,7 +19,7 @@ func buildStore(t *testing.T, dsl string) *sparseStore {
 		}
 
 		s.count += int(n)
-		s.bins = append(s.bins, bin{k: k, n: uint16(n)})
+		s.bins = append(s.bins, bin{k: k, n: uint32(n)})
 	})
 
 	return s

--- a/pkg/quantile/store_test.go
+++ b/pkg/quantile/store_test.go
@@ -13,7 +13,7 @@ import (
 func buildStore(t *testing.T, dsl string) *sparseStore {
 	s := &sparseStore{}
 
-	eachParsedToken(t, dsl, 16, func(k Key, n uint64) {
+	eachParsedToken(t, dsl, 32, func(k Key, n uint64) {
 		if n > maxBinWidth {
 			t.Fatal("n > max", n, maxBinWidth)
 		}
@@ -95,7 +95,7 @@ func TestStore(t *testing.T) {
 			},
 			{
 				s: "1:max 1:max 1:1 2:max 3:1 4:1",
-				e: "1:65535 1:65535 2:1 2:65535 3:1 4:1",
+				e: "1:4294967295 1:4294967295 2:1 2:4294967295 3:1 4:1",
 				b: 3,
 			},
 			{
@@ -159,8 +159,6 @@ func TestStore(t *testing.T) {
 			c("0:1 0:max 0:max", "0:3 0:max 0:max", 0, 0),
 			c("1:1 3:1 4:1 5:1 6:1 7:1", "1:1 2:1 3:2 4:1 5:1 6:1 7:1", 2, 3),
 			c("1:1 3:1", "1:1 2:3 3:1", 2, 2, 2),
-			c("1:1", "0:3 0:max 1:1", make([]Key, maxBinWidth+3)...),
-			c("", "0:1 0:max 0:max", make([]Key, maxBinWidth*2+1)...),
 			c("0:max-3", "0:2 0:max", make([]Key, 5)...),
 		} {
 			// TODO|TEST: that we never exceed binLimit.


### PR DESCRIPTION
### What does this PR do?

Improve interpolation performance of buckets from e.g. Prom/OM histograms

### Motivation

Ran into an issue with large counts, this addresses both the size of the count bins and the performance of interpolating bins

### Additional Notes

This also introduces a change to counts, using uint32 instead of uint16

Benchmark results:

```
➜ datadog-agent git:(joel.barciauskas/better-interp-buckets) /usr/local/bin/go test -benchmem -run=^$ github.com/DataDog/datadog-agent/pkg/aggregator -bench ^\(BenchmarkAddBucketWide1e10\)$
goos: darwin
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/aggregator
BenchmarkAddBucketWide1e10-4   	    3612	    318575 ns/op	   76086 B/op	     412 allocs/op
PASS
ok  	github.com/DataDog/datadog-agent/pkg/aggregator	2.095s
```

Note this test fails after 11 minutes on master. It only runs 4 times on the uint16 branch (#4932 )