### PR TITLE
Fix flaky test

### DIFF
--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -53,7 +53,7 @@ func isLocked(l lockable) bool {
 	select {
 	case <-ok:
 		return false
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		return true
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Give slow machines more times before asserting the store is locked 

### Motivation

Flakes are bad

### Additional Notes

Fails sometimes only on appveyor CI
