### PR TITLE
Add dogstatsd_entity_id_precedence parameter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -293,6 +293,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})
 	config.BindEnvAndSetDefault("dogstatsd_mapper_cache_size", 1000)
 	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)
+	config.BindEnvAndSetDefault("dogstatsd_entity_id_precedence", false)
 	config.SetKnown("dogstatsd_mapper_profiles")
 
 	config.BindEnvAndSetDefault("statsd_forward_host", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -293,6 +293,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})
 	config.BindEnvAndSetDefault("dogstatsd_mapper_cache_size", 1000)
 	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)
+	// Enable check for Entity-ID presence when enriching Dogstatsd metrics with tags
 	config.BindEnvAndSetDefault("dogstatsd_entity_id_precedence", false)
 	config.SetKnown("dogstatsd_mapper_profiles")
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -801,6 +801,11 @@ api_key:
 #
 # dogstatsd_mapper_cache_size: 1000
 
+## @param dogstatsd_entity_id_precedence - boolean - optional - default: false
+## Enable check for Entity-ID presence when enriching Dogstatsd metrics with tags
+#
+# dogstatsd_entity_id_precedence: false
+
 ## @param statsd_forward_host - string - optional - default: ""
 ## Forward every packet received by the DogStatsD server to another statsd server.
 ## WARNING: Make sure that forwarded packets are regular statsd packets and not "DogStatsD" packets,

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -802,7 +802,7 @@ api_key:
 # dogstatsd_mapper_cache_size: 1000
 
 ## @param dogstatsd_entity_id_precedence - boolean - optional - default: false
-## Enable check for Entity-ID presence when enriching Dogstatsd metrics with tags
+## Disable enriching Dogstatsd metrics with tags from "origin detection" when Entity-ID is set.
 #
 # dogstatsd_entity_id_precedence: false
 

--- a/pkg/dogstatsd/enrich.go
+++ b/pkg/dogstatsd/enrich.go
@@ -20,7 +20,7 @@ var (
 	getTags tagRetriever = tagger.Tag
 )
 
-func enrichTags(tags []string, defaultHostname string, originTagsFunc func() []string) ([]string, string) {
+func enrichTags(tags []string, defaultHostname string, originTagsFunc func() []string, entityIDPrecedenceEnabled bool) ([]string, string) {
 	if len(tags) == 0 {
 		return nil, defaultHostname
 	}
@@ -40,7 +40,7 @@ func enrichTags(tags []string, defaultHostname string, originTagsFunc func() []s
 		}
 	}
 	tags = tags[:n]
-	if entityIDValue == "" {
+	if entityIDValue == "" || !entityIDPrecedenceEnabled {
 		// Add origin tags only if the entity id tags is not provided
 		tags = append(tags, originTagsFunc()...)
 	} else if entityIDValue != entityIDIgnoreValue {
@@ -87,9 +87,9 @@ func isBlacklisted(metricName, namespace string, namespaceBlacklist []string) bo
 	return false
 }
 
-func enrichMetricSample(metricSample dogstatsdMetricSample, namespace string, namespaceBlacklist []string, defaultHostname string, originTagsFunc func() []string) metrics.MetricSample {
+func enrichMetricSample(metricSample dogstatsdMetricSample, namespace string, namespaceBlacklist []string, defaultHostname string, originTagsFunc func() []string, entityIDPrecedenceEnabled bool) metrics.MetricSample {
 	metricName := metricSample.name
-	tags, hostname := enrichTags(metricSample.tags, defaultHostname, originTagsFunc)
+	tags, hostname := enrichTags(metricSample.tags, defaultHostname, originTagsFunc, entityIDPrecedenceEnabled)
 
 	if !isBlacklisted(metricName, namespace, namespaceBlacklist) {
 		metricName = namespace + metricName
@@ -130,8 +130,8 @@ func enrichEventAlertType(dogstatsdAlertType alertType) metrics.EventAlertType {
 	return metrics.EventAlertTypeSuccess
 }
 
-func enrichEvent(event dogstatsdEvent, defaultHostname string, originTagsFunc func() []string) *metrics.Event {
-	tags, hostFromTags := enrichTags(event.tags, defaultHostname, originTagsFunc)
+func enrichEvent(event dogstatsdEvent, defaultHostname string, originTagsFunc func() []string, entityIDPrecedenceEnabled bool) *metrics.Event {
+	tags, hostFromTags := enrichTags(event.tags, defaultHostname, originTagsFunc, entityIDPrecedenceEnabled)
 
 	enrichedEvent := &metrics.Event{
 		Title:          event.title,
@@ -166,8 +166,8 @@ func enrichServiceCheckStatus(status serviceCheckStatus) metrics.ServiceCheckSta
 	return metrics.ServiceCheckUnknown
 }
 
-func enrichServiceCheck(serviceCheck dogstatsdServiceCheck, defaultHostname string, originTagsFunc func() []string) *metrics.ServiceCheck {
-	tags, hostFromTags := enrichTags(serviceCheck.tags, defaultHostname, originTagsFunc)
+func enrichServiceCheck(serviceCheck dogstatsdServiceCheck, defaultHostname string, originTagsFunc func() []string, entityIDPrecedenceEnabled bool) *metrics.ServiceCheck {
+	tags, hostFromTags := enrichTags(serviceCheck.tags, defaultHostname, originTagsFunc, entityIDPrecedenceEnabled)
 
 	enrichedServiceCheck := &metrics.ServiceCheck{
 		CheckName: serviceCheck.name,

--- a/releasenotes/notes/add-dogstatsd_entity_id_precedence-bae6aeda44dc7896.yaml
+++ b/releasenotes/notes/add-dogstatsd_entity_id_precedence-bae6aeda44dc7896.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add new config parameter (dogstatsd_entity_id_precedence) to enable DD_ENTITY_ID
+    presence check when enriching Dogstatsd metrics with tags.


### PR DESCRIPTION
### What does this PR do?

Add new dogstatsd server parameter to activate or not a new feature.
During QA we discovered that the new `DD_ENTITY_ID` tagging precedence in dogstatsd should be behind a configuration variable and defaulted to "false" by default. 

### Motivation

In a specific configuration: UDS and ENTITY_ID dogstatsd origin detection is activated, but the ENTITY_ID is not valid, the tags coming from the UDS detection are not added.

### Additional Notes

Anything else we should know when reviewing?
