### PR TITLE
pkg/trace/obfuscate: obfuscate AUTH command in Redis

### DIFF
--- a/pkg/trace/obfuscate/redis.go
+++ b/pkg/trace/obfuscate/redis.go
@@ -131,6 +131,14 @@ func obfuscateRedisCmd(out *strings.Builder, cmd string, args ...string) {
 	out.WriteByte(' ')
 
 	switch strings.ToUpper(cmd) {
+	case "AUTH":
+		// Obfuscate everything after command
+		// • AUTH password
+		if len(args) > 0 {
+			args[0] = "?"
+			args = args[:1]
+		}
+
 	case "APPEND", "GETSET", "LPUSHX", "GEORADIUSBYMEMBER", "RPUSHX",
 		"SET", "SETNX", "SISMEMBER", "ZRANK", "ZREVRANK", "ZSCORE":
 		// Obfuscate 2nd argument:

--- a/pkg/trace/obfuscate/redis_test.go
+++ b/pkg/trace/obfuscate/redis_test.go
@@ -105,6 +105,18 @@ func TestRedisObfuscator(t *testing.T) {
 		in, out string
 	}{
 		{
+			"AUTH my-secret-password",
+			"AUTH ?",
+		},
+		{
+			"AUTH james my-secret-password",
+			"AUTH ?",
+		},
+		{
+			"AUTH",
+			"AUTH",
+		},
+		{
 			"APPEND key value",
 			"APPEND key ?",
 		},

--- a/releasenotes/notes/apm-obfuscate-redis-auth-2936583a1bbc70de.yaml
+++ b/releasenotes/notes/apm-obfuscate-redis-auth-2936583a1bbc70de.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: correctly obfuscate AUTH command.


### PR DESCRIPTION
This change ensures that all parameters after the AUTH command get
obfuscated.