### PR TITLE
[py3linter] Re-introduce serial linting, and lint once per check name

### DIFF
--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -38,8 +38,11 @@ import "C"
 var (
 	pyLoaderStats    *expvar.Map
 	configureErrors  map[string][]string
+	py3Linted        map[string]struct{}
 	py3Warnings      map[string][]string
 	statsLock        sync.RWMutex
+	py3LintedLock    sync.Mutex
+	linterLock       sync.Mutex
 	agentVersionTags []string
 )
 
@@ -58,6 +61,7 @@ func init() {
 	loaders.RegisterLoader(20, factory)
 
 	configureErrors = map[string][]string{}
+	py3Linted = map[string]struct{}{}
 	py3Warnings = map[string][]string{}
 	pyLoaderStats = expvar.NewMap("pyLoader")
 	pyLoaderStats.Set("ConfigureErrors", expvar.Func(expvarConfigureErrors))
@@ -254,12 +258,15 @@ func expvarPy3Warnings() interface{} {
 func reportPy3Warnings(checkName string, checkFilePath string) {
 
 	// check if the check has already been linted
-	statsLock.RLock()
-	_, found := py3Warnings[checkName]
-	statsLock.RUnlock()
+	py3LintedLock.Lock()
+	_, found := py3Linted[checkName]
 	if found {
+		py3LintedLock.Unlock()
 		return
+	} else {
+		py3Linted[checkName] = struct{}{}
 	}
+	py3LintedLock.Unlock()
 
 	status := a7TagUnknown
 	metricValue := 0.0
@@ -273,20 +280,28 @@ func reportPy3Warnings(checkName string, checkFilePath string) {
 			// the linter used by validatePython3 doesn't work when run from python3
 			status = a7TagPython3
 			metricValue = 1.0
-		} else if warnings, err := validatePython3(checkName, checkFilePath); err != nil {
-			status = a7TagUnknown
-			log.Errorf("Failed to validate Python 3 linting for check '%s': '%s'", checkName, err)
-		} else if len(warnings) == 0 {
-			status = a7TagReady
-			metricValue = 1.0
 		} else {
-			status = a7TagNotReady
-			log.Warnf("The Python 3 linter returned warnings for check '%s'. For more details, check the output of the 'status' command or the status page of the Agent GUI).", checkName)
-			statsLock.Lock()
-			defer statsLock.Unlock()
-			for _, warning := range warnings {
-				log.Debug(warning)
-				py3Warnings[checkName] = append(py3Warnings[checkName], warning)
+			// validatePython3 is CPU and memory hungry, make sure we only run one instance of it
+			// at once to avoid CPU and mem usage spikes
+			linterLock.Lock()
+			warnings, err := validatePython3(checkName, checkFilePath)
+			linterLock.Unlock()
+
+			if err != nil {
+				status = a7TagUnknown
+				log.Errorf("Failed to validate Python 3 linting for check '%s': '%s'", checkName, err)
+			} else if len(warnings) == 0 {
+				status = a7TagReady
+				metricValue = 1.0
+			} else {
+				status = a7TagNotReady
+				log.Warnf("The Python 3 linter returned warnings for check '%s'. For more details, check the output of the 'status' command or the status page of the Agent GUI).", checkName)
+				statsLock.Lock()
+				defer statsLock.Unlock()
+				for _, warning := range warnings {
+					log.Debug(warning)
+					py3Warnings[checkName] = append(py3Warnings[checkName], warning)
+				}
 			}
 		}
 	}

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -263,9 +263,8 @@ func reportPy3Warnings(checkName string, checkFilePath string) {
 	if found {
 		py3LintedLock.Unlock()
 		return
-	} else {
-		py3Linted[checkName] = struct{}{}
 	}
+	py3Linted[checkName] = struct{}{}
 	py3LintedLock.Unlock()
 
 	status := a7TagUnknown


### PR DESCRIPTION
### What does this PR do?

* Fixes regression introduced in #4966 (it was reverting the behavior of https://github.com/DataDog/datadog-agent/pull/4113, but we actually want to keep that behavior).
* On top of that, improves the way we check whether a check has already been linted or not.
  Previously, we would unnecessarily re-run the linter on the same check unless it actually had linter warnings on previous linter runs. Especially important to fix since this logic is now called for every instance of the check, instead of once per config file, since https://github.com/DataDog/datadog-agent/pull/5141

### Motivation

Ensure the linter has a footprint that's as small as possible on agent startup:

* avoid running more than one linter process at once
* avoid running it more than once per custom check

And still keep the behavior of #4966, i.e. avoid blocking the `status` command on the linter.

### Additional notes

This validation code is getting quite messy. Should be extracted out in its own file, with its own struct. Will do after 7.19.

### QA

Haven't QA'ed this change on a fully-built agent. To QA I recommend the following:

1. set up a custom check like the following:

```py
from datadog_checks.base.checks import AgentCheck

# importing and using this module makes the linter lint it, which takes a few seconds
from kubernetes import client, config

class CustomCheck(AgentCheck):
  def check(self, instance):
    print("custom check running")
    config.load_kube_config()
    v1 = client.CoreV1Api()
    v1.list_pod_for_all_namespaces(watch=False)
```

2. configure a few instances of that check
3. set `python_version: 2` in agent config
3. check after an agent restart that the linter only runs once and that the `status` command is not blocked on the linter finishing, and displays the linter warning. If the warning is addressed in the check code and the agent restarted again, the linter must still run only once and report no warning.