### PR TITLE
[kitchen] Fix SUSE install script test

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -63,7 +63,6 @@ end
 
 directory wrk_dir do
   owner 'installuser'
-  group 'installuser'
   mode '0755'
 end
 


### PR DESCRIPTION
### What does this PR do?

Do not try to change the install directory's group to `installuser`, as it's not needed and not necessarily created by `useradd` (eg. on SUSE systems).

### Motivation

Fix broken kitchen tests.

