### PR TITLE
Add snmp_listener config

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -466,11 +466,12 @@ api_key:
     #
     # port: 161
 
-    ## @param version - integer - optional - default: 2
-    ## If you are using SNMP v1 set version to 1.
-    ## If you are using SNMP v3 set version to 3.
+    ## @param version - integer - optional - default: <BEST_GUESS>
+    ## Set the version of the SNMP protocol. Value can be `1`, `2` or `3`.
+    ## If unset, the Agent tries to guess the correct version based on other configuration
+    ## parameters. i.e if `user` is set, the Agent will use SNMP v3.
     #
-    # version: 2
+    # version: <VERSION>
 
     ## @param timeout - integer - optional - default: 5
     ## Number of seconds before timing out.
@@ -490,6 +491,7 @@ api_key:
 
     ## @param user - string - optional
     ## The username to connect to your SNMP devices.
+    ## SNMPv3 only.
     #
     # user: <USERNAME>
 
@@ -520,12 +522,6 @@ api_key:
     ## SNMPv3 only.
     #
     # privacy_protocol: <PRIVACY_TYPE>
-
-    ## @param context_engine_id - string - optional
-    ## ID of your context engine; typically unneeded.
-    ## (optional SNMP v3-only parameter)
-    #
-    # context_engine_id: <CONTEXT_ENGINE_ID>
 
     ## @param context_name - string - optional
     ## Name of your context (optional SNMP v3-only parameter).

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -415,6 +415,125 @@ api_key:
 #
 # secret_backend_timeout: 5
 
+## @param snmp_listener - custom object - optional
+## Creates and schedules an snmp listener to automatically discover your SNMP devices.
+## Discover devices can then be monitored with the snmp integration by using
+## the provided auto_conf.yaml file.
+#
+# snmp_listener:
+
+  ## @param workers - integer - optional - default: 2
+  ## Number of goroutines used to discover SNMP devices. Increasing this value
+  ## will help to discover devices faster but at the cost of increased resource consumption.
+  #
+  # workers: 2
+
+  ## @param discovery_interval - integer - optional - default: 3600
+  ## How often to discover new SNMP devices. Decreasing this value
+  ## will help to discover devices faster but at the cost of increased resource consumption.
+  #
+  # discovery_interval: 3600
+
+  ## @param allowed_failures - integer - optional - default: 3
+  ## Number of failed requests to a given SNMP device before removing it for the list of monitored
+  ## devices.
+  ## If a device shuts down, the Agent will stop monitoring it after `discovery_interval * allowed_failures`
+  #
+  # allowed_failures: 3
+
+  ## @param configs - custom object - required
+  ## The actual configurations used to discover SNMP devices in various subnets.
+  #
+  # configs:
+
+    ## @param network - string - required
+    ## The subnet in CIDR format to scan for SNMP devices.
+    ## Ex: 10.0.0.0/24
+    #
+    # network: <NETWORK>
+
+    ## @param ignored_ip_addresses - list of strings - optional
+    ## A list of IP addresses to ignore when scanning the network.
+    #
+    # ignored_ip_addresses:
+    #   - <IP_ADDRESS_1>
+    #   - <IP_ADDRESS_2>
+
+    ## @param port - integer - optional - default: 161
+    ## Default SNMP port.
+    #
+    # port: 161
+
+    ## @param version - integer - optional - default: 2
+    ## If you are using SNMP v1 set version to 1. (required)
+    ## If you are using SNMP v3 set version to 3. (required)
+    #
+    # version: 2
+
+    ## @param timeout - integer - optional - default: 5
+    ## Number of seconds before timing out.
+    #
+    # timeout: 5
+
+    ## @param retries - integer - optional - default: 3
+    ## Amount of retries before failure.
+    #
+    # retries: 3
+
+    ## @param community - string - optional
+    ## Required for SNMP v1 & v2.
+    ## Ex: 'public'
+    #
+    # community: <COMMUNITY_STRING>
+
+    ## @param user - string - optional
+    ## The username to connect to your SNMP devices.
+    #
+    # user: <USERNAME>
+
+    ## @param authentication_key - string - optional
+    ## Authentication key to use with your Authentication type.
+    #
+    # authentication_key: <AUTHENTICATION_TYPE_KEY>
+
+    ## @param authentication_protocol - string - optional
+    ## Authentication type to use when connecting to your SNMP devices.
+    ## It can be one of: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
+    ## Default to MD5 when `authentication_key` is specified.
+    #
+    # authentication_protocol: <AUTHENTICATION_PROTOCOL>
+
+    ## @param privacy_key - string - optional
+    ## Privacy type key to use with your Privacy type.
+    #
+    # privacy_key: <PRIVACY_TYPE_KEY>
+
+    ## @param privacy_protocol - string - optional
+    ## Privacy type to use when connecting to your SNMP devices.
+    ## It can be one of: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
+    ## Default to DES when `privKey` is specified.
+    #
+    # privacy_protocol: <PRIVACY_TYPE>
+
+    ## @param context_engine_id - string - optional
+    ## ID of your context engine; typically unneeded.
+    ## (optional SNMP v3-only parameter)
+    #
+    # context_engine_id: <CONTEXT_ENGINE_ID>
+
+    ## @param context_name - string - optional
+    ## Name of your context (optional SNMP v3-only parameter).
+    #
+    # context_name: <CONTEXT_NAME>
+
+    ## @param ad_identifier - string - optional - default: snmp
+    ## A unique identifier to attach to devices from that subnetwork.
+    ## When configuring the snmp integration from the snmp.d/auto_conf.yaml file,
+    ## you can specify the corresponding ad_identifier at the top of the file.
+    ##
+    #
+    # ad_identifier: snmp
+
 {{ end -}}
 {{- if .LogsAgent }}
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -417,27 +417,27 @@ api_key:
 
 ## @param snmp_listener - custom object - optional
 ## Creates and schedules an snmp listener to automatically discover your SNMP devices.
