### PR TITLE
[forwarder] fix test flakes

### DIFF
--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,7 +63,7 @@ func TestComputeDomainsURL(t *testing.T) {
 	fh := forwarderHealth{keysPerDomains: keysPerDomains}
 	fh.init()
 
-	assert.Equal(t, expectedMap, fh.keysPerAPIEndpoint)
+	assert.True(t, reflect.DeepEqual(expectedMap, fh.keysPerAPIEndpoint))
 }
 
 func TestHasValidAPIKeyErrors(t *testing.T) {

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,10 +60,20 @@ func TestComputeDomainsURL(t *testing.T) {
 		"https://app.myproxy.com":        {"api_key8"},
 	}
 
+	// just sort the expected map for easy comparison
+	for _, keys := range expectedMap {
+		sort.Strings(keys)
+	}
+
 	fh := forwarderHealth{keysPerDomains: keysPerDomains}
 	fh.init()
 
-	assert.True(t, reflect.DeepEqual(expectedMap, fh.keysPerAPIEndpoint))
+	// lexicographical sort for assert
+	for _, keys := range fh.keysPerAPIEndpoint {
+		sort.Strings(keys)
+	}
+
+	assert.Equal(t, expectedMap, fh.keysPerAPIEndpoint)
 }
 
 func TestHasValidAPIKeyErrors(t *testing.T) {

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -96,12 +96,12 @@ def test(
     print("--- go generating:")
     generate(ctx)
 
-    print("--- Linting licenses:")
-    lint_licenses(ctx)
-
     if skip_linters:
         print("--- [skipping linters]")
     else:
+        print("--- Linting licenses:")
+        lint_licenses(ctx)
+
         print("--- Linting filenames:")
         lint_filenames(ctx)
 


### PR DESCRIPTION
### What does this PR do?

- Fixes a map comparison flake in the forwarder tests; thought testify had already fixed this, turns out they hadn't.
- Moves the license linting to the linter section in case we want to skip it.

### Motivation

(very) flakey tests.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Flakes be gone! ;)
