### PR TITLE
Fix buildtags for some cluster agent related files

### DIFF
--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
+// +build clusterchecks
+
 package app
 
 import (

--- a/cmd/cluster-agent-cloudfoundry/main.go
+++ b/cmd/cluster-agent-cloudfoundry/main.go
@@ -4,6 +4,7 @@
 // Copyright 2016-2020 Datadog, Inc.
 
 // +build !windows
+// +build clusterchecks
 
 //go:generate go run ../../pkg/config/render_config.go dcacf ../../pkg/config/config_template.yaml ../../cloudfoundry.yaml
 

--- a/cmd/cluster-agent/commands/clusterchecks.go
+++ b/cmd/cluster-agent/commands/clusterchecks.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build clusterchecks
+// +build kubeapiserver clusterchecks
 
 package commands
 


### PR DESCRIPTION
### What does this PR do?

Properly sets build tags on some files added in PR http://github.com/DataDog/datadog-agent/pull/4935 in order for Snyk testing to pass.

(The change in `cmd/cluster-agent/commands/clusterchecks.go` is to make it consistent with `cmd/cluster-agent/commands/configcheck.go`)

### Motivation

Snyk go module fails right now, as it runs without considering build tags, so it would see `cmd/cluster-agent-cloudfoundry/app/app.go`, but not ` cmd/cluster-agent/commands` as that has buildtags on all files.

### Additional Notes

Anything else we should know when reviewing?
