### PR TITLE
[AD][Kubelet] Support tag keys with multiple values

### DIFF
--- a/releasenotes/notes/ad-support-tags-with-multiple-values-857102ef7ceb7edb.yaml
+++ b/releasenotes/notes/ad-support-tags-with-multiple-values-857102ef7ceb7edb.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Pod and container tags autodiscovered via pod annotations
+    now support multiple values for the same key.


### PR DESCRIPTION
### What does this PR do?

Make the JSON tags map more dynamic (defined in pod annotations) by supporting the following possibilities:
- `{"key1": "val1", "key2": "val2"}`-> string values only (what we support currently)
- `{"key1": ["val1", "val11"], "key2": ["val2", "val22"]}` -> array values only
- `{"key1": "val1", "key2": ["val2", "val22"]}` -> combined string and array values

### Motivation

Support multiple tag values for the same tag key when using the annotations `ad.datadoghq.com/tags` and `ad.datadoghq.com/<container>.tags`