### PR TITLE
[system-probe] Re-enable ENOBUFs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -607,6 +607,7 @@ func initConfig(config Config) {
 	config.SetKnown("system_probe_config.collect_local_dns")
 	config.SetKnown("system_probe_config.use_local_system_probe")
 	config.SetKnown("system_probe_config.enable_conntrack")
+	config.SetKnown("system_probe_config.enable_enobufs")
 	config.SetKnown("system_probe_config.sysprobe_socket")
 	config.SetKnown("system_probe_config.conntrack_short_term_buffer_size")
 	config.SetKnown("system_probe_config.max_conns_per_message")

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -64,6 +64,11 @@ type Config struct {
 	// EnableConntrack enables probing conntrack for network address translation via netlink
 	EnableConntrack bool
 
+	// EnableENOBUFS will enable ENOBUF errors on the netlink socket, causing conntrack event processing
+	// to be halted when the socket buffer overruns. If enabled, this acts as a circuit breaker when we're
+	// not processing conntrack events fast enough.
+	EnableENOBUFS bool
+
 	// ConntrackMaxStateSize specifies the maximum number of connections with NAT we can track
 	ConntrackMaxStateSize int
 

--- a/pkg/ebpf/netlink/conntracker_integration_test.go
+++ b/pkg/ebpf/netlink/conntracker_integration_test.go
@@ -21,7 +21,7 @@ func TestConntracker(t *testing.T) {
 		t.Errorf("setup command output: %s", string(out))
 	}
 
-	ct, err := NewConntracker("/proc", 100)
+	ct, err := NewConntracker("/proc", 100, false)
 	require.NoError(t, err)
 	defer ct.Close()
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -192,7 +192,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 
 	conntracker := netlink.NewNoOpConntracker()
 	if config.EnableConntrack {
-		if c, err := netlink.NewConntracker(config.ProcRoot, config.ConntrackMaxStateSize); err != nil {
+		if c, err := netlink.NewConntracker(config.ProcRoot, config.ConntrackMaxStateSize, config.EnableENOBUFS); err != nil {
 			log.Warnf("could not initialize conntrack, tracer will continue without NAT tracking: %s", err)
 		} else {
 			conntracker = c

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -85,6 +85,7 @@ type AgentConfig struct {
 	ExcludedSourceConnections      map[string][]string
 	ExcludedDestinationConnections map[string][]string
 	EnableConntrack                bool
+	EnableENOBUFS                  bool
 	ConntrackMaxStateSize          int
 	SystemProbeDebugPort           int
 	ClosedChannelSize              int
@@ -192,6 +193,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		SystemProbeLogFile:    defaultSystemProbeFilePath,
 		MaxTrackedConnections: defaultMaxTrackedConnections,
 		EnableConntrack:       true,
+		EnableENOBUFS:         false,
 		ClosedChannelSize:     500,
 		ConntrackMaxStateSize: defaultMaxTrackedConnections * 2,
 
@@ -377,6 +379,7 @@ func loadEnvVariables() {
 		// System probe specific configuration (Beta)
 		{"DD_SYSTEM_PROBE_ENABLED", "system_probe_config.enabled"},
 		{"DD_SYSPROBE_SOCKET", "system_probe_config.sysprobe_socket"},
+		{"DD_SYSTEM_PROBE_ENABLE_ENOBUFS", "system_probe_config.enable_enobufs"},
 		{"DD_DISABLE_TCP_TRACING", "system_probe_config.disable_tcp"},
 		{"DD_DISABLE_UDP_TRACING", "system_probe_config.disable_udp"},
 		{"DD_DISABLE_IPV6_TRACING", "system_probe_config.disable_ipv6"},

--- a/pkg/process/config/tracer_config.go
+++ b/pkg/process/config/tracer_config.go
@@ -52,6 +52,7 @@ func SysProbeConfigFromConfig(cfg *AgentConfig) *ebpf.Config {
 	tracerConfig.ProcRoot = util.GetProcRoot()
 	tracerConfig.BPFDebug = cfg.SysProbeBPFDebug
 	tracerConfig.EnableConntrack = cfg.EnableConntrack
+	tracerConfig.EnableENOBUFS = cfg.EnableENOBUFS
 	tracerConfig.ConntrackMaxStateSize = cfg.ConntrackMaxStateSize
 	tracerConfig.DebugPort = cfg.SystemProbeDebugPort
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -69,6 +69,9 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	if config.Datadog.IsSet(key(spNS, "enable_conntrack")) {
 		a.EnableConntrack = config.Datadog.GetBool(key(spNS, "enable_conntrack"))
 	}
+	if config.Datadog.IsSet(key(spNS, "enable_enobufs")) {
+		a.EnableENOBUFS = config.Datadog.GetBool(key(spNS, "enable_enobufs"))
+	}
 	if s := config.Datadog.GetInt(key(spNS, "conntrack_max_state_size")); s > 0 {
 		a.ConntrackMaxStateSize = s
 	}


### PR DESCRIPTION
### What does this PR do?

@DataDog/networks 

We're re-enabling ENOBUFs errors on the `netlink` socket as a safeguard against certain workloads that are causing system-probe CPU to spike. In other words, as soon as the netlink socket buffer overruns, we'll stop consuming Conntrack events, so ENOBUFs errors will act as a circuit breaker.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
