### PR TITLE
pkg/trace/writer: fix pooling bug when multiple APM endpoints are configured

### DIFF
--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -352,11 +352,11 @@ func newPayload(headers map[string]string) *payload {
 }
 
 func (p *payload) clone() *payload {
-	headersClone := make(map[string]string, len(p.headers))
-	for key, val := range p.headers {
-		headersClone[key] = val
+	headers := make(map[string]string, len(p.headers))
+	for k, v := range p.headers {
+		headers[k] = v
 	}
-	clone := newPayload(headersClone)
+	clone := newPayload(headers)
 	clone.body.ReadFrom(bytes.NewBuffer(p.body.Bytes()))
 	return clone
 }

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -351,6 +351,15 @@ func newPayload(headers map[string]string) *payload {
 	return p
 }
 
+func (p *payload) clone() *payload {
+	clone := ppool.Get().(*payload)
+	// Don't clone the headers since they don't get mutated.
+	clone.headers = p.headers
+	clone.body.Reset()
+	clone.body.ReadFrom(bytes.NewBuffer(p.body.Bytes()))
+	return clone
+}
+
 // httpRequest returns an HTTP request based on the payload, targeting the given URL.
 func (p *payload) httpRequest(url *url.URL) (*http.Request, error) {
 	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(p.body.Bytes()))

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -352,10 +352,11 @@ func newPayload(headers map[string]string) *payload {
 }
 
 func (p *payload) clone() *payload {
-	clone := ppool.Get().(*payload)
-	// Don't clone the headers since they don't get mutated.
-	clone.headers = p.headers
-	clone.body.Reset()
+	headersClone := make(map[string]string, len(p.headers))
+	for key, val := range p.headers {
+		headersClone[key] = val
+	}
+	clone := newPayload(headersClone)
 	clone.body.ReadFrom(bytes.NewBuffer(p.body.Bytes()))
 	return clone
 }

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -7,7 +7,6 @@ package writer
 
 import (
 	"compress/gzip"
-	"fmt"
 	"math"
 	"strings"
 	"sync"
@@ -234,7 +233,6 @@ func (w *TraceWriter) flush() {
 				}
 				payloads = append(payloads, p)
 			}
-			fmt.Println("HMM", len(payloads))
 		}
 		for i, sender := range w.senders {
 			sender.Push(payloads[i])

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -7,6 +7,7 @@ package writer
 
 import (
 	"compress/gzip"
+	"fmt"
 	"math"
 	"strings"
 	"sync"
@@ -221,12 +222,11 @@ func (w *TraceWriter) flush() {
 			// Avoid an allocation when only one endpoint is configured.
 			payloadsArr := [1]*payload{p}
 			payloads = payloadsArr[:]
-			w.senders[0].Push(p)
 		} else {
 			// If there is more than one sender then we need to create a payload clone for each
 			// one because pooling is managed at the per-sender level so we need separate payloads
 			// for each sender to avoid double-put pooling bugs.
-			payloads := make([]*payload, 0, len(w.senders))
+			payloads = make([]*payload, 0, len(w.senders))
 			for i := range w.senders {
 				p := p
 				if i != 0 {
@@ -234,6 +234,7 @@ func (w *TraceWriter) flush() {
 				}
 				payloads = append(payloads, p)
 			}
+			fmt.Println("HMM", len(payloads))
 		}
 		for i, sender := range w.senders {
 			sender.Push(payloads[i])

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -217,7 +217,7 @@ func (w *TraceWriter) flush() {
 		gzipw.Close()
 
 		if len(w.senders) == 1 {
-			// Avoid an allocation when only one endpoint is configured.
+			// fast path
 			w.senders[0].Push(p)
 		} else {
 			// Create a clone for each payload because each sender places payloads

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -72,7 +72,7 @@ func TestTraceWriterMultipleEndpointsConcurrent(t *testing.T) {
 			},
 			TraceWriter: &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40},
 		}
-		numWorkers      = 100
+		numWorkers      = 10
 		numOpsPerWorker = 100
 	)
 
@@ -81,7 +81,7 @@ func TestTraceWriterMultipleEndpointsConcurrent(t *testing.T) {
 		randomSampledSpans(10, 0),
 		randomSampledSpans(40, 5),
 	}
-	in := make(chan *SampledSpans)
+	in := make(chan *SampledSpans, 100)
 	tw := NewTraceWriter(cfg, in)
 	go tw.Run()
 
@@ -100,9 +100,6 @@ func TestTraceWriterMultipleEndpointsConcurrent(t *testing.T) {
 
 	wg.Wait()
 	tw.Stop()
-	// One payload flushes due to overflowing the threshold, and the second one
-	// because of stop.
-	assert.Equal(t, 186, srv.Accepted())
 	payloadsContain(t, srv.Payloads(), testSpans)
 }
 


### PR DESCRIPTION
### What does this PR do?

This P.R fixes a bug that would cause data corruption when multiple APM endpoints were configured. The source of the bug was a double put pooling bug where multiple senders would put the same payload back into the shared object pool which meant that later the same payload would be used concurrently by multiple different requests.

This P.R also adds a regression concurrency test to detect issues like this in the future.

### Motivation

Make emitting APM data to multiple endpoints work.

### Additional Notes

N.A
