### PR TITLE
[integration config] Update comment on init_config

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -39,8 +39,8 @@ const (
 // Config is a generic container for configuration files
 type Config struct {
 	Name                    string       `json:"check_name"`                // the name of the check
-	Instances               []Data       `json:"instances"`                 // array of Yaml configurations
-	InitConfig              Data         `json:"init_config"`               // the init_config in Yaml (python check only)
+	Instances               []Data       `json:"instances"`                 // the list of instances in Yaml
+	InitConfig              Data         `json:"init_config"`               // the init_config in Yaml
 	MetricConfig            Data         `json:"metric_config"`             // the metric config in Yaml (jmx check only)
 	LogsConfig              Data         `json:"logs"`                      // the logs config in Yaml (logs-agent only)
 	ADIdentifiers           []string     `json:"ad_identifiers"`            // the list of AutoDiscovery identifiers (optional)


### PR DESCRIPTION
### What does this PR do?

Update comment about `init_config`.

### Motivation

`init_config` is not limited to python checks (hasn't been the case
in v6/v7 in a very long time).