### PR TITLE
pkg/trace/api: fix rate_by_service reply for v0.5

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -336,7 +336,7 @@ func (r *HTTPReceiver) replyOK(v Version, w http.ResponseWriter) {
 	switch v {
 	case v01, v02, v03:
 		httpOK(w)
-	case v04:
+	default:
 		httpRateByService(w, r.dynConf)
 	}
 }

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -724,6 +724,24 @@ func BenchmarkWatchdog(b *testing.B) {
 	}
 }
 
+func TestReplyOKV5(t *testing.T) {
+	r := newTestReceiverFromConfig(config.New())
+	r.Start()
+	defer r.Stop()
+
+	data, err := vmsgp.Marshal([2][]interface{}{{}, {}})
+	assert.NoError(t, err)
+	path := fmt.Sprintf("http://%s:%d/v0.5/traces", r.conf.ReceiverHost, r.conf.ReceiverPort)
+	resp, err := http.Post(path, "application/msgpack", bytes.NewReader(data))
+	assert.NoError(t, err)
+	slurp, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	assert.Contains(t, string(slurp), `"rate_by_service"`)
+}
+
 func TestExpvar(t *testing.T) {
 	if testing.Short() {
 		return


### PR DESCRIPTION
This change fixes a bug where requests to the v0.5 endpoint would not
return the rate_by_service values.

Bug introduced in #5965 