### PR TITLE
Fix panic due to concurrent map access in Docker AD provider

### DIFF
--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -89,6 +89,8 @@ func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 		go d.listen()
 	}
 
+	d.RLock()
+	defer d.RUnlock()
 	return parseDockerLabels(containers)
 }
 

--- a/releasenotes/notes/fix-concurrent-map-access-9226d0f36d5f9a39.yaml
+++ b/releasenotes/notes/fix-concurrent-map-access-9226d0f36d5f9a39.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix panic due to concurrent map access in Docker AD provider


### PR DESCRIPTION
### What does this PR do?

In some cases, we give an internal map that should synchronised to an external function that iterates through the map.
We need to read-lock this operation as concurrent writes may happen while this function runs.