### PR TITLE
Small UI fixes to `security-agent flare` and `agent status`

### DIFF
--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -108,7 +108,7 @@ func requestFlare(caseID string) error {
 
 	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
 	if !autoconfirm {
-		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [Y/N]")
+		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [y/N]")
 		if !confirmation {
 			fmt.Fprintln(color.Output, fmt.Sprintf("Aborting. (You can still use %s)", color.YellowString(filePath)))
 			return nil

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -16,10 +16,10 @@ NOTE: Changes made to this template should be reflected on the following templat
   Agent flavor: {{.flavor}}
   {{- if .runnerStats.Workers}}
   Check Runners: {{.runnerStats.Workers}}
-  {{end -}}
+  {{- end }}
   {{- if .config.log_file}}
   Log File: {{.config.log_file}}
-  {{end -}}
+  {{- end }}
   Log Level: {{.config.log_level}}
 
   Paths


### PR DESCRIPTION
### What does this PR do?

Fixes two small glitches on outputs of the mentioned commands.

#### `security-agent flare` before:

```
Are you sure you want to upload a flare? [Y/N]
```

#### `security-agent flare` after:

```
Are you sure you want to upload a flare? [y/N]
```

#### `agent status` before:

```
====================
Agent (v6.21.0-rc.1)
====================
  [ ... ]
  Agent flavor: security_agentLog Level: INFO
  [ ... ]
```

#### `agent status` after:

```
====================
Agent (v6.21.0-rc.1)
====================
  [ ... ]
  Agent flavor: security_agent
  Log Level: INFO
  [ ... ]
```



### Motivation

These are just small cosmetic fixes for consistency and ease of use.