### PR TITLE
pkg/trace/config: remove connection limit by default

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -135,7 +135,6 @@ func New() *AgentConfig {
 
 		ReceiverHost:    "localhost",
 		ReceiverPort:    8126,
-		ConnectionLimit: 2000,
 		MaxRequestBytes: 50 * 1024 * 1024, // 50MB
 
 		StatsWriter:             new(WriterConfig),

--- a/releasenotes/notes/apm-rm-connection-limit-99f1adb6000b7d2a.yaml
+++ b/releasenotes/notes/apm-rm-connection-limit-99f1adb6000b7d2a.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    APM: The maximum connection limit over a 30s period was removed.
+    This can result in an increase of tracing data for users that were
+    affected by this limitation.


### PR DESCRIPTION
This change disables the connection limit by default, but leaves the
option to enable it via config.