### PR TITLE
Disable API key health checks on process/cluster agent

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -244,7 +244,7 @@ func StartAgent() error {
 	if err != nil {
 		log.Error("Misconfiguration of agent endpoints: ", err)
 	}
-	common.Forwarder = forwarder.NewDefaultForwarder(keysPerDomain)
+	common.Forwarder = forwarder.NewDefaultForwarder(forwarder.NewOptions(keysPerDomain))
 	log.Debugf("Starting forwarder")
 	common.Forwarder.Start()
 	log.Debugf("Forwarder started")

--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -162,7 +162,7 @@ func run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		log.Error("Misconfiguration of agent endpoints: ", err)
 	}
-	f := forwarder.NewDefaultForwarder(keysPerDomain)
+	f := forwarder.NewDefaultForwarder(forwarder.NewOptions(keysPerDomain))
 	f.Start()
 	s := serializer.NewSerializer(f)
 

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -165,7 +165,7 @@ func start(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		log.Error("Misconfiguration of agent endpoints: ", err)
 	}
-	f := forwarder.NewDefaultForwarder(keysPerDomain)
+	f := forwarder.NewDefaultForwarder(forwarder.NewOptions(keysPerDomain))
 	f.Start()
 	s := serializer.NewSerializer(f)
 

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -174,7 +174,7 @@ func runAgent() (mainCtx context.Context, mainCtxCancel context.CancelFunc, err 
 	if err != nil {
 		log.Error("Misconfiguration of agent endpoints: ", err)
 	}
-	f := forwarder.NewDefaultForwarder(keysPerDomain)
+	f := forwarder.NewDefaultForwarder(forwarder.NewOptions(keysPerDomain))
 	f.Start()
 	s := serializer.NewSerializer(f)
 

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -69,8 +69,8 @@ func NewCollector(cfg *config.AgentConfig) (Collector, error) {
 		rtIntervalCh:  make(chan time.Duration),
 		cfg:           cfg,
 		groupID:       rand.Int31(),
-		forwarder:     forwarder.NewDefaultForwarder(keysPerDomains(cfg.APIEndpoints)),
-		podForwarder:  forwarder.NewDefaultForwarder(keysPerDomains(cfg.OrchestratorEndpoints)),
+		forwarder:     forwarder.NewDefaultForwarderWithOptions(keysPerDomains(cfg.APIEndpoints), false),
+		podForwarder:  forwarder.NewDefaultForwarderWithOptions(keysPerDomains(cfg.OrchestratorEndpoints), false),
 		enabledChecks: enabledChecks,
 
 		// Defaults for real-time on start

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -64,13 +64,19 @@ func NewCollector(cfg *config.AgentConfig) (Collector, error) {
 		}
 	}
 
+	forwarderOpts := forwarder.NewOptions(keysPerDomains(cfg.APIEndpoints))
+	forwarderOpts.EnableHealthChecking = false
+
+	podForwarderOpts := forwarder.NewOptions(keysPerDomains(cfg.OrchestratorEndpoints))
+	podForwarderOpts.EnableHealthChecking = false
+
 	return Collector{
 		send:          make(chan checkPayload, cfg.QueueSize),
 		rtIntervalCh:  make(chan time.Duration),
 		cfg:           cfg,
 		groupID:       rand.Int31(),
-		forwarder:     forwarder.NewDefaultForwarderWithOptions(keysPerDomains(cfg.APIEndpoints), false),
-		podForwarder:  forwarder.NewDefaultForwarderWithOptions(keysPerDomains(cfg.OrchestratorEndpoints), false),
+		forwarder:     forwarder.NewDefaultForwarder(forwarderOpts),
+		podForwarder:  forwarder.NewDefaultForwarder(podForwarderOpts),
 		enabledChecks: enabledChecks,
 
 		// Defaults for real-time on start

--- a/pkg/clusteragent/orchestrator/controller.go
+++ b/pkg/clusteragent/orchestrator/controller.go
@@ -103,7 +103,7 @@ func newController(ctx ControllerContext) (*Controller, error) {
 		clusterName:             ctx.ClusterName,
 		clusterID:               clusterID,
 		processConfig:           cfg,
-		forwarder:               forwarder.NewDefaultForwarder(keysPerDomain),
+		forwarder:               forwarder.NewDefaultForwarderWithOptions(keysPerDomain, false),
 		IsLeaderFunc:            ctx.IsLeaderFunc,
 	}
 

--- a/pkg/clusteragent/orchestrator/controller.go
+++ b/pkg/clusteragent/orchestrator/controller.go
@@ -95,6 +95,9 @@ func newController(ctx ControllerContext) (*Controller, error) {
 		keysPerDomain[ep.Endpoint.String()] = []string{ep.APIKey}
 	}
 
+	podForwarderOpts := forwarder.NewOptions(keysPerDomain)
+	podForwarderOpts.EnableHealthChecking = false
+
 	oc := &Controller{
 		unassignedPodLister:     podInformer.Lister(),
 		unassignedPodListerSync: podInformer.Informer().HasSynced,
@@ -103,7 +106,7 @@ func newController(ctx ControllerContext) (*Controller, error) {
 		clusterName:             ctx.ClusterName,
 		clusterID:               clusterID,
 		processConfig:           cfg,
-		forwarder:               forwarder.NewDefaultForwarderWithOptions(keysPerDomain, false),
+		forwarder:               forwarder.NewDefaultForwarder(podForwarderOpts),
 		IsLeaderFunc:            ctx.IsLeaderFunc,
 	}
 

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -152,6 +152,24 @@ type Forwarder interface {
 // Compile-time check to ensure that DefaultForwarder implements the Forwarder interface
 var _ Forwarder = &DefaultForwarder{}
 
+// Options contain the configuration options for the DefaultForwarder
+type Options struct {
+	NumberOfWorkers      int
+	RetryQueueSize       int
+	EnableHealthChecking bool
+	KeysPerDomain        map[string][]string
+}
+
+// NewOptions creates new Options with default values
+func NewOptions(keysPerDomain map[string][]string) *Options {
+	return &Options{
+		NumberOfWorkers:      config.Datadog.GetInt("forwarder_num_workers"),
+		RetryQueueSize:       config.Datadog.GetInt("forwarder_retry_queue_max_size"),
+		EnableHealthChecking: true,
+		KeysPerDomain:        keysPerDomain,
+	}
+}
+
 // DefaultForwarder is the default implementation of the Forwarder.
 type DefaultForwarder struct {
 	// NumberOfWorkers Number of concurrent HTTP request made by the DefaultForwarder (default 4).
@@ -165,32 +183,25 @@ type DefaultForwarder struct {
 }
 
 // NewDefaultForwarder returns a new DefaultForwarder.
-func NewDefaultForwarder(keysPerDomains map[string][]string) *DefaultForwarder {
-	return NewDefaultForwarderWithOptions(keysPerDomains, true)
-}
-
-// NewDefaultForwarderWithOptions creates a new DefaultForwarder with the given configuration
-func NewDefaultForwarderWithOptions(keysPerDomains map[string][]string, enableHealthChecks bool) *DefaultForwarder {
+func NewDefaultForwarder(options *Options) *DefaultForwarder {
 	f := &DefaultForwarder{
-		NumberOfWorkers:  config.Datadog.GetInt("forwarder_num_workers"),
+		NumberOfWorkers:  options.NumberOfWorkers,
 		domainForwarders: map[string]*domainForwarder{},
 		keysPerDomains:   map[string][]string{},
 		internalState:    Stopped,
 	}
-	numWorkers := config.Datadog.GetInt("forwarder_num_workers")
-	retryQueueMaxSize := config.Datadog.GetInt("forwarder_retry_queue_max_size")
 
-	if enableHealthChecks {
-		f.healthChecker = &forwarderHealth{keysPerDomains: keysPerDomains}
+	if options.EnableHealthChecking {
+		f.healthChecker = &forwarderHealth{keysPerDomains: options.KeysPerDomain}
 	}
 
-	for domain, keys := range keysPerDomains {
+	for domain, keys := range options.KeysPerDomain {
 		domain, _ := config.AddAgentVersionToDomain(domain, "app")
 		if keys == nil || len(keys) == 0 {
 			log.Errorf("No API keys for domain '%s', dropping domain ", domain)
 		} else {
 			f.keysPerDomains[domain] = keys
-			f.domainForwarders[domain] = newDomainForwarder(domain, numWorkers, retryQueueMaxSize)
+			f.domainForwarders[domain] = newDomainForwarder(domain, options.NumberOfWorkers, options.RetryQueueSize)
 		}
 	}
 

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -36,7 +36,7 @@ var (
 )
 
 func TestNewDefaultForwarder(t *testing.T) {
-	forwarder := NewDefaultForwarder(keysPerDomains)
+	forwarder := NewDefaultForwarder(NewOptions(keysPerDomains))
 
 	assert.NotNil(t, forwarder)
 	assert.Equal(t, 1, forwarder.NumberOfWorkers)
@@ -49,7 +49,7 @@ func TestNewDefaultForwarder(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
-	forwarder := NewDefaultForwarder(monoKeysDomains)
+	forwarder := NewDefaultForwarder(NewOptions(monoKeysDomains))
 	err := forwarder.Start()
 	defer forwarder.Stop()
 
@@ -77,7 +77,7 @@ func TestStopWithPurgingTransaction(t *testing.T) {
 }
 
 func testStop(t *testing.T) {
-	forwarder := NewDefaultForwarder(keysPerDomains)
+	forwarder := NewDefaultForwarder(NewOptions(keysPerDomains))
 	assert.Equal(t, Stopped, forwarder.State())
 	forwarder.Stop() // this should be a noop
 	forwarder.Start()
@@ -92,7 +92,7 @@ func testStop(t *testing.T) {
 }
 
 func TestSubmitIfStopped(t *testing.T) {
-	forwarder := NewDefaultForwarder(monoKeysDomains)
+	forwarder := NewDefaultForwarder(NewOptions(monoKeysDomains))
 
 	require.NotNil(t, forwarder)
 	require.Equal(t, Stopped, forwarder.State())
@@ -108,7 +108,7 @@ func TestSubmitIfStopped(t *testing.T) {
 }
 
 func TestCreateHTTPTransactions(t *testing.T) {
-	forwarder := NewDefaultForwarder(keysPerDomains)
+	forwarder := NewDefaultForwarder(NewOptions(keysPerDomains))
 	endpoint := endpoint{"/api/foo", "foo"}
 	p1 := []byte("A payload")
 	p2 := []byte("Another payload")
@@ -145,7 +145,7 @@ func TestCreateHTTPTransactions(t *testing.T) {
 }
 
 func TestSendHTTPTransactions(t *testing.T) {
-	forwarder := NewDefaultForwarder(keysPerDomains)
+	forwarder := NewDefaultForwarder(NewOptions(keysPerDomains))
 	endpoint := endpoint{"/api/foo", "foo"}
 	p1 := []byte("A payload")
 	payloads := Payloads{&p1}
@@ -163,7 +163,7 @@ func TestSendHTTPTransactions(t *testing.T) {
 }
 
 func TestSubmitV1Intake(t *testing.T) {
-	forwarder := NewDefaultForwarder(monoKeysDomains)
+	forwarder := NewDefaultForwarder(NewOptions(monoKeysDomains))
 	forwarder.Start()
 	defer forwarder.Stop()
 
@@ -206,11 +206,11 @@ func TestForwarderEndtoEnd(t *testing.T) {
 	mockConfig.Set("dd_url", ts.URL)
 	defer mockConfig.Set("dd_url", ddURL)
 
-	f := NewDefaultForwarder(map[string][]string{
+	f := NewDefaultForwarder(NewOptions(map[string][]string{
 		ts.URL:     {"api_key1", "api_key2"},
 		"invalid":  {},
 		"invalid2": nil,
-	})
+	}))
 
 	f.Start()
 	defer f.Stop()
@@ -253,9 +253,9 @@ func TestTransactionEventHandlers(t *testing.T) {
 	mockConfig.Set("dd_url", ts.URL)
 	defer mockConfig.Set("dd_url", ddURL)
 
-	f := NewDefaultForwarder(map[string][]string{
+	f := NewDefaultForwarder(NewOptions(map[string][]string{
 		ts.URL: {"api_key1"},
-	})
+	}))
 
 	_ = f.Start()
 	defer f.Stop()
@@ -311,9 +311,9 @@ func TestTransactionEventHandlersOnRetry(t *testing.T) {
 	mockConfig.Set("dd_url", ts.URL)
 	defer mockConfig.Set("dd_url", ddURL)
 
-	f := NewDefaultForwarder(map[string][]string{
+	f := NewDefaultForwarder(NewOptions(map[string][]string{
 		ts.URL: {"api_key1"},
-	})
+	}))
 
 	_ = f.Start()
 	defer f.Stop()
@@ -365,9 +365,9 @@ func TestTransactionEventHandlersNotRetryable(t *testing.T) {
 	mockConfig.Set("dd_url", ts.URL)
 	defer mockConfig.Set("dd_url", ddURL)
 
-	f := NewDefaultForwarder(map[string][]string{
+	f := NewDefaultForwarder(NewOptions(map[string][]string{
 		ts.URL: {"api_key1"},
-	})
+	}))
 
 	_ = f.Start()
 	defer f.Stop()
@@ -424,9 +424,9 @@ func TestProcessLikePayloadResponseTimeout(t *testing.T) {
 		defaultResponseTimeout = responseTimeout
 	}()
 
-	f := NewDefaultForwarder(map[string][]string{
+	f := NewDefaultForwarder(NewOptions(map[string][]string{
 		ts.URL: {"api_key1"},
-	})
+	}))
 
 	_ = f.Start()
 	defer f.Stop()

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -53,7 +53,7 @@ func TestNewScheduler(t *testing.T) {
 	enableFirstRunCollection = false
 	defer func() { enableFirstRunCollection = true }()
 
-	fwd := forwarder.NewDefaultForwarder(nil)
+	fwd := forwarder.NewDefaultForwarder(forwarder.NewOptions(nil))
 	fwd.Start()
 	s := serializer.NewSerializer(fwd)
 	c := NewScheduler(s)
@@ -65,7 +65,7 @@ func TestStopScheduler(t *testing.T) {
 	enableFirstRunCollection = false
 	defer func() { enableFirstRunCollection = true }()
 
-	fwd := forwarder.NewDefaultForwarder(nil)
+	fwd := forwarder.NewDefaultForwarder(forwarder.NewOptions(nil))
 	fwd.Start()
 	s := serializer.NewSerializer(fwd)
 	c := NewScheduler(s)
@@ -92,7 +92,7 @@ func TestAddCollector(t *testing.T) {
 		SendCalledC: make(chan bool),
 	}
 
-	fwd := forwarder.NewDefaultForwarder(nil)
+	fwd := forwarder.NewDefaultForwarder(forwarder.NewOptions(nil))
 	fwd.Start()
 	s := serializer.NewSerializer(fwd)
 	c := NewScheduler(s)
@@ -127,7 +127,7 @@ func TestAddCollectorWithInit(t *testing.T) {
 		InitCalledC: make(chan bool, 1),
 	}
 
-	fwd := forwarder.NewDefaultForwarder(nil)
+	fwd := forwarder.NewDefaultForwarder(forwarder.NewOptions(nil))
 	fwd.Start()
 	s := serializer.NewSerializer(fwd)
 	c := NewScheduler(s)
@@ -165,7 +165,7 @@ func TestTriggerAndResetCollectorTimer(t *testing.T) {
 		SendCalledC: make(chan bool),
 	}
 
-	fwd := forwarder.NewDefaultForwarder(nil)
+	fwd := forwarder.NewDefaultForwarder(forwarder.NewOptions(nil))
 	fwd.Start()
 	s := serializer.NewSerializer(fwd)
 	c := NewScheduler(s)


### PR DESCRIPTION
### What does this PR do?

The process/orchestrator intake does its own API key validation and does not implement the /validate endpoint that the forwarder health check is using. Having the health check enabled makes for a lot of noisy log lines in the agent

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
