### PR TITLE
[telemetry+dogstatsd] avoid heap escape in telemetry.Counter

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -42,6 +42,8 @@ var (
 
 	tlmProcessed = telemetry.NewCounter("dogstatsd", "processed",
 		[]string{"message_type", "state"}, "Count of service checks/events/metrics processed by dogstatsd")
+	tlmProcessedErrorTags = map[string]string{"message_type": "metrics", "state": "error"}
+	tlmProcessedOkTags    = map[string]string{"message_type": "metrics", "state": "ok"}
 )
 
 func init() {
@@ -376,7 +378,7 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFu
 	sample, err := parser.parseMetricSample(message)
 	if err != nil {
 		dogstatsdMetricParseErrors.Add(1)
-		tlmProcessed.Inc("metrics", "error")
+		tlmProcessed.IncWithTags(tlmProcessedErrorTags)
 		return metrics.MetricSample{}, err
 	}
 	if s.mapper != nil && len(sample.tags) == 0 {
@@ -389,11 +391,7 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFu
 	metricSample := enrichMetricSample(sample, s.metricPrefix, s.metricPrefixBlacklist, s.defaultHostname, originTagsFunc, s.entityIDPrecedenceEnabled)
 	metricSample.Tags = append(metricSample.Tags, s.extraTags...)
 	dogstatsdMetricPackets.Add(1)
-	// FIXME (arthur): remove this check and s.telemetryEnabled once we don't
-	// escape the tags slice to the heap
-	if s.telemetryEnabled {
-		tlmProcessed.Inc("metrics", "ok")
-	}
+	tlmProcessed.IncWithTags(tlmProcessedOkTags)
 	return metricSample, nil
 }
 

--- a/pkg/telemetry/counter.go
+++ b/pkg/telemetry/counter.go
@@ -13,12 +13,24 @@ import (
 
 // Counter tracks how many times something is happening.
 type Counter interface {
-	// Inc increments the counter for the given tags.
+	// Inc increments the counter with the given tags value.
 	Inc(tagsValue ...string)
-	// Add adds the given value to the counter for the given tags.
+	// Add adds the given value to the counter with the given tags value.
 	Add(value float64, tagsValue ...string)
-	// Delete deletes the value for the counter with the given tags.
+	// Delete deletes the value for the counter with the given tags value.
 	Delete(tagsValue ...string)
+	// IncWithTags increments the counter with the given tags.
+	// Even if less convenient, this signature could be used in hot path
+	// instead of Inc(...string) to avoid escaping the parameters on the heap.
+	IncWithTags(tags map[string]string)
+	// AddWithTags adds the given value to the counter with the given tags.
+	// Even if less convenient, this signature could be used in hot path
+	// instead of Add(float64, ...string) to avoid escaping the parameters on the heap.
+	AddWithTags(value float64, tags map[string]string)
+	// DeleteWithTags deletes the value for the counter with the given tags.
+	// Even if less convenient, this signature could be used in hot path
+	// instead of Delete(...string) to avoid escaping the parameters on the heap.
+	DeleteWithTags(tags map[string]string)
 }
 
 // NewCounter creates a Counter with default options for telemetry purpose.

--- a/pkg/telemetry/prom_counter.go
+++ b/pkg/telemetry/prom_counter.go
@@ -14,17 +14,38 @@ type promCounter struct {
 	pc *prometheus.CounterVec
 }
 
-// Add adds the given value to the counter for the given tags.
+// Add adds the given value to the counter with the given tags value.
 func (c *promCounter) Add(value float64, tagsValue ...string) {
 	c.pc.WithLabelValues(tagsValue...).Add(value)
 }
 
-// Inc increments the counter for the given tags.
+// AddWithTags adds the given value to the counter with the given tags.
+// Even if less convenient, this signature could be used in hot path
+// instead of Add(float64, ...string) to avoid escaping the parameters on the heap.
+func (c *promCounter) AddWithTags(value float64, tags map[string]string) {
+	c.pc.With(tags).Add(value)
+}
+
+// Inc increments the counter with the given tags value.
 func (c *promCounter) Inc(tagsValue ...string) {
 	c.pc.WithLabelValues(tagsValue...).Inc()
 }
 
-// Delete deletes the value for the counter with the given tags.
+// IncWithTags increments the counter with the given tags.
+// Even if less convenient, this signature could be used in hot path
+// instead of Inc(...string) to avoid escaping the parameters on the heap.
+func (c *promCounter) IncWithTags(tags map[string]string) {
+	c.pc.With(tags).Inc()
+}
+
+// Delete deletes the value for the counter with the given tags value.
 func (c *promCounter) Delete(tagsValue ...string) {
 	c.pc.DeleteLabelValues(tagsValue...)
+}
+
+// DeleteWithTags deletes the value for the counter with the given tags.
+// Even if less convenient, this signature could be used in hot path
+// instead of Delete(...string) to avoid escaping the parameters on the heap.
+func (c *promCounter) DeleteWithTags(tags map[string]string) {
+	c.pc.Delete(tags)
 }


### PR DESCRIPTION
The `...string` syntax used in the telemetry pkg escapes the strings on the heap. Because it is in a hot path, it's important having access to methods not creating any heap escape.

This PR is adding those methods to the `telemetry.Counter` type. It reduces the total garbage memory generated by the Dogstatsd `parseMetricMessage` and help reducing memory allocation during the spike of metrics sent to Dogstatsd when telemetry is enabled.

Example of behavior change during a spike (preliminary graph, I'll update it once the package is built):
![image](https://user-images.githubusercontent.com/1798689/78296394-fb668700-752d-11ea-9a7b-d4fb97ce9276.png)
