### PR TITLE
[process-agent] Skip containers collection for macOS

### DIFF
--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -30,6 +30,10 @@ func SetContainerSources(names []string) {
 // GetContainers autodetects the best backend from available sources
 // if the users don't specify the preferred container sources
 func GetContainers() ([]*containers.Container, error) {
+	// The docker build tag is no longer removed for darwin. However, there's no
+	// provider that implements containers collection on this platform. This check
+	// must be skipped until it's safe to remove the build tag or a darwin
+	// provider is implemented.
 	if runtime.GOOS == "darwin" {
 		return nil, fmt.Errorf("containers collection not available for darwin")
 	}

--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -31,7 +31,7 @@ func SetContainerSources(names []string) {
 // if the users don't specify the preferred container sources
 func GetContainers() ([]*containers.Container, error) {
 	if runtime.GOOS == "darwin" {
-		nil, fmt.Errorf("containers collection not available for darwin")
+		return nil, fmt.Errorf("containers collection not available for darwin")
 	}
 
 	// Detect sources

--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -28,6 +30,10 @@ func SetContainerSources(names []string) {
 // GetContainers autodetects the best backend from available sources
 // if the users don't specify the preferred container sources
 func GetContainers() ([]*containers.Container, error) {
+	if runtime.GOOS == "darwin" {
+		nil, fmt.Errorf("containers collection not available for darwin")
+	}
+
 	// Detect sources
 	if detectors == nil {
 		// Container sources aren't configured, autodetect the best available source


### PR DESCRIPTION
### What does this PR do?

If docker is running on macOS, the process-agent detects `docker` as a container collector and uses it to collect container data. However, there's no [ContainerImplementation](https://github.com/DataDog/datadog-agent/pull/4885) for docker on `darwin` yet, which makes the agent fail. 

This PR updates the `GetContainers` function to return before trying to detect a container source. This function is called when process-agent is being initialized and every time a process check is performed.

### Motivation

The process-agent crashes on macOS when Docker is also running on the host
```
panic: Trying to get nil ContainerInterface
goroutine 1 [running]:
github.com/DataDog/datadog-agent/pkg/util/containers/providers.ContainerImpl(...)
	/private/var/cache/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/containers/providers/provider.go:20
github.com/DataDog/datadog-agent/pkg/util/docker.(*DockerUtil).ListContainers(0xc00014c000, 0xc0001d3010, 0xc0007ca600, 0x17, 0x1, 0xc0007ca600, 0x17)
	/private/var/cache/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/docker/containers.go:40 +0x121b
github.com/DataDog/datadog-agent/pkg/util/containers/collectors.(*DockerCollector).List(0xc00070d640, 0xc0007ca600, 0x17, 0x0, 0x0, 0x0)
	/private/var/cache/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/containers/collectors/docker.go:43 +0x37
github.com/DataDog/datadog-agent/pkg/process/util.GetContainers(0xc0007a1d28, 0x400e816, 0xc0007028e0, 0x20, 0x20)
	/private/var/cache/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/process/util/containers.go:62 +0x5fa
github.com/DataDog/datadog-agent/pkg/process/config.NewAgentConfig(0x6158797, 0x7, 0x618a402, 0x1f, 0x6196b39, 0x24, 0xd0, 0xd0, 0x5f17500)
	/private/var/cache/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/process/config/config.go:302 +0x34
main.runAgent(0xc0003d60c0)
	/private/var/cache/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/process-agent/main_common.go:95 +0x9f
main.main()
	/private/var/cache/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/process-agent/main.go:24 +0x3b8
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
