### PR TITLE
Revert "Enable zlib build tag in Cluster Agent to enable compression"

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -21,7 +21,6 @@ DEFAULT_BUILD_TAGS = [
     "clusterchecks",
     "secrets",
     "orchestrator",
-    "zlib",
 ]
 
 


### PR DESCRIPTION
Reverts DataDog/datadog-agent#5327