### PR TITLE
[runtime-security] Convert flags, mode and retval as string in event report

### DIFF
--- a/pkg/security/probe/consts.go
+++ b/pkg/security/probe/consts.go
@@ -8,10 +8,14 @@
 package probe
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
+	"golang.org/x/sys/unix"
 )
 
 // EventType describes the type of an event sent from the kernel
@@ -75,185 +79,315 @@ func (t EventType) String() string {
 }
 
 var (
+	errorConstants = map[string]int{
+		"E2BIG":           -int(syscall.E2BIG),
+		"EACCES":          -int(syscall.EACCES),
+		"EADDRINUSE":      -int(syscall.EADDRINUSE),
+		"EADDRNOTAVAIL":   -int(syscall.EADDRNOTAVAIL),
+		"EADV":            -int(syscall.EADV),
+		"EAFNOSUPPORT":    -int(syscall.EAFNOSUPPORT),
+		"EAGAIN":          -int(syscall.EAGAIN),
+		"EALREADY":        -int(syscall.EALREADY),
+		"EBADE":           -int(syscall.EBADE),
+		"EBADF":           -int(syscall.EBADF),
+		"EBADFD":          -int(syscall.EBADFD),
+		"EBADMSG":         -int(syscall.EBADMSG),
+		"EBADR":           -int(syscall.EBADR),
+		"EBADRQC":         -int(syscall.EBADRQC),
+		"EBADSLT":         -int(syscall.EBADSLT),
+		"EBFONT":          -int(syscall.EBFONT),
+		"EBUSY":           -int(syscall.EBUSY),
+		"ECANCELED":       -int(syscall.ECANCELED),
+		"ECHILD":          -int(syscall.ECHILD),
+		"ECHRNG":          -int(syscall.ECHRNG),
+		"ECOMM":           -int(syscall.ECOMM),
+		"ECONNABORTED":    -int(syscall.ECONNABORTED),
+		"ECONNREFUSED":    -int(syscall.ECONNREFUSED),
+		"ECONNRESET":      -int(syscall.ECONNRESET),
+		"EDEADLK":         -int(syscall.EDEADLK),
+		"EDEADLOCK":       -int(syscall.EDEADLOCK),
+		"EDESTADDRREQ":    -int(syscall.EDESTADDRREQ),
+		"EDOM":            -int(syscall.EDOM),
+		"EDOTDOT":         -int(syscall.EDOTDOT),
+		"EDQUOT":          -int(syscall.EDQUOT),
+		"EEXIST":          -int(syscall.EEXIST),
+		"EFAULT":          -int(syscall.EFAULT),
+		"EFBIG":           -int(syscall.EFBIG),
+		"EHOSTDOWN":       -int(syscall.EHOSTDOWN),
+		"EHOSTUNREACH":    -int(syscall.EHOSTUNREACH),
+		"EIDRM":           -int(syscall.EIDRM),
+		"EILSEQ":          -int(syscall.EIDRM),
+		"EINPROGRESS":     -int(syscall.EINPROGRESS),
+		"EINTR":           -int(syscall.EINTR),
+		"EINVAL":          -int(syscall.EINVAL),
+		"EIO":             -int(syscall.EIO),
+		"EISCONN":         -int(syscall.EISCONN),
+		"EISDIR":          -int(syscall.EISDIR),
+		"EISNAM":          -int(syscall.EISNAM),
+		"EKEYEXPIRED":     -int(syscall.EKEYEXPIRED),
+		"EKEYREJECTED":    -int(syscall.EKEYREJECTED),
+		"EKEYREVOKED":     -int(syscall.EKEYREVOKED),
+		"EL2HLT":          -int(syscall.EL2HLT),
+		"EL2NSYNC":        -int(syscall.EL2NSYNC),
+		"EL3HLT":          -int(syscall.EL3HLT),
+		"EL3RST":          -int(syscall.EL3RST),
+		"ELIBACC":         -int(syscall.ELIBACC),
+		"ELIBBAD":         -int(syscall.ELIBBAD),
+		"ELIBEXEC":        -int(syscall.ELIBEXEC),
+		"ELIBMAX":         -int(syscall.ELIBMAX),
+		"ELIBSCN":         -int(syscall.ELIBSCN),
+		"ELNRNG":          -int(syscall.ELNRNG),
+		"ELOOP":           -int(syscall.ELOOP),
+		"EMEDIUMTYPE":     -int(syscall.EMEDIUMTYPE),
+		"EMFILE":          -int(syscall.EMFILE),
+		"EMLINK":          -int(syscall.EMLINK),
+		"EMSGSIZE":        -int(syscall.EMSGSIZE),
+		"EMULTIHOP":       -int(syscall.EMULTIHOP),
+		"ENAMETOOLONG":    -int(syscall.ENAMETOOLONG),
+		"ENAVAIL":         -int(syscall.ENAVAIL),
+		"ENETDOWN":        -int(syscall.ENETDOWN),
+		"ENETRESET":       -int(syscall.ENETRESET),
+		"ENETUNREACH":     -int(syscall.ENETUNREACH),
+		"ENFILE":          -int(syscall.ENFILE),
+		"ENOANO":          -int(syscall.ENOANO),
+		"ENOBUFS":         -int(syscall.ENOBUFS),
+		"ENOCSI":          -int(syscall.ENOCSI),
+		"ENODATA":         -int(syscall.ENODATA),
+		"ENODEV":          -int(syscall.ENODEV),
+		"ENOENT":          -int(syscall.ENOENT),
+		"ENOEXEC":         -int(syscall.ENOEXEC),
+		"ENOKEY":          -int(syscall.ENOKEY),
+		"ENOLCK":          -int(syscall.ENOLCK),
+		"ENOLINK":         -int(syscall.ENOLINK),
+		"ENOMEDIUM":       -int(syscall.ENOMEDIUM),
+		"ENOMEM":          -int(syscall.ENOMEM),
+		"ENOMSG":          -int(syscall.ENOMSG),
+		"ENONET":          -int(syscall.ENONET),
+		"ENOPKG":          -int(syscall.ENOPKG),
+		"ENOPROTOOPT":     -int(syscall.ENOPROTOOPT),
+		"ENOSPC":          -int(syscall.ENOSPC),
+		"ENOSR":           -int(syscall.ENOSR),
+		"ENOSTR":          -int(syscall.ENOSTR),
+		"ENOSYS":          -int(syscall.ENOSYS),
+		"ENOTBLK":         -int(syscall.ENOTBLK),
+		"ENOTCONN":        -int(syscall.ENOTCONN),
+		"ENOTDIR":         -int(syscall.ENOTDIR),
+		"ENOTEMPTY":       -int(syscall.ENOTEMPTY),
+		"ENOTNAM":         -int(syscall.ENOTNAM),
+		"ENOTRECOVERABLE": -int(syscall.ENOTRECOVERABLE),
+		"ENOTSOCK":        -int(syscall.ENOTSOCK),
+		"ENOTSUP":         -int(syscall.ENOTSUP),
+		"ENOTTY":          -int(syscall.ENOTTY),
+		"ENOTUNIQ":        -int(syscall.ENOTUNIQ),
+		"ENXIO":           -int(syscall.ENXIO),
+		"EOPNOTSUPP":      -int(syscall.EOPNOTSUPP),
+		"EOVERFLOW":       -int(syscall.EOVERFLOW),
+		"EOWNERDEAD":      -int(syscall.EOWNERDEAD),
+		"EPERM":           -int(syscall.EPERM),
+		"EPFNOSUPPORT":    -int(syscall.EPFNOSUPPORT),
+		"EPIPE":           -int(syscall.EPIPE),
+		"EPROTO":          -int(syscall.EPROTO),
+		"EPROTONOSUPPORT": -int(syscall.EPROTONOSUPPORT),
+		"EPROTOTYPE":      -int(syscall.EPROTOTYPE),
+		"ERANGE":          -int(syscall.ERANGE),
+		"EREMCHG":         -int(syscall.EREMCHG),
+		"EREMOTE":         -int(syscall.EREMOTE),
+		"EREMOTEIO":       -int(syscall.EREMOTEIO),
+		"ERESTART":        -int(syscall.ERESTART),
+		"ERFKILL":         -int(syscall.ERFKILL),
+		"EROFS":           -int(syscall.EROFS),
+		"ESHUTDOWN":       -int(syscall.ESHUTDOWN),
+		"ESOCKTNOSUPPORT": -int(syscall.ESOCKTNOSUPPORT),
+		"ESPIPE":          -int(syscall.ESPIPE),
+		"ESRCH":           -int(syscall.ESRCH),
+		"ESRMNT":          -int(syscall.ESRMNT),
+		"ESTALE":          -int(syscall.ESTALE),
+		"ESTRPIPE":        -int(syscall.ESTRPIPE),
+		"ETIME":           -int(syscall.ETIME),
+		"ETIMEDOUT":       -int(syscall.ETIMEDOUT),
+		"ETOOMANYREFS":    -int(syscall.ETOOMANYREFS),
+		"ETXTBSY":         -int(syscall.ETXTBSY),
+		"EUCLEAN":         -int(syscall.EUCLEAN),
+		"EUNATCH":         -int(syscall.EUNATCH),
+		"EUSERS":          -int(syscall.EUSERS),
+		"EWOULDBLOCK":     -int(syscall.EWOULDBLOCK),
+		"EXDEV":           -int(syscall.EXDEV),
+		"EXFULL":          -int(syscall.EXFULL),
+	}
+
+	openFlagsConstants = map[string]int{
+		"O_RDONLY":    syscall.O_RDONLY,
+		"O_WRONLY":    syscall.O_WRONLY,
+		"O_RDWR":      syscall.O_RDWR,
+		"O_APPEND":    syscall.O_APPEND,
+		"O_CREAT":     syscall.O_CREAT,
+		"O_EXCL":      syscall.O_EXCL,
+		"O_SYNC":      syscall.O_SYNC,
+		"O_TRUNC":     syscall.O_TRUNC,
+		"O_ACCMODE":   syscall.O_ACCMODE,
+		"O_ASYNC":     syscall.O_ASYNC,
+		"O_CLOEXEC":   syscall.O_CLOEXEC,
+		"O_DIRECT":    syscall.O_DIRECT,
+		"O_DIRECTORY": syscall.O_DIRECTORY,
+		"O_DSYNC":     syscall.O_DSYNC,
+		"O_FSYNC":     syscall.O_FSYNC,
+		"O_LARGEFILE": syscall.O_LARGEFILE,
+		"O_NDELAY":    syscall.O_NDELAY,
+		"O_NOATIME":   syscall.O_NOATIME,
+		"O_NOCTTY":    syscall.O_NOCTTY,
+		"O_NOFOLLOW":  syscall.O_NOFOLLOW,
+		"O_NONBLOCK":  syscall.O_NONBLOCK,
+		"O_RSYNC":     syscall.O_RSYNC,
+	}
+
+	chmodModeConstants = map[string]int{
+		//"S_IEXEC":  syscall.S_IEXEC, deprecated
+		"S_IFBLK":  syscall.S_IFBLK,
+		"S_IFCHR":  syscall.S_IFCHR,
+		"S_IFDIR":  syscall.S_IFDIR,
+		"S_IFIFO":  syscall.S_IFIFO,
+		"S_IFLNK":  syscall.S_IFLNK,
+		"S_IFMT":   syscall.S_IFMT,
+		"S_IFREG":  syscall.S_IFREG,
+		"S_IFSOCK": syscall.S_IFSOCK,
+		//"S_IREAD":  syscall.S_IREAD, deprecated
+		"S_IRGRP": syscall.S_IRGRP,
+		"S_IROTH": syscall.S_IROTH,
+		"S_IRUSR": syscall.S_IRUSR,
+		"S_IRWXG": syscall.S_IRWXG,
+		"S_IRWXO": syscall.S_IRWXO,
+		"S_IRWXU": syscall.S_IRWXU,
+		"S_ISGID": syscall.S_ISGID,
+		"S_ISUID": syscall.S_ISUID,
+		"S_ISVTX": syscall.S_ISVTX,
+		"S_IWGRP": syscall.S_IWGRP,
+		"S_IWOTH": syscall.S_IWOTH,
+		//"S_IWRITE": syscall.S_IWRITE, deprecated
+		"S_IWUSR": syscall.S_IWUSR,
+		"S_IXGRP": syscall.S_IXGRP,
+		"S_IXOTH": syscall.S_IXOTH,
+		"S_IXUSR": syscall.S_IXUSR,
+	}
+
+	unlinkFlagsConstants = map[string]int{
+		"AT_REMOVEDIR": unix.AT_REMOVEDIR,
+	}
+
 	// SECLConstants are constants available in runtime security agent rules
 	SECLConstants = map[string]interface{}{
 		// boolean
 		"true":  &eval.BoolEvaluator{Value: true},
 		"false": &eval.BoolEvaluator{Value: false},
-
-		// errors
-		"E2BIG":           &eval.IntEvaluator{Value: -int(syscall.E2BIG)},
-		"EACCES":          &eval.IntEvaluator{Value: -int(syscall.EACCES)},
-		"EADDRINUSE":      &eval.IntEvaluator{Value: -int(syscall.EADDRINUSE)},
-		"EADDRNOTAVAIL":   &eval.IntEvaluator{Value: -int(syscall.EADDRNOTAVAIL)},
-		"EADV":            &eval.IntEvaluator{Value: -int(syscall.EADV)},
-		"EAFNOSUPPORT":    &eval.IntEvaluator{Value: -int(syscall.EAFNOSUPPORT)},
-		"EAGAIN":          &eval.IntEvaluator{Value: -int(syscall.EAGAIN)},
-		"EALREADY":        &eval.IntEvaluator{Value: -int(syscall.EALREADY)},
-		"EBADE":           &eval.IntEvaluator{Value: -int(syscall.EBADE)},
-		"EBADF":           &eval.IntEvaluator{Value: -int(syscall.EBADF)},
-		"EBADFD":          &eval.IntEvaluator{Value: -int(syscall.EBADFD)},
-		"EBADMSG":         &eval.IntEvaluator{Value: -int(syscall.EBADMSG)},
-		"EBADR":           &eval.IntEvaluator{Value: -int(syscall.EBADR)},
-		"EBADRQC":         &eval.IntEvaluator{Value: -int(syscall.EBADRQC)},
-		"EBADSLT":         &eval.IntEvaluator{Value: -int(syscall.EBADSLT)},
-		"EBFONT":          &eval.IntEvaluator{Value: -int(syscall.EBFONT)},
-		"EBUSY":           &eval.IntEvaluator{Value: -int(syscall.EBUSY)},
-		"ECANCELED":       &eval.IntEvaluator{Value: -int(syscall.ECANCELED)},
-		"ECHILD":          &eval.IntEvaluator{Value: -int(syscall.ECHILD)},
-		"ECHRNG":          &eval.IntEvaluator{Value: -int(syscall.ECHRNG)},
-		"ECOMM":           &eval.IntEvaluator{Value: -int(syscall.ECOMM)},
-		"ECONNABORTED":    &eval.IntEvaluator{Value: -int(syscall.ECONNABORTED)},
-		"ECONNREFUSED":    &eval.IntEvaluator{Value: -int(syscall.ECONNREFUSED)},
-		"ECONNRESET":      &eval.IntEvaluator{Value: -int(syscall.ECONNRESET)},
-		"EDEADLK":         &eval.IntEvaluator{Value: -int(syscall.EDEADLK)},
-		"EDEADLOCK":       &eval.IntEvaluator{Value: -int(syscall.EDEADLOCK)},
-		"EDESTADDRREQ":    &eval.IntEvaluator{Value: -int(syscall.EDESTADDRREQ)},
-		"EDOM":            &eval.IntEvaluator{Value: -int(syscall.EDOM)},
-		"EDOTDOT":         &eval.IntEvaluator{Value: -int(syscall.EDOTDOT)},
-		"EDQUOT":          &eval.IntEvaluator{Value: -int(syscall.EDQUOT)},
-		"EEXIST":          &eval.IntEvaluator{Value: -int(syscall.EEXIST)},
-		"EFAULT":          &eval.IntEvaluator{Value: -int(syscall.EFAULT)},
-		"EFBIG":           &eval.IntEvaluator{Value: -int(syscall.EFBIG)},
-		"EHOSTDOWN":       &eval.IntEvaluator{Value: -int(syscall.EHOSTDOWN)},
-		"EHOSTUNREACH":    &eval.IntEvaluator{Value: -int(syscall.EHOSTUNREACH)},
-		"EIDRM":           &eval.IntEvaluator{Value: -int(syscall.EIDRM)},
-		"EILSEQ":          &eval.IntEvaluator{Value: -int(syscall.EIDRM)},
-		"EINPROGRESS":     &eval.IntEvaluator{Value: -int(syscall.EINPROGRESS)},
-		"EINTR":           &eval.IntEvaluator{Value: -int(syscall.EINTR)},
-		"EINVAL":          &eval.IntEvaluator{Value: -int(syscall.EINVAL)},
-		"EIO":             &eval.IntEvaluator{Value: -int(syscall.EIO)},
-		"EISCONN":         &eval.IntEvaluator{Value: -int(syscall.EISCONN)},
-		"EISDIR":          &eval.IntEvaluator{Value: -int(syscall.EISDIR)},
-		"EISNAM":          &eval.IntEvaluator{Value: -int(syscall.EISNAM)},
-		"EKEYEXPIRED":     &eval.IntEvaluator{Value: -int(syscall.EKEYEXPIRED)},
-		"EKEYREJECTED":    &eval.IntEvaluator{Value: -int(syscall.EKEYREJECTED)},
-		"EKEYREVOKED":     &eval.IntEvaluator{Value: -int(syscall.EKEYREVOKED)},
-		"EL2HLT":          &eval.IntEvaluator{Value: -int(syscall.EL2HLT)},
-		"EL2NSYNC":        &eval.IntEvaluator{Value: -int(syscall.EL2NSYNC)},
-		"EL3HLT":          &eval.IntEvaluator{Value: -int(syscall.EL3HLT)},
-		"EL3RST":          &eval.IntEvaluator{Value: -int(syscall.EL3RST)},
-		"ELIBACC":         &eval.IntEvaluator{Value: -int(syscall.ELIBACC)},
-		"ELIBBAD":         &eval.IntEvaluator{Value: -int(syscall.ELIBBAD)},
-		"ELIBEXEC":        &eval.IntEvaluator{Value: -int(syscall.ELIBEXEC)},
-		"ELIBMAX":         &eval.IntEvaluator{Value: -int(syscall.ELIBMAX)},
-		"ELIBSCN":         &eval.IntEvaluator{Value: -int(syscall.ELIBSCN)},
-		"ELNRNG":          &eval.IntEvaluator{Value: -int(syscall.ELNRNG)},
-		"ELOOP":           &eval.IntEvaluator{Value: -int(syscall.ELOOP)},
-		"EMEDIUMTYPE":     &eval.IntEvaluator{Value: -int(syscall.EMEDIUMTYPE)},
-		"EMFILE":          &eval.IntEvaluator{Value: -int(syscall.EMFILE)},
-		"EMLINK":          &eval.IntEvaluator{Value: -int(syscall.EMLINK)},
-		"EMSGSIZE":        &eval.IntEvaluator{Value: -int(syscall.EMSGSIZE)},
-		"EMULTIHOP":       &eval.IntEvaluator{Value: -int(syscall.EMULTIHOP)},
-		"ENAMETOOLONG":    &eval.IntEvaluator{Value: -int(syscall.ENAMETOOLONG)},
-		"ENAVAIL":         &eval.IntEvaluator{Value: -int(syscall.ENAVAIL)},
-		"ENETDOWN":        &eval.IntEvaluator{Value: -int(syscall.ENETDOWN)},
-		"ENETRESET":       &eval.IntEvaluator{Value: -int(syscall.ENETRESET)},
-		"ENETUNREACH":     &eval.IntEvaluator{Value: -int(syscall.ENETUNREACH)},
-		"ENFILE":          &eval.IntEvaluator{Value: -int(syscall.ENFILE)},
-		"ENOANO":          &eval.IntEvaluator{Value: -int(syscall.ENOANO)},
-		"ENOBUFS":         &eval.IntEvaluator{Value: -int(syscall.ENOBUFS)},
-		"ENOCSI":          &eval.IntEvaluator{Value: -int(syscall.ENOCSI)},
-		"ENODATA":         &eval.IntEvaluator{Value: -int(syscall.ENODATA)},
-		"ENODEV":          &eval.IntEvaluator{Value: -int(syscall.ENODEV)},
-		"ENOENT":          &eval.IntEvaluator{Value: -int(syscall.ENOENT)},
-		"ENOEXEC":         &eval.IntEvaluator{Value: -int(syscall.ENOEXEC)},
-		"ENOKEY":          &eval.IntEvaluator{Value: -int(syscall.ENOKEY)},
-		"ENOLCK":          &eval.IntEvaluator{Value: -int(syscall.ENOLCK)},
-		"ENOLINK":         &eval.IntEvaluator{Value: -int(syscall.ENOLINK)},
-		"ENOMEDIUM":       &eval.IntEvaluator{Value: -int(syscall.ENOMEDIUM)},
-		"ENOMEM":          &eval.IntEvaluator{Value: -int(syscall.ENOMEM)},
-		"ENOMSG":          &eval.IntEvaluator{Value: -int(syscall.ENOMSG)},
-		"ENONET":          &eval.IntEvaluator{Value: -int(syscall.ENONET)},
-		"ENOPKG":          &eval.IntEvaluator{Value: -int(syscall.ENOPKG)},
-		"ENOPROTOOPT":     &eval.IntEvaluator{Value: -int(syscall.ENOPROTOOPT)},
-		"ENOSPC":          &eval.IntEvaluator{Value: -int(syscall.ENOSPC)},
-		"ENOSR":           &eval.IntEvaluator{Value: -int(syscall.ENOSR)},
-		"ENOSTR":          &eval.IntEvaluator{Value: -int(syscall.ENOSTR)},
-		"ENOSYS":          &eval.IntEvaluator{Value: -int(syscall.ENOSYS)},
-		"ENOTBLK":         &eval.IntEvaluator{Value: -int(syscall.ENOTBLK)},
-		"ENOTCONN":        &eval.IntEvaluator{Value: -int(syscall.ENOTCONN)},
-		"ENOTDIR":         &eval.IntEvaluator{Value: -int(syscall.ENOTDIR)},
-		"ENOTEMPTY":       &eval.IntEvaluator{Value: -int(syscall.ENOTEMPTY)},
-		"ENOTNAM":         &eval.IntEvaluator{Value: -int(syscall.ENOTNAM)},
-		"ENOTRECOVERABLE": &eval.IntEvaluator{Value: -int(syscall.ENOTRECOVERABLE)},
-		"ENOTSOCK":        &eval.IntEvaluator{Value: -int(syscall.ENOTSOCK)},
-		"ENOTSUP":         &eval.IntEvaluator{Value: -int(syscall.ENOTSUP)},
-		"ENOTTY":          &eval.IntEvaluator{Value: -int(syscall.ENOTTY)},
-		"ENOTUNIQ":        &eval.IntEvaluator{Value: -int(syscall.ENOTUNIQ)},
-		"ENXIO":           &eval.IntEvaluator{Value: -int(syscall.ENXIO)},
-		"EOPNOTSUPP":      &eval.IntEvaluator{Value: -int(syscall.EOPNOTSUPP)},
-		"EOVERFLOW":       &eval.IntEvaluator{Value: -int(syscall.EOVERFLOW)},
-		"EOWNERDEAD":      &eval.IntEvaluator{Value: -int(syscall.EOWNERDEAD)},
-		"EPERM":           &eval.IntEvaluator{Value: -int(syscall.EPERM)},
-		"EPFNOSUPPORT":    &eval.IntEvaluator{Value: -int(syscall.EPFNOSUPPORT)},
-		"EPIPE":           &eval.IntEvaluator{Value: -int(syscall.EPIPE)},
-		"EPROTO":          &eval.IntEvaluator{Value: -int(syscall.EPROTO)},
-		"EPROTONOSUPPORT": &eval.IntEvaluator{Value: -int(syscall.EPROTONOSUPPORT)},
-		"EPROTOTYPE":      &eval.IntEvaluator{Value: -int(syscall.EPROTOTYPE)},
-		"ERANGE":          &eval.IntEvaluator{Value: -int(syscall.ERANGE)},
-		"EREMCHG":         &eval.IntEvaluator{Value: -int(syscall.EREMCHG)},
-		"EREMOTE":         &eval.IntEvaluator{Value: -int(syscall.EREMOTE)},
-		"EREMOTEIO":       &eval.IntEvaluator{Value: -int(syscall.EREMOTEIO)},
-		"ERESTART":        &eval.IntEvaluator{Value: -int(syscall.ERESTART)},
-		"ERFKILL":         &eval.IntEvaluator{Value: -int(syscall.ERFKILL)},
-		"EROFS":           &eval.IntEvaluator{Value: -int(syscall.EROFS)},
-		"ESHUTDOWN":       &eval.IntEvaluator{Value: -int(syscall.ESHUTDOWN)},
-		"ESOCKTNOSUPPORT": &eval.IntEvaluator{Value: -int(syscall.ESOCKTNOSUPPORT)},
-		"ESPIPE":          &eval.IntEvaluator{Value: -int(syscall.ESPIPE)},
-		"ESRCH":           &eval.IntEvaluator{Value: -int(syscall.ESRCH)},
-		"ESRMNT":          &eval.IntEvaluator{Value: -int(syscall.ESRMNT)},
-		"ESTALE":          &eval.IntEvaluator{Value: -int(syscall.ESTALE)},
-		"ESTRPIPE":        &eval.IntEvaluator{Value: -int(syscall.ESTRPIPE)},
-		"ETIME":           &eval.IntEvaluator{Value: -int(syscall.ETIME)},
-		"ETIMEDOUT":       &eval.IntEvaluator{Value: -int(syscall.ETIMEDOUT)},
-		"ETOOMANYREFS":    &eval.IntEvaluator{Value: -int(syscall.ETOOMANYREFS)},
-		"ETXTBSY":         &eval.IntEvaluator{Value: -int(syscall.ETXTBSY)},
-		"EUCLEAN":         &eval.IntEvaluator{Value: -int(syscall.EUCLEAN)},
-		"EUNATCH":         &eval.IntEvaluator{Value: -int(syscall.EUNATCH)},
-		"EUSERS":          &eval.IntEvaluator{Value: -int(syscall.EUSERS)},
-		"EWOULDBLOCK":     &eval.IntEvaluator{Value: -int(syscall.EWOULDBLOCK)},
-		"EXDEV":           &eval.IntEvaluator{Value: -int(syscall.EXDEV)},
-		"EXFULL":          &eval.IntEvaluator{Value: -int(syscall.EXFULL)},
-
-		// open flags
-		"O_RDONLY": &eval.IntEvaluator{Value: syscall.O_RDONLY},
-		"O_WRONLY": &eval.IntEvaluator{Value: syscall.O_WRONLY},
-		"O_RDWR":   &eval.IntEvaluator{Value: syscall.O_RDWR},
-		"O_APPEND": &eval.IntEvaluator{Value: syscall.O_APPEND},
-		"O_CREAT":  &eval.IntEvaluator{Value: syscall.O_CREAT},
-		"O_EXCL":   &eval.IntEvaluator{Value: syscall.O_EXCL},
-		"O_SYNC":   &eval.IntEvaluator{Value: syscall.O_SYNC},
-		"O_TRUNC":  &eval.IntEvaluator{Value: syscall.O_TRUNC},
-
-		// permissions
-		"S_IEXEC":  &eval.IntEvaluator{Value: syscall.S_IEXEC},
-		"S_IFBLK":  &eval.IntEvaluator{Value: syscall.S_IFBLK},
-		"S_IFCHR":  &eval.IntEvaluator{Value: syscall.S_IFCHR},
-		"S_IFDIR":  &eval.IntEvaluator{Value: syscall.S_IFDIR},
-		"S_IFIFO":  &eval.IntEvaluator{Value: syscall.S_IFIFO},
-		"S_IFLNK":  &eval.IntEvaluator{Value: syscall.S_IFLNK},
-		"S_IFMT":   &eval.IntEvaluator{Value: syscall.S_IFMT},
-		"S_IFREG":  &eval.IntEvaluator{Value: syscall.S_IFREG},
-		"S_IFSOCK": &eval.IntEvaluator{Value: syscall.S_IFSOCK},
-		"S_IREAD":  &eval.IntEvaluator{Value: syscall.S_IREAD},
-		"S_IRGRP":  &eval.IntEvaluator{Value: syscall.S_IRGRP},
-		"S_IROTH":  &eval.IntEvaluator{Value: syscall.S_IROTH},
-		"S_IRUSR":  &eval.IntEvaluator{Value: syscall.S_IRUSR},
-		"S_IRWXG":  &eval.IntEvaluator{Value: syscall.S_IRWXG},
-		"S_IRWXO":  &eval.IntEvaluator{Value: syscall.S_IRWXO},
-		"S_IRWXU":  &eval.IntEvaluator{Value: syscall.S_IRWXU},
-		"S_ISGID":  &eval.IntEvaluator{Value: syscall.S_ISGID},
-		"S_ISUID":  &eval.IntEvaluator{Value: syscall.S_ISUID},
-		"S_ISVTX":  &eval.IntEvaluator{Value: syscall.S_ISVTX},
-		"S_IWGRP":  &eval.IntEvaluator{Value: syscall.S_IWGRP},
-		"S_IWOTH":  &eval.IntEvaluator{Value: syscall.S_IWOTH},
-		"S_IWRITE": &eval.IntEvaluator{Value: syscall.S_IWRITE},
-		"S_IWUSR":  &eval.IntEvaluator{Value: syscall.S_IWUSR},
-		"S_IXGRP":  &eval.IntEvaluator{Value: syscall.S_IXGRP},
-		"S_IXOTH":  &eval.IntEvaluator{Value: syscall.S_IXOTH},
-		"S_IXUSR":  &eval.IntEvaluator{Value: syscall.S_IXUSR},
 	}
 )
