### PR TITLE
[netlink] Conntrack improvements

### DIFF
--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -158,7 +158,7 @@ func newConntrackerOnce(procRoot string, deleteBufferSize, maxStateSize int) (Co
 
 	go ctr.run()
 
-	nfct.Register(context.Background(), ct.Conntrack, ct.NetlinkCtNew|ct.NetlinkCtExpectedNew|ct.NetlinkCtUpdate, ctr.register)
+	nfct.Register(context.Background(), ct.Conntrack, ct.NetlinkCtNew, ctr.register)
 	log.Debugf("initialized register hook")
 
 	nfctDel.Register(context.Background(), ct.Conntrack, ct.NetlinkCtDestroy, ctr.unregister)

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -292,7 +292,7 @@ func (ctr *realConntracker) register(c ct.Con) int {
 	atomic.AddInt64(&ctr.stats.registers, 1)
 	atomic.AddInt64(&ctr.stats.registersTotalTime, then-now)
 
-	log.Debugf("registered %s", conDebug(c))
+	log.Tracef("registered %s", conDebug(c))
 	return 0
 }
 

--- a/pkg/ebpf/netlink/conntracker_integration_test.go
+++ b/pkg/ebpf/netlink/conntracker_integration_test.go
@@ -31,13 +31,21 @@ func TestConntracker(t *testing.T) {
 
 	localAddr := pingTCP(t, "2.2.2.2:5432")
 
-	trans := ct.GetTranslationForConn(util.AddressFromNetIP(localAddr.IP), uint16(localAddr.Port), process.ConnectionType_tcp)
+	trans := ct.GetTranslationForConn(
+		util.AddressFromNetIP(localAddr.IP), uint16(localAddr.Port),
+		util.AddressFromString("2.2.2.2"), uint16(5432),
+		process.ConnectionType_tcp,
+	)
 	require.NotNil(t, trans)
 	assert.Equal(t, util.AddressFromString("1.1.1.1"), trans.ReplSrcIP)
 
 	localAddrUDP := pingUDP(t, net.ParseIP("2.2.2.2"), 5432).(*net.UDPAddr)
 	time.Sleep(time.Second)
-	trans = ct.GetTranslationForConn(util.AddressFromNetIP(localAddrUDP.IP), uint16(localAddrUDP.Port), process.ConnectionType_udp)
+	trans = ct.GetTranslationForConn(
+		util.AddressFromNetIP(localAddrUDP.IP), uint16(localAddrUDP.Port),
+		util.AddressFromString("2.2.2.2"), uint16(5432),
+		process.ConnectionType_udp,
+	)
 	require.NotNil(t, trans)
 	assert.Equal(t, util.AddressFromString("1.1.1.1"), trans.ReplSrcIP)
 
@@ -45,7 +53,11 @@ func TestConntracker(t *testing.T) {
 	localAddr = pingTCP(t, "1.1.1.1:9876")
 	time.Sleep(time.Second)
 
-	trans = ct.GetTranslationForConn(util.AddressFromNetIP(localAddr.IP), uint16(localAddr.Port), process.ConnectionType_tcp)
+	trans = ct.GetTranslationForConn(
+		util.AddressFromNetIP(localAddr.IP), uint16(localAddr.Port),
+		util.AddressFromString("1.1.1.1"), uint16(9876),
+		process.ConnectionType_tcp,
+	)
 	assert.Nil(t, trans)
 
 	defer teardown(t)

--- a/pkg/ebpf/netlink/noop.go
+++ b/pkg/ebpf/netlink/noop.go
@@ -14,7 +14,13 @@ func NewNoOpConntracker() Conntracker {
 	return &noOpConntracker{}
 }
 
-func (*noOpConntracker) GetTranslationForConn(ip util.Address, port uint16, transport process.ConnectionType) *IPTranslation {
+func (*noOpConntracker) GetTranslationForConn(
+	srcIP util.Address,
+	srcPort uint16,
+	dstIP util.Address,
+	dstPort uint16,
+	transport process.ConnectionType,
+) *IPTranslation {
 	return nil
 }
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -283,7 +283,13 @@ func (t *Tracer) initPerfPolling() (*bpflib.PerfMap, error) {
 				if t.shouldSkipConnection(&cs) {
 					atomic.AddInt64(&t.skippedConns, 1)
 				} else {
-					cs.IPTranslation = t.conntracker.GetTranslationForConn(cs.Source, cs.SPort, process.ConnectionType(cs.Type))
+					cs.IPTranslation = t.conntracker.GetTranslationForConn(
+						cs.Source,
+						cs.SPort,
+						cs.Dest,
+						cs.DPort,
+						process.ConnectionType(cs.Type),
+					)
 					t.state.StoreClosedConnection(cs)
 				}
 			case lostCount, ok := <-lostChannel:
@@ -399,7 +405,13 @@ func (t *Tracer) getConnections(active []ConnectionStats) ([]ConnectionStats, ui
 				atomic.AddInt64(&t.skippedConns, 1)
 			} else {
 				// lookup conntrack in for active
-				conn.IPTranslation = t.conntracker.GetTranslationForConn(conn.Source, conn.SPort, process.ConnectionType(conn.Type))
+				conn.IPTranslation = t.conntracker.GetTranslationForConn(
+					conn.Source,
+					conn.SPort,
+					conn.Dest,
+					conn.DPort,
+					process.ConnectionType(conn.Type),
+				)
 				active = append(active, conn)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

* Only subscribe to `NetlinkCtNew` conntrack events (the other ones are useless for our purposes as they track state of the UDP/TCP "connection", like UNREPLIED, ASSURED etc)
* Fix unregister error handling which was generating spurious *exceeded maximum tracked short lived connections* log entries when the cause was actually cache misses;
* Refactor netlink to use both source and destination address when adding/fetching from cache. The idea here is to solve some collision issues which 1) result sometimes in connections getting assigned to the wrong network translations and 2) was causing the bogus *exceeded maximum tracked short lived connections* log entry to be emitted. By using src/dst addresses we now have the option to replace the cache double writes by double reads instead (we would have to validate if that's worth it though, but it would cut the number of cache entries by 50%).

#### Pending work/ideas

* Take some CPU/mem profiles from hosts with lots of NATed connections (likely some of our busiest k8s nodes);
* Write/Attach a BPF filter to the netlink socket we can filter out NAT connections in kernel space;
* Check what's the current default netlink socket readbuffer size and check if we should raise to better handle bursts of events;
  *  I validated this is `212992` bytes on a vanilla Ubuntu box (doing a GETSOCKOPT call with SO_RCVBUF argument) which matches `/proc/sys/net/core/rmem_default`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
