### PR TITLE
Returns nil in SNMP GetCheckNames

### DIFF
--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -373,9 +373,9 @@ func (s *SNMPService) IsReady() bool {
 	return true
 }
 
-// GetCheckNames returns an empty slice
+// GetCheckNames returns nil
 func (s *SNMPService) GetCheckNames() []string {
-	return []string{}
+	return nil
 }
 
 // HasFilter returns false on SNMP


### PR DESCRIPTION
Otherwise the configresolver fails to load local auto file, with error
"another empty config is defined".