### PR TITLE
Add logs stats in cluster-agent status

### DIFF
--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -71,12 +71,16 @@ func FormatDCAStatus(data []byte) (string, error) {
 	autoConfigStats := stats["autoConfigStats"]
 	checkSchedulerStats := stats["checkSchedulerStats"]
 	endpointsInfos := stats["endpointsInfos"]
+	logsStats := stats["logsStats"]
 	title := fmt.Sprintf("Datadog Cluster Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderStatusTemplate(b, "/header.tmpl", stats)
 	renderChecksStats(b, runnerStats, nil, nil, autoConfigStats, checkSchedulerStats, nil, "")
 	renderStatusTemplate(b, "/forwarder.tmpl", forwarderStats)
 	renderStatusTemplate(b, "/endpoints.tmpl", endpointsInfos)
+	if config.Datadog.GetBool("compliance_config.enabled") {
+		renderStatusTemplate(b, "/logsagent.tmpl", logsStats)
+	}
 
 	return b.String(), nil
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -136,6 +136,8 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	stats["config"] = getDCAPartialConfig()
 	stats["leaderelection"] = getLeaderElectionDetails()
 
+	stats["logsStats"] = logs.GetStatus()
+
 	endpointsInfos, err := getEndpointsInfos()
 	if endpointsInfos != nil && err == nil {
 		stats["endpointsInfos"] = endpointsInfos


### PR DESCRIPTION
# What does this PR do?

With the introduction of Compliance checks in the `Cluster-Agent`, We instantiate the logs forwarder.
To ease debugging it is interesting to have "logs stats" information in the `cluster-agent status` 

### Motivation

ease `cluster-agent` investigation

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
