### PR TITLE
Rebuild seelog logger when changing log level

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -54,7 +54,7 @@ var (
 	listRuntimeURLPath = agentConfigURLPath + "/list-runtime"
 )
 
-func showRuntimeConfiguration(cmd *cobra.Command, args []string) error {
+func setupConfig() error {
 	if flagNoColor {
 		color.NoColor = true
 	}
@@ -71,6 +71,14 @@ func showRuntimeConfiguration(cmd *cobra.Command, args []string) error {
 	}
 
 	err = util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func showRuntimeConfiguration(cmd *cobra.Command, args []string) error {
+	err := setupConfig()
 	if err != nil {
 		return err
 	}
@@ -108,7 +116,7 @@ func requestConfig() (string, error) {
 }
 
 func listRuntimeConfigurableValue(cmd *cobra.Command, args []string) error {
-	err := util.SetAuthToken()
+	err := setupConfig()
 	if err != nil {
 		return err
 	}
@@ -144,7 +152,7 @@ func setConfigValue(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
 		return fmt.Errorf("Exactly two parameters are required: the setting name and its value")
 	}
-	err := util.SetAuthToken()
+	err := setupConfig()
 	if err != nil {
 		return err
 	}
@@ -173,7 +181,7 @@ func getConfigValue(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("A single setting name must be specified")
 	}
-	err := util.SetAuthToken()
+	err := setupConfig()
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -70,11 +70,7 @@ func setupConfig() error {
 		return err
 	}
 
-	err = util.SetAuthToken()
-	if err != nil {
-		return err
-	}
-	return nil
+	return util.SetAuthToken()
 }
 
 func showRuntimeConfiguration(cmd *cobra.Command, args []string) error {

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -326,6 +326,7 @@ func extractShortPathFromFullPath(fullPath string) string {
 }
 
 func changeSeelogLevel(level string) error {
+	// We create a new logger to propagate the new log level everywhere seelog is used (including dependencies)
 	seelogConfig.setLogLevel(level)
 	configTemplate, err := seelogConfig.render()
 	if err != nil {
@@ -337,8 +338,9 @@ func changeSeelogLevel(level string) error {
 		return err
 	}
 	seelog.ReplaceLogger(logger)
-	log.SetupDatadogLogger(logger, level)
-	return nil
+
+	// We wire the new logger with the Datadog logic
+	return log.ChangeLogLevel(logger, level)
 }
 
 func init() {

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -28,7 +28,7 @@ const logDateFormat = "2006-01-02 15:04:05 MST" // see time.Format for format sy
 
 var syslogTLSConfig *tls.Config
 
-var seelogConfig *seelogCfg.SeelogConfig
+var seelogConfig *seelogCfg.Config
 
 // buildCommonFormat returns the log common format seelog string
 func buildCommonFormat(loggerName LoggerName) string {
@@ -44,7 +44,7 @@ func createQuoteMsgFormatter(params string) seelog.FormatterFunc {
 // buildJSONFormat returns the log JSON format seelog string
 func buildJSONFormat(loggerName LoggerName) string {
 	seelog.RegisterCustomFormatter("QuoteMsg", createQuoteMsgFormatter)
-	return fmt.Sprintf("{&quot;agent&quot;:&quot;%s&quot;,&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%ShortFilePath&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:%%QuoteMsg}%%n", strings.ToLower(string(loggerName)), logDateFormat)
+	return fmt.Sprintf(`{"agent":"%s","time":"%%Date(%s)","level":"%%LEVEL","file":"%%ShortFilePath","line":"%%Line","func":"%%FuncShort","msg":%%QuoteMsg}%%n`, strings.ToLower(string(loggerName)), logDateFormat)
 }
 
 func getSyslogTLSKeyPair() (*tls.Certificate, error) {

--- a/pkg/config/log_test.go
+++ b/pkg/config/log_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"testing"
 
+	seelogCfg "github.com/DataDog/datadog-agent/pkg/config/seelog"
 	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,11 +29,11 @@ func TestExtractShortPathFromFullPath(t *testing.T) {
 }
 
 func TestSeelogConfig(t *testing.T) {
-	cfg := NewSeelogConfig("TEST", "off", "common", "", "", false)
-	cfg.enableConsoleLog(true)
-	cfg.enableFileLogging("/dev/null", 123, 456)
+	cfg := seelogCfg.NewSeelogConfig("TEST", "off", "common", "", "", false)
+	cfg.EnableConsoleLog(true)
+	cfg.EnableFileLogging("/dev/null", 123, 456)
 
-	seelogConfigStr, err := cfg.render()
+	seelogConfigStr, err := cfg.Render()
 	assert.Nil(t, err)
 
 	logger, err := seelog.LoggerFromConfigAsString(seelogConfigStr)

--- a/pkg/config/log_test.go
+++ b/pkg/config/log_test.go
@@ -27,6 +27,19 @@ func TestExtractShortPathFromFullPath(t *testing.T) {
 	assert.Equal(t, "cmd/agent/collector.go", extractShortPathFromFullPath("/home/jenkins/workspace/process-agent-build-ddagent/go/src/github.com/DataDog/datadog-process-agent/cmd/agent/collector.go"))
 }
 
+func TestSeelogConfig(t *testing.T) {
+	cfg := NewSeelogConfig("TEST", "off", "common", "", "", false)
+	cfg.enableConsoleLog(true)
+	cfg.enableFileLogging("/dev/null", 123, 456)
+
+	seelogConfigStr, err := cfg.render()
+	assert.Nil(t, err)
+
+	logger, err := seelog.LoggerFromConfigAsString(seelogConfigStr)
+	assert.Nil(t, err)
+	assert.NotNil(t, logger)
+}
+
 func benchmarkLogFormat(logFormat string, b *testing.B) {
 	var buff bytes.Buffer
 	w := bufio.NewWriter(&buff)

--- a/pkg/config/runtime_setting_log_level.go
+++ b/pkg/config/runtime_setting_log_level.go
@@ -30,7 +30,7 @@ func (l logLevelRuntimeSetting) Get() (interface{}, error) {
 
 func (l logLevelRuntimeSetting) Set(v interface{}) error {
 	logLevel := v.(string)
-	err := changeSeelogLevel(logLevel)
+	err := changeLogLevel(logLevel)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/runtime_setting_log_level.go
+++ b/pkg/config/runtime_setting_log_level.go
@@ -30,7 +30,7 @@ func (l logLevelRuntimeSetting) Get() (interface{}, error) {
 
 func (l logLevelRuntimeSetting) Set(v interface{}) error {
 	logLevel := v.(string)
-	err := log.ChangeLogLevel(logLevel)
+	err := changeSeelogLevel(logLevel)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/runtime_settings_test.go
+++ b/pkg/config/runtime_settings_test.go
@@ -6,11 +6,8 @@
 package config
 
 import (
-	"io/ioutil"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,14 +63,12 @@ func TestRuntimeSettings(t *testing.T) {
 func TestLogLevel(t *testing.T) {
 	cleanRuntimeSetting()
 	setupConf()
-	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(ioutil.Discard, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	assert.Nil(t, err)
-	log.SetupDatadogLogger(l, "debug")
+	SetupLogger("TEST", "debug", "", "", true, true, true)
 
 	ll := logLevelRuntimeSetting("log_level")
 	assert.Equal(t, "log_level", ll.Name())
 
-	err = ll.Set("off")
+	err := ll.Set("off")
 	assert.Nil(t, err)
 
 	v, err := ll.Get()
@@ -82,7 +77,7 @@ func TestLogLevel(t *testing.T) {
 
 	err = ll.Set("invalid")
 	assert.NotNil(t, err)
-	assert.Equal(t, "bad log level", err.Error())
+	assert.Equal(t, "declared minlevel not found: invalid", err.Error())
 
 	v, err = ll.Get()
 	assert.Equal(t, "off", v)

--- a/pkg/config/seelog/seelog_config.go
+++ b/pkg/config/seelog/seelog_config.go
@@ -44,7 +44,10 @@ func (c *Config) Render() (string, error) {
 	c.Lock()
 	defer c.Unlock()
 	funcMap := template.FuncMap{
-		"getJSONSyslogFormat": getJSONSyslogFormat,
+		// This function will be called by the html/template engine that will perform HTML escaping of quotes caracters in the output string
+		"getJSONSyslogFormat": func(name string) string {
+			return `{"agent":"` + strings.ToLower(name) + `","level":"%LEVEL","relfile":"%ShortFilePath","line":"%Line","msg":"%Msg"}%n`
+		},
 	}
 	tmpl, err := template.New("seelog_config").Funcs(funcMap).Parse(seelogConfigurationTemplate)
 	if err != nil {
@@ -53,10 +56,6 @@ func (c *Config) Render() (string, error) {
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, c.settings)
 	return b.String(), err
-}
-
-func getJSONSyslogFormat(name string) string {
-	return `{"agent":"` + strings.ToLower(name) + `","level":"%LEVEL","relfile":"%ShortFilePath","line":"%Line","msg":"%Msg"}%n`
 }
 
 // EnableConsoleLog sets enable or disable console logging depending on the parameter value

--- a/pkg/config/seelog/seelog_config.go
+++ b/pkg/config/seelog/seelog_config.go
@@ -44,7 +44,7 @@ func (c *Config) Render() (string, error) {
 	c.Lock()
 	defer c.Unlock()
 	funcMap := template.FuncMap{
-		// This function will be called by the html/template engine that will perform HTML escaping of quotes caracters in the output string
+		// This function will be called by the html/template engine that will perform HTML escaping of quotes characters in the output string
 		"getJSONSyslogFormat": func(name string) string {
 			return `{"agent":"` + strings.ToLower(name) + `","level":"%LEVEL","relfile":"%ShortFilePath","line":"%Line","msg":"%Msg"}%n`
 		},

--- a/pkg/config/seelog_config.go
+++ b/pkg/config/seelog_config.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package config
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"text/template"
+)
+
+// SeelogConfig abstract seelog XML configuration definition
+type SeelogConfig struct {
+	settings map[string]interface{}
+	m        sync.Mutex
+}
+
+const seelogConfigurationTemplate = `
+<seelog minlevel="{{.logLevel}}">
+	<outputs formatid="{{.format}}">
+    {{if .consoleLoggingEnabled   }}<console />{{end}}
+    {{if .logfile                 }}<rollingfile type="size" filename="{{.logfile}}" maxsize="{{.maxsize}}" maxrolls="{{.maxrolls}}" />{{end}}
+	{{if .syslogURI               }}<custom name="syslog" formatid="syslog-{{.format}}" data-uri="{{.syslogURI}}" data-tls="{{.syslogUseTLS}}" />{{end}}
+	</outputs>
+	<formats>
+		<format id="json" format="{{.jsonFormat}}"/>
+		<format id="common" format="{{.commonFormat}}"/>
+		<format id="syslog-json" format="%%CustomSyslogHeader(20,{{.syslogRFC}}){&quot;agent&quot;:&quot;{{.loggerNameLowerCase}}&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;relfile&quot;:&quot;%%ShortFilePath&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
+		<format id="syslog-common" format="%%CustomSyslogHeader(20,{{.syslogRFC}}) {{.loggerName}} | %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%Msg%%n" />
+	</formats>
+</seelog>
+`
+
+func (c *SeelogConfig) setValue(k string, v interface{}) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.settings[k] = v
+}
+
+func (c *SeelogConfig) render() (string, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	tmpl, err := template.New("seelog_config").Parse(seelogConfigurationTemplate)
+	if err != nil {
+		return "", err
+	}
+	b := &bytes.Buffer{}
+	err = tmpl.Execute(b, c.settings)
+	return b.String(), err
+}
+
+func (c *SeelogConfig) enableConsoleLog(v bool) {
+	c.setValue("consoleLoggingEnabled", v)
+}
+
+func (c *SeelogConfig) setLogLevel(l string) {
+	c.setValue("logLevel", l)
+}
+
+func (c *SeelogConfig) enableFileLogging(f string, maxsize, maxrolls uint) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.settings["logfile"] = f
+	c.settings["maxsize"] = maxsize
+	c.settings["maxrolls"] = maxrolls
+}
+
+func (c *SeelogConfig) configureSyslog(syslogURI string, usetTLS bool) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.settings["syslogURI"] = syslogURI
+	c.settings["syslogUseTLS"] = usetTLS
+
+}
+
+// NewSeelogConfig return a SeelogConfig filled with correct parameters
+func NewSeelogConfig(name, level, format, jsonFormat, commonFormat string, syslogRFC bool) *SeelogConfig {
+	c := &SeelogConfig{settings: make(map[string]interface{})}
+	c.settings["loggerName"] = name
+	c.settings["loggerNameLowerCase"] = strings.ToLower(name)
+	c.settings["format"] = format
+	c.settings["syslogRFC"] = syslogRFC
+	c.settings["jsonFormat"] = jsonFormat
+	c.settings["commonFormat"] = commonFormat
+	c.settings["logLevel"] = level
+	return c
+}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -557,11 +557,24 @@ func GetLogLevel() (seelog.LogLevel, error) {
 	return seelog.InfoLvl, errors.New("cannot get loglevel: logger not initialized")
 }
 
-// ChangeLogLevel changes the current log level, valide levels are trace, debug, info, warn, error, critical and off
-func ChangeLogLevel(level string) error {
-	if logger != nil {
-		return logger.changeLogLevel(level)
+// ChangeLogLevel changes the current log level, valide levels are trace, debug,
+// info, warn, error, critical and off, it requires a new seelog logger because
+// an existing one cannot be updated
+func ChangeLogLevel(l seelog.LoggerInterface, level string) error {
+	if logger != nil && logger.inner != nil {
+		err := logger.changeLogLevel(level)
+		if err != nil {
+			return err
+		}
+		// See detailed explanation in SetupDatadogLogger(...)
+		err = l.SetAdditionalStackDepth(defaultStackDepth)
+		if err != nil {
+			return err
+		}
+
+		logger.replaceInnerLogger(l)
+		return nil
 	}
 	// need to return something, just set to Info (expected default)
-	return errors.New("cannot set loglevel: logger not initialized")
+	return errors.New("cannot change loglevel: logger not initialized")
 }


### PR DESCRIPTION
### What does this PR do?
It fixes the bug introduced by #4840 that led to systematic trace log level in dependency using seelog. Log level change at runtime now completely rebuilds a new seelog logger each time the log level is modified, the so-said seelog XML configuration is not generated by string concatenation anymore and is instead template-based. 
This PR also includes fixes for the new `list-runtime`,`get` and `set` commands when a non-default config directory/file is defined as the config needs to be initialised before `util.SetAuthToken` is called so it can read the token file from the proper location.

### Motivation
Prevent unwanted log to be emitted, especially considering that dependency log level was being set to `trace`.

### Additional Notes
Logging facility needs a refactor to properly isolate seelog related operations from the rest of the code and only expose seelog-agnostic functions (including logger initialisation, etc.)