### PR TITLE
Remove kubeapiserver build flag in order to fix x86 build

### DIFF
--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -2,7 +2,6 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
-// +build kubeapiserver
 
 package app
 


### PR DESCRIPTION
### What does this PR do?

Remove kubeapiserver build flag in order to fix x86 build

### Motivation

Green tests.

