### PR TITLE
[profiling] enable profiling on the agent as a runtime setting

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -338,9 +338,13 @@ func setRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func getRuntimeConfigurableSettings(w http.ResponseWriter, r *http.Request) {
-	configurableSettings := make(map[string]string)
+
+	configurableSettings := make(map[string]settings.RuntimeSettingResponse)
 	for name, setting := range settings.RuntimeSettings() {
-		configurableSettings[name] = setting.Description()
+		configurableSettings[name] = settings.RuntimeSettingResponse{
+			Description: setting.Description(),
+			Hidden:      setting.Hidden(),
+		}
 	}
 	body, err := json.Marshal(configurableSettings)
 	if err != nil {

--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"html"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/app/settings"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -132,14 +133,16 @@ func listRuntimeConfigurableValue(cmd *cobra.Command, args []string) error {
 		}
 		return err
 	}
-	var settings = make(map[string]string)
+	var settings = make(map[string]settings.RuntimeSettingResponse)
 	err = json.Unmarshal(r, &settings)
 	if err != nil {
 		return err
 	}
 	fmt.Println("=== Settings that can be changed at runtime ===")
-	for setting, desc := range settings {
-		fmt.Printf("%s:\t\t\t%s\n", setting, desc)
+	for setting, details := range settings {
+		if !details.Hidden {
+			fmt.Printf("%s:\t\t\t%s\n", setting, details.Description)
+		}
 	}
 	return nil
 }

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -142,32 +142,10 @@ func StartAgent() error {
 	}
 
 	// Setup Profiling
