### PR TITLE
[docs] mention GO111MODULE which must not be set to `on`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ To build the Agent you need:
       any other platform. We recommend you use the version pinned in the requirements
       file for a smooth development/build experience.
 
+**Note:** The Datadog Agent is not using Go modules yet; the `GO111MODULE` environment
+      variable must either be unset, set to `auto` or to `off`. It must not be set to `on`.
+
 Builds and tests are orchestrated with `invoke`, type `invoke --list` on a shell
 to see the available tasks.
 
@@ -47,7 +50,7 @@ To start working on the Agent, you can build the `master` branch:
 3. Install project's dependencies: `invoke deps`.
    Make sure that `$GOPATH/bin` is in your `$PATH` otherwise this step might fail.
 4. Create a development `datadog.yaml` configuration file in `dev/dist/datadog.yaml`, containing a valid API key: `api_key: <API_KEY>`
-5. Build the agent with `invoke agent.build --build-exclude=systemd`. 
+5. Build the agent with `invoke agent.build --build-exclude=systemd`.
    By default, the Agent will be built to use Python 3 but you can select which Python version you want to use:
    - `invoke agent.build --python-runtimes 2` for Python2 only
    - `invoke agent.build --python-runtimes 3` for Python3 only

--- a/docs/dev/agent_build.md
+++ b/docs/dev/agent_build.md
@@ -42,6 +42,10 @@ This is the complete list of the available components:
 * `containerd`: add support for the containerd integration
 * `kubeapiserver`: enable interaction with Kubernetes API server (required by the cluster Agent)
 
+The `datadog-agent` is not using the Go modules yet, please ensure that you
+don't have explicitly set the `GO111MODULE` environment variable to `on` while
+compiling the Agent. It must be either unset, set to `auto` or set to `off`.
+
 Please note you might need to provide some extra dependencies in your dev
 environment to build certain bits (see [development environment][dev-env]).
 

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -79,6 +79,10 @@ You must install [go](https://golang.org/doc/install) version 1.11.5 or above. M
 sure that `$GOPATH/bin` is in your `$PATH` otherwise Invoke cannot use any
 additional tool it might need.
 
+The `datadog-agent` is not using the Go modules yet, please ensure that you
+don't have explicitly set the `GO111MODULE` environment variable to `on` while
+compiling the Agent. It must be either unset, set to `auto` or set to `off`.
+
 ## Installing dependencies
 
 From the root of `datadog-agent`, run `invoke deps`. This will:


### PR DESCRIPTION
### What does this PR do?

Add mentions that GO111MODULE must not be set to `on` in the build documentation.

### Motivation

The `datadog-agent` is not using the Go modules yet. The default behavior of the Go modules while compiling the Agent in a GOPATH is fine (it's not using the Go modules because we're in a GOPATH and there is no `go.mod` file available), however, if `GO111MODULE` has been forced to `on` in the user environment, the build would fail.