### PR TITLE
pkg/trace/writer: ensure stats payloads are cloned on multiple senders

### DIFF
--- a/pkg/trace/stats/stats_payload.go
+++ b/pkg/trace/stats/stats_payload.go
@@ -9,6 +9,8 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Payload represents the payload to be flushed to the stats endpoint
@@ -24,6 +26,10 @@ func EncodePayload(w io.Writer, payload *Payload) error {
 	if err != nil {
 		return err
 	}
-	defer gz.Close()
+	defer func() {
+		if err := gz.Close(); err != nil {
+			log.Errorf("Error closing gzip stream when writing stats payload: %v", err)
+		}
+	}()
 	return json.NewEncoder(gz).Encode(payload)
 }

--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -120,9 +120,8 @@ func (w *StatsWriter) addStats(s []stats.Bucket) {
 			return
 		}
 		atomic.AddInt64(&w.stats.Bytes, int64(req.body.Len()))
-		for _, sender := range w.senders {
-			sender.Push(req)
-		}
+
+		sendPayloads(w.senders, req)
 	}
 }
 

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -213,29 +213,12 @@ func (w *TraceWriter) flush() {
 			log.Errorf("gzip.NewWriterLevel: %d", err)
 			return
 		}
-		gzipw.Write(b)
+		if _, err := gzipw.Write(b); err != nil {
+			log.Errorf("Error gzipping trace payload: %v", err)
+		}
 		gzipw.Close()
 
-		if len(w.senders) == 1 {
-			// fast path
-			w.senders[0].Push(p)
-		} else {
-			// Create a clone for each payload because each sender places payloads
-			// back onto the pool after they are sent.
-			payloads := make([]*payload, 0, len(w.senders))
-			// Perform all the clones before any sends are to ensure the original
-			// payload body is completely unread.
-			for i := range w.senders {
-				if i == 0 {
-					payloads = append(payloads, p)
-				} else {
-					payloads = append(payloads, p.clone())
-				}
-			}
-			for i, sender := range w.senders {
-				sender.Push(payloads[i])
-			}
-		}
+		sendPayloads(w.senders, p)
 	}()
 }
 

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -216,7 +216,9 @@ func (w *TraceWriter) flush() {
 		if _, err := gzipw.Write(b); err != nil {
 			log.Errorf("Error gzipping trace payload: %v", err)
 		}
-		gzipw.Close()
+		if err := gzipw.Close(); err != nil {
+			log.Errorf("Error closing gzip stream when writing trace payload: %v", err)
+		}
 
 		sendPayloads(w.senders, p)
 	}()


### PR DESCRIPTION
This change ports over the changes from the trace writer introduced in #5117
to stats.