### PR TITLE
[omnibus] python3: set embedded dir as openssl dir

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -19,7 +19,8 @@ if ohai["platform"] != "windows"
   relative_path "Python-#{version}"
 
   python_configure = ["./configure",
-                      "--prefix=#{install_dir}/embedded"]
+                      "--prefix=#{install_dir}/embedded",
+                      "--with-ssl=#{install_dir}/embedded"]
 
   if mac_os_x?
     python_configure.push("--enable-ipv6",


### PR DESCRIPTION
### What does this PR do?

This PR makes sure the python3 build is built against the openssl version we're shipping in the self-contained embedded directory.

### Motivation

We want to make sure we build against the openssl we're shipping with the agent. If we don't build this way we're at risk of building against a different openssl (the builder's openssl). This may or may not be fine, depending on API changes, features available, etc. It's true that the `rpath` has allowed us to get away with this, but I don't think it'll necessarily be the case. Also, we're at the whim of how the `configure` script behaves, so even if it does the right thing currently, it may not be the case down the line if behavior changes there. I believe this is the right thing to do.

### Additional Notes

Tested on macOS and linux.
