### PR TITLE
[KSMv2] Job and CronJob metric transformers

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
@@ -9,9 +9,13 @@ package cluster
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -28,11 +32,11 @@ var (
 		"kube_pod_status_phase":                       func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
 		"kube_pod_container_status_waiting_reason":    func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
 		"kube_pod_container_status_terminated_reason": func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
-		"kube_cronjob_next_schedule_time":             func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
-		"kube_job_complete":                           func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
-		"kube_job_failed":                             func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
-		"kube_job_status_failed":                      func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
-		"kube_job_status_succeeded":                   func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_cronjob_next_schedule_time":             cronJobNextScheduleTransformer,
+		"kube_job_complete":                           jobCompleteTransformer,
+		"kube_job_failed":                             jobFailedTransformer,
+		"kube_job_status_failed":                      jobStatusFailedTransformer,
+		"kube_job_status_succeeded":                   jobStatusSucceededTransformer,
 		"kube_node_status_condition":                  func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
 		"kube_node_spec_unschedulable":                func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
 		"kube_resourcequota":                          resourcequotaTransformer,
@@ -41,6 +45,89 @@ var (
 		"kube_service_spec_type":                      func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
 	}
 )
+
+// now allows testing
+var now = time.Now
+
+// cronJobNextScheduleTransformer sends a service check to alert if the cronjob's next schedule is in the past
+func cronJobNextScheduleTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {
+	message := ""
+	var status metrics.ServiceCheckStatus
+	timeDiff := int64(metric.Val) - now().Unix()
+	if timeDiff >= 0 {
+		status = metrics.ServiceCheckOK
+	} else {
+		status = metrics.ServiceCheckCritical
+		message = fmt.Sprintf("The cron job check scheduled at %s is %d seconds late", time.Unix(int64(metric.Val), 0).UTC(), -timeDiff)
+	}
+	s.ServiceCheck(ksmMetricPrefix+"cronjob.on_schedule_check", status, "", tags, message)
+}
+
+// jobCompleteTransformer sends a service check based on kube_job_complete
+func jobCompleteTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {
+	jobServiceCheck(s, metric, metrics.ServiceCheckOK, tags)
+}
+
+// jobFailedTransformer sends a service check based on kube_job_failed
+func jobFailedTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {
+	jobServiceCheck(s, metric, metrics.ServiceCheckCritical, tags)
+}
+
+// jobTimestampPattern extracts the timestamp in the job name label
+// Used by trimJobTag to remove the timestamp from the job tag
+// Expected job tag format: <job>-<timestamp>
+var jobTimestampPattern = regexp.MustCompile(`(-\d{4,10}$)`)
+
+// trimJobTag removes the timestamp from the job name tag
+// Expected job tag format: <job>-<timestamp>
+func trimJobTag(tag string) string {
+	return jobTimestampPattern.ReplaceAllString(tag, "")
+}
+
+// validateJob detects active jobs and strips the timestamp from the job_name tag
+func validateJob(val float64, tags []string) ([]string, bool) {
+	if val != 1.0 {
+		// Only consider active metrics
+		return nil, false
+	}
+
+	for i, tag := range tags {
+		split := strings.Split(tag, ":")
+		if len(split) == 2 && split[0] == "job" || split[0] == "job_name" {
+			// Trim the timestamp suffix to avoid high cardinality
+			tags[i] = fmt.Sprintf("%s:%s", split[0], trimJobTag(split[1]))
+			return tags, true
+		}
+	}
+
+	return tags, true
+}
+
+// jobServiceCheck sends a service check for jobs
+func jobServiceCheck(s aggregator.Sender, metric ksmstore.DDMetric, status metrics.ServiceCheckStatus, tags []string) {
+	if strippedTags, valid := validateJob(metric.Val, tags); valid {
+		s.ServiceCheck(ksmMetricPrefix+"job.complete", status, "", strippedTags, "")
+	}
+}
+
+// jobStatusSucceededTransformer sends a metric based on kube_job_status_succeeded
+func jobStatusSucceededTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {
+	jobMetric(s, metric, ksmMetricPrefix+"job.succeeded", tags)
+}
+
+// jobStatusFailedTransformer sends a metric based on kube_job_status_failed
+func jobStatusFailedTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {
+	jobMetric(s, metric, ksmMetricPrefix+"job.failed", tags)
+}
+
+// jobMetric sends a gauge for job status
+func jobMetric(s aggregator.Sender, metric ksmstore.DDMetric, metricName string, tags []string) {
+	if strippedTags, valid := validateJob(metric.Val, tags); valid {
+		// TODO: Many problems have been reported about job metrics in the v1 check
+		// This is different compared to what we do in the v1 check already but let's investigate more
+		s.Gauge(metricName, 1, "", strippedTags)
+	}
+}
 
 // resourcequotaTransformer generates dedicated metrics per resource per type from the kube_resourcequota metric
 func resourcequotaTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {

--- a/pkg/collector/corechecks/cluster/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_transformers_test.go
@@ -9,9 +9,11 @@ package cluster
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 func Test_resourcequotaTransformer(t *testing.T) {
@@ -106,6 +108,423 @@ func Test_resourcequotaTransformer(t *testing.T) {
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
 			resourcequotaTransformer(s, tt.args.name, tt.args.metric, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, "", tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}
+
+func Test_cronJobNextScheduleTransformer(t *testing.T) {
+	type args struct {
+		name   string
+		metric ksmstore.DDMetric
+		tags   []string
+		now    func() time.Time
+	}
+	type serviceCheck struct {
+		name    string
+		status  metrics.ServiceCheckStatus
+		tags    []string
+		message string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *serviceCheck
+	}{
+		{
+			name: "On schedule",
+			args: args{
+				name: "kube_cronjob_next_schedule_time",
+				metric: ksmstore.DDMetric{
+					Val: 1595501615,
+					Labels: map[string]string{
+						"cronjob":   "foo",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"cronjob:foo", "namespace:default"},
+				now:  func() time.Time { return time.Unix(int64(1595501615-2), 0) },
+			},
+			expected: &serviceCheck{
+				name:    "kubernetes_state.cronjob.on_schedule_check",
+				status:  metrics.ServiceCheckOK,
+				tags:    []string{"cronjob:foo", "namespace:default"},
+				message: "",
+			},
+		},
+		{
+			name: "Late",
+			args: args{
+				name: "kube_cronjob_next_schedule_time",
+				metric: ksmstore.DDMetric{
+					Val: 1595501615,
+					Labels: map[string]string{
+						"cronjob":   "foo",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"cronjob:foo", "namespace:default"},
+				now:  func() time.Time { return time.Unix(int64(1595501615+2), 0) },
+			},
+			expected: &serviceCheck{
+				name:    "kubernetes_state.cronjob.on_schedule_check",
+				status:  metrics.ServiceCheckCritical,
+				tags:    []string{"cronjob:foo", "namespace:default"},
+				message: "The cron job check scheduled at 2020-07-23 10:53:35 +0000 UTC is 2 seconds late",
+			},
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			now = tt.args.now
+			cronJobNextScheduleTransformer(s, tt.args.name, tt.args.metric, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertServiceCheck(t, tt.expected.name, tt.expected.status, "", tt.expected.tags, tt.expected.message)
+				s.AssertNumberOfCalls(t, "ServiceCheck", 1)
+			} else {
+				s.AssertNotCalled(t, "ServiceCheck")
+			}
+		})
+	}
+}
+
+func Test_jobCompleteTransformer(t *testing.T) {
+	type args struct {
+		name   string
+		metric ksmstore.DDMetric
+		tags   []string
+	}
+	type serviceCheck struct {
+		name   string
+		status metrics.ServiceCheckStatus
+		tags   []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *serviceCheck
+	}{
+		{
+			name: "nominal case, job_name tag",
+			args: args{
+				name: "kube_job_complete",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"job_name":  "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job_name:foo-1509998340", "namespace:default"},
+			},
+			expected: &serviceCheck{
+				name:   "kubernetes_state.job.complete",
+				status: metrics.ServiceCheckOK,
+				tags:   []string{"job_name:foo", "namespace:default"},
+			},
+		},
+		{
+			name: "nominal case, job tag",
+			args: args{
+				name: "kube_job_complete",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"job":       "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job:foo-1509998340", "namespace:default"},
+			},
+			expected: &serviceCheck{
+				name:   "kubernetes_state.job.complete",
+				status: metrics.ServiceCheckOK,
+				tags:   []string{"job:foo", "namespace:default"},
+			},
+		},
+		{
+			name: "inactive",
+			args: args{
+				name: "kube_job_complete",
+				metric: ksmstore.DDMetric{
+					Val: 0,
+					Labels: map[string]string{
+						"job_name":  "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job_name:foo-1509998340", "namespace:default"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			jobCompleteTransformer(s, tt.args.name, tt.args.metric, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertServiceCheck(t, tt.expected.name, tt.expected.status, "", tt.expected.tags, "")
+				s.AssertNumberOfCalls(t, "ServiceCheck", 1)
+			} else {
+				s.AssertNotCalled(t, "ServiceCheck")
+			}
+		})
+	}
+}
+
+func Test_jobFailedTransformer(t *testing.T) {
+	type args struct {
+		name   string
+		metric ksmstore.DDMetric
+		tags   []string
+	}
+	type serviceCheck struct {
+		name   string
+		status metrics.ServiceCheckStatus
+		tags   []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *serviceCheck
+	}{
+		{
+			name: "nominal case, job_name tag",
+			args: args{
+				name: "kube_job_failed",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"job_name":  "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job_name:foo-1509998340", "namespace:default"},
+			},
+			expected: &serviceCheck{
+				name:   "kubernetes_state.job.complete",
+				status: metrics.ServiceCheckCritical,
+				tags:   []string{"job_name:foo", "namespace:default"},
+			},
+		},
+		{
+			name: "nominal case, job tag",
+			args: args{
+				name: "kube_job_failed",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"job":       "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job:foo-1509998340", "namespace:default"},
+			},
+			expected: &serviceCheck{
+				name:   "kubernetes_state.job.complete",
+				status: metrics.ServiceCheckCritical,
+				tags:   []string{"job:foo", "namespace:default"},
+			},
+		},
+		{
+			name: "inactive",
+			args: args{
+				name: "kube_job_failed",
+				metric: ksmstore.DDMetric{
+					Val: 0,
+					Labels: map[string]string{
+						"job_name":  "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job_name:foo-1509998340", "namespace:default"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			jobFailedTransformer(s, tt.args.name, tt.args.metric, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertServiceCheck(t, tt.expected.name, tt.expected.status, "", tt.expected.tags, "")
+				s.AssertNumberOfCalls(t, "ServiceCheck", 1)
+			} else {
+				s.AssertNotCalled(t, "ServiceCheck")
+			}
+		})
+	}
+}
+
+func Test_jobStatusSucceededTransformer(t *testing.T) {
+	type args struct {
+		name   string
+		metric ksmstore.DDMetric
+		tags   []string
+	}
+	type metricsExpected struct {
+		val  float64
+		name string
+		tags []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "nominal case, job_name tag",
+			args: args{
+				name: "kube_job_status_succeeded",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"job_name":  "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job_name:foo-1509998340", "namespace:default"},
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.job.succeeded",
+				val:  1,
+				tags: []string{"job_name:foo", "namespace:default"},
+			},
+		},
+		{
+			name: "nominal case, job tag",
+			args: args{
+				name: "kube_job_status_succeeded",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"job":       "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job:foo-1509998340", "namespace:default"},
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.job.succeeded",
+				val:  1,
+				tags: []string{"job:foo", "namespace:default"},
+			},
+		},
+		{
+			name: "inactive",
+			args: args{
+				name: "kube_job_status_succeeded",
+				metric: ksmstore.DDMetric{
+					Val: 0,
+					Labels: map[string]string{
+						"job_name":  "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job_name:foo-1509998340", "namespace:default"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			jobStatusSucceededTransformer(s, tt.args.name, tt.args.metric, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, "", tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}
+
+func Test_jobStatusFailedTransformer(t *testing.T) {
+	type args struct {
+		name   string
+		metric ksmstore.DDMetric
+		tags   []string
+	}
+	type metricsExpected struct {
+		val  float64
+		name string
+		tags []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "nominal case, job_name tag",
+			args: args{
+				name: "kube_job_status_failed",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"job_name":  "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job_name:foo-1509998340", "namespace:default"},
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.job.failed",
+				val:  1,
+				tags: []string{"job_name:foo", "namespace:default"},
+			},
+		},
+		{
+			name: "nominal case, job tag",
+			args: args{
+				name: "kube_job_status_failed",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"job":       "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job:foo-1509998340", "namespace:default"},
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.job.failed",
+				val:  1,
+				tags: []string{"job:foo", "namespace:default"},
+			},
+		},
+		{
+			name: "inactive",
+			args: args{
+				name: "kube_job_status_failed",
+				metric: ksmstore.DDMetric{
+					Val: 0,
+					Labels: map[string]string{
+						"job_name":  "foo-1509998340",
+						"namespace": "default",
+					},
+				},
+				tags: []string{"job_name:foo-1509998340", "namespace:default"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			jobStatusFailedTransformer(s, tt.args.name, tt.args.metric, tt.args.tags)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, "", tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)


### PR DESCRIPTION
### What does this PR do?

Implement the following metrics transformers:
- `kube_cronjob_next_schedule_time`
- `kube_job_complete`
- `kube_job_failed`
- `kube_job_status_failed`
- `kube_job_status_succeeded`

### Motivation

Feature parity

### Additional Notes

The following transformers were problematic in the KSM check v1, further investigation will be done later
- `kube_job_status_failed`
- `kube_job_status_succeeded`
