### PR TITLE
[Process Agent] Support multiple container sources

### DIFF
--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -311,10 +311,11 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		}
 	}
 
-	// Used to override container source auto-detection.
-	// "docker", "ecs_fargate", "kubelet", etc
-	if containerSource := config.Datadog.GetString(key(ns, "container_source")); containerSource != "" {
-		util.SetContainerSource(containerSource)
+	// Used to override container source auto-detection
+	// and to enable multiple collector sources if needed.
+	// "docker", "ecs_fargate", "kubelet", "kubelet docker", etc.
+	if sources := config.Datadog.GetStringSlice(key(ns, "container_source")); len(sources) > 0 {
+		util.SetContainerSources(sources)
 	}
 
 	// Pull additional parameters from the global config file.

--- a/pkg/process/util/containers_test.go
+++ b/pkg/process/util/containers_test.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+func Test_dedupeContainers(t *testing.T) {
+	tests := []struct {
+		name string
+		ctrs []*containers.Container
+		want []*containers.Container
+	}{
+		{
+			name: "dedupe",
+			ctrs: []*containers.Container{
+				{
+					ID: "ctr1",
+				},
+				{
+					ID: "ctr2",
+				},
+				{
+					ID: "ctr2",
+				},
+			},
+			want: []*containers.Container{
+				{
+					ID: "ctr1",
+				},
+				{
+					ID: "ctr2",
+				},
+			},
+		},
+		{
+			name: "no dedupe",
+			ctrs: []*containers.Container{
+				{
+					ID: "ctr1",
+				},
+				{
+					ID: "ctr2",
+				},
+			},
+			want: []*containers.Container{
+				{
+					ID: "ctr1",
+				},
+				{
+					ID: "ctr2",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, dedupeContainers(tt.ctrs))
+		})
+	}
+}

--- a/releasenotes/notes/process-support-multiple-container-sources-d84907e66c65c753.yaml
+++ b/releasenotes/notes/process-support-multiple-container-sources-d84907e66c65c753.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The process agent can be canfigured to collect containers
+    from multiple sources (e.g kubelet and docker simultaneously).


### PR DESCRIPTION
### What does this PR do?

Support multiple container sources in the Process Agent

### Motivation

In some environments we need to get containers from both `kubelet` and `docker` (e.g Docker Entreprise clusters)

### Additional Notes

`DD_PROCESS_AGENT_CONTAINER_SOURCE="docker kubelet"` to enable both `docker` and `kubelet` collectors
