### PR TITLE
[GCE] Define configurable timeout as an integer

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -436,7 +436,7 @@ func initConfig(config Config) {
 	// GCE
 	config.BindEnvAndSetDefault("collect_gce_tags", true)
 	config.BindEnvAndSetDefault("exclude_gce_tags", []string{"kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings", "windows-startup-script-ps1", "common-psm1", "k8s-node-setup-psm1", "serial-port-logging-enable", "enable-oslogin", "disable-address-manager", "disable-legacy-endpoints", "windows-keys"})
-	config.BindEnvAndSetDefault("gce_metadata_timeout", 1*time.Second)
+	config.BindEnvAndSetDefault("gce_metadata_timeout", 1000) // value in milliseconds
 
 	// Cloud Foundry
 	config.BindEnvAndSetDefault("cloud_foundry", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -240,6 +240,11 @@ api_key:
 #   - "google-container-manifest"
 #   - "bosh_settings"
 
+## @param gce_metadata_timeout - integer - optional - default: 1000
+## Timeout in milliseconds on calls to the GCE metadata endpoints.
+#
+# gce_metadata_timeout: 1000
+
 ## @param flare_stripped_keys - list of strings - optional
 ## By default, the Agent removes known sensitive keys from Agent and Integrations yaml configs before
 ## including them in the flare.

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
@@ -127,7 +128,7 @@ func getResponseWithMaxLength(endpoint string, maxLength int) (string, error) {
 
 func getResponse(url string) (string, error) {
 	client := http.Client{
-		Timeout: config.Datadog.GetDuration("gce_metadata_timeout"),
+		Timeout: time.Duration(config.Datadog.GetInt("gce_metadata_timeout")) * time.Millisecond,
 	}
 
 	req, err := http.NewRequest("GET", url, nil)


### PR DESCRIPTION
### What does this PR do?

Follow up to https://github.com/DataDog/datadog-agent/pull/5419. Changes the new option so it's expressed as an integer in milliseconds rather than a duration string, and documents it.

### Motivation

Prefer an integer to a duration string for consistency with other duration config options expressing a duration.

In milliseconds since a timeout lower than 1 second may be desired. (before 7.20 the default was 300ms)