### PR TITLE
WIP Security/Compliance Agent scaffold

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@
 /cmd/cluster-agent/api/v1/cloudfoundry_metadata.go        @DataDog/integrations-tools-and-libraries
 /cmd/process-agent/                     @DataDog/processes
 /cmd/system-probe/                      @DataDog/networks
+/cmd/security-agent                     @DataDog/container-integrations
 
 /Dockerfiles/                           @DataDog/container-integrations
 
@@ -89,6 +90,7 @@
 /pkg/network/                           @DataDog/networks
 /pkg/ebpf/                              @DataDog/networks
 /pkg/quantile                           @DataDog/metrics-aggregation
+/pkg/compliance                         @DataDog/container-integrations
 
 /releasenotes/                          @DataDog/agent-all
 /releasenotes-dca/                      @DataDog/container-integrations

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -1,0 +1,183 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build kubeapiserver
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// loggerName is the name of the security agent logger
+const loggerName config.LoggerName = "SECURITY"
+
+var (
+	SecurityAgentCmd = &cobra.Command{
+		Use:   "datadog-security-agent [command]",
+		Short: "Datadog Security Agent at your service.",
+		Long: `
+Datadog Security Agent takes care of running compliance and security checks.`,
+	}
+
+	startCmd = &cobra.Command{
+		Use:   "start",
+		Short: "Start the Security Agent",
+		Long:  `Runs Datadog Security agent in the foreground`,
+		RunE:  start,
+	}
+
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version info",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			if flagNoColor {
+				color.NoColor = true
+			}
+			av, _ := version.Agent()
+			meta := ""
+			if av.Meta != "" {
+				meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))
+			}
+			fmt.Fprintln(
+				color.Output,
+				fmt.Sprintf("Security agent %s %s- Commit: '%s' - Serialization version: %s",
+					color.BlueString(av.GetNumberAndPre()),
+					meta,
+					color.GreenString(version.Commit),
+					color.MagentaString(serializer.AgentPayloadVersion),
+				),
+			)
+		},
+	}
+
+	confPath    string
+	flagNoColor bool
+	stopCh      chan struct{}
+)
+
+func init() {
+	// attach the command to the root
+	SecurityAgentCmd.AddCommand(startCmd)
+	SecurityAgentCmd.AddCommand(versionCmd)
+	SecurityAgentCmd.AddCommand(complianceCmd)
+
+	SecurityAgentCmd.PersistentFlags().StringVarP(&confPath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
+	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
+}
+
+func start(cmd *cobra.Command, args []string) error {
+	// we'll search for a config file named `datadog-security.yaml`
+	config.Datadog.SetConfigName("datadog-security")
+	err := common.SetupConfig(confPath)
+	if err != nil {
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
+	// Setup logger
+	syslogURI := config.GetSyslogURI()
+	logFile := config.Datadog.GetString("log_file")
+	if logFile == "" {
+		logFile = common.DefaultDCALogFile
+	}
+	if config.Datadog.GetBool("disable_file_logging") {
+		// this will prevent any logging on file
+		logFile = ""
+	}
+
+	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
+	defer mainCtxCancel() // Calling cancel twice is safe
+
+	err = config.SetupLogger(
+		loggerName,
+		config.Datadog.GetString("log_level"),
+		logFile,
+		syslogURI,
+		config.Datadog.GetBool("syslog_rfc"),
+		config.Datadog.GetBool("log_to_console"),
+		config.Datadog.GetBool("log_format_json"),
+	)
+	if err != nil {
+		log.Criticalf("Unable to setup logger: %s", err)
+		return nil
+	}
+
+	if !config.Datadog.IsSet("api_key") {
+		log.Critical("no API key configured, exiting")
+		return nil
+	}
+
+	// Setup healthcheck port
+	var healthPort = config.Datadog.GetInt("health_port")
+	if healthPort > 0 {
+		err := healthprobe.Serve(mainCtx, healthPort)
+		if err != nil {
+			return log.Errorf("Error starting health port, exiting: %v", err)
+		}
+		log.Debugf("Health check listening on port %d", healthPort)
+	}
+
+	// get hostname
+	hostname, err := util.GetHostname()
+	if err != nil {
+		return log.Errorf("Error while getting hostname, exiting: %v", err)
+	}
+	log.Infof("Hostname is: %s", hostname)
+
+	// setup the forwarder
+	keysPerDomain, err := config.GetMultipleEndpoints()
+	if err != nil {
+		log.Error("Misconfiguration of agent endpoints: ", err)
+	}
+	f := forwarder.NewDefaultForwarder(forwarder.NewOptions(keysPerDomain))
+	f.Start()
+	s := serializer.NewSerializer(f)
+
+	aggregatorInstance := aggregator.InitAggregator(s, hostname, "security_agent")
+	aggregatorInstance.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Security Agent", version.AgentVersion))
+
+	complianceEnabled := config.Datadog.GetBool("compliance_config.enabled")
+	if complianceEnabled {
+		checkInterval := config.Datadog.GetDuration("compliance_config.check_interval")
+		log.Infof("Running compliance checks every %s", checkInterval.String())
+	}
+
+	log.Infof("Datadog Security Agent is now running.")
+
+	// Setup a channel to catch OS signals
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+
+	// Block here until we receive the interrupt signal
+	<-signalCh
+
+	// Cancel the main context to stop components
+	mainCtxCancel()
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+
+	log.Info("See ya!")
+	log.Flush()
+	return nil
+}

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/compliance"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+)
+
+var (
+	complianceCmd = &cobra.Command{
+		Use:   "compliance",
+		Short: "Compliance Agent utility commands",
+	}
+
+	eventCmd = &cobra.Command{
+		Use:   "event",
+		Short: "Issue logs to test Security Agent compliance events",
+		RunE:  event,
+	}
+
+	eventArgs = struct {
+		tags          []string
+		sourceName    string
+		sourceType    string
+		sourceService string
+		event         compliance.RuleEvent
+		data          []string
+	}{}
+)
+
+func init() {
+	complianceCmd.AddCommand(eventCmd)
+	eventCmd.Flags().StringSliceVarP(&eventArgs.tags, "tags", "t", []string{"security:compliance"}, "Tags")
+	eventCmd.Flags().StringVarP(&eventArgs.sourceType, "source-type", "", "compliance", "Log source name")
+	eventCmd.Flags().StringVarP(&eventArgs.sourceName, "source-name", "", "compliance-agent", "Log source name")
+	eventCmd.Flags().StringVarP(&eventArgs.sourceService, "source-service", "", "compliance-agent", "Log source service")
+	eventCmd.Flags().StringVarP(&eventArgs.event.RuleName, "rule-name", "", "", "Rule name")
+	eventCmd.Flags().StringVarP(&eventArgs.event.RuleVersion, "rule-version", "", "", "Rule version")
+	eventCmd.Flags().StringVarP(&eventArgs.event.Framework, "framework", "", "", "Compliance framework")
+	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceID, "resource-id", "", "", "Resource ID")
+	eventCmd.Flags().StringVarP(&eventArgs.event.ResourceType, "resource-type", "", "", "Resource type")
+	eventCmd.Flags().StringSliceVarP(&eventArgs.data, "data", "d", []string{}, "Data KV fields")
+}
+
+func event(cmd *cobra.Command, args []string) error {
+	// we'll search for a config file named `datadog-security.yaml`
+	coreconfig.Datadog.SetConfigName("datadog-security")
+	err := common.SetupConfig(confPath)
+	if err != nil {
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
+
+	httpConnectivity := config.HTTPConnectivityFailure
+	if endpoints, err := config.BuildHTTPEndpoints(); err == nil {
+		httpConnectivity = http.CheckConnectivity(endpoints.Main)
+	}
+	endpoints, err := config.BuildEndpoints(httpConnectivity)
+	if err != nil {
+		return fmt.Errorf("Invalid endpoints: %v", err)
+	}
+
+	destinationsCtx := client.NewDestinationsContext()
+	destinationsCtx.Start()
+	defer destinationsCtx.Stop()
+
+	health := health.Register("security-agent")
+
+	// setup the auditor
+	auditor := auditor.New(coreconfig.Datadog.GetString("compliance_config.run_path"), health)
+	auditor.Start()
+	defer auditor.Stop()
+
+	// setup the pipeline provider that provides pairs of processor and sender
+	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, nil, endpoints, destinationsCtx)
+	pipelineProvider.Start()
+	defer pipelineProvider.Stop()
+
+	src := config.NewLogSource("compliance-agent", &config.LogsConfig{
+		Type:    eventArgs.sourceType,
+		Service: eventArgs.sourceService,
+		Source:  eventArgs.sourceName,
+		Tags:    eventArgs.tags,
+	})
+
+	eventArgs.event.Data = map[string]string{}
+	for _, d := range eventArgs.data {
+		kv := strings.SplitN(d, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		eventArgs.event.Data[kv[0]] = kv[1]
+	}
+	buf, err := json.Marshal(eventArgs.event)
+	if err != nil {
+		return err
+	}
+
+	msg := message.NewMessageWithSource(buf, message.StatusInfo, src)
+
+	ch := pipelineProvider.NextPipelineChan()
+	ch <- msg
+
+	return nil
+}

--- a/cmd/security-agent/main.go
+++ b/cmd/security-agent/main.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	_ "expvar"         // Blank import used because this isn't directly used in this file
+	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/app"
+)
+
+func main() {
+	// Expose the registered metrics via HTTP.
+	http.Handle("/metrics", telemetry.Handler())
+	go http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", config.Datadog.GetInt("metrics_port")), nil)
+
+	if err := app.SecurityAgentCmd.Execute(); err != nil {
+		log.Error(err)
+		os.Exit(-1)
+	}
+}

--- a/pkg/compliance/payload.go
+++ b/pkg/compliance/payload.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package compliance
+
+// RuleEvent describes a log event sent for an evaluated compliance rule.
+type RuleEvent struct {
+	RuleName     string            `json:"rule_name,omitempty"`
+	RuleVersion  string            `json:"rule_version,omitempty"`
+	Framework    string            `json:"framework,omitempty"`
+	ResourceID   string            `json:"resource_id,omitempty"`
+	ResourceType string            `json:"resource_type,omitempty"`
+	Data         map[string]string `json:"data,omitempty"`
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -677,6 +677,10 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("inventories_max_interval", 600) // 10min
 	config.BindEnvAndSetDefault("inventories_min_interval", 300) // 5min
 
+	// Datadog security agent (compliance)
+	config.BindEnvAndSetDefault("compliance_config.enabled", true)
+	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
+
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")
 

--- a/releasenotes/notes/security-compliance-agent-scaffold-09615c91c19629ae.yaml
+++ b/releasenotes/notes/security-compliance-agent-scaffold-09615c91c19629ae.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add scaffold for security/compliance agent CLI.

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -17,6 +17,7 @@ from . import (agent,
     pylauncher,
     release,
     rtloader,
+    security_agent,
     selinux,
     system_probe,
     systray,
@@ -73,6 +74,7 @@ ns.add_collection(rtloader)
 ns.add_collection(system_probe)
 ns.add_collection(process_agent)
 ns.add_collection(uninstallcmd)
+ns.add_collection(security_agent)
 
 ns.configure({
     'run': {

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -1,0 +1,71 @@
+import datetime
+import os
+import re
+import shutil
+import sys
+import shutil
+import tempfile
+from invoke import task
+from invoke.exceptions import Exit
+from subprocess import check_output
+
+from .utils import bin_name, get_gopath, get_build_flags, REPO_PATH, get_version, get_git_branch_name, get_go_version, get_git_commit, get_version_numeric_only
+from .build_tags import get_default_build_tags
+
+BIN_DIR = os.path.join(".", "bin", "security-agent")
+BIN_PATH = os.path.join(BIN_DIR, bin_name("security-agent", android=False))
+GIMME_ENV_VARS = ['GOROOT', 'PATH']
+
+@task
+def build(ctx, race=False, go_version=None, incremental_build=False,
+          major_version='7', arch="x64", go_mod="vendor"):
+    """
+    Build the security agent
+    """
+    ldflags, gcflags, env = get_build_flags(ctx, arch=arch, major_version=major_version)
+
+
+    # TODO use pkg/version for this
+    main = "main."
+    ld_vars = {
+        "Version": get_version(ctx, major_version=major_version),
+        "GoVersion": get_go_version(),
+        "GitBranch": get_git_branch_name(),
+        "GitCommit": get_git_commit(),
+        "BuildDate": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+
+    goenv = {}
+    if go_version:
+        lines = ctx.run("gimme {version}".format(version=go_version)).stdout.split("\n")
+        for line in lines:
+            for env_var in GIMME_ENV_VARS:
+                if env_var in line:
+                    goenv[env_var] = line[line.find(env_var)+len(env_var)+1:-1].strip('\'\"')
+        ld_vars["GoVersion"] = go_version
+
+
+    # extend PATH from gimme with the one from get_build_flags
+    if "PATH" in os.environ and "PATH" in goenv:
+        goenv["PATH"] += ":" + os.environ["PATH"]
+    env.update(goenv)
+
+    ldflags += ' '.join(["-X '{name}={value}'".format(name=main+key, value=value) for key, value in ld_vars.items()])
+    build_tags = get_default_build_tags(puppy=False, process=False, arch=arch)
+
+    # TODO static option
+    cmd = 'go build -mod={go_mod} {race_opt} {build_type} -tags "{go_build_tags}" '
+    cmd += '-o {agent_bin} -gcflags="{gcflags}" -ldflags="{ldflags}" {REPO_PATH}/cmd/security-agent'
+
+    args = {
+        "go_mod": go_mod,
+        "race_opt": "-race" if race else "",
+        "build_type": "" if incremental_build else "-a",
+        "go_build_tags": " ".join(build_tags),
+        "agent_bin": BIN_PATH,
+        "gcflags": gcflags,
+        "ldflags": ldflags,
+        "REPO_PATH": REPO_PATH,
+    }
+
+    ctx.run(cmd.format(**args), env=env)


### PR DESCRIPTION
Security Agent runs as a separate process and is responsible for running compliance checks.

Security Agent uses logs intake to trigger signals based on configured rules.

- Initial CLI for security agent
- `event` command to send a `compliance.RuleEvent` payload to the backend.

```
security-agent compliance event --rule-name=cis-something-1.2.3 --rule-version=v1 --framework=cis_something --data=permissions:644
```

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
