### PR TITLE
Use Debug level when logging open fds errors

### DIFF
--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -245,7 +245,7 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 			pid := p.Pid
 			fdCount, err := cgroup.GetFileDescriptorLen(int(pid))
 			if err != nil {
-				log.Warnf("Failed to get file desc length for pid %d, container %s: %s", pid, ctn.ID()[:12], err)
+				log.Debugf("Failed to get file desc length for pid %d, container %s: %s", pid, ctn.ID()[:12], err)
 				continue
 			}
 			fileDescCount += fdCount

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -373,7 +373,7 @@ func (c ContainerCgroup) IO() (*metrics.ContainerIOStats, error) {
 	for _, pid := range c.Pids {
 		fdCount, err := GetFileDescriptorLen(int(pid))
 		if err != nil {
-			log.Warnf("Failed to get file desc length for pid %d, container %s: %s", pid, c.ContainerID[:12], err)
+			log.Debugf("Failed to get file desc length for pid %d, container %s: %s", pid, c.ContainerID[:12], err)
 			continue
 		}
 		fileDescCount += uint64(fdCount)


### PR DESCRIPTION
### What does this PR do?

Use debug log level instead of warn if we can't get open fds metrics

### Motivation

It's expected that the Agent doesn't have permissions to get these metrics for some processes.

### Additional Notes

https://github.com/DataDog/datadog-agent/issues/4917