### PR TITLE
Add performance profiling to flare command

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/app/settings"
@@ -103,11 +103,10 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 500)
 	}
 
-	filePath := []string{tempDir, hostname}
-	enc := json.NewEncoder(w)
-	if err := enc.Encode(filePath); err != nil {
-		log.Errorf("Error while encoding flare file path: %s,", err)
-	}
+	filePath := flare.Path{"tempDir": tempDir, "hostname": hostname}
+	w.Header().Set("Content-Type", "application/json")
+	j, _ := json.Marshal(filePath)
+	w.Write(j)
 }
 
 func componentConfigHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -9,7 +9,6 @@
 package agent
 
 import (
-	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -103,7 +102,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 500)
 	}
 
-	enc := gob.NewEncoder(w)
+	enc := json.NewEncoder(w)
 	if err := enc.Encode(filePath); err != nil {
 		log.Errorf("Error while encoding flare file path: %s,", err)
 	}

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -9,6 +9,7 @@
 package agent
 
 import (
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -87,7 +88,13 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 
 	log.Infof("Making a flare")
 	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile)
-	if err != nil || filePath == "" {
+
+	if err != nil {
+		log.Errorf("Error creating flare directory: " + err.Error())
+		return
+	}
+
+	if err != nil || len(filePath) == 0 {
 		if err != nil {
 			log.Errorf("The flare failed to be created: %s", err)
 		} else {
@@ -95,7 +102,11 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		}
 		http.Error(w, err.Error(), 500)
 	}
-	w.Write([]byte(filePath))
+
+	enc := gob.NewEncoder(w)
+	if err := enc.Encode(filePath); err != nil {
+		log.Errorf("Error while encoding flare file path: %s,", err)
+	}
 }
 
 func componentConfigHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -225,6 +225,6 @@ func writeCPUProfile(tempDir, hostname, filename, url string) error {
 		return err
 	}
 
-	io.Copy(f, res.Body)
+	_, err = io.Copy(f, res.Body)
 	return err
 }

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -97,6 +97,9 @@ func makeFlare(caseID string) error {
 	}
 
 	zipFilePath, err := flare.ZipArchive(filePath)
+	if err != nil {
+		return err
+	}
 
 	if _, err := os.Stat(zipFilePath); err != nil {
 		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("The flare zipfile \"%s\" does not exist.", zipFilePath)))

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -7,6 +7,7 @@ package app
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -21,9 +22,10 @@ import (
 )
 
 var (
-	customerEmail string
-	autoconfirm   bool
-	forceLocal    bool
+	customerEmail   string
+	autoconfirm     bool
+	forceLocal      bool
+	enableProfiling bool
 )
 
 func init() {
@@ -32,6 +34,7 @@ func init() {
 	flareCmd.Flags().StringVarP(&customerEmail, "email", "e", "", "Your email")
 	flareCmd.Flags().BoolVarP(&autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
 	flareCmd.Flags().BoolVarP(&forceLocal, "local", "l", false, "Force the creation of the flare by the command line instead of the agent process (useful when running in a containerized env)")
+	flareCmd.Flags().BoolVarP(&enableProfiling, "profile", "p", false, "Add performance enableProfiling data to the flare. If used, the flare command will wait for 120s to collect enableProfiling data.")
 	flareCmd.SetArgs([]string{"caseID"})
 }
 
@@ -81,7 +84,7 @@ func makeFlare(caseID string) error {
 		logFile = common.DefaultLogFile
 	}
 
-	var filePath string
+	var filePath []string
 	var err error
 	if forceLocal {
 		filePath, err = createArchive(logFile)
@@ -93,22 +96,24 @@ func makeFlare(caseID string) error {
 		return err
 	}
 
-	if _, err := os.Stat(filePath); err != nil {
-		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("The flare zipfile \"%s\" does not exist.", filePath)))
+	zipFilePath, err := flare.ZipArchive(filePath)
+
+	if _, err := os.Stat(zipFilePath); err != nil {
+		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("The flare zipfile \"%s\" does not exist.", zipFilePath)))
 		fmt.Fprintln(color.Output, color.RedString("If the agent running in a different container try the '--local' option to generate the flare locally"))
 		return err
 	}
 
