### PR TITLE
pkg/trace/obfuscate: avoid infinite loop on non-ASCII numerals

### DIFF
--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -1072,5 +1072,5 @@ func TestCassQuantizer(t *testing.T) {
 func TestUnicodeDigit(t *testing.T) {
 	hangStr := "٩"
 	o := NewObfuscator(nil)
-	o.obfuscateSQLString(hangStr)
+	o.ObfuscateSQLString(hangStr)
 }

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -1068,3 +1068,9 @@ func TestCassQuantizer(t *testing.T) {
 		assert.Equal(testCase.expected, s.Resource)
 	}
 }
+
+func TestUnicodeDigit(t *testing.T) {
+	hangStr := "٩"
+	o := NewObfuscator(nil)
+	o.obfuscateSQLString(hangStr)
+}

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -429,6 +429,9 @@ exponent:
 	}
 
 exit:
+	if buffer.Len() == 0 {
+		return LexError, nil
+	}
 	return Number, buffer.Bytes()
 }
 
@@ -552,7 +555,7 @@ func digitVal(ch rune) int {
 	return 16 // larger than any legal digit val
 }
 
-func isDigit(ch rune) bool { return unicode.IsDigit(ch) }
+func isDigit(ch rune) bool { return '0' <= ch && ch <= '9' }
 
 // runeBytes converts the given rune to a slice of bytes.
 func runeBytes(r rune) []byte {

--- a/releasenotes/notes/apm-avoid-infinite-loop-on-non-ASCII-numerals-3892675b876d4c99.yaml
+++ b/releasenotes/notes/apm-avoid-infinite-loop-on-non-ASCII-numerals-3892675b876d4c99.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+---
+fixes:
+  - |
+    APM : Fix parsing of non-ASCII numerals in the SQL obfuscator. Previously
+    unicode characters for which unicode.IsDigit returns true could cause a
+    hang in the SQL obfuscator

--- a/releasenotes/notes/apm-avoid-infinite-loop-on-non-ASCII-numerals-3892675b876d4c99.yaml
+++ b/releasenotes/notes/apm-avoid-infinite-loop-on-non-ASCII-numerals-3892675b876d4c99.yaml
@@ -6,7 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
----
 fixes:
   - |
     APM : Fix parsing of non-ASCII numerals in the SQL obfuscator. Previously


### PR DESCRIPTION
This commit fixes two problems that lead to a hang in the sql parser:
 1. SQLTokenizer.scanNumber, does not return a failure when it fails to scan
    a number.
 2. isDigit returns true for non-ASCII numerals, such as the unicode
    Arabic-Indic digits.

IsDigit reporting true for non-ASCII numerals caused scanNumber to be
called on a number that it could not parse. ScanNumber would return
successfully without advancing the stream, and the loop would continue in
the same place, causing an infinite loop.

This commit addresses both issues. IsDigit will now return true only for
ascii numerals 0-9, and scanNumber will return a LexError if it fails to
parse a number.
