### PR TITLE
pkg/trace/config: support setting additional endpoints by means of env.

### DIFF
--- a/pkg/trace/config/env.go
+++ b/pkg/trace/config/env.go
@@ -80,6 +80,14 @@ func loadEnv() {
 			log.Errorf("Bad format for %s it should be of the form '[{\"name\": \"tag_name\",\"pattern\":\"pattern\",\"repl\":\"replace_str\"}]', error: %v", "DD_APM_REPLACE_TAGS", err)
 		}
 	}
+	if v := os.Getenv("DD_APM_ADDITIONAL_ENDPOINTS"); v != "" {
+		ap := make(map[string][]string)
+		if err := json.Unmarshal([]byte(v), &ap); err != nil {
+			log.Errorf(`Could not parse DD_APM_ADDITIONAL_ENDPOINTS: %v. It must be of the form '{"https://trace.agent.datadoghq.com": ["apikey1", ...], ...}'.`, err)
+		} else {
+			config.Datadog.Set("apm_config.additional_endpoints", ap)
+		}
+	}
 }
 
 func parseNameAndRate(token string) (string, float64, error) {

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -281,4 +281,17 @@ func TestLoadEnv(t *testing.T) {
 			assert.Equal(7., cfg.MaxEPS)
 		})
 	}
+
+	env = "DD_APM_ADDITIONAL_ENDPOINTS"
+	t.Run(env, func(t *testing.T) {
+		assert := assert.New(t)
+		err := os.Setenv(env, `{"url1": ["key1", "key2"], "url2": ["key3"]}`)
+		assert.NoError(err)
+		defer os.Unsetenv(env)
+		cfg, err := Load("./testdata/full.yaml")
+		assert.NoError(err)
+		assert.Contains(cfg.Endpoints, &Endpoint{APIKey: "key1", Host: "url1"})
+		assert.Contains(cfg.Endpoints, &Endpoint{APIKey: "key2", Host: "url1"})
+		assert.Contains(cfg.Endpoints, &Endpoint{APIKey: "key3", Host: "url2"})
+	})
 }


### PR DESCRIPTION
This change adds support for setting additional endpoints by means of
DD_APM_ADDITIONAL_ENDPOINTS. It's complementary to changes in #4718.

The format for the environment variable is of the type: `'{"https://trace.agent.datadoghq.com": ["apikey1", ...], ...}'.`. Basically an object having the endpoints as keys and the API key(s) as array values.