### PR TITLE
[runtime config] agent config output minor adjustments

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -128,7 +128,7 @@ func listRuntimeConfigurableValue(cmd *cobra.Command, args []string) error {
 	fmt.Println("=== Settings that can be changed at runtime ===")
 	for setting, details := range settings {
 		if !details.Hidden {
-			fmt.Printf("%s:\t\t\t%s\n", setting, details.Description)
+			fmt.Printf("%-30s %s\n", setting, details.Description)
 		}
 	}
 	return nil
@@ -204,7 +204,7 @@ func getConfigValue(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if value, found := setting["value"]; found {
-		fmt.Printf("%s is set to: %s\n", args[0], value)
+		fmt.Printf("%s is set to: %v\n", args[0], value)
 		return nil
 	}
 	return fmt.Errorf("unable to get value for this setting: %v", args[0])


### PR DESCRIPTION
### What does this PR do?

Improve console ouptut for runtime config operations.

Before :

```
# datadog-agent config get dogstatsd_stats
dogstatsd_stats is set to: %!s(bool=false)
# datadog-agent config list-runtime
=== Settings that can be changed at runtime ===
dogstatsd_stats:			Enable/disable the dogstatsd debug stats. Possible values: true, false
log_level:			Set/get the log level, valid values are: trace, debug, info, warn, error, critical and off
```
After

```
# datadog-agent config get dogstatsd_stats
dogstatsd_stats is set to: false
# datadog-agent config list-runtime
=== Settings that can be changed at runtime ===
dogstatsd_stats                Enable/disable the dogstatsd debug stats. Possible values: true, false
log_level                      Set/get the log level, valid values are: trace, debug, info, warn, error, critical and off
```
### Motivation

Better UX.

### Additional Notes

N/A

### Describe your test plan

N/A