### PR TITLE
Added api key sanitization for additional endpoints and logs agent

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -871,7 +871,7 @@ func load(config Config, origin string, loadSecret bool) error {
 	}
 
 	loadProxyFromEnv(config)
-	SanitizeAPIKey(config, "api_key")
+	SanitizeAPIKeyConfig(config, "api_key")
 	applyOverrides(config)
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	setTracemallocEnabled(config)
@@ -914,14 +914,14 @@ func ResolveSecrets(config Config, origin string) error {
 	return nil
 }
 
-// SanitizeAPIKey strips newlines and other control characters from a given key.
-func SanitizeAPIKey(config Config, key string) {
-	config.Set(key, Sanitize(config.GetString(key)))
+// SanitizeAPIKeyConfig strips newlines and other control characters from a given key.
+func SanitizeAPIKeyConfig(config Config, key string) {
+	config.Set(key, SanitizeAPIKey(config.GetString(key)))
 }
 
-// Sanitize strips newlines and other control characters from a given string.
-func Sanitize(s string) string {
-	return strings.TrimSpace(strings.Split(s, ",")[0])
+// SanitizeAPIKey strips newlines and other control characters from a given string.
+func SanitizeAPIKey(key string) string {
+	return strings.TrimSpace(key)
 }
 
 // GetMainInfraEndpoint returns the main DD Infra URL defined in the config, based on the value of `site` and `dd_url`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -916,7 +916,12 @@ func ResolveSecrets(config Config, origin string) error {
 
 // SanitizeAPIKey strips newlines and other control characters from a given key.
 func SanitizeAPIKey(config Config, key string) {
-	config.Set(key, strings.TrimSpace(config.GetString(key)))
+	config.Set(key, Sanitize(config.GetString(key)))
+}
+
+// Sanitize strips newlines and other control characters from a given string.
+func Sanitize(s string) string {
+	return strings.TrimSpace(strings.Split(s, ",")[0])
 }
 
 // GetMainInfraEndpoint returns the main DD Infra URL defined in the config, based on the value of `site` and `dd_url`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -871,7 +871,7 @@ func load(config Config, origin string, loadSecret bool) error {
 	}
 
 	loadProxyFromEnv(config)
-	sanitizeAPIKey(config)
+	SanitizeAPIKey(config, "api_key")
 	applyOverrides(config)
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	setTracemallocEnabled(config)
@@ -914,9 +914,9 @@ func ResolveSecrets(config Config, origin string) error {
 	return nil
 }
 
-// Avoid log ingestion breaking because of a newline in the API key
-func sanitizeAPIKey(config Config) {
-	config.Set("api_key", strings.TrimSpace(config.GetString("api_key")))
+// SanitizeAPIKey strips newlines and other control characters from a given key.
+func SanitizeAPIKey(config Config, key string) {
+	config.Set(key, strings.TrimSpace(config.GetString(key)))
 }
 
 // GetMainInfraEndpoint returns the main DD Infra URL defined in the config, based on the value of `site` and `dd_url`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -659,19 +659,19 @@ func TestSanitizeAPIKey(t *testing.T) {
 	config := setupConf()
 
 	config.Set("api_key", "foo")
-	sanitizeAPIKey(config)
+	SanitizeAPIKey(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 
 	config.Set("api_key", "foo\n")
-	sanitizeAPIKey(config)
+	SanitizeAPIKey(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 
 	config.Set("api_key", "foo\n\n")
-	sanitizeAPIKey(config)
+	SanitizeAPIKey(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 
 	config.Set("api_key", " \n  foo   \n")
-	sanitizeAPIKey(config)
+	SanitizeAPIKey(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -655,23 +655,23 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 	os.Unsetenv("DD_PROXY_NO_PROXY")
 }
 
-func TestSanitizeAPIKey(t *testing.T) {
+func TestSanitizeAPIKeyConfig(t *testing.T) {
 	config := setupConf()
 
 	config.Set("api_key", "foo")
-	SanitizeAPIKey(config, "api_key")
+	SanitizeAPIKeyConfig(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 
 	config.Set("api_key", "foo\n")
-	SanitizeAPIKey(config, "api_key")
+	SanitizeAPIKeyConfig(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 
 	config.Set("api_key", "foo\n\n")
-	SanitizeAPIKey(config, "api_key")
+	SanitizeAPIKeyConfig(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 
 	config.Set("api_key", " \n  foo   \n")
-	SanitizeAPIKey(config, "api_key")
+	SanitizeAPIKeyConfig(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 }
 

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -89,7 +89,7 @@ func GlobalProcessingRules() ([]*ProcessingRule, error) {
 
 // BuildEndpoints returns the endpoints to send logs.
 func BuildEndpoints(httpConnectivity HTTPConnectivity) (*Endpoints, error) {
-	coreConfig.SanitizeAPIKey(coreConfig.Datadog, "logs_config.api_key")
+	coreConfig.SanitizeAPIKeyConfig(coreConfig.Datadog, "logs_config.api_key")
 	if coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl") {
 		log.Warnf("Use of illegal configuration parameter, if you need to send your logs to a proxy, please use 'logs_config.logs_dd_url' and 'logs_config.logs_no_ssl' instead")
 	}
@@ -157,7 +157,7 @@ func buildTCPEndpoints() (*Endpoints, error) {
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
 		additionals[i].ProxyAddress = proxyAddress
-		additionals[i].APIKey = coreConfig.Sanitize(additionals[i].APIKey)
+		additionals[i].APIKey = coreConfig.SanitizeAPIKey(additionals[i].APIKey)
 	}
 	return NewEndpoints(main, additionals, useProto, false, 0), nil
 }
@@ -187,7 +187,7 @@ func BuildHTTPEndpoints() (*Endpoints, error) {
 	additionals := getAdditionalEndpoints()
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
-		additionals[i].APIKey = coreConfig.Sanitize(additionals[i].APIKey)
+		additionals[i].APIKey = coreConfig.SanitizeAPIKey(additionals[i].APIKey)
 	}
 
 	batchWait := batchWait(coreConfig.Datadog)

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -89,6 +89,7 @@ func GlobalProcessingRules() ([]*ProcessingRule, error) {
 
 // BuildEndpoints returns the endpoints to send logs.
 func BuildEndpoints(httpConnectivity HTTPConnectivity) (*Endpoints, error) {
+	coreConfig.SanitizeAPIKey(coreConfig.Datadog, "logs_config.api_key")
 	if coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl") {
 		log.Warnf("Use of illegal configuration parameter, if you need to send your logs to a proxy, please use 'logs_config.logs_dd_url' and 'logs_config.logs_no_ssl' instead")
 	}
@@ -120,7 +121,6 @@ func hasAdditionalEndpoints() bool {
 func buildTCPEndpoints() (*Endpoints, error) {
 	useProto := coreConfig.Datadog.GetBool("logs_config.dev_mode_use_proto")
 	proxyAddress := coreConfig.Datadog.GetString("logs_config.socks5_proxy_address")
-	coreConfig.SanitizeAPIKey(coreConfig.Datadog, "logs_config.api_key")
 	main := Endpoint{
 		APIKey:       getLogsAPIKey(coreConfig.Datadog),
 		ProxyAddress: proxyAddress,
@@ -220,7 +220,6 @@ func isSetAndNotEmpty(config coreConfig.Config, key string) bool {
 // getLogsAPIKey provides the dd api key used by the main logs agent sender.
 func getLogsAPIKey(config coreConfig.Config) string {
 	if isSetAndNotEmpty(config, "logs_config.api_key") {
-		coreConfig.SanitizeAPIKey(config, "logs_config.api_key")
 		return config.GetString("logs_config.api_key")
 	}
 	return config.GetString("api_key")

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 	"time"
 
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -158,7 +157,7 @@ func buildTCPEndpoints() (*Endpoints, error) {
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
 		additionals[i].ProxyAddress = proxyAddress
-		additionals[i].APIKey = strings.TrimSpace(additionals[i].APIKey)
+		additionals[i].APIKey = coreConfig.Sanitize(additionals[i].APIKey)
 	}
 	return NewEndpoints(main, additionals, useProto, false, 0), nil
 }
@@ -188,7 +187,7 @@ func BuildHTTPEndpoints() (*Endpoints, error) {
 	additionals := getAdditionalEndpoints()
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
-		additionals[i].APIKey = strings.TrimSpace(additionals[i].APIKey)
+		additionals[i].APIKey = coreConfig.Sanitize(additionals[i].APIKey)
 	}
 
 	batchWait := batchWait(coreConfig.Datadog)

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -191,7 +191,7 @@ func (suite *ConfigTestSuite) TestMultipleTCPEndpointsEnvVar() {
 	suite.config.Set("logs_config.socks5_proxy_address", "proxy.test:3128")
 	suite.config.Set("logs_config.dev_mode_use_proto", true)
 
-	os.Setenv("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS", `[{"api_key": "456", "host": "additional.endpoint", "port": 1234}]`)
+	os.Setenv("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS", `[{"api_key": "456      \n", "host": "additional.endpoint", "port": 1234}]`)
 	defer os.Unsetenv("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS")
 
 	expectedMainEndpoint := Endpoint{
@@ -227,7 +227,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig() {
 	suite.config.Set("logs_config.logs_no_ssl", false)
 	endpointsInConfig := []map[string]interface{}{
 		{
-			"api_key":           "456",
+			"api_key":           "456     \n\n",
 			"host":              "additional.endpoint.1",
 			"port":              1234,
 			"use_compression":   true,

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -416,7 +416,7 @@ func loadEnvVariables() {
 
 	if apiKey != "" { // We don't want to overwrite the API KEY provided as an environment variable
 		log.Infof("overriding API key from env %s value", envKey)
-		config.Datadog.Set("api_key", strings.TrimSpace(strings.Split(apiKey, ",")[0]))
+		config.Datadog.Set("api_key", config.Sanitize(apiKey))
 	}
 
 	if v := os.Getenv("DD_CUSTOM_SENSITIVE_WORDS"); v != "" {

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -416,7 +416,7 @@ func loadEnvVariables() {
 
 	if apiKey != "" { // We don't want to overwrite the API KEY provided as an environment variable
 		log.Infof("overriding API key from env %s value", envKey)
-		config.Datadog.Set("api_key", config.Sanitize(apiKey))
+		config.Datadog.Set("api_key", config.SanitizeAPIKey(strings.Split(apiKey, ",")[0]))
 	}
 
 	if v := os.Getenv("DD_CUSTOM_SENSITIVE_WORDS"); v != "" {

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -139,6 +139,7 @@ func (c *AgentConfig) applyDatadogConfig() error {
 				continue
 			}
 			for _, key := range keys {
+				key = strings.TrimSpace(key)
 				c.Endpoints = append(c.Endpoints, &Endpoint{Host: url, APIKey: key})
 			}
 		}

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -139,7 +139,7 @@ func (c *AgentConfig) applyDatadogConfig() error {
 				continue
 			}
 			for _, key := range keys {
-				key = strings.TrimSpace(key)
+				key = config.Sanitize(key)
 				c.Endpoints = append(c.Endpoints, &Endpoint{Host: url, APIKey: key})
 			}
 		}

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -139,7 +139,7 @@ func (c *AgentConfig) applyDatadogConfig() error {
 				continue
 			}
 			for _, key := range keys {
-				key = config.Sanitize(key)
+				key = config.SanitizeAPIKey(key)
 				c.Endpoints = append(c.Endpoints, &Endpoint{Host: url, APIKey: key})
 			}
 		}

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -177,6 +177,8 @@ func TestFullYamlConfig(t *testing.T) {
 		{Host: "https://my1.endpoint.com", APIKey: "apikey1"},
 		{Host: "https://my1.endpoint.com", APIKey: "apikey2"},
 		{Host: "https://my2.endpoint.eu", APIKey: "apikey3", NoProxy: noProxy},
+		{Host: "https://my2.endpoint.eu", APIKey: "apikey4", NoProxy: noProxy},
+		{Host: "https://my2.endpoint.eu", APIKey: "apikey5", NoProxy: noProxy},
 	}, c.Endpoints)
 
 	assert.ElementsMatch([]*ReplaceRule{

--- a/pkg/trace/config/testdata/full.yaml
+++ b/pkg/trace/config/testdata/full.yaml
@@ -23,6 +23,8 @@ apm_config:
       - apikey2
     https://my2.endpoint.eu:
       - apikey3
+      - "apikey4              "
+      - "apikey5\n \n         "
   env: test
   receiver_port: 18126
   connection_limit: 123

--- a/releasenotes/notes/sanitize-api-keys-6beaed1627c86ce3.yaml
+++ b/releasenotes/notes/sanitize-api-keys-6beaed1627c86ce3.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    API Keys are now sanitized for `logs_config` and `additional_endpoints`.


### PR DESCRIPTION
### What does this PR do?

For the `api_key` in the YAML config of the agent, whitespaces, newlines and other control characters were only stripped in some cases. This PR adds sanitization to the `api_key` in other locations, such as `logs_config` and `additional_endpoints`.

### Motivation

To prevent invalid API keys from user input.

### Describe your test plan

I added various invalid API keys to the unit tests.