### PR TITLE
[pkg/status] Add flavor to status command

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -3,6 +3,7 @@
     <span class="stat_title">Agent Info</span>
     <span class="stat_data">
       Version: {{.version}}
+      <br>Flavor: {{.flavor}}
       <br>PID: {{.pid}}
       {{- if .runnerStats.Workers}}
         <br>Check Workers: {{.runnerStats.Workers}}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -39,7 +39,7 @@ func FormatStatus(data []byte) (string, error) {
 	endpointsInfos := stats["endpointsInfos"]
 	inventoriesStats := stats["inventories"]
 	systemProbeStats := stats["systemProbeStats"]
-	title := fmt.Sprintf("Agent (v%s)", stats["version"])
+	title := fmt.Sprintf("Agent (v%s %s)", stats["version"], stats["flavor"])
 	stats["title"] = title
 	renderStatusTemplate(b, "/header.tmpl", stats)
 	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, inventoriesStats, "")

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -39,7 +39,7 @@ func FormatStatus(data []byte) (string, error) {
 	endpointsInfos := stats["endpointsInfos"]
 	inventoriesStats := stats["inventories"]
 	systemProbeStats := stats["systemProbeStats"]
-	title := fmt.Sprintf("Agent (v%s %s)", stats["version"], stats["flavor"])
+	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderStatusTemplate(b, "/header.tmpl", stats)
 	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, inventoriesStats, "")

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -40,6 +40,7 @@ func GetStatus() (map[string]interface{}, error) {
 	}
 
 	stats["version"] = version.AgentVersion
+	stats["flavor"] = config.AgentFlavor
 	hostnameData, err := util.GetHostnameData()
 
 	var metadata *host.Payload

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -13,6 +13,7 @@ NOTE: Changes made to this template should be reflected on the following templat
   Python Version: {{.python_version}}
   {{- end }}
   Build arch: {{.build_arch}}
+  Agent flavor: {{.flavor}}
   {{- if .runnerStats.Workers}}
   Check Runners: {{.runnerStats.Workers}}
   {{end -}}

--- a/releasenotes/notes/add-agent-flavor-to-status-command-output-c612a8f770e3b84a.yaml
+++ b/releasenotes/notes/add-agent-flavor-to-status-command-output-c612a8f770e3b84a.yaml
@@ -10,3 +10,6 @@ enhancements:
   - |
     The Agent ``status`` command now includes the flavor
     of the Agent that is running.
+  - |
+    The Agent GUI now includes the flavor
+    of the Agent that is running.

--- a/releasenotes/notes/add-agent-flavor-to-status-command-output-c612a8f770e3b84a.yaml
+++ b/releasenotes/notes/add-agent-flavor-to-status-command-output-c612a8f770e3b84a.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Agent ``status`` command now includes the flavor
+    of the Agent that is running.


### PR DESCRIPTION
### What does this PR do?

- Add the agent flavor to the `status` command output and to the GUI. 

### Motivation

- Have an easy way to check the Agent flavor.

### Describe your test plan

- Run the `status` command. The body should feature a flavor field with the correct flavor.
- Launch the GUI. There should be a flavor field with the correct flavor.