### PR TITLE
pkg/trace/config: increase payload limit from 10MB to 50MB

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -674,6 +674,7 @@ func initConfig(config Config) {
 	config.SetKnown("apm_config.bucket_size_seconds")
 	config.SetKnown("apm_config.receiver_timeout")
 	config.SetKnown("apm_config.watchdog_check_delay")
+	config.SetKnown("apm_config.max_payload_size")
 
 	// inventories
 	config.BindEnvAndSetDefault("inventories_enabled", true)

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -44,11 +44,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	maxRequestBodyLength = 10 * 1024 * 1024
-	tagTraceHandler      = "handler:traces"
-)
-
 // Version is a dumb way to version our collector handlers
 type Version string
 
@@ -82,9 +77,8 @@ type HTTPReceiver struct {
 	dynConf *sampler.DynamicConfig
 	server  *http.Server
 
-	maxRequestBodyLength int64
-	debug                bool
-	rateLimiterResponse  int // HTTP status code when refusing
+	debug               bool
+	rateLimiterResponse int // HTTP status code when refusing
 
 	wg   sync.WaitGroup // waits for all requests to be processed
 	exit chan struct{}
@@ -104,9 +98,8 @@ func NewHTTPReceiver(conf *config.AgentConfig, dynConf *sampler.DynamicConfig, o
 		conf:    conf,
 		dynConf: dynConf,
 
-		maxRequestBodyLength: maxRequestBodyLength,
-		debug:                strings.ToLower(conf.LogLevel) == "debug",
-		rateLimiterResponse:  rateLimiterResponse,
+		debug:               strings.ToLower(conf.LogLevel) == "debug",
+		rateLimiterResponse: rateLimiterResponse,
 
 		exit: make(chan struct{}),
 	}
@@ -271,7 +264,7 @@ func (r *HTTPReceiver) handleWithVersion(v Version, f func(Version, http.Respons
 			return
 		}
 
-		req.Body = NewLimitedReader(req.Body, r.maxRequestBodyLength)
+		req.Body = NewLimitedReader(req.Body, r.conf.MaxRequestBytes)
 
 		f(v, w, req)
 	}
@@ -375,7 +368,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 
 	traces, err := r.decodeTraces(v, req)
 	if err != nil {
-		httpDecodingError(err, []string{tagTraceHandler, fmt.Sprintf("v:%s", v)}, w)
+		httpDecodingError(err, []string{"handler:traces", fmt.Sprintf("v:%s", v)}, w)
 		if err == ErrLimitedReaderLimitReached {
 			atomic.AddInt64(&ts.TracesDropped.PayloadTooLarge, traceCount)
 		} else {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -71,8 +71,8 @@ func TestReceiverRequestBodyLength(t *testing.T) {
 	assert := assert.New(t)
 
 	conf := newTestReceiverConfig()
+	conf.MaxRequestBytes = 2
 	receiver := newTestReceiverFromConfig(conf)
-	receiver.maxRequestBodyLength = 2
 	go receiver.Start()
 
 	defer receiver.Stop()

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -209,6 +209,9 @@ func (c *AgentConfig) applyDatadogConfig() error {
 	if config.Datadog.IsSet("apm_config.ignore_resources") {
 		c.Ignore["resource"] = config.Datadog.GetStringSlice("apm_config.ignore_resources")
 	}
+	if k := "apm_config.max_payload_size"; config.Datadog.IsSet(k) {
+		c.MaxRequestBytes = config.Datadog.GetInt64(k)
+	}
 
 	if config.Datadog.IsSet("apm_config.replace_tags") {
 		rt := make([]*ReplaceRule, 0)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -76,6 +76,7 @@ type AgentConfig struct {
 	ReceiverSocket  string // if not empty, UDS will be enabled on unix://<receiver_socket>
 	ConnectionLimit int    // for rate-limiting, how many unique connections to allow in a lease period (30s)
 	ReceiverTimeout int
+	MaxRequestBytes int64 // specifies the maximum allowed request size for incoming trace payloads
 
 	// Writers
 	StatsWriter *WriterConfig
@@ -134,6 +135,7 @@ func New() *AgentConfig {
 		ReceiverHost:    "localhost",
 		ReceiverPort:    8126,
 		ConnectionLimit: 2000,
+		MaxRequestBytes: 50 * 1024 * 1024, // 50MB
 
 		StatsWriter: new(WriterConfig),
 		TraceWriter: new(WriterConfig),

--- a/releasenotes/notes/apm-payload-size-limit-1a97bd78c8b87864.yaml
+++ b/releasenotes/notes/apm-payload-size-limit-1a97bd78c8b87864.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    APM: The maximum allowed payload size by the agent was increased
+    from 10MB to 50MB. This could result in traffic increases for
+    users which were affected by this issue.


### PR DESCRIPTION
This change increases the the maximum allowed trace payload size from
10MB to 50MB. Additionally, an undocumented setting
`apm_config.max_payload_size` has been added to allow further tuning
this.