### PR TITLE
Remove call to user.Current which doesn't work on Windows Nano

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2021,12 +2021,12 @@
   revision = "3ae76f584e7986aafdb594f1ff1b479829fc558a"
 
 [[projects]]
-  digest = "1:3063061b6514ad2666c4fa292451685884cacf77c803e1b10b4a4fa23f7787fb"
+  branch = "release-1.x"
+  digest = "1:1da5a608286e0ad0e842f173c2687443cec49837d627721a0ea2bd1b6a68e243"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = ""
-  revision = "3ca30a56d8a775276f9cdae009ba326fdc05af7f"
-  version = "v0.4.0"
+  revision = "4ad0115ba9e45c096d06a31d8dfb0e5bd945ec5f"
 
 [[projects]]
   digest = "1:59cce16b16002977ebfa3cbc6a72922d04704d3d4b9ee85ec916057d6b52762e"
@@ -2043,7 +2043,7 @@
   revision = "b3a7cee44a305be0a69e1b9ac03018307287e1b0"
 
 [[projects]]
-  digest = "0:"
+  digest = "1:f27698f7ae7864893ebcfb843e44d821263ac1dcf0ba1d5c2353f9d319a2f28d"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/kubelet/remote/fake",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,6 +19,10 @@
   name = "github.com/Microsoft/go-winio"
   version = "~v0.4.7"
 
+[[override]]
+  name = "k8s.io/klog"
+  branch = "release-1.x"
+
 [[constraint]]
   name = "github.com/hashicorp/consul"
   version = "~1.0.0"

--- a/pkg/api/security/platform_windows.go
+++ b/pkg/api/security/platform_windows.go
@@ -8,7 +8,6 @@ package security
 import (
 	"fmt"
 	"io/ioutil"
-	"os/user"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -50,55 +49,24 @@ func lookupUsernameAndDomain(usid *syscall.SID) (username, domain string, e erro
 func saveAuthToken(token, tokenPath string) error {
 	// get the current user
 	var sidString string
-	currUser, err := user.Current()
-	if err != nil {
-		log.Warnf("Unable to get current user %v", err)
-		log.Infof("Attempting to get current user information directly")
-		tok, e := syscall.OpenCurrentProcessToken()
-		if e != nil {
-			log.Warnf("Couldn't get process token %v", e)
-			return e
-		}
-		defer tok.Close()
-		user, e := tok.GetTokenUser()
-		if e != nil {
-			log.Warnf("Couldn't get  token user %v", e)
-			return e
-		}
-		sidString, e = user.User.Sid.String()
-		if e != nil {
-			log.Warnf("Couldn't get  user sid string %v", e)
-			return e
-		}
-
-		log.Infof("Got sidstring from token user")
-
-		// now just do some debugging, see what we weren't able to get.
-		pg, e := tok.GetTokenPrimaryGroup()
-		if e != nil {
-			log.Warnf("Would have failed getting token PG %v", e)
-		}
-		_, e = pg.PrimaryGroup.String()
-		if e != nil {
-			log.Warnf("Would have failed getting  PG  string %v", e)
-		}
-		dir, e := tok.GetUserProfileDirectory()
-		if e != nil {
-			log.Warnf("Would have failed getting  primary directory %v", e)
-		} else {
-			log.Infof("Profile directory is %v", dir)
-		}
-		username, domain, e := lookupUsernameAndDomain(user.User.Sid)
-		if e != nil {
-			log.Warnf("Would have failed getting username and domain %v", e)
-		} else {
-			log.Infof("Username/domain is %v %v", username, domain)
-		}
-
-	} else {
-		log.Infof("Getting sidstring from current user")
-		sidString = currUser.Uid
+	log.Infof("Getting sidstring from user")
+	tok, e := syscall.OpenCurrentProcessToken()
+	if e != nil {
+		log.Warnf("Couldn't get process token %v", e)
+		return e
 	}
+	defer tok.Close()
+	user, e := tok.GetTokenUser()
+	if e != nil {
+		log.Warnf("Couldn't get  token user %v", e)
+		return e
+	}
+	sidString, e = user.User.Sid.String()
+	if e != nil {
+		log.Warnf("Couldn't get  user sid string %v", e)
+		return e
+	}
+	log.Infof("Getting sidstring from current user")
 	currUserSid, err := windows.StringToSid(sidString)
 	if err != nil {
 		log.Warnf("Unable to get current user sid %v", err)


### PR DESCRIPTION
### What does this PR do?

Until now, we had a call to `user.Current()` plus an alternative code path since `user.Current()` might fail if it can't get all the user info. In Windows Nano, however, `user.Current()` plain crashes the program (see linked golang issue below).

Since we already had alternative code in place, and given the fact that we only need the user SID from `user.Current()`, this replaces the call with the simpler alternative code.

Also it removes some debug prints that we weren't actually checking to debug anything.

### Motivation

Workaround golang incompatibility with Windows Nano: https://github.com/golang/go/issues/21867

