### PR TITLE
Fix 'port 0' in the status page when using the default HTTPS port

### DIFF
--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -74,12 +74,25 @@ func (b *Builder) formatEndpoint(endpoint config.Endpoint, prefix string) string
 	if endpoint.UseCompression {
 		compression = "compressed"
 	}
+
+	host := endpoint.Host
+	port := endpoint.Port
+
 	var protocol string
 	if b.endpoints.UseHTTP {
 		if endpoint.UseSSL {
 			protocol = "HTTPS"
+			if port == 0 {
+				port = 443 // use default port
+			}
 		} else {
 			protocol = "HTTP"
+			// this case technically can't happens. In order to
+			// disable SSL, user have to use a custom URL and
+			// specify the port manually.
+			if port == 0 {
+				port = 80 // use default port
+			}
 		}
 	} else {
 		if endpoint.UseSSL {
@@ -88,8 +101,6 @@ func (b *Builder) formatEndpoint(endpoint config.Endpoint, prefix string) string
 			protocol = "TCP"
 		}
 	}
-	host := endpoint.Host
-	port := endpoint.Port
 	return fmt.Sprintf("%sSending %s logs in %s to %s on port %d", prefix, compression, protocol, host, port)
 }
 

--- a/releasenotes/notes/fix-logs-status-page-port-cb09ece4226cec6f.yaml
+++ b/releasenotes/notes/fix-logs-status-page-port-cb09ece4226cec6f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix logs status page section showing port '0' being used when using the
+    default HTTPS URL. The status page now show 443.


### PR DESCRIPTION
### What does this PR do?

Fix 'port 0' in the status page when using the default HTTPS port
