### PR TITLE
[KSMv2] Set kube_cluster_name tag for all metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state.go
@@ -19,6 +19,7 @@ import (
 	kubestatemetrics "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"gopkg.in/yaml.v2"
@@ -385,9 +386,13 @@ func (k *KSMCheck) mergeLabelJoins(extra map[string]*JoinsConfig) {
 }
 
 // initTags avoids keeping a nil Tags field in the check instance
+// and sets the kube_cluster_name tag for all metrics
 func (k *KSMCheck) initTags() {
 	if k.instance.Tags == nil {
 		k.instance.Tags = []string{}
+	}
+	if clusterName := clustername.GetClusterName(); clusterName != "" {
+		k.instance.Tags = append(k.instance.Tags, "kube_cluster_name:"+clusterName)
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
@@ -32,7 +32,6 @@ var (
 		"container":                        "kube_container_name",
 		"container_id":                     "container_id",
 		"image":                            "image_name",
-		"node":                             "host",
 		"label_tags_datadoghq_com_env":     "env",
 		"label_tags_datadoghq_com_service": "service",
 		"label_tags_datadoghq_com_version": "version",

--- a/pkg/collector/corechecks/cluster/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_test.go
@@ -104,7 +104,7 @@ func TestProcessMetrics(t *testing.T) {
 				{
 					name:     "kubernetes_state.container.running",
 					val:      1,
-					tags:     []string{"kube_container_name:kube-state-metrics", "kube_namespace:default", "pod_name:kube-state-metrics-b7fbc487d-4phhj", "host:minikube"},
+					tags:     []string{"kube_container_name:kube-state-metrics", "kube_namespace:default", "pod_name:kube-state-metrics-b7fbc487d-4phhj", "node:minikube"},
 					hostname: "minikube",
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

- Always add a default tag `kube_cluster_name`
- Keep the node label as tag (same as v1)

### Motivation

- Make it easier to identify the metrics that have empty hostnames
