### PR TITLE
[kitchen] Work around SLES tests failing because of network interface restarts

### DIFF
--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -15,3 +15,4 @@ cookbook 'dd-agent-install-script', path: './site-cookbooks/dd-agent-install-scr
 cookbook 'dd-agent-step-by-step', path: './site-cookbooks/dd-agent-step-by-step'
 cookbook 'dd-agent-import-conf', path: './site-cookbooks/dd-agent-import-conf'
 cookbook 'dd-agent-5', path: './site-cookbooks/dd-agent-5'
+cookbook 'dd-agent-sles-workaround', path: './site-cookbooks/dd-agent-sles-workaround'

--- a/test/kitchen/kitchen-azure-chef-test.yml
+++ b/test/kitchen/kitchen-azure-chef-test.yml
@@ -3,6 +3,7 @@ suites:
 # Install the latest release candidate using Chef
 - name: dd-agent
   run_list:
+    - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install]"
   attributes:
     apt:

--- a/test/kitchen/kitchen-azure-install-script-test.yml
+++ b/test/kitchen/kitchen-azure-install-script-test.yml
@@ -3,6 +3,7 @@ suites:
 # Installs the latest release candidate using the install script
 - name: dd-agent-install-script
   run_list:
+    - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install-script]"
   attributes:
     apt:

--- a/test/kitchen/kitchen-azure-step-by-step-test.yml
+++ b/test/kitchen/kitchen-azure-step-by-step-test.yml
@@ -3,6 +3,7 @@ suites:
 # Installs the latest release candidate using the step-by-step instructions (on dogweb)
 - name: dd-agent-step-by-step
   run_list:
+    - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-step-by-step]"
   attributes:
     apt:

--- a/test/kitchen/kitchen-azure-upgrade5-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade5-test.yml
@@ -11,7 +11,7 @@ suites:
     - <%= p %>
     <% end %>
   run_list:
-    #- "recipe[datadog::dd-agent]" # Setup Agent 5
+    - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-5]"  # Setup agent 5
     - "recipe[dd-agent-upgrade]" # Upgrade to Agent 6
     - "recipe[dd-agent-import-conf]" # Import the configuration from 5 to 6

--- a/test/kitchen/kitchen-azure-upgrade6-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade6-test.yml
@@ -8,6 +8,7 @@ suites:
     - <%= p %>
     <% end %>
   run_list:
+    - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install]"
     - "recipe[dd-agent-upgrade]"
   attributes:

--- a/test/kitchen/kitchen-azure-upgrade7-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade7-test.yml
@@ -4,6 +4,7 @@ suites:
 # candidate
 - name: dd-agent-upgrade-agent7
   run_list:
+    - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install]"
     - "recipe[dd-agent-upgrade]"
   attributes:

--- a/test/kitchen/site-cookbooks/dd-agent-sles-workaround/.gitignore
+++ b/test/kitchen/site-cookbooks/dd-agent-sles-workaround/.gitignore
@@ -1,0 +1,15 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+

--- a/test/kitchen/site-cookbooks/dd-agent-sles-workaround/Berksfile
+++ b/test/kitchen/site-cookbooks/dd-agent-sles-workaround/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+metadata

--- a/test/kitchen/site-cookbooks/dd-agent-sles-workaround/Gemfile
+++ b/test/kitchen/site-cookbooks/dd-agent-sles-workaround/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'bundler', '1.17.3'
+gem 'berkshelf'

--- a/test/kitchen/site-cookbooks/dd-agent-sles-workaround/README.md
+++ b/test/kitchen/site-cookbooks/dd-agent-sles-workaround/README.md
@@ -1,0 +1,4 @@
+# dd-agent-sles-workaround cookbook
+
+Works around the Azure Agent trying to restart network interfaces
+on SLES 11 and 12.

--- a/test/kitchen/site-cookbooks/dd-agent-sles-workaround/chefignore
+++ b/test/kitchen/site-cookbooks/dd-agent-sles-workaround/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/test/kitchen/site-cookbooks/dd-agent-sles-workaround/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-sles-workaround/metadata.rb
@@ -1,0 +1,5 @@
+name             "dd-agent-sles-workaround"
+maintainer       "Datadog"
+description      "Works around waagent restarting network interfaces on SLES 11 and 12"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "0.0.1"

--- a/test/kitchen/site-cookbooks/dd-agent-sles-workaround/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-sles-workaround/recipes/default.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: dd-agent-sles-workaround
+# Recipe:: default
+#
+# Copyright (C) 2020 Datadog
+#
+# All rights reserved - Do Not Redistribute
+#
+
+if node['platform_family'] == 'suse'
+  # Update the waagent conf to stop watching hostname changes.
+  execute 'update Azure Agent conf' do
+    command "sed -i 's/Provisioning\\.MonitorHostName=y/Provisioning\\.MonitorHostName=n/' /etc/waagent.conf"
+  end
+
+  # Change the Windows Azure Agent conf to stop watching hostname changes.
+  # For some reason it's changing the hostname every 30s on SLES 11 and 12, which
+  # leads to a network interface reset, making it likely for tests to fail if a
+  # network call happens during the reset.
+  service 'waagent' do
+    service_name "waagent"
+    action :restart
+  end
+
+  # Put eth0 back up in case the waagent was taking it down while we restarted it.
+  execute 'bring eth0 up' do
+    command "/sbin/ifup eth0"
+  end
+end


### PR DESCRIPTION
### What does this PR do?

Reconfigures the Azure Agent on SLES to not watch hostname changes, as it causes network interface restarts which may make the kitchen tests fail.
Hostname changes seem to be happening every 30s on SLES 11 and 12, for a (currently) unknown reason.

### Motivation

Make pipelines more reliable.
