### PR TITLE
Improve memory usage of enrichTags (dogstatsd)

### DIFF
--- a/pkg/dogstatsd/enrich.go
+++ b/pkg/dogstatsd/enrich.go
@@ -25,6 +25,7 @@ var (
 )
 
 func enrichTags(tags []string, defaultHostname string, originTagsFunc func() []string, entityIDPrecedenceEnabled bool) ([]string, string) {
+	var originTags, entityTags []string
 	host := defaultHostname
 
 	n := 0
@@ -40,9 +41,10 @@ func enrichTags(tags []string, defaultHostname string, originTagsFunc func() []s
 		}
 	}
 	tags = tags[:n]
+
 	if entityIDValue == "" || !entityIDPrecedenceEnabled {
 		// Add origin tags only if the entity id tags is not provided
-		tags = append(tags, originTagsFunc()...)
+		originTags = originTagsFunc()
 	}
 	if entityIDValue != "" && entityIDValue != entityIDIgnoreValue {
 		// Check if the value is not "none" in order to avoid calling
@@ -50,16 +52,29 @@ func enrichTags(tags []string, defaultHostname string, originTagsFunc func() []s
 
 		// currently only supported for pods
 		entity := kubelet.KubePodTaggerEntityPrefix + entityIDValue
-		entityTags, err := getTags(entity, tagger.DogstatsdCardinality)
+		var err error
+		entityTags, err = getTags(entity, tagger.DogstatsdCardinality)
 		if err != nil {
 			log.Tracef("Cannot get tags for entity %s: %s", entity, err)
 			tlmUDPOriginDetectionError.Inc()
-		} else {
-			tags = append(tags, entityTags...)
 		}
 	}
-	return tags, host
+
+	var finalTags []string
+	if cap(tags) >= len(tags)+len(originTags)+len(entityTags) {
+		tags = append(tags, originTags...)
+		tags = append(tags, entityTags...)
+		finalTags = tags
+	} else {
+		finalTags = make([]string, 0, len(tags)+len(originTags)+len(entityTags))
+		finalTags = append(finalTags, tags...)
+		finalTags = append(finalTags, originTags...)
+		finalTags = append(finalTags, entityTags...)
+	}
+
+	return finalTags, host
 }
+
 func enrichMetricType(dogstatsdMetricType metricType) metrics.MetricType {
 	switch dogstatsdMetricType {
 	case gaugeType:

--- a/pkg/dogstatsd/enrich_bench_test.go
+++ b/pkg/dogstatsd/enrich_bench_test.go
@@ -1,0 +1,46 @@
+package dogstatsd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+)
+
+func buildTags(tagCount int) []string {
+	tags := make([]string, 0, tagCount)
+	for i := 0; i < tagCount; i++ {
+		tags = append(tags, fmt.Sprintf("tag%d:val%d", i, i))
+	}
+
+	return tags
+}
+
+// used to store the result and avoid optimizations
+var tags []string
+
+func BenchmarkEnrichTags(b *testing.B) {
+	originalGetTags := getTags
+
+	for i := 20; i <= 200; i += 20 {
+		b.Run(fmt.Sprintf("%d-tags", i), func(sb *testing.B) {
+			baseTags := append([]string{hostTagPrefix + "foo", entityIDTagPrefix + "bar"}, buildTags(i/10)...)
+			extraTags := buildTags(i / 2)
+			taggerTags := buildTags(i)
+			originTagsFunc := func() []string {
+				return extraTags
+			}
+			getTags = func(entity string, cardinality collectors.TagCardinality) ([]string, error) {
+				return taggerTags, nil
+			}
+			sb.ResetTimer()
+
+			for n := 0; n < sb.N; n++ {
+				tags, _ = enrichTags(baseTags, "hostname", originTagsFunc, false)
+			}
+		})
+	}
+
+	// Revert to original value
+	getTags = originalGetTags
+}


### PR DESCRIPTION
### What does this PR do?

Small reduction in dogstatsd memory usage in `enrichTags`:

Before:
```
BenchmarkEnrichTags
BenchmarkEnrichTags/20-tags
BenchmarkEnrichTags/20-tags-8            7303458           172 ns/op         224 B/op          1 allocs/op
BenchmarkEnrichTags/40-tags
BenchmarkEnrichTags/40-tags-8            4497426           261 ns/op         416 B/op          1 allocs/op
BenchmarkEnrichTags/60-tags
BenchmarkEnrichTags/60-tags-8            3551148           334 ns/op         640 B/op          1 allocs/op
BenchmarkEnrichTags/80-tags
BenchmarkEnrichTags/80-tags-8            2889858           414 ns/op         896 B/op          1 allocs/op
BenchmarkEnrichTags/100-tags
BenchmarkEnrichTags/100-tags-8           2305017           507 ns/op        1024 B/op          1 allocs/op
BenchmarkEnrichTags/120-tags
BenchmarkEnrichTags/120-tags-8           2100564           580 ns/op        1280 B/op          1 allocs/op
BenchmarkEnrichTags/140-tags
BenchmarkEnrichTags/140-tags-8           1845979           625 ns/op        1408 B/op          1 allocs/op
BenchmarkEnrichTags/160-tags
BenchmarkEnrichTags/160-tags-8           1474875           822 ns/op        1792 B/op          1 allocs/op
BenchmarkEnrichTags/180-tags
BenchmarkEnrichTags/180-tags-8           1470181           802 ns/op        1792 B/op          1 allocs/op
BenchmarkEnrichTags/200-tags
BenchmarkEnrichTags/200-tags-8           1367126           903 ns/op        2048 B/op          1 allocs/op
```

After:
```
BenchmarkEnrichTags/20-tags
BenchmarkEnrichTags/20-tags-8            7106082           176 ns/op         224 B/op          1 allocs/op
BenchmarkEnrichTags/40-tags
BenchmarkEnrichTags/40-tags-8            4521068           255 ns/op         416 B/op          1 allocs/op
BenchmarkEnrichTags/60-tags
BenchmarkEnrichTags/60-tags-8            3717309           331 ns/op         640 B/op          1 allocs/op
BenchmarkEnrichTags/80-tags
BenchmarkEnrichTags/80-tags-8            2713755           420 ns/op         896 B/op          1 allocs/op
BenchmarkEnrichTags/100-tags
BenchmarkEnrichTags/100-tags-8           2346262           517 ns/op        1024 B/op          1 allocs/op
BenchmarkEnrichTags/120-tags
BenchmarkEnrichTags/120-tags-8           2094024           610 ns/op        1280 B/op          1 allocs/op
BenchmarkEnrichTags/140-tags
BenchmarkEnrichTags/140-tags-8           1826889           631 ns/op        1408 B/op          1 allocs/op
BenchmarkEnrichTags/160-tags
BenchmarkEnrichTags/160-tags-8           1490360           811 ns/op        1792 B/op          1 allocs/op
BenchmarkEnrichTags/180-tags
BenchmarkEnrichTags/180-tags-8           1589427           757 ns/op        1792 B/op          1 allocs/op
BenchmarkEnrichTags/200-tags
BenchmarkEnrichTags/200-tags-8           1419412           882 ns/op        2048 B/op          1 allocs/op
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Performance optimisation, nothing should change before/after.
