### PR TITLE
pkg/trace/obfuscate: fix parsing the double-colon operator in the SQL obfuscator

### DIFF
--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -538,6 +538,10 @@ ORDER BY [b].[Name]`,
 			`SELECT * FROM foo LEFT JOIN bar ON 'embedded \'quote\' in string' = foo.b WHERE foo.name = 'String'`,
 			"SELECT * FROM foo LEFT JOIN bar ON ? = foo.b WHERE foo.name = ?",
 		},
+		{
+			`SELECT a :: VARCHAR(255) FROM foo WHERE foo.name = 'String'`,
+			`SELECT a :: VARCHAR ( ? ) FROM foo WHERE foo.name = ?`,
+		},
 	}
 
 	for _, c := range cases {
@@ -657,6 +661,11 @@ in the middle'`,
 			`'String with backslash \ in the middle missing closing quote`,
 			"String with backslash  in the middle missing closing quote",
 			LexError,
+		},
+		{
+			`::`,
+			`::`,
+			ColonCast,
 		},
 		// The following case will treat the final quote as unescaped
 		{

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -58,6 +58,7 @@ const (
 	Insert
 	Into
 	Join
+	ColonCast
 
 	// FilteredGroupable specifies that the given token has been discarded by one of the
 	// token filters and that it is groupable together with consecutive FilteredGroupable
@@ -149,6 +150,10 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 		case EOFChar:
 			return EOFChar, nil
 		case ':':
+			if tkn.lastChar == ':' {
+				tkn.next()
+				return ColonCast, []byte("::")
+			}
 			if tkn.lastChar != '=' {
 				return tkn.scanBindVar()
 			}

--- a/releasenotes/notes/fix-double-colon-parsing-in-sql-obfuscator-fcf487472126da13.yaml
+++ b/releasenotes/notes/fix-double-colon-parsing-in-sql-obfuscator-fcf487472126da13.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: fix parsing the double-colon operator in the SQL obfuscator.

--- a/releasenotes/notes/fix-double-colon-parsing-in-sql-obfuscator-fcf487472126da13.yaml
+++ b/releasenotes/notes/fix-double-colon-parsing-in-sql-obfuscator-fcf487472126da13.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: fix parsing the double-colon operator in the SQL obfuscator.
+    APM: Allow double-colon operator in SQL obfuscator.


### PR DESCRIPTION
Some SQL dialects use a double-colon (`::`) as a cast operator. This patch
enables the SQL obfuscator to correctly tokenize this operator, fixing
previously unparseable SQL queries.

### Motivation

We have seen queries containing this operator trigger errors in the SQL obfuscator.

### Describe your test plan

There are unit tests that exercise the code.
Manual testing will also be done by sending spans containing SQL queries containing this operator through the agent and making sure they appear correctly obfuscated in the back end.
