### PR TITLE
Add option to switch log to debug for 30sec during a flare

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -195,7 +195,7 @@ func getConfigValueCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	fmt.Printf("%s is set to: %s\n", args[0], value)
 	return nil
 }

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -101,6 +101,7 @@ func switchLogLevelAndWait() error {
 	// Setup a channel to catch OS signals as it very likely that some users will do CTRL+C while waiting for the delay
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Reset(os.Interrupt, syscall.SIGTERM)
 	go func() {
 		_ = <-signalCh
 		err = setConfigValue("log_level", currentLogLevel)
@@ -115,7 +116,7 @@ func switchLogLevelAndWait() error {
 		return err
 	}
 
-	fmt.Fprintln(color.Output, color.BlueString("Waiting %v seconds to get debug logs...\n", delay))
+	fmt.Fprintln(color.Output, color.BlueString("Waiting %v seconds to get debug logs...", delay))
 	time.Sleep(time.Duration(delay) * time.Second)
 
 	return nil

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -37,7 +37,7 @@ func init() {
 	flareCmd.Flags().StringVarP(&customerEmail, "email", "e", "", "Your email")
 	flareCmd.Flags().BoolVarP(&autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
 	flareCmd.Flags().BoolVarP(&forceLocal, "local", "l", false, "Force the creation of the flare by the command line instead of the agent process (useful when running in a containerized env)")
-	flareCmd.Flags().BoolVarP(&debugLog, "debug-log", "d", false, "Switch the log level to debug during the flare, if used the flare command will wait for 30 seconds (it can be overriden using the delay option) to collect log at the debug level")
+	flareCmd.Flags().BoolVarP(&debugLog, "debug-log", "d", false, "Switch the log level to debug during the flare, if used the flare command will wait for 30 seconds (it can be overridden using the delay option) to collect log at the debug level")
 	flareCmd.Flags().IntVarP(&delay, "delay", "w", 30, "Amount of time (in seconds) to wait for debug log collection when the --enable-debug-log option is used (default: 30)")
 
 	flareCmd.SetArgs([]string{"caseID"})
@@ -117,7 +117,7 @@ func switchLogLevelAndWait() error {
 
 	fmt.Fprintln(color.Output, color.BlueString("Waiting %v seconds to get debug logs...\n", delay))
 	time.Sleep(time.Duration(delay) * time.Second)
-	
+
 	return nil
 }
 

--- a/releasenotes/notes/add-option-to-enable-debug-log-durign-flare-e0059b7431041cd6.yaml
+++ b/releasenotes/notes/add-option-to-enable-debug-log-durign-flare-e0059b7431041cd6.yaml
@@ -1,0 +1,6 @@
+enhancements:
+  - |
+    Add an option to switch log level to debug and wait
+    30 seconds (can be overridden) to collect debug log
+    before creating the flare. The option is disabled by
+    default.


### PR DESCRIPTION
### What does this PR do?
Add option to switch log to debug for 30sec during a flare.
The option is disable by default, thus no behaviour change.

### Motivation
Increase flare usability, support effectiveness.

### Additional Notes
It handles interruption because it is 100% sure that a lot of users
will do ctrl+c during the 30 seconds lapse.