### PR TITLE
[omnibus] Target MacOS 10.12 when building on MacOS

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -48,8 +48,7 @@ if ohai["platform"] != "windows"
                           "--with-universal-archs=intel",
                           "--enable-shared",
                           "--without-gcc",
-                          "CC=clang",
-                          "MACOSX_DEPLOYMENT_TARGET=10.12")
+                          "CC=clang")
   elsif linux?
     python_configure.push("--enable-unicode=ucs4",
                           "--enable-shared")

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -412,6 +412,10 @@ def omnibus_build(ctx, puppy=False, agent_binaries=False, log_level="info", base
                 env['SIGN_PFX'] = "{}".format(pfxfile)
                 env['SIGN_PFX_PW'] = "{}".format(pfxpass)
 
+            if sys.platform == 'darwin':
+                # Target MacOS 10.12
+                env['MACOSX_DEPLOYMENT_TARGET'] = '10.12'
+
             if omnibus_s3_cache:
                 args['populate_s3_cache'] = " --populate-s3-cache "
             if skip_sign:


### PR DESCRIPTION
### What does this PR do?

Sets `MACOSX_DEPLOYMENT_TARGET` to `10.12` for the whole omnibus build to make sure we only use symbols available on 10.12.

### Motivation

Be able to build the Agent on newer versions of MacOS.

