### PR TITLE
Avoid conflict on audit registry file

### DIFF
--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -65,7 +65,7 @@ func startCompliance(stopper restart.Stopper, apiCl *apiserver.APIClient) error 
 	health := health.RegisterLiveness("compliance")
 
 	// setup the auditor
-	auditor := auditor.New(coreconfig.Datadog.GetString("compliance_config.run_path"), health)
+	auditor := auditor.New(coreconfig.Datadog.GetString("compliance_config.run_path"), "compliance-cluster-registry.json", health)
 	auditor.Start()
 	stopper.Add(auditor)
 

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -99,7 +99,7 @@ func newComplianceReporter(stopper restart.Stopper, sourceName, sourceType strin
 	health := health.RegisterLiveness("compliance")
 
 	// setup the auditor
-	auditor := auditor.New(coreconfig.Datadog.GetString("compliance_config.run_path"), health)
+	auditor := auditor.New(coreconfig.Datadog.GetString("compliance_config.run_path"), "compliance-registry.json", health)
 	auditor.Start()
 	stopper.Add(auditor)
 

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -26,7 +26,7 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 	health := health.RegisterLiveness("runtime-security")
 
 	// setup the auditor
-	auditor := auditor.New(coreconfig.Datadog.GetString("runtime_security_config.run_path"), health)
+	auditor := auditor.New(coreconfig.Datadog.GetString("runtime_security_config.run_path"), "runtime-security-registry.json", health)
 	auditor.Start()
 	stopper.Add(auditor)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -753,6 +753,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
+	config.BindEnvAndSetDefault("compliance_config.run_path", defaultRunPath)
 
 	// Datadog security agent (runtime)
 	config.BindEnvAndSetDefault("runtime_security_config.enabled", false)
@@ -761,6 +762,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.socket", "/opt/datadog-agent/run/runtime-security.sock")
 	config.BindEnvAndSetDefault("runtime_security_config.enable_kernel_filters", true)
 	config.BindEnvAndSetDefault("runtime_security_config.syscall_monitor.enabled", false)
+	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -49,7 +49,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 	// setup the auditor
 	// We pass the health handle to the auditor because it's the end of the pipeline and the most
 	// critical part. Arguably it could also be plugged to the destination.
-	auditor := auditor.New(coreConfig.Datadog.GetString("logs_config.run_path"), health)
+	auditor := auditor.New(coreConfig.Datadog.GetString("logs_config.run_path"), auditor.DefaultRegistryFilename, health)
 	destinationsCtx := client.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender

--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -21,6 +21,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
+// DefaultRegistryFilename is the default registry filename
+const DefaultRegistryFilename = "registry.json"
+
 const defaultFlushPeriod = 1 * time.Second
 const defaultCleanupPeriod = 300 * time.Second
 const defaultTTL = 23 * time.Hour
@@ -61,10 +64,10 @@ type Auditor struct {
 }
 
 // New returns an initialized Auditor
-func New(runPath string, health *health.Handle) *Auditor {
+func New(runPath string, filename string, health *health.Handle) *Auditor {
 	return &Auditor{
 		health:       health,
-		registryPath: filepath.Join(runPath, "registry.json"),
+		registryPath: filepath.Join(runPath, filename),
 		entryTTL:     defaultTTL,
 	}
 }

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -42,7 +42,7 @@ func (suite *AuditorTestSuite) SetupTest() {
 	_, err = os.Create(suite.testPath)
 	suite.Nil(err)
 
-	suite.a = New("", health.RegisterLiveness("fake"))
+	suite.a = New("", DefaultRegistryFilename, health.RegisterLiveness("fake"))
 	suite.a.registryPath = suite.testPath
 	suite.source = config.NewLogSource("", &config.LogsConfig{Path: testpath})
 }

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -6,8 +6,9 @@
 package pipeline
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 
 	"github.com/stretchr/testify/suite"
 
@@ -23,7 +24,7 @@ type ProviderTestSuite struct {
 }
 
 func (suite *ProviderTestSuite) SetupTest() {
-	suite.a = auditor.New("", health.RegisterLiveness("fake"))
+	suite.a = auditor.New("", auditor.DefaultRegistryFilename, health.RegisterLiveness("fake"))
 	suite.p = &provider{
 		numberOfPipelines: 3,
 		auditor:           suite.a,


### PR DESCRIPTION
### What does this PR do?

This PR allows to change the audit registry filename in order to avoid conflict.
It also set a default run_path for compliance agent in order to avoid creating a registry file at `/`

### Motivation

If agents using the audit package uses the same run_path they will use the same registry.json file. This is case for the compliance cluster agent, the security-agent and the datadog-agent
 
### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Starting the security-agent with compliance and the runtime agent should generate dedicated registry files.
