### PR TITLE
Make agent.exe part of the Dockerfile command

### DIFF
--- a/Dockerfiles/agent/entrypoint.ps1
+++ b/Dockerfiles/agent/entrypoint.ps1
@@ -6,4 +6,6 @@ Get-ChildItem 'entrypoint-ps1' | ForEach-Object {
 	}
 }
 
-return & "C:/Program Files/Datadog/Datadog Agent/bin/agent.exe" $args
+$agent = $args[0]
+$agentArgs = $args | Select-Object -Skip 1
+return & $agent $agentArgs

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -21,4 +21,4 @@ COPY datadog*.yaml C:/ProgramData/Datadog/
 
 ENTRYPOINT ["pwsh", "./entrypoint.ps1"]
 
-CMD ["run"]
+CMD ["C:/Program Files/Datadog/Datadog Agent/bin/agent.exe", "run"]


### PR DESCRIPTION
So it can be changed to start other agents

### Motivation

Support running process and trace agents on separate containers.