### PR TITLE
[DCA] Support "ignore AD tags" parameter for cluster/endpoint checks

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -308,9 +308,10 @@ func (c *Config) Digest() string {
 	for _, i := range c.ADIdentifiers {
 		h.Write([]byte(i)) //nolint:errcheck
 	}
-	h.Write([]byte(c.NodeName))   //nolint:errcheck
-	h.Write([]byte(c.LogsConfig)) //nolint:errcheck
-	h.Write([]byte(c.Entity))     //nolint:errcheck
+	h.Write([]byte(c.NodeName))                                    //nolint:errcheck
+	h.Write([]byte(c.LogsConfig))                                  //nolint:errcheck
+	h.Write([]byte(c.Entity))                                      //nolint:errcheck
+	h.Write([]byte(strconv.FormatBool(c.IgnoreAutodiscoveryTags))) //nolint:errcheck
 
 	return strconv.FormatUint(h.Sum64(), 16)
 }

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -149,43 +149,43 @@ func TestSetField(t *testing.T) {
 
 func TestDigest(t *testing.T) {
 	emptyConfig := &Config{}
-	assert.Equal(t, "cbf29ce484222325", emptyConfig.Digest())
+	assert.Equal(t, "8cbd29bb83d5daa", emptyConfig.Digest())
 	simpleConfig := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 	}
-	assert.Equal(t, "d8cbc7186ba13533", simpleConfig.Digest())
+	assert.Equal(t, "86fa755714dd0344", simpleConfig.Digest())
 	simpleConfigWithLogs := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 	}
-	assert.Equal(t, "6253da85b1624771", simpleConfigWithLogs.Digest())
+	assert.Equal(t, "6221a1957297b66", simpleConfigWithLogs.Digest())
 	simpleConfigWithInstances := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		Instances:  []Data{Data("{foo:bar}")},
 	}
-	assert.Equal(t, "af69af81e022838d", simpleConfigWithInstances.Digest())
+	assert.Equal(t, "88e8dfc8b715052", simpleConfigWithInstances.Digest())
 	simpleConfigWithInstancesAndLogs := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		Instances:  []Data{Data("{foo:bar}")},
 		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 	}
-	assert.Equal(t, "35def8f2c169307f", simpleConfigWithInstancesAndLogs.Digest())
+	assert.Equal(t, "6692ced6b2ad5480", simpleConfigWithInstancesAndLogs.Digest())
 	simpleConfigWithTags := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		Instances:  []Data{Data("tags: [\"foo\", \"foo:bar\"]")},
 	}
-	assert.Equal(t, "87e916adf286a67f", simpleConfigWithTags.Digest())
+	assert.Equal(t, "4702b7464dedf680", simpleConfigWithTags.Digest())
 	simpleConfigWithOtherTags := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		Instances:  []Data{Data("tags: [\"foo\", \"foo:baf\"]")},
 	}
-	assert.Equal(t, "87e902adf2868473", simpleConfigWithOtherTags.Digest())
+	assert.Equal(t, "c3fabecd59ae4584", simpleConfigWithOtherTags.Digest())
 
 	// assert a character change in a tag produces different hash
 	assert.NotEqual(t, simpleConfigWithTags.Digest(), simpleConfigWithOtherTags.Digest())
@@ -195,7 +195,7 @@ func TestDigest(t *testing.T) {
 		InitConfig: Data(""),
 		Instances:  []Data{Data("tags: [\"foo:bar\", \"foo\"]")},
 	}
-	assert.Equal(t, "87e916adf286a67f", simpleConfigWithTagsDifferentOrder.Digest())
+	assert.Equal(t, "4702b7464dedf680", simpleConfigWithTagsDifferentOrder.Digest())
 
 	// assert an order change in the tags list doesn't change the hash
 	assert.Equal(t, simpleConfigWithTags.Digest(), simpleConfigWithTagsDifferentOrder.Digest())
@@ -205,7 +205,7 @@ func TestDigest(t *testing.T) {
 		InitConfig:   Data(""),
 		ClusterCheck: true,
 	}
-	assert.Equal(t, "d8cbc7186ba13533", simpleClusterCheckConfig.Digest())
+	assert.Equal(t, "86fa755714dd0344", simpleClusterCheckConfig.Digest())
 
 	// assert the ClusterCheck field is not taken into account
 	assert.Equal(t, simpleConfig.Digest(), simpleClusterCheckConfig.Digest())
@@ -215,17 +215,27 @@ func TestDigest(t *testing.T) {
 		InitConfig: Data(""),
 		Entity:     "docker://f556178a47cf65fb70cd5772a9e80e661f71e021da49d3dc99565b861707041c",
 	}
-	assert.Equal(t, "41b0c2b6f9c4f3e0", configWithEntity.Digest())
+	assert.Equal(t, "6f0d4b04bfbf4321", configWithEntity.Digest())
 
 	configWithAnotherEntity := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
 		Entity:     "docker://ddcd8a64616772f7ad4524f09fd75c9e3a265144050fc077563e63ea2eb46db0",
 	}
-	assert.Equal(t, "b5c2d0fd13694bf0", configWithAnotherEntity.Digest())
+	assert.Equal(t, "22e040015f8c50b1", configWithAnotherEntity.Digest())
 
 	// assert an entity change produces different hash
 	assert.NotEqual(t, configWithEntity.Digest(), configWithAnotherEntity.Digest())
