### PR TITLE
Adding support for 'env' config option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -132,6 +132,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("skip_ssl_validation", false)
 	config.BindEnvAndSetDefault("hostname", "")
 	config.BindEnvAndSetDefault("tags", []string{})
+	config.BindEnv("env")
 	config.BindEnvAndSetDefault("tag_value_split_separator", map[string]string{})
 	config.BindEnvAndSetDefault("conf_path", ".")
 	config.BindEnvAndSetDefault("confd_path", defaultConfdPath)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -65,6 +65,12 @@ api_key:
 #   - environment:dev
 #   - <TAG_KEY>:<TAG_VALUE>
 
+## @param env - string - optional
+## The environment name where the agent is running. Attached in-app to every
+## metric, event, log, trace, and service check emitted by this Agent.
+#
+# env: <environment name>
+
 ## @param tag_value_split_separator - list of key:value elements - optional
 ## Split tag values according to a given separator. Only applies to host tags,
 ## and tags coming from container integrations. It does not apply to tags on dogstatsd metrics,
@@ -429,9 +435,9 @@ api_key:
   ## compresses logs before sending them.
   #
   # use_compression: true
-  
+
   ## @param compression_level - integer - optional - default: 6
-  ## The compression_level parameter accepts values from 0 (no compression) 
+  ## The compression_level parameter accepts values from 0 (no compression)
   ## to 9 (maximum compression but higher resource usage).
   #
   # compression_level: 6
@@ -457,7 +463,9 @@ api_key:
 
   ## @param env - string - optional - default: none
   ## The environment tag that Traces should be tagged with.
-  ## Inherits from "env" tag if "none" is applied here.
+  ## If not set the value will be inherited, in order, from the top level
+  ## "env" config option if set and then from the 'env:' tag if present in the
+  ## 'tags' top level config option.
   #
   # env: none
 

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -53,6 +53,11 @@ func getHostTags() *tags {
 	hostTags := make([]string, 0, len(rawHostTags))
 	hostTags = appendToHostTags(hostTags, rawHostTags)
 
+	env := config.Datadog.GetString("env")
+	if env != "" {
+		hostTags = appendToHostTags(hostTags, []string{"env:" + env})
+	}
+
 	if config.Datadog.GetBool("collect_ec2_tags") {
 		ec2Tags, err := ec2.GetTags()
 		if err != nil {

--- a/pkg/metadata/host/host_tags_test.go
+++ b/pkg/metadata/host/host_tags_test.go
@@ -45,3 +45,15 @@ func TestGetHostTagsWithoutSplits(t *testing.T) {
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"}, hostTags.System)
 }
+
+func TestGetHostTagsWithEnv(t *testing.T) {
+	mockConfig := config.Mock()
+	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3", "env:prod"})
+	mockConfig.Set("env", "preprod")
+	defer mockConfig.Set("tags", nil)
+	defer mockConfig.Set("env", "")
+
+	hostTags := getHostTags()
+	assert.NotNil(t, hostTags.System)
+	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "env:prod", "env:preprod"}, hostTags.System)
+}

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -175,6 +175,18 @@ func (c *AgentConfig) applyDatadogConfig() error {
 	}
 	if config.Datadog.IsSet("apm_config.env") {
 		c.DefaultEnv = config.Datadog.GetString("apm_config.env")
+		log.Debugf("Setting DefaultEnv to %q (from apm_config.env)", c.DefaultEnv)
+	} else if config.Datadog.IsSet("env") {
+		c.DefaultEnv = config.Datadog.GetString("env")
+		log.Debugf("Setting DefaultEnv to %q (from 'env' config option)", c.DefaultEnv)
+	} else if config.Datadog.IsSet("tags") {
+		for _, tag := range config.Datadog.GetStringSlice("tags") {
+			if strings.HasPrefix(tag, "env:") {
+				c.DefaultEnv = strings.TrimPrefix(tag, "env:")
+				log.Debugf("Setting DefaultEnv to %q (from `env:` entry under the 'tags' config option: %q)", c.DefaultEnv, tag)
+				break
+			}
+		}
 	}
 	if config.Datadog.IsSet("apm_config.receiver_port") {
 		c.ReceiverPort = config.Datadog.GetInt("apm_config.receiver_port")

--- a/releasenotes/notes/add-env-host-tag-d2d2fbdfc9b321ef.yaml
+++ b/releasenotes/notes/add-env-host-tag-d2d2fbdfc9b321ef.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adding new "env" top level config option. This will be added to the host
+    tags and propagated to the trace agent.


### PR DESCRIPTION
### What does this PR do?

Adding support for 'env' config option.
It represents the environment name were the agent is running and will be attached in-app to every metric, event, log, trace, and service check emitted by this Agent.