### PR TITLE
[KSMv2] ResourceQuota metric transformer

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state.go
@@ -229,7 +229,7 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 			if transform, found := metricTransformers[metricFamily.Name]; found {
 				for _, m := range metricFamily.ListMetrics {
 					// TODO: implement metric transformer functions
-					transform(sender, metricFamily.Name, m.Val, k.joinLabels(m.Labels, metricsToGet))
+					transform(sender, metricFamily.Name, m, k.joinLabels(m.Labels, metricsToGet))
 				}
 				continue
 			}

--- a/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
@@ -10,17 +10,11 @@ package cluster
 import (
 	"regexp"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
-
 	"k8s.io/kube-state-metrics/pkg/options"
 )
 
 // ksmMetricPrefix defines the KSM metrics namespace
 const ksmMetricPrefix = "kubernetes_state."
-
-// metricTransformerFunc is used to tweak or generate new metrics from a given KSM metric
-// For name translation only please use metricNamesMapper instead
-type metricTransformerFunc = func(aggregator.Sender, string, float64, []string)
 
 var (
 	// defaultLabelsMapper contains the default label to tag names mapping
@@ -114,27 +108,6 @@ var (
 		"kube_verticalpodautoscaler_spec_updatepolicy_updatemode":                                  "vpa.update_mode",
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed":             "vpa.spec_container_minallowed",
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed":             "vpa.spec_container_maxallowed",
-	}
-
-	// metricTransformers contains KSM metric names and their corresponding transformer functions
-	// These metrics require more than a name translation to generate Datadog metrics, as opposed to the metrics in metricNamesMapper
-	// TODO: implement the metric transformers of these metrics and unit test them
-	// For reference see METRIC_TRANSFORMERS in KSM check V1
-	metricTransformers = map[string]metricTransformerFunc{
-		"kube_pod_status_phase":                       func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_pod_container_status_waiting_reason":    func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_pod_container_status_terminated_reason": func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_cronjob_next_schedule_time":             func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_job_complete":                           func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_job_failed":                             func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_job_status_failed":                      func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_job_status_succeeded":                   func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_node_status_condition":                  func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_node_spec_unschedulable":                func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_resourcequota":                          func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_limitrange":                             func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_persistentvolume_status_phase":          func(s aggregator.Sender, name string, val float64, tags []string) {},
-		"kube_service_spec_type":                      func(s aggregator.Sender, name string, val float64, tags []string) {},
 	}
 
 	// metadata metrics are useful for label joins

--- a/pkg/collector/corechecks/cluster/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_test.go
@@ -179,7 +179,7 @@ func TestProcessMetrics(t *testing.T) {
 			},
 			metricsToGet: []ksmstore.DDMetricsFam{},
 			metricTransformers: map[string]metricTransformerFunc{
-				"kube_pod_status_phase": func(s aggregator.Sender, n string, v float64, t []string) {
+				"kube_pod_status_phase": func(s aggregator.Sender, n string, m ksmstore.DDMetric, t []string) {
 					s.Gauge("kube_pod_status_phase_transformed", 1, "", []string{"transformed:tag"})
 				},
 			},

--- a/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build kubeapiserver
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// metricTransformerFunc is used to tweak or generate new metrics from a given KSM metric
+// For name translation only please use metricNamesMapper instead
+type metricTransformerFunc = func(aggregator.Sender, string, ksmstore.DDMetric, []string)
+
+var (
+	// metricTransformers contains KSM metric names and their corresponding transformer functions
+	// These metrics require more than a name translation to generate Datadog metrics, as opposed to the metrics in metricNamesMapper
+	// TODO: implement the metric transformers of these metrics and unit test them
+	// For reference see METRIC_TRANSFORMERS in KSM check V1
+	metricTransformers = map[string]metricTransformerFunc{
+		"kube_pod_status_phase":                       func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_pod_container_status_waiting_reason":    func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_pod_container_status_terminated_reason": func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_cronjob_next_schedule_time":             func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_job_complete":                           func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_job_failed":                             func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_job_status_failed":                      func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_job_status_succeeded":                   func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_node_status_condition":                  func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_node_spec_unschedulable":                func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_resourcequota":                          resourcequotaTransformer,
+		"kube_limitrange":                             func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_persistentvolume_status_phase":          func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_service_spec_type":                      func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+	}
+)
+
+// resourcequotaTransformer generates dedicated metrics per resource per type from the kube_resourcequota metric
+func resourcequotaTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {
+	resource, found := metric.Labels["resource"]
+	if !found {
+		log.Debugf("Couldn't find 'resource' label, ignoring metric '%s'", name)
+		return
+	}
+	quotaType, found := metric.Labels["type"]
+	if !found {
+		log.Debugf("Couldn't find 'type' label, ignoring metric '%s'", name)
+		return
+	}
+	if quotaType == "hard" {
+		quotaType = "limit"
+	}
+	metricName := ksmMetricPrefix + fmt.Sprintf("resourcequota.%s.%s", resource, quotaType)
+	s.Gauge(metricName, metric.Val, "", tags)
+}

--- a/pkg/collector/corechecks/cluster/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_transformers_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build kubeapiserver
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
+)
+
+func Test_resourcequotaTransformer(t *testing.T) {
+	type args struct {
+		name   string
+		metric ksmstore.DDMetric
+		tags   []string
+	}
+	type metricsExpected struct {
+		val  float64
+		name string
+		tags []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "nominal case, limit",
+			args: args{
+				name: "kube_resourcequota",
+				metric: ksmstore.DDMetric{
+					Val: 15000,
+					Labels: map[string]string{
+						"resource":      "pods",
+						"type":          "hard",
+						"resourcequota": "gke-resource-quotas",
+					},
+				},
+				tags: []string{"resourcequota:gke-resource-quotas", "foo:bar"},
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.resourcequota.pods.limit",
+				val:  15000,
+				tags: []string{"resourcequota:gke-resource-quotas", "foo:bar"},
+			},
+		},
+		{
+			name: "nominal case, used",
+			args: args{
+				name: "kube_resourcequota",
+				metric: ksmstore.DDMetric{
+					Val: 7,
+					Labels: map[string]string{
+						"resource":      "pods",
+						"type":          "used",
+						"resourcequota": "gke-resource-quotas",
+					},
+				},
+				tags: []string{"resourcequota:gke-resource-quotas", "foo:bar"},
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.resourcequota.pods.used",
+				val:  7,
+				tags: []string{"resourcequota:gke-resource-quotas", "foo:bar"},
+			},
+		},
+		{
+			name: "no resource label",
+			args: args{
+				name: "kube_resourcequota",
+				metric: ksmstore.DDMetric{
+					Val: 7,
+					Labels: map[string]string{
+						"type":          "used",
+						"resourcequota": "gke-resource-quotas",
+					},
+				},
+				tags: []string{"resourcequota:gke-resource-quotas", "foo:bar"},
+			},
+			expected: nil,
+		},
+		{
+			name: "no type label",
+			args: args{
+				name: "kube_resourcequota",
+				metric: ksmstore.DDMetric{
+					Val: 7,
+					Labels: map[string]string{
+						"resource":      "pods",
+						"resourcequota": "gke-resource-quotas",
+					},
+				},
+				tags: []string{"resourcequota:gke-resource-quotas", "foo:bar"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			resourcequotaTransformer(s, tt.args.name, tt.args.metric, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, "", tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

- Implement the Resource Quota metric transformer ([reference](https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py#L805))
- Refactor the metric transformers

