### PR TITLE
[KSMv2] Rename job_name label

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
@@ -20,7 +20,7 @@ var (
 	// defaultLabelsMapper contains the default label to tag names mapping
 	defaultLabelsMapper = map[string]string{
 		"namespace":                        "kube_namespace",
-		"job":                              "kube_job",
+		"job_name":                         "kube_job",
 		"cronjob":                          "kube_cronjob",
 		"pod":                              "pod_name",
 		"phase":                            "pod_phase",


### PR DESCRIPTION
### What does this PR do?

remap `job_name` label to `kube_job` 

### Motivation

KSM job metrics have `job_name` labels instead of `job` 
https://github.com/kubernetes/kube-state-metrics/blob/master/docs/job-metrics.md
