### PR TITLE
Add dockerfile for Windows Agent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2141,7 +2141,7 @@ build_agent7_windows:
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
     - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}${TAG_SUFFIX}-win1809-amd64"
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.msi ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.msi
-    - docker build $BUILD_ARG --pull --file $BUILD_CONTEXT/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}
+    - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - docker push ${TARGET_TAG}
 
 # build the cluster-agent image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2135,12 +2135,12 @@ build_agent7_windows:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
-    BUILD_ARG: --build-arg BASE_IMAGE=servercore:1809
+    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809
   script:
     - $ErrorActionPreference = "Stop"
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
     - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}${TAG_SUFFIX}-win1809-amd64"
-    - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.msi ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.msi
+    - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip
     - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - docker push ${TARGET_TAG}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2133,7 +2133,7 @@ build_agent7_windows:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
-    BUILD_CONTEXT: Dockerfiles/agent/windows/amd64/
+    BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
     BUILD_ARG: --build-arg BASE_IMAGE=servercore:1809
   script:
@@ -2141,7 +2141,7 @@ build_agent7_windows:
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
     - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}${TAG_SUFFIX}-win1809-amd64"
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.msi ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.msi
-    - docker build $BUILD_ARG --pull --tag ${TARGET_TAG} ${BUILD_CONTEXT}
+    - docker build $BUILD_ARG --pull --file $BUILD_CONTEXT/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}
     - docker push ${TARGET_TAG}
 
 # build the cluster-agent image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2133,14 +2133,15 @@ build_agent7_windows:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
-    TAG_SUFFIX: -7
     BUILD_CONTEXT: Dockerfiles/agent/windows/amd64/
+    TAG_SUFFIX: -7
+    BUILD_ARG: --build-arg BASE_IMAGE=servercore:1809
   script:
     - $ErrorActionPreference = "Stop"
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
     - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}${TAG_SUFFIX}-win1809-amd64"
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.msi ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.msi
-    - docker build --pull --tag ${TARGET_TAG} ${BUILD_CONTEXT}
+    - docker build $BUILD_ARG --pull --tag ${TARGET_TAG} ${BUILD_CONTEXT}
     - docker push ${TARGET_TAG}
 
 # build the cluster-agent image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2124,6 +2124,25 @@ build_agent7_jmx_arm64:
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
     TESTING_ARG:  --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
 
+# build agent7_windows image
+build_agent7_windows:
+  stage: image_build
+  before_script: [ "# noop" ] # Override top level entry
+  needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
+  <<: *skip_when_unwanted_on_7
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  variables:
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    TAG_SUFFIX: -7
+    BUILD_CONTEXT: Dockerfiles/agent/windows/amd64/
+  script:
+    - $ErrorActionPreference = "Stop"
+    - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
+    - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}${TAG_SUFFIX}-win1809-amd64"
+    - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.msi ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.msi
+    - docker build --pull --tag ${TARGET_TAG} ${BUILD_CONTEXT}
+    - docker push ${TARGET_TAG}
+
 # build the cluster-agent image
 build_cluster_agent_amd64:
   <<: *docker_build_job_definition

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2284,10 +2284,12 @@ dev_branch_docker_hub-a7:
     - fail_on_non_triggered_tag
     - build_agent7
     - build_agent7_jmx
+    - build_agent7_windows
   when: manual
   script:
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-amd64             datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-amd64         datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-amd64     datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-1809
 
 dev_branch_multiarch_docker_hub-a6:
   <<: *skip_when_unwanted_on_6
@@ -2314,7 +2316,6 @@ dev_branch_multiarch_docker_hub-a6:
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-jmx       --template datadog/agent-dev-ARCH:${CI_COMMIT_REF_SLUG}-jmx
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py2-jmx   --template datadog/agent-dev-ARCH:${CI_COMMIT_REF_SLUG}-py2-jmx
 
-
 dev_branch_multiarch_docker_hub-a7:
   <<: *skip_when_unwanted_on_7
   <<: *docker_tag_job_definition
