### PR TITLE
agent_config:specify_cloud_provider

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,6 +133,7 @@ func initConfig(config Config) {
 	config.BindEnv("site")
 	config.BindEnv("dd_url")
 	config.BindEnvAndSetDefault("app_key", "")
+	config.BindEnvAndSetDefault("cloud_provider_metadata", "all")
 	config.SetDefault("proxy", nil)
 	config.BindEnvAndSetDefault("skip_ssl_validation", false)
 	config.BindEnvAndSetDefault("hostname", "")
@@ -1001,6 +1002,17 @@ func getMultipleEndpointsWithConfig(config Config) (map[string][]string, error) 
 	}
 
 	return keysPerDomain, nil
+}
+
+// IsCloudProviderEnabled checks the cloud provider family provided in pkg/util/<cloud_provider>.go against the value for cloud_provider: on the global config object Datadog
+func IsCloudProviderEnabled(cloudProviderName string) bool {
+	cloudProviderFromConfig := Datadog.GetString("cloud_provider_metadata")
+	if strings.ToLower(cloudProviderFromConfig) == "all" || strings.ToLower(cloudProviderFromConfig) == strings.ToLower(cloudProviderName) {
+		log.Debugf("cloud_provider_metadata is set to %s in agent configuration, trying endpoints for %s Cloud Provider", cloudProviderFromConfig, cloudProviderName)
+		return true
+	}
+	log.Debugf("cloud_provider_metadata is set to %s in agent configuration, skipping %s Cloud Provider", cloudProviderFromConfig, cloudProviderName)
+	return false
 }
 
 // IsContainerized returns whether the Agent is running on a Docker container

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -187,6 +187,19 @@ api_key:
 #
 # forwarder_stop_timeout: 2
 
