### PR TITLE
forwarder health refactor

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -986,7 +986,7 @@ func ComputeAPIDomain(domain string) (string, error) {
 	apiDomain := ""
 	parsedDomain, err := url.Parse(domain)
 	if err != nil {
-		return "", fmt.Errorf("Could not parse %s as a URL", domain)
+		return "", fmt.Errorf("could not parse %s as a URL", domain)
 	}
 	if _, found := ddURLs[parsedDomain.Host]; found {
 		apiDomain = strings.Replace(domain, "app.", "api.", 1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -982,7 +982,7 @@ func getMultipleEndpointsWithConfig(config Config) (map[string][]string, error) 
 }
 
 // ComputeAPIDomain returns a domain to be used for API validation
-func ComputeAPIDomain(domain string) string {
+func ComputeAPIDomain(domain string) (string, error) {
 	apiDomain := ""
 	if parsedDomain, err := url.Parse(domain); err == nil {
 		if _, found := ddURLs[parsedDomain.Host]; found {
@@ -990,10 +990,12 @@ func ComputeAPIDomain(domain string) string {
 		} else {
 			apiDomain = domain
 		}
-		return apiDomain
+		return apiDomain, nil
+	} else {
+		return "", err
 	}
-	log.Debugf("Parsing Warning: The domain %s was unable to be parsed for API Validation, the agent will continue to use this domain for API validation instead.", domain)
-	return domain
+	// if no match is found, return the original domain
+	return domain, nil
 }
 
 // IsContainerized returns whether the Agent is running on a Docker container

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -984,18 +984,16 @@ func getMultipleEndpointsWithConfig(config Config) (map[string][]string, error) 
 // ComputeAPIDomain returns a domain to be used for API validation
 func ComputeAPIDomain(domain string) (string, error) {
 	apiDomain := ""
-	if parsedDomain, err := url.Parse(domain); err == nil {
-		if _, found := ddURLs[parsedDomain.Host]; found {
-			apiDomain = strings.Replace(domain, "app.", "api.", 1)
-		} else {
-			apiDomain = domain
-		}
-		return apiDomain, nil
-	} else {
-		return "", err
+	parsedDomain, err := url.Parse(domain)
+	if err != nil {
+		return "", fmt.Errorf("Could not parse %s as a URL", domain)
 	}
-	// if no match is found, return the original domain
-	return domain, nil
+	if _, found := ddURLs[parsedDomain.Host]; found {
+		apiDomain = strings.Replace(domain, "app.", "api.", 1)
+	} else {
+		apiDomain = domain
+	}
+	return apiDomain, nil
 }
 
 // IsContainerized returns whether the Agent is running on a Docker container

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -984,13 +984,16 @@ func getMultipleEndpointsWithConfig(config Config) (map[string][]string, error) 
 // ComputeAPIDomain returns a domain to be used for API validation
 func ComputeAPIDomain(domain string) string {
 	apiDomain := ""
-	matcher := strings.Replace(domain, "https://", "", 1)
-	if _, found := ddURLs[matcher]; found {
-		apiDomain = strings.Replace(domain, "app.", "api.", 1)
-	} else {
-		apiDomain = domain
+	if parsedDomain, err := url.Parse(domain); err == nil {
+		if _, found := ddURLs[parsedDomain.Host]; found {
+			apiDomain = strings.Replace(domain, "app.", "api.", 1)
+		} else {
+			apiDomain = domain
+		}
+		return apiDomain
 	}
-	return apiDomain
+	log.Debugf("Parsing Warning: The domain %s was unable to be parsed for API Validation, the agent will continue to use this domain for API validation instead.", domain)
+	return domain
 }
 
 // IsContainerized returns whether the Agent is running on a Docker container

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -981,6 +981,18 @@ func getMultipleEndpointsWithConfig(config Config) (map[string][]string, error) 
 	return keysPerDomain, nil
 }
 
+// ComputeAPIDomain returns a domain to be used for API validation
+func ComputeAPIDomain(domain string) string {
+	apiDomain := ""
+	matcher := strings.Replace(domain, "https://", "", 1)
+	if _, found := ddURLs[matcher]; found {
+		apiDomain = strings.Replace(domain, "app.", "api.", 1)
+	} else {
+		apiDomain = domain
+	}
+	return apiDomain
+}
+
 // IsContainerized returns whether the Agent is running on a Docker container
 func IsContainerized() bool {
 	return os.Getenv("DOCKER_DD_AGENT") != ""

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -709,6 +709,9 @@ func TestComputeAPIDomain(t *testing.T) {
 		parsedDomains = append(parsedDomains, apiDomain)
 	}
 	assert.Equal(t, match, parsedDomains)
+	_, err := ComputeAPIDomain(":datadoghq.com")
+	assert.Error(t, err)
+
 }
 
 // TestSecretBackendWithMultipleEndpoints tests an edge case of `viper.AllSettings()` when a config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -685,12 +685,30 @@ process_config:
 }
 
 func TestComputeAPIDomain(t *testing.T) {
-	testDomain := "https://app.datadoghq.com"
-	matchDomain := "https://api.datadoghq.com"
-	apiDomain, err := ComputeAPIDomain(testDomain)
+	parsedDomains := []string{}
 
-	assert.NoError(t, err)
-	assert.Equal(t, matchDomain, apiDomain)
+	domains := []string{
+		"https://app.datadoghq.com",
+		"https://app.datadoghq.eu",
+		"https://app.datad0g.com",
+		"https://app.datad0g.eu",
+		"https://custom.datadoghq.com",
+		"https://nochange.com",
+	}
+	match := []string{
+		"https://api.datadoghq.com",
+		"https://api.datadoghq.eu",
+		"https://api.datad0g.com",
+		"https://api.datad0g.eu",
+		"https://custom.datadoghq.com",
+		"https://nochange.com",
+	}
+	for _, domain := range domains {
+		apiDomain, err := ComputeAPIDomain(domain)
+		assert.NoError(t, err)
+		parsedDomains = append(parsedDomains, apiDomain)
+	}
+	assert.Equal(t, match, parsedDomains)
 }
 
 // TestSecretBackendWithMultipleEndpoints tests an edge case of `viper.AllSettings()` when a config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -684,6 +684,14 @@ process_config:
 	}
 }
 
+func TestComputeAPIDomain(t *testing.T) {
+	testDomain := "https://app.datadoghq.com"
+	matchDomain := "https://api.datadoghq.com"
+	apiDomain := ComputeAPIDomain(testDomain)
+
+	assert.Equal(t, apiDomain, matchDomain)
+}
+
 // TestSecretBackendWithMultipleEndpoints tests an edge case of `viper.AllSettings()` when a config
 // key includes the key delimiter. Affects the config package when both secrets and multiple
 // endpoints are configured.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -687,8 +687,9 @@ process_config:
 func TestComputeAPIDomain(t *testing.T) {
 	testDomain := "https://app.datadoghq.com"
 	matchDomain := "https://api.datadoghq.com"
-	apiDomain := ComputeAPIDomain(testDomain)
+	apiDomain, err := ComputeAPIDomain(testDomain)
 
+	assert.NoError(t, err)
 	assert.Equal(t, matchDomain, apiDomain)
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -689,7 +689,7 @@ func TestComputeAPIDomain(t *testing.T) {
 	matchDomain := "https://api.datadoghq.com"
 	apiDomain := ComputeAPIDomain(testDomain)
 
-	assert.Equal(t, apiDomain, matchDomain)
+	assert.Equal(t, matchDomain, apiDomain)
 }
 
 // TestSecretBackendWithMultipleEndpoints tests an edge case of `viper.AllSettings()` when a config

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -130,7 +130,7 @@ func NewDefaultForwarder(keysPerDomains map[string][]string) *DefaultForwarder {
 		domainForwarders: map[string]*domainForwarder{},
 		keysPerDomains:   map[string][]string{},
 		internalState:    Stopped,
-		healthChecker:    &forwarderHealth{keysPerDomains: keysPerDomains},
+		healthChecker:    newForwarderHealth(keysPerDomains),
 	}
 	numWorkers := config.Datadog.GetInt("forwarder_num_workers")
 	retryQueueMaxSize := config.Datadog.GetInt("forwarder_retry_queue_max_size")

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -119,8 +119,9 @@ func (fh *forwarderHealth) computeKeysPerAPIDomain(keysPerDomains map[string][]s
 		apiDomain, err := config.ComputeAPIDomain(domain)
 		if err != nil {
 			log.Errorf("compute API domain error: %s", err)
+		} else {
+			fh.keysPerAPIDomain[apiDomain] = append(fh.keysPerAPIDomain[apiDomain], apiKeys...)
 		}
-		fh.keysPerAPIDomain[apiDomain] = append(fh.keysPerAPIDomain[apiDomain], apiKeys...)
 	}
 }
 func (fh *forwarderHealth) setAPIKeyStatus(apiKey string, domain string, status expvar.Var) {

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -116,8 +116,9 @@ func (fh *forwarderHealth) healthCheckLoop() {
 func (fh *forwarderHealth) computeKeysPerAPIDomain(keysPerDomains map[string][]string) {
 	fh.keysPerAPIDomain = make(map[string][]string)
 	for domain, apiKeys := range keysPerDomains {
-		apiDomain := config.ComputeAPIDomain(domain)
-		fh.keysPerAPIDomain[apiDomain] = append(fh.keysPerAPIDomain[apiDomain], apiKeys...)
+		if apiDomain, err := config.ComputeAPIDomain(domain); err == nil {
+			fh.keysPerAPIDomain[apiDomain] = append(fh.keysPerAPIDomain[apiDomain], apiKeys...)
+		}
 	}
 }
 func (fh *forwarderHealth) setAPIKeyStatus(apiKey string, domain string, status expvar.Var) {

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -50,11 +50,12 @@ type forwarderHealth struct {
 }
 
 func newForwarderHealth(keysPerDomains map[string][]string) *forwarderHealth {
-	var fh forwarderHealth
-	fh.stop = make(chan bool, 1)
-	fh.stopped = make(chan struct{})
-	fh.computeKeysPerAPIDomain(keysPerDomains)
+	fh := forwarderHealth{
+		stop:    make(chan bool, 1),
+		stopped: make(chan struct{}),
+	}
 
+	fh.computeKeysPerAPIDomain(keysPerDomains)
 	// Since timeout is the maximum duration we can wait, we need to divide it
 	// by the total number of api keys to obtain the max duration for each key
 	apiKeyCount := 0

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -116,9 +116,11 @@ func (fh *forwarderHealth) healthCheckLoop() {
 func (fh *forwarderHealth) computeKeysPerAPIDomain(keysPerDomains map[string][]string) {
 	fh.keysPerAPIDomain = make(map[string][]string)
 	for domain, apiKeys := range keysPerDomains {
-		if apiDomain, err := config.ComputeAPIDomain(domain); err == nil {
-			fh.keysPerAPIDomain[apiDomain] = append(fh.keysPerAPIDomain[apiDomain], apiKeys...)
+		apiDomain, err := config.ComputeAPIDomain(domain)
+		if err != nil {
+			log.Errorf("compute API domain error: %s", err)
 		}
+		fh.keysPerAPIDomain[apiDomain] = append(fh.keysPerAPIDomain[apiDomain], apiKeys...)
 	}
 }
 func (fh *forwarderHealth) setAPIKeyStatus(apiKey string, domain string, status expvar.Var) {

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -38,21 +38,21 @@ func TestHasValidAPIKey(t *testing.T) {
 }
 func TestComputeAPIDomains(t *testing.T) {
 	keysPerDomains := map[string][]string{
-		"https://app.datadoghq.com":    {"api_key_1"},
+		"https://app.datadoghq.com":    {"api_key_1", "api_key_1b"},
 		"https://app.datadoghq.eu":     {"api_key_2"},
-		"https://app.datad0g.com":      {"api_key_3"},
+		"https://app.datad0g.com":      {"api_key_3", "api_key_3b"},
 		"https://app.datad0g.eu":       {"api_key_4"},
 		"https://custom.datadoghq.com": {"api_key_5"},
-		"https://nochange.com":         {"api_key_6"},
+		"https://nochange.com":         {"api_key_6", "api_key_6b"},
 	}
 
 	testMap := map[string][]string{
-		"https://api.datadoghq.com":    {"api_key_1"},
+		"https://api.datadoghq.com":    {"api_key_1", "api_key_1b"},
 		"https://api.datadoghq.eu":     {"api_key_2"},
-		"https://api.datad0g.com":      {"api_key_3"},
+		"https://api.datad0g.com":      {"api_key_3", "api_key_3b"},
 		"https://api.datad0g.eu":       {"api_key_4"},
 		"https://custom.datadoghq.com": {"api_key_5"},
-		"https://nochange.com":         {"api_key_6"},
+		"https://nochange.com":         {"api_key_6", "api_key_6b"},
 	}
 
 	fh := newForwarderHealth(keysPerDomains)

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -44,6 +44,7 @@ func TestComputeAPIDomains(t *testing.T) {
 		"https://app.datad0g.eu":       {"api_key_4"},
 		"https://custom.datadoghq.com": {"api_key_5"},
 		"https://nochange.com":         {"api_key_6", "api_key_6b"},
+		":datadoghq.com":               {"api_key_7"},
 	}
 
 	testMap := map[string][]string{

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -36,20 +36,23 @@ func TestHasValidAPIKey(t *testing.T) {
 	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with _key2"))
 	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with key3"))
 }
-
 func TestComputeAPIDomains(t *testing.T) {
 	keysPerDomains := map[string][]string{
-		"https://app.datadoghq.com":   {"api_key1"},
-		"https://shouldnotchange.com": {"api_key_2"},
-		"https://app.datadoghq.eu":    {"api_key_3"},
-		"datadoghq.com":               {"api_key_4"},
-		"custom.datadoghq.com":        {"api_key_5"},
+		"https://app.datadoghq.com":    {"api_key_1"},
+		"https://app.datadoghq.eu":     {"api_key_2"},
+		"https://app.datad0g.com":      {"api_key_3"},
+		"https://app.datad0g.eu":       {"api_key_4"},
+		"https://custom.datadoghq.com": {"api_key_5"},
+		"https://nochange.com":         {"api_key_6"},
 	}
 
 	testMap := map[string][]string{
-		"https://api.datadoghq.com":   {"api_key1", "api_key_4", "api_key_5"},
-		"https://shouldnotchange.com": {"api_key_2"},
-		"https://api.datadoghq.eu":    {"api_key_3"},
+		"https://api.datadoghq.com":    {"api_key_1"},
+		"https://api.datadoghq.eu":     {"api_key_2"},
+		"https://api.datad0g.com":      {"api_key_3"},
+		"https://api.datad0g.eu":       {"api_key_4"},
+		"https://custom.datadoghq.com": {"api_key_5"},
+		"https://nochange.com":         {"api_key_6"},
 	}
 
 	fh := newForwarderHealth(keysPerDomains)

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -76,14 +76,14 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 	defer ts1.Close()
 	defer ts2.Close()
 
-	keysPerAPIDomain := map[string][]string{
+	keysPerDomains := map[string][]string{
 		ts1.URL: {"api_key1", "api_key2"},
 		ts2.URL: {"key3"},
 	}
 
 	fh := forwarderHealth{}
+	fh.keysPerDomains = keysPerDomains
 	fh.init()
-	fh.keysPerAPIDomain = keysPerAPIDomain
 	assert.True(t, fh.hasValidAPIKey())
 
 	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending with _key1"))

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -29,8 +29,7 @@ func TestHasValidAPIKey(t *testing.T) {
 		ts2.URL: {"key3"},
 	}
 
-	fh := forwarderHealth{keysPerDomains: keysPerDomains}
-	fh.init()
+	fh := newForwarderHealth(keysPerDomains)
 	assert.True(t, fh.hasValidAPIKey())
 
 	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with _key1"))
@@ -53,8 +52,7 @@ func TestComputeAPIDomains(t *testing.T) {
 		"https://api.datadoghq.eu":    {"api_key_3"},
 	}
 
-	fh := forwarderHealth{keysPerDomains: keysPerDomains}
-	fh.init()
+	fh := newForwarderHealth(keysPerDomains)
 
 	assert.Equal(t, fh.keysPerAPIDomain, testMap)
 }
@@ -81,9 +79,7 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 		ts2.URL: {"key3"},
 	}
 
-	fh := forwarderHealth{}
-	fh.keysPerDomains = keysPerDomains
-	fh.init()
+	fh := newForwarderHealth(keysPerDomains)
 	assert.True(t, fh.hasValidAPIKey())
 
 	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending with _key1"))

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -38,19 +38,25 @@ func TestHasValidAPIKey(t *testing.T) {
 	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with key3"))
 }
 
-func TestComputeDomainsURL(t *testing.T) {
+func TestComputeAPIDomains(t *testing.T) {
 	keysPerDomains := map[string][]string{
-		"https://app.datadoghq.com": {"api_key1"},
+		"https://app.datadoghq.com":   {"api_key1"},
+		"https://shouldnotchange.com": {"api_key_2"},
+		"https://app.datadoghq.eu":    {"api_key_3"},
+		"datadoghq.com":               {"api_key_4"},
+		"custom.datadoghq.com":        {"api_key_5"},
 	}
 
 	testMap := map[string][]string{
-		"https://api.datadoghq.com": {"api_key1"},
+		"https://api.datadoghq.com":   {"api_key1", "api_key_4", "api_key_5"},
+		"https://shouldnotchange.com": {"api_key_2"},
+		"https://api.datadoghq.eu":    {"api_key_3"},
 	}
 
 	fh := forwarderHealth{keysPerDomains: keysPerDomains}
 	fh.init()
 
-	assert.Equal(t, fh.keysPerAPIEndpoint, testMap)
+	assert.Equal(t, fh.keysPerAPIDomain, testMap)
 }
 
 func TestHasValidAPIKeyErrors(t *testing.T) {
@@ -70,14 +76,14 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 	defer ts1.Close()
 	defer ts2.Close()
 
-	keysPerAPIEndpoint := map[string][]string{
+	keysPerAPIDomain := map[string][]string{
 		ts1.URL: {"api_key1", "api_key2"},
 		ts2.URL: {"key3"},
 	}
 
 	fh := forwarderHealth{}
 	fh.init()
-	fh.keysPerAPIEndpoint = keysPerAPIEndpoint
+	fh.keysPerAPIDomain = keysPerAPIDomain
 	assert.True(t, fh.hasValidAPIKey())
 
 	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending with _key1"))


### PR DESCRIPTION
### What does this PR do?

This PR implements changes suggested in this previously merged PR: https://github.com/DataDog/datadog-agent/pull/4876#pullrequestreview-359632165

It does away with the forwarder health init() function and the fh.keysPerDomains field in the fh struct, replacing it with a newForwarderHealth function

### Motivation


### Additional Notes

