### PR TITLE
Fix one more CloudFoundryListener test flake

### DIFF
--- a/pkg/autodiscovery/listeners/cloudfoundry_test.go
+++ b/pkg/autodiscovery/listeners/cloudfoundry_test.go
@@ -391,15 +391,15 @@ func TestCloudFoundryListener(t *testing.T) {
 		testBBSCache.DesiredLRPs = tc.dLRP
 		testBBSCache.Unlock()
 
+		// make sure at least one refresh loop of the listener has passed *since we updated the cache*
+		cfl.RLock()
+		lastRefreshCount = cfl.refreshCount
+		cfl.RUnlock()
 		testutil.RequireTrueBeforeTimeout(t, 15*time.Millisecond, 250*time.Millisecond, func() bool {
-			// wait until at least one listener refresh loop passes
 			cfl.RLock()
 			defer cfl.RUnlock()
 			return cfl.refreshCount > lastRefreshCount
 		})
-		cfl.RLock()
-		lastRefreshCount = cfl.refreshCount
-		cfl.RUnlock()
 
 		// we have to fail now, otherwise we might get blocked trying to read from the channel
 		require.Equal(t, len(tc.expNew), len(newSvc))


### PR DESCRIPTION
### What does this PR do?

Fixes a test flake such as https://ci.appveyor.com/project/Datadog/datadog-agent/builds/31698740

The reason why we had the test flake was that we weren't making sure that a new refresh loop of the listener happened *since we updated the cache* - we only waited until the listener did *a* loop, which might have been a loop called while the previous loop results were being validated. This ensures that we

1. update the test BBS cache
2. record the current refresh count
3. wait for at least one more refresh loop to run
4. only then we do the checking

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