+## @param cloud_provider_metadata - string - optional - default: <empty>
+## This option restricts which cloud provider endpoint will be used by the agent to retrieve metadata. By default the agent will try
+## all cloud providers.
+## Possible values are:
+## "aws"     AWS EC2, ECS/Fargate
+## "gcp"     Google Cloud Provider
+## "azure"   Azure
+## "alibaba" Alibaba
+## "none"    does not query any cloud metadata endpoints (falling back on system metadata). Using this setting on a cloud provider host may result in duplicated hosts in your account.
+## "all"     default: queries all cloud metadata endpoints
+#
+# cloud_provider_metadata: "all"
+
 ## @param collect_ec2_tags - boolean - optional - default: false
 ## Collect AWS EC2 custom tags as host tags.
 #

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,6 +41,7 @@ func TestDefaults(t *testing.T) {
 	assert.False(t, config.IsSet("dd_url"))
 	assert.Equal(t, "", config.GetString("site"))
 	assert.Equal(t, "", config.GetString("dd_url"))
+	assert.Equal(t, "all", config.GetString("cloud_provider_metadata"))
 }
 
 func TestDefaultSite(t *testing.T) {
@@ -422,6 +423,29 @@ func TestAddAgentVersionToDomain(t *testing.T) {
 	newURL, err = AddAgentVersionToDomain("https://app.myproxy.com", "app")
 	require.Nil(t, err)
 	assert.Equal(t, "https://app.myproxy.com", newURL)
+}
+
+func TestIsCloudProviderEnabled(t *testing.T) {
+	holdValue := Datadog.Get("cloud_provider_metadata")
+	defer Datadog.Set("cloud_provider_metadata", holdValue)
+
+	Datadog.Set("cloud_provider_metadata", "all")
+	assert.True(t, IsCloudProviderEnabled("AWS"))
+	assert.True(t, IsCloudProviderEnabled("GCP"))
+	assert.True(t, IsCloudProviderEnabled("Alibaba"))
+	assert.True(t, IsCloudProviderEnabled("Azure"))
+
+	Datadog.Set("cloud_provider_metadata", "AWS")
+	assert.True(t, IsCloudProviderEnabled("AWS"))
+	assert.False(t, IsCloudProviderEnabled("GCP"))
+	assert.False(t, IsCloudProviderEnabled("Alibaba"))
+	assert.False(t, IsCloudProviderEnabled("Azure"))
+
+	Datadog.Set("cloud_provider_metadata", "none")
+	assert.False(t, IsCloudProviderEnabled("AWS"))
+	assert.False(t, IsCloudProviderEnabled("GCP"))
+	assert.False(t, IsCloudProviderEnabled("Alibaba"))
+	assert.False(t, IsCloudProviderEnabled("Azure"))
 }
 
 func TestEnvNestedConfig(t *testing.T) {

--- a/pkg/util/alibaba/alibaba.go
+++ b/pkg/util/alibaba/alibaba.go
@@ -33,6 +33,9 @@ func IsRunningOn() bool {
 
 // GetHostAlias returns the VM ID from the Alibaba Metadata api
 func GetHostAlias() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	res, err := getResponseWithMaxLength(metadataURL+"/latest/meta-data/instance-id",
 		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {

--- a/pkg/util/azure/azure.go
+++ b/pkg/util/azure/azure.go
@@ -35,6 +35,9 @@ func IsRunningOn() bool {
 
 // GetHostAlias returns the VM ID from the Azure Metadata api
 func GetHostAlias() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	res, err := getResponseWithMaxLength(metadataURL+"/metadata/instance/compute/vmId?api-version=2017-04-02&format=text",
 		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
@@ -45,6 +48,9 @@ func GetHostAlias() (string, error) {
 
 // GetClusterName returns the name of the cluster containing the current VM
 func GetClusterName() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	all, err := getResponse(metadataURL + "/metadata/instance/compute/resourceGroupName?api-version=2017-08-01&format=text")
 	if err != nil {
 		return "", fmt.Errorf("unable to query metadata endpoint: %s", err)

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -32,12 +32,18 @@ var (
 
 // GetInstanceID fetches the instance id for current host from the EC2 metadata API
 func GetInstanceID() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	return getMetadataItemWithMaxLength("/instance-id", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 }
 
 // GetLocalIPv4 gets the local IPv4 for the currently running host using the EC2 metadata API.
 // Returns a []string to implement the HostIPProvider interface expected in pkg/process/util
 func GetLocalIPv4() ([]string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	ip, err := getMetadataItem("/local-ipv4")
 	if err != nil {
 		return nil, err
@@ -55,6 +61,9 @@ func IsRunningOn() bool {
 
 // GetHostname fetches the hostname for current host from the EC2 metadata API
 func GetHostname() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	return getMetadataItemWithMaxLength("/hostname", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 }
 
@@ -62,6 +71,9 @@ func GetHostname() (string, error) {
 // EC2 instances, the the network ID is the VPC ID, if the instance is found to
 // be a part of exactly one VPC.
 func GetNetworkID() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	resp, err := getMetadataItem("/network/interfaces/macs")
 	if err != nil {
 		return "", err
@@ -120,6 +132,9 @@ func getMetadataItem(endpoint string) (string, error) {
 
 // GetClusterName returns the name of the cluster containing the current EC2 instance
 func GetClusterName() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	tags, err := GetTags()
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve clustername from EC2: %s", err)

--- a/pkg/util/ecs/detection.go
+++ b/pkg/util/ecs/detection.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -27,6 +28,9 @@ const (
 
 // IsECSInstance returns whether the agent is running in ECS.
 func IsECSInstance() bool {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return false
+	}
 	_, err := ecsmeta.V1()
 	return err == nil
 }
@@ -36,6 +40,9 @@ func IsECSInstance() bool {
 // This function identifies Fargate on ECS only. Make sure to use the Fargate pkg
 // to identify Fargate instances in other orchestrators (e.g EKS Fargate)
 func IsFargateInstance() bool {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return false
+	}
 	return queryCacheBool(isFargateInstanceCacheKey, func() (bool, time.Duration) {
 
 		// This envvar is set to AWS_ECS_EC2 on classic EC2 instances
@@ -65,6 +72,9 @@ func IsRunningOn() bool {
 // HasEC2ResourceTags returns whether the metadata endpoint in ECS exposes
 // resource tags.
 func HasEC2ResourceTags() bool {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return false
+	}
 	return queryCacheBool(hasEC2ResourceTagsCacheKey, func() (bool, time.Duration) {
 		client, err := ecsmeta.V3FromCurrentTask()
 		if err != nil {
@@ -85,6 +95,9 @@ func HasFargateResourceTags() bool {
 }
 
 func queryCacheBool(cacheKey string, cacheMissEvalFunc func() (bool, time.Duration)) bool {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return false
+	}
 	if cachedValue, found := cache.Cache.Get(cacheKey); found {
 		if v, ok := cachedValue.(bool); ok {
 			return v

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -33,6 +33,9 @@ func IsRunningOn() bool {
 
 // GetHostname returns the hostname querying GCE Metadata api
 func GetHostname() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	hostname, err := getResponseWithMaxLength(metadataURL+"/instance/hostname",
 		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
@@ -43,6 +46,9 @@ func GetHostname() (string, error) {
 
 // GetHostAlias returns the host alias from GCE
 func GetHostAlias() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	instanceName, err := getResponseWithMaxLength(metadataURL+"/instance/name",
 		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
@@ -59,6 +65,9 @@ func GetHostAlias() (string, error) {
 
 // GetClusterName returns the name of the cluster containing the current GCE instance
 func GetClusterName() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	clusterName, err := getResponseWithMaxLength(metadataURL+"/instance/attributes/cluster-name",
 		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
@@ -71,6 +80,9 @@ func GetClusterName() (string, error) {
 // GCE instances, the the network ID is the VPC ID, if the instance is found to
 // be a part of exactly one VPC.
 func GetNetworkID() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
 	resp, err := getResponse(metadataURL + "/instance/network-interfaces/")
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve network-interfaces from GCE: %s", err)

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -243,7 +243,7 @@ func GetHostnameData() (HostnameData, error) {
 				log.Debug(err)
 			}
 		} else {
-			err := fmt.Errorf("not retrieving hostname from AWS: the host is not an ECS instance, and other providers already retrieve non-default hostnames")
+			err := fmt.Errorf("not retrieving hostname from AWS: the host is not an ECS instance and other providers already retrieve non-default hostnames")
 			log.Debug(err.Error())
 			expErr := new(expvar.String)
 			expErr.Set(err.Error())

--- a/releasenotes/notes/cloud_provider_agent_configuration-e722d1992e75ed75.yaml
+++ b/releasenotes/notes/cloud_provider_agent_configuration-e722d1992e75ed75.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Introducing the 'cloud_provider_metadata' option in the Agent configuration
+    to restrict which cloud provider metadata endpoints will be queried.


### PR DESCRIPTION
### What does this PR do?

Adds a cloud_provider_metadata: parameter to agent configuration that is used to only check the user configured cloud provider, rather than ping each cloud provider endpoint to see which, if any, returns a positive response.  All options for this new parameter can be found in the config_template.yaml file.

### Motivation

Scattered complaints the the agent querying cloud provider metadata endpoints were causing false positive firewall alerts on some customer setups
