### PR TITLE
Remove "-i" flag from go build as not necessary and prevents non-root build of DCA

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -162,7 +162,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     args = {
         "go_mod": go_mod,
         "race_opt": "-race" if race else "",
-        "build_type": "-a" if rebuild else ("-i" if precompile_only else ""),
+        "build_type": "-a" if rebuild else "",
         "go_build_tags": " ".join(build_tags),
         "agent_bin": os.path.join(BIN_PATH, bin_name("agent", android=False)),
         "gcflags": gcflags,

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -64,7 +64,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     cmd += "-o {agent_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/agent/android"
     args = {
         "race_opt": "-race" if race else "",
-        "build_type": "-a" if rebuild else ("-i" if precompile_only else ""),
+        "build_type": "-a" if rebuild else "",
         "go_build_tags": " ".join(build_tags),
         "agent_bin": os.path.join(BIN_PATH, bin_name("ddagent", android=True)),
         "gcflags": gcflags,

--- a/tasks/cluster_agent_helpers.py
+++ b/tasks/cluster_agent_helpers.py
@@ -33,7 +33,7 @@ def build_common(ctx, command, bin_path, build_tags, bin_suffix, rebuild, build_
     args = {
         "go_mod": go_mod,
         "race_opt": "-race" if race else "",
-        "build_type": "-a" if rebuild else "-i",
+        "build_type": "-a" if rebuild else "",
         "build_tags": " ".join(build_tags),
         "bin_name": os.path.join(
             bin_path, bin_name("datadog-cluster-agent{suffix}".format(suffix=bin_suffix))),

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -166,7 +166,7 @@ def nettop(ctx, incremental_build=False):
         path=os.path.join(REPO_PATH, "pkg", "ebpf", "nettop"),
         bin_path=bin_path,
         go_mod=go_mod,
-        build_type="-i" if incremental_build else "-a",
+        build_type="" if incremental_build else "-a",
     ))
 
     # Run

--- a/tasks/systray.py
+++ b/tasks/systray.py
@@ -58,7 +58,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     args = {
         "go_mod": go_mod,
         "race_opt": "-race" if race else "",
-        "build_type": "-a" if rebuild else ("-i" if precompile_only else ""),
+        "build_type": "-a" if rebuild else "",
         "agent_bin": os.path.join(BIN_PATH, bin_name("ddtray")),
         "ldflags": ldflags,
         "REPO_PATH": REPO_PATH,

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -65,7 +65,7 @@ def build(ctx, rebuild=False, race=False, precompile_only=False, build_include=N
     args = {
         "go_mod": go_mod,
         "race_opt": "-race" if race else "",
-        "build_type": "-a" if rebuild else ("-i" if precompile_only else ""),
+        "build_type": "-a" if rebuild else "",
         "go_build_tags": " ".join(build_tags),
         "agent_bin": os.path.join(BIN_PATH, bin_name("trace-agent", android=False)),
         "gcflags": gcflags,


### PR DESCRIPTION
### What does this PR do?

Remove "-i" flag given to `go build`, it does not make the build faster anymore [since Go 1.10](https://golang.org/doc/go1.10#build)

See also:
https://github.com/golang/go/issues/25138

Currently we get:
```
datadog@docker-desktop:~/go/src/github.com/DataDog/datadog-agent$ inv cluster-agent.build
templates.go
templates.go
go generate ran successfully
go build runtime/cgo: open /usr/local/go/pkg/linux_amd64/runtime/cgo.a: permission denied
```

### Motivation

Allow non-root build.
