### PR TITLE
Fix typo in autoscaler event message

### DIFF
--- a/pkg/util/kubernetes/apiserver/types.go
+++ b/pkg/util/kubernetes/apiserver/types.go
@@ -13,5 +13,5 @@ type LeaderElectorInterface interface {
 }
 
 const (
-	autoscalerNowHandleMsgEvent = "Autoscaler is now handle by the Cluster-Agent"
+	autoscalerNowHandleMsgEvent = "Autoscaler is now handled by the Cluster-Agent"
 )


### PR DESCRIPTION
### What does this PR do?

fix typo in the cluster-agent autoscaler kubernetes event description.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
