### PR TITLE
aggregator/CheckSampler: set interval on metrics sent from checks

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -313,7 +313,7 @@ func (agg *BufferedAggregator) registerSender(id check.ID) error {
 	if _, ok := agg.checkSamplers[id]; ok {
 		return fmt.Errorf("Sender with ID '%s' has already been registered, will use existing sampler", id)
 	}
-	agg.checkSamplers[id] = newCheckSampler()
+	agg.checkSamplers[id] = newCheckSampler(agg.flushInterval)
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Set missing `interval` on metric metadata sent from checks. 

Note that this won't work because the flush interval appears to be tied to the check run time. This change will only fix the problem once we decouple the CheckSampler flush interval from the check run time. 

### Motivation

The metric interval is currently missing from all metrics sent from checks via the aggregator.

This causes all count metrics to be *very* wrong when plotted:
* `self.increment`
* `self.count`
* `self.histogram("foo", ...)` - `foo.count` will be wrong, the rest of the metrics (min, max, median, p95) are ok

Concrete example: `self.increment("foo")` is called 15 times per check run, we expect the per-second rate to be 1 (assuming the default check interval of 15 seconds). However, without the interval in the metric metadata the value of the `foo` metric is going to be `15`, and the `.as_rate()` and `.as_count()` query functions won't work on it.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
