### PR TITLE
[system-probe] Improve conntrack resiliency to deletes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2111,7 +2111,7 @@
   revision = "b3a7cee44a305be0a69e1b9ac03018307287e1b0"
 
 [[projects]]
-  digest = "1:f27698f7ae7864893ebcfb843e44d821263ac1dcf0ba1d5c2353f9d319a2f28d"
+  digest = "0:"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/kubelet/remote/fake",
@@ -2272,6 +2272,7 @@
     "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider",
     "github.com/lxn/walk",
     "github.com/lxn/win",
+    "github.com/mdlayher/netlink",
     "github.com/mholt/archiver",
     "github.com/miekg/dns",
     "github.com/openshift/api/quota/v1",

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -131,7 +131,12 @@ func newConntrackerOnce(procRoot string, deleteBufferSize, maxStateSize int) (Co
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open delete NFCT")
 	}
-	setSocketBufferSize(netlinkBufferSize, nfctDel.Con)
+	if err := setSocketBufferSize(netlinkBufferSize, nfctDel.Con); err != nil {
+		log.Errorf("error setting rcv buffer size for delete netlink socket: %s", err)
+	}
+	if size, err := getSocketBufferSize(nfctDel.Con); err == nil {
+		log.Debugf("rcv buffer size for delete netlink socket is %d bytes", size)
+	}
 
 	ctr := &realConntracker{
 		nfct:                 nfct,

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -23,6 +23,9 @@ const (
 
 	// generationLength must be greater than compactInterval to ensure we have  multiple compactions per generation
 	generationLength = compactInterval + time.Minute
+
+	// netlink socket buffer size in bytes
+	netlinkBufferSize = 1024 * 1024
 )
 
 // Conntracker is a wrapper around go-conntracker that keeps a record of all connections in user space
@@ -128,6 +131,7 @@ func newConntrackerOnce(procRoot string, deleteBufferSize, maxStateSize int) (Co
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open delete NFCT")
 	}
+	setSocketBufferSize(netlinkBufferSize, nfctDel.Con)
 
 	ctr := &realConntracker{
 		nfct:                 nfct,

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -344,6 +344,8 @@ func (ctr *realConntracker) unregister(c ct.Con) int {
 		atomic.AddInt64(&ctr.stats.missedRegisters, 1)
 	}
 
+	log.Tracef("unregistered %s", conDebug(c))
+
 	return 0
 }
 

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -19,10 +19,10 @@ import (
 const (
 	initializationTimeout = time.Second * 10
 
-	compactInterval = time.Minute * 3
+	compactInterval = time.Minute
 
-	// generationLength must be greater than compactInterval to ensure we have  multiple compactions per generation
-	generationLength = compactInterval + time.Minute
+	// generationLength must be greater than compactInterval to ensure we have multiple compactions per generation
+	generationLength = compactInterval + 30*time.Second
 
 	// netlink socket buffer size in bytes
 	netlinkBufferSize = 1024 * 1024

--- a/pkg/ebpf/netlink/logging.go
+++ b/pkg/ebpf/netlink/logging.go
@@ -13,7 +13,8 @@ import (
 // getLogger creates a log.Logger which forwards logs to the agent's logging package at DEBUG leve.
 // Returns nil if the agent loggers level is above DEBUG.
 func getLogger() *log.Logger {
-	if level := strings.ToUpper(config.Datadog.GetString("log_level")); level != "DEBUG" {
+	level := strings.ToUpper(config.Datadog.GetString("log_level"))
+	if level != "DEBUG" && level != "TRACE" {
 		return nil
 	}
 

--- a/pkg/ebpf/netlink/socket_buffer.go
+++ b/pkg/ebpf/netlink/socket_buffer.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/pkg/ebpf/netlink/socket_buffer.go
+++ b/pkg/ebpf/netlink/socket_buffer.go
@@ -1,0 +1,45 @@
+package netlink
+
+import (
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/mdlayher/netlink"
+)
+
+// setSocketBufferSize of a netlink socket.
+// We use this custom function as oposed to netlink.Conn.SetReadBuffer because you can only
+// set a value higher than /proc/sys/net/core/rmem_default (which is around 200kb for most systems)
+// if you use SO_RCVBUFFORCE with CAP_NET_ADMIN (https://linux.die.net/man/7/socket).
+func setSocketBufferSize(sizeInBytes int, c *netlink.Conn) {
+	rawConn, err := c.SyscallConn()
+	if err != nil {
+		log.Warnf("error obtaining raw_conn %s", err)
+		return
+	}
+
+	ctrlErr := rawConn.Control(func(fd uintptr) {
+		err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUFFORCE, sizeInBytes)
+		if err != nil {
+			log.Warnf("error executing setsockopt: %s", err)
+		}
+	})
+
+	if ctrlErr != nil {
+		log.Warnf("error executing executing socket operation: %s", ctrlErr)
+	}
+
+	ctrlErr = rawConn.Control(func(fd uintptr) {
+		value, err := syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+		if err != nil {
+			log.Warnf("error executing getsockopt: %s", err)
+			return
+		}
+
+		log.Infof("netlink socket rcvbuf size is %d bytes", value)
+	})
+
+	if ctrlErr != nil {
+		log.Warnf("error executing executing socket operation: %s", ctrlErr)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

* Increase netlink socket rcvbuf size;
* Expire conntrack entries more aggressively;
* Use `NETLINK_NO_ENOBUFS` socket flag.

@DataDog/networks 

### Motivation

Improve resiliency to large conntrack flushes. 

### Additional Notes

Anything else we should know when reviewing?
