### PR TITLE
Add DogStatsD Mapper trace logs for mapped metrics

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -422,6 +422,7 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFu
 	if s.mapper != nil && len(sample.tags) == 0 {
 		mapResult := s.mapper.Map(sample.name)
 		if mapResult != nil {
+			log.Tracef("Dogstatsd mapper: metric mapped from `%q` to `%q` with tags `%v`", sample.name, mapResult.Name, mapResult.Tags)
 			sample.name = mapResult.Name
 			sample.tags = append(sample.tags, mapResult.Tags...)
 		}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -422,7 +422,7 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFu
 	if s.mapper != nil && len(sample.tags) == 0 {
 		mapResult := s.mapper.Map(sample.name)
 		if mapResult != nil {
-			log.Tracef("Dogstatsd mapper: metric mapped from `%q` to `%q` with tags `%v`", sample.name, mapResult.Name, mapResult.Tags)
+			log.Tracef("Dogstatsd mapper: metric mapped from %q to %q with tags %v", sample.name, mapResult.Name, mapResult.Tags)
 			sample.name = mapResult.Name
 			sample.tags = append(sample.tags, mapResult.Tags...)
 		}


### PR DESCRIPTION
### What does this PR do?

Add dsd mapper trace logs

Demo:
```
2020-07-17 11:26:06 UTC | CORE | TRACE | (pkg/dogstatsd/server.go:340 in parsePackets) | Dogstatsd receive: "datadog.process.agent:1|g|#version:7.22.0-devel,revision:8a52956"
2020-07-17 11:26:06 UTC | CORE | TRACE | (pkg/dogstatsd/server.go:340 in parsePackets) | Dogstatsd receive: "airflow.dag.hello_world_sleep10.hello_world_sleep10_task.duration:1.010616|ms\nairflow.operator_successes_PythonOperator:1|c\nairflow.ti_successes:1|c"
2020-07-17 11:26:06 UTC | CORE | TRACE | (pkg/dogstatsd/server.go:425 in parseMetricMessage) | Dogstatsd mapper: metric mapped from "airflow.dag.hello_world_sleep10.hello_world_sleep10_task.duration" to "airflow.dag.task.duration" with tags [dag_id:hello_world_sleep10 task_id:hello_world_sleep10_task]
2020-07-17 11:26:06 UTC | CORE | TRACE | (pkg/dogstatsd/server.go:425 in parseMetricMessage) | Dogstatsd mapper: metric mapped from "airflow.operator_successes_PythonOperator" to "airflow.operator_successes" with tags [operator_name:PythonOperator]
```

### Motivation

Help debug support cases

### Describe your test plan

Check trace logs are printed correctly.
