### PR TITLE
[gitlab] Add allow_failure: true to promote_install_script manual job & fix dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3242,6 +3242,7 @@ promote_install_script:
   rules:
     - <<: *if_test_kitchen_triggered
       when: manual
+      allow_failure: true
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:$DATADOG_AGENT_BUILDERS
   tags: [ "runner:main", "size:large" ]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3256,6 +3256,9 @@ promote_install_script:
     - kitchen_suse_install_script_agent-a6
     - kitchen_suse_install_script_agent-a7
     - kitchen_suse_install_script_iot_agent-a7
+    - kitchen_ubuntu_install_script_agent-a6
+    - kitchen_ubuntu_install_script_agent-a7
+    - kitchen_ubuntu_install_script_iot_agent-a7
   script:
     - $S3_CP_CMD ./cmd/agent/install_script.sh s3://dd-agent/scripts/install_script.sh --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
     - $S3_CP_CMD ./cmd/agent/install_mac_os.sh s3://dd-agent/scripts/install_mac_os.sh --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732


### PR DESCRIPTION
### What does this PR do?

Follow-up of #5763 and #5777: add missing `allow_failure: true` to manual job, and add missing dependencies.

### Motivation

Prevent pipelines from ending in `Blocked` status.

