### PR TITLE
[release] add release note entry for python 3.8 enforcing utf8 encoding.

### DIFF
--- a/releasenotes/notes/py3-8-utf8-mdoe-0cb975b54408765a.yaml
+++ b/releasenotes/notes/py3-8-utf8-mdoe-0cb975b54408765a.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Following the upgrade to Python 3.8, the Datadog Agent version ``>= 6.18.0``
+    running Python 3 and version ``>= 7.18.0`` are now enforcing UTF8 encoding
+    while running checks (and while running pdb debugger with `-b` option on the
+    `check` cli command). Previous version of the Agents were already using this
+    encoding by default (depending on the environment variables) without enforcing it.

--- a/releasenotes/notes/py3-8-utf8-mdoe-0cb975b54408765a.yaml
+++ b/releasenotes/notes/py3-8-utf8-mdoe-0cb975b54408765a.yaml
@@ -11,5 +11,5 @@ other:
     Following the upgrade to Python 3.8, the Datadog Agent version ``>= 6.18.0``
     running Python 3 and version ``>= 7.18.0`` are now enforcing UTF8 encoding
     while running checks (and while running pdb debugger with `-b` option on the
-    `check` cli command). Previous version of the Agents were already using this
+    `check` cli command). Previous versions of the Agent were already using this
     encoding by default (depending on the environment variables) without enforcing it.


### PR DESCRIPTION
Following the upgrade to Python 3.8, the Datadog Agent version `>= 7.18.0` is now enforcing UTF8 encoding while running checks (and while running pdb debugger with `-b` option on the `check` cli command). Previous version of the Agents were already using this encoding by default (depending on the environment variables) without enforcing it.