### PR TITLE
[DCA] Use APIserver connection retrier

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -184,80 +184,79 @@ func start(cmd *cobra.Command, args []string) error {
 
 	log.Infof("Datadog Cluster Agent is now running.")
 
-	apiCl, err := apiserver.GetAPIClient() // make sure we can connect to the apiserver
+	apiCl, err := apiserver.WaitForAPIClient(context.Background()) // make sure we can connect to the apiserver
 	if err != nil {
-		log.Errorf("Could not connect to the apiserver: %v", err)
+		return log.Errorf("Fatal error: Cannot connect to the apiserver: %v", err)
+	}
+
+	le, err := leaderelection.GetLeaderEngine()
+	if err != nil {
+		return err
+	}
+
+	// Create event recorder
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(log.Infof)
+	eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: apiCl.Cl.CoreV1().Events("")})
+	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "datadog-cluster-agent"})
+
+	ctx := apiserver.ControllerContext{
+		InformerFactory:    apiCl.InformerFactory,
+		WPAClient:          apiCl.WPAClient,
+		WPAInformerFactory: apiCl.WPAInformerFactory,
+		DDClient:           apiCl.DDClient,
+		DDInformerFactory:  apiCl.DDInformerFactory,
+		Client:             apiCl.Cl,
+		IsLeaderFunc:       le.IsLeader,
+		EventRecorder:      eventRecorder,
+		StopCh:             stopCh,
+	}
+
+	if aggErr := apiserver.StartControllers(ctx); aggErr != nil {
+		for _, err := range aggErr.Errors() {
+			log.Warnf("Error while starting controller: %v", err)
+		}
+	}
+
+	// Generate and persist a cluster ID
+	// this must be a UUID, and ideally be stable for the lifetime of a cluster
+	// so we store it in a configmap that we try and read before generating a new one.
+	coreClient := apiCl.Cl.CoreV1().(*corev1.CoreV1Client)
+	_, err = apicommon.GetOrCreateClusterID(coreClient)
+	if err != nil {
+		log.Errorf("Failed to generate or retrieve the cluster ID")
+	}
+
+	// TODO: move rest of the controllers out of the apiserver package
+	orchestratorCtx := orchestrator.ControllerContext{
+		IsLeaderFunc:                 le.IsLeader,
+		UnassignedPodInformerFactory: apiCl.UnassignedPodInformerFactory,
+		InformerFactory:              apiCl.InformerFactory,
+		Client:                       apiCl.Cl,
+		StopCh:                       stopCh,
+		Hostname:                     hostname,
+		ClusterName:                  clustername.GetClusterName(),
+		ConfigPath:                   confPath,
+	}
+	err = orchestrator.StartController(orchestratorCtx)
+	if err != nil {
+		log.Errorf("Could not start orchestrator controller: %v", err)
+	}
+
+	if config.Datadog.GetBool("admission_controller.enabled") {
+		admissionCtx := admissionpkg.ControllerContext{
+			IsLeaderFunc:     le.IsLeader,
+			SecretInformers:  apiCl.CertificateSecretInformerFactory,
+			WebhookInformers: apiCl.WebhookConfigInformerFactory,
+			Client:           apiCl.Cl,
+			StopCh:           stopCh,
+		}
+		err = admissionpkg.StartControllers(admissionCtx)
+		if err != nil {
+			log.Errorf("Could not start admission controller: %v", err)
+		}
 	} else {
-		le, err := leaderelection.GetLeaderEngine()
-		if err != nil {
-			return err
-		}
-
-		// Create event recorder
-		eventBroadcaster := record.NewBroadcaster()
-		eventBroadcaster.StartLogging(log.Infof)
-		eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: apiCl.Cl.CoreV1().Events("")})
-		eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "datadog-cluster-agent"})
-
-		stopCh := make(chan struct{})
-		ctx := apiserver.ControllerContext{
-			InformerFactory:    apiCl.InformerFactory,
-			WPAClient:          apiCl.WPAClient,
-			WPAInformerFactory: apiCl.WPAInformerFactory,
-			DDClient:           apiCl.DDClient,
-			DDInformerFactory:  apiCl.DDInformerFactory,
-			Client:             apiCl.Cl,
-			IsLeaderFunc:       le.IsLeader,
-			EventRecorder:      eventRecorder,
-			StopCh:             stopCh,
-		}
-
-		if aggErr := apiserver.StartControllers(ctx); aggErr != nil {
-			for _, err := range aggErr.Errors() {
-				log.Warnf("Error while starting controller: %v", err)
-			}
-		}
-
-		// Generate and persist a cluster ID
-		// this must be a UUID, and ideally be stable for the lifetime of a cluster
-		// so we store it in a configmap that we try and read before generating a new one.
-		coreClient := apiCl.Cl.CoreV1().(*corev1.CoreV1Client)
-		_, err = apicommon.GetOrCreateClusterID(coreClient)
-		if err != nil {
-			log.Errorf("Failed to generate or retrieve the cluster ID")
-		}
-
-		// TODO: move rest of the controllers out of the apiserver package
-		orchestratorCtx := orchestrator.ControllerContext{
-			IsLeaderFunc:                 le.IsLeader,
-			UnassignedPodInformerFactory: apiCl.UnassignedPodInformerFactory,
-			InformerFactory:              apiCl.InformerFactory,
-			Client:                       apiCl.Cl,
-			StopCh:                       stopCh,
-			Hostname:                     hostname,
-			ClusterName:                  clustername.GetClusterName(),
-			ConfigPath:                   confPath,
-		}
-		err = orchestrator.StartController(orchestratorCtx)
-		if err != nil {
-			log.Errorf("Could not start orchestrator controller: %v", err)
-		}
-
-		if config.Datadog.GetBool("admission_controller.enabled") {
-			admissionCtx := admissionpkg.ControllerContext{
-				IsLeaderFunc:     le.IsLeader,
-				SecretInformers:  apiCl.CertificateSecretInformerFactory,
-				WebhookInformers: apiCl.WebhookConfigInformerFactory,
-				Client:           apiCl.Cl,
-				StopCh:           stopCh,
-			}
-			err = admissionpkg.StartControllers(admissionCtx)
-			if err != nil {
-				log.Errorf("Could not start admission controller: %v", err)
-			}
-		} else {
-			log.Info("Admission controller is disabled")
-		}
+		log.Info("Admission controller is disabled")
 	}
 
 	// Setup a channel to catch OS signals

--- a/releasenotes-dca/notes/dca-apiserver-retrier-870a7760e8004a28.yaml
+++ b/releasenotes-dca/notes/dca-apiserver-retrier-870a7760e8004a28.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    When the Cluster Agent starts, it retries connecting to the Kuberentes APIserver in case the first connection fails.


### PR DESCRIPTION
### What does this PR do?

Use WaitForAPIClient instead of GetAPIClient, when the the Cluster Agent first start with a 5 minutes retrier timeout

### Motivation

Be more resilient to connection failure

