### PR TITLE
Use separate delivery queues for each intake endpoint

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -36,11 +36,8 @@ type Collector struct {
 
 	groupID int32
 
-	send         chan checkPayload
 	rtIntervalCh chan time.Duration
 	cfg          *config.AgentConfig
-	forwarder    forwarder.Forwarder
-	podForwarder forwarder.Forwarder
 
 	// counters for each type of check
 	runCounters   sync.Map
@@ -65,28 +62,24 @@ func NewCollector(cfg *config.AgentConfig) (Collector, error) {
 		}
 	}
 
-	forwarderOpts := forwarder.NewOptions(keysPerDomains(cfg.APIEndpoints))
-	forwarderOpts.EnableHealthChecking = false
+	return NewCollectorWithChecks(cfg, enabledChecks), nil
+}
 
-	podForwarderOpts := forwarder.NewOptions(keysPerDomains(cfg.OrchestratorEndpoints))
-	podForwarderOpts.EnableHealthChecking = false
-
+// NewCollectorWithChecks creates a new Collector
+func NewCollectorWithChecks(cfg *config.AgentConfig, checks []checks.Check) Collector {
 	return Collector{
-		send:          make(chan checkPayload, cfg.QueueSize),
 		rtIntervalCh:  make(chan time.Duration),
 		cfg:           cfg,
 		groupID:       rand.Int31(),
-		forwarder:     forwarder.NewDefaultForwarder(forwarderOpts),
-		podForwarder:  forwarder.NewDefaultForwarder(podForwarderOpts),
-		enabledChecks: enabledChecks,
+		enabledChecks: checks,
 
 		// Defaults for real-time on start
 		realTimeInterval: 2 * time.Second,
 		realTimeEnabled:  0,
-	}, nil
+	}
 }
 
