### PR TITLE
[security-agent] Add config command

### DIFF
--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -130,5 +130,13 @@ func getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, string(body), 500)
 		return
 	}
-	w.Write(runtimeConfig)
+
+	scrubbed, err := log.CredentialsCleanerBytes(runtimeConfig)
+	if err != nil {
+		log.Errorf("Unable to scrub sensitive data from runtime config: %s", err)
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 500)
+		return
+	}
+	w.Write(scrubbed)
 }

--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
@@ -32,6 +33,7 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/stop", stopAgent).Methods("POST")
 	r.HandleFunc("/status", getStatus).Methods("GET")
 	r.HandleFunc("/status/health", getHealth).Methods("GET")
+	r.HandleFunc("/config", getRuntimeConfig).Methods("GET")
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {
@@ -118,4 +120,15 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 500)
 	}
 	w.Write([]byte(filePath))
+}
+
+func getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
+	runtimeConfig, err := yaml.Marshal(config.Datadog.AllSettings())
+	if err != nil {
+		log.Errorf("Unable to marshal runtime config response: %s", err)
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 500)
+		return
+	}
+	w.Write(runtimeConfig)
 }

--- a/cmd/security-agent/api/listener.go
+++ b/cmd/security-agent/api/listener.go
@@ -18,5 +18,5 @@ func newListener() (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	return net.Listen("tcp", fmt.Sprintf("%v:%v", address, config.Datadog.GetInt("compliance_config.cmd_port")))
+	return net.Listen("tcp", fmt.Sprintf("%v:%v", address, config.Datadog.GetInt("security_agent.cmd_port")))
 }

--- a/cmd/security-agent/api/server.go
+++ b/cmd/security-agent/api/server.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/agent"
+	"github.com/DataDog/datadog-agent/cmd/security-agent/api/agent"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"

--- a/cmd/security-agent/app/config.go
+++ b/cmd/security-agent/app/config.go
@@ -62,7 +62,7 @@ var configCommand = &cobra.Command{
 
 func requestConfig() (string, error) {
 	c := util.GetClient(false)
-	apiConfigURL := fmt.Sprintf("https://localhost:%v/config", config.Datadog.GetInt("security_agent.cmd_port"))
+	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", config.Datadog.GetInt("security_agent.cmd_port"))
 
 	r, err := util.DoGet(c, apiConfigURL)
 	if err != nil {

--- a/cmd/security-agent/app/config.go
+++ b/cmd/security-agent/app/config.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build kubeapiserver
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	SecurityAgentCmd.AddCommand(configCommand)
+}
+
+var configCommand = &cobra.Command{
+	Use:   "config",
+	Short: "Print the runtime configuration of a running security agent",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
+		// we'll search for a config file named `datadog.yaml`
+		config.Datadog.SetConfigName("datadog")
+		err := common.SetupConfig(confPath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global security agent configuration: %v", err)
+		}
+
+		err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
+		err = util.SetAuthToken()
+		if err != nil {
+			return err
+		}
+
+		runtimeConfig, err := requestConfig()
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(runtimeConfig)
+		return nil
+	},
+}
+
+func requestConfig() (string, error) {
+	c := util.GetClient(false)
+	apiConfigURL := fmt.Sprintf("https://localhost:%v/config", config.Datadog.GetInt("security_agent.cmd_port"))
+
+	r, err := util.DoGet(c, apiConfigURL)
+	if err != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(r, &errMap) //nolint:errcheck
+		// If the error has been marshalled into a json object, check it and return it properly
+		if e, found := errMap["error"]; found {
+			return "", fmt.Errorf(e)
+		}
+
+		return "", fmt.Errorf("Could not reach security agent: %v \nMake sure the security agent is running before requesting the runtime configuration and contact support if you continue having issues", err)
+	}
+
+	return string(r), nil
+}

--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -78,7 +78,7 @@ func requestFlare(caseID string) error {
 	fmt.Fprintln(color.Output, color.BlueString("Asking the Security Agent to build the flare archive."))
 	var e error
 	c := util.GetClient(false) // FIX: get certificates right then make this true
-	urlstr := fmt.Sprintf("https://localhost:%v/agent/flare", config.Datadog.GetInt("compliance_config.cmd_port"))
+	urlstr := fmt.Sprintf("https://localhost:%v/agent/flare", config.Datadog.GetInt("security_agent.cmd_port"))
 
 	logFile := config.Datadog.GetString("log_file")
 

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -68,7 +68,7 @@ func requestStatus() error {
 	var e error
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true
-	urlstr := fmt.Sprintf("https://localhost:%v/agent/status", config.Datadog.GetInt("compliance_config.cmd_port"))
+	urlstr := fmt.Sprintf("https://localhost:%v/agent/status", config.Datadog.GetInt("security_agent.cmd_port"))
 
 	// Set session token
 	e = util.SetAuthToken()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -734,13 +734,13 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("inventories_min_interval", 300) // 5min
 
 	// Datadog security agent (common)
+	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
 
 	// Datadog security agent (compliance)
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
-	config.BindEnvAndSetDefault("compliance_config.cmd_port", 5010)
 
 	// Datadog security agent (runtime)
 	config.BindEnvAndSetDefault("runtime_security_config.enabled", false)


### PR DESCRIPTION
### What does this PR do?

- Adds `security-agent config` command.
- This is necessary for the multi-container use case where `agent config` may not represent accurate configuration since it relies on settings in the `agent` container.
- Change the `cmd_port` configuration for security-agent to `security_agent.cmd_port`.

### Motivation

Multi-container (helm) use case.

### Describe your test plan

Install using helm chart and run `security-agent config`