### PR TITLE
[pipeline/build] fix android build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,7 +81,7 @@ variables:
   RELEASE_VERSION_6: nightly
   RELEASE_VERSION_7: nightly-a7
   DATADOG_AGENT_BUILDIMAGES: v2287129-4816dc7
-  DATADOG_AGENT_BUILDERS: v2311927-0e261ab
+  DATADOG_AGENT_BUILDERS: v2441729-d4ed0d1
   DATADOG_AGENT_WINBUILDIMAGES: v2348149-ba6640d
   DATADOG_AGENT_ARMBUILDIMAGES: v2287129-4816dc7
   DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v2336045-3227a35
@@ -1299,7 +1299,7 @@ agent_android_apk:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # for now do the steps manually.  Should eventually move this to an invoke
     # task
-    - env GO111MODULE=off inv -e android.build --major-version 7
+    - inv -e android.build --major-version 7
     - mkdir -p $OMNIBUS_PACKAGE_DIR
     - cp ./bin/agent/ddagent-*-unsigned.apk $OMNIBUS_PACKAGE_DIR
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1299,7 +1299,7 @@ agent_android_apk:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # for now do the steps manually.  Should eventually move this to an invoke
     # task
-    - inv -e android.build --major-version 7
+    - env GO111MODULE=off inv -e android.build --major-version 7
     - mkdir -p $OMNIBUS_PACKAGE_DIR
     - cp ./bin/agent/ddagent-*-unsigned.apk $OMNIBUS_PACKAGE_DIR
   artifacts:

--- a/pkg/ebpf/netlink/conntracker.go
+++ b/pkg/ebpf/netlink/conntracker.go
@@ -1,4 +1,5 @@
 // +build linux
+// +build !android
 
 package netlink
 

--- a/pkg/ebpf/netlink/conntracker_test.go
+++ b/pkg/ebpf/netlink/conntracker_test.go
@@ -1,4 +1,5 @@
 // +build linux
+// +build !android
 
 package netlink
 

--- a/pkg/ebpf/netlink/noop.go
+++ b/pkg/ebpf/netlink/noop.go
@@ -1,4 +1,5 @@
 // +build linux
+// +build !android
 
 package netlink
 

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -57,7 +57,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     # Generating go source from templates by running go generate on ./pkg/status
     generate(ctx)
 
-    build_tags = get_default_build_tags(puppy=True)
+    build_tags = get_default_build_tags(android=True)
 
     build_tags.append("android")
     cmd = "gomobile bind -target android {race_opt} {build_type} -tags \"{go_build_tags}\" "

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -36,6 +36,11 @@ PUPPY_TAGS = [
     "systemd",
 ]
 
+ANDROID_TAGS = [
+    "zlib",
+    "android",
+]
+
 PROCESS_ONLY_TAGS = [
     "fargateprocess",
     "orchestrator",
@@ -68,7 +73,7 @@ REDHAT_DEBIAN_SUSE_DIST = [
 ]
 
 
-def get_default_build_tags(puppy=False, process=False, arch="x64"):
+def get_default_build_tags(puppy=False, process=False, arch="x64", android=False):
     """
     Build the default list of tags based on the current platform.
 
@@ -78,6 +83,10 @@ def get_default_build_tags(puppy=False, process=False, arch="x64"):
     include = ["all"]
     if puppy:
         include = PUPPY_TAGS
+
+    # android has its own set of tags
+    if android:
+        include = ANDROID_TAGS
 
     exclude = [] if sys.platform.startswith("linux") else LINUX_ONLY_TAGS
     # if not process agent, ignore process only tags


### PR DESCRIPTION
### What does this PR do?

Fixes the android build.

  - gomobile must be run with go modules disabled, see https://go-review.googlesource.com/c/mobile/+/167659/
  - systemd has been enabled for all build but that's causing issue with the android port
  - part of the code from the system-probe / ebpf should not be built while building the android port