### PR TITLE
Ensure libbcc cannot be used by a non-privileged user

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -202,6 +202,7 @@ fail_on_non_triggered_tag:
     - make -j 4 #"$(nproc)"
     - make install
     - cd /opt/libbcc
+    - chmod go-rwx lib/libbcc*
     - rm share/bcc/introspection/bps
     - cp $(ldd lib/libbcc.so | awk '$1 ~ /^libtinfo/ {system("dirname " $3)}')/libtinfo* lib
     - tar cvaf /tmp/libbcc.tar.xz .


### PR DESCRIPTION
### What does this PR do?

Ensure `libbcc` cannot be used by a non-privileged user

### Motivation

`libbcc` is used to compile and load eBPF programs.
It will be used by `system-probe` with #4619.
This change ensures that an attacker who hasn’t gain root privileges cannot use it.

### Additional Notes
