### PR TITLE
[gitlab] Add missing dependencies in deploy jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3108,6 +3108,9 @@ deploy_deb-7:
   dependencies:
     - agent_deb-x64-a7
     - agent_deb-arm-a7
+    - iot_agent_deb-x64
+    - iot_agent_deb-arm64
+    - dogstatsd_deb-x64
   script:
     # We first check that the current version hasn't already been deployed
     # (same as the check_already_deployed_version). We do this twice to mitigate
@@ -3304,6 +3307,9 @@ deploy_rpm-7:
   dependencies:
     - agent_rpm-x64-a7
     - agent_rpm-arm-a7
+    - iot_agent_rpm-x64
+    - iot_agent_rpm-arm64
+    - dogstatsd_rpm-x64
   script:
     - source /usr/local/rvm/scripts/rvm
     - rvm use 2.4
@@ -3355,6 +3361,7 @@ deploy_suse_rpm-7:
   tags: [ "runner:main", "size:large" ]
   dependencies:
     - agent_suse-x64-a7
+    - dogstatsd_suse-x64
   script:
     - source /usr/local/rvm/scripts/rvm
     - rvm use 2.4


### PR DESCRIPTION
### What does this PR do?

Adds missing `iot-agent` and `dogstatsd` dependencies to `deploy_*_7` jobs.

### Motivation

Deploy all packages. 

### Additional Notes

The `deploy_dogstatsd` and `deploy_iot_agent` jobs are misleading, they do not deploy the packages, only the binaries.
