### PR TITLE
Add eBPF benchmarks that measure probe runtime

### DIFF
--- a/bootstrap.json
+++ b/bootstrap.json
@@ -13,7 +13,8 @@
             "github.com/frapposelli/wwhrd",
             "github.com/goware/modvendor",
             "github.com/shuLhan/go-bindata/cmd/go-bindata",
-            "honnef.co/go/tools/cmd/staticcheck"
+            "honnef.co/go/tools/cmd/staticcheck",
+            "github.com/golang/perf/cmd/benchstat"
         ],
         "golang.org/x/tools/go/ast/astutil": {
             "version": "release-branch.go1.13",
@@ -67,6 +68,10 @@
         },
         "github.com/goware/modvendor": {
             "version": "892bf4ecb805b052575eb45070a60f9db471df8e",
+            "type": "go"
+        },
+        "github.com/golang/perf/cmd/benchstat": {
+            "version": "9c9101da83161dff5e53fc89bf35ed49ea286db8",
             "type": "go"
         }
     }

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/DataDog/agent-payload v4.40.0+incompatible
 	github.com/DataDog/datadog-go v3.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200527110245-7850164045c8
-	github.com/DataDog/ebpf v0.0.0-20200810204017-170f39a7810a
+	github.com/DataDog/ebpf v0.0.0-20200813173322-0c621fa94637
 	github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect
@@ -153,7 +153,7 @@ require (
 	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed
+	golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/DataDog/ebpf v0.0.0-20200728214655-d148b742bc92 h1:F+vgt0/dSR6v3jvw2b
 github.com/DataDog/ebpf v0.0.0-20200728214655-d148b742bc92/go.mod h1:KNnyHMGc9auLVSPvYY8ws1BRvZP5THoxJuhfEOsuW7U=
 github.com/DataDog/ebpf v0.0.0-20200810204017-170f39a7810a h1:oFmjBcE1Oq3YyWfs8K2HszM+G/hAmRwZEqy6IwcEP6o=
 github.com/DataDog/ebpf v0.0.0-20200810204017-170f39a7810a/go.mod h1:KNnyHMGc9auLVSPvYY8ws1BRvZP5THoxJuhfEOsuW7U=
+github.com/DataDog/ebpf v0.0.0-20200813173322-0c621fa94637 h1:JsOzZpmDuaPP7tBqeNoPGbb+yYz4BtPa/gZci3TxZIs=
+github.com/DataDog/ebpf v0.0.0-20200813173322-0c621fa94637/go.mod h1:KNnyHMGc9auLVSPvYY8ws1BRvZP5THoxJuhfEOsuW7U=
 github.com/DataDog/gobpf v0.0.0-20200131184214-6763fd92fd3f h1:vPk11ERhqpKweLLyXanBlUwKFdkpqDTEDWanr/fLZok=
 github.com/DataDog/gobpf v0.0.0-20200131184214-6763fd92fd3f/go.mod h1:rNvi5cSHdpxN6495MOYAWN3yukac8lORoluL+9Osrsw=
 github.com/DataDog/gobpf v0.0.0-20200728095841-88e65b29b186 h1:M/TmXm0VnfBmg9zkqdz+JQpaPgdgohQ81UE+tClyGiQ=
@@ -1552,6 +1554,8 @@ golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 h1:sIky/MyNRSHTrdxfsiUSS4WIA
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed h1:WBkVNH1zd9jg/dK4HCM4lNANnmd12EHC9z+LmcCG4ns=
 golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d h1:QQrM/CCYEzTs91GZylDCQjGHudbPTxF/1fvXdVh5lMo=
+golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180805044716-cb6730876b98/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/ebpf/benchmark_test.go
+++ b/pkg/ebpf/benchmark_test.go
@@ -55,7 +55,7 @@ func setBPFStatsCollection(b *testing.B, enable bool) error {
 	}
 	cmd := exec.Command("sysctl", "-w", fmt.Sprintf("kernel.bpf_stats_enabled=%d", flag))
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("error enabling bpf stats: %s %w", out, err)
+		return fmt.Errorf("error setting sysctl kernel.bpf_stats_enabled: %s %w", out, err)
 	}
 	return nil
 }

