### PR TITLE
[MacOS] Blacklist aerospike integration

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -76,6 +76,9 @@ if osx?
   blacklist_packages.push(/^lxml==/)
   # Blacklist ibm_was, which depends on lxml
   blacklist_folders.push('ibm_was')
+
+  # Blacklist aerospike, new version 3.10 is not supported on MacOS yet
+  blacklist_folders.push('aerospike')
 end
 
 if arm?

--- a/releasenotes/notes/blacklist-aerospike-macos-33175b55ef3bef04.yaml
+++ b/releasenotes/notes/blacklist-aerospike-macos-33175b55ef3bef04.yaml
@@ -1,0 +1,10 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    On MacOS, the Aerospike integration is no longer available since version 3.10
+    of the aerospike-client-python library is not yet available on this platform.


### PR DESCRIPTION
### What does this PR do?

Blacklists aerospike as the current version of the client library we want to build doesn't support MacOS yet.

### Motivation

Do not include the aerospike integration if the aerospike library is not present.
