### PR TITLE
Add tagger list to agent flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -566,6 +566,8 @@ func zipTaggerList(tempDir, hostname string) error {
 	}
 	defer w.Close()
 
+	c := api_util.GetClient(false) // FIX: get certificates right then make this true
+
 	err = api_util.SetAuthToken()
 	if err != nil {
 		return err
@@ -576,7 +578,6 @@ func zipTaggerList(tempDir, hostname string) error {
 		return err
 	}
 
-	c := api_util.GetClient(false)
 	if taggerListURL == "" {
 		taggerListURL = fmt.Sprintf("https://%v:%v/agent/tagger-list", ipcAddress, config.Datadog.GetInt("cmd_port"))
 	}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -586,7 +586,17 @@ func zipTaggerList(tempDir, hostname string) error {
 		return err
 	}
 
-	_, err = w.Write(r)
+	// Pretty print JSON output
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+	err = json.Indent(&b, r, "", "\t")
+	if err != nil {
+		_, err = w.Write(r)
+		return err
+	}
+	writer.Flush()
+
+	_, err = w.Write(b.Bytes())
 	return err
 }
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -249,38 +248,36 @@ func TestCleanDirectoryName(t *testing.T) {
 }
 
 func TestZipTaggerList(t *testing.T) {
-	if _, err := os.Stat(security.GetAuthTokenFilepath()); err == nil {
-		tagMap := make(map[string]response.TaggerListEntity)
-		tagMap["random_entity_name"] = response.TaggerListEntity{
-			Sources: []string{"docker_source_name"},
-			Tags:    []string{"docker_image:custom-agent:latest", "image_name:custom-agent"},
-		}
-		resp := response.TaggerListResponse{
-			Entities: tagMap,
-		}
-
-		s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			out, _ := json.Marshal(resp)
-			w.Write(out)
-		}))
-		defer s.Close()
-
-		dir, err := ioutil.TempDir("", "TestZipTaggerList")
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer os.RemoveAll(dir)
-
-		taggerListURL = s.URL
-		zipTaggerList(dir, "")
-		content, err := ioutil.ReadFile(filepath.Join(dir, "tagger-list.log"))
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		assert.Contains(t, string(content), "random_entity_name")
-		assert.Contains(t, string(content), "docker_source_name")
-		assert.Contains(t, string(content), "docker_image:custom-agent:latest")
-		assert.Contains(t, string(content), "image_name:custom-agent")
+	tagMap := make(map[string]response.TaggerListEntity)
+	tagMap["random_entity_name"] = response.TaggerListEntity{
+		Sources: []string{"docker_source_name"},
+		Tags:    []string{"docker_image:custom-agent:latest", "image_name:custom-agent"},
 	}
+	resp := response.TaggerListResponse{
+		Entities: tagMap,
+	}
+
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		out, _ := json.Marshal(resp)
+		w.Write(out)
+	}))
+	defer s.Close()
+
+	dir, err := ioutil.TempDir("", "TestZipTaggerList")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	taggerListURL = s.URL
+	zipTaggerList(dir, "")
+	content, err := ioutil.ReadFile(filepath.Join(dir, "tagger-list.json"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Contains(t, string(content), "random_entity_name")
+	assert.Contains(t, string(content), "docker_source_name")
+	assert.Contains(t, string(content), "docker_image:custom-agent:latest")
+	assert.Contains(t, string(content), "image_name:custom-agent")
 }

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -246,38 +246,3 @@ func TestCleanDirectoryName(t *testing.T) {
 	assert.Len(t, cleanedHostname, directoryNameMaxSize)
 	assert.True(t, !directoryNameFilter.MatchString(cleanedHostname))
 }
-
-func TestZipTaggerList(t *testing.T) {
-	tagMap := make(map[string]response.TaggerListEntity)
-	tagMap["random_entity_name"] = response.TaggerListEntity{
-		Sources: []string{"docker_source_name"},
-		Tags:    []string{"docker_image:custom-agent:latest", "image_name:custom-agent"},
-	}
-	resp := response.TaggerListResponse{
-		Entities: tagMap,
-	}
-
-	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		out, _ := json.Marshal(resp)
-		w.Write(out)
-	}))
-	defer s.Close()
-
-	dir, err := ioutil.TempDir("", "TestZipTaggerList")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	taggerListURL = s.URL
-	zipTaggerList(dir, "")
-	content, err := ioutil.ReadFile(filepath.Join(dir, "tagger-list.log"))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	assert.Contains(t, string(content), "random_entity_name")
-	assert.Contains(t, string(content), "docker_source_name")
-	assert.Contains(t, string(content), "docker_image:custom-agent:latest")
-	assert.Contains(t, string(content), "image_name:custom-agent")
-}

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -249,7 +249,7 @@ func TestCleanDirectoryName(t *testing.T) {
 }
 
 func TestZipTaggerList(t *testing.T) {
-	if _, err := os.Stat(security.GetAuthTokenFilepath()); err == nil && !os.IsNotExist(err) {
+	if _, err := os.Stat(security.GetAuthTokenFilepath()); err == nil {
 		tagMap := make(map[string]response.TaggerListEntity)
 		tagMap["random_entity_name"] = response.TaggerListEntity{
 			Sources: []string{"docker_source_name"},

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -246,3 +246,38 @@ func TestCleanDirectoryName(t *testing.T) {
 	assert.Len(t, cleanedHostname, directoryNameMaxSize)
 	assert.True(t, !directoryNameFilter.MatchString(cleanedHostname))
 }
+
+func TestZipTaggerList(t *testing.T) {
+	tagMap := make(map[string]response.TaggerListEntity)
+	tagMap["random_entity_name"] = response.TaggerListEntity{
+		Sources: []string{"docker_source_name"},
+		Tags:    []string{"docker_image:custom-agent:latest", "image_name:custom-agent"},
+	}
+	resp := response.TaggerListResponse{
+		Entities: tagMap,
+	}
+
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		out, _ := json.Marshal(resp)
+		w.Write(out)
+	}))
+	defer s.Close()
+
+	dir, err := ioutil.TempDir("", "TestZipTaggerList")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	taggerListURL = s.URL
+	zipTaggerList(dir, "")
+	content, err := ioutil.ReadFile(filepath.Join(dir, "tagger-list.log"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Contains(t, string(content), "random_entity_name")
+	assert.Contains(t, string(content), "docker_source_name")
+	assert.Contains(t, string(content), "docker_image:custom-agent:latest")
+	assert.Contains(t, string(content), "image_name:custom-agent")
+}

--- a/releasenotes/notes/add-tagger-list-to-flare-87afe4791a394f3f.yaml
+++ b/releasenotes/notes/add-tagger-list-to-flare-87afe4791a394f3f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adds Tagger information to Datadog Agent flare for support investigations.


### PR DESCRIPTION
### What does this PR do?

Adds detailed tagger list output to agent flare for use in support investigations

### Motivation

This is often information that is sought in customer tickets

### Additional Notes


### Describe your test plan

Call `agent flare` or `agent flare -l` (and decline to upload) to verify output in tagger-list.log file