### PR TITLE
[runtime-security] Do not mix pid, tgid while accessing pid_cache

### DIFF
--- a/pkg/security/ebpf/c/container.h
+++ b/pkg/security/ebpf/c/container.h
@@ -3,7 +3,7 @@
 
 #include "defs.h"
 
-struct proc_cache_t* get_pid_cache(u64 pid);
+struct proc_cache_t* get_pid_cache(u32 tgid);
 
 static __attribute__((always_inline)) u32 copy_container_id(char dst[CONTAINER_ID_LEN], char src[CONTAINER_ID_LEN]) {
     if (src[0] == 0) {

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -60,18 +60,16 @@ SYSCALL_KPROBE(execveat) {
     return trace__sys_execveat();
 }
 
-struct proc_cache_t * __attribute__((always_inline)) get_pid_cache(u64 pid) {
-    u32 pid_key = pid >> 32;
-    u32 *cookie = (u32 *) bpf_map_lookup_elem(&pid_cookie, &pid_key);
+struct proc_cache_t * __attribute__((always_inline)) get_pid_cache(u32 tgid) {
+    struct proc_cache_t *entry = NULL;
+
+    u32 *cookie = (u32 *) bpf_map_lookup_elem(&pid_cookie, &tgid);
     if (cookie) {
         // Select the old cache entry
         u32 cookie_key = *cookie;
-        struct proc_cache_t *entry = bpf_map_lookup_elem(&proc_cache, &cookie_key);
-        if (entry) {
-            return entry;
-        }
+        entry = bpf_map_lookup_elem(&proc_cache, &cookie_key);
     }
-    return 0;
+    return entry;
 }
 
 int __attribute__((always_inline)) vfs_handle_exec_event(struct pt_regs *ctx, struct syscall_cache_t *syscall) {
@@ -88,8 +86,10 @@ int __attribute__((always_inline)) vfs_handle_exec_event(struct pt_regs *ctx, st
     };
 
     // select parent cache entry
-    u64 pid = bpf_get_current_pid_tgid();
-    struct proc_cache_t *parent_entry = get_pid_cache(pid);
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 tgid = pid_tgid >> 32;
+
+    struct proc_cache_t *parent_entry = get_pid_cache(tgid);
     if (parent_entry) {
         // inherit container ID
         copy_container_id(entry.container_id, parent_entry->container_id);
@@ -100,7 +100,6 @@ int __attribute__((always_inline)) vfs_handle_exec_event(struct pt_regs *ctx, st
     bpf_map_update_elem(&proc_cache, &cookie, &entry, BPF_ANY);
 
     // insert pid <-> cookie mapping
-    u32 tgid = pid >> 32;
     bpf_map_update_elem(&pid_cookie, &tgid, &cookie, BPF_ANY);
 
     pop_syscall();
@@ -128,7 +127,8 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args)
 
 SEC("kprobe/do_exit")
 int kprobe_do_exit(struct pt_regs *ctx) {
-    u64 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
 
     // Delete pid <-> cookie mapping
     bpf_map_delete_elem(&pid_cookie, &pid);

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -159,7 +159,10 @@ int __attribute__((always_inline)) discard_by_flags(struct syscall_cache_t *sysc
 }
 
 int __attribute__((always_inline)) approve_by_process_inode(struct syscall_cache_t *syscall) {
-    struct proc_cache_t *proc = get_pid_cache(syscall->pid);
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 tgid = pid_tgid >> 32;
+
+    struct proc_cache_t *proc = get_pid_cache(tgid);
     if (!proc) {
         return 0;
     }
@@ -167,7 +170,7 @@ int __attribute__((always_inline)) approve_by_process_inode(struct syscall_cache
     struct filter_t *filter = bpf_map_lookup_elem(&open_process_inode_approvers, &inode);
     if (filter) {
 #ifdef DEBUG
-        bpf_printk("kprobe/vfs_open pid %d with inode %d approved\n", syscall->pid, inode);
+        bpf_printk("kprobe/vfs_open pid %d with inode %d approved\n", tgid, inode);
 #endif
         return 1;
     }

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -26,16 +26,19 @@ static struct proc_cache_t * __attribute__((always_inline)) fill_process_data(st
     bpf_get_current_comm(&data->comm, sizeof(data->comm));
 
     // Pid & Tid
-    u64 id = bpf_get_current_pid_tgid();
-    data->pid = id >> 32;
-    data->tid = id;
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 tgid = pid_tgid >> 32;
+
+    // https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#4-bpf_get_current_pid_tgid
+    data->pid = tgid;
+    data->tid = pid_tgid;
 
     // UID & GID
     u64 userid = bpf_get_current_uid_gid();
     data->uid = userid >> 32;
     data->gid = userid;
 
-    struct proc_cache_t *entry = get_pid_cache(data->pid);
+    struct proc_cache_t *entry = get_pid_cache(tgid);
     if (entry) {
         data->executable = entry->executable;
     }

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -12,7 +12,6 @@ struct syscall_cache_t {
     struct policy_t policy;
 
     u16 type;
-    u64 pid;
 
     union {
         struct {
@@ -98,8 +97,8 @@ struct bpf_map_def SEC("maps/syscalls") syscalls = {
 };
 
 void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t *syscall) {
-    syscall->pid = bpf_get_current_pid_tgid();
-    bpf_map_update_elem(&syscalls, &syscall->pid, syscall, BPF_ANY);
+    u64 key = bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&syscalls, &key, syscall, BPF_ANY);
 }
 
 struct syscall_cache_t * __attribute__((always_inline)) peek_syscall() {

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -602,8 +602,7 @@ func (e *UmountEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // ContainerEvent holds the container context of an event
 type ContainerEvent struct {
-	ID              string `field:"id" handler:"ResolveContainerID,string"`
-	OverlayNumlower uint32 `field:"overlay_numlower"`
+	ID string `field:"id" handler:"ResolveContainerID,string"`
 
 	IDRaw [64]byte `field:"-"`
 }
@@ -612,8 +611,7 @@ func (e *ContainerEvent) marshalJSON(resolvers *Resolvers) ([]byte, error) {
 	var buf bytes.Buffer
 	buf.WriteRune('{')
 	if id := e.GetContainerID(); len(id) > 0 {
-		fmt.Fprintf(&buf, `"container_id":"%s",`, id)
-		fmt.Fprintf(&buf, `"overlay_numlower":%d`, e.OverlayNumlower)
+		fmt.Fprintf(&buf, `"container_id":"%s"`, id)
 	}
 	buf.WriteRune('}')
 

--- a/pkg/security/probe/model_accessors.go
+++ b/pkg/security/probe/model_accessors.go
@@ -155,14 +155,6 @@ func (m *Model) GetEvaluator(field eval.Field) (eval.Evaluator, error) {
 			Field: field,
 		}, nil
 
-	case "container.overlay_numlower":
-
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Container.OverlayNumlower) },
-
-			Field: field,
-		}, nil
-
 	case "link.retval":
 
 		return &eval.IntEvaluator{
@@ -863,10 +855,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Container.ResolveContainerID(e.resolvers), nil
 
-	case "container.overlay_numlower":
-
-		return int(e.Container.OverlayNumlower), nil
-
 	case "link.retval":
 
 		return int(e.Link.Retval), nil
@@ -1203,9 +1191,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "container.id":
 		return "*", nil
 
-	case "container.overlay_numlower":
-		return "*", nil
-
 	case "link.retval":
 		return "link", nil
 
@@ -1487,10 +1472,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "container.id":
 
 		return reflect.String, nil
-
-	case "container.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "link.retval":
 
@@ -1909,15 +1890,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if e.Container.ID, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Container.ID"}
 		}
-		return nil
-
-	case "container.overlay_numlower":
-
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Container.OverlayNumlower"}
-		}
-		e.Container.OverlayNumlower = uint32(v)
 		return nil
 
 	case "link.retval":


### PR DESCRIPTION
### What does this PR do?

Keep using tgid while accessing the pid_cache map. Previously there was a mix causing lookup failure.

### Motivation

This fixes container_id in container context.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Generating an event from a container now reports the container_id.
