### PR TITLE
Adding busyness metric

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -131,6 +131,7 @@ func (d *dispatcher) expireNodes() {
 			nodeAgents.Dec()
 			dispatchedConfigs.Delete(name)
 			statsCollectionFails.Delete(name)
+			busyness.Delete(name)
 		}
 		node.RUnlock()
 	}
@@ -182,6 +183,7 @@ func (d *dispatcher) updateRunnersStats() {
 		log.Tracef("Updated CLC Runner stats on node: %s, node IP: %s, stats: %v", name, node.clientIP, stats)
 		node.busyness = calculateBusyness(stats)
 		log.Debugf("Updated busyness on node: %s, node IP: %s, busyness value: %d", name, node.clientIP, node.busyness)
+		busyness.Set(float64(node.busyness), node.name)
 		node.Unlock()
 	}
 }

--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -36,4 +36,7 @@ var (
 	updateStatsDuration = telemetry.NewGaugeWithOpts("cluster_checks", "updating_stats_duration_seconds",
 		nil, "Duration of collecting stats from check runners and updating cache",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+	busyness = telemetry.NewGaugeWithOpts("cluster_checks", "busyness",
+		[]string{"node"}, "Busyness of a node per the number of metrics submitted and average duration of all checks run",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 )


### PR DESCRIPTION
### What does this PR do?

Adds a metric to monitor the advanced dispatching algorithm.

```
2020-02-21 21:20:34 UTC | CLUSTER | DEBUG | (pkg/clusteragent/clusterchecks/dispatcher_nodes.go:185 in updateRunnersStats) | Updated busyness on node: gke-charly-default-pool-6948dc89-fs46.c.datadog-sandbox.internal, node IP: 10.XXX.YYY.7, busyness value: 10932
```

With one node:
```
root@datadog-cluster-agent-86b4596d68-qrllm:/# curl localhost:5000/metrics -s | grep busyness
# HELP cluster_checks_busyness Busyness of a node per the number of metrics submitted and average duration of all checks run
# TYPE cluster_checks_busyness gauge
cluster_checks_busyness{node="gke-charly-default-pool-6948dc89-fs46.c.datadog-sandbox.internal"} 10932
```
Scaling the number of workers to 2, waiting for the algorithm to re-dispatch:
<img width="834" alt="Image 2020-02-21 at 4 48 20 PM" src="https://user-images.githubusercontent.com/7433560/75074596-fe4f7000-54c9-11ea-8206-f1845019b73e.png">

### Motivation

Improving observability for the Cluster Level Checks

### Additional Notes

Anything else we should know when reviewing?
