### PR TITLE
Invoke tasks agent.build and rtloader.build conflict on ARM linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: build rtloader
           command: |
-            inv rtloader.build --install-prefix=/go/src/github.com/DataDog/datadog-agent/dev
+            inv rtloader.make --install-prefix=/go/src/github.com/DataDog/datadog-agent/dev
             inv rtloader.install
       - run:
           name: lint rtloader

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -261,7 +261,7 @@ run_tests_windows-x86:
     - pip install -r requirements.txt
     - go get gopkg.in/yaml.v2
     - go get github.com/stretchr/testify
-    - inv -e rtloader.build --install-prefix=$SRC_PATH/dev --python-runtimes "$PYTHON_RUNTIMES"
+    - inv -e rtloader.make --install-prefix=$SRC_PATH/dev --python-runtimes "$PYTHON_RUNTIMES"
     - inv -e rtloader.install
     - inv -e rtloader.format --raise-if-changed
     - inv -e rtloader.test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build: off
 
 test_script:
   - inv -e deps --dep-vendor-only
-  - inv -e rtloader.build --install-prefix=%APPVEYOR_BUILD_FOLDER%\dev --cmake-options="-G \"MSYS Makefiles\""
+  - inv -e rtloader.make --install-prefix=%APPVEYOR_BUILD_FOLDER%\dev --cmake-options="-G \"MSYS Makefiles\""
   - inv -e rtloader.install
   - inv -e rtloader.format --raise-if-changed
   - inv -e rtloader.test

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -58,12 +58,12 @@ build do
   # we assume the go deps are already installed before running omnibus
   if windows?
     platform = windows_arch_i386? ? "x86" : "x64"
-    command "inv -e rtloader.build --python-runtimes #{py_runtimes_arg} --install-prefix \"#{windows_safe_path(python_2_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\"\" --arch #{platform}", :env => env
+    command "inv -e rtloader.make --python-runtimes #{py_runtimes_arg} --install-prefix \"#{windows_safe_path(python_2_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\"\" --arch #{platform}", :env => env
     command "mv rtloader/bin/*.dll  #{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent/"
     command "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded --arch #{platform}", env: env
     command "inv -e systray.build --major-version #{major_version_arg} --rebuild --no-development --arch #{platform}", env: env
   else
-    command "inv -e rtloader.build --python-runtimes #{py_runtimes_arg} --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER'", :env => env
+    command "inv -e rtloader.make --python-runtimes #{py_runtimes_arg} --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER'", :env => env
     command "inv -e rtloader.install"
     command "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded", env: env
   end

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -20,7 +20,7 @@ from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS,
 from .go import deps, generate
 from .docker import pull_base_images
 from .ssm import get_signing_cert, get_pfx_pass
-from .rtloader import build as rtloader_build
+from .rtloader import make as rtloader_make
 from .rtloader import install as rtloader_install
 from .rtloader import clean as rtloader_clean
 
@@ -94,7 +94,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     """
 
     if not exclude_rtloader and not puppy:
-        rtloader_build(ctx, python_runtimes=python_runtimes)
+        rtloader_make(ctx, python_runtimes=python_runtimes)
         rtloader_install(ctx)
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -48,7 +48,7 @@ def clear_cmake_cache(rtloader_path, settings):
         os.remove(cmake_cache)
 
 @task
-def build(ctx, install_prefix=None, python_runtimes='3', cmake_options='', arch="x64"):
+def make(ctx, install_prefix=None, python_runtimes='3', cmake_options='', arch="x64"):
     dev_path = get_dev_path()
 
     if cmake_options.find("-G") == -1:
@@ -78,7 +78,7 @@ def build(ctx, install_prefix=None, python_runtimes='3', cmake_options='', arch=
     if arch == "x86":
         cmake_args += " -DARCH_I386=ON"
 
-    # Perform "out of the source build" in `rtloader_build_path` folder. 
+    # Perform "out of the source build" in `rtloader_build_path` folder.
     try:
         os.makedirs(rtloader_build_path)
     except OSError as e:
@@ -94,8 +94,8 @@ def build(ctx, install_prefix=None, python_runtimes='3', cmake_options='', arch=
 def clean(ctx):
     """
     Clean up CMake's cache.
-    Necessary when the paths to some libraries found by CMake (for example Python) have changed on the system.    
-    """    
+    Necessary when the paths to some libraries found by CMake (for example Python) have changed on the system.
+    """
     dev_path = get_dev_path()
     include_path = os.path.join(dev_path, "include")
     lib_path = os.path.join(dev_path, "lib")

--- a/tasks/winbuildscripts/unittests.bat
+++ b/tasks/winbuildscripts/unittests.bat
@@ -12,4 +12,4 @@ cd \dev\go\src\github.com\DataDog\datadog-agent
 xcopy /e/s/h/q c:\mnt\*.*
 
 
-Powershell -C "\unittests.ps1"
+Powershell -C "c:\mnt\tasks\winbuildscripts\unittests.ps1"

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -15,11 +15,11 @@ if ($Env:TARGET_ARCH -eq "x86") {
     $archflag = "x86"
 }
 & go get gopkg.in/yaml.v2
-& inv -e rtloader.build --python-runtimes="$Env:PY_RUNTIMES" --install-prefix=$Env:BUILD_ROOT\dev --cmake-options='-G \"Unix Makefiles\"' --arch $archflag
+& inv -e rtloader.make --python-runtimes="$Env:PY_RUNTIMES" --install-prefix=$Env:BUILD_ROOT\dev --cmake-options='-G \"Unix Makefiles\"' --arch $archflag
 $err = $LASTEXITCODE
 Write-Host Build result is $err
 if($err -ne 0){
-    Write-Host -ForegroundColor Red "rtloader build failed $err"
+    Write-Host -ForegroundColor Red "rtloader make failed $err"
     [Environment]::Exit($err)
 }
 
@@ -30,7 +30,7 @@ if($err -ne 0){
 # Write-Host Format result is $err
 
 # if($err -ne 0){
-#   Write-Host -ForegroundColor Red "format build failed $err"
+#   Write-Host -ForegroundColor Red "rtloader format failed $err"
 #   [Environment]::Exit($err)
 # }
 


### PR DESCRIPTION
### What does this PR do?

We don't know why yet but invoke task conflict with one another on ARM
with python 3.5. Temporary workaround is to give them different name to
unblock the CI.
