### PR TITLE
[logs] LI-263: Don't show warning when logs not used

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -222,7 +222,7 @@
           {{ $endpoint }}<br>
         {{- end }}
       {{- end }}
-      {{- if eq .use_http false }}
+      {{- if and (eq .use_http false) (.is_running) }}
 
         You are currently sending Logs to Datadog through TCP. To benefit from increased reliability and better network performances, we strongly encourage to <a href="https://docs.datadoghq.com/agent/logs/?tab=compressionenabled#send-logs-over-https">switch over compressed HTTPS</a> which will become the default protocol in the Agent future version.</br>
       {{- end }}

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -17,7 +17,7 @@ Logs Agent
   {{- end }}
 {{- end }}
 
-{{- if eq .use_http false }}
+{{- if and (eq .use_http false) (eq .is_running true) }}
 
     You are currently sending Logs to Datadog through TCP. To benefit from increased reliability and better network performances, we strongly encourage to switch over compressed HTTPS by using the logs_config.use_http and logs_config.use_compression parameters. This will become the default protocol in the Agent future version.
 {{ end }}


### PR DESCRIPTION
### What does this PR do?

Don't show HTTP migration warning when logs not used

### Motivation

This warning is useless if user doesn't enable logs

### Additional Notes

Anything else we should know when reviewing?
