### PR TITLE
added per-module metrics to system-probe

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -143,6 +143,9 @@ func runAgent(exit <-chan struct{}) {
 		heartbeat := time.NewTicker(15 * time.Second)
 		for range heartbeat.C {
 			statsd.Client.Gauge("datadog.system_probe.agent", 1, tags, 1) //nolint:errcheck
+			for moduleName := range loader.modules {
+				statsd.Client.Gauge(fmt.Sprintf("datadog.system_probe.agent.%s", moduleName), 1, tags, 1) //nolint:errcheck
+			}
 		}
 	}()
 


### PR DESCRIPTION
### What does this PR do?
https://datadoghq.atlassian.net/browse/NET-665

Currently system-probe emits a single metric when enabled.  This PR adds a metric for each module that is enabled as well of the form `datadog.system_probe.agent.<MODULE_NAME>`.  It still keeps the singular metric as well for backwards compatibility.

### Motivation

Add the ability for finer-grained context on which modules are used.

### Describe your test plan

Standard new-metric testing
