### PR TITLE
Add task to build simple test gitlab-ci file

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -38,6 +38,7 @@ from .test import (
     lint_python,
     e2e_tests,
     make_kitchen_gitlab_yml,
+    make_simple_gitlab_yml,
     check_gitlab_broken_dependencies,
     install_shellcheck,
 )
@@ -66,6 +67,7 @@ ns.add_task(lint_python)
 ns.add_task(audit_tag_impact)
 ns.add_task(e2e_tests)
 ns.add_task(make_kitchen_gitlab_yml)
+ns.add_task(make_simple_gitlab_yml)
 ns.add_task(check_gitlab_broken_dependencies)
 ns.add_task(generate)
 ns.add_task(install_shellcheck)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -468,7 +468,7 @@ def make_simple_gitlab_yml(ctx, jobs_to_process, yml_file_src='.gitlab-ci.yml', 
                 del job['only']
 
     out = copy.deepcopy(data)
-    for k,v in data.items():
+    for k,_ in data.items():
         if k not in jobs_processed:
             del out[k]
             continue

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -468,7 +468,7 @@ def make_simple_gitlab_yml(ctx, jobs_to_process, yml_file_src='.gitlab-ci.yml', 
                 del job['only']
 
     out = copy.deepcopy(data)
-    for k,_ in data.items():
+    for k, _ in data.items():
         if k not in jobs_processed:
             del out[k]
             continue

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -474,7 +474,7 @@ def make_simple_gitlab_yml(ctx, jobs_to_process, yml_file_src='.gitlab-ci.yml', 
             continue
 
     with open(yml_file_dest, 'w') as f:
-        documents = yaml.dump(out, f)
+        yaml.dump(out, f)
 
 @task
 def make_kitchen_gitlab_yml(ctx):

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -425,7 +425,9 @@ class TestProfiler:
 
 
 @task
-def make_simple_gitlab_yml(ctx, jobs_to_process, yml_file_src='.gitlab-ci.yml', yml_file_dest='.gitlab-ci.yml', dont_include_deps=False):
+def make_simple_gitlab_yml(
+    ctx, jobs_to_process, yml_file_src='.gitlab-ci.yml', yml_file_dest='.gitlab-ci.yml', dont_include_deps=False
+):
     """
     Replaces .gitlab-ci.yml with one containing only the steps needed to run the given jobs.
 
@@ -438,7 +440,7 @@ def make_simple_gitlab_yml(ctx, jobs_to_process, yml_file_src='.gitlab-ci.yml', 
     with open(yml_file_src) as f:
         data = yaml.load(f, Loader=yaml.FullLoader)
 
-    jobs_processed = set(['stages','variables','include','default'])
+    jobs_processed = set(['stages', 'variables', 'include', 'default'])
     jobs_to_process = set(jobs_to_process.split(','))
     while jobs_to_process:
         job_name = jobs_to_process.pop()

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -444,15 +444,17 @@ def make_simple_gitlab_yml(ctx, jobs_to_run, yml_file_src='.gitlab-ci.yml', yml_
         job = jobs_to_run.pop()
         if job in data:
             jobs.add(job)
+            jobs_to_run.update(data[job].get('extends', []))
             if dont_include_deps:
                 del data[job]['needs']
             else:
-                needs = data[job].get('needs', [])
-                jobs_to_run.update(needs)
+                jobs_to_run.update(data[job].get('needs', []))
 
     out = copy.deepcopy(data)
     stages = []
     for k,v in data.items():
+        # Always include anchors - they don't add additional time to run in the pipeline
+        # and it simplifies things.
         if k not in jobs and not str.startswith(k, '.'):
             del out[k]
             continue

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -447,15 +447,13 @@ def make_simple_gitlab_yml(ctx, jobs_to_run, yml_file_src='.gitlab-ci.yml', yml_
             if dont_include_deps:
                 del data[job]['needs']
             else:
-                needs = data[job].get('needs')
-                if needs is not None:
-                    for dep_k in needs:
-                        jobs_to_run.add(dep_k)
+                needs = data[job].get('needs', [])
+                jobs_to_run.update(needs)
 
     out = copy.deepcopy(data)
     stages = []
     for k,v in data.items():
-        if not k in jobs and not str.startswith(k, '.'):
+        if k not in jobs and not str.startswith(k, '.'):
             del out[k]
             continue
         if not isinstance(v, dict):

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -476,6 +476,7 @@ def make_simple_gitlab_yml(ctx, jobs_to_process, yml_file_src='.gitlab-ci.yml', 
     with open(yml_file_dest, 'w') as f:
         yaml.dump(out, f)
 
+
 @task
 def make_kitchen_gitlab_yml(ctx):
     """

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -440,7 +440,7 @@ def make_simple_gitlab_yml(ctx, jobs_to_run, yml_file_src='.gitlab-ci.yml', yml_
 
     jobs_to_run = set(jobs_to_run.split(','))
     jobs = set(['stages','variables','include','default'])
-    while len(jobs_to_run) > 0:
+    while jobs_to_run:
         job = jobs_to_run.pop()
         if job in data:
             jobs.add(job)
@@ -461,7 +461,7 @@ def make_simple_gitlab_yml(ctx, jobs_to_run, yml_file_src='.gitlab-ci.yml', yml_
         if not isinstance(v, dict):
             continue;
         stage = v.get('stage', None)
-        if stage is not None and not stage in stages:
+        if stage is not None and stage not in stages:
             stages.append(stage)
     out['stages'] = stages
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -459,7 +459,7 @@ def make_simple_gitlab_yml(ctx, jobs_to_run, yml_file_src='.gitlab-ci.yml', yml_
             del out[k]
             continue
         if not isinstance(v, dict):
-            continue;
+            continue
         stage = v.get('stage', None)
         if stage is not None and stage not in stages:
             stages.append(stage)


### PR DESCRIPTION
### What does this PR do?

This PR adds a task that can be used to generate a simpler `gitlab-ci` file when testing & debugging the pipeline.

### Motivation

The pipeline can take a long time to execute. When debugging a specific stage, it can be useful to include only some jobs to be executed.

### Additional Notes

Tested with Python 3.7

### Describe your test plan

Use the task to generate a gitlab-ci file, then run it with the pipeline. It should succeed and only the jobs specified should be run.
