### PR TITLE
Exclude optional dependency from known unsupported targets

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -87,6 +87,10 @@ if arm?
   blacklist_packages.push(/^pymqi==/)
 end
 
+if arm? || !_64_bit?
+  blacklist_packages.push(/^orjson==/)
+end
+
 final_constraints_file = 'final_constraints-py2.txt'
 agent_requirements_file = 'agent_requirements-py2.txt'
 filtered_agent_requirements_in = 'agent_requirements-py2.in'

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -88,6 +88,10 @@ if arm?
   blacklist_packages.push(/^pymqi==/)
 end
 
+if arm? || !_64_bit?
+  blacklist_packages.push(/^orjson==/)
+end
+
 final_constraints_file = 'final_constraints-py3.txt'
 agent_requirements_file = 'agent_requirements-py3.txt'
 filtered_agent_requirements_in = 'agent_requirements-py3.in'


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/6143