### PR TITLE
pkg/trace/api: add a proxy for profiler

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -128,7 +128,7 @@ func (r *HTTPReceiver) Start() {
 	mux.HandleFunc("/v0.3/services", r.handleWithVersion(v03, r.handleServices))
 	mux.HandleFunc("/v0.4/traces", r.handleWithVersion(v04, r.handleTraces))
 	mux.HandleFunc("/v0.4/services", r.handleWithVersion(v04, r.handleServices))
-	mux.Handle("/proxy/profile", r.profileProxyHandler())
+	mux.Handle("/profiling/v1/input", r.profileProxyHandler())
 
 	timeout := 5 * time.Second
 	if r.conf.ReceiverTimeout > 0 {

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -128,6 +128,7 @@ func (r *HTTPReceiver) Start() {
 	mux.HandleFunc("/v0.3/services", r.handleWithVersion(v03, r.handleServices))
 	mux.HandleFunc("/v0.4/traces", r.handleWithVersion(v04, r.handleTraces))
 	mux.HandleFunc("/v0.4/services", r.handleWithVersion(v04, r.handleServices))
+	mux.Handle("/proxy/profile", r.profileProxyHandler())
 
 	timeout := 5 * time.Second
 	if r.conf.ReceiverTimeout > 0 {

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -52,6 +52,7 @@ func (r *HTTPReceiver) profileProxyHandler() http.Handler {
 func newProfileProxy(target *url.URL, apiKey, tags string) *httputil.ReverseProxy {
 	director := func(req *http.Request) {
 		req.URL = target
+		req.Host = target.Host
 		req.Header.Set("DD-API-KEY", apiKey)
 		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", info.Version))
 		if _, ok := req.Header["User-Agent"]; !ok {

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/info"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// profilingURLTemplate specifies the template for obtaining the profiling URL along with the site.
+	profilingURLTemplate = "https://intake.profile.%s/v1/input"
+	// profilingURLDefault specifies the default intake API URL.
+	profilingURLDefault = "https://intake.profile.datadoghq.com/v1/input"
+)
+
+// profilingEndpoint returns the profiling intake API URL based on agent configuration.
+func profilingEndpoint() string {
+	if v := config.Datadog.GetString("apm_config.profiling_dd_url"); v != "" {
+		return v
+	}
+	if site := config.Datadog.GetString("site"); site != "" {
+		return fmt.Sprintf(profilingURLTemplate, site)
+	}
+	return profilingURLDefault
+}
+
+// profileProxyHandler returns a new HTTP handler which will proxy requests to the profiling intake.
+// If the URL can not be computed because of a malformed 'site' config, the returned handler will always
+// return http.StatusInternalServerError along with a clarification.
+func (r *HTTPReceiver) profileProxyHandler() http.Handler {
+	target := profilingEndpoint()
+	u, err := url.Parse(target)
+	if err != nil {
+		log.Errorf("Profile forwarder is OFF because of invalid intake URL: %v", err)
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			msg := fmt.Sprintf("Agent is misconfigured with an invalid intake URL: %q", target)
+			http.Error(w, msg, http.StatusInternalServerError)
+		})
+	}
+	tags := fmt.Sprintf("host:%s,default_env:%s", r.conf.Hostname, r.conf.DefaultEnv)
+	return newProfileProxy(u, r.conf.APIKey(), tags)
+}
+
+// newProfileProxy creates a single-host reverse proxy with the given target, attaching
+// the specified apiKey.
+func newProfileProxy(target *url.URL, apiKey, tags string) *httputil.ReverseProxy {
+	director := func(req *http.Request) {
+		req.URL = target
+		req.Header.Set("DD-API-KEY", apiKey)
+		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", info.Version))
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to the default value
+			// that net/http gives it: Go-http-client/1.1
+			// See https://codereview.appspot.com/7532043
+			req.Header.Set("User-Agent", "")
+
+		}
+		containerID := req.Header.Get(headerContainerID)
+		if ctags := getContainerTags(containerID); ctags != "" {
+			req.Header.Set("X-Datadog-Container-Tags", ctags)
+		}
+		req.Header.Set("X-Datadog-Additional-Tags", tags)
+		metrics.Count("datadog.trace_agent.profile", 1, nil, 1)
+	}
+	return &httputil.ReverseProxy{Director: director}
+}

--- a/pkg/trace/api/profiles_test.go
+++ b/pkg/trace/api/profiles_test.go
@@ -47,8 +47,7 @@ func TestProfileProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 	rec := httptest.NewRecorder()
-	pp := newProfileProxy(u, "123", "key:val")
-	pp.ServeHTTP(rec, req)
+	newProfileProxy(u, "123", "key:val").ServeHTTP(rec, req)
 	slurp, err := ioutil.ReadAll(rec.Result().Body)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/trace/api/profiles_test.go
+++ b/pkg/trace/api/profiles_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func mockConfig(k, v string) func() {
+	oldConfig := config.Datadog
+	config.Mock().Set(k, v)
+	return func() { config.Datadog = oldConfig }
+}
+
+func TestProfileProxy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		slurp, err := ioutil.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if body := string(slurp); body != "body" {
+			t.Fatalf("invalid request body: %q", body)
+		}
+		if v := req.Header.Get("DD-API-KEY"); v != "123" {
+			t.Fatalf("got invalid API key: %q", v)
+		}
+		if v := req.Header.Get("X-Datadog-Additional-Tags"); v != "key:val" {
+			t.Fatalf("got invalid X-Datadog-Additional-Tags: %q", v)
+		}
+		_, err = w.Write([]byte("OK"))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}))
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("POST", "dummy.com/path", strings.NewReader("body"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	pp := newProfileProxy(u, "123", "key:val")
+	pp.ServeHTTP(rec, req)
+	slurp, err := ioutil.ReadAll(rec.Result().Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(slurp) != "OK" {
+		t.Fatal("did not proxy")
+	}
+}
+
+func TestProfilingEndpoint(t *testing.T) {
+	t.Run("dd_url", func(t *testing.T) {
+		defer mockConfig("apm_config.profiling_dd_url", "https://intake.profile.datadoghq.fr/v1/input")()
+		if v := profilingEndpoint(); v != "https://intake.profile.datadoghq.fr/v1/input" {
+			t.Fatalf("invalid endpoint: %s", v)
+		}
+	})
+
+	t.Run("site", func(t *testing.T) {
+		defer mockConfig("site", "datadoghq.eu")()
+		if v := profilingEndpoint(); v != "https://intake.profile.datadoghq.eu/v1/input" {
+			t.Fatalf("invalid endpoint: %s", v)
+		}
+	})
+
+	t.Run("default", func(t *testing.T) {
+		if v := profilingEndpoint(); v != "https://intake.profile.datadoghq.com/v1/input" {
+			t.Fatalf("invalid endpoint: %s", v)
+		}
+	})
+}
+
+func TestProfileProxyHandler(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if v := req.Header.Get("X-Datadog-Additional-Tags"); v != "host:myhost,default_env:none" {
+				t.Fatalf("invalid X-Datadog-Additional-Tags header: %q", v)
+			}
+			called = true
+		}))
+		defer mockConfig("apm_config.profiling_dd_url", srv.URL)()
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conf := newTestReceiverConfig()
+		conf.Hostname = "myhost"
+		receiver := newTestReceiverFromConfig(conf)
+		receiver.profileProxyHandler().ServeHTTP(httptest.NewRecorder(), req)
+		if !called {
+			t.Fatal("request not proxied")
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		defer mockConfig("site", "asd:\r\n")()
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		r := newTestReceiverFromConfig(newTestReceiverConfig())
+		r.profileProxyHandler().ServeHTTP(rec, req)
+		res := rec.Result()
+		if res.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("invalid response: %s", res.Status)
+		}
+		slurp, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(slurp), "misconfigured") {
+			t.Fatalf("invalid message: %q", slurp)
+		}
+	})
+}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -157,6 +157,14 @@ func New() *AgentConfig {
 	}
 }
 
