### PR TITLE
Fix run_security_scan_test in gitlabci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -364,7 +364,7 @@ run_security_scan_test:
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
       snyk monitor --project-name=datadog-agent-requirements.txt --file=requirements.txt --package-manager=pip
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
-      snyk monitor --project-name=datadog-agent-go.sum --file=go.sum
+      snyk monitor --project-name=datadog-agent-go.sum --file=go.mod
 
 # check consistency of go.sum
 run_dep_check_lock:


### PR DESCRIPTION
### What does this PR do?

snyk.io needs to have the link to `go.mod` instead of `go.sum`
snyk was also updated in to support gomodule:  https://github.com/DataDog/images/pull/1295

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
