### PR TITLE
[ecs] Remove Printf usage

### DIFF
--- a/pkg/util/ecs/metadata/detection.go
+++ b/pkg/util/ecs/metadata/detection.go
@@ -106,6 +106,7 @@ func testURLs(urls []string, timeout time.Duration) string {
 		}
 		var resp v1.Commands
 		if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
+			log.Debugf("Error decoding JSON response from '%s': %s", url, err)
 			continue
 		}
 		if len(resp.AvailableCommands) > 0 {

--- a/pkg/util/ecs/metadata/detection.go
+++ b/pkg/util/ecs/metadata/detection.go
@@ -106,7 +106,6 @@ func testURLs(urls []string, timeout time.Duration) string {
 		}
 		var resp v1.Commands
 		if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
-			fmt.Printf("decode err: %s\n", err)
 			continue
 		}
 		if len(resp.AvailableCommands) > 0 {

--- a/releasenotes/notes/hostname-ecs-remove-printf-5888fcbe4871cb3f.yaml
+++ b/releasenotes/notes/hostname-ecs-remove-printf-5888fcbe4871cb3f.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix hostname resolution issue preventing the Process and APM agents from picking
+    up a valid hostname on some containerized environments


### PR DESCRIPTION
### What does this PR do?

Remove `fmt.Printf` usage in `ecs` util.

### Motivation

When the code path is executed, it would break the output of the
`hostname` command as expected by the process and trace agents.

### Additional notes

Long-term, we're planning to make other agents rely on core agent's internal API to avoid such issues (and also have more guarantees on hostname consistency across agents).