### PR TITLE
[omnibus] Fix MacOS build conflicting with system Python 3

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -390,18 +390,8 @@ def omnibus_build(ctx, puppy=False, agent_binaries=False, log_level="info", base
         if sys.platform == 'win32':
             omnibus = "bundle exec omnibus.bat"
         elif sys.platform == 'darwin':
-            # HACK: On MacOS, python3 does an ugly hack to circumvent the limits imposed on processes by Apple on framework builds
-            # (which is the case when installing python3 with brew).
-            # This hack consists in setting __PYVENV_LAUNCHER__ to the location of the system python3 executable, and using
-            # it instead of argv[0] (which is set by the OS). The problem is that this variable is not unset after it's
-            # read, so it's still set in all commands launched by omnibus.
-            # In particular, it's set during the pip installation (in pip3.rb), which makes the
-            # "/opt/datadog-agent/embedded/bin/python3 setup.py install --prefix=/opt/datadog-agent/embedded" command
-            # link pip3 to the system python instead of the embedded python (since that's what the __PYVENV_LAUNCHER__ var
-            # is pointing at), bypassing the "--prefix" option and making the build fail.
-            # More info here: https://stackoverflow.com/questions/26323852/whats-the-meaning-of-pyvenv-launcher-environment-variable
-            # This might be fixed by: https://github.com/pypa/virtualenv/pull/1648, so we should check again if this hack
-            # is still needed in future releases.
+            # HACK: This is an ugly hack to fix another hack made by python3 on MacOS
+            # The full explanation is available on this PR: https://github.com/DataDog/datadog-agent/pull/5010.
             omnibus = "unset __PYVENV_LAUNCHER__ && bundle exec omnibus"
 
         cmd = "{omnibus} build {project_name} --log-level={log_level} {populate_s3_cache} {overrides}"


### PR DESCRIPTION
### What does this PR do?

Work around an implementation detail of Python 3 on MacOS making the build fail (because the embedded pip3 tries to use the system python3 instead of the embedded one).

### Motivation

Make the MacOS build work with Python 3 installed on the system.

### Full explanation

On MacOS, python3 does an ugly hack to circumvent the limits imposed on processes by Apple on framework builds (which is the case when installing python3 with brew).

This hack consists in setting `__PYVENV_LAUNCHER__` to the location of the system python3 executable, and using it instead of `argv[0]` (which is set by the OS). The problem is that this variable is not unset after it's read, so it's still set in all commands launched by omnibus.

In particular, it's set during the pip installation (in `pip3.rb`), which makes the `/opt/datadog-agent/embedded/bin/python3 setup.py install --prefix=/opt/datadog-agent/embedded` command link pip3 to the system python instead of the embedded python (since that's what the `__PYVENV_LAUNCHER__` var is pointing at), bypassing the `--prefix` option and making the build fail.

More info here: https://stackoverflow.com/questions/26323852/whats-the-meaning-of-pyvenv-launcher-environment-variable

This might be fixed by: https://github.com/pypa/virtualenv/pull/1648, so we should check again if this hack is still needed in future releases.