### PR TITLE
Add system.io.r_await and system.io_w_await

### DIFF
--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -79,7 +79,10 @@ func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data, 
 		"Disk Writes/sec":           "system.io.w_s",
 		"Disk Read Bytes/sec":       "system.io.rkb_s",
 		"Disk Reads/sec":            "system.io.r_s",
-		"Current Disk Queue Length": "system.io.avg_q_sz"}
+		"Current Disk Queue Length": "system.io.avg_q_sz",
+		"Avg. Disk sec/Read":        "system.io.r_await",
+		"Avg. Disk sec/Write":       "system.io.w_await",
+	}
 
 	c.counters = make(map[string]*pdhutil.PdhMultiInstanceCounterSet)
 
@@ -117,6 +120,12 @@ func (c *IOCheck) Run() error {
 			if cname == "Disk Write Bytes/sec" || cname == "Disk Read Bytes/sec" {
 				val /= 1024
 			}
+			if cname == "Avg. Disk sec/Read" || cname == "Avg. Disk sec/Write" {
+				// r_await/w_await are in milliseconds, but the performance counter
+				// is (obviously) in seconds.  Normalize:
+				val *= 1000
+			}
+
 			sender.Gauge(c.counternames[cname], val, "", tags)
 		}
 	}

--- a/releasenotes/notes/addwindowsawait-4c37236e18c1da58.yaml
+++ b/releasenotes/notes/addwindowsawait-4c37236e18c1da58.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On Windows, now reports system.io.r_await and system.io.w_await.
+    Metrics are reported from the performance monitor "Avg. Disk sec/Read" and
+    "Avg. Disk sec/Write" metrics.


### PR DESCRIPTION
### What does this PR do?

As the title suggests.  Adds new metrics to match what's reported on other OSes

### Motivation

Customer request

