### PR TITLE
[runtime-security] fix parent discarder post event.basename PR

### DIFF
--- a/pkg/security/config/default.go
+++ b/pkg/security/config/default.go
@@ -32,9 +32,7 @@ rules:
     description: log entries removed
     expression: >-
       unlink.filename =~ "/var/log/*" &&
-      unlink.filename != "/var/log/datadog/system-probe.log" &&
-      unlink.basename !~ "*.tmp" &&
-      process.name != "kubelet"
+      unlink.filename != "/var/log/datadog/system-probe.log"
     tags:
       mitre: T1070
   - id: permissions_changed

--- a/pkg/security/probe/kfilters.go
+++ b/pkg/security/probe/kfilters.go
@@ -115,11 +115,18 @@ func isParentPathDiscarder(rs *rules.RuleSet, eventType eval.EventType, filename
 	//       ex: open.filename == "/etc/passwd"
 	//           open.basename == "shadow"
 	//       These rules won't return any discarder
-	isDiscarder, err := rs.IsDiscarder(eventType+".basename", path.Base(dirname))
-	if err != nil {
-		if _, ok := err.(*eval.ErrFieldNotFound); ok {
-			// no basename rule so we can discard
-			isDiscarder = true
+	var isDiscarder bool
+
+	field := eventType + ".basename"
+	if values := rs.GetFieldValues(field); len(values) == 0 {
+		isDiscarder = true
+	} else {
+		isDiscarder, err = rs.IsDiscarder(field, path.Base(dirname))
+		if err != nil {
+			if _, ok := err.(*eval.ErrFieldNotFound); ok {
+				// no basename rule so we can discard
+				isDiscarder = true
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR fix the parent discovery mechanism. 

### Motivation

As now all the events have a basename field the algorithm need to handle it properly. This will improve the performances.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Check in the log in DEBUG that a parent discarder is discovered when deleting a file in `/tmp` starting with `.` for examples
