### PR TITLE
supporting autodiscovery for tags on fargate

### DIFF
--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -124,6 +124,8 @@ func TestParseMetadata(t *testing.T) {
 				"container_name:ecs-redis-datadog-3-redis-f6eedfd8b18a8fbe1d00",
 				"hightag:value2",
 				"container_id:0fc5bb7a1b29adc30997eabae1415a98fe85591eb7432c23349703a53aa43280",
+				"env:staging",
+				"service:backend"
 			},
 			DeleteEntity: false,
 		},

--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -125,7 +125,7 @@ func TestParseMetadata(t *testing.T) {
 				"hightag:value2",
 				"container_id:0fc5bb7a1b29adc30997eabae1415a98fe85591eb7432c23349703a53aa43280",
 				"env:staging",
-				"service:backend"
+				"service:backend",
 			},
 			DeleteEntity: false,
 		},

--- a/pkg/tagger/collectors/testdata/fargate_meta.json
+++ b/pkg/tagger/collectors/testdata/fargate_meta.json
@@ -83,6 +83,7 @@
         "com.datadoghq.ad.check_names": "[\"redisdb\"]",
         "com.datadoghq.ad.init_configs": "[{}]",
         "com.datadoghq.ad.instances": "[{\"host\": \"%%host%%\", \"port\": 6379}]",
+        "com.datadoghq.ad.tags": "[\"env:staging\", \"service:backend\"]",
         "com.datadoghq.tags.service": "redis",
         "com.datadoghq.tags.env": "prod",
         "com.datadoghq.tags.version": "1.0",


### PR DESCRIPTION
### What does this PR do?

This PR adds support to Autodiscover tags from the `com.datadoghq.ad.tags` Docker label on ECS Fargate environments.

### Motivation

Since Agent v7.20+, a containerized Agent can Autodiscover tags from Docker labels. But this doesn't work on Fargate.
https://docs.datadoghq.com/agent/docker/tag/?tab=containerizedagent#extract-environment-variables-as-tags.

What inspired you to submit this pull request?

I was trying to add custom tags to one of my Fargate containers. However, after looking at the code, I noticed that it wasn't supported. So here is a fix that should add support for that.

