### PR TITLE
Add support for Tencent Cloud host alias (VM ID)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ bin/
 __pycache__
 .pytest_cache
 venv/
+venv27/
+venv3[78]/
 
 **/*.tmp
 **/debug.test

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -187,19 +187,28 @@ api_key:
 #
 # forwarder_stop_timeout: 2
 
-## @param cloud_provider_metadata - string - optional - default: <empty>
-## This option restricts which cloud provider endpoint will be used by the agent to retrieve metadata. By default the agent will try
-## all cloud providers.
+## @param cloud_provider_metadata - list of strings -  optional - default: ["aws", "gcp", "azure", "alibaba"]
+## This option restricts which cloud provider endpoint will be used by the
+## agent to retrieve metadata. By default the agent will try # AWS, GCP, Azure
+## and alibaba providers. Some cloud provider are not enabled by default to not
+## trigger security alert when querying unknown IP (for example, when enabling
+## Tencent on AWS).
+## Setting an empty list will disable querying any cloud metadata endpoints
+## (falling back on system metadata). Using this setting on a cloud provider
+## host may result in duplicated hosts in your account.
+##
 ## Possible values are:
 ## "aws"     AWS EC2, ECS/Fargate
 ## "gcp"     Google Cloud Provider
 ## "azure"   Azure
 ## "alibaba" Alibaba
 ## "tencent" Tencent
-## "none"    does not query any cloud metadata endpoints (falling back on system metadata). Using this setting on a cloud provider host may result in duplicated hosts in your account.
-## "all"     default: queries all cloud metadata endpoints
 #
-# cloud_provider_metadata: "all"
+# cloud_provider_metadata:
+#   - "aws"
+#   - "gcp"
+#   - "azure"
+#   - "alibaba"
 
 ## @param collect_ec2_tags - boolean - optional - default: false
 ## Collect AWS EC2 custom tags as host tags.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,7 +41,7 @@ func TestDefaults(t *testing.T) {
 	assert.False(t, config.IsSet("dd_url"))
 	assert.Equal(t, "", config.GetString("site"))
 	assert.Equal(t, "", config.GetString("dd_url"))
-	assert.Equal(t, "all", config.GetString("cloud_provider_metadata"))
+	assert.Equal(t, []string{"aws", "gcp", "azure", "alibaba"}, config.GetStringSlice("cloud_provider_metadata"))
 }
 
 func TestDefaultSite(t *testing.T) {
@@ -429,28 +429,28 @@ func TestIsCloudProviderEnabled(t *testing.T) {
 	holdValue := Datadog.Get("cloud_provider_metadata")
 	defer Datadog.Set("cloud_provider_metadata", holdValue)
 
-	Datadog.Set("cloud_provider_metadata", "all")
+	Datadog.Set("cloud_provider_metadata", []string{"aws", "gcp", "azure", "alibaba", "tencent"})
 	assert.True(t, IsCloudProviderEnabled("AWS"))
 	assert.True(t, IsCloudProviderEnabled("GCP"))
 	assert.True(t, IsCloudProviderEnabled("Alibaba"))
 	assert.True(t, IsCloudProviderEnabled("Azure"))
 	assert.True(t, IsCloudProviderEnabled("Tencent"))
 
-	Datadog.Set("cloud_provider_metadata", "AWS")
+	Datadog.Set("cloud_provider_metadata", []string{"aws"})
 	assert.True(t, IsCloudProviderEnabled("AWS"))
 	assert.False(t, IsCloudProviderEnabled("GCP"))
 	assert.False(t, IsCloudProviderEnabled("Alibaba"))
 	assert.False(t, IsCloudProviderEnabled("Azure"))
 	assert.False(t, IsCloudProviderEnabled("Tencent"))
 
-	Datadog.Set("cloud_provider_metadata", "Tencent")
+	Datadog.Set("cloud_provider_metadata", []string{"tencent"})
 	assert.False(t, IsCloudProviderEnabled("AWS"))
 	assert.False(t, IsCloudProviderEnabled("GCP"))
 	assert.False(t, IsCloudProviderEnabled("Alibaba"))
 	assert.False(t, IsCloudProviderEnabled("Azure"))
 	assert.True(t, IsCloudProviderEnabled("Tencent"))
 
-	Datadog.Set("cloud_provider_metadata", "none")
+	Datadog.Set("cloud_provider_metadata", []string{})
 	assert.False(t, IsCloudProviderEnabled("AWS"))
 	assert.False(t, IsCloudProviderEnabled("GCP"))
 	assert.False(t, IsCloudProviderEnabled("Alibaba"))

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/alibaba"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/tencent"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 	"github.com/DataDog/datadog-agent/pkg/util/azure"
@@ -27,8 +28,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs"
 
-	yaml "gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
 const packageCachePrefix = "host"
@@ -136,6 +138,14 @@ func getHostAliases() []string {
 	} else if k8sAlias != "" {
 		aliases = append(aliases, k8sAlias)
 	}
+
+	tencentAlias, err := tencent.GetHostAlias()
+	if err != nil {
+		log.Debugf("no Tencent Host Alias: %s", err)
+	} else if tencentAlias != "" {
+		aliases = append(aliases, tencentAlias)
+	}
+
 	return aliases
 }
 

--- a/pkg/util/tencent/tencent.go
+++ b/pkg/util/tencent/tencent.go
@@ -32,6 +32,14 @@ func IsRunningOn() bool {
 	return false
 }
 
+// GetHostAlias returns the VM ID from the Tencent Metadata api
+func GetHostAlias() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
+	return GetInstanceID()
+}
+
 // GetInstanceID fetches the instance id for current host from the Tencent metadata API
 func GetInstanceID() (string, error) {
 	if !config.IsCloudProviderEnabled(CloudProviderName) {

--- a/pkg/util/tencent/tencent_test.go
+++ b/pkg/util/tencent/tencent_test.go
@@ -11,10 +11,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetInstanceID(t *testing.T) {
+	holdValue := config.Datadog.Get("cloud_provider_metadata")
+	defer config.Datadog.Set("cloud_provider_metadata", holdValue)
+	config.Datadog.Set("cloud_provider_metadata", []string{"tencent"})
+
 	expected := "ins-nad6bga0"
 	var lastRequest *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### What does this PR do?

Add support for Tencent Cloud host alias (VM ID).

To avois triggering security alerts on AWS, GCP and other cloud provider when the agent query an unknown IP we disabled Tencent cloud provider by default