### PR TITLE
pkg/trace/writer: replace "APM events" with "Analyzed spans" when logging

### DIFF
--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -158,7 +158,7 @@ func (w *TraceWriter) addSpans(pkg *SampledSpans) {
 		w.traces = append(w.traces, traceutil.APITrace(pkg.Trace))
 	}
 	if len(pkg.Events) > 0 {
-		log.Tracef("Handling new APM events: %v", pkg.Events)
+		log.Tracef("Handling new Analyzed spans: %v", pkg.Events)
 		w.events = append(w.events, pkg.Events...)
 	}
 	w.bufferedSize += size

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -158,7 +158,7 @@ func (w *TraceWriter) addSpans(pkg *SampledSpans) {
 		w.traces = append(w.traces, traceutil.APITrace(pkg.Trace))
 	}
 	if len(pkg.Events) > 0 {
-		log.Tracef("Handling new Analyzed spans: %v", pkg.Events)
+		log.Tracef("Handling new analyzed spans: %v", pkg.Events)
 		w.events = append(w.events, pkg.Events...)
 	}
 	w.bufferedSize += size


### PR DESCRIPTION

### What does this PR do?

update "APM events" to "Analyzed spans" for TRACE level  logs in order to not confuse clients or anyone new to the product when troubleshooting
bigger task will be to replace events by analyzed spans everywhere but that would have to be discussed as this will involve changes in metrics' names

### Motivation
not confusing people when they are troubleshooting the trace agent

### Additional Notes

