### PR TITLE
[docs] Add inline deprecation comment about StandardJMXIntegrations

### DIFF
--- a/pkg/config/standard_names.go
+++ b/pkg/config/standard_names.go
@@ -1,6 +1,11 @@
 package config
 
-// StandardJMXIntegrations is the list of standard jmx integrations
+// StandardJMXIntegrations is the list of standard jmx integrations.
+// This list is used by the Agent to determine if an integration is JMXFetch-based,
+// based only on the integration name.
+// DEPRECATED: this list is only used for backward compatibility with older JMXFetch integration
+// configs. All JMXFetch integrations should instead define `is_jmx: true` at the init_config or
+// instance level.
 var StandardJMXIntegrations = map[string]struct{}{
 	"activemq":    {},
 	"activemq_58": {},


### PR DESCRIPTION
### What does this PR do?

Adds inline deprecation comment about StandardJMXIntegrations

### Motivation

We should only keep this list for backward compatibility with older existing configs, and define `is_jmx: true` in our JMXFetch integration configs instead (already done at the moment)

### Additional Notes

In the future, we may want to report deprecation warning when this list is actually used for a config, and remove the list altogether in a future major version. Adding that to our backlog.