### PR TITLE
[logs] LI-264: Don't default to HTTP when additional endpoints are set

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -92,7 +92,7 @@ func BuildEndpoints(httpConnectivity HTTPConnectivity) (*Endpoints, error) {
 	if coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl") {
 		log.Warnf("Use of illegal configuration parameter, if you need to send your logs to a proxy, please use 'logs_config.logs_dd_url' and 'logs_config.logs_no_ssl' instead")
 	}
-	if isForceHTTPUse() || (bool(httpConnectivity) && !(isForceTCPUse() || isSocks5ProxySet())) {
+	if isForceHTTPUse() || (bool(httpConnectivity) && !(isForceTCPUse() || isSocks5ProxySet() || hasAdditionalEndpoints())) {
 		return BuildHTTPEndpoints()
 	}
 	log.Warn("You are currently sending Logs to Datadog through TCP (either because logs_config.use_tcp or logs_config.socks5_proxy_address is set or the HTTP connectivity test has failed) " +
@@ -111,6 +111,10 @@ func isForceTCPUse() bool {
 
 func isForceHTTPUse() bool {
 	return coreConfig.Datadog.GetBool("logs_config.use_http")
+}
+
+func hasAdditionalEndpoints() bool {
+	return len(getAdditionalEndpoints()) > 0
 }
 
 func buildTCPEndpoints() (*Endpoints, error) {

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -287,6 +287,25 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
+	suite.config.Set("logs_config.socks5_proxy_address", "")
+
+	// When additional_endpoints is not empty always create TCP endpoints
+	suite.config.Set("logs_config.use_http", "false")
+	suite.config.Set("logs_config.use_tcp", "false")
+	suite.config.Set("logs_config.additional_endpoints", []map[string]interface{}{
+		{
+			"host":              "foo",
+			"api_key":           "1234",
+			"use_compression":   true,
+			"compression_level": 1,
+		},
+	})
+	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess)
+	suite.Nil(err)
+	suite.False(endpoints.UseHTTP)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	suite.Nil(err)
+	suite.False(endpoints.UseHTTP)
 }
 
 func (suite *EndpointsTestSuite) TestIsSetAndNotEmpty() {


### PR DESCRIPTION
### What does this PR do?

Don't default to HTTP when additional endpoints are set

### Motivation

If we default to HTTP while users have defined additional endpoints we could break their setup.

### Additional Notes

`logs_config.additional_endpoints` config is not mentioned in the warning log/status/RN because it not a supported feature.
