### PR TITLE
[kitchen] Add iot-agent kitchen tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1985,7 +1985,7 @@ deploy_windows_testing-a7:
 
 .kitchen_scenario_debian_a7:
   extends:
-    - .kitchen_os_windows
+    - .kitchen_os_debian
     - .kitchen_agent_a7
   needs: ["fail_on_non_triggered_tag", "deploy_deb_testing-a7"]
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1910,7 +1910,7 @@ deploy_windows_testing-a7:
   extends:
     - .kitchen_test_upgrade6
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_central_us
+    - .kitchen_azure_location_south_central_us
 
 .kitchen_test_upgrade7_agent:
   extends:
@@ -1919,7 +1919,7 @@ deploy_windows_testing-a7:
     - .kitchen_azure_location_north_central_us
 
 .kitchen_test_windows_installer_agent:
-    extends:
+  extends:
     - .kitchen_test_windows_installer
     - .kitchen_datadog_agent_flavor
     - .kitchen_azure_location_north_central_us

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1587,7 +1587,7 @@ deploy_deb_testing-a6:
 
 deploy_deb_testing-a7:
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "agent_deb-x64-a7"]
+  needs: ["fail_on_non_triggered_tag", "agent_deb-x64-a7", "iot_agent_deb-x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1612,7 +1612,6 @@ deploy_deb_testing-a7:
 
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 7 -b $DEB_TESTING_S3_BUCKET -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_7*amd64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 7 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_7*amd64.deb
-
 
 # deploy rpm packages to yum staging repo
 deploy_rpm_testing-a6:
@@ -1639,7 +1638,7 @@ deploy_rpm_testing-a7:
   <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "agent_rpm-x64-a7"]
