### PR TITLE
Fix atomic var alignment

### DIFF
--- a/pkg/dogstatsd/listeners/listener_telemetry_windows.go
+++ b/pkg/dogstatsd/listeners/listener_telemetry_windows.go
@@ -14,10 +14,10 @@ import (
 )
 
 type listenerTelemetry struct {
-	expvars             *expvar.Map
 	packetReadingErrors expvar.Int
 	packets             expvar.Int
 	bytes               expvar.Int
+	expvars             *expvar.Map
 	tlmPackets          telemetry.Counter
 	tlmPacketsBytes     telemetry.Counter
 }


### PR DESCRIPTION
### What does this PR do?

Fix atomic var alignment that panic on x86 and ARM