### PR TITLE
adds support for including Azure VM metadata

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -354,6 +354,9 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("extra_listeners", []string{})
 	config.BindEnvAndSetDefault("extra_config_providers", []string{})
 
+	// Azure
+	config.BindEnvAndSetDefault("collect_azure_tags", false)
+
 	// Docker
 	config.BindEnvAndSetDefault("docker_query_timeout", int64(5))
 	config.BindEnvAndSetDefault("docker_labels_as_tags", map[string]string{})

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -245,6 +245,11 @@ api_key:
 #
 # gce_metadata_timeout: 1000
 
+## @param collect_azure_tags - boolean - optional - default: false
+## Collect Azure VM metadata as host tags.
+#
+# collect_azure_tags: false
+
 ## @param flare_stripped_keys - list of strings - optional
 ## By default, the Agent removes known sensitive keys from Agent and Integrations yaml configs before
 ## including them in the flare.

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/azure"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
@@ -98,6 +99,15 @@ func getHostTags() *tags {
 			log.Debugf("No GCE host tags %v", err)
 		} else {
 			gceTags = appendToHostTags(gceTags, rawGceTags)
+		}
+	}
+
+	if config.Datadog.GetBool("collect_azure_tags") {
+		azureTags, err := azure.GetTags()
+		if err != nil {
+			log.Debugf("No Azure host tags %v", err)
+		} else {
+			hostTags = appendToHostTags(hostTags, azureTags)
 		}
 	}
 

--- a/pkg/util/azure/azure_tags.go
+++ b/pkg/util/azure/azure_tags.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package azure
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type azureInstanceMetadata struct {
+	VMID          string `json:"vmId"`
+	Zone          string `json:"zone"`
+	VMSize        string `json:"vmSize"`
+	ResourceGroup string `json:"resourceGroupName"`
+}
+
+// GetTags gets the tags from the GCE api
+func GetTags() ([]string, error) {
+	tags := []string{}
+
+	metadataResponse, err := getResponse(metadataURL + "/metadata/instance/compute?api-version=2017-08-01")
+	if err != nil {
+		return tags, fmt.Errorf("unable to query metadata endpoint: %s", err)
+	}
+
+	metadata := azureInstanceMetadata{}
+
+	err = json.Unmarshal([]byte(metadataResponse), &metadata)
+	if err != nil {
+		return tags, err
+	}
+
+	if metadata.VMID != "" {
+		tags = append(tags, fmt.Sprintf("vm-id:%s", metadata.VMID))
+	}
+	if metadata.Zone != "" {
+		tags = append(tags, fmt.Sprintf("zone:%s", metadata.Zone))
+	}
+	if metadata.VMSize != "" {
+		tags = append(tags, fmt.Sprintf("vm-size:%s", metadata.VMSize))
+	}
+	if metadata.ResourceGroup != "" {
+		tags = append(tags, fmt.Sprintf("resource-group:%s", metadata.ResourceGroup))
+	}
+
+	return tags, nil
+}

--- a/pkg/util/azure/azure_tags.go
+++ b/pkg/util/azure/azure_tags.go
@@ -8,6 +8,8 @@ package azure
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 type azureInstanceMetadata struct {
@@ -17,20 +19,24 @@ type azureInstanceMetadata struct {
 	ResourceGroup string `json:"resourceGroupName"`
 }
 
-// GetTags gets the tags from the GCE api
+// GetTags gets the tags from the Azure api
 func GetTags() ([]string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
 	tags := []string{}
 
 	metadataResponse, err := getResponse(metadataURL + "/metadata/instance/compute?api-version=2017-08-01")
 	if err != nil {
-		return tags, fmt.Errorf("unable to query metadata endpoint: %s", err)
+		return nil, fmt.Errorf("unable to query metadata endpoint: %s", err)
 	}
 
 	metadata := azureInstanceMetadata{}
 
 	err = json.Unmarshal([]byte(metadataResponse), &metadata)
 	if err != nil {
-		return tags, err
+		return nil, err
 	}
 
 	if metadata.VMID != "" {

--- a/pkg/util/azure/azure_tags_test.go
+++ b/pkg/util/azure/azure_tags_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package azure
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mockMetadataRequest(t *testing.T) *httptest.Server {
+	lastRequests := []*http.Request{}
+	content, err := ioutil.ReadFile("test/azure_metadata.json")
+	if err != nil {
+		assert.Fail(t, fmt.Sprintf("Error getting test data: %v", err))
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.String(), "/metadata/instance/compute?api-version=2017-08-01")
+		assert.Equal(t, "true", r.Header.Get("Metadata"))
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, string(content))
+		lastRequests = append(lastRequests, r)
+	}))
+	metadataURL = ts.URL
+	return ts
+}
+
+func TestGetHostTags(t *testing.T) {
+	server := mockMetadataRequest(t)
+	defer server.Close()
+	tags, err := GetTags()
+	if err != nil {
+		assert.Fail(t, fmt.Sprintf("Error getting tags: %v", err))
+	}
+
+	expectedTags := []string{
+		"vm-id:13f56399-bd52-4150-9748-7190aae1ff21",
+		"zone:1",
+		"vm-size:Standard_A1_v2",
+		"resource-group:myrg",
+	}
+	require.Len(t, tags, len(expectedTags))
+	for _, tag := range tags {
+		assert.Contains(t, expectedTags, tag)
+	}
+}

