### PR TITLE
[secrets] Consistently resolve secrets when new services are found

### DIFF
--- a/releasenotes/notes/consistent-config-secret-decryption-f24dd89f5c485f88.yaml
+++ b/releasenotes/notes/consistent-config-secret-decryption-f24dd89f5c485f88.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix cases where the resolution of secrets in integration configs would not
+    be performed for autodiscovered containers.


### PR DESCRIPTION
### What does this PR do?

* The secrets resolution logic would only be applied to integration configs when a new config was found/polled (`AutoConfig.processNewConfig` function), not when a new service was found (`AutoConfig.processNewService` function). This would lead to secrets not being resolved when a container was found or was ready only after the integration config for it was polled.
* In addition, the secret resolution would in some cases be run before storing the resolved config in the AD store, sometimes after, causing inconsistencies in the AD store and in the output of the `configcheck` command. Not sure if this actually caused functional bugs though.

This fixes both problems by consistently calling the secrets resolution logic on every config template resolution (and when no template resolution is performed as well).

### Motivation

Bug found on internal infra where secrets are used in integration templates set as k8s annotations.

### Additional Notes

* AFAIK this bug has always been present (or at least for a long time).
* Lacks unit tests.

### Describe your test plan

I tested the fix as follows:

1. reproduced the issue with: an auto_conf template with a secret `ENC[...]` value in it and an AD identifier matching a test docker image, and the secrets feature enabled on the agent. If the Agent is already running when a container using that test docker image is started, the resulting scheduled config will not have its secrets decoded (to confirm this, see the output of `agent configcheck` and make the check print the value of the config)
2. With same setup, and this fix, the issue is fixed: the secret is always resolved.