### PR TITLE
Backport 7.19.2 CHANGELOG update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,21 @@
 Release Notes
 =============
 
+.. _Release Notes_7.19.2:
+
+7.19.2 / 6.19.2
+======
+
+.. _Release Notes_7.19.2_Prelude:
+
+Prelude
+-------
+
+Release on: 2020-05-12
+
+- Please refer to the `7.19.2 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7192>`_ for the list of changes on the Core Checks
+
+
 .. _Release Notes_7.19.1:
 
 7.19.1


### PR DESCRIPTION
### What does this PR do?

Backports 7.19.2 CHANGELOG update to master.

### Motivation

7.19.2 release.
