### PR TITLE
Fix dogstatsd binary size + compliance not default activated

### DIFF
--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -13,7 +13,7 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	jsonutil "github.com/DataDog/datadog-agent/pkg/util/json"
+	"github.com/DataDog/datadog-agent/pkg/util/jsonquery"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"gopkg.in/yaml.v2"
@@ -124,7 +124,7 @@ func jsonGetter(data []byte, query string) (string, error) {
 	if err := json.Unmarshal(data, &jsonContent); err != nil {
 		return "", err
 	}
-	value, _, err := jsonutil.RunSingleOutput(query, jsonContent)
+	value, _, err := jsonquery.RunSingleOutput(query, jsonContent)
 	return value, err
 }
 
@@ -133,7 +133,7 @@ func yamlGetter(data []byte, query string) (string, error) {
 	if err := yaml.Unmarshal(data, &yamlContent); err != nil {
 		return "", err
 	}
-	value, _, err := jsonutil.RunSingleOutput(query, yamlContent)
+	value, _, err := jsonquery.RunSingleOutput(query, yamlContent)
 	return value, err
 }
 

--- a/pkg/compliance/checks/kubeapiserver_check.go
+++ b/pkg/compliance/checks/kubeapiserver_check.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	"github.com/DataDog/datadog-agent/pkg/util/json"
+	"github.com/DataDog/datadog-agent/pkg/util/jsonquery"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,7 +121,7 @@ func (c *kubeApiserverCheck) reportResource(p unstructured.Unstructured) error {
 	for _, field := range c.kubeResource.Report {
 		switch field.Kind {
 		case compliance.PropertyKindJSONQuery:
-			reportValue, valueFound, err := json.RunSingleOutput(field.Property, p.Object)
+			reportValue, valueFound, err := jsonquery.RunSingleOutput(field.Property, p.Object)
 			if err != nil {
 				return fmt.Errorf("unable to report field: '%s' for kubernetes object '%s / %s / %s' - json query error: %v", field.Property, p.GroupVersionKind().String(), p.GetNamespace(), p.GetName(), err)
 			}
@@ -158,7 +158,7 @@ func (c *kubeApiserverCheck) reportResource(p unstructured.Unstructured) error {
 
 func shouldReportResource(filters []compliance.Filter, object interface{}) (bool, error) {
 	applyCondition := func(c *compliance.Condition) (bool, error) {
-		value, _, err := json.RunSingleOutput(c.Property, object)
+		value, _, err := jsonquery.RunSingleOutput(c.Property, object)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -722,7 +722,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("inventories_min_interval", 300) // 5min
 
 	// Datadog security agent (compliance)
-	config.BindEnvAndSetDefault("compliance_config.enabled", true)
+	config.BindEnvAndSetDefault("compliance_config.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
 	config.BindEnvAndSetDefault("compliance_config.cmd_port", 5010)

--- a/pkg/util/jsonquery/jsonquery.go
+++ b/pkg/util/jsonquery/jsonquery.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2020 Datadog, Inc.
 
-package json
+package jsonquery
 
 import (
 	"fmt"

--- a/pkg/util/jsonquery/jsonquery_test.go
+++ b/pkg/util/jsonquery/jsonquery_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2020 Datadog, Inc.
 
-package json
+package jsonquery
 
 import (
 	"testing"


### PR DESCRIPTION
### What does this PR do?

Fix Dogstatsd binary size. Compliance not default activated (especially useful for cluster-agent)
