### PR TITLE
Ensure we ship up-to-date packages inside the agent docker images

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -96,9 +96,7 @@ ENV DOCKER_DD_AGENT=true \
 # make sure we have recent dependencies
 RUN apt-get update \
   # CVE-fixing time!
-  && apt-get install -y util-linux ncurses-bin ncurses-base libncursesw5:amd64 \
-  # https://security-tracker.debian.org/tracker/CVE-2018-15686
-  && apt-get install -y libudev1 libsystemd0 \
+  && apt full-upgrade -y \
   # https://security-tracker.debian.org/tracker/CVE-2016-2779
   && rm -f /usr/sbin/runuser \
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6954

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -96,9 +96,7 @@ ENV DOCKER_DD_AGENT=true \
 # make sure we have recent dependencies
 RUN apt-get update \
   # CVE-fixing time!
-  && apt-get install -y util-linux ncurses-bin ncurses-base libncursesw5:arm64 \
-  # https://security-tracker.debian.org/tracker/CVE-2018-15686
-  && apt-get install -y libudev1 libsystemd0 \
+  && apt full-upgrade -y \
   # https://security-tracker.debian.org/tracker/CVE-2016-2779
   && rm -f /usr/sbin/runuser \
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6954

--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -31,9 +31,8 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 ENV PATH="/opt/datadog-agent/bin/:$PATH"
 
 RUN apt-get update \
+    && apt full-upgrade -y \
     && apt-get install --no-install-recommends -y ca-certificates curl \
-    # https://security-tracker.debian.org/tracker/CVE-2018-15686
-    && apt-get install -y libudev1 libsystemd0 \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=builder /output /

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -30,9 +30,8 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 ENV PATH="/opt/datadog-agent/bin/:$PATH"
 
 RUN apt-get update \
+    && apt full-upgrade -y \
     && apt-get install --no-install-recommends -y ca-certificates curl \
-    # https://security-tracker.debian.org/tracker/CVE-2018-15686
-    && apt-get install -y libudev1 libsystemd0 \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=builder /output /


### PR DESCRIPTION
### What does this PR do?

Run an `apt full-upgrade` command at the beginning of the agent docker image construction to ensure all the packages are up-to-date.

### Motivation

If the base image is not fully up-to-date, we may ship agent docker images with packages suffering from a vulnerability whereas the fix is available.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
