### PR TITLE
Fix release note.

### DIFF
--- a/releasenotes/notes/bump-go-to-1.13.11-de62f7d057ea740b.yaml
+++ b/releasenotes/notes/bump-go-to-1.13.11-de62f7d057ea740b.yaml
@@ -8,4 +8,4 @@
 ---
 other:
   - |
-    The Agent, Logs Agent and the system-probe are now compiled with Go ``1.13.11``.
+    All Agents binaries are now compiled with Go ``1.13.11``.


### PR DESCRIPTION
### What does this PR do?

Fix release note for go 1.13.11 as go 1.13.11 is used for all Agents binaries.


