### PR TITLE
[System probe] Add unsupported getstats to system probe flare

### DIFF
--- a/pkg/status/status_system_probe.go
+++ b/pkg/status/status_system_probe.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
 // +build !zlib
 
 package status

--- a/pkg/status/status_system_probe.go
+++ b/pkg/status/status_system_probe.go
@@ -1,3 +1,5 @@
+// +build !zlib
+
 package status
 
 import (

--- a/pkg/status/status_system_probe_unsupported.go
+++ b/pkg/status/status_system_probe_unsupported.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
 // +build zlib
 
 package status
@@ -8,6 +13,6 @@ import (
 
 func getSystemProbeStats() map[string]interface{} {
 	return map[string]interface{}{
-		"Errors": fmt.Sprintf("System Probe Unsupported"),
+		"Errors": fmt.Sprintf("System Probe is not supported when built without zstd support"),
 	}
 }

--- a/pkg/status/status_system_probe_unsupported.go
+++ b/pkg/status/status_system_probe_unsupported.go
@@ -1,0 +1,13 @@
+// +build zlib
+
+package status
+
+import (
+	"fmt"
+)
+
+func getSystemProbeStats() map[string]interface{} {
+	return map[string]interface{}{
+		"Errors": fmt.Sprintf("System Probe Unsupported"),
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a build tag on getting the system probe status so that we can build a version for the puppy agent. 

### Motivation

The puppy agent build was broken. 

### Additional Notes
Related:

- https://github.com/DataDog/datadog-agent/pull/5179
- https://github.com/DataDog/datadog-agent/pull/5258