+  needs: ["fail_on_non_triggered_tag", "agent_rpm-x64-a7", "iot_agent_rpm-x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -1680,7 +1679,7 @@ deploy_suse_rpm_testing-a7:
   <<: *run_only_when_testkitchen_triggered
   <<: *skip_when_unwanted_on_7
   stage: testkitchen_deploy
-  needs: ["fail_on_non_triggered_tag", "agent_suse-x64-a7"]
+  needs: ["fail_on_non_triggered_tag", "agent_suse-x64-a7", "iot_agent_suse-x64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -1808,36 +1807,34 @@ deploy_windows_testing-a7:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-
-
 # Kitchen: tests
 # --------------
 
-.kitchen_test_chef: &kitchen_test_chef
+.kitchen_test_chef:
   script:
-    - AZURE_LOCATION='North Central US' bash -l tasks/run-test-kitchen.sh chef-test $AGENT_MAJOR_VERSION
+    - bash -l tasks/run-test-kitchen.sh chef-test $AGENT_MAJOR_VERSION
 
-.kitchen_test_step_by_step: &kitchen_test_step_by_step
+.kitchen_test_step_by_step:
   script:
-    - AZURE_LOCATION='Central US' bash -l tasks/run-test-kitchen.sh step-by-step-test $AGENT_MAJOR_VERSION
+    - bash -l tasks/run-test-kitchen.sh step-by-step-test $AGENT_MAJOR_VERSION
 
-.kitchen_test_install_script: &kitchen_test_install_script
+.kitchen_test_install_script:
   script:
-    - AZURE_LOCATION='South Central US' bash -l tasks/run-test-kitchen.sh install-script-test $AGENT_MAJOR_VERSION
+    - bash -l tasks/run-test-kitchen.sh install-script-test $AGENT_MAJOR_VERSION
 
-.kitchen_test_upgrade5: &kitchen_test_upgrade5
+.kitchen_test_upgrade5:
   script:
-    - AZURE_LOCATION='Central US' bash -l tasks/run-test-kitchen.sh upgrade5-test $AGENT_MAJOR_VERSION
+    - bash -l tasks/run-test-kitchen.sh upgrade5-test $AGENT_MAJOR_VERSION
 
-.kitchen_test_upgrade6: &kitchen_test_upgrade6
+.kitchen_test_upgrade6:
   script:
-    - AZURE_LOCATION='South Central US' bash -l tasks/run-test-kitchen.sh upgrade6-test $AGENT_MAJOR_VERSION
+    - bash -l tasks/run-test-kitchen.sh upgrade6-test $AGENT_MAJOR_VERSION
 
-.kitchen_test_upgrade7: &kitchen_test_upgrade7
+.kitchen_test_upgrade7:
   script:
-    - AZURE_LOCATION='North Central US' bash -l tasks/run-test-kitchen.sh upgrade7-test $AGENT_MAJOR_VERSION
+    - bash -l tasks/run-test-kitchen.sh upgrade7-test $AGENT_MAJOR_VERSION
 
-.kitchen_test_windows_installer: &kitchen_test_windows_installer
+.kitchen_test_windows_installer:
   before_script: # Override kitchen_os_windows default with a smaller set of TEST_PLATFORMS
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
     - rsync -azr --delete ./ $SRC_PATH
@@ -1845,61 +1842,151 @@ deploy_windows_testing-a7:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
   script:
-    - AZURE_LOCATION='North Central US' bash -l tasks/run-test-kitchen.sh windows-install-test $AGENT_MAJOR_VERSION
+    - bash -l tasks/run-test-kitchen.sh windows-install-test $AGENT_MAJOR_VERSION
 
+# Kitchen: Agent flavor locations
+# -------------------------------
+
+.kitchen_datadog_agent_flavor:
+  variables:
+    AGENT_FLAVOR: "datadog-agent"
+
+.kitchen_datadog_iot_agent_flavor:
+  variables:
+    AGENT_FLAVOR: "datadog-iot-agent"
+
+# Kitchen: Azure locations
+# -------------------------------
+
+.kitchen_azure_location_north_central_us:
+  variables:
+    AZURE_LOCATION: "North Central US"
+
+.kitchen_azure_location_west_central_us:
+  variables:
+    AZURE_LOCATION: "West Central US"
+
+.kitchen_azure_location_central_us:
+  variables:
+    AZURE_LOCATION: "Central US"
+
+.kitchen_azure_location_south_central_us:
+  variables:
+    AZURE_LOCATION: "South Central US"
+
+# Kitchen: Test types (test suite * agent flavor + azure location)
+# -------------------------------
+
+.kitchen_test_chef_agent:
+  extends:
+    - .kitchen_test_chef
+    - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_north_central_us
+
+.kitchen_test_step_by_step_agent:
+  extends:
+    - .kitchen_test_step_by_step
+    - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_central_us
+
+.kitchen_test_install_script_agent:
+  extends:
+    - .kitchen_test_install_script
+    - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_south_central_us
+
+.kitchen_test_install_script_iot_agent:
+  extends:
+    - .kitchen_test_install_script
+    - .kitchen_datadog_iot_agent_flavor
+    - .kitchen_azure_location_west_central_us
+
+.kitchen_test_upgrade5_agent:
+  extends:
+    - .kitchen_test_upgrade5
+    - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_central_us
+
+.kitchen_test_upgrade6_agent:
+  extends:
+    - .kitchen_test_upgrade6
+    - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_central_us
+
+.kitchen_test_upgrade7_agent:
+  extends:
+    - .kitchen_test_upgrade7
+    - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_north_central_us
+
+.kitchen_test_windows_installer_agent:
+    extends:
+    - .kitchen_test_windows_installer
+    - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_north_central_us
 
 
 # Kitchen: scenarios (os * agent)
 # -------------------------------
 
-.kitchen_scenario_windows_a6: &kitchen_scenario_windows_a6
-  <<: *kitchen_os_windows
-  <<: *kitchen_agent_a6
+.kitchen_scenario_windows_a6:
+  extends:
+    - .kitchen_os_windows
+    - .kitchen_agent_a6
   needs: ["fail_on_non_triggered_tag", "deploy_windows_testing-a6"]
 
-.kitchen_scenario_windows_a7: &kitchen_scenario_windows_a7
-  <<: *kitchen_os_windows
-  <<: *kitchen_agent_a7
+.kitchen_scenario_windows_a7:
+  extends:
+    - .kitchen_os_windows
+    - .kitchen_agent_a7
   needs: ["fail_on_non_triggered_tag", "deploy_windows_testing-a7"]
 
-.kitchen_scenario_centos_a6: &kitchen_scenario_centos_a6
-  <<: *kitchen_os_centos
-  <<: *kitchen_agent_a6
+.kitchen_scenario_centos_a6:
+  extends:
+    - .kitchen_os_centos
+    - .kitchen_agent_a6
   needs: ["fail_on_non_triggered_tag", "deploy_rpm_testing-a6"]
 
-.kitchen_scenario_centos_a7: &kitchen_scenario_centos_a7
-  <<: *kitchen_os_centos
-  <<: *kitchen_agent_a7
+.kitchen_scenario_centos_a7:
+  extends:
+    - .kitchen_os_centos
+    - .kitchen_agent_a7
   needs: ["fail_on_non_triggered_tag", "deploy_rpm_testing-a7"]
 
-.kitchen_scenario_ubuntu_a6: &kitchen_scenario_ubuntu_a6
-  <<: *kitchen_os_ubuntu
-  <<: *kitchen_agent_a6
+.kitchen_scenario_ubuntu_a6:
+  extends:
+    - .kitchen_os_ubuntu
+    - .kitchen_agent_a6
   needs: ["fail_on_non_triggered_tag", "deploy_deb_testing-a6"]
 
-.kitchen_scenario_ubuntu_a7: &kitchen_scenario_ubuntu_a7
-  <<: *kitchen_os_ubuntu
-  <<: *kitchen_agent_a7
+.kitchen_scenario_ubuntu_a7:
+  extends:
+    - .kitchen_os_ubuntu
+    - .kitchen_agent_a7
   needs: ["fail_on_non_triggered_tag", "deploy_deb_testing-a7"]
 
-.kitchen_scenario_suse_a6: &kitchen_scenario_suse_a6
-  <<: *kitchen_os_suse
-  <<: *kitchen_agent_a6
+.kitchen_scenario_suse_a6:
+  extends:
+    - .kitchen_os_suse
+    - .kitchen_agent_a6
   needs: ["fail_on_non_triggered_tag", "deploy_suse_rpm_testing-a6"]
 
-.kitchen_scenario_suse_a7: &kitchen_scenario_suse_a7
-  <<: *kitchen_os_suse
-  <<: *kitchen_agent_a7
+.kitchen_scenario_suse_a7:
+  extends:
+    - .kitchen_os_suse
+    - .kitchen_agent_a7
   needs: ["fail_on_non_triggered_tag", "deploy_suse_rpm_testing-a7"]
 
-.kitchen_scenario_debian_a6: &kitchen_scenario_debian_a6
-  <<: *kitchen_os_debian
-  <<: *kitchen_agent_a6
+.kitchen_scenario_debian_a6:
+  extends:
+    - .kitchen_os_debian
+    - .kitchen_agent_a6
   needs: ["fail_on_non_triggered_tag", "deploy_deb_testing-a6"]
 
-.kitchen_scenario_debian_a7: &kitchen_scenario_debian_a7
-  <<: *kitchen_os_debian
-  <<: *kitchen_agent_a7
+.kitchen_scenario_debian_a7:
+  extends:
+    - .kitchen_os_windows
+    - .kitchen_agent_a7
   needs: ["fail_on_non_triggered_tag", "deploy_deb_testing-a7"]
 
 
@@ -1908,279 +1995,356 @@ deploy_windows_testing-a7:
 # ----------------------------------------------
 
 # run dd-agent-testing for the windows installer
-kitchen_windows_installer-a6:
+kitchen_windows_installer_agent-a6:
   allow_failure: true
-  <<: *kitchen_scenario_windows_a6
-  <<: *kitchen_test_windows_installer
+  extends:
+    - .kitchen_scenario_windows_a6
+    - .kitchen_test_windows_installer_agent
   retry: 0
 
-kitchen_windows_installer-a7:
+kitchen_windows_installer_agent-a7:
   allow_failure: true
-  <<: *kitchen_scenario_windows_a7
-  <<: *kitchen_test_windows_installer
+  extends:
+    - .kitchen_scenario_windows_a7
+    - .kitchen_test_windows_installer_agent
   retry: 0
 
 # run dd-agent-testing on windows
-kitchen_windows_chef-a6:
+kitchen_windows_chef_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_windows_a6
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_windows_a6
+    - .kitchen_test_chef_agent
 
-kitchen_windows_chef-a7:
+kitchen_windows_chef_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_windows_a7
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_windows_a7
+    - .kitchen_test_chef_agent
 
-kitchen_windows_upgrade5-a6:
+kitchen_windows_upgrade5_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_windows_a6
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_windows_a6
+    - .kitchen_test_upgrade5_agent
 
-kitchen_windows_upgrade5-a7:
+kitchen_windows_upgrade5_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_windows_a7
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_windows_a7
+    - .kitchen_test_upgrade5_agent
 
-kitchen_windows_upgrade6-a6:
+kitchen_windows_upgrade6_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_windows_a6
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_windows_a6
+    - .kitchen_test_upgrade6_agent
 
-kitchen_windows_upgrade6-a7:
+kitchen_windows_upgrade6_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_windows_a7
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_windows_a7
+    - .kitchen_test_upgrade6_agent
 
-kitchen_windows_upgrade7-a7:
+kitchen_windows_upgrade7_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_windows_a7
-  <<: *kitchen_test_upgrade7
+  extends:
+    - .kitchen_scenario_windows_a7
+    - .kitchen_test_upgrade7_agent
 
 # run dd-agent-testing on centos
-kitchen_centos_chef-a6:
+kitchen_centos_chef_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a6
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_centos_a6
+    - .kitchen_test_chef_agent
 
-kitchen_centos_chef-a7:
+kitchen_centos_chef_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a7
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_centos_a7
+    - .kitchen_test_chef_agent
 
-kitchen_centos_install_script-a6:
+kitchen_centos_install_script_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a6
-  <<: *kitchen_test_install_script
+  extends:
+    - .kitchen_scenario_centos_a6
+    - .kitchen_test_install_script_agent
 
-kitchen_centos_install_script-a7:
+kitchen_centos_install_script_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a7
-  <<: *kitchen_test_install_script
+  extends:
+    - .kitchen_scenario_centos_a7
+    - .kitchen_test_install_script_agent
 
-kitchen_centos_step_by_step-a6:
+kitchen_centos_install_script_iot_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a6
-  <<: *kitchen_test_step_by_step
+  extends:
+    - .kitchen_scenario_centos_a7
+    - .kitchen_test_install_script_iot_agent
 
-kitchen_centos_step_by_step-a7:
+kitchen_centos_step_by_step_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a7
-  <<: *kitchen_test_step_by_step
+  extends:
+    - .kitchen_scenario_centos_a6
+    - .kitchen_test_step_by_step_agent
 
-kitchen_centos_upgrade5-a6:
+kitchen_centos_step_by_step_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a6
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_centos_a7
+    - .kitchen_test_step_by_step_agent
 
-kitchen_centos_upgrade5-a7:
+kitchen_centos_upgrade5_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a7
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_centos_a6
+    - .kitchen_test_upgrade5_agent
 
-kitchen_centos_upgrade6-a6:
+kitchen_centos_upgrade5_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a6
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_centos_a7
+    - .kitchen_test_upgrade5_agent
 
-kitchen_centos_upgrade6-a7:
+kitchen_centos_upgrade6_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a7
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_centos_a6
+    - .kitchen_test_upgrade6_agent
 
-kitchen_centos_upgrade7-a7:
+kitchen_centos_upgrade6_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_centos_a7
-  <<: *kitchen_test_upgrade7
+  extends:
+    - .kitchen_scenario_centos_a7
+    - .kitchen_test_upgrade6_agent
+
+kitchen_centos_upgrade7_agent-a7:
+  allow_failure: false
+  extends:
+    - .kitchen_scenario_centos_a7
+    - .kitchen_test_upgrade7_agent
 
 # run dd-agent-testing on ubuntu
 # Could fail if we encounter the issue with apt locks/azure agent, but should be investigated if that's the case
-kitchen_ubuntu_chef-a6:
+kitchen_ubuntu_chef_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a6
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_ubuntu_a6
+    - .kitchen_test_chef_agent
 
-kitchen_ubuntu_chef-a7:
+kitchen_ubuntu_chef_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a7
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_test_chef_agent
 
-kitchen_ubuntu_install_script-a6:
+kitchen_ubuntu_install_script_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a6
-  <<: *kitchen_test_install_script
+  extends:
+    - .kitchen_scenario_ubuntu_a6
+    - .kitchen_test_install_script_agent
 
-kitchen_ubuntu_install_script-a7:
+kitchen_ubuntu_install_script_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a7
-  <<: *kitchen_test_install_script
+  extends:
+    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_test_install_script_agent
 
-kitchen_ubuntu_step_by_step-a6:
+kitchen_ubuntu_install_script_iot_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a6
-  <<: *kitchen_test_step_by_step
+  extends:
+    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_test_install_script_iot_agent
 
-kitchen_ubuntu_step_by_step-a7:
+kitchen_ubuntu_step_by_step_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a7
-  <<: *kitchen_test_step_by_step
+  extends:
+    - .kitchen_scenario_ubuntu_a6
+    - .kitchen_test_step_by_step_agent
 
-kitchen_ubuntu_upgrade5-a6:
+kitchen_ubuntu_step_by_step_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a6
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_test_step_by_step_agent
 
-kitchen_ubuntu_upgrade5-a7:
+kitchen_ubuntu_upgrade5_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a7
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_ubuntu_a6
+    - .kitchen_test_upgrade5_agent
 
-kitchen_ubuntu_upgrade6-a6:
+kitchen_ubuntu_upgrade5_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a6
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_test_upgrade5_agent
 
-kitchen_ubuntu_upgrade6-a7:
+kitchen_ubuntu_upgrade6_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a7
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_ubuntu_a6
+    - .kitchen_test_upgrade6_agent
 
-kitchen_ubuntu_upgrade7-a7:
+kitchen_ubuntu_upgrade6_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_ubuntu_a7
-  <<: *kitchen_test_upgrade7
+  extends:
+    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_test_upgrade6_agent
+
+kitchen_ubuntu_upgrade7_agent-a7:
+  allow_failure: false
+  extends:
+    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_test_upgrade7_agent
 
 # run dd-agent-testing on suse
-kitchen_suse_chef-a6:
+kitchen_suse_chef_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a6
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_suse_a6
+    - .kitchen_test_chef_agent
 
-kitchen_suse_chef-a7:
+kitchen_suse_chef_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a7
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_suse_a7
+    - .kitchen_test_chef_agent
 
-kitchen_suse_install_script-a6:
+kitchen_suse_install_script_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a6
-  <<: *kitchen_test_install_script
+  extends:
+    - .kitchen_scenario_suse_a6
+    - .kitchen_test_install_script_agent
 
-kitchen_suse_install_script-a7:
+kitchen_suse_install_script_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a7
-  <<: *kitchen_test_install_script
+  extends:
+    - .kitchen_scenario_suse_a7
+    - .kitchen_test_install_script_agent
 
-kitchen_suse_step_by_step-a6:
+kitchen_suse_install_script_iot_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a6
-  <<: *kitchen_test_step_by_step
+  extends:
+    - .kitchen_scenario_suse_a7
+    - .kitchen_test_install_script_iot_agent
 
-kitchen_suse_step_by_step-a7:
+kitchen_suse_step_by_step_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a7
-  <<: *kitchen_test_step_by_step
+  extends:
+    - .kitchen_scenario_suse_a6
+    - .kitchen_test_step_by_step_agent
 
-kitchen_suse_upgrade5-a6:
+kitchen_suse_step_by_step_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a6
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_suse_a7
+    - .kitchen_test_step_by_step_agent
 
-kitchen_suse_upgrade5-a7:
+kitchen_suse_upgrade5_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a7
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_suse_a6
+    - .kitchen_test_upgrade5_agent
 
-kitchen_suse_upgrade6-a6:
+kitchen_suse_upgrade5_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a6
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_suse_a7
+    - .kitchen_test_upgrade5_agent
 
-kitchen_suse_upgrade6-a7:
+kitchen_suse_upgrade6_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a7
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_suse_a6
+    - .kitchen_test_upgrade6_agent
 
-kitchen_suse_upgrade7-a7:
+kitchen_suse_upgrade6_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_suse_a7
-  <<: *kitchen_test_upgrade7
+  extends:
+    - .kitchen_scenario_suse_a7
+    - .kitchen_test_upgrade6_agent
+
+kitchen_suse_upgrade7_agent-a7:
+  allow_failure: false
+  extends:
+    - .kitchen_scenario_suse_a7
+    - .kitchen_test_upgrade7_agent
 
 # run dd-agent-testing on debian
 # Could fail if we encounter the issue with apt locks/azure agent, but should be investigated if that's the case
-kitchen_debian_chef-a6:
+kitchen_debian_chef_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a6
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_debian_a6
+    - .kitchen_test_chef_agent
 
-kitchen_debian_chef-a7:
+kitchen_debian_chef_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a7
-  <<: *kitchen_test_chef
+  extends:
+    - .kitchen_scenario_debian_a7
+    - .kitchen_test_chef_agent
 
-kitchen_debian_install_script-a6:
+kitchen_debian_install_script_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a6
-  <<: *kitchen_test_install_script
+  extends:
+    - .kitchen_scenario_debian_a6
+    - .kitchen_test_install_script_agent
 
-kitchen_debian_install_script-a7:
+kitchen_debian_install_script_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a7
-  <<: *kitchen_test_install_script
+  extends:
+    - .kitchen_scenario_debian_a7
+    - .kitchen_test_install_script_agent
 
-kitchen_debian_step_by_step-a6:
+kitchen_debian_install_script_iot_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a6
-  <<: *kitchen_test_step_by_step
+  extends:
+    - .kitchen_scenario_debian_a7
+    - .kitchen_test_install_script_iot_agent
 
-kitchen_debian_step_by_step-a7:
+kitchen_debian_step_by_step_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a7
-  <<: *kitchen_test_step_by_step
+  extends:
+    - .kitchen_scenario_debian_a6
+    - .kitchen_test_step_by_step_agent
 
-kitchen_debian_upgrade5-a6:
+kitchen_debian_step_by_step_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a6
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_debian_a7
+    - .kitchen_test_step_by_step_agent
 
-kitchen_debian_upgrade5-a7:
+kitchen_debian_upgrade5_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a7
-  <<: *kitchen_test_upgrade5
+  extends:
+    - .kitchen_scenario_debian_a6
+    - .kitchen_test_upgrade5_agent
 
-kitchen_debian_upgrade6-a6:
+kitchen_debian_upgrade5_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a6
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_debian_a7
+    - .kitchen_test_upgrade5_agent
 
-kitchen_debian_upgrade6-a7:
+kitchen_debian_upgrade6_agent-a6:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a7
-  <<: *kitchen_test_upgrade6
+  extends:
+    - .kitchen_scenario_debian_a6
+    - .kitchen_test_upgrade6_agent
 
-kitchen_debian_upgrade7-a7:
+kitchen_debian_upgrade6_agent-a7:
   allow_failure: false
-  <<: *kitchen_scenario_debian_a7
-  <<: *kitchen_test_upgrade7
+  extends:
+    - .kitchen_scenario_debian_a7
+    - .kitchen_test_upgrade6_agent
+
+kitchen_debian_upgrade7_agent_agent-a7:
+  allow_failure: false
+  extends:
+    - .kitchen_scenario_debian_a7
+    - .kitchen_test_upgrade7_agent
 
 .kitchen_cleanup_s3_common: &kitchen_cleanup_s3_common
   stage: testkitchen_cleanup

--- a/test/kitchen/kitchen-azure-install-script-test.yml
+++ b/test/kitchen/kitchen-azure-install-script-test.yml
@@ -2,6 +2,12 @@ suites:
 
 # Installs the latest release candidate using the install script
 - name: dd-agent-install-script
+  <% if ENV['AGENT_FLAVOR'] == "datadog-iot-agent" %> # IoT Agent doesn't work on SLES 11 (no SysVInit files)
+  excludes: <% if (sles11_platforms.nil? || sles11_platforms.empty?) %>[]<% end %>
+    <% sles11_platforms.each do |p| %>
+    - <%= p %>
+    <% end %>
+  <% end %>
   run_list:
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install-script]"

--- a/test/kitchen/kitchen-azure-install-script-test.yml
+++ b/test/kitchen/kitchen-azure-install-script-test.yml
@@ -10,7 +10,7 @@ suites:
       unattended_upgrades:
         enable: false
     dd-agent-install-script:
-      agent_flavor: <%= ENV['AGENT_FLAVOR'] || datadog-agent %>
+      agent_flavor: <%= ENV['AGENT_FLAVOR'] || "datadog-agent" %>
       api_key: <%= api_key %>
       install_script_url: https://raw.githubusercontent.com/DataDog/datadog-agent/<%= ENV['CI_COMMIT_SHA'] %>/cmd/agent/install_script.sh
       repo_branch_apt: <%= aptrepo_dist %>
@@ -18,4 +18,5 @@ suites:
       repo_branch_yum: pipeline-<%= ENV['DD_PIPELINE_ID'] %>/<%= agent_major_version %>
       install_candidate: true
     dd-agent-rspec:
+      agent_flavor: <%= ENV['AGENT_FLAVOR'] || "datadog-agent" %>
       skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>

--- a/test/kitchen/kitchen-azure-install-script-test.yml
+++ b/test/kitchen/kitchen-azure-install-script-test.yml
@@ -10,6 +10,7 @@ suites:
       unattended_upgrades:
         enable: false
     dd-agent-install-script:
+      agent_flavor: <%= ENV['AGENT_FLAVOR'] || datadog-agent %>
       api_key: <%= api_key %>
       install_script_url: https://raw.githubusercontent.com/DataDog/datadog-agent/<%= ENV['CI_COMMIT_SHA'] %>/cmd/agent/install_script.sh
       repo_branch_apt: <%= aptrepo_dist %>

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/attributes/default.rb
@@ -6,6 +6,7 @@ default['dd-agent-install-script']['install_candidate'] = true
 default['dd-agent-install-script']['repo_url'] = 'datad0g.com'
 default['dd-agent-install-script']['dd_url'] = 'datad0g.com'
 default['dd-agent-install-script']['dd_site'] = 'datadoghq.eu'
+default['dd-agent-install-script']['agent_flavor'] = 'datadog-agent'
 
 default['dd-agent-install-script']['repo_domain_yum'] = 'yumtesting.datad0g.com'
 default['dd-agent-install-script']['repo_branch_yum'] = 'testing'

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -29,6 +29,7 @@ kitchen_environment_variables = {
   'REPO_URL' => node['dd-agent-install-script']['repo_url'],
   'DD_URL' => node['dd-agent-install-script']['dd_url'],
   'DD_SITE' => node['dd-agent-install-script']['dd_site'],
+  'DD_AGENT_FLAVOR' => node['dd-agent-install-script']['agent_flavor'],
 
   'TESTING_APT_URL' => node['dd-agent-install-script']['repo_domain_apt'],
   'TESTING_YUM_URL' => node['dd-agent-install-script']['repo_domain_yum'],

--- a/test/kitchen/test/integration/common/rspec/iot_spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/iot_spec_helper.rb
@@ -3,14 +3,15 @@ require 'spec_helper'
 # We retrieve the value defined in kitchen.yml because there is no simple way
 # to set env variables on the target machine or via parameters in Kitchen/Busser
 # See https://github.com/test-kitchen/test-kitchen/issues/662 for reference
-let(:agent_flavor) {
-    if os == :windows
-      dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
-    else
-      dna_json_path = "/tmp/kitchen/dna.json"
-    end
-    JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('agent_flavor')
-}
+
+def get_agent_flavor
+  if os == :windows
+    dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
+  else
+    dna_json_path = "/tmp/kitchen/dna.json"
+  end
+  JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('agent_flavor')
+end
 
 shared_examples_for 'IoT Agent install' do
   it_behaves_like 'an installed Agent'

--- a/test/kitchen/test/integration/common/rspec/iot_spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/iot_spec_helper.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+# We retrieve the value defined in kitchen.yml because there is no simple way
+# to set env variables on the target machine or via parameters in Kitchen/Busser
+# See https://github.com/test-kitchen/test-kitchen/issues/662 for reference
+let(:agent_flavor) {
+    if os == :windows
+      dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
+    else
+      dna_json_path = "/tmp/kitchen/dna.json"
+    end
+    JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('agent_flavor')
+}
+
+shared_examples_for 'IoT Agent install' do
+  it_behaves_like 'an installed Agent'
+end
+
+shared_examples_for 'IoT Agent behavior' do
+  it_behaves_like 'a running Agent with no errors'
+  it_behaves_like 'an Agent that stops'
+  it_behaves_like 'an Agent that restarts'
+end
+
+shared_examples_for 'IoT Agent uninstall' do
+  it_behaves_like 'an IoT Agent that is removed'
+end
+
+shared_examples_for 'an IoT Agent that is removed' do
+  it 'should remove the agent' do
+    if os == :windows
+      # uninstallcmd = "start /wait msiexec /q /x 'C:\\Users\\azure\\AppData\\Local\\Temp\\kitchen\\cache\\ddagent-cli.msi'"
+      uninstallcmd='for /f "usebackq" %n IN (`wmic product where "name like \'datadog%\'" get IdentifyingNumber ^| find "{"`) do start /wait msiexec /log c:\\uninst.log /q /x %n'
+      expect(system(uninstallcmd)).to be_truthy
+    else
+      if system('which apt-get &> /dev/null')
+        expect(system("sudo apt-get -q -y remove datadog-iot-agent > /dev/null")).to be_truthy
+      elsif system('which yum &> /dev/null')
+        expect(system("sudo yum -y remove datadog-iot-agent > /dev/null")).to be_truthy
+      elsif system('which zypper &> /dev/null')
+        expect(system("sudo zypper --non-interactive remove datadog-iot-agent > /dev/null")).to be_truthy
+      else
+        raise 'Unknown package manager'
+      end
+    end
+  end
+
+  it 'should not be running the agent after removal' do
+    sleep 5
+    expect(agent_processes_running?).to be_falsey
+  end
+
+  it 'should remove the installation directory' do
+    if os == :windows
+      expect(File).not_to exist("C:\\Program Files\\Datadog\\Datadog Agent\\")
+    else
+      expect(File).not_to exist("/opt/datadog-agent/")
+    end
+  end
+
+  if os != :windows
+    it 'should remove the agent link from bin' do
+      expect(File).not_to exist('/usr/bin/datadog-agent')
+    end
+  end
+end

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -323,18 +323,8 @@ shared_examples_for 'Agent behavior' do
   it_behaves_like 'an Agent that restarts'
 end
 
-shared_examples_for 'IoT Agent behavior' do
-  it_behaves_like 'a running Agent with no errors'
-  it_behaves_like 'an Agent that stops'
-  it_behaves_like 'an Agent that restarts'
-end
-
 shared_examples_for 'Agent uninstall' do
   it_behaves_like 'an Agent that is removed'
-end
-
-shared_examples_for 'IoT Agent uninstall' do
-  it_behaves_like 'an IoT Agent that is removed'
 end
 
 shared_examples_for "an installed Agent" do
@@ -667,45 +657,6 @@ shared_examples_for 'an Agent that is removed' do
         expect(system("sudo yum -y remove datadog-agent > /dev/null")).to be_truthy
       elsif system('which zypper &> /dev/null')
         expect(system("sudo zypper --non-interactive remove datadog-agent > /dev/null")).to be_truthy
-      else
-        raise 'Unknown package manager'
-      end
-    end
-  end
-
-  it 'should not be running the agent after removal' do
-    sleep 5
-    expect(agent_processes_running?).to be_falsey
-  end
-
-  it 'should remove the installation directory' do
-    if os == :windows
-      expect(File).not_to exist("C:\\Program Files\\Datadog\\Datadog Agent\\")
-    else
-      expect(File).not_to exist("/opt/datadog-agent/")
-    end
-  end
-
-  if os != :windows
-    it 'should remove the agent link from bin' do
-      expect(File).not_to exist('/usr/bin/datadog-agent')
-    end
-  end
-end
-
-shared_examples_for 'an IoT Agent that is removed' do
-  it 'should remove the agent' do
-    if os == :windows
-      # uninstallcmd = "start /wait msiexec /q /x 'C:\\Users\\azure\\AppData\\Local\\Temp\\kitchen\\cache\\ddagent-cli.msi'"
-      uninstallcmd='for /f "usebackq" %n IN (`wmic product where "name like \'datadog%\'" get IdentifyingNumber ^| find "{"`) do start /wait msiexec /log c:\\uninst.log /q /x %n'
-      expect(system(uninstallcmd)).to be_truthy
-    else
-      if system('which apt-get &> /dev/null')
-        expect(system("sudo apt-get -q -y remove datadog-iot-agent > /dev/null")).to be_truthy
-      elsif system('which yum &> /dev/null')
-        expect(system("sudo yum -y remove datadog-iot-agent > /dev/null")).to be_truthy
-      elsif system('which zypper &> /dev/null')
-        expect(system("sudo zypper --non-interactive remove datadog-iot-agent > /dev/null")).to be_truthy
       else
         raise 'Unknown package manager'
       end

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -309,7 +309,6 @@ def fetch_python_version(timeout = 15)
   return nil
 end
 
-
 shared_examples_for 'Agent install' do
   it_behaves_like 'an installed Agent'
 end
@@ -324,10 +323,19 @@ shared_examples_for 'Agent behavior' do
   it_behaves_like 'an Agent that restarts'
 end
 
+shared_examples_for 'IoT Agent behavior' do
+  it_behaves_like 'a running Agent with no errors'
+  it_behaves_like 'an Agent that stops'
+  it_behaves_like 'an Agent that restarts'
+end
+
 shared_examples_for 'Agent uninstall' do
   it_behaves_like 'an Agent that is removed'
 end
 
+shared_examples_for 'IoT Agent uninstall' do
+  it_behaves_like 'an IoT Agent that is removed'
+end
 
 shared_examples_for "an installed Agent" do
   wait_until_started
@@ -355,7 +363,6 @@ shared_examples_for "an installed Agent" do
     end
     JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('skip_windows_signing_test')
   }
-
 
   it 'is properly signed' do
     puts "swsc is #{skip_windows_signing_check}"
@@ -684,7 +691,45 @@ shared_examples_for 'an Agent that is removed' do
       expect(File).not_to exist('/usr/bin/datadog-agent')
     end
   end
+end
 
+shared_examples_for 'an IoT Agent that is removed' do
+  it 'should remove the agent' do
+    if os == :windows
+      # uninstallcmd = "start /wait msiexec /q /x 'C:\\Users\\azure\\AppData\\Local\\Temp\\kitchen\\cache\\ddagent-cli.msi'"
+      uninstallcmd='for /f "usebackq" %n IN (`wmic product where "name like \'datadog%\'" get IdentifyingNumber ^| find "{"`) do start /wait msiexec /log c:\\uninst.log /q /x %n'
+      expect(system(uninstallcmd)).to be_truthy
+    else
+      if system('which apt-get &> /dev/null')
+        expect(system("sudo apt-get -q -y remove datadog-iot-agent > /dev/null")).to be_truthy
+      elsif system('which yum &> /dev/null')
+        expect(system("sudo yum -y remove datadog-iot-agent > /dev/null")).to be_truthy
+      elsif system('which zypper &> /dev/null')
+        expect(system("sudo zypper --non-interactive remove datadog-iot-agent > /dev/null")).to be_truthy
+      else
+        raise 'Unknown package manager'
+      end
+    end
+  end
+
+  it 'should not be running the agent after removal' do
+    sleep 5
+    expect(agent_processes_running?).to be_falsey
+  end
+
+  it 'should remove the installation directory' do
+    if os == :windows
+      expect(File).not_to exist("C:\\Program Files\\Datadog\\Datadog Agent\\")
+    else
+      expect(File).not_to exist("/opt/datadog-agent/")
+    end
+  end
+
+  if os != :windows
+    it 'should remove the agent link from bin' do
+      expect(File).not_to exist('/usr/bin/datadog-agent')
+    end
+  end
 end
 
 shared_examples_for 'an Agent with APM enabled' do

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -1,9 +1,18 @@
 require 'spec_helper'
 
-describe 'dd-agent-installation-script' do
-  include_examples 'Agent install'
-  include_examples 'Agent behavior'
+# We retrieve the value defined in kitchen.yml because there is no simple way
+# to set env variables on the target machine or via parameters in Kitchen/Busser
+# See https://github.com/test-kitchen/test-kitchen/issues/662 for reference
+let(:agent_flavor) {
+  if os == :windows
+    dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
+  else
+    dna_json_path = "/tmp/kitchen/dna.json"
+  end
+  JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('agent_flavor')
+}
 
+shared_examples_for 'Agent installed by the install script' do
   context 'when testing DD_SITE' do
     let(:config) do
       YAML.load_file('/etc/datadog-agent/datadog.yaml')
@@ -30,7 +39,18 @@ describe 'dd-agent-installation-script' do
         'installer_version' => /^install_script-\d+\.\d+\.\d+$/
       )
     end
