### PR TITLE
Bump JMXFetch to 0.37.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -3,15 +3,15 @@
         "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
-        "JMXFETCH_VERSION": "0.36.2",
-        "JMXFETCH_HASH": "f782b9a5e9dffbce3463245562858fd8fed1508269222e8bebeefd3f865d10d8"
+        "JMXFETCH_VERSION": "0.37.0",
+        "JMXFETCH_HASH": "468f104a052ae078fd7fca43195a1a1f40f0c553fa163b339b72064e0dd310ad"
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
-        "JMXFETCH_VERSION": "0.36.2",
-        "JMXFETCH_HASH": "f782b9a5e9dffbce3463245562858fd8fed1508269222e8bebeefd3f865d10d8"
+        "JMXFETCH_VERSION": "0.37.0",
+        "JMXFETCH_HASH": "468f104a052ae078fd7fca43195a1a1f40f0c553fa163b339b72064e0dd310ad"
     },
     "6.20.0": {
         "INTEGRATIONS_CORE_VERSION": "7.20.0",

--- a/releasenotes/notes/jmxfetch-0-37-0-52029258df2c0db5.yaml
+++ b/releasenotes/notes/jmxfetch-0-37-0-52029258df2c0db5.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    JMXFetch upgraded to `0.37.0 <https://github.com/DataDog/jmxfetch/releases/0.37.0>`_


### PR DESCRIPTION
### What does this PR do?

Bump JMXFetch to 0.37.0: https://github.com/DataDog/jmxfetch/releases/tag/0.37.0