### PR TITLE
Ensure that current weight is properly tracked

### DIFF
--- a/pkg/process/util/api/weighted_queue.go
+++ b/pkg/process/util/api/weighted_queue.go
@@ -151,6 +151,7 @@ func (q *WeightedQueue) Add(item WeightedItem) {
 		for iter := q.iterator(); iter.hasNext(); iter.next() {
 			if v := iter.value(); v.Type() == item.Type() {
 				iter.remove()
+				q.currentWeight -= v.Weight()
 				removed = true
 				break
 			}
@@ -158,7 +159,10 @@ func (q *WeightedQueue) Add(item WeightedItem) {
 
 		// No similar items, remove the oldest element from the queue
 		if !removed {
-			q.queue.Remove(q.queue.Front())
+			e := q.queue.Front()
+			v := e.Value.(WeightedItem)
+			q.currentWeight -= v.Weight()
+			q.queue.Remove(e)
 		}
 	}
 

--- a/pkg/process/util/api/weighted_queue_test.go
+++ b/pkg/process/util/api/weighted_queue_test.go
@@ -86,6 +86,7 @@ func TestWeightedQueueItemsEvicted(t *testing.T) {
 	assert.Equal(t, int64(4), item.Weight())
 
 	assert.Equal(t, 0, q.Len())
+	assert.Equal(t, int64(0), q.Weight())
 }
 
 func TestWeightedQueueItemsEvictedByType(t *testing.T) {
@@ -113,6 +114,34 @@ func TestWeightedQueueItemsEvictedByType(t *testing.T) {
 	assert.Equal(t, int64(4), item.Weight())
 
 	assert.Equal(t, 0, q.Len())
+}
+
+func TestWeightedQueueItemsEvictedFromHead(t *testing.T) {
+	q := NewWeightedQueue(3, math.MaxInt64)
+	exit := make(chan struct{})
+
+	q.Add(newItem("item", 1))
+	q.Add(newItem("item", 2))
+	q.Add(newItem("item", 3))
+	q.Add(newItem("item-new", 4))
+
+	item, ok := q.Poll(exit)
+	assert.True(t, ok)
+	assert.Equal(t, "item", item.Type())
+	assert.Equal(t, int64(2), item.Weight())
+
+	item, ok = q.Poll(exit)
+	assert.True(t, ok)
+	assert.Equal(t, "item", item.Type())
+	assert.Equal(t, int64(3), item.Weight())
+
+	item, ok = q.Poll(exit)
+	assert.True(t, ok)
+	assert.Equal(t, "item-new", item.Type())
+	assert.Equal(t, int64(4), item.Weight())
+
+	assert.Equal(t, 0, q.Len())
+	assert.Equal(t, int64(0), q.Weight())
 }
 
 func TestWeightedQueueItemsEvictedByTypeForWeight(t *testing.T) {
@@ -157,6 +186,7 @@ func TestWeightedQueueItemsEvictedForWeight(t *testing.T) {
 	assert.Equal(t, int64(10), item.Weight())
 
 	assert.Equal(t, 0, q.Len())
+	assert.Equal(t, int64(0), q.Weight())
 }
 
 func TestWeightedQueueAvailableWeightCorrectlySetEvictingItemsOfSameType(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This commit fixes an issue where the current weight was not correctly updated when items were evicted from the queue based on queue size

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
