### PR TITLE
[system-probe] Use same Go version from datadog-agent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -581,7 +581,7 @@ run_dogstatsd_arm_size_test:
     - tar -xvf /tmp/libbcc.tar.xz -C /opt/datadog-agent/embedded
 
   script:
-    - CGO_CFLAGS='-I/opt/datadog-agent/embedded/include' CGO_LDFLAGS='-Wl,-rpath,/opt/datadog-agent/embedded/lib -L/opt/datadog-agent/embedded/lib' inv -e system-probe.build --go-version=1.10.1
+    - CGO_CFLAGS='-I/opt/datadog-agent/embedded/include' CGO_LDFLAGS='-Wl,-rpath,/opt/datadog-agent/embedded/lib -L/opt/datadog-agent/embedded/lib' inv -e system-probe.build
     - $S3_CP_CMD $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe $S3_ARTIFACTS_URI/system-probe.$ARCH
 
 build_system-probe-x64:

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -118,8 +118,7 @@ build do
 
     copy 'bin/process-agent/process-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
   else
-    # TODO(processes): change this to be ebpf:latest when we move to go1.12.x on the agent
-    command "invoke -e process-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --go-version=1.10.1", :env => env
+    command "invoke -e process-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg}", :env => env
     copy 'bin/process-agent/process-agent', "#{install_dir}/embedded/bin"
   end
 

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -119,12 +119,12 @@ func newConntrackerOnce(procRoot string, deleteBufferSize, maxStateSize int) (Co
 	netns := getGlobalNetNSFD(procRoot)
 
 	logger := getLogger()
-	nfct, err := ct.Open(&ct.Config{ReadTimeout: 10 * time.Millisecond, NetNS: netns, Logger: logger})
+	nfct, err := ct.Open(&ct.Config{NetNS: netns, Logger: logger})
 	if err != nil {
 		return nil, err
 	}
 
-	nfctDel, err := ct.Open(&ct.Config{ReadTimeout: 10 * time.Millisecond, NetNS: netns, Logger: logger})
+	nfctDel, err := ct.Open(&ct.Config{NetNS: netns, Logger: logger})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open delete NFCT")
 	}

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -59,8 +59,6 @@ def build(ctx, race=False, go_version=None, incremental_build=False,
     }
 
     goenv = {}
-    # TODO: this is a temporary workaround to avoid the garbage collection issues that the process-agent+go1.11 have had.
-    # Once we have upgraded the go version to 1.12, this can be removed
     if go_version:
         lines = ctx.run("gimme {version}".format(version=go_version)).stdout.split("\n")
         for line in lines:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -41,7 +41,6 @@ def build(ctx, race=False, go_version=None, incremental_build=False, major_versi
     }
 
     goenv = {}
-    # TODO: this is a temporary workaround. system probe had issues when built with go 1.11 and 1.12
     if go_version:
         lines = ctx.run("gimme {version}".format(version=go_version)).stdout.split("\n")
         for line in lines:


### PR DESCRIPTION
### What does this PR do?

Builds `system-probe` using the same Go of the datadog-agent

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
