### PR TITLE
[System Probe] Switch build tags for system probe status page

### DIFF
--- a/pkg/status/status_system_probe.go
+++ b/pkg/status/status_system_probe.go
@@ -3,12 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build !zlib
+// +build process
 
 package status
 
 import (
 	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 )
 

--- a/pkg/status/status_system_probe_unsupported.go
+++ b/pkg/status/status_system_probe_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build zlib
+// +build !process
 
 package status
 

--- a/pkg/status/status_system_probe_unsupported.go
+++ b/pkg/status/status_system_probe_unsupported.go
@@ -13,6 +13,6 @@ import (
 
 func getSystemProbeStats() map[string]interface{} {
 	return map[string]interface{}{
-		"Errors": fmt.Sprintf("System Probe is not supported when built without zstd support"),
+		"Errors": fmt.Sprintf("System Probe is not supported on systems not running the process agent"),
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Sets the system probe status to only attempt querying the agent socket if the process agent is being built with the agent. 

We only run the system probe on hosts that are also running the process agent, so only build the status code that will attempt to query the system probe if it is with the process agent. 

### Motivation

Currently, this behavior is based upon zlib which si built with every agent and is returning incorrect values. 
