### PR TITLE
Refactor freetds to only copy needed files

### DIFF
--- a/omnibus/config/software/freetds.rb
+++ b/omnibus/config/software/freetds.rb
@@ -22,19 +22,8 @@ build do
 
   command configure_command, env: env, in_msys_bash: true
   make env: env
-  make "install", env: env
 
-  # removing unused files
-  delete "#{install_dir}/embedded/bin/bsqldb"
-  delete "#{install_dir}/embedded/bin/bsqlodbc"
-  delete "#{install_dir}/embedded/bin/datacopy"
-  delete "#{install_dir}/embedded/bin/defncopy"
-  delete "#{install_dir}/embedded/bin/fisql"
-  delete "#{install_dir}/embedded/bin/freebcp"
-  delete "#{install_dir}/embedded/bin/osql"
-  delete "#{install_dir}/embedded/bin/tdspool"
-  delete "#{install_dir}/embedded/bin/tsql"
-  delete "#{install_dir}/embedded/etc/freetds.conf"
-  delete "#{install_dir}/embedded/etc/locales.conf"
-  delete "#{install_dir}/embedded/etc/pool.conf"
+  copy "src/odbc/.libs/libtdsodbc.so", "#{install_dir}/embedded/lib/libtdsodbc.so"
+  copy "src/odbc/.libs/libtdsodbc.so.0.0.0", "#{install_dir}/embedded/lib/libtdsodbc.so.0.0.0"
+
 end

--- a/omnibus/config/software/freetds.rb
+++ b/omnibus/config/software/freetds.rb
@@ -15,7 +15,6 @@ build do
 
   configure_args = [
     "--disable-readline",
-    "--prefix=#{install_dir}/embedded",
   ]
 
   configure_command = configure_args.unshift("./configure").join(" ")

--- a/omnibus/config/software/freetds.rb
+++ b/omnibus/config/software/freetds.rb
@@ -22,6 +22,8 @@ build do
   command configure_command, env: env, in_msys_bash: true
   make env: env
 
+  # Only `libtdsodbc.so/libtdsodbc.so.0.0.0` are needed for SQLServer integration.
+  # Hence we only need to copy those.
   copy "src/odbc/.libs/libtdsodbc.so", "#{install_dir}/embedded/lib/libtdsodbc.so"
   copy "src/odbc/.libs/libtdsodbc.so.0.0.0", "#{install_dir}/embedded/lib/libtdsodbc.so.0.0.0"
 

--- a/omnibus/config/software/freetds.rb
+++ b/omnibus/config/software/freetds.rb
@@ -25,8 +25,15 @@ build do
   make "install", env: env
 
   # removing unused files
-  delete "#{install_dir}/embedded/bin/tsql"
+  delete "#{install_dir}/embedded/bin/bsqldb"
+  delete "#{install_dir}/embedded/bin/bsqlodbc"
+  delete "#{install_dir}/embedded/bin/datacopy"
+  delete "#{install_dir}/embedded/bin/defncopy"
   delete "#{install_dir}/embedded/bin/fisql"
+  delete "#{install_dir}/embedded/bin/freebcp"
+  delete "#{install_dir}/embedded/bin/osql"
+  delete "#{install_dir}/embedded/bin/tdspool"
+  delete "#{install_dir}/embedded/bin/tsql"
   delete "#{install_dir}/embedded/etc/freetds.conf"
   delete "#{install_dir}/embedded/etc/locales.conf"
   delete "#{install_dir}/embedded/etc/pool.conf"

--- a/omnibus/config/software/freetds.rb
+++ b/omnibus/config/software/freetds.rb
@@ -27,4 +27,7 @@ build do
   # removing unused files
   delete "#{install_dir}/embedded/bin/tsql"
   delete "#{install_dir}/embedded/bin/fisql"
+  delete "#{install_dir}/embedded/etc/freetds.conf"
+  delete "#{install_dir}/embedded/etc/locales.conf"
+  delete "#{install_dir}/embedded/etc/pool.conf"
 end


### PR DESCRIPTION
### What does this PR do?

Avoid adding unnecessary files to agent build.

Only copying `libtdsodbc.so` and `libtdsodbc.so.0.0.0` works:

Image: `datadog/agent-dev:alex-clean-up-freetds-install-copy`

```

  Running Checks
  ==============

    sqlserver (1.18.0)
    ------------------
      Instance ID: sqlserver:588d528f1739085e [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/sqlserver.d/sqlserver.yaml
      Total Runs: 1
      Metric Samples: Last Run: 17, Total: 17
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 16ms
      Last Execution Date : 2020-07-01 13:03:20.000000 UTC
      Last Successful Execution Date : 2020-07-01 13:03:20.000000 UTC
```

### Motivation

Avoid adding unnecessary files to agent build.

List of files here: https://github.com/DataDog/datadog-agent/pull/5864

### Describe your test plan

e2e QA 
