### PR TITLE
Adds installation information to Agent's flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -241,6 +241,11 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 		log.Errorf("Could not zip logs: %s", err)
 	}
 
+	err = zipInstallInfo(tempDir, hostname)
+	if err != nil {
+		log.Errorf("Could not zip install_info: %s", err)
+	}
+
 	// gets files infos and write the permissions.log file
 	if err := permsInfos.commit(tempDir, hostname, os.ModePerm); err != nil {
 		log.Errorf("Could not write permissions.log file: %s", err)
@@ -539,6 +544,30 @@ func zipHealth(tempDir, hostname string) error {
 	defer w.Close()
 
 	_, err = w.Write(yamlValue)
+	return err
+}
+
+func zipInstallInfo(tempDir, hostname string) error {
+	originalPath := filepath.Join(config.FileUsedDir(), "install_info")
+	original, err := os.Open(originalPath)
+	if err != nil {
+		return err
+	}
+	defer original.Close()
+
+	zippedPath := filepath.Join(tempDir, hostname, "install_info")
+	err = ensureParentDirsExist(zippedPath)
+	if err != nil {
+		return err
+	}
+
+	zipped, err := os.OpenFile(zippedPath, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer zipped.Close()
+
+	_, err = io.Copy(zipped, original)
 	return err
 }
 

--- a/releasenotes/notes/Adds-installation-information-to-flare-36aeffc06b8f4db7.yaml
+++ b/releasenotes/notes/Adds-installation-information-to-flare-36aeffc06b8f4db7.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Agent's flare now includes information about the method used
+    to install the Agent.


### PR DESCRIPTION
### What does this PR do?

Adds a new file to the Agent's flare that will contain metadata about agent installation.

### Motivation

- Allow users to track their installation methods
- Allows Datadog to make stats on installation methods

### Additional Notes

The `install_info` file added to the flare by this PR is not yet created by the different installation methods, so it should be manually created at the Agent's configuration directory for testing.

### Describe your test plan

- Create a mock `install_info` file at the Agent's configuration directory
- Run the `agent flare` command to create a flare and check that a copy of the `install_info` file is available in the resulting zip.
- Delete the mock file and repeat the process to see that the flare is created correctly without that file. Ensure that the missing file error is logged.
