### PR TITLE
Remove agent-platform as the owner of some tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -111,9 +111,8 @@
 
 /test/benchmarks/                       @DataDog/agent-core
 /test/e2e/                              @DataDog/container-integrations
-/test/integration/                      @DataDog/agent-all
+/test/integration/                      @DataDog/container-integrations
 /test/kitchen/                          @DataDog/agent-platform
 /test/system/                           @DataDog/agent-core
-/test/util/                             @DataDog/agent-all
 
 /tools/ebpf/                            @DataDog/networks

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/test/util"
 
 	"gopkg.in/zorkian/go-datadog-api.v2"
 )
@@ -206,7 +205,7 @@ func main() {
 		return
 	}
 
-	util.SetHostname("foo")
+	SetHostname("foo")
 
 	f := &forwarderBenchStub{}
 	s := serializer.NewSerializer(f)

--- a/test/benchmarks/aggregator/memory.go
+++ b/test/benchmarks/aggregator/memory.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/test/util"
 	log "github.com/cihub/seelog"
 
 	"gopkg.in/zorkian/go-datadog-api.v2"
@@ -19,7 +18,7 @@ import (
 func preAllocateMetrics(n int) map[string][]*metrics.MetricSample {
 
 	metricMap := make(map[string][]*metrics.MetricSample)
-	metricTemplate := "benchmark.metric." + util.RandomString(7)
+	metricTemplate := "benchmark.metric." + RandomString(7)
 
 	for mType := metrics.GaugeType; mType <= metrics.DistributionType; mType++ {
 		// Not supported for now
@@ -38,7 +37,7 @@ func preAllocateMetrics(n int) map[string][]*metrics.MetricSample {
 				Tags:       []string{"a", "b:21", "c"},
 				Host:       "localhost",
 				SampleRate: 1,
-				Timestamp:  util.TimeNowNano(),
+				Timestamp:  TimeNowNano(),
 			}
 			samples[i] = s
 		}
@@ -76,7 +75,7 @@ func preAllocateServiceChecks(n int) []*metrics.ServiceCheck {
 
 	for i := range scs {
 		sc := &metrics.ServiceCheck{
-			CheckName: "benchmark.sc." + util.RandomString(4),
+			CheckName: "benchmark.sc." + RandomString(4),
 			Status:    metrics.ServiceCheckOK,
 			Host:      "localhost",
 			Ts:        time.Now().Unix(),

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/test/util"
 )
 
 const (
@@ -210,7 +209,7 @@ func createMetric(value float64, tags []string, name string, t int64) datadog.Me
 func main() {
 	mockConfig := config.Mock()
 
-	if err := util.InitLogging("info"); err != nil {
+	if err := InitLogging("info"); err != nil {
 		log.Infof("Unable to replace logger, default logging will apply (highly verbose): %s", err)
 	}
 	defer log.Flush()
@@ -270,7 +269,7 @@ func main() {
 				if !(*rnd) {
 					packets = make([]string, *ser)
 					for i := range packets {
-						packets[i] = buildPayload("foo.bar", rand.Int63n(1000), []byte("|g"), []string{util.RandomString(*pad)}, 1)
+						packets[i] = buildPayload("foo.bar", rand.Int63n(1000), []byte("|g"), []string{RandomString(*pad)}, 1)
 					}
 				}
 
@@ -285,9 +284,9 @@ func main() {
 						if *rnd {
 							buf.Reset()
 							buf.WriteString("foo.")
-							buf.WriteString(util.RandomString(*ser))
+							buf.WriteString(RandomString(*ser))
 
-							err = submitPacket([]byte(buildPayload(buf.String(), rand.Int63n(1000), []byte("|g"), []string{util.RandomString(*pad)}, 2)), generator)
+							err = submitPacket([]byte(buildPayload(buf.String(), rand.Int63n(1000), []byte("|g"), []string{RandomString(*pad)}, 2)), generator)
 						} else {
 							err = submitPacket([]byte(packets[rand.Int63n(int64(*ser))]), generator)
 						}

--- a/test/benchmarks/util.go
+++ b/test/benchmarks/util.go
@@ -1,4 +1,4 @@
-package util
+package main
 
 import (
 	"fmt"


### PR DESCRIPTION
### What does this PR do?

- Merge `test/util` into `test/benchmarks` since it was only used there.
- Assign `/test/integration` to `container-integrations` since all tests there are Docker-related.

### Motivation

Reduce code incorrectly assigned to Agent Platform.
