### PR TITLE
Add agent info to host metadata + fix install script

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -6,6 +6,7 @@
 # using the package manager and Datadog repositories.
 
 set -e
+install_script_version=7.19.0
 logfile="ddagent-install.log"
 
 LEGACY_ETCDIR="/etc/dd-agent"
@@ -342,6 +343,14 @@ else
   $sudo_cmd chown dd-agent:dd-agent $CONF
   $sudo_cmd chmod 640 $CONF
 fi
+
+# Creating or overriding the install information
+echo "---
+install_method:
+  name: install_script
+  tool: install_script
+  version: $install_script_version
+" > $ETCDIR/install_info
 
 # On SUSE 11, sudo service datadog-agent start fails (because /sbin is not in a base user's path)
 # However, sudo /sbin/service datadog-agent does work.

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -6,7 +6,7 @@
 # using the package manager and Datadog repositories.
 
 set -e
-install_script_version=7.19.0
+install_script_version=1.0.0
 logfile="ddagent-install.log"
 
 LEGACY_ETCDIR="/etc/dd-agent"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -345,12 +345,13 @@ else
 fi
 
 # Creating or overriding the install information
-echo "---
+install_info_content="---
 install_method:
   tool: install_script
   tool_version: install_script
   installer_version: install_script-$install_script_version
-" > $ETCDIR/install_info
+"
+$sudo_cmd sh -c "echo '$install_info_content' > $ETCDIR/install_info"
 
 # On SUSE 11, sudo service datadog-agent start fails (because /sbin is not in a base user's path)
 # However, sudo /sbin/service datadog-agent does work.

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -349,7 +349,7 @@ echo "---
 install_method:
   tool: install_script
   tool_version: install_script
-  installer_version: $install_script_version
+  installer_version: install_script-$install_script_version
 " > $ETCDIR/install_info
 
 # On SUSE 11, sudo service datadog-agent start fails (because /sbin is not in a base user's path)

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -347,9 +347,9 @@ fi
 # Creating or overriding the install information
 echo "---
 install_method:
-  name: install_script
   tool: install_script
