### PR TITLE
[Tagger][PodWatcher] Detect kubernetes pod phase change

### DIFF
--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -67,9 +67,7 @@ func (w *PodWatcher) PullChanges() ([]*Pod, error) {
 	if err != nil {
 		return podList, err
 	}
-	changes, err := w.computeChanges(podList)
-
-	return changes, err
+	return w.computeChanges(podList)
 }
 
 // computeChanges is used by PullChanges, split for testing
@@ -128,6 +126,7 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 
 		// Detect changes in labels and annotations values
 		newLabelsOrAnnotations := false
+		// Detect changes in the pod phase
 		newPhase := false
 		if w.isWatchingTags() {
 			newTagsDigest := digestPodMeta(pod.Metadata)
@@ -136,9 +135,10 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 				w.tagsDigest[podEntity] = newTagsDigest
 				newLabelsOrAnnotations = true
 			}
+			// compared to our last seen phase the pod phase has changed.
 			if foundPod && pod.Status.Phase != w.oldPhase[podEntity] {
-				newPhase = true
 				w.oldPhase[podEntity] = pod.Status.Phase
+				newPhase = true
 			}
 		}
 		if newStaticPod || updatedContainer || newLabelsOrAnnotations || newPhase {

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -331,9 +331,9 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
+		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
-
 	_, err = watcher.computeChanges(sourcePods)
 	require.Nil(suite.T(), err)
 	// 7 pods (including 2 statics) + 5 container statuses (static pods don't report these)
@@ -373,6 +373,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
+		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -450,6 +451,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherLabelsValueChange() {
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
+		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 	twoPods := sourcePods[:2]
@@ -483,6 +485,52 @@ func (suite *PodwatcherTestSuite) TestPodWatcherLabelsValueChange() {
 	require.Len(suite.T(), changes, 2)
 }
 
+func (suite *PodwatcherTestSuite) TestPodWatcherPhaseChange() {
+	sourcePods, err := loadPodsFixture("./testdata/podlist_1.8-2.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 7)
+
+	watcher := &PodWatcher{
+		lastSeen:       make(map[string]time.Time),
+		lastSeenReady:  make(map[string]time.Time),
+		tagsDigest:     make(map[string]string),
+		oldPhase:       make(map[string]string),
+		expiryDuration: 5 * time.Minute,
+	}
+	twoPods := sourcePods[:2]
+	changes, err := watcher.computeChanges(twoPods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 2)
+
+	twoPods[0].Status.Phase = "Succeeded"
+	changes, err = watcher.computeChanges(twoPods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 1)
+}
+
+// TestPodWatcherPhaseChangeNotRegistered test makes sure that we only check for
+// pod phases in the tagger and not for auto discovery
+func (suite *PodwatcherTestSuite) TestPodWatcherPhaseChangeNotRegistered() {
+	sourcePods, err := loadPodsFixture("./testdata/podlist_1.8-2.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 7)
+
+	watcher := &PodWatcher{
+		lastSeen:       make(map[string]time.Time),
+		lastSeenReady:  make(map[string]time.Time),
+		expiryDuration: 5 * time.Minute,
+	}
+	twoPods := sourcePods[:2]
+	changes, err := watcher.computeChanges(twoPods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 2)
+
+	twoPods[0].Status.Phase = "Succeeded"
+	changes, err = watcher.computeChanges(twoPods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 0)
+}
+
 func (suite *PodwatcherTestSuite) TestPodWatcherAnnotationsValueChange() {
 	sourcePods, err := loadPodsFixture("./testdata/podlist_1.8-2.json")
 	require.Nil(suite.T(), err)
@@ -492,6 +540,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherAnnotationsValueChange() {
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
+		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 	twoPods := sourcePods[:2]

--- a/releasenotes/notes/fix-podphase-tagging-2db951956eeed605.yaml
+++ b/releasenotes/notes/fix-podphase-tagging-2db951956eeed605.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug when a kubernetes job has exited after some time the tagger does not update it even if it did change it's state.

--- a/releasenotes/notes/fix-podphase-tagging-2db951956eeed605.yaml
+++ b/releasenotes/notes/fix-podphase-tagging-2db951956eeed605.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix a bug when a kubernetes job has exited after some time the tagger does not update it even if it did change it's state.
+    Fix a bug when a kubernetes job has exited after some time the tagger does not update it even if it did change its state.


### PR DESCRIPTION
### What does this PR do?

- pods that exit (e.g. jobs) finish and change their state from `running` to `succeed` or `fail` 

The tagger tries to only update tags for pods where we have calculated changes. Currently detections are only for `metadata`, `container` and `staticpods`.
Pods that have exited after a long run can be missed by the tagger. Therefore this PR watches the `phase` of the pod as well.

### Motivation

- missmatch between tag:`pod_phase` and actual `phase`
- jira: CAP-95

### Additional Notes

It does touch the podWatcher to make sure we are safe I added some additional tests and put it under the isWatchingTags part.

### Describe your test plan

Write there any instructions and details you may have to test your PR.
