### PR TITLE
Adding an option to use RFC3339 format for the log time.

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1047,6 +1047,11 @@ api_key:
 #
 # syslog_tls_verify: true
 
+## @param log_format_rfc3339 - boolean - optional - default false
+## If enabled the Agent will log using the RFC3339 format for the log time.
+#
+# log_format_rfc3339: false
+
 {{ end -}}
 {{- if .Autoconfig }}
 

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	seelogCfg "github.com/DataDog/datadog-agent/pkg/config/seelog"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -30,9 +31,16 @@ var syslogTLSConfig *tls.Config
 
 var seelogConfig *seelogCfg.Config
 
+func getLogDateFormat() string {
+	if Datadog.GetBool("log_format_rfc3339") {
+		return time.RFC3339
+	}
+	return logDateFormat
+}
+
 // buildCommonFormat returns the log common format seelog string
 func buildCommonFormat(loggerName LoggerName) string {
-	return fmt.Sprintf("%%Date(%s) | %s | %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%Msg%%n", logDateFormat, loggerName)
+	return fmt.Sprintf("%%Date(%s) | %s | %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%Msg%%n", getLogDateFormat(), loggerName)
 }
 
 func createQuoteMsgFormatter(params string) seelog.FormatterFunc {
@@ -44,7 +52,7 @@ func createQuoteMsgFormatter(params string) seelog.FormatterFunc {
 // buildJSONFormat returns the log JSON format seelog string
 func buildJSONFormat(loggerName LoggerName) string {
 	seelog.RegisterCustomFormatter("QuoteMsg", createQuoteMsgFormatter) //nolint:errcheck
-	return fmt.Sprintf(`{"agent":"%s","time":"%%Date(%s)","level":"%%LEVEL","file":"%%ShortFilePath","line":"%%Line","func":"%%FuncShort","msg":%%QuoteMsg}%%n`, strings.ToLower(string(loggerName)), logDateFormat)
+	return fmt.Sprintf(`{"agent":"%s","time":"%%Date(%s)","level":"%%LEVEL","file":"%%ShortFilePath","line":"%%Line","func":"%%FuncShort","msg":%%QuoteMsg}%%n`, strings.ToLower(string(loggerName)), getLogDateFormat())
 }
 
 func getSyslogTLSKeyPair() (*tls.Certificate, error) {

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -274,6 +274,7 @@ func (j *JMXFetch) Start(manage bool) error {
 		"--reconnection_timeout", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_reconnection_timeout")), // Timeout for instance reconnection in seconds
 		"--reconnection_thread_pool_size", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_reconnection_thread_pool_size")), // Size for the JMXFetch reconnection thread pool
 		"--log_level", jmxLogLevel,
+		"--log_format_rfc3339", fmt.Sprintf("%v", config.Datadog.GetBool("log_format_rfc3339")),
 		"--reporter", reporter, // Reporter to use
 	)
 

--- a/releasenotes/notes/rfc3339-log-format-421cb22a034845bf.yaml
+++ b/releasenotes/notes/rfc3339-log-format-421cb22a034845bf.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adding a 'log_format_rfc3339' option to use the RFC3339 format for the log
+    time.


### PR DESCRIPTION
### What does this PR do?

Adding an option to use RFC3339 format for the log time.

This PR depends on: https://github.com/DataDog/jmxfetch/pull/300
