### PR TITLE
Fix error type returned by ExternalMetric server and fix panic when referencing unexisting DatadogMetric

### DIFF
--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
@@ -138,11 +138,14 @@ func (w *AutoscalerWatcher) processAutoscalers() {
 	}
 
 	// In `datadogMetricReferences` we now only have existing references that we should create
+	// Or autoscalers referencing inexisting DatadogMetrics (in this case, externalMetric is nil)
 	for datadogMetricID, externalMetric := range datadogMetricReferences {
-		autogenQuery := buildDatadogQueryForExternalMetric(externalMetric.metricName, externalMetric.metricLabels)
-		autogenDatadogMetric := model.NewDatadogMetricInternalFromExternalMetric(datadogMetricID, autogenQuery, externalMetric.metricName)
-		log.Infof("Creating DatadogMetric: %s for ExternalMetric: %s, Query: %s", datadogMetricID, externalMetric.metricName, autogenQuery)
-		w.store.Set(datadogMetricID, autogenDatadogMetric, autoscalerWatcherStoreID)
+		if externalMetric != nil {
+			autogenQuery := buildDatadogQueryForExternalMetric(externalMetric.metricName, externalMetric.metricLabels)
+			autogenDatadogMetric := model.NewDatadogMetricInternalFromExternalMetric(datadogMetricID, autogenQuery, externalMetric.metricName)
+			log.Infof("Creating DatadogMetric: %s for ExternalMetric: %s, Query: %s", datadogMetricID, externalMetric.metricName, autogenQuery)
+			w.store.Set(datadogMetricID, autogenDatadogMetric, autoscalerWatcherStoreID)
+		}
 	}
 }
 

--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher_test.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher_test.go
@@ -223,6 +223,14 @@ func TestCreateAutogenDatadogMetrics(t *testing.T) {
 				},
 			},
 		}),
+		newFakeHorizontalPodAutoscaler("ns0", "hpa1", []autoscaler.MetricSpec{
+			{
+				Type: autoscaler.ExternalMetricSourceType,
+				External: &autoscaler.ExternalMetricSource{
+					MetricName: "datadogmetric@ns0:donotexist",
+				},
+			},
+		}),
 	}
 
 	f.wpaLister = []*datadoghq.WatermarkPodAutoscaler{

--- a/pkg/clusteragent/externalmetrics/provider_test.go
+++ b/pkg/clusteragent/externalmetrics/provider_test.go
@@ -47,7 +47,7 @@ func (f *providerFixture) runGetExternalMetric(t *testing.T) {
 		datadogMetricProvider.store.Set(datadogMetric.ID, datadogMetric, "utest")
 	}
 
-	externalMetrics, err := datadogMetricProvider.GetExternalMetric(f.queryNamespace, labels.Set(f.querySelector).AsSelector(), provider.ExternalMetricInfo{Metric: f.queryMetricName})
+	externalMetrics, err := datadogMetricProvider.getExternalMetric(f.queryNamespace, labels.Set(f.querySelector).AsSelector(), provider.ExternalMetricInfo{Metric: f.queryMetricName})
 	if err != nil {
 		assert.Equal(t, f.expectedError, err)
 		assert.Nil(t, externalMetrics)


### PR DESCRIPTION
### What does this PR do?

Wrap all errors returned by `GetExternalMetric` to a known type from `k8s.io/apimachinery/pkg/api/errors`, it avoids having non-agent formatted logs.

Fixes an issue where DCA would `panic` when autoscalers reference un-existing `DatadogMetric`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
