### PR TITLE
[runtime-security] update runtime security metrics prefix

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -25,7 +25,7 @@ import (
 )
 
 // MetricPrefix is the prefix of the metrics sent by the runtime security agent
-const MetricPrefix = "datadog.agent.runtime_security"
+const MetricPrefix = "datadog.runtime_security"
 
 // EventHandler represents an handler for the events sent by the probe
 type EventHandler interface {


### PR DESCRIPTION
### What does this PR do?

This PR updates the runtime security metrics prefix to better follow the standards of the agent.