### PR TITLE
[gitlab] Remove deploy_staging_iot_agent job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3547,21 +3547,6 @@ deploy_staging_dsd:
     - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)
     - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/linux/dogstatsd-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-# deploy iot-agent binary to staging bucket
-deploy_staging_iot_agent:
-  rules:
-    - <<: *if_not_version_7
-      when: never
-    - <<: *if_triggered
-  stage: deploy7
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
-  tags: [ "runner:main", "size:large" ]
-  dependencies: []
-  script:
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/iot/agent ./agent
-    - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)
-    - aws s3 cp --region us-east-1 ./agent $S3_DSD6_URI/linux/iot/agent-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-
 # deploy agent windows zip to the staging bucket, currently used for cloudfoundry bosh
 deploy_staging_datadog_agent_windows_zip:
   rules:


### PR DESCRIPTION
### What does this PR do?

Removes `deploy_staging_iot_agent` job, as it now fails and is useless.

### Motivation

#5585 removed the IoT Agent binary builds, so the S3 bucket we were trying to copy (`$S3_ARTIFACTS_URI/iot/agent`) didn't exist.
There's no reason to keep this job anymore if we're not building the binaries.

### Additional notes

Do the IoT Agent binaries really serve no purpose anymore? We were still publicly releasing them here: https://s3.amazonaws.com/dd-agent until 7.20.2.
