### PR TITLE
pkg/trace/api: remove WriteHeader call from httpOK

### DIFF
--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -55,7 +55,6 @@ func httpDecodingError(err error, tags []string, w http.ResponseWriter) {
 
 // httpOK is a dumb response for when things are a OK
 func httpOK(w http.ResponseWriter) {
-	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, "OK\n")
 }
 

--- a/releasenotes/notes/apm-superfluous-header-01753e9cc4c72365.yaml
+++ b/releasenotes/notes/apm-superfluous-header-01753e9cc4c72365.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix a small programming error causing the "superfluous response.WriteHeader call" warning.


### PR DESCRIPTION
This change removes the `(http.ResponseWriter).WriteHeader` call from
the `httpOK` call in order to avoid superfluous call errors. The problem was
only occurring for <v3 endpoints.

In the case of OK, the standard library automatically writes the 200
header on first write call by default. It is not necessary to explicitly write
it. See https://github.com/golang/go/blob/go1.13/src/net/http/server.go#L143-L146