### PR TITLE
[DCA] Admission Controller observability

### DIFF
--- a/pkg/clusteragent/admission/status.go
+++ b/pkg/clusteragent/admission/status.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build kubeapiserver
+
+package admission
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetStatus returns status info for the secret and webhook controllers.
+func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
+	status := make(map[string]interface{})
+	if !config.Datadog.GetBool("admission_controller.enabled") {
+		status["Disabled"] = "The admission controller is not enabled on the Cluster Agent"
+		return status
+	}
+
+	ns := common.GetResourcesNamespace()
+	webhookName := config.Datadog.GetString("admission_controller.webhook_name")
+	secretName := config.Datadog.GetString("admission_controller.certificate.secret_name")
+	status["WebhookName"] = webhookName
+	status["SecretName"] = fmt.Sprintf("%s/%s", ns, secretName)
+
+	webhookStatus, err := getWebhookStatus(webhookName, apiCl)
+	if err != nil {
+		status["WebhookError"] = err.Error()
+	} else {
+		status["Webhooks"] = webhookStatus
+	}
+
+	secretStatus, err := getSecretStatus(ns, secretName, apiCl)
+	if err != nil {
+		status["SecretError"] = err.Error()
+	} else {
+		status["Secret"] = secretStatus
+	}
+
+	return status
+}
+
+func getWebhookStatus(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
+	webhookStatus := make(map[string]interface{})
+	webhook, err := apiCl.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(name, metav1.GetOptions{})
+	if err != nil {
+		return webhookStatus, err
+	}
+
+	webhookStatus["Name"] = webhook.GetName()
+	webhookStatus["CreatedAt"] = webhook.GetCreationTimestamp()
+
+	webhooksConfig := make(map[string]map[string]interface{})
+	webhookStatus["Webhooks"] = webhooksConfig
+	for _, w := range webhook.Webhooks {
+		webhooksConfig[w.Name] = make(map[string]interface{})
+		svc := w.ClientConfig.Service
+		if svc != nil {
+			webhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - Port: %d - Path: %s", svc.Namespace, svc.Name, *svc.Port, *svc.Path)
+		}
+		if w.ObjectSelector != nil {
+			webhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+		}
+		for i, r := range w.Rules {
+			webhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+		}
+		webhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
+	}
+	return webhookStatus, nil
+}
+
+func getSecretStatus(ns, name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
+	secretStatus := make(map[string]interface{})
+	secret, err := apiCl.CoreV1().Secrets(ns).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return secretStatus, err
+	}
+	secretStatus["Name"] = secret.GetName()
+	secretStatus["Namespace"] = secret.GetNamespace()
+	secretStatus["CreatedAt"] = secret.GetCreationTimestamp()
+	secretStatus["CABundleDigest"] = getDigest(secret.Data["cert.pem"])
+	t, err := certificate.GetDurationBeforeExpiration(secret.Data)
+	if err != nil {
+		log.Errorf("Cannot get certificate validity duration: %v", err)
+	}
+	secretStatus["CertValidDuration"] = t.String()
+	return secretStatus, nil
+}
+
+func getDigest(b []byte) string {
+	h := fnv.New64()
+	_, _ = h.Write(b)
+	return strconv.FormatUint(h.Sum64(), 16)
+}

--- a/pkg/clusteragent/admission/status_no_apiserver.go
+++ b/pkg/clusteragent/admission/status_no_apiserver.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build !kubeapiserver
+
+package admission
+
+// GetStatus returns status info for the secret and webhook controllers.
+func GetStatus(apiCl interface{}) map[string]interface{} {
+	status := make(map[string]interface{})
+	status["Disabled"] = "The admission controller is not compiled-in"
+	return status
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -176,8 +177,10 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	apiCl, err := apiserver.GetAPIClient()
 	if err != nil {
 		stats["custommetrics"] = map[string]string{"Error": err.Error()}
+		stats["admissionWebhook"] = map[string]string{"Error": err.Error()}
 	} else {
 		stats["custommetrics"] = custommetrics.GetStatus(apiCl.Cl)
+		stats["admissionWebhook"] = admission.GetStatus(apiCl.Cl)
 	}
 
 	if config.Datadog.GetBool("cluster_checks.enabled") {

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -160,4 +160,49 @@ Cluster Checks Dispatching
   Status: unknown
 {{- end }}
 {{- end }}
+
+{{- if .admissionWebhook }}
+
+Admission Controller
+====================
+  {{- if .admissionWebhook.Error }}
+  Error: {{ .admissionWebhook.Error }}
+  {{ else }}
+  {{- if .admissionWebhook.Disabled }}
+  Disabled: {{ .admissionWebhook.Disabled }}
+  {{ else }}
+  {{ if .admissionWebhook.WebhookError }}
+  MutatingWebhookConfigurations name: {{ .admissionWebhook.WebhookName }}
+  Error: {{ .admissionWebhook.WebhookError }}
+  {{- end }}
+  {{- if .admissionWebhook.Webhooks }}
+    Webhooks info
+    -------------
+      MutatingWebhookConfigurations name: {{ .admissionWebhook.Webhooks.Name }}
+      Created at: {{ .admissionWebhook.Webhooks.CreatedAt }}
+
+      {{- range $name, $config := .admissionWebhook.Webhooks.Webhooks }}
+      ---------
+        Name: {{ $name }}
+        {{- range $k, $v := $config }}
+        {{$k}}: {{$v}}
+        {{- end }}
+      {{- end }}
+  {{- end }}
+  {{ if .admissionWebhook.SecretError }}
+  Secret name: {{ .admissionWebhook.SecretName }}
+  Error: {{ .admissionWebhook.SecretError }}
+  {{- end }}
+  {{- if .admissionWebhook.Secret }}
+    Secret info
+    -----------
+    Secret name: {{ .admissionWebhook.Secret.Name }}
+    Secret namespace: {{ .admissionWebhook.Secret.Namespace }}
+    Created at: {{ .admissionWebhook.Secret.CreatedAt }}
+    CA bundle digest: {{ .admissionWebhook.Secret.CABundleDigest }}
+    Duration before certificate expiration: {{ .admissionWebhook.Secret.CertValidDuration }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
 {{/* this line intentionally left blank */}}


### PR DESCRIPTION
### What does this PR do?

- Add admission controller section to the `agent status` (included in the flare)

### Motivation

Help debugging the admission controller

### Example output 
```
Admission Controller
====================

    Webhooks info
    -------------
      MutatingWebhookConfigurations name: datadog-webhook
      Created at: 2020-06-03T15:13:57Z
      ---------
        Name: datadog.webhook.config
        CA bundle digest: a89cd74a90035e31
        Object selector: &LabelSelector{MatchLabels:map[string]string{admission.datadoghq.com/enabled: true,},MatchExpressions:[]LabelSelectorRequirement{},}
        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
        Service: default/datadog-admission-controller - Port: 443 - Path: /injectconfig
      ---------
        Name: datadog.webhook.tags
        CA bundle digest: a89cd74a90035e31
        Object selector: &LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:admission.datadoghq.com/enabled,Operator:NotIn,Values:[false],},},}
        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
        Service: default/datadog-admission-controller - Port: 443 - Path: /injecttags

    Secret info
    -----------
    Secret name: webhook-certificate
    Secret namespace: default
    Created at: 2020-05-15T17:56:06Z
    CA bundle digest: a89cd74a90035e31
    Duration before certificate expiration: 1h57m0.776907519s
```

