### PR TITLE
[io] On Windows, add option to send lowercased device tag value

### DIFF
--- a/cmd/agent/dist/conf.d/io.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/io.d/conf.yaml.default
@@ -9,5 +9,14 @@ init_config:
   #
   # device_blacklist_re: <REGEX>
 
+  ## @param lowercase_device_tag - boolean - optional - default: false
+  ## Windows only. By default, on Windows, the value of the `device` tag sent by
+  ## the io check can have uppercase characters (example: `device:C:`), which is
+  ## inconsistent with the `device` tag sent by the `disk` check.
+  ##
+  ## Set this to `true` to send a lowercased `device` tag value.
+  #
+  # lowercase_device_tag: false
+
 instances:
 - {}

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -41,6 +42,15 @@ func (c *IOCheck) commonConfigure(data integration.Data, initConfig integration.
 			c.blacklist, err = regexp.Compile(regex)
 		}
 	}
+
+	if lowercaseDeviceTagOption, ok := conf["lowercase_device_tag"]; ok {
+		if lowercaseDeviceTag, ok := lowercaseDeviceTagOption.(bool); ok {
+			c.lowercaseDeviceTag = lowercaseDeviceTag
+		} else {
+			log.Warn("Can't cast value of 'lowercase_device_tag' option to boolean: ", lowercaseDeviceTagOption)
+		}
+	}
+
 	return err
 }
 

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -31,9 +31,10 @@ var (
 // IOCheck doesn't need additional fields
 type IOCheck struct {
 	core.CheckBase
-	blacklist *regexp.Regexp
-	ts        int64
-	stats     map[string]disk.IOCountersStat
+	blacklist          *regexp.Regexp
+	lowercaseDeviceTag bool // no effect on non-Windows platforms
+	ts                 int64
+	stats              map[string]disk.IOCountersStat
 }
 
 // Configure the IOstats check

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"strings"
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -40,9 +41,10 @@ const (
 // IOCheck doesn't need additional fields
 type IOCheck struct {
 	core.CheckBase
-	blacklist    *regexp.Regexp
-	counters     map[string]*pdhutil.PdhMultiInstanceCounterSet
-	counternames map[string]string
+	blacklist          *regexp.Regexp
+	lowercaseDeviceTag bool
+	counters           map[string]*pdhutil.PdhMultiInstanceCounterSet
+	counternames       map[string]string
 }
 
 var pfnGetDriveType = getDriveType
@@ -115,6 +117,9 @@ func (c *IOCheck) Run() error {
 			}
 			tagbuff.Reset()
 			tagbuff.WriteString("device:")
+			if c.lowercaseDeviceTag {
+				inst = strings.ToLower(inst)
+			}
 			tagbuff.WriteString(inst)
 			tags := []string{tagbuff.String()}
 			if cname == "Disk Write Bytes/sec" || cname == "Disk Read Bytes/sec" {

--- a/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
@@ -9,6 +9,8 @@ package system
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
@@ -101,10 +103,11 @@ func TestIoCheckLowercaseDeviceTag(t *testing.T) {
 	addDefaultQueryReturnValues()
 
 	ioCheck := new(IOCheck)
-	instanceYaml := `
+	rawInitConfigYaml := []byte(`
 lowercase_device_tag: true
-`
-	ioCheck.Configure([]byte(instanceYaml), nil, "test")
+`)
+	err := ioCheck.Configure(nil, rawInitConfigYaml, "test")
+	require.NoError(t, err)
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 

--- a/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
@@ -56,6 +56,7 @@ func addDriveDReturnValues() {
 	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(HarddiskVolume2)\\Current Disk Queue Length", 5.555)
 
 }
+
 func TestIoCheckWindows(t *testing.T) {
 
 	pfnGetDriveType = testGetDriveType
@@ -82,6 +83,45 @@ func TestIoCheckWindows(t *testing.T) {
 
 	mock.On("Gauge", "system.io.avg_q_sz", 5.222, "", []string{"device:C:"}).Return().Times(1)
 	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+
+	mock.On("Commit").Return().Times(1)
+	ioCheck.Run()
+
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 10)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+
+}
+
+func TestIoCheckLowercaseDeviceTag(t *testing.T) {
+
+	pfnGetDriveType = testGetDriveType
+	pdhtest.SetupTesting("testfiles\\counter_indexes_en-us.txt", "testfiles\\allcounters_en-us.txt")
+
+	addDefaultQueryReturnValues()
+
+	ioCheck := new(IOCheck)
+	instanceYaml := `
+lowercase_device_tag: true
+`
+	ioCheck.Configure([]byte(instanceYaml), nil, "test")
+
+	mock := mocksender.NewMockSender(ioCheck.ID())
+
+	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:c:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:harddiskvolume1"}).Return().Times(1)
+
+	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:c:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:harddiskvolume1"}).Return().Times(1)
+
+	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:c:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:harddiskvolume1"}).Return().Times(1)
+
+	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:c:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:harddiskvolume1"}).Return().Times(1)
+
+	mock.On("Gauge", "system.io.avg_q_sz", 5.222, "", []string{"device:c:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:harddiskvolume1"}).Return().Times(1)
 
 	mock.On("Commit").Return().Times(1)
 	ioCheck.Run()

--- a/releasenotes/notes/win-io-lowercase-device-tag-978f242b19f6ecd1.yaml
+++ b/releasenotes/notes/win-io-lowercase-device-tag-978f242b19f6ecd1.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``lowercase_device_tag`` option to the system ``io`` core check on Windows.
+    When enabled, sends metrics with a lowercased ``device`` tag, which is consistent with the
+    ``system.io.*`` metrics of Agent v5 and the ``system.disk.*`` metrics of all Agent
+    versions.


### PR DESCRIPTION
### What does this PR do?

On Windows `io` check, add `init_config`-level option to send lowercased device tag value (e.g. `device:c:` instead of `device:C:`. Opt-in.

### Motivation

Allows sending the device tag with the same case as Agent 5, and the same case as the `disk` check.

Note that regular tags are lowercased in the intake, but the `host` and `device` tags (actually, the `host` and `device` _fields_ of the timeseries payload) are exceptions, which is why case sensitivity is an issue here.

Another specificity of the `device` and `host` tags is that there can't be more than one per timeseries. Therefore the only way to make this code backward-compatible with earlier v6/v7 versions while allowing a non-breaking upgrade from v5 is to add an opt-in option.

### Describe your test plan

Added a unit test. Haven't actually tested on a Windows build (should be done as QA).
