### PR TITLE
[DCA] Admission Controller metrics

### DIFF
--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
@@ -81,6 +82,7 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 }
 
 func mutateHandler(w http.ResponseWriter, r *http.Request, mutateFunc admissionFunc, dc dynamic.Interface) {
+	metrics.WebhooksReceived.Inc()
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		log.Warnf("Invalid method %s, only POST requests are allowed", r.Method)

--- a/pkg/clusteragent/admission/controllers/webhook/controller.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -193,11 +194,13 @@ func (c *Controller) processNextWorkItem() bool {
 	if err := c.reconcile(); err != nil {
 		c.requeue(key)
 		log.Infof("Couldn't reconcile Webhook %s: %v", c.config.GetName(), err)
+		metrics.ReconcileErrors.Inc(metrics.WebhooksControllerName)
 		return true
 	}
 
 	c.queue.Forget(key)
 	log.Debugf("Webhook %s reconciled successfully", c.config.GetName())
+	metrics.ReconcileSuccess.Inc(metrics.WebhooksControllerName)
 
 	return true
 }

--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build kubeapiserver
+
+package metrics
+
+import "github.com/DataDog/datadog-agent/pkg/telemetry"
+
+const (
+	SecretControllerName   = "secrets"
+	WebhooksControllerName = "webhooks"
+	TagsMutationType       = "standard_tags"
+	ConfigMutationType     = "agent_config"
+)
+
+var (
+	ReconcileSuccess = telemetry.NewGaugeWithOpts("admission_webhooks", "reconcile_success",
+		[]string{"controller"}, "Number of reconcile success per controller.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	ReconcileErrors = telemetry.NewGaugeWithOpts("admission_webhooks", "reconcile_errors",
+		[]string{"controller"}, "Number of reconcile errors per controller.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	CertificateDuration = telemetry.NewGaugeWithOpts("admission_webhooks", "certificate_expiry",
+		[]string{}, "Time left before the certificate expires in hours.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	MutationAttempts = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_attempts",
+		[]string{"mutation_type", "injected"}, "Number of pod mutation attempts by mutation type (agent config, standard tags).",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	MutationErrors = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_errors",
+		[]string{"mutation_type", "reason"}, "Number of mutation failures by mutation type (agent config, standard tags).",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	WebhooksReceived = telemetry.NewGaugeWithOpts("admission_webhooks", "webhooks_received",
+		[]string{}, "Number of mutation webhook requests received.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+)

--- a/pkg/clusteragent/admission/mutate/common.go
+++ b/pkg/clusteragent/admission/mutate/common.go
@@ -65,7 +65,8 @@ func contains(envs []corev1.EnvVar, name string) bool {
 }
 
 // injectEnv injects an env var into a pod template if it doesn't exist
-func injectEnv(pod *corev1.Pod, env corev1.EnvVar) {
+func injectEnv(pod *corev1.Pod, env corev1.EnvVar) bool {
+	injected := false
 	podStr := podString(pod)
 	log.Debugf("Injecting env var '%s' into pod %s", env.Name, podStr)
 	for i, ctr := range pod.Spec.Containers {
@@ -74,7 +75,9 @@ func injectEnv(pod *corev1.Pod, env corev1.EnvVar) {
 			continue
 		}
 		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, env)
+		injected = true
 	}
+	return injected
 }
 
 // podString returns a string that helps identify the pod

--- a/pkg/clusteragent/admission/mutate/common_test.go
+++ b/pkg/clusteragent/admission/mutate/common_test.go
@@ -65,7 +65,7 @@ func Test_injectEnv(t *testing.T) {
 		name        string
 		args        args
 		wantPodFunc func() corev1.Pod
-		wantErr     bool
+		injected    bool
 	}{
 		{
 			name: "1 container, 1 inject env",
@@ -78,6 +78,7 @@ func Test_injectEnv(t *testing.T) {
 				pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, fakeEnv("inject-me"))
 				return *pod
 			},
+			injected: true,
 		},
 		{
 			name: "1 container, 0 inject env",
@@ -88,6 +89,7 @@ func Test_injectEnv(t *testing.T) {
 			wantPodFunc: func() corev1.Pod {
 				return *fakePodWithContainer("foo-pod", fakeContainer("foo-container"))
 			},
+			injected: false,
 		},
 		{
 			name: "2 container, 2 inject env",
@@ -101,6 +103,7 @@ func Test_injectEnv(t *testing.T) {
 				pod.Spec.Containers[1].Env = append(pod.Spec.Containers[1].Env, fakeEnv("inject-me"))
 				return *pod
 			},
+			injected: true,
 		},
 		{
 			name: "2 container, 1 inject env",
@@ -113,11 +116,15 @@ func Test_injectEnv(t *testing.T) {
 				pod.Spec.Containers[1].Env = append(pod.Spec.Containers[1].Env, fakeEnv("foo-container-env-foo"))
 				return *pod
 			},
+			injected: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			injectEnv(tt.args.pod, tt.args.env)
+			got := injectEnv(tt.args.pod, tt.args.env)
+			if got != tt.injected {
+				t.Errorf("injectEnv() = %v, want %v", got, tt.injected)
+			}
 			if tt.args.pod != nil && !reflect.DeepEqual(tt.args.pod.Spec.Containers, tt.wantPodFunc().Spec.Containers) {
 				t.Errorf("injectEnv() = %v, want %v", tt.args.pod.Spec.Containers, tt.wantPodFunc().Spec.Containers)
 			}

--- a/pkg/clusteragent/admission/mutate/tags.go
+++ b/pkg/clusteragent/admission/mutate/tags.go
@@ -10,9 +10,11 @@ package mutate
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -45,7 +47,13 @@ func InjectTags(req *admiv1beta1.AdmissionRequest, dc dynamic.Interface) (*admiv
 // injectTags injects DD_ENV, DD_VERSION, DD_SERVICE
 // env vars into a pod template if needed
 func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface) error {
+	var injected bool
+	defer func() {
+		metrics.MutationAttempts.Inc(metrics.TagsMutationType, strconv.FormatBool(injected))
+	}()
+
 	if pod == nil {
+		metrics.MutationErrors.Inc(metrics.TagsMutationType, "nil pod")
 		return errors.New("cannot inject tags into nil pod")
 	}
 
@@ -54,7 +62,8 @@ func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface) error {
 		return nil
 	}
 
-	if injected := injectTagsFromLabels(pod.GetLabels(), pod); injected {
+	var found bool
+	if found, injected = injectTagsFromLabels(pod.GetLabels(), pod); found {
 		// Standard labels found in the pod's labels
 		// No need to lookup the pod's owner
 		return nil
@@ -64,6 +73,7 @@ func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface) error {
 		if pod.GetNamespace() != "" {
 			ns = pod.GetNamespace()
 		} else {
+			metrics.MutationErrors.Inc(metrics.TagsMutationType, "empty namespace")
 			return errors.New("cannot get standard tags from parent object: empty namespace")
 		}
 	}
@@ -76,11 +86,13 @@ func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface) error {
 
 	owner, err := getOwner(owners[0], ns, dc)
 	if err != nil {
+		metrics.MutationErrors.Inc(metrics.TagsMutationType, "cannot get owner")
 		return err
 	}
 
 	log.Debugf("Looking for standard labels on '%s/%s' - kind '%s' owner of pod %s", owner.GetNamespace(), owner.GetName(), owner.GetKind(), podString(pod))
-	_ = injectTagsFromLabels(owner.GetLabels(), pod)
+	_, injected = injectTagsFromLabels(owner.GetLabels(), pod)
+
 	return nil
 }
 
@@ -94,19 +106,22 @@ func shouldInjectTags(pod *corev1.Pod) bool {
 
 // injectTagsFromLabels looks for standard tags in pod labels
 // and injects them as environment variables if found
-func injectTagsFromLabels(labels map[string]string, pod *corev1.Pod) bool {
-	injected := false
+func injectTagsFromLabels(labels map[string]string, pod *corev1.Pod) (bool, bool) {
+	found := false
+	injectedAtLeastOnce := false
 	for l, envName := range labelsToEnv {
-		if tagValue, found := labels[l]; found {
+		if tagValue, labelFound := labels[l]; labelFound {
 			env := corev1.EnvVar{
 				Name:  envName,
 				Value: tagValue,
 			}
-			injectEnv(pod, env)
-			injected = true
+			if injected := injectEnv(pod, env); injected {
+				injectedAtLeastOnce = true
+			}
+			found = true
 		}
 	}
-	return injected
+	return found, injectedAtLeastOnce
 }
 
 // getOwnerInfo returns the required information to get the owner object

--- a/pkg/clusteragent/admission/mutate/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/test_utils.go
@@ -57,6 +57,10 @@ func fakePodWithLabel(k, v string) *corev1.Pod {
 	}
 }
 
+func fakePodWithEnv(name, env string) *corev1.Pod {
+	return fakePodWithContainer(name, corev1.Container{Name: name + "-container", Env: []corev1.EnvVar{fakeEnv(env)}})
+}
+
 func fakePod(name string) *corev1.Pod {
 	return fakePodWithContainer(name, corev1.Container{Name: name + "-container"})
 }


### PR DESCRIPTION
### What does this PR do?

- Add admission controller metrics
- Add the metrics payload to the flare (TODO in another PR)

### Motivation

Better observability

### Additional Notes

```
# HELP admission_webhooks_certificate_expiry Time left before the certificate expires in hours.
# TYPE admission_webhooks_certificate_expiry gauge
admission_webhooks_certificate_expiry{duration="1h42m52.834752317s"} 1.7146763200880555
# HELP admission_webhooks_mutation_attempts Number of pod mutation attempts by mutation type (agent config, standard tags).
# TYPE admission_webhooks_mutation_attempts gauge
admission_webhooks_mutation_attempts{injected="true",mutation_type="agent_config"} 1
admission_webhooks_mutation_attempts{injected="true",mutation_type="standard_tags"} 1
# HELP admission_webhooks_reconcile_success Number of reconcile success per controller.
# TYPE admission_webhooks_reconcile_success gauge
admission_webhooks_reconcile_success{controller="secrets"} 1
admission_webhooks_reconcile_success{controller="webhooks"} 1
# HELP admission_webhooks_webhooks_received Number of mutation webhook requests received.
# TYPE admission_webhooks_webhooks_received gauge
admission_webhooks_webhooks_received 2
```
