### PR TITLE
Harmonize acceptable log_level input

### DIFF
--- a/pkg/config/runtime_settings_test.go
+++ b/pkg/config/runtime_settings_test.go
@@ -75,11 +75,18 @@ func TestLogLevel(t *testing.T) {
 	assert.Equal(t, "off", v)
 	assert.Nil(t, err)
 
-	err = ll.Set("invalid")
-	assert.NotNil(t, err)
-	assert.Equal(t, "declared minlevel not found: invalid", err.Error())
+	err = ll.Set("WARNING")
+	assert.Nil(t, err)
 
 	v, err = ll.Get()
-	assert.Equal(t, "off", v)
+	assert.Equal(t, "warn", v)
+	assert.Nil(t, err)
+
+	err = ll.Set("invalid")
+	assert.NotNil(t, err)
+	assert.Equal(t, "unknown log level: invalid", err.Error())
+
+	v, err = ll.Get()
+	assert.Equal(t, "warn", v)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
### What does this PR do?
The log_level value in config file & the value passed for changing it at runtime now have a common validation logic : they are both case insensitive and accept warning for warn.

### Motivation
Consistency.

### Additional Notes
N/A
