### PR TITLE
[cmd/agent/main_windows.go] Fix event log type mismatch

### DIFF
--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -94,7 +94,7 @@ loop:
 				break loop
 			default:
 				log.Warnf("unexpected control request #%d", c)
-				elog.Warning(0xc0000009, string(c.Cmd))
+				elog.Error(0xc0000009, string(c.Cmd))
 			}
 		case <-signals.Stopper:
 			elog.Info(0x4000000a, config.ServiceName)


### PR DESCRIPTION
### What does this PR do?

Actually send the `unexpected control request` error log as an error.

### Motivation

Fix mismatch in event log type.
