### PR TITLE
Auth token file creation only happens with `agent run` command

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -53,7 +53,7 @@ func StartServer() error {
 		return fmt.Errorf("Unable to create the api server: %v", err)
 	}
 
-	err = util.SetAuthToken()
+	err = util.CreateAndSetAuthToken()
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/clcrunnerapi/clc_runner_server.go
+++ b/cmd/agent/clcrunnerapi/clc_runner_server.go
@@ -50,7 +50,7 @@ func StartCLCRunnerServer() error {
 
 	// CLC Runner token
 	// Use the Cluster Agent token
-	err = util.SetDCAAuthToken()
+	err = util.InitDCAAuthToken()
 	if err != nil {
 		return err
 	}

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -56,7 +56,7 @@ func StartServer(sc clusteragent.ServerContext) error {
 	util.SetAuthToken()
 
 	// DCA client token
-	util.SetDCAAuthToken()
+	util.InitDCAAuthToken()
 
 	// create cert
 	hosts := []string{"127.0.0.1", "localhost"}

--- a/cmd/cluster-agent/api/server_test.go
+++ b/cmd/cluster-agent/api/server_test.go
@@ -20,7 +20,7 @@ import (
 func TestValidateTokenMiddleware(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("cluster_agent.auth_token", "abc123")
-	util.SetDCAAuthToken()
+	util.InitDCAAuthToken()
 
 	tests := []struct {
 		path, authToken    string

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -118,6 +118,25 @@ func GetAuthTokenFilepath() string {
 // Requires that the config has been set up before calling
 func FetchAuthToken() (string, error) {
 	authTokenFile := GetAuthTokenFilepath()
+	// Read the token
+	authTokenRaw, e := ioutil.ReadFile(authTokenFile)
+	if e != nil {
+		return "", fmt.Errorf("unable to read authentication token file: " + e.Error())
+	}
+
+	// Do some basic validation
+	authToken := string(authTokenRaw)
+	if len(authToken) < authTokenMinimalLen {
+		return "", fmt.Errorf("invalid authentication token: must be at least %d characters in length", authTokenMinimalLen)
+	}
+
+	return authToken, nil
+}
+
+// CreateOrFetchToken gets the authentication token from the auth token file & creates one if it doesn't exist
+// Requires that the config has been set up before calling
+func CreateOrFetchToken() (string, error) {
+	authTokenFile := GetAuthTokenFilepath()
 
 	// Create a new token if it doesn't exist
 	if _, e := os.Stat(authTokenFile); os.IsNotExist(e) {
@@ -134,20 +153,7 @@ func FetchAuthToken() (string, error) {
 		}
 		log.Infof("Saved a new authentication token to %s", authTokenFile)
 	}
-
-	// Read the token
-	authTokenRaw, e := ioutil.ReadFile(authTokenFile)
-	if e != nil {
-		return "", fmt.Errorf("unable to access authentication token file: " + e.Error())
-	}
-
-	// Do some basic validation
-	authToken := string(authTokenRaw)
-	if len(authToken) < authTokenMinimalLen {
-		return "", fmt.Errorf("invalid authentication token: must be at least %d characters in length", authTokenMinimalLen)
-	}
-
-	return authToken, nil
+	return FetchAuthToken()
 }
 
 // DeleteAuthToken removes auth_token file (test clean up)

--- a/pkg/api/security/security_test.go
+++ b/pkg/api/security/security_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -20,24 +21,52 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-func TestFetchAuthTokenValidGen(t *testing.T) {
+func initMockConf(t *testing.T) string {
 	testDir, err := ioutil.TempDir("", "fake-datadog-etc-")
 	require.Nil(t, err, fmt.Sprintf("%v", err))
-	defer os.RemoveAll(testDir)
 
 	f, err := ioutil.TempFile(testDir, "fake-datadog-yaml-")
 	require.Nil(t, err, fmt.Errorf("%v", err))
-	defer os.Remove(f.Name())
 
 	mockConfig := config.Mock()
 	mockConfig.SetConfigFile(f.Name())
-	expectTokenPath := filepath.Join(testDir, "auth_token")
-	defer os.Remove(expectTokenPath)
-
 	mockConfig.Set("auth_token", "")
-	token, err := FetchAuthToken()
+
+	return filepath.Join(testDir, "auth_token")
+}
+
+func cleanMockConf(tokenPath string) {
+	testDir := path.Dir(tokenPath)
+	os.RemoveAll(testDir)
+}
+
+func TestCreateOrFetchAuthTokenValidGen(t *testing.T) {
+	expectTokenPath := initMockConf(t)
+	defer cleanMockConf(expectTokenPath)
+	token, err := CreateOrFetchToken()
 	require.Nil(t, err, fmt.Sprintf("%v", err))
 	assert.True(t, len(token) > authTokenMinimalLen, fmt.Sprintf("%d", len(token)))
 	_, err = os.Stat(expectTokenPath)
 	require.Nil(t, err)
+}
+
+func TestFetchAuthToken(t *testing.T) {
+	expectTokenPath := initMockConf(t)
+	defer cleanMockConf(expectTokenPath)
+
+	token, err := FetchAuthToken()
+	require.NotNil(t, err)
+	require.Equal(t, "", token)
+	_, err = os.Stat(expectTokenPath)
+	require.True(t, os.IsNotExist(err))
+
+	newToken, err := CreateOrFetchToken()
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+	require.True(t, len(newToken) > authTokenMinimalLen, fmt.Sprintf("%d", len(newToken)))
+	_, err = os.Stat(expectTokenPath)
+	require.Nil(t, err)
+
+	token, err = FetchAuthToken()
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+	require.Equal(t, newToken, token)
 }

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -32,6 +32,20 @@ func SetAuthToken() error {
 	return err
 }
 
+// CreateAndSetAuthToken creates and sets the authorization token
+// Requires that the config has been set up before calling
+func CreateAndSetAuthToken() error {
+	// Noop if token is already set
+	if token != "" {
+		return nil
+	}
+
+	// token is only set once, no need to mutex protect
+	var err error
+	token, err = security.CreateOrFetchToken()
+	return err
+}
+
 // GetAuthToken gets the session token
 func GetAuthToken() string {
 	return token

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -51,9 +51,9 @@ func GetAuthToken() string {
 	return token
 }
 
-// SetDCAAuthToken sets the session token for the Cluster Agent
+// InitDCAAuthToken initialize the session token for the Cluster Agent based on config options
 // Requires that the config has been set up before calling
-func SetDCAAuthToken() error {
+func InitDCAAuthToken() error {
 	// Noop if dcaToken is already set
 	if dcaToken != "" {
 		return nil
@@ -61,7 +61,7 @@ func SetDCAAuthToken() error {
 
 	// dcaToken is only set once, no need to mutex protect
 	var err error
-	dcaToken, err = security.GetClusterAgentAuthToken()
+	dcaToken, err = security.CreateOrGetClusterAgentAuthToken()
 	return err
 }
 

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -259,7 +259,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentEndpointEmpty() {
 func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenEmpty() {
 	mockConfig.Set("cluster_agent.auth_token", "")
 
-	_, err := security.GetClusterAgentAuthToken()
+	_, err := security.CreateOrGetClusterAgentAuthToken()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 

--- a/releasenotes/notes/create-auth-token-file-only-for-run-cmd-d98a86e00fefaa9f.yaml
+++ b/releasenotes/notes/create-auth-token-file-only-for-run-cmd-d98a86e00fefaa9f.yaml
@@ -1,6 +1,6 @@
 enhancements:
   - |
     The authentication token file is now only created
-    when the agent is effectively run. It prevents command
-    such as ``agent status`` to create an authentication 
-    token file with the wrong user.
+    when the agent is launch with the ``agent run`` command
+    It prevents command such as ``agent status`` to create
+    an authentication token file owned by a wrong user.

--- a/releasenotes/notes/create-auth-token-file-only-for-run-cmd-d98a86e00fefaa9f.yaml
+++ b/releasenotes/notes/create-auth-token-file-only-for-run-cmd-d98a86e00fefaa9f.yaml
@@ -1,0 +1,6 @@
+enhancements:
+  - |
+    The authentication token file is now only created
+    when the agent is effectively run. It prevents command
+    such as ``agent status`` to create an authentication 
+    token file with the wrong user.

--- a/releasenotes/notes/create-auth-token-file-only-for-run-cmd-d98a86e00fefaa9f.yaml
+++ b/releasenotes/notes/create-auth-token-file-only-for-run-cmd-d98a86e00fefaa9f.yaml
@@ -1,6 +1,6 @@
 enhancements:
   - |
     The authentication token file is now only created
-    when the agent is launch with the ``agent run`` command
+    when the agent is launched with the ``agent start`` command
     It prevents command such as ``agent status`` to create
     an authentication token file owned by a wrong user.


### PR DESCRIPTION
### What does this PR do?
It prevents the agent from creating an auth_token file when running anything else than `agent run`.

### Motivation
If someone run `agent status` before the agent is actually started It will prevent the creation of a token file with a wrong owner (root). Such a situation may prevent the agent to properly start afterwards.

### Additional Notes
DCA has similar pattern. After a quick discussion we agreed to adjust the change to keep a consistent behaviour across both agent.