### PR TITLE
[compliance] Fixes for compliance rule init and execution

### DIFF
--- a/pkg/compliance/agent/agent.go
+++ b/pkg/compliance/agent/agent.go
@@ -60,6 +60,8 @@ func RunChecks(reporter event.Reporter, configDir string, options ...checks.Buil
 		return err
 	}
 
+	defer builder.Close()
+
 	agent := &Agent{
 		builder:   builder,
 		configDir: configDir,
@@ -77,6 +79,8 @@ func RunChecksFromFile(reporter event.Reporter, file string, options ...checks.B
 	if err != nil {
 		return err
 	}
+
+	defer builder.Close()
 
 	agent := &Agent{
 		builder: builder,

--- a/pkg/compliance/agent/agent_test.go
+++ b/pkg/compliance/agent/agent_test.go
@@ -111,7 +111,7 @@ func TestRun(t *testing.T) {
 				eventMatch{
 					ruleID:       "cis-kubernetes-1",
 					resourceID:   "the-host",
-					resourceType: "kubernetesCluster",
+					resourceType: "docker",
 					result:       "failed",
 					path:         "/files/kube-apiserver.yaml",
 					permissions:  0644,
@@ -133,12 +133,17 @@ func TestRun(t *testing.T) {
 		check.Run()
 	})
 
+	dockerClient := &mocks.DockerClient{}
+	dockerClient.On("Close").Return(nil).Once()
+	defer dockerClient.AssertExpectations(t)
+
 	agent, err := New(
 		reporter,
 		scheduler,
 		e.dir,
 		checks.WithHostname("the-host"),
 		checks.WithHostRootMount(e.dir),
+		checks.WithDockerClient(dockerClient),
 	)
 	assert.NoError(err)
 
@@ -173,6 +178,10 @@ func TestRunChecks(t *testing.T) {
 
 	defer reporter.AssertExpectations(t)
 
+	dockerClient := &mocks.DockerClient{}
+	dockerClient.On("Close").Return(nil).Once()
+	defer dockerClient.AssertExpectations(t)
+
 	err := RunChecks(
 		reporter,
 		e.dir,
@@ -180,6 +189,7 @@ func TestRunChecks(t *testing.T) {
 		checks.WithMatchRule(checks.IsRuleID("cis-docker-1")),
 		checks.WithHostname("the-host"),
 		checks.WithHostRootMount(e.dir),
+		checks.WithDockerClient(dockerClient),
 	)
 	assert.NoError(err)
 }
@@ -198,7 +208,7 @@ func TestRunChecksFromFile(t *testing.T) {
 				eventMatch{
 					ruleID:       "cis-kubernetes-1",
 					resourceID:   "the-host",
-					resourceType: "kubernetesCluster",
+					resourceType: "docker",
 					result:       "failed",
 					path:         "/files/kube-apiserver.yaml",
 					permissions:  0644,
@@ -209,11 +219,16 @@ func TestRunChecksFromFile(t *testing.T) {
 
 	defer reporter.AssertExpectations(t)
 
+	dockerClient := &mocks.DockerClient{}
+	dockerClient.On("Close").Return(nil).Once()
+	defer dockerClient.AssertExpectations(t)
+
 	err := RunChecksFromFile(
 		reporter,
 		filepath.Join(e.dir, "cis-kubernetes.yaml"),
 		checks.WithHostname("the-host"),
 		checks.WithHostRootMount(e.dir),
+		checks.WithDockerClient(dockerClient),
 	)
 	assert.NoError(err)
 }

--- a/pkg/compliance/agent/testdata/configs/cis-kubernetes.yaml
+++ b/pkg/compliance/agent/testdata/configs/cis-kubernetes.yaml
@@ -4,7 +4,8 @@ version: 1.5.0
 rules:
 - id: cis-kubernetes-1
   scope:
-    kubernetesCluster: true
+    # Hack for now to avoid triggering kubernetesCluster or kubernetesNode rule scope matcher
+    docker: true
   resources:
   - file:
       path: /files/kube-apiserver.yaml

--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -245,19 +245,25 @@ func (b *builder) ChecksFromFile(file string, onCheck compliance.CheckVisitor) e
 			continue
 		}
 
+		if len(r.Resources) == 0 {
+			log.Debugf("%s/%s: skipping rule %s - no configured resources", suite.Meta.Name, suite.Meta.Version, r.ID)
+			continue
+		}
+
 		log.Debugf("%s/%s: loading rule %s", suite.Meta.Name, suite.Meta.Version, r.ID)
 		check, err := b.CheckFromRule(&suite.Meta, &r)
 
 		if err != nil {
-			if err == ErrRuleDoesNotApply {
-				continue
+			if err != ErrRuleDoesNotApply {
+				log.Warnf("%s/%s: failed to load rule %s: %v", suite.Meta.Name, suite.Meta.Version, r.ID, err)
 			}
-			return err
+			continue
 		}
 
 		log.Debugf("%s/%s: init check %s", suite.Meta.Name, suite.Meta.Version, check.ID())
 		err = onCheck(check)
 		if err != nil {
+			log.Errorf("%s/%s: onCheck failed %s", suite.Meta.Name, suite.Meta.Version, check.ID())
 			return err
 		}
 	}

--- a/pkg/compliance/checks/checkable.go
+++ b/pkg/compliance/checks/checkable.go
@@ -36,5 +36,5 @@ func (list checkableList) check(env env.Env) (*report, error) {
 			continue
 		}
 	}
-	return result, nil
+	return result, err
 }

--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -39,7 +39,7 @@ func checkFile(e env.Env, ruleID string, res compliance.Resource, expr *eval.Ite
 
 	file := res.File
 
-	log.Debugf("%s: running file check: %v", ruleID, file)
+	log.Debugf("%s: running file check for %q", ruleID, file.Path)
 
 	path, err := resolvePath(e, file.Path)
 	if err != nil {

--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -58,7 +58,7 @@ func checkFile(e env.Env, ruleID string, res compliance.Resource, expr *eval.Ite
 		fi, err := os.Stat(normalizedPath)
 		if err != nil {
 			// This is not a failure unless we don't have any paths to act on
-			log.Debugf("%s: file check failed to stat %s", ruleID, path)
+			log.Debugf("%s: file check failed to stat %s [%s]", ruleID, normalizedPath, path)
 			continue
 		}
 
@@ -87,7 +87,7 @@ func checkFile(e env.Env, ruleID string, res compliance.Resource, expr *eval.Ite
 	}
 
 	if len(instances) == 0 {
-		return nil, fmt.Errorf("no files found for file check")
+		return nil, fmt.Errorf("no files found for file check %q", file.Path)
 	}
 
 	it := &instanceIterator{

--- a/pkg/compliance/checks/helpers.go
+++ b/pkg/compliance/checks/helpers.go
@@ -70,7 +70,7 @@ func evalGoTemplate(s string, obj interface{}) string {
 
 	b := &strings.Builder{}
 	if err := tmpl.Execute(b, obj); err != nil {
-		log.Warnf("failed to execute template %q: %v", s, err)
+		log.Tracef("failed to execute template %q: %v", s, err)
 		return ""
 	}
 	return b.String()

--- a/pkg/compliance/checks/resource_check.go
+++ b/pkg/compliance/checks/resource_check.go
@@ -62,6 +62,7 @@ func newResourceCheck(env env.Env, ruleID string, resource compliance.Resource) 
 	}
 
 	return &resourceCheck{
+		ruleID:     ruleID,
 		resource:   resource,
 		expression: expression,
 		checkFn:    checkFn,

--- a/pkg/compliance/resource.go
+++ b/pkg/compliance/resource.go
@@ -81,7 +81,7 @@ type KubernetesResource struct {
 	Kind      string `yaml:"kind"`
 	Version   string `yaml:"version,omitempty"`
 	Group     string `yaml:"group"`
-	Namespace string `yaml:"namespace"`
+	Namespace string `yaml:"namespace,omitempty"`
 
 	// A selector to restrict the list of returned objects by their labels.
 	// Defaults to everything.
@@ -101,7 +101,7 @@ func (kr *KubernetesResource) String() string {
 // KubernetesAPIRequest defines it check applies to a single object or a list
 type KubernetesAPIRequest struct {
 	Verb         string `yaml:"verb"`
-	ResourceName string `yaml:"resourceName"`
+	ResourceName string `yaml:"resourceName,omitempty"`
 }
 
 // Group describes a group membership resource

--- a/pkg/compliance/rule.go
+++ b/pkg/compliance/rule.go
@@ -25,9 +25,9 @@ const (
 
 // Scope defines when a rule can be run based on observed properties of the environment
 type Scope struct {
-	Docker            bool `yaml:"docker"`
-	KubernetesNode    bool `yaml:"kubernetesNode"`
-	KubernetesCluster bool `yaml:"kubernetesCluster"`
+	Docker            bool `yaml:"docker,omitempty"`
+	KubernetesNode    bool `yaml:"kubernetesNode,omitempty"`
+	KubernetesCluster bool `yaml:"kubernetesCluster,omitempty"`
 }
 
 // HostSelector allows to activate/deactivate dynamically based on host properties


### PR DESCRIPTION
### What does this PR do?

- Properly return errors from `checkable.Check`.
- Properly handle rule scope for `docker` and `kubernetesCluster` when running on a node.
- Missing initialization of `ruleID` in `resourceCheck`.
- Close `builder` in `RunChecks` and `RunChecksFromFIle`.
- Use `omitempty` for optional fields in the yaml rule schema.

### Motivation

Working compliance checks.
