### PR TITLE
Remove LeaderElectorInterface

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -195,7 +195,7 @@ func start(cmd *cobra.Command, args []string) error {
 			WPAClient:          apiCl.WPAClient,
 			WPAInformerFactory: apiCl.WPAInformerFactory,
 			Client:             apiCl.Cl,
-			LeaderElector:      le,
+			IsLeaderFunc:       le.IsLeader,
 			EventRecorder:      eventRecorder,
 			StopCh:             stopCh,
 		}

--- a/pkg/clusteragent/orchestrator/controller.go
+++ b/pkg/clusteragent/orchestrator/controller.go
@@ -53,7 +53,7 @@ type Controller struct {
 	clusterID               string
 	forwarder               forwarder.Forwarder
 	processConfig           *processcfg.AgentConfig
-	IsLeaderFunc            func() bool
+	isLeaderFunc            func() bool
 }
 
 // StartController starts the orchestrator controller
@@ -110,7 +110,7 @@ func newController(ctx ControllerContext) (*Controller, error) {
 		clusterID:               clusterID,
 		processConfig:           cfg,
 		forwarder:               forwarder.NewDefaultForwarder(podForwarderOpts),
-		IsLeaderFunc:            ctx.IsLeaderFunc,
+		isLeaderFunc:            ctx.IsLeaderFunc,
 	}
 
 	oc.processConfig = cfg
@@ -139,7 +139,7 @@ func (o *Controller) Run(stopCh <-chan struct{}) {
 }
 
 func (o *Controller) processPods() {
-	if !o.IsLeaderFunc() {
+	if !o.isLeaderFunc() {
 		return
 	}
 	podList, err := o.unassignedPodLister.List(labels.Everything())

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -49,7 +49,7 @@ type ControllerContext struct {
 	WPAClient          wpa_client.Interface
 	WPAInformerFactory externalversions.SharedInformerFactory
 	Client             kubernetes.Interface
-	LeaderElector      LeaderElectorInterface
+	IsLeaderFunc       func() bool
 	EventRecorder      record.EventRecorder
 	StopCh             chan struct{}
 }
@@ -106,7 +106,7 @@ func startAutoscalersController(ctx ControllerContext) error {
 	autoscalersController, err := NewAutoscalersController(
 		ctx.Client,
 		ctx.EventRecorder,
-		ctx.LeaderElector,
+		ctx.IsLeaderFunc,
 		dogCl,
 	)
 	if err != nil {

--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -64,7 +64,7 @@ func newFakeHorizontalPodAutoscaler(name, ns string, uid string, metricName stri
 	}
 }
 
-func newFakeAutoscalerController(t *testing.T, client kubernetes.Interface, itf LeaderElectorInterface, dcl autoscalers.DatadogClient) (*AutoscalersController, informers.SharedInformerFactory) {
+func newFakeAutoscalerController(t *testing.T, client kubernetes.Interface, isLeaderFunc func() bool, dcl autoscalers.DatadogClient) (*AutoscalersController, informers.SharedInformerFactory) {
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 
 	eventBroadcaster := record.NewBroadcaster()
@@ -73,7 +73,7 @@ func newFakeAutoscalerController(t *testing.T, client kubernetes.Interface, itf 
 	autoscalerController, _ := NewAutoscalersController(
 		client,
 		eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "FakeAutoscalerController"}),
-		itf,
+		isLeaderFunc,
 		dcl,
 	)
 	autoscalerController.EnableHPA(informerFactory.Autoscaling().V2beta1().HorizontalPodAutoscalers())
@@ -83,13 +83,7 @@ func newFakeAutoscalerController(t *testing.T, client kubernetes.Interface, itf 
 	return autoscalerController, informerFactory
 }
 
-var alwaysLeader = &fakeLeaderElector{true}
-
-type fakeLeaderElector struct {
-	isLeader bool
-}
-
-func (le *fakeLeaderElector) IsLeader() bool { return le.isLeader }
+var alwaysLeader = func() bool { return true }
 
 type fakeDatadogClient struct {
 	queryMetricsFunc  func(from, to int64, query string) ([]datadog.Series, error)
@@ -564,9 +558,8 @@ func TestAutoscalerControllerGC(t *testing.T) {
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("#%d %s", i, testCase.caseName), func(t *testing.T) {
 			store, client := newFakeConfigMapStore(t, "default", fmt.Sprintf("test-%d", i), testCase.metrics)
-			i := &fakeLeaderElector{}
 			d := &fakeDatadogClient{}
-			hctrl, inf := newFakeAutoscalerController(t, client, i, d)
+			hctrl, inf := newFakeAutoscalerController(t, client, alwaysLeader, d)
 
 			hctrl.store = store
 

--- a/pkg/util/kubernetes/apiserver/types.go
+++ b/pkg/util/kubernetes/apiserver/types.go
@@ -7,11 +7,6 @@
 
 package apiserver
 
-// LeaderElectorInterface is the interface avoiding the import cycle between the LeaderElection and the APIServer
-type LeaderElectorInterface interface {
-	IsLeader() bool
-}
-
 const (
 	autoscalerNowHandleMsgEvent = "Autoscaler is now handled by the Cluster-Agent"
 )

--- a/pkg/util/kubernetes/apiserver/wpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/wpa_controller.go
@@ -255,7 +255,7 @@ func (h *AutoscalersController) deleteWPAutoscaler(obj interface{}) {
 		toDelete.External = autoscalers.InspectWPA(deletedWPA)
 		h.deleteFromLocalStore(toDelete.External)
 		log.Debugf("Deleting %s/%s from the local cache", deletedWPA.Namespace, deletedWPA.Name)
-		if !h.le.IsLeader() {
+		if !h.isLeaderFunc() {
 			return
 		}
 		log.Infof("Deleting entries of metrics from Ref %s/%s in the Global Store", deletedWPA.Namespace, deletedWPA.Name)


### PR DESCRIPTION
### What does this PR do?

Remove `LeaderElectorInterface` as we can directly pass the function instead

### Motivation

The interface was introduced to avoid cycle imports but it can still cause them

### Additional Notes

Anything else we should know when reviewing?
