### PR TITLE
remove hostname tag on eks fargate

### DIFF
--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -157,7 +157,7 @@ func GetHostnameData() (HostnameData, error) {
 	log.Debug("Trying to determine a reliable host name automatically...")
 
 	// if fargate we strip the hostname
-	if ecs.IsFargateInstance() {
+	if ecs.IsFargateInstance() || config.Datadog.GetBool("eks_fargate") {
 		hostnameData := saveHostnameData(cacheHostnameKey, "", "")
 		return hostnameData, nil
 	}


### PR DESCRIPTION
### What does this PR do?

This PR add the "eks on fargate" environment detection to support the hostname tag removal in this serverless environment. 

