### PR TITLE
Handle SystemD missing SystemState attribute

### DIFF
--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -203,10 +203,9 @@ func (c *SystemdCheck) connect(sender aggregator.Sender) (*dbus.Conn, error) {
 		newErr := fmt.Errorf("cannot create a connection: %v", err)
 		sender.ServiceCheck(canConnectServiceCheck, metrics.ServiceCheckCritical, "", nil, newErr.Error())
 		return nil, newErr
-	} else {
-		sender.ServiceCheck(canConnectServiceCheck, metrics.ServiceCheckOK, "", nil, "")
-		return conn, nil
 	}
+	sender.ServiceCheck(canConnectServiceCheck, metrics.ServiceCheckOK, "", nil, "")
+	return conn, nil
 }
 
 func (c *SystemdCheck) submitSystemdState(sender aggregator.Sender, conn *dbus.Conn) {

--- a/releasenotes/notes/handdle_systemd_missing_systemstate-b42a10c8033cc6bc.yaml
+++ b/releasenotes/notes/handdle_systemd_missing_systemstate-b42a10c8033cc6bc.yaml
@@ -9,5 +9,3 @@
 fixes:
   - |
     Make ``systemd`` core check handle gracefully missing ``SystemState`` attribute.
-    ``SystemState`` attribute is only available from ``systemd`` version 212.
-    Source: https://github.com/systemd/systemd/blob/d4ffda38716d33dbc17faaa12034ccb77d0ed68b/NEWS#L7292-L7300

--- a/releasenotes/notes/handdle_systemd_missing_systemstate-b42a10c8033cc6bc.yaml
+++ b/releasenotes/notes/handdle_systemd_missing_systemstate-b42a10c8033cc6bc.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Make ``systemd`` core check handle gracefully missing ``SystemState`` attribute.
+    ``SystemState`` attribute is only available from ``systemd`` version 212.
+    Source: https://github.com/systemd/systemd/blob/d4ffda38716d33dbc17faaa12034ccb77d0ed68b/NEWS#L7292-L7300


### PR DESCRIPTION
### What does this PR do?

Handle SystemD missing SystemState attribute

### Motivation

SystemState is only available from `SystemD` version 212: 

https://github.com/systemd/systemd/blob/d4ffda38716d33dbc17faaa12034ccb77d0ed68b/NEWS#L7292-L7300

`sles12-sp1` uses systemd v210

### Additional Notes

The new TODOs (lower priority) will be addressed in separate PRs.
