### PR TITLE
[kitchen] Rename CentOS 7.7 image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1391,7 +1391,7 @@ deploy_windows_testing-a7:
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export TEST_PLATFORMS="centos-69,urn,OpenLogic:CentOS:6.9:6.9.20180530"
-    - export TEST_PLATFORMS="$TEST_PLATFORMS|centos-77,urn,OpenLogic:CentOS:7.7:7.7.20191209"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|centos-77,urn,OpenLogic:CentOS:7.7:7.7.201912090"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|rhel-81,urn,RedHat:RHEL:8.1:8.1.2020020415"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh


### PR DESCRIPTION
### What does this PR do?

Use the CentOS 7.7 URN that is still present on Azure.

### Motivation

There used to be two URNs pointing to the same image: `OpenLogic:CentOS:7.7:7.7.20191209` and `OpenLogic:CentOS:7.7:7.7.201912090`. They removed the duplicate yesterday, which made the kitchen tests fail.
