### PR TITLE
Support cloud_provider_metadata in tags and ecs

### DIFF
--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -27,6 +28,10 @@ var (
 // GetTags grabs the host tags from the EC2 api
 func GetTags() ([]string, error) {
 	tags := []string{}
+
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return tags, fmt.Errorf("cloud provider is disabled by configuration")
+	}
 
 	instanceIdentity, err := getInstanceIdentity()
 	if err != nil {

--- a/pkg/util/gce/gce_tags.go
+++ b/pkg/util/gce/gce_tags.go
@@ -38,6 +38,10 @@ type gceProjectMetadata struct {
 func GetTags() ([]string, error) {
 	tags := []string{}
 
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return tags, fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
 	metadataResponse, err := getResponse(metadataURL + "/?recursive=true")
 	if err != nil {
 		return tags, err


### PR DESCRIPTION
### What does this PR do?

Support cloud_provider_metadata in tags and ecs. We missed a few exposed function in the original PR.