### PR TITLE
 Install custom SELinux policy only on CentOS/RHEL 7

### DIFF
--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -17,7 +17,7 @@ if [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIB
     DISTRIBUTION_FAMILY="SUSE"
 fi
 
-if [ "$DISTRIBUTION_FAMILY" == "SUSE" ]; then
+if [ "$DISTRIBUTION_FAMILY" = "SUSE" ]; then
     # HACK: Check if we're running on SUSE 11. In that case, we support SysVInit scripts.
     # Otherwise, remove the SysVInit files.
     # This is necessary because, at least on SLES 15, the presence of these files makes systemd crash
@@ -55,9 +55,15 @@ else
     echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
 fi
 
-# SELinux policy not shipped on SUSE for now
-# FIXME: Refactor warning messages
-if [ "$DISTRIBUTION_FAMILY" != "SUSE" ]; then
+INSTALL_SELINUX_POLICY="false"
+if [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "RedHat" ]; then
+    OS_RELEASE_VERSION=$(grep VERSION_ID /etc/os-release | cut -d = -f 2 | tr -d '"')
+    if [ "$OS_RELEASE_VERSION" = "7" ]; then
+        INSTALL_SELINUX_POLICY="true"
+    fi
+fi
+
+if [ "$INSTALL_SELINUX_POLICY" = "true" ]; then
     # Setup SELinux policy and label if SELinux detected on the host
     if command -v semodule >/dev/null 2>&1 && [ -f "$INSTALL_DIR/embedded/bin/system-probe" ]; then
         echo "Loading SELinux policy module for datadog-agent."

--- a/releasenotes/notes/selinux-policy-rhel7-only-c8a72ff5eb0474f6.yaml
+++ b/releasenotes/notes/selinux-policy-rhel7-only-c8a72ff5eb0474f6.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fixed system-probe not working on CentOS/RHEL 8 due to our custom SELinux policy.
+    We now install the custom policy only on CentOS/RHEL 7, where the system-probe is known
+    not to work with the default. On other platform the default will be used.


### PR DESCRIPTION
### What does this PR do?

Installs our custom SELinux policy for the system-probe only on CentOS/RHEL 7 instead of always.

### Motivation

It seems to cause problems on version 8 and to not be needed anywhere else.

Fixes: #5207

### Describe your test plan

Tested on CentOS 7 and 8 as well as several Fedora versions (all in VirtualBox using Vagrant). All versions of Fedora I tested didn't need the policy, so I've limited it to CentOS/RHEL. Older CentOS/RHEL don't support the system-probe to start with because of the kernel version.
