### PR TITLE
[circleci] Use new version of MacOS script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
     macos:
       xcode: 10.1.0
     environment:
-      BUILDIMAGES_VERSION: "a8226a8e78774afad285e7372fe8c6c179340dd9" # datadog-agent-buildimages commit to fetch to get the MacOS scripts
+      BUILDIMAGES_VERSION: "f43e0e081e9a54fea3241ef0efde28374981f7a0" # datadog-agent-buildimages commit to fetch to get the MacOS scripts
       RELEASE_VERSION: "nightly-a7"
       AGENT_MAJOR_VERSION: "7"
       PYTHON_RUNTIMES: "3"


### PR DESCRIPTION

### What does this PR do?

Backport of #5924.
Updates version of build script used, following brew update of the Python formula.

### Motivation

7.21.0 release prep.

