### PR TITLE
[ebpf] Fix linter flaky error

### DIFF
--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -3,11 +3,12 @@ package ebpf
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/pkg/errors"
-	"os"
-	"strings"
 )
 
 // Feature versions sourced from: https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md
@@ -26,24 +27,6 @@ var (
 	// ErrNotImplemented will be returned on non-linux environments like Windows and Mac OSX
 	ErrNotImplemented = errors.New("BPF-based system probe not implemented on non-linux systems")
 )
-
-func kernelCodeToString(code uint32) string {
-	// Kernel "a.b.c", the version number will be (a<<16 + b<<8 + c)
-	a, b, c := code>>16, code>>8&0xff, code&0xff
-	return fmt.Sprintf("%d.%d.%d", a, b, c)
-}
-
-func stringToKernelCode(str string) uint32 {
-	var a, b, c uint32
-	fmt.Sscanf(str, "%d.%d.%d", &a, &b, &c)
-	return linuxKernelVersionCode(a, b, c)
-}
-
-// KERNEL_VERSION(a,b,c) = (a << 16) + (b << 8) + (c)
-// Per https://github.com/torvalds/linux/blob/master/Makefile#L1187
-func linuxKernelVersionCode(major, minor, patch uint32) uint32 {
-	return (major << 16) + (minor << 8) + patch
-}
 
 // IsTracerSupportedByOS returns whether or not the current kernel version supports tracer functionality
 // along with some context on why it's not supported

--- a/pkg/ebpf/common_linux.go
+++ b/pkg/ebpf/common_linux.go
@@ -4,6 +4,7 @@ package ebpf
 
 import (
 	"encoding/binary"
+	"fmt"
 	"strings"
 	"unsafe"
 )
@@ -45,4 +46,22 @@ func isRHEL(platform string) bool {
 // isPre410Kernel compares current kernel version to the minimum kernel version(4.1.0) and see if it's older
 func isPre410Kernel(currentKernelCode uint32) bool {
 	return currentKernelCode < stringToKernelCode("4.1.0")
+}
+
+func kernelCodeToString(code uint32) string {
+	// Kernel "a.b.c", the version number will be (a<<16 + b<<8 + c)
+	a, b, c := code>>16, code>>8&0xff, code&0xff
+	return fmt.Sprintf("%d.%d.%d", a, b, c)
+}
+
+func stringToKernelCode(str string) uint32 {
+	var a, b, c uint32
+	fmt.Sscanf(str, "%d.%d.%d", &a, &b, &c)
+	return linuxKernelVersionCode(a, b, c)
+}
+
+// KERNEL_VERSION(a,b,c) = (a << 16) + (b << 8) + (c)
+// Per https://github.com/torvalds/linux/blob/master/Makefile#L1187
+func linuxKernelVersionCode(major, minor, patch uint32) uint32 {
+	return (major << 16) + (minor << 8) + patch
 }

--- a/pkg/ebpf/common_linux_test.go
+++ b/pkg/ebpf/common_linux_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestLinuxKernelVersionCode(t *testing.T) {
+	// Some sanity checks
+	assert.Equal(t, linuxKernelVersionCode(2, 6, 9), uint32(132617))
+	assert.Equal(t, linuxKernelVersionCode(3, 2, 12), uint32(197132))
+	assert.Equal(t, linuxKernelVersionCode(4, 4, 0), uint32(263168))
+
+	assert.Equal(t, stringToKernelCode("2.6.9"), uint32(132617))
+	assert.Equal(t, stringToKernelCode("3.2.12"), uint32(197132))
+	assert.Equal(t, stringToKernelCode("4.4.0"), uint32(263168))
+
+	assert.Equal(t, kernelCodeToString(uint32(132617)), "2.6.9")
+	assert.Equal(t, kernelCodeToString(uint32(197132)), "3.2.12")
+	assert.Equal(t, kernelCodeToString(uint32(263168)), "4.4.0")
+}
+
 func TestHasPre410Kernel(t *testing.T) {
 	oldKernels := []string{"3.10.0", "2.5.0", "4.0.10", "4.0"}
 	for _, kernel := range oldKernels {

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -6,21 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLinuxKernelVersionCode(t *testing.T) {
-	// Some sanity checks
-	assert.Equal(t, linuxKernelVersionCode(2, 6, 9), uint32(132617))
-	assert.Equal(t, linuxKernelVersionCode(3, 2, 12), uint32(197132))
-	assert.Equal(t, linuxKernelVersionCode(4, 4, 0), uint32(263168))
-
-	assert.Equal(t, stringToKernelCode("2.6.9"), uint32(132617))
-	assert.Equal(t, stringToKernelCode("3.2.12"), uint32(197132))
-	assert.Equal(t, stringToKernelCode("4.4.0"), uint32(263168))
-
-	assert.Equal(t, kernelCodeToString(uint32(132617)), "2.6.9")
-	assert.Equal(t, kernelCodeToString(uint32(197132)), "3.2.12")
-	assert.Equal(t, kernelCodeToString(uint32(263168)), "4.4.0")
-}
-
 func TestVerifyKernelFuncs(t *testing.T) {
 	missing, err := verifyKernelFuncs("./testdata/kallsyms.supported")
 	assert.Empty(t, missing)


### PR DESCRIPTION
### What does this PR do?

- Move a number of functions to the Linux only file for EBPF

### Motivation

- Fix a (flaky) `golangci-lint` error