### PR TITLE
Patch libbcc to remove references to glibc symbols with a too recent version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,10 +192,16 @@ fail_on_non_triggered_tag:
   needs: ["fail_on_non_triggered_tag"]
   script:
     - git clone -b "$BCC_VERSION" --depth=1 https://github.com/iovisor/bcc.git /tmp/bcc
+    # Patch libbcc to remove references to glibc symbols with a too recent version
+    - cd /tmp/bcc
+    - patch -p1 < "$CI_PROJECT_DIR"/omnibus/config/software/libbcc_compat.patch
     - mkdir /tmp/bcc/build
     - cd /tmp/bcc/build
     - cmake .. -DCMAKE_INSTALL_PREFIX=/opt/libbcc -DCMAKE_EXE_LINKER_FLAGS='-Wl,-rpath,/opt/datadog-agent/embedded/lib' -DCMAKE_SHARED_LINKER_FLAGS='-Wl,-rpath,/opt/datadog-agent/embedded/lib'
     - make -j 4 #"$(nproc)"
+    # Check that libbcc has no references to too recent glibc
+    - objdump -p src/cc/libbcc.so | grep GLIBC_2.29 && exit 1
+    - objdump -p src/cc/libbcc.so | grep GLIBC_2.26 && exit 1
     - make install
     - cd /opt/libbcc
     - chmod go-rwx lib/libbcc*

