### PR TITLE
[runtime-security] Avoid partial evaluation on invalid value

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -140,7 +140,7 @@ func (m *Module) HandleEvent(event *sprobe.Event) {
 func LoadPolicies(config *config.Config, probe *sprobe.Probe) (*rules.RuleSet, error) {
 	var result *multierror.Error
 
-	ruleSet := probe.NewRuleSet(eval.NewOptsWithParams(config.Debug, sprobe.SECLConstants))
+	ruleSet := probe.NewRuleSet(rules.NewOptsWithParams(config.Debug, sprobe.SECLConstants, sprobe.InvalidDiscarders))
 
 	policyFiles, err := ioutil.ReadDir(config.PoliciesDir)
 	if err != nil {

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -27,6 +27,24 @@ import (
 	"github.com/pkg/errors"
 )
 
+var dentryInvalidDiscarder = []interface{}{dentryPathKeyNotFound}
+
+// InvalidDiscarders exposes list of values that are not discarders
+var InvalidDiscarders = map[eval.Field][]interface{}{
+	"open.filename":       dentryInvalidDiscarder,
+	"unlink.filename":     dentryInvalidDiscarder,
+	"chmod.filename":      dentryInvalidDiscarder,
+	"chown.filename":      dentryInvalidDiscarder,
+	"mkdir.filename":      dentryInvalidDiscarder,
+	"rmdir.filename":      dentryInvalidDiscarder,
+	"rename.old_filename": dentryInvalidDiscarder,
+	"rename.new_filename": dentryInvalidDiscarder,
+	"utimes.filename":     dentryInvalidDiscarder,
+	"link.src_filename":   dentryInvalidDiscarder,
+	"link.new_filename":   dentryInvalidDiscarder,
+	"process.filename":    dentryInvalidDiscarder,
+}
+
 // ErrNotEnoughData is returned when the buffer is too small to unmarshal the event
 var ErrNotEnoughData = errors.New("not enough data")
 

--- a/pkg/security/probe/model_accessors.go
+++ b/pkg/security/probe/model_accessors.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
-func (m *Model) GetEvaluator(field eval.Field) (interface{}, error) {
+func (m *Model) GetEvaluator(field eval.Field) (eval.Evaluator, error) {
 	switch field {
 
 	case "chmod.container_path":

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -349,7 +349,7 @@ func (caps Capabilities) GetFieldCapabilities() rules.FieldCapabilities {
 }
 
 // NewRuleSet returns a new rule set
-func (p *Probe) NewRuleSet(opts *eval.Opts) *rules.RuleSet {
+func (p *Probe) NewRuleSet(opts *rules.Opts) *rules.RuleSet {
 	eventCtor := func() eval.Event {
 		return NewEvent(p.resolvers)
 	}

--- a/pkg/security/rules/model_test.go
+++ b/pkg/security/rules/model_test.go
@@ -79,7 +79,7 @@ func (m *testModel) ValidateField(key string, value eval.FieldValue) error {
 	return nil
 }
 
-func (m *testModel) GetEvaluator(key string) (interface{}, error) {
+func (m *testModel) GetEvaluator(key string) (eval.Evaluator, error) {
 	switch key {
 
 	case "process.name":

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -8,7 +8,6 @@ package rules
 import (
 	"fmt"
 
-	"github.com/cihub/seelog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
@@ -24,17 +23,55 @@ type RuleSetListener interface {
 	EventDiscarderFound(rs *RuleSet, event eval.Event, field eval.Field)
 }
 
+// Opts defines rules set options
+type Opts struct {
+	eval.Opts
+	InvalidDiscarders map[eval.Field][]interface{}
+}
+
+func (o *Opts) getInvalidDiscarders() map[eval.Field]map[interface{}]bool {
+	invalidDiscarders := make(map[eval.Field]map[interface{}]bool)
+
+	if o.InvalidDiscarders != nil {
+		for field, values := range o.InvalidDiscarders {
+			ivalues := invalidDiscarders[field]
+			if ivalues == nil {
+				ivalues = make(map[interface{}]bool)
+				invalidDiscarders[field] = ivalues
+			}
+			for _, value := range values {
+				ivalues[value] = true
+			}
+		}
+	}
+
+	return invalidDiscarders
+}
+
+// NewOptsWithParams initializes a new Opts instance with Debug and Constants parameters
+func NewOptsWithParams(debug bool, constants map[string]interface{}, invalidDiscarders map[eval.Field][]interface{}) *Opts {
+	return &Opts{
+		Opts: eval.Opts{
+			Debug:     debug,
+			Constants: constants,
+			Macros:    make(map[eval.MacroID]*eval.Macro),
+		},
+		InvalidDiscarders: invalidDiscarders,
+	}
+}
+
 // RuleSet holds a list of rules, grouped in bucket. An event can be evaluated
 // against it. If the rule matches, the listeners for this rule set are notified
 type RuleSet struct {
-	opts             *eval.Opts
+	opts             *Opts
 	eventRuleBuckets map[eval.EventType]*RuleBucket
 	rules            map[policy.RuleID]*eval.Rule
 	model            eval.Model
 	eventCtor        func() eval.Event
 	listeners        []RuleSetListener
 	// fields holds the list of event field queries (like "process.uid") used by the entire set of rules
-	fields []string
+	fields            []string
+	invalidDiscarders map[eval.Field]map[interface{}]bool
 }
 
 // ListRuleIDs returns the list of RuleIDs from the ruleset
@@ -75,7 +112,7 @@ func (rs *RuleSet) AddMacro(macroDef *policy.MacroDefinition) (*eval.Macro, erro
 		return nil, errors.Wrapf(err, "couldn't generate an AST of the macro %s", macroDef.ID)
 	}
 
-	if err := macro.GenEvaluator(rs.model, rs.opts); err != nil {
+	if err := macro.GenEvaluator(rs.model, &rs.opts.Opts); err != nil {
 		return nil, errors.Wrapf(err, "couldn't generate an evaluation of the macro %s", macroDef.ID)
 	}
 
@@ -116,7 +153,7 @@ func (rs *RuleSet) AddRule(ruleDef *policy.RuleDefinition) (*eval.Rule, error) {
 		return nil, err
 	}
 
-	if err := rule.GenEvaluator(rs.model, rs.opts); err != nil {
+	if err := rule.GenEvaluator(rs.model, &rs.opts.Opts); err != nil {
 		return nil, err
 	}
 
@@ -232,6 +269,15 @@ func (rs *RuleSet) IsDiscarder(field eval.Field, value interface{}) (bool, error
 	return true, nil
 }
 
+func (rs *RuleSet) isInvalidDiscarder(field eval.Field, value interface{}) bool {
+	values, exists := rs.invalidDiscarders[field]
+	if !exists {
+		return false
+	}
+
+	return values[value]
+}
+
 // Evaluate the specified event against the set of rules
 func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	ctx := &eval.Context{}
@@ -260,17 +306,21 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 		log.Debugf("Looking for discarders for event `%s`", eventID)
 
 		for _, field := range bucket.fields {
-			var value string
-			if level, _ := log.GetLogLevel(); level == seelog.DebugLvl {
-				evaluator, _ := rs.model.GetEvaluator(field)
-				value = evaluator.(eval.Evaluator).StringValue(ctx)
+			evaluator, err := rs.model.GetEvaluator(field)
+			if err != nil {
+				continue
+			}
+			value := evaluator.Eval(ctx)
+
+			if rs.isInvalidDiscarder(field, value) {
+				continue
 			}
 
 			isDiscarder := true
 			for _, rule := range bucket.rules {
 				isTrue, err := rule.PartialEval(ctx, field)
 
-				log.Debugf("Partial eval of rule %s(`%s`) with field `%s` with value `%s` => %t\n", rule.ID, rule.Expression, field, value, isTrue)
+				log.Tracef("Partial eval of rule %s(`%s`) with field `%s` with value `%v` => %t\n", rule.ID, rule.Expression, field, value, isTrue)
 
 				if err != nil || isTrue {
 					isDiscarder = false
@@ -325,12 +375,13 @@ func (rs *RuleSet) generatePartials() error {
 }
 
 // NewRuleSet returns a new ruleset for the specified data model
-func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *eval.Opts) *RuleSet {
+func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts) *RuleSet {
 	return &RuleSet{
-		model:            model,
-		eventCtor:        eventCtor,
-		opts:             opts,
-		eventRuleBuckets: make(map[eval.EventType]*RuleBucket),
-		rules:            make(map[policy.RuleID]*eval.Rule),
+		model:             model,
+		eventCtor:         eventCtor,
+		opts:              opts,
+		eventRuleBuckets:  make(map[eval.EventType]*RuleBucket),
+		rules:             make(map[policy.RuleID]*eval.Rule),
+		invalidDiscarders: opts.getInvalidDiscarders(),
 	}
 }

--- a/pkg/security/rules/ruleset_test.go
+++ b/pkg/security/rules/ruleset_test.go
@@ -74,7 +74,7 @@ func addRuleExpr(t *testing.T, rs *RuleSet, exprs ...string) {
 }
 
 func TestRuleBuckets(t *testing.T) {
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, eval.NewOptsWithParams(true, testConstants))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(true, testConstants, nil))
 
 	exprs := []string{
 		`(open.filename =~ "/sbin/*" || open.filename =~ "/usr/sbin/*") && process.uid != 0 && open.flags & O_CREAT > 0`,
@@ -105,7 +105,7 @@ func TestRuleSetDiscarders(t *testing.T) {
 		model:   model,
 		filters: make(map[string]testFieldValues),
 	}
-	rs := NewRuleSet(model, func() eval.Event { return &testEvent{} }, eval.NewOptsWithParams(true, testConstants))
+	rs := NewRuleSet(model, func() eval.Event { return &testEvent{} }, NewOptsWithParams(true, testConstants, nil))
 	rs.AddListener(handler)
 
 	exprs := []string{
@@ -165,7 +165,7 @@ func TestRuleSetDiscarders(t *testing.T) {
 }
 
 func TestRuleSetFilters1(t *testing.T) {
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, eval.NewOptsWithParams(true, testConstants))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(true, testConstants, nil))
 
 	addRuleExpr(t, rs, `open.filename in ["/etc/passwd", "/etc/shadow"] && (process.uid == 0 || process.gid == 0)`)
 
@@ -223,7 +223,7 @@ func TestRuleSetFilters1(t *testing.T) {
 }
 
 func TestRuleSetFilters2(t *testing.T) {
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, eval.NewOptsWithParams(true, testConstants))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(true, testConstants, nil))
 
 	exprs := []string{
 		`open.filename in ["/etc/passwd", "/etc/shadow"] && process.uid == 0`,
@@ -279,7 +279,7 @@ func TestRuleSetFilters2(t *testing.T) {
 }
 
 func TestRuleSetFilters3(t *testing.T) {
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, eval.NewOptsWithParams(true, testConstants))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(true, testConstants, nil))
 
 	addRuleExpr(t, rs, `open.filename in ["/etc/passwd", "/etc/shadow"] && (process.uid == process.gid)`)
 
@@ -305,7 +305,7 @@ func TestRuleSetFilters3(t *testing.T) {
 }
 
 func TestRuleSetFilters4(t *testing.T) {
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, eval.NewOptsWithParams(true, testConstants))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(true, testConstants, nil))
 
 	addRuleExpr(t, rs, `open.filename =~ "/etc/passwd" && process.uid == 0`)
 
@@ -333,7 +333,7 @@ func TestRuleSetFilters4(t *testing.T) {
 }
 
 func TestRuleSetFilters5(t *testing.T) {
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, eval.NewOptsWithParams(true, testConstants))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(true, testConstants, nil))
 
 	addRuleExpr(t, rs, `(open.flags & O_CREAT > 0 || open.flags & O_EXCL > 0) && open.flags & O_RDWR > 0`)
 
@@ -357,7 +357,7 @@ func TestRuleSetFilters5(t *testing.T) {
 func TestRuleSetFilters6(t *testing.T) {
 	t.Skip()
 
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, eval.NewOptsWithParams(true, testConstants))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(true, testConstants, nil))
 
 	addRuleExpr(t, rs, `(open.flags & O_CREAT > 0 || open.flags & O_EXCL > 0) || process.name == "httpd"`)
 
@@ -370,5 +370,37 @@ func TestRuleSetFilters6(t *testing.T) {
 
 	if _, err := rs.GetApprovers("open", caps); err == nil {
 		t.Fatal("shouldn't get any approver")
+	}
+}
+
+func TestRuleSetInvalidDiscarders(t *testing.T) {
+	discarders := map[eval.Field][]interface{}{
+		"open.filename": {
+			"aaa",
+			111,
+			false,
+		},
+	}
+
+	rs := NewRuleSet(nil, nil, NewOptsWithParams(true, nil, discarders))
+
+	if !rs.isInvalidDiscarder("open.filename", "aaa") {
+		t.Errorf("should be an invalid discarder")
+	}
+
+	if !rs.isInvalidDiscarder("open.filename", 111) {
+		t.Errorf("should be an invalid discarder")
+	}
+
+	if !rs.isInvalidDiscarder("open.filename", false) {
+		t.Errorf("should be an invalid discarder")
+	}
+
+	if rs.isInvalidDiscarder("open.basename", false) {
+		t.Errorf("shouldn't be an invalid discarder")
+	}
+
+	if rs.isInvalidDiscarder("open.filename", "eee") {
+		t.Errorf("shouldn't be an invalid discarder")
 	}
 }

--- a/pkg/security/secl/eval/eval.go
+++ b/pkg/security/secl/eval/eval.go
@@ -59,7 +59,6 @@ func NewOptsWithParams(debug bool, constants map[string]interface{}) *Opts {
 
 // Evaluator is the interface of an evaluator
 type Evaluator interface {
-	StringValue(ctx *Context) string
 	Eval(ctx *Context) interface{}
 }
 
@@ -70,11 +69,6 @@ type BoolEvaluator struct {
 	Value   bool
 
 	isPartial bool
-}
-
-// StringValue returns a string representation of the evaluation result
-func (b *BoolEvaluator) StringValue(ctx *Context) string {
-	return fmt.Sprintf("%t", b.EvalFnc(nil))
 }
 
 // Eval returns the result of the evaluation
@@ -91,11 +85,6 @@ type IntEvaluator struct {
 	isPartial bool
 }
 
-// StringValue returns a string representation of the evaluation result
-func (i *IntEvaluator) StringValue(ctx *Context) string {
-	return fmt.Sprintf("%d", i.EvalFnc(ctx))
-}
-
 // Eval returns the result of the evaluation
 func (i *IntEvaluator) Eval(ctx *Context) interface{} {
 	return i.EvalFnc(ctx)
@@ -108,11 +97,6 @@ type StringEvaluator struct {
 	Value   string
 
 	isPartial bool
-}
-
-// StringValue returns a string representation of the evaluation result
-func (s *StringEvaluator) StringValue(ctx *Context) string {
-	return s.EvalFnc(ctx)
 }
 
 // Eval returns the result of the evaluation

--- a/pkg/security/secl/eval/model.go
+++ b/pkg/security/secl/eval/model.go
@@ -8,7 +8,7 @@ package eval
 // Model - interface that a model has to implement for the rule compilation
 type Model interface {
 	// GetEvaluator - Returns an evaluator for the given field
-	GetEvaluator(field Field) (interface{}, error)
+	GetEvaluator(field Field) (Evaluator, error)
 	// ValidateField - Returns whether the value use against the field is valid, ex: for constant
 	ValidateField(field Field, value FieldValue) error
 	// NewEvent - Returns a new event instance

--- a/pkg/security/secl/eval/model_test.go
+++ b/pkg/security/secl/eval/model_test.go
@@ -78,7 +78,7 @@ func (m *testModel) ValidateField(key string, value FieldValue) error {
 	return nil
 }
 
-func (m *testModel) GetEvaluator(key string) (interface{}, error) {
+func (m *testModel) GetEvaluator(key string) (Evaluator, error) {
 	switch key {
 
 	case "process.name":

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -322,7 +322,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
-func (m *Model) GetEvaluator(field eval.Field) (interface{}, error) {
+func (m *Model) GetEvaluator(field eval.Field) (eval.Evaluator, error) {
 	switch field {
 	{{range $Name, $Field := .Fields}}
 	{{$Return := $Field.Name | printf "(*Event)(ctx.Object).%s"}}


### PR DESCRIPTION
For example avoid evaluation on dentry resolution
error. When there is a dentry resolution error a placeholder
is used instead of the real filename. We don't have to discard
this placeholder.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
