### PR TITLE
[DCA][CLC] Consider check failure in advanced rebalancing

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1312,6 +1312,50 @@ func TestRebalance(t *testing.T) {
 				},
 			},
 		},
+		{
+			in: map[string]*nodeStore{
+				"A": {
+					name: "A",
+					clcRunnerStats: types.CLCRunnersStats{
+						"checkA0": types.CLCRunnerStats{
+							AverageExecutionTime: 1000,
+							MetricSamples:        1000,
+							LastExecFailed:       true,
+						},
+						"checkA1": types.CLCRunnerStats{
+							AverageExecutionTime: 10,
+							MetricSamples:        10,
+							LastExecFailed:       false,
+						},
+					},
+				},
+				"B": {
+					name:           "B",
+					clcRunnerStats: types.CLCRunnersStats{},
+				},
+			},
+			out: map[string]*nodeStore{
+				"A": {
+					name: "A",
+					clcRunnerStats: types.CLCRunnersStats{
+						"checkA0": types.CLCRunnerStats{
+							AverageExecutionTime: 1000,
+							MetricSamples:        1000,
+							LastExecFailed:       true,
+						},
+						"checkA1": types.CLCRunnerStats{
+							AverageExecutionTime: 10,
+							MetricSamples:        10,
+							LastExecFailed:       false,
+						},
+					},
+				},
+				"B": {
+					name:           "B",
+					clcRunnerStats: types.CLCRunnersStats{},
+				},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			dispatcher := newDispatcher()

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -40,14 +40,18 @@ func timestampNow() int64 {
 func calculateBusyness(checkStats types.CLCRunnersStats) int {
 	busyness := 0
 	for _, stats := range checkStats {
-		busyness += busynessFunc(stats.AverageExecutionTime, stats.MetricSamples)
+		busyness += busynessFunc(stats)
 	}
 	return busyness
 }
 
 // busynessFunc returns the weight of a check
-func busynessFunc(avgExecTime, mSamples int) int {
-	return int(checkExecutionTimeWeight*float64(avgExecTime) + checkMetricSamplesWeight*float64(mSamples))
+func busynessFunc(s types.CLCRunnerStats) int {
+	if s.LastExecFailed {
+		// The check is failing, its weight is 0
+		return 0
+	}
+	return int(checkExecutionTimeWeight*float64(s.AverageExecutionTime) + checkMetricSamplesWeight*float64(s.MetricSamples))
 }
 
 // orderedKeys sorts the keys of a map and return them in a slice

--- a/pkg/clusteragent/clusterchecks/helpers_test.go
+++ b/pkg/clusteragent/clusterchecks/helpers_test.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build clusterchecks
+
+package clusterchecks
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+)
+
+func Test_busynessFunc(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats types.CLCRunnerStats
+		want  int
+	}{
+		{
+			name: "nominal case",
+			stats: types.CLCRunnerStats{
+				AverageExecutionTime: 100,
+				MetricSamples:        100,
+			},
+			want: 100,
+		},
+		{
+			name: "cluster check",
+			stats: types.CLCRunnerStats{
+				AverageExecutionTime: 100,
+				MetricSamples:        100,
+				IsClusterCheck:       true,
+			},
+			want: 100,
+		},
+		{
+			name: "node based check",
+			stats: types.CLCRunnerStats{
+				AverageExecutionTime: 100,
+				MetricSamples:        100,
+				IsClusterCheck:       false,
+			},
+			want: 100,
+		},
+		{
+			name: "failed check",
+			stats: types.CLCRunnerStats{
+				AverageExecutionTime: 100,
+				MetricSamples:        100,
+				LastExecFailed:       true,
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := busynessFunc(tt.stats); got != tt.want {
+				t.Errorf("busynessFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_calculateBusyness(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats types.CLCRunnersStats
+		want  int
+	}{
+		{
+			name: "nominal case",
+			stats: types.CLCRunnersStats{
+				"cluster check": types.CLCRunnerStats{
+					AverageExecutionTime: 100,
+					MetricSamples:        100,
+					IsClusterCheck:       true,
+				},
+				"node check": types.CLCRunnerStats{
+					AverageExecutionTime: 100,
+					MetricSamples:        100,
+					IsClusterCheck:       false,
+				},
+				"failed check": types.CLCRunnerStats{
+					AverageExecutionTime: 100,
+					MetricSamples:        100,
+					LastExecFailed:       true,
+				},
+			},
+			want: 200,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculateBusyness(tt.stats); got != tt.want {
+				t.Errorf("calculateBusyness() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -152,19 +152,19 @@ func (s *nodeStore) GetRunnerStats(checkID string) (types.CLCRunnerStats, error)
 
 // GetBusyness calculates busyness of the node
 // The nodeStore handles thread safety for this public method
-func (s *nodeStore) GetBusyness(busynessFunc func(avgExecTime, mSamples int) int) int {
+func (s *nodeStore) GetBusyness(busynessFunc func(stats types.CLCRunnerStats) int) int {
 	s.RLock()
 	defer s.RUnlock()
 	busyness := 0
 	for _, stats := range s.clcRunnerStats {
-		busyness += busynessFunc(stats.AverageExecutionTime, stats.MetricSamples)
+		busyness += busynessFunc(stats)
 	}
 	return busyness
 }
 
 // GetMostWeightedClusterCheck returns the Cluster Check with the most weight on the node
 // The nodeStore handles thread safety for this public method
-func (s *nodeStore) GetMostWeightedClusterCheck(busynessFunc func(avgExecTime, mSamples int) int) (string, int, error) {
+func (s *nodeStore) GetMostWeightedClusterCheck(busynessFunc func(stats types.CLCRunnerStats) int) (string, int, error) {
 	s.RLock()
 	defer s.RUnlock()
 	if len(s.clcRunnerStats) == 0 {
@@ -175,7 +175,7 @@ func (s *nodeStore) GetMostWeightedClusterCheck(busynessFunc func(avgExecTime, m
 	checkID := ""
 	checkWeight := 0
 	for id, stats := range s.clcRunnerStats {
-		busyness := busynessFunc(stats.AverageExecutionTime, stats.MetricSamples)
+		busyness := busynessFunc(stats)
 		if (busyness > checkWeight || firstItr) && stats.IsClusterCheck {
 			// Only consider Cluster Checks
 			checkWeight = busyness


### PR DESCRIPTION
### What does this PR do?

Set a nil weight for failing checks

### Motivation

Advanced dispatching must be resilient to checks failing that can have important execution time because of timing out.

### Describe your test plan

By scheduling a `redisdb` check that's failing and timing out (targeting an invalid ip) + advanced dispatching. The value of the `cluster_checks_busyness` metric exposed by the cluster agent must be equal to zero.
