### PR TITLE
Fix pupernetes e2e job flakiness

### DIFF
--- a/test/e2e/scripts/run-instance/10-pupernetes-wait.sh
+++ b/test/e2e/scripts/run-instance/10-pupernetes-wait.sh
@@ -12,11 +12,18 @@ done
 
 _wait_binary() {
     echo "waiting for $1 binary to be in PATH=${PATH} ..."
-    for i in {0..120}
+    for i in {0..240}
     do
-        which $1 2> /dev/null && break
+        which "$1" 2> /dev/null && break
         sleep 1
     done
+
+    if which "$1" 2> /dev/null; then
+        echo "$1 appeared in PATH after $i seconds"
+    else
+        echo "$1 didn’t appear in PATH after $i seconds"
+        exit 1
+    fi
 }
 
 _wait_binary pupernetes

--- a/test/e2e/scripts/run-instance/10-pupernetes-wait.sh
+++ b/test/e2e/scripts/run-instance/10-pupernetes-wait.sh
@@ -21,7 +21,7 @@ _wait_binary() {
     if which "$1" 2> /dev/null; then
         echo "$1 appeared in PATH after $i seconds"
     else
-        echo "$1 didn’t appear in PATH after $i seconds"
+        echo "$1 didn't appear in PATH after $i seconds"
         exit 1
     fi
 }

