### PR TITLE
Support expvar in security-agent

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -11,6 +11,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	_ "expvar" // Blank import used because this isn't directly used in this file
+	"net/http"
+	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
@@ -19,10 +23,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
-	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
+	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -92,7 +97,7 @@ func init() {
 func newLogContext() (*config.Endpoints, *client.DestinationsContext, error) {
 	httpConnectivity := config.HTTPConnectivityFailure
 	if endpoints, err := config.BuildHTTPEndpoints(); err == nil {
-		httpConnectivity = http.CheckConnectivity(endpoints.Main)
+		httpConnectivity = logshttp.CheckConnectivity(endpoints.Main)
 	}
 
 	endpoints, err := config.BuildEndpoints(httpConnectivity)
@@ -151,6 +156,14 @@ func start(cmd *cobra.Command, args []string) error {
 		log.Critical("no API key configured, exiting")
 		return nil
 	}
+
+	// Setup expvar server
+	var port = coreconfig.Datadog.GetString("security_agent.expvar_port")
+	coreconfig.Datadog.Set("expvar_port", port)
+	if coreconfig.Datadog.GetBool("telemetry.enabled") {
+		http.Handle("/telemetry", telemetry.Handler())
+	}
+	go http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux) //nolint:errcheck
 
 	// get hostname
 	// FIXME: use gRPC cross-agent communication API to retrieve hostname

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -730,6 +730,9 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("inventories_max_interval", 600) // 10min
 	config.BindEnvAndSetDefault("inventories_min_interval", 300) // 5min
 
+	// Datadog security agent (common)
+	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
+
 	// Datadog security agent (compliance)
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)


### PR DESCRIPTION
### What does this PR do?

Add support for expvar/telemetry port in security-agent with dedicated port.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Telemetry (`/telemetry`) should be available in security-agent container at port `5011` if `telemetry.enabled` is activated.
