### PR TITLE
[cmd/dogstatsd] Improve exit logic (no api key & OS signal handling)

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -154,7 +154,7 @@ func runAgent() (mainCtx context.Context, mainCtxCancel context.CancelFunc, err 
 	}
 
 	if !config.Datadog.IsSet("api_key") {
-		log.Critical("no API key configured, exiting")
+		err = log.Critical("no API key configured, exiting")
 		return
 	}
 

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -90,10 +90,7 @@ func init() {
 func start(cmd *cobra.Command, args []string) error {
 	// Main context passed to components
 	ctx, cancel := context.WithCancel(context.Background())
-
-	defer func(cancel context.CancelFunc) {
-		stopAgent(cancel)
-	}(cancel)
+	defer stopAgent(cancel)
 
 	stopCh := make(chan struct{})
 	go handleSignals(stopCh)

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -95,7 +96,9 @@ func (m *myservice) Execute(args []string, r <-chan svc.ChangeRequest, changes c
 
 	log.Infof("Service control function")
 	importRegistryConfig()
-	mainCtx, mainCtxCancel, err := runAgent()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := runAgent(ctx)
 
 	if err != nil {
 		log.Errorf("Failed to start agent %v", err)
@@ -133,7 +136,7 @@ loop:
 	elog.Info(0x40000006, ServiceName)
 	log.Infof("Initiating service shutdown")
 	changes <- svc.Status{State: svc.StopPending}
-	stopAgent(mainCtx, mainCtxCancel)
+	stopAgent(cancel)
 	changes <- svc.Status{State: svc.Stopped}
 	return
 }

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -104,6 +104,7 @@ func (m *myservice) Execute(args []string, r <-chan svc.ChangeRequest, changes c
 		log.Errorf("Failed to start agent %v", err)
 		elog.Error(0xc0000008, err.Error())
 		errno = 1 // indicates non-successful return from handler.
+		stopAgent(cancel)
 		changes <- svc.Status{State: svc.Stopped}
 		return
 	}

--- a/releasenotes/notes/dogstatsd-standalone-sigpipe-e7b28f919ab5d751.yaml
+++ b/releasenotes/notes/dogstatsd-standalone-sigpipe-e7b28f919ab5d751.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Dogstatsd standalone: when running on a systemd-based system, do not stop
+    Dogstatsd when journald is stopped or restarted.


### PR DESCRIPTION
### What does this PR do?

On dogstatsd standalone:
1. make dogstatsd exit early (instead of waiting indefinitely until an OS interrupt signal is received) with an error when no valid API key is set and no configuration file is set (so a very narrow case).
2. handle `SIGPIPE` correctly (useful when `dogstatsd` service is managed by systemd): I copied the logic that the `agent` has to handle `SIGPIPE` since I saw it was missing, but I haven't actually tried reproducing the issue

Not critical (and no user reports), therefore can wait for 7.21.

### Motivation

Improve exit and signal logic to same level as agent binary.

### Describe your test plan

* I tested on a locally-built dogstatsd binary
* this should be tested on the dogstatsd image as well
