### PR TITLE
Add --full-sketches option to display bins in `agent check` output

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -41,6 +41,7 @@ var (
 	logLevel             string
 	formatJSON           bool
 	breakPoint           string
+	fullSketches         bool
 	profileMemory        bool
 	profileMemoryDir     string
 	profileMemoryFrames  string
@@ -68,6 +69,8 @@ func init() {
 	checkCmd.Flags().BoolVarP(&formatJSON, "json", "", false, "format aggregator and check runner output as json")
 	checkCmd.Flags().StringVarP(&breakPoint, "breakpoint", "b", "", "set a breakpoint at a particular line number (Python checks only)")
 	checkCmd.Flags().BoolVarP(&profileMemory, "profile-memory", "m", false, "run the memory profiler (Python checks only)")
+	checkCmd.Flags().BoolVar(&fullSketches, "full-sketches", false, "output sketches with bins information")
+	config.Datadog.BindPFlag("cmd.check.fullsketches", checkCmd.Flags().Lookup("full-sketches"))
 
 	// Power user flags - mark as hidden
 	createHiddenStringFlag(&profileMemoryDir, "m-dir", "", "an existing directory in which to store memory profiling data, ignoring clean-up")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -617,6 +617,9 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("inventories_max_interval", 600) // 10min
 	config.BindEnvAndSetDefault("inventories_min_interval", 300) // 5min
 
+	// command line options
+	config.SetKnown("cmd.check.fullsketches")
+
 	setAssetFs(config)
 }
 

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/DataDog/agent-payload/gogen"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/quantile"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+	"github.com/DataDog/datadog-agent/pkg/util/common"
 )
 
 // A SketchSeries is a timeseries of quantile sketches.
