### PR TITLE
Fix panic on Fargate when retrieving stats for stopped containers

### DIFF
--- a/pkg/util/ecs/metadata/v2/client.go
+++ b/pkg/util/ecs/metadata/v2/client.go
@@ -57,7 +57,7 @@ func (c *Client) GetContainerStats(id string) (*ContainerStats, error) {
 		return nil, err
 	}
 
-	if s, ok := stats[id]; ok {
+	if s, ok := stats[id]; ok && s != nil {
 		return s, nil
 	}
 

--- a/pkg/util/ecs/metadata/v2/client_test.go
+++ b/pkg/util/ecs/metadata/v2/client_test.go
@@ -331,6 +331,11 @@ func TestGetContainerStats(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(expected, metadata)
 
+	// Container without stats
+	metadata, err = NewClient(ts.URL).GetContainerStats("470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d42")
+	assert.NotNil(err)
+	assert.Nil(metadata)
+
 	select {
 	case r := <-ecsinterface.Requests:
 		assert.Equal("GET", r.Method)

--- a/pkg/util/ecs/metadata/v2/testdata/container_stats.json
+++ b/pkg/util/ecs/metadata/v2/testdata/container_stats.json
@@ -1,4 +1,5 @@
 {
+  "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d42": null,
   "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98": {
     "blkio_stats": {
       "io_merged_recursive": [],


### PR DESCRIPTION
### What does this PR do?

Several issues were raised on Fargate with agent crashing. Investigations showed that this is due to Fargate API returning a pair `<containerd_id>: null` for containers not yet started/stopped.

### Motivation

Fix following bug reports

### Describe your test plan

Create a Fargate taks with failing containers
