### PR TITLE
[logs/docker] configurable docker client read timeout.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -479,7 +479,12 @@ func initConfig(config Config) {
 	// additional config to ensure initial logs are tagged with kubelet tags
 	// wait (seconds) for tagger before start fetching tags of new AD services
 	config.BindEnvAndSetDefault("logs_config.tagger_warmup_duration", 0) // Disabled by default (0 seconds)
-
+	// Configurable docker client timeout while communicating with the docker daemon.
+	// It could happen that the docker daemon takes a lot of time gathering timestamps
+	// before starting to send any data when it has stored several large log files.
+	// This field let you increase the read timeout to avoid the client to timeout
+	// in such a situation. Value in seconds.
+	config.BindEnvAndSetDefault("logs_config.docker_client_read_timeout", 30)
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	config.BindEnv("logs_config.dd_url")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -482,8 +482,8 @@ func initConfig(config Config) {
 	// Configurable docker client timeout while communicating with the docker daemon.
 	// It could happen that the docker daemon takes a lot of time gathering timestamps
 	// before starting to send any data when it has stored several large log files.
-	// This field let you increase the read timeout to avoid the client to timeout
-	// in such a situation. Value in seconds.
+	// This field lets you increase the read timeout to prevent the client from
+	// timing out too early in such a situation. Value in seconds.
 	config.BindEnvAndSetDefault("logs_config.docker_client_read_timeout", 30)
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -41,7 +41,7 @@ type Agent struct {
 	health           *health.Handle
 }
 
-// NewAgent returns a new Agent
+// NewAgent returns a new Logs Agent
 func NewAgent(sources *config.LogSources, services *service.Services, processingRules []*config.ProcessingRule, endpoints *config.Endpoints) *Agent {
 	health := health.Register("logs-agent")
 
@@ -57,7 +57,11 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 	// setup the inputs
 	inputs := []restart.Restartable{
 		file.NewScanner(sources, coreConfig.Datadog.GetInt("logs_config.open_files_limit"), pipelineProvider, auditor, file.DefaultSleepDuration),
-		container.NewLauncher(coreConfig.Datadog.GetBool("logs_config.container_collect_all"), coreConfig.Datadog.GetBool("logs_config.k8s_container_use_file"), sources, services, pipelineProvider, auditor),
+		container.NewLauncher(
+			coreConfig.Datadog.GetBool("logs_config.container_collect_all"),
+			coreConfig.Datadog.GetBool("logs_config.k8s_container_use_file"),
+			time.Duration(coreConfig.Datadog.GetInt("logs_config.docker_client_read_timeout"))*time.Second,
+			sources, services, pipelineProvider, auditor),
 		listener.NewLauncher(sources, coreConfig.Datadog.GetInt("logs_config.frame_size"), pipelineProvider),
 		journald.NewLauncher(sources, pipelineProvider, auditor),
 		windowsevent.NewLauncher(sources, pipelineProvider),

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -6,6 +6,8 @@
 package container
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/input/docker"
@@ -23,7 +25,8 @@ import (
 // collectFromFiles is enabled.
 // If none of those volumes are mounted, returns a lazy docker launcher with a retrier to handle the cases
 // where docker is started after the agent.
-func NewLauncher(collectAll bool, collectFromFiles bool, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) restart.Restartable {
+// dockerReadTimeout is a configurable read timeout for the docker client.
+func NewLauncher(collectAll bool, collectFromFiles bool, dockerReadTimeout time.Duration, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) restart.Restartable {
 	var (
 		launcher restart.Restartable
 		err      error
@@ -37,14 +40,14 @@ func NewLauncher(collectAll bool, collectFromFiles bool, sources *config.LogSour
 		}
 		log.Infof("Could not setup the kubernetes launcher: %v", err)
 
-		launcher, err = docker.NewLauncher(sources, services, pipelineProvider, registry, false)
+		launcher, err = docker.NewLauncher(sources, services, pipelineProvider, registry, false, dockerReadTimeout)
 		if err == nil {
 			log.Info("Docker launcher initialized")
 			return launcher
 		}
 		log.Infof("Could not setup the docker launcher: %v", err)
 	} else {
-		launcher, err = docker.NewLauncher(sources, services, pipelineProvider, registry, false)
+		launcher, err = docker.NewLauncher(sources, services, pipelineProvider, registry, false, dockerReadTimeout)
 		if err == nil {
 			log.Info("Docker launcher initialized")
 			return launcher
@@ -59,7 +62,7 @@ func NewLauncher(collectAll bool, collectFromFiles bool, sources *config.LogSour
 		log.Infof("Could not setup the kubernetes launcher: %v", err)
 	}
 
-	launcher, err = docker.NewLauncher(sources, services, pipelineProvider, registry, true)
+	launcher, err = docker.NewLauncher(sources, services, pipelineProvider, registry, true, dockerReadTimeout)
 	if err != nil {
 		log.Warnf("Could not setup the docker launcher: %v. Will not be able to collect container logs", err)
 		return NewNoopLauncher()

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -40,14 +40,14 @@ func NewLauncher(collectAll bool, collectFromFiles bool, dockerReadTimeout time.
 		}
 		log.Infof("Could not setup the kubernetes launcher: %v", err)
 
-		launcher, err = docker.NewLauncher(sources, services, pipelineProvider, registry, false, dockerReadTimeout)
+		launcher, err = docker.NewLauncher(dockerReadTimeout, sources, services, pipelineProvider, registry, false)
 		if err == nil {
 			log.Info("Docker launcher initialized")
 			return launcher
 		}
 		log.Infof("Could not setup the docker launcher: %v", err)
 	} else {
-		launcher, err = docker.NewLauncher(sources, services, pipelineProvider, registry, false, dockerReadTimeout)
+		launcher, err = docker.NewLauncher(dockerReadTimeout, sources, services, pipelineProvider, registry, false)
 		if err == nil {
 			log.Info("Docker launcher initialized")
 			return launcher
@@ -62,7 +62,7 @@ func NewLauncher(collectAll bool, collectFromFiles bool, dockerReadTimeout time.
 		log.Infof("Could not setup the kubernetes launcher: %v", err)
 	}
 
-	launcher, err = docker.NewLauncher(sources, services, pipelineProvider, registry, true, dockerReadTimeout)
+	launcher, err = docker.NewLauncher(dockerReadTimeout, sources, services, pipelineProvider, registry, true)
 	if err != nil {
 		log.Warnf("Could not setup the docker launcher: %v. Will not be able to collect container logs", err)
 		return NewNoopLauncher()

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -40,10 +40,11 @@ type Launcher struct {
 	erroredContainerID chan string
 	lock               *sync.Mutex
 	collectAllSource   *config.LogSource
+	readTimeout        time.Duration // client read timeout to set on the created tailer
 }
 
 // NewLauncher returns a new launcher
-func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry bool) (*Launcher, error) {
+func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry bool, readTimeout time.Duration) (*Launcher, error) {
 	if !shouldRetry {
 		if _, err := dockerutil.GetDockerUtil(); err != nil {
 			return nil, err
@@ -57,6 +58,7 @@ func NewLauncher(sources *config.LogSources, services *service.Services, pipelin
 		stop:               make(chan struct{}),
 		erroredContainerID: make(chan string),
 		lock:               &sync.Mutex{},
+		readTimeout:        readTimeout,
 	}
 	// FIXME(achntrl): Find a better way of choosing the right launcher
 	// between Docker and Kubernetes
@@ -199,7 +201,7 @@ func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
 		log.Warnf("Could not use docker client, logs for container %s won’t be collected: %v", containerID, err)
 		return
 	}
-	tailer := NewTailer(dockerutil, containerID, overridenSource, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
+	tailer := NewTailer(dockerutil, containerID, overridenSource, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID, l.readTimeout)
 
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), container.service.CreationTime)
@@ -255,7 +257,7 @@ func (l *Launcher) restartTailer(containerID string) {
 		log.Warnf("Could not use docker client, logs for container %s won’t be collected: %v", containerID, err)
 		return
 	}
-	tailer := NewTailer(dockerutil, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
+	tailer := NewTailer(dockerutil, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID, l.readTimeout)
 
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), service.Before)

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -44,7 +44,7 @@ type Launcher struct {
 }
 
 // NewLauncher returns a new launcher
-func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry bool, readTimeout time.Duration) (*Launcher, error) {
+func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry bool) (*Launcher, error) {
 	if !shouldRetry {
 		if _, err := dockerutil.GetDockerUtil(); err != nil {
 			return nil, err

--- a/pkg/logs/input/docker/launcher_nodocker.go
+++ b/pkg/logs/input/docker/launcher_nodocker.go
@@ -8,6 +8,8 @@
 package docker
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
@@ -18,7 +20,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new Launcher
-func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry bool) (*Launcher, error) {
+func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry bool, readTimeout time.Duration) (*Launcher, error) {
 	return &Launcher{}, nil
 }
 

--- a/pkg/logs/input/docker/launcher_nodocker.go
+++ b/pkg/logs/input/docker/launcher_nodocker.go
@@ -20,7 +20,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new Launcher
-func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry bool, readTimeout time.Duration) (*Launcher, error) {
+func NewLauncher(readTimeout time.Duration, psources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry bool) (*Launcher, error) {
 	return &Launcher{}, nil
 }
 

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -27,7 +27,6 @@ import (
 )
 
 const defaultSleepDuration = 1 * time.Second
-const defaultReadTimeout = 30 * time.Second
 
 type dockerContainerLogInterface interface {
 	ContainerLogs(ctx context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error)
@@ -57,7 +56,7 @@ type Tailer struct {
 }
 
 // NewTailer returns a new Tailer
-func NewTailer(cli *dockerutil.DockerUtil, containerID string, source *config.LogSource, outputChan chan *message.Message, erroredContainerID chan string) *Tailer {
+func NewTailer(cli *dockerutil.DockerUtil, containerID string, source *config.LogSource, outputChan chan *message.Message, erroredContainerID chan string, readTimeout time.Duration) *Tailer {
 	return &Tailer{
 		ContainerID:        containerID,
 		outputChan:         outputChan,
@@ -65,7 +64,7 @@ func NewTailer(cli *dockerutil.DockerUtil, containerID string, source *config.Lo
 		source:             source,
 		tagProvider:        tag.NewProvider(dockerutil.ContainerIDToTaggerEntityName(containerID)),
 		dockerutil:         cli,
-		readTimeout:        defaultReadTimeout,
+		readTimeout:        readTimeout,
 		sleepDuration:      defaultSleepDuration,
 		stop:               make(chan struct{}, 1),
 		done:               make(chan struct{}, 1),
@@ -190,6 +189,10 @@ func (t *Tailer) readForever() {
 					// of the tailer, stop reading
 					return
 				case isContextCanceled(err):
+					// It could happen that the docker daemon takes a lot of time gathering timestamps
+					// before starting to send any data when it has stored several large log files.
+					// Increasing the docker_client_read_timeout could help avoiding such a situation.
+					log.Warnf("docker client read timeout (after %s) in the tailer", t.readTimeout.String())
 					if err := t.tryRestartReader("Restarting reader after a read timeout"); err != nil {
 						return
 					}

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -189,10 +189,9 @@ func (t *Tailer) readForever() {
 					// of the tailer, stop reading
 					return
 				case isContextCanceled(err):
-					// It could happen that the docker daemon takes a lot of time gathering timestamps
+					// Note that it could happen that the docker daemon takes a lot of time gathering timestamps
 					// before starting to send any data when it has stored several large log files.
 					// Increasing the docker_client_read_timeout could help avoiding such a situation.
-					log.Warnf("docker client read timeout (after %s) in the tailer", t.readTimeout.String())
 					if err := t.tryRestartReader("Restarting reader after a read timeout"); err != nil {
 						return
 					}


### PR DESCRIPTION
The Docker daemon could have a high latency replying to a docker logs
client call while it's gathering timestamps on several large log files.

Configuring this field to a higher duration could help solve this situation.

Note that a better solution is to configure the docker daemon to not store
too many large log files.
