### PR TITLE
Add system.cpu.num_cores metric

### DIFF
--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -69,8 +69,10 @@ func (c *CPUCheck) Run() error {
 		sender.Gauge("system.cpu.idle", idle*toPercent, "", nil)
 		sender.Gauge("system.cpu.stolen", stolen*toPercent, "", nil)
 		sender.Gauge("system.cpu.guest", guest*toPercent, "", nil)
-		sender.Commit()
 	}
+
+	sender.Gauge("system.cpu.num_cores", c.nbCPU, "", nil)
+	sender.Commit()
 
 	c.lastNbCycle = nbCycle
 	c.lastTimes = t

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -78,13 +78,15 @@ func TestCPUCheckLinux(t *testing.T) {
 	cpuCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(cpuCheck.ID())
+	mock.On("Gauge", "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
 
 	sample = firstSample
 	cpuCheck.Run()
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 0)
-	mock.AssertNumberOfCalls(t, "Commit", 0)
+	mock.AssertNumberOfCalls(t, "Gauge", 1)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
 
 	sample = secondSample
 	mock.On("Gauge", "system.cpu.user", 0.1913803067769472, "", []string(nil)).Return().Times(1)
@@ -93,10 +95,11 @@ func TestCPUCheckLinux(t *testing.T) {
 	mock.On("Gauge", "system.cpu.idle", 94.74272612720159, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.cpu.stolen", 0.0018948545225440318, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)
 	cpuCheck.Run()
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 6)
-	mock.AssertNumberOfCalls(t, "Commit", 1)
+	mock.AssertNumberOfCalls(t, "Gauge", 8)
+	mock.AssertNumberOfCalls(t, "Commit", 2)
 }

--- a/pkg/collector/corechecks/system/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu_windows.go
@@ -83,6 +83,7 @@ func (c *CPUCheck) Run() error {
 
 	nbCycle := t.Total() / c.nbCPU
 
+	sender.Gauge("system.cpu.num_cores", c.nbCPU, "", nil)
 	if c.lastNbCycle != 0 {
 		// gopsutil return the sum of every CPU
 		toPercent := 100 / (nbCycle - c.lastNbCycle)

--- a/releasenotes/notes/cpu-core-77cef52173085bbe.yaml
+++ b/releasenotes/notes/cpu-core-77cef52173085bbe.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add system.cpu.num_cores metric with the number of CPU cores (windows/linux)


### PR DESCRIPTION
### What does this PR do?

Following deprecation of some cAdvisor endpoints on Kubernetes, we won't be able to return the `kubernetes.cpu.num_cores` from the `Kubelet` check anymore.

However it does make sense to return this as a system metric instead.

### Describe your test plan

Run the agent, you should always have a `system.cpu.num_cores` metric with the number of logical cores.
