### PR TITLE
Add retries to every jobs in case of unknown errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,13 @@
 include: 'https://gitlab-templates.ddbuild.io/slack-notifier/v1/template.yml'
 
+default:
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+
 stages:
   - fail_on_tag
   - deps_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ default:
       - runner_system_failure
       - stuck_or_timeout_failure
       - unknown_failure
+      - api_failure
 
 stages:
   - fail_on_tag


### PR DESCRIPTION
### What does this PR do?

Add retries to every jobs in case of runner errors. Basically, it means that if the runner has a system failure, that the job is stuck or that we meet an unknown failure, we will retry the job up to two times.

### Motivation

Make the pipeline more consistent and reliable.

