### PR TITLE
Fix buffer overwrite between read

### DIFF
--- a/pkg/logs/input/file/tailer_windows.go
+++ b/pkg/logs/input/file/tailer_windows.go
@@ -68,8 +68,8 @@ func (t *Tailer) readAvailable() (err error) {
 	}
 	f.Seek(t.GetReadOffset(), io.SeekStart)
 
-	inBuf := make([]byte, 4096)
 	for {
+		inBuf := make([]byte, 4096)
 		n, err := f.Read(inBuf)
 		if n == 0 || err != nil {
 			log.Debugf("Done reading")


### PR DESCRIPTION
### What does this PR do?

On windows recreate the reading buffer (like on linux) to avoid overwrite between read.