--- a/test/e2e/scripts/setup-instance/00-entrypoint-dev.sh
+++ b/test/e2e/scripts/setup-instance/00-entrypoint-dev.sh
@@ -27,7 +27,7 @@ IGNITION_BASE64=$(cat ignition.json | base64 ${BASE64_FLAGS})
 
 tee specification.json << EOF
 {
-  "ImageId": "ami-07cce92cad14cc238",
+  "ImageId": "ami-0a9e4c122b56383bf",
   "InstanceType": "t2.medium",
   "Monitoring": {
     "Enabled": false

--- a/test/e2e/scripts/setup-instance/00-entrypoint-gitlab.sh
+++ b/test/e2e/scripts/setup-instance/00-entrypoint-gitlab.sh
@@ -15,7 +15,7 @@ IGNITION_BASE64=$(cat ignition.json | base64 -w 0)
 # TODO remove the IamInstanceProfile
 tee specification.json << EOF
 {
-  "ImageId": "ami-07cce92cad14cc238",
+  "ImageId": "ami-0a9e4c122b56383bf",
   "InstanceType": "t2.medium",
   "Monitoring": {
     "Enabled": false

--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -46,7 +46,7 @@ tee ignition.json << EOF
       {
         "enabled": true,
         "name": "pupernetes.service",
-        "contents": "[Unit]\nDescription=Run pupernetes\nRequires=setup-pupernetes.service docker.service\nAfter=setup-pupernetes.service docker.service\n\n[Service]\nEnvironment=SUDO_USER=core\nExecStart=/opt/bin/pupernetes daemon run /opt/sandbox --kubectl-link /opt/bin/kubectl -v 5 --hyperkube-version 1.18.0 --run-timeout 6h\nRestart=on-failure\nRestartSec=5\nType=notify\nTimeoutStartSec=600\nTimeoutStopSec=120\n\n[Install]\nWantedBy=multi-user.target\n"
+        "contents": "[Unit]\nDescription=Run pupernetes\nRequires=setup-pupernetes.service docker.service\nAfter=setup-pupernetes.service docker.service\n\n[Service]\nEnvironment=SUDO_USER=core\nExecStart=/opt/bin/pupernetes daemon run /opt/sandbox --kubectl-link /opt/bin/kubectl -v 5 --hyperkube-version 1.10.1 --run-timeout 6h\nRestart=on-failure\nRestartSec=5\nType=notify\nTimeoutStartSec=600\nTimeoutStopSec=120\n\n[Install]\nWantedBy=multi-user.target\n"
       },
       {
         "name": "terminate.service",

--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -46,7 +46,7 @@ tee ignition.json << EOF
       {
         "enabled": true,
         "name": "pupernetes.service",
-        "contents": "[Unit]\nDescription=Run pupernetes\nRequires=setup-pupernetes.service docker.service\nAfter=setup-pupernetes.service docker.service\n\n[Service]\nEnvironment=SUDO_USER=core\nExecStart=/opt/bin/pupernetes daemon run /opt/sandbox --kubectl-link /opt/bin/kubectl -v 5 --hyperkube-version 1.10.1 --run-timeout 48h\nRestart=on-failure\nRestartSec=5\nType=notify\n\n[Install]\nWantedBy=multi-user.target\n"
+        "contents": "[Unit]\nDescription=Run pupernetes\nRequires=setup-pupernetes.service docker.service\nAfter=setup-pupernetes.service docker.service\n\n[Service]\nEnvironment=SUDO_USER=core\nExecStart=/opt/bin/pupernetes daemon run /opt/sandbox --kubectl-link /opt/bin/kubectl -v 5 --hyperkube-version 1.18.0 --run-timeout 6h\nRestart=on-failure\nRestartSec=5\nType=notify\nTimeoutStartSec=600\nTimeoutStopSec=120\n\n[Install]\nWantedBy=multi-user.target\n"
       },
       {
         "name": "terminate.service",
@@ -73,7 +73,7 @@ tee ignition.json << EOF
         "path": "/opt/bin/setup-pupernetes",
         "mode": 320,
         "contents": {
-          "source": "data:,%23%21%2Fbin%2Fbash%20-ex%0Acurl%20-Lf%20https%3A%2F%2Fgithub.com%2FDataDog%2Fpupernetes%2Freleases%2Fdownload%2Fv0.11.0%2Fpupernetes%20-o%20%2Fopt%2Fbin%2Fpupernetes%0Asha512sum%20-c%20%2Fopt%2Fbin%2Fpupernetes.sha512sum%0Achmod%20%2Bx%20%2Fopt%2Fbin%2Fpupernetes%0A"
+          "source": "data:,%23%21%2Fbin%2Fbash%20-ex%0Acurl%20-Lf%20--retry%207%20--retry-connrefused%20https%3A%2F%2Fgithub.com%2FDataDog%2Fpupernetes%2Freleases%2Fdownload%2Fv0.11.0%2Fpupernetes%20-o%20%2Fopt%2Fbin%2Fpupernetes%0Asha512sum%20-c%20%2Fopt%2Fbin%2Fpupernetes.sha512sum%0Achmod%20%2Bx%20%2Fopt%2Fbin%2Fpupernetes%0A"
         },
         "filesystem": "root"
       },
@@ -81,7 +81,7 @@ tee ignition.json << EOF
         "path": "/opt/bin/pupernetes.sha512sum",
         "mode": 256,
         "contents": {
-          "source": "data:,fcbf42316b9fbfbf6966b2f010f1bbc5006f7c882fc856d36b5e9f67a323d6b02361a45b88a4b4f7c64ac733078d9fd7d0cf72ef1229697f191b740c9fc95e61%20%20.%2F/opt/bin/pupernetes%0A"
+          "source": "data:,fcbf42316b9fbfbf6966b2f010f1bbc5006f7c882fc856d36b5e9f67a323d6b02361a45b88a4b4f7c64ac733078d9fd7d0cf72ef1229697f191b740c9fc95e61%20%2Fopt%2Fbin%2Fpupernetes%0A"
         },
         "filesystem": "root"
       }


### PR DESCRIPTION
### What does this PR do?

Add a `--retry` option to the `curl` command that is used to download `pupernetes` in the end-to-end tests.

### Motivation

From time to time, we are seeing [this error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/35821694):
```
waiting for pupernetes binary to be in PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/bin ...
 + sudo -kE pupernetes wait --unit-to-watch pupernetes.service --logging-since 2h --wait-timeout 20m
 sudo: pupernetes: command not found
 + sleep 10
 + sudo -kE pupernetes wait --unit-to-watch pupernetes.service --logging-since 2h --wait-timeout 20m
 sudo: pupernetes: command not found
 + exit 1
Running after_script
00:01
Uploading artifacts for failed job
00:01
 ERROR: Job failed: exit code 1
```

`pupernetes: command not found` can be the sign that its download failed.

In addition to the `--retry`, let’s also check the presence of the `pupernetes` binary at the end of the waiting loop rather than silently ignoring the fact that it never showed up.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
