### PR TITLE
[kitchen] Fix integration command tests to work with pip 20.1

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -206,7 +206,16 @@ def integration_remove(package)
 end
 
 def pip_list
-  `/opt/datadog-agent/embedded/bin/pip list 2>&1`.tap do |output|
+  if os == :windows
+    if info.include? "v6."
+      pip_command = '& "C:\Program Files\Datadog\Datadog Agent\embedded2\python.exe" -m pip'
+    else
+      pip_command = '& "C:\Program Files\Datadog\Datadog Agent\embedded3\python.exe" -m pip'
+    end
+  else
+    pip_command = '/opt/datadog-agent/embedded/bin/python -m pip'
+  end
+  `#{pip_command} list 2>&1`.tap do |output|
     raise "Failed to get pip list - #{output}" unless $? == 0
   end
 end


### PR DESCRIPTION
### What does this PR do?

Uses the new `datadog-agent integration list` (see #6179) command to get the version of the integration we use to test the integration install / uninstall, and fixes the test to conform to `pip list` output (instead of `pip freeze`). `datadog-agent integration freeze` is still tested to check for regressions, but should do the same thing as `list`.

### Motivation

Fix kitchen tests.

### Additional Notes

Needs #6179 to work.
