### PR TITLE
[debian, selinux] Revert adding selinux policy for system-probe

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -90,43 +90,6 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
         fi
 
-        # Setup SELinux policy and label if SELinux detected on the host
-        # FIXME: Refactor warning messages
-        if command -v semodule >/dev/null 2>&1 && [ -f "$INSTALL_DIR/embedded/bin/system-probe" ]; then
-            echo "Loading SELinux policy module for system-probe."
-            semodule -v -i $CONFIG_DIR/selinux/system_probe_policy.pp >/dev/null 2>&1
-            if [ "$?" != "0" ]; then
-                echo "Couldn’t load system-probe policy."
-                echo "To be able to run system-probe on your host, please install or update the"
-                echo "selinux-policy-default and policycoreutils-python-utils packages."
-                echo "Then run the following commands, or reinstall datadog-agent:"
-                echo "    semodule -i $CONFIG_DIR/selinux/system_probe_policy.pp"
-                echo "    semanage fcontext -a -t system_probe_t $INSTALL_DIR/embedded/bin/system-probe"
-                echo "    restorecon -v $INSTALL_DIR/embedded/bin/system-probe"
-            else
-                echo "Labeling SELinux type for the system-probe binary."
-                if command -v semanage >/dev/null 2>&1 && command -v restorecon >/dev/null 2>&1;then
-                    semanage fcontext -a -t system_probe_t $INSTALL_DIR/embedded/bin/system-probe && restorecon -v $INSTALL_DIR/embedded/bin/system-probe
-                    if [ "$?" != "0" ]; then
-                        echo "Couldn’t install system-probe policy."
-                        echo "To be able to run system-probe on your host, please install or update the"
-                        echo "selinux-policy-default and policycoreutils-python-utils packages."
-                        echo "Then run the following commands, or reinstall datadog-agent:"
-                        echo "    semodule -i $CONFIG_DIR/selinux/system_probe_policy.pp"
-                        echo "    semanage fcontext -a -t system_probe_t $INSTALL_DIR/embedded/bin/system-probe"
-                        echo "    restorecon -v $INSTALL_DIR/embedded/bin/system-probe"
-                    fi
-                else
-                    echo "Couldn’t load system-probe policy (missing selinux utilities)."
-                    echo "To be able to run system-probe on your host, please install or update the"
-                    echo "selinux-policy-default and policycoreutils-python-utils packages."
-                    echo "Then run the following commands, or reinstall datadog-agent:"
-                    echo "    semodule -i $CONFIG_DIR/selinux/system_probe_policy.pp"
-                    echo "    semanage fcontext -a -t system_probe_t $INSTALL_DIR/embedded/bin/system-probe"
-                    echo "    restorecon -v $INSTALL_DIR/embedded/bin/system-probe"
-                fi
-            fi
-        fi
 
         # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
         # and avoid restarting when a check conf is invalid

--- a/releasenotes/notes/remove-debian-selinux-policy-00af5b4a09f11219.yaml
+++ b/releasenotes/notes/remove-debian-selinux-policy-00af5b4a09f11219.yaml
@@ -9,4 +9,4 @@
 fixes:
   - |
     On Debian and Ubuntu-based systems, remove system-probe SELinux policy
-    to prevent install crashes.
+    to prevent install failures.

--- a/releasenotes/notes/remove-debian-selinux-policy-00af5b4a09f11219.yaml
+++ b/releasenotes/notes/remove-debian-selinux-policy-00af5b4a09f11219.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Debian and Ubuntu-based systems, remove system-probe SELinux policy
+    to prevent install crashes.


### PR DESCRIPTION
### What does this PR do?

Removes the postinst step which installs the SELinux policy.

### Motivation

It breaks installs on SELinux systems as the policy is not adequate for Ubuntu.
