### PR TITLE
Fix install_info in Docker environments

### DIFF
--- a/Dockerfiles/agent/install_info
+++ b/Dockerfiles/agent/install_info
@@ -1,5 +1,5 @@
 ---
-installer_method:
+install_method:
   tool: docker
   tool_version: docker
   installer_version: docker

--- a/Dockerfiles/cluster-agent/install_info
+++ b/Dockerfiles/cluster-agent/install_info
@@ -1,5 +1,5 @@
 ---
-installer_method:
+install_method:
   tool: docker
   tool_version: docker
   installer_version: docker

--- a/Dockerfiles/dogstatsd/alpine/install_info
+++ b/Dockerfiles/dogstatsd/alpine/install_info
@@ -1,5 +1,5 @@
 ---
-installer_method:
+install_method:
   tool: docker
   tool_version: docker
   installer_version: docker


### PR DESCRIPTION
### What does this PR do?

Fixes the `install_info` yaml file in Docker environments. The correct top-level key is `install_method`, not `installer_method` (see [here](https://github.com/DataDog/datadog-agent/blob/master/pkg/metadata/host/host.go#L44))

### Motivation

Get accurate install information.

