### PR TITLE
Adds install info when installing through MSI

### DIFF
--- a/cmd/agent/agentmsg.mc
+++ b/cmd/agent/agentmsg.mc
@@ -118,3 +118,10 @@ Severity=Warning
 Language=English
 Unable to determine the location of Program Data using the default value %1.
 .
+
+MessageId=16
+SymbolicName=MSG_WARN_INSTALL_INFO_FAILED
+Severity=Warning
+Language=English
+Unable to save installation information: %1.
+.

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -141,6 +141,7 @@ func CheckAndUpgradeConfig() error {
 // SetInstallInfo imports installation information from Windows registry into
 // the install_info file. It leaves the file untouched if it already exists
 func SetInstallInfo() error {
+
 	// get install_info path
 	dataDir, err := winutil.GetProgramDataDir()
 	if err != nil {
@@ -152,12 +153,11 @@ func SetInstallInfo() error {
 	_, err = os.Stat(installInfoPath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("unable to stat %s: %s", installInfoPath, err)
-	} else if err == nil {
-		// File already exists
+	} else if err == nil { // File already exists
 		return nil
 	}
 
-	// Get msiexec version if possible
+	// Get msiexec version from registry
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
 		"SOFTWARE\\Datadog\\Datadog Agent",
 		registry.ALL_ACCESS)
@@ -165,13 +165,12 @@ func SetInstallInfo() error {
 		return fmt.Errorf("unable to open registry config %s", err.Error())
 	}
 	defer k.Close()
-
 	val, _, err := k.GetStringValue("msiexec_version")
 	if err != nil || val == "" {
 		return fmt.Errorf("unable to fetch msiexec version: %s", err.Error())
 	}
 
-	// install info data type for marshalling
+	//  populate install_info data
 	type Method struct {
 		Tool             string `yaml:"tool"`
 		ToolVersion      string `yaml:"tool_version"`

--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -65,6 +65,9 @@ func (m *myservice) Execute(args []string, r <-chan svc.ChangeRequest, changes c
 		elog.Warning(0x80000002, err.Error())
 		// continue running with what we have.
 	}
+	if err := common.SetInstallInfo(); err != nil {
+		elog.Warning(0x80000010, err.Error())
+	}
 	if err := app.StartAgent(); err != nil {
 		log.Errorf("Failed to start agent %v", err)
 		elog.Error(0xc000000B, err.Error())

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -258,7 +258,9 @@
           <RegistryValue Name="hostname_fqdn"
                          Type="string"
                          Value="[HOSTNAME_FQDN_ENABLED]" />
-
+          <RegistryValue Name="msiexec_version"
+                         Type="string"
+                         Value="[VersionMsi]" />
         </RegistryKey>
 
       </Component>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -403,7 +403,10 @@
             Name="datadog.yaml"
             Source="$(var.EtcFiles)\datadog.yaml.example"/>
       </Component>
-      
+
+      <Component Id="install_info" Guid="7285FFA2-9CD1-496A-9E3D-FD2E96AFC15F">
+        <RemoveFile Id="removeInstallInfo" On="uninstall" Name="install_info"/>
+      </Component>
 
       <Directory Id="checks.d" Name="checks.d">
         <Component Id="checks.d"
@@ -487,6 +490,7 @@
       <ComponentRef Id="conffolder" />
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="datadog.yaml.example" />
+      <ComponentRef Id="install_info" />
       <ComponentRef Id="logs" />
       <ComponentRef Id="conf.d" />
       <ComponentRef Id="checks.d" />

--- a/omnibus/resources/dogstatsd/msi/source.wxs.erb
+++ b/omnibus/resources/dogstatsd/msi/source.wxs.erb
@@ -230,7 +230,10 @@
             Name="dogstatsd.yaml"
             Source="$(var.EtcFiles)\dogstatsd.yaml.example"/>
       </Component>
-      
+
+      <Component Id="install_info" Guid="4143C6C9-7D58-4001-AD6C-CAAEA193D22C">
+        <RemoveFile Id="removeInstallInfo" On="uninstall" Name="install_info"/>
+      </Component>
 
 
       <Directory Id="EXAMPLECONFSLOCATION" Name= "conf.d">
@@ -270,6 +273,7 @@
     <Feature Id="MainApplication" Title="Datadog Agent" Level="1" ConfigurableDirectory="APPLICATIONROOTDIRECTORY">
       <ComponentRef Id="conffolder" />
       <ComponentRef Id="datadog.yaml.example" />
+      <ComponentRef Id="install_info" />
       <ComponentRef Id="logs" />
       <ComponentRef Id="conf.d" />
       <ComponentRef Id="DATADOGDSDSERVICE" />

--- a/omnibus/resources/dogstatsd/msi/source.wxs.erb
+++ b/omnibus/resources/dogstatsd/msi/source.wxs.erb
@@ -154,8 +154,9 @@
           <RegistryValue Name="hostname_fqdn"
                          Type="string"
                          Value="[HOSTNAME_FQDN_ENABLED]" />
-
-
+          <RegistryValue Name="msiexec_version"
+                         Type="string"
+                         Value="[VersionMsi]" />
         </RegistryKey>
 
       </Component>

--- a/omnibus/resources/iot/msi/source.wxs.erb
+++ b/omnibus/resources/iot/msi/source.wxs.erb
@@ -312,7 +312,10 @@
             Name="datadog.yaml"
             Source="$(var.EtcFiles)\datadog.yaml.example"/>
       </Component>
-      
+
+      <Component Id="install_info" Guid="D187C786-9493-47FC-8A84-1A6EF80281CC">
+        <RemoveFile Id="removeInstallInfo" On="uninstall" Name="install_info"/>
+      </Component>
 
       <Directory Id="checks.d" Name="checks.d">
         <Component Id="checks.d"
@@ -396,6 +399,7 @@
       <ComponentRef Id="conffolder" />
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="datadog.yaml.example" />
+      <ComponentRef Id="install_info" />
       <ComponentRef Id="logs" />
       <ComponentRef Id="conf.d" />
       <ComponentRef Id="checks.d" />

--- a/omnibus/resources/iot/msi/source.wxs.erb
+++ b/omnibus/resources/iot/msi/source.wxs.erb
@@ -212,7 +212,9 @@
           <RegistryValue Name="hostname_fqdn"
                          Type="string"
                          Value="[HOSTNAME_FQDN_ENABLED]" />
-
+          <RegistryValue Name="msiexec_version"
+                         Type="string"
+                         Value="[VersionMsi]" />
         </RegistryKey>
 
       </Component>

--- a/releasenotes/notes/add-install_info-with-MSI-9304d5c4b5414822.yaml
+++ b/releasenotes/notes/add-install_info-with-MSI-9304d5c4b5414822.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Windows: MSI installer now logs installation information
+    for troubleshooting and telemetry purposes.


### PR DESCRIPTION
### What does this PR do?

- Creates `install_info` file when installing through the Windows MSI Installer
- Removes it during uninstall.

### Motivation

- Allow users to track their installation methods
- Allows Datadog to make stats on installation methods

### Additional Notes

- The intended behavior is:
   * At install time, add an entry to the registry with `msiexec` version.
   * When the agent starts,  if `install_info` doesn't exist and the registry value can be found, create the `install_info` file and populate it with the adequate information.
   * At uninstall time, remove the `install_info` file.
- Creating the file at install time is not advisable so we have to resort to this workaround, similar to the one done for populating the `datadog.yaml` file.
- We fail if `msiexec` version is not found in the registry so that we do not create the file for agents that have been upgraded. 

### Describe your test plan

- (Using the msi installer) Install the Agent
- Check the registry for `msiexec_version`
- Check that the `install_info` file has been created with the appropriate information
- Uninstall the Agent and check that the `install_info` file was removed
- Create dummy `install_info` and ensure that it is kept the same after a new installation
