### PR TITLE
Provide a new API to dynamically create check instance

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -85,6 +85,7 @@ void ReadPersistentCache(char *);
 void SetCheckMetadata(char *, char *, char *);
 void SetExternalTags(char *, char *, char **);
 void WritePersistentCache(char *, char *);
+void ScheduleInstance(char *, char *);
 bool TracemallocEnabled();
 
 void initDatadogAgentModule(rtloader_t *rtloader) {
@@ -97,6 +98,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 	set_set_external_tags_cb(rtloader, SetExternalTags);
 	set_write_persistent_cache_cb(rtloader, WritePersistentCache);
 	set_read_persistent_cache_cb(rtloader, ReadPersistentCache);
+	set_schedule_instance_cb(rtloader, ScheduleInstance);
 	set_tracemalloc_enabled_cb(rtloader, TracemallocEnabled);
 }
 

--- a/rtloader/common/builtins/datadog_agent.h
+++ b/rtloader/common/builtins/datadog_agent.h
@@ -119,6 +119,13 @@
 
     The callback is expected to be provided by the rtloader caller - in go-context: CGO.
 */
+/*! \fn void _set_schedule_instance_cb(cb_schedule_instance_t)
+    \brief Sets a callback to be used by rtloader to allow scheduling a check instance.
+    \param object A function pointer with cb_schedule_instance_t prototype to the callback
+    function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
 
 #include <Python.h>
 #include <rtloader_types.h>
@@ -146,6 +153,7 @@ void _set_set_check_metadata_cb(cb_set_check_metadata_t);
 void _set_set_external_tags_cb(cb_set_external_tags_t);
 void _set_write_persistent_cache_cb(cb_write_persistent_cache_t);
 void _set_read_persistent_cache_cb(cb_read_persistent_cache_t);
+void _set_schedule_instance_cb(cb_schedule_instance_t);
 
 PyObject *_public_headers(PyObject *self, PyObject *args, PyObject *kwargs);
 

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -570,6 +570,16 @@ DATADOG_AGENT_RTLOADER_API void set_write_persistent_cache_cb(rtloader_t *, cb_w
 */
 DATADOG_AGENT_RTLOADER_API void set_read_persistent_cache_cb(rtloader_t *, cb_read_persistent_cache_t);
 
+/*! \fn void set_schedule_instance_cb(rtloader_t *, cb_schedule_instance_t)
+    \brief Sets a callback to be used by rtloader to allow scheduling an instance.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param object A function pointer with cb_schedule_instance_t prototype to the callback
+    function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
+DATADOG_AGENT_RTLOADER_API void set_schedule_instance_cb(rtloader_t *, cb_schedule_instance_t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -427,6 +427,14 @@ public:
     */
     virtual void setReadPersistentCacheCb(cb_read_persistent_cache_t) = 0;
 
+    //! setScheduleInstanceCb member.
+    /*!
+      \param A cb_schedule_instance_t function pointer to the CGO callback.
+
+      This allows us to set the relevant CGO callback that will allow scheduling an instance.
+    */
+    virtual void setScheduleInstanceCb(cb_schedule_instance_t) = 0;
+
 private:
     mutable std::string _error; /*!< string containing a RtLoader error */
     mutable bool _errorFlag; /*!< boolean indicating whether an error was set on RtLoader */

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -125,6 +125,8 @@ typedef void (*cb_set_external_tags_t)(char *, char *, char **);
 typedef void (*cb_write_persistent_cache_t)(char *, char *);
 // (value)
 typedef char *(*cb_read_persistent_cache_t)(char *);
+// (check, config)
+typedef void (*cb_schedule_instance_t)(char *, char *);
 
 // _util
 // (argv, argc, raise, stdout, stderr, ret_code, exception)

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -451,6 +451,11 @@ void set_read_persistent_cache_cb(rtloader_t *rtloader, cb_read_persistent_cache
     AS_TYPE(RtLoader, rtloader)->setReadPersistentCacheCb(cb);
 }
 