--- a/omnibus/config/software/libbcc_compat.patch
+++ b/omnibus/config/software/libbcc_compat.patch
@@ -1,0 +1,140 @@
+Patch to libbcc to remove references to glibc symbols with a too recent version.
+
+Whereas the current build of libbcc works well as long as the runtime target
+is the same as the compilation target, things are not that simple with the CI.
+
+In the CI, the agents are built on old Ubuntu and old CentOS to guarantee that
+the resulting binaries will work on old distributions. libbcc cannot be built
+on those old environments.
+So, libbcc is built on a more recent environment.
+Then, omnibus packages the agents, system-probe and libbcc altogether and
+checks that all symbols can be resolved in libraries that are part of the
+package (in `/opt/datadog-agent/embedded/lib`).
+
+Except for the glibc which is not packaged with the rest. We expect to use
+the glibc shipped with the system.
+
+We are currently facing compatibility issues with old distributions.
+
+Here is the error we get on CentOS 7 when trying to start system-probe:
+```
+[root@qa-linux-agent6-unstable-centos7-node-01 datadog]# /opt/datadog-agent/embedded/bin/system-probe --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
+/opt/datadog-agent/embedded/bin/system-probe: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /opt/datadog-agent/embedded/lib/libbcc.so.0)
+/opt/datadog-agent/embedded/bin/system-probe: /lib64/libc.so.6: version `GLIBC_2.26' not found (required by /opt/datadog-agent/embedded/lib/libbcc.so.0)
+
+[root@qa-linux-agent6-unstable-centos7-node-01 datadog]# datadog-agent version
+Agent 6.21.0-devel - Meta: git.107.a66e1ee - Commit: a66e1ee - Serialization version: 4.34.0 - Go version: go1.13.8
+```
+
+Here is the error we get on Ubuntu 18.04:
+```
+root@qa-linux-agent6-longrun-ubuntu1804-node-01:/home/datadog# /opt/datadog-agent/embedded/bin/system-probe --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid/opt/datadog-agent/embedded/bin/system-probe --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
+/opt/datadog-agent/embedded/bin/system-probe: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /opt/datadog-agent/embedded/lib/libbcc.so.0)
+
+root@qa-linux-agent6-longrun-ubuntu1804-node-01:/home/datadog# datadog-agent version
+Agent 6.21.0-devel - Meta: git.108.910af82 - Commit: 910af82 - Serialization version: 4.34.0 - Go version: go1.13.8
+```
+
+The reference to `GLIBC_2.29` comes from the mathematical functions `exp`,
+`log`, `pow`, `exp2` and `log2`.
+Fortunately, the glibc also provides older versions of those function.
+So, the fix consists in using the `GLIBC_2.2.5` version of those symbols
+instead of the `GLIBC_2.29` version one.
+However, those functions are not used directly by libbcc itself but by the
+LLVM object files that are embedded by it.
+That’s why it was not possible to patch libbcc directly to make it use the
+other version of those symbols.
+Instead, I’m using wrapper functions.
+
+The reference to `GLIBC_2.26` comes from `reallocarray`.
+Unfortunately, that function has been introduced in the glibc at that version
+and the glibc doesn’t provide any older version of that symbol.
+Fortunately, libbcc provides a alternative definition of it.
+However, forcing the use of the alternative definition doesn’t work as it
+generates a double symbol definition.
+That’s why I had to rename `reallocarray` into `my_reallocarray` everywhere.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7bd0f3b..2c5eb36 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,6 +13,8 @@ enable_testing()
+ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/src)
+   execute_process(COMMAND git submodule update --init --recursive
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
++  execute_process(COMMAND sed -i -E s/\\<reallocarray\\>/my_reallocarray/ scripts/check-reallocarray.sh include/tools/libc_compat.h src/libbpf.c
++                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf)
+ endif()
+
+ include(cmake/GetGitRevisionDescription.cmake)
+diff --git a/src/cc/CMakeLists.txt b/src/cc/CMakeLists.txt
+index c53c542..8244f77 100644
+--- a/src/cc/CMakeLists.txt
++++ b/src/cc/CMakeLists.txt
+@@ -46,9 +46,11 @@ set(libbpf_uapi libbpf/include/uapi/linux})
+
+ add_library(bpf-static STATIC libbpf.c perf_reader.c ${libbpf_sources})
+ set_target_properties(bpf-static PROPERTIES OUTPUT_NAME bcc_bpf)
++set_target_properties(bpf-static PROPERTIES COMPILE_DEFINITIONS COMPAT_NEED_REALLOCARRAY)
+ add_library(bpf-shared SHARED libbpf.c perf_reader.c ${libbpf_sources})
+ set_target_properties(bpf-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
+ set_target_properties(bpf-shared PROPERTIES OUTPUT_NAME bcc_bpf)
++set_target_properties(bpf-shared PROPERTIES COMPILE_DEFINITIONS COMPAT_NEED_REALLOCARRAY)
+
+ set(bcc_common_sources bcc_common.cc bpf_module.cc bcc_btf.cc exported_files.cc)
+ if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 6 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 6)
+@@ -71,7 +73,7 @@ set(bcc_api_headers bcc_common.h bpf_module.h bcc_exception.h bcc_syms.h bcc_pro
+ if(ENABLE_CLANG_JIT)
+ add_library(bcc-shared SHARED
+   link_all.cc ${bcc_common_sources} ${bcc_table_sources} ${bcc_sym_sources}
+-  ${bcc_util_sources})
++  ${bcc_util_sources} wrapper.c)
+ set_target_properties(bcc-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
+ set_target_properties(bcc-shared PROPERTIES OUTPUT_NAME bcc)
+
+@@ -133,7 +135,7 @@ endif()
+ add_subdirectory(frontends)
+
+ # Link against LLVM libraries
+-target_link_libraries(bcc-shared ${bcc_common_libs_for_s})
++target_link_libraries(bcc-shared ${bcc_common_libs_for_s} -Wl,--wrap=exp -Wl,--wrap=log -Wl,--wrap=pow -Wl,--wrap=exp2 -Wl,--wrap=log2)
+ target_link_libraries(bcc-static ${bcc_common_libs_for_a} bcc-loader-static)
+ set(bcc-lua-static ${bcc-lua-static} ${bcc_common_libs_for_lua})
+
+diff --git a/src/cc/wrapper.c b/src/cc/wrapper.c
+new file mode 100644
+index 0000000..c01fbe2
+--- /dev/null
++++ b/src/cc/wrapper.c
+@@ -0,0 +1,31 @@
++#ifdef __x86_64__
++#define GLIBC_VERS "GLIBC_2.2.5"
++#elif defined(__aarch64__)
++#define GLIBC_VERS "GLIBC_2.17"
++#else
++#error Unknown architecture
++#endif
++
++#define define_wrapper1_for(func)                               \
++double __ ## func ## _prior_glibc(double x);                    \
++                                                                \
++asm(".symver __" #func "_prior_glibc, " #func "@" GLIBC_VERS);  \
++                                                                \
++double __wrap_ ## func (double x) {                             \
++  return __ ## func ## _prior_glibc(x);                         \
++}
++
++#define define_wrapper2_for(func)                               \
++double __ ## func ## _prior_glibc(double x, double y);          \
++                                                                \
++asm(".symver __" #func "_prior_glibc, " #func "@" GLIBC_VERS);  \
++                                                                \
++double __wrap_ ## func (double x, double y) {                   \
++  return __ ## func ## _prior_glibc(x, y);                      \
++}
++
++define_wrapper1_for(exp)
++define_wrapper1_for(log)
++define_wrapper2_for(pow)
++define_wrapper1_for(exp2)
++define_wrapper1_for(log2)


### PR DESCRIPTION
### What does this PR do?

Patch `libbcc` to remove references to `glibc` symbols with a too recent version.

### Motivation

Whereas the current build of `libbcc` works well as long as the runtime target is the same as the compilation target, things are not that simple with the CI.

In the CI, the agents are built on old Ubuntu and old CentOS to guarantee that the resulting binaries will work on old distributions. `libbcc` cannot be built on those old environments.
So, `libbcc` is built on a more recent environment.
Then, omnibus packages the agents, `system-probe` and `libbcc` altogether and checks that all symbols can be resolved in libraries that are part of the package (in `/opt/datadog-agent/embedded/lib`).

Except for the `glibc` which is not packaged with the rest. We expect to use the `glibc` shipped with the system.

We are currently facing compatibility issues with old distributions.

Here is the error we get on CentOS 7 when trying to start `system-probe`:
```
[root@qa-linux-agent6-unstable-centos7-node-01 datadog]# /opt/datadog-agent/embedded/bin/system-probe --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
/opt/datadog-agent/embedded/bin/system-probe: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /opt/datadog-agent/embedded/lib/libbcc.so.0)
/opt/datadog-agent/embedded/bin/system-probe: /lib64/libc.so.6: version `GLIBC_2.26' not found (required by /opt/datadog-agent/embedded/lib/libbcc.so.0)

[root@qa-linux-agent6-unstable-centos7-node-01 datadog]# datadog-agent version
Agent 6.21.0-devel - Meta: git.107.a66e1ee - Commit: a66e1ee - Serialization version: 4.34.0 - Go version: go1.13.8
```

