### PR TITLE
[jmxfetch] Bump nightlies to 0.35.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,18 +1,18 @@
 {
     "nightly": {
-        "INTEGRATIONS_CORE_VERSION": "master", 
-        "OMNIBUS_SOFTWARE_VERSION": "master", 
-        "OMNIBUS_RUBY_VERSION": "datadog-5.5.0", 
-        "JMXFETCH_VERSION": "0.34.0", 
-        "JMXFETCH_HASH": "b5c053b960f9fa949a76ec3b84c308586c409f956379481e6a0044867deb7b52"
-    }, 
+        "INTEGRATIONS_CORE_VERSION": "master",
+        "OMNIBUS_SOFTWARE_VERSION": "master",
+        "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
+        "JMXFETCH_VERSION": "0.35.0",
+        "JMXFETCH_HASH": "1f1c8435b56050e006990c450b3c8969c3097932c01e080b2c320343a968fcba"
+    },
     "nightly-a7": {
-        "INTEGRATIONS_CORE_VERSION": "master", 
-        "OMNIBUS_SOFTWARE_VERSION": "master", 
-        "OMNIBUS_RUBY_VERSION": "datadog-5.5.0", 
-        "JMXFETCH_VERSION": "0.34.0", 
-        "JMXFETCH_HASH": "b5c053b960f9fa949a76ec3b84c308586c409f956379481e6a0044867deb7b52"
-    }, 
+        "INTEGRATIONS_CORE_VERSION": "master",
+        "OMNIBUS_SOFTWARE_VERSION": "master",
+        "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
+        "JMXFETCH_VERSION": "0.35.0",
+        "JMXFETCH_HASH": "1f1c8435b56050e006990c450b3c8969c3097932c01e080b2c320343a968fcba"
+    },
     "6.17.0": {
         "INTEGRATIONS_CORE_VERSION": "7.17.0", 
         "OMNIBUS_SOFTWARE_VERSION": "7.17.0", 

--- a/releasenotes/notes/jmxfetch-0-35-0-9ed274574706566e.yaml
+++ b/releasenotes/notes/jmxfetch-0-35-0-9ed274574706566e.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    JMXFetch upgraded to `0.35.0 <https://github.com/DataDog/jmxfetch/releases/0.35.0>`_


### PR DESCRIPTION
### What does this PR do?

Bump JMXFetch on nightlies to 0.35.0

### Additional Notes

See https://github.com/DataDog/jmxfetch/releases/tag/0.35.0
