### PR TITLE
Ensure graceful exit upon signals. Ignore SIGPIPE.

### DIFF
--- a/pkg/process/util/signal_nowindows.go
+++ b/pkg/process/util/signal_nowindows.go
@@ -18,9 +18,9 @@ func HandleSignals(exit chan struct{}) {
 	for sig := range sigIn {
 		switch sig {
 		case syscall.SIGINT, syscall.SIGTERM:
-			signal.Stop(sigIn)
 			log.Criticalf("Caught signal '%s'; terminating.", sig)
 			close(exit)
+			return
 		}
 	}
 }

--- a/pkg/process/util/signal_nowindows.go
+++ b/pkg/process/util/signal_nowindows.go
@@ -13,7 +13,7 @@ import (
 // HandleSignals tells us whether we should exit.
 func HandleSignals(exit chan struct{}) {
 	sigIn := make(chan os.Signal, 100)
-	signal.Notify(sigIn, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigIn, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE)
 	// unix only in all likelihood; but we don't care.
 	for sig := range sigIn {
 		switch sig {
@@ -21,6 +21,12 @@ func HandleSignals(exit chan struct{}) {
 			log.Criticalf("Caught signal '%s'; terminating.", sig)
 			close(exit)
 			return
+		case syscall.SIGPIPE:
+			// By default systemd redirects the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal.
+			// Go ignores SIGPIPE signals unless it is when stderr or stdout is closed, in this case the agent is stopped.
+			// We never want the agent to stop upon receiving SIGPIPE, so we intercept the SIGPIPE signals and just discard them.
+			// See https://golang.org/pkg/os/signal/#hdr-SIGPIPE
+			continue
 		}
 	}
 }

--- a/pkg/process/util/signal_windows.go
+++ b/pkg/process/util/signal_windows.go
@@ -18,9 +18,9 @@ func HandleSignals(exit chan struct{}) {
 	for sig := range sigIn {
 		switch sig {
 		case syscall.SIGINT, syscall.SIGTERM:
-			signal.Stop(sigIn)
 			log.Criticalf("Caught signal '%s'; terminating.", sig)
 			close(exit)
+			return
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Ensure that signals are handled such that:
1. `close(exit)` is called once, to prevent a panic.
2. The agent is given a chance to gracefully exit.
3. Handle `SIGPIPE` to prevent an abrupt exit upon `journald` crash.

### Motivation

Reports of system-probe exiting without proper cleanup of probes in #5462

### Additional Notes

`signal.Stop` will reset the signal behavior of the program to default Go behavior. This may cause an unexpected exit before proper cleanup is performed, if two signals come in rapid succession.

Returning from the function (exiting the goroutine) will guarantee we don't call `close(exit)` again, while allowing the agent to gracefully exit.

This `SIGPIPE` handling code was removed in #5200 but was serving a valuable purpose. If we do not handle the `SIGPIPE` signal, then the agent will be abruptly terminated if journald crashes.

### Describe your test plan

