### PR TITLE
fix docker.uptime reporting

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -189,6 +189,9 @@ func (d *DockerCheck) Run() error {
 			}
 		}
 
+		currentUnixTime := time.Now().Unix()
+		d.reportUptime(c.StartedAt, currentUnixTime, tags, sender)
+
 		if c.CPU != nil {
 			d.reportCPUMetrics(c.CPU, &c.Limits, c.StartedAt, tags, sender)
 		} else {


### PR DESCRIPTION
### What does this PR do?

Fix of #5716 where `docker.uptime` metric was inadvertently removed