### PR TITLE
Fix a panic in system-probe when eBPF code cannot be compiled

### DIFF
--- a/cmd/system-probe/loader.go
+++ b/cmd/system-probe/loader.go
@@ -23,8 +23,6 @@ type Loader struct {
 // * Initialization using the provided Factory;
 // * Registering the HTTP endpoints of each module;
 func (l *Loader) Register(cfg *config.AgentConfig, httpMux *http.ServeMux, factories []api.Factory) error {
-	atLeastOneModuleLoaded := false
-
 	for _, factory := range factories {
 		module, err := factory.Fn(cfg)
 
@@ -48,10 +46,9 @@ func (l *Loader) Register(cfg *config.AgentConfig, httpMux *http.ServeMux, facto
 		l.modules[factory.Name] = module
 
 		log.Infof("module: %s started", factory.Name)
-		atLeastOneModuleLoaded = true
 	}
 
-	if !atLeastOneModuleLoaded {
+	if len(l.modules) == 0 {
 		return errors.New("no module could be loaded")
 	}
 

--- a/cmd/system-probe/loader.go
+++ b/cmd/system-probe/loader.go
@@ -36,12 +36,13 @@ func (l *Loader) Register(cfg *config.AgentConfig, httpMux *http.ServeMux, facto
 		// In case a module failed to be started, do not make the whole `system-probe` abort.
 		// Let `system-probe` run the other modules.
 		if err != nil {
-			log.Errorf("new module `%s` error: %v", factory.Name, err)
+			log.Errorf("new module `%s` error: %w", factory.Name, err)
 			continue
 		}
 
 		if err = module.Register(httpMux); err != nil {
-			return errors.Wrapf(err, "error registering HTTP endpoints for module `%s` error", factory.Name)
+			log.Errorf("error registering HTTP endpoints for module `%s` error: %w", factory.Name, err)
+			continue
 		}
 
 		l.modules[factory.Name] = module

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -21,7 +21,11 @@ var OOMKillProbe = api.Factory{
 
 		log.Infof("Starting the OOM Kill probe")
 		okp, err := ebpf.NewOOMKillProbe(config.SysProbeConfigFromConfig(cfg))
-		return &oomKillModule{okp}, err
+		if err != nil {
+			log.Errorf("unable to start the OOM kill probe: %v", err)
+			return nil, err
+		}
+		return &oomKillModule{okp}, nil
 	},
 }
 

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
 // OOMKillProbe Factory
@@ -22,8 +23,7 @@ var OOMKillProbe = api.Factory{
 		log.Infof("Starting the OOM Kill probe")
 		okp, err := ebpf.NewOOMKillProbe(config.SysProbeConfigFromConfig(cfg))
 		if err != nil {
-			log.Errorf("unable to start the OOM kill probe: %v", err)
-			return nil, err
+			return nil, errors.Wrapf(err, "unable to start the OOM kill probe")
 		}
 		return &oomKillModule{okp}, nil
 	},

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -22,6 +22,7 @@ var TCPQueueLength = api.Factory{
 		t, err := ebpf.NewTCPQueueLengthTracer(config.SysProbeConfigFromConfig(cfg))
 		if err != nil {
 			log.Errorf("unable to start the TCP queue length tracer: %v", err)
+			return nil, err
 		}
 
 		return &tcpQueueLengthModule{t}, nil

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
 // TCPQueueLength Factory
@@ -21,8 +22,7 @@ var TCPQueueLength = api.Factory{
 
 		t, err := ebpf.NewTCPQueueLengthTracer(config.SysProbeConfigFromConfig(cfg))
 		if err != nil {
-			log.Errorf("unable to start the TCP queue length tracer: %v", err)
-			return nil, err
+			return nil, errors.Wrapf(err, "unable to start the TCP queue length tracer")
 		}
 
 		return &tcpQueueLengthModule{t}, nil


### PR DESCRIPTION
### What does this PR do?

Fix a panic in `system-probe` when eBPF code cannot be compiled.

### Motivation

Here is the panic that this change is fixing:
```
2020-08-13 08:53:46 UTC | SYS-PROBE | INFO | (cmd/system-probe/loader.go:44 in Register) | module: network_tracer started
sh: 1: modprobe: not found
chdir(/lib/modules/4.19.112+/build): No such file or directory
2020-08-13 08:53:46 UTC | SYS-PROBE | ERROR | (cmd/system-probe/modules/tcp_queue_tracer.go:24 in func4) | unable to start the TCP queue length tracer: Failed to compile "tcp-queue-length-kern.c"
sh: 1: modprobe: not found
2020-08-13 08:53:46 UTC | SYS-PROBE | INFO | (cmd/system-probe/loader.go:44 in Register) | module: tcp_queue_length_tracer started
chdir(/lib/modules/4.19.112+/build): No such file or directory
2020-08-13 08:53:46 UTC | SYS-PROBE | INFO | (cmd/system-probe/modules/oom_kill_probe.go:22 in func2) | Starting the OOM Kill probe
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1d11c82]
goroutine 1 [running]:
github.com/DataDog/datadog-agent/pkg/ebpf.(*TCPQueueLengthTracer).Close(0x0)
	/go/src/github.com/DataDog/datadog-agent/pkg/ebpf/tcp_queue_length.go:83 +0x22
main.(*Loader).Close(0xc0000d40f0)
	/go/src/github.com/DataDog/datadog-agent/cmd/system-probe/loader.go:62 +0x82
main.runAgent(0xc0001ce060)
	/go/src/github.com/DataDog/datadog-agent/cmd/system-probe/main.go:112 +0x627
main.main()
	/go/src/github.com/DataDog/datadog-agent/cmd/system-probe/main_linux.go:21 +0x209
```

### Additional Notes

`system-probe` is now handling several eBPF modules:
* `network_tracer` which rely on offset guessing;
* `tcp_queue_length_tracer` and `oom_kill_probe ` which are relying on runtime eBPF compilation;
* `security runtime`

Those modules are coming with different host requirements and we can imagine that, on some hosts, only the offset guessing based modules are failing and on some other hosts, only the runtime eBPF compilation based modules are failing.

Previously, `system-probe` was exiting if any module was failing to start.
With this change, `system-probe` will keep on running with the modules that could be started even if some others failed to start.

### Describe your test plan

Start the agent with `system-probe` enabled as well as the eBPF-based checks.
```
system_probe_config:
  enable_oom_kill: true
  enable_tcp_queue_length: true
```
on nodes where the kernel headers are not available, like COS GKE nodes for example. (Ubuntu GKE nodes have the kernel headers installed so that there is no issue on those ones.)