### PR TITLE
[gitlab] Fix pupernetes jobs missing distro dependency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2891,7 +2891,10 @@ deploy_cloudfront_invalidate_on_failure:
   stage: e2e
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:large" ]
-  before_script: [ "# noop" ] # Override top level entry
+  before_script:
+  - cd $SRC_PATH
+  - pip install --upgrade --ignore-installed pip setuptools
+  - pip install -r requirements.txt # Override top level entry
   script:
   - inv -e e2e-tests --image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py2
   - inv -e e2e-tests --image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3


### PR DESCRIPTION
### What does this PR do?

Adds missing `pip install -r requirements.txt` step to pupernetes jobs.

### Motivation

They were failing because `distro` is not present in the image, which prevents pipelines from passing.
The jobs are still failing, but because of the e2e tests themselves, which are out of the scope of this PR.

