### PR TITLE
[gitlab] Old msi build jobs: do not run on trigger and allow failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1199,6 +1199,8 @@ windows_zip_agent_binaries_x64-a7:
     expire_in: 2 weeks
     paths:
       - .omnibus/pkg
+  <<: *skip_when_triggered
+  allow_failure: true
 
 .windows_old_main_agent_base:
   extends: .windows_old_msi_base


### PR DESCRIPTION
### What does this PR do?

Make msi build jobs using new builders optional, and do not make them run for releases.

### Motivation

We will remove the old msi jobs soon, once we're fully confident in the new builders.
During releases, do not run jobs that produce unreleased artifacts.