+void set_schedule_instance_cb(rtloader_t *rtloader, cb_schedule_instance_t cb)
+{
+    AS_TYPE(RtLoader, rtloader)->setScheduleInstanceCb(cb);
+}
+
 /*
  * _util API
  */

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -28,6 +28,7 @@ extern void setCheckMetadata(char*, char*, char*);
 extern void setExternalHostTags(char*, char*, char**);
 extern void writePersistentCache(char*, char*);
 extern char* readPersistentCache(char*);
+extern void scheduleInstance(char*, char*);
 
 
 static void initDatadogAgentTests(rtloader_t *rtloader) {
@@ -43,6 +44,7 @@ static void initDatadogAgentTests(rtloader_t *rtloader) {
    set_set_external_tags_cb(rtloader, setExternalHostTags);
    set_write_persistent_cache_cb(rtloader, writePersistentCache);
    set_read_persistent_cache_cb(rtloader, readPersistentCache);
+   set_schedule_instance_cb(rtloader, scheduleInstance);
 }
 */
 import "C"
@@ -228,4 +230,16 @@ func writePersistentCache(key, value *C.char) {
 //export readPersistentCache
 func readPersistentCache(key *C.char) *C.char {
 	return (*C.char)(helpers.TrackedCString("somevalue"))
+}
+
+//export scheduleInstance
+func scheduleInstance(check, config *C.char) {
+	checkName := C.GoString(check)
+	checkConfig := C.GoString(config)
+
+	f, _ := os.OpenFile(tmpfile.Name(), os.O_APPEND|os.O_RDWR|os.O_CREATE, 0600)
+	defer f.Close()
+
+	f.WriteString(checkName)
+	f.WriteString(checkConfig)
 }

--- a/rtloader/test/datadog_agent/datadog_agent_test.go
+++ b/rtloader/test/datadog_agent/datadog_agent_test.go
@@ -436,3 +436,16 @@ func TestReadPersistentCache(t *testing.T) {
 		t.Errorf("Unexpected printed value: '%s'", out)
 	}
 }
+
+func TestScheduleInstance(t *testing.T) {
+	code := `
+	datadog_agent.schedule_instance("check", "someconfig")
+	`
+	out, err := run(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "checksomeconfig" {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+}

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -878,6 +878,11 @@ void Three::setReadPersistentCacheCb(cb_read_persistent_cache_t cb)
     _set_read_persistent_cache_cb(cb);
 }
 
+void Three::setScheduleInstanceCb(cb_schedule_instance_t cb)
+{
+    _set_schedule_instance_cb(cb);
+}
+
 // Python Helpers
 
 // get_integration_list return a list of every datadog's wheels installed.

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -103,6 +103,7 @@ public:
     void setSetExternalTagsCb(cb_set_external_tags_t);
     void setWritePersistentCacheCb(cb_write_persistent_cache_t);
     void setReadPersistentCacheCb(cb_read_persistent_cache_t);
+    void setScheduleInstanceCb(cb_schedule_instance_t);
 
     // _util API
     virtual void setSubprocessOutputCb(cb_get_subprocess_output_t);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -883,6 +883,11 @@ void Two::setReadPersistentCacheCb(cb_read_persistent_cache_t cb)
     _set_read_persistent_cache_cb(cb);
 }
 
+void Two::setScheduleInstanceCb(cb_schedule_instance_t cb)
+{
+    _set_schedule_instance_cb(cb);
+}
+
 // Python Helpers
 
 // get_integration_list return a list of every datadog's wheels installed.

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -102,6 +102,7 @@ public:
     void setSetExternalTagsCb(cb_set_external_tags_t);
     void setWritePersistentCacheCb(cb_write_persistent_cache_t);
     void setReadPersistentCacheCb(cb_read_persistent_cache_t);
+    void setScheduleInstanceCb(cb_schedule_instance_t);
 
     // _util API
     virtual void setSubprocessOutputCb(cb_get_subprocess_output_t);


### PR DESCRIPTION
This adds a new datadog_agent python API to allow checks to create new instances dynamically. This is particularly interesting in the case of SNMP when we discover a network. There is also some potential use case for openmetrics checks talking to various endpoints.