### PR TITLE
Remove device_name logic from populate device field

### DIFF
--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -97,8 +97,6 @@ func (series Series) Marshal() ([]byte, error) {
 // populate the Serie.Device field
 //FIXME(olivier): remove this as soon as the v1 API can handle `device` as a regular tag
 func populateDeviceField(serie *Serie) {
-	var deviceName string
-
 	if !hasDeviceTag(serie) {
 		return
 	}
@@ -110,17 +108,9 @@ func populateDeviceField(serie *Serie) {
 	for _, tag := range serie.Tags {
 		if strings.HasPrefix(tag, "device:") {
 			serie.Device = tag[7:]
-		} else if strings.HasPrefix(tag, "device_name:") {
-			deviceName = tag[12:]
-			filteredTags = append(filteredTags, tag)
 		} else {
 			filteredTags = append(filteredTags, tag)
 		}
-	}
-
-	// Use device_name if device is not present
-	if serie.Device == "" {
-		serie.Device = deviceName
 	}
 
 	serie.Tags = filteredTags
@@ -129,7 +119,7 @@ func populateDeviceField(serie *Serie) {
 // hasDeviceTag checks whether a series contains a device tag
 func hasDeviceTag(serie *Serie) bool {
 	for _, tag := range serie.Tags {
-		if strings.HasPrefix(tag, "device:") || strings.HasPrefix(tag, "device_name:") {
+		if strings.HasPrefix(tag, "device:") {
 			return true
 		}
 	}

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -71,16 +71,6 @@ func TestPopulateDeviceField(t *testing.T) {
 			"/dev/sda1",
 		},
 		{
-			[]string{"some:tag", "device_name:/dev/sda1"},
-			[]string{"some:tag", "device_name:/dev/sda1"},
-			"/dev/sda1",
-		},
-		{
-			[]string{"some:tag", "device:/dev/sda1", "device_name:sda1"},
-			[]string{"some:tag", "device_name:sda1"},
-			"/dev/sda1",
-		},
-		{
 			[]string{"some:tag", "device:/dev/sda2", "some_other:tag"},
 			[]string{"some:tag", "some_other:tag"},
 			"/dev/sda2",

--- a/releasenotes/notes/remove-device_name-populateDeviceField-3967de244ebed07f.yaml
+++ b/releasenotes/notes/remove-device_name-populateDeviceField-3967de244ebed07f.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Removed consideration of the ``device_name`` tag from the populateDeviceField logic in series.
+    The ``device_name`` tag is not used anymore to populate the ``Device`` field of a series. Only the ``device`` tag is considered.

--- a/releasenotes/notes/remove-device_name-populateDeviceField-3967de244ebed07f.yaml
+++ b/releasenotes/notes/remove-device_name-populateDeviceField-3967de244ebed07f.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Removed consideration of the ``device_name`` tag from the populateDeviceField logic in series.


### PR DESCRIPTION
### What does this PR do?

Removes the consideration of the `device_name` tag from the populateDeviceField logic in series.go.

### Motivation

The change was unrelevant at first and brought some instability as sometimes we were using the `device_name` tag and sometimes the `device` tag (this was fixed later on). We should keep using the device tag until this tag is completely removed.
