### PR TITLE
Report jmxfetch startup failure with metadata

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -104,6 +104,13 @@
   <div class="stat">
     <span class="stat_title">JMX Status</span>
     <span class="stat_data">
+      {{ if .JMXStartupError.LastError }}
+      <span class="stat_subtitle">JMX startup errors</span>
+        <span class="stat_subdata">
+          Error: {{ .JMXStartupError.LastError }} <br>
+          Date: {{ formatUnixTime .JMXStartupError.Timestamp }}
+        </span>
+      {{ end -}}
       {{- with .JMXStatus -}}
         {{- if and (not .timestamp) (not .checks)}}
           No JMX status available

--- a/pkg/collector/corechecks/embed/jmx/runner.go
+++ b/pkg/collector/corechecks/embed/jmx/runner.go
@@ -9,10 +9,12 @@ package jmx
 
 import (
 	"runtime"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
+	"github.com/DataDog/datadog-agent/pkg/status"
 )
 
 type runner struct {
@@ -34,6 +36,8 @@ func (r *runner) startRunner() error {
 
 	err := r.jmxfetch.Start(lifecycleMgmt)
 	if err != nil {
+		s := status.JMXStartupError{err.Error(), time.Now().Unix()}
+		status.SetJMXStartupError(s)
 		return err
 	}
 	r.started = true

--- a/pkg/collector/corechecks/embed/jmx/runner.go
+++ b/pkg/collector/corechecks/embed/jmx/runner.go
@@ -36,7 +36,7 @@ func (r *runner) startRunner() error {
 
 	err := r.jmxfetch.Start(lifecycleMgmt)
 	if err != nil {
-		s := status.JMXStartupError{err.Error(), time.Now().Unix()}
+		s := status.JMXStartupError{LastError: err.Error(), Timestamp: time.Now().Unix()}
 		status.SetJMXStartupError(s)
 		return err
 	}

--- a/pkg/collector/metadata/agentchecks/agentchecks.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
+	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -24,6 +25,7 @@ func GetPayload() *Payload {
 	hostnameData, _ := util.GetHostnameData()
 	hostname := hostnameData.Hostname
 	checkStats := runner.GetCheckStats()
+	jmxStartupError := status.GetJMXStartupError()
 
 	for _, stats := range checkStats {
 		for _, s := range stats {
@@ -65,6 +67,13 @@ func GetPayload() *Payload {
 	for check, e := range configErrors {
 		status := []interface{}{
 			check, check, "initialization", "ERROR", e,
+		}
+		agentChecksPayload.AgentChecks = append(agentChecksPayload.AgentChecks, status)
+	}
+
+	if jmxStartupError.LastError != "" {
+		status := []interface{}{
+			"jmx", "jmx", "initialization", "ERROR", jmxStartupError.LastError,
 		}
 		agentChecksPayload.AgentChecks = append(agentChecksPayload.AgentChecks, status)
 	}

--- a/pkg/jmxfetch/jmxfetch_nix.go
+++ b/pkg/jmxfetch/jmxfetch_nix.go
@@ -9,11 +9,13 @@
 package jmxfetch
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -45,7 +47,10 @@ func (j *JMXFetch) Monitor() {
 		// stopTimes here will only start yielding values potentially <= ival _after_ the first
 		// maxRestarts attempts, which is fine and consistent.
 		if stopTimes[idx].Sub(stopTimes[oldestIdx]).Seconds() <= ival {
-			log.Errorf("Too many JMXFetch restarts (%v) in time interval (%vs) - giving up", maxRestarts, ival)
+			msg := fmt.Sprintf("Too many JMXFetch restarts (%v) in time interval (%vs) - giving up", maxRestarts, ival)
+			log.Errorf(msg)
+			s := status.JMXStartupError{msg, time.Now().Unix()}
+			status.SetJMXStartupError(s)
 			return
 		}
 

--- a/pkg/jmxfetch/jmxfetch_nix.go
+++ b/pkg/jmxfetch/jmxfetch_nix.go
@@ -49,7 +49,7 @@ func (j *JMXFetch) Monitor() {
 		if stopTimes[idx].Sub(stopTimes[oldestIdx]).Seconds() <= ival {
 			msg := fmt.Sprintf("Too many JMXFetch restarts (%v) in time interval (%vs) - giving up", maxRestarts, ival)
 			log.Errorf(msg)
-			s := status.JMXStartupError{msg, time.Now().Unix()}
+			s := status.JMXStartupError{LastError: msg, Timestamp: time.Now().Unix()}
 			status.SetJMXStartupError(s)
 			return
 		}

--- a/pkg/status/jmx_status.go
+++ b/pkg/status/jmx_status.go
@@ -20,23 +20,47 @@ type JMXStatus struct {
 	Timestamp    int64          `json:"timestamp"`
 }
 
+// JMXStartupError holds startup status and errors
+type JMXStartupError struct {
+	LastError string
+	Timestamp int64
+}
+
 var (
-	lastJMXStatus JMXStatus
-	m             sync.RWMutex
+	lastJMXStatus            JMXStatus
+	lastJMXStatusMutex       sync.RWMutex
+	lastJMXStartupError      JMXStartupError
+	lastJMXStartupErrorMutex sync.RWMutex
 )
 
 // SetJMXStatus sets the last JMX Status
 func SetJMXStatus(s JMXStatus) {
-	m.Lock()
-	defer m.Unlock()
+	lastJMXStatusMutex.Lock()
+	defer lastJMXStatusMutex.Unlock()
 
 	lastJMXStatus = s
 }
 
 // GetJMXStatus retrieves latest JMX Status
 func GetJMXStatus() JMXStatus {
-	m.RLock()
-	defer m.RUnlock()
+	lastJMXStatusMutex.RLock()
+	defer lastJMXStatusMutex.RUnlock()
 
 	return lastJMXStatus
+}
+
+// SetJMXStartupError sets the last JMX startup error
+func SetJMXStartupError(s JMXStartupError) {
+	lastJMXStatusMutex.Lock()
+	defer lastJMXStatusMutex.Unlock()
+
+	lastJMXStartupError = s
+}
+
+// GetJMXStartupError retrieves latest JMX startup error
+func GetJMXStartupError() JMXStartupError {
+	lastJMXStartupErrorMutex.RLock()
+	defer lastJMXStartupErrorMutex.RUnlock()
+	copy := JMXStartupError{lastJMXStartupError.LastError, lastJMXStartupError.Timestamp}
+	return copy
 }

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -34,7 +34,6 @@ func FormatStatus(data []byte) (string, error) {
 	checkSchedulerStats := stats["checkSchedulerStats"]
 	aggregatorStats := stats["aggregatorStats"]
 	dogstatsdStats := stats["dogstatsdStats"]
-	jmxStats := stats["JMXStatus"]
 	logsStats := stats["logsStats"]
 	dcaStats := stats["clusterAgentStatus"]
 	endpointsInfos := stats["endpointsInfos"]
@@ -43,7 +42,7 @@ func FormatStatus(data []byte) (string, error) {
 	stats["title"] = title
 	renderStatusTemplate(b, "/header.tmpl", stats)
 	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, inventoriesStats, "")
-	renderJMXFetchStatus(b, jmxStats)
+	renderStatusTemplate(b, "/jmxfetch.tmpl", stats)
 	renderStatusTemplate(b, "/forwarder.tmpl", forwarderStats)
 	renderStatusTemplate(b, "/endpoints.tmpl", endpointsInfos)
 	renderStatusTemplate(b, "/logsagent.tmpl", logsStats)
@@ -125,12 +124,6 @@ func renderCheckStats(data []byte, checkName string) (string, error) {
 	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, inventoriesStats, checkName)
 
 	return b.String(), nil
-}
-
-func renderJMXFetchStatus(w io.Writer, jmxStats interface{}) {
-	stats := make(map[string]interface{})
-	stats["JMXStatus"] = jmxStats
-	renderStatusTemplate(w, "/jmxfetch.tmpl", stats)
 }
 
 func renderStatusTemplate(w io.Writer, templateName string, stats interface{}) {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -69,6 +69,7 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["time"] = now.Format(timeFormat)
 
 	stats["JMXStatus"] = GetJMXStatus()
+	stats["JMXStartupError"] = GetJMXStartupError()
 
 	stats["logsStats"] = logs.GetStatus()
 

--- a/pkg/status/templates/jmxfetch.tmpl
+++ b/pkg/status/templates/jmxfetch.tmpl
@@ -4,6 +4,12 @@ NOTE: Changes made to this template should be reflected on the following templat
 */}}========
 JMXFetch
 ========
+{{ if .JMXStartupError.LastError }}
+  JMX startup errors
+  ==================
+    Error: {{ .JMXStartupError.LastError }}
+    Date: {{ formatUnixTime .JMXStartupError.Timestamp }}
+{{ end -}}
 {{ with .JMXStatus }}
   {{- if and (not .timestamp) (not .checks) }}
   no JMX status available


### PR DESCRIPTION
### What does this PR do?
Save jmxfetch startup error and sends those with metadata.
`agent status` and agent web gui also display those errors.

### Motivation
Ease problem identification and awareness.

### Additional Notes
As I'm not fully aware of the future vision for jmxfetch I tried to keep the implementation as simple as possible.
