### PR TITLE
Support legacy k8s logs

### DIFF
--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	basePath   = "/var/log/pods"
-	anyLogFile = "*.log"
+	basePath      = "/var/log/pods"
+	anyLogFile    = "*.log"
+	anyV19LogFile = "%s_*.log"
 )
 
 var errCollectAllDisabled = fmt.Errorf("%s disabled", config.ContainerCollectAll)
@@ -225,14 +226,38 @@ func (l *Launcher) getSourceName(pod *kubelet.Pod, container kubelet.ContainerSt
 // getPath returns a wildcard matching with any logs file of container in pod.
 func (l *Launcher) getPath(basePath string, pod *kubelet.Pod, container kubelet.ContainerStatus) string {
 	// the pattern for container logs is different depending on the version of Kubernetes
-	// so we need to try both format,
-	// until v1.13 it was `/var/log/pods/{pod_uid}/{container_name}/{n}.log`,
+	// so we need to try three possbile formats
+	// until v1.9 it was `/var/log/pods/{pod_uid}/{container_name_n}.log`,
+	// v.1.10 to v1.13 it was `/var/log/pods/{pod_uid}/{container_name}/{n}.log`,
 	// since v1.14 it is `/var/log/pods/{pod_namespace}_{pod_name}_{pod_uid}/{container_name}/{n}.log`.
 	// see: https://github.com/kubernetes/kubernetes/pull/74441 for more information.
 	oldDirectory := filepath.Join(basePath, l.getPodDirectoryUntil1_13(pod))
 	if _, err := os.Stat(oldDirectory); err == nil {
-		return filepath.Join(oldDirectory, container.Name, anyLogFile)
+		v110Dir := filepath.Join(oldDirectory, container.Name)
+		_, err := os.Stat(v110Dir)
+		if err == nil {
+			log.Debugf("Logs path found for container %s, v1.13 >= kubernetes version >= v1.10", container.Name)
+			return filepath.Join(v110Dir, anyLogFile)
+		}
+		if !os.IsNotExist(err) {
+			log.Debugf("Cannot get file info for %s: %v", v110Dir, err)
+		}
+
+		v19Files := filepath.Join(oldDirectory, fmt.Sprintf(anyV19LogFile, container.Name))
+		files, err := filepath.Glob(v19Files)
+		if err == nil && len(files) > 0 {
+			log.Debugf("Logs path found for container %s, kubernetes version <= v1.9", container.Name)
+			return v19Files
+		}
+		if err != nil {
+			log.Debugf("Cannot get file info for %s: %v", v19Files, err)
+		}
+		if len(files) == 0 {
+			log.Debugf("Files matching %s not found", v19Files)
+		}
 	}
+
+	log.Debugf("Using the latest kubernetes logs path for container %s", container.Name)
 	return filepath.Join(basePath, l.getPodDirectorySince1_14(pod), container.Name, anyLogFile)
 }
 

--- a/pkg/logs/input/kubernetes/launcher_test.go
+++ b/pkg/logs/input/kubernetes/launcher_test.go
@@ -222,21 +222,34 @@ func TestGetPath(t *testing.T) {
 	defer os.RemoveAll(basePath)
 	assert.Nil(t, err)
 
-	var (
-		path         string
-		podDirectory string
-	)
-
-	podDirectory = "buu_fuz_baz"
-	path = launcher.getPath(basePath, pod, container)
+	// v1.14+ (default)
+	podDirectory := "buu_fuz_baz"
+	path := launcher.getPath(basePath, pod, container)
 	assert.Equal(t, filepath.Join(basePath, podDirectory, "foo", "*.log"), path)
 
+	// v1.10 - v1.13
 	podDirectory = "baz"
-	err = os.Mkdir(filepath.Join(basePath, podDirectory), 0777)
+	containerDirectory := "foo"
+
+	err = os.MkdirAll(filepath.Join(basePath, podDirectory, containerDirectory), 0777)
 	assert.Nil(t, err)
 
 	path = launcher.getPath(basePath, pod, container)
 	assert.Equal(t, filepath.Join(basePath, podDirectory, "foo", "*.log"), path)
+
+	// v1.9
+	os.RemoveAll(basePath)
+	podDirectory = "baz"
+	logFile := "foo_1.log"
+
+	err = os.MkdirAll(filepath.Join(basePath, podDirectory), 0777)
+	assert.Nil(t, err)
+
+	_, err = os.Create(filepath.Join(basePath, podDirectory, logFile))
+	assert.Nil(t, err)
+
+	path = launcher.getPath(basePath, pod, container)
+	assert.Equal(t, filepath.Join(basePath, podDirectory, "foo_*.log"), path)
 }
 
 // contains returns true if the list contains all the items.

--- a/releasenotes/notes/collect-logs-in-old-k8s-versions-b07c0c4ca779658d.yaml
+++ b/releasenotes/notes/collect-logs-in-old-k8s-versions-b07c0c4ca779658d.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Support collecting logs in old kubernetes versions (< v1.10).


### PR DESCRIPTION
### What does this PR do?

Support collecting logs in kubernetes <= 1.9

### Motivation

Cover all kubernetes versions for logs collection
