### PR TITLE
Fix snmp config name to match `auto_conf.yaml` and `conf.yaml.example`

### DIFF
--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -45,10 +45,10 @@ type Config struct {
 	Retries            int             `mapstructure:"retries"`
 	Community          string          `mapstructure:"community"`
 	User               string          `mapstructure:"user"`
-	AuthKey            string          `mapstructure:"authentication_key"`
-	AuthProtocol       string          `mapstructure:"authentication_protocol"`
-	PrivKey            string          `mapstructure:"privacy_key"`
-	PrivProtocol       string          `mapstructure:"privacy_protocol"`
+	AuthKey            string          `mapstructure:"auth_key"`
+	AuthProtocol       string          `mapstructure:"auth_protocol"`
+	PrivKey            string          `mapstructure:"priv_key"`
+	PrivProtocol       string          `mapstructure:"priv_protocol"`
 	ContextEngineID    string          `mapstructure:"context_engine_id"`
 	ContextName        string          `mapstructure:"context_name"`
 	IgnoredIPAddresses map[string]bool `mapstructure:"ignored_ip_addresses"`


### PR DESCRIPTION
### What does this PR do?

Fix config to match [`auto_conf.yaml`](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/auto_conf.yaml#L42-L64) and and [`conf.yaml.example`](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/conf.yaml.example#L225-L247) (even though the case is different)

### Motivation

More consistent and less error prone.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
