### PR TITLE
[kitchen] Use BYOS images for SLES

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1303,7 +1303,7 @@ deploy_windows_testing-a7:
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export TEST_PLATFORMS="sles-11,id,/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/kitchen-test-images/providers/Microsoft.Compute/galleries/kitchenimages/images/SLES-11-SP4/versions/1.0.0"
-    - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-12,urn,SUSE:SLES:12-SP4:2019.11.13"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-12,urn,SUSE:sles-12-sp5-basic:gen1:2019.12.09"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-15,urn,SUSE:SLES-BYOS:15:2019.11.15"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1302,8 +1302,8 @@ deploy_windows_testing-a7:
 .kitchen_os_suse: &kitchen_os_suse
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
-    - export TEST_PLATFORMS="sles-11,id,/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/kitchen-test-images/providers/Microsoft.Compute/galleries/kitchenimages/images/SLES-11-SP4/versions/1.0.0"
-    - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-12,urn,SUSE:sles-12-sp5-basic:gen1:2019.12.09"
+    - export TEST_PLATFORMS="sles-11,urn,SUSE:SLES-BYOS:11-SP4:2019.12.05"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-12,urn,SUSE:SLES-BYOS:12-SP4:2019.11.13"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-15,urn,SUSE:SLES-BYOS:15:2019.11.15"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh


### PR DESCRIPTION
### What does this PR do?

Switches SLES images to BYOS images.

### Motivation

Prevents random failures when trying to reach zypper repositories while we investigate what's happening (BYOS have no pre-configured official repositories). Failures can still happen while reaching our own repository, but are less likely to happen.
