### PR TITLE
[forwarder] Allow configuring the api key validation interval

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,8 @@ const (
 	DefaultNumWorkers = 4
 	// MaxNumWorkers maximum number of workers for our check runner
 	MaxNumWorkers = 25
+	// DefaultAPIKeyValidationInterval is the default interval of api key validation checks
+	DefaultAPIKeyValidationInterval = 60
 
 	// DefaultForwarderRecoveryInterval is the default recovery interval,
 	// also used if the user-provided value is invalid.
@@ -292,7 +294,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("additional_endpoints", map[string][]string{})
 	config.BindEnvAndSetDefault("forwarder_timeout", 20)
 	config.BindEnvAndSetDefault("forwarder_retry_queue_max_size", 30)
-	config.BindEnvAndSetDefault("forwarder_connection_reset_interval", 0) // in seconds, 0 means disabled
+	config.BindEnvAndSetDefault("forwarder_connection_reset_interval", 0)                                // in seconds, 0 means disabled
+	config.BindEnvAndSetDefault("forwarder_apikey_validation_interval", DefaultAPIKeyValidationInterval) // in minutes
 	config.BindEnvAndSetDefault("forwarder_num_workers", 1)
 	config.BindEnvAndSetDefault("forwarder_stop_timeout", 2)
 	// Forwarder retry settings

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -55,6 +55,7 @@ type forwarderHealth struct {
 	keysPerDomains        map[string][]string
 	keysPerAPIEndpoint    map[string][]string
 	disableAPIKeyChecking bool
+	validationInterval    time.Duration
 }
 
 func (fh *forwarderHealth) init() {
@@ -100,7 +101,7 @@ func (fh *forwarderHealth) Stop() {
 func (fh *forwarderHealth) healthCheckLoop() {
 	log.Debug("Waiting for APIkey validity to be confirmed.")
 
-	validateTicker := time.NewTicker(time.Hour * 1)
+	validateTicker := time.NewTicker(fh.validationInterval)
 	defer validateTicker.Stop()
 	defer close(fh.stopped)
 
@@ -205,7 +206,7 @@ func (fh *forwarderHealth) hasValidAPIKey() bool {
 				log.Debugf("api_key '%s' for domain %s is valid", apiKey, domain)
 				validKey = true
 			} else {
-				log.Debugf("api_key '%s' for domain %s is invalid", apiKey, domain)
+				log.Warnf("api_key '%s' for domain %s is invalid", apiKey, domain)
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Allows configuring the api key validation interval (in minutes), and logs at warning level if an api key is invalid.
Default validation interval unchanged (1h).

### Motivation

Customer request. Having more frequent validation (and feedback through a warning log) can be useful when an API key is revoked (earlier feedback in logs, status and healthcheck command).

### Additional Notes

Note that the validation loop stops as soon as all configured api keys are found to be invalid.

Undocumented. Customers should go through a support request before changing this (the validation endpoint may be rate-limited otherwise).

### Describe your test plan

Checked the setting works (validates at configured interval, default unchanged of 1h).