### PR TITLE
[cmd/agent/gui] Fix GUI pages asset path on Windows

### DIFF
--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -1,4 +1,4 @@
-//go:generate go-bindata -pkg gui -prefix views/ -o ./templates.go views/...
+//go:generate go-bindata -pkg gui -prefix views -o ./templates.go views/...
 //go:generate go fmt ./templates.go
 
 package gui
@@ -111,7 +111,7 @@ func createCSRFToken() error {
 }
 
 func generateIndex(w http.ResponseWriter, r *http.Request) {
-	data, err := Asset("templates/index.tmpl")
+	data, err := Asset("/templates/index.tmpl")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -130,7 +130,7 @@ func generateIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func generateAuthEndpoint(w http.ResponseWriter, r *http.Request) {
-	data, err := Asset("templates/auth.tmpl")
+	data, err := Asset("/templates/auth.tmpl")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -149,7 +149,7 @@ func generateAuthEndpoint(w http.ResponseWriter, r *http.Request) {
 }
 
 func serveAssets(w http.ResponseWriter, req *http.Request) {
-	path := filepath.Join("private", req.URL.Path)
+	path := filepath.Join("/private", req.URL.Path)
 	data, err := Asset(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -90,7 +90,7 @@ func renderError(name string) (string, error) {
 func fillTemplate(w io.Writer, data Data, request string) error {
 	t := template.New(request + ".tmpl")
 	t.Funcs(fmap)
-	tmpl, err := Asset("templates/" + request + ".tmpl")
+	tmpl, err := Asset("/templates/" + request + ".tmpl")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

Removes the `/` in the `-prefix views/` option of `go-bindata`. The `views/` prefix is not recognized on Windows since the paths use backslashes.

### Motivation

Make the Agent GUI work.
