### PR TITLE
pkg/trace/stats: calculate sublayer trace metrics for measured spans

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -207,7 +207,7 @@ func (a *Agent) Process(t *api.Trace) {
 	// which is not thread-safe while samplers and Concentrator might modify it too.
 	traceutil.ComputeTopLevel(t.Spans)
 
-	subtraces := stats.ExtractTopLevelSubtraces(t.Spans, root)
+	subtraces := stats.ExtractSubtraces(t.Spans, root)
 	sublayers := make(map[*pb.Span][]stats.SublayerValue)
 	for _, subtrace := range subtraces {
 		subtraceSublayers := stats.ComputeSublayers(subtrace.Trace)

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -435,7 +435,7 @@ func TestConcentratorSublayersStatsCounts(t *testing.T) {
 	traceutil.ComputeTopLevel(trace)
 	wt := NewWeightedTrace(trace, traceutil.GetRoot(trace))
 
-	subtraces := ExtractTopLevelSubtraces(trace, traceutil.GetRoot(trace))
+	subtraces := ExtractSubtraces(trace, traceutil.GetRoot(trace))
 	sublayers := make(map[*pb.Span][]SublayerValue)
 	for _, subtrace := range subtraces {
 		subtraceSublayers := ComputeSublayers(subtrace.Trace)
@@ -539,15 +539,18 @@ func TestConcentratorAddNow(t *testing.T) {
 				testSpan(3, 2, 50, 5, "A1", "resource1", 0),
 			},
 			map[string]float64{
-				"query|duration|env:none,resource:resource1,service:A1":                                           50,
-				"query|hits|env:none,resource:resource1,service:A1":                                               1,
-				"query|errors|env:none,resource:resource1,service:A1":                                             0,
-				"query|_sublayers.duration.by_service|env:none,resource:resource1,service:A1,sublayer_service:A1": 140,
-				"query|_sublayers.duration.by_type|env:none,resource:resource1,service:A1,sublayer_type:db":       140,
-				"query|_sublayers.span_count|env:none,resource:resource1,service:A1,:":                            3,
-				"custom_query_op|duration|env:none,resource:resource1,service:A1":                                 40,
-				"custom_query_op|hits|env:none,resource:resource1,service:A1":                                     1,
-				"custom_query_op|errors|env:none,resource:resource1,service:A1":                                   1,
+				"query|duration|env:none,resource:resource1,service:A1":                                                     50,
+				"query|hits|env:none,resource:resource1,service:A1":                                                         1,
+				"query|errors|env:none,resource:resource1,service:A1":                                                       0,
+				"query|_sublayers.duration.by_service|env:none,resource:resource1,service:A1,sublayer_service:A1":           140,
+				"query|_sublayers.duration.by_type|env:none,resource:resource1,service:A1,sublayer_type:db":                 140,
+				"query|_sublayers.span_count|env:none,resource:resource1,service:A1,:":                                      3,
+				"custom_query_op|duration|env:none,resource:resource1,service:A1":                                           40,
+				"custom_query_op|hits|env:none,resource:resource1,service:A1":                                               1,
+				"custom_query_op|errors|env:none,resource:resource1,service:A1":                                             1,
+				"custom_query_op|_sublayers.duration.by_service|env:none,resource:resource1,service:A1,sublayer_service:A1": 90,
+				"custom_query_op|_sublayers.duration.by_type|env:none,resource:resource1,service:A1,sublayer_type:db":       90,
+				"custom_query_op|_sublayers.span_count|env:none,resource:resource1,service:A1,:":                            2,
 			},
 		},
 	} {
@@ -559,7 +562,7 @@ func TestConcentratorAddNow(t *testing.T) {
 				Env:   "none",
 				Trace: wt,
 			}
-			subtraces := ExtractTopLevelSubtraces(test.in, traceutil.GetRoot(test.in))
+			subtraces := ExtractSubtraces(test.in, traceutil.GetRoot(test.in))
 			sublayers := make(map[*pb.Span][]SublayerValue)
 			for _, subtrace := range subtraces {
 				subtraceSublayers := ComputeSublayers(subtrace.Trace)

--- a/pkg/trace/stats/subtrace.go
+++ b/pkg/trace/stats/subtrace.go
@@ -52,9 +52,9 @@ func (s *stack) Pop() *spanAndAncestors {
 	return value
 }
 
-// ExtractTopLevelSubtraces extracts all subtraces rooted in a toplevel span,
-// ComputeTopLevel should be called before.
-func ExtractTopLevelSubtraces(t pb.Trace, root *pb.Span) []Subtrace {
+// ExtractSubtraces extracts all subtraces rooted in top-level/measured spans.
+// ComputeTopLevel should be called before so that top-level spans are identified.
+func ExtractSubtraces(t pb.Trace, root *pb.Span) []Subtrace {
 	if root == nil {
 		return []Subtrace{}
 	}
@@ -68,9 +68,9 @@ func ExtractTopLevelSubtraces(t pb.Trace, root *pb.Span) []Subtrace {
 
 	// We do a DFS on the trace to record the toplevel ancesters of each span
 	for current := next.Pop(); current != nil; current = next.Pop() {
-		// We do not extract subtraces for toplevel spans that have no children
-		// since these are not interresting
-		if traceutil.HasTopLevel(current.Span) && len(childrenMap[current.Span.SpanID]) > 0 {
+		// We do not extract subtraces for top-level/measured spans that have no children
+		// since these are not interesting
+		if (traceutil.HasTopLevel(current.Span) || traceutil.IsMeasured(current.Span)) && len(childrenMap[current.Span.SpanID]) > 0 {
 			current.Ancestors = append(current.Ancestors, current.Span)
 		}
 		visited[current.Span] = true

--- a/pkg/trace/stats/subtrace_test.go
+++ b/pkg/trace/stats/subtrace_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExtractTopLevelSubtracesWithSimpleTrace(t *testing.T) {
+func TestExtractSubtracesWithSimpleTrace(t *testing.T) {
 	assert := assert.New(t)
 
 	trace := pb.Trace{
@@ -30,7 +30,7 @@ func TestExtractTopLevelSubtracesWithSimpleTrace(t *testing.T) {
 	}
 
 	traceutil.ComputeTopLevel(trace)
-	subtraces := ExtractTopLevelSubtraces(trace, trace[0])
+	subtraces := ExtractSubtraces(trace, trace[0])
 
 	assert.Equal(len(expected), len(subtraces))
 
@@ -44,7 +44,7 @@ func TestExtractTopLevelSubtracesWithSimpleTrace(t *testing.T) {
 	}
 }
 
-func TestExtractTopLevelSubtracesShouldIgnoreLeafTopLevel(t *testing.T) {
+func TestExtractSubtracesShouldIgnoreLeafTopLevel(t *testing.T) {
 	assert := assert.New(t)
 
 	trace := pb.Trace{
@@ -60,7 +60,7 @@ func TestExtractTopLevelSubtracesShouldIgnoreLeafTopLevel(t *testing.T) {
 	}
 
 	traceutil.ComputeTopLevel(trace)
-	subtraces := ExtractTopLevelSubtraces(trace, trace[0])
+	subtraces := ExtractSubtraces(trace, trace[0])
 
 	assert.Equal(len(expected), len(subtraces))
 
@@ -74,7 +74,7 @@ func TestExtractTopLevelSubtracesShouldIgnoreLeafTopLevel(t *testing.T) {
 	}
 }
 
-func TestExtractTopLevelSubtracesWorksInSpiteOfCycles(t *testing.T) {
+func TestExtractSubtracesWorksInSpiteOfCycles(t *testing.T) {
 	assert := assert.New(t)
 
 	trace := pb.Trace{
@@ -89,7 +89,7 @@ func TestExtractTopLevelSubtracesWorksInSpiteOfCycles(t *testing.T) {
 	}
 
 	traceutil.ComputeTopLevel(trace)
-	subtraces := ExtractTopLevelSubtraces(trace, trace[0])
+	subtraces := ExtractSubtraces(trace, trace[0])
 
 	assert.Equal(len(expected), len(subtraces))
 
@@ -101,4 +101,39 @@ func TestExtractTopLevelSubtracesWorksInSpiteOfCycles(t *testing.T) {
 	for _, s := range expected {
 		assert.ElementsMatch(s.Trace, subtracesMap[s.Root].Trace)
 	}
+}
+
+// TestExtractSubtracesMeasuredSpans tests that subtraces are correctly
+// extracted for measured spans.
+func TestExtractSubtracesMeasuredSpans(t *testing.T) {
+	assert := assert.New(t)
+
+	trace := pb.Trace{
+		&pb.Span{SpanID: 1, ParentID: 0, Service: "s1"},
+		&pb.Span{SpanID: 2, ParentID: 1, Service: "s1"},
+		// measured span has two child leaf spans
+		&pb.Span{SpanID: 3, ParentID: 2, Service: "s1", Metrics: map[string]float64{"_dd.measured": 1.0}},
+		&pb.Span{SpanID: 4, ParentID: 3, Service: "s2"},
+		&pb.Span{SpanID: 5, ParentID: 3, Service: "s3"},
+	}
+
+	expected := []Subtrace{
+		{trace[0], trace},
+		{trace[2], []*pb.Span{trace[2], trace[3], trace[4]}},
+	}
+
+	traceutil.ComputeTopLevel(trace)
+	subtraces := ExtractSubtraces(trace, trace[0])
+
+	assert.Equal(len(expected), len(subtraces))
+
+	subtracesMap := make(map[*pb.Span]Subtrace)
+	for _, s := range subtraces {
+		subtracesMap[s.Root] = s
+	}
+
+	for _, s := range expected {
+		assert.ElementsMatch(s.Trace, subtracesMap[s.Root].Trace)
+	}
+
 }

--- a/releasenotes/notes/apm-calculate-sublayer-metrics-for-measured-spans-5c55eada5df19485.yaml
+++ b/releasenotes/notes/apm-calculate-sublayer-metrics-for-measured-spans-5c55eada5df19485.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Add support for calculating trace sublayer metrics for measured spans.
+    APM: Add support for calculating trace sublayer metrics for measured spans.

--- a/releasenotes/notes/apm-calculate-sublayer-metrics-for-measured-spans-5c55eada5df19485.yaml
+++ b/releasenotes/notes/apm-calculate-sublayer-metrics-for-measured-spans-5c55eada5df19485.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for calculating trace sublayer metrics for measured spans.


### PR DESCRIPTION
### What does this PR do?

Builds on top of measured span support by adding trace sublayer metric calculation.

### Motivation

To ensure that trace metric coverage has parity between existing top-level spans and new measured spans.