-func (l *Collector) runCheck(c checks.Check) {
+func (l *Collector) runCheck(c checks.Check, payloads chan checkPayload) {
 	runCounter := int32(1)
 	if rc, ok := l.runCounters.Load(c.Name()); ok {
 		runCounter = rc.(int32) + 1
@@ -100,7 +93,7 @@ func (l *Collector) runCheck(c checks.Check) {
 	if err != nil {
 		log.Errorf("Unable to run check '%s': %s", c.Name(), err)
 	} else {
-		l.send <- checkPayload{messages, c.Name()}
+		payloads <- checkPayload{messages, c.Name()}
 		// update proc and container count for info
 		updateProcContainerCount(messages)
 		if !c.RealTime() {
@@ -128,91 +121,80 @@ func (l *Collector) run(exit chan bool) error {
 	}
 	log.Infof("Starting process-agent for host=%s, endpoints=%s, orchestrator endpoints=%s, enabled checks=%v", l.cfg.HostName, eps, orchestratorEps, l.cfg.EnabledChecks)
 
-	if err := l.forwarder.Start(); err != nil {
-		return fmt.Errorf("error starting forwarder: %s", err)
-	}
-
-	if err := l.podForwarder.Start(); err != nil {
-		return fmt.Errorf("error starting pod forwarder: %s", err)
-	}
-
 	go util.HandleSignals(exit)
-	heartbeat := time.NewTicker(15 * time.Second)
-	queueSizeTicker := time.NewTicker(10 * time.Second)
+
+	processPayloads := make(chan checkPayload, l.cfg.QueueSize)
+	podPayloads := make(chan checkPayload, l.cfg.QueueSize)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
+
+		heartbeat := time.NewTicker(15 * time.Second)
+		defer heartbeat.Stop()
+
+		queueSizeTicker := time.NewTicker(10 * time.Second)
+		defer queueSizeTicker.Stop()
+
 		tags := []string{
 			fmt.Sprintf("version:%s", Version),
 			fmt.Sprintf("revision:%s", GitCommit),
 		}
 		for {
 			select {
-			case payload := <-l.send:
-				if len(l.send) >= l.cfg.QueueSize {
-					log.Info("Expiring payload from in-memory queue.")
-					// Limit number of items kept in memory while we wait.
-					<-l.send
-				}
-
-				for _, m := range payload.messages {
-					extraHeaders := make(http.Header)
-					extraHeaders.Set(api.HostHeader, l.cfg.HostName)
-					extraHeaders.Set(api.ProcessVersionHeader, Version)
-					extraHeaders.Set(api.ContainerCountHeader, strconv.Itoa(getContainerCount(m)))
-
-					if cid, err := clustername.GetClusterID(); err == nil && cid != "" {
-						extraHeaders.Set(api.ClusterIDHeader, cid)
-					}
-
-					body, err := encodePayload(m)
-					if err != nil {
-						log.Errorf("Unable to encode message: %s", err)
-						continue
-					}
-
-					payloads := forwarder.Payloads{&body}
-					var responses chan forwarder.Response
-
-					switch payload.name {
-					case checks.Process.Name():
-						responses, err = l.forwarder.SubmitProcessChecks(payloads, extraHeaders)
-					case checks.RTProcess.Name():
-						responses, err = l.forwarder.SubmitRTProcessChecks(payloads, extraHeaders)
-					case checks.Container.Name():
-						responses, err = l.forwarder.SubmitContainerChecks(payloads, extraHeaders)
-					case checks.RTContainer.Name():
-						responses, err = l.forwarder.SubmitRTContainerChecks(payloads, extraHeaders)
-					case checks.Connections.Name():
-						responses, err = l.forwarder.SubmitConnectionChecks(payloads, extraHeaders)
-					case checks.Pod.Name():
-						responses, err = l.podForwarder.SubmitPodChecks(payloads, extraHeaders)
-					default:
-						err = fmt.Errorf("unsupported payload type: %s", payload.name)
-					}
-
-					if err != nil {
-						log.Errorf("Unable to submit payload: %s", err)
-						continue
-					}
-
-					if statuses := readResponseStatuses(responses); len(statuses) > 0 {
-						l.updateStatus(statuses)
-					}
-				}
 			case <-heartbeat.C:
 				statsd.Client.Gauge("datadog.process.agent", 1, tags, 1)
 			case <-queueSizeTicker.C:
-				updateQueueSize(l.send)
+				updateQueueSize(len(processPayloads), len(podPayloads))
 			case <-exit:
 				return
 			}
 		}
 	}()
 
+	processForwarderOpts := forwarder.NewOptions(keysPerDomains(l.cfg.APIEndpoints))
+	processForwarderOpts.EnableHealthChecking = false
+	processForwarder := forwarder.NewDefaultForwarder(processForwarderOpts)
+
+	podForwarderOpts := forwarder.NewOptions(keysPerDomains(l.cfg.OrchestratorEndpoints))
+	podForwarderOpts.EnableHealthChecking = false
+	podForwarder := forwarder.NewDefaultForwarder(podForwarderOpts)
+
+	if err := processForwarder.Start(); err != nil {
+		return fmt.Errorf("error starting forwarder: %s", err)
+	}
+
+	if err := podForwarder.Start(); err != nil {
+		return fmt.Errorf("error starting pod forwarder: %s", err)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		l.consumePayloads(processPayloads, processForwarder, exit)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		l.consumePayloads(podPayloads, podForwarder, exit)
+	}()
+
 	for _, c := range l.enabledChecks {
-		go func(c checks.Check) {
+		payloads := processPayloads
+		if c.Name() == checks.Pod.Name() {
+			payloads = podPayloads
+		}
+
+		wg.Add(1)
+		go func(c checks.Check, payloads chan checkPayload) {
+			defer wg.Done()
+
 			// Run the check the first time to prime the caches.
 			if !c.RealTime() {
-				l.runCheck(c)
+				l.runCheck(c, payloads)
 			}
 
 			ticker := time.NewTicker(l.cfg.CheckInterval(c.Name()))
@@ -221,7 +203,7 @@ func (l *Collector) run(exit chan bool) error {
 				case <-ticker.C:
 					realTimeEnabled := atomic.LoadInt32(&l.realTimeEnabled) == 1
 					if !c.RealTime() || realTimeEnabled {
-						l.runCheck(c)
+						l.runCheck(c, payloads)
 					}
 				case d := <-l.rtIntervalCh:
 					// Live-update the ticker.
@@ -235,12 +217,76 @@ func (l *Collector) run(exit chan bool) error {
 					}
 				}
 			}
-		}(c)
+		}(c, payloads)
 	}
+
 	<-exit
-	l.forwarder.Stop()
-	l.podForwarder.Stop()
+	wg.Wait()
+
+	processForwarder.Stop()
+	podForwarder.Stop()
 	return nil
+}
+
+func (l *Collector) consumePayloads(payloads chan checkPayload, fwd forwarder.Forwarder, exit chan bool) {
+	for {
+		select {
+		case payload := <-payloads:
+			if len(payloads) >= l.cfg.QueueSize {
+				log.Info("Expiring payload from in-memory queue.")
+				// Limit number of items kept in memory while we wait.
+				<-payloads
+			}
+
+			for _, m := range payload.messages {
+				extraHeaders := make(http.Header)
+				extraHeaders.Set(api.HostHeader, l.cfg.HostName)
+				extraHeaders.Set(api.ProcessVersionHeader, Version)
+				extraHeaders.Set(api.ContainerCountHeader, strconv.Itoa(getContainerCount(m)))
+
+				if cid, err := clustername.GetClusterID(); err == nil && cid != "" {
+					extraHeaders.Set(api.ClusterIDHeader, cid)
+				}
+
+				body, err := encodePayload(m)
+				if err != nil {
+					log.Errorf("Unable to encode message: %s", err)
+					continue
+				}
+
+				payloads := forwarder.Payloads{&body}
+				var responses chan forwarder.Response
+
+				switch payload.name {
+				case checks.Process.Name():
+					responses, err = fwd.SubmitProcessChecks(payloads, extraHeaders)
+				case checks.RTProcess.Name():
+					responses, err = fwd.SubmitRTProcessChecks(payloads, extraHeaders)
+				case checks.Container.Name():
+					responses, err = fwd.SubmitContainerChecks(payloads, extraHeaders)
+				case checks.RTContainer.Name():
+					responses, err = fwd.SubmitRTContainerChecks(payloads, extraHeaders)
+				case checks.Connections.Name():
+					responses, err = fwd.SubmitConnectionChecks(payloads, extraHeaders)
+				case checks.Pod.Name():
+					responses, err = fwd.SubmitPodChecks(payloads, extraHeaders)
+				default:
+					err = fmt.Errorf("unsupported payload type: %s", payload.name)
+				}
+
+				if err != nil {
+					log.Errorf("Unable to submit payload: %s", err)
+					continue
+				}
+
+				if statuses := readResponseStatuses(responses); len(statuses) > 0 {
+					l.updateStatus(statuses)
+				}
+			}
+		case <-exit:
+			return
+		}
+	}
 }
 
 func (l *Collector) updateStatus(statuses []*model.CollectorStatus) {

--- a/cmd/process-agent/info_test.go
+++ b/cmd/process-agent/info_test.go
@@ -27,7 +27,8 @@ Processes and Containers Agent (v 0.99.0)
   Docker socket: /var/run/docker.sock
   Number of processes: 84
   Number of containers: 0
-  Queue length: 0
+  Process Queue length: 0
+  Pod Queue length: 0
 
   Logs: /var/log/datadog/process-agent.log
 


### PR DESCRIPTION
### What does this PR do?

This commit creates separate delivery queues for each intake endpoint.  As of now, this means that there will be a separate queue for pod payloads and one for process/container/rt/network checks.

### Motivation

PROC-314

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
