### PR TITLE
[circleci] Move shellcheck job to CircleCI & add pre-commit hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,24 @@ jobs:
           name: run filename linting
           command: inv -e lint-filenames
 
+  shell_linting:
+    <<: *job_template
+    steps:
+      - restore_cache: *restore_source
+      - restore_cache: *restore_deps
+      - run:
+          name: Install shellcheck
+          command: inv -e install-shellcheck
+      - run:
+          name: Print shellcheck version
+          command: shellcheck --version
+      - run:
+          name: Run shellcheck
+          #Excludes:
+          #SC2028: echo may not expand escape sequences. Use printf.
+          #SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".
+          command: shellcheck --severity=info -e SC2059 -e SC2028 --shell=bash ./cmd/**/*.sh ./omnibus/package-scripts/*/*
+
   docker_tests:
     <<: *job_template
     steps:
@@ -225,6 +243,9 @@ workflows:
           requires:
             - dependencies
       - filename_linting:
+          requires:
+            - dependencies
+      - shell_linting:
           requires:
             - dependencies
       - docker_tests:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -408,18 +408,6 @@ run_go_tidy_check:
     - go mod tidy
     - git diff-files --exit-code go.mod || (echo "go.mod is out of sync with project imports. Please run 'inv deps' and commit the changes on go.mod/go.sum." && false)
 
-run_shell_script_lint:
-  stage: source_test
-  needs: ["fail_on_non_triggered_tag"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/mars_jenkins_scripts:$DATADOG_AGENT_BUILDERS
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - shellcheck --version
-    #Excludes:
-    #SC2028: echo may not expand escape sequences. Use printf.
-    #SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".
-    - shellcheck --severity=info -e SC2059 -e SC2028 --shell=bash ./cmd/**/*.sh ./omnibus/package-scripts/*/*
-
 #
 # binary_build
 #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+default_language_version:
+  python: 3.8.3
+
+repos:
+- repo: https://github.com/jumanjihouse/pre-commit-hooks
+  rev: 2.1.1
+  hooks:
+    - id: shellcheck
+      args: ["--severity=info", "-e", "SC2059", "-e", "SC2028"]

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -173,3 +173,22 @@ To generate it (using the `invoke rtloader.generate-doc` command), you'll need t
 Alternatively, you can use already-compiled Doxygen binaries from [here](http://www.doxygen.nl/download.html).
 
 To get the dependency graphs, you may also need to install the `dot` executable from [graphviz](http://www.graphviz.org/) and add it to your `$PATH`.
+
+## Pre-commit hooks
+
+It is optional but recommended to install `pre-commit` to run a number of checks done by the CI locally.
+To install it, run:
+
+```sh
+pip install pre-commit
+pre-commit install
+```
+
+The `shellcheck` pre-commit hook requires having the `shellcheck` binary installed and in your `$PATH`.
+To install it, run:
+
+```sh
+inv install-shellcheck --destination <path>
+```
+
+(by default, the shellcheck binary is installed in `/usr/local/bin`).

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -27,7 +27,7 @@ from . import (agent,
 
 
 from .go import fmt, lint, vet, cyclo, golangci_lint, deps, lint_licenses, generate_licenses, reset, generate
-from .test import test, integration_tests, lint_teamassignment, lint_releasenote, lint_milestone, lint_filenames, e2e_tests, make_kitchen_gitlab_yml, check_gitlab_broken_dependencies
+from .test import test, integration_tests, lint_teamassignment, lint_releasenote, lint_milestone, lint_filenames, e2e_tests, make_kitchen_gitlab_yml, check_gitlab_broken_dependencies, install_shellcheck
 from .build_tags import audit_tag_impact
 
 # the root namespace
@@ -54,6 +54,7 @@ ns.add_task(e2e_tests)
 ns.add_task(make_kitchen_gitlab_yml)
 ns.add_task(check_gitlab_broken_dependencies)
 ns.add_task(generate)
+ns.add_task(install_shellcheck)
 
 # add namespaced tasks to the root
 ns.add_collection(agent)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -442,7 +442,7 @@ def install_shellcheck(ctx, version="0.7.0", destination="/usr/local/bin"):
 
     if sys.platform == 'win32':
         print("shellcheck is not supported on Windows")
-        return 1
+        raise Exit(code=1)
     if sys.platform.startswith('darwin'):
         platform = "darwin"
     if sys.platform.startswith('linux'):

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -446,4 +446,5 @@ def install_shellcheck(ctx, version="0.7.0", destination="/usr/local/bin"):
 
     ctx.run("wget -qO- \"https://storage.googleapis.com/shellcheck/shellcheck-v{sc_version}.{platform}.x86_64.tar.xz\" | tar -xJv -C /tmp"
         .format(sc_version=version, platform=sys.platform))
-    ctx.run("cp \"/tmp/shellcheck-v{sc_version}/shellcheck\" /usr/local/bin/ && rm -rf \"/tmp/shellcheck-v{sc_version}\"".format(sc_version=version))
+    ctx.run("cp \"/tmp/shellcheck-v{sc_version}/shellcheck\" /usr/local/bin/ && rm -rf \"/tmp/shellcheck-v{sc_version}\""
+        .format(sc_version=version))

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -450,5 +450,7 @@ def install_shellcheck(ctx, version="0.7.0", destination="/usr/local/bin"):
 
     ctx.run("wget -qO- \"https://storage.googleapis.com/shellcheck/shellcheck-v{sc_version}.{platform}.x86_64.tar.xz\" | tar -xJv -C /tmp"
         .format(sc_version=version, platform=platform))
-    ctx.run("cp \"/tmp/shellcheck-v{sc_version}/shellcheck\" /usr/local/bin/ && rm -rf \"/tmp/shellcheck-v{sc_version}\""
+    ctx.run("cp \"/tmp/shellcheck-v{sc_version}/shellcheck\" {destination}"
+        .format(sc_version=version, destination=destination))
+    ctx.run("rm -rf \"/tmp/shellcheck-v{sc_version}\""
         .format(sc_version=version))

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -446,4 +446,4 @@ def install_shellcheck(ctx, version="0.7.0", destination="/usr/local/bin"):
 
     ctx.run("wget -qO- \"https://storage.googleapis.com/shellcheck/shellcheck-v{sc_version}.{platform}.x86_64.tar.xz\" | tar -xJv"
         .format(sc_version=version, platform=sys.platform))
-    ctx.run("cp \"shellcheck-v{sc_version}/shellcheck\" /usr/local/bin/ && rm -rf \"shellcheck-v{sc_version}/shellcheck\"".format(sc_version=version))
+    ctx.run("cp \"shellcheck-v{sc_version}/shellcheck\" /usr/local/bin/ && rm -rf \"shellcheck-v{sc_version}\"".format(sc_version=version))

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -432,3 +432,18 @@ def check_gitlab_broken_dependencies(ctx):
                 for need in needed:
                     if is_unwanted(data[need], version):
                         print("{} needs on {} but it won't be built for A{}".format(k, need, version))
+
+@task
+def install_shellcheck(ctx, version="0.7.0", destination="/usr/local/bin"):
+    """
+    Installs the requested version of shellcheck in the specified folder (by default /usr/local/bin).
+    Required to run the shellcheck pre-commit hook.
+    """
+
+    if sys.platform == 'win32':
+        print("shellcheck is not supported on Windows")
+        return 1
+
+    ctx.run("wget -qO- \"https://storage.googleapis.com/shellcheck/shellcheck-v{sc_version}.{platform}.x86_64.tar.xz\" | tar -xJv"
+        .format(sc_version=version, platform=sys.platform))
+    ctx.run("cp \"shellcheck-v{sc_version}/shellcheck\" /usr/local/bin/ && rm -rf \"shellcheck-v{sc_version}/shellcheck\"".format(sc_version=version))

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -444,6 +444,6 @@ def install_shellcheck(ctx, version="0.7.0", destination="/usr/local/bin"):
         print("shellcheck is not supported on Windows")
         return 1
 
-    ctx.run("wget -qO- \"https://storage.googleapis.com/shellcheck/shellcheck-v{sc_version}.{platform}.x86_64.tar.xz\" | tar -xJv"
+    ctx.run("wget -qO- \"https://storage.googleapis.com/shellcheck/shellcheck-v{sc_version}.{platform}.x86_64.tar.xz\" | tar -xJv -C /tmp"
         .format(sc_version=version, platform=sys.platform))
-    ctx.run("cp \"shellcheck-v{sc_version}/shellcheck\" /usr/local/bin/ && rm -rf \"shellcheck-v{sc_version}\"".format(sc_version=version))
+    ctx.run("cp \"/tmp/shellcheck-v{sc_version}/shellcheck\" /usr/local/bin/ && rm -rf \"/tmp/shellcheck-v{sc_version}\"".format(sc_version=version))

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -443,8 +443,12 @@ def install_shellcheck(ctx, version="0.7.0", destination="/usr/local/bin"):
     if sys.platform == 'win32':
         print("shellcheck is not supported on Windows")
         return 1
+    if sys.platform.startswith('darwin'):
+        platform = "darwin"
+    if sys.platform.startswith('linux'):
+        platform = "linux"
 
     ctx.run("wget -qO- \"https://storage.googleapis.com/shellcheck/shellcheck-v{sc_version}.{platform}.x86_64.tar.xz\" | tar -xJv -C /tmp"
-        .format(sc_version=version, platform=sys.platform))
+        .format(sc_version=version, platform=platform))
     ctx.run("cp \"/tmp/shellcheck-v{sc_version}/shellcheck\" /usr/local/bin/ && rm -rf \"/tmp/shellcheck-v{sc_version}\""
         .format(sc_version=version))


### PR DESCRIPTION
### What does this PR do?

Moves shell linting job to CircleCI.
Adds invoke task to install shellcheck.
Adds pre-commit hook that uses shellcheck to check the modified shell files' linting.

### Motivation

Make shell linting results available in public PRs.
Add pre-commit hook for easier development.