### PR TITLE
Remove windows puppy builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1315,7 +1315,7 @@ deploy_windows_testing-a6:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "windows_msi_x86-a6", "windows_msi_x64-a6"]
+  needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1327,7 +1327,7 @@ deploy_windows_testing-a7:
   <<: *run_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "windows_msi_x86-a7", "windows_msi_x64-a7"]
+  needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,6 +148,16 @@ before_script:
       - $RELEASE_VERSION_6 == "nightly"
       - $RELEASE_VERSION_7 == "nightly"
 
+# run job only when triggered on nightly AND when it's a merge to master
+.run_when_triggered_on_nightly_or_master: &run_when_triggered_on_nightly_or_master
+  only:
+    refs:
+      - triggers
+      - master
+    variables:
+      - $RELEASE_VERSION_6 == "nightly"
+      - $RELEASE_VERSION_7 == "nightly"
+
 # skip job only when triggered by an external tool (ex: Jenkins) and when
 # BUILD_AGENT_X is set to "no".
 
@@ -235,6 +245,7 @@ run_tests_windows-x64:
     ARCH: "x64"
 
 run_tests_windows-x86:
+  <<: *run_when_triggered_on_nightly_or_master
   # temporarily allow failure for tests
   extends: .run_tests_windows_base
   allow_failure: true
@@ -978,6 +989,7 @@ windows_msi_x86-a7:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_7
   <<: *skip_when_unwanted_on_7
+  <<: *run_when_triggered_on_nightly_or_master
 
 windows_msi_x64-a6:
   extends: .windows_main_agent_base
@@ -998,29 +1010,12 @@ windows_msi_x86-a6:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_6
   <<: *skip_when_unwanted_on_6
+  <<: *run_when_triggered_on_nightly_or_master
 
 .windows_puppy_agent_base:
   extends: .windows_msi_base
   variables:
     OMNIBUS_TARGET: puppy
-
-windows_puppy_msi_x64-a7:
-  extends: .windows_puppy_agent_base
-  variables:
-    ARCH: "x64"
-    AGENT_MAJOR_VERSION: '7'
-  before_script:
-    - set RELEASE_VERSION $RELEASE_VERSION_7
-  <<: *skip_when_unwanted_on_7
-
-windows_puppy_msi_x86-a7:
-  extends: .windows_puppy_agent_base
-  variables:
-    ARCH: "x86"
-    AGENT_MAJOR_VERSION: '7'
-  before_script:
-    - set RELEASE_VERSION $RELEASE_VERSION_7
-  <<: *skip_when_unwanted_on_7
 
 
 # build dogstatsd package for Windows
@@ -1042,6 +1037,7 @@ agent_android_apk:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   <<: *skip_when_unwanted_on_7
+  <<: *run_when_triggered_on_nightly_or_master
   before_script:
     - echo running android before_script
     - cd $SRC_PATH


### PR DESCRIPTION
reduce frequency of 32 bit tests & bulds

### What does this PR do?

Remove/reduce some unused jobs to try to reduce congestion in build pipeline

