### PR TITLE
Add a substate mapper for service checks

### DIFF
--- a/cmd/agent/dist/conf.d/systemd.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/systemd.d/conf.yaml.example
@@ -14,7 +14,30 @@ instances:
     ## using Docker Agent (https://docs.datadoghq.com/agent/docker/).
     ##
     # private_socket: <PATH_TO_SYSTEMD_PRIVATE_SOCKET>
-    
+
+    ## @param substate_status_mapping - object - optional
+    ## Custom mapping of systemd substate for the 'systemd.unit.state' service check status.
+    ## By default this service checks reports OK when the unit state is 'active'.
+    ## In some specific cases it is useful to look at the unit sub-state instead in order to report
+    ## a more meaningful status. Such a case includes units that are expected to be always running
+    ## but the systemd reported state and sub-state is 'active (exited)'. The provided example will send a
+    ## CRITICAL service check in that situation.
+    ## Valid statuses are 'ok', 'warning', 'critical', and 'unknown'. If the substate is not mapped,
+    ## the service check status will report 'unknown'.
+    #
+    # substate_status_mapping:
+    #   <UNIT_NAME_1>:
+    #     running: ok
+    #     exited: critical
+    #   <UNIT_NAME_2>:
+    #     plugged: ok
+    #     mounted: ok
+    #     running: ok
+    #     exited: critical
+    #     stopped: critical
+
+
+
     ## @param tags  - list of key:value elements - optional
     ## List of tags to attach to every metric, event, and service check emitted
     ## by this integration.

--- a/cmd/agent/dist/conf.d/systemd.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/systemd.d/conf.yaml.example
@@ -16,11 +16,11 @@ instances:
     # private_socket: <PATH_TO_SYSTEMD_PRIVATE_SOCKET>
 
     ## @param substate_status_mapping - object - optional
-    ## Custom mapping of systemd substate for the 'systemd.unit.state' service check status.
-    ## By default this service checks reports OK when the unit state is 'active'.
-    ## In some specific cases it is useful to look at the unit sub-state instead in order to report
-    ## a more meaningful status. Such a case includes units that are expected to be always running
-    ## but the systemd reported state and sub-state is 'active (exited)'. The provided example will send a
+    ## The integration will emits an additional `systemd.unit.substate` service check which value is
+    ## based on the provided mapping from systemd substate to service check status.
+    ## This configuration option allows you to be alerted on the unit substate for some specific situations.
+    ## Such a case includes units that are expected to be always running
+    ## but the systemd reported state and substate is 'active (exited)'. The provided example will send a
     ## CRITICAL service check in that situation.
     ## Valid statuses are 'ok', 'warning', 'critical', and 'unknown'. If the substate is not mapped,
     ## the service check status will report 'unknown'.

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -469,7 +469,7 @@ func getServiceCheckStatus(state string, substateMapping map[string]string) metr
 	if !ok {
 		return metrics.ServiceCheckUnknown
 	}
