### PR TITLE
Honor SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET in core agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,6 +64,7 @@
 /pkg/clusteragent/                      @DataDog/container-integrations
 /pkg/collector/corechecks/cluster/      @DataDog/container-integrations
 /pkg/collector/corechecks/containers/   @DataDog/container-integrations
+/pkg/collector/corechecks/ebpf/         @DataDog/container-integrations
 /pkg/collector/corechecks/embed/        @Datadog/agent-platform
 /pkg/collector/corechecks/embed/jmx/    @Datadog/agent-core
 /pkg/collector/corechecks/embed/apm*.go            @Datadog/agent-platform @DataDog/apm-agent

--- a/pkg/collector/corechecks/ebpf/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcp_queue_length.go
@@ -13,6 +13,7 @@
 package ebpf
 
 import (
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -74,7 +75,13 @@ func (t *TCPQueueLengthConfig) Parse(data []byte) error {
 //Configure parses the check configuration and init the check
 func (t *TCPQueueLengthCheck) Configure(config, initConfig integration.Data, source string) error {
 	// TODO: Remove that hard-code and put it somewhere else
-	process_net.SetSystemProbePath(dd_config.Datadog.GetString("system_probe_config.sysprobe_socket"))
+	sysprobeSocket := dd_config.Datadog.GetString("system_probe_config.sysprobe_socket")
+	if sysprobeSocket == "" {
+		sysprobeSocket = os.Getenv("SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET")
+	}
+	if sysprobeSocket != "" {
+		process_net.SetSystemProbePath(sysprobeSocket)
+	}
 
 	err := t.CommonConfigure(config, source)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Honor `SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET` in core agent

### Motivation

The TCP queue length tracer check gets its data from `system-probe`.
Its socket path is set via `SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET`: https://github.com/helm/charts/pull/22188/files#diff-adf018a6543db0e2bca334a71f4ef83aR86-R87

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
