### PR TITLE
Allow setting `is_jmx` at the instance level

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -139,19 +140,31 @@ var checkCmd = &cobra.Command{
 		allConfigs := common.AC.GetAllConfigs()
 
 		// make sure the checks in cs are not JMX checks
-		for _, conf := range allConfigs {
+		for idx := range allConfigs {
+			conf := &allConfigs[idx]
 			if conf.Name != checkName {
 				continue
 			}
 
-			if check.IsJMXConfig(conf) {
+			instances := []integration.Data{}
+
+			if check.IsJMXConfig(*conf) {
 				// we'll mimic the check command behavior with JMXFetch by running
 				// it with the JSON reporter and the list_with_metrics command.
 				fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")
 				if err := RunJmxListWithMetrics(); err != nil {
 					return fmt.Errorf("while running the jmx check: %v", err)
 				}
-				return nil
+
+				// Retain only non-JMX instances for later
+				for _, instance := range conf.Instances {
+					if check.IsJMXInstance(conf.Name, instance, conf.InitConfig) {
+						continue
+					}
+					instances = append(instances, instance)
+				}
+
+				conf.Instances = instances
 			}
 		}
 

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -146,8 +146,6 @@ var checkCmd = &cobra.Command{
 				continue
 			}
 
-			instances := []integration.Data{}
-
 			if check.IsJMXConfig(*conf) {
 				// we'll mimic the check command behavior with JMXFetch by running
 				// it with the JSON reporter and the list_with_metrics command.
@@ -155,6 +153,8 @@ var checkCmd = &cobra.Command{
 				if err := RunJmxListWithMetrics(); err != nil {
 					return fmt.Errorf("while running the jmx check: %v", err)
 				}
+
+				instances := []integration.Data{}
 
 				// Retain only non-JMX instances for later
 				for _, instance := range conf.Instances {

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -144,7 +144,7 @@ var checkCmd = &cobra.Command{
 				continue
 			}
 
-			if check.IsJMXConfig(conf.Name, conf.InitConfig) {
+			if check.IsJMXConfig(conf) {
 				// we'll mimic the check command behavior with JMXFetch by running
 				// it with the JSON reporter and the list_with_metrics command.
 				fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -220,6 +220,9 @@ func loadConfigs(runner *jmxfetch.JMXFetch) {
 			jmx.AddScheduledConfig(c)
 			runner.ConfigureFromInitConfig(c.InitConfig)
 			for _, instance := range c.Instances {
+				if !check.IsJMXInstance(c.Name, instance, c.InitConfig) {
+					continue
+				}
 				runner.ConfigureFromInstance(instance)
 			}
 		}

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -215,7 +215,7 @@ func loadConfigs(runner *jmxfetch.JMXFetch) {
 	includeEverything := len(checks) == 0
 
 	for _, c := range configs {
-		if check.IsJMXConfig(c.Name, c.InitConfig) && (includeEverything || configIncluded(c)) {
+		if check.IsJMXConfig(c) && (includeEverything || configIncluded(c)) {
 			fmt.Println("Config ", c.Name, " was loaded.")
 			jmx.AddScheduledConfig(c)
 			runner.ConfigureFromInitConfig(c.InitConfig)

--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -15,8 +15,7 @@ import (
 // IsJMXConfig checks if a certain YAML config contains at least one instance of a JMX config
 func IsJMXConfig(config integration.Config) bool {
 	for _, instance := range config.Instances {
-		isJMX := IsJMXInstance(config.Name, instance, config.InitConfig)
-		if isJMX {
+		if IsJMXInstance(config.Name, instance, config.InitConfig) {
 			return true
 		}
 	}

--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -12,7 +12,7 @@ import (
 	agentconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
-// IsJMXConfig checks if a certain YAML config is a JMX config
+// IsJMXConfig checks if a certain YAML config contains at least one instance of a JMX config
 func IsJMXConfig(config integration.Config) bool {
 	for _, instance := range config.Instances {
 		isJMX := IsJMXInstance(config.Name, instance, config.InitConfig)

--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -13,34 +13,59 @@ import (
 )
 
 // IsJMXConfig checks if a certain YAML config is a JMX config
-func IsJMXConfig(name string, initConf integration.Data) bool {
+func IsJMXConfig(config integration.Config) bool {
+	for _, instance := range config.Instances {
+		isJMX := IsJMXInstance(config.Name, instance, config.InitConfig)
+		if isJMX {
+			return true
+		}
+	}
 
+	return false
+}
+
+// IsJMXInstance checks if a certain YAML instance is a JMX config
+func IsJMXInstance(name string, instance integration.Data, initConfig integration.Data) bool {
 	if _, ok := agentconfig.StandardJMXIntegrations[name]; ok {
 		return true
 	}
 
-	rawInitConfig := integration.RawMap{}
-	err := yaml.Unmarshal(initConf, &rawInitConfig)
+	rawInstance := integration.RawMap{}
+	err := yaml.Unmarshal(instance, &rawInstance)
 	if err != nil {
 		return false
 	}
 
-	x, ok := rawInitConfig["is_jmx"]
+	x, ok := rawInstance["is_jmx"]
+	if ok {
+		isInstanceJMX, ok := x.(bool)
+		if ok && isInstanceJMX {
+			return true
+		}
+	}
+
+	rawInitConfig := integration.RawMap{}
+	err = yaml.Unmarshal(initConfig, &rawInitConfig)
+	if err != nil {
+		return false
+	}
+
+	x, ok = rawInitConfig["is_jmx"]
 	if !ok {
 		return false
 	}
 
-	isJMX, ok := x.(bool)
-	if !isJMX || !ok {
+	isInitConfigJMX, ok := x.(bool)
+	if !ok {
 		return false
 	}
 
-	return true
+	return isInitConfigJMX
 }
 
 // CollectDefaultMetrics returns if the config is for a JMX check which has collect_default_metrics: true
 func CollectDefaultMetrics(c integration.Config) bool {
-	if !IsJMXConfig(c.String(), c.InitConfig) {
+	if !IsJMXConfig(c) {
 		return false
 	}
 

--- a/pkg/collector/check/loader.go
+++ b/pkg/collector/check/loader.go
@@ -12,8 +12,7 @@ import (
 // Loader is the interface wrapping the operations to load a check from
 // different sources, like Python modules or Go objects.
 //
-// A check is loaded for every `instance` found in the configuration file.
-// Load is supposed to break down instances and return different checks.
+// A single check is loaded for the given `instance` YAML.
 type Loader interface {
 	Load(config integration.Config, instance integration.Data) (Check, error)
 }

--- a/pkg/collector/check/loader.go
+++ b/pkg/collector/check/loader.go
@@ -15,5 +15,5 @@ import (
 // A check is loaded for every `instance` found in the configuration file.
 // Load is supposed to break down instances and return different checks.
 type Loader interface {
-	Load(config integration.Config) ([]Check, error)
+	Load(config integration.Config, instance integration.Data) (Check, error)
 }

--- a/pkg/collector/corechecks/embed/jmx/fixtures/hazelcast.yaml
+++ b/pkg/collector/corechecks/embed/jmx/fixtures/hazelcast.yaml
@@ -1,4 +1,6 @@
 instances:
+  - server: localhost
+    port: 8081
   - host: localhost
     port: 1099
     is_jmx: true

--- a/pkg/collector/corechecks/embed/jmx/fixtures/hazelcast.yaml
+++ b/pkg/collector/corechecks/embed/jmx/fixtures/hazelcast.yaml
@@ -1,0 +1,89 @@
+instances:
+  - host: localhost
+    port: 1099
+    is_jmx: true
+
+init_config:
+  collect_default_metrics: true
+  conf:
+    - include:
+        domain: ManagementCenter
+        exclude_tags:
+          - name
+          - type
+        attribute:
+          LicenseExpirationTime:
+            alias: hazelcast.mc.license_expiration_time
+            metric_type: gauge
+    - include:
+        domain: com.hazelcast
+        type: HazelcastInstance
+        exclude_tags:
+          - instance
+          - name
+          - type
+        tags:
+          hazelcast_instance: $instance
+        attribute:
+          running:
+            alias: hazelcast.instance.running
+            metric_type: gauge
+          version:
+            alias: hazelcast.instance.version
+            metric_type: gauge
+          memberCount:
+            alias: hazelcast.instance.member_count
+            metric_type: gauge
+    - include:
+        domain: com.hazelcast
+        type: HazelcastInstance.PartitionServiceMBean
+        exclude_tags:
+          - instance
+          - name
+          - type
+        tags:
+          hazelcast_instance: $instance
+        attribute:
+          partitionCount:
+            alias: hazelcast.instance.partition_service.partition_count
+            metric_type: gauge
+          activePartitionCount:
+            alias: hazelcast.instance.partition_service.active_partition_count
+            metric_type: gauge
+          isClusterSafe:
+            alias: hazelcast.instance.partition_service.is_cluster_safe
+            metric_type: gauge
+          isLocalMemberSafe:
+            alias: hazelcast.instance.partition_service.is_local_member_safe
+            metric_type: gauge
+    - include:
+        domain: com.hazelcast
+        type: HazelcastInstance.ManagedExecutorService
+        exclude_tags:
+          - instance
+          - name
+          - type
+        tags:
+          hazelcast_instance: $instance
+        attribute:
+          queueSize:
+            alias: hazelcast.instance.managed_executor_service.queue_size
+            metric_type: gauge
+          poolSize:
+            alias: hazelcast.instance.managed_executor_service.pool_size
+            metric_type: gauge
+          maximumPoolSize:
+            alias: hazelcast.instance.managed_executor_service.maximum_pool_size
+            metric_type: gauge
+          remainingQueueCapacity:
+            alias: hazelcast.instance.managed_executor_service.remaining_queue_capacity
+            metric_type: gauge
+          isShutdown:
+            alias: hazelcast.instance.managed_executor_service.is_shutdown
+            metric_type: gauge
+          isTerminated:
+            alias: hazelcast.instance.managed_executor_service.is_terminated
+            metric_type: gauge
+          completedTaskCount:
+            alias: hazelcast.instance.managed_executor_service.completed_task_count
+            metric_type: gauge

--- a/pkg/collector/corechecks/embed/jmx/fixtures/hazelcast.yaml
+++ b/pkg/collector/corechecks/embed/jmx/fixtures/hazelcast.yaml
@@ -1,6 +1,9 @@
 instances:
   - server: localhost
     port: 8081
+  - server: "1.2.3.4"
+    port: 8082
+    is_jmx: false
   - host: localhost
     port: 1099
     is_jmx: true

--- a/pkg/collector/corechecks/embed/jmx/loader.go
+++ b/pkg/collector/corechecks/embed/jmx/loader.go
@@ -8,14 +8,10 @@
 package jmx
 
 import (
-	"errors"
-
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	yaml "gopkg.in/yaml.v2"
 )
 
 // JMXCheckLoader is a specific loader for checks living in this package
@@ -28,10 +24,10 @@ func NewJMXCheckLoader() (*JMXCheckLoader, error) {
 	return &JMXCheckLoader{}, nil
 }
 
-func splitConfig(config integration.Config) []integration.Config {
+func splitConfig(config integration.Config, instances []integration.Data) []integration.Config {
 	configs := []integration.Config{}
 
-	for _, instance := range config.Instances {
+	for _, instance := range instances {
 		c := integration.Config{
 			ADIdentifiers: config.ADIdentifiers,
 			InitConfig:    config.InitConfig,
@@ -48,28 +44,23 @@ func splitConfig(config integration.Config) []integration.Config {
 
 // Load returns an (empty?) list of checks and nil if it all works out
 func (jl *JMXCheckLoader) Load(config integration.Config) ([]check.Check, error) {
-	var err error
 	checks := []check.Check{}
 
-	if !check.IsJMXConfig(config.Name, config.InitConfig) {
-		return checks, errors.New("check is not a jmx check, or unable to determine if it's so")
-	}
-
-	rawInitConfig := integration.RawMap{}
-	err = yaml.Unmarshal(config.InitConfig, &rawInitConfig)
-	if err != nil {
-		log.Errorf("jmx.loader: could not unmarshal instance config: %s", err)
-		return checks, err
-	}
-
+	instancesJMX := []integration.Data{}
 	for _, instance := range config.Instances {
-		if err = state.runner.configureRunner(instance, config.InitConfig); err != nil {
+		if check.IsJMXInstance(config.Name, instance, config.InitConfig) {
+			instancesJMX = append(instancesJMX, instance)
+		}
+	}
+
+	for _, instance := range instancesJMX {
+		if err := state.runner.configureRunner(instance, config.InitConfig); err != nil {
 			log.Errorf("jmx.loader: could not configure check: %s", err)
 			return checks, err
 		}
 	}
 
-	for _, cf := range splitConfig(config) {
+	for _, cf := range splitConfig(config, instancesJMX) {
 		c := newJMXCheck(cf, config.Source)
 		checks = append(checks, c)
 	}

--- a/pkg/collector/corechecks/embed/jmx/loader_test.go
+++ b/pkg/collector/corechecks/embed/jmx/loader_test.go
@@ -57,8 +57,8 @@ func TestLoadCheckConfig(t *testing.T) {
 
 	checks := []check.Check{}
 
-	// should be three valid instances
-	assert.Len(t, cfgs, 4)
+	// should be four valid instances
+	assert.Len(t, cfgs, 5)
 	for _, cfg := range cfgs {
 		loadedChecks, err := jl.Load(cfg)
 		assert.Nil(t, err)

--- a/pkg/collector/corechecks/embed/jmx/loader_test.go
+++ b/pkg/collector/corechecks/embed/jmx/loader_test.go
@@ -71,7 +71,7 @@ func TestLoadCheckConfig(t *testing.T) {
 
 	// should be five valid JMX instances and one non-JMX instance
 	assert.Len(t, checks, 5)
-	assert.Equal(t, numOtherInstances, 1)
+	assert.Equal(t, numOtherInstances, 2)
 
 	for _, cfg := range cfgs {
 		found := false

--- a/pkg/collector/corechecks/embed/jmx/loader_test.go
+++ b/pkg/collector/corechecks/embed/jmx/loader_test.go
@@ -54,19 +54,24 @@ func TestLoadCheckConfig(t *testing.T) {
 
 	cfgs, err := fp.Collect()
 	assert.Nil(t, err)
+	assert.Len(t, cfgs, 5)
 
 	checks := []check.Check{}
+	numOtherInstances := 0
 
-	// should be four valid instances
-	assert.Len(t, cfgs, 5)
 	for _, cfg := range cfgs {
-		loadedChecks, err := jl.Load(cfg)
-		assert.Nil(t, err)
-
-		for _, c := range loadedChecks {
-			checks = append(checks, c)
+		for _, instance := range cfg.Instances {
+			if loadedCheck, err := jl.Load(cfg, instance); err == nil {
+				checks = append(checks, loadedCheck)
+			} else {
+				numOtherInstances++
+			}
 		}
 	}
+
+	// should be five valid JMX instances and one non-JMX instance
+	assert.Len(t, checks, 5)
+	assert.Equal(t, numOtherInstances, 1)
 
 	for _, cfg := range cfgs {
 		found := false

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -7,7 +7,6 @@ package corechecks
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -53,37 +52,24 @@ func NewGoCheckLoader() (*GoCheckLoader, error) {
 	return &GoCheckLoader{}, nil
 }
 
-// Load returns a list of checks, one for every configuration instance found in `config`
-func (gl *GoCheckLoader) Load(config integration.Config) ([]check.Check, error) {
-	checks := []check.Check{}
-
-	// If JMX check, just skip - coincidence
-	if check.IsJMXConfig(config) {
-		return checks, fmt.Errorf("check %s appears to be a JMX check - skipping", config.Name)
-	}
+// Load returns a Go check
+func (gl *GoCheckLoader) Load(config integration.Config, instance integration.Data) (check.Check, error) {
+	var c check.Check
 
 	factory, found := catalog[config.Name]
 	if !found {
 		msg := fmt.Sprintf("Check %s not found in Catalog", config.Name)
-		return checks, fmt.Errorf(msg)
+		return c, fmt.Errorf(msg)
 	}
 
-	errors := []string{}
-	for _, instance := range config.Instances {
-		newCheck := factory()
-		if err := newCheck.Configure(instance, config.InitConfig, config.Source); err != nil {
-			errors = append(errors, fmt.Sprintf("Could not configure check %s: %s", newCheck, err))
-			log.Errorf("core.loader: could not configure check %s: %s", newCheck, err)
-			continue
-		}
-		checks = append(checks, newCheck)
+	c = factory()
+	if err := c.Configure(instance, config.InitConfig, config.Source); err != nil {
+		log.Errorf("core.loader: could not configure check %s: %s", c, err)
+		msg := fmt.Sprintf("Could not configure check %s: %s", c, err)
+		return c, fmt.Errorf(msg)
 	}
 
-	if len(errors) != 0 {
-		return checks, fmt.Errorf(strings.Join(errors, "\n"))
-	}
-
-	return checks, nil
+	return c, nil
 }
 
 func (gl *GoCheckLoader) String() string {
@@ -95,5 +81,5 @@ func init() {
 		return NewGoCheckLoader()
 	}
 
-	loaders.RegisterLoader(20, factory)
+	loaders.RegisterLoader(30, factory)
 }

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -58,7 +58,7 @@ func (gl *GoCheckLoader) Load(config integration.Config) ([]check.Check, error) 
 	checks := []check.Check{}
 
 	// If JMX check, just skip - coincidence
-	if check.IsJMXConfig(config.Name, config.InitConfig) {
+	if check.IsJMXConfig(config) {
 		return checks, fmt.Errorf("check %s appears to be a JMX check - skipping", config.Name)
 	}
 

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -55,61 +55,40 @@ func TestRegisterCheck(t *testing.T) {
 func TestLoad(t *testing.T) {
 	RegisterCheck("foo", testCheckFactory)
 
-	// check is in catalog, pass 2 instances
+	// check is in catalog, pass 1 good instance
 	i := []integration.Data{
 		integration.Data("foo: bar"),
-		integration.Data("bar: baz"),
 	}
 	cc := integration.Config{Name: "foo", Instances: i}
 	l, _ := NewGoCheckLoader()
 
-	lst, err := l.Load(cc)
+	_, err := l.Load(cc, i[0])
 
 	if err != nil {
 		t.Fatalf("Expected nil error, found: %v", err)
 	}
-	if len(lst) != 2 {
-		t.Fatalf("Expected 2 checks, found: %d", len(lst))
-	}
 
-	// check is in catalog, pass 1 good instance & 1 bad instance
+	// check is in catalog, pass 1 bad instance
 	i = []integration.Data{
-		integration.Data("foo: bar"),
 		integration.Data("err"),
 	}
 	cc = integration.Config{Name: "foo", Instances: i}
 
-	lst, err = l.Load(cc)
+	_, err = l.Load(cc, i[0])
 
 	if err == nil {
 		t.Fatalf("Expected error, found: nil")
 	}
-	if len(lst) != 1 {
-		t.Fatalf("Expected 1 checks, found: %d", len(lst))
-	}
-
-	// check is in catalog, pass no instances
-	i = []integration.Data{}
-	cc = integration.Config{Name: "foo", Instances: i}
-
-	lst, err = l.Load(cc)
-
-	if err != nil {
-		t.Fatalf("Expected nil error, found: %v", err)
-	}
-	if len(lst) != 0 {
-		t.Fatalf("Expected 0 checks, found: %d", len(lst))
-	}
 
 	// check not in catalog
-	cc = integration.Config{Name: "bar", Instances: nil}
+	i = []integration.Data{
+		integration.Data("foo: bar"),
+	}
+	cc = integration.Config{Name: "bar", Instances: i}
 
-	lst, err = l.Load(cc)
+	_, err = l.Load(cc, i[0])
 
 	if err == nil {
 		t.Fatal("Expected error, found: nil")
-	}
-	if len(lst) != 0 {
-		t.Fatalf("Expected 0 checks, found: %d", len(lst))
 	}
 }

--- a/pkg/collector/loaders/loaders_test.go
+++ b/pkg/collector/loaders/loaders_test.go
@@ -17,15 +17,24 @@ import (
 
 type LoaderOne struct{}
 
-func (lo LoaderOne) Load(config integration.Config) ([]check.Check, error) { return nil, nil }
+func (lo LoaderOne) Load(config integration.Config, instance integration.Data) (check.Check, error) {
+	var c check.Check
+	return c, nil
+}
 
 type LoaderTwo struct{}
 
-func (lt LoaderTwo) Load(config integration.Config) ([]check.Check, error) { return nil, nil }
+func (lt LoaderTwo) Load(config integration.Config, instance integration.Data) (check.Check, error) {
+	var c check.Check
+	return c, nil
+}
 
 type LoaderThree struct{}
 
-func (lt *LoaderThree) Load(config integration.Config) ([]check.Check, error) { return nil, nil }
+func (lt *LoaderThree) Load(config integration.Config, instance integration.Data) (check.Check, error) {
+	var c check.Check
+	return c, nil
+}
 
 func TestLoaderCatalog(t *testing.T) {
 	l1 := LoaderOne{}

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -55,7 +55,7 @@ func init() {
 	factory := func() (check.Loader, error) {
 		return NewPythonCheckLoader()
 	}
-	loaders.RegisterLoader(10, factory)
+	loaders.RegisterLoader(20, factory)
 
 	configureErrors = map[string][]string{}
 	py3Warnings = map[string][]string{}
@@ -91,12 +91,13 @@ func getRtLoaderError() error {
 
 // Load tries to import a Python module with the same name found in config.Name, searches for
 // subclasses of the AgentCheck class and returns the corresponding Check
-func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, error) {
+func (cl *PythonCheckLoader) Load(config integration.Config, instance integration.Data) (check.Check, error) {
+	var tc check.Check
+
 	if rtloader == nil {
-		return nil, fmt.Errorf("python is not initialized")
+		return tc, fmt.Errorf("python is not initialized")
 	}
 
-	checks := []check.Check{}
 	moduleName := config.Name
 
 	// Lock the GIL
@@ -109,7 +110,7 @@ func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, err
 		log.Debugf("Performing platform loading prep")
 		err = platformLoaderPrep()
 		if err != nil {
-			return nil, err
+			return tc, err
 		}
 		defer platformLoaderDone()
 	} else {
@@ -144,7 +145,7 @@ func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, err
 	// all failed, return error for last failure
 	if checkModule == nil || checkClass == nil {
 		log.Debugf("PyLoader returning %s for %s", err, moduleName)
-		return nil, err
+		return tc, err
 	}
 
 	wheelVersion := "unversioned"
@@ -182,27 +183,23 @@ func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, err
 		go reportPy3Warnings(name, goCheckFilePath)
 	}
 
-	// Get an AgentCheck for each configuration instance and add it to the registry
-	for _, i := range config.Instances {
-		check := NewPythonCheck(moduleName, checkClass)
+	c := NewPythonCheck(moduleName, checkClass)
 
-		// The GIL should be unlocked at this point, `check.Configure` uses its own stickyLock and stickyLocks must not be nested
-		if err := check.Configure(i, config.InitConfig, config.Source); err != nil {
-			addExpvarConfigureError(fmt.Sprintf("%s (%s)", moduleName, wheelVersion), err.Error())
-			continue
-		}
+	// The GIL should be unlocked at this point, `check.Configure` uses its own stickyLock and stickyLocks must not be nested
+	if err := c.Configure(instance, config.InitConfig, config.Source); err != nil {
+		C.rtloader_decref(rtloader, checkClass)
+		C.rtloader_decref(rtloader, checkModule)
 
-		check.version = wheelVersion
-		checks = append(checks, check)
+		addExpvarConfigureError(fmt.Sprintf("%s (%s)", moduleName, wheelVersion), err.Error())
+		return c, fmt.Errorf("Could not configure any python check %s", moduleName)
 	}
+
+	c.version = wheelVersion
 	C.rtloader_decref(rtloader, checkClass)
 	C.rtloader_decref(rtloader, checkModule)
 
-	if len(checks) == 0 {
-		return nil, fmt.Errorf("Could not configure any python check %s", moduleName)
-	}
 	log.Debugf("python loader: done loading check %s (version %s)", moduleName, wheelVersion)
-	return checks, nil
+	return c, nil
 }
 
 func (cl *PythonCheckLoader) String() string {

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -92,10 +92,8 @@ func getRtLoaderError() error {
 // Load tries to import a Python module with the same name found in config.Name, searches for
 // subclasses of the AgentCheck class and returns the corresponding Check
 func (cl *PythonCheckLoader) Load(config integration.Config, instance integration.Data) (check.Check, error) {
-	var tc check.Check
-
 	if rtloader == nil {
-		return tc, fmt.Errorf("python is not initialized")
+		return nil, fmt.Errorf("python is not initialized")
 	}
 
 	moduleName := config.Name
@@ -110,7 +108,7 @@ func (cl *PythonCheckLoader) Load(config integration.Config, instance integratio
 		log.Debugf("Performing platform loading prep")
 		err = platformLoaderPrep()
 		if err != nil {
-			return tc, err
+			return nil, err
 		}
 		defer platformLoaderDone()
 	} else {
@@ -145,7 +143,7 @@ func (cl *PythonCheckLoader) Load(config integration.Config, instance integratio
 	// all failed, return error for last failure
 	if checkModule == nil || checkClass == nil {
 		log.Debugf("PyLoader returning %s for %s", err, moduleName)
-		return tc, err
+		return nil, err
 	}
 
 	wheelVersion := "unversioned"

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -191,7 +191,7 @@ func (cl *PythonCheckLoader) Load(config integration.Config, instance integratio
 		C.rtloader_decref(rtloader, checkModule)
 
 		addExpvarConfigureError(fmt.Sprintf("%s (%s)", moduleName, wheelVersion), err.Error())
-		return c, fmt.Errorf("Could not configure any python check %s", moduleName)
+		return c, fmt.Errorf("could not configure check instance for python check %s: %s", moduleName, err.Error())
 	}
 
 	c.version = wheelVersion

--- a/pkg/collector/python/test_loader.go
+++ b/pkg/collector/python/test_loader.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 /*
@@ -102,9 +101,8 @@ func testLoadCustomCheck(t *testing.T) {
 	C.reset_loader_mock()
 
 	conf := integration.Config{
-		Name: "fake_check",
-		Instances: []integration.Data{integration.Data("{\"value\": 1}"),
-			integration.Data("{\"value\": 2}")},
+		Name:       "fake_check",
+		Instances:  []integration.Data{integration.Data("{\"value\": 1}")},
 		InitConfig: integration.Data("{}"),
 	}
 
@@ -121,15 +119,11 @@ func testLoadCustomCheck(t *testing.T) {
 	C.get_class_py_class = &C.rtloader_pyobject_t{}
 	C.get_attr_string_return = 0
 
-	checks, err := loader.Load(conf)
+	check, err := loader.Load(conf, conf.Instances[0])
 	assert.Nil(t, err)
-	require.Len(t, checks, 2)
-	assert.Equal(t, "fake_check", checks[0].(*PythonCheck).ModuleName)
-	assert.Equal(t, "fake_check", checks[1].(*PythonCheck).ModuleName)
-	assert.Equal(t, "unversioned", checks[0].(*PythonCheck).version)
-	assert.Equal(t, "unversioned", checks[1].(*PythonCheck).version)
-	assert.Equal(t, C.get_class_py_class, checks[0].(*PythonCheck).class)
-	assert.Equal(t, C.get_class_py_class, checks[1].(*PythonCheck).class)
+	assert.Equal(t, "fake_check", check.(*PythonCheck).ModuleName)
+	assert.Equal(t, "unversioned", check.(*PythonCheck).version)
+	assert.Equal(t, C.get_class_py_class, check.(*PythonCheck).class)
 	// test we call get_attr_string on the module
 	assert.Equal(t, C.get_attr_string_py_class, C.get_class_py_module)
 }
@@ -138,9 +132,8 @@ func testLoadWheelCheck(t *testing.T) {
 	C.reset_loader_mock()
 
 	conf := integration.Config{
-		Name: "fake_check",
-		Instances: []integration.Data{integration.Data("{\"value\": 1}"),
-			integration.Data("{\"value\": 2}")},
+		Name:       "fake_check",
+		Instances:  []integration.Data{integration.Data("{\"value\": 1}")},
 		InitConfig: integration.Data("{}"),
 	}
 
@@ -158,15 +151,11 @@ func testLoadWheelCheck(t *testing.T) {
 	C.get_attr_string_return = 1
 	C.get_attr_string_attr_value = C.CString("1.2.3")
 
-	checks, err := loader.Load(conf)
+	check, err := loader.Load(conf, conf.Instances[0])
 	assert.Nil(t, err)
-	require.Len(t, checks, 2)
-	assert.Equal(t, "fake_check", checks[0].(*PythonCheck).ModuleName)
-	assert.Equal(t, "fake_check", checks[1].(*PythonCheck).ModuleName)
-	assert.Equal(t, "1.2.3", checks[0].(*PythonCheck).version)
-	assert.Equal(t, "1.2.3", checks[1].(*PythonCheck).version)
-	assert.Equal(t, C.get_class_dd_wheel_py_class, checks[0].(*PythonCheck).class)
-	assert.Equal(t, C.get_class_dd_wheel_py_class, checks[1].(*PythonCheck).class)
+	assert.Equal(t, "fake_check", check.(*PythonCheck).ModuleName)
+	assert.Equal(t, "1.2.3", check.(*PythonCheck).version)
+	assert.Equal(t, C.get_class_dd_wheel_py_class, check.(*PythonCheck).class)
 	// test we call get_attr_string on the module
 	assert.Equal(t, C.get_attr_string_py_class, C.get_class_dd_wheel_py_module)
 }

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -130,22 +130,35 @@ func (s *CheckScheduler) AddLoader(loader check.Loader) {
 // getChecks takes a check configuration and returns a slice of Check instances
 // along with any error it might happen during the process
 func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, error) {
-	for _, loader := range s.loaders {
-		res, err := loader.Load(config)
-		if err == nil {
-			log.Debugf("%v: successfully loaded check '%s'", loader, config.Name)
-			errorStats.removeLoaderErrors(config.Name)
-			return res, nil
+	checks := []check.Check{}
+	numLoaders := len(s.loaders)
+
+	for _, instance := range config.Instances {
+		errors := []string{}
+
+		for _, loader := range s.loaders {
+			c, err := loader.Load(config, instance)
+			if err == nil {
+				log.Debugf("%v: successfully loaded check '%s'", loader, config.Name)
+				errorStats.removeLoaderErrors(config.Name)
+				checks = append(checks, c)
+				break
+			} else {
+				errorStats.setLoaderError(config.Name, fmt.Sprintf("%v", loader), err.Error())
+				errors = append(errors, fmt.Sprintf("%v: unable to load the check '%s': %s", loader, config.Name, err))
+			}
 		}
-		// Check if some check instances were loaded correctly (can occur if there's multiple check instances)
-		if len(res) != 0 {
-			return res, nil
+
+		if len(errors) == numLoaders {
+			log.Debugf(strings.Join(errors, "\n"))
 		}
-		errorStats.setLoaderError(config.Name, fmt.Sprintf("%v", loader), err.Error())
-		log.Debugf("%v: unable to load the check '%s': %s", loader, config.Name, err)
 	}
 
-	return []check.Check{}, fmt.Errorf("unable to load any check from config '%s'", config.Name)
+	if len(checks) == 0 {
+		return checks, fmt.Errorf("unable to load any check from config '%s'", config.Name)
+	}
+
+	return checks, nil
 }
 
 // GetChecksByNameForConfigs returns checks matching name for passed in configs

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -150,7 +150,7 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 		}
 
 		if len(errors) == numLoaders {
-			log.Debugf(strings.Join(errors, "\n"))
+			log.Debugf("Unable to load a check from instance of config '%s': %s", config.Name, strings.Join(errors, "; "))
 		}
 	}
 

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -145,7 +145,7 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 				break
 			} else {
 				errorStats.setLoaderError(config.Name, fmt.Sprintf("%v", loader), err.Error())
-				errors = append(errors, fmt.Sprintf("%v: unable to load the check '%s': %s", loader, config.Name, err))
+				errors = append(errors, fmt.Sprintf("%v: %s", loader, err))
 			}
 		}
 

--- a/pkg/collector/scheduler_test.go
+++ b/pkg/collector/scheduler_test.go
@@ -16,8 +16,7 @@ import (
 type MockLoader struct{}
 
 func (l *MockLoader) Load(config integration.Config, instance integration.Data) (check.Check, error) {
-	var c check.Check
-	return c, nil
+	return nil, nil
 }
 
 func TestAddLoader(t *testing.T) {

--- a/pkg/collector/scheduler_test.go
+++ b/pkg/collector/scheduler_test.go
@@ -15,8 +15,9 @@ import (
 
 type MockLoader struct{}
 
-func (l *MockLoader) Load(config integration.Config) ([]check.Check, error) {
-	return []check.Check{}, nil
+func (l *MockLoader) Load(config integration.Config, instance integration.Data) (check.Check, error) {
+	var c check.Check
+	return c, nil
 }
 
 func TestAddLoader(t *testing.T) {

--- a/releasenotes/notes/allow-defining-jmx-instance-level-018fe85d4898b684.yaml
+++ b/releasenotes/notes/allow-defining-jmx-instance-level-018fe85d4898b684.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Allow setting ``is_jmx`` at the instance level, thereby enabling integrations
+    to utilize JMXFetch and Python/Go.


### PR DESCRIPTION
### What does this PR do?

Allow setting `is_jmx` at the instance level, thereby enabling integrations to utilize JMXFetch and Python/Go.

### Changes

1. The `Load` method of the `Loader` interface is now called for each instance of a configuration, and is supposed to return one `Check` (or an error); instead of being called for each configuration file (`integration.Config`).
1. The JMXFetch loader now has the highest precedence instead of lowest, meaning custom checks with the name of a hard-coded JMX check (`cassandra` for example) would get loaded as a JMX check rather than a Python check as they would currently.
1. The Python loader will now go through the logic of importing the Python module of a check for every instance of a check, instead of each config file.