### PR TITLE
[MacOS] Blacklist aerospike integration on Python 2

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -75,6 +75,9 @@ if osx?
   blacklist_packages.push(/^lxml==/)
   # Blacklist ibm_was, which depends on lxml
   blacklist_folders.push('ibm_was')
+
+  # Blacklist aerospike, new version 3.10 is not supported on MacOS yet
+  blacklist_folders.push('aerospike')
 end
 
 if arm?


### PR DESCRIPTION
### What does this PR do?

Updates the `datadog-agent-integrations-py2` software definition to blacklist aerospike (forgotten in #5014).

### Motivation

Do not ship the aerospike integration without the aerospike library.

