### PR TITLE
Fix S6 supervisor management when the core agent dies

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -155,7 +155,9 @@ RUN if [ ! -z "$PYTHON_VERSION" ]; then \
 
 
 # Override the exit script by ours to fix --pid=host operations
-COPY init-stage3 /etc/s6/init/init-stage3
+RUN  mv /etc/s6/init/init-stage3 /etc/s6/init/init-stage3-original
+COPY init-stage3          /etc/s6/init/init-stage3
+COPY init-stage3-host-pid /etc/s6/init/init-stage3-host-pid
 
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -155,7 +155,9 @@ RUN if [ ! -z "$PYTHON_VERSION" ]; then \
 
 
 # Override the exit script by ours to fix --pid=host operations
-COPY init-stage3 /etc/s6/init/init-stage3
+RUN  mv /etc/s6/init/init-stage3 /etc/s6/init/init-stage3-original
+COPY init-stage3          /etc/s6/init/init-stage3
+COPY init-stage3-host-pid /etc/s6/init/init-stage3-host-pid
 
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp

--- a/Dockerfiles/agent/init-stage3
+++ b/Dockerfiles/agent/init-stage3
@@ -1,14 +1,8 @@
-#!/bin/execlineb -S0
+#!/bin/bash
+set -euo pipefail
 
-# This is the shutdown script, running as process 1.
-cd /
-
-# Merge environments from our custom stage into current context
-s6-envdir -I /var/run/s6/env-stage3
-
-# Reap all the zombies, and we're done.
-wait { }
-
-# Use CMD exit code defaulting to zero if not present.
-importas -u -D0 S6_STAGE2_EXITED S6_STAGE2_EXITED
-exit ${S6_STAGE2_EXITED}
+if [[ $$ == 1 ]]; then
+    exec /etc/s6/init/init-stage3-original
+else
+    exec /etc/s6/init/init-stage3-host-pid
+fi

--- a/Dockerfiles/agent/init-stage3-host-pid
+++ b/Dockerfiles/agent/init-stage3-host-pid
@@ -1,0 +1,14 @@
+#!/bin/execlineb -S0
+
+# This is the shutdown script, running as process 1.
+cd /
+
+# Merge environments from our custom stage into current context
+s6-envdir -I /var/run/s6/env-stage3
+
+# Reap all the zombies, and we're done.
+wait { }
+
+# Use CMD exit code defaulting to zero if not present.
+importas -u -D0 S6_STAGE2_EXITED S6_STAGE2_EXITED
+exit ${S6_STAGE2_EXITED}

--- a/Dockerfiles/agent/s6-services/sysprobe/run
+++ b/Dockerfiles/agent/s6-services/sysprobe/run
@@ -1,13 +1,11 @@
 #!/usr/bin/execlineb -P
 
 # Check if the system-probe exists before running it
-ifthenelse
+ifelse -n
     { s6-test -x "/opt/datadog-agent/embedded/bin/system-probe" }
-    {
-        foreground { /initlog.sh "starting system-probe" }
-        system-probe --config=/etc/datadog-agent/system-probe.yaml
-    }
     {
         foreground { /initlog.sh "system-probe not bundled, disabling" }
         foreground { /bin/s6-svc -d /var/run/s6/services/sysprobe/ }
     }
+    foreground { /initlog.sh "starting system-probe" }
+    system-probe --config=/etc/datadog-agent/system-probe.yaml

