### PR TITLE
[compliance] Implement resource fallbacks to support config overrides

### DIFF
--- a/pkg/compliance/checks/audit_check.go
+++ b/pkg/compliance/checks/audit_check.go
@@ -21,9 +21,14 @@ var auditReportedFields = []string{
 	compliance.AuditFieldPermissions,
 }
 
-func checkAudit(e env.Env, ruleID string, res compliance.Resource, expr *eval.IterableExpression) (*compliance.Report, error) {
+func checkAudit(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
 	if res.Audit == nil {
 		return nil, fmt.Errorf("%s: expecting audit resource in audit check", ruleID)
+	}
+
+	expr, err := eval.Cache.ParseIterable(res.Condition)
+	if err != nil {
+		return nil, err
 	}
 
 	audit := res.Audit

--- a/pkg/compliance/checks/audit_check.go
+++ b/pkg/compliance/checks/audit_check.go
@@ -6,6 +6,7 @@
 package checks
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
@@ -21,14 +22,9 @@ var auditReportedFields = []string{
 	compliance.AuditFieldPermissions,
 }
 
-func checkAudit(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
+func resolveAudit(_ context.Context, e env.Env, ruleID string, res compliance.Resource) (interface{}, error) {
 	if res.Audit == nil {
 		return nil, fmt.Errorf("%s: expecting audit resource in audit check", ruleID)
-	}
-
-	expr, err := eval.Cache.ParseIterable(res.Condition)
-	if err != nil {
-		return nil, err
 	}
 
 	audit := res.Audit
@@ -70,16 +66,9 @@ func checkAudit(e env.Env, ruleID string, res compliance.Resource) (*compliance.
 		}
 	}
 
-	it := &instanceIterator{
+	return &instanceIterator{
 		instances: instances,
-	}
-
-	result, err := expr.EvaluateIterator(it, globalInstance)
-	if err != nil {
-		return nil, err
-	}
-
-	return instanceResultToReport(result, auditReportedFields), nil
+	}, nil
 }
 
 func auditPermissionsString(r *rule.FileWatchRule) string {

--- a/pkg/compliance/checks/audit_check_test.go
+++ b/pkg/compliance/checks/audit_check_test.go
@@ -120,7 +120,10 @@ func TestAuditCheck(t *testing.T) {
 				test.setup(t, env)
 			}
 
-			result, err := checkAudit(env, "rule-id", test.resource)
+			auditCheck, err := newResourceCheck(env, "rule-id", test.resource)
+			assert.NoError(err)
+
+			result, err := auditCheck.check(env)
 
 			assert.Equal(test.expectError, err)
 			assert.Equal(test.expectReport, result)

--- a/pkg/compliance/checks/audit_check_test.go
+++ b/pkg/compliance/checks/audit_check_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 	"github.com/elastic/go-libaudit/rule"
@@ -121,10 +120,7 @@ func TestAuditCheck(t *testing.T) {
 				test.setup(t, env)
 			}
 
-			expr, err := eval.ParseIterable(test.resource.Condition)
-			assert.NoError(err)
-
-			result, err := checkAudit(env, "rule-id", test.resource, expr)
+			result, err := checkAudit(env, "rule-id", test.resource)
 
 			assert.Equal(test.expectError, err)
 			assert.Equal(test.expectReport, result)

--- a/pkg/compliance/checks/checkable.go
+++ b/pkg/compliance/checks/checkable.go
@@ -15,10 +15,13 @@ type checkable interface {
 	check(env env.Env) (*compliance.Report, error)
 }
 
-// checkableList abstracts a series of resource checks
+// checkableList abstracts a list of resource checks
 type checkableList []checkable
 
 // check implements checkable interface for checkableList
+// note that this implements AND for all checkables in a check:
+// failure or error from a single checkable fails the check, all checkables must
+// return Passed in order for the check to be successful.
 func (list checkableList) check(env env.Env) (*compliance.Report, error) {
 	var (
 		result *compliance.Report
@@ -27,7 +30,7 @@ func (list checkableList) check(env env.Env) (*compliance.Report, error) {
 
 	for _, c := range list {
 		result, err = c.check(env)
-		if err == nil && result.Passed {
+		if err != nil || !result.Passed {
 			break
 		}
 	}

--- a/pkg/compliance/checks/checkable_test.go
+++ b/pkg/compliance/checks/checkable_test.go
@@ -29,7 +29,7 @@ func TestCheckableList(t *testing.T) {
 		expected outcome
 	}{
 		{
-			name: "first succeeds and is the result",
+			name: "first=passed, second=failed => result=[failed from second]",
 			list: []outcome{
 				{
 					report: &compliance.Report{
@@ -50,15 +50,15 @@ func TestCheckableList(t *testing.T) {
 			},
 			expected: outcome{
 				report: &compliance.Report{
-					Passed: true,
+					Passed: false,
 					Data: event.Data{
-						"something": "passed",
+						"something": "failed",
 					},
 				},
 			},
 		},
 		{
-			name: "first is error and second succeeds and is the result",
+			name: "first=error, second=passed => result[error from first]",
 			list: []outcome{
 				{
 					err: errors.New("some error"),
@@ -73,16 +73,11 @@ func TestCheckableList(t *testing.T) {
 				},
 			},
 			expected: outcome{
-				report: &compliance.Report{
-					Passed: true,
-					Data: event.Data{
-						"something else": "passed",
-					},
-				},
+				err: errors.New("some error"),
 			},
 		},
 		{
-			name: "first not passed and second succeeds and is the result",
+			name: "first=failed, second=passed => result[failed from first]",
 			list: []outcome{
 				{
 					report: &compliance.Report{
@@ -103,15 +98,15 @@ func TestCheckableList(t *testing.T) {
 			},
 			expected: outcome{
 				report: &compliance.Report{
-					Passed: true,
+					Passed: false,
 					Data: event.Data{
-						"something else": "passed",
+						"something": "failed",
 					},
 				},
 			},
 		},
 		{
-			name: "first not passed and second is error and is the result",
+			name: "first=failed, second=error => result[failed from first]",
 			list: []outcome{
 				{
 					report: &compliance.Report{
@@ -126,7 +121,12 @@ func TestCheckableList(t *testing.T) {
 				},
 			},
 			expected: outcome{
-				err: errors.New("some other error"),
+				report: &compliance.Report{
+					Passed: false,
+					Data: event.Data{
+						"something": "failed",
+					},
+				},
 			},
 		},
 	}

--- a/pkg/compliance/checks/command_check.go
+++ b/pkg/compliance/checks/command_check.go
@@ -24,9 +24,14 @@ var commandReportedFields = []string{
 	compliance.CommandFieldExitCode,
 }
 
-func checkCommand(_ env.Env, ruleID string, res compliance.Resource, expr *eval.IterableExpression) (*compliance.Report, error) {
+func checkCommand(_ env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
 	if res.Command == nil {
 		return nil, fmt.Errorf("%s: expecting command resource in command check", ruleID)
+	}
+
+	expr, err := eval.Cache.ParseIterable(res.Condition)
+	if err != nil {
+		return nil, err
 	}
 
 	command := res.Command

--- a/pkg/compliance/checks/command_check.go
+++ b/pkg/compliance/checks/command_check.go
@@ -24,14 +24,9 @@ var commandReportedFields = []string{
 	compliance.CommandFieldExitCode,
 }
 
-func checkCommand(_ env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
+func resolveCommand(ctx context.Context, _ env.Env, ruleID string, res compliance.Resource) (interface{}, error) {
 	if res.Command == nil {
 		return nil, fmt.Errorf("%s: expecting command resource in command check", ruleID)
-	}
-
-	expr, err := eval.Cache.ParseIterable(res.Condition)
-	if err != nil {
-		return nil, err
 	}
 
 	command := res.Command
@@ -55,7 +50,7 @@ func checkCommand(_ env.Env, ruleID string, res compliance.Resource) (*complianc
 		commandTimeout = time.Duration(command.TimeoutSeconds) * time.Second
 	}
 
-	context, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	context, cancel := context.WithTimeout(ctx, commandTimeout)
 	defer cancel()
 
 	exitCode, stdout, err := commandRunner(context, execCommand.Name, execCommand.Args, true)
@@ -63,17 +58,10 @@ func checkCommand(_ env.Env, ruleID string, res compliance.Resource) (*complianc
 		return nil, fmt.Errorf("command '%v' execution failed, error: %v", command, err)
 	}
 
-	instance := &eval.Instance{
+	return &eval.Instance{
 		Vars: eval.VarMap{
 			compliance.CommandFieldExitCode: exitCode,
 			compliance.CommandFieldStdout:   string(stdout),
 		},
-	}
-
-	passed, err := expr.Evaluate(instance)
-	if err != nil {
-		return nil, err
-	}
-
-	return instanceToReport(instance, passed, commandReportedFields), nil
+	}, nil
 }

--- a/pkg/compliance/checks/command_check_test.go
+++ b/pkg/compliance/checks/command_check_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 
@@ -54,10 +53,7 @@ func (f *commandFixture) run(t *testing.T) {
 	env := &mocks.Env{}
 	defer env.AssertExpectations(t)
 
-	expr, err := eval.ParseIterable(f.resource.Condition)
-	assert.NoError(err)
-
-	result, err := checkCommand(env, "rule-id", f.resource, expr)
+	result, err := checkCommand(env, "rule-id", f.resource)
 	assert.Equal(f.expectReport, result)
 	assert.Equal(f.expectError, err)
 

--- a/pkg/compliance/checks/command_check_test.go
+++ b/pkg/compliance/checks/command_check_test.go
@@ -53,7 +53,10 @@ func (f *commandFixture) run(t *testing.T) {
 	env := &mocks.Env{}
 	defer env.AssertExpectations(t)
 
-	result, err := checkCommand(env, "rule-id", f.resource)
+	commandCheck, err := newResourceCheck(env, "rule-id", f.resource)
+	assert.NoError(err)
+
+	result, err := commandCheck.check(env)
 	assert.Equal(f.expectReport, result)
 	assert.Equal(f.expectError, err)
 

--- a/pkg/compliance/checks/custom/kube_defaultserviceaccounts.go
+++ b/pkg/compliance/checks/custom/kube_defaultserviceaccounts.go
@@ -21,7 +21,7 @@ func init() {
 	registerCustomCheck("kubernetesDefaultServiceAccounts", kubernetesDefaultServiceAccountsCheck)
 }
 
-func kubernetesDefaultServiceAccountsCheck(e env.Env, ruleID string, vars map[string]string, expr *eval.IterableExpression) (*compliance.Report, error) {
+func kubernetesDefaultServiceAccountsCheck(e env.Env, ruleID string, vars map[string]string, _ *eval.IterableExpression) (*compliance.Report, error) {
 	if e.KubeClient() == nil {
 		return nil, fmt.Errorf("unable to run kubernetesDefaultServiceAccounts check for rule: %s - Kubernetes client not initialized", ruleID)
 	}

--- a/pkg/compliance/checks/custom/kube_networkpolicies.go
+++ b/pkg/compliance/checks/custom/kube_networkpolicies.go
@@ -20,7 +20,7 @@ func init() {
 	registerCustomCheck("kubernetesNetworkPolicies", kubernetesNetworkPoliciesCheck)
 }
 
-func kubernetesNetworkPoliciesCheck(e env.Env, ruleID string, vars map[string]string, expr *eval.IterableExpression) (*compliance.Report, error) {
+func kubernetesNetworkPoliciesCheck(e env.Env, ruleID string, vars map[string]string, _ *eval.IterableExpression) (*compliance.Report, error) {
 	if e.KubeClient() == nil {
 		return nil, fmt.Errorf("unable to run kubernetesNetworkPolicies check for rule: %s - Kubernetes client not initialized", ruleID)
 	}

--- a/pkg/compliance/checks/custom_check.go
+++ b/pkg/compliance/checks/custom_check.go
@@ -14,9 +14,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 )
 
-func checkCustom(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
-	if res.Custom == nil || res.Custom.Name == "" {
+type customCheck struct {
+	ruleID    string
+	custom    *compliance.Custom
+	expr      *eval.IterableExpression
+	checkFunc custom.CheckFunc
+}
+
+func newCustomCheck(ruleID string, res compliance.Resource) (checkable, error) {
+	if res.Custom == nil {
 		return nil, fmt.Errorf("expecting custom resource in custom check")
+	}
+
+	if res.Custom.Name == "" {
+		return nil, fmt.Errorf("expecting custom resource name in custom check")
 	}
 
 	expr, err := eval.Cache.ParseIterable(res.Condition)
@@ -29,5 +40,14 @@ func checkCustom(e env.Env, ruleID string, res compliance.Resource) (*compliance
 		return nil, fmt.Errorf("custom check with name: %s does not exist", res.Custom.Name)
 	}
 
-	return f(e, ruleID, res.Custom.Variables, expr)
+	return &customCheck{
+		ruleID:    ruleID,
+		custom:    res.Custom,
+		expr:      expr,
+		checkFunc: f,
+	}, nil
+}
+
+func (c *customCheck) check(e env.Env) (*compliance.Report, error) {
+	return c.checkFunc(e, c.ruleID, c.custom.Variables, c.expr)
 }

--- a/pkg/compliance/checks/custom_check.go
+++ b/pkg/compliance/checks/custom_check.go
@@ -14,9 +14,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 )
 
-func checkCustom(e env.Env, ruleID string, res compliance.Resource, expr *eval.IterableExpression) (*compliance.Report, error) {
+func checkCustom(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
 	if res.Custom == nil || res.Custom.Name == "" {
 		return nil, fmt.Errorf("expecting custom resource in custom check")
+	}
+
+	expr, err := eval.Cache.ParseIterable(res.Condition)
+	if err != nil {
+		return nil, err
 	}
 
 	f := custom.GetCustomCheck(res.Custom.Name)

--- a/pkg/compliance/checks/custom_check_test.go
+++ b/pkg/compliance/checks/custom_check_test.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package checks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance"
+	"github.com/DataDog/datadog-agent/pkg/compliance/checks/custom"
+	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
+	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
+	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestNewCustomCheck(t *testing.T) {
+	assert := assert.New(t)
+
+	const ruleID = "rule-id"
+
+	expectCheckReport := &compliance.Report{Passed: true}
+	expectCheckError := errors.New("check failed")
+
+	customCheckFunc := func(report *compliance.Report, err error) custom.CheckFunc {
+		return func(e env.Env, ruleID string, vars map[string]string, expr *eval.IterableExpression) (*compliance.Report, error) {
+			return report, err
+		}
+	}
+
+	tests := []struct {
+		name              string
+		resource          compliance.Resource
+		checkFactory      checkFactoryFunc
+		expectError       error
+		expectCheckReport *compliance.Report
+		expectCheckError  error
+	}{
+		{
+			name: "wrong resource kind",
+			resource: compliance.Resource{
+				File: &compliance.File{
+					Path: "/etc/bitsy/spider",
+				},
+			},
+			expectError: errors.New("expecting custom resource in custom check"),
+		},
+		{
+			name: "missing check name",
+			resource: compliance.Resource{
+				Custom: &compliance.Custom{},
+			},
+			expectError: errors.New("missing check name in custom check"),
+		},
+		{
+			name: "allowed empty condition",
+			resource: compliance.Resource{
+				Custom: &compliance.Custom{
+					Name: "check-name",
+				},
+			},
+			checkFactory: func(_ string) custom.CheckFunc {
+				return customCheckFunc(expectCheckReport, nil)
+			},
+			expectCheckReport: expectCheckReport,
+		},
+		{
+			name: "custom check error",
+			resource: compliance.Resource{
+				Custom: &compliance.Custom{
+					Name: "check-name",
+				},
+			},
+			checkFactory: func(_ string) custom.CheckFunc {
+				return customCheckFunc(nil, expectCheckError)
+			},
+			expectCheckError: expectCheckError,
+		},
+		{
+			name: "condition expression failure",
+			resource: compliance.Resource{
+				Custom: &compliance.Custom{
+					Name: "check-name",
+				},
+				Condition: "~",
+			},
+			expectError: errors.New(`1:1: unexpected token "~"`),
+		},
+		{
+			name: "cannot find check by name",
+			resource: compliance.Resource{
+				Custom: &compliance.Custom{
+					Name: "check-name",
+				},
+			},
+			checkFactory: func(_ string) custom.CheckFunc {
+				return nil
+			},
+			expectError: errors.New("custom check with name: check-name does not exist"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			customCheckFactory = test.checkFactory
+			check, err := newCustomCheck(ruleID, test.resource)
+
+			if test.expectError != nil {
+				assert.EqualError(err, test.expectError.Error())
+				assert.Nil(check)
+			} else {
+				assert.NotNil(check)
+				env := &mocks.Env{}
+				report, err := check.check(env)
+				if test.expectCheckError != nil {
+					assert.EqualError(err, test.expectCheckError.Error())
+
+				}
+				assert.Equal(test.expectCheckReport, report)
+			}
+		})
+	}
+}

--- a/pkg/compliance/checks/docker_check.go
+++ b/pkg/compliance/checks/docker_check.go
@@ -43,9 +43,14 @@ func dockerKindNotSupported(kind string) error {
 	return fmt.Errorf("unsupported docker object kind '%s'", kind)
 }
 
-func checkDocker(e env.Env, ruleID string, res compliance.Resource, expr *eval.IterableExpression) (*compliance.Report, error) {
+func checkDocker(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
 	if res.Docker == nil {
 		return nil, fmt.Errorf("expecting docker resource in docker check")
+	}
+
+	expr, err := eval.Cache.ParseIterable(res.Condition)
+	if err != nil {
+		return nil, err
 	}
 
 	client := e.DockerClient()

--- a/pkg/compliance/checks/docker_check.go
+++ b/pkg/compliance/checks/docker_check.go
@@ -17,40 +17,24 @@ import (
 )
 
 var (
-	dockerImageReportedFields = []string{
+	dockerReportedFields = []string{
 		compliance.DockerImageFieldID,
 		compliance.DockerImageFieldTags,
-	}
-
-	dockerContainerReportedFields = []string{
 		compliance.DockerContainerFieldID,
 		compliance.DockerContainerFieldName,
 		compliance.DockerContainerFieldImage,
-	}
-
-	dockerNetworkReportedFields = []string{
 		compliance.DockerNetworkFieldName,
-	}
-
-	dockerVersionReportedFields = []string{
 		compliance.DockerVersionFieldVersion,
 	}
-
-	dockerInfoReportedFields = []string{}
 )
 
 func dockerKindNotSupported(kind string) error {
 	return fmt.Errorf("unsupported docker object kind '%s'", kind)
 }
 
-func checkDocker(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
+func resolveDocker(ctx context.Context, e env.Env, ruleID string, res compliance.Resource) (interface{}, error) {
 	if res.Docker == nil {
 		return nil, fmt.Errorf("expecting docker resource in docker check")
-	}
-
-	expr, err := eval.Cache.ParseIterable(res.Condition)
-	if err != nil {
-		return nil, err
 	}
 
 	client := e.DockerClient()
@@ -59,102 +43,54 @@ func checkDocker(e env.Env, ruleID string, res compliance.Resource) (*compliance
 	}
 
 	switch res.Docker.Kind {
-	case "image", "container", "network":
-		return checkDockerIterator(ruleID, expr, res.Docker, client)
-	case "info", "version":
-		return checkDockerInstance(ruleID, expr, res.Docker, client)
+	case "image":
+		return newDockerImageIterator(ctx, client)
+	case "container":
+		return newDockerContainerIterator(ctx, client)
+	case "network":
+		return newDockerNetworkIterator(ctx, client)
+	case "info":
+		return newDockerInfoInstance(ctx, client)
+	case "version":
+		return newDockerVersionInstance(ctx, client)
 	default:
 		return nil, dockerKindNotSupported(res.Docker.Kind)
 	}
 }
 
-func checkDockerIterator(ruleID string, expr *eval.IterableExpression, docker *compliance.DockerResource, client env.DockerClient) (*compliance.Report, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-
-	var (
-		it             eval.Iterator
-		err            error
-		reportedFields []string
-	)
-
-	switch docker.Kind {
-	case "image":
-		reportedFields = dockerImageReportedFields
-		it, err = newDockerImageIterator(ctx, client)
-
-	case "container":
-		reportedFields = dockerContainerReportedFields
-		it, err = newDockerContainerIterator(ctx, client)
-
-	case "network":
-		reportedFields = dockerNetworkReportedFields
-		it, err = newDockerNetworkIterator(ctx, client)
-
-	default:
-		return nil, dockerKindNotSupported(docker.Kind)
-	}
-
+func newDockerInfoInstance(ctx context.Context, client env.DockerClient) (*eval.Instance, error) {
+	info, err := client.Info(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := expr.EvaluateIterator(it, globalInstance)
-	if err != nil {
-		return nil, err
-	}
-
-	return instanceResultToReport(result, reportedFields), nil
+	return &eval.Instance{
+		Functions: eval.FunctionMap{
+			compliance.DockerFuncTemplate: dockerTemplateQuery(compliance.DockerFuncTemplate, info),
+		},
+	}, nil
 }
 
-func checkDockerInstance(ruleID string, expr *eval.IterableExpression, docker *compliance.DockerResource, client env.DockerClient) (*compliance.Report, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-
-	var (
-		instance       *eval.Instance
-		reportedFields []string
-	)
-
-	switch docker.Kind {
-	case "info":
-		reportedFields = dockerInfoReportedFields
-		if info, err := client.Info(ctx); err == nil {
-			instance = &eval.Instance{
-				Functions: eval.FunctionMap{
-					compliance.DockerFuncTemplate: dockerTemplateQuery(compliance.DockerFuncTemplate, info),
-				},
-			}
-		}
-	case "version":
-		reportedFields = dockerVersionReportedFields
-		if version, err := client.ServerVersion(ctx); err == nil {
-
-			instance = &eval.Instance{
-				Vars: eval.VarMap{
-					compliance.DockerVersionFieldVersion:       version.Version,
-					compliance.DockerVersionFieldAPIVersion:    version.APIVersion,
-					compliance.DockerVersionFieldPlatform:      version.Platform.Name,
-					compliance.DockerVersionFieldExperimental:  version.Experimental,
-					compliance.DockerVersionFieldOS:            version.Os,
-					compliance.DockerVersionFieldArch:          version.Arch,
-					compliance.DokcerVersionFieldKernelVersion: version.KernelVersion,
-				},
-				Functions: eval.FunctionMap{
-					compliance.DockerFuncTemplate: dockerTemplateQuery(compliance.DockerFuncTemplate, version),
-				},
-			}
-		}
-	default:
-		return nil, dockerKindNotSupported(docker.Kind)
-	}
-
-	passed, err := expr.Evaluate(instance)
+func newDockerVersionInstance(ctx context.Context, client env.DockerClient) (*eval.Instance, error) {
+	version, err := client.ServerVersion(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return instanceToReport(instance, passed, reportedFields), nil
+	return &eval.Instance{
+		Vars: eval.VarMap{
+			compliance.DockerVersionFieldVersion:       version.Version,
+			compliance.DockerVersionFieldAPIVersion:    version.APIVersion,
+			compliance.DockerVersionFieldPlatform:      version.Platform.Name,
+			compliance.DockerVersionFieldExperimental:  version.Experimental,
+			compliance.DockerVersionFieldOS:            version.Os,
+			compliance.DockerVersionFieldArch:          version.Arch,
+			compliance.DokcerVersionFieldKernelVersion: version.KernelVersion,
+		},
+		Functions: eval.FunctionMap{
+			compliance.DockerFuncTemplate: dockerTemplateQuery(compliance.DockerFuncTemplate, version),
+		},
+	}, nil
 }
 
 func dockerTemplateQuery(funcName, obj interface{}) eval.Function {

--- a/pkg/compliance/checks/docker_check_test.go
+++ b/pkg/compliance/checks/docker_check_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 	"github.com/docker/docker/api/types"
 
@@ -70,10 +69,7 @@ func TestDockerImageCheck(t *testing.T) {
 	defer env.AssertExpectations(t)
 	env.On("DockerClient").Return(client)
 
-	expr, err := eval.ParseIterable(resource.Condition)
-	assert.NoError(err)
-
-	report, err := checkDocker(env, "rule-id", resource, expr)
+	report, err := checkDocker(env, "rule-id", resource)
 	assert.NoError(err)
 
 	assert.False(report.Passed)
@@ -102,10 +98,7 @@ func TestDockerNetworkCheck(t *testing.T) {
 	defer env.AssertExpectations(t)
 	env.On("DockerClient").Return(client)
 
-	expr, err := eval.ParseIterable(resource.Condition)
-	assert.NoError(err)
-
-	report, err := checkDocker(env, "rule-id", resource, expr)
+	report, err := checkDocker(env, "rule-id", resource)
 	assert.NoError(err)
 
 	assert.True(report.Passed)
@@ -216,10 +209,7 @@ func TestDockerContainerCheck(t *testing.T) {
 			defer env.AssertExpectations(t)
 			env.On("DockerClient").Return(client)
 
-			expr, err := eval.ParseIterable(resource.Condition)
-			assert.NoError(err)
-
-			report, err := checkDocker(env, "rule-id", resource, expr)
+			report, err := checkDocker(env, "rule-id", resource)
 			assert.NoError(err)
 
 			assert.Equal(test.expectPassed, report.Passed)
@@ -251,10 +241,7 @@ func TestDockerInfoCheck(t *testing.T) {
 	defer env.AssertExpectations(t)
 	env.On("DockerClient").Return(client)
 
-	expr, err := eval.ParseIterable(resource.Condition)
-	assert.NoError(err)
-
-	report, err := checkDocker(env, "rule-id", resource, expr)
+	report, err := checkDocker(env, "rule-id", resource)
 	assert.NoError(err)
 
 	assert.False(report.Passed)
@@ -281,10 +268,7 @@ func TestDockerVersionCheck(t *testing.T) {
 	defer env.AssertExpectations(t)
 	env.On("DockerClient").Return(client)
 
-	expr, err := eval.ParseIterable(resource.Condition)
-	assert.NoError(err)
-
-	report, err := checkDocker(env, "rule-id", resource, expr)
+	report, err := checkDocker(env, "rule-id", resource)
 	assert.NoError(err)
 
 	assert.False(report.Passed)

--- a/pkg/compliance/checks/docker_check_test.go
+++ b/pkg/compliance/checks/docker_check_test.go
@@ -69,7 +69,10 @@ func TestDockerImageCheck(t *testing.T) {
 	defer env.AssertExpectations(t)
 	env.On("DockerClient").Return(client)
 
-	report, err := checkDocker(env, "rule-id", resource)
+	dockerCheck, err := newResourceCheck(env, "rule-id", resource)
+	assert.NoError(err)
+
+	report, err := dockerCheck.check(env)
 	assert.NoError(err)
 
 	assert.False(report.Passed)
@@ -98,7 +101,10 @@ func TestDockerNetworkCheck(t *testing.T) {
 	defer env.AssertExpectations(t)
 	env.On("DockerClient").Return(client)
 
-	report, err := checkDocker(env, "rule-id", resource)
+	dockerCheck, err := newResourceCheck(env, "rule-id", resource)
+	assert.NoError(err)
+
+	report, err := dockerCheck.check(env)
 	assert.NoError(err)
 
 	assert.True(report.Passed)
@@ -209,7 +215,10 @@ func TestDockerContainerCheck(t *testing.T) {
 			defer env.AssertExpectations(t)
 			env.On("DockerClient").Return(client)
 
-			report, err := checkDocker(env, "rule-id", resource)
+			dockerCheck, err := newResourceCheck(env, "rule-id", resource)
+			assert.NoError(err)
+
+			report, err := dockerCheck.check(env)
 			assert.NoError(err)
 
 			assert.Equal(test.expectPassed, report.Passed)
@@ -241,7 +250,10 @@ func TestDockerInfoCheck(t *testing.T) {
 	defer env.AssertExpectations(t)
 	env.On("DockerClient").Return(client)
 
-	report, err := checkDocker(env, "rule-id", resource)
+	dockerCheck, err := newResourceCheck(env, "rule-id", resource)
+	assert.NoError(err)
+
+	report, err := dockerCheck.check(env)
 	assert.NoError(err)
 
 	assert.False(report.Passed)
@@ -268,7 +280,10 @@ func TestDockerVersionCheck(t *testing.T) {
 	defer env.AssertExpectations(t)
 	env.On("DockerClient").Return(client)
 
-	report, err := checkDocker(env, "rule-id", resource)
+	dockerCheck, err := newResourceCheck(env, "rule-id", resource)
+	assert.NoError(err)
+
+	report, err := dockerCheck.check(env)
 	assert.NoError(err)
 
 	assert.False(report.Passed)

--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -23,9 +23,14 @@ var fileReportedFields = []string{
 	compliance.FileFieldGroup,
 }
 
-func checkFile(e env.Env, ruleID string, res compliance.Resource, expr *eval.IterableExpression) (*compliance.Report, error) {
+func checkFile(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
 	if res.File == nil {
 		return nil, fmt.Errorf("expecting file resource in file check")
+	}
+
+	expr, err := eval.Cache.ParseIterable(res.Condition)
+	if err != nil {
+		return nil, err
 	}
 
 	file := res.File

--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -6,6 +6,7 @@
 package checks
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,14 +24,9 @@ var fileReportedFields = []string{
 	compliance.FileFieldGroup,
 }
 
-func checkFile(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
+func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.Resource) (interface{}, error) {
 	if res.File == nil {
 		return nil, fmt.Errorf("expecting file resource in file check")
-	}
-
-	expr, err := eval.Cache.ParseIterable(res.Condition)
-	if err != nil {
-		return nil, err
 	}
 
 	file := res.File
@@ -88,16 +84,9 @@ func checkFile(e env.Env, ruleID string, res compliance.Resource) (*compliance.R
 		return nil, fmt.Errorf("no files found for file check %q", file.Path)
 	}
 
-	it := &instanceIterator{
+	return &instanceIterator{
 		instances: instances,
-	}
-
-	result, err := expr.EvaluateIterator(it, globalInstance)
-	if err != nil {
-		return nil, err
-	}
-
-	return instanceResultToReport(result, fileReportedFields), nil
+	}, nil
 }
 
 func fileQuery(path string, get getter) eval.Function {

--- a/pkg/compliance/checks/file_check_test.go
+++ b/pkg/compliance/checks/file_check_test.go
@@ -286,7 +286,10 @@ func TestFileCheck(t *testing.T) {
 				test.setup(t, env, test.resource.File)
 			}
 
-			report, err := checkFile(env, "rule-id", test.resource)
+			fileCheck, err := newResourceCheck(env, "rule-id", test.resource)
+			assert.NoError(err)
+
+			report, err := fileCheck.check(env)
 
 			if test.expectError != nil {
 				assert.EqualError(err, test.expectError.Error())

--- a/pkg/compliance/checks/file_check_test.go
+++ b/pkg/compliance/checks/file_check_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 
 	"github.com/stretchr/testify/mock"
@@ -287,10 +286,7 @@ func TestFileCheck(t *testing.T) {
 				test.setup(t, env, test.resource.File)
 			}
 
-			expr, err := eval.ParseIterable(test.resource.Condition)
-			assert.NoError(err)
-
-			report, err := checkFile(env, "rule-id", test.resource, expr)
+			report, err := checkFile(env, "rule-id", test.resource)
 
 			if test.expectError != nil {
 				assert.EqualError(err, test.expectError.Error())

--- a/pkg/compliance/checks/file_utils.go
+++ b/pkg/compliance/checks/file_utils.go
@@ -38,7 +38,7 @@ func (m pathMapper) relativeToHostRoot(path string) string {
 }
 
 func resolvePath(e env.Env, path string) (string, error) {
-	pathExpr, err := eval.ParsePath(path)
+	pathExpr, err := eval.Cache.ParsePath(path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/compliance/checks/group_check.go
+++ b/pkg/compliance/checks/group_check.go
@@ -30,9 +30,14 @@ var groupReportedFields = []string{
 // ErrGroupNotFound is returned when a group cannot be found
 var ErrGroupNotFound = errors.New("group not found")
 
-func checkGroup(e env.Env, id string, res compliance.Resource, expr *eval.IterableExpression) (*compliance.Report, error) {
+func checkGroup(e env.Env, id string, res compliance.Resource) (*compliance.Report, error) {
 	if res.Group == nil {
 		return nil, fmt.Errorf("%s: expecting group resource in group check", id)
+	}
+
+	expr, err := eval.Cache.ParseIterable(res.Condition)
+	if err != nil {
+		return nil, err
 	}
 
 	group := res.Group

--- a/pkg/compliance/checks/group_check.go
+++ b/pkg/compliance/checks/group_check.go
@@ -8,6 +8,7 @@ package checks
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -30,14 +31,9 @@ var groupReportedFields = []string{
 // ErrGroupNotFound is returned when a group cannot be found
 var ErrGroupNotFound = errors.New("group not found")
 
-func checkGroup(e env.Env, id string, res compliance.Resource) (*compliance.Report, error) {
+func resolveGroup(_ context.Context, e env.Env, id string, res compliance.Resource) (interface{}, error) {
 	if res.Group == nil {
 		return nil, fmt.Errorf("%s: expecting group resource in group check", id)
-	}
-
-	expr, err := eval.Cache.ParseIterable(res.Condition)
-	if err != nil {
-		return nil, err
 	}
 
 	group := res.Group
@@ -64,12 +60,7 @@ func checkGroup(e env.Env, id string, res compliance.Resource) (*compliance.Repo
 		return nil, ErrGroupNotFound
 	}
 
-	passed, err := expr.Evaluate(finder.instance)
-	if err != nil {
-		return nil, err
-	}
-
-	return instanceToReport(finder.instance, passed, groupReportedFields), nil
+	return finder.instance, nil
 }
 
 type groupFinder struct {

--- a/pkg/compliance/checks/group_check_test.go
+++ b/pkg/compliance/checks/group_check_test.go
@@ -71,7 +71,10 @@ func TestGroupCheck(t *testing.T) {
 			env := &mocks.Env{}
 			env.On("EtcGroupPath").Return(test.etcGroupFile)
 
-			result, err := checkGroup(env, "rule-id", test.resource)
+			groupCheck, err := newResourceCheck(env, "rule-id", test.resource)
+			assert.NoError(err)
+
+			result, err := groupCheck.check(env)
 			assert.Equal(test.expectReport, result)
 			assert.Equal(test.expectError, err)
 		})

--- a/pkg/compliance/checks/group_check_test.go
+++ b/pkg/compliance/checks/group_check_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 
@@ -72,10 +71,7 @@ func TestGroupCheck(t *testing.T) {
 			env := &mocks.Env{}
 			env.On("EtcGroupPath").Return(test.etcGroupFile)
 
-			expr, err := eval.ParseIterable(test.resource.Condition)
-			assert.NoError(err)
-
-			result, err := checkGroup(env, "rule-id", test.resource, expr)
+			result, err := checkGroup(env, "rule-id", test.resource)
 			assert.Equal(test.expectReport, result)
 			assert.Equal(test.expectError, err)
 		})

--- a/pkg/compliance/checks/kubeapiserver_check.go
+++ b/pkg/compliance/checks/kubeapiserver_check.go
@@ -29,9 +29,14 @@ var kubeResourceReportedFields = []string{
 	compliance.KubeResourceFieldKind,
 }
 
-func checkKubeapiserver(e env.Env, ruleID string, res compliance.Resource, expr *eval.IterableExpression) (*compliance.Report, error) {
+func checkKubeapiserver(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
 	if res.KubeApiserver == nil {
 		return nil, fmt.Errorf("expecting Kubeapiserver resource in Kubeapiserver check")
+	}
+
+	expr, err := eval.Cache.ParseIterable(res.Condition)
+	if err != nil {
+		return nil, err
 	}
 
 	kubeResource := res.KubeApiserver

--- a/pkg/compliance/checks/kubeapiserver_check_test.go
+++ b/pkg/compliance/checks/kubeapiserver_check_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
-	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 
@@ -66,10 +65,7 @@ func (f *kubeApiserverFixture) run(t *testing.T) {
 	kubeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), f.objects...)
 	env.On("KubeClient").Return(kubeClient)
 
-	expr, err := eval.ParseIterable(f.resource.Condition)
-	assert.NoError(err)
-
-	report, err := checkKubeapiserver(env, "rule-id", f.resource, expr)
+	report, err := checkKubeapiserver(env, "rule-id", f.resource)
 	assert.Equal(f.expectReport, report)
 	if f.expectError != nil {
 		assert.EqualError(err, f.expectError.Error())

--- a/pkg/compliance/checks/kubeapiserver_check_test.go
+++ b/pkg/compliance/checks/kubeapiserver_check_test.go
@@ -65,7 +65,10 @@ func (f *kubeApiserverFixture) run(t *testing.T) {
 	kubeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), f.objects...)
 	env.On("KubeClient").Return(kubeClient)
 
-	report, err := checkKubeapiserver(env, "rule-id", f.resource)
+	kubeCheck, err := newResourceCheck(env, "rule-id", f.resource)
+	assert.NoError(err)
+
+	report, err := kubeCheck.check(env)
 	assert.Equal(f.expectReport, report)
 	if f.expectError != nil {
 		assert.EqualError(err, f.expectError.Error())

--- a/pkg/compliance/checks/process_check.go
+++ b/pkg/compliance/checks/process_check.go
@@ -6,6 +6,7 @@
 package checks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -26,14 +27,9 @@ var processReportedFields = []string{
 	compliance.ProcessFieldCmdLine,
 }
 
-func checkProcess(e env.Env, id string, res compliance.Resource) (*compliance.Report, error) {
+func resolveProcess(_ context.Context, e env.Env, id string, res compliance.Resource) (interface{}, error) {
 	if res.Process == nil {
 		return nil, fmt.Errorf("%s: expecting process resource in process check", id)
-	}
-
-	expr, err := eval.Cache.ParseIterable(res.Condition)
-	if err != nil {
-		return nil, err
 	}
 
 	process := res.Process
@@ -66,31 +62,13 @@ func checkProcess(e env.Env, id string, res compliance.Resource) (*compliance.Re
 		instances = append(instances, instance)
 	}
 
-	it := &instanceIterator{
+	if len(instances) == 1 {
+		return instances[0], nil
+	}
+
+	return &instanceIterator{
 		instances: instances,
-	}
-
-	result, err := expr.EvaluateIterator(it, globalInstance)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.Fallback != nil {
-		fallbackExpr, err := eval.Cache.ParseExpression(res.Fallback.Condition)
-		if err != nil {
-			return nil, err
-		}
-
-		useFallback, err := fallbackExpr.BoolEvaluate(result.Instance)
-		if err != nil {
-			return nil, err
-		}
-		if useFallback {
-			return nil, ErrResourceUseFallback
-		}
-	}
-
-	return instanceResultToReport(result, processReportedFields), nil
+	}, nil
 }
 
 func processFlag(flagValues map[string]string) eval.Function {

--- a/pkg/compliance/checks/resource_check.go
+++ b/pkg/compliance/checks/resource_check.go
@@ -6,10 +6,12 @@
 package checks
 
 import (
+	"context"
 	"errors"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
+	"github.com/DataDog/datadog-agent/pkg/compliance/eval"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -17,41 +19,90 @@ var (
 	// ErrResourceKindNotSupported is returned in case resource kind is not supported by evaluator
 	ErrResourceKindNotSupported = errors.New("resource kind not supported")
 
-	// ErrResourceUseFallback is returned when a resource cannot provide check result and relies on fallback
-	ErrResourceUseFallback = errors.New("resource check uses fallback")
-
 	// ErrResourceFallbackMissing is returned when a resource relies on fallback but no fallback is provided
 	ErrResourceFallbackMissing = errors.New("resource fallback missing")
+
+	// ErrResourceCannotUseFallback is returned when a resource cannot use fallback
+	ErrResourceCannotUseFallback = errors.New("resource cannot use fallback")
+
+	// ErrResourceFailedToResolve is returned when a resource failed to resolve to any instances for evaluation
+	ErrResourceFailedToResolve = errors.New("failed to resolve resource")
 )
 
-type checkFunc func(e env.Env, ruleID string, resource compliance.Resource) (*compliance.Report, error)
+type resolveFunc func(ctx context.Context, e env.Env, ruleID string, resource compliance.Resource) (interface{}, error)
 
 type resourceCheck struct {
 	ruleID   string
 	resource compliance.Resource
 
-	checkFn  checkFunc
+	resolve  resolveFunc
 	fallback checkable
+
+	reportedFields []string
 }
 
 func (c *resourceCheck) check(env env.Env) (*compliance.Report, error) {
-	report, err := c.checkFn(env, c.ruleID, c.resource)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
 
-	if err == ErrResourceUseFallback {
-		if c.fallback != nil {
-			return c.fallback.check(env)
-		}
-		return nil, ErrResourceFallbackMissing
+	conditionExpression, err := eval.Cache.ParseIterable(c.resource.Condition)
+	if err != nil {
+		return nil, err
 	}
 
-	return report, err
+	v, err := c.resolve(ctx, env, c.ruleID, c.resource)
+	if err != nil {
+		return nil, err
+	}
+
+	switch v := v.(type) {
+	case *eval.Instance:
+		if c.resource.Fallback != nil {
+			if c.fallback == nil {
+				return nil, ErrResourceFallbackMissing
+			}
+
+			fallbackExpression, err := eval.Cache.ParseExpression(c.resource.Fallback.Condition)
+			if err != nil {
+				return nil, err
+			}
+
+			useFallback, err := fallbackExpression.BoolEvaluate(v)
+			if err != nil {
+				return nil, err
+			}
+			if useFallback {
+				return c.fallback.check(env)
+			}
+		}
+
+		passed, err := conditionExpression.Evaluate(v)
+		if err != nil {
+			return nil, err
+		}
+		return instanceToReport(v, passed, c.reportedFields), nil
+
+	case eval.Iterator:
+		if c.resource.Fallback != nil {
+			return nil, ErrResourceCannotUseFallback
+		}
+
+		result, err := conditionExpression.EvaluateIterator(v, globalInstance)
+		if err != nil {
+			return nil, err
+		}
+		return instanceResultToReport(result, c.reportedFields), nil
+	default:
+		return nil, ErrResourceFailedToResolve
+	}
 }
 
 func newResourceCheck(env env.Env, ruleID string, resource compliance.Resource) (checkable, error) {
 	// TODO: validate resource here
 	kind := resource.Kind()
-
 	switch kind {
+	case compliance.KindCustom:
+		return newCustomCheck(ruleID, resource)
 	case compliance.KindAudit:
 		if env.AuditClient() == nil {
 			return nil, log.Errorf("%s: audit client not initialized", ruleID)
@@ -66,9 +117,9 @@ func newResourceCheck(env env.Env, ruleID string, resource compliance.Resource) 
 		}
 	}
 
-	checkFn, err := checkFuncForKind(kind)
+	resolve, reportedFields, err := resourceKindToResolverAndFields(kind)
 	if err != nil {
-		return nil, log.Errorf("%s: failed to resolve check handler for kind: %s", ruleID, kind)
+		return nil, log.Errorf("%s: failed to find resource resolver for resource kind: %s", ruleID, kind)
 	}
 
 	var fallback checkable
@@ -80,33 +131,32 @@ func newResourceCheck(env env.Env, ruleID string, resource compliance.Resource) 
 	}
 
 	return &resourceCheck{
-		ruleID:   ruleID,
-		resource: resource,
-		checkFn:  checkFn,
-		fallback: fallback,
+		ruleID:         ruleID,
+		resource:       resource,
+		resolve:        resolve,
+		fallback:       fallback,
+		reportedFields: reportedFields,
 	}, nil
 }
 
-func checkFuncForKind(kind compliance.ResourceKind) (checkFunc, error) {
+func resourceKindToResolverAndFields(kind compliance.ResourceKind) (resolveFunc, []string, error) {
 	switch kind {
 	case compliance.KindFile:
-		return checkFile, nil
+		return resolveFile, fileReportedFields, nil
 	case compliance.KindAudit:
-		return checkAudit, nil
+		return resolveAudit, auditReportedFields, nil
 	case compliance.KindGroup:
-		return checkGroup, nil
+		return resolveGroup, groupReportedFields, nil
 	case compliance.KindCommand:
-		return checkCommand, nil
+		return resolveCommand, commandReportedFields, nil
 	case compliance.KindProcess:
-		return checkProcess, nil
+		return resolveProcess, processReportedFields, nil
 	case compliance.KindDocker:
-		return checkDocker, nil
+		return resolveDocker, dockerReportedFields, nil
 	case compliance.KindKubernetes:
-		return checkKubeapiserver, nil
-	case compliance.KindCustom:
-		return checkCustom, nil
+		return resolveKubeapiserver, kubeResourceReportedFields, nil
 	default:
-		return nil, ErrResourceKindNotSupported
+		return nil, nil, ErrResourceKindNotSupported
 	}
 }
 

--- a/pkg/compliance/checks/resource_check_test.go
+++ b/pkg/compliance/checks/resource_check_test.go
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package checks
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance"
+	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
+	"github.com/DataDog/datadog-agent/pkg/compliance/event"
+	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestResourceCheck(t *testing.T) {
+	assert := assert.New(t)
+
+	e := &mocks.Env{}
+	ruleID := "rule-id"
+	resource := compliance.Resource{}
+
+	fallbackReport := &compliance.Report{
+		Passed: false,
+		Data: event.Data{
+			"fallback": true,
+		},
+	}
+
+	fallback := &mockCheckable{}
+	fallback.On("check", e).Return(fallbackReport, nil)
+
+	tests := []struct {
+		name         string
+		checkFn      checkFunc
+		fallback     checkable
+		expectReport *compliance.Report
+		expectErr    error
+	}{
+		{
+			name: "no fallback provided",
+			checkFn: func(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
+				return &compliance.Report{
+					Passed: true,
+				}, nil
+			},
+			expectReport: &compliance.Report{
+				Passed: true,
+			},
+		},
+		{
+			name: "fallback not used",
+			checkFn: func(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
+				return &compliance.Report{
+					Passed: false,
+				}, nil
+			},
+			fallback: fallback,
+			expectReport: &compliance.Report{
+				Passed: false,
+			},
+		},
+		{
+			name: "fallback used",
+			checkFn: func(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
+				return nil, ErrResourceUseFallback
+			},
+			fallback:     fallback,
+			expectReport: fallbackReport,
+		},
+		{
+			name: "fallback missing",
+			checkFn: func(e env.Env, ruleID string, res compliance.Resource) (*compliance.Report, error) {
+				return nil, ErrResourceUseFallback
+			},
+			expectErr: ErrResourceFallbackMissing,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &resourceCheck{
+				ruleID:   ruleID,
+				resource: resource,
+				checkFn:  test.checkFn,
+				fallback: test.fallback,
+			}
+
+			report, err := c.check(e)
+			assert.Equal(test.expectReport, report)
+			assert.Equal(test.expectErr, err)
+		})
+
+	}
+}

--- a/pkg/compliance/eval/cache.go
+++ b/pkg/compliance/eval/cache.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package eval
+
+import (
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+// ExpressionCache implements cached parsing for expressions
+type ExpressionCache struct {
+	cache *cache.Cache
+}
+
+// NewCache returns a new instance of evalCache
+func NewCache(defaultExpiration, cleanupInterval time.Duration) *ExpressionCache {
+	cache := cache.New(defaultExpiration, cleanupInterval)
+	return &ExpressionCache{
+		cache: cache,
+	}
+}
+
+func (c *ExpressionCache) cached(key string, fn func() (interface{}, error)) (interface{}, error) {
+	if v, ok := c.cache.Get(key); ok {
+		return v, nil
+	}
+	v, err := fn()
+	if err != nil {
+		return nil, err
+	}
+	c.cache.Set(key, v, cache.NoExpiration)
+	return v, nil
+}
+
+// ParseExpression parses Expression from a string
+func (c *ExpressionCache) ParseExpression(s string) (*Expression, error) {
+	v, err := c.cached(s, func() (interface{}, error) {
+		return ParseExpression(s)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*Expression), err
+}
+
+func iterableCacheKey(s string) string {
+	return "iterable:" + s
+}
+
+// ParseIterable parses IterableExpression from a string
+func (c *ExpressionCache) ParseIterable(s string) (*IterableExpression, error) {
+	v, err := c.cached(iterableCacheKey(s), func() (interface{}, error) {
+		return ParseIterable(s)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*IterableExpression), err
+}
+
+func pathCacheKey(s string) string {
+	return "path:" + s
+}
+
+// ParsePath parses PathExpression from a string
+func (c *ExpressionCache) ParsePath(s string) (*PathExpression, error) {
+	v, err := c.cached(pathCacheKey(s), func() (interface{}, error) {
+		return ParsePath(s)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*PathExpression), err
+}
+
+// Cache declares a default cache for expression evaluation with no key experation
+var Cache = NewCache(cache.NoExpiration, 0)

--- a/pkg/compliance/eval/cache_test.go
+++ b/pkg/compliance/eval/cache_test.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package eval
+
+import (
+	"testing"
+
+	"github.com/patrickmn/go-cache"
+	assert "github.com/stretchr/testify/require"
+)
+
+func newTestCache() *ExpressionCache {
+	return NewCache(cache.NoExpiration, 0)
+}
+func TestCacheParseExpression(t *testing.T) {
+	assert := assert.New(t)
+
+	const s = "a > 5"
+	cache := newTestCache()
+	expr, err := cache.ParseExpression(s)
+
+	assert.NotNil(expr)
+	assert.NoError(err)
+
+	cached, ok := cache.cache.Get(s)
+	assert.Equal(cached, expr)
+	assert.True(ok)
+}
+
+func TestCacheParseExpressionError(t *testing.T) {
+	assert := assert.New(t)
+
+	cache := newTestCache()
+	expr, err := cache.ParseExpression("~")
+
+	assert.Nil(expr)
+	assert.EqualError(err, `1:1: unexpected token "~"`)
+	assert.Zero(cache.cache.ItemCount())
+}
+
+func TestCacheParseIterable(t *testing.T) {
+	assert := assert.New(t)
+
+	const s = "count(a > 5) > 0"
+
+	cache := newTestCache()
+	expr, err := cache.ParseIterable(s)
+
+	assert.NotNil(expr)
+	assert.NoError(err)
+
+	cached, ok := cache.cache.Get(iterableCacheKey(s))
+	assert.Equal(cached, expr)
+	assert.True(ok)
+}
+
+func TestCacheParseIterableError(t *testing.T) {
+	assert := assert.New(t)
+
+	cache := newTestCache()
+	expr, err := cache.ParseIterable("len(5 >)")
+
+	assert.Nil(expr)
+	assert.EqualError(err, `1:7: unexpected token ">" (expected ")")`)
+	assert.Zero(cache.cache.ItemCount())
+}
+
+func TestCacheParsePath(t *testing.T) {
+	assert := assert.New(t)
+
+	const s = "/etc/bitsy/spider"
+
+	cache := newTestCache()
+	expr, err := cache.ParsePath(s)
+
+	assert.NotNil(expr)
+	assert.NoError(err)
+
+	cached, ok := cache.cache.Get(pathCacheKey(s))
+	assert.Equal(cached, expr)
+	assert.True(ok)
+}
+
+func TestCacheParsePathError(t *testing.T) {
+	assert := assert.New(t)
+
+	cache := newTestCache()
+	expr, err := cache.ParsePath(`=/abc/`)
+
+	assert.Nil(expr)
+	assert.EqualError(err, `1:1: unexpected token "="`)
+	assert.Zero(cache.cache.ItemCount())
+}

--- a/pkg/compliance/eval/eval.go
+++ b/pkg/compliance/eval/eval.go
@@ -265,6 +265,19 @@ func (e *Expression) Evaluate(instance *Instance) (interface{}, error) {
 	}
 }
 
+// BoolEvaluate evaluates an expression for an instance as a boolean value
+func (e *Expression) BoolEvaluate(instance *Instance) (bool, error) {
+	v, err := e.Evaluate(instance)
+	if err != nil {
+		return false, err
+	}
+	passed, ok := v.(bool)
+	if !ok {
+		return false, lexer.Errorf(e.Pos, "expression must evaluate to a boolean")
+	}
+	return passed, nil
+}
+
 // Evaluate implements Evaluatable interface
 func (c *Comparison) Evaluate(instance *Instance) (interface{}, error) {
 	lhs, err := c.Term.Evaluate(instance)

--- a/pkg/compliance/resource.go
+++ b/pkg/compliance/resource.go
@@ -45,6 +45,7 @@ type Resource struct {
 	KubeApiserver *KubernetesResource `yaml:"kubeApiserver,omitempty"`
 	Custom        *Custom             `yaml:"custom,omitempty"`
 	Condition     string              `yaml:"condition"`
+	Fallback      *Fallback           `yaml:"fallback,omitempty"`
 }
 
 // Kind returns ResourceKind of the resource
@@ -69,6 +70,12 @@ func (r *Resource) Kind() ResourceKind {
 	default:
 		return KindInvalid
 	}
+}
+
+// Fallback specifies optional fallback configuration for a resource
+type Fallback struct {
+	Condition string   `yaml:"condition,omitempty"`
+	Resource  Resource `yaml:"resource"`
 }
 
 // Fields & functions available for File

--- a/releasenotes/notes/compliance-resource-fallbacks-b7a79092eee434c5.yaml
+++ b/releasenotes/notes/compliance-resource-fallbacks-b7a79092eee434c5.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Implements resource fallbacks for complex compliance check assertions.


### PR DESCRIPTION
### What does this PR do?

- Implements resource fallback that can be configured for a resource to provide a proper way to define compliance assertions for configuration overrides.
- Change logic in `checkableList` to require all checks to pass for the overall status to be passed. This effectively changes behavior from OR to AND which is more intuitive and easier to reason about.
- Add `eval.Cache` to cache parsed expressions since many checks have identical condition expressions. This simplifies the signature of checkFunc implementations as well.
- Implement resource fallback behavior for process checks.

### Motivation

Current behavior does not fully support scenario of config file override by a command flag parameter.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test with a check resource defined as follows:
```
process:
  name: dockerd
condition: process.flag("--tlsverify") != ""
fallback:
  condition: >-
    !process.hasFlag("--tlsverify")
  resource:
    file:
      path: /etc/docker/daemon.json
    condition: file.jq(".tlsverify") == "true"
```