### PR TITLE
[omnibus] Fix aerospike_client software definition and cleanup aerospike build

### DIFF
--- a/omnibus/config/software/aerospike-client.rb
+++ b/omnibus/config/software/aerospike-client.rb
@@ -5,13 +5,13 @@ name "aerospike-client"
 # https://github.com/aerospike/aerospike-client-python/blob/3.10.0/setup.py#L32-L33
 default_version "4.6.10"
 
+source git: "git://github.com/aerospike/aerospike-client-c.git",
+       submodules: true
+
 build do
   # The binary wheels on PyPI are not yet compatible with OpenSSL 1.1.0+, see:
   # https://github.com/aerospike/aerospike-client-python/issues/214#issuecomment-385451007
   # https://github.com/aerospike/aerospike-client-python/issues/227#issuecomment-423220411
-  command "git clone https://github.com/aerospike/aerospike-client-c.git ./aerospike"
-  command "git checkout #{version}", cwd: "#{project_dir}/aerospike"
-  command "git submodule update --init", cwd: "#{project_dir}/aerospike"
 
   env = {
     "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
@@ -19,7 +19,7 @@ build do
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
   }
 
-  command "make clean", :env => env, cwd: "#{project_dir}/aerospike"
+  command "make clean", :env => env
   # make fails if used with multiple parallel jobs when building the aerospike client
-  command "make", :env => env, cwd: "#{project_dir}/aerospike"
+  command "make", :env => env
 end

--- a/omnibus/config/software/aerospike-client.rb
+++ b/omnibus/config/software/aerospike-client.rb
@@ -15,7 +15,7 @@ build do
 
   env = {
     "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "EXT_CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
   }
 

--- a/omnibus/config/software/aerospike-client.rb
+++ b/omnibus/config/software/aerospike-client.rb
@@ -9,9 +9,9 @@ build do
   # The binary wheels on PyPI are not yet compatible with OpenSSL 1.1.0+, see:
   # https://github.com/aerospike/aerospike-client-python/issues/214#issuecomment-385451007
   # https://github.com/aerospike/aerospike-client-python/issues/227#issuecomment-423220411
-  command "git clone https://github.com/aerospike/aerospike-client-c.git #{install_dir}/embedded/lib/aerospike"
-  command "cd #{install_dir}/embedded/lib/aerospike && git checkout #{version}"
-  command "cd #{install_dir}/embedded/lib/aerospike && git submodule update --init"
+  command "git clone https://github.com/aerospike/aerospike-client-c.git ./aerospike"
+  command "git checkout #{version}", cwd: "#{project_dir}/aerospike"
+  command "git submodule update --init", cwd: "#{project_dir}/aerospike"
 
   env = {
     "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
@@ -19,6 +19,7 @@ build do
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
   }
 
-  command "cd #{install_dir}/embedded/lib/aerospike && make clean", :env => env
-  command "cd #{install_dir}/embedded/lib/aerospike && make", :env => env
+  command "make clean", :env => env, cwd: "#{project_dir}/aerospike"
+  # make fails if used with multiple parallel jobs when building the aerospike client
+  command "make", :env => env, cwd: "#{project_dir}/aerospike"
 end

--- a/omnibus/config/software/aerospike-py2.rb
+++ b/omnibus/config/software/aerospike-py2.rb
@@ -7,7 +7,7 @@ dependency "pip2"
 build do
   env = {
     "DOWNLOAD_C_CLIENT" => "0",
-    "AEROSPIKE_C_HOME" => "#{Omnibus::Config.source_dir()}/aerospike-client/aerospike",
+    "AEROSPIKE_C_HOME" => "#{Omnibus::Config.source_dir()}/aerospike-client",
   }
 
   command "#{install_dir}/embedded/bin/pip2 install --no-binary :all: aerospike==#{version}", :env => env

--- a/omnibus/config/software/aerospike-py2.rb
+++ b/omnibus/config/software/aerospike-py2.rb
@@ -7,7 +7,7 @@ dependency "pip2"
 build do
   env = {
     "DOWNLOAD_C_CLIENT" => "0",
-    "AEROSPIKE_C_HOME" => "#{install_dir}/embedded/lib/aerospike",
+    "AEROSPIKE_C_HOME" => "#{Omnibus::Config.source_dir()}/aerospike-client/aerospike",
   }
 
   command "#{install_dir}/embedded/bin/pip2 install --no-binary :all: aerospike==#{version}", :env => env

--- a/omnibus/config/software/aerospike-py3.rb
+++ b/omnibus/config/software/aerospike-py3.rb
@@ -7,7 +7,7 @@ dependency "pip3"
 build do
   env = {
     "DOWNLOAD_C_CLIENT" => "0",
-    "AEROSPIKE_C_HOME" => "#{Omnibus::Config.source_dir()}/aerospike-client/aerospike",
+    "AEROSPIKE_C_HOME" => "#{Omnibus::Config.source_dir()}/aerospike-client",
   }
 
   command "#{install_dir}/embedded/bin/pip3 install --no-binary :all: aerospike==#{version}", :env => env

--- a/omnibus/config/software/aerospike-py3.rb
+++ b/omnibus/config/software/aerospike-py3.rb
@@ -7,7 +7,7 @@ dependency "pip3"
 build do
   env = {
     "DOWNLOAD_C_CLIENT" => "0",
-    "AEROSPIKE_C_HOME" => "#{install_dir}/embedded/lib/aerospike",
+    "AEROSPIKE_C_HOME" => "#{Omnibus::Config.source_dir()}/aerospike-client/aerospike",
   }
 
   command "#{install_dir}/embedded/bin/pip3 install --no-binary :all: aerospike==#{version}", :env => env


### PR DESCRIPTION
### What does this PR do?

Uses `EXT_CFLAGS` instead of `CFLAGS` during aerospike C client build.
Builds the C client outside of the install_dir to avoid shipping it (it's not needed at runtime).

### Motivation

Make aerospike build work.
