### PR TITLE
Fix pywin32 checks not working after an Agent upgrade

### DIFF
--- a/omnibus/resources/agent/msi/localbuild/parameters.wxi
+++ b/omnibus/resources/agent/msi/localbuild/parameters.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
-  <?define VersionNumber="6.17.0.1" ?>
-  <?define DisplayVersionNumber="6.17.0" ?>
+  <?define VersionNumber="7.18.0.1" ?>
+  <?define DisplayVersionNumber="7.18.0" ?>
   <?define UpgradeCode="0c50421b-aefb-4f15-a809-7af256d608a5" ?>
   <?define InstallDir="C:/opt/datadog-agent" ?>
   <?define InstallFiles="C:/omnibus-ruby/src/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files" ?>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -66,6 +66,8 @@
                           Timeout="1"
                           RebootPrompt="no"/>
 
+    <!-- -->
+    <Property Id="REINSTALLMODE" Value="amus" />
     <!-- Set property to always log -->
     <Property Id="MsiLogging" Value="iwearucmop!" />
 


### PR DESCRIPTION
### What does this PR do?

Change default installation mode to reinstall all files regardless of whether the included files are newer or older.
MSI gives precedence to files with version resources over files w/o, and some packages (pywin32) seem to lose theirs sometimes

### Motivation

After upgrading, `.pyd` files would be missing from the installation, making checks that used the pywin32 module fail to load: 

```
2020-02-27 14:33:43 GMT | CORE | DEBUG | (pkg/collector/python/loader.go:138 in Load) | Unable to load python module - process_agent_check: unable to import module 'process_agent_check': Traceback (most recent call last):
  File "C:\ProgramData\Datadog\checks.d\process_agent_check.py", line 47, in <module>
    class AgentMetric(PDHBaseCheck):
TypeError: NoneType takes no arguments
```

