### PR TITLE
Fix warnings for dns config variables

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -662,6 +662,8 @@ func initConfig(config Config) {
 	config.SetKnown("system_probe_config.source_excludes")
 	config.SetKnown("system_probe_config.dest_excludes")
 	config.SetKnown("system_probe_config.closed_channel_size")
+	config.SetKnown("system_probe_config.dns_timeout_in_s")
+	config.SetKnown("system_probe_config.collect_dns_stats")
 
 	// Network
 	config.BindEnv("network.id") //nolint:errcheck

--- a/pkg/ebpf/bytecode/tracer-ebpf.go
+++ b/pkg/ebpf/bytecode/tracer-ebpf.go
@@ -106,7 +106,7 @@ func tracerEbpfDebugO() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tracer-ebpf-debug.o", size: 59632, mode: os.FileMode(436), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tracer-ebpf-debug.o", size: 59632, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -47,7 +47,9 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 
 	a.CollectLocalDNS = config.Datadog.GetBool(key(spNS, "collect_local_dns"))
 	a.CollectDNSStats = config.Datadog.GetBool(key(spNS, "collect_dns_stats"))
-	a.DNSTimeout = config.Datadog.GetDuration(key(spNS, "dns_timeout_in_s")) * time.Second
+	if config.Datadog.IsSet(key(spNS, "dns_timeout_in_s")) {
+		a.DNSTimeout = config.Datadog.GetDuration(key(spNS, "dns_timeout_in_s")) * time.Second
+	}
 
 	if config.Datadog.GetBool(key(spNS, "enabled")) {
 		a.EnabledChecks = append(a.EnabledChecks, "connections")


### PR DESCRIPTION
### What does this PR do?
- make dns configuration variables _known_
- check the presence of `dns_timeout_in_s` before extracting the value

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
