### PR TITLE
pkg/trace/info: add endpoint_version as receiver stats

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -298,13 +298,14 @@ const (
 	headerTracerVersion = "Datadog-Meta-Tracer-Version"
 )
 
-func (r *HTTPReceiver) tagStats(req *http.Request) *info.TagStats {
+func (r *HTTPReceiver) tagStats(v Version, req *http.Request) *info.TagStats {
 	return r.Stats.GetTagStats(info.Tags{
-		Lang:          req.Header.Get(headerLang),
-		LangVersion:   req.Header.Get(headerLangVersion),
-		Interpreter:   req.Header.Get(headerLangInterpreter),
-		LangVendor:    req.Header.Get(headerLangInterpreterVendor),
-		TracerVersion: req.Header.Get(headerTracerVersion),
+		Lang:            req.Header.Get(headerLang),
+		LangVersion:     req.Header.Get(headerLangVersion),
+		Interpreter:     req.Header.Get(headerLangInterpreter),
+		LangVendor:      req.Header.Get(headerLangInterpreterVendor),
+		TracerVersion:   req.Header.Get(headerTracerVersion),
+		EndpointVersion: string(v),
 	})
 }
 
@@ -342,7 +343,7 @@ func (r *HTTPReceiver) replyOK(v Version, w http.ResponseWriter) {
 
 // handleTraces knows how to handle a bunch of traces
 func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.Request) {
-	ts := r.tagStats(req)
+	ts := r.tagStats(v, req)
 	traceCount, err := traceCount(req)
 	if err != nil {
 		log.Warnf("Error getting trace count: %q. Functionality may be limited.", err)

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -351,7 +351,7 @@ func TestReceiverDecodingError(t *testing.T) {
 		assert.NoError(err)
 
 		assert.Equal(400, resp.StatusCode)
-		assert.EqualValues(0, r.Stats.GetTagStats(info.Tags{}).TracesDropped.DecodingError)
+		assert.EqualValues(0, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.4"}).TracesDropped.DecodingError)
 	})
 
 	t.Run("with-header", func(t *testing.T) {
@@ -365,7 +365,7 @@ func TestReceiverDecodingError(t *testing.T) {
 		assert.NoError(err)
 
 		assert.Equal(400, resp.StatusCode)
-		assert.EqualValues(traceCount, r.Stats.GetTagStats(info.Tags{}).TracesDropped.DecodingError)
+		assert.EqualValues(traceCount, r.Stats.GetTagStats(info.Tags{EndpointVersion: "v0.4"}).TracesDropped.DecodingError)
 	})
 }
 
@@ -518,7 +518,7 @@ func TestHandleTraces(t *testing.T) {
 
 	// We test stats for each app
 	for _, lang := range langs {
-		ts, ok := rs.Stats[info.Tags{Lang: lang}]
+		ts, ok := rs.Stats[info.Tags{Lang: lang, EndpointVersion: "v0.4"}]
 		assert.True(ok)
 		assert.Equal(int64(20), ts.TracesReceived)
 		assert.Equal(int64(59222), ts.TracesBytes)

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -431,6 +431,7 @@ func (ts *TagStats) WarnString() string {
 // Tags holds the tags we parse when we handle the header of the payload.
 type Tags struct {
 	Lang, LangVersion, LangVendor, Interpreter, TracerVersion string
+	EndpointVersion                                           string
 }
 
 // toArray will transform the Tags struct into a slice of string.
@@ -452,6 +453,9 @@ func (t *Tags) toArray() []string {
 	}
 	if t.TracerVersion != "" {
 		tags = append(tags, "tracer_version:"+t.TracerVersion)
+	}
+	if t.EndpointVersion != "" {
+		tags = append(tags, "endpoint:"+t.EndpointVersion)
 	}
 
 	return tags

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -455,7 +455,7 @@ func (t *Tags) toArray() []string {
 		tags = append(tags, "tracer_version:"+t.TracerVersion)
 	}
 	if t.EndpointVersion != "" {
-		tags = append(tags, "endpoint:"+t.EndpointVersion)
+		tags = append(tags, "endpoint_version:"+t.EndpointVersion)
 	}
 
 	return tags

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -80,6 +80,6 @@ func TestStatsTags(t *testing.T) {
 		"lang_vendor:gov",
 		"interpreter:goi",
 		"tracer_version:1.21.0",
-		"endpoint:v0.4",
+		"endpoint_version:v0.4",
 	})
 }

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -65,3 +65,21 @@ func TestSpansMalformed(t *testing.T) {
 		assert.Equal(t, "resource_empty:1, service_empty:1, service_invalid:1, span_name_truncate:1, type_truncate:1", s.String())
 	})
 }
+
+func TestStatsTags(t *testing.T) {
+	assert.Equal(t, (&Tags{
+		Lang:            "go",
+		LangVersion:     "1.14",
+		LangVendor:      "gov",
+		Interpreter:     "goi",
+		TracerVersion:   "1.21.0",
+		EndpointVersion: "v0.4",
+	}).toArray(), []string{
+		"lang:go",
+		"lang_version:1.14",
+		"lang_vendor:gov",
+		"interpreter:goi",
+		"tracer_version:1.21.0",
+		"endpoint:v0.4",
+	})
+}

--- a/releasenotes/notes/apm-receiver-endpoint-version-tag-42813a31ca2c9977.yaml
+++ b/releasenotes/notes/apm-receiver-endpoint-version-tag-42813a31ca2c9977.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    APM: datadog.trace_agent.receiver.* metrics are now also tagged by endpoint_version 


### PR DESCRIPTION
`datadog.trace_agent.receiver.*` metrics are now also tagged by `endpoint`