### PR TITLE
pkg/trace/writer: consume response and close body for trace http response

### DIFF
--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -314,7 +314,6 @@ func (s *sender) do(req *http.Request) error {
 		// should thus be retried.
 		return &retriableError{err}
 	}
-
 	// From https://golang.org/pkg/net/http/#Response:
 	// The default HTTP client's Transport may not reuse HTTP/1.x "keep-alive"
 	// TCP connections if the Body is not read to completion and closed.

--- a/releasenotes/notes/fix-kal-trace-agent-c0ed330fb13ebd87.yaml
+++ b/releasenotes/notes/fix-kal-trace-agent-c0ed330fb13ebd87.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve connection reuse with http keep-alive in
+    trace agent.

--- a/releasenotes/notes/fix-kal-trace-agent-c0ed330fb13ebd87.yaml
+++ b/releasenotes/notes/fix-kal-trace-agent-c0ed330fb13ebd87.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Improve connection reuse with http keep-alive in
+    APM: Improve connection reuse with HTTP keep-alive in
     trace agent.


### PR DESCRIPTION
### What does this PR do?

Read trace agent http response and close response body to allow connection reuse.

### Motivation

In golang, it is necessary to read the whole response to allow the connection to be reused. 
Currently, a dns resolution and a tls connection is made for each trace which create an important latency and CPU overhead.