### PR TITLE
Use Windows Nano

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2135,7 +2135,7 @@ build_agent7_windows:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
-    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809 --build-arg WITH_JMX=true
+    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1809 --build-arg WITH_JMX=true
   script:
     - $ErrorActionPreference = "Stop"
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,9 +1,4 @@
-ARG BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809
-
-# We will need some code changes to support nano. At least:
-# - netapi32.dll is not there, so go's user.Current() doesn't work
-# Also, "powershell" calls in this script have to be replaced by "pwsh"
-#ARG BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1809
+ARG BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1909
 FROM ${BASE_IMAGE} 
 
 ARG WITH_JMX="false"
@@ -12,10 +7,10 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 
 USER ContainerAdministrator
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 COPY datadog-agent-7-latest.amd64.zip install.ps1 ./
-RUN powershell ./install.ps1
+RUN . ./install.ps1
 
 EXPOSE 8125/udp 8126/tcp
 
@@ -24,6 +19,6 @@ COPY entrypoint.ps1 .
 ADD entrypoint-ps1 ./entrypoint-ps1
 COPY datadog*.yaml C:/ProgramData/Datadog/
 
-ENTRYPOINT ["powershell", "./entrypoint.ps1"]
+ENTRYPOINT ["pwsh", "./entrypoint.ps1"]
 
 CMD ["run"]


### PR DESCRIPTION
### What does this PR do?

Switches base image to Windows Nano.

Everything seems to work after some basic local testing.

Requires rebasing `vboulineau/docker_windows` onto master so it includes https://github.com/DataDog/datadog-agent/pull/5074