### PR TITLE
Add option to generate flare locally

### DIFF
--- a/releasenotes/notes/fix-flare-cmd-heml-f9d16e7f80ff9a36.yaml
+++ b/releasenotes/notes/fix-flare-cmd-heml-f9d16e7f80ff9a36.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix the `flare` command not being able to be created for the non-core agents (trace,
+    network, ...) when running in a separated container, such as in Helm. A new
+    option, `--local`, has been added to the `flare` command to force the
+    creation of the archive using the local filesystem and not the one where
+    the core agent process is in.


### PR DESCRIPTION
### What does this PR do?

In a containerized environment such as helm each datadog agent runs in a
separate container (trace, process, ...). They share the same network
with the core agent but not the same filesystem. This means it's
impossible to generate flare for the local container (the flare will be
created in the core agent container instead).

This PR add an option to force the CLI to create the archive instead.
