### PR TITLE
[DOCS-668] Updating example displayed to link to doc instead

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -514,11 +514,7 @@ api_key:
   ##  * pattern - string - The pattern to match the desired content to replace
   ##  * repl - string - what to inline if the pattern is matched
   ##
-  ## For instance to remove all query parameters from the http.url tag you would use:
-  ##
-  ##   - name: "http.url"
-  ##     pattern: "\?.*$"
-  ##     repl: "?"
+  ## See https://docs.datadoghq.com/tracing/guide/security/#replace-rules
   ##
   #
   # replace_tags:


### PR DESCRIPTION
### What does this PR do?

Removes example displayed and link to documentation instead where examples are more detailed.