### PR TITLE
Fix dogstatsd binary panic when not getting any API key from env var

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -224,13 +224,13 @@ func stopAgent(ctx context.Context, cancel context.CancelFunc) {
 
 	// gracefully shut down any component
 	cancel()
-	
+
 	// stop metaScheduler and statsd if they are initiated
-	if metaScheduler!=nil {
+	if metaScheduler != nil {
 		metaScheduler.Stop()
 	}
 
-	if statsd!=nil{
+	if statsd != nil {
 		statsd.Stop()
 	}
 

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -225,7 +225,7 @@ func stopAgent(ctx context.Context, cancel context.CancelFunc) {
 	// gracefully shut down any component
 	cancel()
 
-	// stop metaScheduler and statsd if they are initiated
+	// stop metaScheduler and statsd if they are instantiated
 	if metaScheduler != nil {
 		metaScheduler.Stop()
 	}

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -224,9 +224,16 @@ func stopAgent(ctx context.Context, cancel context.CancelFunc) {
 
 	// gracefully shut down any component
 	cancel()
+	
+	// stop metaScheduler and statsd if they are initiated
+	if metaScheduler!=nil {
+		metaScheduler.Stop()
+	}
 
-	metaScheduler.Stop()
-	statsd.Stop()
+	if statsd!=nil{
+		statsd.Stop()
+	}
+  
 	log.Info("See ya!")
 	log.Flush()
 	return

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -233,7 +233,7 @@ func stopAgent(ctx context.Context, cancel context.CancelFunc) {
 	if statsd!=nil{
 		statsd.Stop()
 	}
-  
+
 	log.Info("See ya!")
 	log.Flush()
 	return


### PR DESCRIPTION
### What does this PR do?

Fix the dogstatsD standalone bin panic issue when no API key or config file is provided


### Describe your test plan

Try to reproduce the bug on the trello card