### PR TITLE
[Windows] Always add user to required groups

### DIFF
--- a/releasenotes/notes/windows_always_add_user_to_required_groups-b75dcce1806dcf07.yaml
+++ b/releasenotes/notes/windows_always_add_user_to_required_groups-b75dcce1806dcf07.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    On Windows, always add the user to the required groups during installation.


### PR DESCRIPTION
### What does this PR do?

Always add user to required groups for the Datadog Agent to function correctly.

### Motivation

When installing on a non-domain environment with a pre-existing user (specified via `DDAGENTUSER_NAME` and `DDAGENTUSER_PASSWORD`) the installer does not add the user to the required groups.

### Describe your test plan

1) With pre-existing user:
- On a non-domain controller (could be domain-joined but the user should be a local user).
- Create a user using Windows' management tools.
- Run the installer with the `DDAGENTUSER_NAME` and `DDAGENTUSER_PASSWORD` set to the created user.
- Ensure the agent functions correctly with the `status` command. Specifically there should not be any permission errors.
- Upon un-installation, the user is *not* deleted and the user's home folder is *not* deleted.

2) With default values:
- On a non-domain controller (could be domain-joined but the user should be a local user).
- Run the installer without any username nor password.
- Ensure the agent functions correctly with the `status` command. Specifically there should not be any permission errors.
- Upon un-installation, the user *is* deleted and the user's home folder *is* deleted.

3) With a specific non-existing user:
- On a non-domain controller (could be domain-joined but the user should be a local user).
- Run the installer with the `DDAGENTUSER_NAME` and `DDAGENTUSER_PASSWORD` set to a *non-existing* user.
- Ensure the agent functions correctly with the `status` command. Specifically there should not be any permission errors.
- Upon un-installation, the user *is* deleted and the user's home folder *is* deleted.