### PR TITLE
pkg/trace: support version for trace metrics

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -125,7 +125,7 @@ func New() *AgentConfig {
 		Endpoints:  []*Endpoint{{Host: "https://trace.agent.datadoghq.com"}},
 
 		BucketInterval:   time.Duration(10) * time.Second,
-		ExtraAggregators: []string{"http.status_code"},
+		ExtraAggregators: []string{"http.status_code", "version"},
 
 		ExtraSampleRate: 1.0,
 		MaxTPS:          10,

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -114,6 +114,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal("INFO", c.LogLevel)
 	assert.Equal(true, c.Enabled)
 
+	assert.Equal([]string{"http.status_code", "version"}, c.ExtraAggregators)
 }
 
 func TestNoAPMConfig(t *testing.T) {

--- a/releasenotes/notes/apm-support-version-in-trace-metrics-4cd8c3123f06e40c.yaml
+++ b/releasenotes/notes/apm-support-version-in-trace-metrics-4cd8c3123f06e40c.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: add support for `version` as another tag in trace metrics.


### PR DESCRIPTION
### What does this PR do?

Adds `version` as another default aggregator, in addition to `http.status_code`. This allows for `version` to be added to select `trace` metrics.

### Motivation

Adding `version` (when provided in the spans) will let users better connect their trace metrics with new deploys of their services.
