### PR TITLE
Use $S3_CP_CMD in deploy_staging_iot_agent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3667,7 +3667,7 @@ deploy_staging_iot_agent:
   script:
     - $S3_CP_CMD $S3_ARTIFACTS_URI/iot/agent ./agent
     - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)
-    - aws s3 cp --region us-east-1 ./agent $S3_DSD6_URI/linux/iot/agent-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD ./agent $S3_DSD6_URI/linux/iot/agent-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy agent windows zip to the staging bucket, currently used for cloudfoundry bosh
 deploy_staging_datadog_agent_windows_zip:


### PR DESCRIPTION
### What does this PR do?

Use `$S3_CP_CMD` in `deploy_staging_iot_agent`.

### Motivation

#5806 replaced every occurrences of `aws s3 cp` with `$S3_CP_CMD` but #5814 re-introduced the job `deploy_staging_iot_agent` that didn't have the replacement.
