### PR TITLE
[kitchen] Split tests into install/behavior/uninstall

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -310,8 +310,11 @@ def fetch_python_version(timeout = 15)
 end
 
 
-shared_examples_for 'Agent' do
+shared_examples_for 'Agent install' do
   it_behaves_like 'an installed Agent'
+end
+
+shared_examples_for 'Agent behavior' do
   it_behaves_like 'a running Agent with no errors'
   it_behaves_like 'a running Agent with APM'
   it_behaves_like 'a running Agent with APM manually disabled'
@@ -319,6 +322,9 @@ shared_examples_for 'Agent' do
   it_behaves_like 'an Agent with integrations'
   it_behaves_like 'an Agent that stops'
   it_behaves_like 'an Agent that restarts'
+end
+
+shared_examples_for 'Agent uninstall' do
   it_behaves_like 'an Agent that is removed'
 end
 

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe 'dd-agent-installation-script' do
-  include_examples 'Agent'
+  include_examples 'Agent install'
+  include_examples 'Agent behavior'
 
   context 'when testing DD_SITE' do
     let(:config) do
@@ -29,5 +30,7 @@ describe 'dd-agent-installation-script' do
         'installer_version' => /^install_script-\d+\.\d+\.\d+$/
       )
     end
+
+    include_examples 'Agent uninstall'
   end
 end

--- a/test/kitchen/test/integration/dd-agent-step-by-step/rspec/dd-agent-step-by-step_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-step-by-step/rspec/dd-agent-step-by-step_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 describe 'dd-agent-step-by-step' do
-  include_examples 'Agent'
+  include_examples 'Agent install'
+  include_examples 'Agent behavior'
+  include_examples 'Agent uninstall'
 end

--- a/test/kitchen/test/integration/dd-agent-upgrade-x64/rspec/dd-agent-upgrade_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-upgrade-x64/rspec/dd-agent-upgrade_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe 'the upgraded agent' do
-  include_examples 'Agent'
+  include_examples 'Agent install'
+  include_examples 'Agent behavior'
 
   # We retrieve the value defined in kitchen.yml because there is no simple way
   # to set env variables on the target machine or via parameters in Kitchen/Busser
@@ -19,4 +20,6 @@ describe 'the upgraded agent' do
     # Match the first line of the manifest file
     expect(File.open(version_manifest_file) {|f| f.readline.strip}).to match "datadog-agent #{agent_expected_version}"
   end
+
+  include_examples 'Agent uninstall'
 end

--- a/test/kitchen/test/integration/dd-agent-x64/rspec/dd-agent_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-x64/rspec/dd-agent_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 describe 'dd-agent' do
-  include_examples 'Agent'
+  include_examples 'Agent install'
+  include_examples 'Agent behavior'
+  include_examples 'Agent uninstall'
 end

--- a/test/kitchen/test/integration/dd-agent/rspec/dd-agent_spec.rb
+++ b/test/kitchen/test/integration/dd-agent/rspec/dd-agent_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 describe 'dd-agent' do
-  include_examples 'Agent'
+  include_examples 'Agent install'
+  include_examples 'Agent behavior'
+  include_examples 'Agent uninstall'
 end


### PR DESCRIPTION
### What does this PR do?

Splits the common test block (that does install tests + uninstall + uninstall tests) in three separate parts.
Runs the `install_info` test before the Agent uninstall.
That way, each recipe can run its sepcific tests at any point of the test run.

### Motivation

Broken `install_info` test because it was run after the Agent uninstall.

### Describe your test plan

Ran kitchen tests on this PR.