### PR TITLE
[ec2] IMDSv2 opt-in flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -440,7 +440,8 @@ func InitConfig(config Config) {
 
 	// EC2
 	config.BindEnvAndSetDefault("ec2_use_windows_prefix_detection", false)
-	config.BindEnvAndSetDefault("ec2_metadata_timeout", 300) // value in milliseconds
+	config.BindEnvAndSetDefault("ec2_metadata_timeout", 300)          // value in milliseconds
+	config.BindEnvAndSetDefault("ec2_metadata_token_lifetime", 21600) // value in seconds
 	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -441,6 +441,7 @@ func InitConfig(config Config) {
 	// EC2
 	config.BindEnvAndSetDefault("ec2_use_windows_prefix_detection", false)
 	config.BindEnvAndSetDefault("ec2_metadata_timeout", 300) // value in milliseconds
+	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 
 	// ECS

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -221,11 +221,11 @@ api_key:
 # ec2_metadata_timeout: 300
 
 ## @param ec2_prefer_imdsv2 - boolean - optional - default: false
-## If this flags is true then the agent will request EC2 metadata using IMDS v2,
-## which offer additional security while accessing metadata. However to properly
-## work in some situation (like a containerized agent on a plain EC2 instance)
-## it may require additional configuration on the AWS side. Please check AWS
-## guidelines for further details:
+## If this flag is true then the agent will request EC2 metadata using IMDS v2,
+## which offers additional security for accessing metadata. However, in some
+## situations (such as a containerized agent on a plain EC2 instance) it may
+## require additional configuration on the AWS side. See the AWS guidelines
+## for further details:
 ## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2
 #
 # ec2_prefer_imdsv2: false

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -220,6 +220,16 @@ api_key:
 #
 # ec2_metadata_timeout: 300
 
+## @param ec2_prefer_imdsv2 - boolean - optional - default: false
+## If this flags is true then the agent will request EC2 metadata using IMDS v2,
+## which offer additional security while accessing metadata. However to properly
+## work in some situation (like a containerized agent on a plain EC2 instance)
+## it may require additional configuration on the AWS side. Please check AWS
+## guidelines for further details:
+## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2
+#
+# ec2_prefer_imdsv2: false
+
 ## @param collect_gce_tags - boolean - optional - default: true
 ## Collect Google Cloud Engine metadata as host tags
 #

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -209,7 +209,7 @@ func doHTTPRequest(url string, method string, headers map[string]string, useToke
 	if useToken {
 		token, err := getToken()
 		if err != nil {
-			log.Info("ec2_prefer_imdsv2 is set to true in configuration but the agent was unable to get a token: %s", err)
+			log.Warnf("ec2_prefer_imdsv2 is set to true in configuration but the agent was unable to get a token: %s", err)
 		} else {
 			headers["X-aws-ec2-metadata-token"] = token
 		}

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -209,9 +209,10 @@ func doHTTPRequest(url string, method string, headers map[string]string, useToke
 	if useToken {
 		token, err := getToken()
 		if err != nil {
-			return nil, err
+			log.Info("ec2_prefer_imdsv2 is set to true in configuration but the agent was unable to get a token: %s", err)
+		} else {
+			headers["X-aws-ec2-metadata-token"] = token
 		}
-		headers["X-aws-ec2-metadata-token"] = token
 	}
 
 	for header, value := range headers {

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -19,13 +20,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+type ec2Token struct {
+	expirationDate time.Time
+	value          string
+	sync.RWMutex
+}
+
 // declare these as vars not const to ease testing
 var (
 	metadataURL        = "http://169.254.169.254/latest/meta-data"
 	tokenURL           = "http://169.254.169.254/latest/api/token"
 	oldDefaultPrefixes = []string{"ip-", "domu"}
 	defaultPrefixes    = []string{"ip-", "domu", "ec2amaz-"}
-
+	tokenLifetime      = 21600 * time.Second
+	token              = ec2Token{}
 	// CloudProviderName contains the inventory name of for EC2
 	CloudProviderName = "AWS"
 
@@ -222,6 +230,18 @@ func doHTTPRequest(url string, method string, headers map[string]string, retriab
 }
 
 func getToken() (string, error) {
+	token.RLock()
+	// Refresh 15 seconds before expiration
+	if time.Now().Before(token.expirationDate.Add(-15 * time.Second)) {
+		val := token.value
+		token.RUnlock()
+		return val, nil
+	}
+
+	token.RUnlock()
+	token.Lock()
+	defer token.Unlock()
+
 	client := http.Client{
 		Timeout: time.Duration(config.Datadog.GetInt("ec2_metadata_timeout")) * time.Millisecond,
 	}
@@ -231,7 +251,7 @@ func getToken() (string, error) {
 		return "", err
 	}
 
-	req.Header.Add("X-aws-ec2-metadata-token-ttl-seconds", "60")
+	req.Header.Add("X-aws-ec2-metadata-token-ttl-seconds", fmt.Sprintf("%d", int(tokenLifetime.Seconds())))
 	res, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -246,8 +266,9 @@ func getToken() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to read response body, %s", err)
 	}
-
-	return string(all), nil
+	token.value = string(all)
+	token.expirationDate = time.Now().Add(tokenLifetime)
+	return token.value, nil
 }
 
 // IsDefaultHostname returns whether the given hostname is a default one for EC2

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -379,7 +379,7 @@ func TestMetedataRequestWithToken(t *testing.T) {
 
 	assert.Equal(t, "0", requestForToken.Header.Get("X-sequence"))
 	assert.Equal(t, "1", requestWithToken.Header.Get("X-sequence"))
-	assert.Equal(t, "21600", requestForToken.Header.Get("X-aws-ec2-metadata-token-ttl-seconds"))
+	assert.Equal(t, fmt.Sprint(config.Datadog.GetInt("ec2_metadata_token_lifetime")), requestForToken.Header.Get("X-aws-ec2-metadata-token-ttl-seconds"))
 	assert.Equal(t, http.MethodPut, requestForToken.Method)
 	assert.Equal(t, "/", requestForToken.RequestURI)
 	assert.Equal(t, tok, requestWithToken.Header.Get("X-aws-ec2-metadata-token"))

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -434,7 +434,7 @@ func TestMetedataRequestWithoutToken(t *testing.T) {
 	defer ts.Close()
 	metadataURL = ts.URL
 	tokenURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	ips, err := GetLocalIPv4()

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -323,9 +323,10 @@ func TestMetedataRequestWithToken(t *testing.T) {
 	var requestForToken *http.Request
 	var requestWithToken *http.Request
 	var seq int
+	config.Datadog.SetDefault("ec2_prefer_imdsv2", true)
 
 	ipv4 := "198.51.100.1"
-	token := "AQAAAFKw7LyqwVmmBMkqXHpDBuDWw2GnfGswTHi2yiIOGvzD7OMaWw=="
+	tok := "AQAAAFKw7LyqwVmmBMkqXHpDBuDWw2GnfGswTHi2yiIOGvzD7OMaWw=="
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
@@ -339,11 +340,11 @@ func TestMetedataRequestWithToken(t *testing.T) {
 			r.Header.Add("X-sequence", fmt.Sprintf("%v", seq))
 			seq++
 			requestForToken = r
-			io.WriteString(w, token)
+			io.WriteString(w, tok)
 		case http.MethodGet:
 			// Should be a metadata request
 			t := r.Header.Get("X-aws-ec2-metadata-token")
-			if t != token {
+			if t != tok {
 				r.Header.Add("X-sequence", fmt.Sprintf("%v", seq))
 				seq++
 				requestWithoutToken = r
@@ -374,16 +375,14 @@ func TestMetedataRequestWithToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{ipv4}, ips)
 
-	assert.Equal(t, "0", requestWithoutToken.Header.Get("X-sequence"))
-	assert.Equal(t, "1", requestForToken.Header.Get("X-sequence"))
-	assert.Equal(t, "2", requestWithToken.Header.Get("X-sequence"))
-	assert.Equal(t, "", requestWithoutToken.Header.Get("X-aws-ec2-metadata-token"))
-	assert.Equal(t, "/local-ipv4", requestWithoutToken.RequestURI)
-	assert.Equal(t, http.MethodGet, requestWithoutToken.Method)
+	assert.Nil(t, requestWithoutToken)
+
+	assert.Equal(t, "0", requestForToken.Header.Get("X-sequence"))
+	assert.Equal(t, "1", requestWithToken.Header.Get("X-sequence"))
 	assert.Equal(t, "21600", requestForToken.Header.Get("X-aws-ec2-metadata-token-ttl-seconds"))
 	assert.Equal(t, http.MethodPut, requestForToken.Method)
 	assert.Equal(t, "/", requestForToken.RequestURI)
-	assert.Equal(t, token, requestWithToken.Header.Get("X-aws-ec2-metadata-token"))
+	assert.Equal(t, tok, requestWithToken.Header.Get("X-aws-ec2-metadata-token"))
 	assert.Equal(t, "/local-ipv4", requestWithToken.RequestURI)
 	assert.Equal(t, http.MethodGet, requestWithToken.Method)
 
@@ -392,8 +391,56 @@ func TestMetedataRequestWithToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{ipv4}, ips)
 	// Unchanged
-	assert.Equal(t, "1", requestForToken.Header.Get("X-sequence"))
+	assert.Equal(t, "0", requestForToken.Header.Get("X-sequence"))
 	// Incremented
-	assert.Equal(t, "3", requestWithoutToken.Header.Get("X-sequence"))
+	assert.Equal(t, "2", requestWithToken.Header.Get("X-sequence"))
+
+	// Force refresh
+	token.expirationDate = time.Now()
+	ips, err = GetLocalIPv4()
+	require.NoError(t, err)
+	assert.Equal(t, []string{ipv4}, ips)
+	// Incremented
+	assert.Equal(t, "3", requestForToken.Header.Get("X-sequence"))
 	assert.Equal(t, "4", requestWithToken.Header.Get("X-sequence"))
+}
+
+func TestMetedataRequestWithoutToken(t *testing.T) {
+	var requestWithoutToken *http.Request
+	config.Datadog.SetDefault("ec2_prefer_imdsv2", false)
+
+	ipv4 := "198.51.100.1"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		// Put is only use for token
+		assert.NotEqual(t, r.Method, http.MethodPut)
+		switch r.Method {
+		case http.MethodGet:
+			// Should be a metadata request without token
+			token := r.Header.Get("X-aws-ec2-metadata-token")
+			assert.Equal(t, token, "")
+			switch r.RequestURI {
+			case "/local-ipv4":
+				requestWithoutToken = r
+				io.WriteString(w, ipv4)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+	tokenURL = ts.URL
+	timeout = time.Second
+	defer resetPackageVars()
+
+	ips, err := GetLocalIPv4()
+	require.NoError(t, err)
+	assert.Equal(t, []string{ipv4}, ips)
+
+	assert.Equal(t, "/local-ipv4", requestWithoutToken.RequestURI)
+	assert.Equal(t, http.MethodGet, requestWithoutToken.Method)
 }

--- a/releasenotes/notes/imdsv2-optin-flag-3142a9b7b72e09ce.yaml
+++ b/releasenotes/notes/imdsv2-optin-flag-3142a9b7b72e09ce.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When requesting EC2 metadata, using IMDSv2 may be preferred by
+    turning on a new configuration option (``ec2_prefer_imdsv2``).

--- a/releasenotes/notes/imdsv2-optin-flag-3142a9b7b72e09ce.yaml
+++ b/releasenotes/notes/imdsv2-optin-flag-3142a9b7b72e09ce.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    When requesting EC2 metadata, using IMDSv2 may be preferred by
-    turning on a new configuration option (``ec2_prefer_imdsv2``).
+    When requesting EC2 metadata, you can use IMDSv2 by turning
+    on a new configuration option (``ec2_prefer_imdsv2``).


### PR DESCRIPTION
### What does this PR do?
Add a new boolean configuration flag (`ec2_prefer_imdsv2`) and the relevant implementation logic.

### Motivation
Allow agent user so stick to the AWS EC2 IMDSv2 migration guidelines :
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2

### Additional Notes
If the IMDSv2 token request fails the agent will still attempt to
do the metadata request and log a message in order to ease migration.

### Describe your test plan
Updated UT.
IRL tests on EC2.

### QA considerations
Ideally QA would cover the following situation:
* Linux/Windows on EC2 with imdsv2-only (it 's an EC2 instance option) and assess that metadata querying is functional
* Network traffic inspection to check that the token is requested and send only once to ensure token caching is working
* Check for token renewal at expiration time