### PR TITLE
Do not strip token path while scrubbing

### DIFF
--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -72,6 +72,8 @@ func matchYAMLKey(key string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf(`(\s*%s\s*:).+`, key))
 }
 
+// matchYAMLKeyEnding returns a regexp matching a single YAML line with a key ending by the string passed as argument.
+// The returned regexp catches only the key and not the value.
 func matchYAMLKeyEnding(ending string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf(`(\s*(\w|_)*%s\s*:).+`, ending))
 }

--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -46,7 +46,7 @@ func init() {
 		Repl:  []byte(`$1 ********`),
 	}
 	tokenReplacer := Replacer{
-		Regex: matchYAMLKeyPart(`token`),
+		Regex: matchYAMLKeyEnding(`token`),
 		Hints: []string{"token"},
 		Repl:  []byte(`$1 ********`),
 	}
@@ -70,6 +70,10 @@ func matchYAMLKeyPart(part string) *regexp.Regexp {
 
 func matchYAMLKey(key string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf(`(\s*%s\s*:).+`, key))
+}
+
+func matchYAMLKeyEnding(ending string) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf(`(\s*(\w|_)*%s\s*:).+`, ending))
 }
 
 func matchCert() *regexp.Regexp {

--- a/pkg/util/log/strip_test.go
+++ b/pkg/util/log/strip_test.go
@@ -312,6 +312,8 @@ api_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 proxy: http://user:password@host:port
 password: foo
 auth_token: bar
+auth_token_file_path: /foo/bar/baz
+kubelet_auth_token_path: /foo/bar/kube_token
 # comment to strip
 log_level: info`,
 		`dd_url: https://app.datadoghq.com
@@ -319,6 +321,8 @@ api_key: ***************************aaaaa
 proxy: http://user:********@host:port
 password: ********
 auth_token: ********
+auth_token_file_path: /foo/bar/baz
+kubelet_auth_token_path: /foo/bar/kube_token
 log_level: info`)
 }
 


### PR DESCRIPTION
### What does this PR do?
It prevent field like `token_path` from being stripped while keeping field ending by `token` scrubbed.

### Motivation
Extract useful information when they are not sensitive.

### Additional Notes
N/A