### PR TITLE
[slack-notifier] Ping on failures & Add success messages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3016,6 +3016,29 @@ pupernetes-tags-7:
   - VERSION=$(inv -e agent.version --major-version 7)
   - inv -e e2e-tests --image=datadog/agent:${VERSION}
 
+notify-on-success:
+  extends: .slack-notifier-base
+  before_script: ["# noop"]
+  only:
+    - master
+    - triggers
+  script: |
+    BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    COMMIT_URL="$CI_PROJECT_URL/commit/$CI_COMMIT_SHA"
+
+    AUTHOR=$(git show -s --format="%an" HEAD)
+
+    # Only ping on pushes to master (== merged PRs)
+    if [ "$CI_PIPELINE_SOURCE" = "push" ]; then
+      MESSAGE_TEXT=":host-green: :merged: Merge pipeline <$BUILD_URL|$CI_PIPELINE_ID> for $CI_COMMIT_REF_NAME succeeded.
+      $CI_COMMIT_TITLE (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>) by $AUTHOR"
+    else
+      MESSAGE_TEXT=":host-green: :jenkinsparty: Triggered pipeline <$BUILD_URL|$CI_PIPELINE_ID> for $CI_COMMIT_REF_NAME succeeded.
+      $CI_COMMIT_TITLE (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>) by $AUTHOR"
+    fi
+    postmessage "#datadog-agent-pipelines" "$MESSAGE_TEXT"
+  when: on_success
+
 notify-on-failure:
   extends: .slack-notifier.on-failure
   before_script: ["# noop"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2998,7 +2998,6 @@ pupernetes-tags-7:
 
 notify-on-success:
   extends: .slack-notifier-base
-  before_script: ["# noop"]
   only:
     - master
     - triggers

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3026,8 +3026,21 @@ notify-on-failure:
     BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     COMMIT_URL="$CI_PROJECT_URL/commit/$CI_COMMIT_SHA"
 
-    COMMIT_AUTHOR=$(git show -s --format="%an" HEAD)
+    AUTHOR=$(git show -s --format="%an" HEAD)
+    EMAIL=$(git show -s --format="%ae" HEAD)
 
-    MESSAGE_TEXT=":host-red: $CI_PROJECT_NAME: Pipeline <$BUILD_URL|$CI_PIPELINE_ID> for $CI_COMMIT_REF_NAME failed.
-    $CI_COMMIT_TITLE (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>) by $COMMIT_AUTHOR"
+    echo AUTHOR=$AUTHOR EMAIL=$EMAIL
+
+    SLACK_AUTHOR=$(echo $EMAIL | email2slack | slackuser2id | slackignore)
+
+    echo SLACK_AUTHOR=$SLACK_AUTHOR
+
+    # Only ping on pushes to master (== merged PRs)
+    if [ "$CI_PIPELINE_SOURCE" = "push" ] && [ -n "$SLACK_AUTHOR" ]; then
+      MESSAGE_TEXT=":host-red: :merged: Merge pipeline <$BUILD_URL|$CI_PIPELINE_ID> for $CI_COMMIT_REF_NAME failed.
+      $CI_COMMIT_TITLE (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>) by <@$SLACK_AUTHOR>: please check the pipeline failures."
+    else
+      MESSAGE_TEXT=":host-red: :angryjenkins: Triggered pipeline <$BUILD_URL|$CI_PIPELINE_ID> for $CI_COMMIT_REF_NAME failed.
+      $CI_COMMIT_TITLE (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>) by $AUTHOR"
+    fi
     postmessage "#datadog-agent-pipelines" "$MESSAGE_TEXT"


### PR DESCRIPTION
### What does this PR do?

Pings commit author on failure during a merge to master.
Adds success messages.

### Motivation

Make all teams more involved in the process of keeping the pipeline healthy.
