### PR TITLE
Support kube_namespace based exclusion for docker and containerd checks

### DIFF
--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -255,8 +255,8 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 }
 
 func isExcluded(ctn containers.Container, fil *ddContainers.Filter) bool {
-	// The container name is not available in Containerd, we only rely on image name based exclusion
-	return fil.IsExcluded("", ctn.Image, "")
+	// The container name is not available in Containerd, we only rely on image name and kube namespace based exclusion
+	return fil.IsExcluded("", ctn.Image, ctn.Labels["io.kubernetes.pod.namespace"])
 }
 
 func convertTasktoMetrics(metricTask *containerdTypes.Metric) (*v1.Metrics, error) {

--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -226,7 +226,7 @@ func (d *DockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*containers.C
 			log.Warnf("Can't resolve image name %s: %s", c.Image, err)
 		}
 
-		excluded := d.cfg.filter.IsExcluded(c.Names[0], image, "")
+		excluded := d.cfg.filter.IsExcluded(c.Names[0], image, c.Labels["io.kubernetes.pod.namespace"])
 		if excluded && !cfg.FlagExcluded {
 			continue
 		}

--- a/releasenotes/notes/exclude-runtime-metrics-by-kube-ns-b60d1c43aef11a95.yaml
+++ b/releasenotes/notes/exclude-runtime-metrics-by-kube-ns-b60d1c43aef11a95.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Docker and Containerd checks now support filtering containers by kube_namespace.


### PR DESCRIPTION
### What does this PR do?

Allow filtering containers in `docker` and `container` checks using `kube_namespace`

### Motivation

As `kube_namespace` is used to filter AD based checks, core checks also need to support it when possible

### Additional Notes

We rely on the container label `io.kubernetes.pod.namespace` to get the container's namespace

### Describe your test plan

`docker` and `containerd` metrics (e.g `containerd.cpu.*` and `docker.cpu.*`) shouldn't be submitted for the filtered containers