### PR TITLE
[Windows][Installer] Handle DNS name with ".local"

### DIFF
--- a/releasenotes/notes/handle-dot-local-7343479e82e3520d.yaml
+++ b/releasenotes/notes/handle-dot-local-7343479e82e3520d.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    When a DNS name with ".local" is specifed in the parameter DDAGENTUSER_NAME, the correctly finds the corresponding domain.

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -86,10 +86,13 @@ bool CustomActionData::parseUsernameData()
         this->domainUser = false;
     } else {
         WCHAR netBiosDomainName[256];
-        DWORD size = sizeof(netBiosDomainName)/sizeof(WCHAR);
+        DWORD size = sizeof netBiosDomainName/sizeof(WCHAR);
         if (DnsHostnameToComputerName(computed_domain.c_str(), netBiosDomainName, &size))
         {
+            WcaLog(LOGMSG_VERBOSE, "Computed domain was %S. Equivalent NetBIOS name: %S", computed_domain.c_str(), netBiosDomainName);
             computed_domain = netBiosDomainName;
+        } else {
+            WcaLog(LOGMSG_STANDARD, "Warning: DnsHostnameToComputerName(%S) did not return success: %d", computed_domain.c_str(), GetLastError());
         }
 
         if(0 == _wcsicmp(computed_domain.c_str(), computername.c_str())){

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -85,6 +85,13 @@ bool CustomActionData::parseUsernameData()
         computed_domain = computername;
         this->domainUser = false;
     } else {
+        WCHAR netBiosDomainName[256];
+        DWORD size = sizeof(netBiosDomainName)/sizeof(WCHAR);
+        if (DnsHostnameToComputerName(computed_domain.c_str(), netBiosDomainName, &size))
+        {
+            computed_domain = netBiosDomainName;
+        }
+
         if(0 == _wcsicmp(computed_domain.c_str(), computername.c_str())){
             WcaLog(LOGMSG_STANDARD, "Supplied hostname as authority");
             this->domainUser = false;


### PR DESCRIPTION
### What does this PR do?

Handle the case where a DNS name with ".local" is specified in the DDAGENTUSER_NAME parameter to the installer.

### Motivation

Specifying ".local" as the domain of DDAGENTUSER_NAME should be valid.
