### PR TITLE
Update default yaml file to reflect HTTPS log parameters

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -418,11 +418,23 @@ api_key:
   #     name: <RULE_NAME>
   #     pattern: <RULE_PATTERN>
 
-  ## @param use_port_443 - boolean - optional - default: false
-  ## By default, logs are sent to port 10516 *for the US site*, use this parameter
-  ## to force the Agent to send logs in TCP to port 443.
+  ## @param use_http - boolean - optional - default: false
+  ## By default, logs are sent through TCP, use this parameter to for the Agent  
+  ## to send logs in HTTPS batches to port 443
   #
-  # use_port_443: false
+  # use_http: true
+
+  ## @param use_compression - boolean - optional - default: false
+  ## Available when sending logs in HTTPS. When enabled, the Agent
+  ## compresses logs before sending them
+  #
+  # use_compression: true
+  
+  ## @param compression_level - integer - optional - default: 6
+  ## The compression_level parameter accepts values from 0 (no compression) 
+  ## to 9 (maximum compression but higher resource usage).
+  #
+  # compression_level: 6
 
 {{ end -}}
 {{- if .TraceAgent }}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -419,14 +419,14 @@ api_key:
   #     pattern: <RULE_PATTERN>
 
   ## @param use_http - boolean - optional - default: false
-  ## By default, logs are sent through TCP, use this parameter to for the Agent  
+  ## By default, logs are sent through TCP, use this parameter
   ## to send logs in HTTPS batches to port 443
   #
   # use_http: true
 
   ## @param use_compression - boolean - optional - default: false
-  ## Available when sending logs in HTTPS. When enabled, the Agent
-  ## compresses logs before sending them
+  ## This parameter is available when sending logs with HTTPS. If enabled, the Agent
+  ## compresses logs before sending them.
   #
   # use_compression: true
   


### PR DESCRIPTION
### What does this PR do?

Update the default datadog.yaml file to reflect HTTPS forwarding parameters

### Motivation

We strongly recommend to use HTTPS and it was not listed in the parameters in the default datadog.yaml file

### Additional Notes

Anything else we should know when reviewing?
