### PR TITLE
Remove path from API endpoint if specified

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -345,8 +346,13 @@ func keysPerDomains(endpoints []api.Endpoint) map[string][]string {
 	keysPerDomains := make(map[string][]string)
 
 	for _, ep := range endpoints {
-		keysPerDomains[ep.Endpoint.String()] = []string{ep.APIKey}
+		keysPerDomains[removePathIfPresent(ep.Endpoint)] = []string{ep.APIKey}
 	}
 
 	return keysPerDomains
+}
+
+// removePathIfPresent removes the path component from the URL if it is present
+func removePathIfPresent(url *url.URL) string {
+	return fmt.Sprintf("%s://%s", url.Scheme, url.Host)
 }

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
@@ -92,4 +95,26 @@ func TestHasContainers(t *testing.T) {
 	assert.Equal(1, getContainerCount(&collectorContainer))
 	assert.Equal(2, getContainerCount(&collectorRealTime))
 	assert.Equal(1, getContainerCount(&collectorContainerRealTime))
+}
+
+func TestRemovePathIfPresent(t *testing.T) {
+	for _, tt := range []struct {
+		input    string
+		expected string
+	}{
+		{input: "http://foo.com", expected: "http://foo.com"},
+		{input: "http://foo.com/", expected: "http://foo.com"},
+		{input: "http://foo.com/api/v1", expected: "http://foo.com"},
+		{input: "http://foo.com?foo", expected: "http://foo.com"},
+		{input: "http://foo.com/api/v1/?foo", expected: "http://foo.com"},
+		{input: "http://foo.com/api/v1?foo", expected: "http://foo.com"},
+		{input: "http://foo.com:8080", expected: "http://foo.com:8080"},
+		{input: "http://foo.com:8080/", expected: "http://foo.com:8080"},
+		{input: "http://foo.com:8080/api/v1", expected: "http://foo.com:8080"},
+	} {
+		u, err := url.Parse(tt.input)
+		require.NoError(t, err)
+
+		assert.Equal(t, tt.expected, removePathIfPresent(u))
+	}
 }


### PR DESCRIPTION
### What does this PR do?

This is a followup from #5193 that restores the behavior added in #4540.  If the API endpoint has a path specified, we need to strip it out as the forwarder will automatically append the correct path for submitting payloads

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
