### PR TITLE
Cleanup all system-probe modules on clean exit

### DIFF
--- a/cmd/system-probe/loader.go
+++ b/cmd/system-probe/loader.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
@@ -16,6 +17,7 @@ import (
 // * Module termination;
 // * Module telemetry consolidation;
 type Loader struct {
+	once    sync.Once
 	modules map[string]api.Module
 }
 
@@ -58,9 +60,11 @@ func (l *Loader) GetStats() map[string]interface{} {
 
 // Close each registered module
 func (l *Loader) Close() {
-	for _, module := range l.modules {
-		module.Close()
-	}
+	l.once.Do(func() {
+		for _, module := range l.modules {
+			module.Close()
+		}
+	})
 }
 
 // NewLoader returns a new Loader instance

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -153,6 +153,7 @@ func runAgent(exit <-chan struct{}) {
 	}()
 
 	<-exit
+	loader.Close()
 }
 
 func gracefulExit() {

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -105,6 +105,8 @@ func runAgent(exit <-chan struct{}) {
 	}
 
 	loader := NewLoader()
+	defer loader.Close()
+
 	httpMux := http.NewServeMux()
 
 	err = loader.Register(cfg, httpMux, factories)
@@ -153,7 +155,6 @@ func runAgent(exit <-chan struct{}) {
 	}()
 
 	<-exit
-	loader.Close()
 }
 
 func gracefulExit() {


### PR DESCRIPTION
### What does this PR do?

Close the loader on clean exit (and thus calling close on each system-probe module).

### Motivation

The system-probe was not cleaning up ebpf probes on exit. This was mistakenly removed in https://github.com/DataDog/datadog-agent/commit/0521efacae2f28823c402b518704e093eae0c87a

### Describe your test plan

1. Ensure no probes are installed, this command returns nothing: `sudo cat /sys/kernel/debug/tracing/kprobe_events`
    1. (if above command is non-empty, elevate to root `sudo su`, then run `echo > /sys/kernel/debug/tracing/kprobe_events`
1. Run `system-probe`
1. Confirm kprobes are installed with `sudo cat /sys/kernel/debug/tracing/kprobe_events`
1. Stop `system-probe` with `kill -SIGINT <pid>`
1. Confirm cleanup of kprobes: this command returns nothing: `sudo cat /sys/kernel/debug/tracing/kprobe_events`
