### PR TITLE
Fix jmx command arg for log_format_rfc3339

### DIFF
--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -274,9 +274,11 @@ func (j *JMXFetch) Start(manage bool) error {
 		"--reconnection_timeout", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_reconnection_timeout")), // Timeout for instance reconnection in seconds
 		"--reconnection_thread_pool_size", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_reconnection_thread_pool_size")), // Size for the JMXFetch reconnection thread pool
 		"--log_level", jmxLogLevel,
-		"--log_format_rfc3339", fmt.Sprintf("%v", config.Datadog.GetBool("log_format_rfc3339")),
 		"--reporter", reporter, // Reporter to use
 	)
+	if config.Datadog.GetBool("log_format_rfc3339") {
+		subprocessArgs = append(subprocessArgs, "--log_format_rfc3339")
+	}
 
 	subprocessArgs = append(subprocessArgs, j.Command)
 


### PR DESCRIPTION
### What does this PR do?

Fix jmx command for log_format_rfc3339 (https://github.com/DataDog/datadog-agent/pull/5697)

- `log_format_rfc3339: true` should be translated to `--log_format_rfc3339`
- `log_format_rfc3339: false` should be translated to ``

### Motivation

```
2020-06-18 16:02:20 UTC | CORE | DEBUG | (pkg/jmxfetch/jmxfetch.go:324 in Start) | Args: [-Xmx200m -Xms50m -classpath /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar org.datadog.jmxfetch.App --ipc_host localhost --ipc_port 40233 --check_period 15000 --thread_pool_size 3 --collection_timeout 60 --reconnection_timeout 10 --reconnection_thread_pool_size 3 --log_level DEBUG --log_format_rfc3339 false --reporter json list_with_metrics]
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
2020-06-18 16:02:21 UTC | JMX | ERROR | App | false is not in [list_with_metrics, help, list_limited_attributes, list_everything, list_collected_attributes, list_jvms, list_with_rate_metrics, list_matching_attributes, list_not_matching_attributes, collect, version]. Exiting.
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
