### PR TITLE
Move testing RPM repo to yumtesting.datad0g.com/testing/*

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1542,7 +1542,7 @@ deploy_rpm_testing-a6:
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   script:
-    - rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "pipeline-$DD_PIPELINE_ID/6/x86_64/" $OMNIBUS_PACKAGE_DIR/datadog-*-6.*x86_64.rpm
+    - rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/6/x86_64/" $OMNIBUS_PACKAGE_DIR/datadog-*-6.*x86_64.rpm
 
 deploy_rpm_testing-a7:
   rules:
@@ -1558,7 +1558,7 @@ deploy_rpm_testing-a7:
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   script:
-    - rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "pipeline-$DD_PIPELINE_ID/7/x86_64/" $OMNIBUS_PACKAGE_DIR/datadog-*-7.*x86_64.rpm
+    - rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" $OMNIBUS_PACKAGE_DIR/datadog-*-7.*x86_64.rpm
 
 # deploy rpm packages to yum staging repo
 deploy_suse_rpm_testing-a6:
@@ -1575,7 +1575,7 @@ deploy_suse_rpm_testing-a6:
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   script:
-    - rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/pipeline-$DD_PIPELINE_ID/6/x86_64/" $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-6.*x86_64.rpm
+    - rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/6/x86_64/" $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-6.*x86_64.rpm
 
 deploy_suse_rpm_testing-a7:
   rules:
@@ -1591,7 +1591,7 @@ deploy_suse_rpm_testing-a7:
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   script:
-    - rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/pipeline-$DD_PIPELINE_ID/7/x86_64/" $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-7.*x86_64.rpm
+    - rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" $OMNIBUS_PACKAGE_DIR_SUSE/datadog-*-7.*x86_64.rpm
 
 # deploy windows packages to our testing bucket
 deploy_windows_testing-a6:
@@ -2321,8 +2321,8 @@ kitchen_debian_upgrade7_iot_agent-a7:
   tags: [ "runner:main", "size:large" ]
   script:
     - aws s3 rm s3://$DEB_TESTING_S3_BUCKET/dists/pipeline-$DD_PIPELINE_ID --recursive
-    - aws s3 rm s3://$RPM_TESTING_S3_BUCKET/pipeline-$DD_PIPELINE_ID --recursive
-    - aws s3 rm s3://$RPM_TESTING_S3_BUCKET/suse/pipeline-$DD_PIPELINE_ID --recursive
+    - aws s3 rm s3://$RPM_TESTING_S3_BUCKET/testing/pipeline-$DD_PIPELINE_ID --recursive
+    - aws s3 rm s3://$RPM_TESTING_S3_BUCKET/testing/suse/pipeline-$DD_PIPELINE_ID --recursive
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
     - aws s3 rm s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET --recursive
     - cd $OMNIBUS_PACKAGE_DIR

--- a/test/kitchen/kitchen-azure-common.yml
+++ b/test/kitchen/kitchen-azure-common.yml
@@ -174,8 +174,8 @@ platforms:
   url = "https://app.datad0g.com"
   aptrepo = "http://apttesting.datad0g.com/"
   aptrepo_dist = "pipeline-#{ENV['DD_PIPELINE_ID']}"
-  yumrepo = "http://yumtesting.datad0g.com/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['MAJOR_VERSION']}/x86_64/"
-  yumrepo_suse = "http://yumtesting.datad0g.com/suse/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['MAJOR_VERSION']}/x86_64/"
+  yumrepo = "http://yumtesting.datad0g.com/testing/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['MAJOR_VERSION']}/x86_64/"
+  yumrepo_suse = "http://yumtesting.datad0g.com/suse/testing/pipeline-#{ENV['DD_PIPELINE_ID']}/#{ENV['MAJOR_VERSION']}/x86_64/"
   agent_major_version = "#{ENV['MAJOR_VERSION']}"
   windows_agent_url = ENV['WINDOWS_AGENT_URL'] ? ENV['WINDOWS_AGENT_URL'] : "https://#{ENV['WIN_S3_BUCKET']}.s3.amazonaws.com/#{ENV['WINDOWS_TESTING_S3_BUCKET']}"
   dd_agent_config = {

--- a/test/kitchen/kitchen-azure-install-script-test.yml
+++ b/test/kitchen/kitchen-azure-install-script-test.yml
@@ -21,7 +21,7 @@ suites:
       install_script_url: https://raw.githubusercontent.com/DataDog/datadog-agent/<%= ENV['CI_COMMIT_SHA'] %>/cmd/agent/install_script.sh
       repo_branch_apt: <%= aptrepo_dist %>
       repo_component_apt: <%= agent_major_version %>
-      repo_branch_yum: pipeline-<%= ENV['DD_PIPELINE_ID'] %>/<%= agent_major_version %>
+      repo_branch_yum: testing/pipeline-<%= ENV['DD_PIPELINE_ID'] %>/<%= agent_major_version %>
       install_candidate: true
     dd-agent-rspec:
       agent_flavor: <%= ENV['AGENT_FLAVOR'] || "datadog-agent" %>


### PR DESCRIPTION
### What does this PR do?

Put test artifacts in `https://yumtesting.datad0g.com/testing/pipeline-*` instead of `https://yumtesting.datad0g.com/pipeline-*` and the same for SUSE.

### Motivation

So our delete script that runs periodically to delete old test artifacts (and which I can't link here because it's in a private repo) actually deletes them. 


### Additional notes

I changed this instead of the script because the AWS S3 CLI doesn't take wildcards so one can't ask it to delete `yumtesting.datad0g.com/pipeline-*`
