### PR TITLE
[system-probe] don't test with absolute package name

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -119,7 +119,7 @@ def test(ctx, skip_object_files=False, only_check_bpf_bytes=False):
     if not skip_object_files:
         build_object_files(ctx, install=False)
 
-    pkg = os.path.join(REPO_PATH, "pkg", "ebpf", "...")
+    pkg = "./pkg/ebpf/..."
 
     # Pass along the PATH env variable to retrieve the go binary path
     path = os.environ['PATH']


### PR DESCRIPTION
### What does this PR do?

Our new build environment uses symlinks to mount the datadog-agent source code.

`go test` does not follow symlinks, so our system-probe.test task
needs to be changed to run on `./pkg/ebpf/...` instead of
`github.com/DataDog/datadog-agent/pkg/ebpf/...`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
