### PR TITLE
[PROD] change service account name from dca to datadog-agent

### DIFF
--- a/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
+++ b/Dockerfiles/manifests/cluster-agent/cluster-agent.yaml
@@ -17,7 +17,7 @@ spec:
         ad.datadoghq.com/datadog-cluster-agent.init_configs: '[{}]'
         ad.datadoghq.com/datadog-cluster-agent.instances: '[{"prometheus_url": "http://%%host%%:5000/metrics","namespace": "datadog.cluster_agent","metrics": ["go_goroutines","go_memstats_*","process_*","api_requests","datadog_requests","external_metrics", "cluster_checks_*"]}]'
     spec:
-      serviceAccountName: dca
+      serviceAccountName: datadog-agent
       containers:
       - image: datadog/cluster-agent:latest
         imagePullPolicy: Always


### PR DESCRIPTION
### What does this PR do?

Cluster Agent manifest points to wrong `serviceAccountName:` if following instructions recommended on docs page here: https://docs.datadoghq.com/agent/cluster_agent/setup/?tab=secret#configure-the-datadog-cluster-agent

Service Account manifest cited in docs ([linked here](https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/serviceaccount.yaml)) resembles the following:

```
kind: ServiceAccount
apiVersion: v1
metadata:
  name: datadog-agent
  namespace: default
```

There is no Service Account named `dca` mentioned in the docs (aside from in this manifest). 

### Motivation

Came up while setting up the cluster agent with a customer when "no service account" errors appeared. 

### Additional Notes

Anything else we should know when reviewing?