Here is the error we get on Ubuntu 18.04:
```
root@qa-linux-agent6-longrun-ubuntu1804-node-01:/home/datadog# /opt/datadog-agent/embedded/bin/system-probe --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid/opt/datadog-agent/embedded/bin/system-probe --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
/opt/datadog-agent/embedded/bin/system-probe: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /opt/datadog-agent/embedded/lib/libbcc.so.0)

root@qa-linux-agent6-longrun-ubuntu1804-node-01:/home/datadog# datadog-agent version
Agent 6.21.0-devel - Meta: git.108.910af82 - Commit: 910af82 - Serialization version: 4.34.0 - Go version: go1.13.8
```

The reference to `GLIBC_2.29` comes from the mathematical functions `exp`, `log`, `pow`, `exp2` and `log2`.
Fortunately, the `glibc` also provides older versions of those function.
So, the fix consists in using the `GLIBC_2.2.5` version of those symbols instead of the `GLIBC_2.29` version one.
However, those functions are not used directly by `libbcc` itself but by the LLVM object files that are embedded by it.
That’s why it was not possible to patch `libbcc` directly to make it use the other version of those symbols.
Instead, I’m using wrapper functions.

The reference to `GLIBC_2.26` comes from `reallocarray`.
Unfortunately, that function has been introduced in the `glibc` at that version and the `glibc` doesn’t provide any older version of that symbol.
Fortunately, `libbcc` provides a alternative definition of it.
However, forcing the use of the alternative definition doesn’t work as it generates a double symbol definition.
That’s why I had to rename `reallocarray` into `my_reallocarray` everywhere.

### Additional Notes

### Describe your test plan

We can try to start `system-probe` on CentOS 7 or Ubuntu 18.04 and check that the `glibc` version error mentioned above isn’t raised anymore.

Alternatively, we can also inspect `libbcc.so` with `objdump` and check the version of `glibc` it requires:
Before this change:
```
$ objdump -p /opt/datadog-agent/embedded/lib/libbcc.so
[…]
Version References:
[…]
  required from libm.so.6:
    0x06969189 0x00 13 GLIBC_2.29
[…]
 required from libc.so.6:
    0x06969186 0x00 24 GLIBC_2.26
```
After this change, `objdump` should report that `libbcc.so` doesn’t depend on those versions of the `glibc` anymore.