### PR TITLE
Split PCF-DCA build and deploy jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3480,6 +3480,8 @@ deploy_cluster_agent_cloudfoundry:
   <<: *skip_when_unwanted_on_7
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
+  dependencies:
+    - cluster_agent_cloudfoundry-build_amd64
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -562,6 +562,10 @@ cluster_agent_cloudfoundry-build_amd64:
   needs: ["fail_on_non_triggered_tag", "run_go_tidy_check"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
   variables:
     ARCH: amd64
   before_script:
@@ -569,9 +573,10 @@ cluster_agent_cloudfoundry-build_amd64:
     - inv -e deps --no-checks --verbose --dep-vendor-only
   script:
     - inv -e cluster-agent-cloudfoundry.build
-    - $S3_CP_CMD $SRC_PATH/$CLUSTER_AGENT_CLOUDFOUNDRY_BINARIES_DIR/datadog-cluster-agent-cloudfoundry $S3_ARTIFACTS_URI/datadog-cluster-agent-cloudfoundry.$ARCH
-
-
+    - cd $SRC_PATH/$CLUSTER_AGENT_CLOUDFOUNDRY_BINARIES_DIR
+    - mkdir -p $OMNIBUS_PACKAGE_DIR
+    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)
+    - tar cf $OMNIBUS_PACKAGE_DIR/datadog-cluster-agent-cloudfoundry-$PACKAGE_VERSION-$ARCH.tar.xz datadog-cluster-agent-cloudfoundry
 
 #
 # integration_test
@@ -3469,6 +3474,17 @@ deploy_staging_datadog_agent_windows_zip:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7.*.zip" $OMNIBUS_PACKAGE_DIR $S3_DSD6_URI/windows/agent7/bosh/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+
+deploy_cluster_agent_cloudfoundry:
+  <<: *run_only_when_triggered_on_tag_7
+  stage: deploy7
+  needs: [ "cluster_agent_cloudfoundry-x64"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-cluster-agent-cloudfoundry-*.tar.xz" $OMNIBUS_PACKAGE_DIR $S3_DSD6_URI/linux/cluster-agent-cloudfoundry/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy datadog agent windows binaries to staging bucket. Currently used for cloudfoundry builpack
 deploy_staging_datadog_agent_windows_binaries_zip:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3476,7 +3476,8 @@ deploy_staging_datadog_agent_windows_zip:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7.*.zip" $OMNIBUS_PACKAGE_DIR $S3_DSD6_URI/windows/agent7/bosh/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_cluster_agent_cloudfoundry:
-  <<: *run_only_when_triggered_on_tag_7
+  <<: *run_only_when_triggered
+  <<: *skip_when_unwanted_on_7
   stage: deploy7
   needs: [ "cluster_agent_cloudfoundry-x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3479,7 +3479,6 @@ deploy_cluster_agent_cloudfoundry:
   <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   stage: deploy7
-  needs: [ "cluster_agent_cloudfoundry-x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR


### PR DESCRIPTION
### What does this PR do?

Split the job that built the CloudFoundry Cluster Agent in two jobs: a build job and a deploy job.

The build job will run always (to test the build is not broken), while the deploy job will only run on release pipelines.

The built artifacts are put into a tar named with the version and arch before uploading.

This is similar to what we do for the Agent Windows binaries (although those are zipped by omnibus while this is tar'd by the Gitlab job).

### Motivation

CloudFoundry Cluster Agent binary should end up in a publicly accessible bucket, since it will be pulled from there by the scripts that build the bosh package (run either by us or by customers who build it themselves).

The URLs of the artifacts will look like this:
http://s3.amazonaws.com/dsd6-staging/linux/cluster-agent-cloudfoundry/datadog-cluster-agent-cloudfoundry-7.20.0-rc.2.git.2.68e6468-amd64.tar.xz

### Describe your test plan

The link above was built by the pipeline.