### PR TITLE
fix dogstatsd tagging with UDP

### DIFF
--- a/pkg/dogstatsd/enrich.go
+++ b/pkg/dogstatsd/enrich.go
@@ -43,7 +43,8 @@ func enrichTags(tags []string, defaultHostname string, originTagsFunc func() []s
 	if entityIDValue == "" || !entityIDPrecedenceEnabled {
 		// Add origin tags only if the entity id tags is not provided
 		tags = append(tags, originTagsFunc()...)
-	} else if entityIDValue != entityIDIgnoreValue {
+	}
+	if entityIDValue != "" && entityIDValue != entityIDIgnoreValue {
 		// Check if the value is not "none" in order to avoid calling
 		// the tagger for entity that doesn't exist.
 


### PR DESCRIPTION
### What does this PR do?

fix a bug in dogstatsd server tagging introduce in previous fix #5011
If the new parameter wasn't active, the tagger with entity-id and udp wasn't call.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
