### PR TITLE
Send configuration errors with metadata

### DIFF
--- a/pkg/collector/metadata/agentchecks/agentchecks.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks.go
@@ -8,6 +8,7 @@ package agentchecks
 import (
 	"encoding/json"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
@@ -55,6 +56,15 @@ func GetPayload() *Payload {
 		}
 		status := []interface{}{
 			check, check, "initialization", "ERROR", string(jsonErrs),
+		}
+		agentChecksPayload.AgentChecks = append(agentChecksPayload.AgentChecks, status)
+	}
+
+	configErrors := autodiscovery.GetConfigErrors()
+
+	for check, e := range configErrors {
+		status := []interface{}{
+			check, check, "initialization", "ERROR", e,
 		}
 		agentChecksPayload.AgentChecks = append(agentChecksPayload.AgentChecks, status)
 	}

--- a/releasenotes/notes/send-config-errors-with-metadata-60a379fd5d8ab38a.yaml
+++ b/releasenotes/notes/send-config-errors-with-metadata-60a379fd5d8ab38a.yaml
@@ -1,0 +1,6 @@
+enhancements:
+  - |
+    Errors that arise while loading checks configuration
+    files are now send with metadata along with checks
+    loading errors and running errors so they will show
+    up on the infrastructure list in the DataDog app.


### PR DESCRIPTION
### What does this PR do?
It adds the configuration error to the metadata before sending them, then those issue will appear in the "Infra list" in the Datadog app
If configuration errors (malformed yaml files) occur, they will be catch here :
https://github.com/DataDog/datadog-agent/blob/master/pkg/autodiscovery/autoconfig.go#L223-L226

### Motivation
It was a regression from A5.

### Additional Notes
N/A