### PR TITLE
[SNMP Trap] Fix snmpTrapOID  by using instance OID

### DIFF
--- a/pkg/snmp/traps/format.go
+++ b/pkg/snmp/traps/format.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	sysUpTimeInstanceOID = "1.3.6.1.2.1.1.3.0"
-	snmpTrapOID          = "1.3.6.1.6.3.1.1.4.1"
+	snmpTrapOID          = "1.3.6.1.6.3.1.1.4.1.0"
 )
 
 // FormatPacketToJSON converts an SNMP trap packet to a JSON-serializable object.

--- a/pkg/snmp/traps/format_test.go
+++ b/pkg/snmp/traps/format_test.go
@@ -69,7 +69,7 @@ func TestFormatPacketToJSONShouldFailIfNotEnoughVariables(t *testing.T) {
 
 	packet.Content.Variables = []gosnmp.SnmpPDU{
 		// snmpTrapOID and data, but no sysUpTimeInstance
-		{Name: "1.3.6.1.6.3.1.1.4.1", Type: gosnmp.OctetString, Value: "1.3.6.1.4.1.8072.2.3.0.1"},
+		{Name: "1.3.6.1.6.3.1.1.4.1.0", Type: gosnmp.OctetString, Value: "1.3.6.1.4.1.8072.2.3.0.1"},
 		{Name: "1.3.6.1.4.1.8072.2.3.2.1", Type: gosnmp.Integer, Value: 1024},
 		{Name: "1.3.6.1.4.1.8072.2.3.2.2", Type: gosnmp.OctetString, Value: "test"},
 	}

--- a/pkg/snmp/traps/testing.go
+++ b/pkg/snmp/traps/testing.go
@@ -26,7 +26,7 @@ var (
 		// sysUpTimeInstance
 		{Name: "1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(1000)},
 		// snmpTrapOID
-		{Name: "1.3.6.1.6.3.1.1.4.1", Type: gosnmp.OctetString, Value: "1.3.6.1.4.1.8072.2.3.0.1"},
+		{Name: "1.3.6.1.6.3.1.1.4.1.0", Type: gosnmp.OctetString, Value: "1.3.6.1.4.1.8072.2.3.0.1"},
 		// heartBeatRate
 		{Name: "1.3.6.1.4.1.8072.2.3.2.1", Type: gosnmp.Integer, Value: 1024},
 		// heartBeatName
@@ -115,7 +115,7 @@ func assertV2Variables(t *testing.T, packet *SnmpPacket) {
 	assert.Equal(t, gosnmp.TimeTicks, sysUptimeInstance.Type)
 
 	snmptrapOID := variables[1]
-	assert.Equal(t, ".1.3.6.1.6.3.1.1.4.1", snmptrapOID.Name)
+	assert.Equal(t, ".1.3.6.1.6.3.1.1.4.1.0", snmptrapOID.Name)
 	assert.Equal(t, gosnmp.OctetString, snmptrapOID.Type)
 	assert.Equal(t, "1.3.6.1.4.1.8072.2.3.0.1", string(snmptrapOID.Value.([]byte)))
 


### PR DESCRIPTION
Note: there is a QA tips section below

### What does this PR do?

Fix snmpTrapOID by using instance OID

With this fix:

```
2020-08-13 09:08:16 UTC | CORE | DEBUG | (pkg/snmp/traps/server.go:98 in func1) | Packet received from 127.0.0.1:57784 on listener localhost:1162
```

Initial SNMP Traps PR: https://github.com/DataDog/datadog-agent/pull/5470

### Motivation

Running

```
snmptrap -v 2c -c public localhost:1162 '' NET-SNMP-EXAMPLES-MIB::netSnmpExampleHeartbeatNotification netSnmpExampleHeartbeatRate i 123456

snmptrap --version
NET-SNMP version: 5.7.3

```

Getting this error:

```
2020-08-12 16:20:58 UTC | CORE | ERROR | (pkg/logs/input/traps/tailer.go:54 in run) | failed to format packet: expected OID 1.3.6.1.6.3.1.1.4.1, got 1.3.6.1.6.3.1.1.4.1.0
```

### QA

- Update `datadog.yaml`

```yaml
api_key: "******"  # dev org

logs_enabled: true

snmp_traps_enabled: true
snmp_traps_config:
  port: 1620
  community_strings:
    - public
```

- To send a test trap:

```bash
snmptrap -v 2c -c public localhost:1620 '' NET-SNMP-EXAMPLES-MIB::netSnmpExampleHeartbeatNotification netSnmpExampleHeartbeatRate i 123456
```

- Trap logs should show up in Staging Live Tail with `source:snmp`


- And check you can receive metrics in logs Live Tail. If yes, we are good.


