### PR TITLE
Add missing device name tags

### DIFF
--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -367,6 +367,7 @@ func parseAndSubmitBlkio(metricName string, sender aggregator.Sender, list []*v1
 		}
 
 		tags = append(tags, fmt.Sprintf("device:%s", m.Device))
+		tags = append(tags, fmt.Sprintf("device_name:%s", m.Device))
 		if m.Op != "" {
 			tags = append(tags, fmt.Sprintf("operation:%s", m.Op))
 		}

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -383,7 +383,9 @@ func (d *DockerCheck) reportIOMetrics(io *cmetrics.ContainerIOStats, tags []stri
 	// Read values per device, or fallback to sum
 	if len(io.DeviceReadBytes) > 0 {
 		for dev, value := range io.DeviceReadBytes {
-			sender.Rate("docker.io.read_bytes", float64(value), "", append(tags, "device:"+dev))
+			devTags := append(tags, "device:"+dev)
+			devTags = append(tags, "device_name:"+dev)
+			sender.Rate("docker.io.read_bytes", float64(value), "", devTags)
 		}
 	} else {
 		sender.Rate("docker.io.read_bytes", float64(io.ReadBytes), "", tags)
@@ -392,7 +394,9 @@ func (d *DockerCheck) reportIOMetrics(io *cmetrics.ContainerIOStats, tags []stri
 	// Write values per device, or fallback to sum
 	if len(io.DeviceWriteBytes) > 0 {
 		for dev, value := range io.DeviceWriteBytes {
-			sender.Rate("docker.io.write_bytes", float64(value), "", append(tags, "device:"+dev))
+			devTags := append(tags, "device:"+dev)
+			devTags = append(tags, "device_name:"+dev)
+			sender.Rate("docker.io.write_bytes", float64(value), "", devTags)
 		}
 	} else {
 		sender.Rate("docker.io.write_bytes", float64(io.WriteBytes), "", tags)

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -383,9 +383,7 @@ func (d *DockerCheck) reportIOMetrics(io *cmetrics.ContainerIOStats, tags []stri
 	// Read values per device, or fallback to sum
 	if len(io.DeviceReadBytes) > 0 {
 		for dev, value := range io.DeviceReadBytes {
-			devTags := append(tags, "device:"+dev)
-			devTags = append(tags, "device_name:"+dev)
-			sender.Rate("docker.io.read_bytes", float64(value), "", devTags)
+			sender.Rate("docker.io.read_bytes", float64(value), "", append(tags, "device:"+dev, "device_name:"+dev))
 		}
 	} else {
 		sender.Rate("docker.io.read_bytes", float64(io.ReadBytes), "", tags)
@@ -394,9 +392,7 @@ func (d *DockerCheck) reportIOMetrics(io *cmetrics.ContainerIOStats, tags []stri
 	// Write values per device, or fallback to sum
 	if len(io.DeviceWriteBytes) > 0 {
 		for dev, value := range io.DeviceWriteBytes {
-			devTags := append(tags, "device:"+dev)
-			devTags = append(tags, "device_name:"+dev)
-			sender.Rate("docker.io.write_bytes", float64(value), "", devTags)
+			sender.Rate("docker.io.write_bytes", float64(value), "", append(tags, "device:"+dev, "device_name:"+dev))
 		}
 	} else {
 		sender.Rate("docker.io.write_bytes", float64(io.WriteBytes), "", tags)

--- a/pkg/collector/corechecks/containers/docker_test.go
+++ b/pkg/collector/corechecks/containers/docker_test.go
@@ -47,7 +47,9 @@ func TestReportIOMetrics(t *testing.T) {
 		},
 	}
 	sdaTags := append(tags, "device:sda")
+	sdaTags = append(tags, "device_name:sda")
 	sdbTags := append(tags, "device:sdb")
+	sdbTags = append(tags, "device_name:sdb")
 	dockerCheck.reportIOMetrics(ioPerDevice, tags, mockSender)
 	mockSender.AssertMetric(t, "Rate", "docker.io.read_bytes", float64(37858816), "", sdaTags)
 	mockSender.AssertMetric(t, "Rate", "docker.io.write_bytes", float64(671846400), "", sdaTags)

--- a/pkg/collector/corechecks/containers/docker_test.go
+++ b/pkg/collector/corechecks/containers/docker_test.go
@@ -46,10 +46,8 @@ func TestReportIOMetrics(t *testing.T) {
 			"sdb": 0,
 		},
 	}
-	sdaTags := append(tags, "device:sda")
-	sdaTags = append(tags, "device_name:sda")
-	sdbTags := append(tags, "device:sdb")
-	sdbTags = append(tags, "device_name:sdb")
+	sdaTags := append(tags, "device:sda", "device_name:sda")
+	sdbTags := append(tags, "device:sdb", "device_name:sdb")
 	dockerCheck.reportIOMetrics(ioPerDevice, tags, mockSender)
 	mockSender.AssertMetric(t, "Rate", "docker.io.read_bytes", float64(37858816), "", sdaTags)
 	mockSender.AssertMetric(t, "Rate", "docker.io.write_bytes", float64(671846400), "", sdaTags)

--- a/pkg/collector/corechecks/net/network.go
+++ b/pkg/collector/corechecks/net/network.go
@@ -195,7 +195,7 @@ func (c *NetworkCheck) isDeviceExcluded(deviceName string) bool {
 }
 
 func submitInterfaceMetrics(sender aggregator.Sender, interfaceIO net.IOCountersStat) {
-	tags := []string{fmt.Sprintf("device:%s", interfaceIO.Name)}
+	tags := []string{fmt.Sprintf("device:%s", interfaceIO.Name), fmt.Sprintf("device_name:%s", interfaceIO.Name)}
 	sender.Rate("system.net.bytes_rcvd", float64(interfaceIO.BytesRecv), "", tags)
 	sender.Rate("system.net.bytes_sent", float64(interfaceIO.BytesSent), "", tags)
 	sender.Rate("system.net.packets_in.count", float64(interfaceIO.PacketsRecv), "", tags)

--- a/pkg/collector/corechecks/net/network_test.go
+++ b/pkg/collector/corechecks/net/network_test.go
@@ -281,7 +281,7 @@ collect_connection_state: true
 
 	var customTags []string
 
-	eth0Tags := []string{"device:eth0"}
+	eth0Tags := []string{"device:eth0", "device_name:eth0"}
 	mockSender.AssertCalled(t, "Rate", "system.net.bytes_rcvd", float64(10), "", eth0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.bytes_sent", float64(11), "", eth0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.count", float64(12), "", eth0Tags)
@@ -289,7 +289,7 @@ collect_connection_state: true
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.count", float64(14), "", eth0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.error", float64(15), "", eth0Tags)
 
-	lo0Tags := []string{"device:lo0"}
+	lo0Tags := []string{"device:lo0", "device_name:lo0"}
 	mockSender.AssertCalled(t, "Rate", "system.net.bytes_rcvd", float64(16), "", lo0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.bytes_sent", float64(17), "", lo0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.count", float64(18), "", lo0Tags)
@@ -390,7 +390,7 @@ excluded_interfaces:
 	err := networkCheck.Run()
 	assert.Nil(t, err)
 
-	eth0Tags := []string{"device:eth0"}
+	eth0Tags := []string{"device:eth0", "device_name:eth0"}
 	mockSender.AssertCalled(t, "Rate", "system.net.bytes_rcvd", float64(10), "", eth0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.bytes_sent", float64(11), "", eth0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.count", float64(12), "", eth0Tags)
@@ -398,7 +398,7 @@ excluded_interfaces:
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.count", float64(14), "", eth0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.error", float64(15), "", eth0Tags)
 
-	lo0Tags := []string{"device:lo0"}
+	lo0Tags := []string{"device:lo0", "device_name:lo0"}
 	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_rcvd", float64(16), "", lo0Tags)
 	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_sent", float64(17), "", lo0Tags)
 	mockSender.AssertNotCalled(t, "Rate", "system.net.packets_in.count", float64(18), "", lo0Tags)
@@ -461,7 +461,7 @@ excluded_interface_re: "eth[0-9]"
 	err = networkCheck.Run()
 	assert.Nil(t, err)
 
-	eth0Tags := []string{"device:eth0"}
+	eth0Tags := []string{"device:eth0", "device_name:eth0"}
 	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_rcvd", float64(10), "", eth0Tags)
 	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_sent", float64(11), "", eth0Tags)
 	mockSender.AssertNotCalled(t, "Rate", "system.net.packets_in.count", float64(12), "", eth0Tags)
@@ -469,7 +469,7 @@ excluded_interface_re: "eth[0-9]"
 	mockSender.AssertNotCalled(t, "Rate", "system.net.packets_out.count", float64(14), "", eth0Tags)
 	mockSender.AssertNotCalled(t, "Rate", "system.net.packets_out.error", float64(15), "", eth0Tags)
 
-	eth1Tags := []string{"device:eth1"}
+	eth1Tags := []string{"device:eth1", "device_name:eth1"}
 	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_rcvd", float64(16), "", eth1Tags)
 	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_sent", float64(17), "", eth1Tags)
 	mockSender.AssertNotCalled(t, "Rate", "system.net.packets_in.count", float64(18), "", eth1Tags)
@@ -477,7 +477,7 @@ excluded_interface_re: "eth[0-9]"
 	mockSender.AssertNotCalled(t, "Rate", "system.net.packets_out.count", float64(20), "", eth1Tags)
 	mockSender.AssertNotCalled(t, "Rate", "system.net.packets_out.error", float64(21), "", eth1Tags)
 
-	lo0Tags := []string{"device:lo0"}
+	lo0Tags := []string{"device:lo0", "device_name:lo0"}
 	mockSender.AssertCalled(t, "Rate", "system.net.bytes_rcvd", float64(22), "", lo0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.bytes_sent", float64(23), "", lo0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.count", float64(24), "", lo0Tags)

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -108,6 +108,8 @@ func populateDeviceField(serie *Serie) {
 	for _, tag := range serie.Tags {
 		if strings.HasPrefix(tag, "device:") {
 			serie.Device = tag[7:]
+		} else if strings.HasPrefix(tag, "device_name:") {
+			serie.Device = tag[12:]
 		} else {
 			filteredTags = append(filteredTags, tag)
 		}
@@ -118,7 +120,7 @@ func populateDeviceField(serie *Serie) {
 // hasDeviceTag checks whether a series contains a device tag
 func hasDeviceTag(serie *Serie) bool {
 	for _, tag := range serie.Tags {
-		if strings.HasPrefix(tag, "device:") {
+		if strings.HasPrefix(tag, "device:") || strings.HasPrefix(tag, "device_name:") {
 			return true
 		}
 	}

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -71,6 +71,11 @@ func TestPopulateDeviceField(t *testing.T) {
 			"/dev/sda1",
 		},
 		{
+			[]string{"some:tag", "device_name:/dev/sda1"},
+			[]string{"some:tag"},
+			"/dev/sda1",
+		},
+		{
 			[]string{"some:tag", "device:/dev/sda2", "some_other:tag"},
 			[]string{"some:tag", "some_other:tag"},
 			"/dev/sda2",

--- a/releasenotes/notes/add-missing-device_name-tags-07e712f31b5a774d.yaml
+++ b/releasenotes/notes/add-missing-device_name-tags-07e712f31b5a774d.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add missing `device_name` tags on docker, containerd and network checks.
+    Make series manage `device_name` tag if `device` is missing.


### PR DESCRIPTION
### What does this PR do?

It adds the new `device_name` tag on places that produced `device` tags.

### Motivation

Homogeneization of devices tags.

### Additional Notes

I tried to be exhaustive but I'm not 100% sure. It should so help me if it is not.

### Describe your test plan

`device_name` tags are produced on docker/containerd/network checks. I'm not sure how to test on series.