-	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
+	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(zipFilePath)))
 	if !autoconfirm {
 		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [y/N]")
 		if !confirmation {
-			fmt.Fprintln(color.Output, fmt.Sprintf("Aborting. (You can still use %s)", color.YellowString(filePath)))
+			fmt.Fprintln(color.Output, fmt.Sprintf("Aborting. (You can still use %s)", color.YellowString(zipFilePath)))
 			return nil
 		}
 	}
 
-	response, e := flare.SendFlare(filePath, caseID, customerEmail)
+	response, e := flare.SendFlare(zipFilePath, caseID, customerEmail)
 	fmt.Println(response)
 	if e != nil {
 		return e
@@ -116,7 +121,7 @@ func makeFlare(caseID string) error {
 	return nil
 }
 
-func requestArchive(logFile string) (string, error) {
+func requestArchive(logFile string) ([]string, error) {
 	fmt.Fprintln(color.Output, color.BlueString("Asking the agent to build the flare archive."))
 	var e error
 	c := util.GetClient(false) // FIX: get certificates right then make this true
@@ -134,24 +139,32 @@ func requestArchive(logFile string) (string, error) {
 		return createArchive(logFile)
 	}
 
-	r, e := util.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
+	r := bytes.NewBuffer([]byte{})
+	res, e := util.DoPost(c, urlstr, "application/json", r)
 	if e != nil {
-		if r != nil && string(r) != "" {
-			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while making the flare: %s", color.RedString(string(r))))
+		if res != nil && string(res) != "" {
+			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while making the flare: %s", color.RedString(string(res))))
 		} else {
 			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make the flare. (is it running?)"))
 		}
 		return createArchive(logFile)
 	}
-	return string(r), nil
+
+	var filePath []string
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&filePath); err != nil {
+		fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while decoding the flare file path: %s", color.RedString(err.Error())))
+	}
+
+	return filePath, nil
 }
 
-func createArchive(logFile string) (string, error) {
+func createArchive(logFile string) ([]string, error) {
 	fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally."))
-	filePath, e := flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFile)
+	filePath, e := flare.CreateArchive(forceLocal, common.GetDistPath(), common.PyChecksPath, logFile)
 	if e != nil {
-		fmt.Printf("The flare zipfile failed to be created: %s\n", e)
-		return "", e
+		fmt.Printf("The flare directory failed to be created: %s\n", e)
+		return []string{}, e
 	}
 	return filePath, nil
 }

--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -136,14 +137,15 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		logFile = common.DefaultLogFile
 	}
 
-	filePath, e := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile)
+	tempDir, hostname, e := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile)
+	defer os.RemoveAll(tempDir)
 	if e != nil {
 		w.Write([]byte("Error creating flare directory: " + e.Error()))
 		log.Errorf("Error creating flare directory: " + e.Error())
 		return
 	}
 
-	zipFilePath, e := flare.ZipArchive(filePath)
+	zipFilePath, e := flare.ZipArchive(flare.GetArchivePath(), tempDir, hostname)
 	if e != nil {
 		w.Write([]byte("Error creating flare zip: " + e.Error()))
 		log.Errorf("Error creating flare zip: " + e.Error())

--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/gorilla/mux"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Adds the specific handlers for /agent/ endpoints
@@ -138,21 +138,28 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 
 	filePath, e := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile)
 	if e != nil {
-		w.Write([]byte("Error creating flare zipfile: " + e.Error()))
-		log.Errorf("Error creating flare zipfile: " + e.Error())
+		w.Write([]byte("Error creating flare directory: " + e.Error()))
+		log.Errorf("Error creating flare directory: " + e.Error())
+		return
+	}
+
+	zipFilePath, e := flare.ZipArchive(filePath)
+	if e != nil {
+		w.Write([]byte("Error creating flare zip: " + e.Error()))
+		log.Errorf("Error creating flare zip: " + e.Error())
 		return
 	}
 
 	// Send the flare
