### PR TITLE
[netlink] Add DeleteConn method

### DIFF
--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -67,9 +67,8 @@ func TestIsRHEL(t *testing.T) {
 
 func TestSnakeToCamel(t *testing.T) {
 	for test, exp := range map[string]string{
-		"closed_conn_dropped":              "ClosedConnDropped",
-		"closed_conn_polling_lost":         "ClosedConnPollingLost",
-		"Conntrack_short_Term_Buffer_size": "ConntrackShortTermBufferSize",
+		"closed_conn_dropped":      "ClosedConnDropped",
+		"closed_conn_polling_lost": "ClosedConnPollingLost",
 	} {
 		assert.Equal(t, exp, snakeToCapInitialCamel(test))
 	}

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -67,10 +67,6 @@ type Config struct {
 	// ConntrackMaxStateSize specifies the maximum number of connections with NAT we can track
 	ConntrackMaxStateSize int
 
-	// ConntrackShortTermBufferSize is the maximum number of short term conntracked connections that will
-	// held in memory at once
-	ConntrackShortTermBufferSize int
-
 	// DebugPort specifies a port to run golang's expvar and pprof debug endpoint
 	DebugPort int
 
@@ -87,20 +83,19 @@ type Config struct {
 // NewDefaultConfig enables traffic collection for all connection types
 func NewDefaultConfig() *Config {
 	return &Config{
-		CollectTCPConns:              true,
-		CollectUDPConns:              true,
-		CollectIPv6Conns:             true,
-		CollectLocalDNS:              false,
-		DNSInspection:                true,
-		CollectDNSStats:              false,
-		UDPConnTimeout:               30 * time.Second,
-		TCPConnTimeout:               2 * time.Minute,
-		MaxTrackedConnections:        65536,
-		ConntrackMaxStateSize:        65536,
-		ConntrackShortTermBufferSize: 100,
-		ProcRoot:                     "/proc",
-		BPFDebug:                     false,
-		EnableConntrack:              true,
+		CollectTCPConns:       true,
+		CollectUDPConns:       true,
+		CollectIPv6Conns:      true,
+		CollectLocalDNS:       false,
+		DNSInspection:         true,
+		CollectDNSStats:       false,
+		UDPConnTimeout:        30 * time.Second,
+		TCPConnTimeout:        2 * time.Minute,
+		MaxTrackedConnections: 65536,
+		ConntrackMaxStateSize: 65536,
+		ProcRoot:              "/proc",
+		BPFDebug:              false,
+		EnableConntrack:       true,
 		// With clients checking connection stats roughly every 30s, this gives us roughly ~1.6k + ~2.5k objects a second respectively.
 		MaxClosedConnectionsBuffered: 50000,
 		MaxConnectionsStateBuffered:  75000,

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -291,7 +291,7 @@ func (ctr *realConntracker) DeleteConn(
 	)
 	now := time.Now().UnixNano()
 	atomic.AddInt64(&ctr.stats.unregisters, 1)
-	atomic.AddInt64(&ctr.stats.unregistersTotalTime, then-now)
+	atomic.AddInt64(&ctr.stats.unregistersTotalTime, now-then)
 	if misses > 0 {
 		atomic.AddInt64(&ctr.stats.missedRegisters, 1)
 	}

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -37,7 +37,7 @@ type Conntracker interface {
 		dstIP util.Address,
 		dstPort uint16,
 		transport process.ConnectionType) *IPTranslation
-	DeleteConn(
+	DeleteTranslation(
 		srcIP util.Address,
 		srcPort uint16,
 		dstIP util.Address,
@@ -240,7 +240,7 @@ func (ctr *realConntracker) GetStats() map[string]int64 {
 	return m
 }
 
-func (ctr *realConntracker) DeleteConn(
+func (ctr *realConntracker) DeleteTranslation(
 	srcIP util.Address,
 	srcPort uint16,
 	dstIP util.Address,

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -257,15 +257,17 @@ func (ctr *realConntracker) DeleteConn(
 			return
 		}
 
-		// move the mapping from the permanent to "short lived" connection
 		delete(ctr.state, key)
-		if len(ctr.shortLivedBuffer) < ctr.maxShortLivedBuffer {
-			ctr.shortLivedBuffer[key] = translation.IPTranslation
-		} else {
-			log.Warnf("exceeded maximum tracked short lived connections (%d). consider raising system_probe_config.conntrack_short_term_buffer_size.",
+		if len(ctr.shortLivedBuffer) >= ctr.maxShortLivedBuffer {
+			log.Warnf("exceeded maximum tracked short lived connections (%d)."+
+				"consider raising system_probe_config.conntrack_short_term_buffer_size.",
 				ctr.maxShortLivedBuffer,
 			)
+			return
 		}
+
+		// move the mapping from the permanent to "short lived" connection
+		ctr.shortLivedBuffer[key] = translation.IPTranslation
 	}
 
 	then := time.Now().UnixNano()

--- a/pkg/ebpf/netlink/conntracker_integration_test.go
+++ b/pkg/ebpf/netlink/conntracker_integration_test.go
@@ -21,7 +21,7 @@ func TestConntracker(t *testing.T) {
 		t.Errorf("setup command output: %s", string(out))
 	}
 
-	ct, err := NewConntracker("/proc", 100, 100)
+	ct, err := NewConntracker("/proc", 100)
 	require.NoError(t, err)
 	defer ct.Close()
 

--- a/pkg/ebpf/netlink/conntracker_test.go
+++ b/pkg/ebpf/netlink/conntracker_test.go
@@ -172,7 +172,6 @@ func TestGetUpdatesGen(t *testing.T) {
 	require.NotNil(t, iptr)
 
 	require.Len(t, rt.state, 2)
-	require.Len(t, rt.shortLivedBuffer, 0)
 	entry := rt.state[connKey{
 		srcIP: util.AddressFromString("10.0.0.0"), srcPort: 12345,
 		dstIP: util.AddressFromString("50.30.40.10"), dstPort: 80,
@@ -206,8 +205,6 @@ func TestConntrackerMemoryAllocation(t *testing.T) {
 func newConntracker() *realConntracker {
 	return &realConntracker{
 		state:                make(map[connKey]*connValue),
-		shortLivedBuffer:     make(map[connKey]*IPTranslation),
-		maxShortLivedBuffer:  10000,
 		compactTicker:        time.NewTicker(time.Hour),
 		maxStateSize:         10000,
 		exceededSizeLogLimit: util.NewLogLimit(1, time.Minute),

--- a/pkg/ebpf/netlink/noop.go
+++ b/pkg/ebpf/netlink/noop.go
@@ -33,8 +33,6 @@ func (*noOpConntracker) DeleteTranslation(
 
 }
 
-func (*noOpConntracker) ClearShortLived() {}
-
 func (*noOpConntracker) Close() {}
 
 func (*noOpConntracker) GetStats() map[string]int64 {

--- a/pkg/ebpf/netlink/noop.go
+++ b/pkg/ebpf/netlink/noop.go
@@ -24,7 +24,7 @@ func (*noOpConntracker) GetTranslationForConn(
 	return nil
 }
 
-func (*noOpConntracker) DeleteConn(
+func (*noOpConntracker) DeleteTranslation(
 	srcIP util.Address,
 	srcPort uint16,
 	dstIP util.Address,

--- a/pkg/ebpf/netlink/noop.go
+++ b/pkg/ebpf/netlink/noop.go
@@ -24,6 +24,15 @@ func (*noOpConntracker) GetTranslationForConn(
 	return nil
 }
 
+func (*noOpConntracker) DeleteConn(
+	srcIP util.Address,
+	srcPort uint16,
+	dstIP util.Address,
+	dstPort uint16,
+	transport process.ConnectionType) {
+
+}
+
 func (*noOpConntracker) ClearShortLived() {}
 
 func (*noOpConntracker) Close() {}

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -291,7 +291,7 @@ func (t *Tracer) initPerfPolling() (*bpflib.PerfMap, error) {
 					)
 
 					if cs.IPTranslation != nil {
-						t.conntracker.DeleteConn(
+						t.conntracker.DeleteTranslation(
 							cs.Source,
 							cs.SPort,
 							cs.Dest,

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -289,6 +289,13 @@ func (t *Tracer) initPerfPolling() (*bpflib.PerfMap, error) {
 						cs.DPort,
 						process.ConnectionType(cs.Type),
 					)
+					t.conntracker.DeleteConn(
+						cs.Source,
+						cs.SPort,
+						cs.Dest,
+						cs.DPort,
+						process.ConnectionType(cs.Type),
+					)
 					t.state.StoreClosedConnection(cs)
 				}
 			case lostCount, ok := <-lostChannel:

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -289,13 +289,16 @@ func (t *Tracer) initPerfPolling() (*bpflib.PerfMap, error) {
 						cs.DPort,
 						process.ConnectionType(cs.Type),
 					)
-					t.conntracker.DeleteConn(
-						cs.Source,
-						cs.SPort,
-						cs.Dest,
-						cs.DPort,
-						process.ConnectionType(cs.Type),
-					)
+
+					if cs.IPTranslation != nil {
+						t.conntracker.DeleteConn(
+							cs.Source,
+							cs.SPort,
+							cs.Dest,
+							cs.DPort,
+							process.ConnectionType(cs.Type),
+						)
+					}
 					t.state.StoreClosedConnection(cs)
 				}
 			case lostCount, ok := <-lostChannel:

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -193,7 +193,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		MaxTrackedConnections: defaultMaxTrackedConnections,
 		EnableConntrack:       true,
 		ClosedChannelSize:     500,
-		ConntrackMaxStateSize: defaultMaxTrackedConnections,
+		ConntrackMaxStateSize: defaultMaxTrackedConnections * 2,
 
 		// Check config
 		EnabledChecks: enabledChecks,

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -31,8 +31,6 @@ var (
 	// defaultSystemProbeFilePath is the default logging file for the system probe
 	defaultSystemProbeFilePath = "/var/log/datadog/system-probe.log"
 
-	defaultConntrackShortTermBufferSize = 10000
-
 	processChecks   = []string{"process", "rtprocess"}
 	containerChecks = []string{"container", "rtcontainer"}
 )
@@ -87,7 +85,6 @@ type AgentConfig struct {
 	ExcludedSourceConnections      map[string][]string
 	ExcludedDestinationConnections map[string][]string
 	EnableConntrack                bool
-	ConntrackShortTermBufferSize   int
 	ConntrackMaxStateSize          int
 	SystemProbeDebugPort           int
 	ClosedChannelSize              int
@@ -186,18 +183,17 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		StatsdPort: 8125,
 
 		// System probe collection configuration
-		EnableSystemProbe:            false,
-		DisableTCPTracing:            false,
-		DisableUDPTracing:            false,
-		DisableIPv6Tracing:           false,
-		DisableDNSInspection:         false,
-		SystemProbeSocketPath:        defaultSystemProbeSocketPath,
-		SystemProbeLogFile:           defaultSystemProbeFilePath,
-		MaxTrackedConnections:        defaultMaxTrackedConnections,
-		EnableConntrack:              true,
-		ClosedChannelSize:            500,
-		ConntrackShortTermBufferSize: defaultConntrackShortTermBufferSize,
-		ConntrackMaxStateSize:        defaultMaxTrackedConnections,
+		EnableSystemProbe:     false,
+		DisableTCPTracing:     false,
+		DisableUDPTracing:     false,
+		DisableIPv6Tracing:    false,
+		DisableDNSInspection:  false,
+		SystemProbeSocketPath: defaultSystemProbeSocketPath,
+		SystemProbeLogFile:    defaultSystemProbeFilePath,
+		MaxTrackedConnections: defaultMaxTrackedConnections,
+		EnableConntrack:       true,
+		ClosedChannelSize:     500,
+		ConntrackMaxStateSize: defaultMaxTrackedConnections,
 
 		// Check config
 		EnabledChecks: enabledChecks,

--- a/pkg/process/config/tracer_config.go
+++ b/pkg/process/config/tracer_config.go
@@ -52,7 +52,6 @@ func SysProbeConfigFromConfig(cfg *AgentConfig) *ebpf.Config {
 	tracerConfig.ProcRoot = util.GetProcRoot()
 	tracerConfig.BPFDebug = cfg.SysProbeBPFDebug
 	tracerConfig.EnableConntrack = cfg.EnableConntrack
-	tracerConfig.ConntrackShortTermBufferSize = cfg.ConntrackShortTermBufferSize
 	tracerConfig.ConntrackMaxStateSize = cfg.ConntrackMaxStateSize
 	tracerConfig.DebugPort = cfg.SystemProbeDebugPort
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -69,9 +69,6 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	if config.Datadog.IsSet(key(spNS, "enable_conntrack")) {
 		a.EnableConntrack = config.Datadog.GetBool(key(spNS, "enable_conntrack"))
 	}
-	if s := config.Datadog.GetInt(key(spNS, "conntrack_short_term_buffer_size")); s > 0 {
-		a.ConntrackShortTermBufferSize = s
-	}
 	if s := config.Datadog.GetInt(key(spNS, "conntrack_max_state_size")); s > 0 {
 		a.ConntrackMaxStateSize = s
 	}


### PR DESCRIPTION
### What does this PR do?

* Delete Conntrack translation when TCP connection is closed;
* Remove short-lived translation buffer as this is no longer needed;
* Bump `ConntrackMaxStateSize`;

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
