### PR TITLE
pkg/trace/writer: fix a bug where no write queue would exist

### DIFF
--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -65,7 +65,12 @@ func NewStatsWriter(cfg *config.AgentConfig, in <-chan []stats.Bucket) *StatsWri
 	if qsize == 0 {
 		payloadSize := float64(maxEntriesPerPayload * bytesPerEntry)
 		// default to 25% of maximum memory.
-		qsize = int(math.Max(1, cfg.MaxMemory/4/payloadSize))
+		maxmem := cfg.MaxMemory / 4
+		if maxmem == 0 {
+			// or 250MB if unbound
+			maxmem = 250 * 1024 * 1024
+		}
+		qsize = int(math.Max(1, maxmem/payloadSize))
 	}
 	log.Debugf("Stats writer initialized (climit=%d qsize=%d)", climit, qsize)
 	sw.senders = newSenders(cfg, sw, pathStats, climit, qsize)

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -91,7 +91,12 @@ func NewTraceWriter(cfg *config.AgentConfig, in <-chan *SampledSpans) *TraceWrit
 	qsize := cfg.TraceWriter.QueueSize
 	if qsize == 0 {
 		// default to 50% of maximum memory.
-		qsize = int(math.Max(1, cfg.MaxMemory/2/float64(maxPayloadSize)))
+		maxmem := cfg.MaxMemory / 2
+		if maxmem == 0 {
+			// or 500MB if unbound
+			maxmem = 500 * 1024 * 1024
+		}
+		qsize = int(math.Max(1, maxmem/float64(maxPayloadSize)))
 	}
 	if s := cfg.TraceWriter.FlushPeriodSeconds; s != 0 {
 		tw.tick = time.Duration(s*1000) * time.Millisecond

--- a/releasenotes/notes/apm-writer-queues-bug-daf97da4b35303a1.yaml
+++ b/releasenotes/notes/apm-writer-queues-bug-daf97da4b35303a1.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+issues:
+  - |
+    APM: Fixes a problem where writer queues would be inexistent if memory
+    and CPU limitations are disabled.


### PR DESCRIPTION
This change fixes a problem that would occur when memory limits
are disabled (max memory = 0), causing the writers to have no queues.