### PR TITLE
Fix leftover system-probe.pid file

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -133,6 +133,7 @@ func gracefulExit() {
 	// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
 	// http://supervisord.org/subprocess.html#process-states
 	time.Sleep(5 * time.Second)
+	os.Remove(opts.pidFilePath) // defer function that does this won't be called since we do os.Exit.
 	os.Exit(0)
 }
 


### PR DESCRIPTION
### Motivation

Kitchen tests found we were leaving this file behind, now that system-probe is started with the agent.