### PR TITLE
Fix system.swap.pct_free calculation on Windows

### DIFF
--- a/pkg/util/winutil/winmem.go
+++ b/pkg/util/winutil/winmem.go
@@ -136,7 +136,7 @@ func SwapMemory() (*SwapMemoryStat, error) {
 		Total:       tot,
 		Used:        used,
 		Free:        free,
-		UsedPercent: float64(used / tot),
+		UsedPercent: (float64(used) / float64(tot)) * 100,
 	}
 
 	return ret, nil

--- a/releasenotes/notes/fix-system-swap-pctfree-windows-ee795f5c2fbc308b.yaml
+++ b/releasenotes/notes/fix-system-swap-pctfree-windows-ee795f5c2fbc308b.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    On Windows, fix calculation of the system.swap.pct_free metric.
+    On Windows, fix calculation of the ``system.swap.pct_free`` metric.

--- a/releasenotes/notes/fix-system-swap-pctfree-windows-ee795f5c2fbc308b.yaml
+++ b/releasenotes/notes/fix-system-swap-pctfree-windows-ee795f5c2fbc308b.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, fix calculation of the system.swap.pct_free metric.


### PR DESCRIPTION
### What does this PR do?

Multiplies `used / tot` by 100 to calculate `SwapMemoryStat.UsedPercent` as a percentage between 0 and 100.

### Motivation

The `system.swap.pct_free` is computed by dividing `(100 - SwapMemoryStat.UsedPercent)` by 100 here: https://github.com/DataDog/datadog-agent/blob/e8a55e2f0417437e5e4edb50d0e5e1aea340eb33/pkg/collector/corechecks/system/memory_windows.go#L118. 

As `SwapMemoryStat.UsedPercent` was not calculated as a percentage but as a ratio between 0 and 1, `system.swap.pct_free` could only get values between 0.99 and 1.

### Describe your test plan

Install latest Agent on a Windows host, confirm that `system.swap.pct_free` is `1` even though `system.swap.free < system.swap.total` (8.5GB vs. 10GB)
Install Agent from this branch, `system.swap.pct_free` now displays the correct number (`0.84`).
