### PR TITLE
Enable zlib build tag in Cluster Agent to enable compression

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -21,6 +21,7 @@ DEFAULT_BUILD_TAGS = [
     "clusterchecks",
     "secrets",
     "orchestrator",
+    "zlib",
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Enable `zlib` build tag to enable zlib compression from `pkg/util/compression`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
