### PR TITLE
pkg/trace/sampler: return SampleDecision from sampler.Engine

### DIFF
--- a/pkg/trace/agent/sampler.go
+++ b/pkg/trace/agent/sampler.go
@@ -72,13 +72,13 @@ func (s *Sampler) Start() {
 }
 
 // Add samples a trace and returns true if trace was sampled (should be kept), false otherwise
-func (s *Sampler) Add(t ProcessedTrace) (sampled bool, rate float64) {
+func (s *Sampler) Add(t ProcessedTrace) (decision sampler.SampleDecision) {
 	atomic.AddUint64(&s.totalTraceCount, 1)
-	sampled, rate = s.engine.Sample(t.Trace, t.Root, t.Env)
-	if sampled {
+	decision = s.engine.Sample(t.Trace, t.Root, t.Env)
+	if decision.Sampled {
 		atomic.AddUint64(&s.keptTraceCount, 1)
 	}
-	return sampled, rate
+	return decision
 }
 
 // Stop stops the sampler

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -41,6 +41,12 @@ const (
 	PriorityEngineType
 )
 
+type SampleDecision struct {
+	Sampled bool
+	Rate    float64
+	Reason  string
+}
+
 // Engine is a common basic interface for sampler engines.
 type Engine interface {
 	// Run the sampler.
@@ -48,7 +54,7 @@ type Engine interface {
 	// Stop the sampler.
 	Stop()
 	// Sample a trace.
-	Sample(trace pb.Trace, root *pb.Span, env string) (sampled bool, samplingRate float64)
+	Sample(trace pb.Trace, root *pb.Span, env string) (decision SampleDecision)
 	// GetState returns information about the sampler.
 	GetState() interface{}
 	// GetType returns the type of the sampler.

--- a/pkg/trace/sampler/exception_sampler.go
+++ b/pkg/trace/sampler/exception_sampler.go
@@ -61,8 +61,8 @@ func NewExceptionSampler() *ExceptionSampler {
 }
 
 // Add samples a trace and returns true if trace was sampled (should be kept)
-func (e *ExceptionSampler) Add(env string, root *pb.Span, t pb.Trace) (sampled bool) {
-	return e.add(time.Now(), env, root, t)
+func (e *ExceptionSampler) Add(env string, root *pb.Span, t pb.Trace) (decision SampleDecision) {
+	return SampleDecision{Sampled: e.add(time.Now(), env, root, t), Rate: 1, Reason: "ExceptionSampler"}
 }
 
 func (e *ExceptionSampler) add(now time.Time, env string, root *pb.Span, t pb.Trace) (sampled bool) {


### PR DESCRIPTION
The sampler's Engine interface returned a bool and a rate, but no other information.
This changes the Engine interface to return a new SampleDecision struct that
contains a Sampled bool, a Rate float64 and a Reason string.

This will enable us to track which traces are sampled and why.

