### PR TITLE
Berzan/update packer config

### DIFF
--- a/devenv/packer.json.erb
+++ b/devenv/packer.json.erb
@@ -8,17 +8,16 @@
       "cpus":               "2",
       "memory":             "2048",
       "disk_size":          "262144",
-      
-      "iso_checksum":       "<%= builder.checksum %>",
-      "iso_checksum_type":  "sha256",
+
+      "iso_checksum":       "sha256:<%= builder.checksum %>",
       "iso_url":            "<%= builder.isourl %>",
-      
+
       "shutdown_command":   "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-      
+
       "winrm_username":     "dogdev",
       "winrm_password":     "dogdev",
       "winrm_timeout":      "15m",
-      
+
       "floppy_files": [
         "<%= builder.autounattend %>",
         "./scripts/Enable-WinRM.ps1"

--- a/releasenotes/notes/update-packer-config-f15499ab603f28c6.yaml
+++ b/releasenotes/notes/update-packer-config-f15499ab603f28c6.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added the checksum type to the checksum key itself, as it is deprecated to have a separate
+    checksum_type key.


### PR DESCRIPTION
### What does this PR do?
Added the checksum type to the checksum key itself, as it is deprecated to have a separate checksum_type key.

### Motivation

The Packer script for setting up a Windows dev environment failed with the newest version of Packer.

