### PR TITLE
Fix log tailing on Windows

### DIFF
--- a/pkg/logs/input/file/rotate_nix.go
+++ b/pkg/logs/input/file/rotate_nix.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
+// +build !windows
+
 package file
 
 import (

--- a/pkg/logs/input/file/rotate_windows.go
+++ b/pkg/logs/input/file/rotate_windows.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build windows
+
+package file
+
+import (
+	"os"
+)
+
+// DidRotate is not implemented on windows, log rotations are handled by the
+// tailer for now.
+func DidRotate(file *os.File, lastReadOffset int64) (bool, error) {
+	return false, nil
+}

--- a/pkg/logs/input/file/tailer_nix.go
+++ b/pkg/logs/input/file/tailer_nix.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build !windows
+
+package file
+
+import (
+	"io"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// setup sets up the file tailer
+func (t *Tailer) setup(offset int64, whence int) error {
+	fullpath, err := filepath.Abs(t.path)
+	if err != nil {
+		return err
+	}
+	t.fullpath = fullpath
+
+	// adds metadata to enable users to filter logs by filename
+	t.tags = t.buildTailerTags()
+
+	log.Info("Opening ", t.path)
+	f, err := openFile(fullpath)
+	if err != nil {
+		return err
+	}
+
+	t.file = f
+	ret, _ := f.Seek(offset, whence)
+	t.readOffset = ret
+	t.decodedOffset = ret
+
+	return nil
+}
+
+// read lets the tailer tail the content of a file
+// until it is closed or the tailer is stopped.
+func (t *Tailer) read() error {
+	// keep reading data from file
+	inBuf := make([]byte, 4096)
+	n, err := t.file.Read(inBuf)
+	if err != nil && err != io.EOF {
+		// an unexpected error occurred, stop the tailor
+		t.source.Status.Error(err)
+		return log.Error("Unexpected error occurred while reading file: ", err)
+	}
+	if n == 0 {
+		return nil
+	}
+	t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
+	t.incrementReadOffset(n)
+	return nil
+}

--- a/pkg/logs/input/file/tailer_windows.go
+++ b/pkg/logs/input/file/tailer_windows.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build windows
+
+package file
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// setup sets up the file tailer
+func (t *Tailer) setup(offset int64, whence int) error {
+	fullpath, err := filepath.Abs(t.path)
+	if err != nil {
+		return err
+	}
+	t.fullpath = fullpath
+
+	// adds metadata to enable users to filter logs by filename
+	t.tags = t.buildTailerTags()
+
+	log.Info("Opening ", t.fullpath)
+	f, err := openFile(t.fullpath)
+	if err != nil {
+		return err
+	}
+	filePos, _ := f.Seek(offset, whence)
+	f.Close()
+
+	t.readOffset = filePos
+	t.decodedOffset = filePos
+
+	return nil
+}
+
+func (t *Tailer) readAvailable() (err error) {
+	f, err := openFile(t.fullpath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		log.Debugf("Error stat()ing file %v", err)
+		return err
+	}
+
+	sz := st.Size()
+	offset := t.GetReadOffset()
+	log.Debugf("Size is %d, offset is %d", sz, offset)
+	if sz == 0 {
+		log.Debug("File size now zero, resetting offset")
+		t.SetReadOffset(0)
+		t.SetDecodedOffset(0)
+	} else if sz < offset {
+		log.Debug("Offset off end of file, resetting")
+		t.SetReadOffset(0)
+		t.SetDecodedOffset(0)
+	}
+	f.Seek(t.GetReadOffset(), io.SeekStart)
+
+	inBuf := make([]byte, 4096)
+	for {
+		n, err := f.Read(inBuf)
+		if n == 0 || err != nil {
+			log.Debugf("Done reading")
+			return err
+		}
+		log.Debugf("Sending %d bytes to input channel", n)
+		t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
+		t.incrementReadOffset(n)
+	}
+}
+
+// read lets the tailer tail the content of a file until it is closed. The
+// windows version open and close the file between each call to 'read'. This is
+// needed in order not to block the file and prevent the user from renaming it.
+func (t *Tailer) read() error {
+	err := t.readAvailable()
+	if err == io.EOF || os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		t.source.Status.Error(err)
+		return log.Error("Err: ", err)
+	}
+	return nil
+}

--- a/releasenotes/notes/fix-windows-file-tailer-2806f9c14f88cef7.yaml
+++ b/releasenotes/notes/fix-windows-file-tailer-2806f9c14f88cef7.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug in the file tailer on Windows where the log-agent would keep a
+    lock on the file preventing users from renaming the it.


### PR DESCRIPTION
### What does this PR do?

This is a revert of #2460

On Windows the log agent would hold the file open when tailing it, which
prevent users from renaming it.
