### PR TITLE
Prevent race condition from happening in test

### DIFF
--- a/pkg/collector/python/test_loader.go
+++ b/pkg/collector/python/test_loader.go
@@ -8,6 +8,7 @@
 package python
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -120,6 +121,9 @@ func testLoadCustomCheck(t *testing.T) {
 	C.get_attr_string_return = 0
 
 	check, err := loader.Load(conf, conf.Instances[0])
+	// Remove check finalizer that may trigger race condition while testing
+	runtime.SetFinalizer(check, nil)
+
 	assert.Nil(t, err)
 	assert.Equal(t, "fake_check", check.(*PythonCheck).ModuleName)
 	assert.Equal(t, "unversioned", check.(*PythonCheck).version)
@@ -152,6 +156,9 @@ func testLoadWheelCheck(t *testing.T) {
 	C.get_attr_string_attr_value = C.CString("1.2.3")
 
 	check, err := loader.Load(conf, conf.Instances[0])
+	// Remove check finalizer that may trigger race condition while testing
+	runtime.SetFinalizer(check, nil)
+
 	assert.Nil(t, err)
 	assert.Equal(t, "fake_check", check.(*PythonCheck).ModuleName)
 	assert.Equal(t, "1.2.3", check.(*PythonCheck).version)


### PR DESCRIPTION
### What does this PR do?
It disables finalizer for python check objects because those finalizers
are keeping a reference to rtloader that is re-instanciated more than
once during test and unprotected concurrent operations on rtloader 
may arise between those finalizers and subsequent tests.

### Motivation
Prevent
```
==================
WARNING: DATA RACE
Read at 0x000003dcb610 by goroutine 59:
  github.com/DataDog/datadog-agent/pkg/collector/python.newStickyLock.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/collector/python/helpers.go:88 +0x3e
  github.com/DataDog/datadog-agent/pkg/collector/python.newStickyLock()
      /go/src/github.com/DataDog/datadog-agent/pkg/collector/python/helpers.go:88 +0x38
  github.com/DataDog/datadog-agent/pkg/collector/python.pythonCheckFinalizer.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/collector/python/check.go:298 +0x33

Previous write at 0x000003dcb610 by goroutine 58:
  github.com/DataDog/datadog-agent/pkg/collector/python.testLoadWheelCheck()
      /go/src/github.com/DataDog/datadog-agent/pkg/collector/python/test_loader.go:148 +0x24a
  github.com/DataDog/datadog-agent/pkg/collector/python.TestLoadWheelCheck()
      /go/src/github.com/DataDog/datadog-agent/pkg/collector/python/loader_test.go:15 +0x38
  testing.tRunner()
      /root/.gimme/versions/go1.13.8.linux.amd64/src/testing/testing.go:909 +0x199

Goroutine 59 (running) created at:
  github.com/DataDog/datadog-agent/pkg/collector/python.pythonCheckFinalizer()
      /go/src/github.com/DataDog/datadog-agent/pkg/collector/python/check.go:297 +0x4c

Goroutine 58 (running) created at:
  testing.(*T).Run()
      /root/.gimme/versions/go1.13.8.linux.amd64/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /root/.gimme/versions/go1.13.8.linux.amd64/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /root/.gimme/versions/go1.13.8.linux.amd64/src/testing/testing.go:909 +0x199
  testing.runTests()
      /root/.gimme/versions/go1.13.8.linux.amd64/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /root/.gimme/versions/go1.13.8.linux.amd64/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:104 +0x223
==================
--- FAIL: TestLoadWheelCheck (1.12s)
    testing.go:853: race detected during execution of test
FAIL
FAIL    github.com/DataDog/datadog-agent/pkg/collector/python    3.955s

```
From happening during test 

### Additional Notes
Unsure it is the best solution to handle that issue as I have low experience on that piece of code.
Did an 8h endurance test without any occurence of the race condition (Was occurring within 10 minutes before the change).
