### PR TITLE
Increase memory limit of Windows containers for tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,7 +229,7 @@ build_libbcc_arm64:
   needs: ["fail_on_non_triggered_tag"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true -e PY_RUNTIMES="$PYTHON_RUNTIMES" -e NEW_BUILDER="$NEW_BUILDER" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDERS} c:\mnt\tasks\winbuildscripts\unittests.bat
+    - docker run --rm -m 8192M -v "$(Get-Location):c:\mnt" -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true -e PY_RUNTIMES="$PYTHON_RUNTIMES" -e NEW_BUILDER="$NEW_BUILDER" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDERS} c:\mnt\tasks\winbuildscripts\unittests.bat
   variables:
     NEW_BUILDER: "false"
 
@@ -255,7 +255,7 @@ run_old_tests_windows-x86:
   needs: ["fail_on_non_triggered_tag"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e PY_RUNTIMES="$PYTHON_RUNTIMES" -e NEW_BUILDER="$NEW_BUILDER" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\unittests.bat
+    - docker run --rm -m 8192M -v "$(Get-Location):c:\mnt" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e PY_RUNTIMES="$PYTHON_RUNTIMES" -e NEW_BUILDER="$NEW_BUILDER" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\unittests.bat
   variables:
     NEW_BUILDER: "true"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -236,7 +236,6 @@ build_libbcc_arm64:
 run_old_tests_windows-x64:
   # temporarily allow failure for tests
   extends: .run_old_tests_windows_base
-  allow_failure: true
   variables:
     PYTHON_RUNTIMES: 3
     ARCH: "x64"
@@ -262,7 +261,6 @@ run_old_tests_windows-x86:
 run_tests_windows-x64:
   # temporarily allow failure for tests
   extends: .run_tests_windows_base
-  allow_failure: true
   variables:
     PYTHON_RUNTIMES: 3
     ARCH: "x64"


### PR DESCRIPTION
### What does this PR do?

Increases the memory limit of Windows containers to prevent OOM errors in tests:
```
 runtime: VirtualAlloc of 8192 bytes failed with errno=1455
 fatal error: out of memory
```
Make x64 tests mandatory, as they have no reason to fail now.

### Motivation

Make tests more reliable.
