### PR TITLE
Remove logs from functions called by `init` functions

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1068,16 +1068,10 @@ func IsCloudProviderEnabled(cloudProviderName string) bool {
 
 	for _, cloudName := range cloudProviderFromConfig {
 		if strings.ToLower(cloudName) == strings.ToLower(cloudProviderName) {
-			log.Debugf("cloud_provider_metadata is set to %s in agent configuration, trying endpoints for %s Cloud Provider",
-				cloudProviderFromConfig,
-				cloudProviderName)
 			return true
 		}
 	}
 
-	log.Debugf("cloud_provider_metadata is set to %s in agent configuration, skipping %s Cloud Provider",
-		cloudProviderFromConfig,
-		cloudProviderName)
 	return false
 }
 


### PR DESCRIPTION
### What does this PR do?

Remove logs from functions called by `init` functions

### Motivation

Functions that are (indirectly) called by an `init` function
mustn't log anything because such logs would pollute the standard
output of agent commands like `agent status` or `agent hostname`.

### Additional Notes

Here is the stacktrace between an `init` function and the logs that
this commit is removing:
```
github.com/DataDog/datadog-agent/pkg/config.IsCloudProviderEnabled(0x3892f06, 0x3, 0xc0000a81a0)
	/git/datadog-agent/pkg/config/config.go:1075 +0x319
github.com/DataDog/datadog-agent/pkg/util/ecs.IsFargateInstance(0x135936d)
	/git/datadog-agent/pkg/util/ecs/detection.go:41 +0x36
github.com/DataDog/datadog-agent/pkg/util/fargate.IsFargateInstance(0x3418960)
	/git/datadog-agent/pkg/util/fargate/detection.go:17 +0x22
github.com/DataDog/datadog-agent/pkg/tagger/collectors.init.6()
	/git/datadog-agent/pkg/tagger/collectors/static_main.go:49 +0x26
```

### Describe your test plan

Start an agent with the following `datadog.yaml`:
```
cloud_provider_metadata: aws gcp azure alibaba
```
and with `logLevel` set to `DEBUG`.
Then, run `agent status`.
