### PR TITLE
Install JRE in Windows Docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2135,7 +2135,7 @@ build_agent7_windows:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
-    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809
+    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809 --build-arg WITH_JMX=true
   script:
     - $ErrorActionPreference = "Stop"
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -1,6 +1,11 @@
 $ErrorActionPreference = "Stop"
 Trap { Write-Host "Error in install.ps1: $_" }
 
+Invoke-WebRequest -OutFile jre-11.0.6.zip https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_windows_hotspot_11.0.6_10.zip
+Expand-Archive -Path jre-11.0.6.zip -DestinationPath C:/
+Remove-Item jre-11.0.6.zip
+Move-Item C:/jdk-11.0.6+10-jre/ C:/java
+
 Expand-Archive datadog-agent-7-latest.amd64.zip
 Remove-Item datadog-agent-7-latest.amd64.zip
 

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -6,6 +6,7 @@ if ("$env:WITH_JMX" -ne "false") {
     Expand-Archive -Path jre-11.0.6.zip -DestinationPath C:/
     Remove-Item jre-11.0.6.zip
     Move-Item C:/jdk-11.0.6+10-jre/ C:/java
+    setx PATH "$env:PATH;C:\java\bin"
 }
 
 Expand-Archive datadog-agent-7-latest.amd64.zip

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -6,8 +6,6 @@ if ("$env:WITH_JMX" -ne "false") {
     Expand-Archive -Path jre-11.0.6.zip -DestinationPath C:/
     Remove-Item jre-11.0.6.zip
     Move-Item C:/jdk-11.0.6+10-jre/ C:/java
-    setx PATH "$env:PATH;C:\java\bin"
-    java -version
 }
 
 Expand-Archive datadog-agent-7-latest.amd64.zip

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -7,6 +7,7 @@ if ("$env:WITH_JMX" -ne "false") {
     Remove-Item jre-11.0.6.zip
     Move-Item C:/jdk-11.0.6+10-jre/ C:/java
     setx PATH "$env:PATH;C:\java\bin"
+    java -version
 }
 
 Expand-Archive datadog-agent-7-latest.amd64.zip

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = "Stop"
+Trap { Write-Host "Error in install.ps1: $_" }
 
 Expand-Archive datadog-agent-7-latest.amd64.zip
 Remove-Item datadog-agent-7-latest.amd64.zip

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -1,10 +1,12 @@
 $ErrorActionPreference = "Stop"
 Trap { Write-Host "Error in install.ps1: $_" }
 
-Invoke-WebRequest -OutFile jre-11.0.6.zip https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_windows_hotspot_11.0.6_10.zip
-Expand-Archive -Path jre-11.0.6.zip -DestinationPath C:/
-Remove-Item jre-11.0.6.zip
-Move-Item C:/jdk-11.0.6+10-jre/ C:/java
+if ("$env:WITH_JMX" -ne "false") {
+    Invoke-WebRequest -OutFile jre-11.0.6.zip https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_windows_hotspot_11.0.6_10.zip
+    Expand-Archive -Path jre-11.0.6.zip -DestinationPath C:/
+    Remove-Item jre-11.0.6.zip
+    Move-Item C:/jdk-11.0.6+10-jre/ C:/java
+}
 
 Expand-Archive datadog-agent-7-latest.amd64.zip
 Remove-Item datadog-agent-7-latest.amd64.zip

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -6,6 +6,9 @@ if ("$env:WITH_JMX" -ne "false") {
     Expand-Archive -Path jre-11.0.6.zip -DestinationPath C:/
     Remove-Item jre-11.0.6.zip
     Move-Item C:/jdk-11.0.6+10-jre/ C:/java
+    # Add java to the path for jmxfetch
+    setx /m PATH "$Env:Path;C:/java/bin"
+    $Env:Path="$Env:Path;C:/java/bin"
 }
 
 Expand-Archive datadog-agent-7-latest.amd64.zip

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -15,6 +15,9 @@ USER ContainerAdministrator
 COPY datadog-agent-7-latest.amd64.zip install.ps1 ./
 RUN powershell ./install.ps1
 
+RUN setx PATH "%PATH%;C:\java\bin"
+RUN if "%WITH_JMX%" == "false" (echo WITH_JMX not set, JRE not installed) else (java -version)
+
 EXPOSE 8125/udp 8126/tcp
 
 # Config file is choosen at runtime by the entrypoint script

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -8,6 +8,8 @@ FROM ${BASE_IMAGE}
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
+USER ContainerAdministrator
+
 COPY datadog-agent-7-latest.amd64.zip install.ps1 ./
 RUN powershell ./install.ps1
 

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -15,7 +15,6 @@ USER ContainerAdministrator
 COPY datadog-agent-7-latest.amd64.zip install.ps1 ./
 RUN powershell ./install.ps1
 
-ENV PATH="C:\java\bin;${PATH}"
 RUN if "%WITH_JMX%" == "false" (echo WITH_JMX not set, JRE not installed) else (java -version)
 
 EXPOSE 8125/udp 8126/tcp

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -6,6 +6,8 @@ ARG BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809
 #ARG BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1809
 FROM ${BASE_IMAGE} 
 
+ARG WITH_JMX="false"
+
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
 USER ContainerAdministrator
@@ -14,7 +16,7 @@ COPY datadog-agent-7-latest.amd64.zip install.ps1 ./
 RUN powershell ./install.ps1
 
 ENV PATH="C:\java\bin;${PATH}"
-RUN java -version
+RUN if "%WITH_JMX%" == "false" (echo WITH_JMX not set, JRE not installed) else (java -version)
 
 EXPOSE 8125/udp 8126/tcp
 

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -13,6 +13,9 @@ USER ContainerAdministrator
 COPY datadog-agent-7-latest.amd64.zip install.ps1 ./
 RUN powershell ./install.ps1
 
+ENV PATH="C:\java\bin;${PATH}"
+RUN java -version
+
 EXPOSE 8125/udp 8126/tcp
 
 # Config file is choosen at runtime by the entrypoint script

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -15,8 +15,6 @@ USER ContainerAdministrator
 COPY datadog-agent-7-latest.amd64.zip install.ps1 ./
 RUN powershell ./install.ps1
 
-RUN if "%WITH_JMX%" == "false" (echo WITH_JMX not set, JRE not installed) else (java -version)
-
 EXPOSE 8125/udp 8126/tcp
 
 # Config file is choosen at runtime by the entrypoint script

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -12,11 +12,10 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 
 USER ContainerAdministrator
 
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
 COPY datadog-agent-7-latest.amd64.zip install.ps1 ./
 RUN powershell ./install.ps1
-
-RUN setx PATH "%PATH%;C:\java\bin"
-RUN if "%WITH_JMX%" == "false" (echo WITH_JMX not set, JRE not installed) else (java -version)
 
 EXPOSE 8125/udp 8126/tcp
 


### PR DESCRIPTION
### What does this PR do?

Install JRE in Windows Docker image if WITH_JMX is set to true.

Using JRE 11, on par with the Linux image.

### Motivation

Be able to run jmxfetch checks.
