### PR TITLE
Fix install script import command on upgrade

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -269,7 +269,8 @@ if [ "$upgrade" ]; then
   if [ -e $LEGACY_CONF ]; then
     # try to import the config file from the previous version
     icmd="datadog-agent import $LEGACY_ETCDIR $ETCDIR"
-    $sudo_cmd "$icmd" || printf "\033[31mAutomatic import failed, you can still try to manually run: $icmd\n\033[0m\n"
+    # shellcheck disable=SC2086
+    $sudo_cmd $icmd || printf "\033[31mAutomatic import failed, you can still try to manually run: $icmd\n\033[0m\n"
     # fix file owner and permissions since the script moves around some files
     $sudo_cmd chown -R dd-agent:dd-agent $ETCDIR
     $sudo_cmd find $ETCDIR/ -type f -exec chmod 640 {} \;


### PR DESCRIPTION
### What does this PR do?

Remove quotes around `$icmd` when executing `datadog-agent import` command. Use of quotes made `sudo` think the whole `datadog-agent import $LEGACY_ETCDIR $ETCDIR` was one command.

### Motivation

Fix upgrade path in install script.
