### PR TITLE
More fixes to make 32 bit tests succeed.

### DIFF
--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
+// +build kubeapiserver
 
 package app
 

--- a/pkg/network/netlink/circuit_breaker.go
+++ b/pkg/network/netlink/circuit_breaker.go
@@ -43,13 +43,13 @@ type CircuitBreaker struct {
 
 // NewCircuitBreaker instantiates a new CircuitBreaker that only allows
 // a maxEventsPerSec to pass. The rate of events is calculated using an EWMA.
-func NewCircuitBreaker(maxEventsPerSec int) *CircuitBreaker {
+func NewCircuitBreaker(maxEventsPerSec int64) *CircuitBreaker {
 	// -1 will virtually disable the circuit breaker
 	if maxEventsPerSec == -1 {
 		maxEventsPerSec = math.MaxInt64
 	}
 
-	c := &CircuitBreaker{maxEventsPerSec: int64(maxEventsPerSec)}
+	c := &CircuitBreaker{maxEventsPerSec: maxEventsPerSec}
 	c.Reset()
 
 	go func() {

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -103,7 +103,7 @@ func NewConsumer(procRoot string, targetRateLimit int) (*Consumer, error) {
 		pool:            newBufferPool(),
 		workQueue:       make(chan func()),
 		targetRateLimit: targetRateLimit,
-		breaker:         NewCircuitBreaker(targetRateLimit),
+		breaker:         NewCircuitBreaker(int64(targetRateLimit)),
 	}
 	c.initWorker(procRoot)
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -118,7 +118,7 @@ def lint(ctx, targets):
 
 
 @task
-def vet(ctx, targets, rtloader_root=None, build_tags=None):
+def vet(ctx, targets, rtloader_root=None, build_tags=None, arch="x64"):
     """
     Run go vet on targets.
 
@@ -132,7 +132,7 @@ def vet(ctx, targets, rtloader_root=None, build_tags=None):
 
     # add the /... suffix to the targets
     args = ["{}/...".format(t) for t in targets]
-    tags = build_tags or get_default_build_tags()
+    tags = build_tags or get_default_build_tags(arch=arch)
     tags.append("dovet")
 
     _, _, env = get_build_flags(ctx, rtloader_root=rtloader_root)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -65,7 +65,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
     else:
         tool_targets = test_targets = targets
 
-    build_include = get_default_build_tags(process=True) if build_include is None else build_include.split(",")
+    build_include = get_default_build_tags(process=True, arch=arch) if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     build_tags = get_build_tags(build_include, build_exclude)
 
@@ -88,7 +88,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
         # from the 'skip-dirs' list we need to keep using the old functions that
         # lint without build flags (linting some file is better than no linting).
         print("--- Vetting and linting (legacy):")
-        vet(ctx, targets=tool_targets, rtloader_root=rtloader_root, build_tags=build_tags)
+        vet(ctx, targets=tool_targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch)
         fmt(ctx, targets=tool_targets, fail_on_fmt=fail_on_fmt)
         lint(ctx, targets=tool_targets)
         misspell(ctx, targets=tool_targets)


### PR DESCRIPTION
Make sure `go vet` knows what architecture we're compiling for.

### What does this PR do?

make the 32 bit unit tests pass
