### PR TITLE
Cache GCE tags to avoid missing tags when user exceed cloud quotas

### DIFF
--- a/releasenotes/notes/cache-ec2-tags-ec80ccf049e12274.yaml
+++ b/releasenotes/notes/cache-ec2-tags-ec80ccf049e12274.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    When enabling `collect_ec2_tags` option, EC2 tags are now cached to avoid
-    missing tags when user exceed his AWS quotas.
+    When enabling `collect_ec2_tags` or `collect_gce_tags` option, EC2/GCE tags
+    are now cached to avoid missing tags when user exceed his AWS/GCE quotas.


### PR DESCRIPTION
### What does this PR do?

Cache GCE tags to avoid missing tags when user exceed cloud quotas.
