### PR TITLE
[compliance] Refactor rule scope and host selector

### DIFF
--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -102,7 +102,7 @@ func startCompliance(stopper restart.Stopper, apiCl *apiserver.APIClient) error 
 		checks.WithInterval(checkInterval),
 		checks.WithHostname(hostname),
 		checks.WithMatchRule(func(rule *compliance.Rule) bool {
-			return rule.Scope.KubernetesCluster
+			return rule.Scope.Includes(compliance.KubernetesClusterScope)
 		}),
 		checks.WithKubernetesClient(apiCl.DynamicCl),
 	)

--- a/pkg/compliance/agent/node_labels.go
+++ b/pkg/compliance/agent/node_labels.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package agent
+
+import (
+	"math"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/cenkalti/backoff"
+)
+
+const (
+	nodeLabelsCheckInitialInterval = time.Second
+	nodeLabelsCheckMaxInterval     = 10 * time.Second
+	nodeLabelsCheckMultiplier      = 2.0
+	nodeLabelsCheckMaxElapsedTime  = 1 * time.Minute
+)
+
+// WaitGetNodeLabels waits for node labels to become available using a backoff retrier
+func WaitGetNodeLabels() (map[string]string, error) {
+	fetcher := &labelsFetcher{}
+	exp := &backoff.ExponentialBackOff{
+		InitialInterval:     nodeLabelsCheckInitialInterval,
+		RandomizationFactor: 0,
+		Multiplier:          nodeLabelsCheckMultiplier,
+		MaxInterval:         nodeLabelsCheckMaxInterval,
+		MaxElapsedTime:      nodeLabelsCheckMaxElapsedTime,
+		Clock:               backoff.SystemClock,
+	}
+	exp.Reset()
+	err := backoff.RetryNotify(fetcher.fetch, exp, notifyFetchNodeLabels())
+	return fetcher.nodeLabels, err
+}
+
+type labelsFetcher struct {
+	nodeLabels map[string]string
+}
+
+func (f *labelsFetcher) fetch() (err error) {
+	f.nodeLabels, err = hostinfo.GetNodeLabels()
+	return
+}
+
+func notifyFetchNodeLabels() backoff.Notify {
+	attempt := 0
+	return func(err error, delay time.Duration) {
+		attempt++
+		mins := int(delay.Minutes())
+		secs := int(math.Mod(delay.Seconds(), 60))
+		log.Warnf("Failed to get node labels (attempt=%d): will retry in %dm%ds: %v", attempt, mins, secs, err)
+	}
+}

--- a/pkg/compliance/agent/testdata/configs/cis-docker.yaml
+++ b/pkg/compliance/agent/testdata/configs/cis-docker.yaml
@@ -4,10 +4,10 @@ version: 1.2.0
 rules:
 - id: cis-docker-1
   scope:
-    docker: true
+    - docker
   resources:
-  - file:
-      path: /files/daemon.json
-    condition: file.permissions == 0644
+    - file:
+        path: /files/daemon.json
+      condition: file.permissions == 0644
 
 

--- a/pkg/compliance/agent/testdata/configs/cis-kubernetes.yaml
+++ b/pkg/compliance/agent/testdata/configs/cis-kubernetes.yaml
@@ -4,9 +4,9 @@ version: 1.5.0
 rules:
 - id: cis-kubernetes-1
   scope:
-    # Hack for now to avoid triggering kubernetesCluster or kubernetesNode rule scope matcher
-    docker: true
+    - kubernetesNode
+  hostSelector: node.label("kubernetes.io/role") in ["worker"]
   resources:
-  - file:
-      path: /files/kube-apiserver.yaml
-    condition: file.permissions == 0647
+    - file:
+        path: /files/kube-apiserver.yaml
+      condition: file.permissions == 0647

--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -155,6 +155,18 @@ func MayFail(o BuilderOption) BuilderOption {
 	}
 }
 
