### PR TITLE
Adding back debug server

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -98,6 +98,11 @@ func runAgent(exit <-chan struct{}) {
 		cleanupAndExit(1)
 	}
 
+	// if a debug port is specified, we expose the default handler to that port
+	if cfg.SystemProbeDebugPort > 0 {
+		go http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.SystemProbeDebugPort), http.DefaultServeMux) //nolint:errcheck
+	}
+
 	loader := NewLoader()
 	httpMux := http.NewServeMux()
 


### PR DESCRIPTION
### What does this PR do?

Adds the debug server for system-probe back in

### Motivation

No stats from system-probe were being published

### Additional Notes

### Describe your test plan

