### PR TITLE
Update StandardStatsdPrefixes with new JMX integrations

### DIFF
--- a/pkg/config/standard_names.go
+++ b/pkg/config/standard_names.go
@@ -26,6 +26,7 @@ var StandardStatsdPrefixes = []string{
 	"cassandra",
 	"confluent",
 	"hazelcast",
+	"hive",
 	"ignite",
 	"jboss",
 	"jvm",

--- a/pkg/config/standard_names.go
+++ b/pkg/config/standard_names.go
@@ -23,10 +23,16 @@ var StandardStatsdPrefixes = []string{
 	"activemq",
 	"activemq_58",
 	"cassandra",
+	"confluent",
+	"flink",
+	"hazelcast",
+	"ignite",
+	"jboss",
 	"jvm",
+	"kafka",
 	"presto",
 	"solr",
 	"tomcat",
-	"kafka",
+
 	"runtime",
 }

--- a/pkg/config/standard_names.go
+++ b/pkg/config/standard_names.go
@@ -22,15 +22,16 @@ var StandardStatsdPrefixes = []string{
 
 	"activemq",
 	"activemq_58",
+	"airflow",
 	"cassandra",
 	"confluent",
-	"flink",
 	"hazelcast",
 	"ignite",
 	"jboss",
 	"jvm",
 	"kafka",
 	"presto",
+	"sidekiq",
 	"solr",
 	"tomcat",
 

--- a/releasenotes/notes/update-jmx-statsd-prefixes-3578475df54665b6.yaml
+++ b/releasenotes/notes/update-jmx-statsd-prefixes-3578475df54665b6.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    The ``statsd_metric_namespace`` option now ignores the following metric
+    prefixes: ``confluent``, ``flink``, ``hazelcast``, ``ignite``, ``jboss``

--- a/releasenotes/notes/update-jmx-statsd-prefixes-3578475df54665b6.yaml
+++ b/releasenotes/notes/update-jmx-statsd-prefixes-3578475df54665b6.yaml
@@ -2,4 +2,5 @@
 other:
   - |
     The ``statsd_metric_namespace`` option now ignores the following metric
-    prefixes: ``confluent``, ``flink``, ``hazelcast``, ``ignite``, ``jboss``
+    prefixes: ``airflow``, ``confluent``, ``hazelcast``, ``ignite``,
+    ``jboss``, ``sidekiq``

--- a/releasenotes/notes/update-jmx-statsd-prefixes-3578475df54665b6.yaml
+++ b/releasenotes/notes/update-jmx-statsd-prefixes-3578475df54665b6.yaml
@@ -2,5 +2,5 @@
 other:
   - |
     The ``statsd_metric_namespace`` option now ignores the following metric
-    prefixes: ``airflow``, ``confluent``, ``hazelcast``, ``ignite``,
+    prefixes: ``airflow``, ``confluent``, ``hazelcast``, ``hive``, ``ignite``,
     ``jboss``, ``sidekiq``


### PR DESCRIPTION
### Motivation

Customers can configure a prefix that’s applied to all incoming DogStatsD metrics. This, however, also applies to all JMXFetch metrics since that uses DogStatsD, meaning they would accidentally be considered custom metrics.

All metric prefixes used by JMX integrations have to be added to this list.