### PR TITLE
Backport 7.19.1 CHANGELOG update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,28 @@
 Release Notes
 =============
 
+.. _Release Notes_7.19.1:
+
+7.19.1
+======
+
+.. _Release Notes_7.19.1_Prelude:
+
+Prelude
+-------
+
+Release on: 2020-05-04
+
+This release is only an Agent v7 release, as Agent v6 is not affected by the undermentioned bug.
+
+.. _Release Notes_7.19.1_Bug Fixes:
+
+Bug Fixes
+---------
+
+- Fix panic in the dogstatsd standalone package when running in a containerized environment.
+
+
 .. _Release Notes_7.19.0:
 
 7.19.0 / 6.19.0


### PR DESCRIPTION
### What does this PR do?

Backports 7.19.1 CHANGELOG update to master.

### Motivation

7.19.1 release.