-## Discover devices can then be monitored with the snmp integration by using
-## the provided auto_conf.yaml file.
+## Discovered devices can then be monitored with the snmp integration by using
+## the auto_conf.yaml file provided by default.
 #
 # snmp_listener:
 
   ## @param workers - integer - optional - default: 2
-  ## Number of goroutines used to discover SNMP devices. Increasing this value
+  ## Number of concurrent tasks used to discover SNMP devices. Increasing this value
   ## will help to discover devices faster but at the cost of increased resource consumption.
   #
   # workers: 2
 
   ## @param discovery_interval - integer - optional - default: 3600
-  ## How often to discover new SNMP devices. Decreasing this value
+  ## How often to discover new SNMP devices, in seconds. Decreasing this value
   ## will help to discover devices faster but at the cost of increased resource consumption.
   #
   # discovery_interval: 3600
 
   ## @param allowed_failures - integer - optional - default: 3
-  ## Number of failed requests to a given SNMP device before removing it for the list of monitored
+  ## Number of failed requests to a given SNMP device before removing it from the list of monitored
   ## devices.
-  ## If a device shuts down, the Agent will stop monitoring it after `discovery_interval * allowed_failures`
+  ## If a device shuts down, the Agent will stop monitoring it after `discovery_interval * allowed_failures` seconds.
   #
   # allowed_failures: 3
 
@@ -448,6 +448,9 @@ api_key:
 
     ## @param network - string - required
     ## The subnet in CIDR format to scan for SNMP devices.
+    ## All IP addresses in the CIDR range that are not ignored will be scanned.
+    ## For optimal discovery time, be sure to use the smallest network mask
+    ## possible as is appropriate for your network topology.
     ## Ex: 10.0.0.0/24
     #
     # network: <NETWORK>
@@ -460,13 +463,13 @@ api_key:
     #   - <IP_ADDRESS_2>
 
     ## @param port - integer - optional - default: 161
-    ## Default SNMP port.
+    ## The UDP port to use when connecting to SNMP devices.
     #
     # port: 161
 
     ## @param version - integer - optional - default: 2
-    ## If you are using SNMP v1 set version to 1. (required)
-    ## If you are using SNMP v3 set version to 3. (required)
+    ## If you are using SNMP v1 set version to 1.
+    ## If you are using SNMP v3 set version to 3.
     #
     # version: 2
 
@@ -497,7 +500,7 @@ api_key:
     # authentication_key: <AUTHENTICATION_TYPE_KEY>
 
     ## @param authentication_protocol - string - optional
-    ## Authentication type to use when connecting to your SNMP devices.
+    ## Authentication protocol to use when connecting to your SNMP devices.
     ## It can be one of: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
     ## Default to MD5 when `authentication_key` is specified.
     #
