### PR TITLE
pkg/trace/sampler: revert score sampler removal

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -233,12 +233,55 @@ func TestSampling(t *testing.T) {
 		wantRate    float64
 		wantSampled bool
 	}{
+		"score and priority rate": {
+			hasPriority:  true,
+			scoreRate:    0.5,
+			priorityRate: 0.6,
+			wantRate:     sampler.CombineRates(0.5, 0.6),
+		},
+		"score only rate": {
+			scoreRate:    0.5,
+			priorityRate: 0.1,
+			wantRate:     0.5,
+		},
 		"error and priority rate": {
 			hasErrors:      true,
 			hasPriority:    true,
 			scoreErrorRate: 0.8,
 			priorityRate:   0.2,
 			wantRate:       sampler.CombineRates(0.8, 0.2),
+		},
+		"score not sampled decision": {
+			scoreSampled: false,
+			wantSampled:  false,
+		},
+		"score sampled decision": {
+			scoreSampled: true,
+			wantSampled:  true,
+		},
+		"score sampled priority not sampled": {
+			hasPriority:     true,
+			scoreSampled:    true,
+			prioritySampled: false,
+			wantSampled:     true,
+		},
+		"score not sampled priority sampled": {
+			hasPriority:     true,
+			scoreSampled:    false,
+			prioritySampled: true,
+			wantSampled:     true,
+		},
+		"score sampled priority sampled": {
+			hasPriority:     true,
+			scoreSampled:    true,
+			prioritySampled: true,
+			wantSampled:     true,
+		},
+		"score and priority not sampled": {
+			hasPriority:     true,
+			scoreSampled:    false,
+			prioritySampled: false,
+			wantSampled:     false,
 		},
 		"error not sampled decision": {
 			hasErrors:         true,
@@ -281,6 +324,7 @@ func TestSampling(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			a := &Agent{
+				ScoreSampler:       newMockSampler(tt.scoreSampled, tt.scoreRate),
 				ErrorsScoreSampler: newMockSampler(tt.scoreErrorSampled, tt.scoreErrorRate),
 				PrioritySampler:    newMockSampler(tt.prioritySampled, tt.priorityRate),
 			}

--- a/pkg/trace/agent/sampler.go
+++ b/pkg/trace/agent/sampler.go
@@ -32,6 +32,14 @@ type Sampler struct {
 	exit chan struct{}
 }
 
+// NewScoreSampler creates a new empty sampler ready to be started
+func NewScoreSampler(conf *config.AgentConfig) *Sampler {
+	return &Sampler{
+		engine: sampler.NewScoreEngine(conf.ExtraSampleRate, conf.MaxTPS),
+		exit:   make(chan struct{}),
+	}
+}
+
 // NewErrorsSampler creates a new sampler dedicated to traces containing errors
 // to isolate them from the global max tps. It behaves exactly like the normal
 // ScoreSampler except that its statistics are reported under a different name.
@@ -117,6 +125,8 @@ func (s *Sampler) logStats() {
 				// publish through expvar
 				// TODO: avoid type switch, prefer engine method
 				switch s.engine.GetType() {
+				case sampler.NormalScoreEngineType:
+					info.UpdateSamplerInfo(info.SamplerInfo{Stats: stats, State: state})
 				case sampler.ErrorsScoreEngineType:
 					info.UpdateErrorsSamplerInfo(info.SamplerInfo{Stats: stats, State: state})
 				case sampler.PriorityEngineType:

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -33,8 +33,10 @@ const (
 type EngineType int
 
 const (
+	// NormalScoreEngineType is the type of the ScoreEngine sampling non-error traces.
+	NormalScoreEngineType EngineType = iota
 	// ErrorsScoreEngineType is the type of the ScoreEngine sampling error traces.
-	ErrorsScoreEngineType EngineType = iota
+	ErrorsScoreEngineType
 	// PriorityEngineType is type of the priority sampler engine type.
 	PriorityEngineType
 )

--- a/pkg/trace/sampler/scoresampler.go
+++ b/pkg/trace/sampler/scoresampler.go
@@ -20,6 +20,16 @@ type ScoreEngine struct {
 	engineType EngineType
 }
 
+// NewScoreEngine returns an initialized Sampler
+func NewScoreEngine(extraRate float64, maxTPS float64) *ScoreEngine {
+	s := &ScoreEngine{
+		Sampler:    newSampler(extraRate, maxTPS),
+		engineType: NormalScoreEngineType,
+	}
+
+	return s
+}
+
 // NewErrorsEngine returns an initialized Sampler dedicate to errors. It behaves
 // just like the the normal ScoreEngine except for its GetType method (useful
 // for reporting).

--- a/pkg/trace/test/testutil/sampler.go
+++ b/pkg/trace/test/testutil/sampler.go
@@ -43,5 +43,5 @@ func (e *MockEngine) GetState() interface{} {
 
 // GetType mocks Engine.GetType()
 func (e *MockEngine) GetType() sampler.EngineType {
-	return sampler.ErrorsScoreEngineType
+	return sampler.NormalScoreEngineType
 }


### PR DESCRIPTION
### What does this PR do?

Score sampler is still necessary to sample traces that have no priority set on them. 
The removal should be done only on traces with a priority set.
Reverts DataDog/datadog-agent#5198

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
