### PR TITLE
[pkg/status] Fix Cluster Agent status output

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -33,42 +33,21 @@ var timeFormat = "2006-01-02 15:04:05.000000 MST"
 
 // GetStatus grabs the status from expvar and puts it into a map
 func GetStatus() (map[string]interface{}, error) {
-	stats := make(map[string]interface{})
-	stats, err := expvarStats(stats)
+	stats, err := getCommonStatus()
 	if err != nil {
-		log.Errorf("Error Getting ExpVar Stats: %v", err)
+		return nil, err
 	}
 
-	stats["version"] = version.AgentVersion
-	stats["flavor"] = config.AgentFlavor
-	hostnameData, err := util.GetHostnameData()
-
-	var metadata *host.Payload
-	if err != nil {
-		log.Errorf("Error grabbing hostname for status: %v", err)
-		metadata = host.GetPayloadFromCache(util.HostnameData{Hostname: "unknown", Provider: "unknown"})
-	} else {
-		metadata = host.GetPayloadFromCache(hostnameData)
-	}
-	stats["metadata"] = metadata
-
+	stats["config"] = getPartialConfig()
+	metadata := stats["metadata"].(*host.Payload)
 	hostTags := make([]string, 0, len(metadata.HostTags.System)+len(metadata.HostTags.GoogleCloudPlatform))
 	hostTags = append(hostTags, metadata.HostTags.System...)
 	hostTags = append(hostTags, metadata.HostTags.GoogleCloudPlatform...)
 	stats["hostTags"] = hostTags
 
-	stats["config"] = getPartialConfig()
-	stats["conf_file"] = config.Datadog.ConfigFileUsed()
-
-	stats["pid"] = os.Getpid()
-	stats["go_version"] = runtime.Version()
 	pythonVersion := host.GetPythonVersion()
 	stats["python_version"] = strings.Split(pythonVersion, " ")[0]
-	stats["agent_start"] = startTime.Format(timeFormat)
 	stats["hostinfo"] = host.GetStatusInformation()
-	stats["build_arch"] = runtime.GOARCH
-	now := time.Now()
-	stats["time"] = now.Format(timeFormat)
 
 	stats["JMXStatus"] = GetJMXStatus()
 	stats["JMXStartupError"] = GetJMXStartupError()
@@ -148,30 +127,12 @@ func GetCheckStatus(c check.Check, cs *check.Stats) ([]byte, error) {
 
 // GetDCAStatus grabs the status from expvar and puts it into a map
 func GetDCAStatus() (map[string]interface{}, error) {
-	stats := make(map[string]interface{})
-	stats, err := expvarStats(stats)
+	stats, err := getCommonStatus()
 	if err != nil {
-		log.Errorf("Error Getting ExpVar Stats: %v", err)
+		return nil, err
 	}
+
 	stats["config"] = getDCAPartialConfig()
-	stats["conf_file"] = config.Datadog.ConfigFileUsed()
-	stats["version"] = version.AgentVersion
-	stats["flavor"] = config.AgentFlavor
-	stats["pid"] = os.Getpid()
-	hostnameData, err := util.GetHostnameData()
-	if err != nil {
-		log.Errorf("Error grabbing hostname for status: %v", err)
-		stats["metadata"] = host.GetPayloadFromCache(util.HostnameData{Hostname: "unknown", Provider: "unknown"})
-	} else {
-		stats["metadata"] = host.GetPayloadFromCache(hostnameData)
-	}
-
-	stats["go_version"] = runtime.Version()
-	stats["agent_start"] = startTime.Format(timeFormat)
-	stats["build_arch"] = runtime.GOARCH
-
-	now := time.Now()
-	stats["time"] = now.Format(timeFormat)
 	stats["leaderelection"] = getLeaderElectionDetails()
 
 	endpointsInfos, err := getEndpointsInfos()
@@ -259,6 +220,37 @@ func getEndpointsInfos() (map[string]interface{}, error) {
 	}
 
 	return endpointsInfos, nil
+}
+
+// getCommonStatus grabs the status from expvar and puts it into a map.
+// It gets the status elements common to all Agent flavors.
+func getCommonStatus() (map[string]interface{}, error) {
+	stats := make(map[string]interface{})
+	stats, err := expvarStats(stats)
+	if err != nil {
+		log.Errorf("Error Getting ExpVar Stats: %v", err)
+	}
+
+	stats["version"] = version.AgentVersion
+	stats["flavor"] = config.AgentFlavor
+	hostnameData, err := util.GetHostnameData()
+
+	if err != nil {
+		log.Errorf("Error grabbing hostname for status: %v", err)
+		stats["metadata"] = host.GetPayloadFromCache(util.HostnameData{Hostname: "unknown", Provider: "unknown"})
+	} else {
+		stats["metadata"] = host.GetPayloadFromCache(hostnameData)
+	}
+
+	stats["conf_file"] = config.Datadog.ConfigFileUsed()
+	stats["pid"] = os.Getpid()
+	stats["go_version"] = runtime.Version()
+	stats["agent_start"] = startTime.Format(timeFormat)
+	stats["build_arch"] = runtime.GOARCH
+	now := time.Now()
+	stats["time"] = now.Format(timeFormat)
+
+	return stats, nil
 }
 
 func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -156,6 +156,7 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	stats["config"] = getDCAPartialConfig()
 	stats["conf_file"] = config.Datadog.ConfigFileUsed()
 	stats["version"] = version.AgentVersion
+	stats["flavor"] = config.AgentFlavor
 	stats["pid"] = os.Getpid()
 	hostnameData, err := util.GetHostnameData()
 	if err != nil {
@@ -164,6 +165,11 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	} else {
 		stats["metadata"] = host.GetPayloadFromCache(hostnameData)
 	}
+
+	stats["go_version"] = runtime.Version()
+	stats["agent_start"] = startTime.Format(timeFormat)
+	stats["build_arch"] = runtime.GOARCH
+
 	now := time.Now()
 	stats["time"] = now.Format(timeFormat)
 	stats["leaderelection"] = getLeaderElectionDetails()

--- a/releasenotes/notes/Fix-cluster-agent-status-command-3808d84571f703d5.yaml
+++ b/releasenotes/notes/Fix-cluster-agent-status-command-3808d84571f703d5.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix missing values from cluster-agent status command.


### PR DESCRIPTION
### What does this PR do?

- Refactor `GetStatus` and `GetDCAStatus` extracting common part for all flavors
- As a consequence, add information currently missing from the `agent status` command for the cluster agent.

### Motivation

The output of the `status` command for the latest version of the Cluster Agent is missing certain information:

```
  Agent start: <no value>
  Pid: 1
  Go Version: <no value>
  Build arch: <no value>
```

This information was missing because of the duplication in `GetStatus` and `GetDCAStatus`, where in previous PRs like #3675 or #5701, some information was added to the former but not the latter function.

To prevent this from happening again the code is split into a common function `getCommonStatus` which is called from both `GetStatus` and `GetDCAStatus` and has the missing values from the previously mentioned PRs.

### Describe your test plan

- Ran the `status` command in both the full agent and the cluster-agent and verify the output is correct and no longer missing values.
