### PR TITLE
Start system-probe with the Agent also on upstart

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
@@ -4,7 +4,7 @@ Requires=sys-kernel-debug.mount
 Before=datadog-agent.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent.service
-ConditionPathExists=/etc/datadog-agent/system-probe.yaml
+ConditionPathExists=<%= etc_dir %>/system-probe.yaml
 
 [Service]
 Type=simple

--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -15,6 +15,9 @@ env DD_LOG_TO_CONSOLE=false
 
 # mount debugfs before start
 pre-start script
+  # Do not run if config file doesn't exist
+  test -f <%= etc_dir %>/system-probe.yaml || { stop ; exit 0; }
+
   if [ -d /sys/kernel/debug ]; then
     if ! grep -qs '/sys/kernel/debug ' /proc/mounts; then
       mount -t debugfs none /sys/kernel/debug
@@ -23,9 +26,7 @@ pre-start script
 end script
 
 script
-  if [ -f <%= etc_dir %>/system-probe.yaml ]; then
-    exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
-  fi
+  exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
 end script
 
 post-stop script

--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -23,7 +23,7 @@ pre-start script
 end script
 
 script
-  if [ -f /etc/datadog-agent/system-probe.yaml ]; then
+  if [ -f <%= etc_dir %>/system-probe.yaml ]; then
     exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
   fi
 end script

--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -1,6 +1,7 @@
 description "Datadog System Probe"
 
-stop on (runlevel [!2345])
+start on starting datadog-agent
+stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
 respawn limit 10 5
@@ -22,7 +23,9 @@ pre-start script
 end script
 
 script
-  exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
+  if [ -f /etc/datadog-agent/system-probe.yaml ]; then
+    exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
+  fi
 end script
 
 post-stop script

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -29,7 +29,7 @@ script
   # Logging to console from the agent is disabled since the agent already logs using file or
   # syslog depending on its configuration. We then redirect the stdout/stderr of the agent process
   # to log panic/crashes.
-  if [ -f /etc/datadog-agent/system-probe.yaml ]; then
+  if [ -f <%= etc_dir %>/system-probe.yaml ]; then
       exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid &>> /var/log/datadog/system-probe-errors.log
   fi
 end script

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -10,6 +10,9 @@ normal exit 0
 console output
 
 pre-start script
+  # Do not run if config file doesn't exist
+  test -f <%= etc_dir %>/system-probe.yaml || { stop ; exit 0; }
+
   # Manual rotation of errors log
   log_file_size=`du -b /var/log/datadog/system-probe-errors.log | cut -f1`
   if [ -n "$log_file_size" ] && [ $log_file_size -gt 5242880 ]; then
@@ -29,9 +32,7 @@ script
   # Logging to console from the agent is disabled since the agent already logs using file or
   # syslog depending on its configuration. We then redirect the stdout/stderr of the agent process
   # to log panic/crashes.
-  if [ -f <%= etc_dir %>/system-probe.yaml ]; then
-      exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid &>> /var/log/datadog/system-probe-errors.log
-  fi
+  exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid &>> /var/log/datadog/system-probe-errors.log
 end script
 
 post-stop script

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -1,6 +1,7 @@
 description "Datadog System Probe"
 
-stop on (runlevel [!2345])
+start on starting datadog-agent
+stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
 respawn limit 10 5
@@ -28,7 +29,9 @@ script
   # Logging to console from the agent is disabled since the agent already logs using file or
   # syslog depending on its configuration. We then redirect the stdout/stderr of the agent process
   # to log panic/crashes.
-  exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid &>> /var/log/datadog/system-probe-errors.log
+  if [ -f /etc/datadog-agent/system-probe.yaml ]; then
+      exec <%= install_dir %>/embedded/bin/system-probe --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid &>> /var/log/datadog/system-probe-errors.log
+  fi
 end script
 
 post-stop script


### PR DESCRIPTION
### What does this PR do?

Replicates the behaviour in https://github.com/DataDog/datadog-agent/pull/4883 for upstart, which was missing.

### Motivation

My previous PR implemented this logic on systemd but not on upstart.

