### PR TITLE
Add network to available SNMP template extra configs

### DIFF
--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -388,6 +388,8 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 	switch string(key) {
 	case "version":
 		return []byte(s.config.Version), nil
+	case "network":
+		return []byte(s.config.Network), nil
 	case "timeout":
 		return []byte(fmt.Sprintf("%d", s.config.Timeout)), nil
 	case "retries":

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -388,8 +388,6 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 	switch string(key) {
 	case "version":
 		return []byte(s.config.Version), nil
-	case "network":
-		return []byte(s.config.Network), nil
 	case "timeout":
 		return []byte(fmt.Sprintf("%d", s.config.Timeout)), nil
 	case "retries":
@@ -410,6 +408,8 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 		return []byte(s.config.ContextEngineID), nil
 	case "context_name":
 		return []byte(s.config.ContextName), nil
+	case "autodiscovery_subnet":
+		return []byte(s.config.Network), nil
 	}
 	return []byte{}, ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -113,7 +113,7 @@ func TestExtraConfig(t *testing.T) {
 		config:       snmpConfig,
 	}
 
-	info, err := svc.GetExtraConfig([]byte("network"))
+	info, err := svc.GetExtraConfig([]byte("autodiscovery_subnet"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "192.168.0.0/24", string(info))
 

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -113,7 +113,11 @@ func TestExtraConfig(t *testing.T) {
 		config:       snmpConfig,
 	}
 
-	info, err := svc.GetExtraConfig([]byte("community"))
+	info, err := svc.GetExtraConfig([]byte("network"))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "192.168.0.0/24", string(info))
+
+	info, err = svc.GetExtraConfig([]byte("community"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "public", string(info))
 

--- a/releasenotes/notes/add_snmp_devices_count-afbf05f0ce69d14c.yaml
+++ b/releasenotes/notes/add_snmp_devices_count-afbf05f0ce69d14c.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add network to available SNMP template extra configs

--- a/releasenotes/notes/add_snmp_devices_count-afbf05f0ce69d14c.yaml
+++ b/releasenotes/notes/add_snmp_devices_count-afbf05f0ce69d14c.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Add network to available SNMP template extra configs
+    Add ``autodiscovery_subnet`` to available SNMP template extra configs


### PR DESCRIPTION
Related to https://github.com/DataDog/integrations-core/pull/6941

### What does this PR do?

Add network to available SNMP template extra configs

### Motivation

Adding network to available SNMP template extra configs so snmp integration can use it as tag.


### Describe your test plan


