### PR TITLE
Fix the reading of slice of strings in environment variables.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ replace (
 	github.com/lxn/walk => github.com/lxn/walk v0.0.0-20180521183810-02935bac0ab8
 	github.com/mholt/archiver => github.com/mholt/archiver v2.0.1-0.20171012052341-26cf5bb32d07+incompatible
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
+	github.com/spf13/cast => github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3
 	github.com/spf13/viper => github.com/DataDog/viper v1.7.1
 	github.com/ugorji/go => github.com/ugorji/go v1.1.7
 )

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/DataDog/agent-payload v0.0.0-20200803141324-88e73ec658a0 h1:hKSRXt/k5
 github.com/DataDog/agent-payload v0.0.0-20200803141324-88e73ec658a0/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/agent-payload v0.0.0-20200804132429-73f5ac9374eb h1:qvZCi+bBZB+v7SfkWPnHZUMf8Usafkoz4QJE+5j1vrg=
 github.com/DataDog/agent-payload v0.0.0-20200804132429-73f5ac9374eb/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
+github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v3.5.0+incompatible h1:AShr9cqkF+taHjyQgcBcQUt/ZNK+iPq4ROaZwSX5c/U=
 github.com/DataDog/datadog-go v3.5.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/releasenotes/notes/datadog-cast-pin-aff8991253932273.yaml
+++ b/releasenotes/notes/datadog-cast-pin-aff8991253932273.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Restore support of JSON-formatted lists for configuration options passed as environment variables.


### PR DESCRIPTION
### What does this PR do?

Since the migration to Go modules in #5292, we're not using Datadog's fork of the `cast` library anymore, leading to a different way of reading slices of tags in env variables such as `DD_DOGSTATSD_TAGS` (i.e. `["tag1","tag2"]` not supported anymore, only `"tag1 tag2"`).

This PR fixes this dependency link to use the Datadog's fork again.

### Motivation

Restore the known behavior for parsing slice of strings in environment variables.

### Describe your test plan

Run an Agent or DogStatsD server with the environment variables: `DD_DOGSTATSD_TAGS='["dev:agent","team:agent-core"]'`, send metrics to the DogStatsDS server and validate that the metrics are sent to Datadog with those two tags (and not one "string" of these two).
