### PR TITLE
[windows] Fix rtloader test CMakeLists

### DIFF
--- a/rtloader/test/CMakeLists.txt
+++ b/rtloader/test/CMakeLists.txt
@@ -13,7 +13,11 @@ set(PKGS
     "../../test/containers/..."
 )
 
-set(LIBS_PATH "${PROJECT_BINARY_DIR}/rtloader/:${PROJECT_BINARY_DIR}/two/:${PROJECT_BINARY_DIR}/three/")
+if (WIN32)
+    set(LIBS_PATH \"${PROJECT_BINARY_DIR}/rtloader/\;${PROJECT_BINARY_DIR}/two/\;${PROJECT_BINARY_DIR}/three/\")
+else()
+    set(LIBS_PATH "${PROJECT_BINARY_DIR}/rtloader/:${PROJECT_BINARY_DIR}/two/:${PROJECT_BINARY_DIR}/three/")
+endif()
 
 set (CGO_CFLAGS \"-I${CMAKE_SOURCE_DIR}/include -I${CMAKE_SOURCE_DIR}/common -Wno-deprecated-declarations\")
 


### PR DESCRIPTION
### What does this PR do?

Fixes `LIBS_PATH` on Windows (the colon is not a path separator, the semi-colon is).

### Motivation

Prevent failures in `inv rtloader.test`.

