### PR TITLE
Revert "Trim forward slashes from config urls (#4843)"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -786,7 +786,6 @@ func load(config Config, origin string, loadSecret bool) error {
 	loadProxyFromEnv(config)
 	sanitizeAPIKey(config)
 	applyOverrides(config)
-	trimTrailingSlashFromURLS(config)
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	setTracemallocEnabled(config)
 	setNumWorkers(config)
@@ -831,47 +830,6 @@ func ResolveSecrets(config Config, origin string) error {
 // Avoid log ingestion breaking because of a newline in the API key
 func sanitizeAPIKey(config Config) {
 	config.Set("api_key", strings.TrimSpace(config.GetString("api_key")))
-}
-
-//trimTrailingSlashFromURLS trims any forward slashes from the end of various config URL's (site, dd_url, and various additional endpoints)
-func trimTrailingSlashFromURLS(config Config) error {
-	var urls = []string{
-		"site",
-		"dd_url",
-	}
-	var additionalEndpointSelectors = []string{
-		"additional_endpoints",
-		"apm_config.additional_endpoints",
-		"process_config.additional_endpoints",
-	}
-
-	for _, domain := range urls {
-		key := config.GetString(domain)
-		if key == "" {
-			continue
-		}
-		config.Set(domain, strings.TrimRight(key, "/"))
-	}
-
-	for _, es := range additionalEndpointSelectors {
-		additionalEndpoints := make(map[string][]string)
-		sanitizedAdditionalEndpoints := make(map[string][]string)
-
-		err := config.UnmarshalKey(es, &additionalEndpoints)
-
-		if err != nil {
-			return err
-		}
-		for domain, keys := range additionalEndpoints {
-			if domain == "" {
-				continue
-			}
-			domain = strings.TrimRight(domain, "/")
-			sanitizedAdditionalEndpoints[domain] = keys
-		}
-		config.Set(es, sanitizedAdditionalEndpoints)
-	}
-	return nil
 }
 
 // GetMainInfraEndpoint returns the main DD Infra URL defined in the config, based on the value of `site` and `dd_url`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -641,65 +641,6 @@ func TestSanitizeAPIKey(t *testing.T) {
 	assert.Equal(t, "foo", config.GetString("api_key"))
 }
 
-func TestTrimTrailingSlashFromURLS(t *testing.T) {
-	var urls = []string{
-		"site",
-		"dd_url",
-	}
-	var additionalEndpointSelectors = []string{
-		"additional_endpoints",
-		"apm_config.additional_endpoints",
-		"process_config.additional_endpoints",
-	}
-	datadogYaml := `
-api_key: fakeapikey
-site: datadoghq.com/////
-dd_url:
-additional_endpoints:
-  testing.com///:
-  - fakekey
-  test2.com/:
-  - fakekey
-apm_config:
-  additional_endpoints:
-    testingapm.com//:
-    - fakekey
-    test2apm.com/:
-    - fakekey
-process_config:
-  additional_endpoints:
-    testingproc.com/////:
-    - fakekey
-    test2proc.com/:
-    - fakekey
-`
-	testConfig := setupConfFromYAML(datadogYaml)
-	trimTrailingSlashFromURLS(testConfig)
-
-	for _, u := range urls {
-		testString := testConfig.GetString(u)
-		if len(testString) == 0 {
-			continue
-		}
-		if testString[len(testString)-1:] == "/" {
-			t.Errorf("Error: The key %v: has a vlue of %v -- The trailing forward slash was not properly trimmed", u, testConfig.GetString(u))
-		}
-	}
-	for _, es := range additionalEndpointSelectors {
-		additionalEndpoints := make(map[string][]string)
-		err := testConfig.UnmarshalKey(es, &additionalEndpoints)
-		if err != nil {
-			t.Errorf("Error: %v", err)
-		}
-
-		for domain := range additionalEndpoints {
-			if domain[len(domain)-1:] == "/" {
-				t.Errorf("Error: The key %v: has a vlue of %v -- The trailing forward slash was not properly trimmed", es, domain)
-			}
-		}
-	}
-}
-
 // TestSecretBackendWithMultipleEndpoints tests an edge case of `viper.AllSettings()` when a config
 // key includes the key delimiter. Affects the config package when both secrets and multiple
 // endpoints are configured.


### PR DESCRIPTION
### What does this PR do?

Reverts #4843

### Motivation

When the `secrets` feature enabled, and the api key on a `process_config.additional_endpoints` entry uses the secrets feature, the config/secrets package fails to load the decrypted api key and merge it in the config for process-agent.

### Additional notes

It's unclear at this point what the actual root cause of the error is. Let's figure this out later.

Confirmed by @p-lambert that this revert fixes the issue