### PR TITLE
[forwarder] Add option to reset connections at configurable interval

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -155,7 +155,7 @@
     <span class="stat_data">
       {{- with .forwarderStats -}}
         {{- range $key, $value := .Transactions }}
-            {{- if and (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode")}}
+            {{- if and (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode") (ne $key "ConnectionEvents")}}
           {{formatTitle $key}}: {{humanize $value}}<br>
             {{- end}}
         {{- end}}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -282,6 +282,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("additional_endpoints", map[string][]string{})
 	config.BindEnvAndSetDefault("forwarder_timeout", 20)
 	config.BindEnvAndSetDefault("forwarder_retry_queue_max_size", 30)
+	config.BindEnvAndSetDefault("forwarder_connection_reset_interval", 0) // in seconds, 0 means disabled
 	config.BindEnvAndSetDefault("forwarder_num_workers", 1)
 	config.BindEnvAndSetDefault("forwarder_stop_timeout", 2)
 	// Forwarder retry settings

--- a/pkg/forwarder/domain_forwarder_test.go
+++ b/pkg/forwarder/domain_forwarder_test.go
@@ -14,23 +14,25 @@ import (
 )
 
 func TestNewDomainForwarder(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 120*time.Second)
 
 	assert.NotNil(t, forwarder)
 	assert.Equal(t, 1, forwarder.numberOfWorkers)
 	assert.Equal(t, 10, forwarder.retryQueueLimit)
+	assert.Equal(t, 120*time.Second, forwarder.connectionResetInterval)
 	assert.Equal(t, Stopped, forwarder.State())
 	assert.Nil(t, forwarder.highPrio)
 	assert.Nil(t, forwarder.lowPrio)
 	assert.Nil(t, forwarder.requeuedTransaction)
 	assert.Nil(t, forwarder.stopRetry)
+	assert.Nil(t, forwarder.stopConnectionReset)
 	assert.Len(t, forwarder.workers, 0)
 	assert.Len(t, forwarder.retryQueue, 0)
 	assert.NotNil(t, forwarder.blockedList, 0)
 }
 
 func TestDomainForwarderStart(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
 	err := forwarder.Start()
 
 	assert.Nil(t, err)
@@ -41,6 +43,7 @@ func TestDomainForwarderStart(t *testing.T) {
 	assert.NotNil(t, forwarder.lowPrio)
 	assert.NotNil(t, forwarder.requeuedTransaction)
 	assert.NotNil(t, forwarder.stopRetry)
+	assert.NotNil(t, forwarder.stopConnectionReset)
 
 	assert.NotNil(t, forwarder.Start())
 
@@ -48,14 +51,25 @@ func TestDomainForwarderStart(t *testing.T) {
 }
 
 func TestDomainForwarderInit(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
 	forwarder.init()
 	assert.Len(t, forwarder.workers, 0)
 	assert.Len(t, forwarder.retryQueue, 0)
 }
 
 func TestDomainForwarderStop(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
+	forwarder.Stop(false) // this should be a noop
+	forwarder.Start()
+	assert.Equal(t, Started, forwarder.State())
+	forwarder.Stop(false)
+	assert.Len(t, forwarder.workers, 0)
+	assert.Len(t, forwarder.retryQueue, 0)
+	assert.Equal(t, Stopped, forwarder.State())
+}
+
+func TestDomainForwarderStop_WithConnectionReset(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10, 120*time.Second)
 	forwarder.Stop(false) // this should be a noop
 	forwarder.Start()
 	assert.Equal(t, Started, forwarder.State())
@@ -66,14 +80,14 @@ func TestDomainForwarderStop(t *testing.T) {
 }
 
 func TestDomainForwarderSubmitIfStopped(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
 
 	require.NotNil(t, forwarder)
 	assert.NotNil(t, forwarder.sendHTTPTransactions(nil))
 }
 
 func TestDomainForwarderSendHTTPTransactions(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
 	tr := newTestTransaction()
 
 	// fw is stopped, we should get an error
@@ -91,7 +105,7 @@ func TestDomainForwarderSendHTTPTransactions(t *testing.T) {
 }
 
 func TestRequeueTransaction(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
 	tr := NewHTTPTransaction()
 	assert.Len(t, forwarder.retryQueue, 0)
 	forwarder.requeueTransaction(tr)
@@ -99,7 +113,7 @@ func TestRequeueTransaction(t *testing.T) {
 }
 
 func TestRetryTransactions(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
 	forwarder.init()
 	forwarder.retryQueueLimit = 1
 
@@ -130,7 +144,7 @@ func TestRetryTransactions(t *testing.T) {
 }
 
 func TestForwarderRetry(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
 	forwarder.Start()
 	defer forwarder.Stop(false)
 
@@ -162,7 +176,7 @@ func TestForwarderRetry(t *testing.T) {
 }
 
 func TestForwarderRetryLifo(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
 	forwarder.init()
 
 	transaction1 := newTestTransaction()
@@ -191,7 +205,7 @@ func TestForwarderRetryLifo(t *testing.T) {
 }
 
 func TestForwarderRetryLimitQueue(t *testing.T) {
-	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder := newDomainForwarder("test", 1, 10, 0)
 	forwarder.init()
 
 	forwarder.retryQueueLimit = 1

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -15,11 +15,20 @@ import (
 
 type testTransaction struct {
 	mock.Mock
-	processed chan bool
+	assertClient bool
+	processed    chan bool
 }
 
 func newTestTransaction() *testTransaction {
 	t := new(testTransaction)
+	t.assertClient = true
+	t.processed = make(chan bool, 1)
+	return t
+}
+
+func newTestTransactionWithoutClientAssert() *testTransaction {
+	t := new(testTransaction)
+	t.assertClient = false
 	t.processed = make(chan bool, 1)
 	return t
 }
@@ -30,7 +39,11 @@ func (t *testTransaction) GetCreatedAt() time.Time {
 
 func (t *testTransaction) Process(_ context.Context, client *http.Client) error {
 	defer func() { t.processed <- true }()
-	return t.Called(client).Error(0) // we ignore the context to ease mocking
+	// we always ignore the context to ease mocking
+	if !t.assertClient {
+		return t.Called().Error(0)
+	}
+	return t.Called(client).Error(0)
 }
 
 func (t *testTransaction) GetTarget() string {

--- a/pkg/status/templates/forwarder.tmpl
+++ b/pkg/status/templates/forwarder.tmpl
@@ -8,7 +8,7 @@ Forwarder
   Transactions
   ============
   {{- range $key, $value := .Transactions }}
-    {{- if and (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode")}}
+    {{- if and (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode") (ne $key "ConnectionEvents")}}
     {{$key}}: {{humanize $value}}
     {{- end}}
   {{- end}}


### PR DESCRIPTION
### What does this PR do?

Adds option to reset connections at configurable interval (`forwarder_connection_reset_interval`), disabled by default (PR is a no-op unless option is enabled).

When enabled (with a value > 0), forces the forwarder to re-create its connections to Datadog at the configured interval.

Also, adds related expvars/telemetry based on the hooks provided by `httptrace.ClientTrace`, which allow tracking DNS lookups and TCP connection creation. Not displayed on status page/GUI since they shouldn't be useful to end users.

### Motivation

Recreating TCP connections, even while they're still healthy, is useful to make the Agent connect to new intake IPs after the intake's DNS entries have been updated.

### Additional Notes

In a future PR/Agent version, once additional testing is performed, we could consider enabling this config option with a "high" default value (e.g. 1 hr, TBD), documenting and advertising it in the changelog.

The implementation makes no assumptions on the behavior of Go's `http.Client`, and simply closes idle connections + re-creates a new client to reset the connections.

### Describe your test plan

* this has been tested successfully locally with the option enabled (as expected, existing TCP connections are closed, new DNS lookups are performed, and new TCP connections are created)
* confirmed to be a no-op by default