### PR TITLE
update pause container filtering

### DIFF
--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -19,7 +19,8 @@ const (
 	// - asia.gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/gke-release/pause-win:1.1.0
-	pauseContainerGCR        = `image:(.*)gcr\.io(/google_containers/|/gke-release/|/)pause(.*)`
+	// - eu.gcr.io/k8s-artifacts-prod/pause:3.3
+	pauseContainerGCR        = `image:(.*)gcr\.io(/google_containers/|/gke-release/|/k8s-artifacts-prod/|/)pause(.*)`
 	pauseContainerOpenshift3 = "image:(openshift/origin-pod|(.*)rhel7/pod-infrastructure)"
 	pauseContainerKubernetes = "image:kubernetes/pause"
 	pauseContainerECS        = "image:amazon/amazon-ecs-pause"

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -36,17 +36,17 @@ const (
 
 	// amazonaws.com/eks/pause-windows:latest
 	// eks/pause-amd64
-	pauseContainerEKS = `image:(amazonaws.com/)?eks/pause-(amd64|windows)`
+	pauseContainerEKS = `image:(amazonaws\.com/)?eks/pause-(amd64|windows)`
 	// rancher/pause-amd64:3.0
 	pauseContainerRancher = `image:rancher/pause(.*)`
 	// - mcr.microsoft.com/k8s/core/pause-amd64
-	pauseContainerMCR = `image:mcr.microsoft.com(.*)/pause(.*)`
+	pauseContainerMCR = `image:mcr\.microsoft\.com(.*)/pause(.*)`
 	// - aksrepos.azurecr.io/mirror/pause-amd64
-	pauseContainerAKS = `image:aksrepos.azurecr.io(.*)/pause(.*)`
+	pauseContainerAKS = `image:aksrepos\.azurecr\.io(.*)/pause(.*)`
 	// - kubeletwin/pause:latest
 	pauseContainerWin = `image:kubeletwin/pause(.*)`
 	// - ecr.us-east-1.amazonaws.com/pause
-	pauseContainerECR = `image:ecr(.*)amazonaws.com/pause(.*)`
+	pauseContainerECR = `image:ecr(.*)amazonaws\.com/pause(.*)`
 )
 
 // Filter holds the state for the container filtering logic

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -14,26 +14,38 @@ import (
 )
 
 const (
-	// pauseContainerGCR regex matches:
+	// Pause container image names that should be filtered out.
+	// Where appropriate, each constant is loosely structured as
+	// image:domain(.*)/pause(.*)
+
+	pauseContainerKubernetes = "image:kubernetes/pause"
+	pauseContainerECS        = "image:amazon/amazon-ecs-pause"
+	pauseContainerOpenshift  = "image:openshift/origin-pod"
+	pauseContainerOpenshift3 = "image:(.*)rhel7/pod-infrastructure"
+
 	// - k8s.gcr.io/pause-amd64:3.1
 	// - asia.gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/gke-release/pause-win:1.1.0
 	// - eu.gcr.io/k8s-artifacts-prod/pause:3.3
-	pauseContainerGCR        = `image:(.*)gcr\.io(/google_containers/|/gke-release/|/k8s-artifacts-prod/|/)pause(.*)`
-	pauseContainerOpenshift3 = "image:(openshift/origin-pod|(.*)rhel7/pod-infrastructure)"
-	pauseContainerKubernetes = "image:kubernetes/pause"
-	pauseContainerECS        = "image:amazon/amazon-ecs-pause"
-	pauseContainerEKS        = "image:(amazonaws.com/)?eks/pause-(amd64|windows)"
-	// pauseContainerAzure regex matches:
+	pauseContainerGCR = `image:(.*)gcr\.io(.*)/pause(.*)`
+
 	// - k8s-gcrio.azureedge.net/pause-amd64
 	// - gcrio.azureedge.net/google_containers/pause-amd64
-	pauseContainerAzure   = `image:(.*)azureedge\.net(/google_containers/|/)pause(.*)`
+	pauseContainerAzure = `image:(.*)azureedge\.net(.*)/pause(.*)`
+
+	// amazonaws.com/eks/pause-windows:latest
+	// eks/pause-amd64
+	pauseContainerEKS = `image:(amazonaws.com/)?eks/pause-(amd64|windows)`
+	// rancher/pause-amd64:3.0
 	pauseContainerRancher = `image:rancher/pause(.*)`
-	// pauseContainerAKS regex matches:
 	// - mcr.microsoft.com/k8s/core/pause-amd64
+	pauseContainerMCR = `image:mcr.microsoft.com(.*)/pause(.*)`
 	// - aksrepos.azurecr.io/mirror/pause-amd64
-	pauseContainerAKS = `image:(mcr.microsoft.com/k8s/core/|aksrepos.azurecr.io/mirror/|kubeletwin/)pause(.*)`
+	pauseContainerAKS = `image:aksrepos.azurecr.io(.*)/pause(.*)`
+	// - kubeletwin/pause:latest
+	pauseContainerWin = `image:kubeletwin/pause(.*)`
+	// - ecr.us-east-1.amazonaws.com/pause
 	pauseContainerECR = `image:ecr(.*)amazonaws.com/pause(.*)`
 )
 
@@ -146,12 +158,15 @@ func newMetricFilterFromConfig() (*Filter, error) {
 	if config.Datadog.GetBool("exclude_pause_container") {
 		excludeList = append(excludeList,
 			pauseContainerGCR,
+			pauseContainerOpenshift,
 			pauseContainerOpenshift3,
 			pauseContainerKubernetes,
 			pauseContainerAzure,
 			pauseContainerECS,
 			pauseContainerEKS,
 			pauseContainerRancher,
+			pauseContainerMCR,
+			pauseContainerWin,
 			pauseContainerAKS,
 			pauseContainerECR,
 		)

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -16,37 +16,37 @@ import (
 const (
 	// Pause container image names that should be filtered out.
 	// Where appropriate, each constant is loosely structured as
-	// image:domain(.*)/pause(.*)
+	// image:domain.*/pause.*
 
 	pauseContainerKubernetes = "image:kubernetes/pause"
 	pauseContainerECS        = "image:amazon/amazon-ecs-pause"
 	pauseContainerOpenshift  = "image:openshift/origin-pod"
-	pauseContainerOpenshift3 = "image:(.*)rhel7/pod-infrastructure"
+	pauseContainerOpenshift3 = "image:.*rhel7/pod-infrastructure"
 
 	// - k8s.gcr.io/pause-amd64:3.1
 	// - asia.gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/gke-release/pause-win:1.1.0
 	// - eu.gcr.io/k8s-artifacts-prod/pause:3.3
-	pauseContainerGCR = `image:(.*)gcr\.io(.*)/pause(.*)`
+	pauseContainerGCR = `image:.*gcr\.io(.*)/pause.*`
 
 	// - k8s-gcrio.azureedge.net/pause-amd64
 	// - gcrio.azureedge.net/google_containers/pause-amd64
-	pauseContainerAzure = `image:(.*)azureedge\.net(.*)/pause(.*)`
+	pauseContainerAzure = `image:.*azureedge\.net(.*)/pause.*`
 
 	// amazonaws.com/eks/pause-windows:latest
 	// eks/pause-amd64
-	pauseContainerEKS = `image:(amazonaws\.com/)?eks/pause-(amd64|windows)`
+	pauseContainerEKS = `image:(amazonaws\.com/)?eks/pause.*`
 	// rancher/pause-amd64:3.0
-	pauseContainerRancher = `image:rancher/pause(.*)`
+	pauseContainerRancher = `image:rancher/pause.*`
 	// - mcr.microsoft.com/k8s/core/pause-amd64
-	pauseContainerMCR = `image:mcr\.microsoft\.com(.*)/pause(.*)`
+	pauseContainerMCR = `image:mcr\.microsoft\.com(.*)/pause.*`
 	// - aksrepos.azurecr.io/mirror/pause-amd64
-	pauseContainerAKS = `image:aksrepos\.azurecr\.io(.*)/pause(.*)`
+	pauseContainerAKS = `image:aksrepos\.azurecr\.io(.*)/pause.*`
 	// - kubeletwin/pause:latest
-	pauseContainerWin = `image:kubeletwin/pause(.*)`
+	pauseContainerWin = `image:kubeletwin/pause.*`
 	// - ecr.us-east-1.amazonaws.com/pause
-	pauseContainerECR = `image:ecr(.*)amazonaws\.com/pause(.*)`
+	pauseContainerECR = `image:ecr(.*)amazonaws\.com/pause.*`
 )
 
 // Filter holds the state for the container filtering logic

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -195,6 +195,14 @@ func TestFilter(t *testing.T) {
 			},
 			ns: "default",
 		},
+		{
+			c: Container{
+				ID:    "25",
+				Name:  "eu_gcr",
+				Image: "eu.gcr.io/k8s-artifacts-prod/pause:3.3",
+			},
+			ns: "default",
+		},
 	}
 
 	for i, tc := range []struct {
@@ -203,25 +211,25 @@ func TestFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25"},
 		},
 		{
 			excludeList: []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24"},
+			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25"},
 		},
 		{
 			excludeList: []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25"},
 		},
 		{
 			includeList: []string{},
 			excludeList: []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24"},
+			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25"},
 		},
 		{
 			includeList: []string{"name:mysql"},
 			excludeList: []string{"name:dd"},
-			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19", "20", "23", "24"},
+			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19", "20", "23", "24", "25"},
 		},
 		{
 			excludeList: []string{"kube_namespace:.*"},
@@ -230,7 +238,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			excludeList: []string{"kube_namespace:bar"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19", "20", "23", "24"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19", "20", "23", "24", "25"},
 		},
 		// Test kubernetes defaults
 		{

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -244,16 +244,19 @@ func TestFilter(t *testing.T) {
 		{
 			excludeList: []string{
 				pauseContainerGCR,
+				pauseContainerOpenshift,
 				pauseContainerOpenshift3,
 				pauseContainerKubernetes,
 				pauseContainerAzure,
 				pauseContainerECS,
 				pauseContainerEKS,
 				pauseContainerRancher,
+				pauseContainerMCR,
+				pauseContainerWin,
 				pauseContainerAKS,
 				pauseContainerECR,
 			},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "14", "15"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "14", "15"},
 		},
 	} {
 		t.Run("", func(t *testing.T) {

--- a/releasenotes/notes/add-gcr-pause-container-filter-a67be139ecc70432.yaml
+++ b/releasenotes/notes/add-gcr-pause-container-filter-a67be139ecc70432.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Expand GCR pause container image filter


### PR DESCRIPTION
### What does this PR do?

- Adds broader filtering on GCR (to accommodate `eu.gcr.io/k8s-artifacts-prod/pause:3.3`) and other pause image names 
- Reorganizes pause image regexes to share a loose structure

### Motivation

- Necessary filtering of a pod image
- Make the filter constants easier to read and expand

Although, I'm not entirely sure the second motivating factor was achieved - open to other suggestions


### Describe your test plan

Make sure agents running in different providers do not report pause container tags