### PR TITLE
move clusterID CM and orchestrator controller behind config flag

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -218,29 +218,33 @@ func start(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Generate and persist a cluster ID
-	// this must be a UUID, and ideally be stable for the lifetime of a cluster
-	// so we store it in a configmap that we try and read before generating a new one.
-	coreClient := apiCl.Cl.CoreV1().(*corev1.CoreV1Client)
-	_, err = apicommon.GetOrCreateClusterID(coreClient)
-	if err != nil {
-		log.Errorf("Failed to generate or retrieve the cluster ID")
-	}
+	if config.Datadog.GetBool("orchestrator_explorer.enabled") {
+		// Generate and persist a cluster ID
+		// this must be a UUID, and ideally be stable for the lifetime of a cluster
+		// so we store it in a configmap that we try and read before generating a new one.
+		coreClient := apiCl.Cl.CoreV1().(*corev1.CoreV1Client)
+		_, err = apicommon.GetOrCreateClusterID(coreClient)
+		if err != nil {
+			log.Errorf("Failed to generate or retrieve the cluster ID")
+		}
 
-	// TODO: move rest of the controllers out of the apiserver package
-	orchestratorCtx := orchestrator.ControllerContext{
-		IsLeaderFunc:                 le.IsLeader,
-		UnassignedPodInformerFactory: apiCl.UnassignedPodInformerFactory,
-		InformerFactory:              apiCl.InformerFactory,
-		Client:                       apiCl.Cl,
-		StopCh:                       stopCh,
-		Hostname:                     hostname,
-		ClusterName:                  clustername.GetClusterName(),
-		ConfigPath:                   confPath,
-	}
-	err = orchestrator.StartController(orchestratorCtx)
-	if err != nil {
-		log.Errorf("Could not start orchestrator controller: %v", err)
+		// TODO: move rest of the controllers out of the apiserver package
+		orchestratorCtx := orchestrator.ControllerContext{
+			IsLeaderFunc:                 le.IsLeader,
+			UnassignedPodInformerFactory: apiCl.UnassignedPodInformerFactory,
+			InformerFactory:              apiCl.InformerFactory,
+			Client:                       apiCl.Cl,
+			StopCh:                       stopCh,
+			Hostname:                     hostname,
+			ClusterName:                  clustername.GetClusterName(),
+			ConfigPath:                   confPath,
+		}
+		err = orchestrator.StartController(orchestratorCtx)
+		if err != nil {
+			log.Errorf("Could not start orchestrator controller: %v", err)
+		}
+	} else {
+		log.Info("Orchestrator explorer is disabled")
 	}
 
 	if config.Datadog.GetBool("admission_controller.enabled") {

--- a/releasenotes/notes/move-cluster-id-configmap-creation-behind-config-flag-4d6b7e208138e4b4.yaml
+++ b/releasenotes/notes/move-cluster-id-configmap-creation-behind-config-flag-4d6b7e208138e4b4.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Move the cluster-id ConfigMap creation, and Orchestrator
+    Explorer controller instantiation behind the orchestrator_explorer
+    config flag to avoid it failing and generating error logs.


### PR DESCRIPTION
### What does this PR do?

Move clusterID ConfigMap and Orchestrator controller creation behind config flag to avoid writing a confusing error logs.

### Motivation

User reports of error logs.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
