### PR TITLE
pkg/config: clarify dd_url

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -18,7 +18,7 @@ api_key:
 ## @param dd_url - string - optional - default: https://app.datadoghq.com
 ## The host of the Datadog intake server to send metrics to, only set this option
 ## if you need the Agent to send metrics to a custom URL, it overrides the site
-## setting defined in "site". It does not affect APM or logs intake which have their
+## setting defined in "site". It does not affect APM, Logs or Live Process intake which have their
 ## own "*_dd_url" settings.
 #
 # dd_url: https://app.datadoghq.com

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -16,8 +16,10 @@ api_key:
 # site: datadoghq.com
 
 ## @param dd_url - string - optional - default: https://app.datadoghq.com
-## The host of the Datadog intake server to send Agent data to, only set this option
-## if you need the Agent to send data to a custom URL, it overrides the site setting defined in "site".
+## The host of the Datadog intake server to send metrics to, only set this option
+## if you need the Agent to send metrics to a custom URL, it overrides the site
+## setting defined in "site". It does not affect APM or logs intake which have their
+## own "*_dd_url" settings.
 #
 # dd_url: https://app.datadoghq.com
 


### PR DESCRIPTION
This change clarifies dd_url docs. Users were sometimes confused as to
why setting it would result in missing traces in APM.