@@ -511,7 +514,7 @@ api_key:
     ## @param privacy_protocol - string - optional
     ## Privacy type to use when connecting to your SNMP devices.
     ## It can be one of: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
-    ## Default to DES when `privKey` is specified.
+    ## Default to DES when `privacy_key` is specified.
     #
     # privacy_protocol: <PRIVACY_TYPE>
 
@@ -530,7 +533,6 @@ api_key:
     ## A unique identifier to attach to devices from that subnetwork.
     ## When configuring the snmp integration from the snmp.d/auto_conf.yaml file,
     ## you can specify the corresponding ad_identifier at the top of the file.
-    ##
     #
     # ad_identifier: snmp
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -500,7 +500,7 @@ api_key:
     ## The passphrase to use with your Authentication type.
     ## SNMPv3 only.
     #
-    # authentication_key: <AUTHENTICATION_TYPE_KEY>
+    # authentication_key: <AUTHENTICATION_KEY>
 
     ## @param authentication_protocol - string - optional
     ## Authentication protocol to use when connecting to your SNMP devices.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -529,7 +529,7 @@ api_key:
     ## @param privacy_protocol - string - optional
     ## The privacy protocol to use when connecting to your SNMP devices.
     ## Available options are: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
-    ## Default to DES when `privacy_key` is specified.
+    ## Defaults to DES when `privacy_key` is specified.
     ## SNMPv3 only.
     #
     # privacy_protocol: <PRIVACY_PROTOCOL>

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -441,11 +441,10 @@ api_key:
   #
   # allowed_failures: 3
 
-  ## @param configs - custom object - required
+  ## @param configs - list - required
   ## The actual configurations used to discover SNMP devices in various subnets.
   #
-  # configs:
-
+  # configs: 
     ## @param network - string - required
     ## The subnet in CIDR format to scan for SNMP devices.
     ## All IP addresses in the CIDR range that are not ignored will be scanned.
@@ -453,7 +452,7 @@ api_key:
     ## possible as is appropriate for your network topology.
     ## Ex: 10.0.0.0/24
     #
-    # network: <NETWORK>
+    # - network: <NETWORK>
 
     ## @param ignored_ip_addresses - list of strings - optional
     ## A list of IP addresses to ignore when scanning the network.
@@ -495,7 +494,8 @@ api_key:
     # user: <USERNAME>
 
     ## @param authentication_key - string - optional
-    ## Authentication key to use with your Authentication type.
+    ## The passphrase to use with your Authentication type.
+    ## SNMPv3 only.
     #
     # authentication_key: <AUTHENTICATION_TYPE_KEY>
 
@@ -503,18 +503,21 @@ api_key:
     ## Authentication protocol to use when connecting to your SNMP devices.
     ## It can be one of: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
     ## Default to MD5 when `authentication_key` is specified.
+    ## SNMPv3 only.
     #
     # authentication_protocol: <AUTHENTICATION_PROTOCOL>
 
     ## @param privacy_key - string - optional
-    ## Privacy type key to use with your Privacy type.
+    ## The passphrase to use with your Privacy protocol.
+    ## SNMPv3 only.
     #
-    # privacy_key: <PRIVACY_TYPE_KEY>
+    # privacy_key: <PRIVACY_KEY>
 
     ## @param privacy_protocol - string - optional
-    ## Privacy type to use when connecting to your SNMP devices.
+    ## Privacy protocol to use when connecting to your SNMP devices.
     ## It can be one of: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
     ## Default to DES when `privacy_key` is specified.
+    ## SNMPv3 only.
     #
     # privacy_protocol: <PRIVACY_TYPE>
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -504,7 +504,7 @@ api_key:
 
     ## @param authentication_protocol - string - optional
     ## Authentication protocol to use when connecting to your SNMP devices.
-    ## Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
+    ## Available options are: MD5, SHA.
     ## Defaults to MD5 when `authentication_key` is specified.
     ## SNMPv3 only.
     #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -480,7 +480,7 @@ api_key:
     ## @param version - integer - optional - default: <BEST_GUESS>
     ## Set the version of the SNMP protocol. Value can be `1`, `2` or `3`.
     ## If unset, the Agent tries to guess the correct version based on other configuration
