### PR TITLE
[Linux] Remove version history on uninstall

### DIFF
--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -123,11 +123,37 @@ remove_custom_integrations()
     fi
 }
 
+remove_version_history()
+{
+    # Since 6.22.0/7.22.0, a file containing the version history of the currently installed
+    # Agent is created (by default in /opt/datadog-agent/run). On a full uninstall, remove this
+    # file.
+    # This is a best-effort solution, as users can decide to put this file in another place
+    # by changing the logs_config.run_path value.
+
+    if [ -f "$INSTALL_DIR/run/version-history.json" ]; then
+        echo "Removing version history file"
+        rm "$INSTALL_DIR/run/version-history.json"
+    fi
+}
+
 if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
     stop_agent
     deregister_agent
     remove_custom_integrations
     remove_py_compiled_files
+
+    case "$1" in
+        remove)
+            # We're uninstalling.
+            remove_version_history
+        ;;
+        upgrade)
+            # We're upgrading.
+        ;;
+        *)
+        ;;
+    esac
 elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then
     stop_agent
     deregister_agent
@@ -137,6 +163,7 @@ elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/
             # We're uninstalling.
             remove_custom_integrations
             remove_py_compiled_files
+            remove_version_history
         ;;
         1)
             # We're upgrading.

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -133,7 +133,7 @@ remove_version_history()
 
     if [ -f "$INSTALL_DIR/run/version-history.json" ]; then
         echo "Removing version history file"
-        rm "$INSTALL_DIR/run/version-history.json"
+        rm "$INSTALL_DIR/run/version-history.json" || true
     fi
 }
 

--- a/omnibus/package-scripts/iot-agent/prerm
+++ b/omnibus/package-scripts/iot-agent/prerm
@@ -5,6 +5,9 @@
 # .deb: STEP 1 of 5
 # .rpm: STEP 4 of 6
 
+KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || grep -m1 -Eo $KNOWN_DISTRIBUTION /etc/os-release 2>/dev/null || uname -s)
+
 SERVICE_NAME=datadog-agent
 
 stop_agent()
@@ -34,7 +37,49 @@ deregister_agent()
     fi
 }
 
+remove_version_history()
+{
+    # Since 6.22.0/7.22.0, a file containing the version history of the currently installed
+    # Agent is created (by default in /opt/datadog-agent/run). On a full uninstall, remove this
+    # file.
+    # This is a best-effort solution, as users can decide to put this file in another place
+    # by changing the logs_config.run_path value.
+
+    if [ -f "$INSTALL_DIR/run/version-history.json" ]; then
+        echo "Removing version history file"
+        rm "$INSTALL_DIR/run/version-history.json"
+    fi
+}
+
 stop_agent
 deregister_agent
+
+if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
+    case "$1" in
+        remove)
+            # We're uninstalling.
+            remove_version_history
+        ;;
+        upgrade)
+            # We're upgrading.
+        ;;
+        *)
+        ;;
+    esac
+elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then
+    case "$*" in
+        0)
+            # We're uninstalling.
+            remove_version_history
+        ;;
+        1)
+            # We're upgrading.
+        ;;
+        *)
+        ;;
+    esac
+else
+    echo "[ FAILED ]\tYour system is currently not supported by this script.";
+fi
 
 exit 0

--- a/omnibus/package-scripts/iot-agent/prerm
+++ b/omnibus/package-scripts/iot-agent/prerm
@@ -8,6 +8,7 @@
 KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
 DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || grep -m1 -Eo $KNOWN_DISTRIBUTION /etc/os-release 2>/dev/null || uname -s)
 
+INSTALL_DIR=/opt/datadog-agent
 SERVICE_NAME=datadog-agent
 
 stop_agent()

--- a/omnibus/package-scripts/iot-agent/prerm
+++ b/omnibus/package-scripts/iot-agent/prerm
@@ -47,7 +47,7 @@ remove_version_history()
 
     if [ -f "$INSTALL_DIR/run/version-history.json" ]; then
         echo "Removing version history file"
-        rm "$INSTALL_DIR/run/version-history.json"
+        rm "$INSTALL_DIR/run/version-history.json" || true
     fi
 }
 

--- a/omnibus/package-scripts/iot-agent/prerm
+++ b/omnibus/package-scripts/iot-agent/prerm
@@ -78,8 +78,6 @@ elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/
         *)
         ;;
     esac
-else
-    echo "[ FAILED ]\tYour system is currently not supported by this script.";
 fi
 
 exit 0


### PR DESCRIPTION
### What does this PR do?

Remove `version-history.json` file (at the default location) on apt and yum package removal.

### Motivation

Fix kitchen tests.

### Additional Notes

The same needs to be done for Windows to have a consistent behavior.