+// WithNodeLabels configures a builder to use specified Kubernetes node labels
+func WithNodeLabels(nodeLabels map[string]string) BuilderOption {
+	return func(b *builder) error {
+		b.nodeLabels = map[string]string{}
+		for k, v := range nodeLabels {
+			k, v := hostinfo.LabelPreprocessor(k, v)
+			b.nodeLabels[k] = v
+		}
+		return nil
+	}
+}
+
 // IsFramework matches a compliance suite by the name of the framework
 func IsFramework(framework string) SuiteMatcher {
 	return func(s *compliance.SuiteMeta) bool {
@@ -200,6 +212,7 @@ type builder struct {
 	hostname     string
 	pathMapper   *pathMapper
 	etcGroupPath string
+	nodeLabels   map[string]string
 
 	suiteMatcher SuiteMatcher
 	ruleMatcher  RuleMatcher
@@ -269,7 +282,7 @@ func (b *builder) ChecksFromFile(file string, onCheck compliance.CheckVisitor) e
 }
 
 func (b *builder) CheckFromRule(meta *compliance.SuiteMeta, rule *compliance.Rule) (check.Check, error) {
-	ruleScope, err := b.getRuleScope(meta, rule)
+	ruleScope, err := getRuleScope(meta, rule)
 	if err != nil {
 		return nil, err
 	}
@@ -287,20 +300,20 @@ func (b *builder) CheckFromRule(meta *compliance.SuiteMeta, rule *compliance.Rul
 	return b.newCheck(meta, ruleScope, rule), nil
 }
 
-func (b *builder) getRuleScope(meta *compliance.SuiteMeta, rule *compliance.Rule) (string, error) {
+func getRuleScope(meta *compliance.SuiteMeta, rule *compliance.Rule) (compliance.RuleScope, error) {
 	switch {
-	case rule.Scope.Docker:
+	case rule.Scope.Includes(compliance.DockerScope):
 		return compliance.DockerScope, nil
-	case rule.Scope.KubernetesNode:
+	case rule.Scope.Includes(compliance.KubernetesNodeScope):
 		return compliance.KubernetesNodeScope, nil
-	case rule.Scope.KubernetesCluster:
+	case rule.Scope.Includes(compliance.KubernetesClusterScope):
 		return compliance.KubernetesClusterScope, nil
 	default:
 		return "", ErrRuleScopeNotSupported
 	}
 }
 
-func (b *builder) hostMatcher(scope string, rule *compliance.Rule) (bool, error) {
+func (b *builder) hostMatcher(scope compliance.RuleScope, rule *compliance.Rule) (bool, error) {
 	switch scope {
 	case compliance.DockerScope:
 		if b.dockerClient == nil {
@@ -314,12 +327,7 @@ func (b *builder) hostMatcher(scope string, rule *compliance.Rule) (bool, error)
 		}
 	case compliance.KubernetesNodeScope:
 		if config.IsKubernetes() {
-			labels, err := hostinfo.GetNodeLabels()
-			if err != nil {
-				return false, err
-			}
-
-			return b.isKubernetesNodeEligible(rule.HostSelector, labels), nil
+			return b.isKubernetesNodeEligible(rule.HostSelector)
 		}
 		log.Infof("rule %s skipped - not running on a Kubernetes node", rule.ID)
 		return false, nil
@@ -328,44 +336,74 @@ func (b *builder) hostMatcher(scope string, rule *compliance.Rule) (bool, error)
 	return true, nil
 }
 
-func (b *builder) isKubernetesNodeEligible(hostSelector *compliance.HostSelector, nodeLabels map[string]string) bool {
-	if hostSelector == nil {
-		return true
+func (b *builder) isKubernetesNodeEligible(hostSelector string) (bool, error) {
+	if hostSelector == "" {
+		return true, nil
 	}
 
-	// No filtering, no need to fetch node labels
-	if len(hostSelector.KubernetesNodeLabels) == 0 && len(hostSelector.KubernetesNodeRole) == 0 {
-		return true
+	expr, err := eval.ParseExpression(hostSelector)
+	if err != nil {
+		return false, err
 	}
 
-	// Check selector
-	for _, selector := range hostSelector.KubernetesNodeLabels {
-		value, found := nodeLabels[selector.Label]
-		if !found {
-			return false
-		}
+	nodeInstance := &eval.Instance{
+		Functions: eval.FunctionMap{
+			"node.hasLabel": b.nodeHasLabel,
+			"node.label":    b.nodeLabel,
+		},
 
-		if value != selector.Value {
-			return false
-		}
+		Vars: eval.VarMap{
+			"node.labels": b.nodeLabelKeys(),
+		},
 	}
 
-	if len(hostSelector.KubernetesNodeRole) > 0 {
-		// Specific node role matching as multiple syntax exists
-		for key, value := range nodeLabels {
-			key, value = hostinfo.LabelPreprocessor(key, value)
-			if key == hostinfo.NormalizedRoleLabel && value == hostSelector.KubernetesNodeRole {
-				return true
-			}
-		}
-
-		return false
+	result, err := expr.Evaluate(nodeInstance)
+	if err != nil {
+		return false, err
 	}
 
-	return true
+	eligible, ok := result.(bool)
+	if !ok {
+		return false, fmt.Errorf("hostSelector %q does not evaluate to a boolean value", hostSelector)
+	}
+
+	return eligible, nil
 }
 
-func (b *builder) newCheck(meta *compliance.SuiteMeta, ruleScope string, rule *compliance.Rule) *complianceCheck {
+func (b *builder) getNodeLabel(args ...interface{}) (string, bool, error) {
+	if len(args) == 0 {
+		return "", false, errors.New(`expecting one argument for label`)
+	}
+	label, ok := args[0].(string)
+	if !ok {
+		return "", false, fmt.Errorf(`expecting string value for label argument`)
+	}
+	if b.nodeLabels == nil {
+		return "", false, nil
+	}
+	v, ok := b.nodeLabels[label]
+	return v, ok, nil
+}
+
+func (b *builder) nodeHasLabel(_ *eval.Instance, args ...interface{}) (interface{}, error) {
+	_, ok, err := b.getNodeLabel(args...)
+	return ok, err
+}
+
+func (b *builder) nodeLabel(_ *eval.Instance, args ...interface{}) (interface{}, error) {
+	v, _, err := b.getNodeLabel(args...)
+	return v, err
+}
+
+func (b *builder) nodeLabelKeys() []string {
+	var keys []string
+	for k := range b.nodeLabels {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (b *builder) newCheck(meta *compliance.SuiteMeta, ruleScope compliance.RuleScope, rule *compliance.Rule) *complianceCheck {
 	checkable, err := newResourceCheckList(b, rule.ID, rule.Resources)
 
 	if err != nil {
@@ -384,7 +422,8 @@ func (b *builder) newCheck(meta *compliance.SuiteMeta, ruleScope string, rule *c
 		suiteName: meta.Name,
 		version:   meta.Version,
 
-		resourceType: ruleScope,
+		// For now we are using rule scope (e.g. docker, kubernetesNode) as resource type
+		resourceType: string(ruleScope),
 		resourceID:   b.hostname,
 		configError:  err,
 		checkable:    checkable,

--- a/pkg/compliance/checks/builder_test.go
+++ b/pkg/compliance/checks/builder_test.go
@@ -8,9 +8,9 @@ package checks
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
 	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
@@ -21,18 +21,20 @@ import (
 
 func TestKubernetesNodeEligible(t *testing.T) {
 	tests := []struct {
-		selector       *compliance.HostSelector
+		name           string
+		selector       string
 		labels         map[string]string
 		expectEligible bool
+		expectError    error
 	}{
 		{
-			selector:       nil,
+			name:           "empty selector",
+			selector:       "",
 			expectEligible: true,
 		},
 		{
-			selector: &compliance.HostSelector{
-				KubernetesNodeRole: "master",
-			},
+			name:     "role only",
+			selector: `node.label("kubernetes.io/role") in ["master"]`,
 			labels: map[string]string{
 				"node-role.kubernetes.io/master": "",
 				"foo":                            "bar",
@@ -40,15 +42,8 @@ func TestKubernetesNodeEligible(t *testing.T) {
 			expectEligible: true,
 		},
 		{
-			selector: &compliance.HostSelector{
-				KubernetesNodeRole: "master",
-				KubernetesNodeLabels: []compliance.KubeNodeSelector{
-					{
-						Label: "foo",
-						Value: "bar",
-					},
-				},
-			},
+			name:     "role and another label",
+			selector: `node.label("kubernetes.io/role") == "master" && node.label("foo") == "bar"`,
 			labels: map[string]string{
 				"node-role.kubernetes.io/master": "",
 				"foo":                            "bar",
@@ -56,26 +51,60 @@ func TestKubernetesNodeEligible(t *testing.T) {
 			expectEligible: true,
 		},
 		{
-			selector: &compliance.HostSelector{
-				KubernetesNodeRole: "master",
-				KubernetesNodeLabels: []compliance.KubeNodeSelector{
-					{
-						Label: "foo",
-						Value: "bar",
-					},
-				},
-			},
+			name:     "role and missing label",
+			selector: `node.label("kubernetes.io/role") == "master" && node.label("foo") == "bar"`,
 			labels: map[string]string{
 				"node-role.kubernetes.io/master": "",
 				"foo":                            "bazbar",
 			},
 			expectEligible: false,
 		},
+		{
+			name:     "role and label name",
+			selector: `node.label("kubernetes.io/role") == "master" && "foo" in node.labels`,
+			labels: map[string]string{
+				"node-role.kubernetes.io/master": "",
+				"foo":                            "bazbar",
+			},
+			expectEligible: true,
+		},
+		{
+			name:     "not boolean",
+			selector: `node.label("kubernetes.io/role")`,
+			labels: map[string]string{
+				"node-role.kubernetes.io/master": "",
+				"foo":                            "bazbar",
+			},
+			expectEligible: false,
+			expectError:    errors.New(`hostSelector "node.label(\"kubernetes.io/role\")" does not evaluate to a boolean value`),
+		},
+		{
+			name:     "bad expression",
+			selector: `¯\_(ツ)_/¯`,
+			labels: map[string]string{
+				"node-role.kubernetes.io/master": "",
+				"foo":                            "bazbar",
+			},
+			expectEligible: false,
+			expectError:    errors.New(`1:1: no match found for ¯`),
+		},
+		{
+			name:           "nil labels",
+			selector:       `node.label("kubernetes.io/role") != "master" && "foo" in node.labels`,
+			expectEligible: false,
+		},
 	}
 
 	for _, tt := range tests {
-		builder := builder{}
-		assert.Equal(t, tt.expectEligible, builder.isKubernetesNodeEligible(tt.selector, tt.labels))
+		t.Run(tt.name, func(t *testing.T) {
+			builder := &builder{}
+			WithNodeLabels(tt.labels)(builder)
+			eligible, err := builder.isKubernetesNodeEligible(tt.selector)
+			assert.Equal(t, tt.expectEligible, eligible)
+			if tt.expectError != nil {
+				assert.EqualError(t, err, tt.expectError.Error())
+			}
+		})
 	}
 }
 

--- a/pkg/compliance/rule.go
+++ b/pkg/compliance/rule.go
@@ -9,35 +9,32 @@ package compliance
 // Rule defines a rule in a compliance config
 type Rule struct {
 	ID           string        `yaml:"id"`
-	Scope        Scope         `yaml:"scope"`
-	HostSelector *HostSelector `yaml:"hostSelector,omitempty"`
+	Scope        RuleScopeList `yaml:"scope,omitempty"`
+	HostSelector string        `yaml:"hostSelector,omitempty"`
 	Resources    []Resource    `yaml:"resources,omitempty"`
 }
 
+// RuleScope defines scope for applicability of a rule
+type RuleScope string
+
 const (
 	// DockerScope const
-	DockerScope string = "docker"
+	DockerScope RuleScope = "docker"
 	// KubernetesNodeScope const
-	KubernetesNodeScope string = "kubernetesNode"
+	KubernetesNodeScope RuleScope = "kubernetesNode"
 	// KubernetesClusterScope const
-	KubernetesClusterScope string = "kubernetesCluster"
+	KubernetesClusterScope RuleScope = "kubernetesCluster"
 )
 
-// Scope defines when a rule can be run based on observed properties of the environment
-type Scope struct {
-	Docker            bool `yaml:"docker,omitempty"`
-	KubernetesNode    bool `yaml:"kubernetesNode,omitempty"`
-	KubernetesCluster bool `yaml:"kubernetesCluster,omitempty"`
-}
+// RuleScopeList is a set of RuleScopes
+type RuleScopeList []RuleScope
 
-// HostSelector allows to activate/deactivate dynamically based on host properties
-type HostSelector struct {
-	KubernetesNodeLabels []KubeNodeSelector `yaml:"kubernetesRole,omitempty"`
-	KubernetesNodeRole   string             `yaml:"kubernetesNodeRole,omitempty"`
-}
-
-// KubeNodeSelector defines selector for a Kubernetes node
-type KubeNodeSelector struct {
-	Label string `yaml:"label,omitempty"`
-	Value string `yaml:"value,omitempty"`
+// Includes returns true if RuleScopeList includes the specified RuleScope value
+func (l RuleScopeList) Includes(ruleScope RuleScope) bool {
+	for _, s := range l {
+		if s == ruleScope {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/compliance/suite_test.go
+++ b/pkg/compliance/suite_test.go
@@ -20,10 +20,9 @@ func TestParseSuite(t *testing.T) {
 		},
 		Rules: []Rule{
 			{
-				ID: "cis-docker-1",
-				Scope: Scope{
-					Docker: true,
-				},
+				ID:           "cis-docker-1",
+				Scope:        RuleScopeList{DockerScope},
+				HostSelector: `"foo" in node.labels`,
 				Resources: []Resource{
 					{
 						File: &File{

--- a/pkg/compliance/testdata/cis-docker.yaml
+++ b/pkg/compliance/testdata/cis-docker.yaml
@@ -4,8 +4,9 @@ version: 1.2.0
 rules:
 - id: cis-docker-1
   scope:
-    docker: true
+    - docker
+  hostSelector: '"foo" in node.labels'
   resources:
-  - file:
-      path: /etc/docker/daemon.json
-    condition: file.permissions == 0644
+    - file:
+        path: /etc/docker/daemon.json
+      condition: file.permissions == 0644


### PR DESCRIPTION
### What does this PR do?

- Change `Rule.Scope` to be a list of allowed scope values instead of booleans
- Change `Rule.HostSelector` to an expression string that can be evaluated against node labels and other properties in the future.
- Wait for node labels to become available before loading rules.
- Refactor tests in `pkg/compliance/agent` to validate rule scope and host selector.

### Motivation

Simplify working with scope and host selector in compliance rules.

### Describe your test plan

Configuring a compliance rule using scope and host selector like so to validate:
```
- id: cis-kubernetes-1
  scope:
    - kubernetesNode
  hostSelector: node.label("kubernetes.io/role") not in ["master", "etcd"]
```
