### PR TITLE
Add security-agent in deb/rpm packages and fix pidfile argument

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
+	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -74,19 +75,21 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 		},
 	}
 
+	pidfilePath string
 	confPath    string
 	flagNoColor bool
 	stopCh      chan struct{}
 )
 
 func init() {
-	// attach the command to the root
-	SecurityAgentCmd.AddCommand(startCmd)
+	SecurityAgentCmd.PersistentFlags().StringVarP(&confPath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
+	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
+
 	SecurityAgentCmd.AddCommand(versionCmd)
 	SecurityAgentCmd.AddCommand(complianceCmd)
 
-	SecurityAgentCmd.PersistentFlags().StringVarP(&confPath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
-	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
+	startCmd.Flags().StringVarP(&pidfilePath, "pidfile", "p", "", "path to the pidfile")
+	SecurityAgentCmd.AddCommand(startCmd)
 }
 
 func newLogContext() (*config.Endpoints, *client.DestinationsContext, error) {
@@ -139,6 +142,15 @@ func start(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		log.Criticalf("Unable to setup logger: %s", err)
 		return nil
+	}
+
+	if pidfilePath != "" {
+		err = pidfile.WritePID(pidfilePath)
+		if err != nil {
+			return log.Errorf("Error while writing PID file, exiting: %v", err)
+		}
+		defer os.Remove(pidfilePath)
+		log.Infof("pid '%d' written to pid file '%s'", os.Getpid(), pidfilePath)
 	}
 
 	// Check if we have at least one component to start based on config

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -1,7 +1,7 @@
 [Unit]
 Description=Datadog Agent
 After=network.target
-Wants=datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service
+Wants=datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service
 
 [Service]
 Type=simple

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
@@ -6,8 +6,8 @@
 # Description: Datadog Agent
 # Required-Start: $remote_fs
 # Required-Stop: $remote_fs
-# Should-Start: datadog-agent-process datadog-agent-trace
-# Should-Stop: datadog-agent-process datadog-agent-trace
+# Should-Start: datadog-agent-process datadog-agent-trace datadog-agent-security
+# Should-Stop: datadog-agent-process datadog-agent-trace datadog-agent-security
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 ### END INIT INFO
@@ -73,6 +73,7 @@ start_and_wait()
 					log_end_msg 0
 					service datadog-agent-process start
 					service datadog-agent-trace start
+					service datadog-agent-security start
 					return 0
 				else
 					retries=$(($retries - 1))
@@ -114,6 +115,7 @@ stop_and_wait()
 			log_end_msg 0
 			service datadog-agent-process stop
 			service datadog-agent-trace stop
+			service datadog-agent-security stop
 			return 0
 			;;
 		*) log_end_msg 1 ;; # Failed to stop

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
@@ -82,10 +82,11 @@ start_and_wait() {
       while [ $retries -gt 1 ]; do
         checkproc $AGENTPATH
         if [ "$?" -eq "0" ]; then
-          # Successfully started. Start Process and Trace Agents
+          # Successfully started. Start other Agents
           log_success_msg
           service datadog-agent-process start
           service datadog-agent-trace start
+          service datadog-agent-security start
           return 0
         else
           retries=$(($retries - 1))
@@ -122,10 +123,11 @@ stop_and_wait() {
   do_stop
   case "$?" in
     0)
-      # Successfully stopped. Stop Process and Trace Agents
+      # Successfully stopped. Stop other Agents
       log_success_msg
       service datadog-agent-process stop
       service datadog-agent-trace stop
+      service datadog-agent-security stop
       return 0
       ;;
     *) 

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.security.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.security.erb
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 ### BEGIN INIT INFO
-# Provides: datadog-agent-trace
-# Short-Description: Start and stop datadog trace agent
-# Description: Datadog Trace Agent (APM)
+# Provides: datadog-agent-security
+# Short-Description: Start and stop datadog security agent
+# Description: Datadog Security Agent
 # Required-Start: $remote_fs
 # Required-Stop: $remote_fs
 # Default-Start: 2 3 4 5

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -79,6 +79,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
             SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with systemctl"
             SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with systemctl"
+            SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-security || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-security with systemctl"
         elif command -v initctl >/dev/null 2>&1; then
             # Nothing to do, this is defined directly in the upstart job file
             :
@@ -86,6 +87,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             update-rc.d $SERVICE_NAME defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with update-rc.d"
             update-rc.d $SERVICE_NAME-process defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with update-rc.d"
             update-rc.d $SERVICE_NAME-trace defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with update-rc.d"
+            update-rc.d $SERVICE_NAME-security defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-security with update-rc.d"
         else
             echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
         fi

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -29,6 +29,7 @@ if [ "$DISTRIBUTION_FAMILY" = "SUSE" ]; then
         rm -f /etc/init.d/datadog-agent
         rm -f /etc/init.d/datadog-agent-process
         rm -f /etc/init.d/datadog-agent-trace
+        rm -f /etc/init.d/datadog-agent-security
     fi
 fi
 
@@ -46,10 +47,12 @@ elif [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
         update-rc.d $SERVICE_NAME defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with update-rc.d"
         update-rc.d $SERVICE_NAME-process defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with update-rc.d"
         update-rc.d $SERVICE_NAME-trace defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with update-rc.d"
+        update-rc.d $SERVICE_NAME-security defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-security with update-rc.d"
     elif command -v chkconfig >/dev/null 2>&1; then
         chkconfig --set $SERVICE_NAME on || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with chkconfig"
         chkconfig --set $SERVICE_NAME-process on || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with chkconfig"
         chkconfig --set $SERVICE_NAME-trace on || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with chkconfig"
+        chkconfig --set $SERVICE_NAME-security on || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-security with chkconfig"
     fi
 else
     echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -25,17 +25,20 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             systemctl stop $SERVICE_NAME-process || true
             systemctl stop $SERVICE_NAME-sysprobe || true
             systemctl stop $SERVICE_NAME-trace || true
+            systemctl stop $SERVICE_NAME-security || true
             systemctl stop $SERVICE_NAME || true
         elif command -v initctl >/dev/null 2>&1; then
             initctl stop $SERVICE_NAME-process || true
             initctl stop $SERVICE_NAME-sysprobe || true
             initctl stop $SERVICE_NAME-trace || true
+            initctl stop $SERVICE_NAME-security || true
             initctl stop $SERVICE_NAME || true
         elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
             if command -v service >/dev/null 2>&1; then
                 service $SERVICE_NAME-process stop || true
                 service $SERVICE_NAME-sysprobe stop || true
                 service $SERVICE_NAME-trace stop || true
+                service $SERVICE_NAME-security stop || true
                 service $SERVICE_NAME stop || true
             else
                 echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -29,11 +29,13 @@ stop_agent()
         systemctl stop $SERVICE_NAME-process || true
         systemctl stop $SERVICE_NAME-sysprobe || true
         systemctl stop $SERVICE_NAME-trace || true
+        systemctl stop $SERVICE_NAME-security || true
         systemctl stop $SERVICE_NAME || true
     elif command -v initctl >/dev/null 2>&1; then
         initctl stop $SERVICE_NAME-process || true
         initctl stop $SERVICE_NAME-sysprobe || true
         initctl stop $SERVICE_NAME-trace || true
+        initctl stop $SERVICE_NAME-security || true
         initctl stop $SERVICE_NAME || true
     elif [ "$DISTRIBUTION_FAMILY" = "Debian" ] || [ "$SUSE_SYSVINIT_SUPPORT" = "yes" ]; then
         if command -v service >/dev/null 2>&1; then
@@ -42,6 +44,7 @@ stop_agent()
             # If not, remove it.
             service $SERVICE_NAME-sysprobe stop || true
             service $SERVICE_NAME-trace stop || true
+            service $SERVICE_NAME-security stop || true
             service $SERVICE_NAME stop || true
         else
             echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
@@ -60,6 +63,7 @@ deregister_agent()
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-process || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-sysprobe || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-trace || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-security || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME || true
     elif command -v initctl >/dev/null 2>&1; then
         # Nothing to do, this is defined directly in the upstart job file
@@ -71,6 +75,7 @@ deregister_agent()
             # If not, remove it.
             update-rc.d -f $SERVICE_NAME-sysprobe remove || true
             update-rc.d -f $SERVICE_NAME-trace remove || true
+            update-rc.d -f $SERVICE_NAME-security remove || true
             update-rc.d -f $SERVICE_NAME remove || true
         else
             echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
@@ -79,11 +84,13 @@ deregister_agent()
         if command -v update-rc.d >/dev/null 2>&1; then
             update-rc.d -f $SERVICE_NAME-process remove || true
             update-rc.d -f $SERVICE_NAME-trace remove || true
+            update-rc.d -f $SERVICE_NAME-security remove || true
             update-rc.d -f $SERVICE_NAME remove || true
         elif command -v chkconfig >/dev/null 2>&1; then
             chkconfig --set $SERVICE_NAME off || true
             chkconfig --set $SERVICE_NAME-process off || true
             chkconfig --set $SERVICE_NAME-trace off || true
+            chkconfig --set $SERVICE_NAME-security off || true
         fi
     else
         echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."

--- a/releasenotes/notes/security-agent-pkg-d8233761ac894509.yaml
+++ b/releasenotes/notes/security-agent-pkg-d8233761ac894509.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Make security-agent part of automatically started agents in RPM/DEB/etc. packages (will do nothing and exit 0 by default)
+fixes:
+  - |
+    Fix pidfile support on security-agent


### PR DESCRIPTION
### What does this PR do?

- Make security-agent part of automatically started agents in RPM/DEB/etc. packages (will do nothing and exit 0 by default)
fixes
- Fix pidfile support on security-agent

### Describe your test plan

Install DEB or RPM package, verify that `datadog-agent-security` service was enabled, ran and exited 0.
