### PR TITLE
Add DD Event types when converting k8s events

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -8,6 +8,7 @@ package cluster
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -118,7 +119,7 @@ func TestParseComponentStatus(t *testing.T) {
 	mocked.AssertExpectations(t)
 }
 
-func createEvent(count int32, namespace, objname, objkind, objuid, component, hostname, reason string, message string, timestamp int64) *v1.Event {
+func createEvent(count int32, namespace, objname, objkind, objuid, component, hostname, reason, message, typ string, timestamp int64) *v1.Event {
 	return &v1.Event{
 		InvolvedObject: v1.ObjectReference{
 			Name:      objname,
@@ -139,16 +140,17 @@ func createEvent(count int32, namespace, objname, objkind, objuid, component, ho
 			Time: time.Unix(timestamp, 0),
 		},
 		Message: message,
+		Type:    typ,
 	}
 }
 
 func TestProcessBundledEvents(t *testing.T) {
 	// We want to check if the format of several new events and several modified events creates DD events accordingly
 	// We also want to check that a modified event with an existing key is aggregated (i.e. the key is already known)
-	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", 709662600)
-	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", 709662600)
-	ev3 := createEvent(1, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "machine-blue", "MissingClusterDNS", "MountVolume.SetUp succeeded", 709662600)
-	ev4 := createEvent(29, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "machine-blue", "MissingClusterDNS", "MountVolume.SetUp succeeded", 709675200)
+	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Normal", 709662600)
+	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", "Normal", 709662600)
+	ev3 := createEvent(1, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "machine-blue", "MissingClusterDNS", "MountVolume.SetUp succeeded", "Normal", 709662600)
+	ev4 := createEvent(29, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "machine-blue", "MissingClusterDNS", "MountVolume.SetUp succeeded", "Normal", 709675200)
 	// (As Object kinds are Pod and Node here, the event should take the remote hostname `machine-blue`)
 
 	kubeASCheck := NewKubeASCheck(core.NewCheckBase(kubernetesAPIServerCheckName), &KubeASConfig{})
@@ -230,7 +232,7 @@ func TestProcessBundledEvents(t *testing.T) {
 func TestProcessEvent(t *testing.T) {
 	// We want to check if the format of 1 New event creates a DD event accordingly.
 	// We also want to check that filtered and empty events aren't submitted
-	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "ReplicaSet", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", 709662600)
+	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "ReplicaSet", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Warning", 709662600)
 	// (Object kind was changed from Pod to ReplicaSet to test the choice of hostname: it should take here the local hostname below `hostname`)
 
 	kubeASCheck := NewKubeASCheck(core.NewCheckBase(kubernetesAPIServerCheckName), &KubeASConfig{})
@@ -250,6 +252,7 @@ func TestProcessEvent(t *testing.T) {
 		Ts:             709662600,
 		Host:           "",
 		EventType:      "kubernetes_apiserver",
+		AlertType:      metrics.EventAlertTypeWarning,
 	}
 	mocked.On("Event", mock.AnythingOfType("metrics.Event"))
 	kubeASCheck.processEvents(mocked, newKubeEventBundle)
@@ -291,4 +294,42 @@ func TestConvertFilter(t *testing.T) {
 			assert.Equal(t, tc.output, output)
 		})
 	}
+}
+
+func TestProcessEventsType(t *testing.T) {
+	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Normal", 709662600)
+	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", "Normal", 709662600)
+	ev3 := createEvent(4, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "BackOff", "Back-off restarting failed container", "Warning", 709662600)
+
+	kubeASCheck := NewKubeASCheck(core.NewCheckBase(kubernetesAPIServerCheckName), &KubeASConfig{})
+
+	newKubeEventsBundle := []*v1.Event{
+		ev1,
+		ev2,
+		ev3,
+	}
+	mocked := mocksender.NewMockSender(kubeASCheck.ID())
+	mocked.On("Event", mock.AnythingOfType("metrics.Event"))
+
+	kubeASCheck.processEvents(mocked, newKubeEventsBundle)
+
+	// We are only expecting two bundle events from the 3 kubernetes events because the event types differ.
+	// We need to check that the countByAction concatenated string contains the source events.
+	// As the order is not guaranteed we want to use contains.
+	calls := []string{
+		(mocked.Calls[0].Arguments.Get(0)).(metrics.Event).Text,
+		(mocked.Calls[1].Arguments.Get(0)).(metrics.Event).Text,
+	}
+
+	// The order of calls is random in processEvents because of the map eventsByObject
+	// Mocked calls need to be sorted before making assertions
+	sort.Strings(calls)
+
+	assert.Contains(t, calls[0], "2 **Scheduled**")
+	assert.Contains(t, calls[0], "3 **Started**")
+
+	assert.Contains(t, calls[1], "4 **BackOff**")
+
+	mocked.AssertNumberOfCalls(t, "Event", 2)
+	mocked.AssertExpectations(t)
 }

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle_test.go
@@ -8,20 +8,21 @@ package cluster
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 
 	cache "github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 func TestFormatEvent(t *testing.T) {
-	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", 709662600)
-	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", 709662600)
+	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Normal", 709662600)
+	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", "Normal", 709662600)
 
 	eventList := []*v1.Event{
 		ev1,
@@ -54,8 +55,8 @@ func TestFormatEvent(t *testing.T) {
 }
 
 func TestFormatEventWithNodename(t *testing.T) {
-	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", 709662600)
-	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", 709662600)
+	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", "Normal", 709662600)
+	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", "Normal", 709662600)
 
 	eventList := []*v1.Event{
 		ev1,
@@ -92,4 +93,35 @@ func TestFormatEventWithNodename(t *testing.T) {
 
 	assert.Nil(t, err, "not nil")
 	assert.Equal(t, expectedOutput, output)
+}
+
+func Test_getDDAlertType(t *testing.T) {
+	tests := []struct {
+		name    string
+		k8sType string
+		want    metrics.EventAlertType
+	}{
+		{
+			name:    "normal",
+			k8sType: "Normal",
+			want:    metrics.EventAlertTypeInfo,
+		},
+		{
+			name:    "warning",
+			k8sType: "Warning",
+			want:    metrics.EventAlertTypeWarning,
+		},
+		{
+			name:    "unknown",
+			k8sType: "Unknown",
+			want:    metrics.EventAlertTypeInfo,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getDDAlertType(tt.k8sType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getDDAlertType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/releasenotes-dca/notes/k8s-event-types-5caf6cc97f0a23ce.yaml
+++ b/releasenotes-dca/notes/k8s-event-types-5caf6cc97f0a23ce.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Set the Datadog event type (info or warning) when collecting Kubernetes events.


### PR DESCRIPTION
### What does this PR do?

Adds the Datadog event type when collecting Kubernetes events

### Additional Notes

| K8s event type 	| Datadog event type 	|
|----------------	|--------------------	|
| Normal         	| Info               	|
| Warning        	| Warning            	|

### Describe your test plan

Generate events with different types (pod creation, pod in CLB) the changes should be obvious on the events explorer UI
