### PR TITLE
expose SQL Obfuscation to python checks

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -10,6 +10,7 @@ package python
 import (
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/obfuscate"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -184,4 +185,21 @@ func ReadPersistentCache(key *C.char) *C.char {
 		return nil
 	}
 	return TrackedCString(data)
+}
+
+var obfuscator = obfuscate.NewObfuscator(nil)
+
+// ObfuscateSQL obfuscates & normalizes the provided SQL query, writing the error into errResult if the operation
+// fails
+//export ObfuscateSQL
+func ObfuscateSQL(rawQuery *C.char, errResult **C.char) *C.char {
+	s := C.GoString(rawQuery)
+	obfuscatedQuery, err := obfuscator.ObfuscateSQLString(s)
+	if err != nil {
+		// memory will be freed by caller
+		*errResult = TrackedCString(err.Error())
+		return nil
+	}
+	// memory will be freed by caller
+	return TrackedCString(obfuscatedQuery.Query)
 }

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -86,6 +86,7 @@ void SetCheckMetadata(char *, char *, char *);
 void SetExternalTags(char *, char *, char **);
 void WritePersistentCache(char *, char *);
 bool TracemallocEnabled();
+char* ObfuscateSQL(char *, char **);
 
 void initDatadogAgentModule(rtloader_t *rtloader) {
 	set_get_clustername_cb(rtloader, GetClusterName);
@@ -98,6 +99,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 	set_write_persistent_cache_cb(rtloader, WritePersistentCache);
 	set_read_persistent_cache_cb(rtloader, ReadPersistentCache);
 	set_tracemalloc_enabled_cb(rtloader, TracemallocEnabled);
+	set_obfuscate_sql_cb(rtloader, ObfuscateSQL);
 }
 
 //

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -147,9 +147,9 @@ func TestSQLUTF8(t *testing.T) {
 			"SELECT Cli_Establiments.CODCLI, Cli_Establiments.Id_ESTAB_CLI, Cli_Establiments.CODIGO_CENTRO_AXAPTA, Cli_Establiments.NOMESTAB, Cli_Establiments.ADRECA, Cli_Establiments.CodPostal, Cli_Establiments.Poblacio, Cli_Establiments.Provincia, Cli_Establiments.TEL, Cli_Establiments.EMAIL, Cli_Establiments.PERS_CONTACTE, Cli_Establiments.PERS_CONTACTE_CARREC, Cli_Establiments.NumTreb, Cli_Establiments.Localitzacio, Tipus_Activitat.CNAE, Tipus_Activitat.Nom_ES, ACTIVO FROM Cli_Establiments LEFT OUTER JOIN Tipus_Activitat ON Cli_Establiments.Id_ACTIVITAT = Tipus_Activitat.IdActivitat Where CODCLI = ? AND CENTRE_CORRECTE = ? AND ACTIVO = ? ORDER BY Cli_Establiments.CODIGO_CENTRO_AXAPTA",
 		},
 	} {
-		oq, err := NewObfuscator(nil).obfuscateSQLString(tt.in)
+		oq, err := NewObfuscator(nil).ObfuscateSQLString(tt.in)
 		assert.NoError(err)
-		assert.Equal(tt.out, oq.query)
+		assert.Equal(tt.out, oq.Query)
 	}
 }
 
@@ -213,17 +213,17 @@ func TestSQLTableFinder(t *testing.T) {
 		} {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
-				oq, err := NewObfuscator(nil).obfuscateSQLString(tt.query)
+				oq, err := NewObfuscator(nil).ObfuscateSQLString(tt.query)
 				assert.NoError(err)
-				assert.Equal(tt.tables, oq.tablesCSV)
+				assert.Equal(tt.tables, oq.TablesCSV)
 			})
 		}
 	})
 
 	t.Run("off", func(t *testing.T) {
-		oq, err := NewObfuscator(nil).obfuscateSQLString("DELETE FROM table WHERE table.a=1")
+		oq, err := NewObfuscator(nil).ObfuscateSQLString("DELETE FROM table WHERE table.a=1")
 		assert.NoError(t, err)
-		assert.Empty(t, oq.tablesCSV)
+		assert.Empty(t, oq.TablesCSV)
 	})
 }
 
