### PR TITLE
[7.19 Backport] Fix ENV vars propagation to services and start of process-agent service in Windows containers

### DIFF
--- a/Dockerfiles/agent/entrypoint.ps1
+++ b/Dockerfiles/agent/entrypoint.ps1
@@ -6,6 +6,16 @@ Get-ChildItem 'entrypoint-ps1' | ForEach-Object {
 	}
 }
 
+# Set process environment variables (from Docker) from Process to Machine level to allow Windows Services
+# (process-agent, trace-agent) to get their configuration properly
+foreach($key in [System.Environment]::GetEnvironmentVariables([System.EnvironmentVariableTarget]::Process).Keys) {
+	if ($key.StartsWith("DD_") -Or $key -Like "*PROXY*") {
+		Write-Output "Setting ENV var: $key to machine scope"
+		$value = [System.Environment]::GetEnvironmentVariable($key, [System.EnvironmentVariableTarget]::Process)
+		[System.Environment]::SetEnvironmentVariable($key, $value, [System.EnvironmentVariableTarget]::Machine)
+	}
+}
+
 $agent = $args[0]
 $agentArgs = $args | Select-Object -Skip 1
 return & $agent $agentArgs

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -30,3 +30,7 @@ New-Service -Name "datadog-trace-agent" -StartupType "Manual" -BinaryPathName "C
 # Allow to run agent binaries as `agent`
 setx /m PATH "$Env:Path;C:/Program Files/Datadog/Datadog Agent/bin;C:/Program Files/Datadog/Datadog Agent/bin/agent"
 $Env:Path="$Env:Path;C:/Program Files/Datadog/Datadog Agent/bin;C:/Program Files/Datadog/Datadog Agent/bin/agent"
+
+# Set variable indicating we are running in a container
+setx /m DOCKER_DD_AGENT "true"
+$Env:DOCKER_DD_AGENT="true"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -451,6 +451,13 @@ func initConfig(config Config) {
 
 	// Process agent
 	config.SetDefault("process_config.enabled", "false")
+	// process_config.enabled is only used on Windows by the core agent to start the process agent service.
+	// it can be set from file, but not from env. Override it with value from DD_PROCESS_AGENT_ENABLED.
+	ddProcessAgentEnabled, found := os.LookupEnv("DD_PROCESS_AGENT_ENABLED")
+	if found {
+		overrideVars["process_config.enabled"] = ddProcessAgentEnabled
+	}
+
 	config.BindEnv("process_config.process_dd_url", "")
 	config.BindEnv("process_config.orchestrator_dd_url", "")
 


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent/pull/5365 to 7.19