### PR TITLE
Remove SLES11 from Kitchen tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1763,8 +1763,7 @@ deploy_windows_testing-a7:
 .kitchen_os_suse: &kitchen_os_suse
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
-    - export TEST_PLATFORMS="sles-11,urn,SUSE:SLES-BYOS:11-SP4:2019.12.05"
-    - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-12,urn,SUSE:SLES-BYOS:12-SP4:2019.11.13"
+    - export TEST_PLATFORMS="sles-12,urn,SUSE:SLES-BYOS:12-SP4:2019.11.13"
     - export TEST_PLATFORMS="$TEST_PLATFORMS|sles-15,urn,SUSE:SLES-BYOS:15:2019.11.15"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh


### PR DESCRIPTION
### Motivation

The OpenSSL version there (from 2009) doesn't support modern ciphers which
are required to access our yum repo. This made curl fail with:
```
Error message: error:1408D13A:SSL routines:SSL3_GET_KEY_EXCHANGE:unable to find ecdh parameters
```
