### PR TITLE
Add exclusion paths for logs

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -27,6 +27,8 @@ type LogsConfig struct {
 	Port int    // Network
 	Path string // File, Journald
 
+	ExcludePaths []string `mapstructure:"exclude_paths" json:"exclude_paths"` // File
+
 	IncludeUnits  []string `mapstructure:"include_units" json:"include_units"`   // Journald
 	ExcludeUnits  []string `mapstructure:"exclude_units" json:"exclude_units"`   // Journald
 	ContainerMode bool     `mapstructure:"container_mode" json:"container_mode"` // Journald

--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -158,7 +158,7 @@ func (p *Provider) searchFiles(pattern string, source *config.LogSource) ([]*Fil
 	for _, excludePattern := range source.Config.ExcludePaths {
 		excludedGlob, err := filepath.Glob(excludePattern)
 		if err != nil {
-			return nil, fmt.Errorf("malformed exclusion pattern: %s", excludePattern)
+			return nil, fmt.Errorf("malformed exclusion pattern: %s, %s", excludePattern, err)
 		}
 		for _, excludedPath := range excludedGlob {
 			log.Debugf("Adding excluded path: %s", excludedPath)

--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -152,8 +152,27 @@ func (p *Provider) searchFiles(pattern string, source *config.LogSource) ([]*Fil
 	sort.SliceStable(paths, func(i, j int) bool {
 		return filepath.Base(paths[i]) > filepath.Base(paths[j])
 	})
+
+	// Resolve excluded path(s)
+	excludedPaths := make(map[string]int)
+	for _, excludePattern := range source.Config.ExcludePaths {
+		excludedGlob, err := filepath.Glob(excludePattern)
+		if err != nil {
+			return nil, fmt.Errorf("malformed exclusion pattern: %s", excludePattern)
+		}
+		for _, excludedPath := range excludedGlob {
+			log.Debugf("Adding excluded path: %s", excludedPath)
+			excludedPaths[excludedPath]++
+			if excludedPaths[excludedPath] > 1 {
+				log.Debugf("Overlaping excluded path: %s", excludedPath)
+			}
+		}
+	}
+
 	for _, path := range paths {
-		files = append(files, NewFile(path, source, true))
+		if excludedPaths[path] == 0 {
+			files = append(files, NewFile(path, source, true))
+		}
 	}
 	return files, nil
 }

--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -164,7 +164,7 @@ func (p *Provider) searchFiles(pattern string, source *config.LogSource) ([]*Fil
 			log.Debugf("Adding excluded path: %s", excludedPath)
 			excludedPaths[excludedPath]++
 			if excludedPaths[excludedPath] > 1 {
-				log.Debugf("Overlaping excluded path: %s", excludedPath)
+				log.Debugf("Overlapping excluded path: %s", excludedPath)
 			}
 		}
 	}

--- a/pkg/logs/input/file/file_provider_test.go
+++ b/pkg/logs/input/file/file_provider_test.go
@@ -253,6 +253,25 @@ func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 	suite.Equal([]string{"0 files tailed out of 0 files matching"}, logSources[1].Messages.GetMessages())
 }
 
+func (suite *ProviderTestSuite) TestExcludePath() {
+	filesLimit := 6
+	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
+	excludePaths := []string{fmt.Sprintf("%s/2/*.log", suite.testDir)}
+	fileProvider := NewProvider(filesLimit)
+	logSources := []*config.LogSource{
+		config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, ExcludePaths: excludePaths}),
+	}
+
+	files := fileProvider.FilesToTail(logSources)
+	suite.Equal(3, len(files))
+	for i := 0; i < len(files); i++ {
+		suite.Assert().True(files[i].IsWildcardPath)
+	}
+	suite.Equal(fmt.Sprintf("%s/1/3.log", suite.testDir), files[0].Path)
+	suite.Equal(fmt.Sprintf("%s/1/2.log", suite.testDir), files[1].Path)
+	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[2].Path)
+}
+
 func TestProviderTestSuite(t *testing.T) {
 	suite.Run(t, new(ProviderTestSuite))
 }

--- a/releasenotes/notes/add-exclusion-paths-for-logs-30ade45483f38b87.yaml
+++ b/releasenotes/notes/add-exclusion-paths-for-logs-30ade45483f38b87.yaml
@@ -1,0 +1,6 @@
+enhancements:
+  - |
+    Add an option to exclude log files by name when wildcarding
+    directories. The option is named ``exclude_paths``, it can be
+    added for each custom log collection configuration file.
+    The option accepts a list of glob.


### PR DESCRIPTION
### What does this PR do?
Add an option to exclude log files by name when wildcarding directories.

### Motivation
When log collection is enabled with a wildcard path like `/var/log/app*` (to handle rotate log file like `/var/log/app.log`, `/var/log/app.log.1`, `/var/log/app.log.2`, etc.) it can be convenient to exclude compressed file (e.g. `/var/log/app.log.3.gz`). Such a configuration would then looks like :
```
logs:
  - type: file
    path: "/var/log/app.*"
    exclude_paths:
      - "/var/log/app.*.gz"
    service: "app"
    source: "app.stats"
```

### Additional Notes
N/A