### PR TITLE
Wait a bit in tests after the Agent is started

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -330,6 +330,8 @@ end
 
 
 shared_examples_for "an installed Agent" do
+  wait_until_started
+
   it 'has an example config file' do
     if os != :windows
       expect(File).to exist('/etc/datadog-agent/datadog.yaml.example')

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -56,7 +56,7 @@ def wait_until_stopped(timeout = 60)
   sleep 2
 end
 
-def wait_until_started(timeout = 60)
+def wait_until_started(timeout = 30)
   # Check if the agent has started every second
   # Timeout after the given number of seconds
   for _ in 1..timeout do

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -75,7 +75,7 @@ def wait_until_started(timeout = 30)
   # - after: works correctly
   # Until we understand and fix the problem, we're adding this sleep
   # so that we don't get flakes in the kitchen tests.
-  sleep 2
+  sleep 5
 end
 
 def stop


### PR DESCRIPTION
### What does this PR do?

- Sleep to make sure the Agent is started.
- Reduce timeout in half, since 60 seconds is a lot for the Agent to start.
- Increase the sleep time we already had from 2 to 5 seconds.

### Motivation

The Agent isn't immediately available to handle commands through its http API after it's started.
