### PR TITLE
[kitchen] Make install script dir owned by non-root user

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -60,6 +60,12 @@ sudo 'installuser' do
   users 'installuser'
 end
 
+directory wrk_dir do
+  owner 'installuser'
+  group 'installuser'
+  mode '0755'
+end
+
 execute 'run agent install script' do
   user 'installuser'
   cwd wrk_dir


### PR DESCRIPTION
### What does this PR do?

Makes `wrk_dir` owned by the non-root user, to avoid getting:
```
tee: ddagent-install.log: Permission denied
```
when trying to write to the install log file.

### Motivation

Remove error from kitchen test logs.

