### PR TITLE
[SNMP Trap] Remove snmp trap device port tag

### DIFF
--- a/pkg/snmp/traps/format.go
+++ b/pkg/snmp/traps/format.go
@@ -27,7 +27,6 @@ func GetTags(packet *SnmpPacket) []string {
 	return []string{
 		fmt.Sprintf("snmp_version:%s", formatVersion(packet)),
 		fmt.Sprintf("snmp_device:%s", packet.Addr.IP.String()),
-		fmt.Sprintf("snmp_device_port:%d", packet.Addr.Port),
 	}
 }
 

--- a/pkg/snmp/traps/format_test.go
+++ b/pkg/snmp/traps/format_test.go
@@ -83,7 +83,6 @@ func TestGetTags(t *testing.T) {
 	assert.Equal(t, tags, []string{
 		"snmp_version:2",
 		"snmp_device:127.0.0.1",
-		"snmp_device_port:13156",
 	})
 }
 
@@ -95,6 +94,5 @@ func TestGetTagsForUnsupportedVersionShouldStillSucceed(t *testing.T) {
 	assert.Equal(t, tags, []string{
 		"snmp_version:unknown",
 		"snmp_device:127.0.0.1",
-		"snmp_device_port:13156",
 	})
 }


### PR DESCRIPTION
Note: there is a QA tips section below

### What does this PR do?

Remove snmp trap device port tag

Initial SNMP Traps PR: https://github.com/DataDog/datadog-agent/pull/5470

### Motivation

Device port can be random and create a lot of contexts.


### QA

- Update `datadog.yaml`

```yaml
api_key: "******"  # dev org

logs_enabled: true

snmp_traps_enabled: true
snmp_traps_config:
  port: 1620
  community_strings:
    - public
```

- To send a test trap:

```bash
snmptrap -v 2c -c public localhost:1620 '' NET-SNMP-EXAMPLES-MIB::netSnmpExampleHeartbeatNotification netSnmpExampleHeartbeatRate i 123456
```

- Trap logs should show up in Staging Live Tail with `source:snmp`


- Verify that logs don't contain `snmp_device_port` tag


