### PR TITLE
Fix missing import of container provider in cmd/dogstatsd

### DIFF
--- a/cmd/dogstatsd/main_linux.go
+++ b/cmd/dogstatsd/main_linux.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux
+
+package main
+
+import _ "github.com/DataDog/datadog-agent/pkg/util/containers/providers/cgroup"

--- a/cmd/dogstatsd/main_nix.go
+++ b/cmd/dogstatsd/main_nix.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	_ "github.com/DataDog/datadog-agent/pkg/util/containers/providers/cgroup"
 )
 
 const defaultLogFile = "/var/log/datadog/dogstatsd.log"

--- a/cmd/dogstatsd/main_nix.go
+++ b/cmd/dogstatsd/main_nix.go
@@ -15,8 +15,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	_ "github.com/DataDog/datadog-agent/pkg/util/containers/providers/cgroup"
 )
 
 const defaultLogFile = "/var/log/datadog/dogstatsd.log"

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
+	_ "github.com/DataDog/datadog-agent/pkg/util/containers/providers/windows"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 
 	"golang.org/x/sys/windows/registry"

--- a/releasenotes/notes/dogstatsd-fix-missing-providers-cgroup-import-16fb1186bf5097d0.yaml
+++ b/releasenotes/notes/dogstatsd-fix-missing-providers-cgroup-import-16fb1186bf5097d0.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix missing import of container provider in cmd/dogstatsd.
+    Fix panic in the dogstatsd standalone package when running in a containerized environment.

--- a/releasenotes/notes/dogstatsd-fix-missing-providers-cgroup-import-16fb1186bf5097d0.yaml
+++ b/releasenotes/notes/dogstatsd-fix-missing-providers-cgroup-import-16fb1186bf5097d0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix missing import of container provider in cmd/dogstatsd.


### PR DESCRIPTION
### What does this PR do?

With the split of Windows container support, the `_` import of providers/cgroup was missing in the `cmd/dogstatsd` package.

### Motivation

https://github.com/DataDog/datadog-agent/issues/5446

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
