### PR TITLE
[System Probe][Windows] Move bool to end of struct definition

### DIFF
--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -56,11 +56,11 @@ func makeDDAPIVersionBuffer(signature uint64) []byte {
 
 // DriverInterface holds all necessary information for interacting with the windows driver
 type DriverInterface struct {
-	driverFlowHandle      *DriverHandle
-	driverStatsHandle     *DriverHandle
+	totalFlows        int64
+	driverFlowHandle  *DriverHandle
+	driverStatsHandle *DriverHandle
 
-	path       string
-	totalFlows int64
+	path                  string
 	enableMonotonicCounts bool
 }
 

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -58,10 +58,10 @@ func makeDDAPIVersionBuffer(signature uint64) []byte {
 type DriverInterface struct {
 	driverFlowHandle      *DriverHandle
 	driverStatsHandle     *DriverHandle
-	enableMonotonicCounts bool
 
 	path       string
 	totalFlows int64
+	enableMonotonicCounts bool
 }
 
 // NewDriverInterface returns a DriverInterface struct for interacting with the driver

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -56,7 +56,9 @@ func makeDDAPIVersionBuffer(signature uint64) []byte {
 
 // DriverInterface holds all necessary information for interacting with the windows driver
 type DriverInterface struct {
-	totalFlows        int64
+	// declare totalFlows first so it remains on a 64 bit boundary since it is used by atomic functions
+	totalFlows int64
+
 	driverFlowHandle  *DriverHandle
 	driverStatsHandle *DriverHandle
 


### PR DESCRIPTION
### What does this PR do?

Fix error with memory layout of DriverInterface Struct. 

### Motivation

We were getting an error:

```
pkg\network\driver_interface.go:181:32: address of non 64-bit aligned field totalFlows passed to sync/atomic.LoadInt64 (SA1027)
 pkg\network\driver_interface.go:215:19: address of non 64-bit aligned field totalFlows passed to sync/atomic.AddInt64 (SA1027)
```