-	res, e := flare.SendFlare(filePath, payload.CaseID, payload.Email)
+	res, e := flare.SendFlare(zipFilePath, payload.CaseID, payload.Email)
 	if e != nil {
-		w.Write([]byte("Flare zipfile successfully created: " + filePath + "<br><br>" + e.Error()))
-		log.Errorf("Flare zipfile successfully created: " + filePath + "\n" + e.Error())
+		w.Write([]byte("Flare zipfile successfully created: " + zipFilePath + "<br><br>" + e.Error()))
+		log.Errorf("Flare zipfile successfully created: " + zipFilePath + "\n" + e.Error())
 		return
 	}
 
-	w.Write([]byte("Flare zipfile successfully created: " + filePath + "<br><br>" + res))
-	log.Errorf("Flare zipfile successfully created: " + filePath + "\n" + res)
+	w.Write([]byte("Flare zipfile successfully created: " + zipFilePath + "<br><br>" + res))
+	log.Errorf("Flare zipfile successfully created: " + zipFilePath + "\n" + res)
 	return
 }
 

--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -210,7 +210,7 @@ func requestFlare(caseID, customerEmail string) (response string, e error) {
 		}
 		log.Debug("Initiating flare locally.")
 
-		filePath, e := flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFile)
+		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFile)
 		if e != nil {
 			log.Errorf("The flare directory failed to be created: %s\n", e)
 			return

--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"bytes"
-	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -217,7 +217,7 @@ func requestFlare(caseID, customerEmail string) (response string, e error) {
 		}
 
 	} else {
-		dec := gob.NewDecoder(r)
+		dec := json.NewDecoder(r)
 		if err := dec.Decode(&filePath); err != nil {
 			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while decoding the flare file path: %s", color.RedString(err.Error())))
 		}

--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -200,10 +200,9 @@ func requestFlare(caseID, customerEmail string) (response string, e error) {
 		return
 	}
 
-	r := bytes.NewBuffer([]byte{})
-	res, e := util.DoPost(c, urlstr, "application/json", r)
+	res, e := util.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
 	var zipFilePath, tempDir, hostname string
-	var filePath []string
+	var filePath flare.Path
 	if e != nil {
 		if res != nil && string(res) != "" {
 			log.Warnf("The agent ran into an error while making the flare: %s\n", string(res))
@@ -219,11 +218,10 @@ func requestFlare(caseID, customerEmail string) (response string, e error) {
 		}
 
 	} else {
-		dec := json.NewDecoder(r)
-		if err := dec.Decode(&filePath); err != nil {
+		if err := json.Unmarshal(res, &filePath); err != nil {
 			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while decoding the flare file path: %s", color.RedString(err.Error())))
 		}
-		tempDir, hostname = filePath[0], filePath[1]
+		tempDir, hostname = filePath["tempDir"], filePath["hostname"]
 	}
 	defer os.RemoveAll(tempDir)
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -74,6 +74,7 @@ var (
 // SearchPaths is just an alias for a map of strings
 type SearchPaths map[string]string
 
+// Path is an alias to contain the flare file location.
 type Path map[string]string
 
 // permissionsInfos holds permissions info about the files shipped

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -85,6 +85,7 @@ type filePermsInfo struct {
 	group string
 }
 
+// GetArchivePath generates a directory name for the flare zip.
 func GetArchivePath() string {
 	dir := os.TempDir()
 	t := time.Now()
@@ -95,6 +96,7 @@ func GetArchivePath() string {
 	return filePath
 }
 
+// ZipArchive creates a zip for the flare file directory and returns its location.
 func ZipArchive(filePath []string) (string, error) {
 	zipFilePath := GetArchivePath()
 

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -27,7 +27,7 @@ import (
 
 // CreateDCAArchive packages up the files
 func CreateDCAArchive(local bool, distPath, logFilePath string) (string, error) {
-	zipFilePath := getArchivePath()
+	zipFilePath := GetArchivePath()
 	confSearchPaths := SearchPaths{
 		"":     config.Datadog.GetString("confd_path"),
 		"dist": filepath.Join(distPath, "conf.d"),
@@ -87,7 +87,7 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 		return "", err
 	}
 
-	err = zipEnvvars(tempDir, hostname)
+	err = writeEnvvars(tempDir, hostname)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -67,12 +67,12 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 
 	permsInfos := make(permissionsInfos)
 
-	err = zipLogFiles(tempDir, hostname, logFilePath, permsInfos)
+	err = writeLogFiles(tempDir, hostname, logFilePath, permsInfos)
 	if err != nil {
 		return "", err
 	}
 
-	err = zipConfigFiles(tempDir, hostname, confSearchPaths, permsInfos)
+	err = writeConfigFiles(tempDir, hostname, confSearchPaths, permsInfos)
 	if err != nil {
 		return "", err
 	}
@@ -82,7 +82,7 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 		log.Errorf("Could not zip config check: %s", err)
 	}
 
-	err = zipExpVar(tempDir, hostname)
+	err = writeExpVar(tempDir, hostname)
 	if err != nil {
 		return "", err
 	}
@@ -269,7 +269,7 @@ func zipClusterAgentConfigCheck(tempDir, hostname string) error {
 	GetClusterAgentConfigCheck(writer, true) //nolint:errcheck
 	writer.Flush()
 
-	return writeConfigCheck(tempDir, hostname, b.Bytes())
+	return writeConfigCheckLocal(tempDir, hostname, b.Bytes())
 }
 
 func zipClusterAgentDiagnose(tempDir, hostname string) error {

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -134,7 +134,7 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 
 func writeLocal(tempDir, hostname string) error {
 	f := filepath.Join(tempDir, hostname, "local")
-	err := ensureParentDirsExist(f)
+	err := EnsureParentDirsExist(f)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func zipDCAStatusFile(tempDir, hostname string) error {
 
 	f := filepath.Join(tempDir, hostname, "cluster-agent-status.log")
 	log.Infof("Flare status made at %s", tempDir)
-	err = ensureParentDirsExist(f)
+	err = EnsureParentDirsExist(f)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func zipMetadataMap(tempDir, hostname string) error {
 	sByte := []byte(str)
 	f := filepath.Join(tempDir, hostname, "cluster-agent-metadatamapper.log")
 	log.Infof("Flare metadata mapper made at %s", tempDir)
-	err = ensureParentDirsExist(f)
+	err = EnsureParentDirsExist(f)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func zipClusterAgentClusterChecks(tempDir, hostname string) error {
 	writer.Flush()
 
 	f := filepath.Join(tempDir, hostname, "clusterchecks.log")
-	err := ensureParentDirsExist(f)
+	err := EnsureParentDirsExist(f)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func zipHPAStatus(tempDir, hostname string) error {
 	f := filepath.Join(tempDir, hostname, "custommetricsprovider.log")
 	log.Infof("Flare hpa status made at %s", tempDir)
 
-	err = ensureParentDirsExist(f)
+	err = EnsureParentDirsExist(f)
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func zipClusterAgentDiagnose(tempDir, hostname string) error {
 	writer.Flush()
 
 	f := filepath.Join(tempDir, hostname, "diagnose.log")
-	err := ensureParentDirsExist(f)
+	err := EnsureParentDirsExist(f)
 	if err != nil {
 		return err
 	}
@@ -302,7 +302,7 @@ func zipClusterAgentTelemetry(tempDir, hostname string) error {
 	}
 
 	f := filepath.Join(tempDir, hostname, "telemetry.log")
-	err = ensureParentDirsExist(f)
+	err = EnsureParentDirsExist(f)
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -25,7 +25,7 @@ import (
 
 const dockerCommandMaxLength = 29
 
-func zipDockerSelfInspect(tempDir, hostname string) error {
+func writeDockerSelfInspect(tempDir, hostname string) error {
 	du, err := docker.GetDockerUtil()
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func zipDockerSelfInspect(tempDir, hostname string) error {
 	return err
 }
 
-func zipDockerPs(tempDir, hostname string) error {
+func writeDockerPs(tempDir, hostname string) error {
 	du, err := docker.GetDockerUtil()
 	if err != nil {
 		// if we can't reach docker, let's do nothing

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -18,11 +18,11 @@ import (
 	"syscall"
 )
 
-func zipCounterStrings(tempDir, hostname string) error {
+func writeCounterStrings(tempDir, hostname string) error {
 	return nil
 }
 
-func zipTypeperfData(tempDir, hostname string) error {
+func writeTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -85,7 +85,7 @@ func (p permissionsInfos) write(tempDir, hostname string, mode os.FileMode) erro
 	// init the file
 	t := filepath.Join(tempDir, hostname, "permissions.log")
 
-	if err := ensureParentDirsExist(t); err != nil {
+	if err := EnsureParentDirsExist(t); err != nil {
 		return err
 	}
 

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -29,9 +29,12 @@ func TestPermsFile(t *testing.T) {
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
 	zipFilePath := GetArchivePath()
-	path, err := createArchive(true, SearchPaths{}, "")
+	tempDir, hostname, err := createArchive(true, SearchPaths{}, "")
+
+	defer os.RemoveAll(tempDir)
 	assert.Nil(err)
-	filePath, err := ZipArchive(path)
+
+	filePath, err := ZipArchive(zipFilePath, tempDir, hostname)
 
 	defer os.Remove(zipFilePath)
 

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -29,7 +29,7 @@ func TestPermsFile(t *testing.T) {
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(zipFilePath, true, SearchPaths{}, "")
+	filePath, err := createArchive(true, SearchPaths{}, "")
 	defer os.Remove(zipFilePath)
 
 	assert.Nil(err)

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -28,8 +28,11 @@ func TestPermsFile(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
-	zipFilePath := getArchivePath()
-	filePath, err := createArchive(true, SearchPaths{}, "")
+	zipFilePath := GetArchivePath()
+	path, err := createArchive(true, SearchPaths{}, "")
+	assert.Nil(err)
+	filePath, err := ZipArchive(path)
+
 	defer os.Remove(zipFilePath)
 
 	assert.Nil(err)

--- a/pkg/flare/archive_nodocker.go
+++ b/pkg/flare/archive_nodocker.go
@@ -7,10 +7,10 @@
 
 package flare
 
-func zipDockerSelfInspect(tempDir, hostname string) error {
+func writeDockerSelfInspect(tempDir, hostname string) error {
 	return nil
 }
 
-func zipDockerPs(tempDir, hostname string) error {
+func writeDockerPs(tempDir, hostname string) error {
 	return nil
 }

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -20,7 +20,7 @@ import (
 
 // CreateSecurityAgentArchive packages up the files
 func CreateSecurityAgentArchive(local bool, logFilePath string) (string, error) {
-	zipFilePath := getArchivePath()
+	zipFilePath := GetArchivePath()
 	return createSecurityAgentArchive(zipFilePath, local, logFilePath)
 }
 
@@ -56,12 +56,12 @@ func createSecurityAgentArchive(zipFilePath string, local bool, logFilePath stri
 
 	permsInfos := make(permissionsInfos)
 
-	err = zipLogFiles(tempDir, hostname, logFilePath, permsInfos)
+	err = writeLogFiles(tempDir, hostname, logFilePath, permsInfos)
 	if err != nil {
 		return "", err
 	}
 
-	err = zipConfigFiles(tempDir, hostname, SearchPaths{}, permsInfos)
+	err = writeConfigFiles(tempDir, hostname, SearchPaths{}, permsInfos)
 	if err != nil {
 		return "", err
 	}
@@ -71,7 +71,7 @@ func createSecurityAgentArchive(zipFilePath string, local bool, logFilePath stri
 		return "", err
 	}
 
-	err = zipExpVar(tempDir, hostname)
+	err = writeExpVar(tempDir, hostname)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -76,7 +76,7 @@ func createSecurityAgentArchive(zipFilePath string, local bool, logFilePath stri
 		return "", err
 	}
 
-	err = zipEnvvars(tempDir, hostname)
+	err = writeEnvvars(tempDir, hostname)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -112,7 +112,7 @@ func zipSecurityAgentStatusFile(tempDir, hostname string) error {
 
 	f := filepath.Join(tempDir, hostname, "security-agent-status.log")
 	log.Infof("Flare status made at %s", tempDir)
-	err = ensureParentDirsExist(f)
+	err = EnsureParentDirsExist(f)
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/archive_security_test.go
+++ b/pkg/flare/archive_security_test.go
@@ -52,7 +52,7 @@ func TestCreateSecurityAgentArchive(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			zipFilePath := getArchivePath()
+			zipFilePath := GetArchivePath()
 			filePath, err := createSecurityAgentArchive(zipFilePath, test.local, logFilePath)
 			defer os.Remove(zipFilePath)
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -171,7 +171,7 @@ func TestIncludeSystemProbeConfig(t *testing.T) {
 	tempDir, hostname, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
 
 	defer os.RemoveAll(tempDir)
-	assert.Nil(t, err)
+	assert.NoError(err)
 
 	filePath, err := ZipArchive(zipFilePath, tempDir, hostname)
 	assert.NoError(err)
@@ -204,7 +204,7 @@ func TestIncludeConfigFiles(t *testing.T) {
 	tempDir, hostname, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
 
 	defer os.RemoveAll(tempDir)
-	assert.Nil(t, err)
+	assert.NoError(err)
 
 	filePath, err := ZipArchive(zipFilePath, tempDir, hostname)
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -32,9 +32,12 @@ func TestCreateArchive(t *testing.T) {
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
 	zipFilePath := GetArchivePath()
-	flarePath, err := createArchive(true, SearchPaths{}, "")
+	tempDir, hostname, err := createArchive(true, SearchPaths{}, "")
+
+	defer os.RemoveAll(tempDir)
 	assert.Nil(t, err)
-	filePath, err := ZipArchive(flarePath)
+
+	filePath, err := ZipArchive(zipFilePath, tempDir, hostname)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -58,9 +61,12 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 	pprofURL = ts.URL
 
 	zipFilePath := GetArchivePath()
-	flarePath, err := createArchive(true, SearchPaths{}, "")
+	tempDir, hostname, err := createArchive(true, SearchPaths{}, "")
+
+	defer os.RemoveAll(tempDir)
 	assert.Nil(t, err)
-	filePath, err := ZipArchive(flarePath)
+
+	filePath, err := ZipArchive(zipFilePath, tempDir, hostname)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -104,10 +110,12 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 func TestCreateArchiveBadConfig(t *testing.T) {
 	common.SetupConfig("")
 	zipFilePath := GetArchivePath()
-	flarePath, err := createArchive(true, SearchPaths{}, "")
-	assert.Nil(t, err)
-	filePath, err := ZipArchive(flarePath)
+	tempDir, hostname, err := createArchive(true, SearchPaths{}, "")
 
+	defer os.RemoveAll(tempDir)
+	assert.Nil(t, err)
+
+	filePath, err := ZipArchive(zipFilePath, tempDir, hostname)
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
 
@@ -160,9 +168,12 @@ func TestIncludeSystemProbeConfig(t *testing.T) {
 	defer os.Remove("./test/system-probe.yaml")
 
 	zipFilePath := GetArchivePath()
-	flarePath, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
+	tempDir, hostname, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
+
+	defer os.RemoveAll(tempDir)
 	assert.Nil(t, err)
-	filePath, err := ZipArchive(flarePath)
+
+	filePath, err := ZipArchive(zipFilePath, tempDir, hostname)
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)
 
@@ -190,9 +201,12 @@ func TestIncludeConfigFiles(t *testing.T) {
 
 	common.SetupConfig("./test")
 	zipFilePath := GetArchivePath()
-	flarePath, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
+	tempDir, hostname, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
+
+	defer os.RemoveAll(tempDir)
 	assert.Nil(t, err)
-	filePath, err := ZipArchive(flarePath)
+
+	filePath, err := ZipArchive(zipFilePath, tempDir, hostname)
 
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -31,8 +31,10 @@ func TestCreateArchive(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
-	zipFilePath := getArchivePath()
-	filePath, err := createArchive(true, SearchPaths{}, "")
+	zipFilePath := GetArchivePath()
+	flarePath, err := createArchive(true, SearchPaths{}, "")
+	assert.Nil(t, err)
+	filePath, err := ZipArchive(flarePath)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -55,8 +57,10 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 
 	pprofURL = ts.URL
 
-	zipFilePath := getArchivePath()
-	filePath, err := createArchive(true, SearchPaths{}, "")
+	zipFilePath := GetArchivePath()
+	flarePath, err := createArchive(true, SearchPaths{}, "")
+	assert.Nil(t, err)
+	filePath, err := ZipArchive(flarePath)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -99,8 +103,10 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 // The zipfile should be created even if there is no config file.
 func TestCreateArchiveBadConfig(t *testing.T) {
 	common.SetupConfig("")
-	zipFilePath := getArchivePath()
-	filePath, err := createArchive(true, SearchPaths{}, "")
+	zipFilePath := GetArchivePath()
+	flarePath, err := createArchive(true, SearchPaths{}, "")
+	assert.Nil(t, err)
+	filePath, err := ZipArchive(flarePath)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -113,7 +119,7 @@ func TestCreateArchiveBadConfig(t *testing.T) {
 }
 
 // Ensure sensitive data is redacted
-func TestZipConfigCheck(t *testing.T) {
+func TestWriteConfigCheck(t *testing.T) {
 	cr := response.ConfigCheckResponse{
 		Configs: make([]integration.Config, 0),
 	}
@@ -136,7 +142,7 @@ func TestZipConfigCheck(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	zipConfigCheck(dir, "")
+	writeConfigCheck(dir, "")
 	content, err := ioutil.ReadFile(filepath.Join(dir, "config-check.log"))
 	if err != nil {
 		log.Fatal(err)
@@ -153,8 +159,10 @@ func TestIncludeSystemProbeConfig(t *testing.T) {
 	assert.NoError(err, "couldn't create system-probe.yaml")
 	defer os.Remove("./test/system-probe.yaml")
 
-	zipFilePath := getArchivePath()
-	filePath, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
+	zipFilePath := GetArchivePath()
+	flarePath, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
+	assert.Nil(t, err)
+	filePath, err := ZipArchive(flarePath)
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)
 
@@ -181,8 +189,10 @@ func TestIncludeConfigFiles(t *testing.T) {
 	assert := assert.New(t)
 
 	common.SetupConfig("./test")
-	zipFilePath := getArchivePath()
-	filePath, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
+	zipFilePath := GetArchivePath()
+	flarePath, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
+	assert.Nil(t, err)
+	filePath, err := ZipArchive(flarePath)
 
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)
@@ -247,7 +257,7 @@ func TestCleanDirectoryName(t *testing.T) {
 	assert.True(t, !directoryNameFilter.MatchString(cleanedHostname))
 }
 
-func TestZipTaggerList(t *testing.T) {
+func TestWriteTaggerList(t *testing.T) {
 	tagMap := make(map[string]response.TaggerListEntity)
 	tagMap["random_entity_name"] = response.TaggerListEntity{
 		Sources: []string{"docker_source_name"},
@@ -270,7 +280,7 @@ func TestZipTaggerList(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	taggerListURL = s.URL
-	zipTaggerList(dir, "")
+	writeTaggerList(dir, "")
 	content, err := ioutil.ReadFile(filepath.Join(dir, "tagger-list.json"))
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -32,7 +32,7 @@ func TestCreateArchive(t *testing.T) {
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(zipFilePath, true, SearchPaths{}, "")
+	filePath, err := createArchive(true, SearchPaths{}, "")
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -56,7 +56,7 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 	pprofURL = ts.URL
 
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(zipFilePath, true, SearchPaths{}, "")
+	filePath, err := createArchive(true, SearchPaths{}, "")
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -100,7 +100,7 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 func TestCreateArchiveBadConfig(t *testing.T) {
 	common.SetupConfig("")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(zipFilePath, true, SearchPaths{}, "")
+	filePath, err := createArchive(true, SearchPaths{}, "")
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -154,7 +154,7 @@ func TestIncludeSystemProbeConfig(t *testing.T) {
 	defer os.Remove("./test/system-probe.yaml")
 
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(zipFilePath, true, SearchPaths{"": "./test/confd"}, "")
+	filePath, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)
 
@@ -182,7 +182,7 @@ func TestIncludeConfigFiles(t *testing.T) {
 
 	common.SetupConfig("./test")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(zipFilePath, true, SearchPaths{"": "./test/confd"}, "")
+	filePath, err := createArchive(true, SearchPaths{"": "./test/confd"}, "")
 
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -43,7 +43,7 @@ func writeCounterStrings(tempDir, hostname string) error {
 	}
 	clist := winutil.ConvertWindowsStringList(counterlist)
 	fname := filepath.Join(tempDir, hostname, "counter_strings.txt")
-	err := ensureParentDirsExist(fname)
+	err := EnsureParentDirsExist(fname)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func writeTypeperfData(tempDir, hostname string) error {
 		return err
 	}
 	f := filepath.Join(tempDir, hostname, "typeperf.txt")
-	err = ensureParentDirsExist(f)
+	err = EnsureParentDirsExist(f)
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func zipCounterStrings(tempDir, hostname string) error {
+func writeCounterStrings(tempDir, hostname string) error {
 	bufferIncrement := uint32(1024)
 	bufferSize := bufferIncrement
 	var counterlist []uint16
@@ -61,7 +61,7 @@ func zipCounterStrings(tempDir, hostname string) error {
 
 }
 
-func zipTypeperfData(tempDir, hostname string) error {
+func writeTypeperfData(tempDir, hostname string) error {
 	cmd := exec.Command("typeperf", "-qx")
 	var out bytes.Buffer
 	cmd.Stdout = &out

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -100,9 +100,9 @@ func getWhitelistedEnvvars() []string {
 	return found
 }
 
-// zipEnvvars collects whitelisted envvars that can affect the agent's
+// writeEnvvars collects whitelisted envvars that can affect the agent's
 // behaviour while not being handled by viper
-func zipEnvvars(tempDir, hostname string) error {
+func writeEnvvars(tempDir, hostname string) error {
 	envvars := getWhitelistedEnvvars()
 
 	var b bytes.Buffer

--- a/releasenotes/notes/flare-add-performance-profiling-bbae32a7ca98eadc.yaml
+++ b/releasenotes/notes/flare-add-performance-profiling-bbae32a7ca98eadc.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+enhancements:
+  - |
+    Changes flare creation so that archiving is handled from the flare process, leaving the agent to
+    only collect flare information files. This enables us to create a 120s performance profile through
+    a flag for the flare command.


### PR DESCRIPTION
### What does this PR do?

Changes the flare command logic for the core agent to zip in the flare process instead of the agent process. The agent process only collects the necessary files and writes them to disk. This allows us to avoid a timeout during the creation of a 120s CPU and heap profile during flare creation.

### Motivation

It would be useful to have performance profiling data for some support cases.

### Additional Notes

These changes only apply for Agent Core, there should be separate PRs to include this for other agents.

Also a limitation:  Now that the zip creation is separate from the creation of the flare files, I can't defer the removal of the temporary directory where the flare files are created before zipping. That means that theoretically, if the agent crashes during flare creation, the temp directory would not get cleaned up. Would like to hear opinions if there's a better way to make that safe. 

### Describe your test plan

1. Test that the flag works correctly for true and false
2. Test that profile files get created after 120s when creating a flare with the flag enabled
3. Test that flare didn't get broken on other platforms/windows.

### Notes for QA

Should be tested for every platform the core agent runs on.
