### PR TITLE
Do not fail pipelines for dca tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,7 +179,7 @@ fail_on_non_triggered_tag:
   tags: [ "runner:main", "size:2xlarge" ]
   script:
     - echo CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE CI_COMMIT_TAG=$CI_COMMIT_TAG
-    - '[ "$CI_COMMIT_TAG" == "" -o "$CI_PIPELINE_SOURCE" != "push" ]'
+    - '[[ $CI_COMMIT_TAG == dca-* || $CI_COMMIT_TAG == "" || $CI_PIPELINE_SOURCE != "push" ]]'
 
 #
 # deps_build


### PR DESCRIPTION
### What does this PR do?

Change the `fail_on_non_triggered_tag` job to not fail when tags start with `dca-*`.

### Motivation

Build DCA docker images.
