### PR TITLE
Concentrator single goroutine

### DIFF
--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -6,7 +6,6 @@
 package stats
 
 import (
-	"runtime"
 	"sort"
 	"sync"
 	"time"
@@ -90,16 +89,14 @@ func (c *Concentrator) Run() {
 
 	log.Debug("Starting concentrator")
 
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for {
-				select {
-				case i := <-c.In:
-					c.addNow(i, time.Now().UnixNano())
-				}
+	go func() {
+		for {
+			select {
+			case i := <-c.In:
+				c.addNow(i, time.Now().UnixNano())
 			}
-		}()
-	}
+		}
+	}()
 	for {
 		select {
 		case <-flushTicker.C:


### PR DESCRIPTION
Remove goroutines locking each other. As the main loop is behind a mutex.Lock() only one goroutine at a time can process the stream. I had a 2% throughput increase by removing it

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
