### PR TITLE
[pkg/collector] Add error message when rtloader fails

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -342,6 +342,7 @@ func Initialize(paths ...string) error {
 	// Init RtLoader machinery
 	if C.init(rtloader) == 0 {
 		err := fmt.Sprintf("could not initialize rtloader: %s", C.GoString(C.get_error(rtloader)))
+		log.Errorf("Could not initialize rtloader: %s", C.GoString(C.get_error(rtloader)))
 		return addExpvarPythonInitErrors(err)
 	}
 

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -309,6 +309,7 @@ func Initialize(paths ...string) error {
 
 	if rtloader == nil {
 		err := addExpvarPythonInitErrors(fmt.Sprintf("could not load runtime python for version %s: %s", pythonVersion, C.GoString(pyErr)))
+		log.Errorf("Could not load runtime python for version %s: %s", pythonVersion, C.GoString(pyErr))
 		if pyErr != nil {
 			// pyErr tracked when created in rtloader
 			C._free(unsafe.Pointer(pyErr))


### PR DESCRIPTION
### What does this PR do?

- Report errors when loading Python on the log

### Motivation

- Be able to see the errors easily if the agent crashes