### PR TITLE
Fix flaky logs test

### DIFF
--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -8,7 +8,6 @@
 package clusterchecks
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -88,56 +87,6 @@ func (m *mockedPluggableAutoConfig) AddScheduler(name string, s scheduler.Schedu
 func (m *mockedPluggableAutoConfig) RemoveScheduler(name string) {
 	m.Called(name)
 	return
-}
-
-// assertTrueBeforeTimeout regularly checks whether a condition is met. It
-// does so until a timeout is reached, in which case it makes the test fail.
-// Condition is evaluated in a goroutine to avoid tests hanging if a system
-// is deadlocked.
-func assertTrueBeforeTimeout(t *testing.T, frequency, timeout time.Duration, condition func() bool) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	r := make(chan bool, 1)
-
-	go func() {
-		// Try once immediately
-		r <- condition()
-
-		// Retry until timeout
-		checkTicker := time.NewTicker(frequency)
-		defer checkTicker.Stop()
-		for {
-			select {
-			case <-checkTicker.C:
-				ok := condition()
-				r <- ok
-				if ok {
-					return
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	var ranOnce bool
-	for {
-		select {
-		case ok := <-r:
-			if ok {
-				return
-			}
-			ranOnce = true
-		case <-ctx.Done():
-			if ranOnce {
-				assert.Fail(t, "Timeout waiting for condition to happen, function returned false")
-			} else {
-				assert.Fail(t, "Timeout waiting for condition to happen, function never returned")
-			}
-			return
-		}
-	}
 }
 
 type fakeLeaderEngine struct {

--- a/pkg/clusteragent/clusterchecks/handler_test.go
+++ b/pkg/clusteragent/clusterchecks/handler_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
 func (h *Handler) assertLeadershipMessage(t *testing.T, expected state) {
@@ -154,13 +155,13 @@ func TestHandlerRun(t *testing.T) {
 		h.Run(ctx)
 		runReturned <- struct{}{}
 	}()
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// State is unknown
 		h.m.RLock()
 		defer h.m.RUnlock()
 		return h.state == unknown
 	})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// API replys not ready
 		code, reason := h.ShouldHandle()
 		return code == http.StatusServiceUnavailable && reason == notReadyReason
@@ -171,13 +172,13 @@ func TestHandlerRun(t *testing.T) {
 	//
 
 	le.set("1.2.3.4", nil)
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// Internal state change
 		h.m.RLock()
 		defer h.m.RUnlock()
 		return h.state == follower && h.leaderIP == "1.2.3.4"
 	})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// API redirects to leader
 		code, reason := h.ShouldHandle()
 		return code == http.StatusFound && reason == "1.2.3.4:5005"
@@ -188,24 +189,24 @@ func TestHandlerRun(t *testing.T) {
 	//
 
 	le.set("", nil)
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// Internal state change
 		h.m.RLock()
 		defer h.m.RUnlock()
 		return h.state == leader && h.leaderIP == ""
 	})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// API serves requests
 		code, reason := h.ShouldHandle()
 		return code == http.StatusOK && reason == ""
 	})
 	ac.On("AddScheduler", schedulerName, mock.AnythingOfType("*clusterchecks.dispatcher"), true).Return()
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// Keep node-agent caches even when timestamp is off (warmup)
 		response, err := h.PostStatus("dummy", "10.0.0.1", types.NodeStatus{LastChange: -50})
 		return err == nil && response.IsUpToDate == true
 	})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
 		// Test whether we're connected to the AD
 		return ac.AssertNumberOfCalls(dummyT, "AddScheduler", 1)
 	})
@@ -216,12 +217,12 @@ func TestHandlerRun(t *testing.T) {
 		ClusterCheck: true,
 	}
 	h.dispatcher.Schedule([]integration.Config{testConfig})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// Found one configuration for node dummy
 		configs, err := h.GetConfigs("dummy")
 		return err == nil && len(configs.Configs) == 1
 	})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// Flush node-agent caches when timestamp is off
 		response, err := h.PostStatus("dummy", "10.0.0.1", types.NodeStatus{LastChange: -50})
 		return err == nil && response.IsUpToDate == false
