### PR TITLE
Overrides install info on deb/rpm

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -56,26 +56,23 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         esac
         #DEBHELPER#
 
-        # Set the installation information if not already present;
+        # Set the installation information
         # This is done in posttrans for .rpm packages
-        if [ ! -f "$CONFIG_DIR/install_info" ]; then
+        if command -v dpkg >/dev/null 2>&1 && command -v dpkg-query >/dev/null 2>&1; then
+            tool=dpkg
+            tool_version=dpkg-$(dpkg-query --showformat='${Version}' --show dpkg  | cut -d "." -f 1-3 || echo "unknown")
+        else
+            tool=unknown
+            tool_version=unknown
+        fi
 
-            if command -v dpkg >/dev/null 2>&1 && command -v dpkg-query >/dev/null 2>&1; then
-                tool=dpkg
-                tool_version=dpkg-$(dpkg-query --showformat='${Version}' --show dpkg  | cut -d "." -f 1-3 || echo "unknown")
-            else
-                tool=unknown
-                tool_version=unknown
-            fi
-            
-            install_info_content="---
+        install_info_content="---
 install_method:
   tool: $tool
   tool_version: $tool_version
   installer_version: deb_package
 "
-            echo "$install_info_content" > $CONFIG_DIR/install_info
-        fi
+        echo "$install_info_content" > $CONFIG_DIR/install_info
     fi
 
     # Set proper rights to the dd-agent user

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -97,34 +97,31 @@ if [ "$DISTRIBUTION_FAMILY" != "SUSE" ]; then
 fi
 
 
-# Set the installation information if not already present;
+# Set the installation information
 # This is done in the postinst script for .deb packages
-if [ ! -f "$CONFIG_DIR/install_info" ]; then
+if command -v rpm >/dev/null 2>&1; then
+    tool=rpm
+    tool_version=rpm-$(rpm -q --qf "%{VERSION}" rpm || echo "unknown")
+else
+    tool=unknown
+    tool_version=unknown
+fi
 
-    if command -v rpm >/dev/null 2>&1; then
-        tool=rpm
-        tool_version=rpm-$(rpm -q --qf "%{VERSION}" rpm || echo "unknown")
-    else
-        tool=unknown
-        tool_version=unknown
-    fi
+# Distinguish SUSE since it has a different package
+if [ "$DISTRIBUTION_FAMILY" == "SUSE" ]; then
+    installer_version="rpm_suse_package"
+else
+    installer_version="rpm_package"
+fi
 
-    # Distinguish SUSE since it has a different package
-    if [ "$DISTRIBUTION_FAMILY" == "SUSE" ]; then
-        installer_version="rpm_suse_package"
-    else
-        installer_version="rpm_package"
-    fi
-    
-    install_info_content="---
+install_info_content="---
 install_method:
   tool: $tool
   tool_version: $tool_version
   installer_version: $installer_version
 "
-    echo "$install_info_content" > $CONFIG_DIR/install_info
-    chown -R dd-agent:dd-agent ${CONFIG_DIR}
-fi
+echo "$install_info_content" > $CONFIG_DIR/install_info
+chown -R dd-agent:dd-agent ${CONFIG_DIR}
 
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
 # and avoid restarting when a check conf is invalid

--- a/omnibus/package-scripts/iot-agent/postinst
+++ b/omnibus/package-scripts/iot-agent/postinst
@@ -56,26 +56,23 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         esac
         #DEBHELPER#
         
-        # Set the installation information if not already present;
+        # Set the installation information
         # This is done in posttrans for .rpm packages
-	    if [ ! -f "$CONFIG_DIR/install_info" ]; then
+		if command -v dpkg >/dev/null 2>&1 && command -v dpkg-query >/dev/null 2>&1; then
+			tool=dpkg
+			tool_version=dpkg-$(dpkg-query --showformat='${Version}' --show dpkg | cut -d "." -f 1-3 || echo "unknown")
+		else
+			tool=unknown
+			tool_version=unknown
+		fi
 
-		    if command -v dpkg >/dev/null 2>&1 && command -v dpkg-query >/dev/null 2>&1; then
-			    tool=dpkg
-			    tool_version=dpkg-$(dpkg-query --showformat='${Version}' --show dpkg | cut -d "." -f 1-3 || echo "unknown")
-		    else
-			    tool=unknown
-			    tool_version=unknown
-		    fi
-		    
-		    install_info_content="---
+		install_info_content="---
 install_method:
   tool: $tool
   tool_version: $tool_version
   installer_version: deb_package-iot
 "
-		    echo "$install_info_content" > $CONFIG_DIR/install_info
-	    fi
+		echo "$install_info_content" > $CONFIG_DIR/install_info
     fi
 
 	# Set proper rights to the dd-agent user

--- a/omnibus/package-scripts/iot-agent/posttrans
+++ b/omnibus/package-scripts/iot-agent/posttrans
@@ -26,25 +26,22 @@ fi
 
 # Set the installation information if not already present;
 # This is done in the postinst script for .deb packages
-if [ ! -f "$CONFIG_DIR/install_info" ]; then
+if command -v rpm >/dev/null 2>&1; then
+    tool=rpm
+    tool_version=rpm-$(rpm -q --qf "%{VERSION}" rpm || echo "unknown")
+else
+    tool=unknown
+    tool_version=unknown
+fi
 
-    if command -v rpm >/dev/null 2>&1; then
-        tool=rpm
-        tool_version=rpm-$(rpm -q --qf "%{VERSION}" rpm || echo "unknown")
-    else
-        tool=unknown
-        tool_version=unknown
-    fi
-
-    install_info_content="---
+install_info_content="---
 install_method:
   tool: $tool
   tool_version: $tool_version
   installer_version: rpm_package-iot
 "
-    echo "$install_info_content" > $CONFIG_DIR/install_info
-    chown -R dd-agent:dd-agent ${CONFIG_DIR}
-fi
+echo "$install_info_content" > $CONFIG_DIR/install_info
+chown -R dd-agent:dd-agent ${CONFIG_DIR}
 
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
 # and avoid restarting when a check conf is invalid


### PR DESCRIPTION
### What does this PR do?

- Overrides install_info file unconditionally when installing through deb/rpm packages.

### Motivation

- We want to know the installation information at each point in time instead of what we did on #5481 which keeps any existing file.

### Additional Notes

- The fix should be backported to the 7.20.x branch after this gets merged.
