### PR TITLE
set source/service in log config using spec image name

### DIFF
--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -169,7 +169,7 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 				Service: standardService,
 			}
 		} else {
-			shortImageName, err := l.getShortImageName(container)
+			shortImageName, err := l.getShortImageName(pod, container.Name)
 			if err != nil {
 				cfg = &config.LogsConfig{
 					Source:  kubernetesIntegration,
@@ -285,8 +285,12 @@ func (l *Launcher) getPodDirectorySince1_14(pod *kubelet.Pod) string {
 }
 
 // getShortImageName returns the short image name of a container
-func (l *Launcher) getShortImageName(container kubelet.ContainerStatus) (string, error) {
-	_, shortName, _, err := containers.SplitImageName(container.Image)
+func (l *Launcher) getShortImageName(pod *kubelet.Pod, containerName string) (string, error) {
+	containerSpec, err := l.kubeutil.GetSpecForContainerName(pod, containerName)
+	if err != nil {
+		return "", err
+	}
+	_, shortName, _, err := containers.SplitImageName(containerSpec.Image)
 	if err != nil {
 		log.Debugf("Cannot parse image name: %v", err)
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -79,7 +79,7 @@ func ResetCache() {
 	cache.Cache.Delete(podListCacheKey)
 }
 
-func newKubeUtil() *KubeUtil {
+func NewKubeUtil() *KubeUtil {
 	ku := &KubeUtil{
 		kubeletAPIClient:         &http.Client{Timeout: time.Second},
 		kubeletAPIRequestHeaders: &http.Header{},
@@ -101,7 +101,7 @@ func GetKubeUtil() (KubeUtilInterface, error) {
 	globalKubeUtilMutex.Lock()
 	defer globalKubeUtilMutex.Unlock()
 	if globalKubeUtil == nil {
-		globalKubeUtil = newKubeUtil()
+		globalKubeUtil = NewKubeUtil()
 		globalKubeUtil.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck
 			Name:              "kubeutil",
 			AttemptMethod:     globalKubeUtil.init,
@@ -285,6 +285,16 @@ func (ku *KubeUtil) GetStatusForContainerID(pod *Pod, containerID string) (Conta
 		}
 	}
 	return ContainerStatus{}, fmt.Errorf("Container %v not found", containerID)
+}
+
+// GetSpecForContainerName returns the container spec from the pod given a name
+func (ku *KubeUtil) GetSpecForContainerName(pod *Pod, containerName string) (ContainerSpec, error) {
+	for _, containerSpec := range pod.Spec.Containers {
+		if containerName == containerSpec.Name {
+			return containerSpec, nil
+		}
+	}
+	return ContainerSpec{}, fmt.Errorf("Container %v not found", containerName)
 }
 
 func (ku *KubeUtil) GetPodFromUID(podUID string) (*Pod, error) {

--- a/pkg/util/kubernetes/kubelet/kubelet_interface.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_interface.go
@@ -20,6 +20,7 @@ type KubeUtilInterface interface {
 	ForceGetLocalPodList() ([]*Pod, error)
 	GetPodForContainerID(containerID string) (*Pod, error)
 	GetStatusForContainerID(pod *Pod, containerID string) (ContainerStatus, error)
+	GetSpecForContainerName(pod *Pod, containerName string) (ContainerSpec, error)
 	GetPodFromUID(podUID string) (*Pod, error)
 	GetPodForEntityID(entityID string) (*Pod, error)
 	QueryKubelet(path string) ([]byte, int, error)

--- a/pkg/util/kubernetes/kubelet/kubelet_orchestrator.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_orchestrator.go
@@ -26,6 +26,7 @@ type KubeUtilInterface interface {
 	ForceGetLocalPodList() ([]*Pod, error)
 	GetPodForContainerID(containerID string) (*Pod, error)
 	GetStatusForContainerID(pod *Pod, containerID string) (ContainerStatus, error)
+	GetSpecForContainerName(pod *Pod, containerName string) (ContainerSpec, error)
 	GetPodFromUID(podUID string) (*Pod, error)
 	GetPodForEntityID(entityID string) (*Pod, error)
 	QueryKubelet(path string) ([]byte, int, error)

--- a/releasenotes/notes/use-container-spec-for-logs-config-image-31293099db884756.yaml
+++ b/releasenotes/notes/use-container-spec-for-logs-config-image-31293099db884756.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Updates the logs package to get the short image name from Kubernetes ContainerSpec, rather than ContainerStatus.
+    This works around a known issue where the image name in the ContainerStatus may be incorrect.


### PR DESCRIPTION
### What does this PR do?

In the case where there is no service name derived from the Tagger, the logs config `service` and `source` come from the short image name ([code](https://github.com/DataDog/datadog-agent/blob/e0383b4f2b0283ddde3d5d429107314872522e2f/pkg/logs/input/kubernetes/launcher.go#L180-L181)). We get this short image name from the `ContainerStatus` struct. However, in the Tagger we get the short image name from the `ContainerSpec` ([code](https://github.com/DataDog/datadog-agent/blob/adbbd9ba20eee5a016d65c4e9c29244241e798d6/pkg/tagger/collectors/kubelet_extract.go#L213)), and there is a known issue where the [image names from the ContainerStatus is incorrect](https://github.com/kubernetes/kubernetes/issues/51017).

For consistency and to handle this on our side, this PR updates the logs code to use the `ContainerSpec` instead.

### Motivation

Suboptimal experience 

### Additional Notes

### Describe your test plan

1. Pull `nginx:latest` image
1. Tag image with a different tag, e.g. `test:latest`
1. Deploy both image tags in pods (and set up Datadog Kubernetes logging on the pods)
1. Examine output of `kubectl get po -o yaml` to check ContainerStatus.Image
1. Examine `source` and `service` tags in logs to confirm the correct short image is used
