### PR TITLE
[AD] Fix config collision

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -310,6 +310,7 @@ func (c *Config) Digest() string {
 	}
 	h.Write([]byte(c.NodeName))
 	h.Write([]byte(c.LogsConfig))
+	h.Write([]byte(c.Entity))
 
 	return strconv.FormatUint(h.Sum64(), 16)
 }

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -209,6 +209,23 @@ func TestDigest(t *testing.T) {
 
 	// assert the ClusterCheck field is not taken into account
 	assert.Equal(t, simpleConfig.Digest(), simpleClusterCheckConfig.Digest())
+
+	configWithEntity := &Config{
+		Name:       "foo",
+		InitConfig: Data(""),
+		Entity:     "docker://f556178a47cf65fb70cd5772a9e80e661f71e021da49d3dc99565b861707041c",
+	}
+	assert.Equal(t, "41b0c2b6f9c4f3e0", configWithEntity.Digest())
+
+	configWithAnotherEntity := &Config{
+		Name:       "foo",
+		InitConfig: Data(""),
+		Entity:     "docker://ddcd8a64616772f7ad4524f09fd75c9e3a265144050fc077563e63ea2eb46db0",
+	}
+	assert.Equal(t, "b5c2d0fd13694bf0", configWithAnotherEntity.Digest())
+
+	// assert an entity change produces different hash
+	assert.NotEqual(t, configWithEntity.Digest(), configWithAnotherEntity.Digest())
 }
 
 func TestGetNameForInstance(t *testing.T) {

--- a/releasenotes/notes/fix-ad-container-restart-840258fca73e737e.yaml
+++ b/releasenotes/notes/fix-ad-container-restart-840258fca73e737e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix for autodiscovered checks not being rescheduled after container restart.


### PR DESCRIPTION
### What does this PR do?

Takes into account the AD service (container) entity ID when computing the digest of resolved configs.

### Motivation

Fix  [config digest collision in the check scheduler](https://github.com/DataDog/datadog-agent/blob/master/pkg/collector/scheduler.go#L82) triggered by container restart

### Additional Notes

When a container targeted by an AD config from the file config provider restarts:
- The new container is detected and a new AD service with a new entity ID is generated
- The new AD service matches the AD config and is scheduled while the check targeting the old container still runs
- The configs resolved for both services (new and old) have the same digest
- The collector/scheduler already stores the new check and the old check in the same map with the same key [here](https://github.com/DataDog/datadog-agent/blob/master/pkg/collector/scheduler.go#L208)
- The old container is detected dead and AD unschedule its AD service
- The collector/scheduler removes the old AND the new config because they're stored in the same map entry [here](https://github.com/DataDog/datadog-agent/blob/master/pkg/collector/scheduler.go#L82)

This happens only when the config comes from the file config provider because its configs are static and always generates the same digest. Configs coming from other config providers (`docker`, `kubelet`) will have a new digest because we compute the AD Identifiers in the digest (container IDs). For the file configs it's static (short images).

By including the entity ID when calculating the config digest, when a check config is targeting a new restarted container it will be stored in a different map entry in the collector/scheduler.