### PR TITLE
Fix Windows x86 build tags for process-agent

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -67,7 +67,7 @@ REDHAT_DEBIAN_SUSE_DIST = [
 ]
 
 
-def get_default_build_tags(puppy=False, process=False):
+def get_default_build_tags(puppy=False, process=False, arch="x64"):
     """
     Build the default list of tags based on the current platform.
 
@@ -78,13 +78,17 @@ def get_default_build_tags(puppy=False, process=False):
         return PUPPY_TAGS
 
     include = ["all"]
-    exclude = [] if sys.platform.startswith('linux') else LINUX_ONLY_TAGS
+    exclude = [] if sys.platform.startswith("linux") else LINUX_ONLY_TAGS
     # if not process agent, ignore process only tags
     if not process:
         exclude = exclude + PROCESS_ONLY_TAGS
 
     # remove all tags that are not available for current distro
     exclude.extend(get_distro_exclude_tags())
+
+    # Force exclusion of Windows 32bits tag
+    if sys.platform == "win32" and arch == "x86":
+        exclude = exclude + WINDOWS_32BIT_EXCLUDE_TAGS
 
     return get_build_tags(include, exclude)
 

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -77,7 +77,7 @@ def build(ctx, race=False, go_version=None, incremental_build=False,
     env.update(goenv)
 
     ldflags += ' '.join(["-X '{name}={value}'".format(name=main+key, value=value) for key, value in ld_vars.items()])
-    build_tags = get_default_build_tags(puppy=False, process=True)
+    build_tags = get_default_build_tags(puppy=False, process=True, arch=arch)
 
     ## secrets is not supported on windows because the process agent still runs as
     ## root.  No matter what `get_default_build_tags()` returns, take secrets out.


### PR DESCRIPTION
### What does this PR do?

Automatically exclude Win x86 tags in the `get_default_build_tags` method

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
