### PR TITLE
Set pre-commit version to ignore python patch version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: 3.8.3
+  python: python3.8
 
 repos:
 - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
### What does this PR do?

Make it so that pre-commit hook can work with any Python patch version.

### Motivation

To avoid locking everything to one Python patch version.
