### PR TITLE
fix: add missing modprobe command to datadog-agent container

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -16,7 +16,7 @@ ENV S6_VERSION v1.22.1.0
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz /output/s6.tgz
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz.sig /tmp/s6.tgz.sig
 RUN apt-get update \
- && apt-get install --no-install-recommends -y gpg gpg-agent curl ca-certificates \
+ && apt-get install --no-install-recommends -y gpg gpg-agent curl ca-certificates kmod \
  && curl https://keybase.io/justcontainers/key.asc | gpg --import \
  && gpg --verify /tmp/s6.tgz.sig /output/s6.tgz
 

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -16,7 +16,7 @@ ENV S6_VERSION v1.22.1.0
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-aarch64.tar.gz /output/s6.tgz
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-aarch64.tar.gz.sig /tmp/s6.tgz.sig
 RUN apt-get update \
- && apt-get install --no-install-recommends -y gpg gpg-agent curl ca-certificates \
+ && apt-get install --no-install-recommends -y gpg gpg-agent curl ca-certificates kmod \
  && curl https://keybase.io/justcontainers/key.asc | gpg --import \
  && gpg --verify /tmp/s6.tgz.sig /output/s6.tgz
 


### PR DESCRIPTION
### What does this PR do?
Add `modprobe` command that is missing inside `agent` container  more info in [#6215](https://github.com/DataDog/datadog-agent/issues/6215)
### Motivation
Fix broken system-probe functionality on Kubernetes nodes. 
