### PR TITLE
[Process] Avoid warning about container source config

### DIFF
--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -353,8 +353,13 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	// Used to override container source auto-detection
 	// and to enable multiple collector sources if needed.
 	// "docker", "ecs_fargate", "kubelet", "kubelet docker", etc.
-	if sources := config.Datadog.GetStringSlice(key(ns, "container_source")); len(sources) > 0 {
-		util.SetContainerSources(sources)
+	containerSourceKey := key(ns, "container_source")
+	if config.Datadog.Get(containerSourceKey) != nil {
+		// container_source can be nil since we're not forcing default values in the main config file
+		// make sure we don't pass nil value to GetStringSlice to avoid spammy warnings
+		if sources := config.Datadog.GetStringSlice(containerSourceKey); len(sources) > 0 {
+			util.SetContainerSources(sources)
+		}
 	}
 
 	// Pull additional parameters from the global config file.


### PR DESCRIPTION
### What does this PR do?

Do not log `(pkg/config/viper.go:168 in GetStringSlice) | failed to get configuration value for key "process_config.container_source": unable to cast <nil> of type <nil> to []string` when `process_config.container_source` is empty

### Describe your test plan

- shouldn't log anymore `(pkg/config/viper.go:168 in GetStringSlice) | failed to get configuration value for key "process_config.container_source": unable to cast <nil> of type <nil> to []string`  if `DD_PROCESS_AGENT_CONTAINER_SOURCE` is set (see https://github.com/DataDog/datadog-agent/pull/5374)
- this fix shouldn't break https://github.com/DataDog/datadog-agent/pull/5374 `DD_PROCESS_AGENT_CONTAINER_SOURCE` should always accept string or whitespace separated strings and honour the config
