### PR TITLE
[config] move the RuntimeSettings implementation in the runtime `cmd` package

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
+	"github.com/DataDog/datadog-agent/cmd/agent/app/settings"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
@@ -296,11 +297,11 @@ func getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	setting := vars["setting"]
 	log.Infof("Got a request to read a setting value: %s", setting)
 
-	val, err := config.GetRuntimeSetting(setting)
+	val, err := settings.GetRuntimeSetting(setting)
 	if err != nil {
 		body, _ := json.Marshal(map[string]string{"error": err.Error()})
 		switch err.(type) {
-		case *config.SettingNotFoundError:
+		case *settings.SettingNotFoundError:
 			http.Error(w, string(body), 400)
 		default:
 			http.Error(w, string(body), 500)
@@ -324,10 +325,10 @@ func setRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	r.ParseForm() //nolint:errcheck
 	value := html.UnescapeString(r.Form.Get("value"))
 
-	if err := config.SetRuntimeSetting(setting, value); err != nil {
+	if err := settings.SetRuntimeSetting(setting, value); err != nil {
 		body, _ := json.Marshal(map[string]string{"error": err.Error()})
 		switch err.(type) {
-		case *config.SettingNotFoundError:
+		case *settings.SettingNotFoundError:
 			http.Error(w, string(body), 400)
 		default:
 			http.Error(w, string(body), 500)
@@ -338,7 +339,7 @@ func setRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 
 func getRuntimeConfigurableSettings(w http.ResponseWriter, r *http.Request) {
 	configurableSettings := make(map[string]string)
-	for name, setting := range config.RuntimeSettings() {
+	for name, setting := range settings.RuntimeSettings() {
 		configurableSettings[name] = setting.Description()
 	}
 	body, err := json.Marshal(configurableSettings)

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -19,6 +19,7 @@ import (
 	"os/signal"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
+	"github.com/DataDog/datadog-agent/cmd/agent/app/settings"
 	"github.com/DataDog/datadog-agent/cmd/agent/clcrunnerapi"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
@@ -177,6 +178,11 @@ func StartAgent() error {
 	}
 
 	log.Infof("Starting Datadog Agent v%v", version.AgentVersion)
+
+	// init settings that can be changed at runtime
+	if err := settings.InitRuntimeSettings(); err != nil {
+		log.Warnf("Can't initiliaze the runtime settings: %v", err)
+	}
 
 	// Setup expvar server
 	var port = config.Datadog.GetString("expvar_port")

--- a/cmd/agent/app/settings/runtime_setting.go
+++ b/cmd/agent/app/settings/runtime_setting.go
@@ -1,9 +1,9 @@
-/// Unless explicitly stated otherwise all files in this repository are licensed
+// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-package config
+package settings
 
 import (
 	"errors"
@@ -29,9 +29,13 @@ type RuntimeSetting interface {
 	Description() string
 }
 
-func initRuntimeSettings() {
+// InitRuntimeSettings builds the map of runtime settings configurable at runtime.
+func InitRuntimeSettings() error {
 	// Runtime-editable settings must be registered here to dynamically populate command-line information
-	registerRuntimeSetting(logLevelRuntimeSetting("log_level")) //nolint:errcheck
+	if err := registerRuntimeSetting(logLevelRuntimeSetting("log_level")); err != nil {
+		return err
+	}
+	return nil
 }
 
 // RegisterRuntimeSettings keeps track of configurable settings

--- a/cmd/agent/app/settings/runtime_setting_log_level.go
+++ b/cmd/agent/app/settings/runtime_setting_log_level.go
@@ -1,15 +1,16 @@
-/// Unless explicitly stated otherwise all files in this repository are licensed
+// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-package config
+package settings
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// logLevelRuntimeSetting wraps operations to change log level at runtime
+// logLevelRuntimeSetting wraps operations to change log level at runtime.
 type logLevelRuntimeSetting string
 
 func (l logLevelRuntimeSetting) Description() string {
@@ -30,10 +31,10 @@ func (l logLevelRuntimeSetting) Get() (interface{}, error) {
 
 func (l logLevelRuntimeSetting) Set(v interface{}) error {
 	logLevel := v.(string)
-	err := changeLogLevel(logLevel)
+	err := config.ChangeLogLevel(logLevel)
 	if err != nil {
 		return err
 	}
-	Datadog.Set("log_level", logLevel)
+	config.Datadog.Set("log_level", logLevel)
 	return nil
 }

--- a/cmd/agent/app/settings/runtime_settings_test.go
+++ b/cmd/agent/app/settings/runtime_settings_test.go
@@ -3,11 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-package config
+package settings
 
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,8 +63,7 @@ func TestRuntimeSettings(t *testing.T) {
 
 func TestLogLevel(t *testing.T) {
 	cleanRuntimeSetting()
-	setupConf()
-	SetupLogger("TEST", "debug", "", "", true, true, true)
+	config.SetupLogger("TEST", "debug", "", "", true, true, true)
 
 	ll := logLevelRuntimeSetting("log_level")
 	assert.Equal(t, "log_level", ll.Name())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,8 +122,6 @@ func init() {
 	Datadog = NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	// Configuration defaults
 	initConfig(Datadog)
-	// Configuration settings that can be changed at runtime
-	initRuntimeSettings()
 }
 
 // initConfig initializes the config defaults on a config

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -315,7 +315,8 @@ func extractShortPathFromFullPath(fullPath string) string {
 	return slices[len(slices)-1]
 }
 
-func changeLogLevel(level string) error {
+// ChangeLogLevel immediately changes the log level to the given one.
+func ChangeLogLevel(level string) error {
 	seelogLogLevel, err := validateLogLevel(level)
 	if err != nil {
 		return err


### PR DESCRIPTION

### What does this PR do?

The implementation of the RuntimeSettings should be besides the runtime app implementation (i.e. in `cmd`) and this PR is moving it there.

### Motivation

Technically, this let us modify some the runtime of the apps (for example the global instances in `common` such as `common.DSD`) from the runting settings whereas by living in `pkg` we're not able to do so (which is correct semantically, and technically, `cmd` can include `pkg` but `pkg` can't include `cmd`).

### Describe your test plan

Validate that the `config list-settings` and changing the log-level at runtime is still working.