-	switch strings.ToLower(mappedServiceCheckStatus) {
+	switch mappedServiceCheckStatus {
 	case "ok":
 		return metrics.ServiceCheckOK
 	case "warning":
@@ -492,7 +492,7 @@ func (c *SystemdCheck) isMonitored(unitName string) bool {
 
 func isValidServiceCheckStatus(serviceCheckStatus string) bool {
 	for _, validStatus := range validServiceCheckStatus {
-		if strings.EqualFold(serviceCheckStatus, validStatus) {
+		if serviceCheckStatus == validStatus {
 			return true
 		}
 	}

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -310,8 +310,7 @@ func (c *SystemdCheck) submitMetrics(sender aggregator.Sender, conn *dbus.Conn) 
 
 		sender.ServiceCheck(unitStateServiceCheck, getServiceCheckStatus(unit.ActiveState, serviceCheckStateMapping), "", tags, "")
 
-		subStateMapping, ok := c.config.instance.SubstateStatusMapping[unit.Name]
-		if ok {
+		if subStateMapping, found := c.config.instance.SubstateStatusMapping[unit.Name]; found {
 			// User provided a custom mapping for this unit. Submit the systemd.unit.substate service check based on that
 			sender.ServiceCheck(unitSubStateServiceCheck, getServiceCheckStatus(unit.SubState, subStateMapping), "", tags, "")
 		}
@@ -465,11 +464,7 @@ func getPropertyBool(properties map[string]interface{}, propertyName string) (bo
 }
 
 func getServiceCheckStatus(state string, substateMapping map[string]string) metrics.ServiceCheckStatus {
-	mappedServiceCheckStatus, ok := substateMapping[state]
-	if !ok {
-		return metrics.ServiceCheckUnknown
-	}
-	switch mappedServiceCheckStatus {
+	switch substateMapping[state] {
 	case "ok":
 		return metrics.ServiceCheckOK
 	case "warning":

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -122,11 +122,11 @@ unit_names:
 substate_status_mapping:
   foo:
     running: ok
-    exited: invalid_name
+    exited: Critical
 `)
 	err := check.Configure(rawInstanceConfig, []byte(``), "test")
 
-	expectedErrorMsg := "Status 'invalid_name' for unit 'foo' in 'substate_status_mapping' is invalid. It should be one of 'ok, warning, critical, unknown'"
+	expectedErrorMsg := "Status 'Critical' for unit 'foo' in 'substate_status_mapping' is invalid. It should be one of 'ok, warning, critical, unknown'"
 	assert.EqualError(t, err, expectedErrorMsg)
 }
 
@@ -720,15 +720,18 @@ substate_status_mapping:
 	mockSender.AssertCalled(t, "ServiceCheck", systemStateServiceCheck, metrics.ServiceCheckOK, "", []string(nil), mock.Anything)
 
 	tags := []string{"unit:unit1.service"}
-	mockSender.AssertCalled(t, "ServiceCheck", unitStateServiceCheck, metrics.ServiceCheckOK, "", tags, "")
+	mockSender.AssertCalled(t, "ServiceCheck", unitStateServiceCheck, metrics.ServiceCheckUnknown, "", tags, "")
+	mockSender.AssertCalled(t, "ServiceCheck", unitSubStateServiceCheck, metrics.ServiceCheckOK, "", tags, "")
 
 	tags = []string{"unit:unit2.service"}
-	mockSender.AssertCalled(t, "ServiceCheck", unitStateServiceCheck, metrics.ServiceCheckCritical, "", tags, "")
+	mockSender.AssertCalled(t, "ServiceCheck", unitStateServiceCheck, metrics.ServiceCheckUnknown, "", tags, "")
+	mockSender.AssertCalled(t, "ServiceCheck", unitSubStateServiceCheck, metrics.ServiceCheckCritical, "", tags, "")
 
 	tags = []string{"unit:unit3.service"}
-	mockSender.AssertNotCalled(t, "ServiceCheck", unitStateServiceCheck, metrics.ServiceCheckCritical, "", tags, "")
+	mockSender.AssertNotCalled(t, "ServiceCheck", unitStateServiceCheck, metrics.ServiceCheckUnknown, "", tags, "")
+	mockSender.AssertNotCalled(t, "ServiceCheck", unitSubStateServiceCheck, metrics.ServiceCheckCritical, "", tags, "")
 
-	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 4)
+	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 6)
 	mockSender.AssertNumberOfCalls(t, "Commit", 1)
 }
 

--- a/releasenotes/notes/Add-systemd-substate-mapper-for-service-checks-49a9d267d870714d.yaml
+++ b/releasenotes/notes/Add-systemd-substate-mapper-for-service-checks-49a9d267d870714d.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+     Adds a new config option to the systemd core check. It adds the ability to provide a custom
+     mapping from a unit substate to the service check status.


### PR DESCRIPTION
### What does this PR do?
Add a new config option for systemd core check. It adds the ability to provide a custom mapping from substate to service check status. This is useful in situation where the unit state is not good enough to be alerted on. For example a given unit can have an "active" state but an "exited" substate. If you expect this unit to be always running (like a daemon) you may want to be alerted based on that.

### Motivation
Feature request

### Additional Notes

[@florimondmanca Edit] Alternative to https://github.com/DataDog/datadog-agent/pull/4902