### PR TITLE
[runtime-security] Use correct path when changing owners of eBPF programs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -682,6 +682,10 @@ run_dogstatsd_arm_size_test:
     - inv -e system-probe.build --go-version=$SYSTEM_PROBE_GO_VERSION --embedded-path=$DATADOG_AGENT_EMBEDDED_PATH
     - inv -e system-probe.test --only-check-bpf-bytes
     - $S3_CP_CMD $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe $S3_ARTIFACTS_URI/system-probe.$ARCH
+    - $S3_CP_CMD $SRC_PATH/pkg/ebpf/c/tracer-ebpf.o $S3_ARTIFACTS_URI/tracer-ebpf.o.$ARCH
+    - $S3_CP_CMD $SRC_PATH/pkg/ebpf/c/tracer-ebpf-debug.o $S3_ARTIFACTS_URI/tracer-ebpf-debug.o.$ARCH
+    - $S3_CP_CMD $SRC_PATH/pkg/security/ebpf/c/runtime-security.o $S3_ARTIFACTS_URI/runtime-security.o.$ARCH
+    - $S3_CP_CMD $SRC_PATH/pkg/security/ebpf/c/runtime-security-syscall-wrapper.o $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.$ARCH
 
 build_system-probe-x64:
   stage: binary_build
@@ -712,8 +716,13 @@ build_system-probe-arm64:
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
     # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/system-probe.${PACKAGE_ARCH} /tmp/system-probe
-    - chmod 755 /tmp/system-probe
+    - mkdir -p /tmp/system-probe
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/system-probe.${PACKAGE_ARCH} /tmp/system-probe/system-probe
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer-ebpf.o.${PACKAGE_ARCH} /tmp/system-probe/tracer-ebpf.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer-ebpf-debug.o.${PACKAGE_ARCH} /tmp/system-probe/tracer-ebpf-debug.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-syscall-wrapper.o
+    - chmod 755 /tmp/system-probe/system-probe
     - $S3_CP_CMD $S3_ARTIFACTS_URI/libbcc-${PACKAGE_ARCH}.tar.xz /tmp/libbcc.tar.xz
     # Use --skip-deps since the deps are installed by `before_script`.
     - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --system-probe-bin=/tmp/system-probe --libbcc-tarball=/tmp/libbcc.tar.xz
@@ -886,8 +895,13 @@ iot_agent_deb-armhf:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - set -x
 
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/system-probe.${PACKAGE_ARCH} /tmp/system-probe
-    - chmod 755 /tmp/system-probe
+    - mkdir -p /tmp/system-probe
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/system-probe.${PACKAGE_ARCH} /tmp/system-probe/system-probe
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer-ebpf.o.${PACKAGE_ARCH} /tmp/system-probe/tracer-ebpf.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer-ebpf-debug.o.${PACKAGE_ARCH} /tmp/system-probe/tracer-ebpf-debug.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-syscall-wrapper.o
+    - chmod 755 /tmp/system-probe/system-probe
     - $S3_CP_CMD $S3_ARTIFACTS_URI/libbcc-${PACKAGE_ARCH}.tar.xz /tmp/libbcc.tar.xz
     # use --skip-deps since the deps are installed by `before_script`
     - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --base-dir $OMNIBUS_BASE_DIR  ${USE_S3_CACHING} --skip-deps --system-probe-bin=/tmp/system-probe --libbcc-tarball=/tmp/libbcc.tar.xz
@@ -1045,8 +1059,13 @@ iot_agent_rpm-armhf:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase_e09422b3 --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/system-probe.${PACKAGE_ARCH} /tmp/system-probe
-    - chmod 755 /tmp/system-probe
+    - mkdir -p /tmp/system-probe
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/system-probe.${PACKAGE_ARCH} /tmp/system-probe/system-probe
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer-ebpf.o.${PACKAGE_ARCH} /tmp/system-probe/tracer-ebpf.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/tracer-ebpf-debug.o.${PACKAGE_ARCH} /tmp/system-probe/tracer-ebpf-debug.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security.o
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/runtime-security-syscall-wrapper.o.${PACKAGE_ARCH} /tmp/system-probe/runtime-security-syscall-wrapper.o
+    - chmod 755 /tmp/system-probe/system-probe
     - $S3_CP_CMD $S3_ARTIFACTS_URI/libbcc-${PACKAGE_ARCH}.tar.xz /tmp/libbcc.tar.xz
     # use --skip-deps since the deps are installed by `before_script`
     - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --base-dir $OMNIBUS_BASE_DIR_SUSE ${USE_S3_CACHING} --skip-deps --system-probe-bin=/tmp/system-probe --libbcc-tarball=/tmp/libbcc.tar.xz

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3706,6 +3706,10 @@ deploy_staging_process_and_sysprobe:
     - echo "Uploading with name=$NAME"
     - $S3_CP_CMD ./out$DATADOG_AGENT_EMBEDDED_PATH/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-$NAME --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
     - $S3_CP_CMD ./out$DATADOG_AGENT_EMBEDDED_PATH/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-$NAME --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
