### PR TITLE
[netlink] Disable unregister events

### DIFF
--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	ct "github.com/florianl/go-conntrack"
 	"github.com/mdlayher/netlink"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -63,8 +62,7 @@ type realConntracker struct {
 	sync.Mutex
 
 	// we need two nfct handles because we can only register one callback per connection at a time
-	nfct    *ct.Nfct
-	nfctDel *ct.Nfct
+	nfct *ct.Nfct
 
 	state map[connKey]*connValue
 
@@ -82,15 +80,12 @@ type realConntracker struct {
 	statsTicker   *time.Ticker
 	compactTicker *time.Ticker
 	stats         struct {
-		gets                 int64
-		getTimeTotal         int64
-		registers            int64
-		registersTotalTime   int64
-		registersDropped     int64
-		unregisters          int64
-		unregistersTotalTime int64
-		expiresTotal         int64
-		missedRegisters      int64
+		gets               int64
+		getTimeTotal       int64
+		registers          int64
+		registersDropped   int64
+		registersTotalTime int64
+		expiresTotal       int64
 	}
 	exceededSizeLogLimit *util.LogLimit
 }
@@ -130,14 +125,8 @@ func newConntrackerOnce(procRoot string, deleteBufferSize, maxStateSize int) (Co
 		return nil, err
 	}
 
-	nfctDel, err := createNetlinkSocket("unregister", netns, logger)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to open delete NFCT")
-	}
-
 	ctr := &realConntracker{
 		nfct:                 nfct,
-		nfctDel:              nfctDel,
 		compactTicker:        time.NewTicker(compactInterval),
 		state:                make(map[connKey]*connValue),
 		shortLivedBuffer:     make(map[connKey]*IPTranslation),
@@ -166,9 +155,6 @@ func newConntrackerOnce(procRoot string, deleteBufferSize, maxStateSize int) (Co
 
 	nfct.Register(context.Background(), ct.Conntrack, ct.NetlinkCtNew, ctr.register)
 	log.Debugf("initialized register hook")
-
-	nfctDel.Register(context.Background(), ct.Conntrack, ct.NetlinkCtDestroy, ctr.unregister)
-	log.Debugf("initialized unregister hook")
 
 	log.Infof("initialized conntrack")
 
@@ -227,7 +213,6 @@ func (ctr *realConntracker) GetStats() map[string]int64 {
 		"state_size":             int64(size),
 		"short_term_buffer_size": int64(stBufSize),
 		"expires":                int64(ctr.stats.expiresTotal),
-		"missed_registers":       int64(ctr.stats.missedRegisters),
 	}
 
 	if ctr.stats.gets != 0 {
@@ -238,11 +223,6 @@ func (ctr *realConntracker) GetStats() map[string]int64 {
 		m["registers_total"] = ctr.stats.registers
 		m["registers_dropped"] = ctr.stats.registersDropped
 		m["nanoseconds_per_register"] = ctr.stats.registersTotalTime / ctr.stats.registers
-	}
-	if ctr.stats.unregisters != 0 {
-		m["unregisters_total"] = ctr.stats.unregisters
-		m["nanoseconds_per_unregister"] = ctr.stats.unregistersTotalTime / ctr.stats.unregisters
-
 	}
 
 	return m
@@ -308,53 +288,6 @@ func (ctr *realConntracker) logExceededSize() {
 	if ctr.exceededSizeLogLimit.ShouldLog() {
 		log.Warnf("exceeded maximum conntrack state size: %d entries. You may need to increase system_probe_config.max_tracked_connections (will log first ten times, and then once every 10 minutes)", ctr.maxStateSize)
 	}
-}
-
-// unregister is registered to be called whenever a conntrack entry is destroyed.
-// it will keep being called until it returns nonzero.
-func (ctr *realConntracker) unregister(c ct.Con) int {
-	if !isNAT(c) {
-		return 0
-	}
-
-	misses := 0
-	unregisterTuple := func(keyTuple *ct.IPTuple) {
-		key, ok := formatKey(keyTuple)
-		if !ok {
-			return
-		}
-
-		translation, ok := ctr.state[key]
-		if !ok {
-			misses++
-			return
-		}
-
-		// move the mapping from the permanent to "short lived" connection
-		delete(ctr.state, key)
-		if len(ctr.shortLivedBuffer) < ctr.maxShortLivedBuffer {
-			ctr.shortLivedBuffer[key] = translation.IPTranslation
-		} else {
-			log.Warn("exceeded maximum tracked short lived connections")
-		}
-	}
-
-	now := time.Now().UnixNano()
-	ctr.Lock()
-	defer ctr.Unlock()
-	unregisterTuple(c.Origin)
-	unregisterTuple(c.Reply)
-	then := time.Now().UnixNano()
-	atomic.AddInt64(&ctr.stats.unregisters, 1)
-	atomic.AddInt64(&ctr.stats.unregistersTotalTime, then-now)
-	if misses > 0 {
-		log.Debugf("missed register event for: %s", conDebug(c))
-		atomic.AddInt64(&ctr.stats.missedRegisters, 1)
-	}
-
-	log.Tracef("unregistered %s", conDebug(c))
-
-	return 0
 }
 
 func (ctr *realConntracker) run() {

--- a/pkg/ebpf/netlink/conntracker_integration_test.go
+++ b/pkg/ebpf/netlink/conntracker_integration_test.go
@@ -30,6 +30,7 @@ func TestConntracker(t *testing.T) {
 	<-startServerUDP(t, net.ParseIP("1.1.1.1"), 5432)
 
 	localAddr := pingTCP(t, "2.2.2.2:5432")
+	time.Sleep(1 * time.Second)
 
 	trans := ct.GetTranslationForConn(
 		util.AddressFromNetIP(localAddr.IP), uint16(localAddr.Port),

--- a/pkg/ebpf/netlink/conntracker_test.go
+++ b/pkg/ebpf/netlink/conntracker_test.go
@@ -121,31 +121,6 @@ func TestRegisterNat(t *testing.T) {
 	)
 	assert.Nil(t, udpTranslation)
 
-	// even after unregistering, we should be able to access the conn
-	rt.unregister(c)
-	translation2 := rt.GetTranslationForConn(
-		util.AddressFromString("10.0.0.0"), 12345,
-		util.AddressFromString("50.30.40.10"), 80,
-		process.ConnectionType_tcp,
-	)
-	assert.NotNil(t, translation2)
-
-	// double unregisters should never happen, though it will be treated as a no-op
-	rt.unregister(c)
-
-	rt.ClearShortLived()
-	translation3 := rt.GetTranslationForConn(
-		util.AddressFromString("10.0.0.0"), 12345,
-		util.AddressFromString("50.30.40.10"), 80,
-		process.ConnectionType_tcp,
-	)
-	assert.Nil(t, translation3)
-
-	// triple unregisters should never happen, though it will be treated as a no-op
-	rt.unregister(c)
-
-	assert.Equal(t, translation, translation2)
-
 }
 
 func TestRegisterNatUDP(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Disable netlink unregister events. We'll defer the connection expiration to our caching layer.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
