### PR TITLE
[dogstatsd] don't consider the debug loop enabled while creating the server.

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -205,8 +205,7 @@ func NewServer(aggregator *aggregator.BufferedAggregator) (*Server, error) {
 		entityIDPrecedenceEnabled: entityIDPrecedenceEnabled,
 		disableVerboseLogs:        config.Datadog.GetBool("dogstatsd_disable_verbose_logs"),
 		Debug: &dsdServerDebug{
-			Enabled: metricsStatsEnabled,
-			Stats:   make(map[ckey.ContextKey]metricStat),
+			Stats: make(map[ckey.ContextKey]metricStat),
 			metricsCounts: metricsCountBuckets{
 				counts:     [5]uint64{0, 0, 0, 0, 0},
 				metricChan: make(chan struct{}),


### PR DESCRIPTION
While starting the DogStatsD server, if the `dogstatsd_metrics_stats_enabled` flag
was set, the `Server` instance had its `Enabled` debug flag set to true.

Therefore, while entering the `EnabledMetricsStats` method at startup, the test checking if the debug loop was already started was wrongfully assuming that it was the case and was not starting the debug loop at startup (this method should take care of not spawning multiple routines running a debug loop, because the feature could be enabled/disabled at runtime).
meaning that writing into this channel was a blocking write (because nobody's listening).

This bug has been introduced in #5665.

### Describe your test plan

- Start the Agent with the `dogstatsd_metrics_stats_enabled` flag set to `true`.
- Validate that the `agent dogstatsd-stats` is working properly (returning that no metrics has been received)
- Send a metric to DogStatsD
- Validate that the `agent dogstatsd-stats` is working properly (returns that a metric has been sent)
