### PR TITLE
Remove comments mentioning replace tag for "service.name"

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -732,10 +732,10 @@ api_key:
   #     <OBFUSCATION_CONFIGURATION>
 
   ## @param replace_tags - list of objects - optional
-  ## Defines a set of rules to replace or remove certain services, resources, tags containing
+  ## Defines a set of rules to replace or remove certain resources, tags containing
   ## potentially sensitive information.
   ## Each rules has to contain:
-  ##  * name - string - The tag name to replace, for services or resources use "service.name" or "resource.name".
+  ##  * name - string - The tag name to replace, for resources use "resource.name".
   ##  * pattern - string - The pattern to match the desired content to replace
   ##  * repl - string - what to inline if the pattern is matched
   ##


### PR DESCRIPTION


### What does this PR do?
Trace agent configuration: 
Remove "service.name"  in the comments as the possibility for the  replace tags function to replace a service name has never being implemented

### Motivation

Avoid suggesting the use of the replace tags option when someone wants to change their service names

### Additional Notes

Comment about service.name in the yaml configuration example was introduced in 6.3.3:

the code for the replace tags function at the time was:

https://github.com/DataDog/datadog-trace-agent/blob/6.3.3/filters/tag.go#L21

which doesn’t replace the service.name!!

Today’s code:

https://github.com/DataDog/datadog-agent/blob/master/pkg/trace/filters/replacer.go#L25

still doesn’t replace the service.name …..

Official doc: https://docs.datadoghq.com/tracing/custom_instrumentation/agent_customization/?tab=datadogyaml#replace-rules-for-tag-filtering doesn’t mention that service name can be replaced.

Right thing to do: remove the comment in the https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml#L738 regarding service.name.



### Describe your test plan

I didn't run any test
