### PR TITLE
[process-agent] collect requests and limits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v0.0.0-20200624194755-bbcbef3bd83d // 4.36.0
+	github.com/DataDog/agent-payload v0.0.0-20200630140101-31e351744885 // 4.37.0
 	github.com/DataDog/datadog-go v3.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200527110245-7850164045c8
 	github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload v0.0.0-20200624194755-bbcbef3bd83d h1:RMHcMKuZZZNx1h0Qrbde+fy5YVT07fJ7nJNZ4k6c9MM=
 github.com/DataDog/agent-payload v0.0.0-20200624194755-bbcbef3bd83d/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v0.0.0-20200630140101-31e351744885 h1:Vx6oxLrMP2rg9aGObiUBHlcHub059upFySplaj2LB9g=
+github.com/DataDog/agent-payload v0.0.0-20200630140101-31e351744885/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v3.5.0+incompatible h1:AShr9cqkF+taHjyQgcBcQUt/ZNK+iPq4ROaZwSX5c/U=
 github.com/DataDog/datadog-go v3.5.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/releasenotes/notes/collect-resourcerequirements-aba87bf5b54d8272.yaml
+++ b/releasenotes/notes/collect-resourcerequirements-aba87bf5b54d8272.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Enabled the collection of the kubernetes resource requirements (requests and limits)
+    by bumping the agent-payload dep. and collecting the resource requirements.


### PR DESCRIPTION
### What does this PR do?
- bumps payload to enable the collection of `resourceRequirements` of kubernetes (limits and requests)
- enables the collection and sending it to the backend
- run `go mod tidy` 
### Motivation

Related Jira Task: CAP-59
Collection of request and limits for future work

### Additional Notes

- depends on https://github.com/DataDog/agent-payload/pull/57 to be merged first.
- Containers can only contain `Requests` or `Limits`
- `CPU` are calculated as `Millicore`, hence `Millivalue()`
- `Memory` are calculated as `Bytes`, hence `Value()` 
- further information can be found in the corresponding unit-tests

### Describe your test plan

- tested using logging to ensure the pods get's the correct information
- added corresponding unit-tests 
