### PR TITLE
Fixing panic on 32bit when using atomic operations on non 64bit aligned variables

### DIFF
--- a/cmd/agent/app/settings/runtime_settings_test.go
+++ b/cmd/agent/app/settings/runtime_settings_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type runtimeTestSetting struct {
@@ -103,7 +104,7 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 	serializer := serializer.NewSerializer(common.Forwarder)
 	agg := aggregator.InitAggregator(serializer, "", "agent")
 	common.DSD, err = dogstatsd.NewServer(agg)
-	assert.Nil(err)
+	require.Nil(t, err)
 
 	cleanRuntimeSetting()
 

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -78,7 +78,7 @@ type Server struct {
 	histToDist                bool
 	histToDistPrefix          string
 	extraTags                 []string
-	Debug                     dsdServerDebug
+	Debug                     *dsdServerDebug
 	mapper                    *mapper.MetricMapper
 	telemetryEnabled          bool
 	entityIDPrecedenceEnabled bool
@@ -204,7 +204,7 @@ func NewServer(aggregator *aggregator.BufferedAggregator) (*Server, error) {
 		telemetryEnabled:          telemetry.IsEnabled(),
 		entityIDPrecedenceEnabled: entityIDPrecedenceEnabled,
 		disableVerboseLogs:        config.Datadog.GetBool("dogstatsd_disable_verbose_logs"),
-		Debug: dsdServerDebug{
+		Debug: &dsdServerDebug{
 			Enabled: metricsStatsEnabled,
 			Stats:   make(map[ckey.ContextKey]metricStat),
 			metricsCounts: metricsCountBuckets{

--- a/pkg/trace/sampler/exception_sampler.go
+++ b/pkg/trace/sampler/exception_sampler.go
@@ -34,14 +34,15 @@ const (
 // The resulting sampled traces will likely be incomplete and will be flagged with
 // a exceptioKey metric set at 1.
 type ExceptionSampler struct {
+	// Variables access through the 'atomic' package must be 64bits aligned.
+	hits    int64
+	misses  int64
+	shrinks int64
 	mu      sync.RWMutex
-	limiter *rate.Limiter
-	seen    map[Signature]*seenSpans
 
 	tickStats *time.Ticker
-	hits      int64
-	misses    int64
-	shrinks   int64
+	limiter   *rate.Limiter
+	seen      map[Signature]*seenSpans
 }
 
 // NewExceptionSampler returns a NewExceptionSampler that ensures that we sample combinations


### PR DESCRIPTION
### What does this PR do?

Fixing panic on 32bit when using atomic operations on non 64bit aligned variables.
