### PR TITLE
Fix Windows unit tests

### DIFF
--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -15,6 +15,8 @@ if ($Env:TARGET_ARCH -eq "x86") {
     $archflag = "x86"
 }
 & go get gopkg.in/yaml.v2
+& inv -e deps --verbose --dep-vendor-only
+
 & inv -e rtloader.make --python-runtimes="$Env:PY_RUNTIMES" --install-prefix=$Env:BUILD_ROOT\dev --cmake-options='-G \"Unix Makefiles\"' --arch $archflag
 $err = $LASTEXITCODE
 Write-Host Build result is $err
@@ -35,7 +37,6 @@ if($err -ne 0){
 # }
 
 & inv -e rtloader.test
-& inv -e deps --dep-vendor-only
 & inv -e test --race --profile --cpus 4 --arch $archflag --python-runtimes="$Env:PY_RUNTIMES" --python-home-2=$Env:Python2_ROOT_DIR --python-home-3=$Env:Python3_ROOT_DIR --rtloader-root=$Env:BUILD_ROOT\rtloader
 $err = $LASTEXITCODE
 Write-Host Test result is $err

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -26,6 +26,7 @@ if($err -ne 0){
 }
 
 & inv -e rtloader.install
+$err = $LASTEXITCODE
 Write-Host rtloader install result is $err
 if($err -ne 0){
     Write-Host -ForegroundColor Red "rtloader install failed $err"
@@ -42,6 +43,7 @@ if($err -ne 0){
 # }
 
 & inv -e rtloader.test
+$err = $LASTEXITCODE
 Write-Host rtloader test result is $err
 if($err -ne 0){
     Write-Host -ForegroundColor Red "rtloader test failed $err"

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -20,7 +20,6 @@ if ($Env:TARGET_ARCH -eq "x86") {
 & inv -e rtloader.make --python-runtimes="$Env:PY_RUNTIMES" --install-prefix=$Env:BUILD_ROOT\dev --cmake-options='-G \"Unix Makefiles\"' --arch $archflag
 $err = $LASTEXITCODE
 Write-Host Build result is $err
-
 if($err -ne 0){
     Write-Host -ForegroundColor Red "rtloader make failed $err"
     [Environment]::Exit($err)
@@ -44,7 +43,6 @@ if($err -ne 0){
 
 & inv -e rtloader.test
 Write-Host rtloader test result is $err
-
 if($err -ne 0){
     Write-Host -ForegroundColor Red "rtloader test failed $err"
     [Environment]::Exit($err)
@@ -53,7 +51,6 @@ if($err -ne 0){
 & inv -e test --race --profile --cpus 4 --arch $archflag --python-runtimes="$Env:PY_RUNTIMES" --python-home-2=$Env:Python2_ROOT_DIR --python-home-3=$Env:Python3_ROOT_DIR --rtloader-root=$Env:BUILD_ROOT\rtloader
 $err = $LASTEXITCODE
 Write-Host Test result is $err
-
 if($err -ne 0){
     Write-Host -ForegroundColor Red "test failed $err"
     [Environment]::Exit($err)

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -20,12 +20,18 @@ if ($Env:TARGET_ARCH -eq "x86") {
 & inv -e rtloader.make --python-runtimes="$Env:PY_RUNTIMES" --install-prefix=$Env:BUILD_ROOT\dev --cmake-options='-G \"Unix Makefiles\"' --arch $archflag
 $err = $LASTEXITCODE
 Write-Host Build result is $err
+
 if($err -ne 0){
     Write-Host -ForegroundColor Red "rtloader make failed $err"
     [Environment]::Exit($err)
 }
 
 & inv -e rtloader.install
+Write-Host rtloader install result is $err
+if($err -ne 0){
+    Write-Host -ForegroundColor Red "rtloader install failed $err"
+    [Environment]::Exit($err)
+}
 
 # & inv -e rtloader.format --raise-if-changed
 # $err = $LASTEXITCODE
@@ -37,6 +43,13 @@ if($err -ne 0){
 # }
 
 & inv -e rtloader.test
+Write-Host rtloader test result is $err
+
+if($err -ne 0){
+    Write-Host -ForegroundColor Red "rtloader test failed $err"
+    [Environment]::Exit($err)
+}
+
 & inv -e test --race --profile --cpus 4 --arch $archflag --python-runtimes="$Env:PY_RUNTIMES" --python-home-2=$Env:Python2_ROOT_DIR --python-home-3=$Env:Python3_ROOT_DIR --rtloader-root=$Env:BUILD_ROOT\rtloader
 $err = $LASTEXITCODE
 Write-Host Test result is $err


### PR DESCRIPTION
### What does this PR do?

Fixes order of commands in `unittests.ps1`: `inv rtloader.test` needs the dependencies provided by `inv deps`.
Exits early if any of the commands fail.

### Motivation

Make Windows tests succeed.