### PR TITLE
[a5 import] Trim spaces when importing tags

### DIFF
--- a/cmd/agent/common/import_test.go
+++ b/cmd/agent/common/import_test.go
@@ -150,6 +150,13 @@ func validateSelectedParameters(t *testing.T, migratedConfigFile, oldConfigFile 
 	assert.Equal(t, oldProxies["https"], migratedProxies["https"])
 	assert.Equal(t, oldProxies["http"], migratedProxies["http"])
 
+	// Tags
+	oldTags := strings.Split(oldConfig["tags"], ",")
+	for i, tag := range oldTags {
+		oldTags[i] = strings.TrimSpace(tag)
+	}
+	assert.ElementsMatch(t, oldTags, migratedConf["tags"].([]interface{}))
+
 	// Some second level parameters
 	migratedProcessConfig := migratedConf["process_config"].(map[interface{}]interface{})
 	assert.Equal(t, oldConfig["process_agent_enabled"], migratedProcessConfig["enabled"])

--- a/cmd/agent/common/tests/a5_conf/datadog.conf
+++ b/cmd/agent/common/tests/a5_conf/datadog.conf
@@ -10,7 +10,7 @@ hostname: mymachine.mydomain
 apm_enabled: true
 enable_gohai: true
 process_agent_enabled: true
-tags: mytag, env:prod, role:database
+tags: mytag, env:prod, role:database, a_tag:with space
 collect_orchestrator_tags: yes
 forwarder_timeout: 30
 default_integration_http_timeout: 15

--- a/pkg/config/legacy/converter.go
+++ b/pkg/config/legacy/converter.go
@@ -45,7 +45,11 @@ func FromAgentConfig(agentConfig Config, converter *config.LegacyConfigConverter
 		converter.Set("process_config.enabled", "disabled")
 	}
 
-	converter.Set("tags", strings.Split(agentConfig["tags"], ","))
+	tags := strings.Split(agentConfig["tags"], ",")
+	for i, tag := range tags {
+		tags[i] = strings.TrimSpace(tag)
+	}
+	converter.Set("tags", tags)
 
 	if value, err := strconv.Atoi(agentConfig["forwarder_timeout"]); err == nil {
 		converter.Set("forwarder_timeout", value)


### PR DESCRIPTION
### What does this PR do?
Tags listed in coma-separated list in A5 config were no imported
properly in A6/7 config:
`tags: a:b, c:d`
was imported as:
```
tags:
  - a:b
  - ' c:d'
```

### Motivation
Fix A5 import.

### Additional Notes
N/A

### Describe your test plan
Added tags equality assertion in import test.