### PR TITLE
[Chocolatey] Use testing repo for RC

### DIFF
--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -5,12 +5,17 @@ if (($domainRole -eq 4) -Or ($domainRole -eq 5)) {
   Write-Host "Installation on a Domain Controller is not yet supported - aborting"
   exit -1
 }
+url = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($env:chocolateyPackageVersion).msi"
+if ($env:chocolateyPackageVersion -match "(\d+\.\d+\.\d+)-rc\.(\d+)") {
+  url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($env:chocolateyPackageVersion)-1-x86_64.msi"
+}
+
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   fileType      = 'msi'
-  url64bit      = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($env:chocolateyPackageVersion).msi"
+  url64bit      = $url
   softwareName  = 'Datadog Agent'
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
   validExitCodes= @(0, 3010, 1641)

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -5,9 +5,9 @@ if (($domainRole -eq 4) -Or ($domainRole -eq 5)) {
   Write-Host "Installation on a Domain Controller is not yet supported - aborting"
   exit -1
 }
-url = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($env:chocolateyPackageVersion).msi"
+$url = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($env:chocolateyPackageVersion).msi"
 if ($env:chocolateyPackageVersion -match "(\d+\.\d+\.\d+)-rc\.(\d+)") {
-  url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($env:chocolateyPackageVersion)-1-x86_64.msi"
+  $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($env:chocolateyPackageVersion)-1-x86_64.msi"
 }
 
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -1,13 +1,18 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop';
 # See https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-computersystem
 $domainRole = (Get-WmiObject -Class Win32_ComputerSystem).DomainRole
 if (($domainRole -eq 4) -Or ($domainRole -eq 5)) {
   Write-Host "Installation on a Domain Controller is not yet supported - aborting"
   exit -1
 }
+
 $url = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($env:chocolateyPackageVersion).msi"
-if ($env:chocolateyPackageVersion -match "(\d+\.\d+\.\d+)-rc\.(\d+)") {
-  $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($env:chocolateyPackageVersion)-1-x86_64.msi"
+# Note: match x.x.x-rc-x nuspec version format
+$releaseCandidatePattern = "(\d+\.\d+\.\d+)-rc\-(\d+)"
+if ($env:chocolateyPackageVersion -match $releaseCandidatePattern) {
+  # and turn it back into Datadog version format x.x.x-rc.x
+  $agentVersionMatches = $env:chocolateyPackageVersion | Select-String -Pattern $releaseCandidatePattern
+  $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2])-1-x86_64.msi"
 }
 
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"


### PR DESCRIPTION
### What does this PR do?

Makes the install script for the online chocolatey package use the testing repo when we are installing a release candidate.

### Motivation

To be able to test Chocolatey packages during QA.

