### PR TITLE
[gitlab] send_pkg_size-a7: create tmp puppy rpm folder before using it

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2095,7 +2095,7 @@ send_pkg_size-a7:
   script:
     - source /root/.bashrc && conda activate ddpy3
     - mkdir -p /tmp/deb/agent /tmp/deb/dogstatsd /tmp/deb/puppy
-    - mkdir -p /tmp/rpm/agent /tmp/rpm/dogstatsd
+    - mkdir -p /tmp/rpm/agent /tmp/rpm/dogstatsd /tmp/rpm/puppy
     - mkdir -p /tmp/suse/agent /tmp/suse/dogstatsd
 
     # we silence dpkg and cpio output so we don't exceed gitlab log limit


### PR DESCRIPTION
### What does this PR do?

Creates `/tmp/rpm/puppy` before trying to `cd` in it.

### Motivation

Make `send_pkg_size-a7` job work.
