### PR TITLE
[security-agent] Avoid supervisords crash loop when security agent is disabled

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	_ "expvar" // Blank import used because this isn't directly used in this file
 	"net/http"
@@ -161,6 +162,11 @@ func start(cmd *cobra.Command, args []string) error {
 	// Check if we have at least one component to start based on config
 	if !coreconfig.Datadog.GetBool("compliance_config.enabled") && !coreconfig.Datadog.GetBool("runtime_security_config.enabled") {
 		log.Infof("All security-agent components are deactivated, exiting")
+
+		// A sleep is necessary so that sysV doesn't think the agent has failed
+		// to startup because of an error. Only applies on Debian 7 and SUSE 11.
+		time.Sleep(5 * time.Second)
+
 		return nil
 	}
 

--- a/pkg/security/probe/kfilters.go
+++ b/pkg/security/probe/kfilters.go
@@ -124,7 +124,7 @@ func isParentPathDiscarder(rs *rules.RuleSet, eventType eval.EventType, filename
 	}
 
 	if isDiscarder {
-		log.Debugf("`%s` discovered as parent discarder", dirname)
+		log.Tracef("`%s` discovered as parent discarder", dirname)
 	}
 
 	return isDiscarder, nil

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -531,8 +531,6 @@ func (p *Probe) handleLostEvents(count uint64) {
 }
 
 func (p *Probe) handleEvent(data []byte) {
-	log.Debugf("Handling event (len %d)", len(data))
-
 	offset := 0
 	event := NewEvent(p.resolvers)
 
@@ -544,7 +542,7 @@ func (p *Probe) handleEvent(data []byte) {
 	offset += read
 
 	eventType := EventType(event.Type)
-	log.Debugf("Decoding event %s", eventType.String())
+	log.Tracef("Decoding event %s", eventType.String())
 
 	switch eventType {
 	case FileOpenEventType:
@@ -620,7 +618,7 @@ func (p *Probe) handleEvent(data []byte) {
 
 	p.eventsStats.CountEventType(eventType, 1)
 
-	log.Debugf("Dispatching event %+v\n", event)
+	log.Tracef("Dispatching event %+v\n", event)
 	p.DispatchEvent(event)
 }
 
@@ -631,7 +629,7 @@ func (p *Probe) OnNewDiscarder(rs *rules.RuleSet, event *Event, field eval.Field
 		return nil
 	}
 
-	log.Debugf("New discarder event %+v for field %s\n", event, field)
+	log.Tracef("New discarder event %+v for field %s\n", event, field)
 
 	eventType, err := event.GetFieldEventType(field)
 	if err != nil {

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -290,7 +290,7 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	if !exists {
 		return result
 	}
-	log.Debugf("Evaluating event of type `%s` against set of %d rules", eventType, len(bucket.rules))
+	log.Tracef("Evaluating event of type `%s` against set of %d rules", eventType, len(bucket.rules))
 
 	for _, rule := range bucket.rules {
 		if rule.GetEvaluator().Eval(ctx) {
@@ -302,7 +302,7 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	}
 
 	if !result {
-		log.Debugf("Looking for discarders for event of type `%s`", eventType)
+		log.Tracef("Looking for discarders for event of type `%s`", eventType)
 
 		for _, field := range bucket.fields {
 			evaluator, err := rs.model.GetEvaluator(field)
@@ -327,7 +327,7 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 				}
 			}
 			if isDiscarder {
-				log.Debugf("Found a discarder for field `%s` with value `%s`\n", field, value)
+				log.Tracef("Found a discarder for field `%s` with value `%s`\n", field, value)
 				rs.NotifyDiscarderFound(event, field)
 			}
 		}

--- a/pkg/security/tests/tests.go
+++ b/pkg/security/tests/tests.go
@@ -379,7 +379,7 @@ func (t *simpleTest) Path(filename string) (string, unsafe.Pointer, error) {
 func newSimpleTest(macros []*policy.MacroDefinition, rules []*policy.RuleDefinition) (*simpleTest, error) {
 	var logLevel seelog.LogLevel = seelog.InfoLvl
 	if testing.Verbose() {
-		logLevel = seelog.DebugLvl
+		logLevel = seelog.TraceLvl
 	}
 
 	logger, err := seelog.LoggerFromWriterWithMinLevelAndFormat(os.Stderr, logLevel, "%Ns [%LEVEL] %Msg\n")


### PR DESCRIPTION
### What does this PR do?

Wait 5 seconds when all security agent components are disabled.

### Motivation

Exiting too soon makes supervisords grumpy. Let's make it happy by sleeping a bit