### PR TITLE
[circleci] Increase MacOS build timeout threshold

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,7 @@ jobs:
             echo 'eval `gimme '$GO_VERSION'`' >> .build_setup
       - run:
           name: Run omnibus build
+          no_output_timeout: 30m
           command: |
             source .build_setup
             pip install -r requirements.txt


### PR DESCRIPTION
### What does this PR do?

Increases the no output timeout threshold to 30 minutes for the MacOS omnibus build.

### Motivation

Some `make` commands in the omnibus build can take more than 10 minutes, during which omnibus doesn't output anything. 

