### PR TITLE
[rtloader] set std stream encoding to utf-8 in three.

### DIFF
--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -74,6 +74,10 @@ bool Three::init()
     PyImport_AppendInittab(KUBEUTIL_MODULE_NAME, PyInit_kubeutil);
     PyImport_AppendInittab(CONTAINERS_MODULE_NAME, PyInit_containers);
 
+    if (Py_SetStandardStreamEncoding("utf-8", NULL) != 0) {
+        setError("couldn't set default encoding to utf-8");
+    }
+
     Py_Initialize();
 
     if (!Py_IsInitialized()) {

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -64,6 +64,14 @@ void Three::initPythonHome(const char *pythonHome)
 
 bool Three::init()
 {
+    // we want the checks to be runned with the standard encoding utf-8
+    // setting this var to 1 forces the UTF8 mode for CPython >= 3.7
+    // See:
+    //	- PEP UTF8 mode https://www.python.org/dev/peps/pep-0540/
+    //	- about this var https://github.com/python/cpython/pull/12589
+    // This has to be set before the Py_Initialize() call.
+    Py_UTF8Mode = 1;
+
     // add custom builtins init funcs to Python inittab, one by one
     // Unlinke its py2 counterpart, these need to be called before Py_Initialize
     PyImport_AppendInittab(AGGREGATOR_MODULE_NAME, PyInit_aggregator);
@@ -73,10 +81,6 @@ bool Three::init()
     PyImport_AppendInittab(TAGGER_MODULE_NAME, PyInit_tagger);
     PyImport_AppendInittab(KUBEUTIL_MODULE_NAME, PyInit_kubeutil);
     PyImport_AppendInittab(CONTAINERS_MODULE_NAME, PyInit_containers);
-
-    if (Py_SetStandardStreamEncoding("utf-8", NULL) != 0) {
-        setError("couldn't set default encoding to utf-8");
-    }
 
     Py_Initialize();
 


### PR DESCRIPTION
We want to force the default encoding to be utf8 in order to properly support it in checks 
 and integrations. If a check was trying to display some unicode chars, it would fail its run on system where the encoding is not utf8 (for instance due to environment vars `LC_CTYPE`, `LANG`, etc.).

Before
```
2020-02-27 17:52:20 CET | CORE | INFO | (pkg/collector/runner/runner.go:261 in work) | Running check test
2020-02-27 17:52:20 CET | CORE | ERROR | (pkg/collector/runner/runner.go:292 in work) | Error running check test: [{"message": "'ascii' codec can't encode character '\\u30c4' in position 0: ordinal not in range(128)", "traceback": "Traceback (most recent call last):\n  File \"/Users/remy.mathieu/go/src/github.com/DataDog/datadog-agent/venv3/lib/python3.8/site-packages/datadog_checks/base/checks/base.py\", line 713, in run\n    self.check(instance)\n  File \"/Users/remy.mathieu/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/checks.d/test.py\", line 19, in check\n    print(\"\u30c4\")\nUnicodeEncodeError: 'ascii' codec can't encode character '\\u30c4' in position 0: ordinal not in range(128)\n"}]
2020-02-27 17:52:20 CET | CORE | INFO | (pkg/collector/runner/runner.go:327 in work) | Done running check test
```
After
```
2020-02-27 18:00:05 CET | CORE | INFO | (pkg/collector/runner/runner.go:261 in work) | Running check test
ツ
2020-02-27 18:00:05 CET | CORE | INFO | (pkg/collector/runner/runner.go:327 in work) | Done running check test
```

See:
  - PEP UTF8 mode https://www.python.org/dev/peps/pep-0540/
  - about this var https://github.com/python/cpython/pull/12589

It is a regression because it was not impacting `7.17.0` and `7.17.1` which is using Python 3.7.x

**Missing a changelog**