### PR TITLE
Mount the directory containing the docker socket instead of the socket itself

### DIFF
--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -29,6 +29,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+          - {name: DD_CRI_SOCKET_PATH, value: /host/var/run/docker.sock}
+          - {name: DOCKER_HOST, value: unix:///host/var/run/docker.sock}
         resources:
           requests:
             memory: "256Mi"
@@ -37,7 +39,7 @@ spec:
             memory: "256Mi"
             cpu: "200m"
         volumeMounts:
-          - {name: dockersocket, mountPath: /var/run/docker.sock}
+          - {name: dockersocketdir, mountPath: /host/var/run}
           - {name: procdir, mountPath: /host/proc, readOnly: true}
           - {name: cgroups, mountPath: /host/sys/fs/cgroup, readOnly: true}
           - {name: s6-run, mountPath: /var/run/s6}
@@ -51,7 +53,7 @@ spec:
           successThreshold: 1
           failureThreshold: 3
       volumes:
-        - {name: dockersocket, hostPath: {path: /var/run/docker.sock}}
+        - {name: dockersocketdir, hostPath: {path: /var/run}}
         - {name: procdir, hostPath: {path: /proc}}
         - {name: cgroups, hostPath: {path: /sys/fs/cgroup}}
         - {name: s6-run, emptyDir: {}}


### PR DESCRIPTION
### What does this PR do?

In the agent container of the datadog-agent DaemonSet, mount the directory containing the docker socket instead of directly the socket itself.

### Motivation

This is to handle the cases where the docker daemon is restarted.
In this case, the docker daemon will recreate its docker socket.
On k8s context, the containers will not be restarted.
And, if the agent container bind-mounted directly the socket, the container would still have access to the old socket instead of the one of the new docker daemon.
As a consequence, with a bind-mount of the socket directly, a docker restart disconnects the agent from docker forever; until the agent POD is destroyed and recreated.

On the other hand, if we bind-mount the directory containing the socket, when the daemon recreates a new socket following a restart, it will be visible from the agent container. The agent will be disconnected from the old socket, and it will reconnect on the new one.

### Additional Notes

Anything else we should know when reviewing?
