### PR TITLE
[WIP] Remove unused file installe by freetds

### DIFF
--- a/omnibus/config/software/freetds.rb
+++ b/omnibus/config/software/freetds.rb
@@ -25,8 +25,15 @@ build do
   make "install", env: env
 
   # removing unused files
-  delete "#{install_dir}/embedded/bin/tsql"
+  delete "#{install_dir}/embedded/bin/bsqldb"
+  delete "#{install_dir}/embedded/bin/bsqlodbc"
+  delete "#{install_dir}/embedded/bin/datacopy"
+  delete "#{install_dir}/embedded/bin/defncopy"
   delete "#{install_dir}/embedded/bin/fisql"
+  delete "#{install_dir}/embedded/bin/freebcp"
+  delete "#{install_dir}/embedded/bin/osql"
+  delete "#{install_dir}/embedded/bin/tdspool"
+  delete "#{install_dir}/embedded/bin/tsql"
   delete "#{install_dir}/embedded/etc/freetds.conf"
   delete "#{install_dir}/embedded/etc/locales.conf"
   delete "#{install_dir}/embedded/etc/pool.conf"

--- a/omnibus/config/software/freetds.rb
+++ b/omnibus/config/software/freetds.rb
@@ -27,4 +27,7 @@ build do
   # removing unused files
   delete "#{install_dir}/embedded/bin/tsql"
   delete "#{install_dir}/embedded/bin/fisql"
+  delete "#{install_dir}/embedded/etc/freetds.conf"
+  delete "#{install_dir}/embedded/etc/locales.conf"
+  delete "#{install_dir}/embedded/etc/pool.conf"
 end


### PR DESCRIPTION
### What does this PR do?

Remove unused file installe by freetds

Only those 2 files are needed for the integration to work:

```
/opt/datadog-agent/embedded/lib/libtdsodbc.so.0.0.0
/opt/datadog-agent/embedded/lib/libtdsodbc.so
```

TODO:

- [ ] Build without freetds to get a full files diff and see if there are more extra files we can remove: https://github.com/DataDog/datadog-agent/pull/5863

### Motivation

Clean up

### Additional Notes

Diff from `$ diff alex-sandbox-no-freetds-embedded.files 6.21.0-rc.1-embedded.files`
```diff
114a115
> /opt/datadog-agent/embedded/include/sqlfront.h
136a138
> /opt/datadog-agent/embedded/include/bkpublic.h
240a243
> /opt/datadog-agent/embedded/include/sybdb.h
242a246
> /opt/datadog-agent/embedded/include/syberror.h
246a251,252
> /opt/datadog-agent/embedded/include/sqldb.h
> /opt/datadog-agent/embedded/include/odbcss.h
249a256
> /opt/datadog-agent/embedded/include/ctpublic.h
360a368
> /opt/datadog-agent/embedded/include/cstypes.h
375a384
> /opt/datadog-agent/embedded/include/sybfront.h
384a394
> /opt/datadog-agent/embedded/include/cspublic.h
386a397
> /opt/datadog-agent/embedded/include/tds_sysdep_public.h
947a959
> /opt/datadog-agent/embedded/bin/defncopy
1032a1045
> /opt/datadog-agent/embedded/bin/osql
1046a1060
> /opt/datadog-agent/embedded/bin/freebcp
1059a1074
> /opt/datadog-agent/embedded/bin/bsqldb
1066a1082
> /opt/datadog-agent/embedded/bin/tdspool
1067a1084
> /opt/datadog-agent/embedded/bin/datacopy
1097a1115
> /opt/datadog-agent/embedded/bin/bsqlodbc
1166a1185
> /opt/datadog-agent/embedded/etc/freetds.conf
1168a1188
> /opt/datadog-agent/embedded/etc/pool.conf
1171a1192
> /opt/datadog-agent/embedded/etc/locales.conf
1177a1199
> /opt/datadog-agent/embedded/lib/libct.so
1179a1202
> /opt/datadog-agent/embedded/lib/libsybdb.so.5
1259a1283
> /opt/datadog-agent/embedded/lib/libtdsodbc.so.0
5933d5956
< /opt/datadog-agent/embedded/lib/python2.7/site-packages/setuptools-40.9.0.post20200630-py2.7.egg
12077a12101
> /opt/datadog-agent/embedded/lib/python2.7/site-packages/setuptools-40.9.0.post20200629-py2.7.egg
15314a15339
> /opt/datadog-agent/embedded/lib/libtdsodbc.so
15335a15361
> /opt/datadog-agent/embedded/lib/libct.so.4.0.0
15338a15365
> /opt/datadog-agent/embedded/lib/libtdsodbc.so.0.0.0
15383a15411
> /opt/datadog-agent/embedded/lib/libct.la
15389a15418
> /opt/datadog-agent/embedded/lib/libsybdb.so
15398a15428
> /opt/datadog-agent/embedded/lib/libsybdb.la
15400a15431
> /opt/datadog-agent/embedded/lib/libtdsodbc.la
15409a15441
> /opt/datadog-agent/embedded/lib/libsybdb.so.5.1.0
15411a15444
> /opt/datadog-agent/embedded/lib/libct.so.4
```