-  version: $install_script_version
+  tool_version: install_script
+  installer_version: $install_script_version
 " > $ETCDIR/install_info
 
 # On SUSE 11, sudo service datadog-agent start fails (because /sbin is not in a base user's path)

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -8,6 +8,7 @@ package host
 import (
 	"os"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -36,7 +37,6 @@ const packageCachePrefix = "host"
 type installInfo struct {
 	Method struct {
 		Name    string `yaml:"name"`
-		Tool    string `yaml:"tool"`
 		Version string `yaml:"version"`
 	} `yaml:"install_method"`
 }
@@ -258,15 +258,20 @@ func getInstallMethod(infoPath string) *InstallMethod {
 	if err != nil {
 		// consider install info as private
 		return &InstallMethod{
-			Name:    "private",
-			Tool:    "n/a",
-			Version: "n/a",
+			Name:    "undefined",
+			Tool:    nil,
+			Version: nil,
 		}
+	}
+
+	tool := install.Method.Name
+	if dashIndex := strings.Index(tool, "-"); dashIndex >= 0 {
+		tool = tool[0:dashIndex]
 	}
 
 	return &InstallMethod{
 		Name:    install.Method.Name,
-		Tool:    install.Method.Tool,
-		Version: install.Method.Version,
+		Tool:    &tool,
+		Version: &install.Method.Version,
 	}
 }

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -26,9 +26,20 @@ import (
 	kubelet "github.com/DataDog/datadog-agent/pkg/util/hostname/kubelet"
 
 	"github.com/DataDog/datadog-agent/pkg/logs"
+
+	yaml "gopkg.in/yaml.v2"
+	"io/ioutil"
 )
 
 const packageCachePrefix = "host"
+
+type installInfo struct {
+	Method struct {
+		Name    string `yaml:"name"`
+		Tool    string `yaml:"tool"`
+		Version string `yaml:"version"`
+	} `yaml:"install_method"`
+}
 
 // GetPayload builds a metadata payload every time is called.
 // Some data is collected only once, some is cached, some is collected at every call.
@@ -45,6 +56,7 @@ func GetPayload(hostnameData util.HostnameData) *Payload {
 		ContainerMeta: getContainerMeta(1 * time.Second),
 		NetworkMeta:   getNetworkMeta(),
 		LogsMeta:      getLogsMeta(),
+		InstallMethod: getInstallMethod(getInstallInfoPath()),
 	}
 
 	// Cache the metadata for use in other payloads
@@ -216,4 +228,45 @@ func getLogsMeta() *LogsMeta {
 
 func buildKey(key string) string {
 	return path.Join(common.CachePrefix, packageCachePrefix, key)
+}
+
+func getInstallInfoPath() string {
+	return path.Join(config.FileUsedDir(), "install_info")
+}
+
+func getInstallInfo(infoPath string) (*installInfo, error) {
+	yamlContent, err := ioutil.ReadFile(infoPath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var install installInfo
+
+	if err := yaml.UnmarshalStrict(yamlContent, &install); err != nil {
+		// file was manipulated and is not relevant to format
+		return nil, err
+	}
+
+	return &install, nil
+}
+
+func getInstallMethod(infoPath string) *InstallMethod {
+	install, err := getInstallInfo(infoPath)
+
+	// if we could not get install info
+	if err != nil {
+		// consider install info as private
+		return &InstallMethod{
+			Name:    "private",
+			Tool:    "n/a",
+			Version: "n/a",
+		}
+	}
+
+	return &InstallMethod{
+		Name:    install.Method.Name,
+		Tool:    install.Method.Tool,
+		Version: install.Method.Version,
+	}
 }

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -256,7 +256,7 @@ func getInstallMethod(infoPath string) *InstallMethod {
 
 	// if we could not get install info
 	if err != nil {
-		// consider install info as private
+		// consider install info is kept "undefined"
 		return &InstallMethod{
 			ToolVersion:      "undefined",
 			Tool:             nil,

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -8,7 +8,6 @@ package host
 import (
 	"os"
 	"path"
-	"strings"
 	"sync"
 	"time"
 
@@ -36,8 +35,9 @@ const packageCachePrefix = "host"
 
 type installInfo struct {
 	Method struct {
-		Name    string `yaml:"name"`
-		Version string `yaml:"version"`
+		Tool             string `yaml:"tool"`
+		ToolVersion      string `yaml:"tool_version"`
+		InstallerVersion string `yaml:"installer_version"`
 	} `yaml:"install_method"`
 }
 
@@ -258,20 +258,15 @@ func getInstallMethod(infoPath string) *InstallMethod {
 	if err != nil {
 		// consider install info as private
 		return &InstallMethod{
-			Name:    "undefined",
-			Tool:    nil,
-			Version: nil,
+			ToolVersion:      "undefined",
+			Tool:             nil,
+			InstallerVersion: nil,
 		}
 	}
 
-	tool := install.Method.Name
-	if dashIndex := strings.Index(tool, "-"); dashIndex >= 0 {
-		tool = tool[0:dashIndex]
-	}
-
 	return &InstallMethod{
-		Name:    install.Method.Name,
-		Tool:    &tool,
-		Version: &install.Method.Version,
+		ToolVersion:      install.Method.ToolVersion,
+		Tool:             &install.Method.Tool,
+		InstallerVersion: &install.Method.InstallerVersion,
 	}
 }

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -127,41 +127,40 @@ func TestGetInstallMethod(t *testing.T) {
 
 	// ------------- Without file, the install is considered private
 	installMethod := getInstallMethod(installInfoPath)
-	require.Equal(t, "private", installMethod.Name)
-	require.Equal(t, "n/a", installMethod.Tool)
-	require.Equal(t, "n/a", installMethod.Version)
+	require.Equal(t, "undefined", installMethod.Name)
+	assert.Nil(t, installMethod.Tool)
+	assert.Nil(t, installMethod.Version)
 
 	// ------------- with a correct file
 	var installInfoContent = `
 ---
 install_method:
   name: chef-15
-  tool: chef
-  version: chef-4.2.1
+  version: datadog-cookbook-4.2.1
 `
 	assert.Nil(t, ioutil.WriteFile(installInfoPath, []byte(installInfoContent), 0666))
-	// time.Sleep(100 * time.Second)
 
 	// the install is considered coming from chef (example)
 	installMethod = getInstallMethod(installInfoPath)
 	require.Equal(t, "chef-15", installMethod.Name)
-	require.Equal(t, "chef", installMethod.Tool)
-	require.Equal(t, "chef-4.2.1", installMethod.Version)
+	assert.NotNil(t, installMethod.Tool)
+	require.Equal(t, "chef", *installMethod.Tool)
+	assert.NotNil(t, installMethod.Version)
+	require.Equal(t, "datadog-cookbook-4.2.1", *installMethod.Version)
 
 	// ------------- with an incorrect file
 	installInfoContent = `
 ---
 install_methodlol:
   name: chef-15
-  tool: chef
-  version: chef-4.2.1
+  version: datadog-cookbook-4.2.1
 `
 	assert.Nil(t, ioutil.WriteFile(installInfoPath, []byte(installInfoContent), 0666))
 	// time.Sleep(100 * time.Second)
 
 	// the parsing does not occur and the install is considered private
 	installMethod = getInstallMethod(installInfoPath)
-	require.Equal(t, "private", installMethod.Name)
-	require.Equal(t, "n/a", installMethod.Tool)
-	require.Equal(t, "n/a", installMethod.Version)
+	require.Equal(t, "undefined", installMethod.Name)
+	assert.Nil(t, installMethod.Tool)
+	assert.Nil(t, installMethod.Version)
 }

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -157,9 +157,8 @@ install_methodlol:
   version: datadog-cookbook-4.2.1
 `
 	assert.Nil(t, ioutil.WriteFile(installInfoPath, []byte(installInfoContent), 0666))
-	// time.Sleep(100 * time.Second)
 
-	// the parsing does not occur and the install is considered private
+	// the parsing does not occur and the install is kept undefined
 	installMethod = getInstallMethod(installInfoPath)
 	require.Equal(t, "undefined", installMethod.ToolVersion)
 	assert.Nil(t, installMethod.Tool)

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -127,26 +127,27 @@ func TestGetInstallMethod(t *testing.T) {
 
 	// ------------- Without file, the install is considered private
 	installMethod := getInstallMethod(installInfoPath)
-	require.Equal(t, "undefined", installMethod.Name)
+	require.Equal(t, "undefined", installMethod.ToolVersion)
 	assert.Nil(t, installMethod.Tool)
-	assert.Nil(t, installMethod.Version)
+	assert.Nil(t, installMethod.InstallerVersion)
 
 	// ------------- with a correct file
 	var installInfoContent = `
 ---
 install_method:
-  name: chef-15
-  version: datadog-cookbook-4.2.1
+  tool_version: chef-15
+  tool: chef
+  installer_version: datadog-cookbook-4.2.1
 `
 	assert.Nil(t, ioutil.WriteFile(installInfoPath, []byte(installInfoContent), 0666))
 
 	// the install is considered coming from chef (example)
 	installMethod = getInstallMethod(installInfoPath)
-	require.Equal(t, "chef-15", installMethod.Name)
+	require.Equal(t, "chef-15", installMethod.ToolVersion)
 	assert.NotNil(t, installMethod.Tool)
 	require.Equal(t, "chef", *installMethod.Tool)
-	assert.NotNil(t, installMethod.Version)
-	require.Equal(t, "datadog-cookbook-4.2.1", *installMethod.Version)
+	assert.NotNil(t, installMethod.InstallerVersion)
+	require.Equal(t, "datadog-cookbook-4.2.1", *installMethod.InstallerVersion)
 
 	// ------------- with an incorrect file
 	installInfoContent = `
@@ -160,7 +161,7 @@ install_methodlol:
 
 	// the parsing does not occur and the install is considered private
 	installMethod = getInstallMethod(installInfoPath)
-	require.Equal(t, "undefined", installMethod.Name)
+	require.Equal(t, "undefined", installMethod.ToolVersion)
 	assert.Nil(t, installMethod.Tool)
-	assert.Nil(t, installMethod.Version)
+	assert.Nil(t, installMethod.InstallerVersion)
 }

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -46,9 +46,9 @@ type tags struct {
 
 // InstallMethod is metadata about the agent's installation
 type InstallMethod struct {
-	Name    string `json:"method"`
-	Tool    string `json:"tool"`
-	Version string `json:"version"`
+	Name    string  `json:"method"`
+	Tool    *string `json:"tool"`
+	Version *string `json:"version"`
 }
 
 // Payload handles the JSON unmarshalling of the metadata payload

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -44,6 +44,13 @@ type tags struct {
 	GoogleCloudPlatform []string `json:"google cloud platform,omitempty"`
 }
 
+// InstallMethod is metadata about the agent's installation
+type InstallMethod struct {
+	Name    string `json:"method"`
+	Tool    string `json:"tool"`
+	Version string `json:"version"`
+}
+
 // Payload handles the JSON unmarshalling of the metadata payload
 type Payload struct {
 	Os            string            `json:"os"`
@@ -54,4 +61,5 @@ type Payload struct {
 	ContainerMeta map[string]string `json:"container-meta,omitempty"`
 	NetworkMeta   *NetworkMeta      `json:"network"`
 	LogsMeta      *LogsMeta         `json:"logs"`
+	InstallMethod *InstallMethod    `json:"install-method"`
 }

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -46,9 +46,9 @@ type tags struct {
 
 // InstallMethod is metadata about the agent's installation
 type InstallMethod struct {
-	Name    string  `json:"method"`
-	Tool    *string `json:"tool"`
-	Version *string `json:"version"`
+	Tool             *string `json:"tool"`
+	ToolVersion      string  `json:"tool_version"`
+	InstallerVersion *string `json:"installer_version"`
 }
 
 // Payload handles the JSON unmarshalling of the metadata payload

--- a/releasenotes/notes/add-install-info-management-58d81114ab2a369e.yaml
+++ b/releasenotes/notes/add-install-info-management-58d81114ab2a369e.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - Install script creates `install_info` report
+  - Agent detects `install_info` report and sends it through Host metadata

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -23,11 +23,7 @@ describe 'dd-agent-installation-script' do
 
   context 'when testing the install infos' do
     let(:install_info_path) do
-      if os == :windows
-        conf_path = "#{ENV['ProgramData']}\\Datadog\\install_info"
-      else
-        conf_path = '/etc/datadog-agent/install_info'
-      end
+      '/etc/datadog-agent/install_info'
     end
 
     let(:install_info) do

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -4,16 +4,8 @@ describe 'dd-agent-installation-script' do
   include_examples 'Agent'
 
   context 'when testing DD_SITE' do
-    let(:config_file_path) do
-      if os == :windows
-        "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
-      else
-        '/etc/datadog-agent/datadog.yaml'
-      end
-    end
-
     let(:config) do
-      YAML.load_file(config_file_path)
+      YAML.load_file('/etc/datadog-agent/datadog.yaml')
     end
 
     it 'uses DD_SITE to set the site' do

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -34,7 +34,7 @@ describe 'dd-agent-installation-script' do
       expect(install_info['install_method']).to match(
         'tool' => 'install_script',
         'tool_version' => 'install_script',
-        'installer_version' => /^\d+\.\d+\.\d+$/
+        'installer_version' => /^install_script-\d+\.\d+\.\d+$/
       )
     end
   end

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -32,9 +32,9 @@ describe 'dd-agent-installation-script' do
 
     it 'adds an install_info' do
       expect(install_info['install_method']).to match(
-        'name' => 'install_script',
         'tool' => 'install_script',
-        'version' => /^\d+\.\d+\.\d+$/
+        'tool_version' => 'install_script',
+        'installer_version' => /^\d+\.\d+\.\d+$/
       )
     end
   end

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -20,4 +20,26 @@ describe 'dd-agent-installation-script' do
       expect(config['site']).to eq 'datadoghq.eu'
     end
   end
+
+  context 'when testing the install infos' do
+    let(:install_info_path) do
+      if os == :windows
+        conf_path = "#{ENV['ProgramData']}\\Datadog\\install_info"
+      else
+        conf_path = '/etc/datadog-agent/install_info'
+      end
+    end
+
+    let(:install_info) do
+      YAML.load_file(install_info_path)
+    end
+
+    it 'adds an install_info' do
+      expect(install_info['install_method']).to match(
+        'name' => 'install_script',
+        'tool' => 'install_script',
+        'version' => /^\d+\.\d+\.\d+$/
+      )
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?

Fixes PR #5333 by adding missing sudo.
Adds a new sub-structure to the host metadata to send metadata about agent installation, coming from a metadata file created by the agent installation method.
Updates the install-script to create install_info (+kitchen tests)

### Motivation
Allow users to track their installation methods
Allows Datadog to make stats on installation methods