### PR TITLE
Collect and submit systemd version as check metadata

### DIFF
--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -285,8 +285,8 @@ func (c *SystemdCheck) submitVersion(conn *dbus.Conn) {
 		return
 	}
 	checkID := string(c.ID())
+	log.Debugf("Submit version %v for checkID %v", version, checkID)
 	inventories.SetCheckMetadata(checkID, "version.raw", version)
-	log.Debugf("Submitted version %v for checkID %v", version, checkID)
 }
 
 func (c *SystemdCheck) submitMetrics(sender aggregator.Sender, conn *dbus.Conn) error {

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -9,7 +9,6 @@ package systemd
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"strings"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/coreos/go-systemd/dbus"
@@ -200,6 +200,7 @@ func (c *SystemdCheck) Run() error {
 	}
 	defer c.stats.CloseConn(conn)
 
+	c.submitVersion(conn)
 	c.submitSystemdState(sender, conn)
 
 	err = c.submitMetrics(sender, conn)
@@ -208,7 +209,6 @@ func (c *SystemdCheck) Run() error {
 	}
 	sender.Commit()
 
-	c.submitVersion(conn)
 	return nil
 }
 

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -9,6 +9,7 @@ package systemd
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"strings"
 	"time"
 
@@ -146,6 +147,7 @@ type systemdStats interface {
 	SystemState(c *dbus.Conn) (*dbus.Property, error)
 	ListUnits(c *dbus.Conn) ([]dbus.UnitStatus, error)
 	GetUnitTypeProperties(c *dbus.Conn, unitName string, unitType string) (map[string]interface{}, error)
+	GetVersion(c *dbus.Conn) (string, error)
 
 	// Misc
 	UnixNow() int64
@@ -177,6 +179,10 @@ func (s *defaultSystemdStats) GetUnitTypeProperties(c *dbus.Conn, unitName strin
 	return c.GetUnitTypeProperties(unitName, unitType)
 }
 
+func (s *defaultSystemdStats) GetVersion(c *dbus.Conn) (string, error) {
+	return c.GetManagerProperty("Version")
+}
+
 func (s *defaultSystemdStats) UnixNow() int64 {
 	return time.Now().Unix()
 }
@@ -201,6 +207,8 @@ func (c *SystemdCheck) Run() error {
 		return err
 	}
 	sender.Commit()
+
+	c.submitVersion(conn)
 	return nil
 }
 
@@ -268,6 +276,17 @@ func (c *SystemdCheck) getSystemBusSocketConnection() (*dbus.Conn, error) {
 		log.Debugf("Error getting new connection using system bus socket: %v", err)
 	}
 	return conn, err
+}
+
+func (c *SystemdCheck) submitVersion(conn *dbus.Conn) {
+	version, err := c.stats.GetVersion(conn)
+	if err != nil {
+		log.Debugf("Error collection version from the systemd: %v", err)
+		return
+	}
+	checkID := string(c.ID())
+	inventories.SetCheckMetadata(checkID, "version.raw", version)
+	log.Debugf("Submitted version %v for checkID %v", version, checkID)
 }
 
 func (c *SystemdCheck) submitMetrics(sender aggregator.Sender, conn *dbus.Conn) error {

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -281,7 +281,7 @@ func (c *SystemdCheck) getSystemBusSocketConnection() (*dbus.Conn, error) {
 func (c *SystemdCheck) submitVersion(conn *dbus.Conn) {
 	version, err := c.stats.GetVersion(conn)
 	if err != nil {
-		log.Debugf("Error collection version from the systemd: %v", err)
+		log.Debugf("Error collecting version from the systemd: %v", err)
 		return
 	}
 	checkID := string(c.ID())

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -9,12 +9,13 @@ package systemd
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
-	"os"
-	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/metrics"

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -250,6 +250,7 @@ func TestSystemStateCallFailGracefully(t *testing.T) {
 	stats.On("SystemBusSocketConnection").Return(&dbus.Conn{}, nil)
 	stats.On("SystemState", mock.Anything).Return((*dbus.Property)(nil), fmt.Errorf("some error"))
 	stats.On("ListUnits", mock.Anything).Return([]dbus.UnitStatus{}, nil)
+	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
 	check.Configure([]byte(``), []byte(``), "test")

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -270,6 +270,7 @@ func TestSystemStateCallFailGracefully(t *testing.T) {
 func TestListUnitErr(t *testing.T) {
 	stats := createDefaultMockSystemdStats()
 	stats.On("ListUnits", mock.Anything).Return(([]dbus.UnitStatus)(nil), fmt.Errorf("some error"))
+	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
 	check.Configure([]byte(``), []byte(``), "test")

--- a/releasenotes/notes/Collect-and-submit-systemd-version-as-metadata-87533c24e3c2a12a.yaml
+++ b/releasenotes/notes/Collect-and-submit-systemd-version-as-metadata-87533c24e3c2a12a.yaml
@@ -6,6 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-features:
+enhancements:
   - |
     The systemd core check now collects and submits the systemd version as check metadata.

--- a/releasenotes/notes/Collect-and-submit-systemd-version-as-metadata-87533c24e3c2a12a.yaml
+++ b/releasenotes/notes/Collect-and-submit-systemd-version-as-metadata-87533c24e3c2a12a.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The systemd core check now collects and submit the systemd version as check metadata.

--- a/releasenotes/notes/Collect-and-submit-systemd-version-as-metadata-87533c24e3c2a12a.yaml
+++ b/releasenotes/notes/Collect-and-submit-systemd-version-as-metadata-87533c24e3c2a12a.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    The systemd core check now collects and submit the systemd version as check metadata.
+    The systemd core check now collects and submits the systemd version as check metadata.


### PR DESCRIPTION
### What does this PR do?

Collect the systemd version from the dbus connection and submits is in the check metadata payload.
The systemd version consist of a single always-increasing version number that can't be parsed.


### Additional Notes

Anything else we should know when reviewing?
