### PR TITLE
Autodiscover standard tags from Docker containers

### DIFF
--- a/pkg/tagger/collectors/const.go
+++ b/pkg/tagger/collectors/const.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build docker,kubelet
+
+package collectors
+
+const (
+	// Standard tag - Tag keys
+	tagKeyEnv     = "env"
+	tagKeyVersion = "version"
+	tagKeyService = "service"
+
+	// Standard tag - Environment variables
+	envVarEnv     = "DD_ENV"
+	envVarVersion = "DD_VERSION"
+	envVarService = "DD_SERVICE"
+
+	// Docker label keys
+	dockerLabelEnv     = "com.datadoghq.ad.env"
+	dockerLabelVersion = "com.datadoghq.ad.version"
+	dockerLabelService = "com.datadoghq.ad.service"
+)

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -80,8 +80,12 @@ func dockerExtractImage(tags *utils.TagList, co types.ContainerJSON, resolve res
 	tags.AddLow("image_tag", imageTag)
 }
 
-// dockerExtractLabels contain hard-coded labels from:
+// dockerExtractLabels extracts tags from docker labels
+// extracts env, version and service tags
+// extracts labels as tags
+// extracts hard-coded labels from:
 // - Docker swarm
+// - Rancher
 func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string, labelsAsTags map[string]string) {
 	for labelName, labelValue := range containerLabels {
 		switch labelName {
@@ -99,6 +103,14 @@ func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string,
 		case "io.rancher.stack_service.name":
 			tags.AddLow("rancher_service", labelValue)
 
+		// Standard tags
+		case dockerLabelEnv:
+			tags.AddLow(tagKeyEnv, labelValue)
+		case dockerLabelVersion:
+			tags.AddLow(tagKeyVersion, labelValue)
+		case dockerLabelService:
+			tags.AddLow(tagKeyService, labelValue)
+
 		default:
 			if tagName, found := labelsAsTags[strings.ToLower(labelName)]; found {
 				tags.AddAuto(tagName, labelValue)
@@ -107,8 +119,12 @@ func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string,
 	}
 }
 
-// dockerExtractEnvironmentVariables contain hard-coded environment variables from:
+// dockerExtractEnvironmentVariables extracts tags from the container's environment variables
+// extracts env, version and service tags
+// extracts environment variables as tags
+// extracts hard-coded environment variables from:
 // - Mesos/DCOS tags (mesos, marathon, chronos)
+// - Nomad
 func dockerExtractEnvironmentVariables(tags *utils.TagList, containerEnvVariables []string, envAsTags map[string]string) {
 	var envSplit []string
 	var envName, envValue string
@@ -138,6 +154,14 @@ func dockerExtractEnvironmentVariables(tags *utils.TagList, containerEnvVariable
 			tags.AddLow("nomad_job", envValue)
 		case "NOMAD_GROUP_NAME":
 			tags.AddLow("nomad_group", envValue)
+
+		// Standard tags
+		case envVarEnv:
+			tags.AddLow(tagKeyEnv, envValue)
+		case envVarVersion:
+			tags.AddLow(tagKeyVersion, envValue)
+		case envVarService:
+			tags.AddLow(tagKeyService, envValue)
 
 		default:
 			if tagName, found := envAsTags[strings.ToLower(envSplit[0])]; found {

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -228,6 +228,103 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 			expectedOrch: []string{},
 			expectedHigh: []string{},
 		},
+		{
+			testName: "Standard tags in labels",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Labels: map[string]string{
+						"com.datadoghq.ad.service": "redis",
+						"com.datadoghq.ad.env":     "dev",
+						"com.datadoghq.ad.version": "0.0.1",
+					},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow: []string{
+				"service:redis",
+				"env:dev",
+				"version:0.0.1",
+			},
+			expectedOrch: []string{},
+			expectedHigh: []string{},
+		},
+		{
+			testName: "Standard tags in env variables",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{
+						"DD_SERVICE=redis",
+						"DD_ENV=dev",
+						"DD_VERSION=0.0.1",
+					},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow: []string{
+				"service:redis",
+				"env:dev",
+				"version:0.0.1",
+			},
+			expectedOrch: []string{},
+			expectedHigh: []string{},
+		},
+		{
+			testName: "Same standard tags from labels and env variables => no duplicates",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{
+						"DD_SERVICE=redis",
+						"DD_ENV=dev",
+						"DD_VERSION=0.0.1",
+					},
+					Labels: map[string]string{
+						"com.datadoghq.ad.service": "redis",
+						"com.datadoghq.ad.env":     "dev",
+						"com.datadoghq.ad.version": "0.0.1",
+					},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow: []string{
+				"service:redis",
+				"env:dev",
+				"version:0.0.1",
+			},
+			expectedOrch: []string{},
+			expectedHigh: []string{},
+		},
+		{
+			testName: "Different standard tags from labels and env variables => no override",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{
+						"DD_SERVICE=redis",
+						"DD_ENV=dev",
+						"DD_VERSION=0.0.1",
+					},
+					Labels: map[string]string{
+						"com.datadoghq.ad.service": "redis-db",
+						"com.datadoghq.ad.env":     "staging",
+						"com.datadoghq.ad.version": "0.0.2",
+					},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow: []string{
+				"service:redis",
+				"env:dev",
+				"version:0.0.1",
+				"service:redis-db",
+				"env:staging",
+				"version:0.0.2",
+			},
+			expectedOrch: []string{},
+			expectedHigh: []string{},
+		},
 	}
 
 	dc := &DockerCollector{}

--- a/releasenotes/notes/docker-standard-tags-0e5623ff7a0fa4a8.yaml
+++ b/releasenotes/notes/docker-standard-tags-0e5623ff7a0fa4a8.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Extract env, version and service tags from Docker containers


### PR DESCRIPTION
### What does this PR do?

Extract tags from container's env vars:
- `DD_ENV`
- `DD_SERVICE`
- `DD_VERSION`

Extract tags from container's labels:
- `com.datadoghq.ad.service`
- `com.datadoghq.ad.env`
- `com.datadoghq.ad.version`

### Motivation

Unify DD tagging

### Additional Notes

Anything else we should know when reviewing?
