### PR TITLE
[circleci] Add MacOS omnibus build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,10 @@ jobs:
             sudo mkdir -p /opt/datadog-agent /var/cache/omnibus && sudo chown $USER /opt/datadog-agent /var/cache/omnibus
             inv -e agent.omnibus-build --skip-sign --python-runtimes 3 --major-version 7 --release-version nightly-a7
 
+      - run: mkdir -p ~/artifacts && cp omnibus/pkg/*.dmg ~/artifacts
+      - store_artifacts:
+          path: ~/artifacts
+
 workflows:
   version: 2
   test_and_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,10 +204,45 @@ jobs:
   macos_tests:
     macos:
       xcode: 10.1.0
+    working_directory: ~/go/src/github.com/DataDog/datadog-agent
     steps:
       - checkout
-      - run: echo "Hello world"
       - run: /usr/bin/xcodebuild -version
+      - run:
+          command: |
+            CI=1 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+            export GO_VERSION=1.13.8
+            export RUBY_VERSION=2.4
+
+            brew install ruby@$RUBY_VERSION -f
+            export PATH="/usr/local/opt/ruby@$RUBY_VERSION/bin:/usr/local/lib/ruby/gems/$RUBY_VERSION.0/bin:$PATH"
+            echo 'export PATH="/usr/local/opt/ruby@'$RUBY_VERSION'/bin:/usr/local/lib/ruby/gems/'$RUBY_VERSION'.0/bin:$PATH"' >> .build_setup
+
+            gem install bundle -f
+
+            brew install python -f
+            ln -s /usr/local/bin/pip3 /usr/local/bin/pip
+
+            brew install pkg-config -f
+            brew install cmake -f
+
+            mkdir $HOME/go
+            export GOPATH=$HOME/go
+            echo 'export GOPATH=$HOME/go' >> .build_setup
+            export PATH="$GOPATH/bin:$PATH"
+            echo 'export PATH="$GOPATH/bin:$PATH"' >> .build_setup
+
+            brew install gimme
+            eval `gimme $GO_VERSION`
+            echo 'eval `gimme '$GO_VERSION'`' >> .build_setup
+
+      - run:
+          command: |
+            source .build_setup
+            pip install -r requirements.txt
+            sudo rm -rf /opt/datadog-agent ./vendor ./vendor-new /var/cache/omnibus/src/* ./omnibus/Gemfile.lock
+            sudo mkdir -p /opt/datadog-agent /var/cache/omnibus && sudo chown $USER /opt/datadog-agent /var/cache/omnibus
+            inv -e agent.omnibus-build --skip-sign --python-runtimes 3 --major-version 7 --release-version nightly-a7
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,11 +201,21 @@ jobs:
           name: generate doxygen documentation
           command: inv -e rtloader.generate-doc
 
+  macos_tests:
+    macos:
+      xcode: 10.1.0
+    steps:
+      - checkout
+      - run: echo "Hello world"
+      - run: /usr/bin/xcodebuild -version
+
 workflows:
   version: 2
   test_and_build:
     jobs:
       - checkout_code
+      - macos_tests
+
       - dependencies:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,29 +201,30 @@ jobs:
           name: generate doxygen documentation
           command: inv -e rtloader.generate-doc
 
-  macos_tests:
+  macos_build:
     macos:
       xcode: 10.1.0
+    environment:
+      GO_VERSION: "1.13.8"
+      RUBY_VERSION: "2.4"
+      RELEASE_VERSION: "nightly-a7"
+      AGENT_MAJOR_VERSION: "7"
+      PYTHON_RUNTIMES: "3"
     working_directory: ~/go/src/github.com/DataDog/datadog-agent
     steps:
       - checkout
-      - run: /usr/bin/xcodebuild -version
+      - run: brew update
       - run:
+          name: Setup builder
           command: |
-            export GO_VERSION=1.13.8
-            export RUBY_VERSION=2.4
-
-            brew update
-
             brew install ruby@$RUBY_VERSION -f
             export PATH="/usr/local/opt/ruby@$RUBY_VERSION/bin:/usr/local/lib/ruby/gems/$RUBY_VERSION.0/bin:$PATH"
             echo 'export PATH="/usr/local/opt/ruby@'$RUBY_VERSION'/bin:/usr/local/lib/ruby/gems/'$RUBY_VERSION'.0/bin:$PATH"' >> .build_setup
-
             gem install bundle -f
 
-            brew uninstall python@2
-            brew upgrade python || true
-            ln -s /usr/local/bin/pip3 /usr/local/bin/pip
+            brew uninstall python@2 # Remove python2, we don't need it
+            brew upgrade python # Upgrade python3 to latest avilable on brew
+            ln -s /usr/local/bin/pip3 /usr/local/bin/pip # Use pip3 by default
 
             brew install pkg-config -f
             brew install cmake -f
@@ -235,16 +236,15 @@ jobs:
             echo 'export PATH="$GOPATH/bin:$PATH"' >> .build_setup
 
             brew install gimme
-            eval `gimme $GO_VERSION`
             echo 'eval `gimme '$GO_VERSION'`' >> .build_setup
-
       - run:
+          name: Run omnibus build
           command: |
             source .build_setup
             pip install -r requirements.txt
             sudo rm -rf /opt/datadog-agent ./vendor ./vendor-new /var/cache/omnibus/src/* ./omnibus/Gemfile.lock
             sudo mkdir -p /opt/datadog-agent /var/cache/omnibus && sudo chown $USER /opt/datadog-agent /var/cache/omnibus
-            inv -e agent.omnibus-build --skip-sign --python-runtimes 3 --major-version 7 --release-version nightly-a7
+            inv -e agent.omnibus-build --skip-sign --python-runtimes $PYTHON_RUNTIMES --major-version $AGENT_MAJOR_VERSION --release-version $RELEASE_VERSION
 
       - run: mkdir -p ~/artifacts && cp omnibus/pkg/*.dmg ~/artifacts
       - store_artifacts:
@@ -255,8 +255,7 @@ workflows:
   test_and_build:
     jobs:
       - checkout_code
-      - macos_tests
-
+      - macos_build
       - dependencies:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,9 +210,10 @@ jobs:
       - run: /usr/bin/xcodebuild -version
       - run:
           command: |
-            CI=1 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
             export GO_VERSION=1.13.8
             export RUBY_VERSION=2.4
+
+            brew update
 
             brew install ruby@$RUBY_VERSION -f
             export PATH="/usr/local/opt/ruby@$RUBY_VERSION/bin:/usr/local/lib/ruby/gems/$RUBY_VERSION.0/bin:$PATH"
@@ -220,13 +221,14 @@ jobs:
 
             gem install bundle -f
 
-            brew install python -f
+            brew uninstall python@2
+            brew upgrade python || true
             ln -s /usr/local/bin/pip3 /usr/local/bin/pip
 
             brew install pkg-config -f
             brew install cmake -f
 
-            mkdir $HOME/go
+            mkdir -p $HOME/go
             export GOPATH=$HOME/go
             echo 'export GOPATH=$HOME/go' >> .build_setup
             export PATH="$GOPATH/bin:$PATH"


### PR DESCRIPTION
### What does this PR do?

Adds a CircleCI job that sets up a MacOS builder and runs an unsigned MacOS omnibus build, using a tweaked version of [the scripts in the buildimages repo](https://github.com/DataDog/datadog-agent-buildimages/blob/master/macos) to account for the defaults of the CircleCI MacOS VM.
The unsigned `.dmg` is available as a job artifact, to be able to test the build result.

### Motivation

Being able to test the MacOS build before releases.