+
+var (
+	openFlagsStrings   = map[int]string{}
+	chmodModeStrings   = map[int]string{}
+	unlinkFlagsStrings = map[int]string{}
+)
+
+func initOpenConstants() {
+	for k, v := range openFlagsConstants {
+		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+	}
+
+	for k, v := range openFlagsConstants {
+		openFlagsStrings[v] = k
+	}
+}
+
+func initChmodConstants() {
+	for k, v := range chmodModeConstants {
+		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+	}
+
+	for k, v := range chmodModeConstants {
+		chmodModeStrings[v] = k
+	}
+}
+
+func initUnlinkConstanst() {
+	for k, v := range unlinkFlagsConstants {
+		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+	}
+
+	for k, v := range unlinkFlagsConstants {
+		unlinkFlagsStrings[v] = k
+	}
+}
+
+func initErrorConstants() {
+	for k, v := range errorConstants {
+		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+	}
+}
+
+func initConstants() {
+	initErrorConstants()
+	initOpenConstants()
+	initChmodConstants()
+	initUnlinkConstanst()
+}
+
+func bitmaskToString(bitmask int, intToStrMap map[int]string) string {
+	var strs []string
+	var result int
+
+	for v, s := range intToStrMap {
+		if v == 0 {
+			continue
+		}
+
+		if bitmask&v == v {
+			strs = append(strs, s)
+			result |= v
+		}
+	}
+
+	if result != bitmask {
+		strs = append(strs, fmt.Sprintf("%d", bitmask^result))
+	}
+
+	sort.Strings(strs)
+
+	return strings.Join(strs, " | ")
+}
+
+// OpenFlags represents an open flags bitmask value
+type OpenFlags int
+
+func (f OpenFlags) String() string {
+	return bitmaskToString(int(f), openFlagsStrings)
+}
+
+// ChmodMode represent a chmod mode bitmask value
+type ChmodMode int
+
+func (m ChmodMode) String() string {
+	return bitmaskToString(int(m), chmodModeStrings)
+}
+
+// UnlinkFlags represents an unlink flags bitmask value
+type UnlinkFlags int
+
+func (f UnlinkFlags) String() string {
+	return bitmaskToString(int(f), unlinkFlagsStrings)
+}
+
+// ReturnValue represents a syscall return value
+type RetValError int
+
+func (f RetValError) String() string {
+	v := int(f)
+	if v < 0 {
+		return syscall.Errno(-v).Error()
+	}
+	return ""
+}
+
+func init() {
+	initConstants()
+}
 
 var byteOrder = ebpf.ByteOrder

