### PR TITLE
[requirements.txt] Update development requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-# python development requirements for Agent 6
-invoke==1.0.0
-reno==2.9.2
-dulwich==0.19.16
-docker==3.7.3
-requests==2.23.0
-PyYAML==5.3.1
-toml==0.9.4
+# python development requirements for the Datadog Agent
+invoke~=1.4.1
+reno~=3.1.0
+docker~=3.7.3
+requests~=2.23.0
+PyYAML~=5.3.1
+toml~=0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # python development requirements for the Datadog Agent
-invoke~=1.4.1
-reno~=3.1.0
-docker~=3.7.3
-requests~=2.23.0
-PyYAML~=5.3.1
-toml~=0.9.4
+invoke==1.4.1
+reno==3.1.0
+docker==3.7.3
+requests==2.23.0
+PyYAML==5.3.1
+toml==0.9.4


### PR DESCRIPTION
### What does this PR do?

- Bump reno to version 3.
- ~~Move to using [compatible release](https://www.python.org/dev/peps/pep-0440/#compatible-release) operator for dependencies.~~
- Revert #5659

### Motivation

- Have at least one dependency which is Python 3 only so that the pipeline breaks if we add a CI check with no Python 3 support. Since we install the `requirements.txt` dependencies almost everywhere this should be a good way to check it.

### Describe your test plan

- The pipeline passes.
