### PR TITLE
[process-agent] [system-probe] Configure additional endpoints via environment variables

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -416,6 +417,24 @@ func loadEnvVariables() {
 
 	if v := os.Getenv("DD_CUSTOM_SENSITIVE_WORDS"); v != "" {
 		config.Datadog.Set("process_config.custom_sensitive_words", strings.Split(v, ","))
+	}
+
+	if v := os.Getenv("DD_PROCESS_ADDITIONAL_ENDPOINTS"); v != "" {
+		endpoints := make(map[string][]string)
+		if err := json.Unmarshal([]byte(v), &endpoints); err != nil {
+			log.Errorf(`Could not parse DD_PROCESS_ADDITIONAL_ENDPOINTS: %v. It must be of the form '{"https://process.agent.datadoghq.com": ["apikey1", ...], ...}'.`, err)
+		} else {
+			config.Datadog.Set("process_config.additional_endpoints", endpoints)
+		}
+	}
+
+	if v := os.Getenv("DD_ORCHESTRATOR_ADDITIONAL_ENDPOINTS"); v != "" {
+		endpoints := make(map[string][]string)
+		if err := json.Unmarshal([]byte(v), &endpoints); err != nil {
+			log.Errorf(`Could not parse DD_ORCHESTRATOR_ADDITIONAL_ENDPOINTS: %v. It must be of the form '{"https://process.agent.datadoghq.com": ["apikey1", ...], ...}'.`, err)
+		} else {
+			config.Datadog.Set("process_config.orchestrator_additional_endpoints", endpoints)
+		}
 	}
 }
 

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -381,6 +381,60 @@ func TestEnvSiteConfig(t *testing.T) {
 	os.Unsetenv("DD_PROCESS_AGENT_URL")
 }
 
+func TestEnvProcessAdditionalEndpoints(t *testing.T) {
+	config.Datadog = config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	defer restoreGlobalConfig()
+
+	assert := assert.New(t)
+
+	expected := make(map[string]string)
+	expected["key1"] = "url1.com"
+	expected["key2"] = "url2.com"
+	expected["key3"] = "url2.com"
+	expected["apikey_20"] = "my-process-app.datadoghq.com" // from config file
+
+	os.Setenv("DD_PROCESS_ADDITIONAL_ENDPOINTS", `{"https://url1.com": ["key1"], "https://url2.com": ["key2", "key3"]}`)
+	defer os.Unsetenv("DD_PROCESS_ADDITIONAL_ENDPOINTS")
+
+	agentConfig, err := NewAgentConfig(
+		"test",
+		"./testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml",
+		"./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net.yaml",
+	)
+	assert.NoError(err)
+
+	for _, actual := range agentConfig.APIEndpoints {
+		assert.Equal(expected[actual.APIKey], actual.Endpoint.Hostname(), actual)
+	}
+}
+
+func TestEnvOrchestratorAdditionalEndpoints(t *testing.T) {
+	config.Datadog = config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	defer restoreGlobalConfig()
+
+	assert := assert.New(t)
+
+	expected := make(map[string]string)
+	expected["key1"] = "url1.com"
+	expected["key2"] = "url2.com"
+	expected["key3"] = "url2.com"
+	expected["apikey_20"] = "orchestrator.datadoghq.com" // from config file
+
+	os.Setenv("DD_ORCHESTRATOR_ADDITIONAL_ENDPOINTS", `{"https://url1.com": ["key1"], "https://url2.com": ["key2", "key3"]}`)
+	defer os.Unsetenv("DD_ORCHESTRATOR_ADDITIONAL_ENDPOINTS")
+
+	agentConfig, err := NewAgentConfig(
+		"test",
+		"./testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml",
+		"./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net.yaml",
+	)
+	assert.NoError(err)
+
+	for _, actual := range agentConfig.OrchestratorEndpoints {
+		assert.Equal(expected[actual.APIKey], actual.Endpoint.Hostname(), actual)
+	}
+}
+
 func TestIsAffirmative(t *testing.T) {
 	value, err := isAffirmative("yes")
 	assert.Nil(t, err)

--- a/releasenotes/notes/process-additional-endpoints-env-vars-1cd1e5cc796b41b3.yaml
+++ b/releasenotes/notes/process-additional-endpoints-env-vars-1cd1e5cc796b41b3.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Configure additional process and orchestrator endpoints by environment variable.


### PR DESCRIPTION
### What does this PR do?
[PROC-232](https://datadoghq.atlassian.net/browse/PROC-232)

See title. Additional endpoints should be accepted as JSON strings:
```json
{"https://endpoint1.com": ["apikey1", "apikey2"], "https://endpoint2.org": ["apikey3"]}
```

### Motivation

https://trello.com/c/otVR3Kxg/72-config-multiple-endpoints-as-env-vars

### Describe your test plan

I ran the agent with the following command and verified through logs that additional endpoints were added.

```bash
DD_PROCESS_ADDITIONAL_ENDPOINTS='{"http://process.endpoint.lol": ["key1"], "https://process.endpoint.wat": ["key2", "key3"]}' \
DD_ORCHESTRATOR_ADDITIONAL_ENDPOINTS='{"https://orch.endpoint.bbq": ["key4", "key5"], "http://orc.endpoint.lol": ["key6"]}' \
sudo -E ./bin/process-agent/process-agent
```