### PR TITLE
[logs] LI-263: Add a warning in agent's status for HTTP migration

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -222,6 +222,10 @@
           {{ $endpoint }}<br>
         {{- end }}
       {{- end }}
+      {{- if eq .use_http false }}
+
+        You are currently sending Logs to Datadog through TCP. To benefit from increased reliability and better network performances, we strongly encourage to <a href="https://docs.datadoghq.com/agent/logs/?tab=compressionenabled#send-logs-over-https">switch over compressed HTTPS</a> which will become the default protocol in the Agent future version.</br>
+      {{- end }}
       {{- if .metrics }}
 
         {{- range $metric_name, $metric_value := .metrics }}

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -84,6 +84,7 @@ func BuildEndpoints() (*Endpoints, error) {
 		return buildHTTPEndpoints()
 	}
 
+	log.Warn("You are currently sending Logs to Datadog through TCP. To benefit from increased reliability and better network performances, we strongly encourage to switch over compressed HTTPS by using the logs_config.use_http and logs_config.use_compression parameters. This will become the default protocol in the Agent future version.")
 	return buildTCPEndpoints()
 }
 

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -45,6 +45,7 @@ func (b *Builder) BuildStatus() Status {
 		StatusMetrics: b.getMetricsStatus(),
 		Warnings:      b.getWarnings(),
 		Errors:        b.getErrors(),
+		UseHTTP:       b.getUseHTTP(),
 	}
 }
 
@@ -53,6 +54,10 @@ func (b *Builder) BuildStatus() Status {
 // from different commands (start, stop, status).
 func (b *Builder) getIsRunning() bool {
 	return atomic.LoadInt32(b.isRunning) != 0
+}
+
+func (b *Builder) getUseHTTP() bool {
+	return b.endpoints.UseHTTP
 }
 
 func (b *Builder) getEndpoints() []string {

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -42,6 +42,7 @@ type Status struct {
 	Integrations  []Integration    `json:"integrations"`
 	Errors        []string         `json:"errors"`
 	Warnings      []string         `json:"warnings"`
+	UseHTTP       bool             `json:"use_http"`
 }
 
 // Init instantiates the builder that builds the status on the fly.

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -17,6 +17,11 @@ Logs Agent
   {{- end }}
 {{- end }}
 
+{{- if eq .use_http false }}
+
+    You are currently sending Logs to Datadog through TCP. To benefit from increased reliability and better network performances, we strongly encourage to switch over compressed HTTPS by using the logs_config.use_http and logs_config.use_compression parameters. This will become the default protocol in the Agent future version.
+{{ end }}
+
 {{- if .metrics }}
 
   {{- range $metric_name, $metric_value := .metrics }}

--- a/releasenotes/notes/logs-add-warning-in-agent-status-for-http-migration-34f0de1598a519e0.yaml
+++ b/releasenotes/notes/logs-add-warning-in-agent-status-for-http-migration-34f0de1598a519e0.yaml
@@ -1,0 +1,5 @@
+
+---
+features:
+  - |
+    Add a warning in the logs-agent section of the agent status to incite users to switch over HTTP transport.


### PR DESCRIPTION
### What does this PR do?

Add a warning in the agent's status to incite user to switch over HTTP
transport.

### Motivation

Speed up the HTTP migration

### Additional Notes

<img width="1438" alt="Screenshot 2020-02-19 at 18 10 09" src="https://user-images.githubusercontent.com/1171983/74857029-64f65180-5343-11ea-873c-5bbf12cdde13.png">