-    ## parameters. i.e if `user` is set, the Agent will use SNMP v3.
+    ## parameters, for example: if `user` is set, the Agent uses SNMP v3.
     #
     # version: <VERSION>
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -488,7 +488,7 @@ api_key:
     ## Required for SNMP v1 & v2.
     ## Ex: 'public'
     #
-    # community: <COMMUNITY_STRING>
+    # community: <COMMUNITY>
 
     ## @param user - string - optional
     ## The username to connect to your SNMP devices.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -513,7 +513,7 @@ api_key:
     # authentication_key: <AUTHENTICATION_KEY>
 
     ## @param authentication_protocol - string - optional
-    ## Authentication protocol to use when connecting to your SNMP devices.
+    ## The authentication protocol to use when connecting to your SNMP devices.
     ## Available options are: MD5, SHA.
     ## Defaults to MD5 when `authentication_key` is specified.
     ## SNMPv3 only.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -443,7 +443,16 @@ api_key:
   # allowed_failures: 3
 
   ## @param configs - list - required
-  ## The actual configurations used to discover SNMP devices in various subnets.
+  ## The actual list of configurations used to discover SNMP devices in various subnets.
+  ## Example:
+  ## configs:
+  ##  - network: 10.0.0.0/24
+  ##    version: 2
+  ##    community: public
+  ##  - network: 10.0.1.0/28
+  ##    ignored_ip_addresses:
+  ##      - 10.0.0.1.0
+  ##      - 10.0.0.1.1
   #
   # configs:
     ## @param network - string - required
@@ -451,7 +460,7 @@ api_key:
     ## All unignored IP addresses in the CIDR range are scanned.
     ## For optimal discovery time, be sure to use the smallest network mask
     ## possible as is appropriate for your network topology.
-    ## Ex: 10.0.0.0/24
+    ## Ex: 10.0.1.0/24
     #
     # - network: <NETWORK>
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -522,7 +522,7 @@ api_key:
     ## Default to DES when `privacy_key` is specified.
     ## SNMPv3 only.
     #
-    # privacy_protocol: <PRIVACY_TYPE>
+    # privacy_protocol: <PRIVACY_PROTOCOL>
 
     ## @param context_name - string - optional
     ## The name of your context (optional SNMP v3-only parameter).

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -478,7 +478,7 @@ api_key:
     # port: 161
 
     ## @param version - integer - optional - default: <BEST_GUESS>
-    ## Set the version of the SNMP protocol. Value can be `1`, `2` or `3`.
+    ## Set the version of the SNMP protocol. Available options are: `1`, `2` or `3`.
     ## If unset, the Agent tries to guess the correct version based on other configuration
     ## parameters, for example: if `user` is set, the Agent uses SNMP v3.
     #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -416,28 +416,28 @@ api_key:
 # secret_backend_timeout: 5
 
 ## @param snmp_listener - custom object - optional
-## Creates and schedules an snmp listener to automatically discover your SNMP devices.
-## Discovered devices can then be monitored with the snmp integration by using
+## Creates and schedules a listener to automatically discover your SNMP devices.
+## Discovered devices can then be monitored with the SNMP integration by using
 ## the auto_conf.yaml file provided by default.
 #
 # snmp_listener:
 
   ## @param workers - integer - optional - default: 2
-  ## Number of concurrent tasks used to discover SNMP devices. Increasing this value
-  ## will help to discover devices faster but at the cost of increased resource consumption.
+  ## The number of concurrent tasks used to discover SNMP devices. Increasing this value
+  ## discovers devices faster but at the cost of increased resource consumption.
   #
   # workers: 2
 
   ## @param discovery_interval - integer - optional - default: 3600
   ## How often to discover new SNMP devices, in seconds. Decreasing this value
-  ## will help to discover devices faster but at the cost of increased resource consumption.
+  ## discovers devices faster but at the cost of increased resource consumption.
   #
   # discovery_interval: 3600
 
   ## @param allowed_failures - integer - optional - default: 3
-  ## Number of failed requests to a given SNMP device before removing it from the list of monitored
+  ## The number of failed requests to a given SNMP device before removing it from the list of monitored
   ## devices.
-  ## If a device shuts down, the Agent will stop monitoring it after `discovery_interval * allowed_failures` seconds.
+  ## If a device shuts down, the Agent stops monitoring it after `discovery_interval * allowed_failures` seconds.
   #
   # allowed_failures: 3
 
