### PR TITLE
Separate out linux & windows implementation of CollectSystemInfo()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	github.com/DataDog/agent-payload v0.0.0-20200416172112-13d2aa7ab86f // 4.31.0
 	github.com/DataDog/datadog-go v3.5.0+incompatible
-	github.com/DataDog/gohai v0.0.0-20200124154531-8cbe900337f1
+	github.com/DataDog/gohai v0.0.0-20200416230846-f32fac1c10c3
 	github.com/DataDog/gopsutil v0.0.0-20191127151039-7e1a4eadb59e
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect
 	github.com/DataDog/watermarkpodautoscaler v0.1.0
@@ -136,7 +136,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
-	github.com/prometheus/procfs v0.0.0-20190104112138-b1a0a9a36d74 // indirect
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
 	github.com/shirou/gopsutil v2.20.3+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4
@@ -154,7 +153,6 @@ require (
 	github.com/urfave/negroni v1.0.0
 	github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936
 	github.com/vito/go-sse v1.0.0 // indirect
-	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	github.com/zorkian/go-datadog-api v2.28.0+incompatible // indirect
 	go.etcd.io/bbolt v1.3.4 // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/DataDog/gobpf v0.0.0-20200131184214-6763fd92fd3f h1:vPk11ERhqpKweLLyX
 github.com/DataDog/gobpf v0.0.0-20200131184214-6763fd92fd3f/go.mod h1:rNvi5cSHdpxN6495MOYAWN3yukac8lORoluL+9Osrsw=
 github.com/DataDog/gohai v0.0.0-20200124154531-8cbe900337f1 h1:vqMoQXADkTMHpUq5jHAiRcVfGx0gJW6PmzwyQfaSjGw=
 github.com/DataDog/gohai v0.0.0-20200124154531-8cbe900337f1/go.mod h1:cJ+uBTR3AWclJPX7R9nRwDQB5R2HXWTrb6L4Ts4wwcw=
+github.com/DataDog/gohai v0.0.0-20200416230846-f32fac1c10c3 h1:6qyIovX2jzgLIjveGKyK0UMCTkcqYgznydfgVnh2CUg=
+github.com/DataDog/gohai v0.0.0-20200416230846-f32fac1c10c3/go.mod h1:cJ+uBTR3AWclJPX7R9nRwDQB5R2HXWTrb6L4Ts4wwcw=
 github.com/DataDog/gopsutil v0.0.0-20191127151039-7e1a4eadb59e h1:LuTXxCfAI9ntSpWg+5QnBJJ+ysWR7ED+/2ggNdxmKp8=
 github.com/DataDog/gopsutil v0.0.0-20191127151039-7e1a4eadb59e/go.mod h1:tGQp6XG4XpOyy67WG/YWXVxzOY6LejK35e8KcQhtRIQ=
 github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 h1:UcKqIrOowv2PjTkOC27Xm9TMZlPbRi3CK1OCoawdvl0=

--- a/pkg/process/checks/system_info.go
+++ b/pkg/process/checks/system_info.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package checks
 
 import (

--- a/pkg/process/checks/system_info_windows.go
+++ b/pkg/process/checks/system_info_windows.go
@@ -1,0 +1,64 @@
+package checks
+
+import (
+	"fmt"
+	"strconv"
+	"github.com/DataDog/gohai/cpu"
+	"github.com/DataDog/gohai/platform"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+
+	model "github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/process/config"
+)
+
+// CollectSystemInfo collects a set of system-level information that will not
+// change until a restart. This bit of information should be passed along with
+// the process messages.
+func CollectSystemInfo(cfg *config.AgentConfig) (*model.SystemInfo, error) {
+	hi, err := platform.GetArchInfo()
+	if err != nil {
+		return nil, err
+	}
+	cpuInfo, err := cpu.GetCpuInfo()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("cpu info %v\n", cpuInfo)
+	mi, err := winutil.VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+	phys_count, err := strconv.ParseInt(cpuInfo["cpu_pkgs"], 10, 64)
+	logical_count, err := strconv.ParseInt(cpuInfo["cpu_logical_processors"], 10, 64)
+	clock_speed, err := strconv.ParseInt(cpuInfo["mhz"], 10, 64)
+	l2_cache, err := strconv.ParseInt(cpuInfo["cache_size_l2"], 10, 64)
+	cpus := make([]*model.CPUInfo, 0)
+	for i := int64(0) ; i < phys_count ; i++ {
+		cpus = append(cpus, &model.CPUInfo{
+			Number:     int32(i),
+			Vendor:     cpuInfo["vendor_id"],
+			Family:     cpuInfo["family"],
+			Model:      cpuInfo["model"],
+			PhysicalId: "",
+			CoreId:     "",
+			Cores:      int32(logical_count),
+			Mhz:        int64(clock_speed),
+			CacheSize:  int32(l2_cache),
+		})
+	}
+
+	m := &model.SystemInfo{
+		Uuid: "",
+		Os: &model.OSInfo{
+			Name:          hi["kernel_name"].(string),
+			Platform:      hi["os"].(string),
+			Family:        hi["family"].(string),
+			Version:       hi["kernel_release"].(string),
+			KernelVersion: "",
+		},
+		Cpus:        cpus,
+		TotalMemory: int64(mi.Total),
+	}
+	return m, nil
+}

--- a/pkg/process/checks/system_info_windows.go
+++ b/pkg/process/checks/system_info_windows.go
@@ -2,9 +2,9 @@ package checks
 
 import (
 	"fmt"
-	"strconv"
 	"github.com/DataDog/gohai/cpu"
 	"github.com/DataDog/gohai/platform"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 
@@ -29,12 +29,12 @@ func CollectSystemInfo(cfg *config.AgentConfig) (*model.SystemInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	phys_count, err := strconv.ParseInt(cpuInfo["cpu_pkgs"], 10, 64)
-	logical_count, err := strconv.ParseInt(cpuInfo["cpu_logical_processors"], 10, 64)
-	clock_speed, err := strconv.ParseInt(cpuInfo["mhz"], 10, 64)
-	l2_cache, err := strconv.ParseInt(cpuInfo["cache_size_l2"], 10, 64)
+	physCount, _ := strconv.ParseInt(cpuInfo["cpu_pkgs"], 10, 64)
+	logicalCount, _ := strconv.ParseInt(cpuInfo["cpu_logical_processors"], 10, 64)
+	clockSpeed, _ := strconv.ParseInt(cpuInfo["mhz"], 10, 64)
+	l2Cache, _ := strconv.ParseInt(cpuInfo["cache_size_l2"], 10, 64)
 	cpus := make([]*model.CPUInfo, 0)
-	for i := int64(0) ; i < phys_count ; i++ {
+	for i := int64(0); i < physCount; i++ {
 		cpus = append(cpus, &model.CPUInfo{
 			Number:     int32(i),
 			Vendor:     cpuInfo["vendor_id"],
@@ -42,9 +42,9 @@ func CollectSystemInfo(cfg *config.AgentConfig) (*model.SystemInfo, error) {
 			Model:      cpuInfo["model"],
 			PhysicalId: "",
 			CoreId:     "",
-			Cores:      int32(logical_count),
-			Mhz:        int64(clock_speed),
-			CacheSize:  int32(l2_cache),
+			Cores:      int32(logicalCount),
+			Mhz:        int64(clockSpeed),
+			CacheSize:  int32(l2Cache),
 		})
 	}
 

--- a/pkg/process/checks/system_info_windows.go
+++ b/pkg/process/checks/system_info_windows.go
@@ -1,7 +1,6 @@
 package checks
 
 import (
-	"fmt"
 	"github.com/DataDog/gohai/cpu"
 	"github.com/DataDog/gohai/platform"
 	"strconv"
@@ -24,7 +23,6 @@ func CollectSystemInfo(cfg *config.AgentConfig) (*model.SystemInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("cpu info %v\n", cpuInfo)
 	mi, err := winutil.VirtualMemory()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
(do not merge yet.  Needs associated gohai change to be merged first)

On windows, don't use WMI, use gohai implementation that collects
same information (and can gracefully fail when some info isn't
available, e.g. in a container) .

Allows process agent to start in a Nano container.

Requires related gohai change.

### Motivation

allow process agent to run on Nano

