### PR TITLE
[pkg/collector] Fix return value from crash handling function

### DIFF
--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -322,6 +322,8 @@ DATADOG_AGENT_RTLOADER_API const char *get_error(const rtloader_t *);
     provide the go-routine dump. If you need both, just crash twice trying both options :)
 
     Currently only SEGFAULT is handled.
+
+    The returned error C-string must be freed by the caller.
 */
 DATADOG_AGENT_RTLOADER_API int handle_crashes(const int, char **error);
 #endif

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -412,7 +412,7 @@ DATADOG_AGENT_RTLOADER_API int handle_crashes(const int enable, char **error)
         *error = strdupe(err_msg.str().c_str());
     }
 
-    return err;
+    return err == 0 ? 1 : 0;
 }
 #endif
 


### PR DESCRIPTION
### What does this PR do?

- Fix `handle_crashes` return value.
- Update docs to reflect who has to free the `error` C-string.

### Motivation

- Found in QA for #6055

### Additional Notes

- Docstring comment is missing for `make2` and `make3`. Should it be added there too?

### Describe your test plan

- On a Linux machine, set `c_stacktrace_collection` and `c_core_dump` options. Check that there is no`handle_crashes` function error reported.
