### PR TITLE
[gitlab] Fix chocolatey job needs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
   - image_deploy
   - deploy6
   - deploy7
+  - publish_packages
   - deploy_invalidate
   - trigger_release
   - e2e
@@ -1303,12 +1304,12 @@ windows_choco_offline_7_x64:
 
 publish_choco_7_x64:
   rules:
-    - <<: *if_version_7
+    - <<: *if_triggered_on_tag_7
       when: manual
       allow_failure: true
-  stage: image_deploy
+  stage: publish_packages
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["windows_choco_online_7_x64"]
+  needs: ["deploy_staging_windows_tags-a7"]
   variables:
     ARCH: "x64"
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,8 @@ stages:
   - image_deploy
   - deploy6
   - deploy7
-  - publish_packages
+  - choco_build
+  - choco_deploy
   - deploy_invalidate
   - trigger_release
   - e2e
@@ -1262,12 +1263,14 @@ windows_dsd_msi_x64-a7:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_7
 
+# The online version fetches the package from S3 so
+# it is created only when the package is pushed
 windows_choco_online_7_x64:
   rules:
-    - <<: *if_version_7
-  stage: image_build
+    - <<: *if_triggered_on_tag_7
+  stage: choco_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["windows_msi_x64-a7"]
+  needs: ["deploy_staging_windows_tags-a7"]
   variables:
     ARCH: "x64"
   script:
@@ -1307,9 +1310,9 @@ publish_choco_7_x64:
     - <<: *if_triggered_on_tag_7
       when: manual
       allow_failure: true
-  stage: publish_packages
+  stage: choco_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["deploy_staging_windows_tags-a7"]
+  needs: ["windows_choco_online_7_x64"]
   variables:
     ARCH: "x64"
   before_script:


### PR DESCRIPTION
### What does this PR do?

- Fix chocolatey job needs. Since we publish the online version we can't publish the package until it has been deployed to S3, otherwise it will be broken. This creates a new stage since a job can only `need` a job from a previous stage.