### PR TITLE
Change owner of releasenotes and go.mod/sum to reduce spam

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,8 +37,12 @@
 /docs/cluster-agent/                    @DataDog/documentation @DataDog/container-integrations
 /docs/dev/checks/                       @DataDog/documentation @DataDog/agent-core
 
-/go.mod                                 @DataDog/agent-all
-/go.sum                                 @DataDog/agent-all
+# These files are owned by all teams, but assigning them to @DataDog/agent-all causes a lot of spam
+# Assigning them to a group that doesn't exist means nobody will receive notifications for them, but
+# that should be fine since rarely we make PRs that only change those files alone.
+/releasenotes/                          @DataDog/do-not-notify
+/go.mod                                 @DataDog/do-not-notify
+/go.sum                                 @DataDog/do-not-notify
 
 /Makefile.trace                         @DataDog/agent-apm
 
@@ -96,7 +100,6 @@
 /pkg/kubestatemetrics                    @DataDog/container-integrations
 /pkg/security/                          @DataDog/agent-security
 
-/releasenotes/                          @DataDog/agent-all
 /releasenotes-dca/                      @DataDog/container-integrations
 
 /rtloader/                              @DataDog/agent-core


### PR DESCRIPTION
### What does this PR do?

Assigns some frequently-changed files to `@DataDog/do-not-notify` which doesn't exist and thus doesn't notify anyone when the files change.

### Motivation

Since recently, changes to files owned by `@DataDog/agent-all` notify everybody. This creates a lot of spam.

