### PR TITLE
[telemetry] Fix scheduler queue count telemetry metric

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -105,7 +105,7 @@ var (
 	aggregatorHostnameUpdate                   = expvar.Int{}
 
 	tlmFlush = telemetry.NewCounter("aggregator", "flush",
-		[]string{"data_type", "state"}, "Count of flush")
+		[]string{"data_type", "state"}, "Number of metrics/service checks/events flushed")
 	tlmProcessed = telemetry.NewCounter("aggregator", "processed",
 		[]string{"data_type"}, "Amount of metrics/services_checks/events processed by the aggregator")
 	tlmHostnameUpdate = telemetry.NewCounter("aggregator", "hostname_update",

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -27,7 +27,7 @@ var (
 	tlmChecksEntered = telemetry.NewGauge("scheduler", "checks_entered",
 		[]string{"check_name"}, "How many checks are currently tracked by the scheduler")
 	tlmQueuesCount = telemetry.NewCounter("scheduler", "queues_count",
-		[]string{"check_name"}, "How many queues were opened")
+		nil, "How many queues were opened")
 )
 
 func init() {
@@ -92,7 +92,7 @@ func (s *Scheduler) Enter(check check.Check) error {
 		s.jobQueues[check.Interval()] = newJobQueue(check.Interval())
 		s.startQueue(s.jobQueues[check.Interval()])
 		if check.IsTelemetryEnabled() {
-			tlmQueuesCount.Inc(check.String())
+			tlmQueuesCount.Inc()
 		}
 		schedulerQueuesCount.Add(1)
 	}


### PR DESCRIPTION
### What does this PR do?

Fixes scheduler queue count telemetry metric + updates a telemetry metric description.

### Motivation

It was tagged by check_name, which doesn't make sense since it's
incremented when a new scheduler queue is created, so it should
count the total number of queues.

### Additional Notes

If we want to track the check names per queue, we should introduce
another telemetry metric (I'm not sure if it's worth counting that
though).

### Describe your test plan

* with telemetry enabled, check the `datadog.agent.scheduler.queues_count` metric is correct and not tagged by `check_name` anymore