### PR TITLE
[ECS Fargate] Fix for container stats missing in ECS Fargate 1.4.0

### DIFF
--- a/pkg/util/ecs/metadata/v2/client_test.go
+++ b/pkg/util/ecs/metadata/v2/client_test.go
@@ -224,7 +224,7 @@ func TestGetContainerStats(t *testing.T) {
 	assert := assert.New(t)
 
 	containerID := "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98"
-	handlerPath := "/v2/stats/" + containerID
+	handlerPath := "/v2/stats"
 
 	ecsinterface, err := testutil.NewDummyECS(
 		testutil.FileHandlerOption(handlerPath, "./testdata/container_stats.json"),

--- a/pkg/util/ecs/metadata/v2/testdata/container_stats.json
+++ b/pkg/util/ecs/metadata/v2/testdata/container_stats.json
@@ -1,152 +1,154 @@
 {
-  "blkio_stats": {
-    "io_merged_recursive": [],
-    "io_queue_recursive": [],
-    "io_service_bytes_recursive": [
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Read",
-        "value": 12288
+  "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98": {
+    "blkio_stats": {
+      "io_merged_recursive": [],
+      "io_queue_recursive": [],
+      "io_service_bytes_recursive": [
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Read",
+          "value": 12288
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Write",
+          "value": 144908288
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Sync",
+          "value": 8122368
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Async",
+          "value": 136798208
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Total",
+          "value": 144920576
+        }
+      ],
+      "io_service_time_recursive": [],
+      "io_serviced_recursive": [
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Read",
+          "value": 3
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Write",
+          "value": 1618
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Sync",
+          "value": 514
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Async",
+          "value": 1107
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Total",
+          "value": 1621
+        }
+      ],
+      "io_time_recursive": [],
+      "io_wait_time_recursive": [],
+      "sectors_recursive": []
+    },
+    "cpu_stats": {
+      "cpu_usage": {
+        "percpu_usage": [5906703717, 3836886677],
+        "total_usage": 9743590394,
+        "usage_in_kernelmode": 2260000000,
+        "usage_in_usermode": 7450000000
       },
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Write",
-        "value": 144908288
-      },
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Sync",
-        "value": 8122368
-      },
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Async",
-        "value": 136798208
-      },
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Total",
-        "value": 144920576
+      "online_cpus": 2,
+      "system_cpu_usage": 3951680000000,
+      "throttling_data": {
+        "periods": 0,
+        "throttled_periods": 0,
+        "throttled_time": 0
       }
-    ],
-    "io_service_time_recursive": [],
-    "io_serviced_recursive": [
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Read",
-        "value": 3
+    },
+    "id": "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98",
+    "memory_stats": {
+      "limit": 268435456,
+      "max_usage": 139751424,
+      "stats": {
+        "active_anon": 1564672,
+        "active_file": 28020736,
+        "cache": 65499136,
+        "dirty": 0,
+        "hierarchical_memory_limit": 268435456,
+        "hierarchical_memsw_limit": 536870912,
+        "inactive_anon": 0,
+        "inactive_file": 37478400,
+        "mapped_file": 0,
+        "pgfault": 430478,
+        "pgmajfault": 0,
+        "pgpgin": 229452,
+        "pgpgout": 213079,
+        "rss": 1564672,
+        "rss_huge": 0,
+        "total_active_anon": 1564672,
+        "total_active_file": 28020736,
+        "total_cache": 65499136,
+        "total_dirty": 0,
+        "total_inactive_anon": 0,
+        "total_inactive_file": 37478400,
+        "total_mapped_file": 0,
+        "total_pgfault": 430478,
+        "total_pgmajfault": 0,
+        "total_pgpgin": 229452,
+        "total_pgpgout": 213079,
+        "total_rss": 1564672,
+        "total_rss_huge": 0,
+        "total_unevictable": 0,
+        "total_writeback": 0,
+        "unevictable": 0,
+        "writeback": 0
       },
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Write",
-        "value": 1618
+      "usage": 77254656
+    },
+    "name": "/ecs-xavierlucas-test_redis-awsvpc-12-redis-86fe99b5ffeabffeed01",
+    "num_procs": 0,
+    "pids_stats": {
+      "current": 6
+    },
+    "precpu_stats": {
+      "cpu_usage": {
+        "percpu_usage": [5906299037, 3836449635],
+        "total_usage": 9742748672,
+        "usage_in_kernelmode": 2260000000,
+        "usage_in_usermode": 7450000000
       },
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Sync",
-        "value": 514
-      },
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Async",
-        "value": 1107
-      },
-      {
-        "major": 259,
-        "minor": 0,
-        "op": "Total",
-        "value": 1621
+      "online_cpus": 2,
+      "system_cpu_usage": 3949670000000,
+      "throttling_data": {
+        "periods": 0,
+        "throttled_periods": 0,
+        "throttled_time": 0
       }
-    ],
-    "io_time_recursive": [],
-    "io_wait_time_recursive": [],
-    "sectors_recursive": []
-  },
-  "cpu_stats": {
-    "cpu_usage": {
-      "percpu_usage": [5906703717, 3836886677],
-      "total_usage": 9743590394,
-      "usage_in_kernelmode": 2260000000,
-      "usage_in_usermode": 7450000000
     },
-    "online_cpus": 2,
-    "system_cpu_usage": 3951680000000,
-    "throttling_data": {
-      "periods": 0,
-      "throttled_periods": 0,
-      "throttled_time": 0
-    }
-  },
-  "id": "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98",
-  "memory_stats": {
-    "limit": 268435456,
-    "max_usage": 139751424,
-    "stats": {
-      "active_anon": 1564672,
-      "active_file": 28020736,
-      "cache": 65499136,
-      "dirty": 0,
-      "hierarchical_memory_limit": 268435456,
-      "hierarchical_memsw_limit": 536870912,
-      "inactive_anon": 0,
-      "inactive_file": 37478400,
-      "mapped_file": 0,
-      "pgfault": 430478,
-      "pgmajfault": 0,
-      "pgpgin": 229452,
-      "pgpgout": 213079,
-      "rss": 1564672,
-      "rss_huge": 0,
-      "total_active_anon": 1564672,
-      "total_active_file": 28020736,
-      "total_cache": 65499136,
-      "total_dirty": 0,
-      "total_inactive_anon": 0,
-      "total_inactive_file": 37478400,
-      "total_mapped_file": 0,
-      "total_pgfault": 430478,
-      "total_pgmajfault": 0,
-      "total_pgpgin": 229452,
-      "total_pgpgout": 213079,
-      "total_rss": 1564672,
-      "total_rss_huge": 0,
-      "total_unevictable": 0,
-      "total_writeback": 0,
-      "unevictable": 0,
-      "writeback": 0
-    },
-    "usage": 77254656
-  },
-  "name": "/ecs-xavierlucas-test_redis-awsvpc-12-redis-86fe99b5ffeabffeed01",
-  "num_procs": 0,
-  "pids_stats": {
-    "current": 6
-  },
-  "precpu_stats": {
-    "cpu_usage": {
-      "percpu_usage": [5906299037, 3836449635],
-      "total_usage": 9742748672,
-      "usage_in_kernelmode": 2260000000,
-      "usage_in_usermode": 7450000000
-    },
-    "online_cpus": 2,
-    "system_cpu_usage": 3949670000000,
-    "throttling_data": {
-      "periods": 0,
-      "throttled_periods": 0,
-      "throttled_time": 0
-    }
-  },
-  "preread": "2019-10-25T10:07:00.001729463Z",
-  "read": "2019-10-25T10:07:01.006590487Z",
-  "storage_stats": {}
+    "preread": "2019-10-25T10:07:00.001729463Z",
+    "read": "2019-10-25T10:07:01.006590487Z",
+    "storage_stats": {}
+  }
 }

--- a/releasenotes/notes/ecs-fargate-container-stats-fix-1.4.0-df40c0cb2a8f6135.yaml
+++ b/releasenotes/notes/ecs-fargate-container-stats-fix-1.4.0-df40c0cb2a8f6135.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes missing container stats in ECS Fargate 1.4.0.


### PR DESCRIPTION
### What does this PR do?

In ECS Fargate 1.4.0 container-specific stats endpoint [`/v2/stats/{container_id}`] JSON output is
reported differently from previous version of the API:

```
{ "<container_id>" : { .. container stats .. } }
```

as opposed to

```
{ .. container stats.. }
```

This broke reporting container stats reported by the process agent.

The fix is to use the `/v2/stats` endpoint instead which has the same behavior across versions.

### Motivation

Missing container stats for ECS Fargate 1.4.0

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
