### PR TITLE
Support include/exclude containers in ECS Fargate (process-agent)

### DIFF
--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -85,8 +85,8 @@ func (c *ContainerdCheck) Configure(config, initConfig integration.Data, source 
 		return err
 	}
 	c.sub.Filters = c.instance.ContainerdFilters
-	// GetSharedFilter should not return a nil instance of *Filter if there is an error during its setup.
-	fil, err := ddContainers.GetSharedFilter()
+	// GetSharedMetricFilter should not return a nil instance of *Filter if there is an error during its setup.
+	fil, err := ddContainers.GetSharedMetricFilter()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/containerd_test.go
+++ b/pkg/collector/corechecks/containers/containerd_test.go
@@ -92,7 +92,7 @@ func TestComputeEvents(t *testing.T) {
 	mocked := mocksender.NewMockSender(containerdCheck.ID())
 	var err error
 	defer containersutil.ResetSharedFilter()
-	containerdCheck.filters, err = containersutil.GetSharedFilter()
+	containerdCheck.filters, err = containersutil.GetSharedMetricFilter()
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -457,7 +457,7 @@ func TestIsExcluded(t *testing.T) {
 	config.Datadog.Set("container_exclude", "kube_namespace:shouldexclude")
 	defer config.Datadog.SetDefault("container_exclude", "")
 	defer containersutil.ResetSharedFilter()
-	containerdCheck.filters, err = containersutil.GetSharedFilter()
+	containerdCheck.filters, err = containersutil.GetSharedMetricFilter()
 	require.NoError(t, err)
 	c := containers.Container{
 		Image: "kubernetes/pause",

--- a/pkg/collector/python/containers.go
+++ b/pkg/collector/python/containers.go
@@ -48,7 +48,7 @@ func IsContainerExcluded(name, image, namespace *C.char) C.int {
 // Separated to unit testing
 func initContainerFilter() {
 	var err error
-	if filter, err = containers.GetSharedFilter(); err != nil {
+	if filter, err = containers.GetSharedMetricFilter(); err != nil {
 		log.Errorf("Error initializing container filtering: %s", err)
 	}
 }

--- a/pkg/collector/python/test_containers.go
+++ b/pkg/collector/python/test_containers.go
@@ -25,15 +25,15 @@ func testIsContainerExcluded(t *testing.T) {
 
 	r, err := regexp.Compile("bar")
 	assert.Nil(t, err)
-	filter.ImageBlacklist = append(filter.ImageBlacklist, r)
+	filter.ImageExcludeList = append(filter.ImageExcludeList, r)
 
 	r, err = regexp.Compile("white")
 	assert.Nil(t, err)
-	filter.NamespaceWhitelist = append(filter.NamespaceWhitelist, r)
+	filter.NamespaceIncludeList = append(filter.NamespaceIncludeList, r)
 
 	r, err = regexp.Compile("black")
 	assert.Nil(t, err)
-	filter.NamespaceBlacklist = append(filter.NamespaceBlacklist, r)
+	filter.NamespaceExcludeList = append(filter.NamespaceExcludeList, r)
 
 	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("bar"), C.CString("ns")), C.int(1))
 	assert.Equal(t, IsContainerExcluded(C.CString("foo"), C.CString("bar"), C.CString("white")), C.int(0))

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -78,13 +78,13 @@ func parseFilters(filters []string) (imageFilters, nameFilters, namespaceFilters
 	return imageFilters, nameFilters, namespaceFilters, nil
 }
 
-// GetSharedFilter allows to share the result of NewFilterFromConfig
+// GetSharedMetricFilter allows to share the result of NewFilterFromConfig
 // for several user classes
-func GetSharedFilter() (*Filter, error) {
+func GetSharedMetricFilter() (*Filter, error) {
 	if sharedFilter != nil {
 		return sharedFilter, nil
 	}
-	f, err := NewFilterFromConfig()
+	f, err := newMetricFilterFromConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -123,11 +123,14 @@ func NewFilter(whitelist, blacklist []string) (*Filter, error) {
 	}, nil
 }
 
-// NewFilterFromConfig creates a new container filter, sourcing patterns
-// from the pkg/config options
-func NewFilterFromConfig() (*Filter, error) {
+// newMetricFilterFromConfig creates a new container filter, sourcing patterns
+// from the pkg/config options, to be used only for metrics
+func newMetricFilterFromConfig() (*Filter, error) {
 	whitelist := config.Datadog.GetStringSlice("container_include")
 	blacklist := config.Datadog.GetStringSlice("container_exclude")
+	whitelist = append(whitelist, config.Datadog.GetStringSlice("container_include_metrics")...)
+	blacklist = append(blacklist, config.Datadog.GetStringSlice("container_exclude_metrics")...)
+
 	if len(whitelist) == 0 {
 		// support legacy "ac_include" config
 		whitelist = config.Datadog.GetStringSlice("ac_include")

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -38,13 +38,13 @@ const (
 
 // Filter holds the state for the container filtering logic
 type Filter struct {
-	Enabled            bool
-	ImageWhitelist     []*regexp.Regexp
-	NameWhitelist      []*regexp.Regexp
-	NamespaceWhitelist []*regexp.Regexp
-	ImageBlacklist     []*regexp.Regexp
-	NameBlacklist      []*regexp.Regexp
-	NamespaceBlacklist []*regexp.Regexp
+	Enabled              bool
+	ImageIncludeList     []*regexp.Regexp
+	NameIncludeList      []*regexp.Regexp
+	NamespaceIncludeList []*regexp.Regexp
+	ImageExcludeList     []*regexp.Regexp
+	NameExcludeList      []*regexp.Regexp
+	NamespaceExcludeList []*regexp.Regexp
 }
 
 var sharedFilter *Filter
@@ -99,49 +99,51 @@ func ResetSharedFilter() {
 }
 
 // NewFilter creates a new container filter from a two slices of
-// regexp patterns for a whitelist and blacklist. Each pattern should have
+// regexp patterns for a include list and exclude list. Each pattern should have
 // the following format: "field:pattern" where field can be: [image, name].
 // An error is returned if any of the expression don't compile.
-func NewFilter(whitelist, blacklist []string) (*Filter, error) {
-	iwl, nwl, nswl, err := parseFilters(whitelist)
+func NewFilter(includeList, excludeList []string) (*Filter, error) {
+	imgIncl, nameIncl, nsIncl, err := parseFilters(includeList)
 	if err != nil {
 		return nil, err
 	}
-	ibl, nbl, nsbl, err := parseFilters(blacklist)
+	imgExcl, nameExcl, nsExcl, err := parseFilters(excludeList)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Filter{
-		Enabled:            len(whitelist) > 0 || len(blacklist) > 0,
-		ImageWhitelist:     iwl,
-		NameWhitelist:      nwl,
-		NamespaceWhitelist: nswl,
-		ImageBlacklist:     ibl,
-		NameBlacklist:      nbl,
-		NamespaceBlacklist: nsbl,
+		Enabled:              len(includeList) > 0 || len(excludeList) > 0,
+		ImageIncludeList:     imgIncl,
+		NameIncludeList:      nameIncl,
+		NamespaceIncludeList: nsIncl,
+		ImageExcludeList:     imgExcl,
+		NameExcludeList:      nameExcl,
+		NamespaceExcludeList: nsExcl,
 	}, nil
 }
 
 // newMetricFilterFromConfig creates a new container filter, sourcing patterns
 // from the pkg/config options, to be used only for metrics
 func newMetricFilterFromConfig() (*Filter, error) {
-	whitelist := config.Datadog.GetStringSlice("container_include")
-	blacklist := config.Datadog.GetStringSlice("container_exclude")
-	whitelist = append(whitelist, config.Datadog.GetStringSlice("container_include_metrics")...)
-	blacklist = append(blacklist, config.Datadog.GetStringSlice("container_exclude_metrics")...)
+	// We merge `container_include` and `container_include_metrics` as this filter
+	// is used by all core and python checks (so components sending metrics).
+	includeList := config.Datadog.GetStringSlice("container_include")
+	excludeList := config.Datadog.GetStringSlice("container_exclude")
+	includeList = append(includeList, config.Datadog.GetStringSlice("container_include_metrics")...)
+	excludeList = append(excludeList, config.Datadog.GetStringSlice("container_exclude_metrics")...)
 
-	if len(whitelist) == 0 {
+	if len(includeList) == 0 {
 		// support legacy "ac_include" config
-		whitelist = config.Datadog.GetStringSlice("ac_include")
+		includeList = config.Datadog.GetStringSlice("ac_include")
 	}
-	if len(blacklist) == 0 {
+	if len(excludeList) == 0 {
 		// support legacy "ac_exclude" config
-		blacklist = config.Datadog.GetStringSlice("ac_exclude")
+		excludeList = config.Datadog.GetStringSlice("ac_exclude")
 	}
 
 	if config.Datadog.GetBool("exclude_pause_container") {
-		blacklist = append(blacklist,
+		excludeList = append(excludeList,
 			pauseContainerGCR,
 			pauseContainerOpenshift3,
 			pauseContainerKubernetes,
@@ -153,7 +155,7 @@ func newMetricFilterFromConfig() (*Filter, error) {
 			pauseContainerECR,
 		)
 	}
-	return NewFilter(whitelist, blacklist)
+	return NewFilter(includeList, excludeList)
 }
 
 // NewAutodiscoveryFilter creates a new container filter for Autodiscovery
@@ -161,28 +163,28 @@ func newMetricFilterFromConfig() (*Filter, error) {
 // It allows to filter metrics and logs separately
 // For use in autodiscovery.
 func NewAutodiscoveryFilter(filter FilterType) (*Filter, error) {
-	whitelist := []string{}
-	blacklist := []string{}
+	includeList := []string{}
+	excludeList := []string{}
 	switch filter {
 	case GlobalFilter:
-		whitelist = config.Datadog.GetStringSlice("container_include")
-		blacklist = config.Datadog.GetStringSlice("container_exclude")
-		if len(whitelist) == 0 {
+		includeList = config.Datadog.GetStringSlice("container_include")
+		excludeList = config.Datadog.GetStringSlice("container_exclude")
+		if len(includeList) == 0 {
 			// fallback and support legacy "ac_include" config
-			whitelist = config.Datadog.GetStringSlice("ac_include")
+			includeList = config.Datadog.GetStringSlice("ac_include")
 		}
-		if len(blacklist) == 0 {
+		if len(excludeList) == 0 {
 			// fallback and support legacy "ac_exclude" config
-			blacklist = config.Datadog.GetStringSlice("ac_exclude")
+			excludeList = config.Datadog.GetStringSlice("ac_exclude")
 		}
 	case MetricsFilter:
-		whitelist = config.Datadog.GetStringSlice("container_include_metrics")
-		blacklist = config.Datadog.GetStringSlice("container_exclude_metrics")
+		includeList = config.Datadog.GetStringSlice("container_include_metrics")
+		excludeList = config.Datadog.GetStringSlice("container_exclude_metrics")
 	case LogsFilter:
-		whitelist = config.Datadog.GetStringSlice("container_include_logs")
-		blacklist = config.Datadog.GetStringSlice("container_exclude_logs")
+		includeList = config.Datadog.GetStringSlice("container_include_logs")
+		excludeList = config.Datadog.GetStringSlice("container_exclude_logs")
 	}
-	return NewFilter(whitelist, blacklist)
+	return NewFilter(includeList, excludeList)
 }
 
 // IsExcluded returns a bool indicating if the container should be excluded
@@ -192,35 +194,35 @@ func (cf Filter) IsExcluded(containerName, containerImage, podNamespace string) 
 		return false
 	}
 
-	// Any whitelisted take precedence on excluded
-	for _, r := range cf.ImageWhitelist {
+	// Any includeListed take precedence on excluded
+	for _, r := range cf.ImageIncludeList {
 		if r.MatchString(containerImage) {
 			return false
 		}
 	}
-	for _, r := range cf.NameWhitelist {
+	for _, r := range cf.NameIncludeList {
 		if r.MatchString(containerName) {
 			return false
 		}
 	}
-	for _, r := range cf.NamespaceWhitelist {
+	for _, r := range cf.NamespaceIncludeList {
 		if r.MatchString(podNamespace) {
 			return false
 		}
 	}
 
-	// Check if blacklisted
-	for _, r := range cf.ImageBlacklist {
+	// Check if excludeListed
+	for _, r := range cf.ImageExcludeList {
 		if r.MatchString(containerImage) {
 			return true
 		}
 	}
-	for _, r := range cf.NameBlacklist {
+	for _, r := range cf.NameExcludeList {
 		if r.MatchString(containerName) {
 			return true
 		}
 	}
-	for _, r := range cf.NamespaceBlacklist {
+	for _, r := range cf.NamespaceExcludeList {
 		if r.MatchString(podNamespace) {
 			return true
 		}

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -198,43 +198,43 @@ func TestFilter(t *testing.T) {
 	}
 
 	for i, tc := range []struct {
-		whitelist   []string
-		blacklist   []string
+		includeList []string
+		excludeList []string
 		expectedIDs []string
 	}{
 		{
 			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24"},
 		},
 		{
-			blacklist:   []string{"name:secret"},
+			excludeList: []string{"name:secret"},
 			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24"},
 		},
 		{
-			blacklist:   []string{"image:secret"},
+			excludeList: []string{"image:secret"},
 			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24"},
 		},
 		{
-			whitelist:   []string{},
-			blacklist:   []string{"image:apache", "image:alpine"},
+			includeList: []string{},
+			excludeList: []string{"image:apache", "image:alpine"},
 			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24"},
 		},
 		{
-			whitelist:   []string{"name:mysql"},
-			blacklist:   []string{"name:dd"},
+			includeList: []string{"name:mysql"},
+			excludeList: []string{"name:dd"},
 			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19", "20", "23", "24"},
 		},
 		{
-			blacklist:   []string{"kube_namespace:.*"},
-			whitelist:   []string{"kube_namespace:foo"},
+			excludeList: []string{"kube_namespace:.*"},
+			includeList: []string{"kube_namespace:foo"},
 			expectedIDs: []string{"14"},
 		},
 		{
-			blacklist:   []string{"kube_namespace:bar"},
+			excludeList: []string{"kube_namespace:bar"},
 			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19", "20", "23", "24"},
 		},
 		// Test kubernetes defaults
 		{
-			blacklist: []string{
+			excludeList: []string{
 				pauseContainerGCR,
 				pauseContainerOpenshift3,
 				pauseContainerKubernetes,
@@ -249,7 +249,7 @@ func TestFilter(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			f, err := NewFilter(tc.whitelist, tc.blacklist)
+			f, err := NewFilter(tc.includeList, tc.excludeList)
 			require.Nil(t, err, "case %d", i)
 
 			var allowed []string

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -67,7 +67,7 @@ func (d *DockerUtil) init() error {
 		CacheDuration:  10 * time.Second,
 	}
 
-	cfg.filter, err = containers.GetSharedFilter()
+	cfg.filter, err = containers.GetSharedMetricFilter()
 	if err != nil {
 		return err
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -580,7 +580,7 @@ func (ku *KubeUtil) init() error {
 		return err
 	}
 
-	ku.filter, err = containers.GetSharedFilter()
+	ku.filter, err = containers.GetSharedMetricFilter()
 	if err != nil {
 		return err
 	}

--- a/releasenotes/notes/fargate-containers-incl-excl-d564e11f01cfdc6c.yaml
+++ b/releasenotes/notes/fargate-containers-incl-excl-d564e11f01cfdc6c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix `container_include_metrics` support for all container checks
+enhancements:
+  - |
+    Add container incl./excl. lists support for ECS Fargate (process-agent)


### PR DESCRIPTION
### What does this PR do?

Add support to include/exclude containers in ECS Fargate (live container view, process-agent).
Fix support of `container_include_metrics/container_exclude_metrics` in container checks.

### Describe your test plan

Start an ECS cluster with `DD_CONTAINER_EXCLUDE_METRICS = image:fg-proxy name:.*dummy.*` (for instance) and verify that the other containers in your task are properly excluded in:
- Live container view
- Metrics `ecs.fargate.cpu.user`