+    - $S3_CP_CMD ./out$DATADOG_AGENT_EMBEDDED_PATH/share/system-probe/ebpf/tracer-ebpf.o s3://$PROCESS_S3_BUCKET/tracer-ebpf.o --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
+    - $S3_CP_CMD ./out$DATADOG_AGENT_EMBEDDED_PATH/share/system-probe/ebpf/tracer-ebpf-debug.o s3://$PROCESS_S3_BUCKET/tracer-ebpf-debug.o --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
+    - $S3_CP_CMD ./out$DATADOG_AGENT_EMBEDDED_PATH/share/system-probe/ebpf/runtime-security.o s3://$PROCESS_S3_BUCKET/runtime-security.o --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
+    - $S3_CP_CMD ./out$DATADOG_AGENT_EMBEDDED_PATH/share/system-probe/ebpf/runtime-security-syscall-wrapper.o s3://$PROCESS_S3_BUCKET/runtime-security-syscall-wrapper.o --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
 
 #
 # Docker releases

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -103,6 +103,7 @@ build do
             move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "/etc/datadog-agent"
             move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "/etc/datadog-agent"
             move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent", :force=>true
+            move "#{install_dir}/etc/datadog-agent/runtime-security.d", "/etc/datadog-agent", :force=>true
 
             # Move SELinux policy
             if debian? || redhat?

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -183,6 +183,10 @@ build do
             strip_exclude("*psycopg2*")
             strip_exclude("*cffi_backend*")
 
+            # Do not strip eBPF programs
+            strip_exclude("*tracer-ebpf*")
+            strip_exclude("*runtime-security*")
+
         elsif osx?
             # Remove linux specific configs
             delete "#{install_dir}/etc/conf.d/file_handle.d"

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -13,18 +13,20 @@ source path: '..'
 relative_path 'src/github.com/DataDog/datadog-agent'
 
 build do
-  if ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
-    copy ENV['SYSTEM_PROBE_BIN'], "#{install_dir}/embedded/bin/system-probe"
-  end
-
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf"
 
-  copy 'pkg/ebpf/c/COPYING', "#{install_dir}/embedded/share/system-probe/ebpf/"
-  copy 'pkg/ebpf/bytecode/tracer-ebpf.o', "#{install_dir}/embedded/share/system-probe/ebpf/"
-  copy 'pkg/ebpf/bytecode/tracer-ebpf-debug.o', "#{install_dir}/embedded/share/system-probe/ebpf/"
-  copy 'pkg/ebpf/c/oom-kill-kern.c', "#{install_dir}/embedded/share/system-probe/ebpf/"
-  copy 'pkg/ebpf/c/tcp-queue-length-kern.c', "#{install_dir}/embedded/share/system-probe/ebpf/"
+  if ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
+    copy "#{ENV['SYSTEM_PROBE_BIN']}/system-probe", "#{install_dir}/embedded/bin/system-probe"
+    copy "#{ENV['SYSTEM_PROBE_BIN']}/tracer-ebpf.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
+    copy "#{ENV['SYSTEM_PROBE_BIN']}/tracer-ebpf-debug.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
+    copy "#{ENV['SYSTEM_PROBE_BIN']}/runtime-security.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
+    copy "#{ENV['SYSTEM_PROBE_BIN']}/runtime-security-syscall-wrapper.o", "#{install_dir}/embedded/share/system-probe/ebpf/"
+  end
 
-  copy 'pkg/security/ebpf/c/runtime-security.o', "#{install_dir}/embedded/share/system-probe/ebpf/"
-  copy 'pkg/security/ebpf/c/runtime-security-syscall-wrapper.o', "#{install_dir}/embedded/share/system-probe/ebpf/"
+  copy 'pkg/ebpf/c/COPYING', "#{install_dir}/embedded/share/system-probe/ebpf/"
+  copy 'pkg/ebpf/c/oom-kill-kern.c', "#{install_dir}/embedded/share/system-probe/ebpf/"
+  copy 'pkg/ebpf/oom-kill-kern-user.h', "#{install_dir}/embedded/share/system-probe/ebpf/"
+
+  copy 'pkg/ebpf/c/tcp-queue-length-kern.c', "#{install_dir}/embedded/share/system-probe/ebpf/"
+  copy 'pkg/ebpf/tcp-queue-length-kern-user.h', "#{install_dir}/embedded/share/system-probe/ebpf/"
 end

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -9,6 +9,9 @@ if ENV['WITH_BCC'] == 'true'
   dependency 'libbcc'
 end
 
+source path: '..'
+relative_path 'src/github.com/DataDog/datadog-agent'
+
 build do
   if ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
     copy ENV['SYSTEM_PROBE_BIN'], "#{install_dir}/embedded/bin/system-probe"

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -70,7 +70,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
 
     # Make the system-probe binary and eBPF programs owned by root
     chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
-    chown -R root:root ${INSTALL_DIR}/embedded/usr/share/system-probe
+    chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
 
     # Enable and restart the agent service here on Debian platforms
     # On RHEL, this is done in the posttrans script

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -28,7 +28,7 @@ var (
 	defaultProxyPort = 3128
 
 	// defaultSystemProbeBPFDir is the default path for eBPF programs
-	defaultSystemProbeBPFDir = "/opt/datadog-agent/embedded/usr/share/system-probe/ebpf"
+	defaultSystemProbeBPFDir = "/opt/datadog-agent/embedded/share/system-probe/ebpf"
 
 	processChecks   = []string{"process", "rtprocess"}
 	containerChecks = []string{"container", "rtcontainer"}


### PR DESCRIPTION
### What does this PR do?

Fix path of eBPF programs when changing owner in post install script

### Motivation

Postinstall script fails because the path of eBPF is wrong