### PR TITLE
ECS Fargate/Dogstatsd task_arn tag on with orchestrator cardinality

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -499,6 +500,16 @@ func findOriginTags(origin string) []string {
 			log.Errorf(err.Error())
 		} else {
 			tags = append(tags, originTags...)
+		}
+	}
+
+	// Include orchestrator scope tags if the cardinality is set to orchestrator
+	if tagger.DogstatsdCardinality == collectors.OrchestratorCardinality {
+		orchestratorScopeTags, err := tagger.OrchestratorScopeTag()
+		if err != nil {
+			log.Errorf(err.Error())
+		} else {
+			tags = append(tags, orchestratorScopeTags...)
 		}
 	}
 	return tags

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -507,7 +507,7 @@ func findOriginTags(origin string) []string {
 	if tagger.DogstatsdCardinality == collectors.OrchestratorCardinality {
 		orchestratorScopeTags, err := tagger.OrchestratorScopeTag()
 		if err != nil {
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 		} else {
 			tags = append(tags, orchestratorScopeTags...)
 		}

--- a/pkg/tagger/collectors/common.go
+++ b/pkg/tagger/collectors/common.go
@@ -12,6 +12,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
 )
 
+// OrchestratorScopeEntityID defines the orchestrator scope entity ID
+const OrchestratorScopeEntityID = "c843937b-8912-452c-be85-f50bd04ecc0f"
+
 var templateVariables = map[string]struct{}{
 	"label": {},
 }

--- a/pkg/tagger/collectors/common.go
+++ b/pkg/tagger/collectors/common.go
@@ -13,7 +13,7 @@ import (
 )
 
 // OrchestratorScopeEntityID defines the orchestrator scope entity ID
-const OrchestratorScopeEntityID = "c843937b-8912-452c-be85-f50bd04ecc0f"
+const OrchestratorScopeEntityID = "orchestrator-scope-entity-id"
 
 var templateVariables = map[string]struct{}{
 	"label": {},

--- a/pkg/tagger/collectors/common.go
+++ b/pkg/tagger/collectors/common.go
@@ -13,7 +13,7 @@ import (
 )
 
 // OrchestratorScopeEntityID defines the orchestrator scope entity ID
-const OrchestratorScopeEntityID = "orchestrator-scope-entity-id"
+const OrchestratorScopeEntityID = "internal:orchestrator-scope-entity-id"
 
 var templateVariables = map[string]struct{}{
 	"label": {},

--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -10,6 +10,7 @@ package collectors
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -18,6 +19,8 @@ import (
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+var doOnceOrchScope sync.Once
 
 // parseMetadata parses the task metadata and its container list, and returns a list of TagInfo for the new ones.
 // It also updates the lastSeen cache of the ECSFargateCollector and return the list of dead containers to be expired.
@@ -30,7 +33,7 @@ func (c *ECSFargateCollector) parseMetadata(meta *v2.Task, parseAll bool) ([]*Ta
 	}
 	globalTags := config.Datadog.GetStringSlice("tags")
 
-	if parseAll {
+	doOnceOrchScope.Do(func() {
 		tags := utils.NewTagList()
 		tags.AddOrchestrator("task_arn", meta.TaskARN)
 		low, orch, high := tags.Compute()
@@ -42,7 +45,7 @@ func (c *ECSFargateCollector) parseMetadata(meta *v2.Task, parseAll bool) ([]*Ta
 			LowCardTags:          low,
 		}
 		output = append(output, info)
-	}
+	})
 
 	for _, ctr := range meta.Containers {
 		if c.expire.Update(ctr.DockerID, now) || parseAll {

--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -10,7 +10,6 @@ package collectors
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -19,8 +18,6 @@ import (
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-var doOnceOrchScope sync.Once
 
 // parseMetadata parses the task metadata and its container list, and returns a list of TagInfo for the new ones.
 // It also updates the lastSeen cache of the ECSFargateCollector and return the list of dead containers to be expired.
@@ -33,7 +30,7 @@ func (c *ECSFargateCollector) parseMetadata(meta *v2.Task, parseAll bool) ([]*Ta
 	}
 	globalTags := config.Datadog.GetStringSlice("tags")
 
-	doOnceOrchScope.Do(func() {
+	c.doOnceOrchScope.Do(func() {
 		tags := utils.NewTagList()
 		tags.AddOrchestrator("task_arn", meta.TaskARN)
 		low, orch, high := tags.Compute()

--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -30,6 +30,20 @@ func (c *ECSFargateCollector) parseMetadata(meta *v2.Task, parseAll bool) ([]*Ta
 	}
 	globalTags := config.Datadog.GetStringSlice("tags")
 
+	if parseAll {
+		tags := utils.NewTagList()
+		tags.AddOrchestrator("task_arn", meta.TaskARN)
+		low, orch, high := tags.Compute()
+		info := &TagInfo{
+			Source:               ecsFargateCollectorName,
+			Entity:               OrchestratorScopeEntityID,
+			HighCardTags:         high,
+			OrchestratorCardTags: orch,
+			LowCardTags:          low,
+		}
+		output = append(output, info)
+	}
+
 	for _, ctr := range meta.Containers {
 		if c.expire.Update(ctr.DockerID, now) || parseAll {
 			tags := utils.NewTagList()

--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -120,6 +120,16 @@ func TestParseMetadata(t *testing.T) {
 
 	expectedUpdatesParseAll := []*TagInfo{
 		{
+			Source:      "ecs_fargate",
+			Entity:      OrchestratorScopeEntityID,
+			LowCardTags: []string{},
+			OrchestratorCardTags: []string{
+				"task_arn:arn:aws:ecs:eu-central-1:601427279990:task/5308d232-9002-4224-97b5-e1d4843b5244",
+			},
+			HighCardTags: []string{},
+			DeleteEntity: false,
+		},
+		{
 			Source: "ecs_fargate",
 			Entity: "container_id://3827da9d51f12276b4ed2d2a2dfb624b96b239b20d052b859e26c13853071e7c",
 			LowCardTags: []string{
@@ -224,7 +234,7 @@ func TestParseMetadata(t *testing.T) {
 	// Full parsing should show 3 containers
 	updates, err = collector.parseMetadata(&meta, true)
 	assert.NoError(t, err)
-	assert.Len(t, updates, 3)
+	assert.Len(t, updates, 4)
 	assertTagInfoListEqual(t, expectedUpdatesParseAll, updates)
 }
 

--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -252,6 +252,16 @@ func TestParseMetadataV10(t *testing.T) {
 
 	expectedUpdates := []*TagInfo{
 		{
+			Source:      "ecs_fargate",
+			Entity:      OrchestratorScopeEntityID,
+			LowCardTags: []string{},
+			OrchestratorCardTags: []string{
+				"task_arn:arn:aws:ecs:eu-west-1:172597598159:task/648ca535-cbe0-4de7-b102-28e50b81e888",
+			},
+			HighCardTags: []string{},
+			DeleteEntity: false,
+		},
+		{
 			Source: "ecs_fargate",
 			Entity: "container_id://e8d4a9a20a0d931f8f632ec166b3f71a6ff00450aa7e99607f650e586df7d068",
 			LowCardTags: []string{

--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -66,6 +66,16 @@ func TestParseMetadata(t *testing.T) {
 
 	expectedUpdates := []*TagInfo{
 		{
+			Source:      "ecs_fargate",
+			Entity:      OrchestratorScopeEntityID,
+			LowCardTags: []string{},
+			OrchestratorCardTags: []string{
+				"task_arn:arn:aws:ecs:eu-central-1:601427279990:task/5308d232-9002-4224-97b5-e1d4843b5244",
+			},
+			HighCardTags: []string{},
+			DeleteEntity: false,
+		},
+		{
 			Source: "ecs_fargate",
 			Entity: "container_id://1cd08ea0fc13ee643fa058a8e184861661eb29325c7df59ccc543597018ffcd4",
 			LowCardTags: []string{
@@ -119,16 +129,6 @@ func TestParseMetadata(t *testing.T) {
 	}
 
 	expectedUpdatesParseAll := []*TagInfo{
-		{
-			Source:      "ecs_fargate",
-			Entity:      OrchestratorScopeEntityID,
-			LowCardTags: []string{},
-			OrchestratorCardTags: []string{
-				"task_arn:arn:aws:ecs:eu-central-1:601427279990:task/5308d232-9002-4224-97b5-e1d4843b5244",
-			},
-			HighCardTags: []string{},
-			DeleteEntity: false,
-		},
 		{
 			Source: "ecs_fargate",
 			Entity: "container_id://3827da9d51f12276b4ed2d2a2dfb624b96b239b20d052b859e26c13853071e7c",
@@ -234,7 +234,7 @@ func TestParseMetadata(t *testing.T) {
 	// Full parsing should show 3 containers
 	updates, err = collector.parseMetadata(&meta, true)
 	assert.NoError(t, err)
-	assert.Len(t, updates, 4)
+	assert.Len(t, updates, 3)
 	assertTagInfoListEqual(t, expectedUpdatesParseAll, updates)
 }
 

--- a/pkg/tagger/collectors/ecs_fargate_main.go
+++ b/pkg/tagger/collectors/ecs_fargate_main.go
@@ -26,11 +26,12 @@ const (
 
 // ECSFargateCollector polls the ecs metadata api.
 type ECSFargateCollector struct {
-	infoOut         chan<- []*TagInfo
-	expire          *taggerutil.Expire
-	lastExpire      time.Time
-	expireFreq      time.Duration
-	labelsAsTags    map[string]string
+	infoOut      chan<- []*TagInfo
+	expire       *taggerutil.Expire
+	lastExpire   time.Time
+	expireFreq   time.Duration
+	labelsAsTags map[string]string
+	// Used to initialize the orchestrator scope tags which don't need to be refetched after
 	doOnceOrchScope sync.Once
 }
 

--- a/pkg/tagger/collectors/ecs_fargate_main.go
+++ b/pkg/tagger/collectors/ecs_fargate_main.go
@@ -9,6 +9,7 @@ package collectors
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/errors"
@@ -25,11 +26,12 @@ const (
 
 // ECSFargateCollector polls the ecs metadata api.
 type ECSFargateCollector struct {
-	infoOut      chan<- []*TagInfo
-	expire       *taggerutil.Expire
-	lastExpire   time.Time
-	expireFreq   time.Duration
-	labelsAsTags map[string]string
+	infoOut         chan<- []*TagInfo
+	expire          *taggerutil.Expire
+	lastExpire      time.Time
+	expireFreq      time.Duration
+	labelsAsTags    map[string]string
+	doOnceOrchScope sync.Once
 }
 
 // Detect tries to connect to the ECS metadata API

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -57,6 +57,11 @@ func Tag(entity string, cardinality collectors.TagCardinality) ([]string, error)
 	return defaultTagger.Tag(entity, cardinality)
 }
 
+// OrchestratorScopeTag queries tags for orchestrator scope (e.g. task_arn in ECS Fargate)
+func OrchestratorScopeTag() ([]string, error) {
+	return defaultTagger.Tag(collectors.OrchestratorScopeEntityID, collectors.OrchestratorCardinality)
+}
+
 // Stop queues a stop signal to the defaultTagger
 func Stop() error {
 	return defaultTagger.Stop()

--- a/releasenotes/notes/ecs-fargate-dogstatsd-task_arn-4b86cba851ba1fce.yaml
+++ b/releasenotes/notes/ecs-fargate-dogstatsd-task_arn-4b86cba851ba1fce.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  - |
+    Enrich dogstatsd metrics with task_arn tag if
+    DD_DOGSTATSD_TAG_CARDINALITY=orchestrator.


### PR DESCRIPTION
### What does this PR do?

Enrich dogstatsd metrics with `task_arn` tag if `DD_DOGSTATSD_TAG_CARDINALITY=orchestrator`.

### Motivation

Automatically inject `task_arn` tag to all the dogstatsd metric.

### Additional Notes

https://github.com/DataDog/datadog-agent/issues/3159
