### PR TITLE
[dogstatsd] move the string interner reset log message from trace level to debug level.

### DIFF
--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -34,7 +34,7 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	}
 	if len(i.strings) >= i.maxSize {
 		i.strings = make(map[string]string)
-		log.Trace("clearing the string interner cache")
+		log.Debug("clearing the string interner cache")
 	}
 	s := string(key)
 	i.strings[s] = s


### PR DESCRIPTION
From #5050:

> Could be helpful to diagnose dogstatsd performances.

But we've decided to move it to Debug instead of Trace because we think that the debug level will better suit the needs of this message.

