### PR TITLE
change log level of service map error for deleted nodes

### DIFF
--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -168,7 +168,7 @@ func getPodMetadataForNode(w http.ResponseWriter, r *http.Request) {
 	log.Tracef("Fetching metadata map on all pods of the node %s", nodeName)
 	metaList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
 	if errNodes != nil {
-		log.Errorf("Could not collect the service map for %s, err: %v", nodeName, errNodes)
+		log.Warnf("Could not collect the service map for %s, err: %v", nodeName, errNodes)
 	}
 	slcB, err := json.Marshal(metaList)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Changes the log level from error to warning for deleted node/service map

### Motivation

https://github.com/DataDog/datadog-agent/issues/4567

### Additional Notes


