### PR TITLE
[runtime-security] add flare and status

### DIFF
--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -19,24 +19,37 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
+	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// SetupHandlers adds the specific handlers for /agent endpoints
-func SetupHandlers(r *mux.Router) {
-	r.HandleFunc("/version", common.GetVersion).Methods("GET")
-	r.HandleFunc("/flare", makeFlare).Methods("POST")
-	r.HandleFunc("/hostname", getHostname).Methods("GET")
-	r.HandleFunc("/stop", stopAgent).Methods("POST")
-	r.HandleFunc("/status", getStatus).Methods("GET")
-	r.HandleFunc("/status/health", getHealth).Methods("GET")
-	r.HandleFunc("/config", getRuntimeConfig).Methods("GET")
+// Agent handles REST API calls
+type Agent struct {
+	runtimeAgent *secagent.RuntimeSecurityAgent
 }
 
-func stopAgent(w http.ResponseWriter, r *http.Request) {
+// NewAgent returns a new Agent
+func NewAgent(runtimeAgent *secagent.RuntimeSecurityAgent) *Agent {
+	return &Agent{
+		runtimeAgent: runtimeAgent,
+	}
+}
+
+// SetupHandlers adds the specific handlers for /agent endpoints
+func (a *Agent) SetupHandlers(r *mux.Router) {
+	r.HandleFunc("/version", common.GetVersion).Methods("GET")
+	r.HandleFunc("/flare", a.makeFlare).Methods("POST")
+	r.HandleFunc("/hostname", a.getHostname).Methods("GET")
+	r.HandleFunc("/stop", a.stopAgent).Methods("POST")
+	r.HandleFunc("/status", a.getStatus).Methods("GET")
+	r.HandleFunc("/status/health", a.getHealth).Methods("GET")
+	r.HandleFunc("/config", a.getRuntimeConfig).Methods("GET")
+}
+
+func (a *Agent) stopAgent(w http.ResponseWriter, r *http.Request) {
 	signals.Stopper <- true
 	w.Header().Set("Content-Type", "application/json")
 	j, err := json.Marshal("")
@@ -48,7 +61,7 @@ func stopAgent(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
-func getHostname(w http.ResponseWriter, r *http.Request) {
+func (a *Agent) getHostname(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	hname, err := util.GetHostname()
 	if err != nil {
@@ -64,7 +77,7 @@ func getHostname(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
-func getStatus(w http.ResponseWriter, r *http.Request) {
+func (a *Agent) getStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	s, err := status.GetStatus()
 	if err != nil {
@@ -72,6 +85,10 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 		body, _ := json.Marshal(map[string]string{"error": err.Error()})
 		http.Error(w, string(body), 500)
 		return
+	}
+
+	if a.runtimeAgent != nil {
+		s["runtimeSecurityStatus"] = a.runtimeAgent.GetStatus()
 	}
 
 	jsonStats, err := json.Marshal(s)
@@ -85,7 +102,7 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonStats)
 }
 
-func getHealth(w http.ResponseWriter, r *http.Request) {
+func (a *Agent) getHealth(w http.ResponseWriter, r *http.Request) {
 	h := health.GetReady()
 
 	if len(h.Unhealthy) > 0 {
@@ -103,7 +120,7 @@ func getHealth(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonHealth)
 }
 
-func makeFlare(w http.ResponseWriter, r *http.Request) {
+func (a *Agent) makeFlare(w http.ResponseWriter, r *http.Request) {
 	log.Infof("Making a flare")
 	w.Header().Set("Content-Type", "application/json")
 	logFile := config.Datadog.GetString("log_file")
@@ -122,7 +139,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(filePath))
 }
 
-func getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
+func (a *Agent) getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	runtimeConfig, err := yaml.Marshal(config.Datadog.AllSettings())
 	if err != nil {
 		log.Errorf("Unable to marshal runtime config response: %s", err)

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -199,11 +199,12 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	// start runtime security agent
-	if err = startRuntimeSecurity(hostname, endpoints, dstContext, stopper); err != nil {
+	runtimeAgent, err := startRuntimeSecurity(hostname, endpoints, dstContext, stopper)
+	if err != nil {
 		return err
 	}
 
-	srv, err := api.NewServer()
+	srv, err := api.NewServer(runtimeAgent)
 	if err != nil {
 		return log.Errorf("Error while creating api server, exiting: %v", err)
 	}

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -46,21 +46,21 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 	return event.NewReporter(logSource, pipelineProvider.NextPipelineChan()), nil
 }
 
-func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper) error {
+func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper) (*secagent.RuntimeSecurityAgent, error) {
 	enabled := coreconfig.Datadog.GetBool("runtime_security_config.enabled")
 	if !enabled {
 		log.Info("Datadog runtime security agent disabled by config")
-		return nil
+		return nil, nil
 	}
 
 	reporter, err := newRuntimeReporter(stopper, "runtime-security-agent", "runtime-security", endpoints, context)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	agent, err := secagent.NewRuntimeSecurityAgent(hostname, reporter)
 	if err != nil {
-		return errors.Wrap(err, "unable to create a runtime security agent instance")
+		return nil, errors.Wrap(err, "unable to create a runtime security agent instance")
 	}
 	agent.Start()
 
@@ -68,5 +68,5 @@ func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context 
 
 	log.Info("Datadog runtime security agent is now running")
 
-	return nil
+	return agent, nil
 }

--- a/cmd/security-agent/app/runtime_unsupported.go
+++ b/cmd/security-agent/app/runtime_unsupported.go
@@ -14,15 +14,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
+	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper) error {
+func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper) (*secagent.RuntimeSecurityAgent, error) {
 	enabled := coreconfig.Datadog.GetBool("runtime_security_config.enabled")
 	if !enabled {
 		log.Info("Datadog runtime security agent disabled by config")
-		return nil
+		return nil, nil
 	}
 
-	return errors.New("Datadog runtime security agent is only supported on Linux")
+	return nil, errors.New("Datadog runtime security agent is only supported on Linux")
 }

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -105,6 +105,7 @@ func FormatSecurityAgentStatus(data []byte) (string, error) {
 	stats["title"] = title
 	renderStatusTemplate(b, "/header.tmpl", stats)
 	renderComplianceChecksStats(b, runnerStats)
+	renderRuntimeSecurityStats(b, stats["runtimeSecurityStatus"])
 
 	return b.String(), nil
 }
@@ -154,6 +155,12 @@ func renderComplianceChecksStats(w io.Writer, runnerStats /*, checkSchedulerStat
 	checkStats := make(map[string]interface{})
 	checkStats["RunnerStats"] = runnerStats
 	renderStatusTemplate(w, "/compliance.tmpl", checkStats)
+}
+
+func renderRuntimeSecurityStats(w io.Writer, runtimeSecurityStatus interface{}) {
+	status := make(map[string]interface{})
+	status["RuntimeSecurityStatus"] = runtimeSecurityStatus
+	renderStatusTemplate(w, "/runtimesecurity.tmpl", status)
 }
 
 func renderStatusTemplate(w io.Writer, templateName string, stats interface{}) {

--- a/pkg/status/templates/runtimesecurity.tmpl
+++ b/pkg/status/templates/runtimesecurity.tmpl
@@ -1,0 +1,12 @@
+Runtime Security
+================
+
+{{- if not .RuntimeSecurityStatus}}
+  Not enabled
+{{- else}}
+  {{- with .RuntimeSecurityStatus}}
+  Connected: {{.connected}}
+  Events received: {{.eventReceived}}
+  {{- end }}
+{{- end }}
+


### PR DESCRIPTION
### What does this PR do?

This PR adds flare and status for the runtime component of the security-agent.
It also move the cmd_port in the config from the compliance section to a common place

### Motivation

What inspired you to submit this pull request?

### Additional Notes

It currently report the status of the connection between the agent and system-probe and the total of event received.

### Describe your test plan

Just run the `security-agent status` a `Runtime Security` is now present
