### PR TITLE
[gitlab] Add missing dependency to send_pkg_size-a7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2312,6 +2312,7 @@ send_pkg_size-a7:
     - dogstatsd_rpm-x64
     - agent_suse-x64-a7
     - dogstatsd_suse-x64
+    - iot_agent_suse-x64
   script:
     - source /root/.bashrc && conda activate ddpy3
     - mkdir -p /tmp/deb/agent /tmp/deb/dogstatsd /tmp/deb/iot-agent


### PR DESCRIPTION
### What does this PR do?

Adds missing `iot_agent_suse-x64` dependency to `send_pkg_size-a7`

### Motivation

Make package size job work again.
