### PR TITLE
[pkg/metadata] Adds Agent flavor to metadata

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -51,6 +51,7 @@ func GetPayload(hostnameData util.HostnameData) *Payload {
 
 	p := &Payload{
 		Os:            osName,
+		AgentFlavor:   config.AgentFlavor,
 		PythonVersion: GetPythonVersion(),
 		SystemStats:   getSystemStats(),
 		Meta:          meta,

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -26,6 +26,7 @@ import (
 func TestGetPayload(t *testing.T) {
 	p := GetPayload(util.HostnameData{Hostname: "myhostname", Provider: ""})
 	assert.NotEmpty(t, p.Os)
+	assert.NotEmpty(t, p.AgentFlavor)
 	assert.NotEmpty(t, p.PythonVersion)
 	assert.NotNil(t, p.SystemStats)
 	assert.NotNil(t, p.Meta)

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -54,6 +54,7 @@ type InstallMethod struct {
 // Payload handles the JSON unmarshalling of the metadata payload
 type Payload struct {
 	Os            string            `json:"os"`
+	AgentFlavor   string            `json:"agent-flavor"`
 	PythonVersion string            `json:"python"`
 	SystemStats   *systemStats      `json:"systemStats"`
 	Meta          *Meta             `json:"meta"`


### PR DESCRIPTION
### What does this PR do?

- Adds Agent Flavor (full Agent, IoT Agent or DogStatsD) to metadata.

### Motivation

- Ensure this information is available

### Describe your test plan

Set the Agent's `log_level` to `debug` and check that the metadata payload includes the `agent-flavor` field set to the correct string.