### PR TITLE
Mock time.Now() in the retrier tests to make them not flaky

### DIFF
--- a/pkg/util/retry/types.go
+++ b/pkg/util/retry/types.go
@@ -51,4 +51,6 @@ type Config struct {
 	RetryDelay        time.Duration
 	InitialRetryDelay time.Duration
 	MaxRetryDelay     time.Duration
+	// now function is used in unit tests only and should be left to nil otherwise
+	now func() time.Time
 }


### PR DESCRIPTION
### What does this PR do?

Mock `time.Now()` in the retrier tests

### Motivation

Using `time.Now()` and `time.Sleep(…)` in unit tests made them:
* slow to run
* flaky

### Additional Notes

Anything else we should know when reviewing?
