### PR TITLE
[DCA] Allow label joins for autoscaler metrics

### DIFF
--- a/pkg/util/kubernetes/autoscalers/processor_test.go
+++ b/pkg/util/kubernetes/autoscalers/processor_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
+	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -629,20 +630,21 @@ func TestUpdateRateLimiting(t *testing.T) {
 			if err != nil {
 				assert.EqualError(t, tt.error, err.Error())
 			}
-			assert.Equal(t, rateLimitsLimit.(*mockGauge).values[queryEndpoint], tt.results.Limit)
-			assert.Equal(t, rateLimitsReset.(*mockGauge).values[queryEndpoint], tt.results.Reset)
-			assert.Equal(t, rateLimitsPeriod.(*mockGauge).values[queryEndpoint], tt.results.Period)
-			assert.Equal(t, rateLimitsRemaining.(*mockGauge).values[queryEndpoint], tt.results.Remaining)
+			key := strings.Join([]string{queryEndpoint, le.JoinLeaderValue}, ",")
+			assert.Equal(t, rateLimitsLimit.(*mockGauge).values[key], tt.results.Limit)
+			assert.Equal(t, rateLimitsReset.(*mockGauge).values[key], tt.results.Reset)
+			assert.Equal(t, rateLimitsPeriod.(*mockGauge).values[key], tt.results.Period)
+			assert.Equal(t, rateLimitsRemaining.(*mockGauge).values[key], tt.results.Remaining)
 		})
 		resetCounters(queryEndpoint)
 	}
 }
 
 func resetCounters(endpoint string) {
-	rateLimitsRemaining.Set(0, endpoint)
-	rateLimitsPeriod.Set(0, endpoint)
-	rateLimitsLimit.Set(0, endpoint)
-	rateLimitsReset.Set(0, endpoint)
+	rateLimitsRemaining.Set(0, endpoint, "true")
+	rateLimitsPeriod.Set(0, endpoint, "true")
+	rateLimitsLimit.Set(0, endpoint, "true")
+	rateLimitsReset.Set(0, endpoint, "true")
 }
 
 type mockGauge struct {


### PR DESCRIPTION
### What does this PR do?

Adds the label `join_leader:true` to the autoscaling metrics

### Motivation

Label join the `is_leader` label

### Additional Notes

Follow-up on https://github.com/DataDog/datadog-agent/pull/5819