@@ -30,13 +32,47 @@ type SketchPoint struct {
 type SketchSeriesList []SketchSeries
 
 // MarshalJSON serializes sketch series to JSON.
+// Quite slow, but hopefully this method is called only in the `agent check` command
 func (sl SketchSeriesList) MarshalJSON() ([]byte, error) {
-	// use an alias to avoid infinite recursion while serializing a SketchSeriesList
-	type SketchSeriesAlias SketchSeriesList
+	// We use this function to customize generated JSON
+	// This function, only used when displaying `bins`, is especially slow
+	// As `StructToMap` function is using reflection to return a generic map[string]interface{}
+	customSketchSeries := func(srcSl SketchSeriesList) []interface{} {
+		dstSl := make([]interface{}, 0, len(srcSl))
 
-	data := map[string][]SketchSeries{
+		for _, ss := range srcSl {
+			ssMap := common.StructToMap(ss)
+			for i, sketchPoint := range ss.Points {
+				if sketchPoint.Sketch != nil {
+					sketch := ssMap["points"].([]interface{})[i].(map[string]interface{})
+					count, bins := sketchPoint.Sketch.GetRawBins()
+					sketch["binsCount"] = count
+					sketch["bins"] = bins
+				}
+			}
+
+			dstSl = append(dstSl, ssMap)
+		}
+
+		return dstSl
+	}
+
+	// use an alias to avoid infinite recursion while serializing a SketchSeriesList
+	if config.Datadog.GetBool("cmd.check.fullsketches") {
+		data := map[string]interface{}{
+			"sketches": customSketchSeries(sl),
+		}
+
+		reqBody := &bytes.Buffer{}
+		err := json.NewEncoder(reqBody).Encode(data)
+		return reqBody.Bytes(), err
+	}
+
+	type SketchSeriesAlias SketchSeriesList
+	data := map[string]SketchSeriesAlias{
 		"sketches": SketchSeriesAlias(sl),
 	}
+
 	reqBody := &bytes.Buffer{}
 	err := json.NewEncoder(reqBody).Encode(data)
 	return reqBody.Bytes(), err

--- a/pkg/metrics/sketch_series_test.go
+++ b/pkg/metrics/sketch_series_test.go
@@ -4,67 +4,68 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/quantile"
-
 	"github.com/DataDog/agent-payload/gogen"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/quantile"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func makesketch(n int) *quantile.Sketch {
+	s, c := &quantile.Sketch{}, quantile.Default()
+	for i := 0; i < n; i++ {
+		s.Insert(c, float64(i))
+	}
+	return s
+}
+
+// makeseries is deterministic so that we can test for mutation.
+func makeseries(i int) SketchSeries {
+	ss := SketchSeries{
+		Name: fmt.Sprintf("name.%d", i),
+		Tags: []string{
+			fmt.Sprintf("a:%d", i),
+			fmt.Sprintf("b:%d", i),
+		},
+		Host:     fmt.Sprintf("host.%d", i),
+		Interval: int64(i),
+	}
+
+	for j := 0; j < i+5; j++ {
+		ss.Points = append(ss.Points, SketchPoint{
+			Ts:     10 * int64(j),
+			Sketch: makesketch(j),
+		})
+	}
+
+	gen := ckey.NewKeyGenerator()
+	ss.ContextKey = gen.Generate(ss.Name, ss.Host, ss.Tags)
+
+	return ss
+}
+
+func check(t *testing.T, in SketchPoint, pb gogen.SketchPayload_Sketch_Dogsketch) {
+	t.Helper()
+	s, b := in.Sketch, in.Sketch.Basic
+	require.Equal(t, in.Ts, pb.Ts)
+
+	// sketch
+	k, n := s.Cols()
+	require.Equal(t, k, pb.K)
+	require.Equal(t, n, pb.N)
+
+	// summary
+	require.Equal(t, b.Cnt, pb.Cnt)
+	require.Equal(t, b.Min, pb.Min)
+	require.Equal(t, b.Max, pb.Max)
+	require.Equal(t, b.Avg, pb.Avg)
+	require.Equal(t, b.Sum, pb.Sum)
+}
+
 func TestSketchSeriesListMarshal(t *testing.T) {
-	var (
-		sl         = make(SketchSeriesList, 2)
-		makesketch = func(n int) *quantile.Sketch {
-			s, c := &quantile.Sketch{}, quantile.Default()
-			for i := 0; i < n; i++ {
-				s.Insert(c, float64(i))
-			}
-			return s
-		}
-
-		// makeseries is deterministic so that we can test for mutation.
-		makeseries = func(i int) SketchSeries {
-			ss := SketchSeries{
-				Name: fmt.Sprintf("name.%d", i),
-				Tags: []string{
-					fmt.Sprintf("a:%d", i),
-					fmt.Sprintf("b:%d", i),
-				},
-				Host:     fmt.Sprintf("host.%d", i),
-				Interval: int64(i),
-			}
-
-			for j := 0; j < i+5; j++ {
-				ss.Points = append(ss.Points, SketchPoint{
-					Ts:     10 * int64(j),
-					Sketch: makesketch(j),
-				})
-			}
-
-			gen := ckey.NewKeyGenerator()
-			ss.ContextKey = gen.Generate(ss.Name, ss.Host, ss.Tags)
-
-			return ss
-		}
-
-		check = func(in SketchPoint, pb gogen.SketchPayload_Sketch_Dogsketch) {
-			s, b := in.Sketch, in.Sketch.Basic
-			require.Equal(t, in.Ts, pb.Ts)
-
-			// sketch
-			k, n := s.Cols()
-			require.Equal(t, k, pb.K)
-			require.Equal(t, n, pb.N)
-
-			// summary
-			require.Equal(t, b.Cnt, pb.Cnt)
-			require.Equal(t, b.Min, pb.Min)
-			require.Equal(t, b.Max, pb.Max)
-			require.Equal(t, b.Avg, pb.Avg)
-			require.Equal(t, b.Sum, pb.Sum)
-		}
-	)
+	sl := make(SketchSeriesList, 2)
 
 	for i := range sl {
 		sl[i] = makeseries(i)
@@ -94,12 +95,28 @@ func TestSketchSeriesListMarshal(t *testing.T) {
 		require.Len(t, pb.Dogsketches, len(in.Points))
 		for j, pointPb := range pb.Dogsketches {
 
-			check(in.Points[j], pointPb)
+			check(t, in.Points[j], pointPb)
 			// require.Equal(t, pointIn.Ts, pointPb.Ts)
 			// require.Equal(t, pointIn.Ts, pointPb.Ts)
 
 			// fmt.Printf("%#v %#v\n", pin, s)
 		}
 	}
+}
 
+func TestSketchSeriesListJSONMarshal(t *testing.T) {
+	sl := make(SketchSeriesList, 2)
+
+	for i := range sl {
+		sl[i] = makeseries(i)
+	}
+
+	json, err := sl.MarshalJSON()
+	assert.NoError(t, err)
+	assert.JSONEq(t, string(json), `{"sketches":[{"metric":"name.0","tags":["a:0","b:0"],"host":"host.0","interval":0,"points":[{"sketch":{"summary":{"Min":0,"Max":0,"Sum":0,"Avg":0,"Cnt":0}},"ts":0},{"sketch":{"summary":{"Min":0,"Max":0,"Sum":0,"Avg":0,"Cnt":1}},"ts":10},{"sketch":{"summary":{"Min":0,"Max":1,"Sum":1,"Avg":0.5,"Cnt":2}},"ts":20},{"sketch":{"summary":{"Min":0,"Max":2,"Sum":3,"Avg":1,"Cnt":3}},"ts":30},{"sketch":{"summary":{"Min":0,"Max":3,"Sum":6,"Avg":1.5,"Cnt":4}},"ts":40}]},{"metric":"name.1","tags":["a:1","b:1"],"host":"host.1","interval":1,"points":[{"sketch":{"summary":{"Min":0,"Max":0,"Sum":0,"Avg":0,"Cnt":0}},"ts":0},{"sketch":{"summary":{"Min":0,"Max":0,"Sum":0,"Avg":0,"Cnt":1}},"ts":10},{"sketch":{"summary":{"Min":0,"Max":1,"Sum":1,"Avg":0.5,"Cnt":2}},"ts":20},{"sketch":{"summary":{"Min":0,"Max":2,"Sum":3,"Avg":1,"Cnt":3}},"ts":30},{"sketch":{"summary":{"Min":0,"Max":3,"Sum":6,"Avg":1.5,"Cnt":4}},"ts":40},{"sketch":{"summary":{"Min":0,"Max":4,"Sum":10,"Avg":2,"Cnt":5}},"ts":50}]}]}`)
+
+	config.Datadog.Set("cmd.check.fullsketches", true)
+	json, err = sl.MarshalJSON()
+	assert.NoError(t, err)
+	assert.JSONEq(t, string(json), `{"sketches":[{"host":"host.0","interval":0,"metric":"name.0","points":[{"bins":"","binsCount":0,"sketch":{"summary":{"Avg":0,"Cnt":0,"Max":0,"Min":0,"Sum":0}},"ts":0},{"bins":"0:1","binsCount":1,"sketch":{"summary":{"Avg":0,"Cnt":1,"Max":0,"Min":0,"Sum":0}},"ts":10},{"bins":"0:1 1338:1","binsCount":2,"sketch":{"summary":{"Avg":0.5,"Cnt":2,"Max":1,"Min":0,"Sum":1}},"ts":20},{"bins":"0:1 1338:1 1383:1","binsCount":3,"sketch":{"summary":{"Avg":1,"Cnt":3,"Max":2,"Min":0,"Sum":3}},"ts":30},{"bins":"0:1 1338:1 1383:1 1409:1","binsCount":4,"sketch":{"summary":{"Avg":1.5,"Cnt":4,"Max":3,"Min":0,"Sum":6}},"ts":40}],"tags":["a:0","b:0"]},{"host":"host.1","interval":1,"metric":"name.1","points":[{"bins":"","binsCount":0,"sketch":{"summary":{"Avg":0,"Cnt":0,"Max":0,"Min":0,"Sum":0}},"ts":0},{"bins":"0:1","binsCount":1,"sketch":{"summary":{"Avg":0,"Cnt":1,"Max":0,"Min":0,"Sum":0}},"ts":10},{"bins":"0:1 1338:1","binsCount":2,"sketch":{"summary":{"Avg":0.5,"Cnt":2,"Max":1,"Min":0,"Sum":1}},"ts":20},{"bins":"0:1 1338:1 1383:1","binsCount":3,"sketch":{"summary":{"Avg":1,"Cnt":3,"Max":2,"Min":0,"Sum":3}},"ts":30},{"bins":"0:1 1338:1 1383:1 1409:1","binsCount":4,"sketch":{"summary":{"Avg":1.5,"Cnt":4,"Max":3,"Min":0,"Sum":6}},"ts":40},{"bins":"0:1 1338:1 1383:1 1409:1 1427:1","binsCount":5,"sketch":{"summary":{"Avg":2,"Cnt":5,"Max":4,"Min":0,"Sum":10}},"ts":50}],"tags":["a:1","b:1"]}]}`)
 }

--- a/pkg/quantile/sparse.go
+++ b/pkg/quantile/sparse.go
@@ -57,6 +57,11 @@ func (s *Sketch) Reset() {
 	s.bins = s.bins[:0] // TODO: just release to a size tiered pool.
 }
 
+// GetRawBins return raw bins information as string
+func (s *Sketch) GetRawBins() (int, string) {
+	return s.count, strings.Replace(s.bins.String(), "\n", "", -1)
+}
+
 // Insert a single value into the sketch.
 // NOTE: InsertMany is much more efficient.
 func (s *Sketch) Insert(c *Config, vals ...float64) {

--- a/pkg/util/common/common.go
+++ b/pkg/util/common/common.go
@@ -5,6 +5,11 @@
 
 package common
 
+import (
+	"reflect"
+	"strings"
+)
+
 // StringSet represents a list of uniq strings
 type StringSet map[string]struct{}
 
@@ -29,4 +34,80 @@ func (s StringSet) GetAll() []string {
 		res = append(res, item)
 	}
 	return res
+}
+
+// StructToMap converts a struct to a map[string]interface{} based on `json` annotations defaulting to field names
+func StructToMap(obj interface{}) map[string]interface{} {
+	rt, rv := reflect.TypeOf(obj), reflect.ValueOf(obj)
+	if rt != nil && rt.Kind() != reflect.Struct {
+		return make(map[string]interface{}, 0)
+	}
+
+	out := make(map[string]interface{}, rt.NumField())
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+
+		// Unexported fields, access not allowed
+		if field.PkgPath != "" {
+			continue
+		}
+
+		var fieldName string
+		if tagVal, ok := field.Tag.Lookup("json"); ok {
+			// Honor the special "-" in json attribute
+			if strings.HasPrefix(tagVal, "-") {
+				continue
+			}
+			fieldName = tagVal
+		} else {
+			fieldName = field.Name
+		}
+
+		val := valueToInterface(rv.Field(i))
+		if val != nil {
+			out[fieldName] = val
+		}
+	}
+
+	return out
+}
+
+func valueToInterface(value reflect.Value) interface{} {
+	if !value.IsValid() {
+		return nil
+	}
+
+	switch value.Type().Kind() {
+	case reflect.Struct:
+		return StructToMap(value.Interface())
+
+	case reflect.Ptr:
+		if !value.IsNil() {
+			return valueToInterface(value.Elem())
+		}
+
+	case reflect.Array:
+	case reflect.Slice:
+		arr := make([]interface{}, 0, value.Len())
+		for i := 0; i < value.Len(); i++ {
+			val := valueToInterface(value.Index(i))
+			if val != nil {
+				arr = append(arr, val)
+			}
+		}
+		return arr
+
+	case reflect.Map:
+		m := make(map[string]interface{}, value.Len())
+		for _, k := range value.MapKeys() {
+			v := value.MapIndex(k)
+			m[k.String()] = valueToInterface(v)
+		}
+		return m
+
+	default:
+		return value.Interface()
+	}
+
+	return nil
 }

--- a/pkg/util/common/common_test.go
+++ b/pkg/util/common/common_test.go
@@ -43,3 +43,90 @@ func TestStringSetGetAll(t *testing.T) {
 	res.Sort()
 	assert.Equal(t, []string{"a", "b", "c"}, []string(res))
 }
+
+func TestStructToMap(t *testing.T) {
+	type MoreNested struct {
+		Name         string  `json:"name"`
+		Value        float64 `json:"value"`
+		ID           *string `json:"id"`
+		privateValue float64 //nolint:structcheck
+		JSONLessStr  string
+	}
+
+	type Nested struct {
+		Foo []MoreNested `json:"moreNested"`
+	}
+
+	type Top struct {
+		Name      string            `json:"name"`
+		Value     int               `json:"value"`
+		NestedPtr *Nested           `json:"nested"`
+		ID        string            `json:"-"`
+		MyMap     map[string]Nested `json:"mymap"`
+	}
+
+	str := "toto"
+	nested := Nested{
+		Foo: []MoreNested{
+			{
+				Name:         "ms1",
+				Value:        1,
+				ID:           &str,
+				JSONLessStr:  "42",
+				privateValue: 1000,
+			},
+			{
+				Name:  "ms2",
+				Value: 2,
+				ID:    nil,
+			},
+		},
+	}
+
+	top := Top{
+		Name:      "top",
+		Value:     0,
+		NestedPtr: &nested,
+		ID:        "top1",
+		MyMap: map[string]Nested{
+			"n1": nested,
+		},
+	}
+
+	assert.Equal(t, map[string]interface{}{
+		"name":  "top",
+		"value": 0,
+		"nested": map[string]interface{}{
+			"moreNested": []interface{}{
+				map[string]interface{}{
+					"id":          "toto",
+					"name":        "ms1",
+					"value":       float64(1),
+					"JSONLessStr": "42",
+				},
+				map[string]interface{}{
+					"name":        "ms2",
+					"value":       float64(2),
+					"JSONLessStr": "",
+				},
+			},
+		},
+		"mymap": map[string]interface{}{
+			"n1": map[string]interface{}{
+				"moreNested": []interface{}{
+					map[string]interface{}{
+						"id":          "toto",
+						"name":        "ms1",
+						"value":       float64(1),
+						"JSONLessStr": "42",
+					},
+					map[string]interface{}{
+						"name":        "ms2",
+						"value":       float64(2),
+						"JSONLessStr": "",
+					},
+				},
+			},
+		},
+	}, StructToMap(top))
+}

--- a/releasenotes/notes/bins-information-sketches-8d76e76fd919d5b1.yaml
+++ b/releasenotes/notes/bins-information-sketches-8d76e76fd919d5b1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add --full-sketches option to agent check command that displays bins information


### PR DESCRIPTION
Note: PR coming back for 7.19 with fixing the build issue with old golang versions.
https://github.com/DataDog/datadog-agent/pull/4856

### What does this PR do?

Add the bins in the Sketches output when the --full-sketches option is set.

```
    {
      "host": "gke-vboulineau-default-pool-7ce03502-3nzf.c.datadog-sandbox.internal",
      "interval": 0,
      "metric": "openmetrics_gen.http_response_time_seconds_histogram",
      "points": [
        {
          "bins": "1189:1 1190:5 1191:6 1192:7 1193:6 1194:6 1195:6 1196:7 1197:6 1198:7 1199:7 1200:7 1201:7 1202:7 1203:7 1204:7 1205:8 1206:7 1207:8 1208:8 1209:8 1210:8 1211:8 1212:8 1213:9 1214:8 1215:9 1216:9 1217:9 1218:9 1219:9 1220:91221:10 1222:10 1223:10 1224:10 1225:10 1226:10 1227:10 1228:11 1229:11 1230:11 1231:11 1232:11 1233:12 1234:11 1235:12 1236:12 1237:13 1238:12 1239:13 1240:12 1241:13 1242:14 1243:13 1244:14 1245:13 1246:14 1247:15 1248:14 1249:1",
          "binsCount": 566,
          "sketch": {
            "summary": {
              "Avg": 0.17486749191245204,
              "Cnt": 566,
              "Max": 0.24973498233478797,
              "Min": 0.10000000149011612,
              "Sum": 98.97500042244783
            }
          },
          "ts": 1581082664
        }
      ],
      "tags": [
        "image_name:mfpierre/prometheus-generator",
        "image_tag:latest",
        "kube_container_name:openmetrics-generator",
        "kube_deployment:openmetrics-generator",
        "kube_namespace:default",
        "lower_bound:0.1",
        "pod_phase:running",
        "short_image:prometheus-generator",
        "upper_bound:0.25"
      ]
    }
```

Note that the implementation is not straightforward for two reasons:
- json annotations are not dynamic and data we'd like to omit are not pointers
- bins information are private

Current solution is to generate generic map[string]interface{} objects instead of struct to allow data injection wherever we want.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
