### PR TITLE
[logs/message] Send source category as `sourcecategory` tag in JSON

### DIFF
--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -30,7 +30,7 @@ func NewOrigin(source *config.LogSource) *Origin {
 
 // Tags returns the tags of the origin.
 func (o *Origin) Tags() []string {
-	return o.tagsToStringArray("sourcecategory")
+	return o.tagsToStringArray()
 }
 
 // TagsPayload returns the raw tag payload of the origin.
@@ -61,7 +61,7 @@ func (o *Origin) TagsPayload() []byte {
 
 // TagsToString encodes tags to a single string, in a comma separated format
 func (o *Origin) TagsToString() string {
-	tags := o.tagsToStringArray("ddsourcecategory")
+	tags := o.tagsToStringArray()
 
 	if tags == nil {
 		return ""
@@ -70,12 +70,12 @@ func (o *Origin) TagsToString() string {
 	return strings.Join(tags, ",")
 }
 
-func (o *Origin) tagsToStringArray(ddSourceCategory string) []string {
+func (o *Origin) tagsToStringArray() []string {
 	tags := o.tags
 
 	sourceCategory := o.LogSource.Config.SourceCategory
 	if sourceCategory != "" {
-		tags = append(tags, ddSourceCategory+":"+sourceCategory)
+		tags = append(tags, "sourcecategory"+":"+sourceCategory)
 	}
 
 	tags = append(tags, o.LogSource.Config.Tags...)

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -32,7 +32,7 @@ func TestTagsWithConfigTagsOnly(t *testing.T) {
 	origin := NewOrigin(source)
 	assert.Equal(t, []string{"sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload()))
-	assert.Equal(t, "ddsourcecategory:b,c:d,e", origin.TagsToString())
+	assert.Equal(t, "sourcecategory:b,c:d,e", origin.TagsToString())
 }
 
 func TestSetTagsWithNoConfigTags(t *testing.T) {
@@ -44,7 +44,7 @@ func TestSetTagsWithNoConfigTags(t *testing.T) {
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b"}, origin.Tags())
-	assert.Equal(t, "foo:bar,baz,ddsourcecategory:b", origin.TagsToString())
+	assert.Equal(t, "foo:bar,baz,sourcecategory:b", origin.TagsToString())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload()))
 }
 
@@ -58,7 +58,7 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e"}, origin.Tags())
-	assert.Equal(t, "foo:bar,baz,ddsourcecategory:b,c:d,e", origin.TagsToString())
+	assert.Equal(t, "foo:bar,baz,sourcecategory:b,c:d,e", origin.TagsToString())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload()))
 }
 

--- a/pkg/logs/processor/encoder_test.go
+++ b/pkg/logs/processor/encoder_test.go
@@ -214,7 +214,7 @@ func TestJsonEncoder(t *testing.T) {
 
 	assert.Equal(t, logsConfig.Service, log.Service)
 	assert.Equal(t, logsConfig.Source, log.Source)
-	assert.Equal(t, "a,b:c,ddsourcecategory:"+logsConfig.SourceCategory+",foo:bar,baz", log.Tags)
+	assert.Equal(t, "a,b:c,sourcecategory:"+logsConfig.SourceCategory+",foo:bar,baz", log.Tags)
 
 	assert.Equal(t, redactedMessage, log.Message)
 	assert.Equal(t, message.StatusError, log.Status)

--- a/releasenotes/notes/source-category-http-67e8d1008c369672.yaml
+++ b/releasenotes/notes/source-category-http-67e8d1008c369672.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    When the HTTPS transport is used to send logs, send the sourcecategory as the ``sourcecategory:`` tag
+    instead of ``ddsourcecategory:``, for consistency with other transports.


### PR DESCRIPTION
### What does this PR do?

When JSON is used (i.e. default for HTTP), send the value of the `sourcecategory` option as the `sourcecategory:` tag instead of `ddsourcecategory:`, so that the resulting tag in DD is `sourcecategory:` (i.e. consistent with the raw and proto processors).

### Motivation

Without this PR, the source category shows up as `ddsourcecategory` in DD when HTTP/JSON is used.

### Additional Notes

This bug seems to always have been there. Not sure if it was originally done for a specific purpose, or just an oversight.