### PR TITLE
[DOCS-664] Adding receiver_socket parameter doc

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -475,7 +475,7 @@ api_key:
   # receiver_port: 8126
 
   ## @param receiver_socket - string - optional
-  ## Collect your traces through a Unix Domain Sockets.
+  ## Accept traces through Unix Domain Sockets.
   ## It is off by default. When set, it must point to a valid socket file.
   #
   # receiver_socket: <APM_SOCKET>

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -478,7 +478,7 @@ api_key:
   ## Accept traces through Unix Domain Sockets.
   ## It is off by default. When set, it must point to a valid socket file.
   #
-  # receiver_socket: <APM_SOCKET>
+  # receiver_socket: <UNIX_SOCKET_PATH>
 
   ## @param apm_non_local_traffic - boolean - optional - default: false
   ## Set to true so the Trace Agent listens for non local traffic,

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -474,6 +474,12 @@ api_key:
   #
   # receiver_port: 8126
 
+  ## @param receiver_socket - string - optional
+  ## Collect your traces through a Unix Domain Sockets.
+  ## It is off by default. When set, it must point to a valid sock file.
+  #
+  # receiver_socket: <APM_SOCKET>
+
   ## @param apm_non_local_traffic - boolean - optional - default: false
   ## Set to true so the Trace Agent listens for non local traffic,
   ## i.e if Traces are being sent to this Agent from another host/container

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -476,7 +476,7 @@ api_key:
 
   ## @param receiver_socket - string - optional
   ## Collect your traces through a Unix Domain Sockets.
-  ## It is off by default. When set, it must point to a valid sock file.
+  ## It is off by default. When set, it must point to a valid socket file.
   #
   # receiver_socket: <APM_SOCKET>
 


### PR DESCRIPTION
### What does this PR do?

Adds `receiver_socket` parameter documentation.

### Motivation

This parameter was introduced by: https://github.com/DataDog/datadog-agent/pull/3556/ but never documented.

