### PR TITLE
[jmxfetch] Bump to 0.36.2 on nightlies

### DIFF
--- a/release.json
+++ b/release.json
@@ -3,15 +3,15 @@
         "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
-        "JMXFETCH_VERSION": "0.36.1",
-        "JMXFETCH_HASH": "41a8b4c977d87d23c01cf37da9687b0ba117158ec543692fe93f325542f39e99"
+        "JMXFETCH_VERSION": "0.36.2",
+        "JMXFETCH_HASH": "f782b9a5e9dffbce3463245562858fd8fed1508269222e8bebeefd3f865d10d8"
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
-        "JMXFETCH_VERSION": "0.36.1",
-        "JMXFETCH_HASH": "41a8b4c977d87d23c01cf37da9687b0ba117158ec543692fe93f325542f39e99"
+        "JMXFETCH_VERSION": "0.36.2",
+        "JMXFETCH_HASH": "f782b9a5e9dffbce3463245562858fd8fed1508269222e8bebeefd3f865d10d8"
     },
     "6.19.0": {
         "INTEGRATIONS_CORE_VERSION": "7.19.0",

--- a/releasenotes/notes/jmxfetch-0-36-2-852ad2052dfd64b0.yaml
+++ b/releasenotes/notes/jmxfetch-0-36-2-852ad2052dfd64b0.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    JMXFetch upgraded to `0.36.2 <https://github.com/DataDog/jmxfetch/releases/0.36.2>`_


### PR DESCRIPTION
### What does this PR do?

Bumps JMXFetch to 0.36.2 on nightlies.

### Additional Notes

https://github.com/DataDog/jmxfetch/releases/0.36.2

### Describe your test plan

New version works well locally, on basic setup. Regular release QA of the 0.36.2 changes will be needed.
