### PR TITLE
Normalize tag names to lower case and remove duplicates for a given IP

### DIFF
--- a/pkg/ebpf/dns_cache.go
+++ b/pkg/ebpf/dns_cache.go
@@ -2,6 +2,7 @@ package ebpf
 
 import (
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -189,11 +190,12 @@ type dnsCacheVal struct {
 }
 
 func (v *dnsCacheVal) merge(name string) {
-	if i := sort.SearchStrings(v.names, name); i < len(v.names) && v.names[i] == name {
+	normalized := strings.ToLower(name)
+	if i := sort.SearchStrings(v.names, normalized); i < len(v.names) && v.names[i] == normalized {
 		return
 	}
 
-	v.names = append(v.names, name)
+	v.names = append(v.names, normalized)
 	sort.Strings(v.names)
 }
 

--- a/pkg/ebpf/dns_parser.go
+++ b/pkg/ebpf/dns_parser.go
@@ -4,6 +4,7 @@ package ebpf
 
 import (
 	"bytes"
+
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"


### PR DESCRIPTION
### What does this PR do?

We noticed that some IPs were resolving to multiple DNS entries that only differed by their case: [host.name.com, HoSt.nAMe.COM], for example are the same entry. This commit normalizes incoming DNS names by converting them all to lower case which will remove any resulting duplicates

### Motivation

Abnormal DNS payload sizes

### Additional Notes

Anything else we should know when reviewing?
