### PR TITLE
Expose new JMXFetch methods

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -148,10 +148,16 @@ var checkCmd = &cobra.Command{
 
 			if check.IsJMXConfig(*conf) {
 				// we'll mimic the check command behavior with JMXFetch by running
-				// it with the JSON reporter and the list_with_metrics command.
+				// it with the JSON reporter and the aist_with_metrics command.
 				fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")
-				if err := RunJmxListWithMetrics(); err != nil {
-					return fmt.Errorf("while running the jmx check: %v", err)
+				if checkRate {
+					if err := RunJmxListWithRateMetrics(); err != nil {
+						return fmt.Errorf("while running the jmx check: %v", err)
+					}
+				} else {
+					if err := RunJmxListWithMetrics(); err != nil {
+						return fmt.Errorf("while running the jmx check: %v", err)
+					}
 				}
 
 				instances := []integration.Data{}

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -148,7 +148,7 @@ var checkCmd = &cobra.Command{
 
 			if check.IsJMXConfig(*conf) {
 				// we'll mimic the check command behavior with JMXFetch by running
-				// it with the JSON reporter and the aist_with_metrics command.
+				// it with the JSON reporter and the list_with_metrics command.
 				fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")
 				if checkRate {
 					if err := RunJmxListWithRateMetrics(); err != nil {

--- a/cmd/agent/app/check_nojmx.go
+++ b/cmd/agent/app/check_nojmx.go
@@ -14,3 +14,9 @@ import "fmt"
 func RunJmxListWithMetrics() error {
 	return fmt.Errorf("not supported in the Puppy Agent")
 }
+
+// RunJmxListWithRateMetrics is not supported in the Puppy Agent because it doesn't
+// support JMXFetch.
+func RunJmxListWithRateMetrics() error {
+	return fmt.Errorf("not supported in the Puppy Agent")
+}

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -64,6 +64,13 @@ var (
 		RunE:  doJmxListWithMetrics,
 	}
 
+	jmxListWithRateMetricsCmd = &cobra.Command{
+		Use:   "with-rate-metrics",
+		Short: "List attributes and metrics data that match at least one of your instances configuration, including rates and counters.",
+		Long:  ``,
+		RunE:  doJmxListWithRateMetrics,
+	}
+
 	jmxListLimitedCmd = &cobra.Command{
 		Use:   "limited",
 		Short: "List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected.",
@@ -97,7 +104,7 @@ func init() {
 	jmxCmd.AddCommand(jmxCollectCmd)
 
 	//attach list commands to list root
-	jmxListCmd.AddCommand(jmxListEverythingCmd, jmxListMatchingCmd, jmxListLimitedCmd, jmxListCollectedCmd, jmxListNotMatchingCmd, jmxListWithMetricsCmd)
+	jmxListCmd.AddCommand(jmxListEverythingCmd, jmxListMatchingCmd, jmxListLimitedCmd, jmxListCollectedCmd, jmxListNotMatchingCmd, jmxListWithMetricsCmd, jmxListWithRateMetricsCmd)
 
 	jmxListCmd.PersistentFlags().StringSliceVar(&checks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
 	jmxCollectCmd.PersistentFlags().StringSliceVar(&checks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
@@ -120,6 +127,10 @@ func doJmxListMatching(cmd *cobra.Command, args []string) error {
 
 func doJmxListWithMetrics(cmd *cobra.Command, args []string) error {
 	return RunJmxCommand("list_with_metrics", jmxfetch.ReporterConsole, nil)
+}
+
+func doJmxListWithRateMetrics(cmd *cobra.Command, args []string) error {
+	return RunJmxCommand("list_with_rate_metrics", jmxfetch.ReporterConsole, nil)
 }
 
 func doJmxListLimited(cmd *cobra.Command, args []string) error {
@@ -206,6 +217,18 @@ func RunJmxListWithMetrics() error {
 		fmt.Println(a...)
 	}
 	return RunJmxCommand("list_with_metrics", jmxfetch.ReporterJSON, out)
+}
+
+
+// RunJmxListWithRateMetrics runs the JMX command with "with-rate-metrics", reporting
+// the data as a JSON on the console. It is used by the `check jmx --rate` cli command
+// of the Agent.
+func RunJmxListWithRateMetrics() error {
+	// don't pollute the JSON with the log pattern.
+	out := func(a ...interface{}) {
+		fmt.Println(a...)
+	}
+	return RunJmxCommand("list_with_rate_metrics", jmxfetch.ReporterJSON, out)
 }
 
 func loadConfigs(runner *jmxfetch.JMXFetch) {

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -219,7 +219,6 @@ func RunJmxListWithMetrics() error {
 	return RunJmxCommand("list_with_metrics", jmxfetch.ReporterJSON, out)
 }
 
-
 // RunJmxListWithRateMetrics runs the JMX command with "with-rate-metrics", reporting
 // the data as a JSON on the console. It is used by the `check jmx --rate` cli command
 // of the Agent.

--- a/releasenotes/notes/jmx-check-rate-5ea5744536ebbd12.yaml
+++ b/releasenotes/notes/jmx-check-rate-5ea5744536ebbd12.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Expose the new JMXFetch rate with metrics method to test JMX based checks.


### PR DESCRIPTION
We added a new method to JMXFetch which exposes rate metrics, this
exposes it in the jmx namespace and via `check --rate`.