### PR TITLE
[telemetry] Fix checks_entered gauge

### DIFF
--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -131,6 +131,7 @@ func (s *Scheduler) Cancel(id check.ID) error {
 
 	schedulerChecksEntered.Add(-1)
 	if checkName, ok := s.tlmTrackedChecks[id]; ok {
+		delete(s.tlmTrackedChecks, id)
 		tlmChecksEntered.Dec(checkName)
 	}
 	schedulerExpvars.Set("Queues", expvar.Func(expQueues(s)))

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -25,7 +25,7 @@ var (
 	schedulerChecksEntered = expvar.Int{}
 
 	tlmChecksEntered = telemetry.NewGauge("scheduler", "checks_entered",
-		[]string{"check_name"}, "How many checks entered the scheduler")
+		[]string{"check_name"}, "How many checks are currently tracked by the scheduler")
 	tlmQueuesCount = telemetry.NewCounter("scheduler", "queues_count",
 		[]string{"check_name"}, "How many queues were opened")
 )
@@ -39,14 +39,15 @@ func init() {
 // Scheduler keeps things rolling.
 // More docs to come...
 type Scheduler struct {
-	running      uint32                      // Flag to see if the scheduler is running
-	checksPipe   chan<- check.Check          // The pipe the Runner pops the checks from, initially set to nil
-	done         chan bool                   // Guard for the main loop
-	halted       chan bool                   // Used to internally communicate all queues are done
-	started      chan bool                   // Used to internally communicate the queues are up
-	jobQueues    map[time.Duration]*jobQueue // We have one scheduling queue for every interval
-	checkToQueue map[check.ID]*jobQueue      // Keep track of what is the queue for any Check
-	mu           sync.Mutex                  // To protect critical sections in struct's fields
+	running          uint32                      // Flag to see if the scheduler is running
+	checksPipe       chan<- check.Check          // The pipe the Runner pops the checks from, initially set to nil
+	done             chan bool                   // Guard for the main loop
+	halted           chan bool                   // Used to internally communicate all queues are done
+	started          chan bool                   // Used to internally communicate the queues are up
+	jobQueues        map[time.Duration]*jobQueue // We have one scheduling queue for every interval
+	checkToQueue     map[check.ID]*jobQueue      // Keep track of what is the queue for any Check
+	tlmTrackedChecks map[check.ID]string         // Keep track of the checks that are tracked with telemetry
+	mu               sync.Mutex                  // To protect critical sections in struct's fields
 
 	cancelOneTime chan bool      // Used to internally communicate a cancel signal to one-time schedule goroutines
 	wgOneTime     sync.WaitGroup // WaitGroup to track the exit of one-time schedule goroutines
@@ -55,15 +56,16 @@ type Scheduler struct {
 // NewScheduler create a Scheduler and returns a pointer to it.
 func NewScheduler(checksPipe chan<- check.Check) *Scheduler {
 	return &Scheduler{
-		checksPipe:    checksPipe,
-		done:          make(chan bool),
-		halted:        make(chan bool),
-		started:       make(chan bool),
-		jobQueues:     make(map[time.Duration]*jobQueue),
-		checkToQueue:  make(map[check.ID]*jobQueue),
-		running:       0,
-		cancelOneTime: make(chan bool),
-		wgOneTime:     sync.WaitGroup{},
+		checksPipe:       checksPipe,
+		done:             make(chan bool),
+		halted:           make(chan bool),
+		started:          make(chan bool),
+		jobQueues:        make(map[time.Duration]*jobQueue),
+		checkToQueue:     make(map[check.ID]*jobQueue),
+		tlmTrackedChecks: make(map[check.ID]string),
+		running:          0,
+		cancelOneTime:    make(chan bool),
+		wgOneTime:        sync.WaitGroup{},
 	}
 }
 
@@ -100,7 +102,9 @@ func (s *Scheduler) Enter(check check.Check) error {
 
 	schedulerChecksEntered.Add(1)
 	if check.IsTelemetryEnabled() {
-		tlmChecksEntered.Inc(check.String())
+		checkName := check.String()
+		s.tlmTrackedChecks[check.ID()] = checkName
+		tlmChecksEntered.Inc(checkName)
 	}
 	schedulerExpvars.Set("Queues", expvar.Func(expQueues(s)))
 	return nil
@@ -126,6 +130,9 @@ func (s *Scheduler) Cancel(id check.ID) error {
 	delete(s.checkToQueue, id)
 
 	schedulerChecksEntered.Add(-1)
+	if checkName, ok := s.tlmTrackedChecks[id]; ok {
+		tlmChecksEntered.Dec(checkName)
+	}
 	schedulerExpvars.Set("Queues", expvar.Func(expQueues(s)))
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Decrements the gauge when a check is removed from the scheduler. Fixes
ever increasing gauge when AD checks are scheduled/unscheduled.

### Motivation

Fix telemetry metric.

### Additional Notes

* Went for a crude map to track check names by ID, for the purpose of telemetry only
* internal feature, so no changelog

### Describe your test plan

I tested in AD scenario, with telemetry enabled, including details on checks (`telemetry.enabled` and `telemetry.checks`, see `config.go` for details).

1. check `curl http://localhost:5000/telemetry | grep scheduler`
2. start a container that will start an AD-scheduled check
3. check `curl http://localhost:5000/telemetry | grep scheduler` again, the new check should show up, with value of `1`
4. stop the container, the AD-scheduled check should stop, check that the related value is `0` in output of `curl http://localhost:5000/telemetry | grep scheduler` (this is what the PR fixes, with an older agent the value would remain `1`)
