### PR TITLE
Removes hardcoded path from Chocolatey

### DIFF
--- a/chocolatey/tools-offline/chocolateyinstall.ps1
+++ b/chocolatey/tools-offline/chocolateyinstall.ps1
@@ -30,4 +30,5 @@ install_method:
   installer_version: chocolatey-$($env:chocolateyPackageVersion)-offline
 "@
 
-Out-File -FilePath C:\ProgramData\Datadog\install_info -InputObject $installInfo
+$appDataDir = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Datadog\Datadog Agent").ConfigRoot
+Out-File -FilePath $appDataDir\install_info -InputObject $installInfo

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -25,4 +25,5 @@ install_method:
   installer_version: chocolatey-$($env:chocolateyPackageVersion)-online
 "@
 
-Out-File -FilePath C:\ProgramData\Datadog\install_info -InputObject $installInfo
+$appDataDir = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Datadog\Datadog Agent").ConfigRoot
+Out-File -FilePath $appDataDir\install_info -InputObject $installInfo


### PR DESCRIPTION
## What does this PR do?

The application data directory can be set at install time so it should be retrieved from the registry instead of being hardcoded when creating `install_info`.

### Motivation

- To make sure #5505 instructions are reliable and users can set `APPLICATIONDATADIRECTORY` in particular.

### Additional Notes

Unsure if getting the registry can fail; I am trying to mimic this code:
https://github.com/DataDog/datadog-agent/blob/0aa2b94a1be50f84729253f6b77820db87eb4ec5/pkg/util/winutil/shutil.go#L91-L94

### Describe your test plan

Install the Chocolatey package for this branch with 
```PowerShell
choco install -ia="APPLICATIONDATADIRECTORY=""<some path>""" datadog-agent
```
and check that the Agent is correctly installed and `install_info` is saved on the correct directory.