### PR TITLE
Add special built-in variable to allow applying iterable functions without call

### DIFF
--- a/pkg/compliance/eval/eval.go
+++ b/pkg/compliance/eval/eval.go
@@ -52,6 +52,12 @@ const (
 	countFn = "count"
 )
 
+var (
+	builtInVars VarMap = VarMap{
+		"_": true,
+	}
+)
+
 // EvaluateIterator evaluates an iterable expression for an iterator
 func (e *IterableExpression) EvaluateIterator(it Iterator, global *Instance) (*InstanceResult, error) {
 	if e.IterableComparison == nil {
@@ -452,6 +458,9 @@ func (v *Value) Evaluate(instance *Instance) (interface{}, error) {
 		)
 		if instance.Vars != nil {
 			value, ok = instance.Vars[*v.Variable]
+		}
+		if !ok {
+			value, ok = builtInVars[*v.Variable]
 		}
 		if !ok {
 			return nil, lexer.Errorf(v.Pos, `unknown variable %q`, *v.Variable)

--- a/pkg/compliance/eval/eval_test.go
+++ b/pkg/compliance/eval/eval_test.go
@@ -726,6 +726,11 @@ func TestEvalIterable(t *testing.T) {
 			expectResult: true,
 		},
 		{
+			name:         "count everything",
+			expression:   `count(_) == 3`,
+			expectResult: true,
+		},
+		{
 			name:        "count invalid comparison",
 			expression:  `count(file.permissions == 0644) == "yes"`,
 			expectError: newLexerError(0, `expecting an integer rhs for iterable comparison using "count()"`),


### PR DESCRIPTION
### What does this PR do?

Allows to use `count/all/none(_)`

### Describe your test plan

Define a compliance rule using `count(_)`, like:

```
  - id: cis-kubernetes-1.5.0-5.6.4
    scope:
      kubernetesCluster: true
    resources:
      - kubeApiserver:
          kind: services
          version: v1
          namespace: default
          fieldSelector: metadata.name!=kubernetes
          apiRequest:
            verb: list
        condition: count(_) == 0
```
