### PR TITLE
Avoid sending container with no tags for garden

### DIFF
--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -155,12 +155,13 @@ func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.Co
 		if err != nil {
 			log.Errorf("unable to retrieve tags for container: %s", err)
 			tags = []string{}
-			if ctr.Type == containers.RuntimeNameGarden {
-				// If there is an error retrieving tags, don't send the container for garden. It means it hasn't yet been
-				// discovered by the cluster agent, so avoid sending something with no tags, i.e. no container name, ...
-				log.Debugf("No tags found for app %s, it has probably not been discovered by the DCA, skipping.", ctr.ID)
-				continue
-			}
+		}
+
+		if ctr.Type == containers.RuntimeNameGarden && len(tags) == 0 {
+			// If there is an error retrieving tags, don't send the container for garden. It means it hasn't yet been
+			// discovered by the cluster agent, so avoid sending something with no tags, i.e. no container name, ...
+			log.Debugf("No tags found for app %s, it has probably not been discovered by the DCA, skipping.", ctr.ID)
+			continue
 		}
 
 		containersList = append(containersList, &model.Container{

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -134,7 +134,7 @@ func (c *ContainerCheck) filterCtrIDsByPIDs(pids []int32) map[int32]string {
 
 // fmtContainers loops through container list and converts them to a list of container objects
 func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.ContainerRateMetrics, lastRun time.Time) []*model.Container {
-	containers := make([]*model.Container, 0, len(ctrList))
+	containersList := make([]*model.Container, 0, len(ctrList))
 	for _, ctr := range ctrList {
 		lastCtr, ok := lastRates[ctr.ID]
 		if !ok {
@@ -155,9 +155,15 @@ func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.Co
 		if err != nil {
 			log.Errorf("unable to retrieve tags for container: %s", err)
 			tags = []string{}
+			if ctr.Type == containers.RuntimeNameGarden {
+				// If there is an error retrieving tags, don't send the container for garden. It means it hasn't yet been
+				// discovered by the cluster agent, so avoid sending something with no tags, i.e. no container name, ...
+				log.Debugf("No tags found for app %s, it has probably not been discovered by the DCA, skipping.", ctr.ID)
+				continue
+			}
 		}
 
-		containers = append(containers, &model.Container{
+		containersList = append(containersList, &model.Container{
 			Id:          ctr.ID,
 			Type:        ctr.Type,
 			CpuLimit:    float32(ctr.Limits.CPULimit),
@@ -183,7 +189,7 @@ func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.Co
 			Tags:        tags,
 		})
 	}
-	return containers
+	return containersList
 }
 
 // chunkContainers formats and chunks the ctrList into a slice of chunks using a specific number of chunks.

--- a/pkg/process/checks/container_test.go
+++ b/pkg/process/checks/container_test.go
@@ -82,6 +82,14 @@ func TestContainerAddresses(t *testing.T) {
 	assert.Equal(t, results[0].Addresses, addrs)
 }
 
+func TestNoGardenContainerWithEmptyTags(t *testing.T) {
+	ctr := makeContainer("haha")
+	ctr.Type = containers.RuntimeNameGarden
+	// Tags should be empty after call to tagger, so container shouldn't be added
+	results := fmtContainers([]*containers.Container{ctr}, map[string]util.ContainerRateMetrics{}, time.Now())
+	assert.Equal(t, 0, len(results))
+}
+
 func TestContainerNils(t *testing.T) {
 	// Make sure formatting doesn't crash with nils
 	cur := []*containers.Container{{}}

--- a/pkg/util/cloudfoundry/garden.go
+++ b/pkg/util/cloudfoundry/garden.go
@@ -113,7 +113,7 @@ func (gu *GardenUtil) ListContainers() ([]*containers.Container, error) {
 			continue
 		}
 		container := containers.Container{
-			Type:        "garden",
+			Type:        containers.RuntimeNameGarden,
 			ID:          handle,
 			EntityID:    containers.BuildTaggerEntityName(handle),
 			State:       infoEntry.Info.State,

--- a/pkg/util/containers/types.go
+++ b/pkg/util/containers/types.go
@@ -16,6 +16,7 @@ const (
 	RuntimeNameDocker     string = "docker"
 	RuntimeNameContainerd string = "containerd"
 	RuntimeNameCRIO       string = "cri-o"
+	RuntimeNameGarden     string = "garden"
 )
 
 // Supported container states

--- a/releasenotes/notes/skip_garden_no_tags-8b87ede2f03338b2.yaml
+++ b/releasenotes/notes/skip_garden_no_tags-8b87ede2f03338b2.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Stop sending payload for Cloud Foundry applications containers that have no `container_name` tag attached to avoid them showing up in the UI with empty name.


### PR DESCRIPTION
### What does this PR do?

For garden containers on cloudfoundry, tagging relies on the DCA picking up the container and extracting information via a different API than used by the local process agent.

Since the local process agent can discover the container before the DCA, it would then send a payload with empty tags to Datadog, which would show generic containers, with no name in the container list. Then as soon as the container is discovered by the DCA, proper payloads would be sent, but caching mechanisms on the Datadog side would make the empty container linger there for about 10 minutes, before being replaced by one with the proper metadata.

This PR aims to solve that and directly have the container with proper metadata show up in the container list, by not adding the one with empty tags to the payload sent by the agent.


### Describe your test plan

Deploy this in Cloud Foundry env, spin up a new app, it should show up directly with proper metadata in the container list
