### PR TITLE
pkg/trace/config: add _dd.hostname as an extra aggregator for trace metrics

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -127,7 +127,7 @@ func New() *AgentConfig {
 		Endpoints:  []*Endpoint{{Host: "https://trace.agent.datadoghq.com"}},
 
 		BucketInterval:   time.Duration(10) * time.Second,
-		ExtraAggregators: []string{"http.status_code", "version"},
+		ExtraAggregators: []string{"http.status_code", "version", "_dd.hostname"},
 
 		ExtraSampleRate: 1.0,
 		MaxTPS:          10,

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -115,7 +115,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal("INFO", c.LogLevel)
 	assert.Equal(true, c.Enabled)
 
-	assert.Equal([]string{"http.status_code", "version"}, c.ExtraAggregators)
+	assert.Equal([]string{"http.status_code", "version", "_dd.hostname"}, c.ExtraAggregators)
 }
 
 func TestNoAPMConfig(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This change enables aggregating metrics by _dd.hostname to support
clustered agent setups.

### Motivation

This change enables aggregating stats by a hostname set in the trace client rather than the agent.

### Describe your test plan

Basic tests are included in the PR and manual end-to-end tests will be performed.
