### PR TITLE
Bump Go to 1.13.11 Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: datadog/datadog-agent-runner-circle:go1138
+      - image: datadog/datadog-agent-runner-circle:go11311
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent
@@ -234,7 +234,7 @@ jobs:
     macos:
       xcode: 10.1.0
     environment:
-      GO_VERSION: "1.13.8"
+      GO_VERSION: "1.13.11"
       RUBY_VERSION: "2.4"
       RELEASE_VERSION: "nightly-a7"
       AGENT_MAJOR_VERSION: "7"

--- a/.circleci/images/runner/Dockerfile
+++ b/.circleci/images/runner/Dockerfile
@@ -11,7 +11,7 @@ RUN set -ex \
         doxygen graphviz
 
 # Golang
-ENV GIMME_GO_VERSION 1.13.8
+ENV GIMME_GO_VERSION 1.13.11
 ENV GOROOT /root/.gimme/versions/go$GIMME_GO_VERSION.linux.amd64
 ENV GOPATH /go
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
### What does this PR do?

Bump Go to 1.13.11 for Circle CI to support Azure Web service (https://github.com/golang/go/issues/37230).
