### PR TITLE
[CustomAction] Log an error if first LookupAccountName fails

### DIFF
--- a/tools/windows/install-help/cal/userrights.cpp
+++ b/tools/windows/install-help/cal/userrights.cpp
@@ -17,6 +17,7 @@ PSID GetSidForUser(LPCWSTR host, LPCWSTR user) {
 	DWORD err = GetLastError();
 	if (ERROR_INSUFFICIENT_BUFFER != err) {
 		// we don't know what happened
+		WcaLog(LOGMSG_STANDARD, "First call to LookupAccountName failed with %d", GetLastError());
 		return NULL;
 	}
 	newsid = (SID *) new BYTE[cbSid];

--- a/tools/windows/install-help/cal/userrights.cpp
+++ b/tools/windows/install-help/cal/userrights.cpp
@@ -17,7 +17,7 @@ PSID GetSidForUser(LPCWSTR host, LPCWSTR user) {
 	DWORD err = GetLastError();
 	if (ERROR_INSUFFICIENT_BUFFER != err) {
 		// we don't know what happened
-		WcaLog(LOGMSG_STANDARD, "First call to LookupAccountName failed with %d", GetLastError());
+		WcaLog(LOGMSG_STANDARD, "First call to LookupAccountName failed with %d", err);
 		return NULL;
 	}
 	newsid = (SID *) new BYTE[cbSid];


### PR DESCRIPTION
### What does this PR do?

Log the error before we return null.

### Motivation

Even if we don't pass a buffer, this could still fail if the user doesn't
exist and probably for more reasons.