--- a/pkg/ebpf/benchmark_test.go
+++ b/pkg/ebpf/benchmark_test.go
@@ -96,14 +96,14 @@ func RunEBPFBenchmark(b *testing.B, fn func(*testing.B)) {
 
 	err := setBPFStatsCollection(b, true)
 	if err != nil {
-		log.Fatal(err)
+		b.Fatal(err)
 	}
 	defer setBPFStatsCollection(b, false)
 
 	// Enable BPF-based system probe
 	t, err := NewTracer(NewDefaultConfig())
 	if err != nil {
-		log.Fatal(err)
+		b.Fatal(err)
 	}
 	defer t.Stop()
 

--- a/pkg/ebpf/benchmark_test.go
+++ b/pkg/ebpf/benchmark_test.go
@@ -1,0 +1,156 @@
+// +build linux_bpf
+
+package ebpf
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	bpflib "github.com/DataDog/ebpf"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	bpfToolPath       string
+	currKernelVersion uint32
+	readVars          sync.Once
+)
+
+type bpftoolStats struct {
+	RunTimeNS float64 `json:"run_time_ns"`
+	RunCnt    float64 `json:"run_cnt"`
+
+	XlatedBytes float64 `json:"bytes_xlated"`
+	JITedBytes  float64 `json:"bytes_jited"`
+}
+
+func readGlobalVars() {
+	var err error
+	currKernelVersion, err = bpflib.CurrentKernelVersion()
+	if err != nil {
+		log.Fatalf("unable to read kernel version: %s\n", err)
+	}
+	bpfToolPath, err = exec.LookPath("bpftool")
+	if err != nil {
+		log.Fatalf("unable to find bpftool in PATH: %s\n", err)
+	}
+}
+
+func setBPFStatsCollection(b *testing.B, enable bool) error {
+	if currKernelVersion < stringToKernelCode("5.1.0") {
+		b.Skip("kernel version must be at least 5.1.0 for kernel-level eBPF stats collection")
+		return nil
+	}
+
+	flag := 0
+	if enable {
+		flag = 1
+	}
+	cmd := exec.Command("sysctl", "-w", fmt.Sprintf("kernel.bpf_stats_enabled=%d", flag))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("error enabling bpf stats: %s %w", out, err)
+	}
+	return nil
+}
+
+func collectBPFToolStats(progID uint32) (*bpftoolStats, error) {
+	cmd := exec.Command(bpfToolPath, "--json", "prog", "show", "id", fmt.Sprintf("%d", progID))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("error collecting bpf stats: %s %w", out, err)
+	}
+	stats := bpftoolStats{}
+	err = json.Unmarshal(out, &stats)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling json from bpftool: %s", err)
+	}
+	return &stats, nil
+}
+
+func getAllProbeStats(t *Tracer) (map[string]*bpftoolStats, error) {
+	ids, err := t.getProbeProgramIDs()
+	if err != nil {
+		return nil, err
+	}
+
+	allStats := make(map[string]*bpftoolStats, len(ids))
+	for name, id := range ids {
+		stats, err := collectBPFToolStats(id)
+		if err != nil {
+			return nil, err
+		}
+		allStats[name] = stats
+	}
+	return allStats, nil
+}
+
+func RunEBPFBenchmark(b *testing.B, fn func(*testing.B)) {
+	readVars.Do(readGlobalVars)
+
+	err := setBPFStatsCollection(b, true)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer setBPFStatsCollection(b, false)
+
+	// Enable BPF-based system probe
+	t, err := NewTracer(NewDefaultConfig())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer t.Stop()
+
+	var prs map[string]*testing.BenchmarkResult
+	b.Run("probes", func(b *testing.B) {
+		baseline, err := getAllProbeStats(t)
+		require.NoError(b, err)
+
+		b.ResetTimer()
+		fn(b)
+		b.StopTimer()
+
+		post, err := getAllProbeStats(t)
+		require.NoError(b, err)
+
+		// override outer variable here so we only report on the last run of results
+		prs = make(map[string]*testing.BenchmarkResult, len(baseline))
+		for probeName, base := range baseline {
+			p := post[probeName]
+			runTime := p.RunTimeNS - base.RunTimeNS
+			runCount := p.RunCnt - base.RunCnt
+			prs[probeName] = &testing.BenchmarkResult{
+				N: int(runCount),
+				T: time.Duration(runTime) * time.Nanosecond,
+			}
+		}
+	})
+	fmt.Print(prettyPrintEBPFResults(b.Name(), prs))
+}
+
+func prettyPrintEBPFResults(name string, probeResults map[string]*testing.BenchmarkResult) string {
+	maxLen := 0
+	var probeNames []string
+	for pName := range probeResults {
+		if len(pName) > maxLen {
+			maxLen = len(pName)
+		}
+		probeNames = append(probeNames, pName)
+	}
+	sort.Strings(probeNames)
+	buf := new(strings.Builder)
+	for _, probeName := range probeNames {
+		pr := probeResults[probeName]
+		if pr.N == 0 {
+			continue
+		}
+		fmt.Fprintf(buf, "%s/%-*s\t%s\n", name, maxLen, probeName, pr.String())
+	}
+	return buf.String()
+}

