### PR TITLE
Convert kubelet to tagger entity IDs for expiration

### DIFF
--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -145,9 +145,15 @@ func (c *KubeletCollector) Fetch(entity string) ([]string, []string, []string, e
 func (c *KubeletCollector) parseExpires(idList []string) ([]*TagInfo, error) {
 	var output []*TagInfo
 	for _, id := range idList {
+		entityID, err := kubelet.KubeIDToTaggerEntityID(id)
+		if err != nil {
+			log.Warnf("error extracting tagger entity id from %q: %s", id, err)
+			continue
+		}
+
 		info := &TagInfo{
 			Source:       kubeletCollectorName,
-			Entity:       id,
+			Entity:       entityID,
 			DeleteEntity: true,
 		}
 		output = append(output, info)

--- a/pkg/util/kubernetes/kubelet/kubelet_common.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common.go
@@ -20,8 +20,11 @@ var (
 	// User classes should handle that case as gracefully as possible.
 	ErrNotCompiled = errors.New("kubelet support not compiled in")
 
+	// KubePodEntityName is the entity name for Kubernetes pods.
+	KubePodEntityName = "kubernetes_pod"
+
 	// KubePodPrefix is the entity prefix for Kubernetes pods
-	KubePodPrefix = "kubernetes_pod://"
+	KubePodPrefix = KubePodEntityName + containers.EntitySeparator
 
 	// KubePodTaggerEntityName is the tagger entity name for Kubernetes pods
 	KubePodTaggerEntityName = "kubernetes_pod_uid"
@@ -87,4 +90,16 @@ func KubePodUIDToTaggerEntityID(podUID string) (string, error) {
 		return KubePodTaggerEntityName + podUID[sep:], nil
 	}
 	return "", fmt.Errorf("can't extract an entity ID from pod UID %s", podUID)
+}
+
+// KubeIDToTaggerEntityID builds a tagger entity ID from an entity ID belonging to
+// a container or pod.
+func KubeIDToTaggerEntityID(entityName string) (string, error) {
+	prefix, _ := containers.SplitEntityName(entityName)
+
+	if prefix == KubePodEntityName {
+		return KubePodUIDToTaggerEntityID(entityName)
+	}
+
+	return KubeContainerIDToTaggerEntityID(entityName)
 }

--- a/pkg/util/kubernetes/kubelet/kubelet_common_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common_test.go
@@ -87,3 +87,20 @@ func TestKubePodUIDToTaggerEntityID(t *testing.T) {
 		})
 	}
 }
+
+func TestKubeIDToTaggerEntityID(t *testing.T) {
+	for in, out := range map[string]string{
+		"kubernetes_pod://deadbeef": "kubernetes_pod_uid://deadbeef",
+		"kubernetes_pod://d":        "kubernetes_pod_uid://d",
+		"docker://deadbeef":         "container_id://deadbeef",
+		"crio://deadbeef":           "container_id://deadbeef",
+		"kubernetes_pod://":         "",
+		"deadbeef":                  "",
+		"/deadbeef":                 "",
+	} {
+		t.Run(fmt.Sprintf("case: %s", in), func(t *testing.T) {
+			res, _ := KubeIDToTaggerEntityID(in)
+			assert.Equal(t, out, res)
+		})
+	}
+}

--- a/releasenotes/notes/remove-tags-expired-pods-e14594407cafe255.yaml
+++ b/releasenotes/notes/remove-tags-expired-pods-e14594407cafe255.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug where the Agent would not remove tags for pods that no longer
+    exist, potentially causing unbounded memory growth.


### PR DESCRIPTION
The tagger stores entities from the kubelet collector under ids with the
prefixes `container_id://` (for containers) and `kubernetes_pod_uid://`
(for pods), while the collector itself stores those entities under ids
with a different prefix: `$runtime://` (where a possible runtime would
be `docker`) and `kubernetes_pod://`. There is a conversion step from
one to the other when adding those entities, but that step is missing
when trying to purge expired pods and containers in `parseExpires`.

The change in this commit exists under the assumption that everything
that's not prefixed with `kubernetes_pod://` in the kubelet collector
comes from a container runtime. This might be a little brittle but holds
for now. In the future we could consider codifying these ID types into
actual Go types to provide richer data and avoid string comparisons of
this sort.

### Describe your test plan

Start the agent, create any arbitrary deployment (`kubectl create deployment redis --image redis` works great), and check that `agent tagger-list` returns one Entity for the pod, and one for the container. Delete the pods from the deployment you just created and let k8s re-create them. `agent tagger-list` should now return 2 pods and 2 containers. Before this PR, the container would eventually go away, but you'd still get 2 pods. After this PR, after ~5 minutes (the time for the kubelet collector to expire the pod that was removed, plus the time for the tagger store to be pruned of deleted entities), both the old pod and container should be gone.