### PR TITLE
[DCA] Telemetry cmd and flare

### DIFF
--- a/cmd/cluster-agent/app/telemetry.go
+++ b/cmd/cluster-agent/app/telemetry.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build kubeapiserver
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/flare"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	ClusterAgentCmd.AddCommand(telemetryCmd)
+}
+
+var telemetryCmd = &cobra.Command{
+	Use:   "telemetry",
+	Short: "Print the telemetry metrics exposed by the cluster agent",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		payload, err := flare.QueryDCAMetrics()
+		if err != nil {
+			return err
+		}
+		fmt.Print(string(payload))
+		return nil
+	},
+}

--- a/pkg/flare/dca_telemetry.go
+++ b/pkg/flare/dca_telemetry.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package flare
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// QueryDCAMetrics gets the metrics payload exposed by the cluster agent
+func QueryDCAMetrics() ([]byte, error) {
+	r, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", config.Datadog.GetInt("metrics_port")))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	return ioutil.ReadAll(r.Body)
+}

--- a/releasenotes-dca/notes/dca-telemetry-cmd-and-flare-8b4a17dfdbd56bf4.yaml
+++ b/releasenotes-dca/notes/dca-telemetry-cmd-and-flare-8b4a17dfdbd56bf4.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add a new command 'datadog-cluster-agent telemetry' to print the telemetry payload.
+    Add the telemetry payload to the flare.


### PR DESCRIPTION
### What does this PR do?

- Add a new `agent telemetry` command to print the metrics payload of the cluster agent
- Add the telemetry payload to the flare of the cluster agent

