### PR TITLE
[runtime-security] retry eBPF probe loading to ignore temporarily fail

### DIFF
--- a/pkg/security/ebpf/module.go
+++ b/pkg/security/ebpf/module.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strings"
+	"time"
 
 	bpflib "github.com/iovisor/gobpf/elf"
 )
@@ -60,8 +62,46 @@ func (m *Module) RegisterTable(name string) (*Table, error) {
 	return &Table{Map: m.Map(name), module: m.Module}, nil
 }
 
-// eBPFLogSize is the size of the log buffer given to the verifier (2 * 1024 * 1024)
-const eBPFLogSize = 2097152
+const (
+	// eBPFLogSize is the size of the log buffer given to the verifier (2 * 1024 * 1024)
+	eBPFLogSize = 2097152
+
+	// number of retry to avoid fail for permission denied
+	maxDetachRetry = 5
+)
+
+func detach(kprobe *bpflib.Kprobe) error {
+	isKretprobe := strings.HasPrefix(kprobe.Name, "kretprobe/")
+	var err error
+	if isKretprobe {
+		funcName := strings.TrimPrefix(kprobe.Name, "kretprobe/")
+		err = disableKprobe("r" + funcName)
+	} else {
+		funcName := strings.TrimPrefix(kprobe.Name, "kprobe/")
+		err = disableKprobe("p" + funcName)
+	}
+	return err
+}
+
+// Close detach all the registered kProbes
+func (m *Module) Close() error {
+	for kprobe := range m.IterKprobes() {
+		if err := kprobe.Detach(); err != nil {
+			for i := 0; i != maxDetachRetry; i++ {
+				if err = detach(kprobe); err == nil {
+					break
+				}
+				time.Sleep(time.Second)
+			}
+
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return m.Module.Close()
+}
 
 // NewModuleFromReader creates an eBPF from a ReaderAt interface that points to
 // the ELF file containing the eBPF bytecode

--- a/pkg/security/ebpf/probe.go
+++ b/pkg/security/ebpf/probe.go
@@ -73,14 +73,16 @@ func (p *Probe) RegisterTable(table string) error {
 }
 
 // Stop the eBPF probe and its associated perf event arrays
-func (p *Probe) Stop() {
+func (p *Probe) Stop() error {
 	for _, perfMap := range p.perfMapsMap {
 		perfMap.Stop()
 	}
 
 	if p.Module != nil {
-		p.Module.Close()
+		return p.Module.Close()
 	}
+
+	return nil
 }
 
 // Start the eBPF probe and its associated perf event arrays

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -23,8 +23,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// MetricPrefix is the prefix of the metrics sent by the runtime security agent
-const MetricPrefix = "datadog.runtime_security"
+const (
+	// MetricPrefix is the prefix of the metrics sent by the runtime security agent
+	MetricPrefix = "datadog.runtime_security"
+)
 
 // EventHandler represents an handler for the events sent by the probe
 type EventHandler interface {
@@ -414,7 +416,7 @@ func (p *Probe) Start() error {
 		return err
 	}
 
-	if err := p.Load(); err != nil {
+	if err = p.Load(); err != nil {
 		return err
 	}
 
@@ -768,18 +770,16 @@ func (p *Probe) ApplyRuleSet(rs *rules.RuleSet, dryRun bool) (*Report, error) {
 					}
 
 					if err = p.Module.RegisterKprobe(kprobe); err == nil {
-						active++
-
 						log.Infof("kProbe `%s` registered", kprobe.Name)
-						break
+						active++
+					} else {
+						log.Debugf("failed to register kProbe `%s`", kprobe.Name)
 					}
-					log.Debugf("failed to register kProbe `%s`", kprobe.Name)
 				}
 				if len(hookPoint.Tracepoint) > 0 && err == nil {
 					if err = p.Module.RegisterTracepoint(hookPoint.Tracepoint); err == nil {
+						log.Infof("tracepoint `%s` registered", hookPoint.Tracepoint)
 						active++
-
-						log.Debugf("tracepoint `%s` registered", hookPoint.Tracepoint)
 					} else {
 						log.Debugf("failed to register tracepoint `%s`", hookPoint.Tracepoint)
 					}
@@ -791,7 +791,9 @@ func (p *Probe) ApplyRuleSet(rs *rules.RuleSet, dryRun bool) (*Report, error) {
 					}
 				}
 
-				log.Infof("Hook Point `%s` registered with %d active kProbes", hookPoint.Name, active)
+				if active > 0 {
+					log.Infof("Hook Point `%s` registered with %d active kProbes", hookPoint.Name, active)
+				}
 				already[hookPoint] = true
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Retry few times the eBPF loading to ignore temporarily fail

### Motivation

Have seen temporarily fails sometimes especially during functional tests

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
