### PR TITLE
Revert gosnmp upgrade and extra auth protocols

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/shirou/gopsutil v2.20.3+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4
 	github.com/sirupsen/logrus v1.5.0 // indirect
-	github.com/soniah/gosnmp v1.26.0
+	github.com/soniah/gosnmp v1.25.0
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -955,6 +955,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.3/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/soniah/gosnmp v1.25.0 h1:0y8vpjD07NPmnT+wojnUrKkYLX9Fxw1jI4cGTumWugQ=
+github.com/soniah/gosnmp v1.25.0/go.mod h1:8YvfZxH388NIIw2A+X5z2Oh97VcNhtmxDLt5QeUzVuQ=
 github.com/soniah/gosnmp v1.26.0 h1:WkqN0GVuiaYE/ZG2BC62W8TdDvgve1FrYlafxYffCP8=
 github.com/soniah/gosnmp v1.26.0/go.mod h1:hF/8DZgfcJ/2KObJTGoG1KKjitz0a/kC9rE0RFhdPkY=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -150,14 +150,6 @@ func (c *Config) BuildSNMPParams() (*gosnmp.GoSNMP, error) {
 		authProtocol = gosnmp.MD5
 	} else if lowerAuthProtocol == "sha" {
 		authProtocol = gosnmp.SHA
-	} else if lowerAuthProtocol == "sha224" {
-		authProtocol = gosnmp.SHA224
-	} else if lowerAuthProtocol == "sha256" {
-		authProtocol = gosnmp.SHA256
-	} else if lowerAuthProtocol == "sha384" {
-		authProtocol = gosnmp.SHA384
-	} else if lowerAuthProtocol == "sha512" {
-		authProtocol = gosnmp.SHA512
 	} else {
 		return nil, fmt.Errorf("Unsupported authentication protocol: %s", c.AuthProtocol)
 	}

--- a/releasenotes/notes/snmp-revert-more-auth-protocols-810e139380f644b4.yaml
+++ b/releasenotes/notes/snmp-revert-more-auth-protocols-810e139380f644b4.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Revert upgrade of GoSNMP and addition of extra authentication protocols.


### PR DESCRIPTION
### What does this PR do?

Refs https://github.com/DataDog/datadog-agent/pull/5632

- Revert GoSNMP version from 1.26.0 to 1.25.0
- Revert addition of extra auth protocols (since they were added in 1.26.0)

### Motivation
Refs https://github.com/soniah/gosnmp/issues/236#issuecomment-633969927 - Looks like v1.26.0 introduced a bug in how the authentication digest are computed. This means autodiscovery w/ v3 and auth _may_ be broken. Right now this is a hypothesis because we don't have any GoSNMP integration tests currently (so #5632 wouldn't have been able to catch it either).

But after merging master into https://github.com/DataDog/datadog-agent/pull/5470 this morning, my v3+auth traps tests started failing. Locally I confirmed that it seems that under v1.26.0 packets are flagged as non-authentic even though the protocol and passphrase used by the client are correct. Downgrading to 1.25.0 fixed the issue.

### Additional Notes

Follow ups:
- Report/fix issue upstream - See https://github.com/soniah/gosnmp/issues/236
- We need integration tests w/ GoSNMP in the autodiscovery code.

### Describe your test plan

Comparing CI results on #5470:

- Under 1.26.0 - failed :x: https://ci.appveyor.com/project/Datadog/datadog-agent/builds/33200284
- Downgrade to 1.25.0 - succeeded ✅ https://ci.appveyor.com/project/Datadog/datadog-agent/builds/33199391