### PR TITLE
Adds install info with Chocolatey

### DIFF
--- a/chocolatey/tools-offline/chocolateyinstall.ps1
+++ b/chocolatey/tools-offline/chocolateyinstall.ps1
@@ -22,10 +22,11 @@ $packageArgs = @{
 }
 Install-ChocolateyInstallPackage @packageArgs
 
-$installInfo = @"
-tool: chocolatey
-tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)
-installer_version: chocolatey-$($env:chocolateyPackageVersion)-offline
+$installInfo = @"---
+install_method:
+  tool: chocolatey
+  tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)
+  installer_version: chocolatey-$($env:chocolateyPackageVersion)-offline
 "@
 
 Out-File -FilePath C:\ProgramData\Datadog\install_info -InputObject $installInfo

--- a/chocolatey/tools-offline/chocolateyinstall.ps1
+++ b/chocolatey/tools-offline/chocolateyinstall.ps1
@@ -25,7 +25,7 @@ Install-ChocolateyInstallPackage @packageArgs
 $installInfo = @"
 tool: chocolatey
 tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)
-installer_version: $($env:chocolateyPackageVersion)-offline
+installer_version: chocolatey-$($env:chocolateyPackageVersion)-offline
 "@
 
 Out-File -FilePath C:\ProgramData\Datadog\install_info -InputObject $installInfo

--- a/chocolatey/tools-offline/chocolateyinstall.ps1
+++ b/chocolatey/tools-offline/chocolateyinstall.ps1
@@ -21,3 +21,11 @@ $packageArgs = @{
   validExitCodes= @(0, 3010, 1641)
 }
 Install-ChocolateyInstallPackage @packageArgs
+
+$installInfo = @"
+tool: chocolatey
+tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)
+installer_version: $($env:chocolateyPackageVersion)-offline
+"@
+
+Out-File -FilePath C:\ProgramData\Datadog\install_info -InputObject $installInfo

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -17,10 +17,11 @@ $packageArgs = @{
 }
 Install-ChocolateyPackage @packageArgs
 
-$installInfo = @"
-tool: chocolatey
-tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)
-installer_version: chocolatey-$($env:chocolateyPackageVersion)-online
+$installInfo = @"---
+install_method:
+  tool: chocolatey
+  tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)
+  installer_version: chocolatey-$($env:chocolateyPackageVersion)-online
 "@
 
 Out-File -FilePath C:\ProgramData\Datadog\install_info -InputObject $installInfo

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -20,7 +20,7 @@ Install-ChocolateyPackage @packageArgs
 $installInfo = @"
 tool: chocolatey
 tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)
-installer_version: $($env:chocolateyPackageVersion)-online
+installer_version: chocolatey-$($env:chocolateyPackageVersion)-online
 "@
 
 Out-File -FilePath C:\ProgramData\Datadog\install_info -InputObject $installInfo

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -16,3 +16,11 @@ $packageArgs = @{
   validExitCodes= @(0, 3010, 1641)
 }
 Install-ChocolateyPackage @packageArgs
+
+$installInfo = @"
+tool: chocolatey
+tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)
+installer_version: $($env:chocolateyPackageVersion)-online
+"@
+
+Out-File -FilePath C:\ProgramData\Datadog\install_info -InputObject $installInfo

--- a/releasenotes/notes/Adds-Chocolatey-installation-information-1ee3980f1dc714c5.yaml
+++ b/releasenotes/notes/Adds-Chocolatey-installation-information-1ee3980f1dc714c5.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When installing the Agent using Chocolatey,
+    information about the installation is saved for
+    diagnostic and telemetry purposes.


### PR DESCRIPTION
### What does this PR do?

- Creates `install_info` file when installing using Chocolatey, adding information about the Chocolatey version, Agent version and whether it was an online or offline install.

### Motivation

- Allow users to track their installation methods
- Allows Datadog to make stats on installation methods

### Additional Notes

The installer version includes whether the online/offline version of the Chocolatey installer was used. If this setup is temporary we should think if this information is really needed and what is the best way to present it.

### Describe your test plan

Tested that the file was created during installation and contained the relevant information using the [Chocolatey test environment](https://github.com/chocolatey-community/chocolatey-test-environment).