### PR TITLE
fix dogstatsd metrics enrichTags() function

### DIFF
--- a/pkg/dogstatsd/enrich.go
+++ b/pkg/dogstatsd/enrich.go
@@ -21,10 +21,6 @@ var (
 )
 
 func enrichTags(tags []string, defaultHostname string, originTagsFunc func() []string, entityIDPrecedenceEnabled bool) ([]string, string) {
-	if len(tags) == 0 {
-		return nil, defaultHostname
-	}
-
 	host := defaultHostname
 
 	n := 0

--- a/pkg/dogstatsd/enrich_test.go
+++ b/pkg/dogstatsd/enrich_test.go
@@ -817,6 +817,17 @@ func Test_enrichTags(t *testing.T) {
 			want1: "foo",
 		},
 		{
+			name: "entityId not present, host=foo, empty tags list, should return origin tags",
+			args: args{
+				tags:                       nil,
+				defaultHostname:            "foo",
+				originTagsFunc:             func() []string { return []string{"mytag:bar"} },
+				entityIDPrecendenceEnabled: true,
+			},
+			want:  []string{"mytag:bar"},
+			want1: "foo",
+		},
+		{
 			name: "entityId present, host=foo, should not return origin tags",
 			args: args{
 				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "my-id")},


### PR DESCRIPTION
### What does this PR do?

Removes short path in `dogstatsd.enrichTags()` when tags parameter is empty or nil.

Since we add metrics from "entityID" or "origin" event if `tags` parameter is empty, we should not return directly when `len(tags) == 0`. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