@@ -447,7 +447,7 @@ api_key:
   # configs: 
     ## @param network - string - required
     ## The subnet in CIDR format to scan for SNMP devices.
-    ## All IP addresses in the CIDR range that are not ignored will be scanned.
+    ## All unignored IP addresses in the CIDR range are scanned.
     ## For optimal discovery time, be sure to use the smallest network mask
     ## possible as is appropriate for your network topology.
     ## Ex: 10.0.0.0/24
@@ -474,12 +474,12 @@ api_key:
     # version: <VERSION>
 
     ## @param timeout - integer - optional - default: 5
-    ## Number of seconds before timing out.
+    ## The number of seconds before timing out.
     #
     # timeout: 5
 
     ## @param retries - integer - optional - default: 3
-    ## Amount of retries before failure.
+    ## The number of retries before failure.
     #
     # retries: 3
 
@@ -503,35 +503,35 @@ api_key:
 
     ## @param authentication_protocol - string - optional
     ## Authentication protocol to use when connecting to your SNMP devices.
-    ## It can be one of: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
-    ## Default to MD5 when `authentication_key` is specified.
+    ## Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
+    ## Defaults to MD5 when `authentication_key` is specified.
     ## SNMPv3 only.
     #
     # authentication_protocol: <AUTHENTICATION_PROTOCOL>
 
     ## @param privacy_key - string - optional
-    ## The passphrase to use with your Privacy protocol.
+    ## The passphrase to use with your privacy protocol.
     ## SNMPv3 only.
     #
     # privacy_key: <PRIVACY_KEY>
 
     ## @param privacy_protocol - string - optional
-    ## Privacy protocol to use when connecting to your SNMP devices.
-    ## It can be one of: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
+    ## The privacy protocol to use when connecting to your SNMP devices.
+    ## Available options are: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
     ## Default to DES when `privacy_key` is specified.
     ## SNMPv3 only.
     #
     # privacy_protocol: <PRIVACY_TYPE>
 
     ## @param context_name - string - optional
-    ## Name of your context (optional SNMP v3-only parameter).
+    ## The name of your context (optional SNMP v3-only parameter).
     #
     # context_name: <CONTEXT_NAME>
 
     ## @param ad_identifier - string - optional - default: snmp
     ## A unique identifier to attach to devices from that subnetwork.
-    ## When configuring the snmp integration from the snmp.d/auto_conf.yaml file,
-    ## you can specify the corresponding ad_identifier at the top of the file.
+    ## When configuring the SNMP integration in snmp.d/auto_conf.yaml,
+    ## specify the corresponding ad_identifier at the top of the file.
     #
     # ad_identifier: snmp
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -447,9 +447,10 @@ api_key:
   ## Example:
   ## configs:
   ##  - network: 10.0.0.0/24
-  ##    version: 2
+  ##    version: 1
   ##    community: public
   ##  - network: 10.0.1.0/28
+  ##    community: public
   ##    ignored_ip_addresses:
   ##      - 10.0.1.0
   ##      - 10.0.1.1

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -445,7 +445,7 @@ api_key:
   ## @param configs - list - required
   ## The actual configurations used to discover SNMP devices in various subnets.
   #
-  # configs: 
+  # configs:
     ## @param network - string - required
     ## The subnet in CIDR format to scan for SNMP devices.
     ## All unignored IP addresses in the CIDR range are scanned.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -451,8 +451,8 @@ api_key:
   ##    community: public
   ##  - network: 10.0.1.0/28
   ##    ignored_ip_addresses:
-  ##      - 10.0.0.1.0
-  ##      - 10.0.0.1.1
+  ##      - 10.0.1.0
+  ##      - 10.0.1.1
   #
   # configs:
     ## @param network - string - required

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -430,7 +430,8 @@ api_key:
 
   ## @param discovery_interval - integer - optional - default: 3600
   ## How often to discover new SNMP devices, in seconds. Decreasing this value
-  ## discovers devices faster but at the cost of increased resource consumption.
+  ## discovers devices faster (within the limit of the time taken to scan subnets)
+  ## but at the cost of increased resource consumption.
   #
   # discovery_interval: 3600
 


### PR DESCRIPTION
### What does this PR do?

Adds snmp configuration to the config_template.yaml file.
It is in the common section as the snmp listener is expected to work in either the cluster agent or the regular one.

### Motivation

SNMP autodiscovery PR was merged, but documentation had not yet been added. See #5195

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
