### PR TITLE
Add missing env vars

### DIFF
--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -28,6 +28,8 @@ spec:
           - {containerPort: 8126, name: traceport, protocol: TCP}
         env:
           - {name: DD_API_KEY, value: <YOUR_API_KEY>}
+          - {name: DD_CLUSTER_AGENT_AUTH_TOKEN, value: <ThirtyX2XcharactersXlongXtoken>}
+          - {name: DD_CLUSTER_AGENT_ENABLED, value: "true"}
           - {name: KUBERNETES, value: "true"}
           - {name: DD_HEALTH_PORT, value: "5555"}
           - name: DD_KUBERNETES_KUBELET_HOST


### PR DESCRIPTION
### What does this PR do?

Add missing env var holders in example file.

### Motivation

Docs missing env var holders in example file.
https://docs.datadoghq.com/agent/cluster_agent/setup/?tab=secret#step-2-enable-the-datadog-agent

### Additional Notes

No.
