### PR TITLE
[tcp_queue_length] Disable when building without cgo

### DIFF
--- a/pkg/collector/corechecks/ebpf/empty.go
+++ b/pkg/collector/corechecks/ebpf/empty.go
@@ -1,8 +1,8 @@
-// +build !linux
+// +build !linux !cgo
 
 package ebpf
 
-// Avoid the following error on Windows:
-// cmd\agent\app\run.go:49:2: build constraints exclude all Go files in C:\omnibus-ruby\src\datadog-puppy\src\github.com\DataDog\datadog-agent\pkg\collector\corechecks\ebpf
+// Avoid the following error on non-supported platforms:
+// "build constraints exclude all Go files in github.com\DataDog\datadog-agent\pkg\collector\corechecks\ebpf"
 func init() {
 }

--- a/pkg/collector/corechecks/ebpf/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcp_queue_length.go
@@ -3,6 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
+// FIXME: we require the `cgo` build tag because of this dep relationship:
+// github.com/DataDog/datadog-agent/pkg/process/net depends on `github.com/DataDog/agent-payload/process`,
+// which has a hard dependency on `github.com/DataDog/zstd`, which requires CGO.
+// Should be removed once `github.com/DataDog/agent-payload/process` can be imported with CGO disabled.
+// +build cgo
 // +build linux
 
 package ebpf


### PR DESCRIPTION
### What does this PR do?

Disables `tcp_queue_length` core check when building without cgo.

Supersedes/Fixes https://github.com/DataDog/datadog-agent/pull/5273, fixes a bug introduced by https://github.com/DataDog/datadog-agent/pull/4619.

### Motivation

The `tcp_queue_length` core check creates a dependency to `github.com/DataDog/zstd`, which requires cgo, and therefore can't be built on puppy builds.

### Additional Notes

Added a FIXME comment: I think the proper fix would be to remove the CGO dependency that `github.com/DataDog/agent-payload/process` introduces by trying to import `github.com/DataDog/zstd` even when cgo is disabled.

For now, let's simply disable the `tcp_queue_length` check in that case.