### PR TITLE
[collector] Do not keep reference to check after it's uncheduled

### DIFF
--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -42,7 +42,12 @@ func (jb *jobBucket) removeJob(id check.ID) bool {
 
 	for i, c := range jb.jobs {
 		if c.ID() == id {
-			jb.jobs = append(jb.jobs[:i], jb.jobs[i+1:]...)
+			// delete the check from the jobs slice, making sure the backing array
+			// doesn't keep a reference to the check, so that it can be GC'ed.
+			// Logic from https://github.com/golang/go/wiki/SliceTricks
+			copy(jb.jobs[i:], jb.jobs[i+1:])
+			jb.jobs[len(jb.jobs)-1] = nil
+			jb.jobs = jb.jobs[:len(jb.jobs)-1]
 			return true
 		}
 	}

--- a/pkg/collector/scheduler/job_test.go
+++ b/pkg/collector/scheduler/job_test.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package scheduler
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type TestJobCheck struct {
+	TestCheck
+	id string
+}
+
+func (c *TestJobCheck) ID() check.ID { return check.ID(c.id) }
+
+func TestBucket_RemoveJob(t *testing.T) {
+	bucket := &jobBucket{}
+
+	// add 2 dummy checks
+	bucket.addJob(&TestJobCheck{id: "1"})
+	bucket.addJob(&TestJobCheck{id: "2"})
+	require.Equal(t, 2, bucket.size())
+
+	// Add a check with a finalizer to the bucket, then remove it
+	finalized := make(chan struct{}, 1)
+	checkWithFinalizer := &TestJobCheck{id: "withFinalizer"}
+	runtime.SetFinalizer(checkWithFinalizer, func(c *TestJobCheck) {
+		finalized <- struct{}{}
+	})
+	bucket.addJob(checkWithFinalizer)
+	require.Equal(t, 3, bucket.size())
+	bucket.removeJob(checkWithFinalizer.ID())
+	checkWithFinalizer = nil // make sure we don't keep any reference to the check
+
+	require.Equal(t, 2, bucket.size())
+
+	// Trigger a full GC run, which should GC the check. Then leave 10 seconds for
+	// the runtime to run the finalizer.
+	// If the finalizer hasn't run in this timeframe, it probably means that the bucket
+	// still keeps a reference to the check in its internal data structures.
+	runtime.GC()
+	testutil.AssertTrueBeforeTimeout(
+		t,
+		100*time.Millisecond,
+		10*time.Second,
+		func() bool {
+			select {
+			case _ = <-finalized:
+				return true
+			default:
+				return false
+			}
+		},
+	)
+
+	// use the bucket, just to keep it alive during the earlier GC run
+	bucket.addJob(&TestJobCheck{id: "here so the GC doesn't GC the entire bucket"})
+}

--- a/releasenotes/notes/ensure-python-check-finalizer-is-called-5e4a9537e50db5dd.yaml
+++ b/releasenotes/notes/ensure-python-check-finalizer-is-called-5e4a9537e50db5dd.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Ensure Python checks are always garbage-collected after they're unscheduled
+    by AutoDiscovery.


### PR DESCRIPTION
### What does this PR do?

This fixes a reference leak that occurs after unscheduling a check, because a reference to the check is kept in the array backing the `jobBucket`'s slice.

This was likely broken since the bucketed scheduler improvements in `6.5.0`/https://github.com/DataDog/datadog-agent/pull/2127

### Motivation

It's especially important to not keep any reference to a check after it's unscheduled so that the [finalizer set on Python Check](https://github.com/DataDog/datadog-agent/blob/33e9aeb9395fa3c5f22ff1ccf6d3c5b1869cc3ac/pkg/collector/python/check.go#L292-L305) is eventually run once the check is unscheduled. Python checks can rely on this to free up internal/background resources (example at the moment: `snmp` integration).

Note: _eventually_ is an important word here: there's no time guarantee from the runtime on when the object's finalizer is run after there are no remaining references to the object (or even after it's GC'ed). In my local env I've noticed "delays" of up to 20 seconds.

### Additional Notes

Review notes:

* first commit is a small refactor + adds a test reproducing the issue, which fails
* second commit actually fixes the issue (and the test)

Possible future improvements:

1. provide a better API for python checks to free up manually-managed resources once they're unscheduled (this is tracked in a backlog card)
2. we may want to add some telemetry on total number of checks scheduled/unscheduled, and python check finalizers called

### Describe your test plan

* I've tested this manually on local dev env with autodiscovered checks, making sure the python finalizer is called after each unschedule event.
* There _might_ be unforeseen regressions related to the fact that the python checks' finalizer weren't consistently run since `6.5.0`. Our internal k8s deploys should catch any of those during QA.