### PR TITLE
[logs] LI-264: Update release note with use_tcp & use_http

### DIFF
--- a/releasenotes/notes/logs-default-agent-to-http-b96697b94baf78c7.yaml
+++ b/releasenotes/notes/logs-default-agent-to-http-b96697b94baf78c7.yaml
@@ -7,3 +7,5 @@ upgrade:
       * logs_config.use_tcp is set to true
       * logs_config.socks5_proxy_address is set, because socks5 proxies are not yet supported in HTTPS with compression
       * HTTPS connectivity test has failed: at agent startup, an HTTPS test request is sent to determine if HTTPS can be used
+    
+    To force the use of TCP or HTTPS with compression, logs_config.use_tcp or logs_config.use_http can be set to true, respectively.


### PR DESCRIPTION
### What does this PR do?

Update release note with use_tcp & use_http

### Motivation

### Additional Notes
