### PR TITLE
Upgrade pip-tool to 4.2.0 for py2

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -99,8 +99,8 @@ build do
     # Prepare the build env, these dependencies are only needed to build and
     # install the core integrations.
     #
-    command "#{pip} install wheel==0.30.0"
-    command "#{pip} install pip-tools==2.0.2"
+    command "#{pip} install wheel==0.34.1"
+    command "#{pip} install pip-tools==4.2.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {
       "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",

--- a/releasenotes/notes/fix-upgrade-pip-tool-9e1624ae8d646165.yaml
+++ b/releasenotes/notes/fix-upgrade-pip-tool-9e1624ae8d646165.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Upgrade pip-tool and wheel for py2.

--- a/releasenotes/notes/fix-upgrade-pip-tool-9e1624ae8d646165.yaml
+++ b/releasenotes/notes/fix-upgrade-pip-tool-9e1624ae8d646165.yaml
@@ -1,4 +1,4 @@
 ---
-upgrade:
+enhancements:
   - |
     Upgrade ``pip-tools`` and ``wheel`` dependencies for Python 2.

--- a/releasenotes/notes/fix-upgrade-pip-tool-9e1624ae8d646165.yaml
+++ b/releasenotes/notes/fix-upgrade-pip-tool-9e1624ae8d646165.yaml
@@ -1,4 +1,4 @@
 ---
 upgrade:
   - |
-    Upgrade pip-tool and wheel for py2.
+    Upgrade ``pip-tools`` and ``wheel`` dependencies for Python 2.


### PR DESCRIPTION
### What does this PR do?

Upgrade pip-tool to 4.2.0.

Also upgrade wheel to be aligned with py3: https://github.com/DataDog/datadog-agent/blob/master/omnibus/config/software/datadog-agent-integrations-py3.rb#L103-L104

### Motivation

One of the integration need URLs package: https://github.com/DataDog/integrations-core/pull/5729

And pip-tool only support URL packages since 3.7.0: https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md#370-2019-05-09

Error seen on CI.

```
piptools.exceptions.UnsupportedConstraint: pip-compile does not support URLs as packages, unless they are editable. Perhaps add -e option? (constraint was: git+https://github.com/vmware/vsphere-automation-sdk-python@efe345a21b4ab7b346b65e1cb58d56412edd1c10 (from -r /.omnibus/src/datadog-agent-integrations-py2/integrations-core/agent_requirements-py2.in (line 20)))
```

### Additional Notes
