### PR TITLE
Fix the readiness check in case the forward health is disabled

### DIFF
--- a/pkg/status/health/health.go
+++ b/pkg/status/health/health.go
@@ -128,6 +128,12 @@ func (c *catalog) getStatus() Status {
 	c.RLock()
 	defer c.RUnlock()
 
+	// If no component registered, do not check anything, not even the checker itself
+	// as the `run()` function exits in such a case.
+	if len(c.components) == 0 {
+		return status
+	}
+
 	// Test the checker itself
 	if time.Now().After(c.latestRun.Add(2 * pingFrequency)) {
 		status.Unhealthy = append(status.Unhealthy, "healthcheck")

--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -13,17 +13,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEmptyCatalog(t *testing.T) {
+	cat := newCatalog()
+
+	status := cat.getStatus()
+	assert.Len(t, status.Healthy, 0)
+	assert.Len(t, status.Unhealthy, 0)
+}
+
 func TestCatalogStartsHealthy(t *testing.T) {
 	cat := newCatalog()
+	_ = cat.register("test1")
 
 	status := cat.getStatus()
 	assert.Len(t, status.Healthy, 1)
 	assert.Contains(t, status.Healthy, "healthcheck")
-	assert.Len(t, status.Unhealthy, 0)
+	assert.Len(t, status.Unhealthy, 1)
+	assert.Contains(t, status.Unhealthy, "test1")
 }
 
 func TestCatalogGetsUnhealthyAndBack(t *testing.T) {
 	cat := newCatalog()
+	_ = cat.register("test1")
 
 	status := cat.getStatus()
 	assert.Contains(t, status.Healthy, "healthcheck")

--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -23,6 +23,8 @@ func TestEmptyCatalog(t *testing.T) {
 
 func TestCatalogStartsHealthy(t *testing.T) {
 	cat := newCatalog()
+	// Register a fake compoment
+	// because without any registered component, the `healthcheck` component would be disabled
 	_ = cat.register("test1")
 
 	status := cat.getStatus()
@@ -34,6 +36,8 @@ func TestCatalogStartsHealthy(t *testing.T) {
 
 func TestCatalogGetsUnhealthyAndBack(t *testing.T) {
 	cat := newCatalog()
+	// Register a fake compoment
+	// because without any registered component, the `healthcheck` component would be disabled
 	_ = cat.register("test1")
 
 	status := cat.getStatus()

--- a/releasenotes/notes/fix_readiness-c0e1f30b49efe5f5.yaml
+++ b/releasenotes/notes/fix_readiness-c0e1f30b49efe5f5.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes the `/ready` health endpoint on the cluster-agent.

--- a/releasenotes/notes/fix_readiness-c0e1f30b49efe5f5.yaml
+++ b/releasenotes/notes/fix_readiness-c0e1f30b49efe5f5.yaml
@@ -9,3 +9,7 @@
 fixes:
   - |
     Fixes the `/ready` health endpoint on the cluster-agent.
+
+    The `/ready` health endpoint was reporting 200 at the cluster-agent startup and was then, permanently reporting 500 even though the cluster-agent was experiencing no problem.
+    In the body of the response, we could see that a `healthcheck` component was failing.
+    This change fixes this issue.


### PR DESCRIPTION
### What does this PR do?

Fix the readiness check in case the `forward` health check is disabled.

### Motivation

The health check now has to sets of components to probe:
* the ones that are used for both the liveness and the readiness probes.
* the ones that are used only for the readiness probe.

There’s a single component in the later set: `forward`.
Indeed, if the `forward` check fails (because the API key cannot be validated), it is useless to kill and restart the container.
So, it mustn’t be part of the liveness probe.

However, in the cluster-agent, the `forward` check is completely disabled because, if the cluster agent looses the connectivity to Datadog, the `forward` check will fail.
If the readiness probe fails, that cluster-agent instance will get out of its service and it will not be eligible to serve custom metrics anymore.
And this is unfortunate because the cluster-agent would still be able to serve stale/outdated data and this is definitively better that serving no data at all.
For this reason, we don’t want to readiness probe of the cluster-agent to fail when it looses the connectivity to Datadog.

So, the “readiness probe” component set is empty and this led to a permanent failure.

### Additional Notes

Fixes #5846
Fixes helm/charts#22976

### Describe your test plan

Start the cluster agent and check its `/ready` endpoint:
```
kubectl exec "$(kubectl get pod -l app=datadog-cluster-agent --no-headers | cut -d' ' -f 1)" -- curl -s http://localhost:5555/ready
```

Before:
```json
{"Healthy":["healthcheck","collector-queue","clusterchecks-leadership","clusterchecks-dispatch","aggregator","tagger","ad-servicelistening","ad-config-provider-kubernetes-endpoints","ad-config-provider-kubernetes-services"],"Unhealthy":["healthcheck"]}
```

With this fix:
```json
{"Healthy":["healthcheck","collector-queue","clusterchecks-leadership","clusterchecks-dispatch","aggregator","tagger","ad-servicelistening","ad-config-provider-kubernetes-endpoints","ad-config-provider-kubernetes-services"],"Unhealthy":[]}
```