### PR TITLE
Fix previously skipped dirs in golangci-lint for process/network

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,9 +11,6 @@ run:
     - pkg/trace
     # TODO metrics-aggregation
     - pkg/quantile
-    # TODO burrito
-    - pkg/ebpf
-    - pkg/network
 
 issues:
   # Do not limit the number of issues per linter.
@@ -27,7 +24,7 @@ issues:
     - "`\\(\\*DatadogLogger\\).changeLogLevel` is unused"
     - "`defaultRetryDuration` is unused" # used by APM and Process
     - "`defaultRetries` is unused"       # used by APM and Process
-    - "python._Ctype_char, which can be annoying to use" # ignore warning abour returning unexported field from CGO
+    - "python._Ctype_char, which can be annoying to use" # ignore warning about returning unexported field from CGO
 
     # [Golint] Ignore package name repetition for checks since it makes code easier to read/maintain
     - "type name will be used as jmx.JMXCheck by other packages, and that stutters"

--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -137,14 +137,6 @@ func isRHEL(platform string) bool {
 	return strings.Contains(p, "redhat") || strings.Contains(p, "red hat") || strings.Contains(p, "rhel")
 }
 
-func isRHELOrCentOS() (bool, error) {
-	platform, err := util.GetPlatform()
-	if err != nil {
-		return false, err
-	}
-	return isCentOS(platform) || isRHEL(platform), nil
-}
-
 // isPre410Kernel compares current kernel version to the minimum kernel version(4.1.0) and see if it's older
 func isPre410Kernel(currentKernelCode uint32) bool {
 	return currentKernelCode < stringToKernelCode("4.1.0")

--- a/pkg/ebpf/offsetguess.go
+++ b/pkg/ebpf/offsetguess.go
@@ -235,11 +235,10 @@ func checkAndUpdateCurrentOffset(module *elf.Module, mp *elf.Map, status *tracer
 		if *maxRetries == 0 {
 			return fmt.Errorf("invalid guessing state while guessing %v, got %v expected %v",
 				whatString[status.what], stateString[status.state], stateString[stateChecked])
-		} else {
-			*maxRetries--
-			time.Sleep(10 * time.Millisecond)
-			return nil
 		}
+		*maxRetries--
+		time.Sleep(10 * time.Millisecond)
+		return nil
 	}
 
 	switch status.what {
@@ -500,7 +499,7 @@ func acceptHandler(l net.Listener) {
 			return
 		}
 
-		io.Copy(ioutil.Discard, conn)
+		_, _ = io.Copy(ioutil.Discard, conn)
 		conn.Close()
 	}
 }
