### PR TITLE
Run Android and Win x86 jobs on branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,15 +141,11 @@ variables:
       - $RELEASE_VERSION_6 == "nightly"
       - $RELEASE_VERSION_7 == "nightly-a7"
 
-# run job only when triggered on nightly AND when it's a merge to master
-.run_when_triggered_on_nightly_or_master: &run_when_triggered_on_nightly_or_master
-  only:
+# run when not triggered (for jobs we don't want to run on release pipelines)
+.run_when_not_triggered: &run_when_not_triggered
+  except:
     refs:
       - triggers
-      - master
-    variables:
-      - $RELEASE_VERSION_6 == "nightly"
-      - $RELEASE_VERSION_7 == "nightly-a7"
 
 # skip job only when triggered by an external tool (ex: Jenkins) and when
 # BUILD_AGENT_X is set to "no".
@@ -244,7 +240,7 @@ run_tests_windows-x64:
     ARCH: "x64"
 
 run_tests_windows-x86:
-  <<: *run_when_triggered_on_nightly_or_master
+  <<: *run_when_not_triggered
   # temporarily allow failure for tests
   extends: .run_tests_windows_base
   allow_failure: true
@@ -1121,7 +1117,7 @@ windows_msi_x86-a7:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_7
   <<: *skip_when_unwanted_on_7
-  <<: *run_when_triggered_on_nightly_or_master
+  <<: *run_when_not_triggered
 
 windows_msi_x64-a6:
   extends: .windows_main_agent_base
@@ -1142,7 +1138,7 @@ windows_msi_x86-a6:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_6
   <<: *skip_when_unwanted_on_6
-  <<: *run_when_triggered_on_nightly_or_master
+  <<: *run_when_not_triggered
 
 .windows_puppy_agent_base:
   extends: .windows_msi_base
@@ -1169,7 +1165,7 @@ agent_android_apk:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   <<: *skip_when_unwanted_on_7
-  <<: *run_when_triggered_on_nightly_or_master
+  <<: *run_when_not_triggered
   before_script:
     - echo running android before_script
     - cd $SRC_PATH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1111,6 +1111,7 @@ windows_msi_x64-a7:
 
 windows_msi_x86-a7:
   extends: .windows_main_agent_base
+  allow_failure: true
   variables:
     ARCH: "x86"
     AGENT_MAJOR_VERSION: 7
@@ -1132,6 +1133,7 @@ windows_msi_x64-a6:
 
 windows_msi_x86-a6:
   extends: .windows_main_agent_base
+  allow_failure: true
   variables:
     ARCH: "x86"
     AGENT_MAJOR_VERSION: 6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ variables:
 
 # run job only when triggered by an external tool (ex: Jenkins). This is used
 # for jobs that run both on nightlies and tags
-.run_when_triggered: &run_when_triggered
+.run_only_when_triggered: &run_only_when_triggered
   only:
     - triggers
 
@@ -99,7 +99,7 @@ variables:
 #        web interface.  This way, if a kitchen run is desired on a specific branch,
 #        it can be triggered by requesting a specific build)
 #
-.run_when_testkitchen_triggered: &run_when_testkitchen_triggered
+.run_only_when_testkitchen_triggered: &run_only_when_testkitchen_triggered
   only:
     - master
     - tags
@@ -111,7 +111,7 @@ variables:
 # new tagged version of the agent (an RC for example). In both cases the
 # artifacts should be uploaded to our staging repository.
 
-.run_when_triggered_on_tag_6: &run_when_triggered_on_tag_6
+.run_only_when_triggered_on_tag_6: &run_only_when_triggered_on_tag_6
   only:
     refs:
       - triggers
@@ -120,7 +120,7 @@ variables:
       - $RELEASE_VERSION_6 == "nightly"
       - $RELEASE_VERSION_6 == "" # no  RELEASE_VERSION means a nightly build for omnibus
 
-.run_when_triggered_on_tag_7: &run_when_triggered_on_tag_7
+.run_only_when_triggered_on_tag_7: &run_only_when_triggered_on_tag_7
   only:
     refs:
       - triggers
@@ -133,7 +133,7 @@ variables:
 # RELEASE_VERSION_X is "nightly". In this setting we build from master and update
 # the nightly build for windows, linux and docker.
 
-.run_when_triggered_on_nightly: &run_when_triggered_on_nightly
+.run_only_when_triggered_on_nightly: &run_only_when_triggered_on_nightly
   only:
     refs:
       - triggers
@@ -142,7 +142,7 @@ variables:
       - $RELEASE_VERSION_7 == "nightly-a7"
 
 # run when not triggered (for jobs we don't want to run on release pipelines)
