### PR TITLE
Add triggering promotion pipelines when releasing version 6 or 7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ stages:
   - deploy7
   - deploy7-manifests
   - deploy_invalidate
+  - trigger_release
   - e2e
   - testkitchen_cleanup
   - notify
@@ -3744,6 +3745,29 @@ deploy_cloudfront_invalidate_on_success:
 deploy_cloudfront_invalidate_on_failure:
   <<: *deploy_cloudfront_invalidate
   when: on_failure
+
+#
+# Trigger release pipelines
+#
+trigger_release_7:
+  <<: *run_only_when_triggered_on_tag_7
+  stage: trigger_release
+  needs: ["deploy_cloudfront_invalidate_on_success"]
+  variables:
+    RELEASE_VERSION: $RELEASE_VERSION_7
+  trigger:
+    project: DataDog/agent-release-management
+    branch: master
+
+trigger_release_6:
+  <<: *run_only_when_triggered_on_tag_6
+  stage: trigger_release
+  needs: ["deploy_cloudfront_invalidate_on_success"]
+  variables:
+    RELEASE_VERSION: $RELEASE_VERSION_6
+  trigger:
+    project: DataDog/agent-release-management
+    branch: master
 
 #
 # end to end


### PR DESCRIPTION
### What does this PR do?

Updates the gitlab pipeline to trigger specific pipelines when there's a pipeline trigger on a tagged version.

### Motivation

Updates the release process so that it starts a specific pipeline to promote and remove packages from staging and prod repositories on Datadog/agent-release-management.

### Notes
Relates to https://github.com/DataDog/agent-release-management/pull/1