### PR TITLE
[tasks] Honor integrations-core version in deps task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -289,7 +289,7 @@ run_tests_windows-x86:
     - inv -e rtloader.install
     - inv -e rtloader.format --raise-if-changed
     - inv -e rtloader.test
-    - inv -e deps --verbose --dep-vendor-only --release-version "$RELEASE_VERSION"
+    - inv -e deps --verbose --dep-vendor-only --integrations-version "$INTEGRATIONS_VERSION"
 
 # run tests for deb-x64
 run_tests_deb-x64-py2:
@@ -298,7 +298,7 @@ run_tests_deb-x64-py2:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     PYTHON_RUNTIMES: '2'
-    RELEASE_VERSION: $RELEASE_VERSION_6
+    INTEGRATIONS_VERSION: $RELEASE_VERSION_6
     CONDA_ENV: ddpy2
   <<: *run_tests_preparation
   script:
@@ -310,7 +310,7 @@ run_tests_deb-x64-py3:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     PYTHON_RUNTIMES: '3'
-    RELEASE_VERSION: $RELEASE_VERSION_7
+    INTEGRATIONS_VERSION: $RELEASE_VERSION_7
     CONDA_ENV: ddpy3
   <<: *run_tests_preparation
   script:
@@ -323,7 +323,7 @@ run_tests_rpm-x64-py2:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     PYTHON_RUNTIMES: '2'
-    RELEASE_VERSION: $RELEASE_VERSION_6
+    INTEGRATIONS_VERSION: $RELEASE_VERSION_6
     CONDA_ENV: ddpy2
   <<: *run_tests_preparation
   script:
@@ -338,7 +338,7 @@ run_tests_rpm-x64-py3:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     PYTHON_RUNTIMES: '3'
-    RELEASE_VERSION: $RELEASE_VERSION_7
+    INTEGRATIONS_VERSION: $RELEASE_VERSION_7
     CONDA_ENV: ddpy3
   <<: *run_tests_preparation
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -289,7 +289,7 @@ run_tests_windows-x86:
     - inv -e rtloader.install
     - inv -e rtloader.format --raise-if-changed
     - inv -e rtloader.test
-    - inv -e deps --verbose --dep-vendor-only
+    - inv -e deps --verbose --dep-vendor-only --release-version "$RELEASE_VERSION"
 
 # run tests for deb-x64
 run_tests_deb-x64-py2:
@@ -298,6 +298,7 @@ run_tests_deb-x64-py2:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     PYTHON_RUNTIMES: '2'
+    RELEASE_VERSION: $RELEASE_VERSION_6
     CONDA_ENV: ddpy2
   <<: *run_tests_preparation
   script:
@@ -309,6 +310,7 @@ run_tests_deb-x64-py3:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     PYTHON_RUNTIMES: '3'
+    RELEASE_VERSION: $RELEASE_VERSION_7
     CONDA_ENV: ddpy3
   <<: *run_tests_preparation
   script:
@@ -321,6 +323,7 @@ run_tests_rpm-x64-py2:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     PYTHON_RUNTIMES: '2'
+    RELEASE_VERSION: $RELEASE_VERSION_6
     CONDA_ENV: ddpy2
   <<: *run_tests_preparation
   script:
@@ -335,6 +338,7 @@ run_tests_rpm-x64-py3:
   tags: [ "runner:main", "size:2xlarge" ]
   variables:
     PYTHON_RUNTIMES: '3'
+    RELEASE_VERSION: $RELEASE_VERSION_7
     CONDA_ENV: ddpy3
   <<: *run_tests_preparation
   script:

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -235,7 +235,7 @@ def misspell(ctx, targets):
         print("misspell found no issues")
 
 @task
-def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False, dep_vendor_only=False, no_dep_ensure=False, release_version="nightly"):
+def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False, dep_vendor_only=False, no_dep_ensure=False, integrations_version="nightly"):
     """
     Setup Go dependencies
     """
@@ -313,7 +313,7 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False, dep_
             core_dir = os.path.join(os.getcwd(), 'vendor', 'integrations-core')
             checks_base = os.path.join(core_dir, 'datadog_checks_base')
             if not os.path.isdir(core_dir):
-                env = load_release_versions(ctx, release_version)
+                env = load_release_versions(ctx, integrations_version)
                 ctx.run('git clone -{} --branch {} --depth 1 https://github.com/DataDog/integrations-core {}'.format(verbosity, env["INTEGRATIONS_CORE_VERSION"], core_dir))
             ctx.run('pip install -{} "{}[deps]"'.format(verbosity, checks_base))
     checks_done = datetime.datetime.now()

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -11,7 +11,7 @@ import csv
 from invoke import task
 from invoke.exceptions import Exit
 from .build_tags import get_default_build_tags
-from .utils import get_build_flags, get_gopath
+from .utils import get_build_flags, get_gopath, load_release_versions
 from .bootstrap import get_deps, process_deps
 
 #We use `basestring` in the code for compat with python2 unicode strings.
@@ -235,7 +235,7 @@ def misspell(ctx, targets):
         print("misspell found no issues")
 
 @task
-def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False, dep_vendor_only=False, no_dep_ensure=False):
+def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False, dep_vendor_only=False, no_dep_ensure=False, release_version="nightly"):
     """
     Setup Go dependencies
     """
@@ -313,7 +313,8 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False, dep_
             core_dir = os.path.join(os.getcwd(), 'vendor', 'integrations-core')
             checks_base = os.path.join(core_dir, 'datadog_checks_base')
             if not os.path.isdir(core_dir):
-                ctx.run('git clone -{} https://github.com/DataDog/integrations-core {}'.format(verbosity, core_dir))
+                env = load_release_versions(ctx, release_version)
+                ctx.run('git clone -{} --branch {} --depth 1 https://github.com/DataDog/integrations-core {}'.format(verbosity, env["INTEGRATIONS_CORE_VERSION"], core_dir))
             ctx.run('pip install -{} "{}[deps]"'.format(verbosity, checks_base))
     checks_done = datetime.datetime.now()
 


### PR DESCRIPTION
### What does this PR do?

- Clone correct version of integrations-core repository in `deps` task for tests.
- Make a shallow clone to save time

### Motivation

- Ensure correct behavior in the pipeline. I don't know if it should make a difference right now, though.
- Speed up cloning

### Additional note

- I tried to replicate behavior for `omnibus.build` but it does not match exactly so we are using Agent 6 integrations version for Python 2 tests and Agent 7 version for Python 3.

### Describe your test plan

- Pipeline tests have passed correctly