### PR TITLE
Fix strip URI password

### DIFF
--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -36,8 +36,10 @@ func init() {
 		Regex: regexp.MustCompile(`\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b`),
 		Repl:  []byte(`***********************************$1`),
 	}
+	// URI Generic Syntax
+	// https://tools.ietf.org/html/rfc3986
 	uriPasswordReplacer := Replacer{
-		Regex: regexp.MustCompile(`([A-Za-z]+\:\/\/|\b)([A-Za-z0-9_]+)\:([^\s]+)\@`),
+		Regex: regexp.MustCompile(`([A-Za-z][A-Za-z0-9+-.]+\:\/\/|\b)([^\:]+)\:([^\s]+)\@`),
 		Repl:  []byte(`$1$2:********@`),
 	}
 	passwordReplacer := Replacer{

--- a/pkg/util/log/strip_test.go
+++ b/pkg/util/log/strip_test.go
@@ -136,8 +136,11 @@ func TestConfigStripURLPassword(t *testing.T) {
 		`   random_url_key:   'mongodb+srv://user:pass-with-hyphen@abc.example.com/database'   `,
 		`   random_url_key:   'mongodb+srv://user:********@abc.example.com/database'   `)
 	assertClean(t,
-		`   random_url_key:   'mongodb+srv://user-with-hyphen:pass-with-hyphen@abc.example.com/database'   `,
-		`   random_url_key:   'mongodb+srv://user-with-hyphen:********@abc.example.com/database'   `)
+		`   random_url_key:   'http://user-with-hyphen:pass-with-hyphen@abc.example.com/database'   `,
+		`   random_url_key:   'http://user-with-hyphen:********@abc.example.com/database'   `)
+	assertClean(t,
+		`   random_url_key:   'http://user-with-hyphen:pass@abc.example.com/database'   `,
+		`   random_url_key:   'http://user-with-hyphen:********@abc.example.com/database'   `)
 }
 
 func TestTextStripApiKey(t *testing.T) {

--- a/pkg/util/log/strip_test.go
+++ b/pkg/util/log/strip_test.go
@@ -130,8 +130,14 @@ func TestConfigStripURLPassword(t *testing.T) {
 		`   random_url_key:   'http://user:password@host:port'   `,
 		`   random_url_key:   'http://user:********@host:port'   `)
 	assertClean(t,
+		`   random_url_key:   'mongodb+s.r-v://user:password@host:port'   `,
+		`   random_url_key:   'mongodb+s.r-v://user:********@host:port'   `)
+	assertClean(t,
 		`   random_url_key:   'mongodb+srv://user:pass-with-hyphen@abc.example.com/database'   `,
 		`   random_url_key:   'mongodb+srv://user:********@abc.example.com/database'   `)
+	assertClean(t,
+		`   random_url_key:   'mongodb+srv://user-with-hyphen:pass-with-hyphen@abc.example.com/database'   `,
+		`   random_url_key:   'mongodb+srv://user-with-hyphen:********@abc.example.com/database'   `)
 }
 
 func TestTextStripApiKey(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Fix strip uri password regression introduced by https://github.com/DataDog/datadog-agent/pull/5085

Username might contain hyphen. e.g. `dd_url: http://username-with-hyphen:pwd@localhost:1234`


The previous regex `([A-Za-z]+\:\/\/|\b)([A-Za-z0-9_]+)\:([^\s-]+)\@` (before this change https://github.com/DataDog/datadog-agent/pull/5085) worked but wasn't matching correctly. e.g. `([A-Za-z0-9_]+)` matches `hyphen` instead of `username-with-hyphen`

### Additional Notes

Notes:

```
1. Scheme names consist of a sequence of characters beginning with a
   letter and followed by any combination of letters, digits, plus
   ("+"), period ("."), or hyphen ("-"). 

2.    Use of the format "user:password" in the userinfo field is
   deprecated.  Applications should not render as clear text any data
   after the first colon (":") character found within a userinfo
   subcomponent unless the data after the colon is the empty string
   (indicating no password). 
```

From: https://tools.ietf.org/html/rfc3986
