### PR TITLE
[System Probe]Only render template for system probe if we are sure it is running

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -286,7 +286,7 @@ func StartAgent() error {
 	}
 
 	if err = common.SetupSystemProbeConfig(sysProbeConfFilePath); err != nil {
-		log.Infof("System probe config not found, disabling setting system probe status page: %v", err)
+		log.Infof("System probe config not found, disabling pulling system probe info in the status page: %v", err)
 	}
 
 	// Detect Cloud Provider

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -286,7 +286,7 @@ func StartAgent() error {
 	}
 
 	if err = common.SetupSystemProbeConfig(sysProbeConfFilePath); err != nil {
-		log.Errorf("System probe config not read: %v", err)
+		log.Infof("System probe config not found, disabling setting system probe status page: %v", err)
 	}
 
 	// Detect Cloud Provider

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -47,7 +47,9 @@ func FormatStatus(data []byte) (string, error) {
 	renderStatusTemplate(b, "/forwarder.tmpl", forwarderStats)
 	renderStatusTemplate(b, "/endpoints.tmpl", endpointsInfos)
 	renderStatusTemplate(b, "/logsagent.tmpl", logsStats)
-	renderStatusTemplate(b, "/systemprobe.tmpl", systemProbeStats)
+	if config.Datadog.GetBool("system_probe_config.enabled") {
+		renderStatusTemplate(b, "/systemprobe.tmpl", systemProbeStats)
+	}
 	renderStatusTemplate(b, "/trace-agent.tmpl", stats["apmStats"])
 	renderStatusTemplate(b, "/aggregator.tmpl", aggregatorStats)
 	renderStatusTemplate(b, "/dogstatsd.tmpl", dogstatsdStats)


### PR DESCRIPTION
### What does this PR do?

Currently, any agent status will render a template saying that the system probe is running. 

### Motivation

We want to have accurate status messages. 

### Describe your test plan

Run a status command on a host without the system probe enabled. 
