### PR TITLE
pkg/trace/sampler: error sampling rates upscale

### DIFF
--- a/pkg/trace/sampler/scoresampler.go
+++ b/pkg/trace/sampler/scoresampler.go
@@ -8,8 +8,9 @@ package sampler
 import "github.com/DataDog/datadog-agent/pkg/trace/pb"
 
 const (
+	// errorSamplingRateThresholdTo1 defines the maximum allowed sampling rate below 1.
 	// If this is surpassed, the rate is set to 1.
-	errorSamplingRateThresholdTo1 = 0.3
+	errorSamplingRateThresholdTo1 = 0.1
 )
 
 // ScoreEngine is the main component of the sampling logic

--- a/pkg/trace/sampler/scoresampler.go
+++ b/pkg/trace/sampler/scoresampler.go
@@ -7,6 +7,11 @@ package sampler
 
 import "github.com/DataDog/datadog-agent/pkg/trace/pb"
 
+const (
+	// If this is surpassed, the rate is set to 1.
+	errorSamplingRateThresholdTo1 = 0.3
+)
+
 // ScoreEngine is the main component of the sampling logic
 type ScoreEngine struct {
 	// Sampler is the underlying sampler used by this engine, sharing logic among various engines.
@@ -32,6 +37,7 @@ func NewErrorsEngine(extraRate float64, maxTPS float64) *ScoreEngine {
 		Sampler:    newSampler(extraRate, maxTPS),
 		engineType: ErrorsScoreEngineType,
 	}
+	s.Sampler.setRateThresholdTo1(errorSamplingRateThresholdTo1)
 
 	return s
 }


### PR DESCRIPTION
### What does this PR do?

All sampling rates above 0.1 will be set at 1, this will move to over 99% of errors sent to the backend
Error sampling will trigger at 100 errors/s at the agent level, and when triggered considers different errors

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
