### PR TITLE
Don't reuse the same omnibus-ruby tag for all releases

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -247,7 +247,7 @@ def create_new_version(
     integration_version = None,
     omnibus_software_version = None,
     jmxfetch_version = None,
-    omnibus_ruby_version = "datadog-5.5.0",
+    omnibus_ruby_version = None,
     ignore_rc_tag = False):
 
     """
@@ -358,7 +358,7 @@ def create_rc(
     integration_version = None,
     omnibus_software_version = None,
     jmxfetch_version = None,
-    omnibus_ruby_version = "datadog-5.5.0"):
+    omnibus_ruby_version = None):
 
     """
     Creates new entry in the release.json file for a new RC.


### PR DESCRIPTION
### Motivation

We should start tagging each release on omnibus-ruby as well, to ensure build reproducibility.