### PR TITLE
Rely on config providers to identify clc runners

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1235,3 +1235,21 @@ func getDogstatsdMappingProfilesConfig(config Config) ([]MappingProfile, error) 
 	}
 	return mappings, nil
 }
+
+// IsCLCRunner returns whether the Agent is in cluster check runner mode
+func IsCLCRunner() bool {
+	if !Datadog.GetBool("clc_runner_enabled") {
+		return false
+	}
+	var cp []ConfigurationProviders
+	if err := Datadog.UnmarshalKey("config_providers", &cp); err == nil {
+		for _, name := range Datadog.GetStringSlice("extra_config_providers") {
+			cp = append(cp, ConfigurationProviders{Name: name})
+		}
+		if len(cp) == 1 && cp[0].Name == "clusterchecks" {
+			// A cluster check runner is an Agent configured to run clusterchecks only
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -68,7 +68,7 @@ func newTagger() *Tagger {
 // for this host. It then starts the collection logic and is ready for
 // requests.
 func (t *Tagger) Init(catalog collectors.Catalog) {
-	if config.Datadog.GetBool("clc_runner_enabled") {
+	if config.IsCLCRunner() {
 		log.Infof("Tagger not started on CLC")
 		return
 	}

--- a/releasenotes/notes/fix-clc-runner-detection-6ad5c65171e4703b.yaml
+++ b/releasenotes/notes/fix-clc-runner-detection-6ad5c65171e4703b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug where the Agent disables collecting tags when the
+    cluster checks advanced dispatching is enabled in the Daemonset Agent.


### PR DESCRIPTION
### What does this PR do?

Use the config providers and extra config providers to identify cluster check runners in addition to `clc_runner_enabled` 

### Motivation

https://github.com/DataDog/datadog-agent/pull/5775 introduced some logic to disable the tagger for cluster check runners based on `clc_runner_enabled`. In some cases the node agent has the config `clc_runner_enabled=true`  (to enable advanced dispatching). 
The identification of cluster check runner mode should be more resilient and shouldn't just rely on `clc_runner_enabled`

### Describe your test plan

- If the [advanced dispatching](https://docs.datadoghq.com/agent/cluster_agent/clusterchecks/#advanced-dispatching-cluster-check-runner-setup) is enabled for node agents, tagger should start and non-cluster-check metrics should have kubelet tags
- For clc runners, tagger shouldn't start