+end
 
+describe 'dd-agent-installation-script' do
+  include_examples 'Agent install'
+
+  if agent_flavor == "datadog-agent"
+    include_examples 'Agent behavior'
+    include_examples 'Agent installed by the install script'
     include_examples 'Agent uninstall'
+  elsif agent_flavor == "datadog-iot-agent"
+    include_examples 'IoT Agent behavior'
+    include_examples 'Agent installed by the install script'
+    include_examples 'IoT Agent uninstall'
   end
 end

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -32,6 +32,7 @@ shared_examples_for 'Agent installed by the install script' do
 end
 
 describe 'dd-agent-installation-script' do
+  agent_flavor = get_agent_flavor
   if agent_flavor == "datadog-agent"
     include_examples 'Agent install'
     include_examples 'Agent behavior'

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -1,16 +1,5 @@
 require 'spec_helper'
-
-# We retrieve the value defined in kitchen.yml because there is no simple way
-# to set env variables on the target machine or via parameters in Kitchen/Busser
-# See https://github.com/test-kitchen/test-kitchen/issues/662 for reference
-let(:agent_flavor) {
-  if os == :windows
-    dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
-  else
-    dna_json_path = "/tmp/kitchen/dna.json"
-  end
-  JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('agent_flavor')
-}
+require 'iot_spec_helper'
 
 shared_examples_for 'Agent installed by the install script' do
   context 'when testing DD_SITE' do
