### PR TITLE
pkg/trace/stats: speed up concentrator

### DIFF
--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -6,7 +6,6 @@
 package stats
 
 import (
-	"runtime"
 	"sort"
 	"sync"
 	"time"
@@ -90,16 +89,14 @@ func (c *Concentrator) Run() {
 
 	log.Debug("Starting concentrator")
 
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for {
-				select {
-				case i := <-c.In:
-					c.addNow(i, time.Now().UnixNano())
-				}
+	go func() {
+		for {
+			select {
+			case i := <-c.In:
+				c.addNow(i, time.Now().UnixNano())
 			}
-		}()
-	}
+		}
+	}()
 	for {
 		select {
 		case <-flushTicker.C:


### PR DESCRIPTION
This change slightly speeds up the concentrator by easing up lock
contention. We were previously creating NumCPU goroutines only for them
to fight eachother over synchronised code.

This has shown between 0.5% - 1% CPU improvement.