### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@
 /cmd/cluster-agent/api/v1/cloudfoundry_metadata.go        @DataDog/integrations-tools-and-libraries
 /cmd/process-agent/                     @DataDog/processes
 /cmd/system-probe/                      @DataDog/networks
-/cmd/security-agent                     @DataDog/container-integrations
+/cmd/security-agent/                    @DataDog/container-integrations
 
 /Dockerfiles/                           @DataDog/container-integrations
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -89,8 +89,8 @@
 /pkg/process/checks/pod*.go             @DataDog/container-app
 /pkg/network/                           @DataDog/networks
 /pkg/ebpf/                              @DataDog/networks
-/pkg/quantile                           @DataDog/metrics-aggregation
-/pkg/compliance                         @DataDog/container-integrations
+/pkg/quantile/                           @DataDog/metrics-aggregation
+/pkg/compliance/                         @DataDog/container-integrations
 
 /releasenotes/                          @DataDog/agent-all
 /releasenotes-dca/                      @DataDog/container-integrations
@@ -104,11 +104,11 @@
 /tasks/system-probe.py                  @DataDog/networks
 /tasks/trace.py                         @DataDog/apm-agent
 
-/test/benchmarks                        @DataDog/agent-core
-/test/e2e                               @DataDog/container-integrations
-/test/integration                       @DataDog/agent-all
-/test/kitchen                           @DataDog/agent-platform
-/test/system                            @DataDog/agent-core
-/test/util                              @DataDog/agent-all
+/test/benchmarks/                       @DataDog/agent-core
+/test/e2e/                              @DataDog/container-integrations
+/test/integration/                      @DataDog/agent-all
+/test/kitchen/                          @DataDog/agent-platform
+/test/system/                           @DataDog/agent-core
+/test/util/                             @DataDog/agent-all
 
 /tools/ebpf/                            @DataDog/networks


### PR DESCRIPTION
### What does this PR do?

If the final `/` is missing Github thinks it is a file and not a folder, so the CODEOWNERS of the `security-agent` were not set correctly.