### PR TITLE
Add `resolve` option to endpoint checks

### DIFF
--- a/pkg/autodiscovery/providers/kube_endpoints_test.go
+++ b/pkg/autodiscovery/providers/kube_endpoints_test.go
@@ -105,6 +105,7 @@ func TestParseKubeServiceAnnotationsForEndpoints(t *testing.T) {
 func TestGenerateConfigs(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
+		resolveMode endpointResolveMode
 		endpoints   *v1.Endpoints
 		template    integration.Config
 		expectedOut []integration.Config
@@ -116,7 +117,8 @@ func TestGenerateConfigs(t *testing.T) {
 			expectedOut: []integration.Config{{}},
 		},
 		{
-			name: "Endpoints without podRef",
+			name:        "Endpoints without podRef",
+			resolveMode: "auto",
 			endpoints: &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					ResourceVersion: "123",
@@ -164,7 +166,8 @@ func TestGenerateConfigs(t *testing.T) {
 			},
 		},
 		{
-			name: "Endpoints with podRef",
+			name:        "Endpoints with podRef",
+			resolveMode: "unknown",
 			endpoints: &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					ResourceVersion: "123",
@@ -219,9 +222,66 @@ func TestGenerateConfigs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "Endpoints with podRef but with resolve=ip",
+			resolveMode: "ip",
+			endpoints: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					UID:             types.UID("endpoints-uid"),
+					Name:            "myservice",
+					Namespace:       "default",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1", Hostname: "testhost1", NodeName: &nodename1, TargetRef: &v1.ObjectReference{
+								UID:  types.UID("pod-uid-1"),
+								Kind: "Pod",
+							}},
+							{IP: "10.0.0.2", Hostname: "testhost2", NodeName: &nodename2, TargetRef: &v1.ObjectReference{
+								UID:  types.UID("pod-uid-2"),
+								Kind: "Pod",
+							}},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "port123", Port: 123},
+							{Name: "port126", Port: 126},
+						},
+					},
+				},
+			},
+			template: integration.Config{
+				Name:          "http_check",
+				ADIdentifiers: []string{"kube_endpoint_uid://default/myservice/"},
+				InitConfig:    integration.Data("{}"),
+				Instances:     []integration.Data{integration.Data("{\"name\":\"My endpoint\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+				ClusterCheck:  false,
+			},
+			expectedOut: []integration.Config{
+				{
+					Entity:        "kube_endpoint_uid://default/myservice/10.0.0.1",
+					Name:          "http_check",
+					ADIdentifiers: []string{"kube_endpoint_uid://default/myservice/10.0.0.1"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My endpoint\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					ClusterCheck:  true,
+					NodeName:      "",
+				},
+				{
+					Entity:        "kube_endpoint_uid://default/myservice/10.0.0.2",
+					Name:          "http_check",
+					ADIdentifiers: []string{"kube_endpoint_uid://default/myservice/10.0.0.2"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My endpoint\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					ClusterCheck:  true,
+					NodeName:      "",
+				},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
-			cfgs := generateConfigs(tc.template, tc.endpoints)
+			cfgs := generateConfigs(tc.template, tc.resolveMode, tc.endpoints)
 			assert.EqualValues(t, tc.expectedOut, cfgs)
 		})
 	}

--- a/releasenotes-dca/notes/add-resolve-endpoints-check-040074679ddf15bf.yaml
+++ b/releasenotes-dca/notes/add-resolve-endpoints-check-040074679ddf15bf.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add resolve option to endpoint checks through new annotation `ad.datadoghq.com/endpoints.resolve`. With `ip` value, it allows endpoint checks to target static pods


### PR DESCRIPTION
### What does this PR do?

Add support for the `ad.datadoghq.com/endpoints.resolve` annotation on services. It allows to control the way endpoints are resolved.
Currently supports:
- `ip`: force to consider only endpoint (ignore if backed by pods or not)
- `auto`: current behavior which tries to match a POD based on `targetRef`

Fixes an issue where an endpoint cannot be scheduled if backed by a static POD

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Annotate a service backed by PODs with `ad.datadoghq.com/endpoints.resolve=ip`, it should only be resolved as a normal endpoint (e.g. Auto-discovery id should only contain a `kube_endpoint_uid` reference)