### PR TITLE
[kitchen] Increase disk size of runners to avoid out of space errors

### DIFF
--- a/test/kitchen/kitchen-azure-common.yml
+++ b/test/kitchen/kitchen-azure-common.yml
@@ -53,7 +53,7 @@ driver:
 driver_config:
   subscription_id: <%= ENV['AZURE_SUBSCRIPTION_ID'] %>
   location: <%= location %>
-  os_disk_size_gb: 128
+  os_disk_size_gb: 256
   <% if ENV['DD_PIPELINE_ID'] %>
   azure_resource_group_suffix: pl<%= ENV['DD_PIPELINE_ID'] %>
   <% else %>

--- a/test/kitchen/kitchen-azure-common.yml
+++ b/test/kitchen/kitchen-azure-common.yml
@@ -53,6 +53,7 @@ driver:
 driver_config:
   subscription_id: <%= ENV['AZURE_SUBSCRIPTION_ID'] %>
   location: <%= location %>
+  os_disk_size_gb: 128
   <% if ENV['DD_PIPELINE_ID'] %>
   azure_resource_group_suffix: pl<%= ENV['DD_PIPELINE_ID'] %>
   <% else %>


### PR DESCRIPTION
### What does this PR do?

Increases main disk size for kitchen VMs.

### Motivation

Prevent tests from failing to install the Agent package due to lack of space.