### PR TITLE
Run go get with GO111MODULE=off in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -280,8 +280,8 @@ run_tests_windows-x86:
     - source /root/.bashrc && conda activate $CONDA_ENV
     - pip install wheel
     - pip install -r requirements.txt
-    - go get gopkg.in/yaml.v2
-    - go get github.com/stretchr/testify
+    - GO111MODULE=off go get gopkg.in/yaml.v2
+    - GO111MODULE=off go get github.com/stretchr/testify
     - inv -e rtloader.make --install-prefix=$SRC_PATH/dev --python-runtimes "$PYTHON_RUNTIMES"
     - inv -e rtloader.install
     - inv -e rtloader.format --raise-if-changed

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -503,6 +503,7 @@ core,"gopkg.in/Knetic/govaluate.v3",MIT
 core,"gopkg.in/inf.v0",NewBSD
 core,"gopkg.in/natefinch/lumberjack.v2",MIT
 core,"gopkg.in/yaml.v2",Apache-2.0
+core,"gopkg.in/yaml.v3",MIT
 core,"gopkg.in/zorkian/go-datadog-api.v2",NewBSD
 core,"honnef.co/go/tools/arg",MIT
 core,"honnef.co/go/tools/cmd/staticcheck",MIT

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -503,7 +503,6 @@ core,"gopkg.in/Knetic/govaluate.v3",MIT
 core,"gopkg.in/inf.v0",NewBSD
 core,"gopkg.in/natefinch/lumberjack.v2",MIT
 core,"gopkg.in/yaml.v2",Apache-2.0
-core,"gopkg.in/yaml.v3",MIT
 core,"gopkg.in/zorkian/go-datadog-api.v2",NewBSD
 core,"honnef.co/go/tools/arg",MIT
 core,"honnef.co/go/tools/cmd/staticcheck",MIT


### PR DESCRIPTION
### What does this PR do?

Run `go get` with `GO111MODULE=off` in CI to avoid polluting the licenses check.

### Motivation

Fix tests.

