### PR TITLE
[rtloader] Enforce minimum supported python versions with CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and development, is located under [the docs directory](docs) of the present repo
 
 To build the Agent you need:
  * [Go](https://golang.org/doc/install) 1.13 or later. You'll also need to set your `$GOPATH` and have `$GOPATH/bin` in your path.
- * Python 2.7 or 3.x along with development libraries.
+ * Python 2.7 or 3.7+ along with development libraries.
  * Python dependencies. You may install these with `pip install -r requirements.txt`
    This will also pull in [Invoke](http://www.pyinvoke.org) if not yet installed.
  * CMake version 3.12 or later and a C++ compiler
@@ -47,7 +47,7 @@ To start working on the Agent, you can build the `master` branch:
 3. Install project's dependencies: `invoke deps`.
    Make sure that `$GOPATH/bin` is in your `$PATH` otherwise this step might fail.
 4. Create a development `datadog.yaml` configuration file in `dev/dist/datadog.yaml`, containing a valid API key: `api_key: <API_KEY>`
-5. Build the agent with `invoke agent.build --build-exclude=systemd`. 
+5. Build the agent with `invoke agent.build --build-exclude=systemd`.
    By default, the Agent will be built to use Python 3 but you can select which Python version you want to use:
    - `invoke agent.build --python-runtimes 2` for Python2 only
    - `invoke agent.build --python-runtimes 3` for Python3 only
@@ -62,8 +62,8 @@ To start working on the Agent, you can build the `master` branch:
     * Builds the Agent and writes the binary to `bin/agent/agent`.
     * Copies files from `dev/dist` to `bin/agent/dist`. See `https://github.com/DataDog/datadog-agent/blob/master/dev/dist/README.md` for more information.
   If you built an older version of the agent, you may have the error `make: *** No targets specified and no makefile found.  Stop.`.
-  To solve the issue, you should remove `CMakeCache.txt` from `rtloader` folder with `rm rtloader/CMakeCache.txt`. 
-  
+  To solve the issue, you should remove `CMakeCache.txt` from `rtloader` folder with `rm rtloader/CMakeCache.txt`.
+
 
 
 Please refer to the [Agent Developer Guide](docs/dev/README.md) for more details.

--- a/rtloader/three/CMakeLists.txt
+++ b/rtloader/three/CMakeLists.txt
@@ -1,5 +1,12 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.12)
 find_package (Python3 COMPONENTS Interpreter Development)
+
+if(Python3_VERSION_MINOR LESS "7")
+  message(
+    FATAL_ERROR
+    "Python3 version found is too old: found ${Python3_EXECUTABLE} (version \"${Python3_VERSION}\"), minimum required version is 3.7"
+  )
+endif()
 
 project(datadog-agent-three VERSION 0.1.0 DESCRIPTION "CPython backend for the Datadog Agent")
 

--- a/rtloader/two/CMakeLists.txt
+++ b/rtloader/two/CMakeLists.txt
@@ -1,5 +1,12 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.12)
 find_package (Python2 COMPONENTS Interpreter Development)
+
+if(Python2_VERSION_MINOR LESS "7")
+  message(
+    FATAL_ERROR
+    "Python2 version found is too old: found ${Python2_EXECUTABLE} (version \"${Python2_VERSION}\"), minimum required version is 2.7"
+  )
+endif()
 
 project(datadog-agent-two VERSION 0.1.0 DESCRIPTION "CPython backend for the Datadog Agent")
 


### PR DESCRIPTION
### What does this PR do?

Enforces minimum supported python versions with CMake.

Also:

* update README with minimum supported python 3 version
* fix minimum cmake version in `two` and `three` CMakeLists files

### Motivation

Better developer experience if Python 3 version found won't compile/work with rtloader.

### Additional Notes

Even if we currently use Python 3.8, rtloader currently supports 3.7+ (AFAIK the only 3.7-specific feature we use is `Py_UTF8Mode` since https://github.com/DataDog/datadog-agent/pull/5013).

Related cmake docs, for reference: https://cmake.org/cmake/help/v3.12/module/FindPython3.html#module:FindPython3
