### PR TITLE
Adds missing distro definition in iot-agent preinst

### DIFF
--- a/omnibus/package-scripts/iot-agent/preinst
+++ b/omnibus/package-scripts/iot-agent/preinst
@@ -8,6 +8,9 @@
 INSTALL_DIR=/opt/datadog-agent
 SERVICE_NAME=datadog-agent
 
+KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || grep -m1 -Eo $KNOWN_DISTRIBUTION /etc/os-release 2>/dev/null || uname -s)
+
 # Linux installation
 if [ "$DISTRIBUTION" != "Darwin" ]; then
     set -e


### PR DESCRIPTION
### What does this PR do?

Adds back definition of `$DISTRIBUTION` in preinst that got removed in #5444, which is necessary to correctly determine the current distribution.

### Motivation

IoT Agent build was failing on SLES 15, when it shouldn't.

