### PR TITLE
Add 7.17.2 to release.json and changelog prelude

### DIFF
--- a/release.json
+++ b/release.json
@@ -13,14 +13,14 @@
         "JMXFETCH_VERSION": "0.34.0", 
         "JMXFETCH_HASH": "b5c053b960f9fa949a76ec3b84c308586c409f956379481e6a0044867deb7b52"
     }, 
-    "7.17.2-rc.1": {
+    "7.17.2": {
         "INTEGRATIONS_CORE_VERSION": "7.17.1", 
         "OMNIBUS_SOFTWARE_VERSION": "7.17.1", 
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0", 
         "JMXFETCH_VERSION": "0.34.0", 
         "JMXFETCH_HASH": "b5c053b960f9fa949a76ec3b84c308586c409f956379481e6a0044867deb7b52"
     }, 
-    "6.17.2-rc.1": {
+    "6.17.2": {
         "INTEGRATIONS_CORE_VERSION": "7.17.1", 
         "OMNIBUS_SOFTWARE_VERSION": "7.17.1", 
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0", 

--- a/releasenotes/notes/prelude-release-7.17.2-2451416f1017dc0c.yaml
+++ b/releasenotes/notes/prelude-release-7.17.2-2451416f1017dc0c.yaml
@@ -1,0 +1,5 @@
+prelude:
+    |
+    Release on: 2020-02-26
+
+    This is a Windows-only release.


### PR DESCRIPTION
Also adds 6.17.2 which we won't release, since the 7.17.x pipeline can't build a single Agent version.