### PR TITLE
Add ec2 host alias

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -125,6 +125,13 @@ func getHostAliases() []string {
 		aliases = append(aliases, gceAlias)
 	}
 
+	ec2Alias, err := ec2.GetHostname()
+	if err != nil {
+		log.Debugf("no EC2 Host Alias: %s", err)
+	} else if ec2Alias != "" {
+		aliases = append(aliases, ec2Alias)
+	}
+
 	cfAliases, err := cloudfoundry.GetHostAliases()
 	if err != nil {
 		log.Debugf("no Cloud Foundry Host Alias: %s", err)


### PR DESCRIPTION
### What does this PR do?

Add ec2 host alias.

### Motivation

The ec2 hostname is not getting added as a host alias when running kubernetes, resulting in duplicate hosts being detected by things reported directly and being detected with the consul integration.

### Additional Notes


### Describe your test plan

Run agent, check infrastructure list "also known as" reported includes EC2 hostname.