### PR TITLE
[process-agent] Short-circuit container check if no containers were found

### DIFF
--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -78,6 +78,11 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 		return nil, err
 	}
 
+	if len(ctrList) == 0 {
+		log.Trace("no containers found")
+		return nil, nil
+	}
+
 	// Keep track of containers addresses
 	LocalResolver.LoadAddrs(ctrList)
 

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -51,6 +51,11 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 		return nil, err
 	}
 
+	if len(ctrList) == 0 {
+		log.Trace("no containers found")
+		return nil, nil
+	}
+
 	// End check early if this is our first run.
 	if r.lastRates == nil {
 		r.lastRates = util.ExtractContainerRateMetric(ctrList)

--- a/releasenotes/notes/process-containers-div-zero-0740af8161b47b9e.yaml
+++ b/releasenotes/notes/process-containers-div-zero-0740af8161b47b9e.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix process-agent potentially dividing by zero when no containers are found.


### PR DESCRIPTION
### What does this PR do?

See title.

### Motivation

https://dd.slack.com/archives/CE4PS8MHS/p1582721241100700
```
panic: runtime error: integer divide by zero
goroutine 124 [running]:
github.com/DataDog/datadog-agent/pkg/process/checks.fmtContainerStats(0xc4206ee7d0, 0x0, 0x1, 0xc420779920, 0xbf8db7dfa26e3627, 0x180ae4eb24, 0x2d10780, 0x0, 0x1c87fa8, 0xc420909af8, ...)
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/process/checks/container_rt.go:92 +0xbec
github.com/DataDog/datadog-agent/pkg/process/checks.(*RTContainerCheck).Run(0x2d0fac0, 0xc420220780, 0x3f072f8c, 0x1852220, 0xc420babd88, 0x1, 0x0, 0x30)
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/process/checks/container_rt.go:65 +0x141
main.(*Collector).runCheck(0xc4200d1220, 0x1da3480, 0x2d0fac0)
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/process-agent/collector.go:91 +0x206
main.(*Collector).run.func2(0xc4200d1220, 0xc4205d44e0, 0x1da3480, 0x2d0fac0)
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/process-agent/collector.go:165 +0x30b
created by main.(*Collector).run
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/process-agent/collector.go:153 +0x5ee
```

### Additional Notes

