### PR TITLE
Fix typo in AKS pause container regex

### DIFF
--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -33,7 +33,7 @@ const (
 	// pauseContainerAKS regex matches:
 	// - mcr.microsoft.com/k8s/core/pause-amd64
 	// - aksrepos.azurecr.io/mirror/pause-amd64
-	pauseContainerAKS = `image:(mcr.microsoft.com/k8s/core/|aksrepos.azurecr.io/mirror/|kubletwin/)pause(.*)`
+	pauseContainerAKS = `image:(mcr.microsoft.com/k8s/core/|aksrepos.azurecr.io/mirror/|kubeletwin/)pause(.*)`
 	pauseContainerECR = `image:ecr(.*)amazonaws.com/pause(.*)`
 )
 

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -207,7 +207,7 @@ func TestFilter(t *testing.T) {
 			c: Container{
 				ID:    "24",
 				Name:  "k8s_POD_AKS_Win",
-				Image: "kubletwin/pause:latest",
+				Image: "kubeletwin/pause:latest",
 			},
 			ns: "default",
 		},


### PR DESCRIPTION
### What does this PR do?

Fixes a small typo in AKS pause container name

