### PR TITLE
Remove useless `libbcc` artifacts (examples, man pages…)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,7 +208,7 @@ fail_on_non_triggered_tag:
     - make install
     - cd /opt/libbcc
     - chmod go-rwx lib/libbcc*
-    - rm share/bcc/introspection/bps
+    - rm -rf share/bcc/examples share/bcc/introspection share/bcc/man share/bcc/tools
     - cp $(ldd lib/libbcc.so | awk '$1 ~ /^libtinfo/ {system("dirname " $3)}')/libtinfo* lib
     - tar cvaf /tmp/libbcc.tar.xz .
     - $S3_CP_CMD /tmp/libbcc.tar.xz $S3_ARTIFACTS_URI/libbcc-$ARCH.tar.xz


### PR DESCRIPTION
### What does this PR do?

Remove from the datadog agent package the `libbcc` artifacts that are useless:
* man pages
* examples
* tools

### Motivation

They’re useless.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

```
docker run -ti --rm datadog/agent:6.21.0-rc.2 find /opt/datadog-agent/embedded/share/bcc
```
