### PR TITLE
[compliance] Change event.Data to allow storing not only strings

### DIFF
--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -64,7 +64,7 @@ func eventRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to set up compliance log reporter: %w", err)
 	}
 
-	eventArgs.event.Data = map[string]string{}
+	eventArgs.event.Data = event.Data{}
 	for _, d := range eventArgs.data {
 		kv := strings.SplitN(d, ":", 2)
 		if len(kv) != 2 {

--- a/pkg/compliance/checks/file_check_test.go
+++ b/pkg/compliance/checks/file_check_test.go
@@ -94,7 +94,7 @@ func TestFileCheck(t *testing.T) {
 				},
 			}),
 			validate: func(t *testing.T, kv event.Data) {
-				owner, ok := kv["owner"]
+				owner, ok := kv["owner"].(string)
 				assert.True(t, ok)
 				parts := strings.SplitN(owner, ":", 2)
 				assert.Equal(t, parts[0], "root")

--- a/pkg/compliance/event/event.go
+++ b/pkg/compliance/event/event.go
@@ -15,7 +15,7 @@ const (
 )
 
 // Data defines a key value map for storing attributes of a reported rule event
-type Data map[string]string
+type Data map[string]interface{}
 
 // Event describes a log event sent for an evaluated compliance/security rule.
 type Event struct {


### PR DESCRIPTION
### What does this PR do?

Changes `event.Data` type to `map[string]interface{}`

### Motivation

Extensibility