-.run_when_not_triggered: &run_when_not_triggered
+.skip_when_triggered: &skip_when_triggered
   except:
     refs:
       - triggers
@@ -240,7 +240,7 @@ run_tests_windows-x64:
     ARCH: "x64"
 
 run_tests_windows-x86:
-  <<: *run_when_not_triggered
+  <<: *skip_when_triggered
   # temporarily allow failure for tests
   extends: .run_tests_windows_base
   allow_failure: true
@@ -1117,7 +1117,7 @@ windows_msi_x86-a7:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_7
   <<: *skip_when_unwanted_on_7
-  <<: *run_when_not_triggered
+  <<: *skip_when_triggered
 
 windows_msi_x64-a6:
   extends: .windows_main_agent_base
@@ -1138,7 +1138,7 @@ windows_msi_x86-a6:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_6
   <<: *skip_when_unwanted_on_6
-  <<: *run_when_not_triggered
+  <<: *skip_when_triggered
 
 .windows_puppy_agent_base:
   extends: .windows_msi_base
@@ -1165,7 +1165,7 @@ agent_android_apk:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   <<: *skip_when_unwanted_on_7
-  <<: *run_when_not_triggered
+  <<: *skip_when_triggered
   before_script:
     - echo running android before_script
     - cd $SRC_PATH
@@ -1307,7 +1307,7 @@ deploy_deb_testing-a6:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   tags: [ "runner:main", "size:large" ]
   variables:
@@ -1335,7 +1335,7 @@ deploy_deb_testing-a7:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   tags: [ "runner:main", "size:large" ]
   variables:
@@ -1360,7 +1360,7 @@ deploy_deb_testing-a7:
 
 # deploy rpm packages to yum staging repo
 deploy_rpm_testing-a6:
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
   needs: ["fail_on_non_triggered_tag", "agent_rpm-x64-a6"]
@@ -1380,7 +1380,7 @@ deploy_rpm_testing-a6:
     - aws s3 sync ./rpmrepo/ s3://$RPM_TESTING_S3_BUCKET/pipeline-$DD_PIPELINE_ID/6 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_rpm_testing-a7:
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
   needs: ["fail_on_non_triggered_tag", "agent_rpm-x64-a7"]
@@ -1401,7 +1401,7 @@ deploy_rpm_testing-a7:
 
 # deploy rpm packages to yum staging repo
 deploy_suse_rpm_testing-a6:
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
   needs: ["fail_on_non_triggered_tag", "agent_suse-x64-a6"]
@@ -1421,7 +1421,7 @@ deploy_suse_rpm_testing-a6:
     - aws s3 sync ./rpmrepo/suse/ s3://$RPM_TESTING_S3_BUCKET/suse/pipeline-$DD_PIPELINE_ID/6 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_suse_rpm_testing-a7:
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
   needs: ["fail_on_non_triggered_tag", "agent_suse-x64-a7"]
@@ -1442,7 +1442,7 @@ deploy_suse_rpm_testing-a7:
 
 # deploy windows packages to our testing bucket
 deploy_windows_testing-a6:
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
   needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a6"]
@@ -1454,7 +1454,7 @@ deploy_windows_testing-a6:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6.*.msi" $OMNIBUS_PACKAGE_DIR s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET_A6 --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_windows_testing-a7:
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
   needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
@@ -1470,7 +1470,7 @@ deploy_windows_testing-a7:
 #
 
 .kitchen_common: &kitchen_common
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   stage: testkitchen_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
   artifacts:
@@ -1933,7 +1933,7 @@ kitchen_debian_upgrade7-a7:
 send_pkg_size-a6:
   stage: pkg_metrics
   allow_failure: true
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   before_script:
@@ -1973,7 +1973,7 @@ send_pkg_size-a6:
 
 send_pkg_size-a7:
   stage: pkg_metrics
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
@@ -2042,7 +2042,7 @@ send_pkg_size-a7:
 testkitchen_cleanup_s3-a6:
   stage: testkitchen_cleanup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   tags: [ "runner:main", "size:large" ]
   variables:
@@ -2056,7 +2056,7 @@ testkitchen_cleanup_s3-a6:
 testkitchen_cleanup_s3-a7:
   stage: testkitchen_cleanup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   tags: [ "runner:main", "size:large" ]
   variables:
@@ -2071,7 +2071,7 @@ testkitchen_cleanup_s3-a7:
 testkitchen_cleanup_azure-a6:
   stage: testkitchen_cleanup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   # even if this fails, it shouldn't block the pipeline.
   allow_failure: true
   when: always