@@ -2329,10 +2330,12 @@ dev_branch_multiarch_docker_hub-a7:
     # Platform-specific agent images
     - inv -e docker.publish-bulk --signed-push --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-ARCH      --dst-template datadog/agent-dev-ARCH:${CI_COMMIT_REF_SLUG}-py3
     - inv -e docker.publish-bulk --signed-push --platform linux/amd64 --platform linux/arm64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-ARCH  --dst-template datadog/agent-dev-ARCH:${CI_COMMIT_REF_SLUG}-py3-jmx
+    # Other images
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-1809
     # Manifests
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3       --template datadog/agent-dev-ARCH:${CI_COMMIT_REF_SLUG}-py3
     - inv -e docker.publish-manifest --signed-push --platform linux/amd64 --platform linux/arm64 --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx   --template datadog/agent-dev-ARCH:${CI_COMMIT_REF_SLUG}-py3-jmx
-
+    - inv -e docker.publish-manifest --signed-push --platform windows/amd64 --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3   --template datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-1809
 
 dev_branch_multiarch_docker_hub-dogstatsd:
   <<: *skip_when_unwanted_on_7

--- a/Dockerfiles/agent/entrypoint-ps1/01-check-apikey.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/01-check-apikey.ps1
@@ -1,0 +1,10 @@
+
+# Don't allow starting without an apikey set
+if (-not (Test-Path env:DD_API_KEY)) { 
+    Write-Output ""
+    Write-Output "=================================================================================="
+    Write-Output "You must set an DD_API_KEY environment variable to run the Datadog Agent container"
+    Write-Output "=================================================================================="
+    Write-Output ""
+    exit 1
+}

--- a/Dockerfiles/agent/entrypoint-ps1/50-kubernetes.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/50-kubernetes.ps1
@@ -1,0 +1,16 @@
+
+if (-not (Test-Path env:KUBERNETES)) { 
+    exit 0
+}
+
+# Set a default config for Kubernetes if found
+# Don't override datadog.yaml if it exists
+if (-not (Test-Path C:\ProgramData\Datadog\datadog.yaml)) { 
+       Write-Output "Autodiscovery enabled for Kubernetes"
+   if (Test-Path \\.\pipe\docker_engine) { 
+       cp C:\ProgramData\Datadog\datadog-k8s-docker.yaml C:\ProgramData\Datadog\datadog.yaml
+   } else {
+       cp C:\ProgramData\Datadog\datadog-kubernetes.yaml C:\ProgramData\Datadog\datadog.yaml
+   }
+}
+

--- a/Dockerfiles/agent/entrypoint-ps1/51-docker.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/51-docker.ps1
@@ -1,0 +1,21 @@
+
+# We enable docker if either:
+#   - we detect the DOCKER_HOST envvar, overriding the default socket location
+#     (in that case, we trust the user wants docker integration and don't check existence)
+#   - we find the docker socket at it's default location
+if (-Not (Test-Path env:DOCKER_HOST) -And -Not (Test-Path \\.\pipe\docker_engine)) { 
+    exit 0
+}
+
+# Set a config for vanilla Docker if no orchestrator was detected
+# by the 50-* scripts
+# Don't override datadog.yaml if it exists
+if (-not (Test-Path C:\ProgramData\Datadog\datadog.yaml)) { 
+    Write-Output "Autodiscovery enabled for Kubernetes"
+    cp C:\ProgramData\Datadog\datadog-docker.yaml C:\ProgramData\Datadog\datadog.yaml
+}
+
+# Enable the docker corecheck
+if (-Not (Test-Path C:\ProgramData\Datadog\conf.d\docker.d\conf.yaml.default) -And (Test-Path C:\ProgramData\Datadog\conf.d\docker.d\conf.yaml.example)) { 
+    mv C:\ProgramData\Datadog\conf.d\docker.d\conf.yaml.example C:\ProgramData\Datadog\conf.d\docker.d\conf.yaml.default
+}

--- a/Dockerfiles/agent/entrypoint-ps1/59-default.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/59-default.ps1
@@ -1,0 +1,7 @@
+
+# Set a fallback empty config with no AD
+# Don't override /etc/datadog-agent/datadog.yaml if it exists
+if (-not (Test-Path C:\ProgramData\Datadog\datadog.yaml)) { 
+    Write-Output "Autodiscovery not enabled"
+    Write-Output $null >> C:\ProgramData\Datadog\datadog.yaml
+}

