### PR TITLE
[windows] Use call ridk enable on x64 build

### DIFF
--- a/tasks/winbuildscripts/buildwin.bat
+++ b/tasks/winbuildscripts/buildwin.bat
@@ -32,10 +32,9 @@ SET PATH=%PATH%;%GOPATH%/bin
 @echo VSTUDIO_ROOT %VSTUDIO_ROOT%
 @echo TARGET_ARCH %TARGET_ARCH%
 
-REM Equivalent to the "ridk enable" command, but without the exit
 if "%TARGET_ARCH%" == "x64" (
     @echo IN x64 BRANCH
-    @for /f "delims=" %%x in ('"ruby" --disable-gems -x '%RIDK%' enable') do set "%%x"
+    call ridk enable
 )
 
 if "%TARGET_ARCH%" == "x86" (


### PR DESCRIPTION
### What does this PR do?

Simplify path setup in x64 builders.

Using `ridk enable` without `call` doesn't work, as `ridk enable` ends with an `exit` command which makes the `buildwin.bat` script exit.

### Motivation

Remove hack in buildwin script.

