### PR TITLE
[metadata] On EC2 hostname/instance id failure, return data from the cache

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -168,7 +168,7 @@ func getMeta(hostnameData util.HostnameData) *Meta {
 	}
 
 	instanceID, err := ec2.GetInstanceID()
-	if err != nil || ec2Hostname == "" {
+	if err != nil || instanceID == "" {
 		log.Debugf("failed to get ec2 instanceID, trying from the cache: %s", err)
 		if x, found := cache.Cache.Get(key); found {
 			if cachedMeta, ok := x.(*Meta); ok {


### PR DESCRIPTION
### What does this PR do?

The EC2 local metadata endpoint is sometimes unavailable. When this happen, the agent
will report an empty EC2 hostname and EC2 instance ID and will override the current value that is in Datadog.
Since EC2 hostname / instance id do not change, we can easily reuse what we already cached previously

### Motivation

The EC2 local metadata endpoint is sometimes unavailable. When this happen, the agent
will report an empty EC2 hostname and EC2 instance ID and will override the current value that is in Datadog.

### Additional Notes

(This PR currently lacks tests)

### Describe your test plan

Have thorough tests