### PR TITLE
Fix `dogstastd` typo into `dogstatsd`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1295,7 +1295,7 @@ agent_android_apk:
     paths:
       - $OMNIBUS_PACKAGE_DIR
 
-# build Dogstastd package for deb-x64
+# build Dogstatsd package for deb-x64
 dogstatsd_deb-x64:
   rules:
     - <<: *if_version_7
@@ -1329,7 +1329,7 @@ dogstatsd_deb-x64:
     paths:
       - $OMNIBUS_PACKAGE_DIR
 
-# build Dogstastd package for rpm-x64
+# build Dogstatsd package for rpm-x64
 dogstatsd_rpm-x64:
   rules:
     - <<: *if_version_7
@@ -1369,7 +1369,7 @@ dogstatsd_rpm-x64:
       - $OMNIBUS_PACKAGE_DIR
 
 
-# build Dogstastd package for rpm-x64
+# build Dogstatsd package for rpm-x64
 dogstatsd_suse-x64:
   rules:
     - <<: *if_version_7

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -30,7 +30,7 @@ var (
 	// Coll is the global collector instance
 	Coll *collector.Collector
 
-	// DSD is the global dogstastd instance
+	// DSD is the global dogstatsd instance
 	DSD *dogstatsd.Server
 
 	// MetadataScheduler is responsible to orchestrate metadata collection

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -112,7 +112,7 @@ func runAgent() (mainCtx context.Context, mainCtxCancel context.CancelFunc, err 
 
 	// a path to the folder containing the config file was passed
 	if len(confPath) != 0 {
-		// we'll search for a config file named `dogstastd.yaml`
+		// we'll search for a config file named `dogstatsd.yaml`
 		config.Datadog.SetConfigName("dogstatsd")
 		config.Datadog.AddConfigPath(confPath)
 		confErr := config.Load()

--- a/docs/dogstatsd/drops.md
+++ b/docs/dogstatsd/drops.md
@@ -34,7 +34,7 @@ by the client.
 The UDP protocol does not ensure the deliverability of the packets: the packet
 could be either dropped during the transit (on the network) or any other step.
 We leverage this characteristic in the server to let the kernel decide when
-packets should be dropped: the Dogstasd server tries its best to read and process
+packets should be dropped: the Dogstatsd server tries its best to read and process
 all available packets on the socket, however, if there is too much packets to
 handle, the OS kernel will start dropping them and they will be lost.
 

--- a/tasks/bench.py
+++ b/tasks/bench.py
@@ -66,7 +66,7 @@ def build_dogstatsd(ctx):
 
 
 @task(pre=[build_dogstatsd])
-def dogstastd(ctx):
+def dogstatsd(ctx):
     """
     Run Dogstatsd Benchmarks.
     """
@@ -79,6 +79,11 @@ def dogstastd(ctx):
         options += " -api-key {}".format(key)
 
     ctx.run("{} -pps=5000 -dur 45 -ser 5 -brk -inc 1000 {}".format(bin_path, options))
+
+# Temporarily keep compatibility after typo fix
+@task(pre=[build_dogstatsd])
+def dogstastd(ctx):
+    dogstatsd(ctx)
 
 
 @task(pre=[build_aggregator])


### PR DESCRIPTION
### What does this PR do?

Fix the `dogstastd` typo (instead of dogstatsd) in some places.

### Motivation

Small improvement.

### Note

Kept the invoke task retrocompatible.