### PR TITLE
Implement `kube_namespace:` prefix in `ac_include` and `ac_exclude`

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -218,7 +218,7 @@ func (l *DockerListener) createService(cID string) {
 			log.Warnf("error while resolving image name: %s", err)
 			image = ""
 		}
-		if l.filter.IsExcluded(cInspect.Name, image) {
+		if l.filter.IsExcluded(cInspect.Name, image, "") {
 			log.Debugf("container %s filtered out: name %q image %q", cID[:12], cInspect.Name, image)
 			return
 		}
@@ -370,7 +370,7 @@ func (l *DockerListener) isExcluded(co types.Container) bool {
 		image = ""
 	}
 	for _, name := range co.Names {
-		if l.filter.IsExcluded(name, image) {
+		if l.filter.IsExcluded(name, image, "") {
 			log.Debugf("container %s filtered out: name %q image %q", co.ID[:12], name, image)
 			return true
 		}

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -128,7 +128,7 @@ func (l *ECSListener) refreshServices(firstRun bool) {
 			log.Debugf("container %s is in status %s - skipping", c.DockerID, c.KnownStatus)
 			continue
 		}
-		if l.filter.IsExcluded(c.DockerName, c.Image) {
+		if l.filter.IsExcluded(c.DockerName, c.Image, "") {
 			log.Debugf("container %s filtered out: name %q image %q", c.DockerID[:12], c.DockerName, c.Image)
 			continue
 		}

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -217,8 +217,8 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 	var containerName string
 	for _, container := range pod.Status.GetAllContainers() {
 		if container.ID == svc.entity {
-			if l.filter.IsExcluded(container.Name, container.Image) {
-				log.Debugf("container %s filtered out: name %q image %q", container.ID, container.Name, container.Image)
+			if l.filter.IsExcluded(container.Name, container.Image, pod.Metadata.Namespace) {
+				log.Debugf("container %s filtered out: name %q image %q namespace %q", container.ID, container.Name, container.Image, pod.Metadata.Namespace)
 				return
 			}
 			containerName = container.Name

--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -139,7 +139,7 @@ func computeEvents(events []containerdEvent, sender aggregator.Sender, fil *ddCo
 			continue
 		}
 		if split[1] == "images" {
-			if fil.IsExcluded("", e.ID) {
+			if fil.IsExcluded("", e.ID, "") {
 				continue
 			}
 		}
@@ -256,7 +256,7 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 
 func isExcluded(ctn containers.Container, fil *ddContainers.Filter) bool {
 	// The container name is not available in Containerd, we only rely on image name based exclusion
-	return fil.IsExcluded("", ctn.Image)
+	return fil.IsExcluded("", ctn.Image, "")
 }
 
 func convertTasktoMetrics(metricTask *containerdTypes.Metric) (*cgroups.Metrics, error) {

--- a/pkg/collector/python/containers.go
+++ b/pkg/collector/python/containers.go
@@ -23,10 +23,10 @@ import "C"
 var filter *containers.Filter
 
 // IsContainerExcluded returns whether a container should be excluded,
-// based on it's name and image name. Exclusion patterns are configured
+// based on it's name, image name and namespace. Exclusion patterns are configured
 // via the global options (ac_include/ac_exclude/exclude_pause_container)
 //export IsContainerExcluded
-func IsContainerExcluded(name, image *C.char) C.int {
+func IsContainerExcluded(name, image, namespace *C.char) C.int {
 	// If init failed, fallback to False
 	if filter == nil {
 		return 0
@@ -34,8 +34,12 @@ func IsContainerExcluded(name, image *C.char) C.int {
 
 	goName := C.GoString(name)
 	goImg := C.GoString(image)
+	goNs := ""
+	if namespace != nil {
+		goNs = C.GoString(namespace)
+	}
 
-	if filter.IsExcluded(goName, goImg) {
+	if filter.IsExcluded(goName, goImg, goNs) {
 		return 1
 	}
 	return 0

--- a/pkg/collector/python/containers_test.go
+++ b/pkg/collector/python/containers_test.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build python,test
+
+package python
+
+import "testing"
+
+func TestIsContainerExcluded(t *testing.T) {
+	testIsContainerExcluded(t)
+}

--- a/pkg/collector/python/test_containers.go
+++ b/pkg/collector/python/test_containers.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build python,test
+
+package python
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/stretchr/testify/assert"
+)
+
+import "C"
+
+func testIsContainerExcluded(t *testing.T) {
+	filter = &containers.Filter{
+		Enabled: true,
+	}
+	defer func() { filter = nil }()
+
+	r, err := regexp.Compile("bar")
+	assert.Nil(t, err)
+	filter.ImageBlacklist = append(filter.ImageBlacklist, r)
+
+	r, err = regexp.Compile("white")
+	assert.Nil(t, err)
+	filter.NamespaceWhitelist = append(filter.NamespaceWhitelist, r)
+
+	r, err = regexp.Compile("black")
+	assert.Nil(t, err)
+	filter.NamespaceBlacklist = append(filter.NamespaceBlacklist, r)
+
+	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("bar"), C.CString("ns")), C.int(1))
+	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("bar"), C.CString("white")), C.int(0))
+	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("baz"), C.CString("black")), C.int(1))
+	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("baz"), nil), C.int(0))
+}

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -32,35 +32,44 @@ const (
 
 // Filter holds the state for the container filtering logic
 type Filter struct {
-	Enabled        bool
-	ImageWhitelist []*regexp.Regexp
-	NameWhitelist  []*regexp.Regexp
-	ImageBlacklist []*regexp.Regexp
-	NameBlacklist  []*regexp.Regexp
+	Enabled            bool
+	ImageWhitelist     []*regexp.Regexp
+	NameWhitelist      []*regexp.Regexp
+	NamespaceWhitelist []*regexp.Regexp
+	ImageBlacklist     []*regexp.Regexp
+	NameBlacklist      []*regexp.Regexp
+	NamespaceBlacklist []*regexp.Regexp
 }
 
 var sharedFilter *Filter
 
-func parseFilters(filters []string) (imageFilters, nameFilters []*regexp.Regexp, err error) {
+func parseFilters(filters []string) (imageFilters, nameFilters, namespaceFilters []*regexp.Regexp, err error) {
 	for _, filter := range filters {
 		switch {
 		case strings.HasPrefix(filter, "image:"):
 			pat := strings.TrimPrefix(filter, "image:")
 			r, err := regexp.Compile(strings.TrimPrefix(pat, "image:"))
 			if err != nil {
-				return nil, nil, fmt.Errorf("invalid regex '%s': %s", pat, err)
+				return nil, nil, nil, fmt.Errorf("invalid regex '%s': %s", pat, err)
 			}
 			imageFilters = append(imageFilters, r)
 		case strings.HasPrefix(filter, "name:"):
 			pat := strings.TrimPrefix(filter, "name:")
 			r, err := regexp.Compile(pat)
 			if err != nil {
-				return nil, nil, fmt.Errorf("invalid regex '%s': %s", pat, err)
+				return nil, nil, nil, fmt.Errorf("invalid regex '%s': %s", pat, err)
 			}
 			nameFilters = append(nameFilters, r)
+		case strings.HasPrefix(filter, "kube_namespace:"):
+			pat := strings.TrimPrefix(filter, "kube_namespace:")
+			r, err := regexp.Compile(pat)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("invalid regex '%s': %s", pat, err)
+			}
+			namespaceFilters = append(namespaceFilters, r)
 		}
 	}
-	return imageFilters, nameFilters, nil
+	return imageFilters, nameFilters, namespaceFilters, nil
 }
 
 // GetSharedFilter allows to share the result of NewFilterFromConfig
@@ -88,21 +97,23 @@ func ResetSharedFilter() {
 // the following format: "field:pattern" where field can be: [image, name].
 // An error is returned if any of the expression don't compile.
 func NewFilter(whitelist, blacklist []string) (*Filter, error) {
-	iwl, nwl, err := parseFilters(whitelist)
+	iwl, nwl, nswl, err := parseFilters(whitelist)
 	if err != nil {
 		return nil, err
 	}
-	ibl, nbl, err := parseFilters(blacklist)
+	ibl, nbl, nsbl, err := parseFilters(blacklist)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Filter{
-		Enabled:        len(whitelist) > 0 || len(blacklist) > 0,
-		ImageWhitelist: iwl,
-		NameWhitelist:  nwl,
-		ImageBlacklist: ibl,
-		NameBlacklist:  nbl,
+		Enabled:            len(whitelist) > 0 || len(blacklist) > 0,
+		ImageWhitelist:     iwl,
+		NameWhitelist:      nwl,
+		NamespaceWhitelist: nswl,
+		ImageBlacklist:     ibl,
+		NameBlacklist:      nbl,
+		NamespaceBlacklist: nsbl,
 	}, nil
 }
 
@@ -137,7 +148,7 @@ func NewFilterFromConfigIncludePause() (*Filter, error) {
 
 // IsExcluded returns a bool indicating if the container should be excluded
 // based on the filters in the containerFilter instance.
-func (cf Filter) IsExcluded(containerName, containerImage string) bool {
+func (cf Filter) IsExcluded(containerName, containerImage, podNamespace string) bool {
 	if !cf.Enabled {
 		return false
 	}
@@ -153,6 +164,11 @@ func (cf Filter) IsExcluded(containerName, containerImage string) bool {
 			return false
 		}
 	}
+	for _, r := range cf.NamespaceWhitelist {
+		if r.MatchString(podNamespace) {
+			return false
+		}
+	}
 
 	// Check if blacklisted
 	for _, r := range cf.ImageBlacklist {
@@ -165,5 +181,11 @@ func (cf Filter) IsExcluded(containerName, containerImage string) bool {
 			return true
 		}
 	}
+	for _, r := range cf.NamespaceBlacklist {
+		if r.MatchString(podNamespace) {
+			return true
+		}
+	}
+
 	return false
 }

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -15,71 +15,129 @@ import (
 )
 
 func TestFilter(t *testing.T) {
-	containers := []*Container{
+	containers := []struct {
+		c  Container
+		ns string
+	}{
 		{
-			ID:    "1",
-			Name:  "secret-container-dd",
-			Image: "docker-dd-agent",
+			c: Container{
+				ID:    "1",
+				Name:  "secret-container-dd",
+				Image: "docker-dd-agent",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "2",
-			Name:  "webapp1-dd",
-			Image: "apache:2.2",
+			c: Container{
+				ID:    "2",
+				Name:  "webapp1-dd",
+				Image: "apache:2.2",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "3",
-			Name:  "mysql-dd",
-			Image: "mysql:5.3",
+			c: Container{
+				ID:    "3",
+				Name:  "mysql-dd",
+				Image: "mysql:5.3",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "4",
-			Name:  "linux-dd",
-			Image: "alpine:latest",
+			c: Container{
+				ID:    "4",
+				Name:  "linux-dd",
+				Image: "alpine:latest",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "5",
-			Name:  "k8s_superpause_kube-apiserver-mega-node_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
-			Image: "gcr.io/random-project/superpause:1.0",
+			c: Container{
+				ID:    "5",
+				Name:  "k8s_superpause_kube-apiserver-mega-node_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+				Image: "gcr.io/random-project/superpause:1.0",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "6",
-			Name:  "k8s_superpause_kube-apiserver-mega-node_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
-			Image: "gcr.io/random-project/pause:1.0",
+			c: Container{
+				ID:    "6",
+				Name:  "k8s_superpause_kube-apiserver-mega-node_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+				Image: "gcr.io/random-project/pause:1.0",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "7",
-			Name:  "k8s_POD.f8120f_kube-proxy-gke-pool-1-2890-pv0",
-			Image: "gcr.io/google_containers/pause-amd64:3.0",
+			c: Container{
+				ID:    "7",
+				Name:  "k8s_POD.f8120f_kube-proxy-gke-pool-1-2890-pv0",
+				Image: "gcr.io/google_containers/pause-amd64:3.0",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "8",
-			Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
-			Image: "k8s.gcr.io/pause-amd64:3.1",
+			c: Container{
+				ID:    "8",
+				Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+				Image: "k8s.gcr.io/pause-amd64:3.1",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "9",
-			Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
-			Image: "kubernetes/pause:latest",
+			c: Container{
+				ID:    "9",
+				Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+				Image: "kubernetes/pause:latest",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "10",
-			Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
-			Image: "asia.gcr.io/google_containers/pause-amd64:3.0",
+			c: Container{
+				ID:    "10",
+				Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+				Image: "asia.gcr.io/google_containers/pause-amd64:3.0",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "11",
-			Name:  "k8s_POD_AZURE_pause",
-			Image: "k8s-gcrio.azureedge.net/pause-amd64:3.0",
+			c: Container{
+				ID:    "11",
+				Name:  "k8s_POD_AZURE_pause",
+				Image: "k8s-gcrio.azureedge.net/pause-amd64:3.0",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "12",
-			Name:  "k8s_POD_AZURE_pause",
-			Image: "gcrio.azureedge.net/google_containers/pause-amd64",
+			c: Container{
+				ID:    "12",
+				Name:  "k8s_POD_AZURE_pause",
+				Image: "gcrio.azureedge.net/google_containers/pause-amd64",
+			},
+			ns: "default",
 		},
 		{
-			ID:    "13",
-			Name:  "k8s_POD_rancher_pause",
-			Image: "rancher/pause-amd64:3.0",
+			c: Container{
+				ID:    "13",
+				Name:  "k8s_POD_rancher_pause",
+				Image: "rancher/pause-amd64:3.0",
+			},
+			ns: "default",
+		},
+		{
+			c: Container{
+				ID:    "14",
+				Name:  "foo-dd",
+				Image: "foo:1.0",
+			},
+			ns: "foo",
+		},
+		{
+			c: Container{
+				ID:    "15",
+				Name:  "bar-dd",
+				Image: "bar:1.0",
+			},
+			ns: "bar",
 		},
 	}
 
@@ -89,25 +147,34 @@ func TestFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"},
 		},
 		{
 			blacklist:   []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"},
+			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"},
 		},
 		{
 			blacklist:   []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"},
 		},
 		{
 			whitelist:   []string{},
 			blacklist:   []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13"},
+			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"},
 		},
 		{
 			whitelist:   []string{"name:mysql"},
 			blacklist:   []string{"name:dd"},
 			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13"},
+		},
+		{
+			blacklist:   []string{"kube_namespace:.*"},
+			whitelist:   []string{"kube_namespace:foo"},
+			expectedIDs: []string{"14"},
+		},
+		{
+			blacklist:   []string{"kube_namespace:bar"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"},
 		},
 		// Test kubernetes defaults
 		{
@@ -118,7 +185,7 @@ func TestFilter(t *testing.T) {
 				pauseContainerAzure,
 				pauseContainerRancher,
 			},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "14", "15"},
 		},
 	} {
 		t.Run("", func(t *testing.T) {
@@ -127,8 +194,8 @@ func TestFilter(t *testing.T) {
 
 			var allowed []string
 			for _, c := range containers {
-				if !f.IsExcluded(c.Name, c.Image) {
-					allowed = append(allowed, c.ID)
+				if !f.IsExcluded(c.c.Name, c.c.Image, c.ns) {
+					allowed = append(allowed, c.c.ID)
 				}
 			}
 			assert.Equal(t, tc.expectedIDs, allowed, "case %d", i)
@@ -144,16 +211,16 @@ func TestNewFilterFromConfig(t *testing.T) {
 	f, err := NewFilterFromConfig()
 	require.NoError(t, err)
 
-	assert.True(t, f.IsExcluded("dd-152462", "dummy:latest"))
-	assert.False(t, f.IsExcluded("dd-152462", "apache:latest"))
-	assert.False(t, f.IsExcluded("dummy", "dummy"))
-	assert.True(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1"))
-	assert.True(t, f.IsExcluded("dummy", "rancher/pause-amd64:3.1"))
+	assert.True(t, f.IsExcluded("dd-152462", "dummy:latest", ""))
+	assert.False(t, f.IsExcluded("dd-152462", "apache:latest", ""))
+	assert.False(t, f.IsExcluded("dummy", "dummy", ""))
+	assert.True(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1", ""))
+	assert.True(t, f.IsExcluded("dummy", "rancher/pause-amd64:3.1", ""))
 
 	config.Datadog.SetDefault("exclude_pause_container", false)
 	f, err = NewFilterFromConfig()
 	require.NoError(t, err)
-	assert.False(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1"))
+	assert.False(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1", ""))
 
 	config.Datadog.SetDefault("exclude_pause_container", true)
 	config.Datadog.SetDefault("ac_include", []string{})
@@ -168,11 +235,11 @@ func TestNewFilterFromConfigIncludePause(t *testing.T) {
 	f, err := NewFilterFromConfigIncludePause()
 	require.NoError(t, err)
 
-	assert.True(t, f.IsExcluded("dd-152462", "dummy:latest"))
-	assert.False(t, f.IsExcluded("dd-152462", "apache:latest"))
-	assert.False(t, f.IsExcluded("dummy", "dummy"))
-	assert.False(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1"))
-	assert.False(t, f.IsExcluded("dummy", "rancher/pause-amd64:3.1"))
+	assert.True(t, f.IsExcluded("dd-152462", "dummy:latest", ""))
+	assert.False(t, f.IsExcluded("dd-152462", "apache:latest", ""))
+	assert.False(t, f.IsExcluded("dummy", "dummy", ""))
+	assert.False(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1", ""))
+	assert.False(t, f.IsExcluded("dummy", "rancher/pause-amd64:3.1", ""))
 
 	config.Datadog.SetDefault("exclude_pause_container", true)
 	config.Datadog.SetDefault("ac_include", []string{})

--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -219,7 +219,7 @@ func (d *DockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*containers.C
 			log.Warnf("Can't resolve image name %s: %s", c.Image, err)
 		}
 
-		excluded := d.cfg.filter.IsExcluded(c.Names[0], image)
+		excluded := d.cfg.filter.IsExcluded(c.Names[0], image, "")
 		if excluded && !cfg.FlagExcluded {
 			continue
 		}

--- a/pkg/util/docker/event_pull.go
+++ b/pkg/util/docker/event_pull.go
@@ -68,7 +68,7 @@ func (d *DockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent,
 			log.Warnf("can't resolve image name %s: %s", imageName, err)
 		}
 	}
-	if d.cfg.filter.IsExcluded(containerName, imageName) {
+	if d.cfg.filter.IsExcluded(containerName, imageName, "") {
 		log.Tracef("events from %s are skipped as the image is excluded for the event collection", containerName)
 		return nil, nil
 	}

--- a/pkg/util/kubernetes/kubelet/containers.go
+++ b/pkg/util/kubernetes/kubelet/containers.go
@@ -34,7 +34,7 @@ func (ku *KubeUtil) ListContainers() ([]*containers.Container, error) {
 
 	for _, pod := range pods {
 		for _, c := range pod.Status.GetAllContainers() {
-			if ku.filter.IsExcluded(c.Name, c.Image) {
+			if ku.filter.IsExcluded(c.Name, c.Image, pod.Metadata.Namespace) {
 				continue
 			}
 			container, err := parseContainerInPod(c, pod)

--- a/releasenotes/notes/namespace_include_exclude-52ef2afcf7b7bdb2.yaml
+++ b/releasenotes/notes/namespace_include_exclude-52ef2afcf7b7bdb2.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The ``AD_INCLUDE`` and ``AD_EXCLUDE`` auto-discovery parameters have learnt the ``kube_namespace:`` prefix to collect or discard logs and metrics for whole namespaces in addition to the ``name:`` and ``image:`` prefixes to filter on container name and image name.

--- a/releasenotes/notes/namespace_include_exclude-52ef2afcf7b7bdb2.yaml
+++ b/releasenotes/notes/namespace_include_exclude-52ef2afcf7b7bdb2.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    The ``AD_INCLUDE`` and ``AD_EXCLUDE`` auto-discovery parameters have learnt the ``kube_namespace:`` prefix to collect or discard logs and metrics for whole namespaces in addition to the ``name:`` and ``image:`` prefixes to filter on container name and image name.
+    The ``ac_include`` and ``ac_exclude`` auto-discovery parameters now support the ``kube_namespace:`` prefix to collect or discard logs and metrics for whole namespaces in addition to the ``name:`` and ``image:`` prefixes to filter on container name and image name.

--- a/rtloader/common/builtins/containers.c
+++ b/rtloader/common/builtins/containers.c
@@ -45,7 +45,7 @@ void _set_is_excluded_cb(cb_is_excluded_t cb)
     collection or not.
     \param self A PyObject* pointer to the containers module.
     \param args A PyObject* pointer to the python args, typically expected to
-    contain the container and images names as strings.
+    contain the container name, the image name and an optional namespace as strings.
     \return a PyObject * pointer, typically a boolean reflecting if the container
     should be excluded and None, if the callback has not been defined.
 
@@ -62,11 +62,12 @@ PyObject *is_excluded(PyObject *self, PyObject *args)
 
     char *name;
     char *image;
-    if (!PyArg_ParseTuple(args, "ss", &name, &image)) {
+    char *namespace = NULL;
+    if (!PyArg_ParseTuple(args, "ss|s", &name, &image, &namespace)) {
         return NULL;
     }
 
-    int result = cb_is_excluded(name, image);
+    int result = cb_is_excluded(name, image, namespace);
 
     if (result > 0) {
         Py_RETURN_TRUE;

--- a/rtloader/common/builtins/containers.c
+++ b/rtloader/common/builtins/containers.c
@@ -14,7 +14,7 @@ static PyObject *is_excluded(PyObject *self, PyObject *args);
 
 static PyMethodDef methods[] = {
     { "is_excluded", (PyCFunction)is_excluded, METH_VARARGS,
-      "Returns whether a container is excluded per name and image." },
+      "Returns whether a container is excluded per name, image and namespace." },
     { NULL, NULL } // guards
 };
 

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -149,8 +149,8 @@ typedef void (*cb_get_connection_info_t)(char **);
 
 // containers
 //
-// (container_name, image_name, bool_result)
-typedef int (*cb_is_excluded_t)(char *, char *);
+// (container_name, image_name, namespace, bool_result)
+typedef int (*cb_is_excluded_t)(char *, char *, char *);
 
 #ifdef __cplusplus
 }

--- a/rtloader/test/containers/containers.go
+++ b/rtloader/test/containers/containers.go
@@ -16,7 +16,7 @@ import (
 #include "rtloader_mem.h"
 #include "datadog_agent_rtloader.h"
 
-extern int is_excluded(char *, char*);
+extern int is_excluded(char *, char *, char *);
 
 static void initContainersTests(rtloader_t *rtloader) {
    set_is_excluded_cb(rtloader, is_excluded);
@@ -96,7 +96,7 @@ except Exception as e:
 }
 
 //export is_excluded
-func is_excluded(name *C.char, image *C.char) C.int {
+func is_excluded(name *C.char, image *C.char, namespace *C.char) C.int {
 	if C.GoString(name) == "foo" {
 		return 1
 	}

--- a/rtloader/test/containers/containers_test.go
+++ b/rtloader/test/containers/containers_test.go
@@ -26,8 +26,8 @@ func TestIsExcluded(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		f.write("{},{}".format(
-			containers.is_excluded('foo', 'bar'),
-			containers.is_excluded('baz', 'bar'),
+			containers.is_excluded('foo', 'bar', 'ns'),
+			containers.is_excluded('baz', 'bar', 'ns'),
 		))
 	`, tmpfile.Name())
 	out, err := run(code)
@@ -49,7 +49,7 @@ func TestIsExcludedErrorTypeName(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		f.write("{},{}".format(
-			containers.is_excluded(123, 'bar'),
+			containers.is_excluded(123, 'bar', 'ns'),
 		))
 	`, tmpfile.Name())
 	out, err := run(code)
@@ -72,7 +72,7 @@ func TestIsExcludedErrorTypeImage(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
 		f.write("{},{}".format(
-			containers.is_excluded('foo', 123),
+			containers.is_excluded('foo', 123, 'ns'),
 		))
 	`, tmpfile.Name())
 	out, err := run(code)


### PR DESCRIPTION
### What does this PR do?

Implement `kube_namespace:` prefix in `ac_include` and `ac_exclude`

### Motivation

`ac_include` and `ac_exclude` can be used to collect logs and metrics based on container name and image name.
However, some customers want to be able to discard a whole namespace.