### PR TITLE
[security-agent] Fix broken flare with ConfigMaps - skip symlinks inside compliance.d and runtime.d

### DIFF
--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -134,7 +134,7 @@ func zipComplianceFiles(tempDir, hostname string, permsInfos permissionsInfos) e
 		if f == nil {
 			return nil
 		}
-		if f.IsDir() {
+		if f.IsDir() || f.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
 
@@ -161,7 +161,7 @@ func zipRuntimeFiles(tempDir, hostname string, permsInfos permissionsInfos) erro
 		if f == nil {
 			return nil
 		}
-		if f.IsDir() {
+		if f.IsDir() || f.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
 


### PR DESCRIPTION
### What does this PR do?

Addresses the issue with failing to create flare for `security-agent` when ConfigMaps are used to mount `compliance.d` and `runtime.d`. In this scenario paths will contain links `../data` which need to be skipped in the `filepath.Walk`.

### Motivation

Making sure `security-agent flare` command works in all scenarios.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
