### PR TITLE
Build and push Windows 1909 Docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2359,7 +2359,10 @@ dev_branch_docker_hub-a7:
     - fail_on_non_triggered_tag
     - build_agent7
     - build_agent7_jmx
-    - build_agent7_windows
+    - build_agent7_windows1809
+    - build_agent7_windows1809_jmx
+    - build_agent7_windows1909
+    - build_agent7_windows1909_jmx
   when: manual
   script:
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-amd64             datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3
@@ -2371,7 +2374,10 @@ dev_branch_docker_hub-a7-windows:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs:
     - fail_on_non_triggered_tag
-    - build_agent7_windows
+    - build_agent7_windows1809
+    - build_agent7_windows1809_jmx
+    - build_agent7_windows1909
+    - build_agent7_windows1909_jmx
   when: manual
   script:
     - |
@@ -2471,7 +2477,10 @@ dev_master_docker_hub-a7-windows:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs:
     - fail_on_non_triggered_tag
-    - build_agent7_windows
+    - build_agent7_windows1809
+    - build_agent7_windows1809_jmx
+    - build_agent7_windows1909
+    - build_agent7_windows1909_jmx
   only:
     - master
   script:
@@ -2558,7 +2567,10 @@ dev_nightly_docker_hub-a7-windows:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs:
     - fail_on_non_triggered_tag
-    - build_agent7_windows
+    - build_agent7_windows1809
+    - build_agent7_windows1809_jmx
+    - build_agent7_windows1909
+    - build_agent7_windows1909_jmx
   script:
     - |
       @"
@@ -3006,7 +3018,10 @@ tag_release_7_windows:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs:
     - fail_on_non_triggered_tag
-    - build_agent7_windows
+    - build_agent7_windows1809
+    - build_agent7_windows1809_jmx
+    - build_agent7_windows1909
+    - build_agent7_windows1909_jmx
   script:
     - $VERSION = inv -e agent.version --major-version 7
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2108,7 +2108,7 @@ build_agent7_jmx_arm64:
     TESTING_ARG:  --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
 
 # build agent7_windows image
-build_agent7_windows:
+build_agent7_windows1809:
   stage: image_build
   before_script: [ "# noop" ] # Override top level entry
   needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
@@ -2127,7 +2127,7 @@ build_agent7_windows:
     - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - docker push ${TARGET_TAG}
 
-build_agent7_windows_jmx:
+build_agent7_windows1809_jmx:
   stage: image_build
   before_script: [ "# noop" ] # Override top level entry
   needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
@@ -2142,6 +2142,45 @@ build_agent7_windows_jmx:
     - $ErrorActionPreference = "Stop"
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
     - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}${TAG_SUFFIX}-win1809-amd64"
+    - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip
+    - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
+    - docker push ${TARGET_TAG}
+
+# build agent7_windows image
+build_agent7_windows1909:
+  stage: image_build
+  before_script: [ "# noop" ] # Override top level entry
+  needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
+  <<: *skip_when_unwanted_on_7
+  tags: ["runner:windows-docker", "windowsversion:1909"]
+  variables:
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    BUILD_CONTEXT: Dockerfiles/agent
+    TAG_SUFFIX: -7
+    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1909 --build-arg WITH_JMX=false
+  script:
+    - $ErrorActionPreference = "Stop"
+    - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
+    - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}${TAG_SUFFIX}-win1909-amd64"
+    - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip
+    - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
+    - docker push ${TARGET_TAG}
+
+build_agent7_windows1909_jmx:
+  stage: image_build
+  before_script: [ "# noop" ] # Override top level entry
+  needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
+  <<: *skip_when_unwanted_on_7
+  tags: ["runner:windows-docker", "windowsversion:1909"]
+  variables:
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+    BUILD_CONTEXT: Dockerfiles/agent
+    TAG_SUFFIX: -7-jmx
+    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1909 --build-arg WITH_JMX=true
+  script:
+    - $ErrorActionPreference = "Stop"
+    - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
+    - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}${TAG_SUFFIX}-win1909-amd64"
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip
     - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - docker push ${TARGET_TAG}
@@ -2339,6 +2378,8 @@ dev_branch_docker_hub-a7-windows:
       @"
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909
       "@ | Add-Content ci-scripts/docker-publish.ps1
 
 dev_branch_multiarch_docker_hub-a6:
@@ -2438,6 +2479,8 @@ dev_master_docker_hub-a7-windows:
       @"
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-amd64 datadog/agent-dev:master-py3-win1809
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-amd64 datadog/agent-dev:master-py3-jmx-win1809
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-amd64 datadog/agent-dev:master-py3-win1909
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-amd64 datadog/agent-dev:master-py3-jmx-win1909
       "@ | Add-Content ci-scripts/docker-publish.ps1
     - cat ci-scripts/docker-publish.ps1
 
@@ -2521,6 +2564,8 @@ dev_nightly_docker_hub-a7-windows:
       @"
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1809
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1809
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1909
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1909
       "@ | Add-Content ci-scripts/docker-publish.ps1
 
 # deploys nightlies to agent-dev
@@ -2968,8 +3013,12 @@ tag_release_7_windows:
       @"
       inv -e docker.publish-bulk --signed-push --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1809-ARCH --dst-template datadog/agent-ARCH:${VERSION}-win1809
       inv -e docker.publish-bulk --signed-push --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-ARCH --dst-template datadog/agent-ARCH:${VERSION}-jmx-win1809
+      inv -e docker.publish-bulk --signed-push --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1909-ARCH --dst-template datadog/agent-ARCH:${VERSION}-win1909
+      inv -e docker.publish-bulk --signed-push --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-ARCH --dst-template datadog/agent-ARCH:${VERSION}-jmx-win1909
       inv -e docker.publish-manifest --signed-push --platform windows/amd64 --name datadog/agent --tag ${VERSION} --template datadog/agent-ARCH:${VERSION}-win1809
       inv -e docker.publish-manifest --signed-push --platform windows/amd64 --name datadog/agent --tag ${VERSION} --template datadog/agent-ARCH:${VERSION}-jmx-win1809
+      inv -e docker.publish-manifest --signed-push --platform windows/amd64 --name datadog/agent --tag ${VERSION} --template datadog/agent-ARCH:${VERSION}-win1909
+      inv -e docker.publish-manifest --signed-push --platform windows/amd64 --name datadog/agent --tag ${VERSION} --template datadog/agent-ARCH:${VERSION}-jmx-win1909
       "@ | Add-Content ci-scripts/docker-publish.ps1
 
 latest_release_6:


### PR DESCRIPTION
### What does this PR do?

Build the image also on Windows 1909, since we Docker on Windows needs the host and container kernels to match.

### Additional Notes

I'm assuming that pulling, signing and pushing 1909 images can be done on the existing 1809 kernels. I haven't tested if this actually works.
