### PR TITLE
pkg/trace/sampler: catch rare non p1 trace chunks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2318,6 +2318,7 @@
     "golang.org/x/sys/windows/svc/eventlog",
     "golang.org/x/sys/windows/svc/mgr",
     "golang.org/x/text/unicode/norm",
+    "golang.org/x/time/rate",
     "google.golang.org/grpc",
     "gopkg.in/yaml.v2",
     "gopkg.in/zorkian/go-datadog-api.v2",

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -92,7 +92,6 @@ func (a *Agent) Run() {
 		a.Receiver,
 		a.Concentrator,
 		a.ScoreSampler,
-		a.ExceptionSampler,
 		a.ErrorsScoreSampler,
 		a.PrioritySampler,
 		a.EventProcessor,

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -38,6 +38,7 @@ type Agent struct {
 	Replacer           *filters.Replacer
 	ScoreSampler       *Sampler
 	ErrorsScoreSampler *Sampler
+	ExceptionSampler   *sampler.ExceptionSampler
 	PrioritySampler    *Sampler
 	EventProcessor     *event.Processor
 	TraceWriter        *writer.TraceWriter
@@ -71,6 +72,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 		Blacklister:        filters.NewBlacklister(conf.Ignore["resource"]),
 		Replacer:           filters.NewReplacer(conf.ReplaceTags),
 		ScoreSampler:       NewScoreSampler(conf),
+		ExceptionSampler:   sampler.NewExceptionSampler(),
 		ErrorsScoreSampler: NewErrorsSampler(conf),
 		PrioritySampler:    NewPrioritySampler(conf, dynConf),
 		EventProcessor:     newEventProcessor(conf),
@@ -90,6 +92,7 @@ func (a *Agent) Run() {
 		a.Receiver,
 		a.Concentrator,
 		a.ScoreSampler,
+		a.ExceptionSampler,
 		a.ErrorsScoreSampler,
 		a.PrioritySampler,
 		a.EventProcessor,
@@ -132,6 +135,7 @@ func (a *Agent) loop() {
 			a.TraceWriter.Stop()
 			a.StatsWriter.Stop()
 			a.ScoreSampler.Stop()
+			a.ExceptionSampler.Stop()
 			a.ErrorsScoreSampler.Stop()
 			a.PrioritySampler.Stop()
 			a.EventProcessor.Stop()

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -273,7 +273,7 @@ func (a *Agent) runSamplers(pt ProcessedTrace) (bool, float64) {
 }
 
 // samplePriorityTrace samples traces with priority set on them. PrioritySampler and
-// ErrorSampler are run in parallel. The ExceptionSampler catches traces with rate top-level
+// ErrorSampler are run in parallel. The ExceptionSampler catches traces with rare top-level
 // or measured spans that are not caught by PrioritySampler and ErrorSampler.
 func (a *Agent) samplePriorityTrace(pt ProcessedTrace) (sampled bool, rate float64) {
 	sampledPriority, ratePriority := a.PrioritySampler.Add(pt)

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -233,16 +233,9 @@ func TestSampling(t *testing.T) {
 		wantRate    float64
 		wantSampled bool
 	}{
-		"score and priority rate": {
-			hasPriority:  true,
-			scoreRate:    0.5,
-			priorityRate: 0.6,
-			wantRate:     sampler.CombineRates(0.5, 0.6),
-		},
 		"score only rate": {
-			scoreRate:    0.5,
-			priorityRate: 0.1,
-			wantRate:     0.5,
+			scoreRate: 0.5,
+			wantRate:  0.5,
 		},
 		"error and priority rate": {
 			hasErrors:      true,
@@ -259,15 +252,14 @@ func TestSampling(t *testing.T) {
 			scoreSampled: true,
 			wantSampled:  true,
 		},
-		"score sampled priority not sampled": {
+		"priority not sampled": {
 			hasPriority:     true,
 			scoreSampled:    true,
 			prioritySampled: false,
-			wantSampled:     true,
+			wantSampled:     false,
 		},
-		"score not sampled priority sampled": {
+		"priority sampled": {
 			hasPriority:     true,
-			scoreSampled:    false,
 			prioritySampled: true,
 			wantSampled:     true,
 		},

--- a/pkg/trace/sampler/exception_sampler.go
+++ b/pkg/trace/sampler/exception_sampler.go
@@ -1,0 +1,189 @@
+package sampler
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+	"golang.org/x/time/rate"
+)
+
+const (
+	cardinalityLimit      = 1000
+	defaultTTL            = 2 * time.Minute
+	priorityTTL           = 10 * time.Minute
+	ttlRenewalPeriod      = 1 * time.Minute
+	exceptionSamplerTPS   = 5
+	exceptionSamplerBurst = 50
+)
+
+// ExceptionSampler samples traces that are not caught by the Priority sampler.
+// It ensures that we sample traces for each combination of
+// (env, service, name, resource, error type, http status) seen on a measured span.
+// The resulting sampled traces will likely be incomplete.
+type ExceptionSampler struct {
+	mu           sync.RWMutex
+	limiter      *rate.Limiter
+	spanSeenSets map[Signature]*spanSeenSet
+
+	tickStats *time.Ticker
+	hits      int64
+	misses    int64
+}
+
+// NewExceptionSampler returns a NewExceptionSampler that samples rare traces
+// not caught by Priority sampler.
+func NewExceptionSampler() *ExceptionSampler {
+	return &ExceptionSampler{
+		limiter:      rate.NewLimiter(exceptionSamplerTPS, exceptionSamplerBurst),
+		spanSeenSets: make(map[Signature]*spanSeenSet),
+		tickStats:    time.NewTicker(10 * time.Second),
+	}
+}
+
+// Add samples a trace and returns true if trace was sampled (should be kept)
+func (e *ExceptionSampler) Add(now time.Time, env string, root *pb.Span, t pb.Trace) (sampled bool) {
+	if priority, ok := GetSamplingPriority(root); priority > 0 && ok {
+		e.handlePriorityTrace(now, env, t)
+		return false
+	}
+	return e.handleTrace(now, env, t)
+}
+
+// Start starts reporting stats
+func (e *ExceptionSampler) Start() {
+	go func() {
+		for _ = range e.tickStats.C {
+			e.report()
+		}
+	}()
+}
+
+// Stop stops reporting stats
+func (e *ExceptionSampler) Stop() {
+	e.tickStats.Stop()
+}
+
+func (e *ExceptionSampler) handlePriorityTrace(now time.Time, env string, t pb.Trace) {
+	expire := now.Add(priorityTTL)
+	for _, s := range t {
+		if !traceutil.HasTopLevel(s) && !traceutil.IsMeasured(s) {
+			continue
+		}
+		e.addSpan(expire, env, s)
+	}
+}
+
+func (e *ExceptionSampler) handleTrace(now time.Time, env string, t pb.Trace) bool {
+	var sampled bool
+	expire := now.Add(defaultTTL)
+	for _, s := range t {
+		if !traceutil.HasTopLevel(s) && !traceutil.IsMeasured(s) {
+			continue
+		}
+		if !sampled {
+			sampled = e.sampleSpan(now, env, s)
+			continue
+		}
+		e.addSpan(expire, env, s)
+	}
+	return sampled
+}
+
+func (e *ExceptionSampler) addSpan(expire time.Time, env string, s *pb.Span) {
+	shardSig := ServiceSignature{env, s.Service}.Hash()
+	b := e.loadSpanSeenSet(shardSig)
+	b.add(expire, s)
+}
+
+func (e *ExceptionSampler) sampleSpan(now time.Time, env string, s *pb.Span) bool {
+	var sampled bool
+	shardSig := ServiceSignature{env, s.Service}.Hash()
+	b := e.loadSpanSeenSet(shardSig)
+	sig := b.sign(s)
+	expire, ok := b.getExpire(sig)
+	if now.After(expire) || !ok {
+		sampled = e.limiter.Allow()
+		if sampled {
+			b.add(now.Add(defaultTTL), s)
+			atomic.AddInt64(&e.hits, 1)
+		} else {
+			atomic.AddInt64(&e.misses, 1)
+		}
+	}
+	return sampled
+}
+
+func (e *ExceptionSampler) loadSpanSeenSet(shardSig Signature) *spanSeenSet {
+	e.mu.RLock()
+	s, ok := e.spanSeenSets[shardSig]
+	e.mu.RUnlock()
+	if ok {
+		return s
+	}
+	s = &spanSeenSet{expires: make(map[spanHash]time.Time)}
+	e.mu.Lock()
+	e.spanSeenSets[shardSig] = s
+	e.mu.Unlock()
+	return s
+}
+
+func (e *ExceptionSampler) report() {
+	metrics.Count("datadog.trace_agent.trace_sampler.exception.hits", atomic.SwapInt64(&e.hits, 0), nil, 1)
+	metrics.Count("datadog.trace_agent.trace_sampler.exception.misses", atomic.SwapInt64(&e.misses, 0), nil, 1)
+}
+
+type spanSeenSet struct {
+	mu      sync.RWMutex
+	expires map[spanHash]time.Time
+	shrunk  bool
+}
+
+func (ss *spanSeenSet) add(expire time.Time, s *pb.Span) {
+	sig := ss.sign(s)
+	storedExpire, ok := ss.getExpire(sig)
+	if ok && expire.Sub(storedExpire) < ttlRenewalPeriod {
+		return
+	}
+	// slow path
+	ss.mu.Lock()
+	ss.expires[sig] = expire
+
+	// if cardinality limit reached, shrink
+	size := len(ss.expires)
+	if size > cardinalityLimit {
+		ss.shrink()
+	}
+	ss.mu.Unlock()
+}
+
+// shrink limits the cardinality of signatures considered and the memory usage.
+// This ensure that a service with high cardinality of resources does not consume
+// all sampling tokens. The cardinality limit matches a backend limit.
+// This function is not thread safe and should be called between locks
+func (ss *spanSeenSet) shrink() {
+	newExpires := make(map[spanHash]time.Time, cardinalityLimit)
+	for h, expire := range ss.expires {
+		newExpires[h%spanHash(cardinalityLimit)] = expire
+	}
+	ss.expires = newExpires
+	ss.shrunk = true
+}
+
+func (ss *spanSeenSet) getExpire(h spanHash) (time.Time, bool) {
+	ss.mu.RLock()
+	expire, ok := ss.expires[h]
+	ss.mu.RUnlock()
+	return expire, ok
+}
+
+func (ss *spanSeenSet) sign(s *pb.Span) spanHash {
+	h := computeSpanHash(s, "", true)
+	if ss.shrunk {
+		h = h % spanHash(cardinalityLimit)
+	}
+	return h
+}

--- a/pkg/trace/sampler/exception_sampler.go
+++ b/pkg/trace/sampler/exception_sampler.go
@@ -56,7 +56,7 @@ func (e *ExceptionSampler) Add(now time.Time, env string, root *pb.Span, t pb.Tr
 // Start starts reporting stats
 func (e *ExceptionSampler) Start() {
 	go func() {
-		for _ = range e.tickStats.C {
+		for range e.tickStats.C {
 			e.report()
 		}
 	}()

--- a/pkg/trace/sampler/exception_sampler.go
+++ b/pkg/trace/sampler/exception_sampler.go
@@ -29,7 +29,8 @@ const (
 
 // ExceptionSampler samples traces that are not caught by the Priority sampler.
 // It ensures that we sample traces for each combination of
-// (env, service, name, resource, error type, http status) seen on a measured span.
+// (env, service, name, resource, error type, http status) seen on a top level or measured span
+// for which we did not see any span with a priority > 0 (sampled by Priority).
 // The resulting sampled traces will likely be incomplete.
 type ExceptionSampler struct {
 	mu      sync.RWMutex
@@ -41,7 +42,7 @@ type ExceptionSampler struct {
 	misses    int64
 }
 
-// NewExceptionSampler returns a NewExceptionSampler that ensures that we samplexs combinations
+// NewExceptionSampler returns a NewExceptionSampler that ensures that we sample combinations
 // of env, service, name, resource, http-status, error type for each top level or measured spans
 func NewExceptionSampler() *ExceptionSampler {
 	return &ExceptionSampler{

--- a/pkg/trace/sampler/exception_sampler.go
+++ b/pkg/trace/sampler/exception_sampler.go
@@ -18,7 +18,7 @@ const (
 	defaultTTL = 2 * time.Minute
 	// priorityTTL allows to blacklist p1 spans that are sampled entirely, for this period.
 	priorityTTL = 10 * time.Minute
-	// ttlRenewalPeriod prevents from continuously updating expire times for each span seen.
+	// ttlRenewalPeriod specifies the frequency at which we will upload cached entries.
 	ttlRenewalPeriod = 1 * time.Minute
 	// exceptionSamplerTPS traces per second allowed by the rate limiter.
 	exceptionSamplerTPS = 5

--- a/pkg/trace/sampler/exception_sampler_test.go
+++ b/pkg/trace/sampler/exception_sampler_test.go
@@ -24,7 +24,7 @@ func TestSpanSeenTTLExpiration(t *testing.T) {
 		{"p1-ttl-expired", true, testTime.Add(priorityTTL + time.Nanosecond), map[string]float64{"_top_level": 1}},
 		{"p0-ttl-active", false, testTime.Add(priorityTTL + time.Nanosecond), map[string]float64{"_top_level": 1}},
 		{"p0-ttl-before-expiration", false, testTime.Add(priorityTTL + defaultTTL + time.Nanosecond), map[string]float64{"_top_level": 1}},
-		{"p0-ttl-expired", true, testTime.Add(priorityTTL + defaultTTL + 2*time.Nanosecond), map[string]float64{"_top_level": 1}},
+		{"p0-ttl-expired", true, testTime.Add(priorityTTL + defaultTTL + 2*time.Nanosecond), map[string]float64{"_dd.measured": 1}},
 	}
 
 	e := NewExceptionSampler()

--- a/pkg/trace/sampler/exception_sampler_test.go
+++ b/pkg/trace/sampler/exception_sampler_test.go
@@ -1,0 +1,106 @@
+package sampler
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanSeenTTLExpiration(t *testing.T) {
+	type testCase struct {
+		name     string
+		expected bool
+		time     time.Time
+		metrics  map[string]float64
+	}
+	testTime := time.Unix(13829192398, 0)
+	testCases := []testCase{
+		{"blocked-p1", false, testTime, map[string]float64{KeySamplingPriority: 1, "_top_level": 1}},
+		{"p0-blocked-by-p1", false, testTime, map[string]float64{"_top_level": 1}},
+		{"p1-ttl-before-expiration", false, testTime.Add(priorityTTL), map[string]float64{"_top_level": 1}},
+		{"p1-ttl-expired", true, testTime.Add(priorityTTL + time.Nanosecond), map[string]float64{"_top_level": 1}},
+		{"p0-ttl-active", false, testTime.Add(priorityTTL + time.Nanosecond), map[string]float64{"_top_level": 1}},
+		{"p0-ttl-before-expiration", false, testTime.Add(priorityTTL + defaultTTL + time.Nanosecond), map[string]float64{"_top_level": 1}},
+		{"p0-ttl-expired", true, testTime.Add(priorityTTL + defaultTTL + 2*time.Nanosecond), map[string]float64{"_top_level": 1}},
+	}
+
+	e := NewExceptionSampler()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			tr := pb.Trace{
+				&pb.Span{Service: "s1", Resource: "r1", Metrics: tc.metrics},
+			}
+			assert.Equal(tc.expected, e.Add(tc.time, "", tr[0], tr))
+		})
+	}
+}
+
+func TestConsideredSpans(t *testing.T) {
+	type testCase struct {
+		name     string
+		expected bool
+		service  string
+		metrics  map[string]float64
+	}
+	testTime := time.Unix(13829192398, 0)
+	testCases := []testCase{
+		{"p1-blocked", false, "s1", map[string]float64{KeySamplingPriority: 1, "_top_level": 1}},
+		{"p0-top-passes", true, "s2", map[string]float64{"_top_level": 1}},
+		{"p0-measured-passes", true, "s3", map[string]float64{"_dd.measured": 1}},
+		{"p0-non-top-non-measured-blocked", false, "s4", nil},
+	}
+
+	e := NewExceptionSampler()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			tr := pb.Trace{
+				&pb.Span{Service: tc.service, Metrics: tc.metrics},
+			}
+			assert.Equal(tc.expected, e.Add(testTime, "", tr[0], tr))
+		})
+	}
+}
+
+func TestExceptionSamplerRace(t *testing.T) {
+	e := NewExceptionSampler()
+	for i := 0; i < 2; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				tr := pb.Trace{
+					&pb.Span{Resource: strconv.Itoa(j), Metrics: map[string]float64{"_top_level": 1}},
+				}
+				e.Add(time.Now(), "", tr[0], tr)
+			}
+		}()
+	}
+}
+
+func TestCardinalityLimit(t *testing.T) {
+	assert := assert.New(t)
+	e := NewExceptionSampler()
+	for j := 1; j <= cardinalityLimit; j++ {
+		tr := pb.Trace{
+			&pb.Span{Resource: strconv.Itoa(j), Metrics: map[string]float64{KeySamplingPriority: 1, "_top_level": 1}},
+		}
+		e.Add(time.Now(), "", tr[0], tr)
+		for _, set := range e.spanSeenSets {
+			assert.Len(set.expires, j)
+		}
+	}
+	tr := pb.Trace{
+		&pb.Span{Resource: "newResource", Metrics: map[string]float64{"_top_level": 1}},
+	}
+	e.Add(time.Now(), "", tr[0], tr)
+
+	assert.Len(e.spanSeenSets, 1)
+	for _, set := range e.spanSeenSets {
+		assert.True(len(set.expires) <= cardinalityLimit)
+	}
+}

--- a/pkg/trace/sampler/exception_sampler_test.go
+++ b/pkg/trace/sampler/exception_sampler_test.go
@@ -35,7 +35,7 @@ func TestSpanSeenTTLExpiration(t *testing.T) {
 			tr := pb.Trace{
 				&pb.Span{Service: "s1", Resource: "r1", Metrics: tc.metrics},
 			}
-			assert.Equal(tc.expected, e.Add(tc.time, "", tr[0], tr))
+			assert.Equal(tc.expected, e.add(tc.time, "", tr[0], tr))
 		})
 	}
 }
@@ -63,7 +63,7 @@ func TestConsideredSpans(t *testing.T) {
 			tr := pb.Trace{
 				&pb.Span{Service: tc.service, Metrics: tc.metrics},
 			}
-			assert.Equal(tc.expected, e.Add(testTime, "", tr[0], tr))
+			assert.Equal(tc.expected, e.add(testTime, "", tr[0], tr))
 		})
 	}
 }
@@ -76,7 +76,7 @@ func TestExceptionSamplerRace(t *testing.T) {
 				tr := pb.Trace{
 					&pb.Span{Resource: strconv.Itoa(j), Metrics: map[string]float64{"_top_level": 1}},
 				}
-				e.Add(time.Now(), "", tr[0], tr)
+				e.add(time.Now(), "", tr[0], tr)
 			}
 		}()
 	}
