### PR TITLE
[gitlab] Fix chocolatey publish paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1263,6 +1263,9 @@ publish_choco_7_x64:
   before_script:
     - $chocolateyApiKey = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.chocolatey_api_key --with-decryption --query "Parameter.Value" --out text)
   script:
+    - Get-ChildItem $OMNIBUS_PACKAGE_DIR
+    - if (Test-Path nupkg) { remove-item -recurse -force nupkg }
+    - copy $OMNIBUS_PACKAGE_DIR\*.nupkg nupkg\
     - docker run --rm -v "$(Get-Location):c:\mnt" -e CHOCOLATEY_API_KEY=${chocolateyApiKey} 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_1809_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\chocopush.bat
   when: manual
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1263,9 +1263,9 @@ publish_choco_7_x64:
   before_script:
     - $chocolateyApiKey = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.chocolatey_api_key --with-decryption --query "Parameter.Value" --out text)
   script:
-    - Get-ChildItem $OMNIBUS_PACKAGE_DIR
+    - Get-ChildItem .omnibus\pkg
     - if (Test-Path nupkg) { remove-item -recurse -force nupkg }
-    - copy $OMNIBUS_PACKAGE_DIR\*.nupkg nupkg\
+    - copy .omnibus\pkg\*.nupkg nupkg\
     - docker run --rm -v "$(Get-Location):c:\mnt" -e CHOCOLATEY_API_KEY=${chocolateyApiKey} 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_1809_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\chocopush.bat
   when: manual
 

--- a/tasks/winbuildscripts/Publish-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Publish-Chocolatey-Package.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop';
 Set-Location c:\mnt
-$nupkgs = Get-ChildItem .\build-out\datadog-agent*.nupkg
+$nupkgs = Get-ChildItem .\nupkg\datadog-agent*.nupkg
 if (($nupkgs | Measure-Object).Count -gt 1) {
     Write-Host "More than 1 Chocolatey package exists - aborting"
     exit 1


### PR DESCRIPTION
### What does this PR do?

Creates nupkg folder & copies the `nupkg` artifacts needed for publishing in the docker image.

### Motivation

Make chocolatey publish job work.