+
+	simpleIngoreADTagsConfig := &Config{
+		Name:                    "foo",
+		InitConfig:              Data(""),
+		IgnoreAutodiscoveryTags: true,
+	}
+	assert.Equal(t, "ef50ccb77f4cc8eb", simpleIngoreADTagsConfig.Digest())
+
+	// assert the ClusterCheck field is not taken into account
+	assert.NotEqual(t, simpleConfig.Digest(), simpleIngoreADTagsConfig.Digest())
 }
 
 func TestGetNameForInstance(t *testing.T) {

--- a/pkg/autodiscovery/providers/kube_common.go
+++ b/pkg/autodiscovery/providers/kube_common.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build clusterchecks
+// +build kubeapiserver
+
+package providers
+
+import "strings"
+
+const ignoreADTagsAnnotationSuffix = "ignore_autodiscovery_tags"
+
+// ignoreADTagsFromAnnotations returns whether the check should have autodiscovery tags from the service (e.g kube_namespace)
+// based on the value of the annotation ad.datadoghq.com/ignore_autodiscovery_tags
+func ignoreADTagsFromAnnotations(annotations map[string]string, prefix string) bool {
+	if annotations == nil {
+		return false
+	}
+	return strings.ToLower(annotations[prefix+ignoreADTagsAnnotationSuffix]) == "true"
+}

--- a/pkg/autodiscovery/providers/kube_endpoints_test.go
+++ b/pkg/autodiscovery/providers/kube_endpoints_test.go
@@ -51,12 +51,43 @@ func TestParseKubeServiceAnnotationsForEndpoints(t *testing.T) {
 			expectedOut: []configInfo{
 				{
 					tpl: integration.Config{
-						Name:          "http_check",
-						ADIdentifiers: []string{"kube_endpoint_uid://default/myservice/"},
-						InitConfig:    integration.Data("{}"),
-						Instances:     []integration.Data{integration.Data("{\"name\":\"My endpoint\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
-						ClusterCheck:  false,
-						Source:        "kube_endpoints:kube_endpoint_uid://default/myservice/",
+						Name:                    "http_check",
+						ADIdentifiers:           []string{"kube_endpoint_uid://default/myservice/"},
+						InitConfig:              integration.Data("{}"),
+						Instances:               []integration.Data{integration.Data("{\"name\":\"My endpoint\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+						ClusterCheck:            false,
+						Source:                  "kube_endpoints:kube_endpoint_uid://default/myservice/",
+						IgnoreAutodiscoveryTags: false,
+					},
+					namespace: "default",
+					name:      "myservice",
+				},
+			},
+		},
+		{
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("test"),
+					Annotations: map[string]string{
+						"ad.datadoghq.com/endpoints.check_names":               "[\"http_check\"]",
+						"ad.datadoghq.com/endpoints.init_configs":              "[{}]",
+						"ad.datadoghq.com/endpoints.instances":                 "[{\"name\": \"My endpoint\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"ad.datadoghq.com/endpoints.ignore_autodiscovery_tags": "true",
+					},
+					Name:      "myservice",
+					Namespace: "default",
+				},
+			},
+			expectedOut: []configInfo{
+				{
+					tpl: integration.Config{
+						Name:                    "http_check",
+						ADIdentifiers:           []string{"kube_endpoint_uid://default/myservice/"},
+						InitConfig:              integration.Data("{}"),
+						Instances:               []integration.Data{integration.Data("{\"name\":\"My endpoint\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+						ClusterCheck:            false,
+						Source:                  "kube_endpoints:kube_endpoint_uid://default/myservice/",
+						IgnoreAutodiscoveryTags: true,
 					},
 					namespace: "default",
 					name:      "myservice",

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -154,10 +154,12 @@ func parseServiceAnnotations(services []*v1.Service) ([]integration.Config, erro
 		for _, err := range errors {
 			log.Errorf("Cannot parse service template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 		}
+		ignoreADTags := ignoreADTagsFromAnnotations(svc.GetAnnotations(), kubeServiceAnnotationPrefix)
 		// All configurations are cluster checks
 		for i := range svcConf {
 			svcConf[i].ClusterCheck = true
 			svcConf[i].Source = "kube_services:" + serviceID
+			svcConf[i].IgnoreAutodiscoveryTags = ignoreADTags
 		}
 		configs = append(configs, svcConf...)
 	}

--- a/releasenotes-dca/notes/dca-ad-ignore-service-tags-57117564a754176d.yaml
+++ b/releasenotes-dca/notes/dca-ad-ignore-service-tags-57117564a754176d.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    It's now possible to use the Kubernetes Service annotations
+    ad.datadoghq.com/service.ignore_autodiscovery_tags="true"
+    and ad.datadoghq.com/endpoints.ignore_autodiscovery_tags="true"
+    to disable adding Service tags (e.g kube_service, kube_namespace)
+    to Cluster Checks and Endpoint Checks.


### PR DESCRIPTION
### What does this PR do?

- Make `kube_endpoints` and `kube_services` config providers allow configuring `ignore_autodiscovery_tags` via service annotations

### Motivation

https://github.com/DataDog/datadog-agent/pull/4521 introduced the `ignore_autodiscovery_tags` parameter which can be set via file configuration. Kuberentes Service Annotations based config providers should allow configuring this parameter.
