### PR TITLE
Add uninstall-cmd executable for use in Bosh environments.  Undoes the

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -103,7 +103,8 @@ package :zip do
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\trace-agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-three.dll",
-        "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\install-cmd.exe"
+        "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\install-cmd.exe",
+        "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\uninstall-cmd.exe"
       ]
     if ENV['SIGN_PFX']
       signing_identity_file "#{ENV['SIGN_PFX']}", password: "#{ENV['SIGN_PFX_PW']}", algorithm: "SHA256"

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -86,6 +86,7 @@ build do
     command "invoke customaction.build --major-version #{major_version_arg} --arch=" + platform
     unless windows_arch_i386?
       command "invoke installcmd.build --major-version #{major_version_arg} --arch=" + platform
+      command "invoke uninstallcmd.build --major-version #{major_version_arg} --arch=" + platform
     end
   end
 

--- a/omnibus/config/software/datadog-cf-finalize.rb
+++ b/omnibus/config/software/datadog-cf-finalize.rb
@@ -30,6 +30,7 @@ build do
             copy "#{cf_source_root}/agent/agent.exe", "#{cf_bin_root_bin}"
             copy "#{cf_source_root}/agent/libdatadog-agent-three.dll", "#{cf_bin_root_bin}"
             copy "#{cf_source_root}/agent/install-cmd.exe", "#{cf_bin_root_bin}/agent"
+            copy "#{cf_source_root}/agent/uninstall-cmd.exe", "#{cf_bin_root_bin}/agent"
             copy "#{cf_source_root}/agent/process-agent.exe", "#{cf_bin_root_bin}/agent"
             copy "#{cf_source_root}/agent/trace-agent.exe", "#{cf_bin_root_bin}/agent"
         end

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -18,7 +18,8 @@ from . import (agent,
     rtloader,
     system_probe,
     systray,
-    trace_agent
+    trace_agent,
+    uninstallcmd
 )
 
 
@@ -65,6 +66,7 @@ ns.add_collection(release)
 ns.add_collection(rtloader)
 ns.add_collection(system_probe)
 ns.add_collection(process_agent)
