### PR TITLE
Allow reporting on cgroup statistics when the container id isn't in all paths

### DIFF
--- a/pkg/util/containers/providers/cgroup/cgroup_detect_test.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_detect_test.go
@@ -208,6 +208,8 @@ func TestParseCgroupPaths(t *testing.T) {
 				"5:coreos_7xx:/system.slice/docker-a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419.scope",
 				// Legacy systems
 				"6:legacy:a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419.scope",
+				// Docker under systemd
+				"7:systemd:/system.slice/myservice.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
 			},
 			expectedContainer: "a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
 			expectedPaths: map[string]string{
@@ -217,6 +219,7 @@ func TestParseCgroupPaths(t *testing.T) {
 				"kube1.7":    "/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
 				"coreos_7xx": "/system.slice/docker-a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419.scope",
 				"legacy":     "a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419.scope",
+				"systemd":    "/system.slice/myservice.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
 			},
 		},
 		{
@@ -270,6 +273,37 @@ func TestParseCgroupPaths(t *testing.T) {
 				"cpuacct":      "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
 				"cpu":          "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
 				"cpuset":       "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+			},
+		},
+		{
+			contents: []string{
+				"11:memory:/system.slice/ecs-agent.service",
+				"10:pids:/system.slice/ecs-agent.service",
+				"9:hugetlb:/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"8:blkio:/system.slice/ecs-agent.service",
+				"7:net_cls,net_prio:/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"6:devices:/system.slice/ecs-agent.service",
+				"5:perf_event:/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"4:freezer:/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"3:cpuset:/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"2:cpu,cpuacct:/system.slice/ecs-agent.service",
+				"1:name=systemd:/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+			},
+			expectedContainer: "1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+			expectedPaths: map[string]string{
+				"memory":       "/system.slice/ecs-agent.service",
+				"pids":         "/system.slice/ecs-agent.service",
+				"hugetlb":      "/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"blkio":        "/system.slice/ecs-agent.service",
+				"net_cls":      "/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"net_prio":     "/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"devices":      "/system.slice/ecs-agent.service",
+				"perf_event":   "/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"freezer":      "/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"cpuset":       "/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
+				"cpu":          "/system.slice/ecs-agent.service",
+				"cpuacct":      "/system.slice/ecs-agent.service",
+				"name=systemd": "/system.slice/ecs-agent.service/1236529c30c0bf2faf2c5c63c0af2afd134118b91348f321c996734e15b7a8f9",
 			},
 		},
 	} {

--- a/releasenotes/notes/systemd-cgroup-docker-interopability-91e946effb4830b4.yaml
+++ b/releasenotes/notes/systemd-cgroup-docker-interopability-91e946effb4830b4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Add support for examining processes inside Docker containers running under
+    systemd cgroups. This also reduces agent logging volume as it's able to
+    capture those statistics going forward.


### PR DESCRIPTION

### What does this PR do?

Two things!

- Allows for reporting of cgroup/docker stats when all the cgroups don't contain the container id.
- Removes several log lines that are emitted every time the docker/cgroup checks run and there is a systemd service under docker yadda yadda... **On our infrastructure this is responsible for nearly 1.6 million log lines hourly.**

### Background

When running a Docker container under systemd you're supposed to pass the `--cgroup-parent` argument to the run command. This is so systemd is aware of the processes running inside of the Docker container, and it completely changes the cgroups in use, and some of them no longer contain the container id.

The cgroups go from being `/docker/CID/` to `/system.slice/ecs-agent.service/CID`, but `memory`, `pids`, `blkio`, `devices`, and `cpu` are in `/system.slice/ecs-agent.service`. I'm assuming this is because systemd manages those specific namespaces.

Removing the continue inside this statement allows for the first discovered container id to be associated with the cgroups that aren't directly associated with that container id.

### Motivation

I was tired of the DataDog agent being responsible for nearly half of our log volumes.

### Additional Notes

If this PR is merged, there is a good chance you can close ticket 341303 on your end.

edit: For those curious about how this was tracked down: https://gist.github.com/lattwood/e3bbf15348d21ed645fcc4d4f87f1daf