### PR TITLE
[runtime-security] fix parent discarders and refine default rules

### DIFF
--- a/pkg/security/config/default.go
+++ b/pkg/security/config/default.go
@@ -31,7 +31,10 @@ rules:
   - id: logs_removed
     description: log entries removed
     expression: >-
-      unlink.filename =~ "/var/log/*"
+      unlink.filename =~ "/var/log/*" &&
+      unlink.filename != "/var/log/datadog/system-probe.log" &&
+      unlink.basename !~ "*.tmp" &&
+      process.name != "kubelet"
     tags:
       mitre: T1070
   - id: permissions_changed
@@ -46,7 +49,10 @@ rules:
   - id: hidden_file
     description: hidden file creation
     expression: >-
-      open.basename =~ ".*" && open.flags & O_CREAT > 0
+      open.basename =~ ".*" && open.flags & O_CREAT > 0 &&
+      open.filename !~ "/run/containerd/io.containerd.runtime.v1.linux/k8s.io/*" &&
+      open.basename !~ ".*.pid" &&
+      process.name != "runc"
     tags:
       mitre: T1158
   - id: kernel_module

--- a/pkg/security/probe/kfilters_test.go
+++ b/pkg/security/probe/kfilters_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux_bpf
+
+package probe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/policy"
+	"github.com/DataDog/datadog-agent/pkg/security/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
+)
+
+func addRuleExpr(t *testing.T, rs *rules.RuleSet, exprs ...string) {
+	var ruleDefs []*policy.RuleDefinition
+
+	for i, expr := range exprs {
+		ruleDef := &policy.RuleDefinition{
+			ID:         fmt.Sprintf("ID%d", i),
+			Expression: expr,
+			Tags:       make(map[string]string),
+		}
+		ruleDefs = append(ruleDefs, ruleDef)
+	}
+
+	if err := rs.AddRules(ruleDefs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIsParentDiscarder(t *testing.T) {
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
+
+	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.filename != "/var/log/datadog/system-probe.log"`)
+
+	if is, _ := isParentPathDiscarder(rs, "unlink", "/var/log/datadog/system-probe.log"); is {
+		t.Fatal("shouldn't be a parent discarder")
+	}
+}

--- a/pkg/security/probe/open.go
+++ b/pkg/security/probe/open.go
@@ -129,7 +129,7 @@ var openHookPoints = []*HookPoint{
 				fsEvent := event.Open
 				table := "open_path_inode_discarders"
 
-				isDiscarded, err := discardParentInode(probe, rs, field, discarder.Value.(string), fsEvent.MountID, fsEvent.Inode, table)
+				isDiscarded, err := discardParentInode(probe, rs, "open", discarder.Value.(string), fsEvent.MountID, fsEvent.Inode, table)
 				if !isDiscarded || err != nil {
 					// not able to discard the parent then only discard the filename
 					_, err = discardInode(probe, fsEvent.MountID, fsEvent.Inode, table)

--- a/pkg/security/probe/unlink.go
+++ b/pkg/security/probe/unlink.go
@@ -35,7 +35,7 @@ var UnlinkHookPoints = []*HookPoint{
 				fsEvent := event.Unlink
 				table := "unlink_path_inode_discarders"
 
-				isDiscarded, err := discardParentInode(probe, rs, field, discarder.Value.(string), fsEvent.MountID, fsEvent.Inode, table)
+				isDiscarded, err := discardParentInode(probe, rs, "unlink", discarder.Value.(string), fsEvent.MountID, fsEvent.Inode, table)
 				if !isDiscarded || err != nil {
 					// not able to discard the parent then only discard the filename
 					_, err = discardInode(probe, fsEvent.MountID, fsEvent.Inode, table)

--- a/pkg/security/tests/tests.go
+++ b/pkg/security/tests/tests.go
@@ -255,7 +255,7 @@ func (tm *testModule) Close() {
 	time.Sleep(time.Second)
 }
 
-func waitProcScan(test *testProbe) error {
+func waitProcScan(test *testProbe) {
 	// Consume test.events so that testEventHandler.HandleEvent doesn't block
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
@@ -271,7 +271,6 @@ func waitProcScan(test *testProbe) error {
 	}()
 	time.Sleep(5 * time.Second)
 	cancel()
-	return log.ChangeLogLevel(logger, "debug")
 }
 
 func newTestProbe(macros []*policy.MacroDefinition, rules []*policy.RuleDefinition, opts testOpts) (*testProbe, error) {
@@ -328,9 +327,7 @@ func newTestProbe(macros []*policy.MacroDefinition, rules []*policy.RuleDefiniti
 		rs:         ruleSet,
 	}
 
-	if err := waitProcScan(test); err != nil {
-		return nil, err
-	}
+	waitProcScan(test)
 
 	return test, nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the parent discarder calls which were passing the field instead of the event type.

### Motivation

Avoid pushing wrong discarder as in-kernel filter

### Additional Notes

The new rules should limit the amount of events.

### Describe your test plan

With the default rule set an `unlink /var/log/test/test.log` should not report `/var/log/test` as discarder.
