### PR TITLE
[gitlab] Remove needs workaround for fail_on_non_triggered_tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,7 +172,6 @@ variables:
       - $RELEASE_VERSION_7 == ""
 
 # Fail if we're running a pipeline on a non-triggered tag build
-# NOTE: All jobs with 'needs' dependencies should also 'need' this to workaround a Gitlab issue: https://gitlab.com/gitlab-org/gitlab/issues/31526
 fail_on_non_triggered_tag:
   stage: fail_on_tag
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
@@ -346,7 +345,7 @@ run_tests_rpm-x64-py3:
 # run tests for eBPF code
 run_tests_ebpf:
   stage: source_test
-  needs: ["fail_on_non_triggered_tag", "build_libbcc_x64"]
+  needs: ["build_libbcc_x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   before_script:
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
@@ -432,7 +431,7 @@ build_dogstatsd_static-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py3"]
+  needs: ["run_tests_deb-x64-py3"]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --no-checks --verbose --dep-vendor-only
@@ -445,7 +444,7 @@ build_dogstatsd-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py3"]
+  needs: ["run_tests_deb-x64-py3"]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --no-checks --verbose --dep-vendor-only
@@ -458,7 +457,7 @@ build_dogstatsd_static-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py3"]
+  needs: ["run_tests_deb-x64-py3"]
   variables:
     ARCH: arm64
   before_script:
@@ -477,7 +476,7 @@ build_dogstatsd-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py3"]
+  needs: ["run_tests_deb-x64-py3"]
   variables:
     ARCH: arm64
   before_script:
@@ -496,7 +495,7 @@ build_iot_agent-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py3"]
+  needs: ["run_tests_deb-x64-py3"]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --verbose --dep-vendor-only --no-checks
@@ -509,7 +508,7 @@ build_iot_agent-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py3"]
+  needs: ["run_tests_deb-x64-py3"]
   variables:
     ARCH: arm64
   before_script:
@@ -524,7 +523,7 @@ build_iot_agent-deb_arm64:
 
 .cluster_agent-build_common: &cluster_agent-build_common
   stage: binary_build
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check"]
+  needs: ["run_go_tidy_check"]
   script:
     - inv -e cluster-agent.build
     - $S3_CP_CMD $SRC_PATH/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTIFACTS_URI/datadog-cluster-agent.$ARCH
@@ -559,7 +558,7 @@ cluster_agent-build_arm64:
 cluster_agent_cloudfoundry-build_amd64:
   <<: *skip_when_unwanted_on_7
   stage: binary_build
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check"]
+  needs: ["run_go_tidy_check"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
   artifacts:
@@ -608,7 +607,7 @@ cluster_agent_cloudfoundry-build_amd64:
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:
   stage: integration_test
-  needs: ["fail_on_non_triggered_tag", "build_dogstatsd_static-deb_x64"]
+  needs: ["build_dogstatsd_static-deb_x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
   before_script:
@@ -622,7 +621,7 @@ run_dogstatsd_size_test:
 # check the size of the static dogstatsd binary
 run_dogstatsd_arm_size_test:
   stage: integration_test
-  needs: ["fail_on_non_triggered_tag", "build_dogstatsd_static-deb_arm64"]
+  needs: ["build_dogstatsd_static-deb_arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -651,7 +650,7 @@ run_dogstatsd_arm_size_test:
 build_system-probe-x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py3"]
+  needs: ["run_tests_deb-x64-py3"]
   tags: [ "runner:main", "size:large" ]
   extends: .system-probe_build_common
   variables:
@@ -660,7 +659,7 @@ build_system-probe-x64:
 build_system-probe-arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check"]
+  needs: ["run_go_tidy_check"]
   tags: ["runner:docker-arm", "platform:arm64"]
   extends: .system-probe_build_common
   variables:
@@ -686,7 +685,7 @@ build_system-probe-arm64:
 build_system-probe_with-bcc-x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  needs: ["fail_on_non_triggered_tag", "build_libbcc_x64", "run_tests_deb-x64-py3"]
+  needs: ["build_libbcc_x64", "run_tests_deb-x64-py3"]
   tags: [ "runner:main", "size:large" ]
   extends: .system-probe_with-bcc_build_common
   variables:
@@ -695,7 +694,7 @@ build_system-probe_with-bcc-x64:
 build_system-probe_with-bcc-arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  needs: ["fail_on_non_triggered_tag", "build_libbcc_arm64", "run_go_tidy_check"]
+  needs: ["build_libbcc_arm64", "run_go_tidy_check"]
   tags: ["runner:docker-arm", "platform:arm64"]
   extends: .system-probe_with-bcc_build_common
   variables:
@@ -761,7 +760,7 @@ agent_deb-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py2", "run_tests_deb-x64-py3", "build_system-probe-x64"]
+  needs: ["run_tests_deb-x64-py2", "run_tests_deb-x64-py3", "build_system-probe-x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     CONDA_ENV: ddpy3
@@ -781,7 +780,7 @@ agent_deb-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py3", "build_system-probe-x64"]
+  needs: ["run_tests_deb-x64-py3", "build_system-probe-x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     CONDA_ENV: ddpy3
@@ -801,7 +800,7 @@ agent_with-bcc_deb-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["fail_on_non_triggered_tag", "run_tests_deb-x64-py3", "build_system-probe_with-bcc-x64"]
+  needs: ["run_tests_deb-x64-py3", "build_system-probe_with-bcc-x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     CONDA_ENV: ddpy3
@@ -819,7 +818,7 @@ agent_with-bcc_deb-x64-a7:
 
 agent_deb-arm-a6:
   stage: package_build
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check", "build_system-probe-arm64"]
+  needs: ["run_go_tidy_check", "build_system-probe-arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -837,7 +836,7 @@ agent_deb-arm-a6:
 
 agent_deb-arm-a7:
   stage: package_build
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check", "build_system-probe-arm64"]
+  needs: ["run_go_tidy_check", "build_system-probe-arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -858,7 +857,7 @@ iot_agent_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["fail_on_non_triggered_tag", "build_iot_agent-deb_x64"]
+  needs: ["build_iot_agent-deb_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     PACKAGE_ARCH: amd64
@@ -891,7 +890,7 @@ iot_agent_deb-arm64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: [ "fail_on_non_triggered_tag", "build_iot_agent-deb_arm64"]
+  needs: ["build_iot_agent-deb_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
@@ -959,7 +958,7 @@ agent_rpm-x64-a6:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["fail_on_non_triggered_tag", "run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3", "build_system-probe-x64"]
+  needs: ["run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3", "build_system-probe-x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 6
@@ -978,7 +977,7 @@ agent_rpm-x64-a7:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: ["fail_on_non_triggered_tag", "run_tests_rpm-x64-py3", "build_system-probe-x64"]
+  needs: ["run_tests_rpm-x64-py3", "build_system-probe-x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
     AGENT_MAJOR_VERSION: 7
@@ -995,7 +994,7 @@ agent_rpm-x64-a7:
 # build Agent package for rpm-arm64
 agent_rpm-arm-a6:
   stage: package_build
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check", "build_system-probe-arm64"]
+  needs: ["run_go_tidy_check", "build_system-probe-arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -1012,7 +1011,7 @@ agent_rpm-arm-a6:
 # build Agent package for rpm-arm64
 agent_rpm-arm-a7:
   stage: package_build
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check", "build_system-probe-arm64"]
+  needs: ["run_go_tidy_check", "build_system-probe-arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -1030,7 +1029,7 @@ iot_agent_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "fail_on_non_triggered_tag", "build_iot_agent-deb_x64"]
+  needs: ["build_iot_agent-deb_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
@@ -1066,7 +1065,7 @@ iot_agent_rpm-arm64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: [ "fail_on_non_triggered_tag", "build_iot_agent-deb_arm64"]
+  needs: ["build_iot_agent-deb_arm64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
@@ -1143,7 +1142,7 @@ iot_agent_rpm-arm64:
 # build Agent package for suse-x64
 agent_suse-x64-a6:
   stage: package_build
-  needs: ["fail_on_non_triggered_tag", "run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3", "build_system-probe-x64"]
+  needs: ["run_tests_rpm-x64-py2", "run_tests_rpm-x64-py3", "build_system-probe-x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
@@ -1160,7 +1159,7 @@ agent_suse-x64-a6:
 # build Agent package for suse-x64
 agent_suse-x64-a7:
   stage: package_build
-  needs: ["fail_on_non_triggered_tag", "run_tests_rpm-x64-py3", "build_system-probe-x64"]
+  needs: ["run_tests_rpm-x64-py3", "build_system-probe-x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
@@ -1178,7 +1177,7 @@ iot_agent_suse-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:2xlarge" ]
-  needs: [ "fail_on_non_triggered_tag", "build_iot_agent-deb_x64"]
+  needs: ["build_iot_agent-deb_x64"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
@@ -1206,7 +1205,7 @@ iot_agent_suse-x64:
 windows_zip_agent_binaries_x64-a7:
   stage: package_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check"]
+  needs: ["run_go_tidy_check"]
   variables:
     ARCH: "x64"
     AGENT_MAJOR_VERSION: 7
@@ -1231,7 +1230,7 @@ windows_zip_agent_binaries_x64-a7:
 
 .windows_old_msi_base:
   stage: package_build
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check"]
+  needs: ["run_go_tidy_check"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   # Unavailable on gitlab < 12.3
   # timeout: 2h 00m
@@ -1279,7 +1278,7 @@ windows_old_msi_x64-a6:
 
 .windows_msi_base:
   stage: package_build
-  needs: ["fail_on_non_triggered_tag", "run_go_tidy_check"]
+  needs: ["run_go_tidy_check"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   # Unavailable on gitlab < 12.3
   # timeout: 2h 00m
@@ -1362,7 +1361,7 @@ windows_dsd_msi_x64-a7:
 windows_choco_online_7_x64:
   stage: image_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
+  needs: ["windows_msi_x64-a7"]
   variables:
     ARCH: "x64"
   script:
@@ -1378,7 +1377,7 @@ windows_choco_online_7_x64:
 windows_choco_offline_7_x64:
   stage: image_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
+  needs: ["windows_msi_x64-a7"]
   variables:
     ARCH: "x64"
   script:
@@ -1397,7 +1396,7 @@ windows_choco_offline_7_x64:
 publish_choco_7_x64:
   stage: image_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["fail_on_non_triggered_tag", "windows_choco_online_7_x64"]
+  needs: ["windows_choco_online_7_x64"]
   variables:
     ARCH: "x64"
   before_script:
@@ -1452,7 +1451,7 @@ dogstatsd_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: ["fail_on_non_triggered_tag", "build_dogstatsd-deb_x64"]
+  needs: ["build_dogstatsd-deb_x64"]
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -1485,7 +1484,7 @@ dogstatsd_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
-  needs: ["fail_on_non_triggered_tag", "build_dogstatsd-deb_x64"]
+  needs: ["build_dogstatsd-deb_x64"]
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -1524,7 +1523,7 @@ dogstatsd_suse-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:large" ]
-  needs: ["fail_on_non_triggered_tag", "build_dogstatsd-deb_x64"]
+  needs: ["build_dogstatsd-deb_x64"]
   <<: *skip_when_unwanted_on_7
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -1559,7 +1558,7 @@ dogstatsd_suse-x64:
 # deploy debian packages to apt staging repo
 deploy_deb_testing-a6:
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "agent_deb-x64-a6"]
+  needs: ["agent_deb-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1587,7 +1586,7 @@ deploy_deb_testing-a6:
 
 deploy_deb_testing-a7:
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "agent_deb-x64-a7"]
+  needs: ["agent_deb-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1619,7 +1618,7 @@ deploy_rpm_testing-a6:
   <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "agent_rpm-x64-a6"]
+  needs: ["agent_rpm-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1639,7 +1638,7 @@ deploy_rpm_testing-a7:
   <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "agent_rpm-x64-a7"]
+  needs: ["agent_rpm-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1660,7 +1659,7 @@ deploy_suse_rpm_testing-a6:
   <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "agent_suse-x64-a6"]
+  needs: ["agent_suse-x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1680,7 +1679,7 @@ deploy_suse_rpm_testing-a7:
   <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "agent_suse-x64-a7"]
+  needs: ["agent_suse-x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1701,7 +1700,7 @@ deploy_windows_testing-a6:
   <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_6
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a6"]
+  needs: ["windows_msi_x64-a6"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1713,7 +1712,7 @@ deploy_windows_testing-a7:
   <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "windows_msi_x64-a7"]
+  needs: ["windows_msi_x64-a7"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1855,52 +1854,52 @@ deploy_windows_testing-a7:
 .kitchen_scenario_windows_a6: &kitchen_scenario_windows_a6
   <<: *kitchen_os_windows
   <<: *kitchen_agent_a6
-  needs: ["fail_on_non_triggered_tag", "deploy_windows_testing-a6"]
+  needs: ["deploy_windows_testing-a6"]
 
 .kitchen_scenario_windows_a7: &kitchen_scenario_windows_a7
   <<: *kitchen_os_windows
   <<: *kitchen_agent_a7
-  needs: ["fail_on_non_triggered_tag", "deploy_windows_testing-a7"]
+  needs: ["deploy_windows_testing-a7"]
 
 .kitchen_scenario_centos_a6: &kitchen_scenario_centos_a6
   <<: *kitchen_os_centos
   <<: *kitchen_agent_a6
-  needs: ["fail_on_non_triggered_tag", "deploy_rpm_testing-a6"]
+  needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_a7: &kitchen_scenario_centos_a7
   <<: *kitchen_os_centos
   <<: *kitchen_agent_a7
-  needs: ["fail_on_non_triggered_tag", "deploy_rpm_testing-a7"]
+  needs: ["deploy_rpm_testing-a7"]
 
 .kitchen_scenario_ubuntu_a6: &kitchen_scenario_ubuntu_a6
   <<: *kitchen_os_ubuntu
   <<: *kitchen_agent_a6
-  needs: ["fail_on_non_triggered_tag", "deploy_deb_testing-a6"]
+  needs: ["deploy_deb_testing-a6"]
 
 .kitchen_scenario_ubuntu_a7: &kitchen_scenario_ubuntu_a7
   <<: *kitchen_os_ubuntu
   <<: *kitchen_agent_a7
-  needs: ["fail_on_non_triggered_tag", "deploy_deb_testing-a7"]
+  needs: ["deploy_deb_testing-a7"]
 
 .kitchen_scenario_suse_a6: &kitchen_scenario_suse_a6
   <<: *kitchen_os_suse
   <<: *kitchen_agent_a6
-  needs: ["fail_on_non_triggered_tag", "deploy_suse_rpm_testing-a6"]
+  needs: ["deploy_suse_rpm_testing-a6"]
 
 .kitchen_scenario_suse_a7: &kitchen_scenario_suse_a7
   <<: *kitchen_os_suse
   <<: *kitchen_agent_a7
-  needs: ["fail_on_non_triggered_tag", "deploy_suse_rpm_testing-a7"]
+  needs: ["deploy_suse_rpm_testing-a7"]
 
 .kitchen_scenario_debian_a6: &kitchen_scenario_debian_a6
   <<: *kitchen_os_debian
   <<: *kitchen_agent_a6
-  needs: ["fail_on_non_triggered_tag", "deploy_deb_testing-a6"]
+  needs: ["deploy_deb_testing-a6"]
 
 .kitchen_scenario_debian_a7: &kitchen_scenario_debian_a7
   <<: *kitchen_os_debian
   <<: *kitchen_agent_a7
-  needs: ["fail_on_non_triggered_tag", "deploy_deb_testing-a7"]
+  needs: ["deploy_deb_testing-a7"]
 
 
 
@@ -2397,7 +2396,6 @@ docker_build_agent6:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
   needs:
-    - fail_on_non_triggered_tag
     - job: agent_deb-x64-a6
       artifacts: false
   <<: *skip_when_unwanted_on_6
@@ -2412,7 +2410,6 @@ docker_build_agent6_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
   needs:
-    - fail_on_non_triggered_tag
     - job: agent_deb-arm-a6
       artifacts: false
   <<: *skip_when_unwanted_on_6
@@ -2428,7 +2425,6 @@ docker_build_agent6_jmx:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
   needs:
-    - fail_on_non_triggered_tag
     - job: agent_deb-x64-a6
       artifacts: false
   <<: *skip_when_unwanted_on_6
@@ -2445,7 +2441,6 @@ docker_build_agent6_jmx_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
   needs:
-    - fail_on_non_triggered_tag
     - job: agent_deb-arm-a6
       artifacts: false
   <<: *skip_when_unwanted_on_6
@@ -2463,7 +2458,6 @@ docker_build_agent6_py2py3_jmx:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
   needs:
-    - fail_on_non_triggered_tag
     - job: agent_deb-x64-a6
       artifacts: false
   <<: *skip_when_unwanted_on_6
@@ -2479,7 +2473,6 @@ docker_build_agent7:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
   needs:
-    - fail_on_non_triggered_tag
     - job: agent_deb-x64-a7
       artifacts: false
   <<: *skip_when_unwanted_on_7
@@ -2494,7 +2487,6 @@ docker_build_agent7_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
   needs:
-    - fail_on_non_triggered_tag
     - job: agent_deb-arm-a7
       artifacts: false
   <<: *skip_when_unwanted_on_7
@@ -2510,7 +2502,6 @@ docker_build_agent7_jmx:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
   needs:
-    - fail_on_non_triggered_tag
     - job: agent_deb-x64-a7
       artifacts: false
   <<: *skip_when_unwanted_on_7
@@ -2525,7 +2516,6 @@ docker_build_agent7_jmx_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
   needs:
-    - fail_on_non_triggered_tag
     - job: agent_deb-arm-a7
       artifacts: false
   <<: *skip_when_unwanted_on_7
@@ -2541,7 +2531,6 @@ docker_build_agent7_windows1809:
   stage: image_build
   before_script: [ "# noop" ] # Override top level entry
   needs:
-    - fail_on_non_triggered_tag
     - windows_msi_x64-a7
   <<: *skip_when_unwanted_on_7
   tags: ["runner:windows-docker", "windowsversion:1809"]
@@ -2566,7 +2555,6 @@ docker_build_agent7_windows1809_jmx:
   stage: image_build
   before_script: [ "# noop" ] # Override top level entry
   needs:
-    - fail_on_non_triggered_tag
     - windows_msi_x64-a7
   <<: *skip_when_unwanted_on_7
   tags: ["runner:windows-docker", "windowsversion:1809"]
@@ -2592,7 +2580,6 @@ docker_build_agent7_windows1909:
   stage: image_build
   before_script: [ "# noop" ] # Override top level entry
   needs:
-    - fail_on_non_triggered_tag
     - windows_msi_x64-a7
   <<: *skip_when_unwanted_on_7
   tags: ["runner:windows-docker", "windowsversion:1909"]
@@ -2617,7 +2604,6 @@ docker_build_agent7_windows1909_jmx:
   stage: image_build
   before_script: [ "# noop" ] # Override top level entry
   needs:
-    - fail_on_non_triggered_tag
     - windows_msi_x64-a7
   <<: *skip_when_unwanted_on_7
   tags: ["runner:windows-docker", "windowsversion:1909"]
@@ -2643,7 +2629,6 @@ build_cluster_agent_amd64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
   needs:
-    - fail_on_non_triggered_tag
     - job: cluster_agent-build_amd64
       artifacts: false
   variables:
@@ -2654,7 +2639,6 @@ build_cluster_agent_arm64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_arm64
   needs:
-    - fail_on_non_triggered_tag
     - job: cluster_agent-build_arm64
       artifacts: false
   variables:
@@ -2666,7 +2650,6 @@ docker_build_dogstatsd_amd64:
   <<: *docker_build_job_definition
   extends: .docker_build_job_definition_amd64
   needs:
-    - fail_on_non_triggered_tag
     - job: build_dogstatsd_static-deb_x64
       artifacts: false
   variables:
@@ -2791,7 +2774,6 @@ dev_branch_docker_hub-a6:
   <<: *skip_when_unwanted_on_6
   <<: *docker_tag_job_definition
   needs:
-  - fail_on_non_triggered_tag
   - docker_build_agent6
   - docker_build_agent6_jmx
   - docker_build_agent6_py2py3_jmx
@@ -2806,7 +2788,6 @@ dev_branch_docker_hub-a6:
 dev_branch_docker_hub-dogstatsd:
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_dogstatsd_amd64
   when: manual
   script:
@@ -2816,7 +2797,6 @@ dev_branch_docker_hub-a7:
   <<: *skip_when_unwanted_on_7
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7
     - docker_build_agent7_jmx
   when: manual
@@ -2831,7 +2811,6 @@ dev_branch_docker_hub-a7-windows:
     VARIANT: 1909
   tags: ["runner:windows-docker", "windowsversion:1909"]
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7_windows1809
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1909
@@ -2854,7 +2833,6 @@ dev_branch_multiarch_docker_hub-a6:
   <<: *skip_when_unwanted_on_6
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent6
     - docker_build_agent6_arm64
     - docker_build_agent6_jmx
@@ -2879,7 +2857,6 @@ dev_branch_multiarch_docker_hub-a7:
   <<: *skip_when_unwanted_on_7
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7
     - docker_build_agent7_arm64
     - docker_build_agent7_jmx
@@ -2897,7 +2874,6 @@ dev_branch_multiarch_docker_hub-dogstatsd:
   <<: *skip_when_unwanted_on_7
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_dogstatsd_amd64
   when: manual
   script:
@@ -2908,7 +2884,6 @@ dev_master_docker_hub-a6:
   <<: *skip_when_unwanted_on_6
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent6
     - docker_build_agent6_jmx
     - docker_build_agent6_py2py3_jmx
@@ -2924,7 +2899,6 @@ dev_master_docker_hub-a7:
   <<: *skip_when_unwanted_on_7
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7
     - docker_build_agent7_jmx
   only:
@@ -2940,7 +2914,6 @@ dev_master_docker_hub-a7-windows:
     VARIANT: 1909
   tags: ["runner:windows-docker", "windowsversion:1909"]
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7_windows1809
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1909
@@ -2965,7 +2938,6 @@ dev_master_docker_hub-dogstatsd:
   <<: *skip_when_unwanted_on_7
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_dogstatsd_amd64
   only:
     - master
@@ -2975,7 +2947,6 @@ dev_master_docker_hub-dogstatsd:
 dca_dev_branch_docker_hub:
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - build_cluster_agent_amd64
   when: manual
   except:
@@ -2986,7 +2957,6 @@ dca_dev_branch_docker_hub:
 dca_dev_branch_multiarch_docker_hub:
   <<: *docker_tag_job_definition
   needs:
-    - fail_on_non_triggered_tag
     - build_cluster_agent_amd64
     - build_cluster_agent_arm64
   when: manual
@@ -2998,7 +2968,7 @@ dca_dev_branch_multiarch_docker_hub:
 
 dca_dev_master_docker_hub:
   <<: *docker_tag_job_definition
-  needs: ["fail_on_non_triggered_tag", "build_cluster_agent_amd64"]
+  needs: ["build_cluster_agent_amd64"]
   only:
     - master
   script:
@@ -3010,7 +2980,6 @@ dev_nightly_docker_hub-a6:
   <<: *docker_tag_job_definition
   <<: *run_only_when_triggered_on_nightly
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent6
     - docker_build_agent6_jmx
     - docker_build_agent6_py2py3_jmx
@@ -3026,7 +2995,6 @@ dev_nightly_docker_hub-a7:
   <<: *docker_tag_job_definition
   <<: *run_only_when_triggered_on_nightly
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7
     - docker_build_agent7_jmx
   script:
@@ -3041,7 +3009,6 @@ dev_nightly_docker_hub-a7-windows:
     VARIANT: 1909
   tags: ["runner:windows-docker", "windowsversion:1909"]
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7_windows1809
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1909
@@ -3061,7 +3028,6 @@ dev_nightly_docker_hub-dogstatsd:
   <<: *docker_tag_job_definition
   <<: *run_only_when_triggered_on_nightly
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_dogstatsd_amd64
   script:
     - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG}-amd64           datadog/dogstatsd-dev:nightly-${CI_COMMIT_SHORT_SHA}
@@ -3535,7 +3501,6 @@ tag_release_6:
   stage: deploy6
   when: manual
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent6
     - docker_build_agent6_arm64
     - docker_build_agent6_jmx
@@ -3555,7 +3520,6 @@ latest_release_6:
   stage: deploy6
   when: manual
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent6
     - docker_build_agent6_arm64
     - docker_build_agent6_jmx
@@ -3573,7 +3537,6 @@ tag_release_7_linux:
   stage: deploy7
   when: manual
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7
     - docker_build_agent7_arm64
     - docker_build_agent7_jmx
@@ -3594,7 +3557,6 @@ tag_release_7_windows:
     VARIANT: 1909
   tags: ["runner:windows-docker", "windowsversion:1909"]
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7_windows1809
     - docker_build_agent7_windows1809_jmx
     - docker_build_agent7_windows1909
@@ -3643,7 +3605,6 @@ latest_release_7:
   stage: deploy7
   when: manual
   needs:
-    - fail_on_non_triggered_tag
     - docker_build_agent7
     - docker_build_agent7_arm64
     - docker_build_agent7_jmx


### PR DESCRIPTION
### What does this PR do?

Removes workaround initially introduced in #4781 to limit the impact of this Gitlab bug: https://gitlab.com/gitlab-org/gitlab/-/issues/31526

It's not needed anymore, and is now harmful because of this new Gitlab bug: https://gitlab.com/gitlab-org/gitlab/-/issues/213080

### Motivation

Prevent jobs from running when dependent jobs have failed.

### Additional Notes

Here is an example of how we're affected by the new bug: we have
`run_go_tidy_check` -> `cluster_agent-build_amd64` -> `build_cluster_agent_amd64`
`fail_on_non_triggered_tag` -> `build_cluster_agent_amd64`
(-> indicates "is needed by")

`fail_on_non_triggered_tag` always succeeds on pipelines (except on, well, non-triggered tags). If `run_go_tidy_check` happens to fail, then `cluster_agent-build_amd64` is skipped, and thus we get in the issue's situation (one dependent job succeeded, the other got skipped), making `build_cluster_agent_amd64` run.

