### PR TITLE
Decrease the health check interval in docker images

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -162,7 +162,7 @@ COPY init-stage3-host-pid /etc/s6/init/init-stage3-host-pid
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp
 
-HEALTHCHECK --interval=2m --timeout=5s --retries=2 \
+HEALTHCHECK --interval=30s --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
 
 # Leave following directories RW to allow use of kubernetes readonlyrootfs flag

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -162,7 +162,7 @@ COPY init-stage3-host-pid /etc/s6/init/init-stage3-host-pid
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp
 
-HEALTHCHECK --interval=2m --timeout=5s --retries=2 \
+HEALTHCHECK --interval=30s --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
 
 # Leave following directories RW to allow use of kubernetes readonlyrootfs flag


### PR DESCRIPTION
### What does this PR do?

Decrease the health check interval in docker images

### Motivation

When starting an agent docker container, it takes 2 minutes for the container to be considered as “healthy” by docker whereas the agent was in fact ready a long time before.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Start the agent docker container with:
```
docker run --name datadog-agent -p 8126:8126 -e DD_API_KEY=$DD_API_KEY -e DD_APM_ENABLED="true" -e DD_APM_NON_LOCAL_TRAFFIC="true" -e DD_LOGS_ENABLED="true" -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL="true" -e DD_AC_EXCLUDE="name:datadog-agent" -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro datadog/agent:7-jmx
```

In another window, check when `agent health` reports the agent as OK and check when docker starts considering the container as “healthy” with:
```
while true; do date; docker ps; docker exec -ti datadog-agent /probe.sh; sleep 1; done
```

Before the change, the container became “healthy” only 2 minutes after being started. With that change, it must become “healthy” faster.