### PR TITLE
Do not collect docker container logs if they are matching `DD_CONTAINER_EXCLUDE_LOGS`

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -150,7 +150,7 @@ func (l *DockerListener) init() {
 
 		containerImage, err := l.dockerUtil.ResolveImageName(co.Image)
 		if err != nil {
-			log.Warnf("error while resolving image name: %s", err)
+			log.Warnf("Error while resolving image name: %s", err)
 			containerImage = ""
 		}
 		metricsExcluded := false

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -149,6 +149,10 @@ func (l *DockerListener) init() {
 		}
 
 		containerImage, err := l.dockerUtil.ResolveImageName(co.Image)
+		if err != nil {
+			log.Warnf("error while resolving image name: %s", err)
+			containerImage = ""
+		}
 		metricsExcluded := false
 		logsExcluded := false
 		for _, name := range co.Names {

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -132,12 +132,12 @@ func (l *DockerListener) init() {
 	l.m.Lock()
 	defer l.m.Unlock()
 
-	containers, err := l.dockerUtil.RawContainerList(types.ContainerListOptions{})
+	containersList, err := l.dockerUtil.RawContainerList(types.ContainerListOptions{})
 	if err != nil {
 		log.Errorf("Couldn't retrieve container list - %s", err)
 	}
 
-	for _, co := range containers {
+	for _, co := range containersList {
 		if l.isExcluded(co) {
 			continue // helper method already logs
 		}
@@ -146,6 +146,21 @@ func (l *DockerListener) init() {
 		checkNames, err := getCheckNamesFromLabels(co.Labels)
 		if err != nil {
 			log.Errorf("Error getting check names from docker labels on container %s: %v", co.ID, err)
+		}
+
+		containerImage, err := l.dockerUtil.ResolveImageName(co.Image)
+		metricsExcluded := false
+		logsExcluded := false
+		for _, name := range co.Names {
+			if l.filters.IsExcluded(containers.MetricsFilter, name, containerImage, "") {
+				metricsExcluded = true
+			}
+			if l.filters.IsExcluded(containers.LogsFilter, name, containerImage, "") {
+				logsExcluded = true
+			}
+			if metricsExcluded && logsExcluded {
+				break
+			}
 		}
 
 		if findKubernetesInLabels(co.Labels) {
@@ -159,12 +174,14 @@ func (l *DockerListener) init() {
 			}
 		} else {
 			svc = &DockerService{
-				cID:           co.ID,
-				adIdentifiers: l.getConfigIDFromPs(co),
-				hosts:         l.getHostsFromPs(co),
-				ports:         l.getPortsFromPs(co),
-				creationTime:  integration.Before,
-				checkNames:    checkNames,
+				cID:             co.ID,
+				adIdentifiers:   l.getConfigIDFromPs(co),
+				hosts:           l.getHostsFromPs(co),
+				ports:           l.getPortsFromPs(co),
+				creationTime:    integration.Before,
+				checkNames:      checkNames,
+				metricsExcluded: metricsExcluded,
+				logsExcluded:    logsExcluded,
 			}
 		}
 		l.newService <- svc

--- a/releasenotes/notes/honor-DD_CONTAINER_EXCLUDE_LOGS-f42c6b2fa8aa6b32.yaml
+++ b/releasenotes/notes/honor-DD_CONTAINER_EXCLUDE_LOGS-f42c6b2fa8aa6b32.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The agent was collecting docker container logs even if they are matching `DD_CONTAINER_EXCLUDE_LOGS`
+    if they were started before the agent. This is now fixed.

--- a/releasenotes/notes/honor-DD_CONTAINER_EXCLUDE_LOGS-f42c6b2fa8aa6b32.yaml
+++ b/releasenotes/notes/honor-DD_CONTAINER_EXCLUDE_LOGS-f42c6b2fa8aa6b32.yaml
@@ -8,5 +8,7 @@
 ---
 fixes:
   - |
-    The agent was collecting docker container logs even if they are matching `DD_CONTAINER_EXCLUDE_LOGS`
+    The agent was collecting docker container logs (metrics)
+    even if they are matching `DD_CONTAINER_EXCLUDE_LOGS`
+    (resp. `DD_CONTAINER_EXCLUDE_METRICS`)
     if they were started before the agent. This is now fixed.


### PR DESCRIPTION
### What does this PR do?

Make the agent not collect logs on docker containers that are matching `DD_CONTAINER_EXCLUDE_LOGS` even if they were started before the agent.

### Motivation

Whereas `DD_CONTAINER_EXCLUDE_LOGS` was properly honored on Kubernetes, on docker, it was not working for containers which were started before the agent.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Launch the agent inside docker with `DD_CONTAINER_EXCLUDE_LOGS` set:
```
docker run --rm --name datadog-agent -e DD_API_KEY=$DD_API_KEY -e DD_LOGS_ENABLED=true -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true -e 'DD_CONTAINER_EXCLUDE_LOGS=image:.*' -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro datadog/agent:latest
```

Without this PR, the agent container logs are collected:
```
docker exec datadog-agent agent status
```
```
==========
Logs Agent
==========
    Sending compressed logs in HTTPS to agent-http-intake.logs.datadoghq.com on port 443
    BytesSent: 9407
    EncodedBytesSent: 850
    LogsProcessed: 23
    LogsSent: 20

  container_collect_all
  ---------------------
    Type: docker
    Status: OK
    Inputs: 07f1a312d5d41d8f064726ab12c8236daca9229a0e0772aa70040fb0f3b55512
```

With this PR, the agent container logs are not collected:
```
docker exec datadog-agent agent status
```
```
==========
Logs Agent
==========

    Sending compressed logs in HTTPS to agent-http-intake.logs.datadoghq.com on port 443
    BytesSent: 0
    EncodedBytesSent: 28
    LogsProcessed: 0
    LogsSent: 0

  container_collect_all
  ---------------------
    Type: docker
    Status: Pending
```

If `DD_CONTAINER_EXCLUDE_LOGS` is changed, logs are collected again.