### PR TITLE
Fix build flags on tests

### DIFF
--- a/pkg/metrics/event_test.go
+++ b/pkg/metrics/event_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
+//+build zlib
+
 package metrics
 
 import (

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
+//+build zlib
+
 package metrics
 
 import (

--- a/pkg/metrics/service_check_test.go
+++ b/pkg/metrics/service_check_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
+//+build zlib
+
 package metrics
 
 import (


### PR DESCRIPTION
### What does this PR do?

Fix
```
# github.com/DataDog/datadog-agent/pkg/metrics [github.com/DataDog/datadog-agent/pkg/metrics.test]
./event_test.go:329:18: payloadBuilder.Build undefined (type *jsonstream.PayloadBuilder has no field or method Build)
./event_test.go:343:19: payloadBuilder.Build undefined (type *jsonstream.PayloadBuilder has no field or method Build)
./event_test.go:368:18: payloadBuilder.Build undefined (type *jsonstream.PayloadBuilder has no field or method Build)
./event_test.go:370:19: payloadBuilder.Build undefined (type *jsonstream.PayloadBuilder has no field or method Build)
./series_test.go:414:26: builder.Build undefined (type *jsonstream.PayloadBuilder has no field or method Build)
./series_test.go:461:17: builder.Build undefined (type *jsonstream.PayloadBuilder has no field or method Build)
./service_check_test.go:104:26: builder.Build undefined (type *jsonstream.PayloadBuilder has no field or method Build)
./service_check_test.go:185:17: payloadBuilder.Build undefined (type *jsonstream.PayloadBuilder has no field or method Build)
```

