### PR TITLE
[DCA] Add `clusterchecks rebalance` command

### DIFF
--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -27,6 +27,7 @@ import (
 func installClusterCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
 	r.HandleFunc("/clusterchecks/status/{nodeName}", postCheckStatus(sc)).Methods("POST")
 	r.HandleFunc("/clusterchecks/configs/{nodeName}", getCheckConfigs(sc)).Methods("GET")
+	r.HandleFunc("/clusterchecks/rebalance", postRebalanceChecks(sc)).Methods("POST")
 	r.HandleFunc("/clusterchecks", getState(sc)).Methods("GET")
 }
 
@@ -92,6 +93,28 @@ func getCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 		}
 
 		writeJSONResponse(w, response, "getCheckConfigs")
+	}
+}
+
+// postRebalanceChecks requests that the cluster checks be rebalanced
+func postRebalanceChecks(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
+	if sc.ClusterCheckHandler == nil {
+		return clusterChecksDisabledHandler
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !shouldHandle(w, r, sc.ClusterCheckHandler, "postRebalanceChecks") {
+			return
+		}
+
+		response, err := sc.ClusterCheckHandler.RebalanceClusterChecks()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			incrementRequestMetric("postRebalanceChecks", http.StatusInternalServerError)
+			return
+		}
+
+		writeJSONResponse(w, response, "postRebalanceChecks")
 	}
 }
 

--- a/cmd/cluster-agent/app/clusterchecks.go
+++ b/cmd/cluster-agent/app/clusterchecks.go
@@ -11,5 +11,8 @@ package app
 import "github.com/DataDog/datadog-agent/cmd/cluster-agent/commands"
 
 func init() {
-	ClusterAgentCmd.AddCommand(commands.GetClusterChecksCobraCmd(&flagNoColor, &confPath, loggerName))
+	clusterChecksCmd := commands.GetClusterChecksCobraCmd(&flagNoColor, &confPath, loggerName)
+	clusterChecksCmd.AddCommand(commands.RebalanceClusterChecksCobraCmd(&flagNoColor, &confPath, loggerName))
+
+	ClusterAgentCmd.AddCommand(clusterChecksCmd)
 }

--- a/cmd/cluster-agent/commands/clusterchecks.go
+++ b/cmd/cluster-agent/commands/clusterchecks.go
@@ -8,9 +8,13 @@
 package commands
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 
@@ -50,4 +54,75 @@ func GetClusterChecksCobraCmd(flagNoColor *bool, confPath *string, loggerName co
 	}
 
 	return clusterChecksCmd
+}
+
+func RebalanceClusterChecksCobraCmd(flagNoColor *bool, confPath *string, loggerName config.LoggerName) *cobra.Command {
+	clusterChecksCmd := &cobra.Command{
+		Use:   "rebalance",
+		Short: "Rebalances cluster checks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if *flagNoColor {
+				color.NoColor = true
+			}
+
+			// we'll search for a config file named `datadog-cluster.yaml`
+			config.Datadog.SetConfigName("datadog-cluster")
+			err := common.SetupConfig(*confPath)
+			if err != nil {
+				return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
+			}
+
+			err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+			if err != nil {
+				fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+				return err
+			}
+
+			return rebalanceChecks()
+		},
+	}
+
+	return clusterChecksCmd
+}
+
+func rebalanceChecks() error {
+	fmt.Println("Requesting a cluster check rebalance...")
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+	urlstr := fmt.Sprintf("https://localhost:%v/api/v1/clusterchecks/rebalance", config.Datadog.GetInt("cluster_agent.cmd_port"))
+
+	// Set session token
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	r, err := util.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
+	if err != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(r, &errMap) //nolint:errcheck
+		// If the error has been marshalled into a json object, check it and return it properly
+		if e, found := errMap["error"]; found {
+			err = fmt.Errorf(e)
+		}
+
+		fmt.Printf(`
+		Could not reach agent: %v
+		Make sure the agent is running before requesting the cluster checks rebalancing.
+		Contact support if you continue having issues.`, err)
+
+		return err
+	}
+
+	checksMoved := make([]types.RebalanceResponse, 0)
+	json.Unmarshal(r, &checksMoved) //nolint:errcheck
+
+	fmt.Printf("%d cluster checks rebalanced successfully\n", len(checksMoved))
+
+	for _, check := range checksMoved {
+		fmt.Printf("Check %s with weight %d moved from node %s to %s. source diff: %d, dest diff: %d\n",
+			check.CheckID, check.CheckWeight, check.SourceNodeName, check.DestNodeName, check.SourceDiff, check.DestDiff)
+	}
+
+	return nil
 }

--- a/pkg/clusteragent/clusterchecks/api.go
+++ b/pkg/clusteragent/clusterchecks/api.go
@@ -88,3 +88,25 @@ func (h *Handler) GetAllEndpointsCheckConfigs() (types.ConfigResponse, error) {
 	}
 	return response, err
 }
+
+func (h *Handler) RebalanceClusterChecks() ([]types.RebalanceResponse, error) {
+	if !h.dispatcher.advancedDispatching {
+		return nil, fmt.Errorf("no checks to rebalance: advanced dispatching is not enabled")
+	}
+
+	rebalancingDecisions := h.dispatcher.rebalance()
+	response := []types.RebalanceResponse{}
+
+	for _, decision := range rebalancingDecisions {
+		response = append(response, types.RebalanceResponse{
+			CheckID:        decision.CheckID,
+			CheckWeight:    decision.CheckWeight,
+			SourceNodeName: decision.SourceNodeName,
+			SourceDiff:     decision.SourceDiff,
+			DestNodeName:   decision.DestNodeName,
+			DestDiff:       decision.DestDiff,
+		})
+	}
+
+	return response, nil
+}

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -194,10 +194,8 @@ func (d *dispatcher) run(ctx context.Context) {
 				runnerStatsTicker = time.NewTicker(time.Duration(runnerStatsMinutes) * time.Minute)
 			}
 
-			// Update runner stats and rebalance if needed
+			// Rebalance if needed
 			if d.advancedDispatching {
-				// Collect CLC runners stats and update cache
-				d.updateRunnersStats()
 				// Rebalance checks distribution
 				d.rebalance()
 			}

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -19,6 +19,18 @@ type StatusResponse struct {
 	IsUpToDate bool `json:"isuptodate"`
 }
 
+// RebalanceResponse holds the DCA response for a rebalancing request
+type RebalanceResponse struct {
+	CheckID     string `json:"check_id"`
+	CheckWeight int    `json:"check_weight"`
+
+	SourceNodeName string `json:"source_node_name"`
+	SourceDiff     int    `json:"source_diff"`
+
+	DestNodeName string `json:"dest_node_name"`
+	DestDiff     int    `json:"dest_diff"`
+}
+
 // ConfigResponse holds the DCA response for a config query
 type ConfigResponse struct {
 	LastChange int64                `json:"last_change"`

--- a/releasenotes-dca/notes/rebalance-clusterchecks-cmd-e0def15b26ddc0f2.yaml
+++ b/releasenotes-dca/notes/rebalance-clusterchecks-cmd-e0def15b26ddc0f2.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add a new command 'datadog-cluster-agent clusterchecks rebalance' to
+    manually trigger a rebalancing of the cluster level checks.


### PR DESCRIPTION
### What does this PR do?

Adds both an endpoint to the cluster agent's API and a command to the cluster agent binary to manually trigger a cluster level checks rebalancing.

### Motivation

Having the possibility to trigger a rebalancing attempt manually could
be very useful in many use cases