### PR TITLE
Fixes Chocolatey packages

### DIFF
--- a/chocolatey/tools-offline/chocolateyinstall.ps1
+++ b/chocolatey/tools-offline/chocolateyinstall.ps1
@@ -22,7 +22,8 @@ $packageArgs = @{
 }
 Install-ChocolateyInstallPackage @packageArgs
 
-$installInfo = @"---
+$installInfo = @"
+---
 install_method:
   tool: chocolatey
   tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -17,7 +17,8 @@ $packageArgs = @{
 }
 Install-ChocolateyPackage @packageArgs
 
-$installInfo = @"---
+$installInfo = @"
+---
 install_method:
   tool: chocolatey
   tool_version: chocolatey-$($env:CHOCOLATEY_VERSION)


### PR DESCRIPTION
### What does this PR do?

#5469 introduced a bug that makes the Chocolatey package installation fail (the content of an a here-string should start on a different line from the here-string header). This PR fixes it.

### Describe your test plan

Tested on the [test environment](https://github.com/chocolatey-community/chocolatey-test-environment) that the package with the fix applied could be successfully installed.