### PR TITLE
Add the ability to tail log file from the beginning

### DIFF
--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -31,6 +31,7 @@ const registryAPIVersion = 2
 // Registry holds a list of offsets.
 type Registry interface {
 	GetOffset(identifier string) string
+	GetTailingMode(identifier string) string
 }
 
 // A RegistryEntry represents an entry in the registry where we keep track
@@ -38,6 +39,7 @@ type Registry interface {
 type RegistryEntry struct {
 	LastUpdated time.Time
 	Offset      string
+	TailingMode string
 }
 
 // JSONRegistry represents the registry that will be written on disk
@@ -122,6 +124,17 @@ func (a *Auditor) GetOffset(identifier string) string {
 	return entry.Offset
 }
 
+// GetTailingMode returns the last committed offset for a given identifier,
+// returns an empty string if it does not exist.
+func (a *Auditor) GetTailingMode(identifier string) string {
+	r := a.readOnlyRegistryCopy()
+	entry, exists := r[identifier]
+	if !exists {
+		return ""
+	}
+	return entry.TailingMode
+}
+
 // run keeps up to date the registry depending on different events
 func (a *Auditor) run() {
 	cleanUpTicker := time.NewTicker(defaultCleanupPeriod)
@@ -143,7 +156,7 @@ func (a *Auditor) run() {
 				return
 			}
 			// update the registry with new entry
-			a.updateRegistry(msg.Origin.Identifier, msg.Origin.Offset)
+			a.updateRegistry(msg.Origin.Identifier, msg.Origin.Offset, msg.Origin.LogSource.Config.TailingMode)
 		case <-cleanUpTicker.C:
 			// remove expired offsets from registry
 			a.cleanupRegistry()
@@ -195,7 +208,7 @@ func (a *Auditor) cleanupRegistry() {
 }
 
 // updateRegistry updates the registry entry matching identifier with new the offset and timestamp
-func (a *Auditor) updateRegistry(identifier string, offset string) {
+func (a *Auditor) updateRegistry(identifier string, offset string, tailingMode string) {
 	a.registryMutex.Lock()
 	defer a.registryMutex.Unlock()
 	if identifier == "" {
@@ -207,6 +220,7 @@ func (a *Auditor) updateRegistry(identifier string, offset string) {
 	a.registry[identifier] = &RegistryEntry{
 		LastUpdated: time.Now().UTC(),
 		Offset:      offset,
+		TailingMode: tailingMode,
 	}
 }
 

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -62,12 +62,14 @@ func (suite *AuditorTestSuite) TestAuditorStartStop() {
 func (suite *AuditorTestSuite) TestAuditorUpdatesRegistry() {
 	suite.a.registry = make(map[string]*RegistryEntry)
 	suite.Equal(0, len(suite.a.registry))
-	suite.a.updateRegistry(suite.source.Config.Path, "42")
+	suite.a.updateRegistry(suite.source.Config.Path, "42", "end")
 	suite.Equal(1, len(suite.a.registry))
 	suite.Equal("42", suite.a.registry[suite.source.Config.Path].Offset)
-	suite.a.updateRegistry(suite.source.Config.Path, "43")
+	suite.Equal("end", suite.a.registry[suite.source.Config.Path].TailingMode)
+	suite.a.updateRegistry(suite.source.Config.Path, "43", "beginning")
 	suite.Equal(1, len(suite.a.registry))
 	suite.Equal("43", suite.a.registry[suite.source.Config.Path].Offset)
+	suite.Equal("beginning", suite.a.registry[suite.source.Config.Path].TailingMode)
 }
 
 func (suite *AuditorTestSuite) TestAuditorFlushesAndRecoversRegistry() {
@@ -75,11 +77,12 @@ func (suite *AuditorTestSuite) TestAuditorFlushesAndRecoversRegistry() {
 	suite.a.registry[suite.source.Config.Path] = &RegistryEntry{
 		LastUpdated: time.Date(2006, time.January, 12, 1, 1, 1, 1, time.UTC),
 		Offset:      "42",
+		TailingMode: "end",
 	}
 	suite.a.flushRegistry()
 	r, err := ioutil.ReadFile(suite.testPath)
 	suite.Nil(err)
-	suite.Equal("{\"Version\":2,\"Registry\":{\"testpath\":{\"LastUpdated\":\"2006-01-12T01:01:01.000000001Z\",\"Offset\":\"42\"}}}", string(r))
+	suite.Equal("{\"Version\":2,\"Registry\":{\"testpath\":{\"LastUpdated\":\"2006-01-12T01:01:01.000000001Z\",\"Offset\":\"42\",\"TailingMode\":\"end\"}}}", string(r))
 
 	suite.a.registry = make(map[string]*RegistryEntry)
 	suite.a.registry = suite.a.recoverRegistry()

--- a/pkg/logs/auditor/mock/mock.go
+++ b/pkg/logs/auditor/mock/mock.go
@@ -7,7 +7,8 @@ package mock
 
 // Registry does nothing
 type Registry struct {
-	offset string
+	offset      string
+	tailingMode string
 }
 
 // NewRegistry returns a new registry.
@@ -23,4 +24,14 @@ func (r *Registry) GetOffset(identifier string) string {
 // SetOffset sets the offset.
 func (r *Registry) SetOffset(offset string) {
 	r.offset = offset
+}
+
+// GetTailingMode returns the tailing mode.
+func (r *Registry) GetTailingMode(identifier string) string {
+	return r.tailingMode
+}
+
+// SetTailingMode sets the tailing mode.
+func (r *Registry) SetTailingMode(tailingMode string) {
+	r.tailingMode = tailingMode
 }

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Logs source types
@@ -27,7 +28,8 @@ type LogsConfig struct {
 	Port int    // Network
 	Path string // File, Journald
 
-	ExcludePaths []string `mapstructure:"exclude_paths" json:"exclude_paths"` // File
+	ExcludePaths []string `mapstructure:"exclude_paths" json:"exclude_paths"`   // File
+	TailingMode  string   `mapstructure:"start_position" json:"start_position"` // File
 
 	IncludeUnits  []string `mapstructure:"include_units" json:"include_units"`   // Journald
 	ExcludeUnits  []string `mapstructure:"exclude_units" json:"exclude_units"`   // Journald
@@ -48,6 +50,47 @@ type LogsConfig struct {
 	ProcessingRules []*ProcessingRule `mapstructure:"log_processing_rules" json:"log_processing_rules"`
 }
 
+// TailingMode type
+type TailingMode uint8
+
+// Tailing Modes
+const (
+	ForceBeginning = iota
+	ForceEnd
+	Beginning
+	End
+)
+
+var tailingModeTuples = []struct {
+	s string
+	m TailingMode
+}{
+	{"forceBeginning", ForceBeginning},
+	{"forceEnd", ForceEnd},
+	{"beginning", Beginning},
+	{"end", End},
+}
+
+// TailingModeFromString parses a string and returns a corresponding tailing mode, default to End if not found
+func TailingModeFromString(mode string) (TailingMode, bool) {
+	for _, t := range tailingModeTuples {
+		if t.s == mode {
+			return t.m, true
+		}
+	}
+	return End, false
+}
+
+// TailingModeToString returns seelog string representation for a specified tailing mode. Returns "" for invalid tailing mode.
+func (mode TailingMode) String() string {
+	for _, t := range tailingModeTuples {
+		if t.m == mode {
+			return t.s
+		}
+	}
+	return ""
+}
+
 // Validate returns an error if the config is misconfigured
 func (c *LogsConfig) Validate() error {
 	switch {
@@ -56,8 +99,14 @@ func (c *LogsConfig) Validate() error {
 		// an autodiscovery label because so we must override it at some point,
 		// this check is mostly used for sanity purposed to detect an override miss.
 		return fmt.Errorf("a config must have a type")
-	case c.Type == FileType && c.Path == "":
-		return fmt.Errorf("file source must have a path")
+	case c.Type == FileType:
+		if c.Path == "" {
+			return fmt.Errorf("file source must have a path")
+		}
+		err := c.validateTailingMode()
+		if err != nil {
+			return err
+		}
 	case c.Type == TCPType && c.Port == 0:
 		return fmt.Errorf("tcp source must have a port")
 	case c.Type == UDPType && c.Port == 0:
@@ -68,4 +117,20 @@ func (c *LogsConfig) Validate() error {
 		return err
 	}
 	return CompileProcessingRules(c.ProcessingRules)
+}
+
+func (c *LogsConfig) validateTailingMode() error {
+	mode, found := TailingModeFromString(c.TailingMode)
+	if !found && c.TailingMode != "" {
+		return fmt.Errorf("invalid tailing mode '%v' for %v", mode, c.Path)
+	}
+	if ContainsWildcard(c.Path) && (mode == Beginning || mode == ForceBeginning) {
+		return fmt.Errorf("tailing from the beginning is not supported for wildcard path %v", c.Path)
+	}
+	return nil
+}
+
+// ContainsWildcard returns true if the path contains any wildcard character
+func ContainsWildcard(path string) bool {
+	return strings.ContainsAny(path, "*?[")
 }

--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -67,7 +66,7 @@ func (p *Provider) FilesToTail(sources []*config.LogSource) []*File {
 		source := sources[i]
 		tailedFileCounter := 0
 		files, err := p.CollectFiles(source)
-		isWildcardPath := p.containsWildcard(source.Config.Path)
+		isWildcardPath := config.ContainsWildcard(source.Config.Path)
 		if err != nil {
 			source.Status.Error(err)
 			if isWildcardPath {
@@ -118,7 +117,7 @@ func (p *Provider) CollectFiles(source *config.LogSource) ([]*File, error) {
 		return []*File{
 			NewFile(path, source, false),
 		}, nil
-	case p.containsWildcard(path):
+	case config.ContainsWildcard(path):
 		pattern := path
 		return p.searchFiles(pattern, source)
 	default:
@@ -185,9 +184,4 @@ func (p *Provider) exists(filePath string) bool {
 		return false
 	}
 	return true
-}
-
-// containsWildcard returns true if the path contains any wildcard character
-func (p *Provider) containsWildcard(path string) bool {
-	return strings.ContainsAny(path, "*?[")
 }

--- a/pkg/logs/input/file/position.go
+++ b/pkg/logs/input/file/position.go
@@ -10,27 +10,39 @@ import (
 	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 )
 
 // Position returns the position from where logs should be collected.
-func Position(registry auditor.Registry, identifier string, tailFromBeginning bool) (int64, int, error) {
+func Position(registry auditor.Registry, identifier string, mode config.TailingMode) (int64, int, error) {
 	var offset int64
 	var whence int
 	var err error
+
 	value := registry.GetOffset(identifier)
+
 	switch {
+	case mode == config.ForceBeginning:
+		offset, whence = 0, io.SeekStart
+	case mode == config.ForceEnd:
+		offset, whence = 0, io.SeekEnd
 	case value != "":
-		// an offset was registered, tail from the offset
+		// an offset was registered, tailing mode is not forced, tail from the offset
 		whence = io.SeekStart
 		offset, err = strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			offset, whence = 0, io.SeekEnd
+			offset = 0
+			if mode == config.End {
+				whence = io.SeekEnd
+			} else if mode == config.Beginning {
+				whence = io.SeekStart
+			}
 		}
-	case tailFromBeginning:
-		// a new service has been discovered, tail from the beginning
+	case mode == config.Beginning:
 		offset, whence = 0, io.SeekStart
+	case mode == config.End:
+		fallthrough
 	default:
-		// a new config has been discovered, tail from the end
 		offset, whence = 0, io.SeekEnd
 	}
 	return offset, whence, err

--- a/pkg/logs/input/file/position_test.go
+++ b/pkg/logs/input/file/position_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 )
 
 func TestPosition(t *testing.T) {
@@ -21,25 +22,49 @@ func TestPosition(t *testing.T) {
 	var offset int64
 	var whence int
 
-	offset, whence, err = Position(registry, "", false)
+	offset, whence, err = Position(registry, "", config.End)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekEnd, whence)
 
-	offset, whence, err = Position(registry, "", true)
+	offset, whence, err = Position(registry, "", config.Beginning)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekStart, whence)
 
 	registry.SetOffset("123456789")
-	offset, whence, err = Position(registry, "", false)
+	offset, whence, err = Position(registry, "", config.End)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(123456789), offset)
 	assert.Equal(t, io.SeekStart, whence)
 
+	registry.SetOffset("987654321")
+	offset, whence, err = Position(registry, "", config.Beginning)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(987654321), offset)
+	assert.Equal(t, io.SeekStart, whence)
+
 	registry.SetOffset("foo")
-	offset, whence, err = Position(registry, "", false)
+	offset, whence, err = Position(registry, "", config.End)
 	assert.NotNil(t, err)
+	assert.Equal(t, int64(0), offset)
+	assert.Equal(t, io.SeekEnd, whence)
+
+	registry.SetOffset("bar")
+	offset, whence, err = Position(registry, "", config.Beginning)
+	assert.NotNil(t, err)
+	assert.Equal(t, int64(0), offset)
+	assert.Equal(t, io.SeekStart, whence)
+
+	registry.SetOffset("123456789")
+	offset, whence, err = Position(registry, "", config.ForceBeginning)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), offset)
+	assert.Equal(t, io.SeekStart, whence)
+
+	registry.SetOffset("987654321")
+	offset, whence, err = Position(registry, "", config.ForceEnd)
+	assert.Nil(t, err)
 	assert.Equal(t, int64(0), offset)
 	assert.Equal(t, io.SeekEnd, whence)
 }

--- a/pkg/logs/input/file/scanner_test.go
+++ b/pkg/logs/input/file/scanner_test.go
@@ -240,6 +240,58 @@ func TestScannerScanStartNewTailer(t *testing.T) {
 	assert.Equal(t, "world", string(msg.Content))
 }
 
+func TestScannerTailFromTheBeginning(t *testing.T) {
+	var err error
+	var path string
+	var file *os.File
+	var tailer *Tailer
+	var msg *message.Message
+
+	testDir, err := ioutil.TempDir("", "log-scanner-test-")
+	path = fmt.Sprintf("%s/test.log", testDir)
+	assert.Nil(t, err)
+
+	// create scanner
+	openFilesLimit := 2
+	sleepDuration := 20 * time.Millisecond
+	scanner := NewScanner(config.NewLogSources(), openFilesLimit, mock.NewMockProvider(), auditor.NewRegistry(), sleepDuration)
+	source := config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path, TailingMode: "beginning"})
+	// scanner.activeSources = append(scanner.activeSources, source)
+	status.Clear()
+	status.InitStatus(config.CreateSources([]*config.LogSource{source}))
+	defer status.Clear()
+
+	// create file
+	file, err = os.Create(path)
+	assert.Nil(t, err)
+
+	// add content before starting the tailer
+	_, err = file.WriteString("Once\n")
+	assert.Nil(t, err)
+	_, err = file.WriteString("Upon\n")
+	assert.Nil(t, err)
+
+	// test scan from the beginning, it shall read previously written strings
+	scanner.addSource(source)
+	assert.Equal(t, 1, len(scanner.tailers))
+
+	// add content after starting the tailer
+	_, err = file.WriteString("A\n")
+	assert.Nil(t, err)
+	_, err = file.WriteString("Time\n")
+	assert.Nil(t, err)
+
+	tailer = scanner.tailers[path]
+	msg = <-tailer.outputChan
+	assert.Equal(t, "Once", string(msg.Content))
+	msg = <-tailer.outputChan
+	assert.Equal(t, "Upon", string(msg.Content))
+	msg = <-tailer.outputChan
+	assert.Equal(t, "A", string(msg.Content))
+	msg = <-tailer.outputChan
+	assert.Equal(t, "Time", string(msg.Content))
+}
+
 func TestScannerScanWithTooManyFiles(t *testing.T) {
 	var err error
 	var path string

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -172,6 +172,7 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 		dictionary["Port"] = c.Port
 	case config.FileType:
 		dictionary["Path"] = c.Path
+		dictionary["TailingMode"] = c.TailingMode
 	case config.DockerType:
 		dictionary["Image"] = c.Image
 		dictionary["Label"] = c.Label

--- a/releasenotes/notes/logfile-tailing-from-the-begining-fbb49b9c2481204c.yaml
+++ b/releasenotes/notes/logfile-tailing-from-the-begining-fbb49b9c2481204c.yaml
@@ -1,0 +1,8 @@
+enhancements:
+  - |
+    Log configurations now accept a new parameter that allows
+    to specify whether a log shall be tailed from the beginning
+    or the end. It aims to allow whole log collection, including
+    events that may occur before the agent first start. The
+    parameter is named ``start_position`` and it can be set to
+    ``end`` or ``beginning``, the default value is ``end``.


### PR DESCRIPTION
### What does this PR do?
Log integration configs now accept a new parameters named `start_position`.
If it is set to `beginning` then new log file will be read from the beginning.
If it is set to `end` then new log file will be read from the end (current
behaviour). If a file is known then tailing will continue from the previous
known location if any, else the `start_position` setting will be honoured.

### Motivation
Allow to tail log that were generated before the agent starts.

### Additional Notes
It is only available for non-wildcard path. This limitation may be addressed in
the future, it would at lead require to keep track of rotated log not to retail
those from the beginning each time they are renamed but still matching 
the wildcard.