--- a/Dockerfiles/agent/test_image_contents.py
+++ b/Dockerfiles/agent/test_image_contents.py
@@ -20,7 +20,9 @@ EXPECTED_ABSENT = [
 
 EXPECTED_CHECKSUMS = {
     # See https://github.com/DataDog/datadog-agent/pull/1337
-    "/etc/s6/init/init-stage3": "710c5b63d7bf1d23897991cba43b8de68aef163e570a2a676db2d897bb09baf7",
+    # and https://github.com/DataDog/datadog-agent/pull/5362
+    "/etc/s6/init/init-stage3":          "ea2d995df5a28709b2a040d2a212ebaa1e351c8233cc26cd4803fdc6df52d2b3",
+    "/etc/s6/init/init-stage3-host-pid": "710c5b63d7bf1d23897991cba43b8de68aef163e570a2a676db2d897bb09baf7",
 }
 
 

--- a/releasenotes/notes/fix-s6-shutdown-b2460e486a4ba68a.yaml
+++ b/releasenotes/notes/fix-s6-shutdown-b2460e486a4ba68a.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix S6 behavior when the core agent dies.
+    When the core agent died in a multi-process agent container managed by S6,
+    the container stayed in an unhealthy half dead state.
+    S6 configuration has been modified so that it will now exit in case of
+    core agent death so that the whole container will exit and will be restarted.


### PR DESCRIPTION
## What does this PR do?

Fix S6 supervisor management when the core agent dies.

## Issue reproducer

Here is the issue that this change addresses:

Start a multi-process agent container with:
```
/usr/bin/docker run --name datadog-agent \
                --privileged \
                --cap-add=SYS_ADMIN \
                --cap-add=SYS_RESOURCE \
                --cap-add=SYS_PTRACE \
                --cap-add=NET_ADMIN \
                --detach \
                -e DD_API_KEY="${DD_API_KEY}" \
                -e DD_PROCESS_AGENT_ENABLED=true \
                -e DD_SYSTEM_PROBE_ENABLED=true \
                --restart always \
                -p 0.0.0.0:8126:8126/tcp \
                -p 0.0.0.0:8125:8125/udp \
                -v /etc/machine-id:/etc/machine-id:ro \
                -v /proc/:/host/proc/:ro \
                -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
                -v /sys/kernel/debug:/sys/kernel/debug \
                -v /var/log/journal:/var/log/journal:ro \
                -v /var/run/docker.sock:/var/run/docker.sock:ro \
                datadog/agent:7.18.1
```

Check the process tree inside the container:
```
$ docker exec datadog-agent ps -afx
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:00 s6-svscan -t0 /var/run/s6/services
   27 ?        S      0:00 s6-supervise s6-fdholderd
  338 ?        S      0:00 s6-supervise sysprobe
  343 ?        Ss     0:00  \_ ifthenelse  s6-test  -x  /opt/datadog-agent/embedded/bin/system-probe   foreground   /initlog.sh   starting system-probe    system-probe  --config=/etc/datadog-agent/system-probe.yaml   foreground   /initlog.sh   system-probe not bundled, disabling    foreground   /bin/s6-svc   -d   /var/run/s6/services/sysprobe/
  359 ?        Sl     0:00      \_ system-probe --config=/etc/datadog-agent/system-probe.yaml
  339 ?        S      0:00 s6-supervise process
  345 ?        Ssl    0:00  \_ process-agent --config=/etc/datadog-agent/datadog.yaml
  340 ?        S      0:00 s6-supervise agent
  348 ?        Ssl    0:00  \_ agent run
  342 ?        S      0:00 s6-supervise trace
  346 ?        Ssl    0:00  \_ trace-agent --config=/etc/datadog-agent/datadog.yaml
```

and simulate a core agent crash by sending it a `KILL` signal:
```
sudo kill -KILL $(pidof agent)
```

### Expected behaviour:

The core agent dies. It makes S6 exit after having terminated all the tasks it supervises.
Docker then restarts the “failed” container.

### Observed behaviour:

The container stays there forever in a half dead state.
Here are the processes that are in the container:
```
$ docker exec datadog-agent ps -afx
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:00 wait  importas -u -D0 S6_STAGE2_EXITED S6_STAGE2_EXITED exit ${S6_STAGE2_EXITED}
  359 ?        Sl     0:01 system-probe --config=/etc/datadog-agent/system-probe.yaml
```

Because the core agent isn’t there any more, the `agent health` command that is launched by the `/probe.sh` `HEALTHCHECK` is continuously failing with the following error message:
```
Could not reach agent: Get https://localhost:5001/agent/status/health: dial tcp 127.0.0.1:5001: connect: connection refused
Make sure the agent is running before requesting the status and contact support if you continue having issues.
Error: Get https://localhost:5001/agent/status/health: dial tcp 127.0.0.1:5001: connect: connection refused
```
and the container stays forever in this “unhealthy” state.


## First fix

`system-probe` was the only surviving process because it was not a direct child of `s6-supervise`. Instead, there was an additional `ifthenelse` process in the process tree between `s6-supervise` and `system-probe`. That’s the reason why it failed at receiving the proper signals.

The first fix consists in having `system-probe` a direct child of `s6-supervise` and remove the intermediary process.

[This fix is in `Dockerfiles/agent/s6-services/sysprobe/run`](https://github.com/DataDog/datadog-agent/pull/5362/files#diff-f6b38f8630100ab3aa2a7024aeb7e607).

I’ve validated that this fix alone is enough to resolve the issue.

## Second fix

The reason why the container remains in a stuck state is because of an old fix we did to prevent the S6 running inside a container started with `--pid=host` from killing all the processes of the host.
So, the second fix consists in detecting whether we are running with `--pid=host` or not by checking whether the S6 init process is running as PID 1 and, depending on that, either restoring the default S6 behaviour or keeping our previous own S6 behaviour.

[This fix is in the other files of this PR](https://github.com/DataDog/datadog-agent/pull/5362/files#diff-eceb62ac7c87408f0d1aa08d378c412b).

I’ve validated that this fix alone is also enough to resolve the issue, but only in the non `--pid=host` case.