### PR TITLE
[SNMP Trap] Add snmp_traps_config.stop_timeout to config.go

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -416,7 +416,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("snmp_traps_config.port", 162)
 	config.BindEnvAndSetDefault("snmp_traps_config.community_strings", []string{})
 	config.BindEnvAndSetDefault("snmp_traps_config.bind_host", "localhost")
-	config.BindEnvAndSetDefault("snmp_traps_config.stop_timeout", 5.0)
+	config.BindEnvAndSetDefault("snmp_traps_config.stop_timeout", 5) // in seconds
 
 	// Kube ApiServer
 	config.BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -416,6 +416,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("snmp_traps_config.port", 162)
 	config.BindEnvAndSetDefault("snmp_traps_config.community_strings", []string{})
 	config.BindEnvAndSetDefault("snmp_traps_config.bind_host", "localhost")
+	config.BindEnvAndSetDefault("snmp_traps_config.stop_timeout", 5.0)
 
 	// Kube ApiServer
 	config.BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")

--- a/pkg/snmp/traps/config.go
+++ b/pkg/snmp/traps/config.go
@@ -8,8 +8,6 @@ package traps
 import (
 	"errors"
 	"fmt"
-	"time"
-
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/soniah/gosnmp"
 )
@@ -22,10 +20,10 @@ func IsEnabled() bool {
 // Config contains configuration for SNMP trap listeners.
 // YAML field tags provided for test marshalling purposes.
 type Config struct {
-	Port             uint16        `mapstructure:"port" yaml:"port"`
-	CommunityStrings []string      `mapstructure:"community_strings" yaml:"community_strings"`
-	BindHost         string        `mapstructure:"bind_host" yaml:"bind_host"`
-	StopTimeout      time.Duration `mapstructure:"stop_timeout" yaml:"stop_timeout"`
+	Port             uint16   `mapstructure:"port" yaml:"port"`
+	CommunityStrings []string `mapstructure:"community_strings" yaml:"community_strings"`
+	BindHost         string   `mapstructure:"bind_host" yaml:"bind_host"`
+	StopTimeout      int      `mapstructure:"stop_timeout" yaml:"stop_timeout"`
 }
 
 // ReadConfig builds and returns configuration from Agent configuration.

--- a/pkg/snmp/traps/config_test.go
+++ b/pkg/snmp/traps/config_test.go
@@ -6,11 +6,9 @@
 package traps
 
 import (
-	"testing"
-	"time"
-
 	"github.com/soniah/gosnmp"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestConfig(t *testing.T) {
@@ -60,16 +58,16 @@ func TestDefaultStopTimeout(t *testing.T) {
 	config, err := ReadConfig()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 5*time.Second, config.StopTimeout)
+	assert.Equal(t, 5, config.StopTimeout)
 }
 
 func TestStopTimeout(t *testing.T) {
 	Configure(t, Config{
 		CommunityStrings: []string{"public"},
-		StopTimeout:      11 * time.Second,
+		StopTimeout:      11,
 	})
 	config, err := ReadConfig()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 11*time.Second, config.StopTimeout)
+	assert.Equal(t, 11, config.StopTimeout)
 }

--- a/pkg/snmp/traps/config_test.go
+++ b/pkg/snmp/traps/config_test.go
@@ -7,6 +7,7 @@ package traps
 
 import (
 	"testing"
+	"time"
 
 	"github.com/soniah/gosnmp"
 	"github.com/stretchr/testify/assert"
@@ -50,4 +51,25 @@ func TestCommunityStringsMissing(t *testing.T) {
 	Configure(t, Config{})
 	_, err := ReadConfig()
 	assert.Error(t, err)
+}
+
+func TestDefaultStopTimeout(t *testing.T) {
+	Configure(t, Config{
+		CommunityStrings: []string{"public"},
+	})
+	config, err := ReadConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 5 * time.Second, config.StopTimeout)
+}
+
+func TestStopTimeout(t *testing.T) {
+	Configure(t, Config{
+		CommunityStrings: []string{"public"},
+		StopTimeout: 11 * time.Second,
+	})
+	config, err := ReadConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 11 * time.Second, config.StopTimeout)
 }

