### PR TITLE
Automatically enable the tcp_queue_length core check when it has been enabled on system-probe side

### DIFF
--- a/Dockerfiles/agent/entrypoint/60-sysprobe-check.sh
+++ b/Dockerfiles/agent/entrypoint/60-sysprobe-check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if grep -Eq '^ *enable_tcp_queue_length *: *true' /etc/datadog-agent/system-probe.yaml; then
+    mv /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.example \
+       /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.default
+fi


### PR DESCRIPTION
### What does this PR do?

Automatically enable the tcp_queue_length core check when it has been enabled on system-probe side

### Motivation

Reduce the setup complexity to enable the `tcp_queue_length` check.

### Additional Notes

### Describe your test plan

With this PR and helm/charts#22686, setting `datadog.systemProbe.enableTCPQueueLength` to true in the helm `values.yaml` become the only thing to do to enable the check.