--- a/pkg/security/probe/consts_test.go
+++ b/pkg/security/probe/consts_test.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux_bpf
+
+package probe
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+)
+
+func TestFlagsToString(t *testing.T) {
+	str := OpenFlags(syscall.O_EXCL | syscall.O_TRUNC).String()
+	if str != "O_EXCL | O_TRUNC" {
+		t.Errorf("expexted flags not found, got: %s", str)
+	}
+
+	str = ChmodMode(syscall.S_IWGRP | syscall.S_IRUSR).String()
+	if str != "S_IRUSR | S_IWGRP" {
+		t.Errorf("expexted flags not found, got: %s", str)
+	}
+
+	str = OpenFlags(syscall.O_EXCL | syscall.O_TRUNC | 1<<32).String()
+	if str != fmt.Sprintf("%d | O_EXCL | O_TRUNC", 1<<32) {
+		t.Errorf("expexted flags not found, got: %s", str)
+	}
+}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -81,7 +81,7 @@ func (e *ChmodEvent) marshalJSON(resolvers *Resolvers) ([]byte, error) {
 	fmt.Fprintf(&buf, `"inode":%d,`, e.Inode)
 	fmt.Fprintf(&buf, `"mount_id":%d,`, e.MountID)
 	fmt.Fprintf(&buf, `"overlay_numlower":%d,`, e.OverlayNumLower)
-	fmt.Fprintf(&buf, `"mode":%d`, e.Mode)
+	fmt.Fprintf(&buf, `"mode":"%s"`, ChmodMode(e.Mode))
 	buf.WriteRune('}')
 
 	return buf.Bytes(), nil
@@ -196,8 +196,8 @@ func (e *ChownEvent) ResolveContainerPath(resolvers *Resolvers) string {
 
 // OpenEvent represents an open event
 type OpenEvent struct {
-	Flags           uint32 `yaml:"flags" field:"flags"`
-	Mode            uint32 `yaml:"mode" field:"mode"`
+	Flags           uint32 `field:"flags"`
+	Mode            uint32 `field:"mode"`
 	Inode           uint64 `field:"inode"`
 	MountID         uint32 `field:"-"`
 	OverlayNumLower int32  `field:"overlay_num_lower"`
@@ -215,7 +215,7 @@ func (e *OpenEvent) marshalJSON(resolvers *Resolvers) ([]byte, error) {
 	fmt.Fprintf(&buf, `"mount_id":%d,`, e.MountID)
 	fmt.Fprintf(&buf, `"overlay_numlower":%d,`, e.OverlayNumLower)
 	fmt.Fprintf(&buf, `"mode":%d,`, e.Mode)
-	fmt.Fprintf(&buf, `"flags":%d`, e.Flags)
+	fmt.Fprintf(&buf, `"flags":"%s"`, OpenFlags(e.Flags))
 	buf.WriteRune('}')
 
 	return buf.Bytes(), nil
@@ -415,7 +415,7 @@ func (e *UnlinkEvent) marshalJSON(resolvers *Resolvers) ([]byte, error) {
 	var buf bytes.Buffer
 	buf.WriteRune('{')
 	fmt.Fprintf(&buf, `"filename":"%s",`, e.ResolveInode(resolvers))
-	fmt.Fprintf(&buf, `"flags":%d,`, e.Flags)
+	fmt.Fprintf(&buf, `"flags":"%s",`, UnlinkFlags(e.Flags))
 	fmt.Fprintf(&buf, `"container_path":"%s",`, e.ResolveContainerPath(resolvers))
 	fmt.Fprintf(&buf, `"inode":%d,`, e.Inode)
 	fmt.Fprintf(&buf, `"mount_id":%d,`, e.MountID)
@@ -889,6 +889,9 @@ func (k *KernelEvent) marshalJSON(resolvers *Resolvers) ([]byte, error) {
 	fmt.Fprintf(&buf, `"type":"%s",`, k.ResolveType(resolvers))
 	fmt.Fprintf(&buf, `"timestamp":"%s",`, k.ResolveMonoliticTimestamp(resolvers))
 	fmt.Fprintf(&buf, `"retval":%d`, k.Retval)
+	if k.Retval < 0 {
+		fmt.Fprintf(&buf, `,"error":"%s"`, RetValError(k.Retval))
+	}
 	buf.WriteRune('}')
 
 	return buf.Bytes(), nil


### PR DESCRIPTION
### What does this PR do?

Convert some event reported values from integer to string

### Motivation

Currently some reported event values are sent as integer and could be sent as string. This is the case of flags, mode, or retval errors

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
