### PR TITLE
Blacklist aerospike dependency

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -57,15 +57,11 @@ blacklist_folders = [
 # package names of dependencies that won't be added to the Agent Python environment
 blacklist_packages = Array.new
 
-if suse?
-  blacklist_folders.push('aerospike')  # Temporarily blacklist Aerospike until builder supports new dependency
-  blacklist_packages.push(/^aerospike==/)  # Temporarily blacklist Aerospike until builder supports new dependency
-end
+blacklist_packages.push(/^aerospike==/)
+blacklist_folders.push('aerospike')
 
 if arm?
   # These two checks don't build on ARM
-  blacklist_folders.push('aerospike')
-  blacklist_packages.push(/^aerospike==/)
   blacklist_folders.push('ibm_mq')
   blacklist_packages.push(/^pymqi==/)
 end

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -58,15 +58,11 @@ blacklist_folders = [
 # package names of dependencies that won't be added to the Agent Python environment
 blacklist_packages = Array.new
 
-if suse?
-  blacklist_folders.push('aerospike')  # Temporarily blacklist Aerospike until builder supports new dependency
-  blacklist_packages.push(/^aerospike==/)  # Temporarily blacklist Aerospike until builder supports new dependency
-end
+blacklist_packages.push(/^aerospike==/)
+blacklist_folders.push('aerospike')
 
 if arm?
   # These two checks don't build on ARM
-  blacklist_folders.push('aerospike')
-  blacklist_packages.push(/^aerospike==/)
   blacklist_folders.push('ibm_mq')
   blacklist_packages.push(/^pymqi==/)
 end


### PR DESCRIPTION
### What does this PR do?

Blacklists the download of the aerospike package until #4933 is merged, as it's breaking builds.

### Motivation

Being able to correctly test package builds.
