### PR TITLE
Add unixodbc dependency on MacOS

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -22,6 +22,10 @@ if arm?
   dependency 'libxslt'
 end
 
+if osx?
+  dependency 'unixodbc'
+end
+
 if linux?
   # add nfsiostat script
   dependency 'unixodbc'

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -22,6 +22,10 @@ if arm?
   dependency 'libxslt'
 end
 
+if osx?
+  dependency 'unixodbc'
+end
+
 if linux?
   # add nfsiostat script
   dependency 'unixodbc'


### PR DESCRIPTION
### What does this PR do?

Adds unixodbc dependency on MacOS to build pyodbc.

### Motivation

Make the MacOS build work again.

