### PR TITLE
Improve resolution of docker sha256 to docker image name in some cases

### DIFF
--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -348,6 +348,26 @@ func TestDockerExtractImage(t *testing.T) {
 				"image_tag:latest",
 			},
 		},
+		{
+			testName: "Some Nomad Setup",
+			co: types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					Image: "sha256:380b233f1574da39494e2b36e65f262214fe158af5ae7a94d026b7a4e46fa358",
+				},
+				Config: &container.Config{
+					Image: "quay.io/hashicorp/cloud-consul-ama:3451-be4c56f",
+				},
+			},
+			resolveMap: map[string]string{
+				"sha256:380b233f1574da39494e2b36e65f262214fe158af5ae7a94d026b7a4e46fa358": "sha256:380b233f1574da39494e2b36e65f262214fe158af5ae7a94d026b7a4e46fa358",
+			},
+			expectedTags: []string{
+				"docker_image:sha256:380b233f1574da39494e2b36e65f262214fe158af5ae7a94d026b7a4e46fa358",
+				"image_name:quay.io/hashicorp/cloud-consul-ama",
+				"short_image:cloud-consul-ama",
+				"image_tag:3451-be4c56f",
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.testName), func(t *testing.T) {
 			resolve := func(image string) (string, error) { return tc.resolveMap[image], nil }

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -355,7 +355,7 @@ func TestDockerExtractImage(t *testing.T) {
 					Image: "sha256:380b233f1574da39494e2b36e65f262214fe158af5ae7a94d026b7a4e46fa358",
 				},
 				Config: &container.Config{
-					Image: "quay.io/hashicorp/cloud-consul-ama:3451-be4c56f",
+					Image: "quay.io/foo/bar:3451-be4c56f",
 				},
 			},
 			resolveMap: map[string]string{
@@ -363,8 +363,8 @@ func TestDockerExtractImage(t *testing.T) {
 			},
 			expectedTags: []string{
 				"docker_image:sha256:380b233f1574da39494e2b36e65f262214fe158af5ae7a94d026b7a4e46fa358",
-				"image_name:quay.io/hashicorp/cloud-consul-ama",
-				"short_image:cloud-consul-ama",
+				"image_name:quay.io/foo/bar",
+				"short_image:bar",
 				"image_tag:3451-be4c56f",
 			},
 		},

--- a/pkg/util/containers/image.go
+++ b/pkg/util/containers/image.go
@@ -13,7 +13,7 @@ import (
 var (
 	// ErrEmptyImage is returned when image name argument is empty
 	ErrEmptyImage = errors.New("empty image name")
-	// ErrImageIsSha256 is returned when argument is a not an image name but a sha256
+	// ErrImageIsSha256 is returned when image name argument is a sha256
 	ErrImageIsSha256 = errors.New("invalid image name (is a sha256)")
 )
 

--- a/pkg/util/containers/image.go
+++ b/pkg/util/containers/image.go
@@ -10,6 +10,13 @@ import (
 	"strings"
 )
 
+var (
+	// ErrEmptyImage is returned when argument is empty
+	ErrEmptyImage = errors.New("empty image name")
+	// ErrImageIsSha256 is returned when argument is a not an image name but a sha256
+	ErrImageIsSha256 = errors.New("invalid image name (is a sha256)")
+)
+
 // SplitImageName splits a valid image name (from ResolveImageName) and returns:
 //    - the "long image name" with registry and prefix, without tag
 //    - the "short image name", without registry, prefix nor tag
@@ -18,7 +25,10 @@ import (
 func SplitImageName(image string) (string, string, string, error) {
 	// See TestSplitImageName for supported formats (number 6 will surprise you!)
 	if image == "" {
-		return "", "", "", errors.New("empty image name")
+		return "", "", "", ErrEmptyImage
+	}
+	if strings.HasPrefix(image, "sha256:") {
+		return "", "", "", ErrImageIsSha256
 	}
 	long := image
 	if pos := strings.LastIndex(long, "@sha"); pos > 0 {

--- a/pkg/util/containers/image.go
+++ b/pkg/util/containers/image.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	// ErrEmptyImage is returned when argument is empty
+	// ErrEmptyImage is returned when image name argument is empty
 	ErrEmptyImage = errors.New("empty image name")
 	// ErrImageIsSha256 is returned when argument is a not an image name but a sha256
 	ErrImageIsSha256 = errors.New("invalid image name (is a sha256)")

--- a/pkg/util/containers/image_test.go
+++ b/pkg/util/containers/image_test.go
@@ -22,6 +22,8 @@ func TestSplitImageName(t *testing.T) {
 	}{
 		// Empty
 		{"", "", "", "", fmt.Errorf("empty image name")},
+		// A sha256 string
+		{"sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0", "", "", "", fmt.Errorf("invalid image name (is a sha256)")},
 		// Shortest possibility
 		{"alpine", "alpine", "alpine", "", nil},
 		// Historical docker format

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -201,6 +201,7 @@ func (d *DockerUtil) ResolveImageName(image string) (string, error) {
 			sp := strings.SplitN(r.RepoDigests[0], "@", 2)
 			d.imageNameBySha[image] = sp[0]
 		} else {
+			log.Debugf("No information in image/inspect to resolve: %s", image)
 			d.imageNameBySha[image] = image
 		}
 	}

--- a/releasenotes/notes/docker-image-name-7febcbe00bb068df.yaml
+++ b/releasenotes/notes/docker-image-name-7febcbe00bb068df.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Make sure we don't recognize `sha256:...` as a valid image name and add fallback to .Config.Image in case it's impossible to map `sha256:...` to a proper image name


### PR DESCRIPTION
### What does this PR do?

We've seen issues in some cases, where we don't tag properly when image/inspect does not have sufficient information to retrieve a valid image name.

Solution is to add a fallback to .Config.Image in case first image/inspect did not work.
Note that it may still trigger some tagging changes (especially for `docker_image` tag if image/inspect answers differently over time).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
