### PR TITLE
[logs] Log correct value in log message

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -122,7 +122,7 @@ func (c *LogsConfig) Validate() error {
 func (c *LogsConfig) validateTailingMode() error {
 	mode, found := TailingModeFromString(c.TailingMode)
 	if !found && c.TailingMode != "" {
-		return fmt.Errorf("invalid tailing mode '%v' for %v", mode, c.Path)
+		return fmt.Errorf("invalid tailing mode '%v' for %v", c.TailingMode, c.Path)
 	}
 	if ContainsWildcard(c.Path) && (mode == Beginning || mode == ForceBeginning) {
 		return fmt.Errorf("tailing from the beginning is not supported for wildcard path %v", c.Path)

--- a/releasenotes/notes/logfile-tailing-from-the-begining-fbb49b9c2481204c.yaml
+++ b/releasenotes/notes/logfile-tailing-from-the-begining-fbb49b9c2481204c.yaml
@@ -1,8 +1,8 @@
 enhancements:
   - |
-    Log configurations now accept a new parameter that allows
+    Log configurations of type ``file`` now accept a new parameter that allows
     to specify whether a log shall be tailed from the beginning
     or the end. It aims to allow whole log collection, including
-    events that may occur before the agent first start. The
+    events that may occur before the agent first starts. The
     parameter is named ``start_position`` and it can be set to
     ``end`` or ``beginning``, the default value is ``end``.


### PR DESCRIPTION
### What does this PR do?

Tiny fixes to https://github.com/DataDog/datadog-agent/pull/5091, for 7.19.0:

* fixes the value logged in error message (so that we log the actual invalid value, not what we default to)
* small fix to changelog

### Additional Notes

I have a few additional tiny fixes that are not important for 7.19, I'll open a separate PR for those