### PR TITLE
Decrease the default log verbosity of the JMX command

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -153,7 +153,7 @@ func RunJmxCommand(command string, reporter jmxfetch.JMXReporter, output func(..
 		overrides["log_level"] = jmxLogLevel
 		config.AddOverrides(overrides)
 	} else {
-		jmxLogLevel = config.GetEnv("DD_LOG_LEVEL", "off")
+		jmxLogLevel = config.GetEnv("DD_LOG_LEVEL", "error")
 	}
 
 	overrides := make(map[string]interface{})

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -153,7 +153,7 @@ func RunJmxCommand(command string, reporter jmxfetch.JMXReporter, output func(..
 		overrides["log_level"] = jmxLogLevel
 		config.AddOverrides(overrides)
 	} else {
-		jmxLogLevel = config.GetEnv("DD_LOG_LEVEL", "debug")
+		jmxLogLevel = config.GetEnv("DD_LOG_LEVEL", "off")
 	}
 
 	overrides := make(map[string]interface{})

--- a/releasenotes/notes/decrease-verbosity-of-JMX-command-4671455fc35e6099.yaml
+++ b/releasenotes/notes/decrease-verbosity-of-JMX-command-4671455fc35e6099.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Decrease the default log verbosity of the JMX command.


### PR DESCRIPTION
### What does this PR do?

Matches the check command:

https://github.com/DataDog/datadog-agent/blob/66817d7ab85253da0d360151462545de8a62f7b2/cmd/agent/app/check.go#L99-L101

### Motivation

It's way too noisy