### PR TITLE
Periodically log the delivery queue stats

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -191,6 +191,9 @@ func (l *Collector) run(exit chan struct{}) error {
 		queueSizeTicker := time.NewTicker(10 * time.Second)
 		defer queueSizeTicker.Stop()
 
+		queueLogTicker := time.NewTicker(time.Minute)
+		defer queueLogTicker.Stop()
+
 		tags := []string{
 			fmt.Sprintf("version:%s", Version),
 			fmt.Sprintf("revision:%s", GitCommit),
@@ -202,6 +205,11 @@ func (l *Collector) run(exit chan struct{}) error {
 			case <-queueSizeTicker.C:
 				updateQueueBytes(processResults.Weight(), podResults.Weight())
 				updateQueueSize(processResults.Len(), podResults.Len())
+			case <-queueLogTicker.C:
+				log.Infof(
+					"Delivery queues: process[size=%d, weight=%d], pod[size=%d, weight=%d]",
+					processResults.Len(), processResults.Weight(), podResults.Len(), podResults.Weight(),
+				)
 			case <-exit:
 				return
 			}


### PR DESCRIPTION
### What does this PR do?

This will provide some visibility in to the state of the queues.  I opted to do this rather than in response to queue full or retry events so that the logs don't get spammed (or spammed and then cut off) and also to provide regular visibility in to the state of the delivery queues

### Motivation

PROC-403
