### PR TITLE
[system-probe] make http.Serve not blocking the rest of the execution

### DIFF
--- a/cmd/system-probe/loader.go
+++ b/cmd/system-probe/loader.go
@@ -3,12 +3,12 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
 // Loader is responsible for managing the lifecyle of each api.Module, which includes:
@@ -32,11 +32,11 @@ func (l *Loader) Register(cfg *config.AgentConfig, httpMux *http.ServeMux, facto
 		}
 
 		if err != nil {
-			return fmt.Errorf("new module `%s` error", factory.Name)
+			return errors.Wrapf(err, "new module `%s` error", factory.Name)
 		}
 
 		if err = module.Register(httpMux); err != nil {
-			return fmt.Errorf("error registering HTTP endpoints for module `%s` error", factory.Name)
+			return errors.Wrapf(err, "error registering HTTP endpoints for module `%s` error", factory.Name)
 		}
 
 		l.modules[factory.Name] = module

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -119,11 +119,13 @@ func runAgent(exit <-chan struct{}) {
 		utils.WriteAsJSON(w, stats)
 	})
 
-	err = http.Serve(conn.GetListener(), httpMux)
-	if err != nil {
-		log.Criticalf("Error creating HTTP server: %s", err)
-		cleanupAndExit(1)
-	}
+	go func() {
+		err = http.Serve(conn.GetListener(), httpMux)
+		if err != nil {
+			log.Criticalf("Error creating HTTP server: %s", err)
+			cleanupAndExit(1)
+		}
+	}()
 
 	log.Infof("system probe successfully started")
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the system-probe main function execution which is blocked by the http.Serve call

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
