### PR TITLE
[logging] Makes jmxfetch use its own logger

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -101,9 +101,12 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 	if logFile == "" {
 		logFile = common.DefaultLogFile
 	}
-
+	jmxLogFile := config.Datadog.GetString("jmx_log_file")
+	if jmxLogFile == "" {
+		jmxLogFile = common.DefaultJmxLogFile
+	}
 	log.Infof("Making a flare")
-	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile, profile)
+	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, []string{logFile, jmxLogFile}, profile)
 	if err != nil || filePath == "" {
 		if err != nil {
 			log.Errorf("The flare failed to be created: %s", err)

--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -39,6 +39,7 @@ monitoring and performance data.`,
 
 // loggerName is the name of the core agent logger
 const loggerName config.LoggerName = "CORE"
+const jmxLoggerName config.LoggerName = "JMX"
 
 func init() {
 	AgentCmd.PersistentFlags().StringVarP(&confFilePath, "cfgpath", "c", "", "path to directory containing datadog.yaml")

--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -39,7 +39,7 @@ monitoring and performance data.`,
 
 // loggerName is the name of the core agent logger
 const loggerName config.LoggerName = "CORE"
-const jmxLoggerName config.LoggerName = "JMX"
+const jmxLoggerName config.LoggerName = "JMXFETCH"
 
 func init() {
 	AgentCmd.PersistentFlags().StringVarP(&confFilePath, "cfgpath", "c", "", "path to directory containing datadog.yaml")

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -151,9 +151,15 @@ func StartAgent() error {
 			logFile = common.DefaultLogFile
 		}
 
+		jmxLogFile := config.Datadog.GetString("jmx_log_file")
+		if jmxLogFile == "" {
+			jmxLogFile = common.DefaultJmxLogFile
+		}
+
 		if config.Datadog.GetBool("disable_file_logging") {
 			// this will prevent any logging on file
 			logFile = ""
+			jmxLogFile = ""
 		}
 
 		err = config.SetupLogger(
@@ -165,6 +171,20 @@ func StartAgent() error {
 			config.Datadog.GetBool("log_to_console"),
 			config.Datadog.GetBool("log_format_json"),
 		)
+
+		//Setup JMX logger
+		if err == nil {
+			err = config.SetupJMXLogger(
+				jmxLoggerName,
+				config.Datadog.GetString("log_level"),
+				jmxLogFile,
+				syslogURI,
+				config.Datadog.GetBool("syslog_rfc"),
+				config.Datadog.GetBool("log_to_console"),
+				config.Datadog.GetBool("log_format_json"),
+			)
+		}
+
 	} else {
 		err = config.SetupLogger(
 			loggerName,
@@ -175,6 +195,19 @@ func StartAgent() error {
 			true,  // always log to console
 			false, // not in json
 		)
+
+		//Setup JMX logger
+		if err == nil {
+			err = config.SetupJMXLogger(
+				jmxLoggerName,
+				config.Datadog.GetString("log_level"),
+				"", // no log file on android
+				"", // no syslog on android,
+				false,
+				true,  // always log to console
+				false, // not in json
+			)
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("Error while setting up logging, exiting: %v", err)

--- a/cmd/agent/common/common_android.go
+++ b/cmd/agent/common/common_android.go
@@ -16,6 +16,8 @@ const (
 	DefaultLogFile = "/var/log/datadog/agent.log"
 	// DefaultDCALogFile points to the log file that will be used if not configured
 	DefaultDCALogFile = "/var/log/datadog/cluster-agent.log"
+	//DefaultJmxLogFile points to the jmx fetch log file that will be used if not configured
+	DefaultJmxLogFile = "/var/log/datadog/jmxfetch.log"
 )
 
 var (

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -16,6 +16,8 @@ const (
 	DefaultLogFile = "/var/log/datadog/agent.log"
 	// DefaultDCALogFile points to the log file that will be used if not configured
 	DefaultDCALogFile = "/var/log/datadog/cluster-agent.log"
+	//DefaultJmxLogFile points to the jmx fetch log file that will be used if not configured
+	DefaultJmxLogFile = "/var/log/datadog/jmxfetch.log"
 )
 
 var (

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -22,6 +22,8 @@ const (
 	DefaultLogFile = "/var/log/datadog/agent.log"
 	// DefaultDCALogFile points to the log file that will be used if not configured
 	DefaultDCALogFile = "/var/log/datadog/cluster-agent.log"
+	//DefaultJmxLogFile points to the jmx fetch log file that will be used if not configured
+	DefaultJmxLogFile = "/var/log/datadog/jmxfetch.log"
 )
 
 var (

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -46,6 +46,8 @@ var (
 	DefaultLogFile = "c:\\programdata\\datadog\\logs\\agent.log"
 	// DefaultDCALogFile points to the log file that will be used if not configured
 	DefaultDCALogFile = "c:\\programdata\\datadog\\logs\\cluster-agent.log"
+	//DefaultJmxLogFile points to the jmx fetch log file that will be used if not configured
+	DefaultJmxLogFile = "c:\\programdata\\datadog\\logs\\jmxfetch.log"
 )
 
 func init() {

--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -135,8 +135,12 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 	if logFile == "" {
 		logFile = common.DefaultLogFile
 	}
+	jmxLogFile := config.Datadog.GetString("jmx_log_file")
+	if jmxLogFile == "" {
+		jmxLogFile = common.DefaultJmxLogFile
+	}
 
-	filePath, e := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile, nil)
+	filePath, e := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, []string{logFile, jmxLogFile}, nil)
 	if e != nil {
 		w.Write([]byte("Error creating flare zipfile: " + e.Error()))
 		log.Errorf("Error creating flare zipfile: " + e.Error())

--- a/cmd/security-agent/common/check_command.go
+++ b/cmd/security-agent/common/check_command.go
@@ -156,7 +156,7 @@ func configureLogger() error {
 		return err
 	}
 
-	log.SetupDatadogLogger(logger, logLevel)
+	log.SetupLogger(logger, logLevel)
 	return nil
 }
 

--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -206,7 +206,7 @@ func requestFlare(caseID, customerEmail string) (response string, e error) {
 		}
 		log.Debug("Initiating flare locally.")
 
-		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFile, nil)
+		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, []string{logFile}, nil)
 		if e != nil {
 			log.Errorf("The flare zipfile failed to be created: %s\n", e)
 			return

--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -190,6 +190,11 @@ func requestFlare(caseID, customerEmail string) (response string, e error) {
 		logFile = common.DefaultLogFile
 	}
 
+	jmxLogFile := config.Datadog.GetString("jmx_log_file")
+	if jmxLogFile == "" {
+		jmxLogFile = common.DefaultJmxLogFile
+	}
+
 	// Set session token
 	e = util.SetAuthToken()
 	if e != nil {
@@ -206,7 +211,7 @@ func requestFlare(caseID, customerEmail string) (response string, e error) {
 		}
 		log.Debug("Initiating flare locally.")
 
-		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, []string{logFile}, nil)
+		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, []string{logFile, jmxLogFile}, nil)
 		if e != nil {
 			log.Errorf("The flare zipfile failed to be created: %s\n", e)
 			return

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,6 +152,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("conf_path", ".")
 	config.BindEnvAndSetDefault("confd_path", defaultConfdPath)
 	config.BindEnvAndSetDefault("additional_checksd", defaultAdditionalChecksPath)
+	config.BindEnvAndSetDefault("jmx_log_file", "")
 	config.BindEnvAndSetDefault("log_payloads", false)
 	config.BindEnvAndSetDefault("log_file", "")
 	config.BindEnvAndSetDefault("log_file_max_size", "10Mb")

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -53,7 +53,7 @@ func createQuoteMsgFormatter(params string) seelog.FormatterFunc {
 
 // buildCommonFormat returns the log common format seelog string
 func buildCommonFormat(loggerName LoggerName) string {
-	if loggerName == "JMX" {
+	if loggerName == "JMXFETCH" {
 		return `%Msg%n`
 	}
 	return fmt.Sprintf("%%Date(%s) | %s | %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%ExtraTextContext%%Msg%%n", getLogDateFormat(), loggerName)
@@ -62,7 +62,7 @@ func buildCommonFormat(loggerName LoggerName) string {
 // buildJSONFormat returns the log JSON format seelog string
 func buildJSONFormat(loggerName LoggerName) string {
 	seelog.RegisterCustomFormatter("QuoteMsg", createQuoteMsgFormatter) //nolint:errcheck
-	if loggerName == "JMX" {
+	if loggerName == "JMXFETCH" {
 		return `{"msg":%QuoteMsg}%n`
 	}
 	return fmt.Sprintf(`{"agent":"%s","time":"%%Date(%s)","level":"%%LEVEL","file":"%%ShortFilePath","line":"%%Line","func":"%%FuncShort","msg":%%QuoteMsg%%ExtraJSONContext}%%n`, strings.ToLower(string(loggerName)), getLogDateFormat())

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -100,7 +100,7 @@ func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, sys
 	if err != nil {
 		return err
 	}
-	seelogConfig, err := buildLoggerConfig(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat)
+	seelogConfig, err = buildLoggerConfig(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func SetupJMXLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, 
 	if err != nil {
 		return err
 	}
-	jmxSeelogConfig, err := buildLoggerConfig(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat)
+	jmxSeelogConfig, err = buildLoggerConfig(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -124,7 +124,7 @@ func SetupJMXLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, 
 		return err
 	}
 	jmxLoggerInterface, err := GenerateLoggerInterface(jmxSeelogConfig)
-	log.SetupJmxLogger(jmxLoggerInterface, seelogLogLevel)
+	log.SetupJMXLogger(jmxLoggerInterface, seelogLogLevel)
 	return err
 }
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -124,17 +124,17 @@ func CreatePerformanceProfile(prefix, debugURL string, cpusec int, target *Profi
 }
 
 // CreateArchive packages up the files
-func CreateArchive(local bool, distPath, pyChecksPath, logFilePath string, pdata ProfileData) (string, error) {
+func CreateArchive(local bool, distPath, pyChecksPath string, logFilePaths []string, pdata ProfileData) (string, error) {
 	zipFilePath := getArchivePath()
 	confSearchPaths := SearchPaths{
 		"":        config.Datadog.GetString("confd_path"),
 		"dist":    filepath.Join(distPath, "conf.d"),
 		"checksd": pyChecksPath,
 	}
-	return createArchive(confSearchPaths, local, zipFilePath, logFilePath, pdata)
+	return createArchive(confSearchPaths, local, zipFilePath, logFilePaths, pdata)
 }
 
-func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath, logFilePath string, pdata ProfileData) (string, error) {
+func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, logFilePaths []string, pdata ProfileData) (string, error) {
 	tempDir, err := createTempDir()
 	if err != nil {
 		return "", err
@@ -277,9 +277,11 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath, logFile
 
 	// force a log flush before zipping them
 	log.Flush()
-	err = zipLogFiles(tempDir, hostname, logFilePath, permsInfos)
-	if err != nil {
-		log.Errorf("Could not zip logs: %s", err)
+	for _, logFilePath := range logFilePaths {
+		err = zipLogFiles(tempDir, hostname, logFilePath, permsInfos)
+		if err != nil {
+			log.Errorf("Could not zip logs: %s", err)
+		}
 	}
 
 	err = zipInstallInfo(tempDir, hostname)

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -29,7 +29,7 @@ func TestPermsFile(t *testing.T) {
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, "", nil)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil)
 	defer os.Remove(zipFilePath)
 
 	assert.Nil(err)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -32,7 +32,7 @@ func TestCreateArchive(t *testing.T) {
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, "", nil)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -56,7 +56,7 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 	pprofURL = ts.URL
 
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, "", nil)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -100,7 +100,7 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 func TestCreateArchiveBadConfig(t *testing.T) {
 	common.SetupConfig("")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, "", nil)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -154,7 +154,7 @@ func TestIncludeSystemProbeConfig(t *testing.T) {
 	defer os.Remove("./test/system-probe.yaml")
 
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{"": "./test/confd"}, true, zipFilePath, "", nil)
+	filePath, err := createArchive(SearchPaths{"": "./test/confd"}, true, zipFilePath, []string{""}, nil)
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)
 
@@ -182,7 +182,7 @@ func TestIncludeConfigFiles(t *testing.T) {
 
 	common.SetupConfig("./test")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{"": "./test/confd"}, true, zipFilePath, "", nil)
+	filePath, err := createArchive(SearchPaths{"": "./test/confd"}, true, zipFilePath, []string{""}, nil)
 
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)
@@ -289,7 +289,7 @@ func TestPerformanceProfile(t *testing.T) {
 		"third":  []byte{},
 	}
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, "", testProfile)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, testProfile)
 
 	assert.NoError(t, err)
 	assert.Equal(t, zipFilePath, filePath)

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -173,7 +173,7 @@ func (j *JMXFetch) setDefaults() {
 		j.Checks = []string{}
 	}
 	if j.Output == nil {
-		j.Output = log.Info
+		j.Output = log.JMXInfo
 	}
 }
 
@@ -317,7 +317,7 @@ func (j *JMXFetch) Start(manage bool) error {
 	scan:
 		in := bufio.NewScanner(stderr)
 		for in.Scan() {
-			log.Error(in.Text())
+			log.JMXError(in.Text())
 		}
 		if in.Err() == bufio.ErrTooLong {
 			goto scan

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -688,7 +688,7 @@ func BenchmarkThroughput(b *testing.B) {
 		b.SkipNow()
 	}
 
-	ddlog.SetupDatadogLogger(seelog.Disabled, "") // disable logging
+	ddlog.SetupLogger(seelog.Disabled, "") // disable logging
 
 	folder := filepath.Join(env, "benchmarks")
 	filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {

--- a/pkg/trace/logutil/throttled_test.go
+++ b/pkg/trace/logutil/throttled_test.go
@@ -59,7 +59,7 @@ func TestThrottled(t *testing.T) {
 		if err := seelog.ReplaceLogger(logger); err != nil {
 			t.Fatal(err)
 		}
-		log.SetupDatadogLogger(logger, "INFO")
+		log.SetupLogger(logger, "INFO")
 		l := NewThrottled(2, 10*time.Millisecond)
 		l.Write([]byte("1\n"))
 		time.Sleep(20 * time.Millisecond) // reset

--- a/pkg/trace/watchdog/logonpanic_test.go
+++ b/pkg/trace/watchdog/logonpanic_test.go
@@ -28,7 +28,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	log.SetupDatadogLogger(logger, "INFO")
+	log.SetupLogger(logger, "INFO")
 }
 
 func TestLogOnPanicMain(t *testing.T) {

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -28,7 +28,7 @@ import (
 const testAPIKey = "123"
 
 func TestMain(m *testing.M) {
-	log.SetupDatadogLogger(seelog.Disabled, "error")
+	log.SetupLogger(seelog.Disabled, "error")
 	os.Exit(m.Run())
 }
 

--- a/pkg/util/kubernetes/apiserver/wpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/wpa_controller_test.go
@@ -581,7 +581,7 @@ func configureLoggerForTest(t *testing.T) func() {
 		t.Fatalf("unable to configure logger, err: %v", err)
 	}
 	seelog.ReplaceLogger(logger) //nolint:errcheck
-	log.SetupDatadogLogger(logger, "trace")
+	log.SetupLogger(logger, "trace")
 	return log.Flush
 }
 

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -43,16 +43,15 @@ type DatadogLogger struct {
 
 // SetupLogger setup agent wide logger
 func SetupLogger(i seelog.LoggerInterface, level string) {
-	logger = SetupCommonLogger(i, level)
+	logger = setupCommonLogger(i, level)
 }
 
 // SetupJMXLogger setup JMXfetch specific logger
 func SetupJMXLogger(i seelog.LoggerInterface, level string) {
-	jmxLogger = SetupCommonLogger(i, level)
+	jmxLogger = setupCommonLogger(i, level)
 }
 
-// SetupCommonLogger configures logger singleton with seelog interface
-func SetupCommonLogger(i seelog.LoggerInterface, level string) *DatadogLogger {
+func setupCommonLogger(i seelog.LoggerInterface, level string) *DatadogLogger {
 
 	l := &DatadogLogger{
 		inner: i,

--- a/pkg/util/log/log_bench_test.go
+++ b/pkg/util/log/log_bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkLogScrubbing(b *testing.B) {
 	w := bufio.NewWriter(&buff)
 
 	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupDatadogLogger(l, "info")
+	SetupLogger(l, "info")
 
 	for n := 0; n < b.N; n++ {
 		Infof("this is a credential encoding uri: %s", "http://user:password@host:port")
@@ -47,7 +47,7 @@ func BenchmarkLogScrubbingLevels(b *testing.B) {
 	w := bufio.NewWriter(&buff)
 
 	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupDatadogLogger(l, "info")
+	SetupLogger(l, "info")
 
 	for n := 0; n < b.N; n++ {
 		Debugf("this is a credential encoding uri: %s", "http://user:password@host:port")
@@ -62,7 +62,7 @@ func BenchmarkLogScrubbingMulti(b *testing.B) {
 	lA, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(wA, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	lB, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(wB, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 
-	SetupDatadogLogger(lA, "info")
+	SetupLogger(lA, "info")
 	_ = RegisterAdditionalLogger("extra", lB)
 
 	Info("this is an API KEY: ", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")

--- a/pkg/util/log/log_bench_test.go
+++ b/pkg/util/log/log_bench_test.go
@@ -78,7 +78,7 @@ func BenchmarkLogWithContext(b *testing.B) {
 	w := bufio.NewWriter(&buff)
 
 	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupDatadogLogger(l, "info")
+	SetupLogger(l, "info")
 
 	for n := 0; n < b.N; n++ {
 		Infoc("this is a credential encoding uri: %s", "http://user:password@host:port", "extra", "context")

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -34,7 +34,7 @@ func TestBasicLogging(t *testing.T) {
 	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
 
-	SetupDatadogLogger(l, "debug")
+	SetupLogger(l, "debug")
 	assert.NotNil(t, logger)
 
 	Tracef("%s", "foo")
@@ -84,7 +84,7 @@ func TestLogBuffer(t *testing.T) {
 	Errorf("%s", "foo")
 	Criticalf("%s", "foo")
 
-	SetupDatadogLogger(l, "debug")
+	SetupLogger(l, "debug")
 	assert.NotNil(t, logger)
 
 	w.Flush()
@@ -100,7 +100,7 @@ func TestCredentialScrubbingLogging(t *testing.T) {
 	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
 
-	SetupDatadogLogger(l, "info")
+	SetupLogger(l, "info")
 	assert.NotNil(t, logger)
 
 	Info("this is an API KEY: ", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
@@ -123,7 +123,7 @@ func TestExtraLogging(t *testing.T) {
 	lA, err := seelog.LoggerFromWriterWithMinLevelAndFormat(wA, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
 	assert.Nil(t, err)
 
-	SetupDatadogLogger(l, "info")
+	SetupLogger(l, "info")
 	assert.NotNil(t, logger)
 
 	err = RegisterAdditionalLogger("extra", lA)
@@ -158,7 +158,7 @@ func TestWarnNotNil(t *testing.T) {
 	assert.NotNil(t, Warn("test"))
 
 	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.CriticalLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupDatadogLogger(l, "critical")
+	SetupLogger(l, "critical")
 
 	assert.NotNil(t, Warn("test"))
 
@@ -174,7 +174,7 @@ func TestWarnfNotNil(t *testing.T) {
 	assert.NotNil(t, Warn("test"))
 
 	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.CriticalLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupDatadogLogger(l, "critical")
+	SetupLogger(l, "critical")
 
 	assert.NotNil(t, Warn("test"))
 
@@ -190,7 +190,7 @@ func TestErrorNotNil(t *testing.T) {
 	assert.NotNil(t, Error("test"))
 
 	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.CriticalLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupDatadogLogger(l, "critical")
+	SetupLogger(l, "critical")
 
 	assert.NotNil(t, Error("test"))
 
@@ -206,7 +206,7 @@ func TestErrorfNotNil(t *testing.T) {
 	assert.NotNil(t, Errorf("test"))
 
 	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.CriticalLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupDatadogLogger(l, "critical")
+	SetupLogger(l, "critical")
 
 	assert.NotNil(t, Errorf("test"))
 
@@ -222,7 +222,7 @@ func TestCriticalNotNil(t *testing.T) {
 	assert.NotNil(t, Critical("test"))
 
 	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.InfoLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupDatadogLogger(l, "info")
+	SetupLogger(l, "info")
 
 	assert.NotNil(t, Critical("test"))
 }
@@ -234,7 +234,7 @@ func TestCriticalfNotNil(t *testing.T) {
 	assert.NotNil(t, Criticalf("test"))
 
 	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.InfoLvl, "[%LEVEL] %FuncShort: %Msg")
-	SetupDatadogLogger(l, "info")
+	SetupLogger(l, "info")
 
 	assert.NotNil(t, Criticalf("test"))
 }


### PR DESCRIPTION
### What does this PR do?
- Create an extra logger for jmxfetch so jmx checks logs are written to another log file while keeping agent's log config. 
- Added a new agent level config option : 

`
jmx_log_file: <path_of_the_jmx_log_file>
`
Default location : "/var/log/datadog/jmxfetch.log" for nix systems and "c:\\programdata\\datadog\\logs\\jmxfetch.log" for Windows

### Motivation
Embed dev task

### Additional Notes

- Involves also some format adjustment in this PR: https://github.com/DataDog/jmxfetch/pull/299 
- Json format for jmx logs still needs to be adjusted. Currently everything is in the "msg" field due to the fact that the jmx logs lines are read from stdout written by jmxfetch

```
 {"msg":"2020-06-04 12:51:23 CEST | JMX | INFO  | Instance | Connected to JMX Server at localhost:7199"}
```

### Describe your test plan

- tested locally for log file location, rotation:  ✅ 
- json format:  ✅  *we only populate the `msg` field*
- tested manually for syslog: ✅ 
- checked that log level change at runtime works: ✅ 
- jmx log included in flare (even if in a differente directory) : ✅ 