### PR TITLE
[MacOS] Add code signing entitlements

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -28,6 +28,9 @@ else
     unless ENV['SKIP_SIGN_MAC'] == 'true'
       code_signing_identity 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)'
     end
+    if ENV['HARDENED_RUNTIME_MAC'] == 'true'
+      entitlements_file "#{files_path}/macos/Entitlements.plist"
+    end
   end
 
   install_dir '/opt/datadog-agent'

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -183,7 +183,7 @@ build do
             delete "#{install_dir}/etc/conf.d/winproc.d"
 
             if ENV['HARDENED_RUNTIME_MAC'] == 'true'
-                hardened_runtime = "-o runtime --entitlements #{project.files_path}/macos/Entitlements.plist "
+                hardened_runtime = "-o runtime --entitlements #{entitlements_file} "
             else 
                 hardened_runtime = ""
             end

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -183,9 +183,9 @@ build do
             delete "#{install_dir}/etc/conf.d/winproc.d"
 
             if ENV['HARDENED_RUNTIME_MAC'] == 'true'
-                hardened_runtime = '-o runtime '
+                hardened_runtime = "-o runtime --entitlements #{project.files_path}/macos/Entitlements.plist "
             else 
-                hardened_runtime = ''
+                hardened_runtime = ""
             end
 
             if code_signing_identity

--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -33,9 +33,9 @@ build do
     delete "jmxfetch.jar"
 
     if ENV['HARDENED_RUNTIME_MAC'] == 'true'
-      hardened_runtime = '-o runtime '
+      hardened_runtime = "-o runtime --entitlements #{project.files_path}/macos/Entitlements.plist "
     else
-      hardened_runtime = ''
+      hardened_runtime = ""
     end
 
     command "find . -type f | grep -E '(\\.so|\\.dylib|\\.jnilib)' | xargs codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}'"

--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -33,7 +33,7 @@ build do
     delete "jmxfetch.jar"
 
     if ENV['HARDENED_RUNTIME_MAC'] == 'true'
-      hardened_runtime = "-o runtime --entitlements #{project.files_path}/macos/Entitlements.plist "
+      hardened_runtime = "-o runtime --entitlements #{entitlements_file} "
     else
       hardened_runtime = ""
     end

--- a/omnibus/files/macos/Entitlements.plist
+++ b/omnibus/files/macos/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
+</plist>

--- a/release.json
+++ b/release.json
@@ -2,14 +2,14 @@
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "master",
-        "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
+        "OMNIBUS_RUBY_VERSION": "kserrania/add-entitlements-file",
         "JMXFETCH_VERSION": "0.35.0",
         "JMXFETCH_HASH": "1f1c8435b56050e006990c450b3c8969c3097932c01e080b2c320343a968fcba"
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "master",
-        "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
+        "OMNIBUS_RUBY_VERSION": "kserrania/add-entitlements-file",
         "JMXFETCH_VERSION": "0.35.0",
         "JMXFETCH_HASH": "1f1c8435b56050e006990c450b3c8969c3097932c01e080b2c320343a968fcba"
     },


### PR DESCRIPTION
### What does this PR do?

Adds an entitlements file which adds the `com.apple.security.cs.allow-unsigned-executable-memory` runtime exception to prevent some Python checks from crashing when running.

### Motivation

Make the new MacOS build work.

