### PR TITLE
Collect JMX metrics via Dogstatsd

### DIFF
--- a/cmd/agent/app/standalone/jmx.go
+++ b/cmd/agent/app/standalone/jmx.go
@@ -27,28 +27,18 @@ func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel str
 	return execJmxCommand(command, selectedChecks, jmxfetch.ReporterConsole, log.Info, logLevel)
 }
 
-// ExecJmxListWithMetricsJSON runs the JMX command with "with-metrics", reporting
-// the data as a JSON on the console. It is used by the `check jmx` cli command
-// of the Agent.
+// ExecJmxListWithMetricsStatsd runs the JMX command with "with-metrics".
+// It is used by the `check jmx` cli command of the Agent.
 // The common utils, including AutoConfig, must have already been initialized.
-func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string) error {
-	// don't pollute the JSON with the log pattern.
-	out := func(a ...interface{}) {
-		fmt.Println(a...)
-	}
-	return execJmxCommand("list_with_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel)
+func ExecJmxListWithMetricsStatsd(selectedChecks []string, logLevel string) error {
+	return execJmxCommand("list_with_metrics", selectedChecks, jmxfetch.ReporterStatsd, log.Info, logLevel)
 }
 
-// ExecJmxListWithRateMetricsJSON runs the JMX command with "with-rate-metrics", reporting
-// the data as a JSON on the console. It is used by the `check jmx --rate` cli command
-// of the Agent.
+// ExecJmxListWithRateMetricsStatsd runs the JMX command with "with-rate-metrics".
+// It is used by the `check jmx --rate` cli command of the Agent.
 // The common utils, including AutoConfig, must have already been initialized.
-func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string) error {
-	// don't pollute the JSON with the log pattern.
-	out := func(a ...interface{}) {
-		fmt.Println(a...)
-	}
-	return execJmxCommand("list_with_rate_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel)
+func ExecJmxListWithRateMetricsStatsd(selectedChecks []string, logLevel string) error {
+	return execJmxCommand("list_with_rate_metrics", selectedChecks, jmxfetch.ReporterStatsd, log.Info, logLevel)
 }
 
 // execJmxCommand runs the provided JMX command name on the selected checks.

--- a/cmd/agent/app/standalone/jmx_nojmx.go
+++ b/cmd/agent/app/standalone/jmx_nojmx.go
@@ -14,12 +14,12 @@ func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel str
 	return fmt.Errorf("not supported: the Agent is compiled without the 'jmx' build tag")
 }
 
-// ExecJmxListWithMetricsJSON is not supported when the 'jmx' build tag isn't included
-func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string) error {
+// ExecJmxListWithMetricsStatsd is not supported when the 'jmx' build tag isn't included
+func ExecJmxListWithMetricsStatsd(selectedChecks []string, logLevel string) error {
 	return fmt.Errorf("not supported: the Agent is compiled without the 'jmx' build tag")
 }
 
-// ExecJmxListWithRateMetricsJSON is not supported when the 'jmx' build tag isn't included
-func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string) error {
+// ExecJmxListWithRateMetricsStatsd is not supported when the 'jmx' build tag isn't included
+func ExecJmxListWithRateMetricsStatsd(selectedChecks []string, logLevel string) error {
 	return fmt.Errorf("not supported: the Agent is compiled without the 'jmx' build tag")
 }


### PR DESCRIPTION
[Sandbox PR](https://github.com/DataDog/datadog-agent/pull/5372)

### What does this PR do?

The goal of this PR is to collect `metrics` and `service checks` from Dogstatsd instead of JMX Json Reporter.

To achieve that, when running `agent check`, we need to tell JMX to send the the metrics and service checks to the StatsD Reporter instead of the JSON Reporter.

To do so, we also need be able to call `list_with_metrics` and `list_with_rate_metrics` with StasD Reporter.

### Motivation

`agent check` json output is used for integrations e2e testing and the expected metrics is `in-app` metric types. But currently, the metric types reported for JMX integrations correspond to JMX types (output of JMX Reporter). 

That makes it harder to test metrics types of JMX integrations. Examples:
- https://github.com/DataDog/integrations-core/blob/dc5d740cf4f6d374ae219b7be9c11a9457c0ef10/solr/tests/test_check.py#L23-L24
- https://github.com/DataDog/integrations-core/blob/1f235f8a24329dba31287031e012b3918037981b/activemq/tests/test_check.py#L22-L23

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
