### PR TITLE
Default iot_host to true when building the IoT agent

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,7 @@ var (
 // Variables to initialize at build time
 var (
 	DefaultPython string
+	AgentFlavor   = "datadog-agent"
 
 	// ForceDefaultPython has its value set to true at compile time if we should ignore
 	// the Python version set in the configuration and use `DefaultPython` instead.
@@ -170,6 +171,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
+	config.BindEnvAndSetDefault("iot_host", AgentFlavor == "datadog-iot-agent")
+
 	// Debugging + C-land crash feature flags
 	config.BindEnvAndSetDefault("c_stacktrace_collection", false)
 	config.BindEnvAndSetDefault("c_core_dump", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,10 +56,17 @@ var (
 	proxies *Proxy
 )
 
+//Values for AgentFlavor below
+const (
+	DefaultAgentFlavor = "agent"
+	IotAgentFlavor     = "iot_agent"
+	DogstatsdFlavor    = "dogstatsd"
+)
+
 // Variables to initialize at build time
 var (
 	DefaultPython string
-	AgentFlavor   = "datadog-agent"
+	AgentFlavor   = DefaultAgentFlavor
 
 	// ForceDefaultPython has its value set to true at compile time if we should ignore
 	// the Python version set in the configuration and use `DefaultPython` instead.
@@ -171,7 +178,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
-	config.BindEnvAndSetDefault("iot_host", AgentFlavor == "datadog-iot-agent")
+	config.BindEnvAndSetDefault("iot_host", AgentFlavor == IotAgentFlavor)
 
 	// Debugging + C-land crash feature flags
 	config.BindEnvAndSetDefault("c_stacktrace_collection", false)

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -99,7 +99,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
 
-    agent_flavor = "datadog-iot-agent" if iot else "datadog-agent"
+    agent_flavor = "iot_agent" if iot else "agent"
 
     ldflags, gcflags, env = get_build_flags(ctx, embedded_path=embedded_path,
             rtloader_root=rtloader_root, python_home_2=python_home_2, python_home_3=python_home_3,

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -99,9 +99,11 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
 
+    agent_flavor = "datadog-iot-agent" if iot else "datadog-agent"
+
     ldflags, gcflags, env = get_build_flags(ctx, embedded_path=embedded_path,
             rtloader_root=rtloader_root, python_home_2=python_home_2, python_home_3=python_home_3,
-            major_version=major_version, python_runtimes=python_runtimes, arch=arch)
+            major_version=major_version, python_runtimes=python_runtimes, arch=arch, agent_flavor=agent_flavor)
 
     if not sys.platform.startswith('linux'):
         for ex in LINUX_ONLY_TAGS:

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -40,7 +40,7 @@ def build(ctx, rebuild=False, race=False, static=False, build_include=None,
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     build_tags = get_build_tags(build_include, build_exclude)
-    ldflags, gcflags, env = get_build_flags(ctx, static=static, major_version=major_version)
+    ldflags, gcflags, env = get_build_flags(ctx, static=static, major_version=major_version, agent_flavor="dogstatsd")
     bin_path = DOGSTATSD_BIN_PATH
 
     # generate windows resources

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -61,7 +61,7 @@ def get_win_py_runtime_var(python_runtimes):
 
 def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
                     rtloader_root=None, python_home_2=None, python_home_3=None,
-                    major_version='7', python_runtimes='3', arch="x64", agent_flavor="datadog-agent"):
+                    major_version='7', python_runtimes='3', arch="x64", agent_flavor="agent"):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
 

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -61,7 +61,7 @@ def get_win_py_runtime_var(python_runtimes):
 
 def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
                     rtloader_root=None, python_home_2=None, python_home_3=None,
-                    major_version='7', python_runtimes='3', arch="x64"):
+                    major_version='7', python_runtimes='3', arch="x64", agent_flavor="datadog-agent"):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
 
@@ -93,6 +93,8 @@ def get_build_flags(ctx, static=False, prefix=None, embedded_path=None,
         ldflags += "-X {}/pkg/config.ForceDefaultPython=true ".format(REPO_PATH)
 
     ldflags += "-X {}/pkg/config.DefaultPython={} ".format(REPO_PATH, get_default_python(python_runtimes))
+
+    ldflags += "-X {}/pkg/config.AgentFlavor={} ".format(REPO_PATH, agent_flavor)
 
     # adding rtloader libs and headers to the env
     if rtloader_lib:


### PR DESCRIPTION
### What does this PR do?

Adds an AgentFlavor variable we can check at runtime.

As of now it's only used to chose a default value for `iot_host` but we can reuse this variable to include it in the host metadata.

### Motivation

Avoid having to manually set `iot_host` on the IoT agent.

### Describe your test plan

Run both `datadog-agent` and `datadog-iot-agent` and check the value of `iot_host` is set accordingly.