### PR TITLE
Remove rpm_bucket resource_group

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3327,7 +3327,6 @@ deploy_staging_rpm-6:
   <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_6
   stage: deploy6
-  resource_group: rpm_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -3355,7 +3354,6 @@ deploy_staging_rpm-7:
   <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   stage: deploy7
-  resource_group: rpm_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -3388,7 +3386,6 @@ deploy_staging_suse_rpm-6:
   <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_6
   stage: deploy6
-  resource_group: rpm_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -3412,7 +3409,6 @@ deploy_staging_suse_rpm-7:
   <<: *run_only_when_triggered
   <<: *skip_when_unwanted_on_7
   stage: deploy7
-  resource_group: rpm_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE


### PR DESCRIPTION
### What does this PR do?
Removes the mutex for the rpm repos, since they don't have any shared
metadata that needs locking around and this was making the deploy slow.

### Motivation

Faster pipelines.
