### PR TITLE
[System Probe][Windows] Convert Flows to ConnectionStats

### DIFF
--- a/pkg/ebpf/c/ddfilterapi.h
+++ b/pkg/ebpf/c/ddfilterapi.h
@@ -189,11 +189,11 @@ typedef struct _perFlowData {
     // stats common to all
 
     uint64_t packetsOut;
-    uint64_t bytesOut;              // total bytes including ip header
+    uint64_t monotonicSentBytes;              // total bytes including ip header
     uint64_t transportBytesOut;     // payload (not including ip or transport header)
 
     uint64_t packetsIn;
-    uint64_t bytesIn;
+    uint64_t monotonicRecvBytes;
     uint64_t transportBytesIn;
 
     uint16_t        localPort;      // host byte order

--- a/pkg/ebpf/event_windows.go
+++ b/pkg/ebpf/event_windows.go
@@ -1,0 +1,99 @@
+// +build windows
+
+package ebpf
+
+/*
+#include "c/ddfilterapi.h"
+*/
+import "C"
+import (
+	"net"
+	"syscall"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+const (
+	// TCPProtocol represents the IANA protocol number for TCP
+	TCPProtocol = 17
+
+	// UDPProtocol represents the IANA protocol number for UDP
+	UDPProtocol = 6
+)
+
+func connFamily(addressFamily C.uint16_t) ConnectionFamily {
+	if addressFamily == syscall.AF_INET {
+		return AFINET
+	}
+	return AFINET6
+}
+
+func connType(protocol C.uint16_t) ConnectionType {
+	if protocol == TCPProtocol {
+		return TCP
+	}
+	return UDP
+}
+
+func convertV4Addresses(local [16]C.uint8_t, remote [16]C.uint8_t) (localAddress util.Address, remoteAddress util.Address) {
+	// We only read the first 4 bytes for v4 address
+	localAddress = util.V4AddressFromBytes(C.GoBytes(unsafe.Pointer(&local), net.IPv4len))
+	remoteAddress = util.V4AddressFromBytes(C.GoBytes(unsafe.Pointer(&remote), net.IPv4len))
+	return
+}
+
+func convertV6Addresses(local [16]C.uint8_t, remote [16]C.uint8_t) (localAddress util.Address, remoteAddress util.Address) {
+	// We read all 16 bytes for v6 address
+	localAddress = util.V6AddressFromBytes(C.GoBytes(unsafe.Pointer(&local), net.IPv6len))
+	remoteAddress = util.V6AddressFromBytes(C.GoBytes(unsafe.Pointer(&remote), net.IPv6len))
+	return
+}
+
+func flowToConnStat(flow *C.struct__perFlowData) (connStat ConnectionStats) {
+	var (
+		family ConnectionFamily
+		source util.Address
+		dest   util.Address
+	)
+	family = connFamily(flow.addressFamily)
+
+	// V4 Address
+	if family == AFINET {
+		source, dest = convertV4Addresses(flow.localAddress, flow.remoteAddress)
+		// V6 Address
+	} else {
+		source, dest = convertV6Addresses(flow.localAddress, flow.remoteAddress)
+	}
+
+	return ConnectionStats{
+		Source:                 source,
+		Dest:                   dest,
+		MonotonicSentBytes:     0,
+		LastSentBytes:          0,
+		MonotonicRecvBytes:     0,
+		LastRecvBytes:          0,
+		LastUpdateEpoch:        0,
+		MonotonicRetransmits:   0,
+		LastRetransmits:        0,
+		RTT:                    0,
+		RTTVar:                 0,
+		Pid:                    uint32(flow.processId),
+		NetNS:                  0,
+		SPort:                  uint16(flow.localPort),
+		DPort:                  uint16(flow.remotePort),
+		Type:                   connType(flow.protocol),
+		Family:                 family,
+		Direction:              0,
+		IPTranslation:          nil,
+		IntraHost:              false,
+		DNSSuccessfulResponses: 0,
+	}
+}
+
+func flowsToConnStats(pfds []*C.struct__perFlowData) (connStats []ConnectionStats) {
+	for _, pfd := range pfds {
+		connStats = append(connStats, flowToConnStat(pfd))
+	}
+	return
+}

--- a/pkg/ebpf/event_windows.go
+++ b/pkg/ebpf/event_windows.go
@@ -50,7 +50,7 @@ func convertV6Addresses(local [16]C.uint8_t, remote [16]C.uint8_t) (localAddress
 	return
 }
 
-func flowToConnStat(flow *C.struct__perFlowData) (connStat ConnectionStats) {
+func flowToConnStat(flow *C.struct__perFlowData) ConnectionStats {
 	var (
 		family         ConnectionFamily
 		source         util.Address
@@ -88,9 +88,10 @@ func flowToConnStat(flow *C.struct__perFlowData) (connStat ConnectionStats) {
 	}
 }
 
-func flowsToConnStats(pfds []*C.struct__perFlowData) (connStats []ConnectionStats) {
-	for _, pfd := range pfds {
-		connStats = append(connStats, flowToConnStat(pfd))
+func flowsToConnStats(pfds []*C.struct__perFlowData) []ConnectionStats {
+	connStats := make([]ConnectionStats, len(pfds))
+	for i, pfd := range pfds {
+		connStats[i] = flowToConnStat(pfd)
 	}
-	return
+	return connStats
 }

--- a/pkg/ebpf/event_windows.go
+++ b/pkg/ebpf/event_windows.go
@@ -20,12 +20,6 @@ const (
 
 	// UDPProtocol represents the IANA protocol number for UDP
 	UDPProtocol = 6
-
-	// TCPFlowDataLen represents the bytes filled for the protocol_u struct in _perFlowData.
-	TCPFlowDataLen = 24
-
-	// UDPFlowDataLen represents the bytes filled for the protocol_u struct in _perFlowData
-	UDPFlowDataLen = 4
 )
 
 func connFamily(addressFamily C.uint16_t) ConnectionFamily {


### PR DESCRIPTION
### What does this PR do?

Creates necessary function for converting a C.struct__perFlowData object into ConnectionStats{} object. 

This does not currently translate the union object out of the struct, and it was not something that I could get immediately. Since we do not need these values yet, I decided to leave it for a later time. 