### PR TITLE
[Backport] pkg/trace/agent: exit gracefully when API_KEY is missing in 7.21.x

### DIFF
--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -40,6 +40,19 @@ func Run(ctx context.Context) {
 
 	cfg, err := config.Load(flags.ConfigPath)
 	if err != nil {
+		if err == config.ErrMissingAPIKey {
+			fmt.Println(config.ErrMissingAPIKey)
+
+			// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
+			// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
+			// http://supervisord.org/subprocess.html#process-states
+			time.Sleep(5 * time.Second)
+
+			// Don't use os.Exit() method here, even with os.Exit(0) the Service Control Manager
+			// on Windows will consider the process failed and log an error in the Event Viewer and
+			// attempt to restart the process.
+			return
+		}
 		osutil.Exitf("%v", err)
 	}
 	err = info.InitInfo(cfg) // for expvar & -info option

--- a/releasenotes/notes/trace_agent_exit_gracefully_no_api_key-aaa2ad5a46506604.yaml
+++ b/releasenotes/notes/trace_agent_exit_gracefully_no_api_key-aaa2ad5a46506604.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    APM: The agent now exits with code 0 when the API key is not specified. This is so to prevent the Windows SCM 
+    from restarting the process. 


### PR DESCRIPTION
Backport of #5928

(cherry picked from commit b2fc5ff7aa8f629c26fbcec4f623d3d4ba196c94)