@@ -89,18 +89,18 @@ func TestCardinalityLimit(t *testing.T) {
 		tr := pb.Trace{
 			&pb.Span{Resource: strconv.Itoa(j), Metrics: map[string]float64{KeySamplingPriority: 1, "_top_level": 1}},
 		}
-		e.Add(time.Now(), "", tr[0], tr)
-		for _, set := range e.spanSeenSets {
+		e.add(time.Now(), "", tr[0], tr)
+		for _, set := range e.seen {
 			assert.Len(set.expires, j)
 		}
 	}
 	tr := pb.Trace{
 		&pb.Span{Resource: "newResource", Metrics: map[string]float64{"_top_level": 1}},
 	}
-	e.Add(time.Now(), "", tr[0], tr)
+	e.add(time.Now(), "", tr[0], tr)
 
-	assert.Len(e.spanSeenSets, 1)
-	for _, set := range e.spanSeenSets {
+	assert.Len(e.seen, 1)
+	for _, set := range e.seen {
 		assert.True(len(set.expires) <= cardinalityLimit)
 	}
 }

--- a/pkg/trace/sampler/exception_sampler_test.go
+++ b/pkg/trace/sampler/exception_sampler_test.go
@@ -28,6 +28,7 @@ func TestSpanSeenTTLExpiration(t *testing.T) {
 	}
 
 	e := NewExceptionSampler()
+	e.Stop()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -56,6 +57,7 @@ func TestConsideredSpans(t *testing.T) {
 	}
 
 	e := NewExceptionSampler()
+	e.Stop()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -70,6 +72,7 @@ func TestConsideredSpans(t *testing.T) {
 
 func TestExceptionSamplerRace(t *testing.T) {
 	e := NewExceptionSampler()
+	e.Stop()
 	for i := 0; i < 2; i++ {
 		go func() {
 			for j := 0; j < 100; j++ {
@@ -85,6 +88,7 @@ func TestExceptionSamplerRace(t *testing.T) {
 func TestCardinalityLimit(t *testing.T) {
 	assert := assert.New(t)
 	e := NewExceptionSampler()
+	e.Stop()
 	for j := 1; j <= cardinalityLimit; j++ {
 		tr := pb.Trace{
 			&pb.Span{Resource: strconv.Itoa(j), Metrics: map[string]float64{KeySamplingPriority: 1, "_top_level": 1}},

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -36,10 +36,11 @@ func SetTopLevel(s *pb.Span, topLevel bool) {
 	}
 	// Setting the metrics value, so that code downstream in the pipeline
 	// can identify this as top-level without recomputing everything.
-	setMetric(s, topLevelKey, 1)
+	SetMetric(s, topLevelKey, 1)
 }
 
-func setMetric(s *pb.Span, key string, val float64) {
+// SetMetric sets the metric at key to the val on the span s.
+func SetMetric(s *pb.Span, key string, val float64) {
 	if s.Metrics == nil {
 		s.Metrics = make(map[string]float64)
 	}


### PR DESCRIPTION
### What does this PR do?

Add a sampler that will catch trace chunks with rare measured/top_level spans that are not caught by the priority sampler.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
