### PR TITLE
Remove @processes codeowner from ecs, docker, and k8s packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,9 +77,9 @@
 /pkg/util/clusteragent/                 @DataDog/container-integrations
 /pkg/util/containers/                   @DataDog/container-integrations
 /pkg/util/containers/collectors/cloudfoundry.go              @DataDog/integrations-tools-and-libraries
-/pkg/util/docker/                       @DataDog/container-integrations @DataDog/processes
-/pkg/util/ecs/                          @DataDog/container-integrations @DataDog/processes
-/pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/processes @DataDog/container-app
+/pkg/util/docker/                       @DataDog/container-integrations
+/pkg/util/ecs/                          @DataDog/container-integrations
+/pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/container-app
 /pkg/util/retry/                        @DataDog/container-integrations
 /pkg/logs/                              @DataDog/logs-intake @DataDog/agent-core
 /pkg/metadata/ecs/                      @DataDog/networks


### PR DESCRIPTION
### What does this PR do?

No longer have @processes as a codeowner for ecs, docker, and k8s packages.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
