### PR TITLE
[proc] Regenerate procmatch default catalog

### DIFF
--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -6,15 +6,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	model "github.com/DataDog/agent-payload/process"
-	"github.com/DataDog/datadog-agent/pkg/ebpf/encoding"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/retry"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"sync"
 	"time"
+
+	model "github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/encoding"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
 // Conn is a wrapper over some net.Listener

--- a/pkg/procmatch/default_catalog.go
+++ b/pkg/procmatch/default_catalog.go
@@ -294,6 +294,14 @@ var DefaultCatalog IntegrationCatalog = IntegrationCatalog{
 		},
 	},
 	IntegrationEntry{
+		DisplayName:  "RethinkDB",
+		MetricPrefix: "rethinkdb.",
+		Name:         "rethinkdb",
+		Signatures: []string{
+			"rethinkdb",
+		},
+	},
+	IntegrationEntry{
 		DisplayName:  "Riak CS",
 		MetricPrefix: "riakcs.",
 		Name:         "riakcs",
@@ -360,6 +368,7 @@ var DefaultCatalog IntegrationCatalog = IntegrationCatalog{
 		Name:         "varnish",
 		Signatures: []string{
 			"service varnish start",
+			"varnishd",
 		},
 	},
 	IntegrationEntry{

--- a/pkg/procmatch/procmatch_test.go
+++ b/pkg/procmatch/procmatch_test.go
@@ -41,6 +41,10 @@ func TestMatchIntegration(t *testing.T) {
 			"supervisord"},
 		{"/usr/sbin/pgbouncer -d /etc/pgbouncer/pgbouncer.ini",
 			"pgbouncer"},
+		{"varnishd -j unix,user=vcache -F -a :6081 -T localhost:6082 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m",
+			"varnish"},
+		{"rethinkdb --daemon --config-file /etc/rethinkdb/instances.d/instance1.conf --runuser rethinkdb --rungroup rethinkdb --pid-file /var/run/rethinkdb/instance1/pid_file --directory /var/lib/rethinkdb/instance1/data",
+			"rethinkdb"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
### What does this PR do?

Updates the `varnish` signature and adds the `rethinkdb` signature on the procmatch default catalog. It also adds some unit tests.

### Motivation

We want to improve the `procmatch` catalog to match these integrations.

### Additional Notes

@DataDog/processes 
