### PR TITLE
[DCA] fix permission for SecretBackend with dd-agent user

### DIFF
--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -15,7 +15,7 @@ COPY readsecret.sh .
 
 RUN chmod 755 entrypoint.sh \
     && chown root:root readsecret.sh \
-    && chmod 500 readsecret.sh \
+    && chmod 555 readsecret.sh \
     && chmod g+r,g+w,g+X -R etc/datadog-agent/ \
     && chmod +x opt/datadog-agent/bin/datadog-cluster-agent \
     && ln -s /opt/datadog-agent/bin/datadog-cluster-agent opt/datadog-agent/bin/agent

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -14,7 +14,7 @@ COPY readsecret.sh .
 
 RUN chmod 755 entrypoint.sh \
     && chown root:root readsecret.sh \
-    && chmod 500 readsecret.sh \
+    && chmod 555 readsecret.sh \
     && chmod g+r,g+w,g+X -R etc/datadog-agent/ \
     && chmod +x opt/datadog-agent/bin/datadog-cluster-agent \
     && ln -s /opt/datadog-agent/bin/datadog-cluster-agent opt/datadog-agent/bin/agent

--- a/releasenotes-dca/notes/fix-dd-agent-perssion-with-secret-backend-f2f1d90973a2b600.yaml
+++ b/releasenotes-dca/notes/fix-dd-agent-perssion-with-secret-backend-f2f1d90973a2b600.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix permission in docker image when executing "/readsecret.sh" script with dd-agent user


### PR DESCRIPTION
### What does this PR do?

update `/readsecret.sh` script permission: change the script owner (from `root` to `dd-agent`) to allow running the script with the dd-agent user.

### Motivation

be able to use the `/readsecret.sh` script with the `dd-agent` user.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
