### PR TITLE
[tasks, pre-commit] Fix vet task and pre-commit

### DIFF
--- a/tasks/git-hooks/govet.py
+++ b/tasks/git-hooks/govet.py
@@ -10,7 +10,6 @@ EXCLUDED_FOLDERS = {
     "./cmd/agent/windows/service",
     "./cmd/cluster-agent",
     "./cmd/cluster-agent/app",
-    "./cmd/system-probe",
     "./cmd/systray",
     "./pkg/clusteragent/orchestrator",
     "./pkg/process/config/testdata",
@@ -24,9 +23,6 @@ EXCLUDED_FOLDERS = {
     "./pkg/util/winutil",
     "./pkg/util/winutil/iphelper",
     "./pkg/util/winutil/pdhutil",
-    "./test/benchmarks/aggregator",
-    "./test/benchmarks/dogstatsd",
-    "./test/integration/util/kube_apiserver",
 }
 
 

--- a/tasks/git-hooks/govet.py
+++ b/tasks/git-hooks/govet.py
@@ -29,9 +29,15 @@ EXCLUDED_FOLDERS = {
     "./test/integration/util/kube_apiserver",
 }
 
+
+def is_go_file(path):
+    """Checks if file is a go file from the Agent code."""
+    return (path.startswith("pkg") or path.startswith("cmd")) and path.endswith(".go")
+
+
 # Exclude non go files
 # Get the package for each file
-targets = {"./" + os.path.dirname(path) for path in sys.argv[1:] if path.endswith(".go")}
+targets = {"./" + os.path.dirname(path) for path in sys.argv[1:] if is_go_file(path)}
 
 # Call invoke command
 # We do this workaround since we can't do relative imports

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -135,6 +135,7 @@ def vet(ctx, targets, rtloader_root=None, build_tags=None, arch="x64"):
     tags.append("dovet")
 
     _, _, env = get_build_flags(ctx, rtloader_root=rtloader_root)
+    env["CGO_ENABLED"] = "1"
 
     ctx.run("go vet -tags \"{}\" ".format(" ".join(tags)) + " ".join(args), env=env)
     # go vet exits with status 1 when it finds an issue, if we're here


### PR DESCRIPTION
### What does this PR do?

- Fixes `vet` task. It would fail on packages that use cgo since cgo was not enabled.
- Updates git hook whitelisted modules.
- Limits git hook to Agent go files since cgo would fail on the rest.

### Motivation

- Have a working pre-commit hook