### PR TITLE
api: avoid the obfuscation of the errors mentioning auth token.

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -124,13 +124,13 @@ func FetchAuthToken() (string, error) {
 		key := make([]byte, authTokenMinimalLen)
 		_, e = rand.Read(key)
 		if e != nil {
-			return "", fmt.Errorf("error creating authentication token: %s", e)
+			return "", fmt.Errorf("can't create agent authentication token value: %s", e)
 		}
 
 		// Write the auth token to the auth token file (platform-specific)
 		e = saveAuthToken(hex.EncodeToString(key), authTokenFile)
 		if e != nil {
-			return "", fmt.Errorf("error creating authentication token: %s", e)
+			return "", fmt.Errorf("error writing authentication token file on fs: %s", e)
 		}
 		log.Infof("Saved a new authentication token to %s", authTokenFile)
 	}
@@ -138,7 +138,7 @@ func FetchAuthToken() (string, error) {
 	// Read the token
 	authTokenRaw, e := ioutil.ReadFile(authTokenFile)
 	if e != nil {
-		return "", fmt.Errorf("unable to access authentication token: " + e.Error())
+		return "", fmt.Errorf("unable to access authentication token file: " + e.Error())
 	}
 
 	// Do some basic validation
@@ -177,13 +177,13 @@ func GetClusterAgentAuthToken() (string, error) {
 		key := make([]byte, authTokenMinimalLen)
 		_, e = rand.Read(key)
 		if e != nil {
-			return "", fmt.Errorf("error creating authentication token: %s", e)
+			return "", fmt.Errorf("can't create cluster agent authentication token value: %s", e)
 		}
 
 		// Write the auth token to the auth token file (platform-specific)
 		e = saveAuthToken(hex.EncodeToString(key), tokenAbsPath)
 		if e != nil {
-			return "", fmt.Errorf("error creating authentication token: %s", e)
+			return "", fmt.Errorf("error writing authentication token file on fs: %s", e)
 		}
 		log.Infof("Saved a new authentication token for the Cluster Agent at %s", tokenAbsPath)
 	}

--- a/releasenotes/notes/auth-token-err-log-6f23d6be744dd32d.yaml
+++ b/releasenotes/notes/auth-token-err-log-6f23d6be744dd32d.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Errors mentioning the authentication token are now more specific and
+    won't be obfuscated anymore.


### PR DESCRIPTION
### What does this PR do?

The `token:` pattern was catched by an obfuscation regexp, we took the opportunity to differentiate the errors thrown while something bad happen during the authentication token initialization and to avoid using the `token:` pattern in the errors string.

### QA

Set the `auth_token_file_path` config field to something random (or on a directory where you don't have permissions) to throw some errors during Agent startup.