### PR TITLE
[compliance] Improve handling of resolvePath in file checks

### DIFF
--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -601,14 +601,7 @@ func valueFromProcessFlag(name string, flag string) (interface{}, error) {
 	matchedProcesses := processes.findProcessesByName(name)
 	for _, mp := range matchedProcesses {
 		flagValues := parseProcessCmdLine(mp.Cmdline)
-		flagValue, found := flagValues[flag]
-		if !found {
-			return false, nil
-		}
-		if flagValue == "" {
-			return true, nil
-		}
-		return flagValue, nil
+		return flagValues[flag], nil
 	}
 	return "", fmt.Errorf("failed to find process: %s", name)
 }

--- a/pkg/compliance/checks/file_check_test.go
+++ b/pkg/compliance/checks/file_check_test.go
@@ -8,6 +8,7 @@
 package checks
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -24,6 +25,8 @@ import (
 )
 
 func TestFileCheck(t *testing.T) {
+	assert := assert.New(t)
+
 	type setupFileFunc func(t *testing.T, env *mocks.Env, file *compliance.File)
 	type validateFunc func(t *testing.T, file *compliance.File, report *report)
 
@@ -37,7 +40,7 @@ func TestFileCheck(t *testing.T) {
 	createTempFiles := func(t *testing.T, numFiles int) (string, []string) {
 		paths := make([]string, 0, numFiles)
 		dir, err := ioutil.TempDir("", "cmplFileTest")
-		assert.NoError(t, err)
+		assert.NoError(err)
 		cleanUpDirs = append(cleanUpDirs, dir)
 
 		for i := 0; i < numFiles; i++ {
@@ -47,7 +50,7 @@ func TestFileCheck(t *testing.T) {
 
 			f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
 			defer f.Close()
-			assert.NoError(t, err)
+			assert.NoError(err)
 		}
 
 		return dir, paths
@@ -75,9 +78,9 @@ func TestFileCheck(t *testing.T) {
 				env.On("RelativeToHostRoot", filePaths[0]).Return(file.Path)
 			},
 			validate: func(t *testing.T, file *compliance.File, report *report) {
-				assert.True(t, report.passed)
-				assert.Equal(t, file.Path, report.data["file.path"])
-				assert.Equal(t, uint64(0644), report.data["file.permissions"])
+				assert.True(report.passed)
+				assert.Equal(file.Path, report.data["file.path"])
+				assert.Equal(uint64(0644), report.data["file.permissions"])
 			},
 		},
 		{
@@ -97,9 +100,9 @@ func TestFileCheck(t *testing.T) {
 				env.On("NormalizeToHostRoot", file.Path).Return(path.Join(tempDir, "/*.dat"))
 			},
 			validate: func(t *testing.T, file *compliance.File, report *report) {
-				assert.True(t, report.passed)
-				assert.Regexp(t, "/etc/test-[0-9]-[0-9]+", report.data["file.path"])
-				assert.Equal(t, uint64(0644), report.data["file.permissions"])
+				assert.True(report.passed)
+				assert.Regexp("/etc/test-[0-9]-[0-9]+", report.data["file.path"])
+				assert.Equal(uint64(0644), report.data["file.permissions"])
 			},
 		},
 		{
@@ -112,10 +115,10 @@ func TestFileCheck(t *testing.T) {
 			},
 			setup: normalizePath,
 			validate: func(t *testing.T, file *compliance.File, report *report) {
-				assert.True(t, report.passed)
-				assert.Equal(t, "/tmp", report.data["file.path"])
-				assert.Equal(t, "root", report.data["file.user"])
-				assert.Contains(t, []string{"root", "wheel"}, report.data["file.group"])
+				assert.True(report.passed)
+				assert.Equal("/tmp", report.data["file.path"])
+				assert.Equal("root", report.data["file.user"])
+				assert.Contains([]string{"root", "wheel"}, report.data["file.group"])
 			},
 		},
 		{
@@ -131,10 +134,10 @@ func TestFileCheck(t *testing.T) {
 				env.On("RelativeToHostRoot", "./testdata/file/daemon.json").Return(file.Path)
 			},
 			validate: func(t *testing.T, file *compliance.File, report *report) {
-				assert.True(t, report.passed)
-				assert.Equal(t, "/etc/docker/daemon.json", report.data["file.path"])
-				assert.NotEmpty(t, report.data["file.user"])
-				assert.NotEmpty(t, report.data["file.group"])
+				assert.True(report.passed)
+				assert.Equal("/etc/docker/daemon.json", report.data["file.path"])
+				assert.NotEmpty(report.data["file.user"])
+				assert.NotEmpty(report.data["file.group"])
 			},
 		},
 		{
@@ -150,10 +153,10 @@ func TestFileCheck(t *testing.T) {
 				env.On("RelativeToHostRoot", "./testdata/file/daemon.json").Return(file.Path)
 			},
 			validate: func(t *testing.T, file *compliance.File, report *report) {
-				assert.False(t, report.passed)
-				assert.Equal(t, "/etc/docker/daemon.json", report.data["file.path"])
-				assert.NotEmpty(t, report.data["file.user"])
-				assert.NotEmpty(t, report.data["file.group"])
+				assert.False(report.passed)
+				assert.Equal("/etc/docker/daemon.json", report.data["file.path"])
+				assert.NotEmpty(report.data["file.user"])
+				assert.NotEmpty(report.data["file.group"])
 			},
 		},
 		{
@@ -171,11 +174,50 @@ func TestFileCheck(t *testing.T) {
 				env.On("RelativeToHostRoot", "./testdata/file/daemon.json").Return(path)
 			},
 			validate: func(t *testing.T, file *compliance.File, report *report) {
-				assert.True(t, report.passed)
-				assert.Equal(t, "/etc/docker/daemon.json", report.data["file.path"])
-				assert.NotEmpty(t, report.data["file.user"])
-				assert.NotEmpty(t, report.data["file.group"])
+				assert.True(report.passed)
+				assert.Equal("/etc/docker/daemon.json", report.data["file.path"])
+				assert.NotEmpty(report.data["file.user"])
+				assert.NotEmpty(report.data["file.group"])
 			},
+		},
+		{
+			name: "jq(experimental) and path expression - empty path",
+			resource: compliance.Resource{
+				File: &compliance.File{
+					Path: `process.flag("dockerd", "--config-file")`,
+				},
+				Condition: `file.jq(".experimental") == "false"`,
+			},
+			setup: func(t *testing.T, env *mocks.Env, file *compliance.File) {
+				env.On("EvaluateFromCache", mock.Anything).Return("", nil)
+			},
+			expectError: errors.New(`failed to resolve path: empty path from process.flag("dockerd", "--config-file")`),
+		},
+		{
+			name: "jq(experimental) and path expression - wrong type",
+			resource: compliance.Resource{
+				File: &compliance.File{
+					Path: `process.flag("dockerd", "--config-file")`,
+				},
+				Condition: `file.jq(".experimental") == "false"`,
+			},
+			setup: func(t *testing.T, env *mocks.Env, file *compliance.File) {
+				env.On("EvaluateFromCache", mock.Anything).Return(true, nil)
+			},
+			expectError: errors.New(`failed to resolve path: expected string from process.flag("dockerd", "--config-file") got "true"`),
+		},
+		{
+			name: "jq(experimental) and path expression - expression failed",
+			resource: compliance.Resource{
+				File: &compliance.File{
+					Path: `process.unknown()`,
+				},
+				Condition: `file.jq(".experimental") == "false"`,
+			},
+			setup: func(t *testing.T, env *mocks.Env, file *compliance.File) {
+				env.On("EvaluateFromCache", mock.Anything).Return(nil, errors.New("1:1: unknown function process.unknown()"))
+			},
+			expectError: errors.New(`failed to resolve path: 1:1: unknown function process.unknown()`),
 		},
 		{
 			name: "jq(ulimits)",
@@ -190,10 +232,10 @@ func TestFileCheck(t *testing.T) {
 				env.On("RelativeToHostRoot", "./testdata/file/daemon.json").Return(file.Path)
 			},
 			validate: func(t *testing.T, file *compliance.File, report *report) {
-				assert.True(t, report.passed)
-				assert.Equal(t, "/etc/docker/daemon.json", report.data["file.path"])
-				assert.NotEmpty(t, report.data["file.user"])
-				assert.NotEmpty(t, report.data["file.group"])
+				assert.True(report.passed)
+				assert.Equal("/etc/docker/daemon.json", report.data["file.path"])
+				assert.NotEmpty(report.data["file.user"])
+				assert.NotEmpty(report.data["file.group"])
 			},
 		},
 		{
@@ -209,10 +251,10 @@ func TestFileCheck(t *testing.T) {
 				env.On("RelativeToHostRoot", "./testdata/file/pod.yaml").Return(file.Path)
 			},
 			validate: func(t *testing.T, file *compliance.File, report *report) {
-				assert.True(t, report.passed)
-				assert.Equal(t, "/etc/pod.yaml", report.data["file.path"])
-				assert.NotEmpty(t, report.data["file.user"])
-				assert.NotEmpty(t, report.data["file.group"])
+				assert.True(report.passed)
+				assert.Equal("/etc/pod.yaml", report.data["file.path"])
+				assert.NotEmpty(report.data["file.user"])
+				assert.NotEmpty(report.data["file.group"])
 			},
 		},
 	}
@@ -227,14 +269,14 @@ func TestFileCheck(t *testing.T) {
 			}
 
 			expr, err := eval.ParseIterable(test.resource.Condition)
-			assert.NoError(t, err)
+			assert.NoError(err)
 
 			report, err := checkFile(env, "rule-id", test.resource, expr)
 
 			if test.expectError != nil {
-				assert.Equal(t, test.expectError, err)
+				assert.EqualError(err, test.expectError.Error())
 			} else {
-				assert.NoError(t, err)
+				assert.NoError(err)
 				test.validate(t, test.resource.File, report)
 			}
 		})

--- a/pkg/compliance/checks/file_utils.go
+++ b/pkg/compliance/checks/file_utils.go
@@ -47,15 +47,19 @@ func resolvePath(e env.Env, path string) (string, error) {
 		return *pathExpr.Path, nil
 	}
 
-	v, err := e.EvaluateFromCache(pathExpr)
+	v, err := e.EvaluateFromCache(pathExpr.Expression)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to resolve path: %w", err)
 	}
 
-	path, ok := v.(string)
+	res, ok := v.(string)
 	if !ok {
-		return "", fmt.Errorf("resource path expression not resolved to string: %s", path)
+		return "", fmt.Errorf(`failed to resolve path: expected string from %s got "%v"`, path, v)
 	}
 
-	return path, nil
+	if res == "" {
+		return "", fmt.Errorf("failed to resolve path: empty path from %s", path)
+	}
+
+	return res, nil
 }


### PR DESCRIPTION
### What does this PR do?

Improve handling of resolvePath in file checks.

### Motivation

Currently when a compliance check fails to find a CLI flag for a targeted process, file resolution fails with a cryptic error `resource path expression not resolved to string:`. This improves handling of this and other errors.

### Describe your test plan

Author a check targeting file using `process.flag()` and failing to find the flag or process.
