### PR TITLE
Add config for deep_database_monitoring

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -733,6 +733,9 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
 	config.BindEnvAndSetDefault("compliance_config.cmd_port", 5010)
 
+	// Deep Database Monitoring
+	config.BindEnvAndSetDefault("deep_database_monitoring", false)
+
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")
 


### PR DESCRIPTION
### What does this PR do?

Add config for `deep_database_monitoring` to enable statement-level metrics and execution plan collection on database hosts.

### Motivation

This will be needed for use in the database checks (MySQL and Postgres) to enable statement-level metrics and execution plans.

It will also be used as a temporary feature flag for additional functionality like arbitrary tag values and [new SQL normalization](https://github.com/DataDog/datadog-agent/pull/5664) while they are in a transition state.

### Additional Notes

Are there any other touch points for adding config? It should be undocumented for now while the feature is under development.

### Describe your test plan

Manually tested. The flag will be tested when the feature is used.