### PR TITLE
[gitlab] Skip android deploy on triggered pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3313,7 +3313,9 @@ deploy_staging_android_tags:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
+  # This means this job is never run, but let's keep it around in case we need it one day
   <<: *run_only_when_triggered_on_tag_7
+  <<: *skip_when_triggered
   tags: [ "runner:main", "size:large" ]
   dependencies:
     - agent_android_apk


### PR DESCRIPTION
### What does this PR do?

Skips android deploy step on triggered pipelines, as the build step is not done on triggered pipelines.

### Motivation

Android artifacts are not published.
