### PR TITLE
Add MacOS IBM WAS blacklist release note

### DIFF
--- a/releasenotes/notes/blacklist-ibm-was-macos-6edceb9c144e2c1c.yaml
+++ b/releasenotes/notes/blacklist-ibm-was-macos-6edceb9c144e2c1c.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    On MacOS, the IBM WAS integration is no longer available since it
+    relies on the lxml package which currently doesn't pass Apple's
+    notarization tests.
+


### PR DESCRIPTION
### What does this PR do?

Adds missing release note for #4779 (which blacklists the `ibm_was` integration on MacOS).

### Motivation

7.18.0 release.

