### PR TITLE
[ec2] Cache instance ID and EC2 hostname, make timeout configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -434,12 +434,13 @@ func InitConfig(config Config) {
 
 	// EC2
 	config.BindEnvAndSetDefault("ec2_use_windows_prefix_detection", false)
+	config.BindEnvAndSetDefault("ec2_metadata_timeout", 300) // value in milliseconds
+	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 
 	// ECS
 	config.BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected
 	config.BindEnvAndSetDefault("ecs_agent_container_name", "ecs-agent")
 	config.BindEnvAndSetDefault("ecs_collect_resource_tags_ec2", false)
-	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 
 	// GCE
 	config.BindEnvAndSetDefault("collect_gce_tags", true)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -215,6 +215,11 @@ api_key:
 #
 # collect_ec2_tags: false
 
+## @param ec2_metadata_timeout - integer - optional - default: 300
+## Timeout in milliseconds on calls to the AWS EC2 metadata endpoints.
+#
+# ec2_metadata_timeout: 300
+
 ## @param collect_gce_tags - boolean - optional - default: true
 ## Collect Google Cloud Engine metadata as host tags
 #
@@ -938,7 +943,7 @@ api_key:
   ## Syscall monitoring
   #
   # syscall_monitor:
-  
+
     ## @param enabled - boolean - optional - default: false
     ## Set to true to enable the Syscall monitoring.
     #

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -23,7 +23,6 @@ import (
 var (
 	metadataURL        = "http://169.254.169.254/latest/meta-data"
 	tokenURL           = "http://169.254.169.254/latest/api/token"
-	timeout            = 100 * time.Millisecond
 	oldDefaultPrefixes = []string{"ip-", "domu"}
 	defaultPrefixes    = []string{"ip-", "domu", "ec2amaz-"}
 
@@ -191,7 +190,7 @@ func extractClusterName(tags []string) (string, error) {
 
 func doHTTPRequest(url string, method string, headers map[string]string, retriableWithFreshToken bool) (*http.Response, error) {
 	client := http.Client{
-		Timeout: timeout,
+		Timeout: time.Duration(config.Datadog.GetInt("ec2_metadata_timeout")) * time.Millisecond,
 	}
 
 	req, err := http.NewRequest(method, url, nil)
@@ -224,7 +223,7 @@ func doHTTPRequest(url string, method string, headers map[string]string, retriab
 
 func getToken() (string, error) {
 	client := http.Client{
-		Timeout: timeout,
+		Timeout: time.Duration(config.Datadog.GetInt("ec2_metadata_timeout")) * time.Millisecond,
 	}
 
 	req, err := http.NewRequest(http.MethodPut, tokenURL, nil)

--- a/pkg/util/ec2/ec2_tags_test.go
+++ b/pkg/util/ec2/ec2_tags_test.go
@@ -14,8 +14,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,7 +34,7 @@ func TestGetIAMRole(t *testing.T) {
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	val, err := getIAMRole()
@@ -58,7 +58,7 @@ func TestGetSecurityCreds(t *testing.T) {
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	cred, err := getSecurityCreds()
@@ -77,7 +77,7 @@ func TestGetInstanceIdentity(t *testing.T) {
 	}))
 	defer ts.Close()
 	instanceIdentityURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	val, err := getInstanceIdentity()

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -60,9 +61,11 @@ func TestIsDefaultHostnameForIntake(t *testing.T) {
 
 func TestGetInstanceID(t *testing.T) {
 	expected := "i-0123456789abcdef0"
+	var responseCode int
 	var lastRequest *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(responseCode)
 		io.WriteString(w, expected)
 		lastRequest = r
 	}))
@@ -71,7 +74,31 @@ func TestGetInstanceID(t *testing.T) {
 	timeout = time.Second
 	defer resetPackageVars()
 
+	// API errors out, should return error
+	responseCode = http.StatusInternalServerError
 	val, err := GetInstanceID()
+	assert.NotNil(t, err)
+	assert.Equal(t, "", val)
+	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
+
+	// API successful, should return API result
+	responseCode = http.StatusOK
+	val, err = GetInstanceID()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, val)
+	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
+
+	// the internal cache is populated now, should return the cached value even if API errors out
+	responseCode = http.StatusInternalServerError
+	val, err = GetInstanceID()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, val)
+	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
+
+	// the internal cache is populated, should refresh result if API call succeeds
+	responseCode = http.StatusOK
+	expected = "i-aaaaaaaaaaaaaaaaa"
+	val, err = GetInstanceID()
 	assert.Nil(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
@@ -79,9 +106,11 @@ func TestGetInstanceID(t *testing.T) {
 
 func TestGetHostname(t *testing.T) {
 	expected := "ip-10-10-10-10.ec2.internal"
+	var responseCode int
 	var lastRequest *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(responseCode)
 		io.WriteString(w, expected)
 		lastRequest = r
 	}))
@@ -90,11 +119,37 @@ func TestGetHostname(t *testing.T) {
 	timeout = time.Second
 	defer resetPackageVars()
 
+	// API errors out, should return error
+	responseCode = http.StatusInternalServerError
 	val, err := GetHostname()
+	assert.NotNil(t, err)
+	assert.Equal(t, "", val)
+	assert.Equal(t, lastRequest.URL.Path, "/hostname")
+
+	// API successful, should return hostname
+	responseCode = http.StatusOK
+	val, err = GetHostname()
 	assert.Nil(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/hostname")
 
+	// the internal cache is populated now, should return the cached hostname even if API errors out
+	responseCode = http.StatusInternalServerError
+	val, err = GetHostname()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, val)
+	assert.Equal(t, lastRequest.URL.Path, "/hostname")
+
+	// the internal cache is populated, should refresh result if API call succeeds
+	responseCode = http.StatusOK
+	expected = "ip-20-20-20-20.ec2.internal"
+	val, err = GetHostname()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, val)
+	assert.Equal(t, lastRequest.URL.Path, "/hostname")
+
+	// clear internal cache
+	cache.Cache.Delete(hostnameCacheKey)
 	// ensure we get an empty string along with the error when not on EC2
 	metadataURL = "foo"
 	val, err = GetHostname()

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -21,13 +21,13 @@ import (
 )
 
 var (
-	initialTimeout     = timeout
+	initialTimeout     = time.Duration(config.Datadog.GetInt("ec2_metadata_timeout")) * time.Millisecond
 	initialMetadataURL = metadataURL
 	initialTokenURL    = tokenURL
 )
 
 func resetPackageVars() {
-	timeout = initialTimeout
+	config.Datadog.Set("ec2_metadata_timeout", initialTimeout)
 	metadataURL = initialMetadataURL
 	tokenURL = initialTokenURL
 }
@@ -71,7 +71,7 @@ func TestGetInstanceID(t *testing.T) {
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	// API errors out, should return error
@@ -116,7 +116,7 @@ func TestGetHostname(t *testing.T) {
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	// API errors out, should return error
@@ -220,7 +220,7 @@ func TestGetNetworkID(t *testing.T) {
 
 	defer ts.Close()
 	metadataURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	val, err := GetNetworkID()
@@ -235,7 +235,7 @@ func TestGetInstanceIDNoMac(t *testing.T) {
 
 	defer ts.Close()
 	metadataURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	_, err := GetNetworkID()
@@ -265,7 +265,7 @@ func TestGetInstanceIDMultipleVPC(t *testing.T) {
 
 	defer ts.Close()
 	metadataURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	_, err := GetNetworkID()
@@ -287,7 +287,7 @@ func TestGetLocalIPv4(t *testing.T) {
 
 	defer ts.Close()
 	metadataURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	ips, err := GetLocalIPv4()
@@ -309,7 +309,7 @@ func TestGetToken(t *testing.T) {
 
 	defer ts.Close()
 	tokenURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	token, err := getToken()
@@ -366,7 +366,7 @@ func TestMetedataRequestWithToken(t *testing.T) {
 	defer ts.Close()
 	metadataURL = ts.URL
 	tokenURL = ts.URL
-	timeout = time.Second
+	config.Datadog.Set("ec2_metadata_timeout", 1000)
 	defer resetPackageVars()
 
 	ips, err := GetLocalIPv4()

--- a/releasenotes/notes/ec2-host-aliases-caching-7a29703c681a091a.yaml
+++ b/releasenotes/notes/ec2-host-aliases-caching-7a29703c681a091a.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    If the retrieval of the AWS EC2 instance ID or hostname fails, previously-retrieved
+    values are now sent, which should mitigate host aliases flapping issues in-app.
+  - |
+    Increase default timeout on AWS EC2 metadata endpoints, and make it configurable
+    with ``ec2_metadata_timeout``


### PR DESCRIPTION
### What does this PR do?

2 changes (see 2 commits):

1. Return cached EC2 instance ID and hostnames on retrieval failure:
    * since they're sent as host aliases every 30min (by default), if they fail to be retrieved, sending no values removes the host aliases from DD, which causes host alias flapping (and can cause host duplication with AWS crawlers). To avoid this as much as possible, we want to send the cached value instead.
    * this supersedes https://github.com/DataDog/datadog-agent/pull/5941/
    * logic is similar to what was done for host tags in https://github.com/DataDog/datadog-agent/pull/5663
2. Make the EC2 metadata retrieval timeout configurable (new `ec2_metadata_timeout` option), and increase default from 100ms to 300ms:
    * should slightly decrease metadata resolution flakiness, and provide a knob if longer timeouts are
needed on some environments
    * similar to what was done for GCE metadata in https://github.com/DataDog/datadog-agent/pull/5419

### Additional Notes

* We're starting to have a lot of caching logic in the metadata retrieval packages. I'll create a card in our backlog to factorize the common caching logic (with 2 strategies: always retrieve from cache, and retrieve from cache on failure).

### Describe your test plan

Tested with unit tests only so far.

For future QA:
* can't think of a great way to test the caching logic. Should probably focus on confirming nominal code path (successful API calls) has unchanged behavior.
* timeout option should be tested with nominal code path, and by setting very low values on EC2 env
