### PR TITLE
[DCA] Autodiscover standard tags for Cluster and Endpoint Checks

### DIFF
--- a/pkg/autodiscovery/listeners/common.go
+++ b/pkg/autodiscovery/listeners/common.go
@@ -8,15 +8,27 @@ package listeners
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
+	// Label keys of Docker Autodiscovery
 	newIdentifierLabel         = "com.datadoghq.ad.check.id"
 	legacyIdentifierLabel      = "com.datadoghq.sd.check.id"
 	dockerADTemplateCheckNames = "com.datadoghq.ad.check_names"
+	// Label keys of standard tags
+	labelKeyEnv     = "tags.datadoghq.com/env"
+	labelKeyVersion = "tags.datadoghq.com/version"
+	labelKeyService = "tags.datadoghq.com/service"
+	// Keys of standard tags
+	tagKeyEnv     = "env"
+	tagKeyVersion = "version"
+	tagKeyService = "service"
 )
 
 // ComputeContainerServiceIDs takes an entity name, an image (resolved to an actual name) and labels
@@ -60,4 +72,45 @@ func getCheckNamesFromLabels(labels map[string]string) ([]string, error) {
 		return checkNames, nil
 	}
 	return nil, nil
+}
+
+// getStandardTags extract standard tags from labels of kubernetes services
+func getStandardTags(labels map[string]string) []string {
+	tags := []string{}
+	if labels == nil {
+		return tags
+	}
+	labelToTagKeys := map[string]string{
+		labelKeyEnv:     tagKeyEnv,
+		labelKeyVersion: tagKeyVersion,
+		labelKeyService: tagKeyService,
+	}
+	for labelKey, tagKey := range labelToTagKeys {
+		if tagValue, found := labels[labelKey]; found {
+			tags = append(tags, fmt.Sprintf("%s:%s", tagKey, tagValue))
+		}
+	}
+	return tags
+}
+
+// standardTagsDigest computes the hash of standard tags in a map
+func standardTagsDigest(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	h := fnv.New64()
+	h.Write([]byte(labels[labelKeyEnv]))
+	h.Write([]byte(labels[labelKeyVersion]))
+	h.Write([]byte(labels[labelKeyService]))
+	return strconv.FormatUint(h.Sum64(), 16)
+}
+
+// isServiceAnnotated returns true if the Service has an annotation with a given key
+func isServiceAnnotated(ksvc *v1.Service, annotationKey string) bool {
+	if ksvc != nil {
+		if _, found := ksvc.GetAnnotations()[annotationKey]; found {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/autodiscovery/listeners/common_test.go
+++ b/pkg/autodiscovery/listeners/common_test.go
@@ -1,0 +1,161 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-2020 Datadog, Inc.
+
+package listeners
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getStandardTags(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   []string
+	}{
+		{
+			name: "nominal case",
+			labels: map[string]string{
+				"app.kubernetes.io/instance":   "cluster-agent",
+				"app.kubernetes.io/managed-by": "datadog-operator",
+				"app.kubernetes.io/name":       "datadog-agent-deployment",
+				"app.kubernetes.io/part-of":    "datadog-agent",
+				"app.kubernetes.io/version":    "0.3.1",
+				"tags.datadoghq.com/env":       "prod",
+				"tags.datadoghq.com/version":   "1.5.2",
+				"tags.datadoghq.com/service":   "datadog",
+			},
+			want: []string{
+				"env:prod",
+				"version:1.5.2",
+				"service:datadog",
+			},
+		},
+		{
+			name:   "nil input",
+			labels: nil,
+			want:   []string{},
+		},
+		{
+			name: "standard tags not found",
+			labels: map[string]string{
+				"app.kubernetes.io/instance":   "cluster-agent",
+				"app.kubernetes.io/managed-by": "datadog-operator",
+				"app.kubernetes.io/name":       "datadog-agent-deployment",
+				"app.kubernetes.io/part-of":    "datadog-agent",
+				"app.kubernetes.io/version":    "0.3.1",
+			},
+			want: []string{},
+		},
+		{
+			name: "standard tags not all found",
+			labels: map[string]string{
+				"app.kubernetes.io/instance":   "cluster-agent",
+				"app.kubernetes.io/managed-by": "datadog-operator",
+				"app.kubernetes.io/name":       "datadog-agent-deployment",
+				"app.kubernetes.io/part-of":    "datadog-agent",
+				"app.kubernetes.io/version":    "0.3.1",
+				"tags.datadoghq.com/env":       "prod",
+				"tags.datadoghq.com/service":   "datadog",
+			},
+			want: []string{
+				"env:prod",
+				"service:datadog",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getStandardTags(tt.labels)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func Test_standardTagsDigest(t *testing.T) {
+	tests := []struct {
+		name      string
+		first     map[string]string
+		second    map[string]string
+		equalHash bool
+	}{
+		{
+			name: "same standard tags",
+			first: map[string]string{
+				"app.kubernetes.io/instance": "cluster-agent",
+				"tags.datadoghq.com/env":     "prod",
+				"tags.datadoghq.com/version": "1.5.2",
+				"tags.datadoghq.com/service": "datadog",
+			},
+			second: map[string]string{
+				"tags.datadoghq.com/version": "1.5.2",
+				"tags.datadoghq.com/env":     "prod",
+				"tags.datadoghq.com/service": "datadog",
+			},
+			equalHash: true,
+		},
+		{
+			name: "1 standard deleted",
+			first: map[string]string{
+				"app.kubernetes.io/instance": "cluster-agent",
+				"tags.datadoghq.com/env":     "prod",
+				"tags.datadoghq.com/version": "1.5.2",
+			},
+			second: map[string]string{
+				"tags.datadoghq.com/version": "1.5.2",
+				"tags.datadoghq.com/env":     "prod",
+				"tags.datadoghq.com/service": "datadog",
+			},
+			equalHash: false,
+		},
+		{
+			name: "1 standard changed value",
+			first: map[string]string{
+				"tags.datadoghq.com/env":     "prod",
+				"tags.datadoghq.com/version": "1.5.2",
+				"tags.datadoghq.com/service": "datadog",
+			},
+			second: map[string]string{
+				"tags.datadoghq.com/env":     "prod",
+				"tags.datadoghq.com/version": "1.5.3",
+				"tags.datadoghq.com/service": "datadog",
+			},
+			equalHash: false,
+		},
+		{
+			name: "no standard tags",
+			first: map[string]string{
+				"app.kubernetes.io/instance": "cluster-agent",
+			},
+			second:    map[string]string{},
+			equalHash: true,
+		},
+		{
+			name:      "no labels",
+			first:     map[string]string{},
+			second:    map[string]string{},
+			equalHash: true,
+		},
+		{
+			name:  "nil labels",
+			first: nil,
+			second: map[string]string{
+				"tags.datadoghq.com/service": "datadog",
+			},
+			equalHash: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := standardTagsDigest(tt.first)
+			second := standardTagsDigest(tt.second)
+			if (first == second) != tt.equalHash {
+				t.Errorf("hash1: %s, hash2: %s, want: %v", first, second, tt.equalHash)
+			}
+		})
+	}
+}

--- a/pkg/autodiscovery/listeners/kube_endpoints_test.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints_test.go
@@ -42,7 +42,7 @@ func TestProcessEndpoints(t *testing.T) {
 		},
 	}
 
-	eps := processEndpoints(kep, true)
+	eps := processEndpoints(kep, true, []string{"foo:bar"})
 
 	// Sort eps to impose the order
 	sort.Slice(eps, func(i, j int) bool {
@@ -75,7 +75,7 @@ func TestProcessEndpoints(t *testing.T) {
 
 	tags, err := eps[0].GetTags()
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"kube_service:myservice", "kube_namespace:default", "kube_endpoint_ip:10.0.0.1"}, tags)
+	assert.Equal(t, []string{"kube_service:myservice", "kube_namespace:default", "kube_endpoint_ip:10.0.0.1", "foo:bar"}, tags)
 
 	assert.Equal(t, "kube_endpoint_uid://default/myservice/10.0.0.2", eps[1].GetEntity())
 	assert.Equal(t, integration.Before, eps[1].GetCreationTime())
@@ -94,9 +94,9 @@ func TestProcessEndpoints(t *testing.T) {
 
 	tags, err = eps[1].GetTags()
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"kube_service:myservice", "kube_namespace:default", "kube_endpoint_ip:10.0.0.2"}, tags)
+	assert.Equal(t, []string{"kube_service:myservice", "kube_namespace:default", "kube_endpoint_ip:10.0.0.2", "foo:bar"}, tags)
 
-	eps = processEndpoints(kep, false)
+	eps = processEndpoints(kep, false, []string{"foo:bar"})
 	assert.Equal(t, integration.After, eps[0].GetCreationTime())
 	assert.Equal(t, integration.After, eps[1].GetCreationTime())
 }

--- a/releasenotes-dca/notes/standard-tags-clc-4333bc927d135aba.yaml
+++ b/releasenotes-dca/notes/standard-tags-clc-4333bc927d135aba.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Standard tags (env, version, service) can be autodiscovered from Service labels
+    and added to Endpoint and Cluster checks.


### PR DESCRIPTION
### What does this PR do?

- Convert the following Service labels into tags attached to CLC and Endpoint Checks
  - `tags.datadoghq.com/env`
  - `tags.datadoghq.com/version`
  - `tags.datadoghq.com/service`
- Refactor few common helpers used by `kube_services` and `kube_endpoints` AD listeners

### Motivation

Unify DD tagging, including CLC and Endpoint Checks.
