### PR TITLE
[iot-agent] Only render relevant sections in config

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -726,9 +726,9 @@ api_key:
 {{ end -}}
 {{- if .Dogstatsd }}
 
-############################
+#############################
 ## DogStatsD Configuration ##
-############################
+#############################
 
 ## @param use_dogstatsd - boolean - optional - default: true
 ## Set this option to false to disable the Agent DogStatsD server.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -257,6 +257,7 @@ api_key:
 
 {{ end }}
 {{- if .Agent }}
+{{- if .Python }}
 {{- if .BothPythonPresent -}}
 ## @param python_version - integer - optional - default: 2
 ## The major version of Python used to run integrations and custom checks.
@@ -265,6 +266,7 @@ api_key:
 #
 # python_version: 2
 
+{{ end -}}
 {{ end }}
 
 ############################
@@ -346,7 +348,7 @@ api_key:
 ## integrations and affect their behavior if they rely on the psutil python package.
 #
 # procfs_path: <PROCFS_PATH>
-
+{{ if .Python }}
 ## @param disable_py3_validation - boolean - optional - default: false
 ## Disable Python3 validation of python checks.
 #
@@ -387,7 +389,7 @@ api_key:
 ## Disabled by default, so we only load Python libraries bundled with the Agent.
 #
 # windows_use_pythonpath: false
-
+{{ end }}
 ## @param secret_backend_command - string - optional
 ## `secret_backend_command` is the path to the script to execute to fetch secrets.
 ## The executable must have specific rights that differ on Windows and Linux.

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -19,7 +19,8 @@ import (
 type context struct {
 	Common            bool
 	Agent             bool
-	BothPythonPresent bool
+	Python            bool // Sub-option of Agent
+	BothPythonPresent bool // Sub-option of Agent - Python
 	Metadata          bool
 	Dogstatsd         bool
 	LogsAgent         bool
@@ -47,6 +48,7 @@ func mkContext(buildType string) context {
 	agentContext := context{
 		Common:            true,
 		Agent:             true,
+		Python:            true,
 		Metadata:          true,
 		Dogstatsd:         true,
 		LogsAgent:         true,
@@ -71,6 +73,15 @@ func mkContext(buildType string) context {
 	case "agent-py2py3":
 		agentContext.BothPythonPresent = true
 		return agentContext
+	case "iot-agent":
+		return context{
+			Common:    true,
+			Agent:     true,
+			Metadata:  true,
+			Dogstatsd: true,
+			LogsAgent: true,
+			Logging:   true,
+		}
 	case "system-probe":
 		return context{
 			SystemProbe: true,

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -180,9 +180,15 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     # Render the Agent configuration file template
     cmd = "go run {go_file} {build_type} {template_file} {output_file}"
 
+    build_type = "agent-py3"
+    if iot:
+        build_type = "iot-agent"
+    elif has_both_python(python_runtimes):
+        build_type = "agent-py2py3"
+
     args = {
         "go_file": "./pkg/config/render_config.go",
-        "build_type": "agent-py2py3" if has_both_python(python_runtimes) else "agent-py3",
+        "build_type": build_type,
         "template_file": "./pkg/config/config_template.yaml",
         "output_file": "./cmd/agent/dist/datadog.yaml",
     }


### PR DESCRIPTION
### What does this PR do?

Creates a new `iot-agent` build type for `render_config.go` to render
Adds a new `Python` template section dedicated to python options (which is not used for the `iot-agent`).

### Motivation

More accurate `iot-agent` config file.

### Describe your test plan

Tested output of:
`go run ./pkg/config/render_config.go agent-py3 ./pkg/config/config_template.yaml datadog.yaml`,
`go run ./pkg/config/render_config.go agent-py2py3 ./pkg/config/config_template.yaml datadog.yaml`,
`go run ./pkg/config/render_config.go iot-agent ./pkg/config/config_template.yaml datadog.yaml`

as well as:
`inv agent.build --build-exclude=systemd`
`inv agent.build --build-exclude=systemd --python-runtimes "2,3"`
`inv agent.build --build-exclude=systemd --iot`