### PR TITLE
Remove tests `.pem` files from docker images

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -39,7 +39,8 @@ RUN find / -maxdepth 1 -type f -name 'datadog-agent*_amd64.deb' ! -name "$DD_AGE
     # ditto for this older libsystemd
     usr/lib/x86_64-linux-gnu/libsystemd.so.0.21.0 \
     # self-test certificates that are detected (false positive) as private keys
-    opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest \
+    opt/datadog-agent/embedded/lib/python*/site-packages/Cryptodome/SelfTest \
+    opt/datadog-agent/embedded/lib/python*/site-packages/future/backports/test \
  && if [ "$PYTHON_VERSION" = "2" ]; then \
         rm -rf \
             opt/datadog-agent/embedded/bin/2to3-3* \

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -39,7 +39,8 @@ RUN find / -maxdepth 1 -type f -name 'datadog-agent*_arm64.deb' ! -name "$DD_AGE
     # ditto for this older libsystemd
     usr/lib/x86_64-linux-gnu/libsystemd.so.0.21.0 \
     # self-test certificates that are detected (false positive) as private keys
-    opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest \
+    opt/datadog-agent/embedded/lib/python*/site-packages/Cryptodome/SelfTest \
+    opt/datadog-agent/embedded/lib/python*/site-packages/future/backports/test \
  && if [ "$PYTHON_VERSION" = "2" ]; then \
         rm -rf \
             opt/datadog-agent/embedded/bin/2to3-3* \


### PR DESCRIPTION
### What does this PR do?

Remove tests `.pem` files from docker images.

### Motivation

Customers are scanning our docker images with some security solutions which are wrongly reporting some test certificates as private keys.
So, let clean them up from the image.

### Additional Notes
