### PR TITLE
Fix release.update-changelog command to ignore A6 release tag

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,7 +1,7 @@
 ---
 collapse_pre_releases: true
 no_show_source: true
-release_tag_re: '^[67]\.([\d.-]|rc|devel)+$'
+release_tag_re: '^7\.([\d.-]|rc|devel)+$'
 pre_release_tag_re: '(?P<pre_release>-rc\.\d+)$'
 template: |
           # Each section from every releasenote are combined when the


### PR DESCRIPTION
### What does this PR do?

Fix release.update-changelog command to ignore A6 release tag.

Or else reno attribute all the commit to either 6 or 7 (depending on tagging order it seems).