### PR TITLE
Support installing non-core integrations

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -83,7 +83,7 @@ func init() {
 		&localWheel, "local-wheel", "w", false, fmt.Sprintf("install an agent check from a locally available wheel file. %s", disclaimer),
 	)
 	installCmd.Flags().BoolVarP(
-		&thirdParty, "third-party", "3p", false, "indicate acceptance of unofficial integrations",
+		&thirdParty, "third-party", "t", false, "indicate acceptance of unofficial integrations",
 	)
 }
 

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -56,17 +56,12 @@ var (
 	useSysPython        bool
 	versionOnly         bool
 	localWheel          bool
-	integrationType     string
+	thirdParty          bool
 	rootDir             string
 	pythonMajorVersion  string
 	pythonMinorVersion  string
 	reqAgentReleasePath string
 	constraintsPath     string
-
-	rootLayoutTypeMap = map[string]string{
-		"core":    "core",
-		"contrib": "extras",
-	}
 )
 
 func init() {
@@ -87,8 +82,8 @@ func init() {
 	installCmd.Flags().BoolVarP(
 		&localWheel, "local-wheel", "w", false, fmt.Sprintf("install an agent check from a locally available wheel file. %s", disclaimer),
 	)
-	installCmd.Flags().StringVarP(
-		&integrationType, "type", "t", "core", "indicate the type of integration (default: core), among: core, contrib",
+	installCmd.Flags().BoolVarP(
+		&thirdParty, "third-party", "3p", false, "indicate acceptance of unofficial integrations",
 	)
 }
 
@@ -417,9 +412,9 @@ func install(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	rootLayoutType, exists := rootLayoutTypeMap[integrationType]
-	if !exists {
-		return fmt.Errorf("unknown integration type: %s", integrationType)
+	rootLayoutType := "core"
+	if thirdParty {
+		rootLayoutType = "extras"
 	}
 
 	// Download the wheel

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -83,7 +83,7 @@ func init() {
 		&localWheel, "local-wheel", "w", false, fmt.Sprintf("install an agent check from a locally available wheel file. %s", disclaimer),
 	)
 	installCmd.Flags().BoolVarP(
-		&thirdParty, "third-party", "t", false, "indicate acceptance of unofficial integrations",
+		&thirdParty, "third-party", "t", false, "install a community or vendor-contributed integration",
 	)
 }
 

--- a/releasenotes/notes/support-installing-non-core-integrations-985b24d4d4a08f4f.yaml
+++ b/releasenotes/notes/support-installing-non-core-integrations-985b24d4d4a08f4f.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    Support installing non-core integrations with the ``integration`` command,
+    such as those located in the ``integrations-extras`` repository.


### PR DESCRIPTION
### Motivation

We are beginning to support this, see: https://github.com/DataDog/integrations-core/pull/6856

### Additional Notes

For `integrations-extras` I thought `extras` wasn't a great name and `community` was too verbose so I went with `contrib` to match https://github.com/DataDog/integrations-extras/blob/09466b78f715754522a6365a39dc2e44c9cedc75/auth0/manifest.json#L11