### PR TITLE
[Main Agent]Fix system probe flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -176,9 +176,11 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 		log.Errorf("Could not zip exp var: %s", err)
 	}
 
-	err = zipSystemProbeStats(tempDir, hostname)
-	if err != nil {
-		log.Errorf("Could not zip system probe exp var stats: %s", err)
+	if config.Datadog.GetBool("system_probe_config.enabled") {
+		err = zipSystemProbeStats(tempDir, hostname)
+		if err != nil {
+			log.Errorf("Could not zip system probe exp var stats: %s", err)
+		}
 	}
 
 	err = zipDiagnose(tempDir, hostname)
@@ -386,7 +388,7 @@ func zipExpVar(tempDir, hostname string) error {
 }
 
 func zipSystemProbeStats(tempDir, hostname string) error {
-	sysProbeStats := status.GetSystemProbeStats()
+	sysProbeStats := status.GetSystemProbeStats(config.Datadog.GetString("system_probe_config.sysprobe_socket"))
 	sysProbeFile := filepath.Join(tempDir, hostname, "expvar", "system-probe")
 	sysProbeWriter, err := newRedactingWriter(sysProbeFile, os.ModePerm, true)
 	if err != nil {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -84,7 +84,7 @@ func GetStatus() (map[string]interface{}, error) {
 		stats["clusterAgentStatus"] = getDCAStatus()
 	}
 
-	if config.Datadog.GetBool("system_probe_config.enabled"){
+	if config.Datadog.GetBool("system_probe_config.enabled") {
 		stats["systemProbeStats"] = GetSystemProbeStats(config.Datadog.GetString("system_probe_config.sysprobe_socket"))
 	}
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -84,7 +84,9 @@ func GetStatus() (map[string]interface{}, error) {
 		stats["clusterAgentStatus"] = getDCAStatus()
 	}
 
-	stats["systemProbeStats"] = GetSystemProbeStats()
+	if config.Datadog.GetBool("system_probe_config.enabled"){
+		stats["systemProbeStats"] = GetSystemProbeStats(config.Datadog.GetString("system_probe_config.sysprobe_socket"))
+	}
 
 	return stats, nil
 }

--- a/pkg/status/status_system_probe.go
+++ b/pkg/status/status_system_probe.go
@@ -14,10 +14,10 @@ import (
 )
 
 // GetSystemProbeStats returns the expvar stats of the system probe
-func GetSystemProbeStats() map[string]interface{} {
+func GetSystemProbeStats(socketPath string) map[string]interface{} {
 
 	// TODO: Pull system-probe path from system-probe.yaml
-	net.SetSystemProbePath("/opt/datadog-agent/run/sysprobe.sock")
+	net.SetSystemProbePath(socketPath)
 	probeUtil, err := net.GetRemoteSystemProbeUtil()
 
 	if err != nil {

--- a/pkg/status/status_system_probe.go
+++ b/pkg/status/status_system_probe.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build process
+// +build process,!windows
 
 package status
 

--- a/pkg/status/status_system_probe_unsupported.go
+++ b/pkg/status/status_system_probe_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build !process
+// +build !process windows
 
 package status
 
@@ -14,6 +14,6 @@ import (
 // GetSystemProbeStats returns a notice that it is not supported on systems that do not at least build the process agent
 func GetSystemProbeStats(socketPath string) map[string]interface{} {
 	return map[string]interface{}{
-		"Errors": fmt.Sprintf("System Probe is not supported on systems not running the process agent"),
+		"Errors": fmt.Sprintf("System Probe is not supported on this system"),
 	}
 }

--- a/pkg/status/status_system_probe_unsupported.go
+++ b/pkg/status/status_system_probe_unsupported.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetSystemProbeStats returns a notice that it is not supported on systems that do not at least build the process agent
-func GetSystemProbeStats() map[string]interface{} {
+func GetSystemProbeStats(socketPath string) map[string]interface{} {
 	return map[string]interface{}{
 		"Errors": fmt.Sprintf("System Probe is not supported on systems not running the process agent"),
 	}


### PR DESCRIPTION
### What does this PR do?

With PR https://github.com/DataDog/datadog-agent/pull/5473, this PR ensures that we check the appropriate path for the system probe stats, and only run it when the system probe is enabled with an agent. 

### Motivation

We had to remove this functionality from the last release, and this PR ensures that we can release this functionality with agent 7.20 without problems. 

### Describe your test plan:

- Install the agent
- Enable Process agent/System Probe
- Execute a flare command
- Ensure there is a /expvar/system-probe file
- Ensure there is an entry for system probe in status.log