@@ -233,18 +234,18 @@ func TestHandlerRun(t *testing.T) {
 
 	ac.On("RemoveScheduler", schedulerName).Return()
 	le.set("1.2.3.6", nil)
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// Internal state change
 		h.m.RLock()
 		defer h.m.RUnlock()
 		return h.state == follower && h.leaderIP == "1.2.3.6"
 	})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// API redirects to leader again
 		code, reason := h.ShouldHandle()
 		return code == http.StatusFound && reason == "1.2.3.6:5005"
 	})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
 		// RemoveScheduler is called
 		return ac.AssertNumberOfCalls(dummyT, "RemoveScheduler", 1)
 	})
@@ -254,19 +255,19 @@ func TestHandlerRun(t *testing.T) {
 	//
 
 	le.set("", nil)
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// API serves requests
 		code, reason := h.ShouldHandle()
 		return code == http.StatusOK && reason == ""
 	})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// Dispatcher has been flushed, no config remain
 		state, err := h.GetState()
 		return err == nil && len(state.Nodes) == 0 && len(state.Dangling) == 0
 	})
 
 	h.PostStatus("dummy", "10.0.0.1", types.NodeStatus{})
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
 		// Test whether we're connected to the AD
 		return ac.AssertNumberOfCalls(dummyT, "AddScheduler", 2)
 	})
@@ -284,7 +285,7 @@ func TestHandlerRun(t *testing.T) {
 		assert.Fail(t, "Timeout while waiting for Run method to end")
 	}
 
-	assertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
 		// RemoveScheduler is called
 		return ac.AssertNumberOfCalls(dummyT, "RemoveScheduler", 2)
 	})

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+
+	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
 type AgentTestSuite struct {
@@ -100,8 +102,10 @@ func (suite *AgentTestSuite) TestAgent() {
 
 	agent.Start()
 	sources.AddSource(suite.source)
-	// Give the tailer some time to start its job.
-	time.Sleep(10 * time.Millisecond)
+	// Give the agent at most one second to send the logs.
+	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, time.Second, func() bool {
+		return suite.fakeLogs == metrics.LogsSent.Value()
+	})
 	agent.Stop()
 
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsDecoded.Value())
@@ -122,8 +126,10 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongBackend() {
 
 	agent.Start()
 	sources.AddSource(suite.source)
-	// Give the tailer some time to start its job.
-	time.Sleep(10 * time.Millisecond)
+	// Give the agent at most one second to process the logs.
+	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, time.Second, func() bool {
+		return suite.fakeLogs == metrics.LogsProcessed.Value()
+	})
 	agent.Stop()
 
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsDecoded.Value())
@@ -146,8 +152,10 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongAdditionalBackend() {
 
 	agent.Start()
 	sources.AddSource(suite.source)
-	// Give the tailer some time to start its job.
-	time.Sleep(10 * time.Millisecond)
+	// Give the agent at most one second to send the logs.
+	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, time.Second, func() bool {
+		return int64(2) == metrics.LogsSent.Value()
+	})
 	agent.Stop()
 
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsDecoded.Value())

--- a/pkg/util/testutil/timeout.go
+++ b/pkg/util/testutil/timeout.go
@@ -1,0 +1,59 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertTrueBeforeTimeout regularly checks whether a condition is met. It
+// does so until a timeout is reached, in which case it makes the test fail.
+// Condition is evaluated in a goroutine to avoid tests hanging if a system
+// is deadlocked.
+func AssertTrueBeforeTimeout(t *testing.T, frequency, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	r := make(chan bool, 1)
+
+	go func() {
+		// Try once immediately
+		r <- condition()
+
+		// Retry until timeout
+		checkTicker := time.NewTicker(frequency)
+		defer checkTicker.Stop()
+		for {
+			select {
+			case <-checkTicker.C:
+				ok := condition()
+				r <- ok
+				if ok {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	var ranOnce bool
+	for {
+		select {
+		case ok := <-r:
+			if ok {
+				return
+			}
+			ranOnce = true
+		case <-ctx.Done():
+			if ranOnce {
+				assert.Fail(t, "Timeout waiting for condition to happen, function returned false")
+			} else {
+				assert.Fail(t, "Timeout waiting for condition to happen, function never returned")
+			}
+			return
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fixes a flaky log test, see https://ci.appveyor.com/project/Datadog/datadog-agent/builds/30752598 for example.

### Motivation

flaky is bad

### Additional Notes

I moved and re-used the existing `assertTrueBeforeTimeout` function. It's a bit overkill for our use case here, but it works well so we might as well use it!
