### PR TITLE
Fixes missing C runtime DLL (specifically for jpype, probably others

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -63,6 +63,7 @@ if ohai["platform"] != "windows"
   end
 
 else
+  dependency "vc_redist_14"
   #
   # note for next version after 3.8.1, remove the `-withcrt` as the filename won't
   # include that any more
@@ -79,7 +80,9 @@ else
          :sha256 => "1da0a5e43c24ed62a43c9f3a4d42e72abb4905b0e1fa4923f01c9ee5814ef9e7"
 
   end
+  vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"
   build do
     command "XCOPY /YEHIR *.* \"#{windows_safe_path(python_3_embedded)}\""
+    command "copy /y \"#{windows_safe_path(vcrt140_root)}\\msvc*.dll\" \"#{windows_safe_path(python_3_embedded)}\""
   end
 end

--- a/omnibus/config/software/vc_redist_14.rb
+++ b/omnibus/config/software/vc_redist_14.rb
@@ -1,0 +1,24 @@
+# Microsoft Visual C++ redistributable
+
+name "vc_redist_140"
+default_version "140"
+
+if windows_arch_i386?
+  source :url => "https://s3.amazonaws.com/dd-agent-omnibus/Microsoft_VC141_CRT_x86.msm",
+         :sha256 => "d582b8069174edaefb1fa04b84ebca375602655b5bdbb17aa15d61f43b25a67e",
+         :target_filename => "Microsoft_VC141_CRT_x86.msm"
+else
+  source :url => "https://s3.amazonaws.com/dd-agent-omnibus/Microsoft_VC141_CRT_x64.msm",
+         :sha256 => "102a2127f528865f6e462c5b28589a7249f70d0d4201676c3b2f2cc46f997b84",
+         :target_filename => "Microsoft_VC141_CRT_x64.msm"
+end
+build do
+   # expand the MSM so that anyone that needs the individual components can find it
+   script_root = "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/tools/windows/decompress_merge_module.ps1"
+   if windows_arch_i386?
+     source_msm = "Microsoft_VC141_CRT_x86.msm"
+   else
+     source_msm = "Microsoft_VC141_CRT_x64.msm"
+   end
+   command "powershell -C \"#{windows_safe_path(script_root)} -file #{source_msm} -targetDir .\\expanded\""
+end

--- a/releasenotes/notes/addcruntimejpype-ed68ff8e996d75a6.yaml
+++ b/releasenotes/notes/addcruntimejpype-ed68ff8e996d75a6.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, for Python3, add additional C-runtime DLLs.  fixes
+    missing dependency for jpype

--- a/releasenotes/notes/addcruntimejpype-ed68ff8e996d75a6.yaml
+++ b/releasenotes/notes/addcruntimejpype-ed68ff8e996d75a6.yaml
@@ -8,5 +8,4 @@
 ---
 fixes:
   - |
-    On Windows, for Python3, add additional C-runtime DLLs.  fixes
-    missing dependency for jpype
+    On Windows, for Python3, add additional C-runtime DLLs to fix missing dependencies (notably for jpype).


### PR DESCRIPTION
too)

### What does this PR do?

Puts the VC_runtime_140 omnibus def back in.
Does _not_ use the MSM, though (we removed that because of installation reboots).
Manually extracts the MSM, and then copies additional DLLs.

### Motivation

Some python modules (specifically jpype) needed more DLLs than we were including.
Those DLLS had been installed by the merge module, so integration support regressed.

### Additional Notes

Anything else we should know when reviewing?
