### PR TITLE
Document how to use fake_datadog in-cluster

### DIFF
--- a/test/e2e/containers/fake_datadog/README.md
+++ b/test/e2e/containers/fake_datadog/README.md
@@ -195,5 +195,6 @@ kubectl apply -f fake-datadog.yaml
   env:
     ...
     - name: DD_DD_URL
-      value: "http://fake-datadog.default.svc.cluster.local"
+      # if you deployed the service & deployment in a separate namespace, add `.<NAMESPACE>.svc.cluster.local
+      value: "http://fake-datadog"
 ```

--- a/test/e2e/containers/fake_datadog/README.md
+++ b/test/e2e/containers/fake_datadog/README.md
@@ -4,7 +4,7 @@
 Expose the needed API to make the agent submit payloads.
 
 
-#### API 
+#### API
 
 Prefer using mongo.
 
@@ -92,9 +92,9 @@ db.series.findOne({metric: "kubernetes.network.tx_errors"})
 Advanced find:
 ```js
 db.series.find({
-    metric: "kubernetes.cpu.usage.total", 
+    metric: "kubernetes.cpu.usage.total",
     tags: { $all: ["kube_namespace:kube-system", "pod_name:kube-controller-manager"] }
-}, {_id: 0}) // .count() 
+}, {_id: 0}) // .count()
 ```
 
 #### Aggregation pipeline
@@ -153,7 +153,7 @@ Aggregate a metric and a tag as timeseries:
 db.series.aggregate([
 	{ $match: { tags: "kube_deployment:dd", metric: "kubernetes.cpu.usage.total"} },
 	{ $unwind: "$points" },
-	{ $project: { 
+	{ $project: {
 		_id: { $arrayElemAt: [ "$points", 0 ] },
 		value: { $arrayElemAt: [ "$points", 1 ] },
 		tags: "$tags"
@@ -172,4 +172,28 @@ db.series.aggregate([
 	{ $group: {_id: "$tags", count: { $sum: 1 } } },
 	{ $sort: {count: -1} }
 ])
+```
+
+#### Use standalone
+
+This tool can be used as a debug proxy to inspect agent payloads. Here is how to do it for Kubernetes.
+
+- run the following from within this folder:
+
+```console
+docker build -t fake-datadog:latest .
+docker tag fake-datadog:latest <YOUR_REPO/IMAGE:TAG>
+docker push <YOUR_REPO/IMAGE:TAG>
+# replace <YOUR_REPO/IMAGE:TAG> in fake-datadog.yaml before running the next command
+kubectl apply -f fake-datadog.yaml
+```
+
+- edit your Datadog Agent Daemonset to use the service deployed above as the Datadog API. Be aware that each agent has its own intake - configuring `DD_DD_URL` doesn't cover the logs agent for example.
+
+```yaml
+...
+  env:
+    ...
+    - name: DD_DD_URL
+      value: "http://fake-datadog.default.svc.cluster.local"
 ```

--- a/test/e2e/containers/fake_datadog/app/api.py
+++ b/test/e2e/containers/fake_datadog/app/api.py
@@ -223,9 +223,18 @@ def logs():
     insert_logs(data)
     return Response(status=200)
 
+@app.route("/api/v1/orchestrator", methods=["POST"])
+def orchestrator():
+    # TODO
+    return Response(status=200)
 
 @app.before_request
 def logging():
+    # use only if you need to check headers
+    # mind where the logs of this container go since headers contain an API key
+    # app.logger.info(
+    #     "path: %s, method: %s, content-type: %s, content-encoding: %s, content-length: %s, headers: %s",
+    #     request.path, request.method, request.content_type, request.content_encoding, request.content_length, request.headers)
     app.logger.info(
         "path: %s, method: %s, content-type: %s, content-encoding: %s, content-length: %s",
         request.path, request.method, request.content_type, request.content_encoding, request.content_length)

--- a/test/e2e/containers/fake_datadog/fake-datadog.yaml
+++ b/test/e2e/containers/fake_datadog/fake-datadog.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fake-datadog
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+    name: api
+  - port: 27017
+    protocol: TCP
+    targetPort: 27017
+    name: mongo
+  selector:
+    app: fake-datadog
+  type: ClusterIP
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fake-datadog
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fake-datadog
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: fake-datadog
+    spec:
+      containers:
+      - name: api
+        image: <YOUR_REPO/IMAGE:TAG>
+        imagePullPolicy: Always
+      - name: mongo
+        image: mongo:3.6.3
+

--- a/test/e2e/containers/fake_datadog/fake-datadog.yaml
+++ b/test/e2e/containers/fake_datadog/fake-datadog.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: fake-datadog
-  namespace: default
 spec:
   ports:
   - port: 80
@@ -23,7 +22,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fake-datadog
-  namespace: default
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
### What does this PR do?

Document how to use fake_datadog in a Kubernetes cluster for packet inspection.

### Motivation

I needed to inspect http headers and this was the easiest way i could think of.

### Additional Notes

Anything else we should know when reviewing?
