### PR TITLE
Don't panic when RemoteSysProbeUtil is not initialized

### DIFF
--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -141,18 +141,6 @@ func (r *RemoteSysProbeUtil) GetStats() (map[string]interface{}, error) {
 	return stats, nil
 }
 
-// ShouldLogTracerUtilError will return whether or not errors sourced from the RemoteSysProbeUtil _should_ be logged, for less noisy logging.
-// We only want to log errors if the tracer has been initialized, or it's the first error for a particular tracer status
-// (e.g. retrying, permafail)
-func ShouldLogTracerUtilError() bool {
-	status := globalUtil.initRetry.RetryStatus()
-
-	_, logged := hasLoggedErrForStatus[status]
-	hasLoggedErrForStatus[status] = struct{}{}
-
-	return status == retry.OK || !logged
-}
-
 func newSystemProbe() *RemoteSysProbeUtil {
 	return &RemoteSysProbeUtil{
 		path: globalSocketPath,

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -31,15 +31,10 @@ const (
 )
 
 var (
-	globalUtil            *RemoteSysProbeUtil
-	globalUtilOnce        sync.Once
-	globalSocketPath      string
-	hasLoggedErrForStatus map[retry.Status]struct{}
+	globalUtil       *RemoteSysProbeUtil
+	globalUtilOnce   sync.Once
+	globalSocketPath string
 )
-
-func init() {
-	hasLoggedErrForStatus = make(map[retry.Status]struct{})
-}
 
 // RemoteSysProbeUtil wraps interactions with a remote system probe service
 type RemoteSysProbeUtil struct {

--- a/pkg/process/net/common_unsupported.go
+++ b/pkg/process/net/common_unsupported.go
@@ -34,8 +34,3 @@ func (r *RemoteSysProbeUtil) GetConnections(clientID string) (*model.Connections
 func (r *RemoteSysProbeUtil) GetStats() (map[string]interface{}, error) {
 	return nil, ebpf.ErrNotImplemented
 }
-
-// ShouldLogTracerUtilError is not supported
-func ShouldLogTracerUtilError() bool {
-	return false
-}


### PR DESCRIPTION
### What does this PR do?

ShouldLogTracerUtilError determines if the network check should log errors about initializing the system probe util.

However, ShouldLogTracer relies on the util being (partially) initialized.

This PR moves all the log management into the network check. 

### Motivation

@DataDog/networks 
@DataDog/processes 


### Additional Notes

Anything else we should know when reviewing?