@@ -837,9 +837,9 @@ LIMIT 1000`,
 
 	// The consumer is the same between executions
 	for _, tc := range testCases {
-		oq, err := NewObfuscator(nil).obfuscateSQLString(tc.query)
+		oq, err := NewObfuscator(nil).ObfuscateSQLString(tc.query)
 		assert.Nil(err)
-		assert.Equal(tc.expected, oq.query)
+		assert.Equal(tc.expected, oq.Query)
 	}
 }
 
@@ -850,7 +850,7 @@ func TestConsumerError(t *testing.T) {
 	// what to do with malformed SQL
 	input := "SELECT * FROM users WHERE users.id = '1 AND users.name = 'dog'"
 
-	_, err := NewObfuscator(nil).obfuscateSQLString(input)
+	_, err := NewObfuscator(nil).ObfuscateSQLString(input)
 	assert.NotNil(err)
 }
 
@@ -934,7 +934,7 @@ func TestSQLErrors(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			_, err := NewObfuscator(nil).obfuscateSQLString(tc.query)
+			_, err := NewObfuscator(nil).ObfuscateSQLString(tc.query)
 			assert.Error(t, err)
 			assert.Equal(t, tc.expected, err.Error())
 		})
@@ -988,7 +988,7 @@ func TestLiteralEscapesUpdates(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			o := NewObfuscator(nil)
 			o.SetSQLLiteralEscapes(c.initial)
-			_, err := o.obfuscateSQLString(c.query)
+			_, err := o.ObfuscateSQLString(c.query)
 			if c.err != nil {
 				assert.Equal(t, c.err, err)
 			} else {
@@ -1013,7 +1013,7 @@ func BenchmarkTokenizer(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_, _ = NewObfuscator(nil).obfuscateSQLString(bm.query)
+				_, _ = NewObfuscator(nil).ObfuscateSQLString(bm.query)
 			}
 		})
 	}

--- a/releasenotes/notes/sql-obfuscation-in-python-checks-eae7d46a4109f4f9.yaml
+++ b/releasenotes/notes/sql-obfuscation-in-python-checks-eae7d46a4109f4f9.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Expose agent's sql obfuscation to python checks via new `datadog_agent.obfuscate_sql` method

--- a/rtloader/common/builtins/datadog_agent.h
+++ b/rtloader/common/builtins/datadog_agent.h
@@ -146,6 +146,7 @@ void _set_set_check_metadata_cb(cb_set_check_metadata_t);
 void _set_set_external_tags_cb(cb_set_external_tags_t);
 void _set_write_persistent_cache_cb(cb_write_persistent_cache_t);
 void _set_read_persistent_cache_cb(cb_read_persistent_cache_t);
+void _set_obfuscate_sql_cb(cb_obfuscate_sql_t);
 
 PyObject *_public_headers(PyObject *self, PyObject *args, PyObject *kwargs);
 

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -570,6 +570,17 @@ DATADOG_AGENT_RTLOADER_API void set_write_persistent_cache_cb(rtloader_t *, cb_w
 */
 DATADOG_AGENT_RTLOADER_API void set_read_persistent_cache_cb(rtloader_t *, cb_read_persistent_cache_t);
 
+/*! \fn void set_obfuscate_sql_cb(rtloader_t *, cb_obfuscate_sql_t)
+    \brief Sets a callback to be used by rtloader to allow retrieving a value for a given
+    check instance.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param object A function pointer with cb_obfuscate_sql_t prototype to the callback
+    function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
+DATADOG_AGENT_RTLOADER_API void set_obfuscate_sql_cb(rtloader_t *, cb_obfuscate_sql_t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -427,6 +427,15 @@ public:
     */
     virtual void setReadPersistentCacheCb(cb_read_persistent_cache_t) = 0;
 
+    //! setObfuscateSqlCb member.
+    /*!
+      \param A cb_obfuscate_sql_t function pointer to the CGO callback.
+
+      This allows us to set the relevant CGO callback that will allow retrieving value for
+      specific check instances.
+    */
+    virtual void setObfuscateSqlCb(cb_obfuscate_sql_t) = 0;
+
 private:
     mutable std::string _error; /*!< string containing a RtLoader error */
     mutable bool _errorFlag; /*!< boolean indicating whether an error was set on RtLoader */

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -125,6 +125,8 @@ typedef void (*cb_set_external_tags_t)(char *, char *, char **);
 typedef void (*cb_write_persistent_cache_t)(char *, char *);
 // (value)
 typedef char *(*cb_read_persistent_cache_t)(char *);
+// (sql_query, error_message)
+typedef char *(*cb_obfuscate_sql_t)(char *, char **);
 
 // _util
 // (argv, argc, raise, stdout, stderr, ret_code, exception)

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -451,6 +451,11 @@ void set_read_persistent_cache_cb(rtloader_t *rtloader, cb_read_persistent_cache
     AS_TYPE(RtLoader, rtloader)->setReadPersistentCacheCb(cb);
 }
 
+void set_obfuscate_sql_cb(rtloader_t *rtloader, cb_obfuscate_sql_t cb)
+{
+    AS_TYPE(RtLoader, rtloader)->setObfuscateSqlCb(cb);
+}
+
 /*
  * _util API
  */

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -886,6 +886,11 @@ void Three::setReadPersistentCacheCb(cb_read_persistent_cache_t cb)
     _set_read_persistent_cache_cb(cb);
 }
 
+void Three::setObfuscateSqlCb(cb_obfuscate_sql_t cb)
+{
+    _set_obfuscate_sql_cb(cb);
+}
+
 // Python Helpers
 
 // get_integration_list return a list of every datadog's wheels installed.

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -103,6 +103,7 @@ public:
     void setSetExternalTagsCb(cb_set_external_tags_t);
     void setWritePersistentCacheCb(cb_write_persistent_cache_t);
     void setReadPersistentCacheCb(cb_read_persistent_cache_t);
+    void setObfuscateSqlCb(cb_obfuscate_sql_t);
 
     // _util API
     virtual void setSubprocessOutputCb(cb_get_subprocess_output_t);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -883,6 +883,11 @@ void Two::setReadPersistentCacheCb(cb_read_persistent_cache_t cb)
     _set_read_persistent_cache_cb(cb);
 }
 
+void Two::setObfuscateSqlCb(cb_obfuscate_sql_t cb)
+{
+    _set_obfuscate_sql_cb(cb);
+}
+
 // Python Helpers
 
 // get_integration_list return a list of every datadog's wheels installed.

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -102,6 +102,7 @@ public:
     void setSetExternalTagsCb(cb_set_external_tags_t);
     void setWritePersistentCacheCb(cb_write_persistent_cache_t);
     void setReadPersistentCacheCb(cb_read_persistent_cache_t);
+    void setObfuscateSqlCb(cb_obfuscate_sql_t);
 
     // _util API
     virtual void setSubprocessOutputCb(cb_get_subprocess_output_t);


### PR DESCRIPTION
### What does this PR do?

Exposes sql obfuscation from `pkg/trace/obfuscate` to python checks:
  * required methods, structs, and fields were made public to allow for doing sql obfuscation directly on a string

### Motivation

Goal is to enable any python check dealing with raw sql queries to obfuscate and normalize them the same way we do for traces. 

### Describe your test plan

Unit tests cover expected obfuscation feature as well as expected response to a variety of invalid input error cases. 
