### PR TITLE
Fix 'check' command segfault when running for more than 1hour

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -54,9 +54,6 @@ var (
 	profileMemoryVerbose string
 )
 
-// Make the check cmd aggregator never flush by setting a very high interval
-const checkCmdFlushInterval = time.Hour
-
 func init() {
 	AgentCmd.AddCommand(checkCmd)
 
@@ -128,7 +125,8 @@ var checkCmd = &cobra.Command{
 		}
 
 		s := serializer.NewSerializer(common.Forwarder)
-		agg := aggregator.InitAggregatorWithFlushInterval(s, nil, hostname, "agent", checkCmdFlushInterval)
+		// Initializing the aggregator with a flush interval of 0 (which disable the flush goroutine)
+		agg := aggregator.InitAggregatorWithFlushInterval(s, nil, hostname, "agent", 0)
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 
 		if config.Datadog.GetBool("inventories_enabled") {

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -620,9 +620,13 @@ func (agg *BufferedAggregator) Stop() {
 
 func (agg *BufferedAggregator) run() {
 	if agg.TickerChan == nil {
-		flushPeriod := agg.flushInterval
-		agg.TickerChan = time.NewTicker(flushPeriod).C
+		if agg.flushInterval != 0 {
+			agg.TickerChan = time.NewTicker(agg.flushInterval).C
+		} else {
+			log.Debugf("aggregator flushInterval set to 0: aggregator won't flush data")
+		}
 	}
+
 	for {
 		select {
 		case <-agg.stopChan:

--- a/releasenotes/notes/fix-check-segfault-27d75a9b2dbd906b.yaml
+++ b/releasenotes/notes/fix-check-segfault-27d75a9b2dbd906b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix 'check' command segfault when running for more than 1 hour (which could
+    happen when using the '-b' option to set breakpoint).


### PR DESCRIPTION
### What does this PR do?

When running the check command for one hour the agent would crash. This
is due to the aggregator flushing data to an uninitialized Forwarder.
