### PR TITLE
[aggregator] use const defined strings for Agent name and introduce the IoT agent

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -114,9 +114,17 @@ var checkCmd = &cobra.Command{
 			return err
 		}
 
+		// is this instance running as an iot agent
+		var iotAgent bool = config.Datadog.GetBool("iot_host")
+
+		agentName := aggregator.AgentName
+		if iotAgent {
+			agentName = aggregator.IotAgentName
+		}
+
 		s := serializer.NewSerializer(common.Forwarder)
 		// Initializing the aggregator with a flush interval of 0 (which disable the flush goroutine)
-		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, "agent", 0)
+		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, agentName, 0)
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 
 		if config.Datadog.GetBool("inventories_enabled") {

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -231,6 +231,9 @@ func StartAgent() error {
 		}
 	}
 
+	// is this instance running as an iot agent
+	var iotAgent bool = config.Datadog.GetBool("iot_host")
+
 	// start the GUI server
 	guiPort := config.Datadog.GetString("GUI_port")
 	if guiPort == "-1" {
@@ -249,9 +252,14 @@ func StartAgent() error {
 	common.Forwarder.Start()
 	log.Debugf("Forwarder started")
 
+	agentName := "agent"
+	if iotAgent {
+		agentName = "iot_agent"
+	}
+
 	// setup the aggregator
 	s := serializer.NewSerializer(common.Forwarder)
-	agg := aggregator.InitAggregator(s, hostname, "agent")
+	agg := aggregator.InitAggregator(s, hostname, agentName)
 	agg.AddAgentStartupTelemetry(version.AgentVersion)
 
 	// start dogstatsd

--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -165,7 +165,7 @@ func run(cmd *cobra.Command, args []string) error {
 	f.Start()
 	s := serializer.NewSerializer(f)
 
-	aggregatorInstance := aggregator.InitAggregator(s, hostname, "cluster_agent")
+	aggregatorInstance := aggregator.InitAggregator(s, hostname, aggregator.ClusterAgentName)
 	aggregatorInstance.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Cluster Agent", version.AgentVersion))
 
 	log.Infof("Datadog Cluster Agent is now running.")

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -170,7 +170,7 @@ func start(cmd *cobra.Command, args []string) error {
 	f.Start()
 	s := serializer.NewSerializer(f)
 
-	aggregatorInstance := aggregator.InitAggregator(s, hostname, "cluster_agent")
+	aggregatorInstance := aggregator.InitAggregator(s, hostname, aggregator.ClusterAgentName)
 	aggregatorInstance.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Cluster Agent", version.AgentVersion))
 
 	log.Infof("Datadog Cluster Agent is now running.")

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -203,7 +203,7 @@ func runAgent() (mainCtx context.Context, mainCtxCancel context.CancelFunc, err 
 		tagger.Init()
 	}
 
-	aggregatorInstance := aggregator.InitAggregator(s, hname, "agent")
+	aggregatorInstance := aggregator.InitAggregator(s, hname, aggregator.AgentName)
 	statsd, err = dogstatsd.NewServer(aggregatorInstance)
 	if err != nil {
 		log.Criticalf("Unable to start dogstatsd: %s", err)

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -152,7 +152,7 @@ func start(cmd *cobra.Command, args []string) error {
 	f.Start()
 	s := serializer.NewSerializer(f)
 
-	aggregatorInstance := aggregator.InitAggregator(s, hostname, "security_agent")
+	aggregatorInstance := aggregator.InitAggregator(s, hostname, aggregator.SecurityAgentName)
 	aggregatorInstance.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Security Agent", version.AgentVersion))
 
 	complianceEnabled := config.Datadog.GetBool("compliance_config.enabled")

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -44,6 +44,17 @@ var (
 	stateError = "error"
 )
 
+const (
+	// AgentName is the default agent name
+	AgentName = "agent"
+	// IotAgentName is the name for an IoT instance of the Agent
+	IotAgentName = "iot_agent"
+	// ClusterAgentName is the Cluster Agent name
+	ClusterAgentName = "cluster_agent"
+	// SecurityAgentName is the Security Agent name
+	SecurityAgentName = "security_agent"
+)
+
 func (s *Stats) add(stat int64) {
 	s.m.Lock()
 	defer s.m.Unlock()

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -27,7 +27,7 @@ var checkID2 check.ID = "2"
 func TestRegisterCheckSampler(t *testing.T) {
 	resetAggregator()
 
-	agg := InitAggregator(nil, "", "agent")
+	agg := InitAggregator(nil, "", AgentName)
 	err := agg.registerSender(checkID1)
 	assert.Nil(t, err)
 	assert.Len(t, aggregatorInstance.checkSamplers, 1)
@@ -44,7 +44,7 @@ func TestRegisterCheckSampler(t *testing.T) {
 func TestDeregisterCheckSampler(t *testing.T) {
 	resetAggregator()
 
-	agg := InitAggregator(nil, "", "agent")
+	agg := InitAggregator(nil, "", AgentName)
 	agg.registerSender(checkID1)
 	agg.registerSender(checkID2)
 	assert.Len(t, aggregatorInstance.checkSamplers, 2)
@@ -59,7 +59,7 @@ func TestDeregisterCheckSampler(t *testing.T) {
 
 func TestAddServiceCheckDefaultValues(t *testing.T) {
 	resetAggregator()
-	agg := InitAggregator(nil, "resolved-hostname", "agent")
+	agg := InitAggregator(nil, "resolved-hostname", AgentName)
 
 	agg.addServiceCheck(metrics.ServiceCheck{
 		// leave Host and Ts fields blank
@@ -88,7 +88,7 @@ func TestAddServiceCheckDefaultValues(t *testing.T) {
 
 func TestAddEventDefaultValues(t *testing.T) {
 	resetAggregator()
-	agg := InitAggregator(nil, "resolved-hostname", "agent")
+	agg := InitAggregator(nil, "resolved-hostname", AgentName)
 
 	agg.addEvent(metrics.Event{
 		// only populate required fields
@@ -134,7 +134,7 @@ func TestAddEventDefaultValues(t *testing.T) {
 
 func TestSetHostname(t *testing.T) {
 	resetAggregator()
-	agg := InitAggregator(nil, "hostname", "agent")
+	agg := InitAggregator(nil, "hostname", AgentName)
 	assert.Equal(t, "hostname", agg.hostname)
 	sender, err := GetSender(checkID1)
 	require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestSetHostname(t *testing.T) {
 func TestDefaultData(t *testing.T) {
 	resetAggregator()
 	s := &serializer.MockSerializer{}
-	agg := InitAggregator(s, "hostname", "agent")
+	agg := InitAggregator(s, "hostname", AgentName)
 	start := time.Now()
 
 	s.On("SendServiceChecks", metrics.ServiceChecks{{
@@ -185,7 +185,7 @@ func TestDefaultData(t *testing.T) {
 func TestRecurentSeries(t *testing.T) {
 	resetAggregator()
 	s := &serializer.MockSerializer{}
-	agg := NewBufferedAggregator(s, "hostname", "agent", DefaultFlushInterval)
+	agg := NewBufferedAggregator(s, "hostname", AgentName, DefaultFlushInterval)
 
 	// Add two recurrentSeries
 	AddRecurrentSeries(&metrics.Serie{


### PR DESCRIPTION
### What does this PR do?

We're sending different metrics for running / started Agent depending of the type of instance running (Cluster Agent, Agent, etc.).
This PR is removing static strings here and there in the code to use centralized declared const strings and is introducing the IoT Agent entry.

### Describe your test plan

Validate that when the `iot_host` flag is set, the `datadog.iot_agent.running` metric is emitted.