### PR TITLE
Update dca RBAC to allow creating events

### DIFF
--- a/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml
+++ b/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml
@@ -7,7 +7,6 @@ rules:
   - ""
   resources:
   - services
-  - events
   - endpoints
   - pods
   - nodes
@@ -16,6 +15,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
 - apiGroups:
   - "autoscaling"
   resources:


### PR DESCRIPTION
### What does this PR do?

The DCA, when used as External Metrics Server, tries to create an event in the HPA objects that it manages, but the current RBAC rules don't allow to do this, getting the following error in the cluster-agent logs:

```
2020-02-18 09:14:19 UTC | CLUSTER | INFO | (vendor/k8s.io/client-go/tools/record/event.go:258 in func1) | Event(v1.ObjectReference{Kind:"HorizontalPodAutoscaler", Namespace:"datadog", Name:"nginxext", UID:"34a2a035-5227-11ea-bf01-0ef0e3c74fbe", APIVersion:"autoscaling/v2beta1", ResourceVersion:"526688", FieldPath:""}): type: 'Normal' reason: 'Autoscaler is now handle by the Cluster-Agent'
E0218 09:14:19.635532       1 event.go:240] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"nginxext.15f47450d4f78d54", GenerateName:"", Namespace:"datadog", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"HorizontalPodAutoscaler", Namespace:"datadog", Name:"nginxext", UID:"34a2a035-5227-11ea-bf01-0ef0e3c74fbe", APIVersion:"autoscaling/v2beta1", ResourceVersion:"526688", FieldPath:""}, Reason:"Autoscaler is now handle by the Cluster-Agent", Message:"", Source:v1.EventSource{Component:"datadog-cluster-agent", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xbf8b089ae5bc1f54, ext:648981381, loc:(*time.Location)(0x33d7d20)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xbf8b089ae5bc1f54, ext:648981381, loc:(*time.Location)(0x33d7d20)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events is forbidden: User "system:serviceaccount:datadog:datadog-agent" cannot create resource "events" in API group "" in the namespace "datadog"' (will not retry!)
```

