### PR TITLE
[forwarder] Fully support 3-level domain `site` setting

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -757,12 +758,7 @@ func InitConfig(config Config) {
 }
 
 var (
-	ddURLs = map[string]interface{}{
-		"app.datadoghq.com": nil,
-		"app.datadoghq.eu":  nil,
-		"app.datad0g.com":   nil,
-		"app.datad0g.eu":    nil,
-	}
+	ddURLRegexp = regexp.MustCompile(`^app(\.(us|eu)\d)?\.datad(oghq|0g)\.(com|eu)$`)
 )
 
 // GetProxies returns the proxy settings from the configuration
@@ -992,8 +988,8 @@ func AddAgentVersionToDomain(DDURL string, app string) (string, error) {
 		return "", err
 	}
 
-	// we don't udpdate unknown URL (ie: proxy or custom StatsD server)
-	if _, found := ddURLs[u.Host]; !found {
+	// we don't update unknown URLs (ie: proxy or custom DD domain)
+	if !ddURLRegexp.MatchString(u.Host) {
 		return DDURL, nil
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -403,6 +403,7 @@ additional_endpoints:
 }
 
 func TestAddAgentVersionToDomain(t *testing.T) {
+	// US
 	newURL, err := AddAgentVersionToDomain("https://app.datadoghq.com", "app")
 	require.Nil(t, err)
 	assert.Equal(t, "https://"+getDomainPrefix("app")+".datadoghq.com", newURL)
@@ -411,6 +412,7 @@ func TestAddAgentVersionToDomain(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "https://"+getDomainPrefix("flare")+".datadoghq.com", newURL)
 
+	// EU
 	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.eu", "app")
 	require.Nil(t, err)
 	assert.Equal(t, "https://"+getDomainPrefix("app")+".datadoghq.eu", newURL)
@@ -419,6 +421,52 @@ func TestAddAgentVersionToDomain(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "https://"+getDomainPrefix("flare")+".datadoghq.eu", newURL)
 
+	// Additional site
+	newURL, err = AddAgentVersionToDomain("https://app.us2.datadoghq.com", "app")
+	require.Nil(t, err)
+	assert.Equal(t, "https://"+getDomainPrefix("app")+".us2.datadoghq.com", newURL)
+
+	newURL, err = AddAgentVersionToDomain("https://app.us2.datadoghq.com", "flare")
+	require.Nil(t, err)
+	assert.Equal(t, "https://"+getDomainPrefix("flare")+".us2.datadoghq.com", newURL)
+
+	// Custom DD URL: leave unchanged
+	newURL, err = AddAgentVersionToDomain("https://custom.datadoghq.com", "app")
+	require.Nil(t, err)
+	assert.Equal(t, "https://custom.datadoghq.com", newURL)
+
+	newURL, err = AddAgentVersionToDomain("https://custom.datadoghq.com", "flare")
+	require.Nil(t, err)
+	assert.Equal(t, "https://custom.datadoghq.com", newURL)
+
+	// Custom DD URL with 'agent' subdomain: leave unchanged
+	newURL, err = AddAgentVersionToDomain("https://custom.agent.datadoghq.com", "app")
+	require.Nil(t, err)
+	assert.Equal(t, "https://custom.agent.datadoghq.com", newURL)
+
+	newURL, err = AddAgentVersionToDomain("https://custom.agent.datadoghq.com", "flare")
+	require.Nil(t, err)
+	assert.Equal(t, "https://custom.agent.datadoghq.com", newURL)
+
+	// Custom DD URL: unclear if anyone is actually using such a URL, but for now leave unchanged
+	newURL, err = AddAgentVersionToDomain("https://app.custom.datadoghq.com", "app")
+	require.Nil(t, err)
+	assert.Equal(t, "https://app.custom.datadoghq.com", newURL)
+
+	newURL, err = AddAgentVersionToDomain("https://app.custom.datadoghq.com", "flare")
+	require.Nil(t, err)
+	assert.Equal(t, "https://app.custom.datadoghq.com", newURL)
+
+	// Custom top-level domain: unclear if anyone is actually using this, but for now leave unchanged
+	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.internal", "app")
+	require.Nil(t, err)
+	assert.Equal(t, "https://app.datadoghq.internal", newURL)
+
+	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.internal", "flare")
+	require.Nil(t, err)
+	assert.Equal(t, "https://app.datadoghq.internal", newURL)
+
+	// DD URL set to proxy, leave unchanged
 	newURL, err = AddAgentVersionToDomain("https://app.myproxy.com", "app")
 	require.Nil(t, err)
 	assert.Equal(t, "https://app.myproxy.com", newURL)

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -131,7 +131,7 @@ func (fh *forwarderHealth) healthCheckLoop() {
 func (fh *forwarderHealth) computeDomainsURL() {
 	for domain, apiKeys := range fh.keysPerDomains {
 		apiDomain := ""
-		re := regexp.MustCompile("datadoghq.[a-z]*")
+		re := regexp.MustCompile(`((us|eu)\d\.)?datadoghq.[a-z]+$`)
 		if re.MatchString(domain) {
 			apiDomain = "https://api." + re.FindString(domain)
 		} else {

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -40,17 +40,23 @@ func TestHasValidAPIKey(t *testing.T) {
 
 func TestComputeDomainsURL(t *testing.T) {
 	keysPerDomains := map[string][]string{
-		"https://app.datadoghq.com":          {"api_key1"},
-		"https://custom.datadoghq.com":       {"api_key2"},
-		"https://custom.agent.datadoghq.com": {"api_key3"},
-		"https://app.datadoghq.eu":           {"api_key4"},
-		"https://app.myproxy.com":            {"api_key5"},
+		"https://app.datadoghq.com":              {"api_key1"},
+		"https://custom.datadoghq.com":           {"api_key2"},
+		"https://custom.agent.datadoghq.com":     {"api_key3"},
+		"https://app.datadoghq.eu":               {"api_key4"},
+		"https://app.us2.datadoghq.com":          {"api_key5"},
+		"https://custom.agent.us2.datadoghq.com": {"api_key6"},
+		// debatable whether the next one should be changed to `api.`, preserve pre-existing behavior for now
+		"https://app.datadoghq.internal": {"api_key7"},
+		"https://app.myproxy.com":        {"api_key8"},
 	}
 
 	expectedMap := map[string][]string{
-		"https://api.datadoghq.com": {"api_key1", "api_key2", "api_key3"},
-		"https://api.datadoghq.eu":  {"api_key4"},
-		"https://app.myproxy.com":   {"api_key5"},
+		"https://api.datadoghq.com":      {"api_key1", "api_key2", "api_key3"},
+		"https://api.datadoghq.eu":       {"api_key4"},
+		"https://api.us2.datadoghq.com":  {"api_key5", "api_key6"},
+		"https://api.datadoghq.internal": {"api_key7"},
+		"https://app.myproxy.com":        {"api_key8"},
 	}
 
 	fh := forwarderHealth{keysPerDomains: keysPerDomains}

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -40,17 +40,23 @@ func TestHasValidAPIKey(t *testing.T) {
 
 func TestComputeDomainsURL(t *testing.T) {
 	keysPerDomains := map[string][]string{
-		"https://app.datadoghq.com": {"api_key1"},
+		"https://app.datadoghq.com":          {"api_key1"},
+		"https://custom.datadoghq.com":       {"api_key2"},
+		"https://custom.agent.datadoghq.com": {"api_key3"},
+		"https://app.datadoghq.eu":           {"api_key4"},
+		"https://app.myproxy.com":            {"api_key5"},
 	}
 
-	testMap := map[string][]string{
-		"https://api.datadoghq.com": {"api_key1"},
+	expectedMap := map[string][]string{
+		"https://api.datadoghq.com": {"api_key1", "api_key2", "api_key3"},
+		"https://api.datadoghq.eu":  {"api_key4"},
+		"https://app.myproxy.com":   {"api_key5"},
 	}
 
 	fh := forwarderHealth{keysPerDomains: keysPerDomains}
 	fh.init()
 
-	assert.Equal(t, fh.keysPerAPIEndpoint, testMap)
+	assert.Equal(t, expectedMap, fh.keysPerAPIEndpoint)
 }
 
 func TestHasValidAPIKeyErrors(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds full support for some patterns of 3-level domains in `site` setting (with a 3rd-level domain matching regexp `(eu|us)\d)`, e.g. `us2.datadoghq.com`).

This requires changes to the Infra Agent, in 2 places:

1. In config package: add the `{x.y.z}-app.agent.` prefix when such a 3-level `site` value is used (see first commit).
  Example: `site: us2.datadoghq.com` ==> 7.22.0 infra agent reports to `7.22.0-app.agent.us2.datadoghq.com`
1. In forwarder: update the API domain inference logic accordingly (see 2nd and 3rd commits).

Unfortunately, the Infra Agent has to keep this "regex-based" logic for backward-compatibility reasons.

### Motivation

Support such 3-level domains as value of `site` option.

### Additional Notes

This PR only makes the most conservative, safest changes possible to fully support `site` settings such as `us7.datadoghq.com` and `eu3.datadoghq.eu`, and keeping the behavior unchanged for custom `dd_url` values.

There are 2 identified areas of improvement, for future PRs (I'll create follow-up cards accordingly):

1. Refactor the API domain inference logic in the forwarder, which has nothing to do in the forwarder (this was started in https://github.com/DataDog/datadog-agent/pull/4958, but not finished yet).
1. Generalize the `ddURLRegexp` pattern in `config.go`, so it's more future-proof (i.e. supports more patterns 3-level domains while preserving backward compatibility with custom domains).

### Describe your test plan

* added lots of test cases in unit tests

QA'ed as follows:
* with no specific `site` config set, infra agent continues sending to the same `datadoghq.com` domains (behavior unchanged).
* with `site` set to `us2.datadoghq.com`, and check in core agent logs that the infra agent tries to send payloads to domain `{version}-app.agent.us2.datadoghq.com`, and tries to validate API keys against `api.us2.datadoghq.com`

Other site/dd_url combinations could be QA'ed as well.