### PR TITLE
[ad] Ignore AKS pause containers hosted at aksrepos.azurecr.io

### DIFF
--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -29,8 +29,11 @@ const (
 	// - gcrio.azureedge.net/google_containers/pause-amd64
 	pauseContainerAzure   = `image:(.*)azureedge\.net(/google_containers/|/)pause(.*)`
 	pauseContainerRancher = `image:rancher/pause(.*)`
-	pauseContainerAKS     = `image:mcr.microsoft.com/k8s/core/pause(.*)`
-	pauseContainerECR     = `image:ecr(.*)amazonaws.com/pause(.*)`
+	// pauseContainerAKS regex matches:
+	// - mcr.microsoft.com/k8s/core/pause-amd64
+	// - aksrepos.azurecr.io/mirror/pause-amd64
+	pauseContainerAKS = `image:(mcr.microsoft.com/k8s/core/|aksrepos.azurecr.io/mirror/)pause(.*)`
+	pauseContainerECR = `image:ecr(.*)amazonaws.com/pause(.*)`
 )
 
 // Filter holds the state for the container filtering logic

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -163,6 +163,14 @@ func TestFilter(t *testing.T) {
 			},
 			ns: "bar",
 		},
+		{
+			c: Container{
+				ID:    "19",
+				Name:  "k8s_POD_AKS_pause",
+				Image: "aksrepos.azurecr.io/mirror/pause-amd64:3.1",
+			},
+			ns: "default",
+		},
 	}
 
 	for i, tc := range []struct {
@@ -171,25 +179,25 @@ func TestFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"},
 		},
 		{
 			blacklist:   []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"},
+			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"},
 		},
 		{
 			blacklist:   []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"},
 		},
 		{
 			whitelist:   []string{},
 			blacklist:   []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"},
+			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"},
 		},
 		{
 			whitelist:   []string{"name:mysql"},
 			blacklist:   []string{"name:dd"},
-			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18"},
+			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19"},
 		},
 		{
 			blacklist:   []string{"kube_namespace:.*"},
@@ -198,7 +206,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			blacklist:   []string{"kube_namespace:bar"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19"},
 		},
 		// Test kubernetes defaults
 		{

--- a/releasenotes/notes/ad_aks_ignore_pause_containers-024d32ddbc62d1ad.yaml
+++ b/releasenotes/notes/ad_aks_ignore_pause_containers-024d32ddbc62d1ad.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Ignore AKS pause containers hosted in the aksrepos.azurecr.io
+    container registry.


### PR DESCRIPTION
### What does this PR do?

This address issue #5459 where AKS pause containers in the new 'aksrepos.azurecr.io' container registry are not ignored.

### Motivation

Cleaner out-of-the-box Datadog integration with AKS

### Additional Notes

This is my first PR, feedback is really welcomed! 😃 

### Describe your test plan

Test passed locally.
