### PR TITLE
[runtime-security] Set event ID only when sending the event

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -119,7 +119,7 @@ func (m *Module) RuleMatch(rule *eval.Rule, event eval.Event) {
 	if m.rateLimiter.Allow(rule.ID) {
 		m.eventServer.SendEvent(rule, event)
 	} else {
-		log.Debugf("Event %s on rule %s was dropped due to rate limiting", event.GetID(), rule.ID)
+		log.Debugf("Event on rule %s was dropped due to rate limiting", rule.ID)
 	}
 }
 

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -64,7 +64,7 @@ func (m *Model) ValidateField(key string, field eval.FieldValue) error {
 	if strings.HasSuffix(key, "filename") || strings.HasSuffix(key, "_path") {
 		value, ok := field.Value.(string)
 		if ok {
-			if value != path.Clean(value) || strings.HasPrefix(value, "..") {
+			if value != path.Clean(value) || !path.IsAbs(value) {
 				return fmt.Errorf("invalid path `%s`, all the path have to be absolute", value)
 			}
 		}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -1120,9 +1120,11 @@ type eventMarshaler struct {
 
 // MarshalJSON returns the JSON encoding of the event
 func (e *Event) MarshalJSON() ([]byte, error) {
+	eventID, _ := uuid.NewRandom()
+
 	var buf bytes.Buffer
 	buf.WriteRune('{')
-	fmt.Fprintf(&buf, `"id":"%s",`, e.ID)
+	fmt.Fprintf(&buf, `"id":"%s",`, eventID)
 
 	entries := []eventMarshaler{
 		{
@@ -1240,11 +1242,6 @@ func (e *Event) GetTags() []string {
 	return []string{"type:" + e.GetType()}
 }
 
-// GetID returns the event identifier
-func (e *Event) GetID() string {
-	return e.ID
-}
-
 // GetPointer return an unsafe.Pointer of the Event
 func (e *Event) GetPointer() unsafe.Pointer {
 	return unsafe.Pointer(e)
@@ -1262,9 +1259,7 @@ func (e *Event) UnmarshalBinary(data []byte) (int, error) {
 
 // NewEvent returns a new event
 func NewEvent(resolvers *Resolvers) *Event {
-	id, _ := uuid.NewRandom()
 	return &Event{
-		ID:        id.String(),
 		resolvers: resolvers,
 	}
 }

--- a/pkg/security/rules/model_test.go
+++ b/pkg/security/rules/model_test.go
@@ -44,10 +44,6 @@ type testEvent struct {
 type testModel struct {
 }
 
-func (e *testEvent) GetID() string {
-	return e.id
-}
-
 func (e *testEvent) GetType() string {
 	return e.kind
 }

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -284,14 +284,13 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	ctx.SetObject(event.GetPointer())
 
 	eventType := event.GetType()
-	eventID := event.GetID()
 
 	result := false
 	bucket, exists := rs.eventRuleBuckets[eventType]
 	if !exists {
 		return result
 	}
-	log.Debugf("Evaluating event `%s` of type `%s` against set of %d rules", eventID, eventType, len(bucket.rules))
+	log.Debugf("Evaluating event of type `%s` against set of %d rules", eventType, len(bucket.rules))
 
 	for _, rule := range bucket.rules {
 		if rule.GetEvaluator().Eval(ctx) {
@@ -303,7 +302,7 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	}
 
 	if !result {
-		log.Debugf("Looking for discarders for event `%s`", eventID)
+		log.Debugf("Looking for discarders for event of type `%s`", eventType)
 
 		for _, field := range bucket.fields {
 			evaluator, err := rs.model.GetEvaluator(field)

--- a/pkg/security/secl/eval/event.go
+++ b/pkg/security/secl/eval/event.go
@@ -15,8 +15,6 @@ type EventType = string
 
 // Event is an interface that an Event has to implement for the evaluation
 type Event interface {
-	// GetID returns the ID of the Event
-	GetID() string
 	// GetType returns the Type of the Event
 	GetType() EventType
 	// GetFieldEventType returns the Event Type for the given Field

--- a/pkg/security/secl/eval/model_test.go
+++ b/pkg/security/secl/eval/model_test.go
@@ -43,10 +43,6 @@ type testEvent struct {
 type testModel struct {
 }
 
-func (e *testEvent) GetID() string {
-	return e.id
-}
-
 func (e *testEvent) GetType() string {
 	return e.kind
 }


### PR DESCRIPTION
### What does this PR do?

It removes the ID from the event constructor and set it only when the event is sent to the agent.

### Motivation

At lot of event comes from the kernel that will be finally discarded because of rules. Generating an ID that finally won't be used is costly. It is better to postpone this generation only when needed.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
