### PR TITLE
[config] remove a warning on telemetry.checks config key.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -510,6 +510,7 @@ func initConfig(config Config) {
 	// Enable telemetry metrics on the internals of the Agent.
 	// This create a lot of billable custom metrics.
 	config.BindEnvAndSetDefault("telemetry.enabled", false)
+	config.SetKnown("telemetry.checks")
 
 	// Declare other keys that don't have a default/env var.
 	// Mostly, keys we use IsSet() on, because IsSet always returns true if a key has a default.


### PR DESCRIPTION
### What does this PR do?

Set this configuration field as a known field.

### Motivation

Do not throw a warning on agent startup.