### PR TITLE
[HOLD] Add snmp.discovered_devices_count metric

### DIFF
--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -321,7 +321,7 @@ func (l *SNMPListener) deleteService(entityID string, subnet *snmpSubnet) {
 			subnet.deviceFailures[entityID]++
 			failure++
 		}
-		log.Debugf("Removing service. entityID: %s, failure: %d/%d", entityID, failure, l.config.AllowedFailures)
+		log.Debugf("Service failure status for entityID %s: failure: %d/%d", entityID, failure, l.config.AllowedFailures)
 		if l.config.AllowedFailures != -1 && failure >= l.config.AllowedFailures {
 			l.delService <- svc
 			delete(l.services, entityID)

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -27,7 +27,7 @@ const (
 	defaultWorkers           = 2
 	defaultAllowedFailures   = 3
 	defaultDiscoveryInterval = 3600
-	senderCheckId            = check.ID("SNMP_LISTENER")
+	senderCheckID            = check.ID("SNMP_LISTENER")
 )
 
 func init() {
@@ -275,7 +275,7 @@ func (l *SNMPListener) checkDevices() {
 }
 
 func (l *SNMPListener) collectMetrics(subnets []snmpSubnet) {
-	sender, senderErr := aggregator.GetSender(senderCheckId)
+	sender, senderErr := aggregator.GetSender(senderCheckID)
 	if senderErr != nil {
 		log.Errorf("Error getting aggregator sender: %s", senderErr)
 		return

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -235,9 +235,11 @@ func (l *SNMPListener) checkDevices() {
 			startingIP := make(net.IP, len(subnet.startingIP))
 			copy(startingIP, subnet.startingIP)
 			for currentIP := startingIP; subnet.network.Contains(currentIP); incrementIP(currentIP) {
+
 				if ignored := subnet.config.IsIPIgnored(currentIP); ignored {
 					continue
 				}
+
 				jobIP := make(net.IP, len(currentIP))
 				copy(jobIP, currentIP)
 				job := snmpJob{
@@ -253,7 +255,9 @@ func (l *SNMPListener) checkDevices() {
 				}
 			}
 		}
+
 		l.collectMetrics(subnets)
+
 		select {
 		case <-l.stop:
 			return

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -273,14 +273,10 @@ func (l *SNMPListener) collectMetrics(subnets []snmpSubnet) {
 		return
 	}
 	for _, subnet := range subnets {
-		if senderErr == nil {
-			tags := []string{"network:" + subnet.configNetwork}
-			sender.Gauge("snmp.discovered_devices_count", float64(len(subnet.devices)), "", tags)
-		}
+		tags := []string{"network:" + subnet.configNetwork}
+		sender.Gauge("snmp.discovered_devices_count", float64(len(subnet.devices)), "", tags)
 	}
-	if senderErr == nil {
-		sender.Commit()
-	}
+	sender.Commit()
 }
 
 func (l *SNMPListener) createService(entityID string, subnet *snmpSubnet, deviceIP string, writeCache bool) {

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -260,7 +260,7 @@ func (l *SNMPListener) checkDevices() {
 			}
 			if senderErr == nil {
 				tags := []string{"network:" + subnet.configNetwork}
-				sender.Gauge("snmp.discovered_devices_count", float64(discoveredDevicesCount), "", tags)
+				sender.Gauge("snmp.discovered_devices_count", float64(len(subnet.devices)), "", tags)
 			}
 		}
 		if senderErr == nil {

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/persistentcache"
 	"github.com/DataDog/datadog-agent/pkg/snmp"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -26,6 +27,7 @@ const (
 	defaultWorkers           = 2
 	defaultAllowedFailures   = 3
 	defaultDiscoveryInterval = 3600
+	senderCheckId            = check.ID("SNMP_LISTENER")
 )
 
 func init() {
@@ -267,7 +269,7 @@ func (l *SNMPListener) checkDevices() {
 }
 
 func (l *SNMPListener) collectMetrics(subnets []snmpSubnet) {
-	sender, senderErr := aggregator.GetSender("snmp_listener")
+	sender, senderErr := aggregator.GetSender(senderCheckId)
 	if senderErr != nil {
 		log.Errorf("Error getting aggregator sender: %s", senderErr)
 		return

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -8,11 +8,11 @@ package listeners
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"net"
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/persistentcache"
 	"github.com/DataDog/datadog-agent/pkg/snmp"

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -58,7 +58,7 @@ func TestSNMPListener(t *testing.T) {
 	assert.Equal(t, "192.168.0.0", job.subnet.startingIP.String())
 
 	// Make sure we reach the end of checkDevices for better coverage
-	// Will test that listener work fine even if we can't get the metric sender
+	// Will test that listener works fine even if we can't get the metric sender
 	for i := 1; i <= 254; i++ {
 		_ = <-testChan
 	}
@@ -101,13 +101,15 @@ func TestSNMPListenerMetrics(t *testing.T) {
 	assert.Equal(t, nil, err)
 	l.Listen(newSvc, delSvc)
 
-	for i := 1; i <= 512; i++ {
+	job := <-testChan
+	job.subnet.devices = map[string]string{"id1": "192.168.0.1", "id2": "192.168.0.1"}
+	for i := 1; i <= 511; i++ {
 		_ = <-testChan
 	}
 	l.Stop()
 
-	mockSender.AssertCalled(t, "Gauge", "snmp.discovered_devices_count", float64(256), "", []string{"network:192.168.0.0/24"})
-	mockSender.AssertCalled(t, "Gauge", "snmp.discovered_devices_count", float64(256), "", []string{"network:192.168.1.0/24"})
+	mockSender.AssertCalled(t, "Gauge", "snmp.discovered_devices_count", float64(2), "", []string{"network:192.168.0.0/24"})
+	mockSender.AssertCalled(t, "Gauge", "snmp.discovered_devices_count", float64(0), "", []string{"network:192.168.1.0/24"})
 	mockSender.AssertNumberOfCalls(t, "Commit", 1)
 }
 

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -56,6 +56,13 @@ func TestSNMPListener(t *testing.T) {
 	job = <-testChan
 	assert.Equal(t, "192.168.0.1", job.currentIP.String())
 	assert.Equal(t, "192.168.0.0", job.subnet.startingIP.String())
+
+	// Make sure we reach the end of checkDevices for better coverage
+	// Will test that listener work fine even if we can't get the metric sender
+	for i := 1; i <= 254; i++ {
+		_ = <-testChan
+	}
+	l.Stop()
 }
 
 func TestSNMPListenerMetrics(t *testing.T) {

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -6,14 +6,14 @@
 package listeners
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
-	"github.com/stretchr/testify/mock"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/snmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestSNMPListener(t *testing.T) {

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -86,7 +86,7 @@ func TestSNMPListenerMetrics(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("snmp_listener", listenerConfig)
 
-	mockSender := mocksender.NewMockSender("snmp_listener")
+	mockSender := mocksender.NewMockSender(senderCheckId)
 	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockSender.On("Commit").Return()
 

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -102,7 +102,8 @@ func TestSNMPListenerMetrics(t *testing.T) {
 	l.Listen(newSvc, delSvc)
 
 	job := <-testChan
-	job.subnet.devices = map[string]string{"id1": "192.168.0.1", "id2": "192.168.0.1"}
+	job.subnet.devices["id1"] = "192.168.0.1"
+	job.subnet.devices["id2"] = "192.168.0.2"
 	for i := 1; i <= 511; i++ {
 		_ = <-testChan
 	}

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -86,7 +86,7 @@ func TestSNMPListenerMetrics(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("snmp_listener", listenerConfig)
 
-	mockSender := mocksender.NewMockSender(senderCheckId)
+	mockSender := mocksender.NewMockSender(senderCheckID)
 	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	mockSender.On("Commit").Return()
 

--- a/releasenotes/notes/add_snmp_devices_count-afbf05f0ce69d14c.yaml
+++ b/releasenotes/notes/add_snmp_devices_count-afbf05f0ce69d14c.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add snmp per network devices count metric.


### PR DESCRIPTION
### What does this PR do?

Add snmp.discovered_devices_count metric

### Motivation

- User request
- Parity with python auto discovery check: https://github.com/DataDog/integrations-core/blob/6ec9d74ee303dc54e4b171a2b0ab274c28dac39b/snmp/datadog_checks/snmp/snmp.py#L340

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
