### PR TITLE
Pin dulwich dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # python development requirements for Agent 6
 invoke==1.0.0
 reno==2.9.2
+dulwich==0.19.16
 docker==3.7.3
 requests==2.20.1
 PyYAML==5.3.1


### PR DESCRIPTION
### What does this PR do?

Pins `dulwich` to 0.19.16.

### Motivation

`dulwich 0.20.x` doesn't build on Windows with the current builders. `dulwich 0.20.0` dropped Python 2 support, and the Windows builders are currently using Python 2 as the system python.

