### PR TITLE
Update PyYAML to 5.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ invoke==1.0.0
 reno==2.9.2
 docker==3.7.3
 requests==2.20.1
-PyYAML==5.3
+PyYAML==5.3.1
 toml==0.9.4
 distro==1.4.0


### PR DESCRIPTION
This PR updates the PyYAML dependency from 5.3.0 to 5.3.1 to include a patch for [CVE-2020-1747](https://nvd.nist.gov/vuln/detail/CVE-2020-1747)

As documented [here](https://github.com/yaml/pyyaml/blob/master/CHANGES), the CVE patch is the only change between those two versions.