### PR TITLE
Improve AKS cluster name auto-detection

### DIFF
--- a/pkg/util/azure/azure.go
+++ b/pkg/util/azure/azure.go
@@ -6,7 +6,6 @@
 package azure
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -43,7 +42,8 @@ func GetHostAlias() (string, error) {
 	return res, nil
 }
 
-// GetClusterName returns the name of the cluster containing the current VM
+// GetClusterName returns the name of the cluster containing the current VM by parsing the resource group name.
+// It expects the resource group name to have the format (MC|mc)_resource-group_cluster-name_zone
 func GetClusterName() (string, error) {
 	all, err := getResponse(metadataURL + "/metadata/instance/compute/resourceGroupName?api-version=2017-08-01&format=text")
 	if err != nil {
@@ -51,12 +51,11 @@ func GetClusterName() (string, error) {
 	}
 
 	splitAll := strings.Split(all, "_")
-	if len(splitAll) < 4 || splitAll[0] != "MC" {
-		return "", errors.New("cannot parse the clustername from metadata")
+	if len(splitAll) < 4 || strings.ToLower(splitAll[0]) != "mc" {
+		return "", fmt.Errorf("cannot parse the clustername from resource group name: %s", all)
 	}
 
-	clusterName := splitAll[len(splitAll)-2]
-	return clusterName, nil
+	return splitAll[len(splitAll)-2], nil
 }
 
 func getResponseWithMaxLength(endpoint string, maxLength int) (string, error) {

--- a/pkg/util/azure/azure_test.go
+++ b/pkg/util/azure/azure_test.go
@@ -33,20 +33,46 @@ func TestGetHostname(t *testing.T) {
 }
 
 func TestGetClusterName(t *testing.T) {
-	apiResponse := "MC_aks-kenafeh_aks-kenafeh-eu_westeurope"
-	expectedClusterName := "aks-kenafeh-eu"
-	var lastRequest *http.Request
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		io.WriteString(w, apiResponse)
-		lastRequest = r
-	}))
-	defer ts.Close()
-	metadataURL = ts.URL
-
-	val, err := GetClusterName()
-	assert.Nil(t, err)
-	assert.Equal(t, expectedClusterName, val)
-	assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute/resourceGroupName")
-	assert.Equal(t, lastRequest.URL.RawQuery, "api-version=2017-08-01&format=text")
+	tests := []struct {
+		name    string
+		rgName  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "uppercase prefix",
+			rgName:  "MC_aks-kenafeh_aks-kenafeh-eu_westeurope",
+			want:    "aks-kenafeh-eu",
+			wantErr: false,
+		},
+		{
+			name:    "lowercase prefix",
+			rgName:  "mc_foo-bar-aks-k8s-rg_foo-bar-aks-k8s_westeurope",
+			want:    "foo-bar-aks-k8s",
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			rgName:  "unexpected-resource-group-name-format",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var lastRequest *http.Request
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				io.WriteString(w, tt.rgName)
+				lastRequest = r
+			}))
+			defer ts.Close()
+			metadataURL = ts.URL
+			got, err := GetClusterName()
+			assert.Equal(t, tt.wantErr, (err != nil))
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute/resourceGroupName")
+			assert.Equal(t, lastRequest.URL.RawQuery, "api-version=2017-08-01&format=text")
+		})
+	}
 }

--- a/releasenotes/notes/fix-aks-clustername-detection-792e31467af7cf8a.yaml
+++ b/releasenotes/notes/fix-aks-clustername-detection-792e31467af7cf8a.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Improve cluster name auto-detection on Azure AKS.


### PR DESCRIPTION
### What does this PR do?

Expect the resource group name to have the format `(MC|mc)_resource-group_cluster-name_zone` instead of `MC_resource-group_cluster-name_zone`

### Motivation

The resource group name can have a lowercase prefix

### Additional Notes

Feature request