### PR TITLE
Fix 'check' command segfault when running for more than 1 hour

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -54,9 +54,6 @@ var (
 	profileMemoryVerbose string
 )
 
-// Make the check cmd aggregator never flush by setting a very high interval
-const checkCmdFlushInterval = time.Hour
-
 func init() {
 	AgentCmd.AddCommand(checkCmd)
 
@@ -128,7 +125,8 @@ var checkCmd = &cobra.Command{
 		}
 
 		s := serializer.NewSerializer(common.Forwarder)
-		agg := aggregator.InitAggregatorWithFlushInterval(s, nil, hostname, "agent", checkCmdFlushInterval)
+		// Initializing the aggregator with a flush interval of 0 (which disable the flush goroutine)
+		agg := aggregator.InitAggregatorWithFlushInterval(s, nil, hostname, "agent", 0)
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 
 		if config.Datadog.GetBool("inventories_enabled") {

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -153,7 +153,11 @@ func InitAggregator(s serializer.MetricSerializer, metricPool *metrics.MetricSam
 func InitAggregatorWithFlushInterval(s serializer.MetricSerializer, metricPool *metrics.MetricSamplePool, hostname, agentName string, flushInterval time.Duration) *BufferedAggregator {
 	aggregatorInit.Do(func() {
 		aggregatorInstance = NewBufferedAggregator(s, metricPool, hostname, agentName, flushInterval)
-		go aggregatorInstance.run()
+		if flushInterval != 0 {
+			go aggregatorInstance.run()
+		} else {
+			log.Debugf("aggregator flushInterval set to %s: skipping run", flushInterval)
+		}
 	})
 
 	return aggregatorInstance

--- a/releasenotes/notes/fix-check-segfault-27d75a9b2dbd906b.yaml
+++ b/releasenotes/notes/fix-check-segfault-27d75a9b2dbd906b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix 'check' command segfault when running for more than 1 hour (which could
+    happen when using the '-b' option to set breakpoint).


### PR DESCRIPTION
### What does this PR do?

When running the check command for one hour the agent would crash. This
is due to the aggregator flushing data to an uninitialized Forwarder.