### PR TITLE
[gitlab] Fix None duration edge case on canceled jobs in inv pipeline.follow + misc fixes

### DIFF
--- a/tasks/deploy/pipeline_tools.py
+++ b/tasks/deploy/pipeline_tools.py
@@ -234,6 +234,11 @@ def print_job_status(job):
     link = ''  # Link to the pipeline. Only filled for failing jobs, to be able to quickly go to the failing job.
     color = 'grey'  # Log output color
 
+    # A None duration is set by Gitlab when the job gets canceled before it was started.
+    # In that case, set a duration of 0s.
+    if duration is None:
+        duration = 0
+
     if status == 'success':
         job_status = 'succeeded'
         color = 'green'

--- a/tasks/deploy/pipeline_tools.py
+++ b/tasks/deploy/pipeline_tools.py
@@ -18,15 +18,12 @@ def trigger_agent_pipeline(ref="master", release_version_6="nightly", release_ve
 
     args["DEPLOY_AGENT"] = "true"
 
-    # The build tag appended to all released binaries
     if release_version_6 is not None:
         args["RELEASE_VERSION_6"] = release_version_6
 
-    # Override the environment to release the binaries to (prod or staging)
     if release_version_7 is not None:
         args["RELEASE_VERSION_7"] = release_version_7
 
-    # Override the environment to release the binaries to (prod or staging)
     if branch is not None:
         args["DEB_RPM_BUCKET_BRANCH"] = branch
 
@@ -122,8 +119,8 @@ def pipeline_status(gitlab, proj, pipeline_id, job_status):
         page += 1
 
     job_status = update_job_status(jobs, job_status)
-    # check pipeline status
 
+    # Check pipeline status
     pipeline = gitlab.pipeline(proj, pipeline_id)
     pipestatus = pipeline["status"].lower().strip()
     ref = pipeline["ref"]

--- a/tasks/deploy/pipeline_tools.py
+++ b/tasks/deploy/pipeline_tools.py
@@ -205,17 +205,11 @@ def print_job_status(job):
     Prints notifications about job changes.
     """
 
-    def print_job(name, stage, color, finish_date, duration, status, link):
+    def print_job(name, stage, color, date, duration, status, link):
         print(
             color_message(
-                "[{finish_date}] Job {name} (stage: {stage}) {status} [job duration: {m:.0f}m{s:2.0f}s]\n{link}".format(
-                    name=name,
-                    stage=stage,
-                    finish_date=finish_date,
-                    m=(duration // 60),
-                    s=(duration % 60),
-                    status=status,
-                    link=link,
+                "[{date}] Job {name} (stage: {stage}) {status} [job duration: {m:.0f}m{s:2.0f}s]\n{link}".format(
+                    name=name, stage=stage, date=date, m=(duration // 60), s=(duration % 60), status=status, link=link,
                 ).strip(),
                 color,
             )


### PR DESCRIPTION
### What does this PR do?

Fixes edge case for jobs canceled before they start: in that case `duration` is set to `None`, and we tried performing operations on it.
Renames `finish_date` to `date` in `print_job` (since it's not always the finish date of the job).
Removes inaccurate comments.

### Motivation

Clean up `pipeline` invoke tasks.