--- a/pkg/util/azure/test/azure_metadata.json
+++ b/pkg/util/azure/test/azure_metadata.json
@@ -1,0 +1,82 @@
+{
+  "azEnvironment": "AzurePublicCloud",
+  "customData": "",
+  "location": "centralus",
+  "name": "negasonic",
+  "offer": "lampstack",
+  "osType": "Linux",
+  "placementGroupId": "",
+  "plan": {
+      "name": "5-6",
+      "product": "lampstack",
+      "publisher": "bitnami"
+  },
+  "platformFaultDomain": "0",
+  "platformUpdateDomain": "0",
+  "provider": "Microsoft.Compute",
+  "publicKeys": [],
+  "publisher": "bitnami",
+  "resourceGroupName": "myrg",
+  "resourceId": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/myrg/providers/Microsoft.Compute/virtualMachines/negasonic",
+  "sku": "5-6",
+  "storageProfile": {
+      "dataDisks": [
+        {
+          "caching": "None",
+          "createOption": "Empty",
+          "diskSizeGB": "1024",
+          "image": {
+            "uri": ""
+          },
+          "lun": "0",
+          "managedDisk": {
+            "id": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampledatadiskname",
+            "storageAccountType": "Standard_LRS"
+          },
+          "name": "exampledatadiskname",
+          "vhd": {
+            "uri": ""
+          },
+          "writeAcceleratorEnabled": "false"
+        }
+      ],
+      "imageReference": {
+        "id": "",
+        "offer": "UbuntuServer",
+        "publisher": "Canonical",
+        "sku": "16.04.0-LTS",
+        "version": "latest"
+      },
+      "osDisk": {
+        "caching": "ReadWrite",
+        "createOption": "FromImage",
+        "diskSizeGB": "30",
+        "diffDiskSettings": {
+          "option": "Local"
+        },
+        "encryptionSettings": {
+          "enabled": "false"
+        },
+        "image": {
+          "uri": ""
+        },
+        "managedDisk": {
+          "id": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampleosdiskname",
+          "storageAccountType": "Standard_LRS"
+        },
+        "name": "exampleosdiskname",
+        "osType": "Linux",
+        "vhd": {
+          "uri": ""
+        },
+        "writeAcceleratorEnabled": "false"
+      }
+  },
+  "subscriptionId": "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
+  "tags": "Department:IT;Environment:Test;Role:WebRole",
+  "version": "7.1.1902271506",
+  "vmId": "13f56399-bd52-4150-9748-7190aae1ff21",
+  "vmScaleSetName": "",
+  "vmSize": "Standard_A1_v2",
+  "zone": "1"
+}

--- a/releasenotes/notes/collect-azure-metadata-2773087e11627255.yaml
+++ b/releasenotes/notes/collect-azure-metadata-2773087e11627255.yaml
@@ -2,5 +2,5 @@
 enhancements:
   - |
     Azure VM instance metadata may now be included as host
-    tags by using the ``collect_azure_tags``` configuration
+    tags by using the `collect_azure_tags` configuration
     option.

--- a/releasenotes/notes/collect-azure-metadata-2773087e11627255.yaml
+++ b/releasenotes/notes/collect-azure-metadata-2773087e11627255.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Azure VM instance metadata may now be included as host
+    tags by using the ``collect_azure_tags``` configuration
+    option.


### PR DESCRIPTION
### What does this PR do?

 When `collect_azure_tags` is set to true, specific instance metadata will be included as part of the host tags.

### Motivation

Similar functionality already exists for AWS and GCE. My company needs it for Azure as well. 

### Describe your test plan

Used the branch to build a binary and tested on internal infrastructure. 