### PR TITLE
[System Probe][Windows]Fix reversed protocol numbers

### DIFF
--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -16,10 +16,10 @@ import (
 
 const (
 	// TCPProtocol represents the IANA protocol number for TCP
-	TCPProtocol = 17
+	TCPProtocol = 6
 
 	// UDPProtocol represents the IANA protocol number for UDP
-	UDPProtocol = 6
+	UDPProtocol = 17
 )
 
 func connFamily(addressFamily C.uint16_t) ConnectionFamily {


### PR DESCRIPTION
### What does this PR do?

Reverses the protocol identification numbers for TCP and UDP. 

### Motivation

Currently improperly identifying connections. 

