### PR TITLE
Revert "Fix check command when there are JMX and Python/Go instances"

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -138,7 +138,6 @@ var checkCmd = &cobra.Command{
 		}
 
 		allConfigs := common.AC.GetAllConfigs()
-		hasJMXConfig := false
 
 		// make sure the checks in cs are not JMX checks
 		for idx := range allConfigs {
@@ -148,7 +147,19 @@ var checkCmd = &cobra.Command{
 			}
 
 			if check.IsJMXConfig(*conf) {
-				hasJMXConfig = true
+				// we'll mimic the check command behavior with JMXFetch by running
+				// it with the JSON reporter and the list_with_metrics command.
+				fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")
+				if checkRate {
+					if err := RunJmxListWithRateMetrics(); err != nil {
+						return fmt.Errorf("while running the jmx check: %v", err)
+					}
+				} else {
+					if err := RunJmxListWithMetrics(); err != nil {
+						return fmt.Errorf("while running the jmx check: %v", err)
+					}
+				}
+
 				instances := []integration.Data{}
 
 				// Retain only non-JMX instances for later
@@ -361,19 +372,6 @@ var checkCmd = &cobra.Command{
 				printMetrics(agg)
 				checkStatus, _ := status.GetCheckStatus(c, s)
 				fmt.Println(string(checkStatus))
-			}
-		}
-
-		// FIXME: We require that this run after all Python instances because `common.SetupAutoConfig` is called a
-		// second time via `RunJmxListWithMetrics` when the check command is called on JMXFetch checks, but it's not
-		// idempotent and should only be called once. Here, calling it twice breaks the rtloader logic that only
-		// expects to be called once, which is why after the second call Python shows as not being initialized.
-		if hasJMXConfig {
-			// we'll mimic the check command behavior with JMXFetch by running
-			// it with the JSON reporter and the list_with_metrics command.
-			fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")
-			if err := RunJmxListWithMetrics(); err != nil {
-				return fmt.Errorf("while running the jmx check: %v", err)
 			}
 		}
 

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -239,20 +239,12 @@ func loadConfigs(runner *jmxfetch.JMXFetch) {
 	for _, c := range configs {
 		if check.IsJMXConfig(c) && (includeEverything || configIncluded(c)) {
 			fmt.Println("Config ", c.Name, " was loaded.")
-			instances := []integration.Data{}
-
-			// Retain only JMX instances
+			jmx.AddScheduledConfig(c)
+			runner.ConfigureFromInitConfig(c.InitConfig)
 			for _, instance := range c.Instances {
 				if !check.IsJMXInstance(c.Name, instance, c.InitConfig) {
 					continue
 				}
-				instances = append(instances, instance)
-			}
-			c.Instances = instances
-
-			jmx.AddScheduledConfig(c)
-			runner.ConfigureFromInitConfig(c.InitConfig)
-			for _, instance := range c.Instances {
 				runner.ConfigureFromInstance(instance)
 			}
 		}


### PR DESCRIPTION
Reverts DataDog/datadog-agent#5229 due to new segfaults https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=12114&view=logs&jobId=910f82a4-622d-5ace-f877-8b75c045486c&j=910f82a4-622d-5ace-f877-8b75c045486c&t=74cc1a12-f874-5594-cc49-c7523e5c8c66