### PR TITLE
trace/obfuscator: refactor to simplify obfuscator config

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -78,7 +78,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 		EventProcessor:     newEventProcessor(conf),
 		TraceWriter:        writer.NewTraceWriter(conf, out),
 		StatsWriter:        writer.NewStatsWriter(conf, statsChan),
-		obfuscator:         newObfuscator(conf.Obfuscation),
+		obfuscator:         obfuscate.NewObfuscator(conf.Obfuscation),
 		In:                 in,
 		Out:                out,
 		conf:               conf,
@@ -316,25 +316,4 @@ func newEventProcessor(conf *config.AgentConfig) *event.Processor {
 	}
 
 	return event.NewProcessor(extractors, conf.MaxEPS)
-}
-
-func newObfuscator(cfg *config.ObfuscationConfig) *obfuscate.Obfuscator {
-	if cfg == nil {
-		return obfuscate.NewObfuscator(nil)
-	}
-	return obfuscate.NewObfuscator(&obfuscate.Config{
-		ES: obfuscate.JSONSettings{
-			Enabled:    cfg.ES.Enabled,
-			KeepValues: cfg.ES.KeepValues,
-		},
-		Mongo: obfuscate.JSONSettings{
-			Enabled:    cfg.Mongo.Enabled,
-			KeepValues: cfg.Mongo.KeepValues,
-		},
-		RemoveQueryString: cfg.HTTP.RemoveQueryString,
-		RemovePathDigits:  cfg.HTTP.RemovePathDigits,
-		RemoveStackTraces: cfg.RemoveStackTraces,
-		Redis:             cfg.Redis.Enabled,
-		Memcached:         cfg.Memcached.Enabled,
-	})
 }

