### PR TITLE
[cmd/check] Stop after running JMXFetch if no other instances are set

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -157,6 +157,11 @@ var checkCmd = &cobra.Command{
 					instances = append(instances, instance)
 				}
 
+				if len(instances) == 0 {
+					fmt.Printf("All instances of '%s' are JMXFetch instances, and have completed running\n", checkName)
+					return nil
+				}
+
 				conf.Instances = instances
 			}
 		}

--- a/cmd/agent/app/standalone/jmx.go
+++ b/cmd/agent/app/standalone/jmx.go
@@ -79,7 +79,11 @@ func execJmxCommand(command string, selectedChecks []string, reporter jmxfetch.J
 		return err
 	}
 
-	fmt.Println("JMXFetch exited successfully. If nothing was displayed please check your configuration, flags and the JMXFetch log file.")
+	fmt.Printf(
+		"JMXFetch exited successfully. If nothing was displayed please check your configuration and flags, "+
+			"or re-run the command with a more verbose log level (current log level: '%s').\n",
+		logLevel,
+	)
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

* Stops the `check` command after running JMXFetch instances when no other instances are available
* Makes printed message a bit friendlier

### Motivation

Tiny UX improvement to the `check`/`jmx` commands

_edit: in the case of JMXFetch-only integrations, this bug could be regarded as a regression, so changing the milestone to 7.19_