### PR TITLE
Do not log at warning level when version-history.json is absent

### DIFF
--- a/pkg/util/version_history.go
+++ b/pkg/util/version_history.go
@@ -40,7 +40,7 @@ func logVersionHistoryToFile(versionHistoryFilePath, agentVersion string, timest
 	history := versionHistoryEntries{}
 
 	if err != nil {
-		log.Warnf("Cannot read file: %s, will create a new one. %v", versionHistoryFilePath, err)
+		log.Infof("Cannot read file: %s, will create a new one. %v", versionHistoryFilePath, err)
 	} else {
 		err = json.Unmarshal(file, &history)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

When the `version-history.json` file is not found, log message at the `INFO` level instead of `WARN`.

### Motivation

The file is expected to not be present on fresh installs, so we shouldn't have this at warning level.

