### PR TITLE
Added support for parent directory info to flare zip

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -289,10 +289,12 @@ func writeStatusFile(tempDir, hostname string, data []byte) error {
 
 func addParentPerms(dirPath string, permsInfos permissionsInfos) {
 	parent := filepath.Dir(dirPath)
-	for parent != "." {
+	for parent != "/" {
 		permsInfos.add(parent)
 		parent = filepath.Dir(parent)
 	}
+
+	permsInfos.add("/")
 }
 
 func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsInfos) error {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -287,8 +287,21 @@ func writeStatusFile(tempDir, hostname string, data []byte) error {
 	return err
 }
 
+func addParentPerms(dirPath string, permsInfos permissionsInfos) {
+	parent := filepath.Dir(dirPath)
+	for parent != "." {
+		permsInfos.add(parent)
+		parent = filepath.Dir(parent)
+	}
+}
+
 func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsInfos) error {
 	logFileDir := filepath.Dir(logFilePath)
+
+	if permsInfos != nil {
+		addParentPerms(logFileDir, permsInfos)
+	}
+
 	err := filepath.Walk(logFileDir, func(src string, f os.FileInfo, err error) error {
 		if f == nil {
 			return nil
@@ -623,6 +636,11 @@ func zipHTTPCallContent(tempDir, hostname, filename, url string) error {
 
 func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, permsInfos permissionsInfos) error {
 	for prefix, filePath := range confSearchPaths {
+
+		if permsInfos != nil {
+			addParentPerms(filePath, permsInfos)
+		}
+
 		err := filepath.Walk(filePath, func(src string, f os.FileInfo, err error) error {
 			if f == nil {
 				return nil

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -289,20 +289,18 @@ func writeStatusFile(tempDir, hostname string, data []byte) error {
 
 func addParentPerms(dirPath string, permsInfos permissionsInfos) {
 	parent := filepath.Dir(dirPath)
-	for parent != "/" {
+	for parent != "." {
+		if parent == "/" {
+			permsInfos.add(parent)
+			break
+		}
 		permsInfos.add(parent)
 		parent = filepath.Dir(parent)
 	}
-
-	permsInfos.add("/")
 }
 
 func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsInfos) error {
 	logFileDir := filepath.Dir(logFilePath)
-
-	if permsInfos != nil {
-		addParentPerms(logFileDir, permsInfos)
-	}
 
 	err := filepath.Walk(logFileDir, func(src string, f os.FileInfo, err error) error {
 		if f == nil {
@@ -317,6 +315,7 @@ func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsIn
 
 			if permsInfos != nil {
 				permsInfos.add(src)
+				addParentPerms(src, permsInfos)
 			}
 
 			return util.CopyFileAll(src, dst)
@@ -639,9 +638,9 @@ func zipHTTPCallContent(tempDir, hostname, filename, url string) error {
 func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, permsInfos permissionsInfos) error {
 	for prefix, filePath := range confSearchPaths {
 
-		if permsInfos != nil {
-			addParentPerms(filePath, permsInfos)
-		}
+		// if permsInfos != nil {
+		// 	addParentPerms(filePath, permsInfos)
+		// }
 
 		err := filepath.Walk(filePath, func(src string, f os.FileInfo, err error) error {
 			if f == nil {
@@ -678,6 +677,7 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, 
 
 				if permsInfos != nil {
 					permsInfos.add(src)
+					addParentPerms(src, permsInfos)
 				}
 			}
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -656,10 +656,6 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, 
 			firstSuffix := getFirstSuffix(f.Name())
 			ext := filepath.Ext(f.Name())
 
-			if permsInfos != nil {
-				addParentPerms(filePath, permsInfos)
-			}
-
 			if cnfFileExtRx.Match([]byte(firstSuffix)) || cnfFileExtRx.Match([]byte(ext)) {
 				baseName := strings.Replace(src, filePath, "", 1)
 				f := filepath.Join(tempDir, hostname, "etc", "confd", prefix, baseName)
@@ -680,6 +676,7 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, 
 
 				if permsInfos != nil {
 					permsInfos.add(src)
+					addParentPerms(filePath, permsInfos)
 				}
 			}
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -302,6 +302,10 @@ func addParentPerms(dirPath string, permsInfos permissionsInfos) {
 func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsInfos) error {
 	logFileDir := filepath.Dir(logFilePath)
 
+	if permsInfos != nil {
+		addParentPerms(logFileDir, permsInfos)
+	}
+
 	err := filepath.Walk(logFileDir, func(src string, f os.FileInfo, err error) error {
 		if f == nil {
 			return nil
@@ -315,7 +319,6 @@ func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsIn
 
 			if permsInfos != nil {
 				permsInfos.add(src)
-				addParentPerms(src, permsInfos)
 			}
 
 			return util.CopyFileAll(src, dst)
@@ -638,10 +641,6 @@ func zipHTTPCallContent(tempDir, hostname, filename, url string) error {
 func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, permsInfos permissionsInfos) error {
 	for prefix, filePath := range confSearchPaths {
 
-		// if permsInfos != nil {
-		// 	addParentPerms(filePath, permsInfos)
-		// }
-
 		err := filepath.Walk(filePath, func(src string, f os.FileInfo, err error) error {
 			if f == nil {
 				return nil
@@ -656,6 +655,10 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, 
 
 			firstSuffix := getFirstSuffix(f.Name())
 			ext := filepath.Ext(f.Name())
+
+			if permsInfos != nil {
+				addParentPerms(filePath, permsInfos)
+			}
 
 			if cnfFileExtRx.Match([]byte(firstSuffix)) || cnfFileExtRx.Match([]byte(ext)) {
 				baseName := strings.Replace(src, filePath, "", 1)
@@ -677,7 +680,6 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, 
 
 				if permsInfos != nil {
 					permsInfos.add(src)
-					addParentPerms(src, permsInfos)
 				}
 			}
 

--- a/releasenotes/notes/include-parent-directory-permissions-in-flare-22df1fb86fe46bd3.yaml
+++ b/releasenotes/notes/include-parent-directory-permissions-in-flare-22df1fb86fe46bd3.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Flare now includes the permission information for parents of config and log file directories.


### PR DESCRIPTION
### What does this PR do?

Gets permissions for parent directories when collecting logs and configs for flare creation.

### Motivation

Small nice-to-have item to troubleshoot filesystem perm issues (would have helped in some agent support cases during the SSL cert outage, unrelated to the SSL certs themselves though).

At the moment we only include in flare's zip the permissions of the Agent's log/config files themselves (permissions.log), not the perms of the parent directories. Let's include the latter so that it's easier to troubleshoot when customers set permissions that won't work on parent directories.