+// APIKey returns the first (main) endpoint's API key.
+func (c *AgentConfig) APIKey() string {
+	if len(c.Endpoints) == 0 {
+		return ""
+	}
+	return c.Endpoints[0].APIKey
+}
+
 // Validate validates if the current configuration is good for the agent to start with.
 func (c *AgentConfig) validate() error {
 	if len(c.Endpoints) == 0 || c.Endpoints[0].APIKey == "" {

--- a/releasenotes/notes/apm-profile-proxy-720c4e90dee22f33.yaml
+++ b/releasenotes/notes/apm-profile-proxy-720c4e90dee22f33.yaml
@@ -8,5 +8,5 @@
 ---
 features:
   - |
-    APM: A new endpoint was added which helps forward and augment profiles
-    to the intake.
+    APM: A new endpoint was added which helps augment and forward profiles
+    to Datadog's intake.

--- a/releasenotes/notes/apm-profile-proxy-720c4e90dee22f33.yaml
+++ b/releasenotes/notes/apm-profile-proxy-720c4e90dee22f33.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: A new endpoint was added which helps forward and augment profiles
+    to the intake.


### PR DESCRIPTION
### Description

This change adds a new endpoint to the `trace-agent` which proxies all requests to the profiling intake, modifying the request as follows:

* Adds the API key from the main endpoint into the `DD-API-KEY` HTTP header.
* If the request contains a non-empty string in the HTTP header `X-Datadog-Container-ID`, the proxied request will have `X-Datadog-Container-Tags` with the container tags.

### TODO

- [x] Add changelog
- [x] Get endpoint path signed off