### PR TITLE
Improve the text colors for the command `agent version` on Windows

### DIFF
--- a/cmd/agent/app/version.go
+++ b/cmd/agent/app/version.go
@@ -39,8 +39,8 @@ var versionCmd = &cobra.Command{
 				color.CyanString(av.GetNumberAndPre()),
 				meta,
 				color.GreenString(av.Commit),
-				color.MagentaString(serializer.AgentPayloadVersion),
-				color.BlueString(runtime.Version()),
+				color.YellowString(serializer.AgentPayloadVersion),
+				color.RedString(runtime.Version()),
 			),
 		)
 	},


### PR DESCRIPTION
### What does this PR do?

Improve the text colors for the command `agent version` on Windows when using Powershell.

**Before**
![Screen Shot 2020-02-14 at 2 26 46 PM](https://user-images.githubusercontent.com/52180542/74535683-a5666180-4f36-11ea-83b5-57855193c396.png)

**After**
![Screen Shot 2020-02-14 at 2 25 54 PM](https://user-images.githubusercontent.com/52180542/74535711-b44d1400-4f36-11ea-97dc-79a1a36962f3.png)
![Screen Shot 2020-02-14 at 2 25 12 PM](https://user-images.githubusercontent.com/52180542/74535716-b7480480-4f36-11ea-88bb-d4f5b24caf8e.png)

iTerm
![Screen Shot 2020-02-14 at 2 56 46 PM](https://user-images.githubusercontent.com/52180542/74537377-41459c80-4f3a-11ea-90ef-e38c40952c0c.png)


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
