### PR TITLE
Let Chocolatey be installed on Domain Controllers

### DIFF
--- a/chocolatey/tools-offline/chocolateyinstall.ps1
+++ b/chocolatey/tools-offline/chocolateyinstall.ps1
@@ -1,10 +1,5 @@
 ﻿$ErrorActionPreference = 'Stop';
-# See https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-computersystem
-$domainRole = (Get-WmiObject -Class Win32_ComputerSystem).DomainRole
-if (($domainRole -eq 4) -Or ($domainRole -eq 5)) {
-  Write-Host "Installation on a Domain Controller is not yet supported - aborting"
-  exit -1 
-}
+
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $nupkgs = Get-ChildItem $toolsDir\datadog-agent*.msi
 if (($nupkgs | Measure-Object).Count -gt 1) {

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -1,10 +1,4 @@
 $ErrorActionPreference = 'Stop';
-# See https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-computersystem
-$domainRole = (Get-WmiObject -Class Win32_ComputerSystem).DomainRole
-if (($domainRole -eq 4) -Or ($domainRole -eq 5)) {
-  Write-Host "Installation on a Domain Controller is not yet supported - aborting"
-  exit -1
-}
 
 $url = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($env:chocolateyPackageVersion).msi"
 # Note: match x.x.x-rc-x nuspec version format

--- a/releasenotes/notes/chocolatey_on_domain_controller-84dace3c399b2c7d.yaml
+++ b/releasenotes/notes/chocolatey_on_domain_controller-84dace3c399b2c7d.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Chocolatey package can be installed on Domain Controller


### PR DESCRIPTION
### What does this PR do?

Remove early bail out if installing chocolatey on domain controller.

### Motivation

Since the user can pass parameters to the MSI via install arguments (https://chocolatey.org/docs/commandsinstall) it makes sense to let it be installed on Domain Controller.