--- a/Dockerfiles/agent/entrypoint-ps1/60-disable-infra.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/60-disable-infra.ps1
@@ -1,0 +1,10 @@
+
+# Disable infra checks that would report metrics from the container (instead of the host)
+Remove-Item C:\ProgramData\Datadog\conf.d\disk.d\conf.yaml.default
+Remove-Item C:\ProgramData\Datadog\conf.d\network.d\conf.yaml.default
+Remove-Item C:\ProgramData\Datadog\conf.d\winproc.d\conf.yaml.default
+Remove-Item C:\ProgramData\Datadog\conf.d\file_handle.d\conf.yaml.default
+
+# TODO: Conditionally enable the IO check if the host drives are mounted in the container
+Remove-Item C:\ProgramData\Datadog\conf.d\io.d\conf.yaml.default
+

--- a/Dockerfiles/agent/entrypoint-ps1/89-copy-customfiles.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/89-copy-customfiles.ps1
@@ -1,0 +1,8 @@
+
+# Copy the custom checks and confs in the datadog-agent folder
+if (Test-Path C:\conf.d) { 
+    Copy-Item -Recurse -Force C:\conf.d C:\ProgramData\Datadog
+}
+if (Test-Path C:\checks.d) { 
+    Copy-Item -Recurse -Force C:\checks.d C:\ProgramData\Datadog
+}

--- a/Dockerfiles/agent/entrypoint.ps1
+++ b/Dockerfiles/agent/entrypoint.ps1
@@ -1,0 +1,9 @@
+
+Get-ChildItem 'entrypoint-ps1' | ForEach-Object {
+	& $_.FullName
+	if (-Not $?) {
+		exit 1
+	}
+}
+
+return & "C:/Program Files/Datadog/Datadog Agent/bin/agent.exe" $args

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = "Stop"
+
+Expand-Archive datadog-agent-7-latest.amd64.zip
+Remove-Item datadog-agent-7-latest.amd64.zip
+
+Get-ChildItem -Path datadog-agent-7-* | Rename-Item -NewName "Datadog Agent"
+
+New-Item -ItemType directory -Path "C:/Program Files/Datadog"
+Move-Item "Datadog Agent" "C:/Program Files/Datadog/"
+
+New-Item -ItemType directory -Path 'C:/ProgramData/Datadog' 
+Move-Item "C:/Program Files/Datadog/Datadog Agent/EXAMPLECONFSLOCATION" "C:/ProgramData/Datadog/conf.d"

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,7 +1,9 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
+ARG MSI_FILE=datadog-agent-7-latest.amd64.msi
 LABEL maintainer "Datadog <package@datadoghq.com>"
 WORKDIR C:\\mnt
-COPY C:/datadog-agent-7.18.0-devel.git.82.99b5ce2-1-x86_64.msi .
+COPY C:/${MSI_FILE}.msi .
 EXPOSE 8125/udp 8126/tcp
-RUN msiexec /qn /i C:\\mnt\\datadog-agent-7.18.0-devel.git.82.99b5ce2-1-x86_64.msi
-CMD [ "START", "/W", "C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe", "start-service" ]
+RUN msiexec /qn /i C:\\mnt\\%MSI_FILE%.msi
+ENTRYPOINT ["C:/Program Files/Datadog/Datadog Agent/bin/agent.exe"]
+CMD ["run"]

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,11 +1,14 @@
 ARG BASE_IMAGE=servercore:ltsc2019
+
 FROM mcr.microsoft.com/windows/${BASE_IMAGE}
-ARG MSI_FILE=datadog-agent-7-latest.amd64.msi
+
 LABEL maintainer "Datadog <package@datadoghq.com>"
-WORKDIR C:\\mnt
-COPY ${MSI_FILE} .
+
+COPY datadog-agent-7-latest.amd64.msi .
+RUN msiexec /i datadog-agent-7-latest.amd64.msi /qn
+
 EXPOSE 8125/udp 8126/tcp
-RUN msiexec /i C:\mnt\%MSI_FILE% /qn
-RUN del /F /Q C:\mnt
+
 ENTRYPOINT ["C:/Program Files/Datadog/Datadog Agent/bin/agent.exe"]
