### PR TITLE
Include helpful message about config file permissions if "permission denied" returned

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -861,7 +862,11 @@ func load(config Config, origin string, loadSecret bool) (*Warnings, error) {
 	warnings := Warnings{}
 
 	if err := config.ReadInConfig(); err != nil {
-		log.Warnf("Error loading config: %v", err)
+		if errors.Is(err, os.ErrPermission) {
+			log.Warnf("Error loading config: %v (check config file permissions for dd-agent user)", err)
+		} else {
+			log.Warnf("Error loading config: %v", err)
+		}
 		return &warnings, err
 	}
 


### PR DESCRIPTION
### What does this PR do?

Gives a helpful message if a "permission denied" error is returned while trying to read a config file.

### Motivation

Better direct the user to a solution.

### Describe your test plan

Change permissions so `dd-agent` does not have access to config file (for example `system-probe.yaml`) and start agent.