@@ -2087,7 +2087,7 @@ testkitchen_cleanup_azure-a6:
 testkitchen_cleanup_azure-a7:
   stage: testkitchen_cleanup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
-  <<: *run_when_testkitchen_triggered
+  <<: *run_only_when_testkitchen_triggered
   # even if this fails, it shouldn't block the pipeline.
   allow_failure: true
   when: always
@@ -2691,7 +2691,7 @@ dca_dev_master_docker_hub:
 dev_nightly_docker_hub-a6:
   <<: *skip_when_unwanted_on_6
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_nightly
+  <<: *run_only_when_triggered_on_nightly
   needs:
     - fail_on_non_triggered_tag
     - build_agent6
@@ -2707,7 +2707,7 @@ dev_nightly_docker_hub-a6:
 dev_nightly_docker_hub-a7:
   <<: *skip_when_unwanted_on_7
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_nightly
+  <<: *run_only_when_triggered_on_nightly
   needs:
     - fail_on_non_triggered_tag
     - build_agent7
@@ -2718,7 +2718,7 @@ dev_nightly_docker_hub-a7:
 
 dev_nightly_docker_hub-a7-windows:
   <<: *skip_when_unwanted_on_7
-  <<: *run_when_triggered_on_nightly
+  <<: *run_only_when_triggered_on_nightly
   extends: .docker_tag_windows_job_definition
   variables:
     VARIANT: 1909
@@ -2742,7 +2742,7 @@ dev_nightly_docker_hub-a7-windows:
 dev_nightly_docker_hub-dogstatsd:
   <<: *skip_when_unwanted_on_7
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_nightly
+  <<: *run_only_when_triggered_on_nightly
   needs:
     - fail_on_non_triggered_tag
     - build_dogstatsd_amd64
@@ -2756,7 +2756,7 @@ dev_nightly_docker_hub-dogstatsd:
 # overwrite a public package). To update an erroneous package, first remove it
 # from our S3 bucket.
 check_already_deployed_version_6:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_6
   stage: check_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -2768,7 +2768,7 @@ check_already_deployed_version_6:
     - cd $OMNIBUS_PACKAGE_DIR && /deploy_scripts/fail_deb_is_pkg_already_exists.sh datadog-agent_6*_arm64.deb
 
 check_already_deployed_version_7:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   stage: check_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -2781,7 +2781,7 @@ check_already_deployed_version_7:
 
 # If we trigger a build only pipeline we stop here.
 check_if_build_only:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   stage: check_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -2796,7 +2796,7 @@ check_if_build_only:
 
 # deploy debian packages to apt staging repo
 deploy_deb-6:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_6
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -2829,7 +2829,7 @@ deploy_deb-6:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c $DEB_RPM_BUCKET_BRANCH -m 6 -b $DEB_S3_BUCKET -a arm64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*_6.*arm64.deb
 
 deploy_deb-7:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -2867,7 +2867,7 @@ deploy_windows_master-a6:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_nightly
+  <<: *run_only_when_triggered_on_nightly
   <<: *skip_when_unwanted_on_6
   tags: [ "runner:main", "size:large" ]
   script:
@@ -2879,7 +2879,7 @@ deploy_windows_master-a7:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_nightly
+  <<: *run_only_when_triggered_on_nightly
   <<: *skip_when_unwanted_on_7
   tags: [ "runner:main", "size:large" ]
   script:
@@ -2892,7 +2892,7 @@ deploy_windows_master-latest-a6:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_nightly
+  <<: *run_only_when_triggered_on_nightly
   <<: *skip_when_unwanted_on_6
   tags: [ "runner:main", "size:large" ]
   script:
@@ -2904,7 +2904,7 @@ deploy_windows_master-latest-a7:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_nightly
+  <<: *run_only_when_triggered_on_nightly
   <<: *skip_when_unwanted_on_7
   tags: [ "runner:main", "size:large" ]
   script:
@@ -2916,7 +2916,7 @@ deploy_windows_tags-a6:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_tag_6
+  <<: *run_only_when_triggered_on_tag_6
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-6*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
@@ -2927,7 +2927,7 @@ deploy_windows_tags-a7:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
@@ -2938,7 +2938,7 @@ deploy_windows_tags-latest-a6:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_tag_6
+  <<: *run_only_when_triggered_on_tag_6
   tags: [ "runner:main", "size:large" ]
   script:
     # By default we update the "latest" artifacts on our s3 bucket so the
@@ -2952,7 +2952,7 @@ deploy_windows_tags-latest-a7:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   tags: [ "runner:main", "size:large" ]
   script:
     # By default we update the "latest" artifacts on our s3 bucket so the
