### PR TITLE
Fix non-ascii character in release note

### DIFF
--- a/releasenotes/notes/check_hostname_is_usable-dc4b99e6f7242b34.yaml
+++ b/releasenotes/notes/check_hostname_is_usable-dc4b99e6f7242b34.yaml
@@ -13,6 +13,6 @@ upgrade:
 
     This change only affects you if your agent is currently using a container ID or a kubernetes POD name as hostname.
     The hostname of the agent can be checked with ``agent hostname``.
-    If the output stays stable when the container or POD of the agent is destroyed and recreated, you’re not impacted by this change.
+    If the output stays stable when the container or POD of the agent is destroyed and recreated, you're not impacted by this change.
     If the output changes, it means that the agent was unable to talk to EC2/GKE metadata server, it was unable to get the k8s node name from the kubelet, it was unable to get the hostname from the docker daemon and it is running in its dedicated UTS namespace.
     Under those conditions, you should set explicitly define the host name to be used by the agent in its configuration file.


### PR DESCRIPTION
### What does this PR do?

Remove non-ascii character in release note

### Motivation

It's making the `reno lint` check fail on master, because we switched from Python 2.7 to 3.6.