+
 CMD ["run"]

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+LABEL maintainer "Datadog <package@datadoghq.com>"
+WORKDIR C:\\mnt
+COPY C:/datadog-agent-7.18.0-devel.git.82.99b5ce2-1-x86_64.msi .
+EXPOSE 8125/udp 8126/tcp
+RUN msiexec /qn /i C:\\mnt\\datadog-agent-7.18.0-devel.git.82.99b5ce2-1-x86_64.msi
+CMD [ "START", "/W", "C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe", "start-service" ]

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=servercore:1803
+ARG BASE_IMAGE=servercore:1809
 
 FROM mcr.microsoft.com/windows/${BASE_IMAGE}
 

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,9 +1,11 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+ARG BASE_IMAGE=servercore:ltsc2019
+FROM mcr.microsoft.com/windows/${BASE_IMAGE}
 ARG MSI_FILE=datadog-agent-7-latest.amd64.msi
 LABEL maintainer "Datadog <package@datadoghq.com>"
 WORKDIR C:\\mnt
-COPY C:/${MSI_FILE}.msi .
+COPY ${MSI_FILE} .
 EXPOSE 8125/udp 8126/tcp
-RUN msiexec /qn /i C:\\mnt\\%MSI_FILE%.msi
+RUN msiexec /i C:\mnt\%MSI_FILE% /qn
+RUN del /F /Q C:\mnt
 ENTRYPOINT ["C:/Program Files/Datadog/Datadog Agent/bin/agent.exe"]
 CMD ["run"]

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=servercore:ltsc2019
+ARG BASE_IMAGE=servercore:1803
 
 FROM mcr.microsoft.com/windows/${BASE_IMAGE}
 
@@ -9,6 +9,12 @@ RUN msiexec /i datadog-agent-7-latest.amd64.msi /qn
 
 EXPOSE 8125/udp 8126/tcp
 
-ENTRYPOINT ["C:/Program Files/Datadog/Datadog Agent/bin/agent.exe"]
+# Config file is choosen at runtime by the entrypoint script
+RUN del C:/ProgramData/Datadog/datadog.yaml
+COPY entrypoint.ps1 .
+ADD entrypoint-ps1 ./entrypoint-ps1
+COPY datadog*.yaml C:/ProgramData/Datadog
+
+ENTRYPOINT ["powershell", "./entrypoint.ps1"]
 
 CMD ["run"]

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,19 +1,22 @@
-ARG BASE_IMAGE=servercore:1809
+ARG BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809
 
-FROM mcr.microsoft.com/windows/${BASE_IMAGE}
+# We will need some code changes to support nano. At least:
+# - netapi32.dll is not there, so go's user.Current() doesn't work
+# Also, "powershell" calls in this script have to be replaced by "pwsh"
+#ARG BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1809
+FROM ${BASE_IMAGE} 
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
-COPY datadog-agent-7-latest.amd64.msi .
-RUN msiexec /i datadog-agent-7-latest.amd64.msi /qn
+COPY datadog-agent-7-latest.amd64.zip install.ps1 ./
+RUN powershell ./install.ps1
 
 EXPOSE 8125/udp 8126/tcp
 
 # Config file is choosen at runtime by the entrypoint script
-RUN del C:/ProgramData/Datadog/datadog.yaml
 COPY entrypoint.ps1 .
 ADD entrypoint-ps1 ./entrypoint-ps1
-COPY datadog*.yaml C:/ProgramData/Datadog
+COPY datadog*.yaml C:/ProgramData/Datadog/
 
 ENTRYPOINT ["powershell", "./entrypoint.ps1"]
 

--- a/pkg/util/containers/providers/windows/dummy.go
+++ b/pkg/util/containers/providers/windows/dummy.go
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-2020 Datadog, Inmetrics.
+
+// +build windows
+
+// We need a file in this package as it's referenced by a file with +build windows only
+package windows


### PR DESCRIPTION
### What does this PR do?

Adds a Dockerfile to build the Windows docker agent

### Motivation

There is a Linux docker agent, we should have one for Windows too

### Additional notes

To build the image, copy the msi into the same folder as the Dockerfile and run:
```
docker image build -t datadog-agent-windows:ltsc2019 .
```

To run the image:
```
docker run -e DD_API_KEY="an_api_key" -e DD_HOSTNAME="a_hostname" datadog-agent-windows:ltsc2019
```

The entry point being the agent, all the usual agent commands work:
```
docker run ... datadog-agent-windows:ltsc2019 check
```