### PR TITLE
[backport] [dogstatsd] on parse errors, display origin tags in the log message w…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -298,6 +298,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)
 	// Enable check for Entity-ID presence when enriching Dogstatsd metrics with tags
 	config.BindEnvAndSetDefault("dogstatsd_entity_id_precedence", false)
+	// Sends Dogstatsd parse errors to the Debug level instead of the Error level
+	config.BindEnvAndSetDefault("dogstatsd_disable_verbose_logs", false)
 	config.SetKnown("dogstatsd_mapper_profiles")
 
 	config.BindEnvAndSetDefault("statsd_forward_host", "")

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -77,6 +77,11 @@ type Server struct {
 	mapper                    *mapper.MetricMapper
 	telemetryEnabled          bool
 	entityIDPrecedenceEnabled bool
+	// disableVerboseLogs is a feature flag to disable the logs capable
+	// of flooding the logger output (e.g. parsing messages error).
+	// NOTE(remy): this should probably be dropped and use a throttler logger, see
+	// package (pkg/trace/logutils) for a possible throttler implemetation.
+	disableVerboseLogs bool
 }
 
 // metricStat holds how many times a metric has been
@@ -172,6 +177,7 @@ func NewServer(samplePool *metrics.MetricSamplePool, samplesOut chan<- []metrics
 		metricsStats:              make(map[string]metricStat),
 		telemetryEnabled:          telemetry.IsEnabled(),
 		entityIDPrecedenceEnabled: entityIDPrecedenceEnabled,
+		disableVerboseLogs:        config.Datadog.GetBool("dogstatsd_disable_verbose_logs"),
 	}
 
 	forwardHost := config.Datadog.GetString("statsd_forward_host")
@@ -298,21 +304,36 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*liste
 			case serviceCheckType:
 				serviceCheck, err := s.parseServiceCheckMessage(parser, message, originTagger.getTags)
 				if err != nil {
-					log.Errorf("Dogstatsd: error parsing service check %q: %s", message, err)
+					originTags := originTagger.getTags()
+					if len(originTags) > 0 {
+						s.errLog("Dogstatsd: error parsing service check '%q' origin tags %v: %s", message, originTags, err)
+					} else {
+						s.errLog("Dogstatsd: error parsing service check '%q': %s", message, err)
+					}
 					continue
 				}
 				batcher.appendServiceCheck(serviceCheck)
 			case eventType:
 				event, err := s.parseEventMessage(parser, message, originTagger.getTags)
 				if err != nil {
-					log.Errorf("Dogstatsd: error parsing event %q: %s", message, err)
+					originTags := originTagger.getTags()
+					if len(originTags) > 0 {
+						s.errLog("Dogstatsd: error parsing event '%q' origin tags %v: %s", message, originTags, err)
+					} else {
+						s.errLog("Dogstatsd: error parsing event '%q': %s", message, err)
+					}
 					continue
 				}
 				batcher.appendEvent(event)
 			case metricSampleType:
 				sample, err := s.parseMetricMessage(parser, message, originTagger.getTags)
 				if err != nil {
-					log.Errorf("Dogstatsd: error parsing metric message %q: %s", message, err)
+					originTags := originTagger.getTags()
+					if len(originTags) > 0 {
+						s.errLog("Dogstatsd: error parsing metric message '%q' origin tags %v: %s", message, originTags, err)
+					} else {
+						s.errLog("Dogstatsd: error parsing metric message '%q': %s", message, err)
+					}
 					continue
 				}
 				if s.debugMetricsStats {
@@ -330,6 +351,14 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*liste
 		s.packetPool.Put(packet)
 	}
 	batcher.flush()
+}
+
+func (s *Server) errLog(format string, params ...interface{}) {
+	if s.disableVerboseLogs {
+		log.Debugf(format, params...)
+	} else {
+		log.Errorf(format, params...)
+	}
 }
 
 func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFunc func() []string) (metrics.MetricSample, error) {


### PR DESCRIPTION
Backport of #5142 

### What does this PR do?

On Dogstatsd parse errors, display origin tags in the log message when they're available.

### Motivation

Helpful to diagnose which hosts are sending malformed packets.
A config flag has been added to send the parse errors to the Debug level
in order to not flood the output.

This configuration field is meant to be temporary and could be dropped in future versions without warning.