### PR TITLE
[backport] Run go get with GO111MODULE=off in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -283,8 +283,8 @@ run_tests_windows-x86:
     - source /root/.bashrc && conda activate $CONDA_ENV
     - pip install wheel
     - pip install -r requirements.txt
-    - go get gopkg.in/yaml.v2
-    - go get github.com/stretchr/testify
+    - GO111MODULE=off go get gopkg.in/yaml.v2
+    - GO111MODULE=off go get github.com/stretchr/testify
     - inv -e rtloader.make --install-prefix=$SRC_PATH/dev --python-runtimes "$PYTHON_RUNTIMES"
     - inv -e rtloader.install
     - inv -e rtloader.format --raise-if-changed


### PR DESCRIPTION
### What does this PR do?

Backport of #5644.

Run go get with GO111MODULE=off in CI to avoid polluting the licenses check.
