### PR TITLE
[NET-19] Increase batch size to 600 on agent

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -197,7 +197,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		LogToConsole:          false,
 		QueueSize:             20,
 		MaxPerMessage:         100,
-		MaxConnsPerMessage:    300,
+		MaxConnsPerMessage:    600,
 		AllowRealTime:         true,
 		HostName:              "",
 		Transport:             NewDefaultTransport(),


### PR DESCRIPTION
### What does this PR do?

We have tested increasing the batch size on prod and the results look good. So we want to increase the default value on the agent. (Please see https://datadoghq.atlassian.net/browse/NET-19 for more details).

