### PR TITLE
Fix master

### DIFF
--- a/pkg/process/net/check.go
+++ b/pkg/process/net/check.go
@@ -26,7 +26,7 @@ func (r *RemoteSysProbeUtil) GetCheck(check string) ([]tcpqueuelength.Stats, err
 	if err != nil {
 		return nil, err
 	} else if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("conn request failed: socket %s, url %s, status code: %d", r.socketPath, fmt.Sprintf("%s/%s", checksURL, check), resp.StatusCode)
+		return nil, fmt.Errorf("conn request failed: socket %s, url %s, status code: %d", r.path, fmt.Sprintf("%s/%s", checksURL, check), resp.StatusCode)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
### What does this PR do?

Fix `master` branch

### Motivation

The `RemoteSysProbeUtil` field `socketPath` has been renamed `path` in #5179
and #5179 was merged between the last rebase on `master` of #4619 and its merge.

### Additional Notes