### PR TITLE
[gitlab] Fix missing folder in windows_choco_online_7_x64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1275,6 +1275,9 @@ windows_choco_online_7_x64:
     ARCH: "x64"
   script:
     - $ErrorActionPreference = "Stop"
+    - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
+    - if (Test-Path build-out) { remove-item -recurse -force build-out }
+    - mkdir .omnibus\pkg
     - docker run --rm -v "$(Get-Location):c:\mnt" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDERS} c:\mnt\tasks\winbuildscripts\chocopack.bat online
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - copy build-out\*.nupkg .omnibus\pkg


### PR DESCRIPTION
### What does this PR do?

Adds missing folder at the start of the windows_choco_online_7_x64 job.
Adds initial cleanup to make sure we start from a clean state.

### Motivation

#5889 fixed the `windows_choco_online_7_x64` dependencies. The less-than-obvious side effect is that the `.omnibus\pkg` is not present by default anymore*, and thus needs to be created.

\* The reason why `.omnibus\pkg` was present before was that we downloaded the artifacts of `windows_msi_x64-a7`, which were put in this folder.
