### PR TITLE
Add IO operations monitoring for Docker check

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -394,23 +394,23 @@ func (d *DockerCheck) reportIOMetrics(io *cmetrics.ContainerIOStats, tags []stri
 		return
 	}
 
-	// Read values per device, or fallback to sum
-	if len(io.DeviceReadBytes) > 0 {
-		for dev, value := range io.DeviceReadBytes {
-			sender.Rate("docker.io.read_bytes", float64(value), "", append(tags, "device:"+dev, "device_name:"+dev))
+	reportDeviceStat := func(metricName string, deviceMap map[string]uint64, fallbackValue uint64) {
+		if len(deviceMap) > 0 {
+			for dev, value := range deviceMap {
+				sender.Rate(metricName, float64(value), "", append(tags, "device:"+dev, "device_name:"+dev))
+			}
+		} else {
+			sender.Rate(metricName, float64(fallbackValue), "", tags)
 		}
-	} else {
-		sender.Rate("docker.io.read_bytes", float64(io.ReadBytes), "", tags)
 	}
 
-	// Write values per device, or fallback to sum
-	if len(io.DeviceWriteBytes) > 0 {
-		for dev, value := range io.DeviceWriteBytes {
-			sender.Rate("docker.io.write_bytes", float64(value), "", append(tags, "device:"+dev, "device_name:"+dev))
-		}
-	} else {
-		sender.Rate("docker.io.write_bytes", float64(io.WriteBytes), "", tags)
-	}
+	// Throughput
+	reportDeviceStat("docker.io.read_bytes", io.DeviceReadBytes, io.ReadBytes)
+	reportDeviceStat("docker.io.write_bytes", io.DeviceWriteBytes, io.WriteBytes)
+
+	// IOPS
+	reportDeviceStat("docker.io.read_operations", io.DeviceReadOperations, io.ReadOperations)
+	reportDeviceStat("docker.io.write_operations", io.DeviceWriteOperations, io.WriteOperations)
 
 	// Collect open file descriptor counts
 	sender.Gauge("docker.container.open_fds", float64(io.OpenFiles), "", tags)

--- a/pkg/collector/corechecks/containers/docker_test.go
+++ b/pkg/collector/corechecks/containers/docker_test.go
@@ -45,6 +45,14 @@ func TestReportIOMetrics(t *testing.T) {
 			"sda": 671846400,
 			"sdb": 0,
 		},
+		DeviceReadOperations: map[string]uint64{
+			"sda": 1042,
+			"sdb": 42,
+		},
+		DeviceWriteOperations: map[string]uint64{
+			"sda": 2042,
+			"sdb": 1042,
+		},
 	}
 	sdaTags := append(tags, "device:sda", "device_name:sda")
 	sdbTags := append(tags, "device:sdb", "device_name:sdb")
@@ -53,6 +61,10 @@ func TestReportIOMetrics(t *testing.T) {
 	mockSender.AssertMetric(t, "Rate", "docker.io.write_bytes", float64(671846400), "", sdaTags)
 	mockSender.AssertMetric(t, "Rate", "docker.io.read_bytes", float64(1130496), "", sdbTags)
 	mockSender.AssertMetric(t, "Rate", "docker.io.write_bytes", float64(0), "", sdbTags)
+	mockSender.AssertMetric(t, "Rate", "docker.io.read_operations", float64(1042), "", sdaTags)
+	mockSender.AssertMetric(t, "Rate", "docker.io.write_operations", float64(2042), "", sdaTags)
+	mockSender.AssertMetric(t, "Rate", "docker.io.read_operations", float64(42), "", sdbTags)
+	mockSender.AssertMetric(t, "Rate", "docker.io.write_operations", float64(1042), "", sdbTags)
 }
 
 func TestReportUptime(t *testing.T) {

--- a/pkg/util/containers/metrics/types.go
+++ b/pkg/util/containers/metrics/types.go
@@ -115,17 +115,21 @@ type ContainerCPUStats struct {
 // ContainerIOStats store I/O statistics about a cgroup.
 // Sums are stored in ReadBytes and WriteBytes
 type ContainerIOStats struct {
-	// docker.io.read_bytes
-	ReadBytes uint64
-
-	// docker.io.write_bytes
+	// docker.io.read_bytes / write_bytes
+	ReadBytes  uint64
 	WriteBytes uint64
 
-	// docker.io.read_bytes
-	DeviceReadBytes map[string]uint64
-
-	// docker.io.write_bytes
+	// docker.io.read_bytes / write_bytes
+	DeviceReadBytes  map[string]uint64
 	DeviceWriteBytes map[string]uint64
+
+	// dodcker.io.read_ops / write_ops
+	ReadOperations  uint64
+	WriteOperations uint64
+
+	// dodcker.io.read_ops / write_ops
+	DeviceReadOperations  map[string]uint64
+	DeviceWriteOperations map[string]uint64
 
 	// docker.container.open_fds
 	OpenFiles uint64

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -360,19 +360,11 @@ func (c ContainerCgroup) CPULimit() (float64, error) {
 //
 func (c ContainerCgroup) IO() (*metrics.ContainerIOStats, error) {
 	ret := &metrics.ContainerIOStats{
-		DeviceReadBytes:  make(map[string]uint64),
-		DeviceWriteBytes: make(map[string]uint64),
+		DeviceReadBytes:       make(map[string]uint64),
+		DeviceWriteBytes:      make(map[string]uint64),
+		DeviceReadOperations:  make(map[string]uint64),
+		DeviceWriteOperations: make(map[string]uint64),
 	}
-
-	statfile := c.cgroupFilePath("blkio", "blkio.throttle.io_service_bytes")
-	f, err := os.Open(statfile)
-	if os.IsNotExist(err) {
-		log.Debugf("Missing cgroup file: %s", statfile)
-		return ret, nil
-	} else if err != nil {
-		return nil, err
-	}
-	defer f.Close()
 
 	// Get device id->name mapping
 	var devices map[string]string
@@ -384,11 +376,10 @@ func (c ContainerCgroup) IO() (*metrics.ContainerIOStats, error) {
 		devices = mapping.idToName
 	}
 
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		fields := strings.Split(scanner.Text(), " ")
+	err = c.scanStatFile("blkio", "blkio.throttle.io_service_bytes", func(line string) error {
+		fields := strings.Split(line, " ")
 		if len(fields) < 3 {
-			continue
+			return nil
 		}
 		deviceName := devices[fields[0]]
 		if fields[1] == "Read" {
@@ -408,9 +399,39 @@ func (c ContainerCgroup) IO() (*metrics.ContainerIOStats, error) {
 				}
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	if err := scanner.Err(); err != nil {
-		return ret, fmt.Errorf("error reading %s: %s", statfile, err)
+
+	err = c.scanStatFile("blkio", "blkio.throttle.io_serviced", func(line string) error {
+		fields := strings.Split(line, " ")
+		if len(fields) < 3 {
+			return nil
+		}
+		deviceName := devices[fields[0]]
+		if fields[1] == "Read" {
+			read, err := strconv.ParseUint(fields[2], 10, 64)
+			if err == nil {
+				ret.ReadOperations += read
+				if deviceName != "" {
+					ret.DeviceReadOperations[deviceName] = read
+				}
+			}
+		} else if fields[1] == "Write" {
+			write, err := strconv.ParseUint(fields[2], 10, 64)
+			if err == nil {
+				ret.WriteOperations += write
+				if deviceName != "" {
+					ret.DeviceWriteOperations[deviceName] = write
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	var fileDescCount uint64
@@ -487,4 +508,30 @@ func (c ContainerCgroup) ParseSingleStat(target, file string) (uint64, error) {
 		return 0, err
 	}
 	return value, nil
+}
+
+// Parse file
+func (c ContainerCgroup) scanStatFile(target, file string, parser func(line string) error) error {
+	filePath := c.cgroupFilePath(target, file)
+	f, err := os.Open(filePath)
+	if os.IsNotExist(err) {
+		log.Debugf("Missing cgroup file: %s", filePath)
+		return nil
+	} else if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if err = parser(scanner.Text()); err != nil {
+			return err
+		}
+	}
+
+	if err = scanner.Err(); err != nil {
+		return fmt.Errorf("error reading %s: %s", filePath, err)
+	}
+
+	return nil
 }

--- a/pkg/util/containers/providers/cgroup/disk_test.go
+++ b/pkg/util/containers/providers/cgroup/disk_test.go
@@ -121,6 +121,22 @@ func (s *DiskMappingTestSuite) TestContainerCgroupIO() {
 		55:0 Total 55
 	`))
 
+	tempFolder.add("blkio/blkio.throttle.io_serviced", detab(`
+		8:16 Read 15
+		8:16 Write 0
+		8:16 Sync 15
+		8:16 Async 0
+		8:16 Discard 0
+		8:16 Total 15
+		8:0 Read 26
+		8:0 Write 512625
+		8:0 Sync 26
+		8:0 Async 512625
+		8:0 Discard 0
+		8:0 Total 512651
+		Total 512666
+	`))
+
 	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "blkio", "blkio")
 
 	expectedStats := &metrics.ContainerIOStats{
@@ -132,6 +148,16 @@ func (s *DiskMappingTestSuite) TestContainerCgroupIO() {
 		},
 		DeviceWriteBytes: map[string]uint64{
 			"sda": 671846400,
+			"sdb": 0,
+		},
+		ReadOperations:  uint64(15 + 26),
+		WriteOperations: uint64(0 + 512625),
+		DeviceReadOperations: map[string]uint64{
+			"sda": 26,
+			"sdb": 15,
+		},
+		DeviceWriteOperations: map[string]uint64{
+			"sda": 512625,
 			"sdb": 0,
 		},
 	}
@@ -170,10 +196,12 @@ func (s *DiskMappingTestSuite) TestContainerCgroupIOFailedMapping() {
 	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "blkio", "blkio")
 
 	expectedStats := &metrics.ContainerIOStats{
-		ReadBytes:        uint64(1130496 + 37858816 + 55),
-		WriteBytes:       uint64(0 + 671846400 + 55),
-		DeviceReadBytes:  map[string]uint64{},
-		DeviceWriteBytes: map[string]uint64{},
+		ReadBytes:             uint64(1130496 + 37858816 + 55),
+		WriteBytes:            uint64(0 + 671846400 + 55),
+		DeviceReadBytes:       map[string]uint64{},
+		DeviceWriteBytes:      map[string]uint64{},
+		DeviceReadOperations:  map[string]uint64{},
+		DeviceWriteOperations: map[string]uint64{},
 	}
 
 	ioStat, err := cgroup.IO()

--- a/releasenotes/notes/docker-io-operations-8f9e56539c73b6cc.yaml
+++ b/releasenotes/notes/docker-io-operations-8f9e56539c73b6cc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add IO operations monitoring for Docker check (docker.io.read/write_operations)


### PR DESCRIPTION
### What does this PR do?

Add IO operations monitoring for Docker check, new metrics:
`docker.io.read/write_operations`
