### PR TITLE
Make DSD Mapper also map metrics that already contain tags.

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -419,7 +419,7 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFu
 		tlmProcessed.IncWithTags(tlmProcessedErrorTags)
 		return metrics.MetricSample{}, err
 	}
-	if s.mapper != nil && len(sample.tags) == 0 {
+	if s.mapper != nil {
 		mapResult := s.mapper.Map(sample.name)
 		if mapResult != nil {
 			sample.name = mapResult.Name

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -581,8 +581,8 @@ dogstatsd_mapper_profiles:
 			},
 			expectedSamples: []MetricSample{
 				{Name: "test.job.duration", Tags: []string{"job_type:my_job_type", "job_name:my_job_name"}, Mtype: metrics.GaugeType, Value: 666.0},
-				{Name: "test.job.duration.my_job_type.my_job_name", Tags: []string{"some:tag"}, Mtype: metrics.GaugeType, Value: 666.0},
-				{Name: "test.job.duration.my_job_type.my_job_name", Tags: []string{"some:tag", "more:tags"}, Mtype: metrics.GaugeType, Value: 666.0},
+				{Name: "test.job.duration", Tags: []string{"job_type:my_job_type", "job_name:my_job_name", "some:tag"}, Mtype: metrics.GaugeType, Value: 666.0},
+				{Name: "test.job.duration", Tags: []string{"job_type:my_job_type", "job_name:my_job_name", "some:tag", "more:tags"}, Mtype: metrics.GaugeType, Value: 666.0},
 			},
 			expectedCacheSize: 1000,
 		},

--- a/releasenotes/notes/dsd_mapper_remove_tags_condition-a3cdccda119a27be.yaml
+++ b/releasenotes/notes/dsd_mapper_remove_tags_condition-a3cdccda119a27be.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Make DSD Mapper also map metrics that already contain tags.


### PR DESCRIPTION
### What does this PR do?

DSD mapper remove tags condition

### Motivation

User request. We have use cases where we want the mapper to be effective even if there are already tags.

The condition for skipping metrics with tags is not that useful since we filter by profile prefix (it was added before profiles prefix implementation).

https://github.com/DataDog/datadog-agent/blob/460ad2c13a7e990ec65660f9dc3aec574c0d6d78/pkg/dogstatsd/mapper/mapper.go#L114-L115

### Additional Notes

This change should have a minor performance impact:
- the mapper is active only if enabled
- metrics are first filtered by prefix which is quite inexpensive.

AGENT-581

### Describe your test plan


### Demo

```
echo -n "airflow.dag.hello_world_sleep10.hello_world_sleep10_task.duration:1.010616|ms|#fooBar" | nc -4u -w0 127.0.0.1 8125
```

Before:

```

Metric                                   | Tags                 | Count      | Last Seen
----------------------------------------------------------------------------------------------------
airflow.dag.hello_world_sleep10.hello_world_sleep10_task.duration | fooBar               | 1          | 2020-07-17 11:33:12.436343161 +0000 UTC
```

After:

```
Metric                                   | Tags                 | Count      | Last Seen
----------------------------------------------------------------------------------------------------
airflow.dag.task.duration                | dag_id:hello_world_sleep10 fooBar task_id:hello_world_sleep10_task | 2          | 2020-07-17 11:32:08.373572196 +0000 UTC
```