### PR TITLE
[KSMv2] Add persistentvolume by phase and service type transformers

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
@@ -147,3 +147,22 @@ func resourcequotaTransformer(s aggregator.Sender, name string, metric ksmstore.
 	metricName := ksmMetricPrefix + fmt.Sprintf("resourcequota.%s.%s", resource, quotaType)
 	s.Gauge(metricName, metric.Val, "", tags)
 }
+
+// submitActiveMetrics only sends metrics with non-zero values
+func submitActiveMetric(s aggregator.Sender, metricName string, metric ksmstore.DDMetric, tags []string) {
+	if metric.Val != 1.0 {
+		// Only consider active metrics
+		return
+	}
+	s.Gauge(metricName, 1, "", tags)
+}
+
+// pvPhaseTransformer generates metrics per persistentvolume and per phase from the kube_persistentvolume_status_phase metric
+func pvPhaseTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {
+	submitActiveMetric(s, ksmMetricPrefix+"persistentvolume.by_phase", metric, tags)
+}
+
+// serviceTypeTransformer generates metrics per service, namespace, and type from the kube_service_spec_type metric
+func serviceTypeTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {
+	submitActiveMetric(s, ksmMetricPrefix+"service.type", metric, tags)
+}

--- a/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
@@ -41,8 +41,8 @@ var (
 		"kube_node_spec_unschedulable":                func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
 		"kube_resourcequota":                          resourcequotaTransformer,
 		"kube_limitrange":                             func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
-		"kube_persistentvolume_status_phase":          func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
-		"kube_service_spec_type":                      func(s aggregator.Sender, name string, metric ksmstore.DDMetric, tags []string) {},
+		"kube_persistentvolume_status_phase":          pvPhaseTransformer,
+		"kube_service_spec_type":                      serviceTypeTransformer,
 	}
 )
 
@@ -148,7 +148,7 @@ func resourcequotaTransformer(s aggregator.Sender, name string, metric ksmstore.
 	s.Gauge(metricName, metric.Val, "", tags)
 }
 
-// submitActiveMetrics only sends metrics with non-zero values
+// submitActiveMetrics only sends metrics with value '1'
 func submitActiveMetric(s aggregator.Sender, metricName string, metric ksmstore.DDMetric, tags []string) {
 	if metric.Val != 1.0 {
 		// Only consider active metrics

--- a/pkg/collector/corechecks/cluster/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_transformers_test.go
@@ -534,3 +534,137 @@ func Test_jobStatusFailedTransformer(t *testing.T) {
 		})
 	}
 }
+
+func Test_pvPhaseTransformer(t *testing.T) {
+	type args struct {
+		name   string
+		metric ksmstore.DDMetric
+		tags   []string
+	}
+	type metricsExpected struct {
+		val  float64
+		name string
+		tags []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "Active",
+			args: args{
+				name: "kube_persistentvolume_status_phase",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"persistentvolume": "local-pv-103fef5d",
+						"phase":            "Available",
+					},
+				},
+				tags: []string{"persistentvolume:local-pv-103fef5d", "phase:Available"},
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.persistentvolume.by_phase",
+				val:  1,
+				tags: []string{"persistentvolume:local-pv-103fef5d", "phase:Available"},
+			},
+		},
+		{
+			name: "Not active",
+			args: args{
+				name: "kube_persistentvolume_status_phase",
+				metric: ksmstore.DDMetric{
+					Val: 0,
+					Labels: map[string]string{
+						"persistentvolume": "local-pv-103fef5d",
+						"phase":            "Available",
+					},
+				},
+				tags: []string{"persistentvolume:local-pv-103fef5d", "phase:Available"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			pvPhaseTransformer(s, tt.args.name, tt.args.metric, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, "", tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}
+
+func Test_serviceTypeTransformer(t *testing.T) {
+	type args struct {
+		name   string
+		metric ksmstore.DDMetric
+		tags   []string
+	}
+	type metricsExpected struct {
+		val  float64
+		name string
+		tags []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "Active",
+			args: args{
+				name: "kube_service_spec_type",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"namespace": "default",
+						"service":   "kubernetes",
+						"type":      "ClusterIP",
+					},
+				},
+				tags: []string{"namespace:default", "service:kubernetes", "type:ClusterIP"},
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.service.type",
+				val:  1,
+				tags: []string{"namespace:default", "service:kubernetes", "type:ClusterIP"},
+			},
+		},
+		{
+			name: "Not active",
+			args: args{
+				name: "kube_service_spec_type",
+				metric: ksmstore.DDMetric{
+					Val: 0,
+					Labels: map[string]string{
+						"namespace": "default",
+						"service":   "kubernetes",
+						"type":      "ClusterIP",
+					},
+				},
+				tags: []string{"namespace:default", "service:kubernetes", "type:ClusterIP"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			serviceTypeTransformer(s, tt.args.name, tt.args.metric, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, "", tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds metric transformers for the following metrics:

* `kubernetes_state.persistentvolume.by_phase`
* `kubernetes_state.service.type`

### Motivation

Feature parity

### Additional Notes

* `kubernetes_state.persistentvolume.by_phase` and `kubernetes_state.service.type` will have different behavior compared to the `kubernetes_state` v1 check. Instead of submitting a count per whitelisted tag, they will submit any active (non-zero value) metrics with all of the metrics' associated tags. To get a count to match the v1 check, the in-app aggregator `sum` can be used
* [kubernetes_state.persistentvolumes.by_phase](https://github.com/DataDog/integrations-core/blob/3fbe97799224e5ed6838b43df909fab33e8a2ab8/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py#L93) renamed to `kubernetes_state.persistentvolume.by_phase` to match the metric name listed in KSMv1's `metadata.csv`
* [kubernetes_state.service.count](https://github.com/DataDog/integrations-core/blob/3fbe97799224e5ed6838b43df909fab33e8a2ab8/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py#L96) renamed to `kubernetes_state.service.type` to better fit the metric's new behavior

