### PR TITLE
pkg/trace/api: add "hostname" tag to metrtics for incoming traces

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -317,12 +317,21 @@ const (
 )
 
 func (r *HTTPReceiver) tagStats(req *http.Request) *info.TagStats {
+	hostname := req.URL.Host
+	if hostname != "" && strings.Index(hostname, ":") >= 0 {
+		// presumably host:port
+		host, _, err := net.SplitHostPort(hostname)
+		if err == nil {
+			hostname = host
+		}
+	}
 	return r.Stats.GetTagStats(info.Tags{
 		Lang:          req.Header.Get(headerLang),
 		LangVersion:   req.Header.Get(headerLangVersion),
 		Interpreter:   req.Header.Get(headerLangInterpreter),
 		LangVendor:    req.Header.Get(headerLangInterpreterVendor),
 		TracerVersion: req.Header.Get(headerTracerVersion),
+		Hostname:      hostname,
 	})
 }
 

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -431,6 +431,7 @@ func (ts *TagStats) WarnString() string {
 // Tags holds the tags we parse when we handle the header of the payload.
 type Tags struct {
 	Lang, LangVersion, LangVendor, Interpreter, TracerVersion string
+	Hostname                                                  string
 }
 
 // toArray will transform the Tags struct into a slice of string.
@@ -438,20 +439,23 @@ type Tags struct {
 func (t *Tags) toArray() []string {
 	tags := make([]string, 0, 5)
 
-	if t.Lang != "" {
-		tags = append(tags, "lang:"+t.Lang)
+	if v := t.Lang; v != "" {
+		tags = append(tags, "lang:"+v)
 	}
-	if t.LangVersion != "" {
-		tags = append(tags, "lang_version:"+t.LangVersion)
+	if v := t.LangVersion; v != "" {
+		tags = append(tags, "lang_version:"+v)
 	}
-	if t.LangVendor != "" {
-		tags = append(tags, "lang_vendor:"+t.LangVendor)
+	if v := t.LangVendor; v != "" {
+		tags = append(tags, "lang_vendor:"+v)
 	}
-	if t.Interpreter != "" {
-		tags = append(tags, "interpreter:"+t.Interpreter)
+	if v := t.Interpreter; v != "" {
+		tags = append(tags, "interpreter:"+v)
 	}
-	if t.TracerVersion != "" {
-		tags = append(tags, "tracer_version:"+t.TracerVersion)
+	if v := t.TracerVersion; v != "" {
+		tags = append(tags, "tracer_version:"+v)
+	}
+	if v := t.Hostname; v != "" {
+		tags = append(tags, "hostname:"+v)
 	}
 
 	return tags

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -6,10 +6,19 @@
 package info
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestTagsToArray(t *testing.T) {
+	if got, want := (&Tags{Lang: "go", Hostname: "localhost"}).toArray(),
+		[]string{"lang:go", "hostname:localhost"}; !reflect.DeepEqual(got, want) {
+		t.Fatal(want, "!=", got)
+	}
+
+}
 
 func TestTracesDropped(t *testing.T) {
 	s := TracesDropped{


### PR DESCRIPTION
This change adds a new hostname tag along with language and tracer
version information. It will help identify which hosts are sending
traces.