### PR TITLE
[system-probe, selinux] Fix debian postinstall crash when installing module on unsupported platforms

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -94,8 +94,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         # FIXME: Refactor warning messages
         if command -v semodule >/dev/null 2>&1 && [ -f "$INSTALL_DIR/embedded/bin/system-probe" ]; then
             echo "Loading SELinux policy module for system-probe."
-            semodule -v -i $CONFIG_DIR/selinux/system_probe_policy.pp >/dev/null 2>&1
-            if [ "$?" != "0" ]; then
+            if ! semodule -i $CONFIG_DIR/selinux/system_probe_policy.pp >/dev/null 2>&1; then
                 echo "Couldn’t load system-probe policy."
                 echo "To be able to run system-probe on your host, please install or update the"
                 echo "selinux-policy-default and policycoreutils-python-utils packages."
@@ -105,9 +104,8 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
                 echo "    restorecon -v $INSTALL_DIR/embedded/bin/system-probe"
             else
                 echo "Labeling SELinux type for the system-probe binary."
-                if command -v semanage >/dev/null 2>&1 && command -v restorecon >/dev/null 2>&1;then
-                    semanage fcontext -a -t system_probe_t $INSTALL_DIR/embedded/bin/system-probe && restorecon -v $INSTALL_DIR/embedded/bin/system-probe
-                    if [ "$?" != "0" ]; then
+                if command -v semanage >/dev/null 2>&1 && command -v restorecon >/dev/null 2>&1; then
+                    if ! semanage fcontext -a -t system_probe_t $INSTALL_DIR/embedded/bin/system-probe || ! restorecon -v $INSTALL_DIR/embedded/bin/system-probe; then
                         echo "Couldn’t install system-probe policy."
                         echo "To be able to run system-probe on your host, please install or update the"
                         echo "selinux-policy-default and policycoreutils-python-utils packages."


### PR DESCRIPTION
### What does this PR do?

Changes the way we run SELinux commands on Debian / Ubuntu to avoid crashes on expected failures.
Contrary to the RHEL posttrans script, the Debian / Ubuntu postinst crashes on any error (because of the `set -e` at the start of the block).

### Motivation

Makes SELinux installation resilient to expected failures (old kernel / policies incompatible with system-probe).

### Additional Notes

Needs thorough review and testing on all supported Ubuntu / Debian platforms (the CI doesn't currently take care of all cases).
