### PR TITLE
[Codecov] Disable codecov on PR

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,4 @@ coverage:
 
   status:
     project: off
-    patch:
-      default:
-        target: '30'
+    patch: off


### PR DESCRIPTION
### What does this PR do?

- Disable Codecov on Pull Requests.

### Motivation

- New feature is too spammy and the reported percentages are not useful to most people

### Additional Notes

- Codecov is still running on AppVeyor.