### PR TITLE
Unset PYTHONPATH env var

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -315,12 +315,6 @@ func Initialize(paths ...string) error {
 		C.add_python_path(rtloader, TrackedCString(p))
 	}
 
-	// On Windows, it's not uncommon to have a system-wide PYTHONPATH env var set.
-	// Remove it, so our embedded python doesn't try to load things from the system.
-	if runtime.GOOS == "windows" && !config.Datadog.GetBool("windows_use_pythonpath") {
-		os.Unsetenv("PYTHONPATH")
-	}
-
 	// Any platform-specific initialization
 	if initializePlatform() != nil {
 		log.Warnf("unable to complete platform-specific initialization - should be non-fatal")

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -317,7 +317,7 @@ func Initialize(paths ...string) error {
 
 	// On Windows, it's not uncommon to have a system-wide PYTHONPATH env var set.
 	// Remove it, so our embedded python doesn't try to load things from the system.
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && !config.Datadog.GetBool("windows_use_pythonpath") {
 		os.Unsetenv("PYTHONPATH")
 	}
 

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -315,6 +315,9 @@ func Initialize(paths ...string) error {
 		C.add_python_path(rtloader, TrackedCString(p))
 	}
 
+	// Remove PYTHONPATH env var, if set, since it would be picked up by the embedded python
+	os.Unsetenv("PYTHONPATH")
+
 	// Any platform-specific initialization
 	if initializePlatform() != nil {
 		log.Warnf("unable to complete platform-specific initialization - should be non-fatal")

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -315,8 +315,11 @@ func Initialize(paths ...string) error {
 		C.add_python_path(rtloader, TrackedCString(p))
 	}
 
-	// Remove PYTHONPATH env var, if set, since it would be picked up by the embedded python
-	os.Unsetenv("PYTHONPATH")
+	// On Windows, it's not uncommon to have a system-wide PYTHONPATH env var set.
+	// Remove it, so our embedded python doesn't try to load things from the system.
+	if runtime.GOOS == "windows" {
+		os.Unsetenv("PYTHONPATH")
+	}
 
 	// Any platform-specific initialization
 	if initializePlatform() != nil {

--- a/pkg/collector/python/init_windows.go
+++ b/pkg/collector/python/init_windows.go
@@ -8,7 +8,17 @@
 
 package python
 
+import (
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
 // Any platform-specific initialization belongs here.
 func initializePlatform() error {
-	return nil
+	// On Windows, it's not uncommon to have a system-wide PYTHONPATH env var set.
+	// Unset it, so our embedded python doesn't try to load things from the system.
+	if !config.Datadog.GetBool("windows_use_pythonpath") {
+		os.Unsetenv("PYTHONPATH")
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,6 +178,9 @@ func initConfig(config Config) {
 	//       can only increase this timeout value. Linting operation is async.
 	config.BindEnvAndSetDefault("python3_linter_timeout", 120)
 
+	// Whether to honour the value of PYTHONPATH, if set, on Windows. On other OSes we always do.
+	config.BindEnvAndSetDefault("windows_use_pythonpath", false)
+
 	// if/when the default is changed to true, make the default platform
 	// dependent; default should remain false on Windows to maintain backward
 	// compatibility with Agent5 behavior/win

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -352,6 +352,12 @@ api_key:
 #
 # tracemalloc_blacklist: <TRACEMALLOC_BLACKLIST>
 
+## @param windows_use_pythonpath - boolean - optional
+## Whether to honour the value of the PYTHONPATH env var when set on Windows.
+## Disabled by default, so we only load Python libraries bundled with the Agent.
+#
+# windows_use_pythonpath: false
+
 ## @param secret_backend_command - string - optional
 ## `secret_backend_command` is the path to the script to execute to fetch secrets.
 ## The executable must have specific rights that differ on Windows and Linux.

--- a/releasenotes/notes/unset-pythonpath-a0f3ca4bde613590.yaml
+++ b/releasenotes/notes/unset-pythonpath-a0f3ca4bde613590.yaml
@@ -1,6 +1,6 @@
 ---
 upgrade:
   - |
-    The embedded Python will no longer use the PYTHONPATH environment
-    variable, restricting its access to the Python packages installed
-    with the Agent.
+    On Windows, the embedded Python will no longer use the PYTHONPATH
+    environment variable, restricting its access to the Python packages 
+    installed with the Agent.

--- a/releasenotes/notes/unset-pythonpath-a0f3ca4bde613590.yaml
+++ b/releasenotes/notes/unset-pythonpath-a0f3ca4bde613590.yaml
@@ -3,4 +3,5 @@ upgrade:
   - |
     On Windows, the embedded Python will no longer use the PYTHONPATH
     environment variable, restricting its access to the Python packages 
-    installed with the Agent.
+    installed with the Agent. Set windows_use_pythonpath to true to keep
+    the previous behavior.

--- a/releasenotes/notes/unset-pythonpath-a0f3ca4bde613590.yaml
+++ b/releasenotes/notes/unset-pythonpath-a0f3ca4bde613590.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The embedded Python will no longer use the PYTHONPATH environment
+    variable, restricting its access to the Python packages installed
+    with the Agent.


### PR DESCRIPTION
### What does this PR do?

Unset PYTHONPATH env var before initializing the embedded Python runtime.

### Motivation

On Windows, it's not uncommon to set PYTHONPATH. If set, it would be picked up by the embedded Python, mixing our bundled site-packages with the system ones (and likely breaking things).