### PR TITLE
Collect recommended k8s labels as tags

### DIFF
--- a/pkg/tagger/collectors/const.go
+++ b/pkg/tagger/collectors/const.go
@@ -13,6 +13,14 @@ const (
 	tagKeyVersion = "version"
 	tagKeyService = "service"
 
+	// Standard K8s labels - Tag keys
+	tagKeyKubeAppName      = "kube_app_name"
+	tagKeyKubeAppInstance  = "kube_app_instance"
+	tagKeyKubeAppVersion   = "kube_app_version"
+	tagKeyKubeAppComponent = "kube_app_component"
+	tagKeyKubeAppPartOf    = "kube_app_part_of"
+	tagKeyKubeAppManagedBy = "kube_app_managed_by"
+
 	// Standard tag - Environment variables
 	envVarEnv     = "DD_ENV"
 	envVarVersion = "DD_VERSION"

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -56,6 +56,18 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 				tags.AddLow(tagKeyVersion, value)
 			case kubernetes.ServiceTagLabelKey:
 				tags.AddLow(tagKeyService, value)
+			case kubernetes.KubeAppNameLabelKey:
+				tags.AddLow(tagKeyKubeAppName, value)
+			case kubernetes.KubeAppInstanceLabelKey:
+				tags.AddLow(tagKeyKubeAppInstance, value)
+			case kubernetes.KubeAppVersionLabelKey:
+				tags.AddLow(tagKeyKubeAppVersion, value)
+			case kubernetes.KubeAppComponentLabelKey:
+				tags.AddLow(tagKeyKubeAppComponent, value)
+			case kubernetes.KubeAppPartOfLabelKey:
+				tags.AddLow(tagKeyKubeAppPartOf, value)
+			case kubernetes.KubeAppManagedByLabelKey:
+				tags.AddLow(tagKeyKubeAppManagedBy, value)
 			}
 			for pattern, tmpl := range c.labelsAsTags {
 				n := strings.ToLower(name)

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -174,6 +174,51 @@ func TestParsePods(t *testing.T) {
 			expectedInfo: nil,
 		},
 		{
+			desc: "pod + k8s recommended tags",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:      "dd-agent-rc-qd876",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "dd-agent",
+						"app.kubernetes.io/instance":   "dd-agent-rc",
+						"app.kubernetes.io/version":    "1.1.0",
+						"app.kubernetes.io/component":  "dd-agent",
+						"app.kubernetes.io/part-of":    "dd",
+						"app.kubernetes.io/managed-by": "spinnaker",
+					},
+				},
+				Status: dockerContainerStatus,
+				Spec:   dockerContainerSpec,
+			},
+			labelsAsTags: map[string]string{},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_namespace:default",
+					"kube_container_name:dd-agent",
+					"image_tag:latest5",
+					"kube_app_name:dd-agent",
+					"kube_app_instance:dd-agent-rc",
+					"kube_app_version:1.1.0",
+					"kube_app_component:dd-agent",
+					"kube_app_part_of:dd",
+					"kube_app_managed_by:spinnaker",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
+					"pod_phase:running",
+				},
+				OrchestratorCardTags: []string{
+					"pod_name:dd-agent-rc-qd876",
+				},
+				HighCardTags: []string{
+					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+					"display_container_name:dd-agent_dd-agent-rc-qd876",
+				},
+			}},
+		},
+		{
 			desc: "daemonset + common tags",
 			pod: &kubelet.Pod{
 				Metadata: kubelet.PodMetadata{
@@ -790,6 +835,7 @@ func TestParsePods(t *testing.T) {
 					"foo_k8s-app:kubernetes-dashboard",
 					"foo_pod-template-hash:490794276",
 					"foo_app.kubernetes.io/managed-by:spinnaker",
+					"kube_app_managed_by:spinnaker",
 					"image_name:datadog/docker-dd-agent",
 					"image_tag:latest5",
 					"kube_container_name:dd-agent",

--- a/pkg/util/kubernetes/const.go
+++ b/pkg/util/kubernetes/const.go
@@ -12,6 +12,20 @@ const (
 	ServiceTagLabelKey = "tags.datadoghq.com/service"
 	// VersionTagLabelKey is the label key of the version standard tag
 	VersionTagLabelKey = "tags.datadoghq.com/version"
+
+	// KubeAppNameLabelKey is the label key of the name of the application
+	KubeAppNameLabelKey = "app.kubernetes.io/name"
+	// KubeAppInstanceLabelKey is the label key of unique name identifying the instance of an application
+	KubeAppInstanceLabelKey = "app.kubernetes.io/instance"
+	// KubeAppVersionLabelKey is the label key of the current version of the application
+	KubeAppVersionLabelKey = "app.kubernetes.io/version"
+	// KubeAppComponentLabelKey is the label key of the component within the architecture
+	KubeAppComponentLabelKey = "app.kubernetes.io/component"
+	// KubeAppPartOfLabelKey is the label key of the name of a higher level application one's part of
+	KubeAppPartOfLabelKey = "app.kubernetes.io/part-of"
+	// KubeAppManagedByLabelKey is the label key of the tool being used to manage the operation of an application
+	KubeAppManagedByLabelKey = "app.kubernetes.io/managed-by"
+
 	// EnvTagEnvVar is the environment variable of the env standard tag
 	EnvTagEnvVar = "DD_ENV"
 	// ServiceTagEnvVar is the environment variable of the service standard tag

--- a/releasenotes/notes/collect-recommended-k8s-tags-095651035a2030a7.yaml
+++ b/releasenotes/notes/collect-recommended-k8s-tags-095651035a2030a7.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Agent now collects recommended "app.kubernetes.io" Kubernetes labels as
+    tags by default, and exposes them under a "kube_app" prefix.


### PR DESCRIPTION
K8s recommends that certain labels be present in all resources [1], and
it makes sense for the tagger to collect them.

Some of them (like app.kubernetes.io/version) can collide with other
Datadog tags, so to avoid any clashes we're prefixing them with
"kube_app", so "app.kubernetes.io/version: 1.1.0" becomes
"kube_app_version:1.1.0".

[1] https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/