### PR TITLE
[pkg/metrics/series] Only use device_name if device is not present

### DIFF
--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -97,6 +97,8 @@ func (series Series) Marshal() ([]byte, error) {
 // populate the Serie.Device field
 //FIXME(olivier): remove this as soon as the v1 API can handle `device` as a regular tag
 func populateDeviceField(serie *Serie) {
+	var deviceName string
+
 	if !hasDeviceTag(serie) {
 		return
 	}
@@ -109,11 +111,18 @@ func populateDeviceField(serie *Serie) {
 		if strings.HasPrefix(tag, "device:") {
 			serie.Device = tag[7:]
 		} else if strings.HasPrefix(tag, "device_name:") {
-			serie.Device = tag[12:]
+			deviceName = tag[12:]
+			filteredTags = append(filteredTags, tag)
 		} else {
 			filteredTags = append(filteredTags, tag)
 		}
 	}
+
+	// Use device_name if device is not present
+	if serie.Device == "" {
+		serie.Device = deviceName
+	}
+
 	serie.Tags = filteredTags
 }
 

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -76,6 +76,11 @@ func TestPopulateDeviceField(t *testing.T) {
 			"/dev/sda1",
 		},
 		{
+			[]string{"some:tag", "device:/dev/sda1", "device_name:sda1"},
+			[]string{"some:tag", "device_name:sda1"},
+			"/dev/sda1",
+		},
+		{
 			[]string{"some:tag", "device:/dev/sda2", "some_other:tag"},
 			[]string{"some:tag", "some_other:tag"},
 			"/dev/sda2",

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -72,7 +72,7 @@ func TestPopulateDeviceField(t *testing.T) {
 		},
 		{
 			[]string{"some:tag", "device_name:/dev/sda1"},
-			[]string{"some:tag"},
+			[]string{"some:tag", "device_name:/dev/sda1"},
 			"/dev/sda1",
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

With the previous behavior, the value of `serie.Device` could be overwritten by the contents of the `device_name` tag if the `device_name` tag appears after the `device` tag in the `serie.Tags` list. 
This could lead to a  sudden device value change when upgrading an Agent, as `device_name` doesn't necessarily have the same value as `device`.
To fix this, the `device_name` tag is only used if no `device` tag is present.

Moreover, the previous logic removes the `device_name` tag from the list of tags, which is not desired.
To fix this, the `device_name` tag is not removed anymore when populating the `serie.Device` field.

### Motivation

Fix the device population logic to bring back the `device_name` tag.
