### PR TITLE
Hide sensitive data from `agent configcheck` command output

### DIFF
--- a/releasenotes/notes/scrub-sensitive-data-from-agent-configcheck-output-33baa8916e28a46f.yaml
+++ b/releasenotes/notes/scrub-sensitive-data-from-agent-configcheck-output-33baa8916e28a46f.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  - |
+    The agent configcheck command output now scrubs sensitive
+    data and prevents API keys, password, token, etc. to
+    appear in the console.


### PR DESCRIPTION
### What does this PR do?
The `agent configcheck` command output now scrubs sensitive data, it makes the `agent configcheck` command behaviour consistent with the `agent config` command (cf. #4802)

### Motivation
Prevent sensitive data to appear in the console and/or being redirected and/or being written somewhere to limit the risk of credentials/passwords/API keys/Tokens/etc. leak. 

### Additional Notes
Reuse logic from ./pkg/util/log/strip.go
