### PR TITLE
[kitchen] Remove linux chef tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1930,7 +1930,8 @@ kitchen_windows_installer_agent-a7:
     - .kitchen_test_windows_installer_agent
   retry: 0
 
-# run dd-agent-testing on windows
+# Windows kitchen tests
+
 kitchen_windows_chef_agent-a6:
   allow_failure: false
   extends:
@@ -1973,18 +1974,7 @@ kitchen_windows_upgrade7_agent-a7:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_upgrade7_agent
 
-# run dd-agent-testing on centos
-kitchen_centos_chef_agent-a6:
-  allow_failure: false
-  extends:
-    - .kitchen_scenario_centos_a6
-    - .kitchen_test_chef_agent
-
-kitchen_centos_chef_agent-a7:
-  allow_failure: false
-  extends:
-    - .kitchen_scenario_centos_a7
-    - .kitchen_test_chef_agent
+# CentOS kitchen tests
 
 kitchen_centos_install_script_agent-a6:
   allow_failure: false
@@ -2058,19 +2048,8 @@ kitchen_centos_upgrade7_iot_agent-a7:
     - .kitchen_scenario_centos_a7
     - .kitchen_test_upgrade7_iot_agent
 
-# run dd-agent-testing on ubuntu
+# Ubuntu kitchen tests
 # Could fail if we encounter the issue with apt locks/azure agent, but should be investigated if that's the case
-kitchen_ubuntu_chef_agent-a6:
-  allow_failure: false
-  extends:
-    - .kitchen_scenario_ubuntu_a6
-    - .kitchen_test_chef_agent
-
-kitchen_ubuntu_chef_agent-a7:
-  allow_failure: false
-  extends:
-    - .kitchen_scenario_ubuntu_a7
-    - .kitchen_test_chef_agent
 
 kitchen_ubuntu_install_script_agent-a6:
   allow_failure: false
@@ -2144,18 +2123,7 @@ kitchen_ubuntu_upgrade7_iot_agent-a7:
     - .kitchen_scenario_ubuntu_a7
     - .kitchen_test_upgrade7_iot_agent
 
-# run dd-agent-testing on suse
-kitchen_suse_chef_agent-a6:
-  allow_failure: false
-  extends:
-    - .kitchen_scenario_suse_a6
-    - .kitchen_test_chef_agent
-
-kitchen_suse_chef_agent-a7:
-  allow_failure: false
-  extends:
-    - .kitchen_scenario_suse_a7
-    - .kitchen_test_chef_agent
+# SUSE kitchen tests
 
 kitchen_suse_install_script_agent-a6:
   allow_failure: false
@@ -2229,19 +2197,8 @@ kitchen_suse_upgrade7_iot_agent-a7:
     - .kitchen_scenario_suse_a7
     - .kitchen_test_upgrade7_iot_agent
 
-# run dd-agent-testing on debian
+# Debian kitchen tests
 # Could fail if we encounter the issue with apt locks/azure agent, but should be investigated if that's the case
-kitchen_debian_chef_agent-a6:
-  allow_failure: false
-  extends:
-    - .kitchen_scenario_debian_a6
-    - .kitchen_test_chef_agent
-
-kitchen_debian_chef_agent-a7:
-  allow_failure: false
-  extends:
-    - .kitchen_scenario_debian_a7
-    - .kitchen_test_chef_agent
 
 kitchen_debian_install_script_agent-a6:
   allow_failure: false


### PR DESCRIPTION
### What does this PR do?

Removes chef kitchen tests on Linux platforms.

### Motivation

Reduce our resource usage & complexity of the pipeline.
The chef kitchen tests provide little additional coverage: we already have install script & step-by-step tests which fulfill the same role (installing the Agent). Moreover, the chef-datadog repository has its own tests (unit tests & kitchen tests) to check that the Agent install using Chef works.

The Windows install tests will still use chef (because there are no other vanilla install recipes for this platform yet), until we add a proper step-by-step install recipe.

Note: the `dd-agent-install` recipe is currently still used in the upgrade tests (to do the initial Agent install), thus it can't be removed yet.