### PR TITLE
Add retries to some jobs in case of unknown errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,15 @@ variables:
     variables:
       - $RELEASE_VERSION_7 == ""
 
+.retry-job: &retry-job
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+
 # Fail if we're running a pipeline on a non-triggered tag build
 # NOTE: All jobs with 'needs' dependencies should also 'need' this to workaround a Gitlab issue: https://gitlab.com/gitlab-org/gitlab/issues/31526
 fail_on_non_triggered_tag:
@@ -204,6 +213,7 @@ build_libbcc_x64:
     ARCH: amd64
 
 build_libbcc_arm64:
+  <<: *retry-job
   extends: .build_libbcc_common
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -406,6 +416,7 @@ build_dogstatsd-deb_x64:
 
 # build dogstatsd static for deb-arm
 build_dogstatsd_static-deb_arm64:
+  <<: *retry-job
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -425,6 +436,7 @@ build_dogstatsd_static-deb_arm64:
 
 # build dogstatsd linked for deb-arm
 build_dogstatsd-deb_arm64:
+  <<: *retry-job
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -457,6 +469,7 @@ build_puppy_agent-deb_x64:
 
 # build puppy agent for ARM, to make sure the build is not broken because of build targets
 build_puppy_agent-deb_arm64:
+  <<: *retry-job
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -493,6 +506,7 @@ cluster_agent-build_amd64:
     - inv -e deps --no-checks --verbose --dep-vendor-only
 
 cluster_agent-build_arm64:
+  <<: *retry-job
   <<: *cluster_agent-build_common
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -551,6 +565,7 @@ run_dogstatsd_size_test:
 
 # check the size of the static dogstatsd binary
 run_dogstatsd_arm_size_test:
+  <<: *retry-job
   stage: integration_test
   needs: ["fail_on_non_triggered_tag", "build_dogstatsd_static-deb_arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
@@ -592,6 +607,7 @@ build_system-probe-x64:
     ARCH: amd64
 
 build_system-probe-arm64:
+  <<: *retry-job
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   needs: ["fail_on_non_triggered_tag", "build_libbcc_arm64", "run_dep_check_lock"]
@@ -688,6 +704,7 @@ agent_deb-arm-a6:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
   <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_deb
+  <<: *retry-job
 
 agent_deb-arm-a7:
   stage: package_build
@@ -706,6 +723,7 @@ agent_deb-arm-a7:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
   <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_deb
+  <<: *retry-job
 
 # build Agent package for deb-x64
 puppy_deb-x64:
@@ -813,7 +831,7 @@ agent_rpm-x64-a7:
   <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_rpm
 
-  # build Agent package for rpm-arm64
+# build Agent package for rpm-arm64
 agent_rpm-arm-a6:
   stage: package_build
   needs: ["fail_on_non_triggered_tag", "run_dep_check_lock", "build_system-probe-arm64"]
@@ -829,6 +847,7 @@ agent_rpm-arm-a6:
     - export RELEASE_VERSION=$RELEASE_VERSION_6
   <<: *skip_when_unwanted_on_6
   <<: *agent_build_common_rpm
+  <<: *retry-job
 
 # build Agent package for rpm-arm64
 agent_rpm-arm-a7:
@@ -846,6 +865,7 @@ agent_rpm-arm-a7:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
   <<: *skip_when_unwanted_on_7
   <<: *agent_build_common_rpm
+  <<: *retry-job
 
 
 .agent_build_common_suse_rpm: &agent_build_common_suse_rpm
@@ -2018,6 +2038,7 @@ build_agent6_arm64:
   extends: .docker_build_job_definition_arm64
   needs: ["fail_on_non_triggered_tag", "agent_deb-arm-a6"]
   <<: *skip_when_unwanted_on_6
+  <<: *retry-job
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -2045,6 +2066,7 @@ build_agent6_jmx_arm64:
   extends: .docker_build_job_definition_arm64
   needs: ["fail_on_non_triggered_tag", "agent_deb-arm-a6"]
   <<: *skip_when_unwanted_on_6
+  <<: *retry-job
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -2085,6 +2107,7 @@ build_agent7_arm64:
   extends: .docker_build_job_definition_arm64
   needs: ["fail_on_non_triggered_tag", "agent_deb-arm-a7"]
   <<: *skip_when_unwanted_on_7
+  <<: *retry-job
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -2110,6 +2133,7 @@ build_agent7_jmx_arm64:
   extends: .docker_build_job_definition_arm64
   needs: ["fail_on_non_triggered_tag", "agent_deb-arm-a7"]
   <<: *skip_when_unwanted_on_7
+  <<: *retry-job
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -2208,6 +2232,7 @@ build_cluster_agent_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
   needs: ["fail_on_non_triggered_tag", "cluster_agent-build_arm64"]
+  <<: *retry-job
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent


### PR DESCRIPTION
### What does this PR do?

It adds retries to ARM jobs if the runner has a system failure, that the job is stuck or that we meet an unknown failure or a Gitlab API failure.

### Motivation

Make the pipeline more reliable and stable. Our version of Gitlab does not support default retries, so I just set up the retries on ARM jobs for now and will make it default when we upgrade Gitlab.