### PR TITLE
Set cluster agent flavor

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,6 +62,7 @@ var (
 const (
 	DefaultAgentFlavor = "agent"
 	IotAgentFlavor     = "iot_agent"
+	ClusterAgentFlavor = "cluster_agent"
 	DogstatsdFlavor    = "dogstatsd"
 )
 

--- a/tasks/cluster_agent_helpers.py
+++ b/tasks/cluster_agent_helpers.py
@@ -23,7 +23,7 @@ def build_common(ctx, command, bin_path, build_tags, bin_suffix, rebuild, build_
     build_tags = get_build_tags(build_include, build_exclude)
 
     # We rely on the go libs embedded in the debian stretch image to build dynamically
-    ldflags, gcflags, env = get_build_flags(ctx, static=False, prefix='dca')
+    ldflags, gcflags, env = get_build_flags(ctx, static=False, prefix='dca', agent_flavor="cluster_agent")
 
     # Generating go source from templates by running go generate on ./pkg/status
     generate(ctx)


### PR DESCRIPTION
### What does this PR do?

- Set agent flavor to cluster agent as `cluster_agent`.

### Motivation

- Be able to distinguish this agent flavor from the full agent in the backend.
- Be able to tell the agent flavor that is running.

### Describe your test plan

- Check the output of the `status` command.