### PR TITLE
Add extra debug output for rate errors

### DIFF
--- a/pkg/metrics/rate.go
+++ b/pkg/metrics/rate.go
@@ -35,12 +35,13 @@ func (r *Rate) flush(timestamp float64) ([]*Serie, error) {
 	}
 
 	value, ts := (r.sample-r.previousSample)/(r.timestamp-r.previousTimestamp), r.timestamp
-	r.previousSample, r.previousTimestamp = r.sample, r.timestamp
-	r.sample, r.timestamp = 0., 0.
 
 	if value < 0 {
-		return []*Serie{}, fmt.Errorf("Rate value is negative, discarding it (the underlying counter may have been reset)")
+		return []*Serie{}, fmt.Errorf("Rate value is negative (%f - %f = %f), discarding it (the underlying counter may have been reset)", r.sample, r.previousSample, value)
 	}
+
+	r.previousSample, r.previousTimestamp = r.sample, r.timestamp
+	r.sample, r.timestamp = 0., 0.
 
 	return []*Serie{
 		{

--- a/pkg/metrics/rate.go
+++ b/pkg/metrics/rate.go
@@ -35,11 +35,12 @@ func (r *Rate) flush(timestamp float64) ([]*Serie, error) {
 	}
 
 	value, ts := (r.sample-r.previousSample)/(r.timestamp-r.previousTimestamp), r.timestamp
+
+	origSample, origPreviousSample := r.sample, r.previousSample
 	r.previousSample, r.previousTimestamp = r.sample, r.timestamp
 	r.sample, r.timestamp = 0., 0.
 
 	if value < 0 {
-		origSample, origPreviousSample := r.previousSample, value+r.previousSample
 		return []*Serie{}, fmt.Errorf("Rate value is negative (%f - %f = %f), discarding it (the underlying counter may have been reset)", origSample, origPreviousSample, value)
 	}
 

--- a/pkg/metrics/rate.go
+++ b/pkg/metrics/rate.go
@@ -35,13 +35,13 @@ func (r *Rate) flush(timestamp float64) ([]*Serie, error) {
 	}
 
 	value, ts := (r.sample-r.previousSample)/(r.timestamp-r.previousTimestamp), r.timestamp
-
-	if value < 0 {
-		return []*Serie{}, fmt.Errorf("Rate value is negative (%f - %f = %f), discarding it (the underlying counter may have been reset)", r.sample, r.previousSample, value)
-	}
-
 	r.previousSample, r.previousTimestamp = r.sample, r.timestamp
 	r.sample, r.timestamp = 0., 0.
+
+	if value < 0 {
+		origSample, origPreviousSample := r.previousSample, value+r.previousSample
+		return []*Serie{}, fmt.Errorf("Rate value is negative (%f - %f = %f), discarding it (the underlying counter may have been reset)", origSample, origPreviousSample, value)
+	}
 
 	return []*Serie{
 		{

--- a/releasenotes/notes/Add-extra-debug-to-rate-processing-ed9782a825ac26e6.yaml
+++ b/releasenotes/notes/Add-extra-debug-to-rate-processing-ed9782a825ac26e6.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Add extra debug to rate processing


### PR DESCRIPTION
### What does this PR do?

We have a customer reporting certain rate metrics that are getting reset, but the underlying values aren't known.  This adds the values involved in the calculation to the log output for better diagnosis.

### Motivation

Customer support.

### Additional Notes

Anything else we should know when reviewing?
