### PR TITLE
[release] fix release note entry about Go 1.13.8

### DIFF
--- a/releasenotes/notes/go-1-13-8-d98857855401db29.yaml
+++ b/releasenotes/notes/go-1-13-8-d98857855401db29.yaml
@@ -1,4 +1,4 @@
 ---
 other:
   - |
-    The Agent, Logs Agent and the system-probe are now compiled with Go ``1.13.8``
+    All Agents binaries are now compiled with Go ``1.13.8``


### PR DESCRIPTION
### What does this PR do?

Fix release note entry about Go 1.13.8

### Motivation

Make it clearer.