@@ -42,13 +31,13 @@ shared_examples_for 'Agent installed by the install script' do
 end
 
 describe 'dd-agent-installation-script' do
-  include_examples 'Agent install'
-
   if agent_flavor == "datadog-agent"
+    include_examples 'Agent install'
     include_examples 'Agent behavior'
     include_examples 'Agent installed by the install script'
     include_examples 'Agent uninstall'
   elsif agent_flavor == "datadog-iot-agent"
+    include_examples 'IoT Agent install'
     include_examples 'IoT Agent behavior'
     include_examples 'Agent installed by the install script'
     include_examples 'IoT Agent uninstall'

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/dd-agent-install-script_spec.rb
@@ -28,6 +28,7 @@ shared_examples_for 'Agent installed by the install script' do
         'installer_version' => /^install_script-\d+\.\d+\.\d+$/
       )
     end
+  end
 end
 
 describe 'dd-agent-installation-script' do

--- a/test/kitchen/test/integration/dd-agent-install-script/rspec/iot_spec_helper.rb
+++ b/test/kitchen/test/integration/dd-agent-install-script/rspec/iot_spec_helper.rb
@@ -1,0 +1,1 @@
+../../common/rspec/iot_spec_helper.rb


### PR DESCRIPTION
### What does this PR do?

Adds kitchen tests for the IoT Agent package (install script only for now, other install types can be added once they're supported).

### Motivation

Improve test coverage of our pipeline.
