### PR TITLE
Add install_info file to Docker images

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -69,6 +69,8 @@ RUN find / -maxdepth 1 -type f -name 'datadog-agent*_amd64.deb' ! -name "$DD_AGE
 #   - copy default config files
 COPY datadog*.yaml etc/datadog-agent/
 
+# Installation information
+COPY install_info etc/datadog-agent/
 
 ######################################
 #  Actual docker image construction  #

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -69,6 +69,8 @@ RUN find / -maxdepth 1 -type f -name 'datadog-agent*_arm64.deb' ! -name "$DD_AGE
 #   - copy default config files
 COPY datadog*.yaml etc/datadog-agent/
 
+# Installation information
+COPY install_info etc/datadog-agent/
 
 ######################################
 #  Actual docker image construction  #

--- a/Dockerfiles/agent/install_info
+++ b/Dockerfiles/agent/install_info
@@ -1,0 +1,5 @@
+---
+installer_method:
+  tool: docker
+  tool_version: docker
+  installer_version: docker

--- a/Dockerfiles/agent/test_image_contents.py
+++ b/Dockerfiles/agent/test_image_contents.py
@@ -12,6 +12,7 @@ EXPECTED_PRESENT = [
     "/etc/datadog-agent/datadog-kubernetes.yaml",
     "/etc/datadog-agent/datadog-k8s-docker.yaml",
     "/etc/datadog-agent/datadog-ecs.yaml",
+    "/etc/datadog-agent/install_info",
 ]
 
 EXPECTED_ABSENT = [

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -18,6 +18,7 @@ EXPOSE 8125/udp 8126/tcp
 COPY entrypoint.ps1 .
 ADD entrypoint-ps1 ./entrypoint-ps1
 COPY datadog*.yaml C:/ProgramData/Datadog/
+COPY install_info C:/ProgramData/Datadog/
 
 ENTRYPOINT ["pwsh", "./entrypoint.ps1"]
 CMD ["agent", "run"]

--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /output
 COPY datadog-cluster-agent.amd64 opt/datadog-agent/bin/datadog-cluster-agent
 COPY ./conf.d etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml etc/datadog-agent/datadog-cluster.yaml
+COPY ./install_info etc/datadog-agent/install_info
 COPY entrypoint.sh .
 COPY readsecret.sh .
 

--- a/Dockerfiles/cluster-agent/install_info
+++ b/Dockerfiles/cluster-agent/install_info
@@ -1,0 +1,5 @@
+---
+installer_method:
+  tool: docker
+  tool_version: docker
+  installer_version: docker

--- a/Dockerfiles/dogstatsd/alpine/amd64/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/amd64/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --no-cache ca-certificates
 
 COPY entrypoint.sh probe.sh /
 COPY dogstatsd.yaml /etc/datadog-agent/dogstatsd.yaml
+COPY install_info /etc/datadog-agent/install_info
 COPY static/dogstatsd /dogstatsd
 
 EXPOSE 8125/udp

--- a/Dockerfiles/dogstatsd/alpine/arm64/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/arm64/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --no-cache ca-certificates
 
 COPY entrypoint.sh probe.sh /
 COPY dogstatsd.yaml /etc/datadog-agent/dogstatsd.yaml
+COPY install_info /etc/datadog-agent/install_info
 COPY static/dogstatsd /dogstatsd
 
 EXPOSE 8125/udp

--- a/Dockerfiles/dogstatsd/alpine/install_info
+++ b/Dockerfiles/dogstatsd/alpine/install_info
@@ -1,0 +1,5 @@
+---
+installer_method:
+  tool: docker
+  tool_version: docker
+  installer_version: docker


### PR DESCRIPTION
### What does this PR do?

Add file with installation information to docker images which overrides any previously set contents

### Motivation

- Send this information as metadata
- Add this information to the agent flare for troubleshooting

### Describe your test plan

Build and run the docker images from this branch. Check that there is an `install_info` file on the configuration directory with `tool: docker`.