### PR TITLE
new `obfuscate_sql` logs processing rule 

### DIFF
--- a/pkg/logs/config/processing_rules.go
+++ b/pkg/logs/config/processing_rules.go
@@ -16,6 +16,7 @@ const (
 	IncludeAtMatch = "include_at_match"
 	MaskSequences  = "mask_sequences"
 	MultiLine      = "multi_line"
+	ObfuscateSQL   = "obfuscate_sql"
 )
 
 // ProcessingRule defines an exclusion or a masking rule to
@@ -42,7 +43,7 @@ func ValidateProcessingRules(rules []*ProcessingRule) error {
 		}
 
 		switch rule.Type {
-		case ExcludeAtMatch, IncludeAtMatch, MaskSequences, MultiLine:
+		case ExcludeAtMatch, IncludeAtMatch, MaskSequences, MultiLine, ObfuscateSQL:
 			break
 		case "":
 			return fmt.Errorf("type must be set for processing rule `%s`", rule.Name)
@@ -69,7 +70,8 @@ func CompileProcessingRules(rules []*ProcessingRule) error {
 			return err
 		}
 		switch rule.Type {
-		case ExcludeAtMatch, IncludeAtMatch:
+		case ExcludeAtMatch, IncludeAtMatch, ObfuscateSQL:
+			// TODO: better validation of ObfuscateSQL, check for valid named subgroups
 			rule.Regex = re
 		case MaskSequences:
 			rule.Regex = re

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -18,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/twmb/murmur3"
 )
 
 const sqlQueryTag = "sql.query"
@@ -341,4 +343,10 @@ func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
 		return
 	}
 	traceutil.SetMeta(span, sqlQueryTag, oq.Query)
+}
+
+// HashObfuscatedSQL returns the hash of an already obfuscated query as 32 char hex string
+// the query must already have been obfuscated using ObfuscateSQLString
+func HashObfuscatedSQL(obfuscatedSQL string) string {
+	return strconv.FormatUint(murmur3.Sum64([]byte(obfuscatedSQL)), 16)
 }


### PR DESCRIPTION
### What does this PR do?

Rule features:
* obfuscate sql in log lines by pattern
* inject sql signature based on obfuscated sql
* inject sql signature from query text in postgres auto_explain plan

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