@@ -2966,14 +2966,14 @@ deploy_android_tags:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.apk" $OMNIBUS_PACKAGE_DIR s3://$ANDROID_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy rpm packages to yum staging repo
 deploy_rpm-6:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_6
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -2997,7 +2997,7 @@ deploy_rpm-6:
     - aws s3 sync --only-show-errors ./rpmrepo/6/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_rpm-7:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -3023,7 +3023,7 @@ deploy_rpm-7:
 # deploy suse rpm packages to yum staging repo
 # NOTE: no SuSE ARM builds currently.
 deploy_suse_rpm-6:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_6
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -3044,7 +3044,7 @@ deploy_suse_rpm-6:
     - aws s3 sync --only-show-errors ./rpmrepo/6/ s3://$RPM_S3_BUCKET/suse/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_suse_rpm-7:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -3066,7 +3066,7 @@ deploy_suse_rpm-7:
 
 # deploy dsd binary to staging bucket
 deploy_dsd:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -3080,7 +3080,7 @@ deploy_dsd:
 
 # deploy puppy binary to staging bucket
 deploy_puppy:
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -3094,7 +3094,7 @@ deploy_puppy:
 
 # deploy agent windows zip to the staging bucket, currently used for cloudfoundry bosh
 deploy_datadog_agent_windows_zip:
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   stage: deploy7
   needs: [ "windows_msi_x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -3106,7 +3106,7 @@ deploy_datadog_agent_windows_zip:
 
 # deploy datadog agent windows binaries to staging bucket. Currently used for cloudfoundry builpack
 deploy_datadog_agent_windows_binaries_zip:
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   stage: deploy7
   needs: [ "windows_zip_agent_binaries_x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
@@ -3142,7 +3142,7 @@ deploy_process_and_sysprobe:
 
 tag_release_6:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag_6
+  <<: *run_only_when_triggered_on_tag_6
   stage: deploy6
   when: manual
   script:
@@ -3156,7 +3156,7 @@ tag_release_6:
 
 latest_release_6:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag_6
+  <<: *run_only_when_triggered_on_tag_6
   stage: deploy6
   when: manual
   script:
@@ -3168,7 +3168,7 @@ latest_release_6:
 
 tag_release_7_linux:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   stage: deploy7
   when: manual
   script:
@@ -3178,7 +3178,7 @@ tag_release_7_linux:
     - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG}-amd64 datadog/dogstatsd:${VERSION}
 
 tag_release_7_windows:
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   stage: deploy7
   when: manual
   extends: .docker_tag_windows_job_definition
@@ -3203,7 +3203,7 @@ tag_release_7_windows:
 
 tag_release_7_manifests:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   stage: deploy7-manifests
   needs:
     - tag_release_7_linux
@@ -3223,7 +3223,7 @@ tag_release_7_manifests:
 
 latest_release_7:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   stage: deploy7
   when: manual
   script:
@@ -3322,7 +3322,7 @@ latest_release_7:
 # then retried successfully, the cloudfront invalidation will also run after the successful retry.
 #
 .deploy_cloudfront_invalidate: &deploy_cloudfront_invalidate
-  <<: *run_when_triggered
+  <<: *run_only_when_triggered
   stage: deploy_invalidate
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
@@ -3374,7 +3374,7 @@ pupernetes-master:
 
 pupernetes-tags-6:
   <<: *pupernetes_template
-  <<: *run_when_triggered_on_tag_6
+  <<: *run_only_when_triggered_on_tag_6
   when: manual
   script:
   - VERSION=$(inv -e agent.version --major-version 6)
@@ -3382,7 +3382,7 @@ pupernetes-tags-6:
 
 pupernetes-tags-7:
   <<: *pupernetes_template
-  <<: *run_when_triggered_on_tag_7
+  <<: *run_only_when_triggered_on_tag_7
   when: manual
   script:
   - VERSION=$(inv -e agent.version --major-version 7)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,6 +143,7 @@ variables:
 
 # run when not triggered (for jobs we don't want to run on release pipelines)
 .skip_when_triggered: &skip_when_triggered
+  # TODO (with rules?): exclude triggered pipelines but not nightlies
   except:
     refs:
       - triggers


### PR DESCRIPTION
### What does this PR do?

Only exclude triggered pipelines (ie: release pipelines but also nightlies)

### Motivation

We want to know when the build breaks on a branch pipeline, but we don't want to block a release if a Windows 32bit build fails.

### Additional Notes

Unfortunately I didn't manage to exclude triggered pipelines but not nightlies, so I had to exclude both. I don't think it's a big issue since each merge to master will be built and tested.
