### PR TITLE
Update the flag for passing in the system probe config path

### DIFF
--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -43,5 +43,5 @@ const loggerName config.LoggerName = "CORE"
 func init() {
 	AgentCmd.PersistentFlags().StringVarP(&confFilePath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
 	AgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
-	AgentCmd.PersistentFlags().StringVarP(&sysProbeConfFilePath, "sysprobecfgpath", "x", "", "path to directory containing system-probe.yaml")
+	AgentCmd.PersistentFlags().StringVarP(&sysProbeConfFilePath, "sysprobecfgpath", "", "", "path to directory containing system-probe.yaml")
 }

--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -43,5 +43,5 @@ const loggerName config.LoggerName = "CORE"
 func init() {
 	AgentCmd.PersistentFlags().StringVarP(&confFilePath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
 	AgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
-	AgentCmd.PersistentFlags().StringVarP(&sysProbeConfFilePath, "sysprobecfgpath", "s", "", "path to directory containing system-probe.yaml")
+	AgentCmd.PersistentFlags().StringVarP(&sysProbeConfFilePath, "sysprobecfgpath", "x", "", "path to directory containing system-probe.yaml")
 }


### PR DESCRIPTION
### What does this PR do?

Updates the flag for passing in the system probe config path. 
### Motivation

Currently conflicts with the flare command, causing a panic. 

### Additional Notes

