### PR TITLE
fix multiple sigint in system-probe

### DIFF
--- a/pkg/process/util/signal_nowindows.go
+++ b/pkg/process/util/signal_nowindows.go
@@ -13,23 +13,14 @@ import (
 // HandleSignals tells us whether we should exit.
 func HandleSignals(exit chan bool) {
 	sigIn := make(chan os.Signal, 100)
-	signal.Notify(sigIn)
+	signal.Notify(sigIn, syscall.SIGINT, syscall.SIGTERM)
 	// unix only in all likelihood; but we don't care.
 	for sig := range sigIn {
 		switch sig {
 		case syscall.SIGINT, syscall.SIGTERM:
+			signal.Stop(sigIn)
 			log.Criticalf("Caught signal '%s'; terminating.", sig)
 			close(exit)
-		case syscall.SIGCHLD:
-			// Running docker.GetDockerStat() spins up / kills a new process
-			continue
-		case syscall.SIGPIPE:
-			// By default systemd redirects the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal.
-			// Go ignores SIGPIPE signals unless it is when stdout or stdout is closed, in this case the agent is stopped.
-			// We never want the agent to stop upon receiving SIGPIPE, so we intercept the SIGPIPE signals and just discard them.
-			continue
-		default:
-			log.Tracef("Caught signal %s; continuing/ignoring.", sig)
 		}
 	}
 }

--- a/pkg/process/util/signal_windows.go
+++ b/pkg/process/util/signal_windows.go
@@ -13,15 +13,14 @@ import (
 // HandleSignals tells us whether we should exit.
 func HandleSignals(exit chan bool) {
 	sigIn := make(chan os.Signal, 100)
-	signal.Notify(sigIn)
+	signal.Notify(sigIn, syscall.SIGINT, syscall.SIGTERM)
 	// unix only in all likelihood;  but we don't care.
 	for sig := range sigIn {
 		switch sig {
 		case syscall.SIGINT, syscall.SIGTERM:
+			signal.Stop(sigIn)
 			log.Criticalf("Caught signal '%s'; terminating.", sig)
 			close(exit)
-		default:
-			log.Tracef("Caught signal %s; continuing/ignoring.", sig)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

currently a chan is closed each time a SIGINT or SIGTERM signal
is received. Receiving multiple signals generates a panic as the same
chan will be closed multiple times.
This patch stop listening signal after the first one.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
