### PR TITLE
[runtime-security] Only delete pid_cache entry in do_exit on process exit not thread

### DIFF
--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -128,10 +128,13 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args)
 SEC("kprobe/do_exit")
 int kprobe_do_exit(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    u32 pid = pid_tgid >> 32;
+    u32 tgid = pid_tgid >> 32;
+    u32 pid = pid_tgid;
 
     // Delete pid <-> cookie mapping
-    bpf_map_delete_elem(&pid_cookie, &pid);
+    if (tgid == pid) {
+        bpf_map_delete_elem(&pid_cookie, &tgid);
+    }
     // (do not delete cookie <-> proc_cache entry since it can be used by a parent process)
     return 0;
 }


### PR DESCRIPTION
### What does this PR do?

Fixes container-id not reported due to parent pid_cache deleted on newly created container.

### Motivation

Parent pid cache entry was not found as it was deleted due to thread exit. Container-id was working only when a process was started in a container before system-probe was started.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Exec in a container after system-probe started should report now the container-id
