### PR TITLE
Append network stats

### DIFF
--- a/pkg/util/containers/providers/windows/provider.go
+++ b/pkg/util/containers/providers/windows/provider.go
@@ -167,6 +167,8 @@ func (mp *provider) GetNetworkMetrics(containerID string, networks map[string]st
 		stat.BytesSent = netStat.TxBytes
 		stat.PacketsRcvd = netStat.RxPackets
 		stat.PacketsSent = netStat.TxPackets
+
+		netStats = append(netStats, stat)
 	}
 	return netStats, nil
 }


### PR DESCRIPTION
### What does this PR do?

Add missing append that prevented network metrics from showing up in dogweb.
