### PR TITLE
Dockerfiles/agent: enable APM by default

### DIFF
--- a/Dockerfiles/agent/datadog-docker.yaml
+++ b/Dockerfiles/agent/datadog-docker.yaml
@@ -9,9 +9,7 @@ config_providers:
     polling: true
     poll_interval: 1s
 
-# Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:
-  enabled: false
   apm_non_local_traffic: true
 
 # Use java container support

--- a/Dockerfiles/agent/datadog-k8s-docker.yaml
+++ b/Dockerfiles/agent/datadog-k8s-docker.yaml
@@ -13,10 +13,10 @@ config_providers:
     polling: true
     poll_interval: 1s
 
-# Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:
-  enabled: false
   apm_non_local_traffic: true
+  max_memory: 0
+  max_cpu_percent: 0
 
 # Use java container support
 jmx_use_container_support: true

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -8,10 +8,10 @@ config_providers:
   - name: kubelet
     polling: true
 
-# Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:
-  enabled: false
   apm_non_local_traffic: true
+  max_memory: 0
+  max_cpu_percent: 0
 
 # Use java container support
 jmx_use_container_support: true


### PR DESCRIPTION
This change ensures that APM is automatically enabled in Kubernetes
deployments in order to simply onboarding and minimise support cases
about APM not working out of the box.

Additionally, the API rate limiter that was based on CPU and memory
usage thresholds is also disabled because it was another source of
endless escalations and complaints causing increase memory spikes (due
to the agent being blocked from taking full advantage of CPU power
because of this limitation) and lost data. Kubernetes already manages
container resource usage through its limits settings.