### PR TITLE
Fix panic in compliance/process check

### DIFF
--- a/pkg/compliance/checks/builder_test.go
+++ b/pkg/compliance/checks/builder_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 
-	"github.com/DataDog/gopsutil/process"
 	assert "github.com/stretchr/testify/require"
 )
 
@@ -117,8 +116,8 @@ func TestResolveValueFrom(t *testing.T) {
 			name:       "from process",
 			expression: `process.flag("buddy", "--path")`,
 			setup: func(t *testing.T) {
-				processFetcher = func() (map[int32]*process.FilledProcess, error) {
-					return map[int32]*process.FilledProcess{
+				processFetcher = func() (processes, error) {
+					return processes{
 						42: {
 							Name:    "buddy",
 							Cmdline: []string{"--path=/home/root/hiya-buddy.txt"},

--- a/pkg/compliance/checks/process_utils.go
+++ b/pkg/compliance/checks/process_utils.go
@@ -20,10 +20,8 @@ const (
 	processCacheKey string = "compliance-processes"
 )
 
-type processFetcherFunc func() (map[int32]*process.FilledProcess, error)
-
 var (
-	processFetcher processFetcherFunc = process.AllProcesses
+	processFetcher func() (processes, error) = fetchProcesses
 )
 
 func (p processes) findProcessesByName(name string) []*process.FilledProcess {
@@ -43,19 +41,23 @@ func (p processes) findProcesses(matchFunc func(*process.FilledProcess) bool) []
 	return results
 }
 
+func fetchProcesses() (processes, error) {
+	return process.AllProcesses()
+}
+
 func getProcesses(maxAge time.Duration) (processes, error) {
 	if value, found := cache.Cache.Get(processCacheKey); found {
 		return value.(processes), nil
 	}
 
 	log.Debug("Updating process cache")
-	cachedProcesses, err := processFetcher()
+	rawProcesses, err := processFetcher()
 	if err != nil {
 		return nil, err
 	}
 
-	cache.Cache.Set(processCacheKey, cachedProcesses, maxAge)
-	return cachedProcesses, nil
+	cache.Cache.Set(processCacheKey, rawProcesses, maxAge)
+	return rawProcesses, nil
 }
 
 // Parsing is far from being exhaustive, however for now it works sufficiently well


### PR DESCRIPTION
### What does this PR do?

Fix type stored in global cache, avoids panic on cache retrieval

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Run a `process` check for a while, should not panic
