### PR TITLE
[release] 6.20.1, 7.20.1 entries and prelude

### DIFF
--- a/release.json
+++ b/release.json
@@ -13,6 +13,20 @@
         "JMXFETCH_VERSION": "0.36.2",
         "JMXFETCH_HASH": "f782b9a5e9dffbce3463245562858fd8fed1508269222e8bebeefd3f865d10d8"
     },
+    "6.20.1": {
+        "INTEGRATIONS_CORE_VERSION": "7.20.1",
+        "OMNIBUS_SOFTWARE_VERSION": "7.20.0",
+        "OMNIBUS_RUBY_VERSION": "7.20.0",
+        "JMXFETCH_VERSION": "0.36.2",
+        "JMXFETCH_HASH": "f782b9a5e9dffbce3463245562858fd8fed1508269222e8bebeefd3f865d10d8"
+    },
+    "7.20.1": {
+        "INTEGRATIONS_CORE_VERSION": "7.20.1",
+        "OMNIBUS_SOFTWARE_VERSION": "7.20.0",
+        "OMNIBUS_RUBY_VERSION": "7.20.0",
+        "JMXFETCH_VERSION": "0.36.2",
+        "JMXFETCH_HASH": "f782b9a5e9dffbce3463245562858fd8fed1508269222e8bebeefd3f865d10d8"
+    },
     "6.20.0": {
         "INTEGRATIONS_CORE_VERSION": "7.20.0",
         "OMNIBUS_SOFTWARE_VERSION": "7.20.0",

--- a/releasenotes/notes/prelude-release-7.20.1-cbecc819364435f2.yaml
+++ b/releasenotes/notes/prelude-release-7.20.1-cbecc819364435f2.yaml
@@ -1,0 +1,5 @@
+prelude:
+    |
+    Release on: 2020-06-11
+
+    - Please refer to the `7.20.1 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7201>`_ for the list of changes on the Core Checks


### PR DESCRIPTION
### What does this PR do?

Adds build entries for 6.20.1 and 7.20.1.

### Motivation

New release fixing badly renamed default yaml configuration for the disk check. Fixed here: https://github.com/DataDog/integrations-core/pull/6880

### Additional Notes

Anything else we should know when reviewing?
