### PR TITLE
Fix start of security-agent

### DIFF
--- a/Dockerfiles/agent/s6-services/security/run
+++ b/Dockerfiles/agent/s6-services/security/run
@@ -1,4 +1,4 @@
 #!/usr/bin/execlineb -P
 
 foreground { /initlog.sh "starting security-agent" }
-security-agent start -config=/etc/datadog-agent/datadog.yaml
+security-agent start -c=/etc/datadog-agent/datadog.yaml


### PR DESCRIPTION
### What does this PR do?

Parameter name was incorrect

### Describe your test plan

docker run -e DD_API_KEY=xxx datadog/agent:6.21.0-rc.3; security-agent should not report errors.