@@ -526,7 +525,7 @@ func tcpGetInfo(conn net.Conn) (*syscall.TCPInfo, error) {
 	size := uint32(unsafe.Sizeof(tcpInfo))
 	_, _, errno := syscall.Syscall6(
 		syscall.SYS_GETSOCKOPT,
-		uintptr(file.Fd()),
+		file.Fd(),
 		uintptr(syscall.SOL_TCP),
 		uintptr(syscall.TCP_INFO),
 		uintptr(unsafe.Pointer(&tcpInfo)),

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -153,7 +153,9 @@ func NewTracer(config *Config) (*Tracer, error) {
 			if isSysCall(probeName) {
 				fixedName := fixSyscallName(prefix, probeName)
 				log.Debugf("attaching section %s to %s", string(probeName), fixedName)
-				m.SetKprobeForSection(string(probeName), fixedName)
+				if err = m.SetKprobeForSection(string(probeName), fixedName); err != nil {
+					return nil, fmt.Errorf("could not update kprobe \"%s\" to \"%s\" : %s", k.Name, fixedName, err)
+				}
 			}
 
 			if err = m.EnableKprobe(string(probeName), maxActive); err != nil {
@@ -170,7 +172,9 @@ func NewTracer(config *Config) (*Tracer, error) {
 			if mp == nil {
 				return nil, fmt.Errorf("error retrieving the bpf %s map: %s", configMap, err)
 			}
-			m.UpdateElement(mp, unsafe.Pointer(&zero), unsafe.Pointer(&zero), 0)
+			if err := m.UpdateElement(mp, unsafe.Pointer(&zero), unsafe.Pointer(&zero), 0); err != nil {
+				return nil, fmt.Errorf("error updating element of bpf %s map: %s", configMap, err)
+			}
 		}
 
 		filter := m.SocketFilter("socket/dns_filter")
@@ -187,7 +191,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 		); err == nil {
 			reverseDNS = snooper
 		} else {
-			fmt.Errorf("error enabling DNS traffic inspection: %s", err)
+			return nil, fmt.Errorf("error enabling DNS traffic inspection: %s", err)
 		}
 	}
 
@@ -708,7 +712,9 @@ func (t *Tracer) initTCPCloseBatchMap() error {
 
 	for i := 0; i < 1024; i++ {
 		b := new(batch)
-		t.m.UpdateElement(batchMap, unsafe.Pointer(&i), unsafe.Pointer(b), 0)
+		if err = t.m.UpdateElement(batchMap, unsafe.Pointer(&i), unsafe.Pointer(b), 0); err != nil {
+			return fmt.Errorf("error updating element of bpf %s map: %s", tcpCloseBatchMap, err)
+		}
 	}
 
 	return nil

--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -618,14 +618,14 @@ func TestTCPOverIPv6(t *testing.T) {
 	// Create TCP Server which sends back serverMessageSize bytes
 	go func() {
 		for {
-			if c, err := ln.Accept(); err != nil {
+			c, err := ln.Accept()
+			if err != nil {
 				return
-			} else {
-				r := bufio.NewReader(c)
-				r.ReadBytes(byte('\n'))
-				c.Write(genPayload(serverMessageSize))
-				c.Close()
 			}
+			r := bufio.NewReader(c)
+			r.ReadBytes(byte('\n'))
+			c.Write(genPayload(serverMessageSize))
+			c.Close()
 		}
 	}()
 
@@ -1165,9 +1165,9 @@ func searchConnections(c *network.Connections, predicate func(network.Connection
 }
 
 func addrMatches(addr net.Addr, host string, port uint16) bool {
-	addrUrl := url.URL{Scheme: addr.Network(), Host: addr.String()}
+	addrURL := url.URL{Scheme: addr.Network(), Host: addr.String()}
 
-	return addrUrl.Hostname() == host && addrUrl.Port() == strconv.Itoa(int(port))
+	return addrURL.Hostname() == host && addrURL.Port() == strconv.Itoa(int(port))
 }
 
 func runBenchtests(b *testing.B, payloads []int, prefix string, f func(p int) func(*testing.B)) {
@@ -1357,11 +1357,11 @@ func (s *TCPServer) Run(done chan struct{}) {
 
 	go func() {
 		for {
-			if conn, err := ln.Accept(); err != nil {
+			conn, err := ln.Accept()
+			if err != nil {
 				return
-			} else {
-				s.onMessage(conn)
 			}
+			s.onMessage(conn)
 		}
 	}()
 }
@@ -1393,10 +1393,11 @@ func (s *UDPServer) Run(done chan struct{}, payloadSize int) {
 
 	go func() {
 		buf := make([]byte, payloadSize)
-		for {
+		running := true
+		for running {
 			select {
 			case <-done:
-				break
+				running = false
 			default:
 				ln.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
 				n, addr, err := ln.ReadFrom(buf)

--- a/pkg/network/dns_parser.go
+++ b/pkg/network/dns_parser.go
@@ -14,8 +14,8 @@ import (
 const maxIPBufferSize = 200
 
 var (
-	errTruncated   = errors.New("the packet is truncated")
-	skippedPayload = errors.New("the packet does not contain relevant DNS response")
+	errTruncated      = errors.New("the packet is truncated")
+	errSkippedPayload = errors.New("the packet does not contain relevant DNS response")
 )
 
 type dnsParser struct {
@@ -69,7 +69,7 @@ func (p *dnsParser) ParseInto(data []byte, t *translation, pktInfo *dnsPacketInf
 
 	// If there is a DNS layer then it would be the last layer
 	if p.layers[len(p.layers)-1] != layers.LayerTypeDNS {
-		return skippedPayload
+		return errSkippedPayload
 	}
 
 	if err := p.parseAnswerInto(p.dnsPayload, t, pktInfo); err != nil {
@@ -129,12 +129,12 @@ func (p *dnsParser) parseAnswerInto(
 ) error {
 	// Only consider singleton, A-record questions
 	if len(dns.Questions) != 1 {
-		return skippedPayload
+		return errSkippedPayload
 	}
 
 	question := dns.Questions[0]
 	if question.Type != layers.DNSTypeA || question.Class != layers.DNSClassIN {
-		return skippedPayload
+		return errSkippedPayload
 	}
 
 	// Only consider responses

--- a/pkg/network/dns_snooper.go
+++ b/pkg/network/dns_snooper.go
@@ -149,7 +149,7 @@ func (s *SocketFilterSnooper) processPacket(data []byte) {
 
 	if err := s.parser.ParseInto(data, t, &pktInfo); err != nil {
 		switch err {
-		case skippedPayload: // no need to count or log cases where the packet is valid but has no relevant content
+		case errSkippedPayload: // no need to count or log cases where the packet is valid but has no relevant content
 		case errTruncated:
 			atomic.AddInt64(&s.truncatedPkts, 1)
 		default:

--- a/pkg/network/netlink/align.go
+++ b/pkg/network/netlink/align.go
@@ -22,11 +22,13 @@ func nlmsgAlign(len int) int {
 }
 
 // #define NLMSG_LENGTH(len) ((len) + NLMSG_HDRLEN)
+//nolint:unused,deadcode
 func nlmsgLength(len int) int {
 	return len + nlmsgHeaderLen
 }
 
 // #define NLMSG_HDRLEN ((int) NLMSG_ALIGN(sizeof(struct nlmsghdr)))
+//nolint:unused
 var nlmsgHeaderLen = nlmsgAlign(int(unsafe.Sizeof(netlink.Header{})))
 
 // #define NLA_ALIGNTO 4

--- a/pkg/network/netlink/attribute_scanner.go
+++ b/pkg/network/netlink/attribute_scanner.go
@@ -16,9 +16,8 @@ var attrTypeMask uint16 = 0x3fff
 
 // errors
 var (
-	errInvalidAttribute  = errors.New("invalid attribute; length too short or too large")
-	errMessageTooShort   = errors.New("netlink message is too short")
-	errMissingNestedAttr = errors.New("netlink message is missing nested attribute")
+	errInvalidAttribute = errors.New("invalid attribute; length too short or too large")
+	errMessageTooShort  = errors.New("netlink message is too short")
 )
 
 // AttributeScanner provides an iterator API to traverse each field in a netlink message.

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -57,7 +57,6 @@ type realConntracker struct {
 	// The maximum size the state map will grow before we reject new entries
 	maxStateSize int
 
-	statsTicker   *time.Ticker
 	compactTicker *time.Ticker
 	stats         struct {
 		gets                 int64
@@ -148,7 +147,7 @@ func (ctr *realConntracker) GetStats() map[string]int64 {
 
 	m := map[string]int64{
 		"state_size": int64(size),
-		"expires":    int64(ctr.stats.expiresTotal),
+		"expires":    ctr.stats.expiresTotal,
 	}
 
 	if ctr.stats.gets != 0 {
@@ -359,20 +358,4 @@ func formatKey(tuple *ct.IPTuple) (k connKey, ok bool) {
 	}
 
 	return
-}
-
-func conDebug(c ct.Con) string {
-	proto := "tcp"
-	if *c.Origin.Proto.Number == 17 {
-		proto = "udp"
-	}
-
-	return fmt.Sprintf(
-		"orig_src=%s:%d orig_dst=%s:%d reply_src=%s:%d reply_dst=%s:%d proto=%s",
-		c.Origin.Src, *c.Origin.Proto.SrcPort,
-		c.Origin.Dst, *c.Origin.Proto.DstPort,
-		c.Reply.Src, *c.Reply.Proto.SrcPort,
-		c.Reply.Dst, *c.Reply.Proto.DstPort,
-		proto,
-	)
 }

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -127,7 +127,7 @@ func (c *Consumer) Events() <-chan Event {
 	c.do(false, func() {
 		defer close(output)
 		c.streaming = true
-		c.conn.JoinGroup(netlinkCtNew)
+		_ = c.conn.JoinGroup(netlinkCtNew)
 		c.receive(output)
 	})
 
@@ -187,7 +187,7 @@ func (c *Consumer) Stop() {
 // This go-routine is responsible for all socket system calls.
 func (c *Consumer) initWorker(procRoot string) {
 	go func() {
-		util.WithRootNS(procRoot, func() {
+		_ = util.WithRootNS(procRoot, func() {
 			for {
 				fn, ok := <-c.workQueue
 				if !ok {
@@ -347,9 +347,7 @@ func (c *Consumer) throttle(numMessages int) error {
 	// Reset circuit breaker
 	c.breaker.Reset()
 	// Re-subscribe netlinkCtNew messages
-	c.conn.JoinGroup(netlinkCtNew)
-
-	return nil
+	return c.conn.JoinGroup(netlinkCtNew)
 }
 
 func newBufferPool() *sync.Pool {

--- a/pkg/network/netlink/decoding.go
+++ b/pkg/network/netlink/decoding.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ctaUnspec = iota
+	_ = iota
 	ctaTupleOrig
 	ctaTupleReply
 )
@@ -20,7 +20,7 @@ const (
 const (
 	ctaTupleIP    = 1
 	ctaTupleProto = 2
-	ctaTupleZone  = 3
+	ctaTupleZone  = 3 //nolint:deadcode
 )
 
 const (
@@ -47,7 +47,10 @@ func DecodeAndReleaseEvent(e Event) []ct.Con {
 
 	for _, msg := range msgs {
 		c := &ct.Con{}
-		scanner.ResetTo(msg.Data)
+		if err := scanner.ResetTo(msg.Data); err != nil {
+			log.Debugf("error decoding netlink message: %s", err)
+			continue
+		}
 		err := unmarshalCon(scanner, c)
 		if err != nil {
 			log.Debugf("error decoding netlink message: %s", err)
@@ -129,7 +132,7 @@ func unmarshalProto(s *AttributeScanner, t *ct.IPTuple) error {
 		switch s.Type() {
 		case ctaProtoNum:
 			toDecode--
-			protoNum := uint8(s.Bytes()[0])
+			protoNum := s.Bytes()[0]
 			t.Proto.Number = &protoNum
 		case ctaProtoSrcPort:
 			toDecode--

--- a/pkg/network/netlink/generation.go
+++ b/pkg/network/netlink/generation.go
@@ -18,5 +18,5 @@ func getCurrentGeneration(genLength time.Duration, nowNanos int64) uint8 {
 
 func getNthGeneration(genLength time.Duration, nowNanos int64, n uint8) uint8 {
 	curr := getCurrentGeneration(genLength, nowNanos)
-	return uint8((curr + n) % maxUint8)
+	return (curr + n) % maxUint8
 }

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -177,6 +177,12 @@ def golangci_lint(ctx, targets, rtloader_root=None, build_tags=None):
         targets = targets.split(',')
 
     tags = build_tags or get_default_build_tags()
+
+    # we need linux_bpf tag for linting to pass, but do not want to run unit tests on ebpf
+    if sys.platform.startswith("linux"):
+        # we want a new list with linux_bpf, not to modify the original
+        tags = tags + ["linux_bpf"]
+
     _, _, env = get_build_flags(ctx, rtloader_root=rtloader_root)
     # we split targets to avoid going over the memory limit from circleCI
     for target in targets:


### PR DESCRIPTION
### What does this PR do?

Removes `pkg/ebpf` and `pkg/network` from the skipped directories during `golangci-lint` runs. 

### Motivation

Removing exceptions from linting. 😄 

### Additional Notes

It is necessary for the `linux_bpf` tag to be present during the linting, but not during the unit tests, since the eBPF tests require a specific environment.

### Describe your test plan


