### PR TITLE
[compliance] Use omitempty on KubernetesResource Group field

### DIFF
--- a/pkg/compliance/resource.go
+++ b/pkg/compliance/resource.go
@@ -80,7 +80,7 @@ type Process struct {
 type KubernetesResource struct {
 	Kind      string `yaml:"kind"`
 	Version   string `yaml:"version,omitempty"`
-	Group     string `yaml:"group"`
+	Group     string `yaml:"group,omitempty"`
 	Namespace string `yaml:"namespace,omitempty"`
 
 	// A selector to restrict the list of returned objects by their labels.


### PR DESCRIPTION
### What does this PR do?

Use omitempty on KubernetesResource Group field (optional attribute).

### Motivation

Clean up rules yaml.
