### PR TITLE
cmd/trace-agent: fix darwin build problem

### DIFF
--- a/cmd/trace-agent/main_linux.go
+++ b/cmd/trace-agent/main_linux.go
@@ -7,6 +7,4 @@
 
 package main
 
-import (
-	_ "github.com/DataDog/datadog-agent/pkg/util/containers/providers/cgroup"
-)
+import _ "github.com/DataDog/datadog-agent/pkg/util/containers/providers/cgroup"

--- a/cmd/trace-agent/main_other.go
+++ b/cmd/trace-agent/main_other.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build !windows
+// +build !windows,!linux
 
 package main
 


### PR DESCRIPTION
This change fixes the build on darwin by moving the cgroups file to a
Linux-only build.