### PR TITLE
[system-probe] Revert listening for all namespaces

### DIFF
--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -236,10 +236,6 @@ func (c *Consumer) initNetlinkSocket(samplingRate float64) error {
 		log.Debugf("rcv buffer size for netlink socket is %d bytes", size)
 	}
 
-	if err := c.socket.SetSockoptInt(unix.SOL_NETLINK, unix.NETLINK_LISTEN_ALL_NSID, 1); err != nil {
-		log.Errorf("error enabling listen for all namespaces on netlink socket: %s", err)
-	}
-
 	// Attach BPF sampling filter if necessary
 	c.samplingRate = samplingRate
 	atomic.StoreInt64(&c.samplingPct, int64(samplingRate*100.0))


### PR DESCRIPTION
### What does this PR do?

This is a revert of https://github.com/DataDog/datadog-agent/pull/6041

### Motivation

This does not fully do what we want. In particular does not have conntrack info for all namespaces in the initial dump.

### Additional Notes

### Describe your test plan
