### PR TITLE
pkg/trace/test: ensure atomic struct field is 64-bit aligned

### DIFF
--- a/pkg/trace/test/backend.go
+++ b/pkg/trace/test/backend.go
@@ -32,9 +32,9 @@ const defaultBackendAddress = "localhost:8888"
 const defaultChannelSize = 100
 
 type fakeBackend struct {
-	srv     http.Server
-	out     chan interface{} // payload output
 	started uint64           // 0 if server is stopped
+	out     chan interface{} // payload output
+	srv     http.Server
 }
 
 func newFakeBackend(channelSize int) *fakeBackend {


### PR DESCRIPTION
Validate `staticcheck`