### PR TITLE
Adds note about Chocolatey settings

### DIFF
--- a/chocolatey/datadog-agent-offline.nuspec
+++ b/chocolatey/datadog-agent-offline.nuspec
@@ -15,7 +15,14 @@
     <docsUrl>https://docs.datadoghq.com</docsUrl>
     <tags>datadog agent monitoring admin</tags>
     <summary>The Datadog Agent for Microsoft Windows</summary>
-    <description>The Datadog Agent faithfully collects events and metrics and brings them to Datadog on your behalf so that you can do something useful with your monitoring and performance data.</description>
+    <description>The Datadog Agent faithfully collects events and metrics and brings them to Datadog on your behalf so that you can do something useful with your monitoring and performance data.
+
+## Package settings
+
+You may set [custom settings](https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=commandline#installation) to the Agent when installing by using the  [`--installer-arguments` option of `choco install`](https://chocolatey.org/docs/getting-started#overriding-default-install-directory-or-other-advanced-install-concepts).
+
+For example, to set the API key you may run:
+`choco install -ia="APIKEY=""YOUR_DATADOG_API_KEY""" datadog-agent-offline`</description>
     <releaseNotes>$release_notes$</releaseNotes>
   </metadata>
   <files>

--- a/chocolatey/datadog-agent-online.nuspec
+++ b/chocolatey/datadog-agent-online.nuspec
@@ -15,7 +15,14 @@
     <docsUrl>https://docs.datadoghq.com</docsUrl>
     <tags>datadog agent monitoring admin</tags>
     <summary>The Datadog Agent for Microsoft Windows</summary>
-    <description>The Datadog Agent faithfully collects events and metrics and brings them to Datadog on your behalf so that you can do something useful with your monitoring and performance data.</description>
+    <description>The Datadog Agent faithfully collects events and metrics and brings them to Datadog on your behalf so that you can do something useful with your monitoring and performance data.
+
+## Package settings
+
+You may set [custom settings](https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=commandline#installation) to the Agent when installing by using the  [`--installer-arguments` option of `choco install`](https://chocolatey.org/docs/getting-started#overriding-default-install-directory-or-other-advanced-install-concepts).
+
+For example, to set the API key you may run:
+`choco install -ia="APIKEY=""YOUR_DATADOG_API_KEY""" datadog-agent`</description>
     <releaseNotes>$release_notes$</releaseNotes>
   </metadata>
   <files>


### PR DESCRIPTION
### What does this PR do?

Changes description of Chocolatey packages to add note about installer arguments.

### Additional Notes

I am copying the updated description after the line to verify that it renders correctly and so that it can be reviewed easily.

*****

The Datadog Agent faithfully collects events and metrics and brings them to Datadog on your behalf so that you can do something useful with your monitoring and performance data.

## Package settings

You may set [custom settings](https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=commandline#installation) to the Agent when installing by using the  [`--installer-arguments` option of `choco install`](https://chocolatey.org/docs/getting-started#overriding-default-install-directory-or-other-advanced-install-concepts).

For example, to set the API key you may run:
`choco install -ia="APIKEY=""YOUR_DATADOG_API_KEY""" datadog-agent-offline`