### PR TITLE
Revert the default value management for `system_probe_config.sysprobe_socket`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,9 +46,6 @@ const (
 
 	// ClusterIDCacheKey is the key name for the orchestrator cluster id in the agent in-mem cache
 	ClusterIDCacheKey = "orchestratorClusterID"
-
-	// defaultSystemProbeSocketPath is the default unix socket path to be used for connecting to the system probe
-	defaultSystemProbeSocketPath = "/opt/datadog-agent/run/sysprobe.sock"
 )
 
 var overrideVars = make(map[string]interface{})
@@ -590,7 +587,7 @@ func initConfig(config Config) {
 	config.SetKnown("system_probe_config.collect_local_dns")
 	config.SetKnown("system_probe_config.use_local_system_probe")
 	config.SetKnown("system_probe_config.enable_conntrack")
-	config.BindEnvAndSetDefault("system_probe_config.sysprobe_socket", defaultSystemProbeSocketPath)
+	config.SetKnown("system_probe_config.sysprobe_socket")
 	config.SetKnown("system_probe_config.conntrack_short_term_buffer_size")
 	config.SetKnown("system_probe_config.max_conns_per_message")
 	config.SetKnown("system_probe_config.max_tracked_connections")


### PR DESCRIPTION
### What does this PR do?

Revert the default value management for `system_probe_config.sysprobe_socket`
https://github.com/DataDog/datadog-agent/pull/4619/files#diff-091ace02b49a46f55f2586cfec89a160

### Motivation

Whereas `system-probe` was correctly using the socket path defined in `system-probe.yaml`, `process-agent` wasn’t.
This PR reverts to the previous behaviour where both `system-probe` and `process-agent` are honoring the configuration file.

### Additional Notes

Anything else we should know when reviewing?
