### PR TITLE
[pipeline] Add inv pipeline.run-all-tests for development

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,12 +135,13 @@ variables:
 # - web (when the build is triggered by a specific build request through the
 #        web interface.  This way, if a kitchen run is desired on a specific branch,
 #        it can be triggered by requesting a specific build)
+# - api (when the build is triggered by an API call)
 #
 .if_test_kitchen_deploy: &if_test_kitchen_deploy
-  if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_TAG != null || $DEPLOY_AGENT == "true" || $CI_PIPELINE_SOURCE == "web"
+  if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_TAG != null || $DEPLOY_AGENT == "true" || $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api"
 
 .if_not_test_kitchen_deploy: &if_not_test_kitchen_deploy
-  if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_TAG == null && $DEPLOY_AGENT != "true" && $CI_PIPELINE_SOURCE != "web"
+  if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_TAG == null && $DEPLOY_AGENT != "true" && $CI_PIPELINE_SOURCE != "web" && $CI_PIPELINE_SOURCE != "api"
 
 # true only on deploys and when RELEASE_VERSION_X is NOT "nightly". In this setting
 # we are building either a new tagged version of the agent (an RC for example).

--- a/tasks/deploy/pipeline_tools.py
+++ b/tasks/deploy/pipeline_tools.py
@@ -8,14 +8,17 @@ from .gitlab import Gitlab
 PIPELINE_FINISH_TIMEOUT_SEC = 3600 * 5
 
 
-def trigger_agent_pipeline(ref="master", release_version_6="nightly", release_version_7="nightly-a7", branch="nightly"):
+def trigger_agent_pipeline(
+    ref="master", release_version_6="nightly", release_version_7="nightly-a7", branch="nightly", deploy=True
+):
     """
     Trigger a pipeline to deploy an Agent to staging repos
     (as specified with the DEPLOY_AGENT arg).
     """
     args = {}
 
-    args["DEPLOY_AGENT"] = "true"
+    if deploy:
+        args["DEPLOY_AGENT"] = "true"
 
     if release_version_6 is not None:
         args["RELEASE_VERSION_6"] = release_version_6

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -25,8 +25,8 @@ def trigger(ctx, git_ref="master", release_version_6="nightly", release_version_
 @task
 def run_all_tests(ctx, git_ref="master", here=False, release_version_6="nightly", release_version_7="nightly-a7"):
     """
-    Trigger a pipeline on the given git ref, or on the current branch if --here is given. This pipeline will run
-    all tests, including kitchen tests.
+    Trigger a pipeline on the given git ref, or on the current branch if --here is given.
+    This pipeline will run all tests, including kitchen tests.
     The packages built won't be deployed to the staging repository. Use invoke pipeline.trigger if you want to
     deploy them.
     The --release-version-6 and --release-version-7 options indicate which release.json entries are used.

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -9,7 +9,17 @@ from .deploy.pipeline_tools import trigger_agent_pipeline, wait_for_pipeline
 
 @task
 def trigger(ctx, git_ref="master", release_version_6="nightly", release_version_7="nightly-a7", repo_branch="nightly"):
-    pipeline_id = trigger_agent_pipeline(git_ref, release_version_6, release_version_7, repo_branch)
+    pipeline_id = trigger_agent_pipeline(git_ref, release_version_6, release_version_7, repo_branch, deploy=True)
+    wait_for_pipeline("DataDog/datadog-agent", pipeline_id)
+
+
+@task
+def run_with_all_tests(
+    ctx, git_ref="master", here=False, release_version_6="nightly", release_version_7="nightly-a7", repo_branch="none"
+):
+    if here:
+        git_ref = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
+    pipeline_id = trigger_agent_pipeline(git_ref, release_version_6, release_version_7, repo_branch, deploy=False)
     wait_for_pipeline("DataDog/datadog-agent", pipeline_id)
 
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -14,6 +14,9 @@ def trigger(ctx, git_ref="master", release_version_6="nightly", release_version_
     The --release-version-6 and --release-version-7 options indicate which release.json entries are used.
     To not build Agent 6, set --release-version-6 "". To not build Agent 7, set --release-version-7 "".
     The --repo-branch option indicates which branch of the staging repository the packages will be deployed to.
+
+    Example:
+    inv pipeline.trigger --git-ref 7.22.0 --release-version-6 "6.22.0" --release-version-7 "7.22.0" --repo-branch "stable"
     """
     pipeline_id = trigger_agent_pipeline(git_ref, release_version_6, release_version_7, repo_branch, deploy=True)
     wait_for_pipeline("DataDog/datadog-agent", pipeline_id)
@@ -28,6 +31,10 @@ def run_all_tests(ctx, git_ref="master", here=False, release_version_6="nightly"
     deploy them.
     The --release-version-6 and --release-version-7 options indicate which release.json entries are used.
     To not build Agent 6, set --release-version-6 "". To not build Agent 7, set --release-version-7 "".
+
+    Examples:
+    inv pipeline.run-all-tests --git-ref my-branch
+    inv pipeline.run-all-tests --here
     """
     if here:
         git_ref = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
@@ -42,6 +49,11 @@ def follow(ctx, id=None, git_ref=None, here=False):
     Use --here to follow the latest pipeline on your current branch.
     Use --git-ref to follow the latest pipeline on a given tag or branch.
     Use --id to follow a specific pipeline.
+
+    Examples:
+    inv pipeline.follow --git-ref my-branch
+    inv pipeline.follow --here
+    inv pipeline.follow --id 1234567
     """
     if id is not None:
         wait_for_pipeline("DataDog/datadog-agent", id)


### PR DESCRIPTION
### What does this PR do?

Adds `invoke pipeline.run-all-tests [--git-ref <git-ref>] [--here] [--release-version-6 <version-6>] [--release-version-7 <version-7>]` to trigger a pipeline that runs kitchen tests (equivalent to using the "Run pipeline" UI option on Gitlab).

(name of the task subject to change if anyone has a better idea).

### Motivation

Have an easy way to run a pipeline with kitchen tests if needed (but without all the deploy jobs, which aren't usually necessary for development).

