### PR TITLE
[runtime-security] use tags to identify rules and events metrics

### DIFF
--- a/pkg/security/module/rate_limiter.go
+++ b/pkg/security/module/rate_limiter.go
@@ -94,7 +94,7 @@ func (rl *RateLimiter) GetStats() map[string]RateLimiterStat {
 // for the set of rules
 func (rl *RateLimiter) SendStats(client *statsd.Client) error {
 	for ruleID, counts := range rl.GetStats() {
-		tags := []string{fmt.Sprintf("rule_id:%s",ruleID)}
+		tags := []string{fmt.Sprintf("rule_id:%s", ruleID)}
 		if counts.dropped > 0 {
 			if err := client.Count(probe.MetricPrefix+".rules.rate_limiter.drop", counts.dropped, tags, 1.0); err != nil {
 				return err

--- a/pkg/security/module/rate_limiter.go
+++ b/pkg/security/module/rate_limiter.go
@@ -8,6 +8,7 @@
 package module
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -93,11 +94,16 @@ func (rl *RateLimiter) GetStats() map[string]RateLimiterStat {
 // for the set of rules
 func (rl *RateLimiter) SendStats(client *statsd.Client) error {
 	for ruleID, counts := range rl.GetStats() {
-		if err := client.Count(probe.MetricPrefix+".rules."+ruleID+".rate_limiter.drop", counts.dropped, nil, 1.0); err != nil {
-			return err
+		tags := []string{fmt.Sprintf("rule_id:%s",ruleID)}
+		if counts.dropped > 0 {
+			if err := client.Count(probe.MetricPrefix+".rules.rate_limiter.drop", counts.dropped, tags, 1.0); err != nil {
+				return err
+			}
 		}
-		if err := client.Count(probe.MetricPrefix+".rules."+ruleID+".rate_limiter.allow", counts.allowed, nil, 1.0); err != nil {
-			return err
+		if counts.allowed > 0 {
+			if err := client.Count(probe.MetricPrefix+".rules.rate_limiter.allow", counts.allowed, tags, 1.0); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/security/probe/event_stats.go
+++ b/pkg/security/probe/event_stats.go
@@ -12,7 +12,6 @@ import "sync/atomic"
 // EventsStats holds statistics about the number of lost and received events
 type EventsStats struct {
 	Lost         int64
-	Received     int64
 	PerEventType [maxEventType]int64
 }
 
@@ -21,19 +20,9 @@ func (e *EventsStats) GetLost() int64 {
 	return atomic.LoadInt64(&e.Lost)
 }
 
-// GetReceived returns the number of received events
-func (e *EventsStats) GetReceived() int64 {
-	return atomic.LoadInt64(&e.Received)
-}
-
 // GetAndResetLost returns the number of lost events and resets the counter
 func (e *EventsStats) GetAndResetLost() int64 {
 	return atomic.SwapInt64(&e.Lost, 0)
-}
-
-// GetAndResetReceived returns the number of received events and resets the counter
-func (e *EventsStats) GetAndResetReceived() int64 {
-	return atomic.SwapInt64(&e.Received, 0)
 }
 
 // GetEventCount returns the number of received events of the specified type
@@ -49,11 +38,6 @@ func (e *EventsStats) GetAndResetEventCount(eventType EventType) int64 {
 // CountLost adds `count` to the counter of lost events
 func (e *EventsStats) CountLost(count int64) {
 	atomic.AddInt64(&e.Lost, count)
-}
-
-// CountReceived adds `count` to the counter of received events
-func (e *EventsStats) CountReceived(count int64) {
-	atomic.AddInt64(&e.Received, count)
 }
 
 // CountEventType adds `count` to the counter of received events of the specified type

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -482,7 +482,7 @@ func (p *Probe) SendStats(statsdClient *statsd.Client) error {
 		}
 
 		eventType := EventType(i)
-		tags := []string{fmt.Sprintf("event_type:%s",eventType.String())}
+		tags := []string{fmt.Sprintf("event_type:%s", eventType.String())}
 		if value := p.eventsStats.GetAndResetEventCount(eventType); value > 0 {
 			if err := statsdClient.Count(receivedEvents, value, tags, 1.0); err != nil {
 				return err

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -9,6 +9,7 @@ package probe
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"strings"
 
@@ -481,7 +482,7 @@ func (p *Probe) SendStats(statsdClient *statsd.Client) error {
 		}
 
 		eventType := EventType(i)
-		tags := []string{eventType.String()}
+		tags := []string{fmt.Sprintf("event_type:%s",eventType.String())}
 		if value := p.eventsStats.GetAndResetEventCount(eventType); value > 0 {
 			if err := statsdClient.Count(receivedEvents, value, tags, 1.0); err != nil {
 				return err

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -474,19 +474,18 @@ func (p *Probe) SendStats(statsdClient *statsd.Client) error {
 		return err
 	}
 
-	if err := statsdClient.Count(MetricPrefix+".events.received", p.eventsStats.GetAndResetReceived(), nil, 1.0); err != nil {
-		return err
-	}
-
+	receivedEvents := MetricPrefix + ".events.received"
 	for i := range p.eventsStats.PerEventType {
 		if i == 0 {
 			continue
 		}
 
 		eventType := EventType(i)
-		key := MetricPrefix + ".events." + eventType.String()
-		if err := statsdClient.Count(key, p.eventsStats.GetAndResetEventCount(eventType), nil, 1.0); err != nil {
-			return err
+		tags := []string{eventType.String()}
+		if value := p.eventsStats.GetAndResetEventCount(eventType); value > 0 {
+			if err := statsdClient.Count(receivedEvents, value, tags, 1.0); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -500,7 +499,6 @@ func (p *Probe) GetStats() (map[string]interface{}, error) {
 	syscalls, err := p.syscallMonitor.GetStats()
 
 	stats["events"] = map[string]interface{}{
-		"received": p.eventsStats.GetReceived(),
 		"lost":     p.eventsStats.GetLost(),
 		"syscalls": syscalls,
 	}
@@ -531,7 +529,6 @@ func (p *Probe) handleLostEvents(count uint64) {
 
 func (p *Probe) handleEvent(data []byte) {
 	log.Debugf("Handling dentry event (len %d)", len(data))
-	p.eventsStats.CountReceived(1)
 
 	offset := 0
 	event := NewEvent(p.resolvers)


### PR DESCRIPTION
### What does this PR do?

This PR updates how the runtime security agent exports its metrics. Instead of having the name of the event or the rule ID in the name of the metrics, we now use tags.

### Motivation

Using tags makes it easier to graph the metrics and generate alerts.