### PR TITLE
[kitchen] Whitelist C:/Windows/Assembly/Temp

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -672,6 +672,7 @@ shared_examples_for 'an Agent that is removed' do
   if os == :windows
     it 'should not make changes to system files' do
       exclude = [
+            'C:/Windows/Assembly/Temp/',
             'C:/Windows/Temp/',
             'C:/Windows/Prefetch/',
             'C:/Windows/Installer/',


### PR DESCRIPTION
### What does this PR do?

Adds `C:/Windows/Assembly/Temp/` to the whitelist when checking if the Agent didn't remove files. `C:/Windows/Assembly/Temp/` is used as a temp folder when assemblies are installed / uninstalled in the system (which can happen for many reasons: installer running, Windows update, etc.)

### Motivation

Remove flake from kitchen tests.

