### PR TITLE
[choco] Install invoke to be able to fetch agent version

### DIFF
--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -7,6 +7,10 @@ Param(
 
 $ErrorActionPreference = 'Stop';
 Set-Location c:\mnt
+
+# Install dev tools, including invoke
+pip3 install -r requirements.txt
+
 $outputDirectory = "c:\mnt\build-out"
 $rawAgentVersion = (inv agent.version)
 $copyright = "Datadog {0}" -f (Get-Date).Year


### PR DESCRIPTION
### What does this PR do?

Adds `pip3 install -r requirements.txt` in the `Generate-Chocolatey-Package.ps1` script to get invoke.

### Motivation

#6146 made the chocolatey jobs use the new Windows builders. However, they don't come with python packages pre-installed. Thus they need to be installed in the chocolatey script.

### Describe your test plan

Tested the `windows_choco_offline_7_x64` job.