### PR TITLE
config: set proper default value for `aggregator_buffer_size` and `dogstatsd_string_interner_size`

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -207,11 +207,7 @@ type BufferedAggregator struct {
 
 // NewBufferedAggregator instantiates a BufferedAggregator
 func NewBufferedAggregator(s serializer.MetricSerializer, metricPool *metrics.MetricSamplePool, hostname, agentName string, flushInterval time.Duration) *BufferedAggregator {
-
 	bufferSize := config.Datadog.GetInt("aggregator_buffer_size")
-	if bufferSize == 0 {
-		bufferSize = 100
-	}
 
 	aggregator := &BufferedAggregator{
 		metricPool:             metricPool,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -234,6 +234,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
 	config.BindEnvAndSetDefault("histogram_percentiles", []string{"0.95"})
 	config.BindEnvAndSetDefault("aggregator_stop_timeout", 2)
+	config.BindEnvAndSetDefault("aggregator_buffer_size", 100)
 	// Serializer
 	config.BindEnvAndSetDefault("enable_stream_payload_serialization", true)
 	config.BindEnvAndSetDefault("enable_service_checks_stream_payload_serialization", true)
@@ -289,6 +290,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})
 	config.BindEnvAndSetDefault("dogstatsd_mapper_cache_size", 1000)
+	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)
 	config.SetKnown("dogstatsd_mapper_profiles")
 
 	config.BindEnvAndSetDefault("statsd_forward_host", "")

--- a/pkg/dogstatsd/parse.go
+++ b/pkg/dogstatsd/parse.go
@@ -33,9 +33,6 @@ type parser struct {
 
 func newParser() *parser {
 	stringInternerCacheSize := config.Datadog.GetInt("dogstatsd_string_interner_size")
-	if stringInternerCacheSize == 0 {
-		stringInternerCacheSize = 4096
-	}
 
 	return &parser{
 		interner: newStringInterner(stringInternerCacheSize),


### PR DESCRIPTION
The default value for these two new fields were not handled properly.

(For history, these fields were added in #4749 and #4879)