### PR TITLE
Patch AD config to remove AD ID for CF configs

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
@@ -65,7 +65,7 @@ func (d *dispatcher) patchEndpointsConfiguration(in integration.Config) (integra
 	if out.Provider == names.CloudFoundryBBS {
 		// Remove ADIdentifiers if the config comes from the cloudfoundry provider, so that they are ready
 		// to be scheduled on the node agent directly (config is already resolved by the DCA)
-		out.ADIdentifiers = []string{}
+		out.ADIdentifiers = nil
 	}
 
 	// Deep copy the instances to avoid modifying the original

--- a/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_endpoints_configs.go
@@ -9,6 +9,7 @@ package clusterchecks
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 )
 
 // getEndpointsConfigs provides configs templates of endpoints checks queried by node name.
@@ -60,6 +61,12 @@ func (d *dispatcher) removeEndpointConfig(config integration.Config, nodename st
 func (d *dispatcher) patchEndpointsConfiguration(in integration.Config) (integration.Config, error) {
 	out := in
 	out.ClusterCheck = false
+
+	if out.Provider == names.CloudFoundryBBS {
+		// Remove ADIdentifiers if the config comes from the cloudfoundry provider, so that they are ready
+		// to be scheduled on the node agent directly (config is already resolved by the DCA)
+		out.ADIdentifiers = []string{}
+	}
 
 	// Deep copy the instances to avoid modifying the original
 	out.Instances = make([]integration.Data, len(in.Instances))


### PR DESCRIPTION
### What does this PR do?

Patch AD config to remove AD ID for CF configs

### Motivation

The configs are already resolved by the DCA, so remove the AD when dispatching them so the node agent can directly schedule them.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
