### PR TITLE
[status] jmxfetch: pass the map with expected structure

### DIFF
--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -130,7 +130,7 @@ func renderCheckStats(data []byte, checkName string) (string, error) {
 func renderJMXFetchStatus(w io.Writer, jmxStats interface{}) {
 	stats := make(map[string]interface{})
 	stats["JMXStatus"] = jmxStats
-	renderStatusTemplate(w, "/jmxfetch.tmpl", jmxStats)
+	renderStatusTemplate(w, "/jmxfetch.tmpl", stats)
 }
 
 func renderStatusTemplate(w io.Writer, templateName string, stats interface{}) {


### PR DESCRIPTION
### What does this PR do?

Fixes a small JMXFetch rendering issue by passing in the map structure the JMXFetch status template is expecting. 

### Motivation

Small regression found during testing.
