### PR TITLE
Add Heroku Agent flavor

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -220,6 +220,10 @@ func NewBufferedAggregator(s serializer.MetricSerializer, hostname string, flush
 		// Override the agentName if this Agent is configured to report as IotAgent
 		agentName = flavor.IotAgent
 	}
+	if config.Datadog.GetBool("heroku_dyno") {
+		// Override the agentName if this Agent is configured to report as Heroku Dyno
+		agentName = flavor.HerokuAgent
+	}
 
 	aggregator := &BufferedAggregator{
 		bufferedMetricIn:       make(chan []metrics.MetricSample, bufferSize),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,6 +178,8 @@ func InitConfig(config Config) {
 
 	// overridden in IoT Agent main
 	config.BindEnvAndSetDefault("iot_host", false)
+	// overridden in Heroku buildpack
+	config.BindEnvAndSetDefault("heroku_dyno", false)
 
 	// Debugging + C-land crash feature flags
 	config.BindEnvAndSetDefault("c_stacktrace_collection", false)

--- a/pkg/util/flavor/flavor.go
+++ b/pkg/util/flavor/flavor.go
@@ -18,6 +18,8 @@ const (
 	Dogstatsd = "dogstatsd"
 	// SecurityAgent is the Security Agent flavor
 	SecurityAgent = "security_agent"
+	// HerokuAgent is the Heroku Agent flavor
+	HerokuAgent = "heroku_agent"
 )
 
 var agentFlavor string = DefaultAgent


### PR DESCRIPTION
### What does this PR do?

This PR creates a new agent flavor for Heroku dynos. This is a normal agent, so new build is needed.

### Motivation

Right now it is very difficult for customers to track which of their agents are running in a Heroku dyno. With this change they will be able to track which agents are reporting from a Heroku dyno going forward.

### Describe your test plan

I have tested this in in a Heroku dyno running the Datadog Heroku buildpack from master (which contains the needed changes in the buildpack side) and the new flavor was reported correctly

cc @jeremy-lq 
