### PR TITLE
Return copy instead of unprotected reference in expvar funcs

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -195,7 +195,12 @@ func expvarPythonInitErrors() interface{} {
 	pyInitLock.RLock()
 	defer pyInitLock.RUnlock()
 
-	return pyInitErrors
+	pyInitErrorsCopy := []string{}
+	for i := range pyInitErrors {
+		pyInitErrorsCopy = append(pyInitErrorsCopy, pyInitErrors[i])
+	}
+
+	return pyInitErrorsCopy
 }
 
 func addExpvarPythonInitErrors(msg string) error {

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -213,7 +213,16 @@ func expvarConfigureErrors() interface{} {
 	statsLock.RLock()
 	defer statsLock.RUnlock()
 
-	return configureErrors
+	configureErrorsCopy := map[string][]string{}
+	for k, v := range configureErrors {
+		errors := []string{}
+		for i := range v {
+			errors = append(errors, v[i])
+		}
+		configureErrorsCopy[k] = errors
+	}
+
+	return configureErrorsCopy
 }
 
 func addExpvarConfigureError(check string, errMsg string) {
@@ -233,7 +242,16 @@ func expvarPy3Warnings() interface{} {
 	statsLock.RLock()
 	defer statsLock.RUnlock()
 
-	return py3Warnings
+	py3WarningsCopy := map[string][]string{}
+	for k, v := range py3Warnings {
+		warnings := []string{}
+		for i := range v {
+			warnings = append(warnings, v[i])
+		}
+		py3WarningsCopy[k] = warnings
+	}
+
+	return py3WarningsCopy
 }
 
 // reportPy3Warnings runs the a7 linter and exports the result in both expvar


### PR DESCRIPTION
### What does this PR do?
In 3 places expvar func were returning unprotected references. This PR implement a deep-copy replacement. 

### Motivation
Avoid possible issue.

### Additional Notes
Once merged  #4966 could be considered.