### PR TITLE
Bump PyYAML and Docker dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - set PATH=%APPVEYOR_BUILD_FOLDER%\dev\lib;%GOPATH%\bin;%Python2_ROOT_DIR%;%Python2_ROOT_DIR%\Scripts;%Python3_ROOT_DIR%;%Python3_ROOT_DIR%\Scripts;%MSYS_ROOT%\mingw64\bin;%MSYS_ROOT%\usr\bin\;%PATH%
   - git clone --depth 1 https://github.com/datadog/integrations-core
   - "%PIP2% install codecov -r requirements.txt"
-  - "%PIP3% install PyYAML==5.1"
+  - "%PIP3% install PyYAML==5.3"
   # download specific go version
   - md c:\tmp
   - ps: $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;(New-Object System.Net.WebClient).DownloadFile("https://dl.google.com/go/go$ENV:GOVERSION.windows-amd64.zip", "c:\tmp\godl.zip")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - set PATH=%APPVEYOR_BUILD_FOLDER%\dev\lib;%GOPATH%\bin;%Python2_ROOT_DIR%;%Python2_ROOT_DIR%\Scripts;%Python3_ROOT_DIR%;%Python3_ROOT_DIR%\Scripts;%MSYS_ROOT%\mingw64\bin;%MSYS_ROOT%\usr\bin\;%PATH%
   - git clone --depth 1 https://github.com/datadog/integrations-core
   - "%PIP2% install codecov -r requirements.txt"
-  - "%PIP3% install PyYAML==5.3"
+  - "%PIP3% install -r requirements.txt"
   # download specific go version
   - md c:\tmp
   - ps: $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;(New-Object System.Net.WebClient).DownloadFile("https://dl.google.com/go/go$ENV:GOVERSION.windows-amd64.zip", "c:\tmp\godl.zip")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ invoke==1.0.0
 reno==2.9.2
 docker==3.0.1
 requests==2.20.1
-PyYAML==5.1
+PyYAML==5.3
 toml==0.9.4
 distro==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # python development requirements for Agent 6
 invoke==1.0.0
 reno==2.9.2
-docker==3.0.1
+docker==3.7.3
 requests==2.20.1
 PyYAML==5.3
 toml==0.9.4


### PR DESCRIPTION
### What does this PR do?

Bumps PyYAML to 5.3 to match the version used in integrations-core: https://github.com/DataDog/integrations-core/pull/6043
Bumps Docker to 3.7.3 to fix a dependency issue on Windows with Python 3.7: https://github.com/docker/docker-py/commit/d7bb808ca63b4ef8175e404f722a77be57de0f0e

### Motivation

Keep dependencies up to date.
Fix AppVeyor CI test.
