### PR TITLE
Remove check of bpf_probe_read presence

### DIFF
--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -19,8 +19,7 @@ var requiredKernelFuncs = []string{
 	"bpf_map_lookup_elem",
 	"bpf_map_update_elem",
 	"bpf_map_delete_elem",
-	// kprobes (4.1)
-	"bpf_probe_read",
+	// bpf_probe_read intentionally omitted since it was renamed in kernel 5.5
 	// Perf events (4.4)
 	"bpf_perf_event_output",
 	"bpf_perf_event_read",


### PR DESCRIPTION
### What does this PR do?

Removes a check on a function that was removed in newest kernels

### Motivation

Since 5.5, the `bpf_probe_read` symbol was renamed to `bpf_probe_read_kernel` and `bpf_probe_read_user`.

### Additional Notes

The check on the function presence forbids system-probe to start, even though the eBPF program would be loaded correctly by the kernel.
While we could use other behaviours (check for either `bpf_probe_read` of `bpf_probe_read_kernel` or run the check on symbols later and only if the eBPF could not be loaded), removing the check is probably enough. Indeed, it was introduced way before `bpf_perf_event_output` and `bpf_perf_event_read` which are also required and there is no situation where we could have `bpf_perf_event_output` and not `bpf_probe_read`.


Steps for QA: run the system-probe on a newer kernel (fedora 31 is easy to run on vagrant)
