### PR TITLE
[clusterchecks] Use bosh ID for nodename when running on cloudfoundry

### DIFF
--- a/pkg/autodiscovery/providers/clusterchecks.go
+++ b/pkg/autodiscovery/providers/clusterchecks.go
@@ -39,6 +39,15 @@ func NewClusterChecksConfigProvider(cfg config.ConfigurationProviders) (ConfigPr
 	}
 
 	c.nodeName, _ = util.GetHostname()
+	if config.Datadog.GetBool("cloud_foundry") {
+		boshID := config.Datadog.GetString("bosh_id")
+		if boshID == "" {
+			log.Warn("configuration variable cloud_foundry is set to true, but bosh_id is empty, can't retrieve node name")
+		} else {
+			c.nodeName = boshID
+		}
+	}
+
 	if cfg.GraceTimeSeconds > 0 {
 		c.graceDuration = time.Duration(cfg.GraceTimeSeconds) * time.Second
 	}


### PR DESCRIPTION
### What does this PR do?

Use bosh ID for nodename when running on cloudfoundry

### Motivation

nodes are identified by bosh id on cloudfoundry

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
