### PR TITLE
Exclude more ecr/gcr/mcr pause containers

### DIFF
--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -18,7 +18,8 @@ const (
 	// - k8s.gcr.io/pause-amd64:3.1
 	// - asia.gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/google_containers/pause-amd64:3.0
-	pauseContainerGCR        = `image:(.*)gcr\.io(/google_containers/|/)pause(.*)`
+	// - gcr.io/gke-release/pause-win:1.1.0
+	pauseContainerGCR        = `image:(.*)gcr\.io(/google_containers/|/gke-release/|/)pause(.*)`
 	pauseContainerOpenshift  = "image:openshift/origin-pod"
 	pauseContainerKubernetes = "image:kubernetes/pause"
 	pauseContainerECS        = "image:amazon/amazon-ecs-pause"
@@ -28,6 +29,8 @@ const (
 	// - gcrio.azureedge.net/google_containers/pause-amd64
 	pauseContainerAzure   = `image:(.*)azureedge\.net(/google_containers/|/)pause(.*)`
 	pauseContainerRancher = `image:rancher/pause(.*)`
+	pauseContainerAKS     = `image:mcr.microsoft.com/k8s/core/pause(.*)`
+	pauseContainerECR     = `image:ecr(.*)amazonaws.com/pause(.*)`
 )
 
 // Filter holds the state for the container filtering logic
@@ -132,6 +135,8 @@ func NewFilterFromConfig() (*Filter, error) {
 			pauseContainerECS,
 			pauseContainerEKS,
 			pauseContainerRancher,
+			pauseContainerAKS,
+			pauseContainerECR,
 		)
 	}
 	return NewFilter(whitelist, blacklist)

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -139,6 +139,30 @@ func TestFilter(t *testing.T) {
 			},
 			ns: "bar",
 		},
+		{
+			c: Container{
+				ID:    "16",
+				Name:  "foo",
+				Image: "gcr.io/gke-release/pause-win:1.1.0",
+			},
+			ns: "bar",
+		},
+		{
+			c: Container{
+				ID:    "17",
+				Name:  "foo",
+				Image: "mcr.microsoft.com/k8s/core/pause:1.2.0",
+			},
+			ns: "bar",
+		},
+		{
+			c: Container{
+				ID:    "18",
+				Name:  "foo",
+				Image: "ecr.us-east-1.amazonaws.com/pause",
+			},
+			ns: "bar",
+		},
 	}
 
 	for i, tc := range []struct {
@@ -147,25 +171,25 @@ func TestFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"},
 		},
 		{
 			blacklist:   []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"},
+			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"},
 		},
 		{
 			blacklist:   []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"},
 		},
 		{
 			whitelist:   []string{},
 			blacklist:   []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"},
+			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"},
 		},
 		{
 			whitelist:   []string{"name:mysql"},
 			blacklist:   []string{"name:dd"},
-			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13"},
+			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18"},
 		},
 		{
 			blacklist:   []string{"kube_namespace:.*"},
@@ -184,6 +208,8 @@ func TestFilter(t *testing.T) {
 				pauseContainerKubernetes,
 				pauseContainerAzure,
 				pauseContainerRancher,
+				pauseContainerAKS,
+				pauseContainerECR,
 			},
 			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "14", "15"},
 		},

--- a/releasenotes/notes/exclude-more-pause-containers-75297c120188da8f.yaml
+++ b/releasenotes/notes/exclude-more-pause-containers-75297c120188da8f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    More pause containers from `ecr`, `gcr` and `mcr` are excluded automatically by the Agent.


### PR DESCRIPTION
### What does this PR do?

Add the following pause container images to the list of excluded containers
`mcr.microsoft.com/k8s/core/pause`
`ecr<zone>amazonaws.com/pause`
`gcr.io/gke-release/pause-win` 

### Motivation

Shouldn't bill for pause containers
