### PR TITLE
Shorten DatadogMetrics autogen names to avoid matching scrubbing rules

### DIFF
--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher_test.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher_test.go
@@ -273,7 +273,7 @@ func TestCreateAutogenDatadogMetrics(t *testing.T) {
 		Error:      nil,
 	}, f.store.Get("default/dd-metric-0"))
 	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
-		ID:                 "default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d2265",
+		ID:                 "default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22",
 		Active:             true,
 		Query:              "avg:docker.cpu.usage{foo:bar}.rollup(30)",
 		Valid:              false,
@@ -282,9 +282,9 @@ func TestCreateAutogenDatadogMetrics(t *testing.T) {
 		Value:              0.0,
 		UpdateTime:         updateTime,
 		Error:              nil,
-	}, f.store.Get("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d2265"))
+	}, f.store.Get("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22"))
 	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
-		ID:                 "default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412f8",
+		ID:                 "default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412",
 		Active:             true,
 		Query:              "avg:docker.cpu.usage{bar:foo}.rollup(30)",
 		Valid:              false,
@@ -293,7 +293,7 @@ func TestCreateAutogenDatadogMetrics(t *testing.T) {
 		Value:              0.0,
 		UpdateTime:         updateTime,
 		Error:              nil,
-	}, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412f8"))
+	}, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))
 }
 
 func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
@@ -313,8 +313,8 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 		Error:      nil,
 	}, "utest")
 	// HPA has been deleted but last update time was 30 minutes ago, we should keep it
-	f.store.Set("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d2265", model.DatadogMetricInternal{
-		ID:                 "default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d2265",
+	f.store.Set("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22", model.DatadogMetricInternal{
+		ID:                 "default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22",
 		Active:             true,
 		Query:              "avg:docker.cpu.usage{foo:bar}.rollup(30)",
 		Valid:              false,
@@ -326,8 +326,8 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 		Error:              nil,
 	}, "utest")
 	// WPA has been deleted for 90 minutes, we should flag this as deleted
-	f.store.Set("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412f8", model.DatadogMetricInternal{
-		ID:                 "default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412f8",
+	f.store.Set("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412", model.DatadogMetricInternal{
+		ID:                 "default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412",
 		Active:             true,
 		Query:              "avg:docker.cpu.usage{bar:foo}.rollup(30)",
 		Valid:              false,
@@ -354,7 +354,7 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 		Error:      nil,
 	}, f.store.Get("default/dd-metric-0"))
 	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
-		ID:                 "default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d2265",
+		ID:                 "default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22",
 		Active:             false,
 		Query:              "avg:docker.cpu.usage{foo:bar}.rollup(30)",
 		Valid:              false,
@@ -364,9 +364,9 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 		Value:              0.0,
 		UpdateTime:         oldUpdateTime,
 		Error:              nil,
-	}, f.store.Get("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d2265"))
+	}, f.store.Get("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22"))
 	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
-		ID:                 "default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412f8",
+		ID:                 "default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412",
 		Active:             false,
 		Query:              "avg:docker.cpu.usage{bar:foo}.rollup(30)",
 		Valid:              false,
@@ -376,5 +376,5 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 		Value:              0.0,
 		UpdateTime:         expiredUpdateTime,
 		Error:              nil,
-	}, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412f8"))
+	}, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))
 }

--- a/pkg/clusteragent/externalmetrics/provider_test.go
+++ b/pkg/clusteragent/externalmetrics/provider_test.go
@@ -178,7 +178,7 @@ func TestGetExternalMetrics(t *testing.T) {
 			},
 			queryMetricName:         "nginx.net.request_per_s",
 			expectedExternalMetrics: nil,
-			expectedError:           fmt.Errorf("DatadogMetric not found for metric name: nginx.net.request_per_s, datadogmetricid: default/dcaautogen-32402d8dfc05cf540928a606d78ed68c0607f758"),
+			expectedError:           fmt.Errorf("DatadogMetric not found for metric name: nginx.net.request_per_s, datadogmetricid: default/dcaautogen-32402d8dfc05cf540928a606d78ed68c0607f7"),
 		},
 	}
 

--- a/pkg/clusteragent/externalmetrics/utils.go
+++ b/pkg/clusteragent/externalmetrics/utils.go
@@ -68,9 +68,10 @@ func getAutogenDatadogMetricNameFromSelector(metricName string, labels labels.Se
 
 // We use query and not metricName + labels as key. It ensures we'll handle changes of config parameters.
 func getAutogenDatadogMetricName(query string) string {
-	// We keep 20 bytes (160 bits), it should provide a 40-chars hex string
+	// We keep 19 bytes (152 bits), it should provide a 38-chars hex string
+	// Not using 40chars as it conflicts with appKey scrubbing
 	sum := sha256.Sum256([]byte(query))
-	return autogenDatadogMetricPrefix + hex.EncodeToString(sum[0:20])
+	return autogenDatadogMetricPrefix + hex.EncodeToString(sum[0:19])
 }
 
 func buildDatadogQueryForExternalMetric(metricName string, labels map[string]string) string {

--- a/pkg/clusteragent/externalmetrics/utils_test.go
+++ b/pkg/clusteragent/externalmetrics/utils_test.go
@@ -65,7 +65,7 @@ func TestDatadogMetricNameGeneration(t *testing.T) {
 	idFromMap := getAutogenDatadogMetricNameFromLabels(testMetricName, testLabels)
 	idFromSelector := getAutogenDatadogMetricNameFromSelector(testMetricName, labels.Set(testLabels).AsSelector())
 
-	assert.Equal(t, "dcaautogen-595b170252cd5c77580b802084753c17ed1a181b", idRef)
+	assert.Equal(t, "dcaautogen-595b170252cd5c77580b802084753c17ed1a18", idRef)
 	assert.Equal(t, idRef, idFromMap)
 	assert.Equal(t, idRef, idFromSelector)
 }
@@ -79,7 +79,7 @@ func TestDatadogMetricNameGenerationNoLabels(t *testing.T) {
 	idFromMap := getAutogenDatadogMetricNameFromLabels(testMetricName, testLabels)
 	idFromSelector := getAutogenDatadogMetricNameFromSelector(testMetricName, labels.Set(testLabels).AsSelector())
 
-	assert.Equal(t, "dcaautogen-cb3c76c6adbd97b438d75e29a6a8efc4cefa8108", idRef)
+	assert.Equal(t, "dcaautogen-cb3c76c6adbd97b438d75e29a6a8efc4cefa81", idRef)
 	assert.Equal(t, idRef, idFromMap)
 	assert.Equal(t, idRef, idFromSelector)
 }


### PR DESCRIPTION
### What does this PR do?

Avoid log scrubbing of autogen DDM id.

### Describe your test plan

Run DCA with autogen DDM, in logs DDM id should be in clear text.
