### PR TITLE
Fix systemd tests on master

### DIFF
--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -722,6 +722,7 @@ substate_status_mapping:
 	stats.On("GetUnitTypeProperties", mock.Anything, "unit2.service", dbusTypeMap[typeUnit]).Return(map[string]interface{}{
 		"ActiveEnterTimestamp": uint64(200),
 	}, nil)
+	stats.On("GetVersion", mock.Anything).Return(systemdVersion)
 
 	check := SystemdCheck{stats: stats}
 	check.Configure(rawInstanceConfig, nil, "test")


### PR DESCRIPTION
Merging this PR: https://github.com/DataDog/datadog-agent/pull/5053 broke the master build despite the fact that all tests were looking good on the branch.

That branch was not totally up to date and apparently the gitlab pipeline runs tests on the branch directly and not on the master + merge.

This small PR fixes that failing tests.