### PR TITLE
Fix erroneous error when running jmx check

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -124,6 +124,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		allConfigs := common.AC.GetAllConfigs()
+		hasJMXConfigs := false
 
 		// make sure the checks in cs are not JMX checks
 		for idx := range allConfigs {
@@ -133,6 +134,8 @@ var checkCmd = &cobra.Command{
 			}
 
 			if check.IsJMXConfig(*conf) {
+				hasJMXConfigs = true
+
 				// we'll mimic the check command behavior with JMXFetch by running
 				// it with the JSON reporter and the list_with_metrics command.
 				fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")
@@ -263,7 +266,10 @@ var checkCmd = &cobra.Command{
 					}
 				}
 			}
-			return fmt.Errorf("no valid check found")
+
+			if !hasJMXConfigs {
+				return fmt.Errorf("no valid check found")
+			}
 		}
 
 		if len(cs) > 1 {


### PR DESCRIPTION
### What does this PR do?

Error message appears despite JMX check run runs successfully.

```
JMXFetch exited successfully. If nothing was displayed please check your configuration, flags and the JMXFetch log file.
Error: no valid check found
```

### Motivation

Don't print error message when it's not expected.

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
