### PR TITLE
Drop packetsbuffer on saturated channel

### DIFF
--- a/pkg/dogstatsd/listeners/packet_buffer_test.go
+++ b/pkg/dogstatsd/listeners/packet_buffer_test.go
@@ -10,7 +10,7 @@ import (
 func buildPacketBuffer(buffersSize int) (*packetBuffer, chan Packets) {
 	pool := NewPacketPool(buffersSize)
 	out := make(chan Packets, 16)
-	psb := newPacketsBuffer(1, 1*time.Hour, out)
+	psb := newPacketsBuffer(pool, 1, 1*time.Hour, out)
 	pb := newPacketBuffer(pool, 100*time.Millisecond, psb)
 	return pb, out
 }

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -76,7 +76,7 @@ func NewUDPListener(packetOut chan Packets, packetPool *PacketPool) (*UDPListene
 	flushTimeout := config.Datadog.GetDuration("dogstatsd_packet_buffer_flush_timeout")
 
 	buffer := make([]byte, bufferSize)
-	packetsBuffer := newPacketsBuffer(uint(packetsBufferSize), flushTimeout, packetOut)
+	packetsBuffer := newPacketsBuffer(packetPool, uint(packetsBufferSize), flushTimeout, packetOut)
 	packetBuffer := newPacketBuffer(packetPool, flushTimeout, packetsBuffer)
 
 	listener := &UDPListener{

--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -107,7 +107,7 @@ func NewUDSListener(packetOut chan Packets, packetPool *PacketPool) (*UDSListene
 		OriginDetection: originDetection,
 		packetPool:      packetPool,
 		conn:            conn,
-		packetsBuffer: newPacketsBuffer(uint(config.Datadog.GetInt("dogstatsd_packet_buffer_size")),
+		packetsBuffer: newPacketsBuffer(packetPool, uint(config.Datadog.GetInt("dogstatsd_packet_buffer_size")),
 			config.Datadog.GetDuration("dogstatsd_packet_buffer_flush_timeout"), packetOut),
 	}
 

--- a/releasenotes/notes/drop-packets-on-full-buffer-f64a9e06dfc55dac.yaml
+++ b/releasenotes/notes/drop-packets-on-full-buffer-f64a9e06dfc55dac.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  - |
+    Drop packets when buffer is full to avoid blocking
+    applications sending data through unix socket.


### PR DESCRIPTION
### What does this PR do?

Drop packets instead of blocking on available buffer. 

### Motivation

When using UDS, having the server block can impact application sending points. At that point, it's better to drop the data than to add latency to the applications.
The target is to be able to constraint the agent's memory footprint by lowering the channel's size without impacting the application and also provide a metric on the number of packets dropped due to full buffer.

### Additional Notes

Anything else we should know when reviewing?
