### PR TITLE
Make the docker entrypoint script honor DD_CRI_SOCKET_PATH

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-kubernetes.sh
+++ b/Dockerfiles/agent/entrypoint/50-kubernetes.sh
@@ -7,7 +7,7 @@ fi
 # Set a default config for Kubernetes if found
 # Don't override /etc/datadog-agent/datadog.yaml if it exists
 if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
-    if [[ -e /var/run/docker.sock ]]; then
+    if [[ -S /var/run/docker.sock ]] || ( [[ "$DD_CRI_SOCKET_PATH" =~ docker\.sock ]] && [[ -S "$DD_CRI_SOCKET_PATH" ]] ); then
         ln -s /etc/datadog-agent/datadog-k8s-docker.yaml \
            /etc/datadog-agent/datadog.yaml
     else


### PR DESCRIPTION
### What does this PR do?

Make the docker entrypoint script honor `DD_CRI_SOCKET_PATH`

### Motivation

In order to fix an issue when the docker daemon is restarted while
a containerized agent is connected to it, the docker socket is now
mounted in a different path.

This change was effective in the Helm chart v2.

We must now ensure that the `DD_CRI_SOCKET_PATH` parameter is honored everywhere.

### Additional Notes

Fixes helm/charts#21223