--- a/pkg/ebpf/testdata/run_latency_bench.sh
+++ b/pkg/ebpf/testdata/run_latency_bench.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+if [ "${EUID}" != "0" ]
+then
+  echo "Error: this command must be run as root" >&2
+  exit 1
+fi
+
+if ! [ -x "$(command -v benchstat)" ]
+then
+  echo "Error: benchstat could not be found" >&2
+  exit 1
+fi
+
+now=$(date -u +"%Y-%m-%dT%H%M%S")
+RESFILE=/tmp/ebpf-bench-results.${now}
+STATFILE=/tmp/ebpf-bench-benchstat.${now}
+
+# using the test.count flag doesn't let us report probe times for each iteration
+# use bash loop instead
+for _ in {1..5}
+do
+  go test \
+    -mod=vendor \
+    -tags linux_bpf,ebpf_bindata \
+    ./pkg/ebpf/... \
+    -bench BenchmarkTCPLatency \
+    -count=1 \
+    -run XXX \
+    >> "${RESFILE}"
+  go test \
+    -mod=vendor \
+    -tags linux_bpf,ebpf_bindata \
+    ./pkg/ebpf/... \
+    -bench BenchmarkUDPLatency \
+    -count=1 \
+    -run XXX \
+    >> "${RESFILE}"
+done
+
+benchstat -sort name "${RESFILE}" > "${STATFILE}"
+echo "${RESFILE}"
+echo "${STATFILE}"

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -796,7 +796,7 @@ func (t *Tracer) getProbeProgramIDs() (map[string]uint32, error) {
 		}
 		prog := p.Program()
 		if prog == nil {
-			fmt.Printf("unable to find program for %s\n", p.Section)
+			log.Debugf("unable to find program for %s\n", p.Section)
 			continue
 		}
 		id, err := prog.ID()

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -787,3 +787,23 @@ func (t *Tracer) determineConnectionDirection(conn *network.ConnectionStats) net
 
 	return network.OUTGOING
 }
+
+func (t *Tracer) getProbeProgramIDs() (map[string]uint32, error) {
+	fds := make(map[string]uint32, 0)
+	for _, p := range t.m.Probes {
+		if !p.Enabled {
+			continue
+		}
+		prog := p.Program()
+		if prog == nil {
+			fmt.Printf("unable to find program for %s\n", p.Section)
+			continue
+		}
+		id, err := prog.ID()
+		if err != nil {
+			return nil, err
+		}
+		fds[p.Section] = uint32(id)
+	}
+	return fds, nil
+}

