### PR TITLE
Remove latest MSIs from staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3496,41 +3496,6 @@ deploy_staging_windows_tags-a7:
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-# deploy builds latest (6, x64 only), deployed to bucket/tagged
-deploy_staging_windows_tags-latest-a6:
-  rules:
-    - <<: *if_deploy_on_tag_6
-  stage: deploy6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  tags: [ "runner:main", "size:large" ]
-  dependencies:
-    - windows_msi_x64-a6
-  script:
-    # By default we update the "latest" artifacts on our s3 bucket so the
-    # staging box can pick it up. Allow the job to skip this step if needed
-    # (when building a custom beta for example).
-    - if [ "WINDOWS_DO_NOT_UPDATE_LATEST" != "true" ]; then $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-6*-x86_64.msi s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/datadog-agent-6-latest.amd64.msi --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732; fi
-
-# deploy builds latest (7, x64 only), deployed to bucket/tagged
-deploy_staging_windows_tags-latest-a7:
-  rules:
-    - <<: *if_deploy_on_tag_7
-  stage: deploy7
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  tags: [ "runner:main", "size:large" ]
-  dependencies:
-    - windows_msi_x64-a7
-    - windows_dsd_msi_x64-a7
-  script:
-    # By default we update the "latest" artifacts on our s3 bucket so the
-    # staging box can pick it up. Allow the job to skip this step if needed
-    # (when building a custom beta for example).
-    - if [ "WINDOWS_DO_NOT_UPDATE_LATEST" != "true" ]; then $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-7*-x86_64.msi s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/datadog-agent-7-latest.amd64.msi --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732; fi
-
 # deploy android packages to a public s3 bucket when tagged
 deploy_staging_android_tags:
   rules:

--- a/tasks/deploy/pipeline_tools.py
+++ b/tasks/deploy/pipeline_tools.py
@@ -9,13 +9,7 @@ from time import sleep, time
 PIPELINE_FINISH_TIMEOUT_SEC = 3600 * 5
 
 
-def trigger_agent_pipeline(
-    ref="master",
-    release_version_6="nightly",
-    release_version_7="nightly-a7",
-    branch="nightly",
-    windows_update_latest=True,
-):
+def trigger_agent_pipeline(ref="master", release_version_6="nightly", release_version_7="nightly-a7", branch="nightly"):
     """
     Trigger a pipeline to deploy an Agent to staging repos
     (as specified with the DEPLOY_AGENT arg).
@@ -35,10 +29,6 @@ def trigger_agent_pipeline(
     # Override the environment to release the binaries to (prod or staging)
     if branch is not None:
         args["DEB_RPM_BUCKET_BRANCH"] = branch
-
-    # Override the environment to release the binaries to (prod or staging)
-    if windows_update_latest is not None:
-        args["WINDOWS_DO_NOT_UPDATE_LATEST"] = str(not windows_update_latest).lower()
 
     print(
         "Creating pipeline for datadog-agent on branch/tag {} with args:\n{}".format(

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -8,17 +8,8 @@ from .deploy.gitlab import Gitlab
 
 
 @task
-def trigger(
-    ctx,
-    git_ref="master",
-    release_version_6="nightly",
-    release_version_7="nightly-a7",
-    repo_branch="nightly",
-    windows_update_latest=True,
-):
-    pipeline_id = trigger_agent_pipeline(
-        git_ref, release_version_6, release_version_7, repo_branch, windows_update_latest
-    )
+def trigger(ctx, git_ref="master", release_version_6="nightly", release_version_7="nightly-a7", repo_branch="nightly"):
+    pipeline_id = trigger_agent_pipeline(git_ref, release_version_6, release_version_7, repo_branch)
     wait_for_pipeline("DataDog/datadog-agent", pipeline_id)
 
 


### PR DESCRIPTION
### What does this PR do?

Removes the flag and promotion jobs to push `datadog-agent-6-latest.amd64.msi` and `datadog-agent-7-latest.amd64.msi` to `dd-agent-mstesting`.

### Motivation

I don't think anyone is using them, and we didn't update them consistently

### Describe your test plan

I've manually deleted the existing MSIs from the bucket. If somebody complains, that will mean they were used.
