### PR TITLE
[Gitlab] Fix deploy_staging_suse_rpm-7 rule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3617,7 +3617,7 @@ deploy_staging_suse_rpm-6:
 
 deploy_staging_suse_rpm-7:
   rules:
-    - <<: *if_not_version_6
+    - <<: *if_not_version_7
       when: never
     - <<: *if_deploy
   stage: deploy7


### PR DESCRIPTION
### What does this PR do?

Fixes erroneous rule used in the deploy_staging_suse_rpm-7 job.

### Motivation

The rule was disabling the job on A7-only pipelines and enabling it on A6-only pipelines, which is the opposite of what should happen.