+ns.add_collection(uninstallcmd)
 
 ns.configure({
     'run': {

--- a/tasks/uninstallcmd.py
+++ b/tasks/uninstallcmd.py
@@ -1,0 +1,88 @@
+"""
+customaction namespaced tasks
+"""
+from __future__ import print_function
+import glob
+import os
+import shutil
+import sys
+import platform
+from distutils.dir_util import copy_tree
+
+import invoke
+from invoke import task
+from invoke.exceptions import Exit
+
+from .utils import bin_name, get_build_flags, get_version_numeric_only, load_release_versions
+from .utils import REPO_PATH
+from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, REDHAT_DEBIAN_SUSE_ONLY_TAGS, REDHAT_DEBIAN_SUSE_DIST
+from .go import deps
+
+# constants
+BIN_PATH = os.path.join(".", "bin", "agent")
+AGENT_TAG = "datadog/agent:master"
+CUSTOM_ACTION_ROOT_DIR = "tools\\windows\\install-help"
+
+@task
+def build(ctx, major_version='7', vstudio_root=None, arch="x64", debug=False):
+    """
+    Build the custom action library for the agent
+    """
+
+    if sys.platform != 'win32':
+        print("Custom action library is only for Win32")
+        raise Exit(code=1)
+
+    ver = get_version_numeric_only(ctx, env=os.environ, major_version=major_version)
+    build_maj, build_min, build_patch = ver.split(".")
+    verprops = " /p:MAJ_VER={build_maj} /p:MIN_VER={build_min} /p:PATCH_VER={build_patch} ".format(
+            build_maj=build_maj,
+            build_min=build_min,
+            build_patch=build_patch
+        )
+    print("arch is {}".format(arch))
+    cmd = ""
+    configuration = "Release"
+    if debug:
+        configuration = "Debug"
+
+    if not os.getenv("VCINSTALLDIR"):
+        print("VC Not installed in environment; checking other locations")
+
+        vsroot = vstudio_root or os.getenv('VSTUDIO_ROOT')
+        if not vsroot:
+            print("Must have visual studio installed")
+            raise Exit(code=2)
+        batchfile = "vcvars64.bat"
+        if arch == "x86":
+            batchfile = "vcvars32.bat"
+        vs_env_bat = '{}\\VC\\Auxiliary\\Build\\{}'.format(vsroot, batchfile)
+        cmd = 'call \"{}\" && msbuild {}\\uninstall-cmd\\uninstall-cmd.vcxproj /p:Configuration={} /p:Platform={}'.format(
+            vs_env_bat, CUSTOM_ACTION_ROOT_DIR, configuration, arch)
+    else:
+        cmd = 'msbuild {}\\uninstall-cmd\\uninstall-cmd.vcxproj /p:Configuration={} /p:Platform={}'.format(
+            CUSTOM_ACTION_ROOT_DIR, configuration, arch)
+
+    cmd += verprops
+    print("Build Command: %s" % cmd)
+
+    ctx.run(cmd)
+    srcdll = None
+    if arch is not None and arch == "x86":
+        srcdll = "{}\\uninstall-cmd\\{}\\uninstall-cmd.exe".format(CUSTOM_ACTION_ROOT_DIR, configuration)
+    else:
+        srcdll = "{}\\uninstall-cmd\\x64\\{}\\uninstall-cmd.exe".format(CUSTOM_ACTION_ROOT_DIR, configuration)
+    shutil.copy2(srcdll, BIN_PATH)
+
+@task
+def clean(ctx, arch="x64", debug=False):
+    configuration = "Release"
+    if debug:
+        configuration = "Debug"
+
+    if arch is not None and arch == "x86":
+        srcdll = "{}\\uninstall-cmd\\{}".format(CUSTOM_ACTION_ROOT_DIR, configuration)
+    else:
+        srcdll = "{}\\uninstall-cmd\\x64\\{}".format(CUSTOM_ACTION_ROOT_DIR, configuration)
+    shutil.rmtree(srcdll, BIN_PATH)
+

--- a/tools/windows/install-help/cal/CustomAction.cpp
+++ b/tools/windows/install-help/cal/CustomAction.cpp
@@ -78,12 +78,8 @@ LExit:
     return WcaFinalize(er);
 
 }
-typedef enum _uninstall_type {
-    UNINSTALL_UNINSTALL,
-    UNINSTALL_ROLLBACK
-} UNINSTALL_TYPE;
 
-UINT doUninstallAs(MSIHANDLE hInstall, UNINSTALL_TYPE t);
+
 extern "C" UINT __stdcall DoUninstall(MSIHANDLE hInstall) {
     // that's helpful.  WcaInitialize Log header silently limited to 32 chars
     HRESULT hr = WcaInitialize(hInstall, "CA: DoUninstall");
@@ -92,7 +88,7 @@ extern "C" UINT __stdcall DoUninstall(MSIHANDLE hInstall) {
      
     WcaLog(LOGMSG_STANDARD, "Initialized.");
     initializeStringsFromStringTable();
-    er = doUninstallAs(hInstall, UNINSTALL_UNINSTALL);
+    er = doUninstallAs(UNINSTALL_UNINSTALL);
     if (er != 0) {
         hr = -1;
     }
@@ -120,7 +116,7 @@ extern "C" UINT __stdcall DoRollback(MSIHANDLE hInstall) {
     // we'll need to stop the services manually if we got far enough to start
     // them before installation failed.
     DoStopSvc(agentService);
-    er = doUninstallAs(hInstall, UNINSTALL_ROLLBACK);
+    er = doUninstallAs(UNINSTALL_ROLLBACK);
     if (er != 0) {
         hr = -1;
     }
@@ -140,133 +136,7 @@ LExit:
     er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
     return WcaFinalize(er);
 }
-UINT doUninstallAs(MSIHANDLE hInstall, UNINSTALL_TYPE t)
-{
 
-    DWORD er = ERROR_SUCCESS;
-    CustomActionData data;
-    PSID sid = NULL;
-    LSA_HANDLE hLsa = NULL;
-    std::wstring propval;
-    ddRegKey regkey;
-    RegKey installState;
-    std::wstring waitval;
-    DWORD nErr = 0;
-    LOCALGROUP_MEMBERS_INFO_0 lmi0;
-    memset(&lmi0, 0, sizeof(LOCALGROUP_MEMBERS_INFO_0));
-    BOOL willDeleteUser = false;
-    BOOL isDC = isDomainController();
-    if (t == UNINSTALL_UNINSTALL) {
-        regkey.createSubKey(strUninstallKeyName.c_str(), installState);
-    }
-    else {
-        regkey.createSubKey(strRollbackKeyName.c_str(), installState);
-    }
-    // check to see if we created the user, and if so, what the user's name was
-    std::wstring installedUser, installedDomain, installedComplete;
-    if (installState.getStringValue(installCreatedDDUser.c_str(), installedUser))
-    {
-        WcaLog(LOGMSG_STANDARD, "This install installed user %S", installedUser.c_str());
-        size_t ndx;
-        if((ndx = installedUser.find(L'\\')) != std::string::npos)
-        {
-            installedUser = installedUser.substr(ndx + 1);
-        }
-        // username is now stored fully qualified (<domain>\<user>).  However, removal
-        // code expects the unqualified name. Split it out here.
-        if (installState.getStringValue(installCreatedDDDomain.c_str(), installedDomain)) {
-            WcaLog(LOGMSG_STANDARD, "NOT Removing user from domain %S", installedDomain.c_str());
-            WcaLog(LOGMSG_STANDARD, "Domain user can be removed.");
-            installedComplete = installedDomain + L"\\";
-        } else if (isDC) {
-            WcaLog(LOGMSG_STANDARD, "NOT Removing user %S from domain controller", installedUser.c_str());
-            WcaLog(LOGMSG_STANDARD, "Domain user can be removed.");
-    
-        } else {
-            WcaLog(LOGMSG_STANDARD, "Will delete user %S from local user store", installedUser.c_str());
-            willDeleteUser = true;
-        }
-        installedComplete += installedUser;
-        
-    }
-
-    if (willDeleteUser)
-    {
-        sid = GetSidForUser(NULL, installedComplete.c_str());
-
-        // remove dd user from programdata root
-        removeUserPermsFromFile(programdataroot, sid);
-
-        // remove dd user from log directory
-        removeUserPermsFromFile(logdir, sid);
-
-        // remove dd user from conf directory
-        removeUserPermsFromFile(confddir, sid);
-
-        // remove dd user from datadog.yaml
-        removeUserPermsFromFile(datadogyamlfile, sid);
-
-        // remove dd user from Performance monitor users
-        DelUserFromGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
-        DelUserFromGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
-
-        // remove dd user right for
-        //   SE_SERVICE_LOGON NAME
-        //   SE_DENY_REMOVE_INTERACTIVE_LOGON_NAME
-        //   SE_DENY_NETWORK_LOGIN_NAME
-        //   SE_DENY_INTERACTIVE_LOGIN_NAME
-        if ((hLsa = GetPolicyHandle()) != NULL) {
-            if (!RemovePrivileges(sid, hLsa, SE_DENY_INTERACTIVE_LOGON_NAME)) {
-                WcaLog(LOGMSG_STANDARD, "failed to remove deny interactive login right");
-            }
-
-            if (!RemovePrivileges(sid, hLsa, SE_DENY_NETWORK_LOGON_NAME)) {
-                WcaLog(LOGMSG_STANDARD, "failed to remove deny network login right");
-            }
-            if (!RemovePrivileges(sid, hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME)) {
-                WcaLog(LOGMSG_STANDARD, "failed to remove deny remote interactive login right");
-            }
-            if (!RemovePrivileges(sid, hLsa, SE_SERVICE_LOGON_NAME)) {
-                WcaLog(LOGMSG_STANDARD, "failed to remove service login right");
-            }
-        }
-        // delete the user
-        er = DeleteUser(NULL, installedUser.c_str());
-        if (0 != er) {
-            // don't actually fail on failure.  We're doing an uninstall,
-            // and failing will just leave the system in a more confused state
-            WcaLog(LOGMSG_STANDARD, "Didn't delete the datadog user %d", er);
-        }
-    }
-    // remove the auth token file altogether
-
-    DeleteFile(authtokenfilename.c_str());
-    std::wstring svcsInstalled;
-    if (installState.getStringValue(installInstalledServices.c_str(), svcsInstalled))
-    {
-        // uninstall the services
-        uninstallServices(data);
-    }
-    else {
-        // this would have to be the rollback state, during an upgrade.
-        // attempt to restart the services
-        if (doesServiceExist(agentService)) {
-            // attempt to start it back up
-            DoStartSvc(agentService);
-        }
-    }
-    std::wstring embedded = installdir + L"\\embedded";
-    RemoveDirectory(embedded.c_str());
-
-    if (sid) {
-        delete[](BYTE *) sid;
-    }
-    if (hLsa) {
-        LsaClose(hLsa);
-    }
-    return 0;
-
-}
 HMODULE hDllModule;
 
 // DllMain - Initialize and cleanup WiX custom action utils.

--- a/tools/windows/install-help/cal/customaction.h
+++ b/tools/windows/install-help/cal/customaction.h
@@ -63,3 +63,11 @@ extern HMODULE hDllModule;
 
 //FinalizeInstall.cpp
 UINT doFinalizeInstall(CustomActionData &data);
+
+//doUninstall.cpp
+typedef enum _uninstall_type {
+    UNINSTALL_UNINSTALL,
+    UNINSTALL_ROLLBACK
+} UNINSTALL_TYPE;
+
+UINT doUninstallAs(UNINSTALL_TYPE t);

--- a/tools/windows/install-help/cal/doUninstall.cpp
+++ b/tools/windows/install-help/cal/doUninstall.cpp
@@ -1,0 +1,131 @@
+#include "stdafx.h"
+
+UINT doUninstallAs(UNINSTALL_TYPE t)
+{
+
+    DWORD er = ERROR_SUCCESS;
+    CustomActionData data;
+    PSID sid = NULL;
+    LSA_HANDLE hLsa = NULL;
+    std::wstring propval;
+    ddRegKey regkey;
+    RegKey installState;
+    std::wstring waitval;
+    DWORD nErr = 0;
+    LOCALGROUP_MEMBERS_INFO_0 lmi0;
+    memset(&lmi0, 0, sizeof(LOCALGROUP_MEMBERS_INFO_0));
+    BOOL willDeleteUser = false;
+    BOOL isDC = isDomainController();
+    if (t == UNINSTALL_UNINSTALL) {
+        regkey.createSubKey(strUninstallKeyName.c_str(), installState);
+    }
+    else {
+        regkey.createSubKey(strRollbackKeyName.c_str(), installState);
+    }
+    // check to see if we created the user, and if so, what the user's name was
+    std::wstring installedUser, installedDomain, installedComplete;
+    if (installState.getStringValue(installCreatedDDUser.c_str(), installedUser))
+    {
+        WcaLog(LOGMSG_STANDARD, "This install installed user %S", installedUser.c_str());
+        size_t ndx;
+        if ((ndx = installedUser.find(L'\\')) != std::string::npos)
+        {
+            installedUser = installedUser.substr(ndx + 1);
+        }
+        // username is now stored fully qualified (<domain>\<user>).  However, removal
+        // code expects the unqualified name. Split it out here.
+        if (installState.getStringValue(installCreatedDDDomain.c_str(), installedDomain)) {
+            WcaLog(LOGMSG_STANDARD, "NOT Removing user from domain %S", installedDomain.c_str());
+            WcaLog(LOGMSG_STANDARD, "Domain user can be removed.");
+            installedComplete = installedDomain + L"\\";
+        }
+        else if (isDC) {
+            WcaLog(LOGMSG_STANDARD, "NOT Removing user %S from domain controller", installedUser.c_str());
+            WcaLog(LOGMSG_STANDARD, "Domain user can be removed.");
+
+        }
+        else {
+            WcaLog(LOGMSG_STANDARD, "Will delete user %S from local user store", installedUser.c_str());
+            willDeleteUser = true;
+        }
+        installedComplete += installedUser;
+
+    }
+
+    if (willDeleteUser)
+    {
+        sid = GetSidForUser(NULL, installedComplete.c_str());
+
+        // remove dd user from programdata root
+        removeUserPermsFromFile(programdataroot, sid);
+
+        // remove dd user from log directory
+        removeUserPermsFromFile(logdir, sid);
+
+        // remove dd user from conf directory
+        removeUserPermsFromFile(confddir, sid);
+
+        // remove dd user from datadog.yaml
+        removeUserPermsFromFile(datadogyamlfile, sid);
+
+        // remove dd user from Performance monitor users
+        DelUserFromGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
+        DelUserFromGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
+
+        // remove dd user right for
+        //   SE_SERVICE_LOGON NAME
+        //   SE_DENY_REMOVE_INTERACTIVE_LOGON_NAME
+        //   SE_DENY_NETWORK_LOGIN_NAME
+        //   SE_DENY_INTERACTIVE_LOGIN_NAME
+        if ((hLsa = GetPolicyHandle()) != NULL) {
+            if (!RemovePrivileges(sid, hLsa, SE_DENY_INTERACTIVE_LOGON_NAME)) {
+                WcaLog(LOGMSG_STANDARD, "failed to remove deny interactive login right");
+            }
+
+            if (!RemovePrivileges(sid, hLsa, SE_DENY_NETWORK_LOGON_NAME)) {
+                WcaLog(LOGMSG_STANDARD, "failed to remove deny network login right");
+            }
+            if (!RemovePrivileges(sid, hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME)) {
+                WcaLog(LOGMSG_STANDARD, "failed to remove deny remote interactive login right");
+            }
+            if (!RemovePrivileges(sid, hLsa, SE_SERVICE_LOGON_NAME)) {
+                WcaLog(LOGMSG_STANDARD, "failed to remove service login right");
+            }
+        }
+        // delete the user
+        er = DeleteUser(NULL, installedUser.c_str());
+        if (0 != er) {
+            // don't actually fail on failure.  We're doing an uninstall,
+            // and failing will just leave the system in a more confused state
+            WcaLog(LOGMSG_STANDARD, "Didn't delete the datadog user %d", er);
+        }
+    }
+    // remove the auth token file altogether
+
+    DeleteFile(authtokenfilename.c_str());
+    std::wstring svcsInstalled;
+    if (installState.getStringValue(installInstalledServices.c_str(), svcsInstalled))
+    {
+        // uninstall the services
+        uninstallServices(data);
+    }
+    else {
+        // this would have to be the rollback state, during an upgrade.
+        // attempt to restart the services
+        if (doesServiceExist(agentService)) {
+            // attempt to start it back up
+            DoStartSvc(agentService);
+        }
+    }
+    std::wstring embedded = installdir + L"\\embedded";
+    RemoveDirectory(embedded.c_str());
+
+    if (sid) {
+        delete[](BYTE *) sid;
+    }
+    if (hLsa) {
+        LsaClose(hLsa);
+    }
+    return 0;
+
+}

--- a/tools/windows/install-help/install-cmd.sln
+++ b/tools/windows/install-help/install-cmd.sln
@@ -7,6 +7,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "install-cmd", "install-cmd\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "customaction", "cal\customaction.vcxproj", "{330D78DA-3542-4456-9694-41F10646B172}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "uninstall-cmd", "uninstall-cmd\uninstall-cmd.vcxproj", "{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -31,6 +33,14 @@ Global
 		{330D78DA-3542-4456-9694-41F10646B172}.Release|x64.Build.0 = Release|x64
 		{330D78DA-3542-4456-9694-41F10646B172}.Release|x86.ActiveCfg = Release|Win32
 		{330D78DA-3542-4456-9694-41F10646B172}.Release|x86.Build.0 = Release|Win32
+		{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}.Debug|x64.ActiveCfg = Debug|x64
+		{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}.Debug|x64.Build.0 = Debug|x64
+		{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}.Debug|x86.ActiveCfg = Debug|Win32
+		{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}.Debug|x86.Build.0 = Debug|Win32
+		{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}.Release|x64.ActiveCfg = Release|x64
+		{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}.Release|x64.Build.0 = Release|x64
+		{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}.Release|x86.ActiveCfg = Release|Win32
+		{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/windows/install-help/uninstall-cmd/PropertySheet.props
+++ b/tools/windows/install-help/uninstall-cmd/PropertySheet.props
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <MAJ_VER>5</MAJ_VER>
+    <MIN_VER>99</MIN_VER>
+    <PATCH_VER>99</PATCH_VER>
+  </PropertyGroup>
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+  <ItemGroup>
+    <BuildMacro Include="MAJ_VER">
+      <Value>$(MAJ_VER)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="MIN_VER">
+      <Value>$(MIN_VER)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="PATCH_VER">
+      <Value>$(PATCH_VER)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/tools/windows/install-help/uninstall-cmd/cmdargs.h
+++ b/tools/windows/install-help/uninstall-cmd/cmdargs.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <map>
+#include <string>
+
+bool parseArgs(int argc, wchar_t **argv, std::wstring &calstring);

--- a/tools/windows/install-help/uninstall-cmd/cmdline.cpp
+++ b/tools/windows/install-help/uninstall-cmd/cmdline.cpp
@@ -1,0 +1,75 @@
+#include "stdafx.h"
+const wchar_t * opts[] = {
+    L"-bindir",
+    L"-confdir",
+    L"-uname",
+};
+
+const wchar_t * calargs[] = {
+    L"PROJECTLOCATION",
+    L"APPLICATIONDATADIRECTORY",
+    L"DDAGENTUSER_NAME",
+};
+
+const wchar_t * defaults[] = {
+    L"C:\\Program Files\\Datadog\\Datadog Agent\\",
+    L"C:\\ProgramData\\Datadog\\",
+    L"",
+    L""
+};
+typedef enum _cmdargs {
+    ARG_BINDIR = 0,
+    ARG_CONFDIR,
+    ARG_USERNAME,
+    ARG_LAST
+} CMDARGS;
+
+CMDARGS operator++( CMDARGS &r, int) {
+    r = (CMDARGS)((int)r + 1);
+    return r;
+}
+
+void usage() {
+    wprintf(L"Usage: uninstall-cmd [-bindir <path>] [-confdir <path>] [-uname <username>] \n\n");
+    return;
+}
+bool parseArgs(int argc, wchar_t **argv, std::wstring &calstring)
+{
+    std::map<CMDARGS, bool> suppliedArgs;
+    // all the args take params, so we better have an even number
+    if (argc % 2 != 0) {
+        usage();
+        return false;
+    }
+    for (int i = 0; i < argc - 1; i++) {
+        bool bFound = false;
+        for (CMDARGS a = ARG_BINDIR; a < ARG_LAST; a++)
+        {
+            if (_wcsicmp(argv[i], opts[(int)a]) == 0) {
+                bFound = true;
+                i++;
+                suppliedArgs[a] = true;
+                calstring += calargs[(int)a];
+                calstring += L"=";
+                calstring += argv[i];
+                calstring += L";";
+                break;
+            }
+        }
+        if (!bFound) {
+            usage();
+            return false;
+        }
+    }
+    for (CMDARGS a = ARG_BINDIR; a < ARG_LAST; a++) {
+        if (suppliedArgs.find(a) == suppliedArgs.end()) {
+            // didn't supply it; add the empty string on
+            calstring += calargs[(int)a];
+            calstring += L"=";
+            calstring += defaults[(int)a];
+            calstring += L";";
+        }
+    }
+    return true;
+
+}

--- a/tools/windows/install-help/uninstall-cmd/resource.h
+++ b/tools/windows/install-help/uninstall-cmd/resource.h
@@ -1,0 +1,7 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by uninstall-cmd.rc
+
+// Next default values for new objects
+// 
+#include "..\cal\resource.h"

--- a/tools/windows/install-help/uninstall-cmd/stdafx.cpp
+++ b/tools/windows/install-help/uninstall-cmd/stdafx.cpp
@@ -1,0 +1,5 @@
+// pch.cpp: source file corresponding to pre-compiled header; necessary for compilation to succeed
+
+#include "stdafx.h"
+
+// In general, ignore this file, but keep it around if you are using pre-compiled headers.

--- a/tools/windows/install-help/uninstall-cmd/stdafx.h
+++ b/tools/windows/install-help/uninstall-cmd/stdafx.h
@@ -1,0 +1,61 @@
+// Tips for Getting Started: 
+//   1. Use the Solution Explorer window to add/manage files
+//   2. Use the Team Explorer window to connect to source control
+//   3. Use the Output window to see build output and other messages
+//   4. Use the Error List window to view errors
+//   5. Go to Project > Add New Item to create new code files, or Project > Add Existing Item to add existing code files to the project
+//   6. In the future, to open this project again, go to File > Open > Project and select the .sln file
+
+#ifndef PCH_H
+#define PCH_H
+
+// TODO: add headers that you want to pre-compile here
+#include "..\cal\targetver.h"
+
+#define NTDDI_VERSION NTDDI_VISTA
+#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+// Windows Header Files:
+#include <windows.h>
+#include <bcrypt.h>
+#include <ntsecapi.h>
+#include <AccCtrl.h>
+#include <AclAPI.h>
+#include <sddl.h>
+#include <shlwapi.h>
+#include <shlobj.h>
+
+#include <stdlib.h>
+#include <strsafe.h>
+#include <msiquery.h>
+#include <lm.h>
+#include <lmaccess.h>
+#include <lmerr.h>
+
+// std c++ lib
+#include <string>
+#include <sstream>
+#include <map>
+#include <sstream>
+#include <filesystem>
+
+// WiX Header Files:
+#include "uninstall-cmd.h"
+#include "cmdargs.h"
+
+
+// TODO: reference additional headers your program requires here
+#include "..\cal\winacl.h"
+#include "..\cal\customactiondata.h"
+#include "..\cal\customaction.h"
+#include "..\cal\strings.h"
+#include "..\cal\ddreg.h"
+
+
+#include "resource.h"
+
+#ifdef _WIN64
+// define __REGISTER_ALL_SERVICES to have the custom action install APM & process
+// agent.  Otherwise, only the core service will be installed.
+#define __REGISTER_ALL_SERVICES
+#endif
+#endif //PCH_H

--- a/tools/windows/install-help/uninstall-cmd/uninstall-cmd.cpp
+++ b/tools/windows/install-help/uninstall-cmd/uninstall-cmd.cpp
@@ -1,0 +1,49 @@
+// uninstall-cmd.cpp : This file contains the 'main' function. Program execution begins and ends there.
+//
+
+#include "stdafx.h"
+#include <iostream>
+#define MAX_LOG_LINE 1024
+HMODULE hDllModule = NULL;
+
+void __cdecl WcaLog(__in LOGLEVEL llv, __in_z __format_string PCSTR fmt, ...)
+{
+    static char szBuf[MAX_LOG_LINE]; // note.  This makes this function NOT thread safe.
+    va_list args;
+    va_start(args, fmt);
+    vprintf(fmt, args);
+    wprintf(L"\n");
+    va_end(args);
+}
+
+// replace this function with an error.  We should never be calling this during the
+// console based invocation.
+UINT  WINAPI MsiGetPropertyW(MSIHANDLE hInstall,
+    LPCWSTR szName,           // property identifier, case-sensitive
+    _Out_writes_opt_(*pcchValueBuf)  LPWSTR  szValueBuf,       // buffer for returned property value
+    _Inout_opt_                      LPDWORD  pcchValueBuf)    // in/out buffer character count
+{
+    return ERROR_INVALID_FUNCTION;
+}
+int wmain(int argc, wchar_t **argv)
+{
+    hDllModule = GetModuleHandle(NULL);
+    initializeStringsFromStringTable();
+    std::wstring defaultData;
+    parseArgs(argc - 1, &(argv[1]), defaultData);
+    wprintf(L"%s\n", defaultData.c_str());
+    CustomActionData data;
+    data.init(defaultData);
+    doUninstallAs(UNINSTALL_UNINSTALL);
+}
+
+// Run program: Ctrl + F5 or Debug > Start Without Debugging menu
+// Debug program: F5 or Debug > Start Debugging menu
+
+// Tips for Getting Started: 
+//   1. Use the Solution Explorer window to add/manage files
+//   2. Use the Team Explorer window to connect to source control
+//   3. Use the Output window to see build output and other messages
+//   4. Use the Error List window to view errors
+//   5. Go to Project > Add New Item to create new code files, or Project > Add Existing Item to add existing code files to the project
+//   6. In the future, to open this project again, go to File > Open > Project and select the .sln file

--- a/tools/windows/install-help/uninstall-cmd/uninstall-cmd.h
+++ b/tools/windows/install-help/uninstall-cmd/uninstall-cmd.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    // provide this definition so that code shared with the custom action can log
+    // straight to STDOUT
+    typedef enum LOGLEVEL
+    {
+        LOGMSG_TRACEONLY,  // Never written to the log file (except in DEBUG builds)
+        LOGMSG_VERBOSE,    // Written to log when LOGVERBOSE
+        LOGMSG_STANDARD    // Written to log whenever informational logging is enabled
+    } LOGLEVEL;
+    void __cdecl WcaLog(__in LOGLEVEL llv, __in_z __format_string PCSTR fmt, ...);
+#ifdef __cplusplus
+}
+#endif

--- a/tools/windows/install-help/uninstall-cmd/uninstall-cmd.rc
+++ b/tools/windows/install-help/uninstall-cmd/uninstall-cmd.rc
@@ -1,0 +1,94 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE 9, 1
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE  
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE  
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE  
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef APSTUDIO_INVOKED
+#define VS_VERSION_INFO 1
+ VS_VERSION_INFO VERSIONINFO
+ FILEVERSION RC_FILE_VERSION
+ PRODUCTVERSION RC_FILE_VERSION
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x0L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "Datadog, Inc."
+            VALUE "FileDescription", "Datadog Agent Console Installation Helper"
+            VALUE "FileVersion", FILE_VERSION_STRING
+            VALUE "InternalName", "Agent7"
+            VALUE "LegalCopyright", "Copyright (C) 2016-2020"
+            VALUE "OriginalFilename", "uninstall-cmd.exe"
+            VALUE "ProductName", "Datadog Agent"
+            VALUE "ProductVersion", FILE_VERSION_STRING
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+#endif //APSTUDIO_INVOKED
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/tools/windows/install-help/uninstall-cmd/uninstall-cmd.vcxproj
+++ b/tools/windows/install-help/uninstall-cmd/uninstall-cmd.vcxproj
@@ -20,33 +20,36 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
-    <ProjectGuid>{330D78DA-3542-4456-9694-41F10646B172}</ProjectGuid>
+    <ProjectGuid>{1BF8041F-BB84-407E-9A5D-AE066CACC2D2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
+    <RootNamespace>installcmd</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -74,125 +77,128 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <TargetExt>.dll</TargetExt>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <TargetExt>.dll</TargetExt>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;CUSTOMACTION_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>false</ConformanceMode>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <TargetMachine>MachineX86</TargetMachine>
+      <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>version.lib;dutil.lib;bcrypt.lib;wcautil.lib;netapi32.lib;msi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>$(WIX)sdk\VS2017\lib\x86</AdditionalLibraryDirectories>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CUSTOMACTION_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-    </ClCompile>
-    <Link>
-      <TargetMachine>MachineX86</TargetMachine>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>version.lib;dutil.lib;bcrypt.lib;wcautil.lib;netapi32.lib;msi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>$(WIX)sdk\VS2017\lib\x86</AdditionalLibraryDirectories>
+      <AdditionalDependencies>bcrypt.lib;netapi32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_DEBUG;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>false</ConformanceMode>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>bcrypt.lib;version.lib;advapi32.lib;wcautil.lib;dutil.lib;netapi32.lib;msi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(WIX)sdk\VS2017\lib\x64</AdditionalLibraryDirectories>
-      <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>bcrypt.lib;netapi32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>false</ConformanceMode>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>bcrypt.lib;netapi32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>false</ConformanceMode>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>bcrypt.lib;version.lib;advapi32.lib;wcautil.lib;dutil.lib;netapi32.lib;msi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(WIX)sdk\VS2017\lib\x64</AdditionalLibraryDirectories>
-      <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>bcrypt.lib;netapi32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="CustomAction.cpp" />
-    <ClCompile Include="customactiondata.cpp" />
-    <ClCompile Include="ddreg.cpp" />
-    <ClCompile Include="delfiles.cpp" />
-    <ClCompile Include="doUninstall.cpp" />
-    <ClCompile Include="FinalizeInstall.cpp" />
-    <ClCompile Include="rollback.cpp" />
+    <ClInclude Include="cmdargs.h" />
+    <ClInclude Include="uninstall-cmd.h" />
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="resource.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\cal\caninstall.cpp" />
+    <ClCompile Include="..\cal\customactiondata.cpp" />
+    <ClCompile Include="..\cal\ddreg.cpp" />
+    <ClCompile Include="..\cal\doUninstall.cpp" />
+    <ClCompile Include="..\cal\stopservices.cpp" />
+    <ClCompile Include="..\cal\strings.cpp" />
+    <ClCompile Include="..\cal\usercreate.cpp" />
+    <ClCompile Include="..\cal\userrights.cpp" />
+    <ClCompile Include="..\cal\winacl.cpp" />
+    <ClCompile Include="cmdline.cpp" />
+    <ClCompile Include="uninstall-cmd.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
-    <ClCompile Include="stopservices.cpp" />
-    <ClCompile Include="strings.cpp" />
-    <ClCompile Include="usercreate.cpp" />
-    <ClCompile Include="userrights.cpp" />
-    <ClCompile Include="winacl.cpp" />
-    <ClCompile Include="caninstall.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="CustomAction.def" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="customactiondata.h" />
-    <ClInclude Include="ddreg.h" />
-    <ClInclude Include="resource.h" />
-    <ClInclude Include="stdafx.h" />
-    <ClInclude Include="strings.h" />
-    <ClInclude Include="targetver.h" />
-    <ClInclude Include="customaction.h" />
-    <ClInclude Include="winacl.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="customaction.rc">
+    <ResourceCompile Include="..\cal\stringtable.rc" />
+    <ResourceCompile Include="uninstall-cmd.rc">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">_UNICODE;UNICODE;%(PreprocessorDefinitions);MAJ_VER=$(MAJ_VER);MIN_VER=$(MIN_VER);PATCH_VER=$(PATCH_VER)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">_UNICODE;UNICODE;%(PreprocessorDefinitions);MAJ_VER=$(MAJ_VER);MIN_VER=$(MIN_VER);PATCH_VER=$(PATCH_VER)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_UNICODE;UNICODE;%(PreprocessorDefinitions);MAJ_VER=$(MAJ_VER);MIN_VER=$(MIN_VER);PATCH_VER=$(PATCH_VER)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">_UNICODE;UNICODE;%(PreprocessorDefinitions);MAJ_VER=$(MAJ_VER);MIN_VER=$(MIN_VER);PATCH_VER=$(PATCH_VER)</PreprocessorDefinitions>
     </ResourceCompile>
-    <ResourceCompile Include="stringtable.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
installation steps added with `uninstall-cmd`

### What does this PR do?

Adds a new executable to the bosh package.
Further factors the installer custom action so that it's linkable from the command line application

### Motivation

Clean uninstall of Bosh environments

### Additional Notes

Anything else we should know when reviewing?
