### PR TITLE
Do not use DD_CRI_SOCKET_PATH for a docker socket

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-cri.sh
+++ b/Dockerfiles/agent/entrypoint/50-cri.sh
@@ -12,7 +12,7 @@ if [[ ! -e /etc/datadog-agent/conf.d/cri.d/conf.yaml.default ]]; then
 fi
 
 # If the CRI is containerd, enable the containerd check
-if [[ $(echo $DD_CRI_SOCKET_PATH | sed -n '/containerd/p') ]]; then
+if [[ $DD_CRI_SOCKET_PATH =~ containerd ]]; then
      mv /etc/datadog-agent/conf.d/containerd.d/conf.yaml.example \
         /etc/datadog-agent/conf.d/containerd.d/conf.yaml.default
 fi

--- a/Dockerfiles/agent/entrypoint/50-kubernetes.sh
+++ b/Dockerfiles/agent/entrypoint/50-kubernetes.sh
@@ -7,7 +7,7 @@ fi
 # Set a default config for Kubernetes if found
 # Don't override /etc/datadog-agent/datadog.yaml if it exists
 if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
-    if [[ -S /var/run/docker.sock ]] || ( [[ "$DD_CRI_SOCKET_PATH" =~ docker\.sock ]] && [[ -S "$DD_CRI_SOCKET_PATH" ]] ); then
+    if [[ -n "${DOCKER_HOST}" || -S /var/run/docker.sock ]]; then
         ln -s /etc/datadog-agent/datadog-k8s-docker.yaml \
            /etc/datadog-agent/datadog.yaml
     else

--- a/Dockerfiles/agent/entrypoint/51-docker.sh
+++ b/Dockerfiles/agent/entrypoint/51-docker.sh
@@ -5,7 +5,7 @@
 #     (in that case, we trust the user wants docker integration and don't check existence)
 #   - we find the docker socket at it's default location
 
-if [[ -z "${DOCKER_HOST}" && ! -e /var/run/docker.sock ]]; then
+if [[ -z "${DOCKER_HOST}" && ! -S /var/run/docker.sock ]]; then
     exit 0
 fi
 

--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -34,7 +34,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - {name: DD_CRI_SOCKET_PATH, value: /host/var/run/docker.sock}
           - {name: DOCKER_HOST, value: unix:///host/var/run/docker.sock}
         resources:
           requests:


### PR DESCRIPTION
### What does this PR do?

Do not use `DD_CRI_SOCKET_PATH` for a docker socket

### Motivation

Setting `DD_CRI_SOCKET_PATH` for a docker socket will enable the `cri` check whereas the docker daemon doesn't support the CRI API.

Also, when checking the existence of `/var/run/docker.sock`, we must check that it's really a UNIX socket.
The issue is when the agent is started in a non-docker container with a bind mount of `/var/run/docker.sock` by mistake whereas there's no docker on the host.
In that case, a new directory named `/var/run/docker.sock/` will be created and mounted inside the container.
In this case of configuration error, we mustn't activate the `docker` features.