### PR TITLE
[runtime-security] Fix runtime security flare

### DIFF
--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -127,7 +127,13 @@ func (a *Agent) makeFlare(w http.ResponseWriter, r *http.Request) {
 	if logFile == "" {
 		logFile = common.DefaultLogFile
 	}
-	filePath, err := flare.CreateSecurityAgentArchive(false, logFile)
+
+	var runtimeAgentStatus map[string]interface{}
+	if a.runtimeAgent != nil {
+		runtimeAgentStatus = a.runtimeAgent.GetStatus()
+	}
+
+	filePath, err := flare.CreateSecurityAgentArchive(false, logFile, runtimeAgentStatus)
 	if err != nil || filePath == "" {
 		if err != nil {
 			log.Errorf("The flare failed to be created: %s", err)

--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -97,7 +97,7 @@ func requestFlare(caseID string) error {
 			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make a full flare: %s.", e.Error()))
 		}
 		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally, some logs will be missing."))
-		filePath, e = flare.CreateSecurityAgentArchive(true, logFile)
+		filePath, e = flare.CreateSecurityAgentArchive(true, logFile, nil)
 		if e != nil {
 			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 			return e

--- a/omnibus/config/templates/datadog-agent/systemd.security.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.security.service.erb
@@ -6,7 +6,6 @@ BindsTo=datadog-agent.service
 [Service]
 Type=simple
 PIDFile=<%= install_dir %>/run/security-agent.pid
-User=dd-agent
 Restart=on-failure
 ExecStart=<%= install_dir %>/embedded/bin/security-agent start -c <%= etc_dir %>/datadog.yaml -p <%= install_dir %>/run/security-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.security.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.security.erb
@@ -17,7 +17,6 @@ INSTALL_DIR="<%= install_dir %>"
 AGENTPATH="$INSTALL_DIR/embedded/bin/security-agent"
 PIDFILE="$INSTALL_DIR/run/security-agent.pid"
 AGENT_ARGS="start -c=$ETC_DIR/datadog.yaml -p=$PIDFILE"
-AGENT_USER="dd-agent"
 NAME="datadog-agent-security"
 DESC="Datadog Security Agent"
 
@@ -42,9 +41,9 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --test --quiet --pidfile $PIDFILE --user $AGENT_USER --startas $AGENTPATH > /dev/null \
+	start-stop-daemon --start --test --quiet --pidfile $PIDFILE --user root --startas $AGENTPATH > /dev/null \
 		|| return 1
-	start-stop-daemon --start --background --chuid $AGENT_USER --quiet --pidfile $PIDFILE --user $AGENT_USER --startas $AGENTPATH -- \
+	start-stop-daemon --start --background --chuid root --quiet --pidfile $PIDFILE --user root --startas $AGENTPATH -- \
 		$AGENT_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready
@@ -67,7 +66,7 @@ start_and_wait()
 			# check if the agent is running once per second for 5 seconds
 			retries=5
 			while [ $retries -gt 1 ]; do
-				start-stop-daemon --start --test --quiet --pidfile $PIDFILE --user $AGENT_USER --startas $AGENTPATH
+				start-stop-daemon --start --test --quiet --pidfile $PIDFILE --user root --startas $AGENTPATH
 				if [ "$?" -eq "1" ]; then
 					# We've started up successfully. Exit cleanly
 					log_end_msg 0
@@ -94,7 +93,7 @@ do_stop()
 	#   1 if daemon was already stopped
 	#   2 if daemon could not be stopped
 	#   other if a failure occurred
-	start-stop-daemon --stop --quiet --retry=30 --pidfile $PIDFILE --user $AGENT_USER --startas $AGENTPATH
+	start-stop-daemon --stop --quiet --retry=30 --pidfile $PIDFILE --user root --startas $AGENTPATH
 	RETVAL="$?"
 	rm -f $PIDFILE
 	return $RETVAL

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.security.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.security.erb
@@ -15,7 +15,6 @@ INSTALL_DIR="<%= install_dir %>"
 AGENTPATH="$INSTALL_DIR/embedded/bin/security-agent"
 PIDFILE="$INSTALL_DIR/run/security-agent.pid"
 AGENT_ARGS="start -c=$ETC_DIR/datadog.yaml -p=$PIDFILE"
-AGENT_USER="dd-agent"
 NAME="datadog-agent-security"
 DESC="Datadog Security Agent"
 

--- a/omnibus/config/templates/datadog-agent/upstart_debian.security.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.security.conf.erb
@@ -13,8 +13,6 @@ normal exit 0
 console log
 env DD_LOG_TO_CONSOLE=false
 
-setuid dd-agent
-
 script
   exec <%= install_dir %>/embedded/bin/security-agent start -c <%= etc_dir %>/datadog.yaml -p <%= install_dir %>/run/security-agent.pid
 end script

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -19,12 +19,9 @@ import (
 )
 
 // CreateSecurityAgentArchive packages up the files
-func CreateSecurityAgentArchive(local bool, logFilePath string) (string, error) {
+func CreateSecurityAgentArchive(local bool, logFilePath string, runtimeStatus map[string]interface{}) (string, error) {
 	zipFilePath := getArchivePath()
-	return createSecurityAgentArchive(zipFilePath, local, logFilePath)
-}
 
-func createSecurityAgentArchive(zipFilePath string, local bool, logFilePath string) (string, error) {
 	tempDir, err := createTempDir()
 	if err != nil {
 		return "", err
@@ -47,7 +44,7 @@ func createSecurityAgentArchive(zipFilePath string, local bool, logFilePath stri
 	} else {
 		// The Status will be unavailable unless the agent is running.
 		// Only zip it up if the agent is running
-		err = zipSecurityAgentStatusFile(tempDir, hostname)
+		err = zipSecurityAgentStatusFile(tempDir, hostname, runtimeStatus)
 		if err != nil {
 			log.Infof("Error getting the status of the Security Agent, %q", err)
 			return "", err
@@ -99,10 +96,10 @@ func createSecurityAgentArchive(zipFilePath string, local bool, logFilePath stri
 	return zipFilePath, nil
 }
 
-func zipSecurityAgentStatusFile(tempDir, hostname string) error {
+func zipSecurityAgentStatusFile(tempDir, hostname string, runtimeStatus map[string]interface{}) error {
 	// Grab the status
 	log.Infof("Zipping the status at %s for %s", tempDir, hostname)
-	s, err := status.GetAndFormatSecurityAgentStatus()
+	s, err := status.GetAndFormatSecurityAgentStatus(runtimeStatus)
 	if err != nil {
 		log.Infof("Error zipping the status: %q", err)
 		return err

--- a/pkg/flare/archive_security_test.go
+++ b/pkg/flare/archive_security_test.go
@@ -52,12 +52,10 @@ func TestCreateSecurityAgentArchive(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			zipFilePath := getArchivePath()
-			filePath, err := createSecurityAgentArchive(zipFilePath, test.local, logFilePath)
+			zipFilePath, err := CreateSecurityAgentArchive(test.local, logFilePath, nil)
 			defer os.Remove(zipFilePath)
 
 			assert.NoError(err)
-			assert.Equal(zipFilePath, filePath)
 
 			// asserts that it as indeed created a permissions.log file
 			z, err := zip.OpenReader(zipFilePath)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -188,11 +188,12 @@ func GetAndFormatDCAStatus() ([]byte, error) {
 }
 
 // GetAndFormatSecurityAgentStatus gets and formats the security agent status
-func GetAndFormatSecurityAgentStatus() ([]byte, error) {
+func GetAndFormatSecurityAgentStatus(runtimeStatus map[string]interface{}) ([]byte, error) {
 	s, err := GetStatus()
 	if err != nil {
 		return nil, err
 	}
+	s["runtimeSecurityStatus"] = runtimeStatus
 
 	statusJSON, err := json.Marshal(s)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Run the security agent as root and include runtime security status in flare

### Motivation

Security agent flare does not include runtime security status. Besides, the security-agent has to run as root