### PR TITLE
Update the shellcheck download link

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -592,7 +592,7 @@ def install_shellcheck(ctx, version="0.7.0", destination="/usr/local/bin"):
         platform = "linux"
 
     ctx.run(
-        "wget -qO- \"https://storage.googleapis.com/shellcheck/shellcheck-v{sc_version}.{platform}.x86_64.tar.xz\" | tar -xJv -C /tmp".format(
+        "wget -qO- \"https://github.com/koalaman/shellcheck/releases/download/v{sc_version}/shellcheck-v{sc_version}.{platform}.x86_64.tar.xz\" | tar -xJv -C /tmp".format(
             sc_version=version, platform=platform
         )
     )


### PR DESCRIPTION
### What does this PR do?

Update the shellcheck download link

### Motivation

The `master` branch is currently broken with the following error:

```
You are downloading ShellCheck from an outdated URL!

Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/v0.7.0/shellcheck-v0.7.0.linux.x86_64.tar.xz

For more information, see:
https://github.com/koalaman/shellcheck/issues/1871

PS: Sorry for breaking your build. The hosting costs were getting out of hand :(

Exited with code exit status 1
```

### Additional Notes

Broken `master`: https://app.circleci.com/pipelines/github/DataDog/datadog-agent/4954/workflows/0e53eb98-b6ce-4a7a-95cc-e2e390b67586/jobs/248434

### Describe your test plan