### PR TITLE
Add check error status in CLCStats

### DIFF
--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -66,4 +66,5 @@ type CLCRunnerStats struct {
 	AverageExecutionTime int  `json:"AverageExecutionTime"`
 	MetricSamples        int  `json:"MetricSamples"`
 	IsClusterCheck       bool `json:"IsClusterCheck"`
+	LastExecFailed       bool `json:"LastExecFailed"`
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -361,7 +361,11 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 // and puts it into a CLCChecks struct
 func GetExpvarRunnerStats() (CLCChecks, error) {
 	runnerStatsJSON := []byte(expvar.Get("runner").String())
+	return convertExpvarRunnerStats(runnerStatsJSON)
+}
+
+func convertExpvarRunnerStats(inputJSON []byte) (CLCChecks, error) {
 	runnerStats := CLCChecks{}
-	err := json.Unmarshal(runnerStatsJSON, &runnerStats)
+	err := json.Unmarshal(inputJSON, &runnerStats)
 	return runnerStats, err
 }

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package status
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_convertExpvarRunnerStats(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputJSON []byte
+		want      CLCChecks
+		wantErr   bool
+	}{
+		{
+			name:      "no error present",
+			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "LastError": ""}}}}`),
+			want: CLCChecks{
+				Checks: map[string]map[string]CLCStats{
+					"foo": {
+						"id1": {
+							AverageExecutionTime: 42,
+							MetricSamples:        100,
+							LastExecFailed:       false,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "error present",
+			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "LastError": "this is an error"}}}}`),
+			want: CLCChecks{
+				Checks: map[string]map[string]CLCStats{
+					"foo": {
+						"id1": {
+							AverageExecutionTime: 42,
+							MetricSamples:        100,
+							LastExecFailed:       true,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertExpvarRunnerStats(tt.inputJSON)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertExpvarRunnerStats() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertExpvarRunnerStats() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -49,6 +49,12 @@ func Test_convertExpvarRunnerStats(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:      "bad json",
+			inputJSON: []byte(`{"Checks": bad-json{}}`),
+			want:      CLCChecks{},
+			wantErr:   true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -5,6 +5,12 @@
 
 package status
 
+import (
+	"encoding/json"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
 // CLCChecks is used to unmarshall the runner expvar payload for CLC Runner
 type CLCChecks struct {
 	Checks map[string]map[string]CLCStats `json:"Checks"`
@@ -12,6 +18,22 @@ type CLCChecks struct {
 
 // CLCStats is used to unmarshall the stats needed from the runner expvar payload
 type CLCStats struct {
-	AverageExecutionTime int `json:"AverageExecutionTime"`
-	MetricSamples        int `json:"MetricSamples"`
+	AverageExecutionTime int  `json:"AverageExecutionTime"`
+	MetricSamples        int  `json:"MetricSamples"`
+	LastExecFailed       bool `json:"LastExecFailed"`
+}
+
+// UnmarshalJSON overwrites the unmarshall method for CLCStats
+func (d *CLCStats) UnmarshalJSON(data []byte) error {
+	var stats check.Stats
+	if err := json.Unmarshal(data, &stats); err != nil {
+		return err
+	}
+	d.AverageExecutionTime = int(stats.AverageExecutionTime)
+	d.MetricSamples = int(stats.MetricSamples)
+	if stats.LastError != "" {
+		d.LastExecFailed = true
+	}
+
+	return nil
 }

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -33,6 +33,8 @@ func (d *CLCStats) UnmarshalJSON(data []byte) error {
 	d.MetricSamples = int(stats.MetricSamples)
 	if stats.LastError != "" {
 		d.LastExecFailed = true
+	} else {
+		d.LastExecFailed = false
 	}
 
 	return nil


### PR DESCRIPTION
### What does this PR do?

Add Error check execution status in the clustercheck stats Agent API.
future PR will add the logic inside the Cluster-Agent

### Motivation

Improve the cluster check load balancing logic  in case of check in failure state.

### Additional Notes

Anything else we should know when reviewing?
