### PR TITLE
[gitlab] Fix build_puppy_agent-deb_arm64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -481,7 +481,7 @@ build_puppy_agent-deb_arm64:
     - cd $SRC_PATH
     - inv -e deps --verbose --dep-vendor-only --no-checks
   script:
-    - GOOS=linux GOARCH=arm inv -e agent.build --puppy --major-version 7
+    - inv -e agent.build --puppy --major-version 7
 
 .cluster_agent-build_common: &cluster_agent-build_common
   stage: binary_build


### PR DESCRIPTION
### What does this PR do?

Removes the `GOOS` and `GOARCH` variable definitions in `build_puppy_agent-deb_arm64` to build puppy natively on `arm64`.

### Motivation

The `build_puppy_agent-deb_arm64` job was setting `GOOS=linux` and `GOARCH=arm`, thus cross-compiling the puppy agent for 32-bit `arm` ([list of valid GOARCH values](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63#a-list-of-valid-32-bit-goarch-values)) instead of doing a native `arm64` build.

### Additional Notes

We can reintroduce 32-bit ARM tests in another PR if we actively want to test this build.