--- a/pkg/ebpf/tracer_benchmark_test.go
+++ b/pkg/ebpf/tracer_benchmark_test.go
@@ -1,0 +1,95 @@
+// +build linux_bpf
+
+package ebpf
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func BenchmarkTCPLatency(b *testing.B) {
+	RunEBPFBenchmark(b, benchLatencyEchoTCP(64))
+}
+
+func BenchmarkUDPLatency(b *testing.B) {
+	RunEBPFBenchmark(b, benchLatencyEchoUDP(64))
+}
+
+func benchLatencyEchoTCP(size int) func(b *testing.B) {
+	payload := genPayload(size)
+	echoOnMessage := func(c net.Conn) {
+		r := bufio.NewReader(c)
+		for {
+			buf, err := r.ReadBytes(byte('\n'))
+			if err == io.EOF {
+				c.Close()
+				return
+			}
+			c.Write(buf)
+		}
+	}
+
+	return func(b *testing.B) {
+		end := make(chan struct{})
+		server := NewTCPServer(echoOnMessage)
+		server.Run(end)
+		defer close(end)
+
+		c, err := net.DialTimeout("tcp", server.address, 50*time.Millisecond)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer c.Close()
+		r := bufio.NewReader(c)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.Write(payload)
+			buf, err := r.ReadBytes(byte('\n'))
+
+			if err != nil || len(buf) != len(payload) || !bytes.Equal(payload, buf) {
+				b.Fatalf("Sizes: %d, %d. Equal: %v. Error: %s", len(buf), len(payload), bytes.Equal(payload, buf), err)
+			}
+		}
+		b.StopTimer()
+	}
+}
+
+func benchLatencyEchoUDP(size int) func(b *testing.B) {
+	payload := genPayload(size)
+	echoOnMessage := func(b []byte, n int) []byte {
+		resp := make([]byte, len(b))
+		copy(resp, b)
+		return resp
+	}
+
+	return func(b *testing.B) {
+		end := make(chan struct{})
+		server := NewUDPServer(echoOnMessage)
+		server.Run(end, size)
+		defer close(end)
+
+		c, err := net.DialTimeout("udp", server.address, 50*time.Millisecond)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer c.Close()
+		r := bufio.NewReader(c)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.Write(payload)
+			buf := make([]byte, size)
+			n, err := r.Read(buf)
+
+			if err != nil || n != len(payload) || !bytes.Equal(payload, buf) {
+				b.Fatalf("Sizes: %d, %d. Equal: %v. Error: %s", len(buf), len(payload), bytes.Equal(payload, buf), err)
+			}
+		}
+		b.StopTimer()
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a framework for running benchmarks and reporting the runtime and trigger count for eBPF probes. Also adds a bash script to run the benchmarks multiple times to report a variance value using `benchstat`.

### Motivation

The networks team wanted a way to measure and prevent regressions to eBPF performance.

### Additional Notes

Requires linux kernel `5.1` or greater and `bpftool`. This could be improved in the future to use `BPF_OBJ_GET_INFO_BY_FD` to avoid need to call `bpftool`.

Example output:
```
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/ebpf
BenchmarkTCPLatency/probes-4         	   66741	     20344 ns/op
BenchmarkTCPLatency/kprobe/sys_bind           	       1	       568 ns/op
BenchmarkTCPLatency/kprobe/sys_socket         	       3	      1110 ns/op
BenchmarkTCPLatency/kprobe/tcp_cleanup_rbuf   	  266952	       295 ns/op
BenchmarkTCPLatency/kprobe/tcp_close          	       3	      1977 ns/op
BenchmarkTCPLatency/kprobe/tcp_sendmsg        	  133482	       685 ns/op
BenchmarkTCPLatency/kprobe/tcp_set_state      	      10	       350 ns/op
BenchmarkTCPLatency/kprobe/tcp_v4_destroy_sock	       3	       300 ns/op
BenchmarkTCPLatency/kprobe/udp_destroy_sock   	       1	       607 ns/op
BenchmarkTCPLatency/kretprobe/inet_csk_accept 	       2	       971 ns/op
BenchmarkTCPLatency/kretprobe/sys_bind        	       1	       539 ns/op
BenchmarkTCPLatency/kretprobe/sys_socket      	       3	      1155 ns/op
BenchmarkTCPLatency/kretprobe/tcp_close       	       3	      7856 ns/op
BenchmarkTCPLatency/socket/dns_filter         	  271176	        68.1 ns/op

goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/ebpf
BenchmarkUDPLatency/probes-4         	   81630	     18142 ns/op
BenchmarkUDPLatency/kprobe/sys_bind           	       1	      1396 ns/op
BenchmarkUDPLatency/kprobe/sys_socket         	       2	      1334 ns/op
BenchmarkUDPLatency/kprobe/udp_destroy_sock   	       2	      1548 ns/op
BenchmarkUDPLatency/kprobe/udp_recvmsg        	  321011	       174 ns/op
BenchmarkUDPLatency/kprobe/udp_sendmsg        	  163260	       363 ns/op
BenchmarkUDPLatency/kretprobe/sys_bind        	       1	      1192 ns/op
BenchmarkUDPLatency/kretprobe/sys_socket      	       2	       886 ns/op
BenchmarkUDPLatency/kretprobe/udp_recvmsg     	  321011	       272 ns/op
BenchmarkUDPLatency/socket/dns_filter         	  326520	        57.0 ns/op
```

```
name                                   time/op
TCPLatency/kprobe/sys_bind               650ns ±15%
TCPLatency/kprobe/sys_socket            1.00µs ±23%
TCPLatency/kprobe/tcp_cleanup_rbuf       256ns ±15%
TCPLatency/kprobe/tcp_close             1.84µs ±13%
TCPLatency/kprobe/tcp_sendmsg            605ns ±13%
TCPLatency/kprobe/tcp_set_state          414ns ±20%
TCPLatency/kprobe/tcp_v4_destroy_sock    244ns ±48%
TCPLatency/kprobe/udp_destroy_sock       649ns ±18%
TCPLatency/kretprobe/inet_csk_accept     789ns ±23%
TCPLatency/kretprobe/sys_bind            698ns ±23%
TCPLatency/kretprobe/sys_socket         1.13µs ± 2%
TCPLatency/kretprobe/tcp_close         3.95µs ±135%
TCPLatency/probes-4                     17.7µs ±16%
TCPLatency/socket/dns_filter            58.2ns ±18%
UDPLatency/kprobe/sys_bind              1.37µs ± 6%
UDPLatency/kprobe/sys_socket            1.28µs ± 5%
UDPLatency/kprobe/udp_destroy_sock      1.22µs ±32%
UDPLatency/kprobe/udp_recvmsg            163ns ± 9%
UDPLatency/kprobe/udp_sendmsg            335ns ± 8%
UDPLatency/kretprobe/sys_bind           1.45µs ±22%
UDPLatency/kretprobe/sys_socket         1.16µs ±23%
UDPLatency/kretprobe/udp_recvmsg         249ns ±10%
UDPLatency/probes-4                     16.7µs ±12%
UDPLatency/socket/dns_filter            54.9ns ±13%
```
