### PR TITLE
[compliance] Report check error in event data

### DIFF
--- a/pkg/compliance/checks/check_test.go
+++ b/pkg/compliance/checks/check_test.go
@@ -1,0 +1,124 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package checks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/event"
+	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestCheckRun(t *testing.T) {
+	assert := assert.New(t)
+
+	const (
+		ruleID       = "rule-id"
+		resourceType = "resource-type"
+		resourceID   = "resource-id"
+	)
+
+	tests := []struct {
+		name        string
+		configErr   error
+		checkReport *report
+		checkErr    error
+		expectEvent *event.Event
+		expectErr   error
+	}{
+		{
+			name:      "config error",
+			configErr: errors.New("configuration failed"),
+			expectErr: errors.New("configuration failed"),
+		},
+		{
+			name: "successful check",
+			checkReport: &report{
+				passed: true,
+				data: event.Data{
+					"file.permissions": 0644,
+				},
+			},
+			expectEvent: &event.Event{
+				AgentRuleID:  ruleID,
+				ResourceType: resourceType,
+				ResourceID:   resourceID,
+				Result:       "passed",
+				Data: event.Data{
+					"file.permissions": 0644,
+				},
+			},
+		},
+		{
+			name: "failed check",
+			checkReport: &report{
+				passed: false,
+				data: event.Data{
+					"file.permissions": 0644,
+				},
+			},
+			expectEvent: &event.Event{
+				AgentRuleID:  ruleID,
+				ResourceType: resourceType,
+				ResourceID:   resourceID,
+				Result:       "failed",
+				Data: event.Data{
+					"file.permissions": 0644,
+				},
+			},
+		},
+		{
+			name:     "check error",
+			checkErr: errors.New("check error"),
+			expectEvent: &event.Event{
+				AgentRuleID:  ruleID,
+				ResourceType: resourceType,
+				ResourceID:   resourceID,
+				Result:       "error",
+				Data: event.Data{
+					"error": "check error",
+				},
+			},
+			expectErr: errors.New("check error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := &mocks.Env{}
+			defer env.AssertExpectations(t)
+
+			reporter := &mocks.Reporter{}
+			defer reporter.AssertExpectations(t)
+
+			checkable := &mockCheckable{}
+			defer checkable.AssertExpectations(t)
+
+			check := &complianceCheck{
+				Env: env,
+
+				ruleID:       ruleID,
+				resourceType: resourceType,
+				resourceID:   resourceID,
+
+				configError: test.configErr,
+
+				checkable: checkable,
+			}
+
+			if test.configErr == nil {
+				env.On("Reporter").Return(reporter)
+				reporter.On("Report", test.expectEvent).Once()
+				checkable.On("check", check).Return(test.checkReport, test.checkErr)
+			}
+
+			err := check.Run()
+			assert.Equal(test.expectErr, err)
+		})
+	}
+}

--- a/pkg/compliance/checks/checkable.go
+++ b/pkg/compliance/checks/checkable.go
@@ -21,6 +21,7 @@ type checkable interface {
 	check(env env.Env) (*report, error)
 }
 
+// checkableList abstracts a series of resource checks
 type checkableList []checkable
 
 // check implements checkable interface for checkableList
@@ -32,8 +33,8 @@ func (list checkableList) check(env env.Env) (*report, error) {
 
 	for _, c := range list {
 		result, err = c.check(env)
-		if err != nil || !result.passed {
-			continue
+		if err == nil && result.passed {
+			break
 		}
 	}
 	return result, err

--- a/pkg/compliance/checks/checkable_test.go
+++ b/pkg/compliance/checks/checkable_test.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package checks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/event"
+	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestCheckableList(t *testing.T) {
+	assert := assert.New(t)
+
+	type outcome struct {
+		report *report
+		err    error
+	}
+
+	tests := []struct {
+		name     string
+		list     []outcome
+		expected outcome
+	}{
+		{
+			name: "first succeeds and is the result",
+			list: []outcome{
+				{
+					report: &report{
+						passed: true,
+						data: event.Data{
+							"something": "passed",
+						},
+					},
+				},
+				{
+					report: &report{
+						passed: false,
+						data: event.Data{
+							"something": "failed",
+						},
+					},
+				},
+			},
+			expected: outcome{
+				report: &report{
+					passed: true,
+					data: event.Data{
+						"something": "passed",
+					},
+				},
+			},
+		},
+		{
+			name: "first is error and second succeeds and is the result",
+			list: []outcome{
+				{
+					err: errors.New("some error"),
+				},
+				{
+					report: &report{
+						passed: true,
+						data: event.Data{
+							"something else": "passed",
+						},
+					},
+				},
+			},
+			expected: outcome{
+				report: &report{
+					passed: true,
+					data: event.Data{
+						"something else": "passed",
+					},
+				},
+			},
+		},
+		{
+			name: "first not passed and second succeeds and is the result",
+			list: []outcome{
+				{
+					report: &report{
+						passed: false,
+						data: event.Data{
+							"something": "failed",
+						},
+					},
+				},
+				{
+					report: &report{
+						passed: true,
+						data: event.Data{
+							"something else": "passed",
+						},
+					},
+				},
+			},
+			expected: outcome{
+				report: &report{
+					passed: true,
+					data: event.Data{
+						"something else": "passed",
+					},
+				},
+			},
+		},
+		{
+			name: "first not passed and second is error and is the result",
+			list: []outcome{
+				{
+					report: &report{
+						passed: false,
+						data: event.Data{
+							"something": "failed",
+						},
+					},
+				},
+				{
+					err: errors.New("some other error"),
+				},
+			},
+			expected: outcome{
+				err: errors.New("some other error"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := &mocks.Env{}
+
+			var list checkableList
+
+			for _, outcome := range test.list {
+				c := &mockCheckable{}
+				c.On("check", env).Return(outcome.report, outcome.err)
+				list = append(list, c)
+			}
+
+			report, err := list.check(env)
+			assert.Equal(test.expected.report, report)
+			assert.Equal(test.expected.err, err)
+		})
+	}
+}

--- a/pkg/compliance/checks/mock_checkable.go
+++ b/pkg/compliance/checks/mock_checkable.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package checks
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type mockCheckable struct {
+	mock.Mock
+}
+
+func (m *mockCheckable) check(env env.Env) (*report, error) {
+	args := m.Called(env)
+	return args.Get(0).(*report), args.Error(1)
+}


### PR DESCRIPTION
### What does this PR do?

- Report error as a string in `event.Data`.
- Add more tests for checkable and complianceCheck.

### Motivation

Provide clarity about why checks are in error state to the backend (can be formatted in a message).

### Describe your test plan

Tests with compliance checks reporting errors (missing files) and checks containing > 1 resource.
