### PR TITLE
Add a retry loop around `docker push` to workaround notary intermittent failures

### DIFF
--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import os
 import re
+import time
 
 from invoke import task
 from invoke.exceptions import Exit
@@ -139,10 +140,26 @@ def publish(ctx, src, dst, signed_pull=False, signed_push=False):
     push_env = {}
     if signed_push:
         push_env["DOCKER_CONTENT_TRUST"] = "1"
-    ctx.run(
-        "docker push {dst}".format(dst=dst),
-        env=push_env
-    )
+    remaining_retries = 5
+    while True:
+        warn = True
+        if remaining_retries == 0:
+            warn = False
+
+        r = ctx.run(
+            "docker push {dst}".format(dst=dst),
+            env=push_env,
+            warn=warn
+        )
+
+        if r.ok:
+            break
+
+        # docker push might have failed because of a notary temporary error.
+        # Let give some time to the server to recover by itself before making a new attempt.
+        time.sleep(5)
+
+        remaining_retries -= 1
 
 @task(iterable=['platform'])
 def publish_bulk(ctx, platform, src_template, dst_template, signed_push=False):


### PR DESCRIPTION
### What does this PR do?

Add a retry loop around `docker push` to workaround notary intermittent failures

### Motivation

Docker pushes are sometimes failing with the following error:
```
Signing and pushing trust metadata
failed to sign docker.io/datadog/agent-dev:nightly-1984e857-jmx: trust server rejected operation.
```

This looks like a notary error and relaunching the job is enough to fix it.
So, it looks like those errors are just caused by notary server instabilities.
Let’s just add a retry so that we don’t have to manually relaunch the job for a notary
server issue.

### Additional Notes

Anything else we should know when reviewing?
