### PR TITLE
Pin conntrack commit as per maintainer's request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/elastic/go-libaudit v0.4.0
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
 	github.com/fatih/color v1.9.0
-	github.com/florianl/go-conntrack v0.1.0
+	github.com/florianl/go-conntrack v0.1.1-0.20191002182014-06743d3a59db
 	github.com/go-ini/ini v1.55.0
 	github.com/go-ole/go-ole v1.2.4
 	github.com/go-test/deep v1.0.5 // indirect


### PR DESCRIPTION
### What does this PR do?

Pin the commit which the tag was pointing to, instead of the tag.

### Motivation

Tags are going to be removed upstream. See linked issue.

Fixes: #5949

### Additional Notes

For some reason running `go get github.com/florianl/go-conntrack@06743d3a59db` still seems to retain information about the tag in `go.mod`. We might need to re-run `go get` again when tags are deleted upstream if it breaks.
