### PR TITLE
pkg/trace: add tests for sublayer annotation

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -296,6 +296,66 @@ func TestProcess(t *testing.T) {
 		// without missing a trace
 		assert.Equal(t, gotCount, len(traces))
 	})
+
+	t.Run("sublayer", func(t *testing.T) {
+		for _, tt := range []struct {
+			trace pb.Trace
+			f     func(t *testing.T, spans []*pb.Span)
+		}{
+			{
+				trace: pb.Trace{
+					{
+						Service: "something &&<@# that should be a metric!",
+						TraceID: 1,
+						SpanID:  1,
+						Metrics: map[string]float64{sampler.KeySamplingPriority: 2},
+					},
+					{
+						Service:  "something &&<@# that should be a metric!",
+						TraceID:  1,
+						SpanID:   2,
+						ParentID: 1,
+						Metrics:  map[string]float64{sampler.KeySamplingPriority: 2},
+					},
+				},
+				f: func(t *testing.T, spans []*pb.Span) { assert.Equal(t, 2.0, spans[0].Metrics["_sublayers.span_count"]) },
+			},
+			{
+				trace: pb.Trace{
+					{
+						Service: "something &&<@# that should be a metric!",
+						TraceID: 1,
+						SpanID:  1,
+						Metrics: map[string]float64{sampler.KeySamplingPriority: -1},
+					},
+					{
+						Service:  "something &&<@# that should be a metric!",
+						TraceID:  1,
+						SpanID:   2,
+						ParentID: 1,
+						Metrics:  map[string]float64{sampler.KeySamplingPriority: -1},
+					},
+				},
+				f: func(t *testing.T, spans []*pb.Span) { assert.NotContains(t, spans[0].Metrics, "_sublayers.span_count") },
+			},
+		} {
+			t.Run("", func(t *testing.T) {
+				cfg := config.New()
+				cfg.Endpoints[0].APIKey = "test"
+				ctx, cancel := context.WithCancel(context.Background())
+				agnt := NewAgent(ctx, cfg)
+				cancel()
+
+				traces := pb.Traces{tt.trace}
+				traceutil.SetTopLevel(tt.trace[0], true)
+				agnt.Process(&api.Payload{
+					Traces: traces,
+					Source: agnt.Receiver.Stats.GetTagStats(info.Tags{}),
+				}, stats.NewSublayerCalculator())
+				tt.f(t, tt.trace)
+			})
+		}
+	})
 }
 
 func TestSampling(t *testing.T) {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -305,13 +305,11 @@ func TestProcess(t *testing.T) {
 			{
 				trace: pb.Trace{
 					{
-						Service: "something &&<@# that should be a metric!",
 						TraceID: 1,
 						SpanID:  1,
 						Metrics: map[string]float64{sampler.KeySamplingPriority: 2},
 					},
 					{
-						Service:  "something &&<@# that should be a metric!",
 						TraceID:  1,
 						SpanID:   2,
 						ParentID: 1,
@@ -323,13 +321,11 @@ func TestProcess(t *testing.T) {
 			{
 				trace: pb.Trace{
 					{
-						Service: "something &&<@# that should be a metric!",
 						TraceID: 1,
 						SpanID:  1,
 						Metrics: map[string]float64{sampler.KeySamplingPriority: -1},
 					},
 					{
-						Service:  "something &&<@# that should be a metric!",
 						TraceID:  1,
 						SpanID:   2,
 						ParentID: 1,

--- a/pkg/trace/test/testsuite/sublayers_test.go
+++ b/pkg/trace/test/testsuite/sublayers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/test"
@@ -84,17 +85,19 @@ func TestSublayerDurations(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer r.KillAgent()
-
+	baseStart := agent.Year2000NanosecTS
 	span := func(id, parentId uint64, service, spanType string, start, duration int64) *pb.Span {
 		return &pb.Span{
+			Name:     "foo",
+			Resource: "foo",
 			TraceID:  1,
 			SpanID:   id,
 			ParentID: parentId,
 			Service:  service,
 			Type:     spanType,
-			Start:    start,
+			Start:    baseStart + start,
 			Duration: duration,
-			Metrics:  make(map[string]float64),
+			Metrics:  map[string]float64{},
 		}
 	}
 	payload := pb.Traces{{
@@ -123,23 +126,23 @@ func TestSublayerDurations(t *testing.T) {
 			metric    string
 			duration  float64
 		}{
-			{0, "_sublayers.duration.by_service.sublayer_service:web-server", 130.0},
-			{0, "_sublayers.duration.by_service.sublayer_service:pg", 50.0},
-			{0, "_sublayers.duration.by_service.sublayer_service:render", 30.0},
-			{0, "_sublayers.duration.by_service.sublayer_service:pg-read", 30.0},
-			{0, "_sublayers.duration.by_service.sublayer_service:redis", 55.0},
-			{0, "_sublayers.duration.by_service.sublayer_service:rpc1", 60.0},
-			{0, "_sublayers.duration.by_service.sublayer_service:alert", 40.0},
-			{0, "_sublayers.duration.by_type.sublayer_type:cache", 55.000000},
-			{0, "_sublayers.duration.by_type.sublayer_type:db", 80.000000},
-			{0, "_sublayers.duration.by_type.sublayer_type:rpc", 100.000000},
-			{0, "_sublayers.duration.by_type.sublayer_type:web", 160.000000},
-			{1, "_sublayers.duration.by_service.sublayer_service:pg", 50.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:web-server", 15.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:pg", 12.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:render", 15.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:pg-read", 15.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:redis", 27.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:rpc1", 30.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:alert", 35.0},
+			{0, "_sublayers.duration.by_type.sublayer_type:cache", 27.0},
+			{0, "_sublayers.duration.by_type.sublayer_type:db", 27.0},
+			{0, "_sublayers.duration.by_type.sublayer_type:rpc", 65.0},
+			{0, "_sublayers.duration.by_type.sublayer_type:web", 30.0},
+			{1, "_sublayers.duration.by_service.sublayer_service:pg", 20.0},
 			{1, "_sublayers.duration.by_service.sublayer_service:pg-read", 30.0},
-			{1, "_sublayers.duration.by_type.sublayer_type:db", 80.000000},
-			{5, "_sublayers.duration.by_service.sublayer_service:rpc1", 60.0},
+			{1, "_sublayers.duration.by_type.sublayer_type:db", 50.0},
+			{5, "_sublayers.duration.by_service.sublayer_service:rpc1", 50.0},
 			{5, "_sublayers.duration.by_service.sublayer_service:alert", 40.0},
-			{5, "_sublayers.duration.by_type.sublayer_type:rpc", 100.000000},
+			{5, "_sublayers.duration.by_type.sublayer_type:rpc", 90.0},
 		} {
 			val, ok := spans[tt.spanIndex].Metrics[tt.metric]
 			if !ok {

--- a/pkg/trace/test/testsuite/sublayers_test.go
+++ b/pkg/trace/test/testsuite/sublayers_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package testsuite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
+	"github.com/DataDog/datadog-agent/pkg/trace/test"
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+)
+
+func TestSublayers(t *testing.T) {
+	r := test.Runner{Verbose: true}
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := r.Shutdown(time.Second); err != nil {
+			t.Log("shutdown: ", err)
+		}
+	}()
+	if err := r.RunAgent(nil); err != nil {
+		t.Fatal(err)
+	}
+	defer r.KillAgent()
+
+	span1 := testutil.TestSpan()
+	span1.SpanID = 1
+	span2 := testutil.TestSpan()
+	span2.SpanID = 2
+	span2.TraceID = span1.TraceID
+	span2.ParentID = span1.SpanID
+	span3 := testutil.TestSpan()
+	span3.SpanID = 3
+	span3.TraceID = span1.TraceID
+	span3.ParentID = span2.SpanID
+	traceutil.SetTopLevel(span1, true)
+	payload := pb.Traces{pb.Trace{span1, span2, span3}, pb.Trace{testutil.RandomSpan()}}
+	payload[0][0].Metrics[sampler.KeySamplingPriority] = 2
+	payload[1][0].Metrics[sampler.KeySamplingPriority] = -1
+	if err := r.Post(payload); err != nil {
+		t.Fatal(err)
+	}
+	waitForTrace(t, &r, func(v pb.TracePayload) {
+		if n := len(v.Traces); n != 1 {
+			t.Fatalf("expected %d traces, got %d", 1, n)
+		}
+		if n := len(v.Traces[0].Spans); n != len(payload[0]) {
+			t.Fatalf("expected %d spans, got %d", len(payload[0]), n)
+		}
+		span := v.Traces[0].Spans[0]
+		if n := span.Metrics["_sublayers.span_count"]; n != float64(len(payload[0])) {
+			t.Fatalf(`expected span.Metrics["_sublayers.span_count"] == %d, but was got %f`, len(payload[0]), n)
+		}
+	})
+}

--- a/pkg/trace/test/testsuite/sublayers_test.go
+++ b/pkg/trace/test/testsuite/sublayers_test.go
@@ -127,14 +127,14 @@ func TestSublayerDurations(t *testing.T) {
 			duration  float64
 		}{
 			{0, "_sublayers.duration.by_service.sublayer_service:web-server", 15.0},
-			{0, "_sublayers.duration.by_service.sublayer_service:pg", 12.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:pg", 13.0},
 			{0, "_sublayers.duration.by_service.sublayer_service:render", 15.0},
 			{0, "_sublayers.duration.by_service.sublayer_service:pg-read", 15.0},
-			{0, "_sublayers.duration.by_service.sublayer_service:redis", 27.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:redis", 28.0},
 			{0, "_sublayers.duration.by_service.sublayer_service:rpc1", 30.0},
 			{0, "_sublayers.duration.by_service.sublayer_service:alert", 35.0},
-			{0, "_sublayers.duration.by_type.sublayer_type:cache", 27.0},
-			{0, "_sublayers.duration.by_type.sublayer_type:db", 27.0},
+			{0, "_sublayers.duration.by_type.sublayer_type:cache", 28.0},
+			{0, "_sublayers.duration.by_type.sublayer_type:db", 28.0},
 			{0, "_sublayers.duration.by_type.sublayer_type:rpc", 65.0},
 			{0, "_sublayers.duration.by_type.sublayer_type:web", 30.0},
 			{1, "_sublayers.duration.by_service.sublayer_service:pg", 20.0},

--- a/pkg/trace/test/testsuite/sublayers_test.go
+++ b/pkg/trace/test/testsuite/sublayers_test.go
@@ -6,6 +6,7 @@
 package testsuite
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -16,7 +17,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
-func TestSublayers(t *testing.T) {
+type BySpanID []*pb.Span
+
+func (s BySpanID) Len() int           { return len(s) }
+func (s BySpanID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s BySpanID) Less(i, j int) bool { return s[i].SpanID < s[j].SpanID }
+
+func TestSublayerCounts(t *testing.T) {
 	r := test.Runner{Verbose: true}
 	if err := r.Start(); err != nil {
 		t.Fatal(err)
@@ -55,9 +62,91 @@ func TestSublayers(t *testing.T) {
 		if n := len(v.Traces[0].Spans); n != len(payload[0]) {
 			t.Fatalf("expected %d spans, got %d", len(payload[0]), n)
 		}
+		sort.Sort(BySpanID(v.Traces[0].Spans))
 		span := v.Traces[0].Spans[0]
 		if n := span.Metrics["_sublayers.span_count"]; n != float64(len(payload[0])) {
 			t.Fatalf(`expected span.Metrics["_sublayers.span_count"] == %d, but was got %f`, len(payload[0]), n)
+		}
+	})
+}
+
+func TestSublayerDurations(t *testing.T) {
+	r := test.Runner{Verbose: true}
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := r.Shutdown(time.Second); err != nil {
+			t.Log("shutdown: ", err)
+		}
+	}()
+	if err := r.RunAgent(nil); err != nil {
+		t.Fatal(err)
+	}
+	defer r.KillAgent()
+
+	span := func(id, parentId uint64, service, spanType string, start, duration int64) *pb.Span {
+		return &pb.Span{
+			TraceID:  1,
+			SpanID:   id,
+			ParentID: parentId,
+			Service:  service,
+			Type:     spanType,
+			Start:    start,
+			Duration: duration,
+			Metrics:  make(map[string]float64),
+		}
+	}
+	payload := pb.Traces{{
+		span(1, 0, "web-server", "web", 0, 130),
+		span(2, 1, "pg", "db", 10, 50),
+		span(3, 1, "render", "web", 80, 30),
+		span(4, 2, "pg-read", "db", 20, 30),
+		span(5, 1, "redis", "cache", 15, 55),
+		span(6, 1, "rpc1", "rpc", 60, 60),
+		span(7, 6, "alert", "rpc", 110, 40),
+	}}
+	if err := r.Post(payload); err != nil {
+		t.Fatal(err)
+	}
+	waitForTrace(t, &r, func(v pb.TracePayload) {
+		if n := len(v.Traces); n != len(payload) {
+			t.Fatalf("expected %d traces, got %d", len(payload), n)
+		}
+		if n := len(v.Traces[0].Spans); n != len(payload[0]) {
+			t.Fatalf("expected %d spans, got %d", len(payload[0]), n)
+		}
+		spans := v.Traces[0].Spans
+		sort.Sort(BySpanID(spans))
+		for _, tt := range []struct {
+			spanIndex int
+			metric    string
+			duration  float64
+		}{
+			{0, "_sublayers.duration.by_service.sublayer_service:web-server", 130.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:pg", 50.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:render", 30.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:pg-read", 30.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:redis", 55.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:rpc1", 60.0},
+			{0, "_sublayers.duration.by_service.sublayer_service:alert", 40.0},
+			{0, "_sublayers.duration.by_type.sublayer_type:cache", 55.000000},
+			{0, "_sublayers.duration.by_type.sublayer_type:db", 80.000000},
+			{0, "_sublayers.duration.by_type.sublayer_type:rpc", 100.000000},
+			{0, "_sublayers.duration.by_type.sublayer_type:web", 160.000000},
+			{1, "_sublayers.duration.by_service.sublayer_service:pg", 50.0},
+			{1, "_sublayers.duration.by_service.sublayer_service:pg-read", 30.0},
+			{1, "_sublayers.duration.by_type.sublayer_type:db", 80.000000},
+			{5, "_sublayers.duration.by_service.sublayer_service:rpc1", 60.0},
+			{5, "_sublayers.duration.by_service.sublayer_service:alert", 40.0},
+			{5, "_sublayers.duration.by_type.sublayer_type:rpc", 100.000000},
+		} {
+			val, ok := spans[tt.spanIndex].Metrics[tt.metric]
+			if !ok {
+				t.Errorf(`Expected spans[%d].Metrics to contain the key "%s", but it was not present.`, tt.spanIndex, tt.metric)
+			} else if val != tt.duration {
+				t.Errorf(`Expected spans[%d].Metrics["%s"] == %f, but got %f.`, tt.spanIndex, tt.metric, tt.duration, val)
+			}
 		}
 	})
 }


### PR DESCRIPTION
This adds tests to ensure that sublayer annotation is done when a trace is
sampled, and not done when the trace is not sampled.

This relates to #5961

There should be no release notes related to this change, as it only adds tests and will not affect the end user.

### Motivation

This testing was performed as part of QA for release 7.22.0
