### PR TITLE
.github: remove releasenotes/ from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,7 +96,6 @@
 /pkg/kubestatemetrics                    @DataDog/container-integrations
 /pkg/security/                          @DataDog/agent-security
 
-/releasenotes/                          @DataDog/agent-all
 /releasenotes-dca/                      @DataDog/container-integrations
 
 /rtloader/                              @DataDog/agent-core


### PR DESCRIPTION
There is no need for everyone to get notified of all changes.