--- a/pkg/trace/obfuscate/http.go
+++ b/pkg/trace/obfuscate/http.go
@@ -18,7 +18,7 @@ func (o *Obfuscator) obfuscateHTTP(span *pb.Span) {
 	if span.Meta == nil {
 		return
 	}
-	if !o.opts.RemoveQueryString && !o.opts.RemovePathDigits {
+	if !o.opts.HTTP.RemoveQueryString && !o.opts.HTTP.RemovePathDigits {
 		// nothing to do
 		return
 	}
@@ -34,11 +34,11 @@ func (o *Obfuscator) obfuscateHTTP(span *pb.Span) {
 		span.Meta[k] = "?"
 		return
 	}
-	if o.opts.RemoveQueryString && u.RawQuery != "" {
+	if o.opts.HTTP.RemoveQueryString && u.RawQuery != "" {
 		u.ForceQuery = true // add the '?'
 		u.RawQuery = ""
 	}
-	if o.opts.RemovePathDigits {
+	if o.opts.HTTP.RemovePathDigits {
 		segs := strings.Split(u.Path, "/")
 		var changed bool
 		for i, seg := range segs {

--- a/pkg/trace/obfuscate/http_test.go
+++ b/pkg/trace/obfuscate/http_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,9 @@ func TestObfuscateHTTP(t *testing.T) {
 	}, nil))
 
 	t.Run("query", func(t *testing.T) {
-		conf := &Config{RemoveQueryString: true}
+		conf := &config.ObfuscationConfig{HTTP: config.HTTPObfuscationConfig{
+			RemoveQueryString: true,
+		}}
 		for ti, tt := range []inOutTest{
 			{
 				in:  "http://foo.com/",
@@ -58,7 +61,9 @@ func TestObfuscateHTTP(t *testing.T) {
 	})
 
 	t.Run("digits", func(t *testing.T) {
-		conf := &Config{RemovePathDigits: true}
+		conf := &config.ObfuscationConfig{HTTP: config.HTTPObfuscationConfig{
+			RemovePathDigits: true,
+		}}
 		for ti, tt := range []inOutTest{
 			{
 				in:  "http://foo.com/",
@@ -102,7 +107,10 @@ func TestObfuscateHTTP(t *testing.T) {
 	})
 
 	t.Run("both", func(t *testing.T) {
-		conf := &Config{RemoveQueryString: true, RemovePathDigits: true}
+		conf := &config.ObfuscationConfig{HTTP: config.HTTPObfuscationConfig{
+			RemoveQueryString: true,
+			RemovePathDigits:  true,
+		}}
 		for ti, tt := range []inOutTest{
 			{
 				in:  "http://foo.com/",
@@ -140,18 +148,20 @@ func TestObfuscateHTTP(t *testing.T) {
 	t.Run("wrong-type", func(t *testing.T) {
 		assert := assert.New(t)
 		span := pb.Span{Type: "web_server", Meta: map[string]string{"http.url": testURL}}
-		NewObfuscator(&Config{
-			RemoveQueryString: true,
-			RemovePathDigits:  true,
+		NewObfuscator(&config.ObfuscationConfig{
+			HTTP: config.HTTPObfuscationConfig{
+				RemoveQueryString: true,
+				RemovePathDigits:  true,
+			},
 		}).Obfuscate(&span)
 		assert.Equal(testURL, span.Meta["http.url"])
 	})
 }
 
 // testHTTPObfuscation tests that the given input results in the given output using the passed configuration.
-func testHTTPObfuscation(tt *inOutTest, conf *Config) func(t *testing.T) {
+func testHTTPObfuscation(tt *inOutTest, conf *config.ObfuscationConfig) func(t *testing.T) {
 	return func(t *testing.T) {
-		var cfg Config
+		var cfg config.ObfuscationConfig
 		if conf != nil {
 			cfg = *conf
 		}

--- a/pkg/trace/obfuscate/json.go
+++ b/pkg/trace/obfuscate/json.go
@@ -8,17 +8,9 @@ package obfuscate
 import (
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 )
-
-// JSONSettings specifies the behaviour of the JSON obfuscator.
-type JSONSettings struct {
-	// Enabled will specify whether obfuscation should be enabled.
-	Enabled bool
-
-	// KeepValues specifies a set of keys for which their values will not be obfuscated.
-	KeepValues []string
-}
 
 // obfuscateJSON obfuscates the given span's tag using the given obfuscator. If the obfuscator is
 // nil it is considered disabled.
@@ -45,7 +37,7 @@ type jsonObfuscator struct {
 	keepDepth int  // the depth at which we've stopped obfuscating
 }
 
-func newJSONObfuscator(cfg *JSONSettings) *jsonObfuscator {
+func newJSONObfuscator(cfg *config.JSONObfuscationConfig) *jsonObfuscator {
 	keepValue := make(map[string]bool, len(cfg.KeepValues))
 	for _, v := range cfg.KeepValues {
 		keepValue[v] = true

--- a/pkg/trace/obfuscate/json_test.go
+++ b/pkg/trace/obfuscate/json_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,7 +80,7 @@ func TestObfuscateJSON(t *testing.T) {
 	runTest := func(s *xmlObfuscateTest) func(*testing.T) {
 		return func(t *testing.T) {
 			assert := assert.New(t)
-			cfg := &JSONSettings{KeepValues: s.KeepValues}
+			cfg := &config.JSONObfuscationConfig{KeepValues: s.KeepValues}
 			out, err := newJSONObfuscator(cfg).obfuscate([]byte(s.In))
 			if !s.DontNormalize {
 				assert.NoError(err)
@@ -98,7 +99,7 @@ func TestObfuscateJSON(t *testing.T) {
 }
 
 func BenchmarkObfuscateJSON(b *testing.B) {
-	cfg := &JSONSettings{KeepValues: []string{"highlight"}}
+	cfg := &config.JSONObfuscationConfig{KeepValues: []string{"highlight"}}
 	if len(jsonSuite) == 0 {
 		b.Fatal("no test suite loaded")
 	}

--- a/pkg/trace/obfuscate/obfuscate.go
+++ b/pkg/trace/obfuscate/obfuscate.go
@@ -11,41 +11,16 @@ import (
 	"bytes"
 	"sync/atomic"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 )
 
 // Obfuscator quantizes and obfuscates spans. The obfuscator is not safe for
 // concurrent use.
 type Obfuscator struct {
-	opts  *Config
+	opts  *config.ObfuscationConfig
 	es    *jsonObfuscator // nil if disabled
 	mongo *jsonObfuscator // nil if disabled
-}
-
-// Config specifies the obfuscator configuration.
-type Config struct {
-	// ES holds the obfuscation configuration for ElasticSearch bodies.
-	ES JSONSettings
-
-	// Mongo holds the obfuscation configuration for MongoDB queries.
-	Mongo JSONSettings
-
-	// RemoveQueryStrings specifies whether query strings should be removed from HTTP URLs.
-	RemoveQueryString bool
-
-	// RemovePathDigits specifies whether digits in HTTP path segments to be removed.
-	RemovePathDigits bool
-
-	// RemoveStackTraces specifies whether stack traces should be removed. More specifically,
-	// the "error.stack" tag values will be cleared from spans.
-	RemoveStackTraces bool
-
-	// Redis enables obfuscatiion of the "redis.raw_command" tag for spans of type "redis".
-	Redis bool
-
-	// Redis enables obfuscatiion of the "memcached.command" tag for spans of type "memcached".
-	Memcached bool
-
 	// sqlLiteralEscapes reports whether we should treat escape characters literally or as escape characters.
 	// A non-zero value means 'yes'. Different SQL engines behave in different ways and the tokenizer needs
 	// to be generic.
@@ -56,21 +31,21 @@ type Config struct {
 // SetSQLLiteralEscapes sets whether or not escape characters should be treated literally by the SQL obfuscator.
 func (o *Obfuscator) SetSQLLiteralEscapes(ok bool) {
 	if ok {
-		atomic.StoreInt32(&o.opts.sqlLiteralEscapes, 1)
+		atomic.StoreInt32(&o.sqlLiteralEscapes, 1)
 	} else {
-		atomic.StoreInt32(&o.opts.sqlLiteralEscapes, 0)
+		atomic.StoreInt32(&o.sqlLiteralEscapes, 0)
 	}
 }
 
 // SQLLiteralEscapes reports whether escape characters should be treated literally by the SQL obfuscator.
 func (o *Obfuscator) SQLLiteralEscapes() bool {
-	return atomic.LoadInt32(&o.opts.sqlLiteralEscapes) == 1
+	return atomic.LoadInt32(&o.sqlLiteralEscapes) == 1
 }
 
-// NewObfuscator creates a new Obfuscator.
-func NewObfuscator(cfg *Config) *Obfuscator {
+// NewObfuscator creates a new obfuscator from the provided config
+func NewObfuscator(cfg *config.ObfuscationConfig) *Obfuscator {
 	if cfg == nil {
-		cfg = new(Config)
+		cfg = new(config.ObfuscationConfig)
 	}
 	o := Obfuscator{opts: cfg}
 	if cfg.ES.Enabled {
@@ -90,11 +65,11 @@ func (o *Obfuscator) Obfuscate(span *pb.Span) {
 		o.obfuscateSQL(span)
 	case "redis":
 		o.quantizeRedis(span)
-		if o.opts.Redis {
+		if o.opts.Redis.Enabled {
 			o.obfuscateRedis(span)
 		}
 	case "memcached":
-		if o.opts.Memcached {
+		if o.opts.Memcached.Enabled {
 			o.obfuscateMemcached(span)
 		}
 	case "web", "http":

--- a/releasenotes/notes/refactor-trace-obfuscator-config-3da22d15bd9ede0a.yaml
+++ b/releasenotes/notes/refactor-trace-obfuscator-config-3da22d15bd9ede0a.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Refactor & simplify APM trace obfuscator config


### PR DESCRIPTION
### What does this PR do?

Remove unnecessary duplicate structs:
* `obfuscate.Config` removed in favor of `config.ObfuscatorConfig`
* `obfuscate.JSONSettings` removed in favor of `config.JSONObfuscatorConfig`

Now it's no longer necessary to copy/convert from one struct to the other as was being done in the agent.

### Motivation

Simplify obfuscator config & initialization as we are now using the obfuscator from python checks and need a way to use the same configuration as the obfuscator instance in the trace agent. See upcoming PR https://github.com/DataDog/datadog-agent/pull/5692.

### Describe your test plan

There are no functional changes so as long as tests pass we should be good. 
