### PR TITLE
Map UDP source addr to Kubernetes pod

### DIFF
--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -8,13 +8,21 @@ package listeners
 import (
 	"expvar"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+const (
+	addrToEntityCacheKeyPrefix = "addr_to_entity"
+	addrToEntityCacheDuration  = time.Minute
 )
 
 var (
@@ -38,12 +46,13 @@ func init() {
 // UDPListener implements the StatsdListener interface for UDP protocol.
 // It listens to a given UDP address and sends back packets ready to be
 // processed.
-// Origin detection is not implemented for UDP.
 type UDPListener struct {
-	conn            *net.UDPConn
-	packetsBuffer   *packetsBuffer
-	packetAssembler *packetAssembler
-	buffer          []byte
+	conn             *net.UDPConn
+	packetsBuffer    *packetsBuffer
+	packetAssembler  *packetAssembler
+	sharedPacketPool *PacketPool
+	buffer           []byte
+	OriginDetection  bool
 }
 
 // NewUDPListener returns an idle UDP Statsd listener
@@ -77,16 +86,19 @@ func NewUDPListener(packetOut chan Packets, sharedPacketPool *PacketPool) (*UDPL
 	bufferSize := config.Datadog.GetInt("dogstatsd_buffer_size")
 	packetsBufferSize := config.Datadog.GetInt("dogstatsd_packet_buffer_size")
 	flushTimeout := config.Datadog.GetDuration("dogstatsd_packet_buffer_flush_timeout")
+	originDetection := config.Datadog.GetBool("dogstatsd_origin_detection")
 
 	buffer := make([]byte, bufferSize)
 	packetsBuffer := newPacketsBuffer(uint(packetsBufferSize), flushTimeout, packetOut)
 	packetAssembler := newPacketAssembler(flushTimeout, packetsBuffer, sharedPacketPool)
 
 	listener := &UDPListener{
-		conn:            conn,
-		packetsBuffer:   packetsBuffer,
-		packetAssembler: packetAssembler,
-		buffer:          buffer,
+		OriginDetection:  originDetection,
+		conn:             conn,
+		packetsBuffer:    packetsBuffer,
+		packetAssembler:  packetAssembler,
+		sharedPacketPool: sharedPacketPool,
+		buffer:           buffer,
 	}
 	log.Debugf("dogstatsd-udp: %s successfully initialized", conn.LocalAddr())
 	return listener, nil
@@ -97,7 +109,7 @@ func (l *UDPListener) Listen() {
 	log.Infof("dogstatsd-udp: starting to listen on %s", l.conn.LocalAddr())
 	for {
 		udpPackets.Add(1)
-		n, _, err := l.conn.ReadFrom(l.buffer)
+		n, addr, err := l.conn.ReadFrom(l.buffer)
 		if err != nil {
 			// connection has been closed
 			if strings.HasSuffix(err.Error(), " use of closed network connection") {
@@ -114,8 +126,29 @@ func (l *UDPListener) Listen() {
 		udpBytes.Add(int64(n))
 		tlmUDPPacketsBytes.Add(float64(n))
 
-		// packetAssembler merges multiple packets together and sends them when its buffer is full
-		l.packetAssembler.addMessage(l.buffer[:n])
+		// TODO: extend packetAssembler to support setting per-packet origin
+		if l.OriginDetection {
+			// retrieve an available packet from the packet pool,
+			// which will be pushed back by the server when processed.
+			packet := l.sharedPacketPool.Get()
+			packet.Contents = l.buffer[:n]
+
+			// Extract container id from source address
+			container, taggingErr := getEntityForAddr(addr)
+			if taggingErr != nil {
+				log.Warnf("dogstatsd-udp: error processing origin, data will not be tagged : %v", taggingErr)
+				udsOriginDetectionErrors.Add(1)
+				tlmUDSOriginDetectionError.Inc()
+			} else {
+				packet.Origin = container
+			}
+
+			// packetsBuffer handles the forwarding of the packets to the dogstatsd server intake channel
+			l.packetsBuffer.append(packet)
+		} else {
+			// packetAssembler merges multiple packets together and sends them when its buffer is full
+			l.packetAssembler.addMessage(l.buffer[:n])
+		}
 	}
 }
 
@@ -124,4 +157,46 @@ func (l *UDPListener) Stop() {
 	l.packetAssembler.close()
 	l.packetsBuffer.close()
 	l.conn.Close()
+}
+
+// getEntityForAddr returns the container entity name and caches the value for future lookups
+// As the result is cached and the lookup is really fast (parsing local files), it can be
+// called from the intake goroutine.
+func getEntityForAddr(addr net.Addr) (string, error) {
+	key := cache.BuildAgentKey(addrToEntityCacheKeyPrefix, addr.String())
+	if x, found := cache.Cache.Get(key); found {
+		return x.(string), nil
+	}
+
+	entity, err := entityForAddr(addr)
+	switch err {
+	case nil:
+		// No error, yay!
+		cache.Cache.Set(key, entity, addrToEntityCacheDuration)
+		return entity, nil
+	case errNoContainerMatch:
+		// No runtime detected, cache the `NoOrigin` result
+		cache.Cache.Set(key, NoOrigin, addrToEntityCacheDuration)
+		return NoOrigin, nil
+	default:
+		// Other lookup error, retry next time
+		return NoOrigin, err
+	}
+}
+
+// entityForAddr returns the entity ID for a given network address.
+func entityForAddr(addr net.Addr) (string, error) {
+	// TODO: support other providers (e.g. docker)
+	ku, err := kubelet.GetKubeUtil()
+	if err != nil {
+		return "", err
+	}
+
+	podIP := addr.(*net.UDPAddr).IP.String()
+	pod, err := ku.GetPodFromPodIP(podIP)
+	if err != nil {
+		return "", err
+	}
+
+	return kubelet.PodUIDToTaggerEntityName(pod.Metadata.UID), nil
 }

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -314,6 +314,33 @@ func (ku *KubeUtil) GetPodFromUID(podUID string) (*Pod, error) {
 	return nil, fmt.Errorf("uid %s not found in pod list", podUID)
 }
 
+func (ku *KubeUtil) GetPodFromPodIP(ip string) (*Pod, error) {
+	if ip == "" {
+		return nil, fmt.Errorf("pod IP is empty")
+	}
+	pods, err := ku.GetLocalPodList()
+	if err != nil {
+		return nil, err
+	}
+	for _, pod := range pods {
+		if pod.Status.PodIP == ip {
+			return pod, nil
+		}
+	}
+	log.Debugf("cannot get the pod uid %q: %s, retrying without cache...", ip, err)
+
+	pods, err = ku.ForceGetLocalPodList()
+	if err != nil {
+		return nil, err
+	}
+	for _, pod := range pods {
+		if pod.Status.PodIP == ip {
+			return pod, nil
+		}
+	}
+	return nil, fmt.Errorf("ip %s not found in pod list", ip)
+}
+
 // GetPodForEntityID returns a pointer to the pod that corresponds to an entity ID.
 // If the pod is not found it returns nil and an error.
 func (ku *KubeUtil) GetPodForEntityID(entityID string) (*Pod, error) {

--- a/pkg/util/kubernetes/kubelet/kubelet_interface.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_interface.go
@@ -21,6 +21,7 @@ type KubeUtilInterface interface {
 	GetPodForContainerID(containerID string) (*Pod, error)
 	GetStatusForContainerID(pod *Pod, containerID string) (ContainerStatus, error)
 	GetPodFromUID(podUID string) (*Pod, error)
+	GetPodFromPodIP(podIP string) (*Pod, error)
 	GetPodForEntityID(entityID string) (*Pod, error)
 	QueryKubelet(path string) ([]byte, int, error)
 	GetKubeletAPIEndpoint() string


### PR DESCRIPTION
### What does this PR do?

Map UDP source addr to Kubernetes pod entity ID, with the intent of having dogstatsd automatically enrich tags without requiring explicit entity ID tagging.

### Motivation

Gain enriched tags without requiring all clients to use supported statsd client libraries and flags.

<!-- 
### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
-->