### PR TITLE
Fixed ECS client initializers to check whether AWS is configured

### DIFF
--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -106,7 +106,7 @@ func (l *ECSListener) Stop() {
 func (l *ECSListener) refreshServices(firstRun bool) {
 	client, err := ecsmeta.V2()
 	if err != nil {
-		log.Error(err)
+		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 		return
 	}
 

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -26,6 +26,7 @@ import (
 // new containers to monitor, and old containers to stop monitoring
 type ECSListener struct {
 	task       *v2.Task
+	client     *v2.Client
 	filters    *containerFilters
 	services   map[string]Service // maps container IDs to services
 	newService chan<- Service
@@ -61,11 +62,18 @@ func init() {
 
 // NewECSListener creates an ECSListener
 func NewECSListener() (ServiceListener, error) {
+	client, err := ecsmeta.V2()
+	if err != nil {
+		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
+		return nil, err
+	}
+
 	filters, err := newContainerFilters()
 	if err != nil {
 		return nil, err
 	}
 	return &ECSListener{
+		client:   client,
 		services: make(map[string]Service),
 		stop:     make(chan bool),
 		filters:  filters,
@@ -104,13 +112,7 @@ func (l *ECSListener) Stop() {
 // compares the container list to the local cache and sends new/dead services
 // over newService and delService accordingly
 func (l *ECSListener) refreshServices(firstRun bool) {
-	client, err := ecsmeta.V2()
-	if err != nil {
-		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
-		return
-	}
-
-	meta, err := client.GetTask()
+	meta, err := l.client.GetTask()
 	if err != nil {
 		log.Errorf("failed to get task metadata, not refreshing services - %s", err)
 		return

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -104,7 +104,13 @@ func (l *ECSListener) Stop() {
 // compares the container list to the local cache and sends new/dead services
 // over newService and delService accordingly
 func (l *ECSListener) refreshServices(firstRun bool) {
-	meta, err := ecsmeta.V2().GetTask()
+	client, err := ecsmeta.V2()
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	meta, err := client.GetTask()
 	if err != nil {
 		log.Errorf("failed to get task metadata, not refreshing services - %s", err)
 		return

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -22,12 +22,22 @@ const (
 
 // ECSConfigProvider implements the ConfigProvider interface.
 // It collects configuration templates from the ECS metadata API.
-type ECSConfigProvider struct{}
+type ECSConfigProvider struct {
+	client *v2.Client
+}
 
 // NewECSConfigProvider returns a new ECSConfigProvider.
 // It configures an http Client with a 500 ms timeout.
 func NewECSConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
-	return new(ECSConfigProvider), nil
+	client, err := ecsmeta.V2()
+	if err != nil {
+		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
+		return nil, err
+	}
+
+	return &ECSConfigProvider{
+		client: client,
+	}, nil
 }
 
 // String returns a string representation of the ECSConfigProvider
@@ -43,15 +53,11 @@ func (p *ECSConfigProvider) IsUpToDate() (bool, error) {
 // Collect finds all running containers in the agent's task, reads their labels
 // and extract configuration templates from them for auto discovery.
 func (p *ECSConfigProvider) Collect() ([]integration.Config, error) {
-	client, err := ecsmeta.V2()
+	meta, err := p.client.GetTask()
 	if err != nil {
 		return nil, err
 	}
 
-	meta, err := client.GetTask()
-	if err != nil {
-		return nil, err
-	}
 	return parseECSContainers(meta.Containers)
 }
 

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -43,7 +43,13 @@ func (p *ECSConfigProvider) IsUpToDate() (bool, error) {
 // Collect finds all running containers in the agent's task, reads their labels
 // and extract configuration templates from them for auto discovery.
 func (p *ECSConfigProvider) Collect() ([]integration.Config, error) {
-	meta, err := ecsmeta.V2().GetTask()
+	client, err := ecsmeta.V2()
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	meta, err := client.GetTask()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -45,7 +45,6 @@ func (p *ECSConfigProvider) IsUpToDate() (bool, error) {
 func (p *ECSConfigProvider) Collect() ([]integration.Config, error) {
 	client, err := ecsmeta.V2()
 	if err != nil {
-		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 		return nil, err
 	}
 

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -45,7 +45,7 @@ func (p *ECSConfigProvider) IsUpToDate() (bool, error) {
 func (p *ECSConfigProvider) Collect() ([]integration.Config, error) {
 	client, err := ecsmeta.V2()
 	if err != nil {
-		log.Error(err)
+		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 		return nil, err
 	}
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -194,8 +194,8 @@ api_key:
 ## trigger security alert when querying unknown IP (for example, when enabling
 ## Tencent on AWS).
 ## Setting an empty list will disable querying any cloud metadata endpoints
-## (falling back on system metadata). Using this setting on a cloud provider
-## host may result in duplicated hosts in your account.
+## (falling back on system metadata). Disabling metadata for the cloud provider in which an Agent runs may result in
+## duplicated hosts in your Datadog account and missing Autodiscovery features
 ##
 ## Possible values are:
 ## "aws"     AWS EC2, ECS/Fargate

--- a/pkg/tagger/collectors/ecs_fargate_main.go
+++ b/pkg/tagger/collectors/ecs_fargate_main.go
@@ -16,7 +16,6 @@ import (
 	taggerutil "github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
-	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -62,7 +61,7 @@ func (c *ECSFargateCollector) Detect(out chan<- []*TagInfo) (CollectionMode, err
 func (c *ECSFargateCollector) Pull() error {
 	client, err := ecsmeta.V2()
 	if err != nil {
-		log.Error(err)
+		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 		return err
 	}
 
@@ -98,9 +97,9 @@ func (c *ECSFargateCollector) Pull() error {
 // Fetch parses tags for a container on cache miss. We avoid races with Pull,
 // we re-parse the whole list, but don't send updates on other containers.
 func (c *ECSFargateCollector) Fetch(container string) ([]string, []string, []string, error) {
-	client, err := metadata.V2()
+	client, err := ecsmeta.V2()
 	if err != nil {
-		log.Error(err)
+		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 		return []string{}, []string{}, []string{}, err
 	}
 

--- a/pkg/util/cloudprovider.go
+++ b/pkg/util/cloudprovider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/azure"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
+	ecscommon "github.com/DataDog/datadog-agent/pkg/util/ecs/common"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/tencent"
@@ -30,7 +31,7 @@ type cloudProviderDetector struct {
 // * Tencent
 func DetectCloudProvider() {
 	detectors := []cloudProviderDetector{
-		{name: ecs.CloudProviderName, callback: ecs.IsRunningOn},
+		{name: ecscommon.CloudProviderName, callback: ecs.IsRunningOn},
 		{name: ec2.CloudProviderName, callback: ec2.IsRunningOn},
 		{name: gce.CloudProviderName, callback: gce.IsRunningOn},
 		{name: azure.CloudProviderName, callback: azure.IsRunningOn},

--- a/pkg/util/ecs/common.go
+++ b/pkg/util/ecs/common.go
@@ -27,7 +27,7 @@ func ListContainersInCurrentTask() ([]*containers.Container, error) {
 
 	client, err := metadata.V2()
 	if err != nil {
-		log.Error(err)
+		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 		return cList, err
 	}
 
@@ -50,7 +50,7 @@ func UpdateContainerMetrics(cList []*containers.Container) error {
 	for _, ctr := range cList {
 		client, err := metadata.V2()
 		if err != nil {
-			log.Error(err)
+			log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 			return err
 		}
 

--- a/pkg/util/ecs/common.go
+++ b/pkg/util/ecs/common.go
@@ -25,7 +25,13 @@ import (
 func ListContainersInCurrentTask() ([]*containers.Container, error) {
 	var cList []*containers.Container
 
-	task, err := metadata.V2().GetTask()
+	client, err := metadata.V2()
+	if err != nil {
+		log.Error(err)
+		return cList, err
+	}
+
+	task, err := client.GetTask()
 	if err != nil || len(task.Containers) == 0 {
 		log.Error("Unable to get the container list from ecs")
 		return cList, err
@@ -42,7 +48,13 @@ func ListContainersInCurrentTask() ([]*containers.Container, error) {
 // container representations based on stats collected from the ECS metadata v2 API
 func UpdateContainerMetrics(cList []*containers.Container) error {
 	for _, ctr := range cList {
-		stats, err := metadata.V2().GetContainerStats(ctr.ID)
+		client, err := metadata.V2()
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+
+		stats, err := client.GetContainerStats(ctr.ID)
 		if err != nil {
 			log.Debugf("Unable to get stats from ECS for container %s: %s", ctr.ID, err)
 			continue

--- a/pkg/util/ecs/common/common.go
+++ b/pkg/util/ecs/common/common.go
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-2020 Datadog, Inc.
+
+package common
+
+// CloudProviderName contains the inventory name of for ECS
+const CloudProviderName = "AWS"

--- a/pkg/util/ecs/detection.go
+++ b/pkg/util/ecs/detection.go
@@ -54,7 +54,13 @@ func IsFargateInstance() bool {
 			return newBoolEntry(false)
 		}
 
-		_, err := ecsmeta.V2().GetTask()
+		client, err := ecsmeta.V2()
+		if err != nil {
+			log.Error(err)
+			return newBoolEntry(false)
+		}
+
+		_, err = client.GetTask()
 		if err != nil {
 			log.Debug(err)
 			return newBoolEntry(false)
@@ -89,7 +95,13 @@ func HasEC2ResourceTags() bool {
 // exposes resource tags.
 func HasFargateResourceTags() bool {
 	return queryCacheBool(hasFargateResourceTagsCacheKey, func() (bool, time.Duration) {
-		_, err := ecsmeta.V2().GetTaskWithTags()
+		client, err := ecsmeta.V2()
+		if err != nil {
+			log.Error(err)
+			return newBoolEntry(false)
+		}
+
+		_, err = client.GetTaskWithTags()
 		return newBoolEntry(err == nil)
 	})
 }

--- a/pkg/util/ecs/detection.go
+++ b/pkg/util/ecs/detection.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -21,14 +22,11 @@ const (
 	isFargateInstanceCacheKey      = "IsFargateInstanceCacheKey"
 	hasFargateResourceTagsCacheKey = "HasFargateResourceTagsCacheKey"
 	hasEC2ResourceTagsCacheKey     = "HasEC2ResourceTagsCacheKey"
-
-	// CloudProviderName contains the inventory name of for ECS
-	CloudProviderName = "AWS"
 )
 
 // IsECSInstance returns whether the agent is running in ECS.
 func IsECSInstance() bool {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
+	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
 		return false
 	}
 	_, err := ecsmeta.V1()
@@ -40,7 +38,7 @@ func IsECSInstance() bool {
 // This function identifies Fargate on ECS only. Make sure to use the Fargate pkg
 // to identify Fargate instances in other orchestrators (e.g EKS Fargate)
 func IsFargateInstance() bool {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
+	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
 		return false
 	}
 	return queryCacheBool(isFargateInstanceCacheKey, func() (bool, time.Duration) {
@@ -78,7 +76,7 @@ func IsRunningOn() bool {
 // HasEC2ResourceTags returns whether the metadata endpoint in ECS exposes
 // resource tags.
 func HasEC2ResourceTags() bool {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
+	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
 		return false
 	}
 	return queryCacheBool(hasEC2ResourceTagsCacheKey, func() (bool, time.Duration) {
@@ -107,7 +105,7 @@ func HasFargateResourceTags() bool {
 }
 
 func queryCacheBool(cacheKey string, cacheMissEvalFunc func() (bool, time.Duration)) bool {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
+	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
 		return false
 	}
 	if cachedValue, found := cache.Cache.Get(cacheKey); found {

--- a/pkg/util/ecs/detection.go
+++ b/pkg/util/ecs/detection.go
@@ -56,7 +56,7 @@ func IsFargateInstance() bool {
 
 		client, err := ecsmeta.V2()
 		if err != nil {
-			log.Error(err)
+			log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 			return newBoolEntry(false)
 		}
 
@@ -97,7 +97,7 @@ func HasFargateResourceTags() bool {
 	return queryCacheBool(hasFargateResourceTagsCacheKey, func() (bool, time.Duration) {
 		client, err := ecsmeta.V2()
 		if err != nil {
-			log.Error(err)
+			log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 			return newBoolEntry(false)
 		}
 

--- a/pkg/util/ecs/detection_nodocker.go
+++ b/pkg/util/ecs/detection_nodocker.go
@@ -7,11 +7,6 @@
 
 package ecs
 
-const (
-	// CloudProviderName contains the inventory name of for ECS
-	CloudProviderName = "AWS"
-)
-
 // IsECSInstance returns whether the agent is running in ECS.
 func IsECSInstance() bool {
 	return false

--- a/pkg/util/ecs/diagnosis.go
+++ b/pkg/util/ecs/diagnosis.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 )
 
@@ -58,7 +59,13 @@ func diagnoseECSTags() error {
 
 // diagnose the ECS Fargate metadata API availability
 func diagnoseFargate() error {
-	if _, err := ecsmeta.V2().GetTask(); err != nil {
+	client, err := metadata.V2()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	if _, err := client.GetTask(); err != nil {
 		log.Error(err)
 		return err
 	}

--- a/pkg/util/ecs/diagnosis.go
+++ b/pkg/util/ecs/diagnosis.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 )
 
@@ -59,9 +58,9 @@ func diagnoseECSTags() error {
 
 // diagnose the ECS Fargate metadata API availability
 func diagnoseFargate() error {
-	client, err := metadata.V2()
+	client, err := ecsmeta.V2()
 	if err != nil {
-		log.Error(err)
+		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 		return err
 	}
 

--- a/pkg/util/ecs/metadata/clients.go
+++ b/pkg/util/ecs/metadata/clients.go
@@ -22,7 +22,8 @@ import (
 )
 
 var globalUtil util
-var cloudProviderName = "AWS"
+
+const CloudProviderName = "AWS"
 
 type util struct {
 	// used to setup the ECSUtil
@@ -40,13 +41,13 @@ type util struct {
 // endpoint, by detecting the endpoint address. Returns an error if it was not
 // possible to detect the endpoint address.
 func V1() (*v1.Client, error) {
-	if !config.IsCloudProviderEnabled(cloudProviderName) {
-		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
 	}
 
 	globalUtil.initV1.Do(func() {
 		globalUtil.initRetryV1.SetupRetrier(&retry.Config{ //nolint:errcheck
-			Name:              "ecsutil-meta-v1",
+			Name:              "til-meta-v1",
 			AttemptMethod:     initV1,
 			Strategy:          retry.Backoff,
 			InitialRetryDelay: 1 * time.Second,
@@ -63,8 +64,8 @@ func V1() (*v1.Client, error) {
 // V2 returns a client for the ECS metadata API v2 that uses the default
 // endpoint address.
 func V2() (*v2.Client, error) {
-	if !config.IsCloudProviderEnabled(cloudProviderName) {
-		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
 	}
 
 	globalUtil.initV2.Do(func() {
@@ -78,8 +79,8 @@ func V2() (*v2.Client, error) {
 // address for the specified container. Returns an error if it was not possible
 // to detect the endpoint address.
 func V3(containerID string) (*v3.Client, error) {
-	if !config.IsCloudProviderEnabled(cloudProviderName) {
-		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
 	}
 
 	return newClientV3ForContainer(containerID)
@@ -89,13 +90,13 @@ func V3(containerID string) (*v3.Client, error) {
 // the endpoint address from the task the executable is running in. Returns an
 // error if it was not possible to detect the endpoint address.
 func V3FromCurrentTask() (*v3.Client, error) {
-	if !config.IsCloudProviderEnabled(cloudProviderName) {
-		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
 	}
 
 	globalUtil.initV3.Do(func() {
 		globalUtil.initRetryV3.SetupRetrier(&retry.Config{ //nolint:errcheck
-			Name:              "ecsutil-meta-v3",
+			Name:              "til-meta-v3",
 			AttemptMethod:     initV3,
 			Strategy:          retry.Backoff,
 			InitialRetryDelay: 1 * time.Second,

--- a/pkg/util/ecs/metadata/clients.go
+++ b/pkg/util/ecs/metadata/clients.go
@@ -16,15 +16,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
 	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
 )
 
 var globalUtil util
-
-// CloudProviderName contains the inventory name of for ECS
-const CloudProviderName = "AWS"
 
 type util struct {
 	// used to setup the ECSUtil
@@ -42,13 +40,13 @@ type util struct {
 // endpoint, by detecting the endpoint address. Returns an error if it was not
 // possible to detect the endpoint address.
 func V1() (*v1.Client, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
+	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
 
 	globalUtil.initV1.Do(func() {
 		globalUtil.initRetryV1.SetupRetrier(&retry.Config{ //nolint:errcheck
-			Name:              "til-meta-v1",
+			Name:              "ecsutil-meta-v1",
 			AttemptMethod:     initV1,
 			Strategy:          retry.Backoff,
 			InitialRetryDelay: 1 * time.Second,
@@ -65,8 +63,8 @@ func V1() (*v1.Client, error) {
 // V2 returns a client for the ECS metadata API v2 that uses the default
 // endpoint address.
 func V2() (*v2.Client, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
+	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
 
 	globalUtil.initV2.Do(func() {
@@ -80,8 +78,8 @@ func V2() (*v2.Client, error) {
 // address for the specified container. Returns an error if it was not possible
 // to detect the endpoint address.
 func V3(containerID string) (*v3.Client, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
+	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
 
 	return newClientV3ForContainer(containerID)
@@ -91,13 +89,13 @@ func V3(containerID string) (*v3.Client, error) {
 // the endpoint address from the task the executable is running in. Returns an
 // error if it was not possible to detect the endpoint address.
 func V3FromCurrentTask() (*v3.Client, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
+	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
 
 	globalUtil.initV3.Do(func() {
 		globalUtil.initRetryV3.SetupRetrier(&retry.Config{ //nolint:errcheck
-			Name:              "til-meta-v3",
+			Name:              "ecsutil-meta-v3",
 			AttemptMethod:     initV3,
 			Strategy:          retry.Backoff,
 			InitialRetryDelay: 1 * time.Second,

--- a/pkg/util/ecs/metadata/clients.go
+++ b/pkg/util/ecs/metadata/clients.go
@@ -23,6 +23,7 @@ import (
 
 var globalUtil util
 
+// CloudProviderName contains the inventory name of for ECS
 const CloudProviderName = "AWS"
 
 type util struct {

--- a/pkg/util/ecs/metadata/clients.go
+++ b/pkg/util/ecs/metadata/clients.go
@@ -8,9 +8,11 @@
 package metadata
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 
@@ -20,6 +22,7 @@ import (
 )
 
 var globalUtil util
+var cloudProviderName = "AWS"
 
 type util struct {
 	// used to setup the ECSUtil
@@ -37,6 +40,10 @@ type util struct {
 // endpoint, by detecting the endpoint address. Returns an error if it was not
 // possible to detect the endpoint address.
 func V1() (*v1.Client, error) {
+	if !config.IsCloudProviderEnabled(cloudProviderName) {
+		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
 	globalUtil.initV1.Do(func() {
 		globalUtil.initRetryV1.SetupRetrier(&retry.Config{ //nolint:errcheck
 			Name:              "ecsutil-meta-v1",
@@ -55,17 +62,26 @@ func V1() (*v1.Client, error) {
 
 // V2 returns a client for the ECS metadata API v2 that uses the default
 // endpoint address.
-func V2() *v2.Client {
+func V2() (*v2.Client, error) {
+	if !config.IsCloudProviderEnabled(cloudProviderName) {
+		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
 	globalUtil.initV2.Do(func() {
 		globalUtil.v2 = v2.NewDefaultClient()
 	})
-	return globalUtil.v2
+
+	return globalUtil.v2, nil
 }
 
 // V3 returns a client for the ECS metadata API v3 by detecting the endpoint
 // address for the specified container. Returns an error if it was not possible
 // to detect the endpoint address.
 func V3(containerID string) (*v3.Client, error) {
+	if !config.IsCloudProviderEnabled(cloudProviderName) {
+		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
 	return newClientV3ForContainer(containerID)
 }
 
@@ -73,6 +89,10 @@ func V3(containerID string) (*v3.Client, error) {
 // the endpoint address from the task the executable is running in. Returns an
 // error if it was not possible to detect the endpoint address.
 func V3FromCurrentTask() (*v3.Client, error) {
+	if !config.IsCloudProviderEnabled(cloudProviderName) {
+		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
 	globalUtil.initV3.Do(func() {
 		globalUtil.initRetryV3.SetupRetrier(&retry.Config{ //nolint:errcheck
 			Name:              "ecsutil-meta-v3",

--- a/pkg/util/ecs/metadata/clients_nodocker.go
+++ b/pkg/util/ecs/metadata/clients_nodocker.go
@@ -18,6 +18,9 @@ import (
 	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
 )
 
+// CloudProviderName contains the inventory name of for ECS
+const CloudProviderName = "AWS"
+
 // V1 returns a client for the ECS metadata API v1, also called introspection
 // endpoint, by detecting the endpoint address. Returns an error if it was not
 // possible to detect the endpoint address.

--- a/pkg/util/ecs/metadata/clients_nodocker.go
+++ b/pkg/util/ecs/metadata/clients_nodocker.go
@@ -13,13 +13,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
 	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
 )
-
-// CloudProviderName contains the inventory name of for ECS
-const CloudProviderName = "AWS"
 
 // V1 returns a client for the ECS metadata API v1, also called introspection
 // endpoint, by detecting the endpoint address. Returns an error if it was not
@@ -31,8 +29,8 @@ func V1() (*v1.Client, error) {
 // V2 returns a client for the ECS metadata API v2 that uses the default
 // endpoint address.
 func V2() (*v2.Client, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
+	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
 
 	return v2.NewDefaultClient(), nil

--- a/pkg/util/ecs/metadata/clients_nodocker.go
+++ b/pkg/util/ecs/metadata/clients_nodocker.go
@@ -8,12 +8,17 @@
 package metadata
 
 import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
 	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
 )
+
+var cloudProviderName = "AWS"
 
 // V1 returns a client for the ECS metadata API v1, also called introspection
 // endpoint, by detecting the endpoint address. Returns an error if it was not
@@ -24,8 +29,12 @@ func V1() (*v1.Client, error) {
 
 // V2 returns a client for the ECS metadata API v2 that uses the default
 // endpoint address.
-func V2() *v2.Client {
-	return v2.NewDefaultClient()
+func V2() (*v2.Client, error) {
+	if !config.IsCloudProviderEnabled(cloudProviderName) {
+		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
+	return v2.NewDefaultClient(), nil
 }
 
 // V3 returns a client for the ECS metadata API v3 by detecting the endpoint

--- a/pkg/util/ecs/metadata/clients_nodocker.go
+++ b/pkg/util/ecs/metadata/clients_nodocker.go
@@ -18,8 +18,6 @@ import (
 	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
 )
 
-var cloudProviderName = "AWS"
-
 // V1 returns a client for the ECS metadata API v1, also called introspection
 // endpoint, by detecting the endpoint address. Returns an error if it was not
 // possible to detect the endpoint address.
@@ -30,8 +28,8 @@ func V1() (*v1.Client, error) {
 // V2 returns a client for the ECS metadata API v2 that uses the default
 // endpoint address.
 func V2() (*v2.Client, error) {
-	if !config.IsCloudProviderEnabled(cloudProviderName) {
-		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", CloudProviderName)
 	}
 
 	return v2.NewDefaultClient(), nil

--- a/pkg/util/fargate/hostname_process.go
+++ b/pkg/util/fargate/hostname_process.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
+	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -37,9 +37,9 @@ func getFargateHost(orchestrator OrchestratorName, ecsFunc, eksFunc func() (stri
 }
 
 func getECSHost() (string, error) {
-	client, err := metadata.V2()
+	client, err := ecsmeta.V2()
 	if err != nil {
-		log.Error(err)
+		log.Debugf("error while initializing ECS metadata V2 client: %s", err)
 		return "", err
 	}
 

--- a/pkg/util/fargate/hostname_process.go
+++ b/pkg/util/fargate/hostname_process.go
@@ -40,7 +40,7 @@ func getECSHost() (string, error) {
 	client, err := metadata.V2()
 	if err != nil {
 		log.Error(err)
-		return err
+		return "", err
 	}
 
 	// Use the task ARN as hostname

--- a/pkg/util/fargate/hostname_process.go
+++ b/pkg/util/fargate/hostname_process.go
@@ -11,7 +11,8 @@ import (
 	"errors"
 	"fmt"
 
-	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // GetFargateHost returns the hostname to be used
@@ -36,8 +37,14 @@ func getFargateHost(orchestrator OrchestratorName, ecsFunc, eksFunc func() (stri
 }
 
 func getECSHost() (string, error) {
+	client, err := metadata.V2()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
 	// Use the task ARN as hostname
-	taskMeta, err := ecsmeta.V2().GetTask()
+	taskMeta, err := client.GetTask()
 	if err != nil {
 		return "", err
 	}

--- a/releasenotes/notes/fix-fargate-metadata-not-disabled-93e50a3f9fc02240.yaml
+++ b/releasenotes/notes/fix-fargate-metadata-not-disabled-93e50a3f9fc02240.yaml
@@ -9,4 +9,4 @@
 fixes:
   - |
     Fixes a bug where the ECS metadata endpoint V2 would get queried even though it was not configured
-    in the cloud_metadata providers.
+    with the configuration option `cloud_provider_metadata`.

--- a/releasenotes/notes/fix-fargate-metadata-not-disabled-93e50a3f9fc02240.yaml
+++ b/releasenotes/notes/fix-fargate-metadata-not-disabled-93e50a3f9fc02240.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug where the ECS metadata endpoint V2 would get queried even though it was not configured
+    in the cloud_metadata providers.


### PR DESCRIPTION
Seems the [option](https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml#L190) cloud_provider_metadata: is not working as expected, i.e. when setting this to azure, they are still seeing some queries to AWS. EC2 metadata is disabled, which is correct

```bash
=== Running EC2 Metadata availability diagnosis ===
[ERROR] error: cloud provider is disabled by configuration - 1592529464323954665
===> FAIL
```

But not ECS:

```bash
=== Running ECS Fargate Metadata availability diagnosis ===
[ERROR] error: Get http://169.254.170.2/v2/metadata: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) - 1592529464824415674
```

In the [config file](https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml#L190) we do mention that this should be disabled, when it is not in the list:

```yaml
@param cloud_provider_metadata - list of strings -  optional - default: ["aws", "gcp", "azure", "alibaba"]
## "aws"     AWS EC2, ECS/Fargate
cloud_provider_metadata:
  - "azure"
```

This was tested on my own agent, but the customer is seeing the same problem, the issue is that the agent is making requests and using ports (51678) that they do not want it to use, and so they would like to disable metadata for AWS as they use azure.

### What does this PR do?

The changes are to check if the `AWS` cloud provider option is set before initializing clients for the ECS metadata endpoints (V1, V2 and V3 in `pkg/util/ecs/metadata/v2/clients.go`). To reflect this change, The initializiation of the `V2()` endpoint and the invocation of `GetTask()` for that endpoint were also separated, as initializing with `V2` can now throw an error.

### Describe your test plan

I tested that the flare does now correctly report ECS Fargate as `cloud provider is disabled by configuration`.

### Notes for QA

Packages `autodiscovery` and `tagger` should be QA'ed on ECS (Classic and Fargate) after merging this PR.