### PR TITLE
Build system-probe with go version 1.10.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,6 @@ variables:
   DATADOG_AGENT_BUILDERS: v2194239-8bba855
   DATADOG_AGENT_WINBUILDIMAGES: v2123666-a884483
   DATADOG_AGENT_ARMBUILDIMAGES: v2195996-580f7f3
-  DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v2232268-5c33d51
   BCC_VERSION: v0.12.0
 
 
@@ -570,6 +569,11 @@ run_dogstatsd_arm_size_test:
 
 .system-probe_build_common:
   before_script:
+    # HACK: install gimme so we can build with go 1.10.1
+    - apt-get install -y wget
+    - wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+    - chmod +x /bin/gimme
+
     # Hack to work around the cloning issue with arm runners
     - mkdir -p $GOPATH/src/github.com/DataDog
     - '[[ "$ARCH" == arm64 ]] && cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog'
@@ -586,7 +590,7 @@ run_dogstatsd_arm_size_test:
 
 build_system-probe-x64:
   stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_BUILDIMAGES
   needs: ["fail_on_non_triggered_tag", "build_libbcc_x64", "run_tests_deb-x64-py3"]
   tags: [ "runner:main", "size:large" ]
   extends: .system-probe_build_common
@@ -595,7 +599,7 @@ build_system-probe-x64:
 
 build_system-probe-arm64:
   stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   needs: ["fail_on_non_triggered_tag", "build_libbcc_arm64", "run_dep_check_lock"]
   tags: ["runner:docker-arm", "platform:arm64"]
   extends: .system-probe_build_common

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -578,6 +578,10 @@ run_dogstatsd_arm_size_test:
     - $S3_CP_CMD $S3_ARTIFACTS_URI/libbcc-$ARCH.tar.xz /tmp/libbcc.tar.xz
     - mkdir -p /opt/datadog-agent/embedded
     - tar -xvf /tmp/libbcc.tar.xz -C /opt/datadog-agent/embedded
+
+    # HACK: install gimme so we can build with go 1.10.1
+    - curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+    - chmod +x /bin/gimme
   script:
     - CGO_CFLAGS='-I/opt/datadog-agent/embedded/include' CGO_LDFLAGS='-Wl,-rpath,/opt/datadog-agent/embedded/lib -L/opt/datadog-agent/embedded/lib' inv -e system-probe.build --go-version=1.10.1
     - $S3_CP_CMD $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe $S3_ARTIFACTS_URI/system-probe.$ARCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -579,7 +579,7 @@ run_dogstatsd_arm_size_test:
     - mkdir -p /opt/datadog-agent/embedded
     - tar -xvf /tmp/libbcc.tar.xz -C /opt/datadog-agent/embedded
   script:
-    - CGO_CFLAGS='-I/opt/datadog-agent/embedded/include' CGO_LDFLAGS='-Wl,-rpath,/opt/datadog-agent/embedded/lib -L/opt/datadog-agent/embedded/lib' inv -e system-probe.build
+    - CGO_CFLAGS='-I/opt/datadog-agent/embedded/include' CGO_LDFLAGS='-Wl,-rpath,/opt/datadog-agent/embedded/lib -L/opt/datadog-agent/embedded/lib' inv -e system-probe.build --go-version=1.10.1
     - $S3_CP_CMD $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe $S3_ARTIFACTS_URI/system-probe.$ARCH
 
 build_system-probe-x64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -569,6 +569,10 @@ run_dogstatsd_arm_size_test:
 
 .system-probe_build_common:
   before_script:
+    # HACK: install gimme so we can build with go 1.10.1
+    - wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+    - chmod +x /bin/gimme
+
     # Hack to work around the cloning issue with arm runners
     - mkdir -p $GOPATH/src/github.com/DataDog
     - '[[ "$ARCH" == arm64 ]] && cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog'
@@ -579,9 +583,6 @@ run_dogstatsd_arm_size_test:
     - mkdir -p /opt/datadog-agent/embedded
     - tar -xvf /tmp/libbcc.tar.xz -C /opt/datadog-agent/embedded
 
-    # HACK: install gimme so we can build with go 1.10.1
-    - curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-    - chmod +x /bin/gimme
   script:
     - CGO_CFLAGS='-I/opt/datadog-agent/embedded/include' CGO_LDFLAGS='-Wl,-rpath,/opt/datadog-agent/embedded/lib -L/opt/datadog-agent/embedded/lib' inv -e system-probe.build --go-version=1.10.1
     - $S3_CP_CMD $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe $S3_ARTIFACTS_URI/system-probe.$ARCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -591,7 +591,7 @@ run_dogstatsd_arm_size_test:
 build_system-probe-x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_BUILDIMAGES
-  needs: ["fail_on_non_triggered_tag" ]
+  needs: ["fail_on_non_triggered_tag", "build_libbcc_x64", "run_tests_deb-x64-py3"]
   tags: [ "runner:main", "size:large" ]
   extends: .system-probe_build_common
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -570,6 +570,7 @@ run_dogstatsd_arm_size_test:
 .system-probe_build_common:
   before_script:
     # HACK: install gimme so we can build with go 1.10.1
+    - apt-get install -y wget
     - wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
     - chmod +x /bin/gimme
 
@@ -590,7 +591,7 @@ run_dogstatsd_arm_size_test:
 build_system-probe-x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_BUILDIMAGES
-  needs: ["fail_on_non_triggered_tag", "build_libbcc_x64", "run_tests_deb-x64-py3"]
+  needs: ["fail_on_non_triggered_tag" ]
   tags: [ "runner:main", "size:large" ]
   extends: .system-probe_build_common
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,6 +74,7 @@ variables:
   DATADOG_AGENT_BUILDERS: v2194239-8bba855
   DATADOG_AGENT_WINBUILDIMAGES: v2123666-a884483
   DATADOG_AGENT_ARMBUILDIMAGES: v2195996-580f7f3
+  DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v2232268-5c33d51
   BCC_VERSION: v0.12.0
 
 
@@ -569,11 +570,6 @@ run_dogstatsd_arm_size_test:
 
 .system-probe_build_common:
   before_script:
-    # HACK: install gimme so we can build with go 1.10.1
-    - apt-get install -y wget
-    - wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-    - chmod +x /bin/gimme
-
     # Hack to work around the cloning issue with arm runners
     - mkdir -p $GOPATH/src/github.com/DataDog
     - '[[ "$ARCH" == arm64 ]] && cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog'
@@ -590,7 +586,7 @@ run_dogstatsd_arm_size_test:
 
 build_system-probe-x64:
   stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_BUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   needs: ["fail_on_non_triggered_tag", "build_libbcc_x64", "run_tests_deb-x64-py3"]
   tags: [ "runner:main", "size:large" ]
   extends: .system-probe_build_common
@@ -599,7 +595,7 @@ build_system-probe-x64:
 
 build_system-probe-arm64:
   stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   needs: ["fail_on_non_triggered_tag", "build_libbcc_arm64", "run_dep_check_lock"]
   tags: ["runner:docker-arm", "platform:arm64"]
   extends: .system-probe_build_common


### PR DESCRIPTION
### What does this PR do?

Due to #4871 , we started building the system-probe with 1.13.0.

We have a pull request in progress to build the system-probe with a newer go version (#4929) but haven't tested it thoroughly. This PR will go back to building with 1.10.1   until we can upgrade properly.  

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
