### PR TITLE
[kitchen] Enable A6->A7 tests for SUSE 11

### DIFF
--- a/test/kitchen/kitchen-azure-common.yml
+++ b/test/kitchen/kitchen-azure-common.yml
@@ -80,6 +80,7 @@ platforms:
     ]
 
     windows_platforms = []
+    sles11_platforms = []
     sles15_platforms = []
 
     idx = 0
@@ -93,6 +94,7 @@ platforms:
     platform_name = platform[0] + "-#{host}"
 
     windows = platform_name.include?("win")
+    sles11 = platform_name.include?("sles-11")
     sles15 = platform_name.include?("sles-15")
     windows2008 = windows && platform_name.include?("2008")
 
@@ -102,6 +104,9 @@ platforms:
     else
       if sles15
         sles15_platforms << platform_name
+      end
+      if sles11
+        sles11_platforms << platform_name
       end
       size = sizes[idx % sizes.length]
     end

--- a/test/kitchen/kitchen-azure-common.yml
+++ b/test/kitchen/kitchen-azure-common.yml
@@ -80,7 +80,6 @@ platforms:
     ]
 
     windows_platforms = []
-    sles11_platforms = []
     sles15_platforms = []
 
     idx = 0
@@ -94,7 +93,6 @@ platforms:
     platform_name = platform[0] + "-#{host}"
 
     windows = platform_name.include?("win")
-    sles11 = platform_name.include?("sles-11")
     sles15 = platform_name.include?("sles-15")
     windows2008 = windows && platform_name.include?("2008")
 
@@ -104,9 +102,6 @@ platforms:
     else
       if sles15
         sles15_platforms << platform_name
-      end
-      if sles11
-        sles11_platforms << platform_name
       end
       size = sizes[idx % sizes.length]
     end

--- a/test/kitchen/kitchen-azure-upgrade6-test.yml
+++ b/test/kitchen/kitchen-azure-upgrade6-test.yml
@@ -3,10 +3,6 @@ suites:
 # Installs the latest release Agent 6, then updates it to the latest release
 # candidate
 - name: dd-agent-upgrade-agent6
-  excludes: <% if sles11_platforms.nil? || sles11_platforms.empty? %>[]<% end %> # No stable Agent 6 SUSE 11 package yet
-    <% sles11_platforms.each do |p| %>
-    - <%= p %>
-    <% end %>
   run_list:
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install]"


### PR DESCRIPTION
### What does this PR do?

Enables A6->A7 upgrade tests for SUSE 11, which were disabled because we didn't have a stable version of A6 working on SUSE 11 with systemd.

### Motivation

Add test coverage.