File sizes:

```
root@d48ef5749a4a:/# du -h /opt/datadog-agent/embedded/include/sqlfront.h /opt/datadog-agent/embedded/include/bkpublic.h /opt/datadog-agent/embedded/include/sybdb.h /opt/datadog-agent/embedded/include/syberror.h /opt/datadog-agent/embedded/include/sqldb.h /opt/datadog-agent/embedded/include/odbcss.h /opt/datadog-agent/embedded/include/ctpublic.h /opt/datadog-agent/embedded/include/cstypes.h /opt/datadog-agent/embedded/include/sybfront.h /opt/datadog-agent/embedded/include/cspublic.h /opt/datadog-agent/embedded/include/tds_sysdep_public.h /opt/datadog-agent/embedded/bin/defncopy /opt/datadog-agent/embedded/bin/osql /opt/datadog-agent/embedded/bin/freebcp /opt/datadog-agent/embedded/bin/bsqldb /opt/datadog-agent/embedded/bin/tdspool /opt/datadog-agent/embedded/bin/datacopy /opt/datadog-agent/embedded/bin/bsqlodbc /opt/datadog-agent/embedded/etc/freetds.conf /opt/datadog-agent/embedded/etc/pool.conf /opt/datadog-agent/embedded/etc/locales.conf /opt/datadog-agent/embedded/lib/libct.so /opt/datadog-agent/embedded/lib/libsybdb.so.5 /opt/datadog-agent/embedded/lib/libtdsodbc.so.0 /opt/datadog-agent/embedded/lib/python2.7/site-packages/setuptools-40.9.0.post20200629-py2.7.egg /opt/datadog-agent/embedded/lib/libtdsodbc.so /opt/datadog-agent/embedded/lib/libct.so.4.0.0 /opt/datadog-agent/embedded/lib/libtdsodbc.so.0.0.0 /opt/datadog-agent/embedded/lib/libct.la /opt/datadog-agent/embedded/lib/libsybdb.so /opt/datadog-agent/embedded/lib/libsybdb.la /opt/datadog-agent/embedded/lib/libtdsodbc.la /opt/datadog-agent/embedded/lib/libsybdb.so.5.1.0 /opt/datadog-agent/embedded/lib/libct.so.4 | sort -h -r
```

```
1012K	/opt/datadog-agent/embedded/lib/python2.7/site-packages/setuptools-40.9.0.post20200629-py2.7.egg
444K	/opt/datadog-agent/embedded/lib/libtdsodbc.so.0.0.0
440K	/opt/datadog-agent/embedded/lib/libsybdb.so.5.1.0
360K	/opt/datadog-agent/embedded/lib/libct.so.4.0.0
284K	/opt/datadog-agent/embedded/bin/tdspool
64K	/opt/datadog-agent/embedded/include/sybdb.h
32K	/opt/datadog-agent/embedded/bin/bsqldb
24K	/opt/datadog-agent/embedded/include/cspublic.h
20K	/opt/datadog-agent/embedded/bin/freebcp
20K	/opt/datadog-agent/embedded/bin/defncopy
20K	/opt/datadog-agent/embedded/bin/datacopy
20K	/opt/datadog-agent/embedded/bin/bsqlodbc
12K	/opt/datadog-agent/embedded/include/odbcss.h
12K	/opt/datadog-agent/embedded/bin/osql
8.0K	/opt/datadog-agent/embedded/include/tds_sysdep_public.h
8.0K	/opt/datadog-agent/embedded/include/sqldb.h
8.0K	/opt/datadog-agent/embedded/include/ctpublic.h
8.0K	/opt/datadog-agent/embedded/include/cstypes.h
4.0K	/opt/datadog-agent/embedded/lib/libtdsodbc.la
4.0K	/opt/datadog-agent/embedded/lib/libsybdb.la
4.0K	/opt/datadog-agent/embedded/lib/libct.la
4.0K	/opt/datadog-agent/embedded/include/sybfront.h
4.0K	/opt/datadog-agent/embedded/include/syberror.h
4.0K	/opt/datadog-agent/embedded/include/sqlfront.h
4.0K	/opt/datadog-agent/embedded/include/bkpublic.h
4.0K	/opt/datadog-agent/embedded/etc/pool.conf
4.0K	/opt/datadog-agent/embedded/etc/locales.conf
4.0K	/opt/datadog-agent/embedded/etc/freetds.conf
0	/opt/datadog-agent/embedded/lib/libtdsodbc.so.0
0	/opt/datadog-agent/embedded/lib/libtdsodbc.so
0	/opt/datadog-agent/embedded/lib/libsybdb.so.5
0	/opt/datadog-agent/embedded/lib/libsybdb.so
0	/opt/datadog-agent/embedded/lib/libct.so.4
0	/opt/datadog-agent/embedded/lib/libct.so
```

### Describe your test plan

Write there any instructions and details you may have to test your PR.
