### PR TITLE
pkg/trace/info: ensure "payload_too_large" metric is correct

### DIFF
--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -350,6 +350,7 @@ func (s *Stats) update(recent *Stats) {
 
 func (s *Stats) reset() {
 	atomic.StoreInt64(&s.TracesReceived, 0)
+	atomic.StoreInt64(&s.TracesDropped.PayloadTooLarge, 0)
 	atomic.StoreInt64(&s.TracesDropped.DecodingError, 0)
 	atomic.StoreInt64(&s.TracesDropped.EmptyTrace, 0)
 	atomic.StoreInt64(&s.TracesDropped.TraceIDZero, 0)

--- a/releasenotes/notes/apm-payload-too-large-metric-1515000ee3a3552b.yaml
+++ b/releasenotes/notes/apm-payload-too-large-metric-1515000ee3a3552b.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: The reported "payload_too_large" metric, which counts dropped payloads
+    due to their size, was previously incorrect and showed larger than normal numbers.


### PR DESCRIPTION
This change ensures the correct resetting of the PayloadTooLarge metric
when submitting. The previous value was cumulative and inaccurate.