### PR TITLE
Collect network metadata if running docker in host mode

### DIFF
--- a/pkg/metadata/gohai/gohai.go
+++ b/pkg/metadata/gohai/gohai.go
@@ -55,8 +55,7 @@ func getGohaiInfo() *gohai {
 		log.Errorf("Failed to retrieve memory metadata: %s", err)
 	}
 
-	detectDocker0()
-	if !config.IsContainerized() || docker0Detected {
+	if !config.IsContainerized() || detectDocker0() {
 		networkPayload, err := new(network.Network).Collect()
 		if err == nil {
 			res.Network = networkPayload
@@ -75,11 +74,13 @@ func getGohaiInfo() *gohai {
 	return res
 }
 
-var docker0Detector = sync.Once{}
+var docker0Detector sync.Once
 
-func detectDocker0() {
+func detectDocker0() bool {
 	docker0Detector.Do(func() {
 		iface, _ := net.InterfaceByName("docker0")
 		docker0Detected = iface != nil
 	})
+
+	return docker0Detected
 }

--- a/pkg/metadata/gohai/gohai.go
+++ b/pkg/metadata/gohai/gohai.go
@@ -6,6 +6,9 @@
 package gohai
 
 import (
+	"net"
+	"sync"
+
 	"github.com/DataDog/gohai/cpu"
 	"github.com/DataDog/gohai/filesystem"
 	"github.com/DataDog/gohai/memory"
@@ -14,6 +17,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	// we can use this a hint that docker is running in host mode and it's safe to use detect
+	docker0Detected = false
 )
 
 // GetPayload builds a payload of every metadata collected with gohai except processes metadata.
@@ -47,7 +55,8 @@ func getGohaiInfo() *gohai {
 		log.Errorf("Failed to retrieve memory metadata: %s", err)
 	}
 
-	if !config.IsContainerized() {
+	detectDocker0()
+	if !config.IsContainerized() || docker0Detected {
 		networkPayload, err := new(network.Network).Collect()
 		if err == nil {
 			res.Network = networkPayload
@@ -64,4 +73,13 @@ func getGohaiInfo() *gohai {
 	}
 
 	return res
+}
+
+var docker0Detector = sync.Once{}
+
+func detectDocker0() {
+	docker0Detector.Do(func() {
+		iface, _ := net.InterfaceByName("docker0")
+		docker0Detected = iface != nil
+	})
 }

--- a/pkg/metadata/gohai/gohai_test.go
+++ b/pkg/metadata/gohai/gohai_test.go
@@ -26,6 +26,7 @@ func TestGetPayloadContainerized(t *testing.T) {
 	os.Setenv("DOCKER_DD_AGENT", "true")
 	defer os.Unsetenv("DOCKER_DD_AGENT")
 
+	detectDocker0()
 	oldDocker0Detected := docker0Detected
 	docker0Detected = false
 	defer func() { docker0Detected = oldDocker0Detected }()
@@ -43,6 +44,7 @@ func TestGetPayloadContainerizedWithDocker0(t *testing.T) {
 	os.Setenv("DOCKER_DD_AGENT", "true")
 	defer os.Unsetenv("DOCKER_DD_AGENT")
 
+	detectDocker0()
 	oldDocker0Detected := docker0Detected
 	docker0Detected = true
 	defer func() { docker0Detected = oldDocker0Detected }()

--- a/pkg/metadata/gohai/gohai_test.go
+++ b/pkg/metadata/gohai/gohai_test.go
@@ -26,11 +26,32 @@ func TestGetPayloadContainerized(t *testing.T) {
 	os.Setenv("DOCKER_DD_AGENT", "true")
 	defer os.Unsetenv("DOCKER_DD_AGENT")
 
+	oldDocker0Detected := docker0Detected
+	docker0Detected = false
+	defer func() { docker0Detected = oldDocker0Detected }()
+
 	gohai := GetPayload()
 
 	assert.NotNil(t, gohai.Gohai.CPU)
 	assert.NotNil(t, gohai.Gohai.FileSystem)
 	assert.NotNil(t, gohai.Gohai.Memory)
 	assert.Nil(t, gohai.Gohai.Network)
+	assert.NotNil(t, gohai.Gohai.Platform)
+}
+
+func TestGetPayloadContainerizedWithDocker0(t *testing.T) {
+	os.Setenv("DOCKER_DD_AGENT", "true")
+	defer os.Unsetenv("DOCKER_DD_AGENT")
+
+	oldDocker0Detected := docker0Detected
+	docker0Detected = true
+	defer func() { docker0Detected = oldDocker0Detected }()
+
+	gohai := GetPayload()
+
+	assert.NotNil(t, gohai.Gohai.CPU)
+	assert.NotNil(t, gohai.Gohai.FileSystem)
+	assert.NotNil(t, gohai.Gohai.Memory)
+	assert.NotNil(t, gohai.Gohai.Network)
 	assert.NotNil(t, gohai.Gohai.Platform)
 }

--- a/releasenotes/notes/docker-host-network-d12a266ca8e87f0e.yaml
+++ b/releasenotes/notes/docker-host-network-d12a266ca8e87f0e.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Network information is collected when the agent is running in docker (host mode only).


### PR DESCRIPTION
### What does this PR do?

gohai, which is responsible for detecting host metadata such as a host's IP address would skip collecting all network data if it detected that the agent was running in a container. This is generally correct, as a container gets a dedicated network namespace, which means functions like net.Interfaces() returns values that only make sense inside the container.


However, if we detect docker0, this generally means we're running the container in  host
mode, and we can get at useful network information. 

Getting at host IPs means network performance monitoring can resolve traffic destined for these hosts. 

### Motivation  

### Additional Notes

Anything else we should know when reviewing?
