### PR TITLE
Fix permissions of files and directories which are world writable

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -159,6 +159,8 @@ RUN  mv /etc/s6/init/init-stage3 /etc/s6/init/init-stage3-original
 COPY init-stage3          /etc/s6/init/init-stage3
 COPY init-stage3-host-pid /etc/s6/init/init-stage3-host-pid
 
+RUN find /etc -type d,f -perm -o+w -print0 | xargs -0 chmod g-w,o-w
+
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp
 

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -159,6 +159,8 @@ RUN  mv /etc/s6/init/init-stage3 /etc/s6/init/init-stage3-original
 COPY init-stage3          /etc/s6/init/init-stage3
 COPY init-stage3-host-pid /etc/s6/init/init-stage3-host-pid
 
+RUN find /etc -type d,f -perm -o+w -print0 | xargs -0 chmod g-w,o-w
+
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp
 

--- a/Dockerfiles/agent/test_image_contents.py
+++ b/Dockerfiles/agent/test_image_contents.py
@@ -60,25 +60,5 @@ class TestFiles(unittest.TestCase):
                 self.assertFalse(has_write_permissions(os.path.join(root, name)))
 
 
-def correct_permissions(root):
-    def correct_perm(path):
-        try:
-            mode = os.stat(path).st_mode
-        except Exception:
-            return
-
-        if bool(mode & stat.S_IWOTH):
-            mode -= mode & (stat.S_IWGRP | stat.S_IWOTH)
-            print("Changing permissions for: ", path)
-            os.chmod(path, mode)
-
-    for root, dirs, files in os.walk(root):
-        for name in files:
-            correct_perm(os.path.join(root, name))
-        for name in dirs:
-            correct_perm(os.path.join(root, name))
-
-
 if __name__ == "__main__":
-    correct_permissions("/etc")
     unittest.main()


### PR DESCRIPTION
### What does this PR do?

Fix permissions of files and directories which are world writable

### Motivation

Fixes #5610

### Additional Notes


### Describe your test plan

```
docker run datadog/agent:6.21.0-rc.1 find /etc -type d,f -perm -002 -ls
```