### PR TITLE
Use portable macro for accessing pt_regs* in security probe syscall wrapper

### DIFF
--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -28,7 +28,7 @@ int __attribute__((always_inline)) trace__sys_chmod(struct pt_regs *ctx, umode_t
 SYSCALL_KPROBE(chmod) {
     umode_t mode;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&mode, sizeof(mode), &PT_REGS_PARM2(ctx));
 #else
     mode = (umode_t) PT_REGS_PARM2(ctx);
@@ -39,7 +39,7 @@ SYSCALL_KPROBE(chmod) {
 SYSCALL_KPROBE(fchmod) {
     umode_t mode;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&mode, sizeof(mode), &PT_REGS_PARM2(ctx));
 #else
     mode = (umode_t) PT_REGS_PARM2(ctx);
@@ -50,7 +50,7 @@ SYSCALL_KPROBE(fchmod) {
 SYSCALL_KPROBE(fchmodat) {
     umode_t mode;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&mode, sizeof(mode), &PT_REGS_PARM3(ctx));
 #else
     mode = (umode_t) PT_REGS_PARM3(ctx);

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -32,7 +32,7 @@ SYSCALL_KPROBE(chown) {
     uid_t user;
     gid_t group;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&user, sizeof(user), &PT_REGS_PARM2(ctx));
     bpf_probe_read(&group, sizeof(group), &PT_REGS_PARM3(ctx));
 #else
@@ -46,7 +46,7 @@ SYSCALL_KPROBE(fchown) {
     uid_t user;
     gid_t group;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&user, sizeof(user), &PT_REGS_PARM2(ctx));
     bpf_probe_read(&group, sizeof(group), &PT_REGS_PARM3(ctx));
 #else
@@ -60,7 +60,7 @@ SYSCALL_KPROBE(fchownat) {
     uid_t user;
     gid_t group;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&user, sizeof(user), &(PT_REGS_PARM3(ctx)));
     // for some reason, this doesn't work on 5.6 kernels, so
     // we get mode from security_inode_setattr
@@ -76,7 +76,7 @@ SYSCALL_KPROBE(lchown) {
     uid_t user;
     gid_t group;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&user, sizeof(user), &PT_REGS_PARM2(ctx));
     bpf_probe_read(&group, sizeof(group), &PT_REGS_PARM3(ctx));
 #else

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -29,7 +29,7 @@ int __attribute__((always_inline)) trace__sys_mkdir(struct pt_regs *ctx, umode_t
 SYSCALL_KPROBE(mkdir) {
     umode_t mode;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&mode, sizeof(mode), &PT_REGS_PARM2(ctx));
 #else
     mode = (umode_t) PT_REGS_PARM2(ctx);
@@ -40,7 +40,7 @@ SYSCALL_KPROBE(mkdir) {
 SYSCALL_KPROBE(mkdirat) {
     umode_t mode;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&mode, sizeof(mode), &PT_REGS_PARM3(ctx));
 #else
     mode = (umode_t) PT_REGS_PARM3(ctx);

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -22,7 +22,7 @@ struct mount_event_t {
 SYSCALL_KPROBE(mount) {
     struct syscall_cache_t syscall = {};
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&syscall.mount.fstype, sizeof(void *), &PT_REGS_PARM3(ctx));
 #else
     syscall.mount.fstype = (void *)PT_REGS_PARM3(ctx);

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -96,7 +96,7 @@ SYSCALL_KPROBE(open) {
     int flags;
     umode_t mode;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&flags, sizeof(flags), &PT_REGS_PARM2(ctx));
     bpf_probe_read(&mode, sizeof(mode), &PT_REGS_PARM3(ctx));
 #else
@@ -110,7 +110,7 @@ SYSCALL_KPROBE(openat) {
     int flags;
     umode_t mode;
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&flags, sizeof(flags), &PT_REGS_PARM3(ctx));
     bpf_probe_read(&mode, sizeof(mode), &PT_REGS_PARM4(ctx));
 #else

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -43,7 +43,7 @@ SYSCALL_KPROBE(unlinkat) {
     int flags;
 
 #if USE_SYSCALL_WRAPPER
-    ctx = (struct pt_regs *) ctx->di;
+    ctx = (struct pt_regs *) PT_REGS_PARM1(ctx);
     bpf_probe_read(&flags, sizeof(flags), &PT_REGS_PARM3(ctx));
 #else
     flags = (int) PT_REGS_PARM3(ctx);


### PR DESCRIPTION
### What does this PR do?

Fixes the security probe on `arm64`, which doesn't have a `di` register.

### Motivation

Failing builds for `system-probe` on `arm64`.
