### PR TITLE
pkg/trace/sampler: error sampling update signatures

### DIFF
--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -42,6 +42,12 @@ const (
 
 	// KeySamplingPriority is the key of the sampling priority value in the metrics map of the root span
 	KeySamplingPriority = "_sampling_priority_v1"
+
+	// KeyErrorType is the key of the error type in the meta map
+	KeyErrorType = "error.type"
+
+	// KeyHTTPStatusCode is the key of the http status code in the meta map
+	KeyHTTPStatusCode = "http.status_code"
 )
 
 // SamplingPriority is the type encoding a priority sampling decision.
@@ -160,6 +166,14 @@ func getMetric(s *pb.Span, k string) (float64, bool) {
 		return 0, false
 	}
 	val, ok := s.Metrics[k]
+	return val, ok
+}
+
+func getMeta(s *pb.Span, k string) (string, bool) {
+	if s.Meta == nil {
+		return "", false
+	}
+	val, ok := s.Meta[k]
 	return val, ok
 }
 

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -169,14 +169,6 @@ func getMetric(s *pb.Span, k string) (float64, bool) {
 	return val, ok
 }
 
-func getMeta(s *pb.Span, k string) (string, bool) {
-	if s.Meta == nil {
-		return "", false
-	}
-	val, ok := s.Meta[k]
-	return val, ok
-}
-
 // getMetricDefault gets a value in the span Metrics map or default if no value is stored there.
 func getMetricDefault(s *pb.Span, k string, def float64) float64 {
 	if val, ok := getMetric(s, k); ok {

--- a/pkg/trace/sampler/signature.go
+++ b/pkg/trace/sampler/signature.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
 // Signature is a hash representation of trace or a service, used to identify
@@ -80,13 +81,13 @@ func computeSpanHash(span *pb.Span, env string, withResource bool) spanHash {
 	if withResource {
 		h.Write([]byte(span.Resource))
 	}
-	statusCode, ok := getMeta(span, KeyHTTPStatusCode)
+	code, ok := traceutil.GetMeta(span, KeyHTTPStatusCode)
 	if ok {
-		h.Write([]byte(statusCode))
+		h.Write([]byte(code))
 	}
-	errorType, ok := getMeta(span, KeyErrorType)
+	typ, ok := traceutil.GetMeta(span, KeyErrorType)
 	if ok {
-		h.Write([]byte(errorType))
+		h.Write([]byte(typ))
 	}
 	return spanHash(h.Sum32())
 }

--- a/pkg/trace/sampler/signature_test.go
+++ b/pkg/trace/sampler/signature_test.go
@@ -73,6 +73,32 @@ func TestSignatureDifferentRoot(t *testing.T) {
 	assert.NotEqual(testComputeSignature(t1), testComputeSignature(t2))
 }
 
+func TestSignatureDifferentStatusCode(t *testing.T) {
+	assert := assert.New(t)
+
+	t1 := pb.Trace{
+		&pb.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
+	}
+	t2 := pb.Trace{
+		&pb.Span{TraceID: 103, SpanID: 1031, Service: "x1", Name: "y1", Resource: "z1", Duration: 19207, Meta: map[string]string{KeyHTTPStatusCode: "200"}},
+	}
+
+	assert.NotEqual(testComputeSignature(t1), testComputeSignature(t2))
+}
+
+func TestSignatureDifferentErrorType(t *testing.T) {
+	assert := assert.New(t)
+
+	t1 := pb.Trace{
+		&pb.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
+	}
+	t2 := pb.Trace{
+		&pb.Span{TraceID: 103, SpanID: 1031, Service: "x1", Name: "y1", Resource: "z1", Duration: 19207, Meta: map[string]string{KeyErrorType: "error : nil"}},
+	}
+
+	assert.NotEqual(testComputeSignature(t1), testComputeSignature(t2))
+}
+
 func testComputeServiceSignature(trace pb.Trace) Signature {
 	root := traceutil.GetRoot(trace)
 	env := traceutil.GetEnv(trace)

--- a/pkg/trace/sampler/signature_test.go
+++ b/pkg/trace/sampler/signature_test.go
@@ -73,30 +73,28 @@ func TestSignatureDifferentRoot(t *testing.T) {
 	assert.NotEqual(testComputeSignature(t1), testComputeSignature(t2))
 }
 
-func TestSignatureDifferentStatusCode(t *testing.T) {
-	assert := assert.New(t)
-
-	t1 := pb.Trace{
-		&pb.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
+func TestSignatureDifference(t *testing.T) {
+	type testCase struct {
+		name string
+		meta map[string]string
 	}
-	t2 := pb.Trace{
-		&pb.Span{TraceID: 103, SpanID: 1031, Service: "x1", Name: "y1", Resource: "z1", Duration: 19207, Meta: map[string]string{KeyHTTPStatusCode: "200"}},
-	}
-
-	assert.NotEqual(testComputeSignature(t1), testComputeSignature(t2))
-}
-
-func TestSignatureDifferentErrorType(t *testing.T) {
-	assert := assert.New(t)
-
-	t1 := pb.Trace{
-		&pb.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
-	}
-	t2 := pb.Trace{
-		&pb.Span{TraceID: 103, SpanID: 1031, Service: "x1", Name: "y1", Resource: "z1", Duration: 19207, Meta: map[string]string{KeyErrorType: "error : nil"}},
+	testCases := []testCase{
+		{"status-code", map[string]string{KeyHTTPStatusCode: "200"}},
+		{"error-type", map[string]string{KeyErrorType: "error: nil"}},
 	}
 
-	assert.NotEqual(testComputeSignature(t1), testComputeSignature(t2))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			t1 := pb.Trace{
+				&pb.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
+			}
+			t2 := pb.Trace{
+				&pb.Span{TraceID: 103, SpanID: 1031, Service: "x1", Name: "y1", Resource: "z1", Duration: 19207, Meta: tc.meta},
+			}
+			assert.NotEqual(testComputeSignature(t1), testComputeSignature(t2))
+		})
+	}
 }
 
 func testComputeServiceSignature(trace pb.Trace) Signature {

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -53,3 +53,12 @@ func SetMeta(s *pb.Span, key, val string) {
 	}
 	s.Meta[key] = val
 }
+
+// GetMeta gets the metadata value in the span Meta map.
+func GetMeta(s *pb.Span, key string) (string, bool) {
+	if s.Meta == nil {
+		return "", false
+	}
+	val, ok := s.Meta[key]
+	return val, ok
+}


### PR DESCRIPTION
### What does this PR do?

Updating span signature computation to ensure that we sample traces for all different combinations of http status code and error type. This impacts only error sampler. 

### Motivation

Improve the quality of the signature sampling for errors by being more granular. This is something we can allow ourselves because the ring for errors tend to be small enough for the signature to be more granular (across all users, 95% of errors are sent to the backend).