--- a/pkg/snmp/traps/config_test.go
+++ b/pkg/snmp/traps/config_test.go
@@ -60,16 +60,16 @@ func TestDefaultStopTimeout(t *testing.T) {
 	config, err := ReadConfig()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 5 * time.Second, config.StopTimeout)
+	assert.Equal(t, 5*time.Second, config.StopTimeout)
 }
 
 func TestStopTimeout(t *testing.T) {
 	Configure(t, Config{
 		CommunityStrings: []string{"public"},
-		StopTimeout: 11 * time.Second,
+		StopTimeout:      11 * time.Second,
 	})
 	config, err := ReadConfig()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 11 * time.Second, config.StopTimeout)
+	assert.Equal(t, 11*time.Second, config.StopTimeout)
 }

--- a/pkg/snmp/traps/constants.go
+++ b/pkg/snmp/traps/constants.go
@@ -5,10 +5,8 @@
 
 package traps
 
-import "time"
-
 const (
 	defaultPort        = uint16(162) // Standard UDP port for traps.
-	defaultStopTimeout = 5 * time.Second
+	defaultStopTimeout = 5
 	packetsChanSize    = 100
 )

--- a/pkg/snmp/traps/server.go
+++ b/pkg/snmp/traps/server.go
@@ -138,8 +138,8 @@ func (s *TrapServer) Stop() {
 
 	select {
 	case <-stopped:
-	case <-time.After(s.config.StopTimeout):
-		log.Error("Stopping server timed out")
+	case <-time.After(time.Duration(s.config.StopTimeout) * time.Second):
+		log.Error("Stopping server. Timeout after: %d", s.config.StopTimeout)
 	}
 
 	// Let consumers know that we will not be sending any more packets.

--- a/pkg/snmp/traps/server.go
+++ b/pkg/snmp/traps/server.go
@@ -139,7 +139,7 @@ func (s *TrapServer) Stop() {
 	select {
 	case <-stopped:
 	case <-time.After(time.Duration(s.config.StopTimeout) * time.Second):
-		log.Error("Stopping server. Timeout after: %d", s.config.StopTimeout)
+		log.Errorf("Stopping server. Timeout after: %d", s.config.StopTimeout)
 	}
 
 	// Let consumers know that we will not be sending any more packets.

--- a/pkg/snmp/traps/server.go
+++ b/pkg/snmp/traps/server.go
@@ -139,7 +139,7 @@ func (s *TrapServer) Stop() {
 	select {
 	case <-stopped:
 	case <-time.After(time.Duration(s.config.StopTimeout) * time.Second):
-		log.Errorf("Stopping server. Timeout after: %d", s.config.StopTimeout)
+		log.Errorf("Stopping server. Timeout after %d seconds", s.config.StopTimeout)
 	}
 
 	// Let consumers know that we will not be sending any more packets.


### PR DESCRIPTION
Note: there is a QA tips section below

### What does this PR do?

Add snmp_traps_config.stop_timeout to config.go

Initial SNMP Traps PR: https://github.com/DataDog/datadog-agent/pull/5470

### Motivation

The config was missing. Leading to unknown config error when trying to use it.

### QA


- Update `datadog.yaml`

```yaml
api_key: "******"  # dev org

logs_enabled: true

snmp_traps_enabled: true
snmp_traps_config:
  port: 1620
  community_strings:
    - public
```

- Stop the agent: `sudo systemctl stop datadog-agent.service`

- You should see a log saying the Trap server is being stopped.

- It's not easy to simulate a real timeout with a slow snmp server, the QA above is reasonably enough.
