### PR TITLE
[DCA] Add `health` command

### DIFF
--- a/cmd/agent/common/commands/health.go
+++ b/cmd/agent/common/commands/health.go
@@ -1,0 +1,110 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// Health returns a cobra command to report on the agent's health
+func Health(loggerName config.LoggerName, confPath string, flagNoColor bool) *cobra.Command {
+	return &cobra.Command{
+		Use:          "health",
+		Short:        "Print the current agent health",
+		Long:         ``,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if flagNoColor {
+				color.NoColor = true
+			}
+
+			if flavor.GetFlavor() == flavor.ClusterAgent {
+				config.Datadog.SetConfigName("datadog-cluster")
+			}
+
+			err := common.SetupConfig(confPath)
+			if err != nil {
+				return fmt.Errorf("unable to set up global agent configuration: %v", err)
+			}
+
+			err = config.SetupLogger(loggerName, config.GetEnv("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+			if err != nil {
+				fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+				return err
+			}
+
+			return requestHealth()
+		},
+	}
+}
+func requestHealth() error {
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+
+	ipcAddress, err := config.GetIPCAddress()
+	if err != nil {
+		return err
+	}
+
+	var urlstr string
+	if flavor.GetFlavor() == flavor.ClusterAgent {
+		urlstr = fmt.Sprintf("https://%v:%v/status/health", ipcAddress, config.Datadog.GetInt("cluster_agent.cmd_port"))
+	} else {
+		urlstr = fmt.Sprintf("https://%v:%v/agent/status/health", ipcAddress, config.Datadog.GetInt("cmd_port"))
+	}
+
+	// Set session token
+	err = util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	r, err := util.DoGet(c, urlstr)
+	if err != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(r, &errMap) //nolint:errcheck
+		// If the error has been marshalled into a json object, check it and return it properly
+		if e, found := errMap["error"]; found {
+			err = fmt.Errorf(e)
+		}
+
+		fmt.Printf("Could not reach agent: %v \nMake sure the agent is running before requesting the status and contact support if you continue having issues. \n", err)
+		return err
+	}
+
+	s := new(health.Status)
+	if err = json.Unmarshal(r, s); err != nil {
+		return fmt.Errorf("Error unmarshalling json: %s", err)
+	}
+
+	sort.Strings(s.Unhealthy)
+	sort.Strings(s.Healthy)
+
+	statusString := color.GreenString("PASS")
+	if len(s.Unhealthy) > 0 {
+		statusString = color.RedString("FAIL")
+	}
+	fmt.Fprintln(color.Output, fmt.Sprintf("Agent health: %s", statusString))
+
+	if len(s.Healthy) > 0 {
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s healthy components ===", color.GreenString(strconv.Itoa(len(s.Healthy)))))
+		fmt.Fprintln(color.Output, strings.Join(s.Healthy, ", "))
+	}
+	if len(s.Unhealthy) > 0 {
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s unhealthy components ===", color.RedString(strconv.Itoa(len(s.Unhealthy)))))
+		fmt.Fprintln(color.Output, strings.Join(s.Unhealthy, ", "))
+		return fmt.Errorf("found %d unhealthy components", len(s.Unhealthy))
+	}
+
+	return nil
+}

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -39,6 +40,7 @@ func SetupHandlers(r *mux.Router, sc clusteragent.ServerContext) {
 	r.HandleFunc("/flare", makeFlare).Methods("POST")
 	r.HandleFunc("/stop", stopAgent).Methods("POST")
 	r.HandleFunc("/status", getStatus).Methods("GET")
+	r.HandleFunc("/status/health", getHealth).Methods("GET")
 	r.HandleFunc("/config-check", getConfigCheck).Methods("GET")
 	r.HandleFunc("/config", getRuntimeConfig).Methods("GET")
 
@@ -62,6 +64,24 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Write(jsonStats)
+}
+
+func getHealth(w http.ResponseWriter, r *http.Request) {
+	h := health.GetReady()
+
+	if len(h.Unhealthy) > 0 {
+		log.Debugf("Healthcheck failed on: %v", h.Unhealthy)
+	}
+
+	jsonHealth, err := json.Marshal(h)
+	if err != nil {
+		log.Errorf("Error marshalling status. Error: %v, Status: %v", err, h)
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 500)
+		return
+	}
+
+	w.Write(jsonHealth)
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {

--- a/cmd/cluster-agent/app/health.go
+++ b/cmd/cluster-agent/app/health.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
+// +build kubeapiserver
+
 package app
 
 import (
@@ -10,5 +12,5 @@ import (
 )
 
 func init() {
-	AgentCmd.AddCommand(commands.Health(loggerName, confFilePath, flagNoColor))
+	ClusterAgentCmd.AddCommand(commands.Health(loggerName, confPath, flagNoColor))
 }

--- a/releasenotes-dca/notes/cluster-agent-health-9f44481193961ad2.yaml
+++ b/releasenotes-dca/notes/cluster-agent-health-9f44481193961ad2.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add a new command 'datadog-cluster-agent health' to show the cluster
+    agent's health, similar to the already existing `agent health`.


### PR DESCRIPTION
### What does this PR do?

There is already a `health` command for the main agent, but it hadn't
been implemented for the cluster agent yet. This commit just moves that
implementation into a common package, and refers to it from the
`cluster-agent` cmd.

### Describe your test plan

As this changes both cmds `agent` and `cluster-agent`, both of them need to be tested.