### PR TITLE
Add device_name tag in iostats_pdh if device is not drive letter

### DIFF
--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -123,7 +123,8 @@ func (c *IOCheck) Run() error {
 			tagbuff.WriteString(inst)
 			tags := []string{tagbuff.String()}
 
-			if matched, _ := regexp.MatchString(`^[A-z]:`, inst); !matched {
+			if !driveLetterPattern.MatchString(inst) {
+				// if this is not a drive letter, add device_name to tags
 				tags = append(tags, "device_name:"+inst)
 			}
 

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -122,6 +122,11 @@ func (c *IOCheck) Run() error {
 			}
 			tagbuff.WriteString(inst)
 			tags := []string{tagbuff.String()}
+
+			if matched, _ := regexp.MatchString(`^[A-z]:`, inst); !matched {
+				tags = append(tags, "device_name:"+inst)
+			}
+
 			if cname == "Disk Write Bytes/sec" || cname == "Disk Read Bytes/sec" {
 				val /= 1024
 			}

--- a/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
@@ -72,19 +72,19 @@ func TestIoCheckWindows(t *testing.T) {
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
 	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:C:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:C:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:C:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:C:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.avg_q_sz", 5.222, "", []string{"device:C:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(1)
 
 	mock.On("Commit").Return().Times(1)
 	ioCheck.Run()
@@ -154,35 +154,35 @@ func TestIoCheckInstanceAdded(t *testing.T) {
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
 	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:C:"}).Return().Times(2)
-	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1"}).Return().Times(2)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
 
 	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:C:"}).Return().Times(2)
-	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1"}).Return().Times(2)
+	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
 
 	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:C:"}).Return().Times(2)
-	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1"}).Return().Times(2)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
 
 	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:C:"}).Return().Times(2)
-	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1"}).Return().Times(2)
+	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
 
 	mock.On("Gauge", "system.io.avg_q_sz", 5.222, "", []string{"device:C:"}).Return().Times(2)
-	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1"}).Return().Times(2)
+	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(2)
 
 	// and the checks for the added instance
 	mock.On("Gauge", "system.io.wkb_s", 1.444/1024, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.wkb_s", 1.555/1024, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.555/1024, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.w_s", 2.444, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.w_s", 2.555, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.w_s", 2.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.rkb_s", 3.444/1024, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.rkb_s", 3.555/1024, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.555/1024, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.r_s", 4.444, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.r_s", 4.555, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.r_s", 4.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.avg_q_sz", 5.444, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.avg_q_sz", 5.555, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.avg_q_sz", 5.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 	mock.On("Commit").Return().Times(2)
 	ioCheck.Run()
 	ioCheck.Run()
@@ -213,35 +213,35 @@ func TestIoCheckInstanceRemoved(t *testing.T) {
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
 	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:C:"}).Return().Times(3)
-	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1"}).Return().Times(3)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
 
 	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:C:"}).Return().Times(3)
-	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1"}).Return().Times(3)
+	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
 
 	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:C:"}).Return().Times(3)
-	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1"}).Return().Times(3)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
 
 	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:C:"}).Return().Times(3)
-	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1"}).Return().Times(3)
+	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
 
 	mock.On("Gauge", "system.io.avg_q_sz", 5.222, "", []string{"device:C:"}).Return().Times(3)
-	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1"}).Return().Times(3)
+	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1", "device_name:HarddiskVolume1"}).Return().Times(3)
 
 	// and the checks for the added instance
 	mock.On("Gauge", "system.io.wkb_s", 1.444/1024, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.wkb_s", 1.555/1024, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.555/1024, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.w_s", 2.444, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.w_s", 2.555, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.w_s", 2.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.rkb_s", 3.444/1024, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.rkb_s", 3.555/1024, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.555/1024, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.r_s", 4.444, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.r_s", 4.555, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.r_s", 4.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.avg_q_sz", 5.444, "", []string{"device:Y:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.avg_q_sz", 5.555, "", []string{"device:HarddiskVolume2"}).Return().Times(1)
+	mock.On("Gauge", "system.io.avg_q_sz", 5.555, "", []string{"device:HarddiskVolume2", "device_name:HarddiskVolume2"}).Return().Times(1)
 	mock.On("Commit").Return().Times(3)
 	ioCheck.Run()
 	pdhtest.RemoveCounterInstance("LogicalDisk", "Y:")

--- a/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
@@ -112,19 +112,19 @@ lowercase_device_tag: true
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
 	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:c:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:harddiskvolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:c:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:harddiskvolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:c:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:harddiskvolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:c:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:harddiskvolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
 
 	mock.On("Gauge", "system.io.avg_q_sz", 5.222, "", []string{"device:c:"}).Return().Times(1)
-	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:harddiskvolume1"}).Return().Times(1)
+	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:harddiskvolume1", "device_name:harddiskvolume1"}).Return().Times(1)
 
 	mock.On("Commit").Return().Times(1)
 	ioCheck.Run()

--- a/releasenotes/notes/add-device_name-tag-iostats_pdh-8bc652571e2d33f8.yaml
+++ b/releasenotes/notes/add-device_name-tag-iostats_pdh-8bc652571e2d33f8.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add missing ``device_name`` tag in iostats_pdh


### PR DESCRIPTION
### What does this PR do?

When we are browsing devices, there is drive letters and drive identifiers. When it is a drive identifier, adds a device_name tag to match.

### Motivation

Moving from heterogeneous `device` tags to uniform `device_name` tags.

### Additional Notes

I'd like @derekwbrown 's opinion on this as I'm not sure of what will happen when we will remove `device` tags later.