### PR TITLE
Improve the flare error message when the API_KEY is not valid.

### DIFF
--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -132,7 +132,7 @@ func analyzeResponse(r *http.Response, err error) (string, error) {
 	err = json.Unmarshal(b, &res)
 	if err != nil {
 		response = fmt.Sprintf("An unknown error has occurred - Please contact support by email.")
-		return response, err
+		return response, fmt.Errorf("%v\nServer returned:\n%s", err, string(b)[:150])
 	}
 
 	if res.Error != "" {

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -7,6 +7,7 @@ package flare
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -20,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/pkg/errors"
 )
 
 var datadogSupportURL = "/support/flare"
@@ -136,7 +136,7 @@ func analyzeResponse(r *http.Response, err error) (string, error) {
 	var res = flareResponse{}
 	err = json.Unmarshal(b, &res)
 	if err != nil {
-		response = fmt.Sprintf("An unknown error has occurred - Please contact support by email.")
+		response = fmt.Sprintf("Error: could not deserialize response body -- Please contact support by email.")
 		return response, fmt.Errorf("%v\nServer returned:\n%s", err, string(b)[:150])
 	}
 

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -7,7 +7,6 @@ package flare
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -129,7 +128,19 @@ func analyzeResponse(r *http.Response, err error) (string, error) {
 		return response, err
 	}
 	if r.StatusCode == http.StatusForbidden {
-		return response, errors.New("HTTP 403 Forbidden: Make sure your API key is valid")
+		apiKey := config.Datadog.GetString("api_key")
+		var errStr string
+
+		if len(apiKey) == 0 {
+			errStr = "API key is missing"
+		} else {
+			if len(apiKey) > 5 {
+				apiKey = apiKey[len(apiKey)-5:]
+			}
+			errStr = fmt.Sprintf("Make sure your API key is valid. API Key ending with: %v", apiKey)
+		}
+
+		return response, fmt.Errorf("HTTP 403 Forbidden: %s", errStr)
 	}
 
 	b, _ := ioutil.ReadAll(r.Body)

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/pkg/errors"
 )
 
 var datadogSupportURL = "/support/flare"
@@ -127,6 +128,10 @@ func analyzeResponse(r *http.Response, err error) (string, error) {
 	if err != nil {
 		return response, err
 	}
+	if r.StatusCode == http.StatusForbidden {
+		return response, errors.New("HTTP 403 Forbidden: Make sure your API key is valid")
+	}
+
 	b, _ := ioutil.ReadAll(r.Body)
 	var res = flareResponse{}
 	err = json.Unmarshal(b, &res)


### PR DESCRIPTION
### What does this PR do?

Improve the flare error message when the API_KEY is not valid.

Before:
```
An unknown error has occurred - Please contact support by email.
Error: invalid character '<' looking for beginning of value
```

After:
```
Error: HTTP 403 Forbidden: Make sure your API key is valid
```


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
