### PR TITLE
Autodiscover standard tags in ECS Fargate

### DIFF
--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -76,6 +76,15 @@ func (c *ECSFargateCollector) parseMetadata(meta *v2.Task, parseAll bool) ([]*Ta
 			}
 
 			for labelName, labelValue := range ctr.Labels {
+				switch labelName {
+				case dockerLabelEnv:
+					tags.AddLow(tagKeyEnv, labelValue)
+				case dockerLabelVersion:
+					tags.AddLow(tagKeyVersion, labelValue)
+				case dockerLabelService:
+					tags.AddLow(tagKeyService, labelValue)
+				}
+
 				if tagName, found := c.labelsAsTags[strings.ToLower(labelName)]; found {
 					tags.AddAuto(tagName, labelValue)
 				}

--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -102,6 +102,9 @@ func TestParseMetadata(t *testing.T) {
 				"ecs_container_name:redis",
 				"lowtag:myvalue",
 				"region:eu-central-1",
+				"service:redis",
+				"env:prod",
+				"version:1.0",
 			},
 			OrchestratorCardTags: []string{
 				"task_arn:arn:aws:ecs:eu-central-1:601427279990:task/5308d232-9002-4224-97b5-e1d4843b5244",
@@ -182,6 +185,9 @@ func TestParseMetadata(t *testing.T) {
 				"region:eu-central-1",
 				"tag1:value1",
 				"tag3:value:2:value:3",
+				"service:redis",
+				"env:prod",
+				"version:1.0",
 			},
 			OrchestratorCardTags: []string{
 				"task_arn:arn:aws:ecs:eu-central-1:601427279990:task/5308d232-9002-4224-97b5-e1d4843b5244",
@@ -269,6 +275,9 @@ func TestParseMetadataV10(t *testing.T) {
 				"task_family:redis-datadog",
 				"task_version:1",
 				"ecs_container_name:redis",
+				"service:redis",
+				"env:prod",
+				"version:1.0",
 			},
 			OrchestratorCardTags: []string{
 				"task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",

--- a/pkg/tagger/collectors/testdata/fargate_meta.json
+++ b/pkg/tagger/collectors/testdata/fargate_meta.json
@@ -83,6 +83,9 @@
         "com.datadoghq.ad.check_names": "[\"redisdb\"]",
         "com.datadoghq.ad.init_configs": "[{}]",
         "com.datadoghq.ad.instances": "[{\"host\": \"%%host%%\", \"port\": 6379}]",
+        "com.datadoghq.ad.service": "redis",
+        "com.datadoghq.ad.env": "prod",
+        "com.datadoghq.ad.version": "1.0",
         "highlabel": "value2",
         "mylabel": "myvalue"
       },

--- a/pkg/tagger/collectors/testdata/fargate_meta_v1.0.json
+++ b/pkg/tagger/collectors/testdata/fargate_meta_v1.0.json
@@ -42,7 +42,10 @@
 			"com.amazonaws.ecs.container-name": "redis",
 			"com.amazonaws.ecs.task-arn": "arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
 			"com.amazonaws.ecs.task-definition-family": "redis-datadog",
-			"com.amazonaws.ecs.task-definition-version": "1"
+			"com.amazonaws.ecs.task-definition-version": "1",
+			"com.datadoghq.ad.service": "redis",
+			"com.datadoghq.ad.env": "prod",
+			"com.datadoghq.ad.version": "1.0"
 		},
 		"DesiredStatus": "RUNNING",
 		"KnownStatus": "RUNNING",

--- a/releasenotes/notes/ecs-fargate-standard-tags-ad5e4e01b373f5ef.yaml
+++ b/releasenotes/notes/ecs-fargate-standard-tags-ad5e4e01b373f5ef.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Extract env, version and service tags from ECS Fargate containers


### PR DESCRIPTION
### What does this PR do?

Extract tags from ECS container's labels:
- `com.datadoghq.ad.service`
- `com.datadoghq.ad.env`
- `com.datadoghq.ad.version`

### Motivation

Unify DD tagging

### Additional Notes

Anything else we should know when reviewing?