-	// TODO: make this runtime configurable
 	if config.Datadog.GetBool("profiling.enabled") {
-		v, _ := version.Agent()
-
-		var s string
-		if config.Datadog.IsSet("site") {
-			s = config.Datadog.GetString("site")
-		} else {
-			s = config.DefaultSite
-		}
-		site := fmt.Sprintf("https://intake.profile.%s/v1/input", s)
-		if config.Datadog.IsSet("profiling.profile_dd_url") {
-			site = config.Datadog.GetString("profiling.profile_dd_url")
-		}
-
-		err := profiler.Start(
-			profiler.WithURL(site),
-			profiler.WithAPIKey(config.Datadog.GetString("api_key")),
-			profiler.WithService("agent"),
-			profiler.WithEnv(config.Datadog.GetString("env")),
-			profiler.WithTags(fmt.Sprintf("version:%v", v)),
-		)
+		err := config.SetRuntimeSetting("profiling", true)
 		if err != nil {
 			log.Errorf("Error starting profiler: %v", err)
-		} else {
-			log.Infof("Profiling started! Submitting to: %s", site)
 		}
 	}
 

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -141,14 +141,6 @@ func StartAgent() error {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
 
-	// Setup Profiling
-	if config.Datadog.GetBool("profiling.enabled") {
-		err := config.SetRuntimeSetting("profiling", true)
-		if err != nil {
-			log.Errorf("Error starting profiler: %v", err)
-		}
-	}
-
 	// Setup logger
 	if runtime.GOOS != "android" {
 		syslogURI := config.GetSyslogURI()
@@ -191,6 +183,14 @@ func StartAgent() error {
 	// init settings that can be changed at runtime
 	if err := settings.InitRuntimeSettings(); err != nil {
 		log.Warnf("Can't initiliaze the runtime settings: %v", err)
+	}
+
+	// Setup Profiling
+	if config.Datadog.GetBool("profiling.enabled") {
+		err := settings.SetRuntimeSetting("profiling", true)
+		if err != nil {
+			log.Errorf("Error starting profiler: %v", err)
+		}
 	}
 
 	// Setup expvar server

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -153,6 +153,9 @@ func StartAgent() error {
 			s = config.DefaultSite
 		}
 		site := fmt.Sprintf("https://intake.profile.%s/v1/input", s)
+		if config.Datadog.IsSet("profiling.profile_dd_url") {
+			site = config.Datadog.GetString("profiling.profile_dd_url")
+		}
 
 		err := profiler.Start(
 			profiler.WithURL(site),

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -144,7 +144,7 @@ func StartAgent() error {
 	// Setup Profiling
 	// TODO: make this runtime configurable
 	if config.Datadog.GetBool("profiling.enabled") {
-		v, _ := version.Agent()
+		// v, _ := version.Agent()
 
 		var s string
 		if config.Datadog.IsSet("site") {
@@ -162,7 +162,7 @@ func StartAgent() error {
 			profiler.WithAPIKey(config.Datadog.GetString("api_key")),
 			profiler.WithService("agent"),
 			profiler.WithEnv(config.Datadog.GetString("env")),
-			profiler.WithTags(fmt.Sprintf("version:%v", v)),
+			// profiler.WithTags(fmt.Sprintf("version:%v", v)),
 		)
 		if err != nil {
 			log.Errorf("Error starting profiler: %v", err)

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -145,7 +145,9 @@ func StartAgent() error {
 	// TODO: make this runtime configurable
 	if config.Datadog.GetBool("profiling.enabled") {
 		v, _ := version.Agent()
+		site := fmt.Sprintf("https://intake.profile.%s/v1/input", config.Datadog.GetString("site"))
 		err := profiler.Start(
+			profiler.WithURL(site),
 			profiler.WithAPIKey(config.Datadog.GetString("api_key")),
 			profiler.WithService("agent"),
 			profiler.WithEnv(config.Datadog.GetString("env")),

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -144,7 +144,7 @@ func StartAgent() error {
 	// Setup Profiling
 	// TODO: make this runtime configurable
 	if config.Datadog.GetBool("profiling.enabled") {
-		// v, _ := version.Agent()
+		v, _ := version.Agent()
 
 		var s string
 		if config.Datadog.IsSet("site") {
@@ -162,14 +162,13 @@ func StartAgent() error {
 			profiler.WithAPIKey(config.Datadog.GetString("api_key")),
 			profiler.WithService("agent"),
 			profiler.WithEnv(config.Datadog.GetString("env")),
-			// profiler.WithTags(fmt.Sprintf("version:%v", v)),
+			profiler.WithTags(fmt.Sprintf("version:%v", v)),
 		)
 		if err != nil {
 			log.Errorf("Error starting profiler: %v", err)
 		} else {
 			log.Infof("Profiling started! Submitting to: %s", site)
 		}
-		defer profiler.Stop()
 	}
 
 	// Setup logger
@@ -374,8 +373,11 @@ func StopAgent() {
 	if common.Forwarder != nil {
 		common.Forwarder.Stop()
 	}
+
 	logs.Stop()
 	gui.StopGUIServer()
+	profiler.Stop()
+
 	os.Remove(pidfilePath)
 	log.Info("See ya!")
 	log.Flush()

--- a/cmd/agent/app/settings/runtime_setting.go
+++ b/cmd/agent/app/settings/runtime_setting.go
@@ -38,7 +38,9 @@ func InitRuntimeSettings() error {
 	if err := registerRuntimeSetting(dsdStatsRuntimeSetting("dogstatsd_stats")); err != nil {
 		return err
 	}
-	return nil
+	if err := registerRuntimeSetting(logLevelRuntimeSetting("profiling")); err != nil {
+		return nil
+	}
 }
 
 // RegisterRuntimeSettings keeps track of configurable settings

--- a/cmd/agent/app/settings/runtime_setting.go
+++ b/cmd/agent/app/settings/runtime_setting.go
@@ -38,7 +38,7 @@ func InitRuntimeSettings() error {
 	if err := registerRuntimeSetting(dsdStatsRuntimeSetting("dogstatsd_stats")); err != nil {
 		return err
 	}
-	if err := registerRuntimeSetting(logLevelRuntimeSetting("profiling")); err != nil {
+	if err := registerRuntimeSetting(profilingRuntimeSetting("profiling")); err != nil {
 		return err
 	}
 

--- a/cmd/agent/app/settings/runtime_setting.go
+++ b/cmd/agent/app/settings/runtime_setting.go
@@ -39,7 +39,7 @@ func InitRuntimeSettings() error {
 		return err
 	}
 	if err := registerRuntimeSetting(logLevelRuntimeSetting("profiling")); err != nil {
-		return nil
+		return err
 	}
 }
 

--- a/cmd/agent/app/settings/runtime_setting.go
+++ b/cmd/agent/app/settings/runtime_setting.go
@@ -41,6 +41,8 @@ func InitRuntimeSettings() error {
 	if err := registerRuntimeSetting(logLevelRuntimeSetting("profiling")); err != nil {
 		return err
 	}
+
+	return nil
 }
 
 // RegisterRuntimeSettings keeps track of configurable settings

--- a/cmd/agent/app/settings/runtime_setting.go
+++ b/cmd/agent/app/settings/runtime_setting.go
@@ -17,6 +17,12 @@ type SettingNotFoundError struct {
 	name string
 }
 
+// RuntimeSettingResponse is used to communicate settings config
+type RuntimeSettingResponse struct {
+	Description string
+	Hidden      bool
+}
+
 func (e *SettingNotFoundError) Error() string {
 	return fmt.Sprintf("setting %s not found", e.name)
 }
@@ -27,6 +33,7 @@ type RuntimeSetting interface {
 	Set(v interface{}) error
 	Name() string
 	Description() string
+	Hidden() bool
 }
 
 // InitRuntimeSettings builds the map of runtime settings configurable at runtime.

--- a/cmd/agent/app/settings/runtime_setting_dogstatsd_stats.go
+++ b/cmd/agent/app/settings/runtime_setting_dogstatsd_stats.go
@@ -20,6 +20,10 @@ func (s dsdStatsRuntimeSetting) Description() string {
 	return "Enable/disable the dogstatsd debug stats. Possible values: true, false"
 }
 
+func (s dsdStatsRuntimeSetting) Hidden() bool {
+	return false
+}
+
 func (s dsdStatsRuntimeSetting) Name() string {
 	return string(s)
 }

--- a/cmd/agent/app/settings/runtime_setting_log_level.go
+++ b/cmd/agent/app/settings/runtime_setting_log_level.go
@@ -17,6 +17,10 @@ func (l logLevelRuntimeSetting) Description() string {
 	return "Set/get the log level, valid values are: trace, debug, info, warn, error, critical and off"
 }
 
+func (l logLevelRuntimeSetting) Hidden() bool {
+	return false
+}
+
 func (l logLevelRuntimeSetting) Name() string {
 	return string(l)
 }

--- a/cmd/agent/app/settings/runtime_setting_profiling.go
+++ b/cmd/agent/app/settings/runtime_setting_profiling.go
@@ -3,12 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-package config
+package settings
 
 import (
 	"fmt"
 	"strconv"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -25,7 +26,7 @@ func (l profilingRuntimeSetting) Name() string {
 }
 
 func (l profilingRuntimeSetting) Get() (interface{}, error) {
-	return Datadog.GetBool("profiling.enabled"), nil
+	return config.Datadog.GetBool("profiling.enabled"), nil
 }
 
 func (l profilingRuntimeSetting) Set(v interface{}) error {
@@ -46,31 +47,31 @@ func (l profilingRuntimeSetting) Set(v interface{}) error {
 
 	if profile {
 		// populate site
-		s := DefaultSite
-		if Datadog.IsSet("site") {
-			s = Datadog.GetString("site")
+		s := config.DefaultSite
+		if config.Datadog.IsSet("site") {
+			s = config.Datadog.GetString("site")
 		}
 
 		// allow full url override for development use
 		site := fmt.Sprintf(profiling.ProfileURLTemplate, s)
-		if Datadog.IsSet("profiling.profile_dd_url") {
-			site = Datadog.GetString("profiling.profile_dd_url")
+		if config.Datadog.IsSet("profiling.profile_dd_url") {
+			site = config.Datadog.GetString("profiling.profile_dd_url")
 		}
 
 		v, _ := version.Agent()
 		err := profiling.Start(
-			Datadog.GetString("api_key"),
+			config.Datadog.GetString("api_key"),
 			site,
-			Datadog.GetString("env"),
+			config.Datadog.GetString("env"),
 			profiling.ProfileCoreService,
 			fmt.Sprintf("version:%v", v),
 		)
 		if err == nil {
-			Datadog.Set("profiling.enabled", true)
+			config.Datadog.Set("profiling.enabled", true)
 		}
 	} else {
 		profiling.Stop()
-		Datadog.Set("profiling.enabled", false)
+		config.Datadog.Set("profiling.enabled", false)
 	}
 
 	return nil

--- a/cmd/agent/app/settings/runtime_setting_profiling.go
+++ b/cmd/agent/app/settings/runtime_setting_profiling.go
@@ -7,7 +7,6 @@ package settings
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
@@ -19,6 +18,10 @@ type profilingRuntimeSetting string
 
 func (l profilingRuntimeSetting) Description() string {
 	return "Enable/disable profiling on the agent, valid values are: true, false"
+}
+
+func (l profilingRuntimeSetting) Hidden() bool {
+	return true
 }
 
 func (l profilingRuntimeSetting) Name() string {
@@ -33,16 +36,10 @@ func (l profilingRuntimeSetting) Set(v interface{}) error {
 	var profile bool
 	var err error
 
-	switch p := v.(type) {
-	case bool:
-		profile = p
-	case string:
-		profile, err = strconv.ParseBool(p)
-		if err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("Unsupported type for profile runtime setting")
+	profile, err = getBool(v)
+
+	if err != nil {
+		return fmt.Errorf("Unsupported type for profile runtime setting: %v", err)
 	}
 
 	if profile {

--- a/cmd/agent/app/settings/runtime_settings_test.go
+++ b/cmd/agent/app/settings/runtime_settings_test.go
@@ -6,6 +6,7 @@
 package settings
 
 import (
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -37,6 +38,12 @@ func (t *runtimeTestSetting) Get() (interface{}, error) {
 func (t *runtimeTestSetting) Set(v interface{}) error {
 	t.value = v.(int)
 	return nil
+}
+
+func setupConf() config.Config {
+	conf := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	config.InitConfig(conf)
+	return conf
 }
 
 func cleanRuntimeSetting() {

--- a/cmd/agent/app/settings/runtime_settings_test.go
+++ b/cmd/agent/app/settings/runtime_settings_test.go
@@ -155,3 +155,21 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(v, true)
 }
+
+func TestProfiling(t *testing.T) {
+	cleanRuntimeSetting()
+	setupConf()
+
+	ll := profilingRuntimeSetting("profiling")
+	assert.Equal(t, "profiling", ll.Name())
+
+	err := ll.Set("false")
+	assert.Nil(t, err)
+
+	v, err := ll.Get()
+	assert.Equal(t, false, v)
+	assert.Nil(t, err)
+
+	err = ll.Set("on")
+	assert.NotNil(t, err)
+}

--- a/cmd/agent/app/settings/runtime_settings_test.go
+++ b/cmd/agent/app/settings/runtime_settings_test.go
@@ -40,6 +40,10 @@ func (t *runtimeTestSetting) Set(v interface{}) error {
 	return nil
 }
 
+func (t *runtimeTestSetting) Hidden() bool {
+	return false
+}
+
 func setupConf() config.Config {
 	conf := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	config.InitConfig(conf)

--- a/go.mod
+++ b/go.mod
@@ -141,6 +141,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	gomodules.xyz/jsonpatch/v3 v3.0.1
 	google.golang.org/grpc v1.27.1
+	gopkg.in/DataDog/dd-trace-go.v1 v1.23.1
 	gopkg.in/Knetic/govaluate.v3 v3.0.0 // indirect
 	gopkg.in/ini.v1 v1.55.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -1630,23 +1630,18 @@ google.golang.org/genproto v0.0.0-20200305110556-506484158171 h1:xes2Q2k+d/+YNXV
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
-<<<<<<< HEAD
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
-=======
 gopkg.in/DataDog/dd-trace-go.v1 v1.23.1 h1:WwxQG9Sk+kcW/vepd1zFrRZUTzJHoYL/Cl0ArmMlVXo=
 gopkg.in/DataDog/dd-trace-go.v1 v1.23.1/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
->>>>>>> 26cc5f7af... [profiling] add profiling to the agent
 gopkg.in/Knetic/govaluate.v3 v3.0.0 h1:18mUyIt4ZlRlFZAAfVetz4/rzlJs9yhN+U02F4u1AOc=
 gopkg.in/Knetic/govaluate.v3 v3.0.0/go.mod h1:csKLBORsPbafmSCGTEh3U7Ozmsuq8ZSIlKk1bcqph0E=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/gcfg.v1 v1.2.0/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
@@ -1661,7 +1656,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.55.0 h1:E8yzL5unfpW3M6fz/eB7Cb5MQAYSZ7GKo4Qth+N2sgQ=
 gopkg.in/ini.v1 v1.55.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mcuadros/go-syslog.v2 v2.2.1/go.mod h1:l5LPIyOOyIdQquNg+oU6Z3524YwrcqEm0aKH+5zpt2U=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
@@ -1671,7 +1665,6 @@ gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473/go.mod h1:N1eN2tsCx
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.0.0-20180411045311-89060dee6a84/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.1/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
@@ -1693,7 +1686,6 @@ gopkg.in/yaml.v3 v3.0.0-20200506231410-2ff61e1afc86/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/zorkian/go-datadog-api.v2 v2.29.0 h1:S4AsWFkQ6JDG7WZfYk6C3EggsO/4IvGUsCfz7I3zjPk=
 gopkg.in/zorkian/go-datadog-api.v2 v2.29.0/go.mod h1:kx0CSMRpzEZfx/nFH62GLU4stZjparh/BRpM89t4XCQ=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/gotestsum v0.3.5/go.mod h1:Mnf3e5FUzXbkCfynWBGOwLssY7gTQgCHObK9tMpAriY=
 helm.sh/helm/v3 v3.1.0/go.mod h1:WYsFJuMASa/4XUqLyv54s0U/f3mlAaRErGmyy4z921g=
@@ -1703,7 +1695,6 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.2/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.0.0-20191016110408-35e52d86657a h1:VVUE9xTCXP6KUPMf92cQmN88orz600ebexcRRaBTepQ=

--- a/go.sum
+++ b/go.sum
@@ -1630,7 +1630,12 @@ google.golang.org/genproto v0.0.0-20200305110556-506484158171 h1:xes2Q2k+d/+YNXV
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+<<<<<<< HEAD
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
+=======
+gopkg.in/DataDog/dd-trace-go.v1 v1.23.1 h1:WwxQG9Sk+kcW/vepd1zFrRZUTzJHoYL/Cl0ArmMlVXo=
+gopkg.in/DataDog/dd-trace-go.v1 v1.23.1/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
+>>>>>>> 26cc5f7af... [profiling] add profiling to the agent
 gopkg.in/Knetic/govaluate.v3 v3.0.0 h1:18mUyIt4ZlRlFZAAfVetz4/rzlJs9yhN+U02F4u1AOc=
 gopkg.in/Knetic/govaluate.v3 v3.0.0/go.mod h1:csKLBORsPbafmSCGTEh3U7Ozmsuq8ZSIlKk1bcqph0E=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -128,11 +128,11 @@ func init() {
 	// Configure Datadog global configuration
 	Datadog = NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	// Configuration defaults
-	initConfig(Datadog)
+	InitConfig(Datadog)
 }
 
-// initConfig initializes the config defaults on a config
-func initConfig(config Config) {
+// InitConfig initializes the config defaults on a config
+func InitConfig(config Config) {
 	// Agent
 	// Don't set a default on 'site' to allow detecting with viper whether it's set in config
 	config.BindEnv("site")   //nolint:errcheck

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -474,7 +474,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("expvar_port", "5000")
 
 	// Profiling
-	config.BindEnvAndSetDefault("profiling.enabled", true)
+	config.BindEnvAndSetDefault("profiling.enabled", false)
 
 	// Trace agent
 	// Note that trace-agent environment variables are parsed in pkg/trace/config/env.go

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -475,7 +475,7 @@ func InitConfig(config Config) {
 
 	// Profiling
 	config.BindEnvAndSetDefault("profiling.enabled", false)
-	config.BindEnv("profiling.profile_dd_url")
+	config.BindEnv("profiling.profile_dd_url", "") //nolint:errcheck
 
 	// Trace agent
 	// Note that trace-agent environment variables are parsed in pkg/trace/config/env.go

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -473,6 +473,9 @@ func initConfig(config Config) {
 	// Go_expvar server port
 	config.BindEnvAndSetDefault("expvar_port", "5000")
 
+	// Profiling
+	config.BindEnvAndSetDefault("profiling.enabled", true)
+
 	// Trace agent
 	// Note that trace-agent environment variables are parsed in pkg/trace/config/env.go
 	// since some of them require custom parsing algorithms. DO NOT add environment variable

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -475,6 +475,7 @@ func initConfig(config Config) {
 
 	// Profiling
 	config.BindEnvAndSetDefault("profiling.enabled", false)
+	config.BindEnv("profiling.profile_dd_url")
 
 	// Trace agent
 	// Note that trace-agent environment variables are parsed in pkg/trace/config/env.go

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -546,7 +546,21 @@ api_key:
     #
     # ad_identifier: snmp
 
+{{- if .Profiling -}}
+## @param profiling - custom object - optional
+## Enter specific configurations for profiling.
+## Uncomment this parameter and the one below to enable them.
+#
+# profiling:
+#
+  ## @param enabled - boolean - optional - default: false
+  ## Enable profiling for the agent process
+  #
+  # enabled: false
+
+{{ end }}
 {{ end -}}
+
 {{- if .LogsAgent }}
 
 ##################################

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -549,7 +549,7 @@ api_key:
 {{- if .Profiling -}}
 ## @param profiling - custom object - optional
 ## Enter specific configurations for profiling.
-## Uncomment this parameter and the one below to enable them.
+## Uncomment this parameter and the one below to enable profiling.
 #
 # profiling:
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -554,7 +554,7 @@ api_key:
 # profiling:
 #
   ## @param enabled - boolean - optional - default: false
-  ## Enable profiling for the agent process
+  ## Enable profiling for the Agent process.
   #
   # enabled: false
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -550,6 +550,11 @@ api_key:
 ## @param profiling - custom object - optional
 ## Enter specific configurations for profiling.
 ## Uncomment this parameter and the one below to enable profiling.
+## See https://docs.datadoghq.com/tracing/profiling/
+#
+## NOTE: If enabled this option may incur in billing charges or other
+##       unexpected side-effects (ie. agent profiles showing with your
+##       services).
 #
 # profiling:
 #

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,7 @@ import (
 
 func setupConf() Config {
 	conf := NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
-	initConfig(conf)
+	InitConfig(conf)
 	return conf
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,8 +23,7 @@ func setupConf() Config {
 }
 
 func setupConfFromYAML(yamlConfig string) Config {
-	conf := NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
-	initConfig(conf)
+	conf := setupConf()
 	conf.SetConfigType("yaml")
 	e := conf.ReadConfig(bytes.NewBuffer([]byte(yamlConfig)))
 	if e != nil {

--- a/pkg/config/legacy_converter.go
+++ b/pkg/config/legacy_converter.go
@@ -23,6 +23,6 @@ func NewConfigConverter() *LegacyConfigConverter {
 	// Configure Datadog global configuration
 	Datadog = NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	// Configuration defaults
-	initConfig(Datadog)
+	InitConfig(Datadog)
 	return &LegacyConfigConverter{Datadog}
 }

--- a/pkg/config/mock.go
+++ b/pkg/config/mock.go
@@ -22,6 +22,6 @@ func Mock() *MockConfig {
 	// Configure Datadog global configuration
 	Datadog = NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	// Configuration defaults
-	initConfig(Datadog)
+	InitConfig(Datadog)
 	return &MockConfig{Datadog}
 }

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -22,6 +22,7 @@ type context struct {
 	Python            bool // Sub-option of Agent
 	BothPythonPresent bool // Sub-option of Agent - Python
 	Metadata          bool
+	Profiling         bool
 	Dogstatsd         bool
 	LogsAgent         bool
 	JMX               bool
@@ -50,6 +51,7 @@ func mkContext(buildType string) context {
 		Agent:             true,
 		Python:            true,
 		Metadata:          true,
+		Profiling:         true,
 		Dogstatsd:         true,
 		LogsAgent:         true,
 		JMX:               true,

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -51,7 +51,7 @@ func mkContext(buildType string) context {
 		Agent:             true,
 		Python:            true,
 		Metadata:          true,
-		Profiling:         true,
+		Profiling:         false, // NOTE: hidden for now
 		Dogstatsd:         true,
 		LogsAgent:         true,
 		JMX:               true,

--- a/pkg/config/runtime_setting_profiling.go
+++ b/pkg/config/runtime_setting_profiling.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -16,7 +17,7 @@ import (
 type profilingRuntimeSetting string
 
 func (l profilingRuntimeSetting) Description() string {
-	return "Enable/disable profiling on the agent, valid values are: enabled, disabled, true, false, on or off"
+	return "Enable/disable profiling on the agent, valid values are: true, false"
 }
 
 func (l profilingRuntimeSetting) Name() string {
@@ -28,7 +29,21 @@ func (l profilingRuntimeSetting) Get() (interface{}, error) {
 }
 
 func (l profilingRuntimeSetting) Set(v interface{}) error {
-	profile := v.(bool)
+	var profile bool
+	var err error
+
+	switch p := v.(type) {
+	case bool:
+		profile = p
+	case string:
+		profile, err = strconv.ParseBool(p)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("Unsupported type for profile runtime setting")
+	}
+
 	if profile {
 		// populate site
 		s := DefaultSite

--- a/pkg/config/runtime_setting_profiling.go
+++ b/pkg/config/runtime_setting_profiling.go
@@ -1,0 +1,62 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// profilingRuntimeSetting wraps operations to change log level at runtime
+type profilingRuntimeSetting string
+
+func (l profilingRuntimeSetting) Description() string {
+	return "Enable/disable profiling on the agent, valid values are: enabled, disabled, true, false, on or off"
+}
+
+func (l profilingRuntimeSetting) Name() string {
+	return string(l)
+}
+
+func (l profilingRuntimeSetting) Get() (interface{}, error) {
+	return Datadog.GetBool("profiling.enabled"), nil
+}
+
+func (l profilingRuntimeSetting) Set(v interface{}) error {
+	profile := v.(bool)
+	if profile {
+		// populate site
+		s := DefaultSite
+		if Datadog.IsSet("site") {
+			s = Datadog.GetString("site")
+		}
+
+		// allow full url override for development use
+		site := fmt.Sprintf(profiling.ProfileURLTemplate, s)
+		if Datadog.IsSet("profiling.profile_dd_url") {
+			site = Datadog.GetString("profiling.profile_dd_url")
+		}
+
+		v, _ := version.Agent()
+		err := profiling.Start(
+			Datadog.GetString("api_key"),
+			site,
+			Datadog.GetString("env"),
+			Datadog.GetString("service"),
+			fmt.Sprintf("version:%v", v),
+		)
+		if err == nil {
+			Datadog.Set("profiling.enabled", true)
+		}
+	} else {
+		profiling.Stop()
+		Datadog.Set("profiling.enabled", false)
+	}
+
+	return nil
+}

--- a/pkg/config/runtime_setting_profiling.go
+++ b/pkg/config/runtime_setting_profiling.go
@@ -62,7 +62,7 @@ func (l profilingRuntimeSetting) Set(v interface{}) error {
 			Datadog.GetString("api_key"),
 			site,
 			Datadog.GetString("env"),
-			Datadog.GetString("service"),
+			profiling.ProfileCoreService,
 			fmt.Sprintf("version:%v", v),
 		)
 		if err == nil {

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -1,0 +1,63 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiling
+
+import (
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
+)
+
+var (
+	mu      sync.RWMutex
+	running bool
+)
+
+const (
+	ProfileURLTemplate = "https://intake.profile.%s/v1/input"
+)
+
+func Active() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	return running
+}
+
+func Start(api, site, env, service string, tags ...string) error {
+	if Active() {
+		return nil
+	}
+
+	err := profiler.Start(
+		profiler.WithAPIKey(api),
+		profiler.WithEnv(env),
+		profiler.WithService(service),
+		profiler.WithURL(site),
+		profiler.WithTags(tags...),
+	)
+	if err == nil {
+		mu.Lock()
+		defer mu.Unlock()
+
+		log.Debugf("Profiling started! Submitting to: %s", site)
+		running = true
+	}
+
+	return err
+}
+
+func Stop() {
+	if Active() {
+		mu.Lock()
+		defer mu.Unlock()
+
+		profiler.Stop()
+		running = false
+	}
+}

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -19,8 +19,10 @@ var (
 )
 
 const (
-	// ProfileURLTemplate constant template for expected profiling endpoint URL
+	// ProfileURLTemplate constant template for expected profiling endpoint URL.
 	ProfileURLTemplate = "https://intake.profile.%s/v1/input"
+	// ProfileCoreService default service for the core agent profiler.
+	ProfileCoreService = "datadog-agent"
 )
 
 // Active returns a boolean indicating whether profiling is active or not;

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -19,9 +19,12 @@ var (
 )
 
 const (
+	// ProfileURLTemplate constant template for expected profiling endpoint URL
 	ProfileURLTemplate = "https://intake.profile.%s/v1/input"
 )
 
+// Active returns a boolean indicating whether profiling is active or not;
+// this function is thread-safe.
 func Active() bool {
 	mu.RLock()
 	defer mu.RUnlock()
@@ -29,6 +32,8 @@ func Active() bool {
 	return running
 }
 
+// Start initiates profiling with the supplied parameters;
+// this function is thread-safe.
 func Start(api, site, env, service string, tags ...string) error {
 	if Active() {
 		return nil
@@ -52,6 +57,7 @@ func Start(api, site, env, service string, tags ...string) error {
 	return err
 }
 
+// Stop stops the profiler if running - idempotent; this function is thread-safe.
 func Stop() {
 	if Active() {
 		mu.Lock()

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -36,13 +36,13 @@ func Active() bool {
 
 // Start initiates profiling with the supplied parameters;
 // this function is thread-safe.
-func Start(api, site, env, service string, tags ...string) error {
+func Start(apiKey, site, env, service string, tags ...string) error {
 	if Active() {
 		return nil
 	}
 
 	err := profiler.Start(
-		profiler.WithAPIKey(api),
+		profiler.WithAPIKey(apiKey),
 		profiler.WithEnv(env),
 		profiler.WithService(service),
 		profiler.WithURL(site),

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -1,0 +1,28 @@
+/// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package profiling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProfiling(t *testing.T) {
+	err := Start(
+		"fake-api",
+		"https://nowhere.testing.dev",
+		"testing",
+		ProfileCoreService,
+		"1.0.0",
+	)
+	assert.Nil(t, err)
+
+	assert.True(t, Active())
+
+	Stop()
+	assert.False(t, Active())
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds profiling to the agent. It will typically be off by default but can be automatically started with a config entry (new section added, we can discuss if it's overkill), and can then be toggled as it has be designed a runtime option; we should also discuss if the option should be hidden.

### Motivation

The motivation is for better observability into process behavior and troubleshooting, typically an option that our customer will want disabled, but very useful for us.

### Additional Notes

This has been designed such that it may be easily used by other agents like trace, process, cluster-agent, etc. But please let me know if anything about the interface is unclear or cluttered.

### Describe your test plan

Tested locally working fine, will be tested on staging as soon as it is merged. The feature relies on `pprof` profiles so performance impact should be negligible given that these are already enabled.
