### PR TITLE
[System Probe] Fix flare code for unsupported OS's

### DIFF
--- a/pkg/process/net/common_unsupported.go
+++ b/pkg/process/net/common_unsupported.go
@@ -17,7 +17,7 @@ func SetSystemProbePath(_ string) {
 
 // CheckPath is not supported
 func CheckPath() error {
-	return error.New("Not Supported")
+	return ebpf.ErrNotImplemented
 }
 
 // GetRemoteSystemProbeUtil is not supported

--- a/pkg/process/net/common_unsupported.go
+++ b/pkg/process/net/common_unsupported.go
@@ -15,6 +15,11 @@ func SetSystemProbePath(_ string) {
 	// no-op
 }
 
+// CheckPath is not supported
+func CheckPath() error {
+	return error.New("Not Supported")
+}
+
 // GetRemoteSystemProbeUtil is not supported
 func GetRemoteSystemProbeUtil() (*RemoteSysProbeUtil, error) {
 	return &RemoteSysProbeUtil{}, ebpf.ErrNotImplemented
@@ -22,6 +27,11 @@ func GetRemoteSystemProbeUtil() (*RemoteSysProbeUtil, error) {
 
 // GetConnections is not supported
 func (r *RemoteSysProbeUtil) GetConnections(clientID string) (*model.Connections, error) {
+	return nil, ebpf.ErrNotImplemented
+}
+
+// GetStats is not supported
+func (r *RemoteSysProbeUtil) GetStats() (map[string]interface{}, error) {
 	return nil, ebpf.ErrNotImplemented
 }
 


### PR DESCRIPTION
### What does this PR do?

This adds functions that were implemented to run on linux OS's to return unsupported errors on other architectures.

### Motivation

Agent builds were breaking.