### PR TITLE
[logs] Aggregates long lines when tailing in a k8s env - part #1

### DIFF
--- a/pkg/logs/decoder/decoder.go
+++ b/pkg/logs/decoder/decoder.go
@@ -28,8 +28,22 @@ func NewInput(content []byte) *Input {
 	}
 }
 
-// Output represents a structured line.
-type Output struct {
+// DecodedInput represents a decoded line and the raw length
+type DecodedInput struct {
+	content    []byte
+	rawDataLen int
+}
+
+// NewDecodedInput returns a new decoded input.
+func NewDecodedInput(content []byte, rawDataLen int) *DecodedInput {
+	return &DecodedInput{
+		content:    content,
+		rawDataLen: rawDataLen,
+	}
+}
+
+// Message represents a structured line.
+type Message struct {
 	Content    []byte
 	Status     string
 	RawDataLen int
@@ -37,8 +51,8 @@ type Output struct {
 }
 
 // NewOutput returns a new output.
-func NewOutput(content []byte, status string, rawDataLen int, timestamp string) *Output {
-	return &Output{
+func NewOutput(content []byte, status string, rawDataLen int, timestamp string) *Message {
+	return &Message{
 		Content:    content,
 		Status:     status,
 		RawDataLen: rawDataLen,
@@ -49,11 +63,13 @@ func NewOutput(content []byte, status string, rawDataLen int, timestamp string) 
 // Decoder splits raw data into lines and passes them to a lineHandler that emits outputs
 type Decoder struct {
 	InputChan       chan *Input
-	OutputChan      chan *Output
+	OutputChan      chan *Message
 	matcher         EndLineMatcher
 	lineBuffer      *bytes.Buffer
 	lineHandler     LineHandler
+	lineParser      LineParser
 	contentLenLimit int
+	rawDataLen      int
 }
 
 // InitializeDecoder returns a properly initialized Decoder
@@ -64,9 +80,11 @@ func InitializeDecoder(source *config.LogSource, parser parser.Parser) *Decoder 
 // NewDecoderWithEndLineMatcher initialize a decoder with given endline strategy.
 func NewDecoderWithEndLineMatcher(source *config.LogSource, parser parser.Parser, matcher EndLineMatcher) *Decoder {
 	inputChan := make(chan *Input)
-	outputChan := make(chan *Output)
+	outputChan := make(chan *Message)
 	lineLimit := defaultContentLenLimit
 	var lineHandler LineHandler
+	var lineParser LineParser
+
 	for _, rule := range source.Config.ProcessingRules {
 		if rule.Type == config.MultiLine {
 			lineHandler = NewMultiLineHandler(outputChan, rule.Regex, defaultFlushTimeout, parser, lineLimit)
@@ -76,17 +94,20 @@ func NewDecoderWithEndLineMatcher(source *config.LogSource, parser parser.Parser
 		lineHandler = NewSingleLineHandler(outputChan, parser, lineLimit)
 	}
 
-	return New(inputChan, outputChan, lineHandler, lineLimit, matcher)
+	lineParser = NewSingleLineParser(parser, lineHandler)
+
+	return New(inputChan, outputChan, lineHandler, lineParser, lineLimit, matcher)
 }
 
 // New returns an initialized Decoder
-func New(InputChan chan *Input, OutputChan chan *Output, lineHandler LineHandler, contentLenLimit int, matcher EndLineMatcher) *Decoder {
+func New(InputChan chan *Input, OutputChan chan *Message, lineHandler LineHandler, lineParser LineParser, contentLenLimit int, matcher EndLineMatcher) *Decoder {
 	var lineBuffer bytes.Buffer
 	return &Decoder{
 		InputChan:       InputChan,
 		OutputChan:      OutputChan,
 		lineBuffer:      &lineBuffer,
 		lineHandler:     lineHandler,
+		lineParser:      lineParser,
 		contentLenLimit: contentLenLimit,
 		matcher:         matcher,
 	}
@@ -95,6 +116,7 @@ func New(InputChan chan *Input, OutputChan chan *Output, lineHandler LineHandler
 // Start starts the Decoder
 func (d *Decoder) Start() {
 	d.lineHandler.Start()
+	d.lineParser.Start()
 	go d.run()
 }
 
@@ -109,6 +131,7 @@ func (d *Decoder) run() {
 		d.decodeIncomingData(data.content)
 	}
 	// finish to stop decoder
+	d.lineParser.Stop()
 	d.lineHandler.Stop()
 }
 
@@ -122,17 +145,21 @@ func (d *Decoder) decodeIncomingData(inBuf []byte) {
 		if j == maxj {
 			// send line because it is too long
 			d.lineBuffer.Write(inBuf[i:j])
+			d.rawDataLen += (j - i)
 			d.sendLine()
 			i = j
 			maxj = i + d.contentLenLimit
 		} else if d.matcher.Match(d.lineBuffer.Bytes(), inBuf, i, j) {
 			d.lineBuffer.Write(inBuf[i:j])
+			d.rawDataLen += (j - i)
+			d.rawDataLen++ // account for the matching byte
 			d.sendLine()
 			i = j + 1 // skip the last bytes of the matched sequence
 			maxj = i + d.contentLenLimit
 		}
 	}
 	d.lineBuffer.Write(inBuf[i:j])
+	d.rawDataLen += (j - i)
 }
 
 // sendLine copies content from lineBuffer which is passed to lineHandler
@@ -141,5 +168,6 @@ func (d *Decoder) sendLine() {
 	content := make([]byte, d.lineBuffer.Len()-(d.matcher.SeparatorLen()-1))
 	copy(content, d.lineBuffer.Bytes())
 	d.lineBuffer.Reset()
-	d.lineHandler.Handle(content)
+	d.lineParser.Handle(NewDecodedInput(content, d.rawDataLen))
+	d.rawDataLen = 0
 }

--- a/pkg/logs/decoder/decoder.go
+++ b/pkg/logs/decoder/decoder.go
@@ -62,7 +62,7 @@ func NewMessage(content []byte, status string, rawDataLen int, timestamp string)
 
 // Decoder splits raw data into lines and passes them to a lineParser that passes them to
 // a lineHandler that emits outputs
-// Input->[decoder]->[parser]->[handler]->Output
+// Input->[decoder]->[parser]->[handler]->Message
 type Decoder struct {
 	InputChan       chan *Input
 	OutputChan      chan *Message

--- a/pkg/logs/decoder/decoder_test.go
+++ b/pkg/logs/decoder/decoder_test.go
@@ -242,7 +242,7 @@ func TestDecoderWithDockerHeader(t *testing.T) {
 	input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
 	d.InputChan <- NewInput(input)
 
-	var output *Output
+	var output *Message
 	output = <-d.OutputChan
 	assert.Equal(t, "hello", string(output.Content))
 

--- a/pkg/logs/decoder/decoder_test.go
+++ b/pkg/logs/decoder/decoder_test.go
@@ -15,87 +15,87 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type MockLineHandler struct {
-	lineChan chan []byte
+type MockLineParser struct {
+	inputChan chan *DecodedInput
 }
 
-func NewMockLineHandler() *MockLineHandler {
-	return &MockLineHandler{
-		lineChan: make(chan []byte, 10),
+func NewMockLineParser() *MockLineParser {
+	return &MockLineParser{
+		inputChan: make(chan *DecodedInput, 10),
 	}
 }
 
-func (h *MockLineHandler) Handle(content []byte) {
-	h.lineChan <- content
+func (p *MockLineParser) Handle(input *DecodedInput) {
+	p.inputChan <- input
 }
 
-func (h *MockLineHandler) Start() {
+func (p *MockLineParser) Start() {
 
 }
 
-func (h *MockLineHandler) Stop() {
-	close(h.lineChan)
+func (p *MockLineParser) Stop() {
+	close(p.inputChan)
 }
 
 const contentLenLimit = 100
 
 func TestDecodeIncomingData(t *testing.T) {
-	h := NewMockLineHandler()
-	d := New(nil, nil, h, contentLenLimit, &NewLineMatcher{})
+	p := NewMockLineParser()
+	d := New(nil, nil, p, contentLenLimit, &newLineMatcher{})
 
-	var line []byte
+	var line *DecodedInput
 
 	// one line in one raw should be sent
 	d.decodeIncomingData([]byte("helloworld\n"))
-	line = <-h.lineChan
-	assert.Equal(t, "helloworld", string(line))
+	line = <-p.inputChan
+	assert.Equal(t, "helloworld", string(line.content))
 	assert.Equal(t, "", d.lineBuffer.String())
 
 	// multiple lines in one raw should be sent
 	d.decodeIncomingData([]byte("helloworld\nhowayou\ngoodandyou"))
-	line = <-h.lineChan
-	assert.Equal(t, "helloworld", string(line))
-	line = <-h.lineChan
-	assert.Equal(t, "howayou", string(line))
+	line = <-p.inputChan
+	assert.Equal(t, "helloworld", string(line.content))
+	line = <-p.inputChan
+	assert.Equal(t, "howayou", string(line.content))
 	assert.Equal(t, "goodandyou", d.lineBuffer.String())
 	d.lineBuffer.Reset()
 
 	// multiple lines in multiple rows should be sent
 	d.decodeIncomingData([]byte("helloworld\nthisisa"))
-	line = <-h.lineChan
-	assert.Equal(t, "helloworld", string(line))
+	line = <-p.inputChan
+	assert.Equal(t, "helloworld", string(line.content))
 	assert.Equal(t, "thisisa", d.lineBuffer.String())
 	d.decodeIncomingData([]byte("longinput\nindeed"))
-	line = <-h.lineChan
-	assert.Equal(t, "thisisalonginput", string(line))
+	line = <-p.inputChan
+	assert.Equal(t, "thisisalonginput", string(line.content))
 	assert.Equal(t, "indeed", d.lineBuffer.String())
 	d.lineBuffer.Reset()
 
 	// one line in multiple rows should be sent
 	d.decodeIncomingData([]byte("hello world"))
 	d.decodeIncomingData([]byte("!\n"))
-	line = <-h.lineChan
-	assert.Equal(t, "hello world!", string(line))
+	line = <-p.inputChan
+	assert.Equal(t, "hello world!", string(line.content))
 
 	// too long line in one raw should be sent by chuncks
 	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
-	line = <-h.lineChan
-	assert.Equal(t, contentLenLimit, len(line))
-	line = <-h.lineChan
-	assert.Equal(t, strings.Repeat("a", 10), string(line))
+	line = <-p.inputChan
+	assert.Equal(t, contentLenLimit, len(line.content))
+	line = <-p.inputChan
+	assert.Equal(t, strings.Repeat("a", 10), string(line.content))
 
 	// too long line in multiple rows should be sent by chuncks
 	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit-5)))
 	d.decodeIncomingData([]byte(strings.Repeat("a", 15) + "\n"))
-	line = <-h.lineChan
-	assert.Equal(t, contentLenLimit, len(line))
-	line = <-h.lineChan
-	assert.Equal(t, strings.Repeat("a", 10), string(line))
+	line = <-p.inputChan
+	assert.Equal(t, contentLenLimit, len(line.content))
+	line = <-p.inputChan
+	assert.Equal(t, strings.Repeat("a", 10), string(line.content))
 
 	// empty lines should be sent
 	d.decodeIncomingData([]byte("\n"))
-	line = <-h.lineChan
-	assert.Equal(t, "", string(line))
+	line = <-p.inputChan
+	assert.Equal(t, "", string(line.content))
 	assert.Equal(t, "", d.lineBuffer.String())
 
 	// empty message should not change anything
@@ -188,32 +188,32 @@ func TestDecodeIncomingDataWithSingleByteCustomSequence(t *testing.T) {
 }
 
 func TestDecoderLifeCycle(t *testing.T) {
-	h := NewMockLineHandler()
-	d := New(nil, nil, h, contentLenLimit, &NewLineMatcher{})
+	p := NewMockLineParser()
+	d := New(nil, nil, p, contentLenLimit, &newLineMatcher{})
 
-	// lineHandler should not receive any lines
+	// LineParser should not receive any lines
 	d.Start()
 	select {
-	case <-h.lineChan:
-		assert.Fail(t, "LineHandler should not handle anything")
+	case <-p.inputChan:
+		assert.Fail(t, "LineParser should not handle anything")
 	default:
 		break
 	}
 
-	// lineHandler should not receive any lines
-	h.Stop()
+	// LineParser should not receive any lines
+	p.Stop()
 	select {
-	case <-h.lineChan:
+	case <-p.inputChan:
 		break
 	default:
-		assert.Fail(t, "LineHandler should be stopped")
+		assert.Fail(t, "LineParser should be stopped")
 	}
 }
 
 func TestDecoderInputNotDockerHeader(t *testing.T) {
 	inputChan := make(chan *Input)
-	h := NewMockLineHandler()
-	d := New(inputChan, nil, h, 100, &NewLineMatcher{})
+	h := NewMockLineParser()
+	d := New(inputChan, nil, h, 100, &newLineMatcher{})
 	d.Start()
 
 	input := []byte("hello")
@@ -221,14 +221,14 @@ func TestDecoderInputNotDockerHeader(t *testing.T) {
 	input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
 	inputChan <- NewInput(input)
 
-	var output []byte
-	output = <-h.lineChan
+	var output *DecodedInput
+	output = <-h.inputChan
 	expected1 := append([]byte("hello"), []byte{1, 0, 0, 0, 0}...)
-	assert.Equal(t, expected1, output)
+	assert.Equal(t, expected1, output.content)
 
-	output = <-h.lineChan
+	output = <-h.inputChan
 	expected2 := append([]byte{0, 0}, []byte("2018-06-14T18:27:03.246999277Z app logs")...)
-	assert.Equal(t, expected2, output)
+	assert.Equal(t, expected2, output.content)
 	d.Stop()
 }
 

--- a/pkg/logs/decoder/decoder_test.go
+++ b/pkg/logs/decoder/decoder_test.go
@@ -88,7 +88,7 @@ func TestDecodeIncomingData(t *testing.T) {
 	assert.Equal(t, "hello world!", string(line.content))
 	assert.Equal(t, len("hello world!\n"), line.rawDataLen)
 
-	// too long line in one raw should be sent by chuncks
+	// excessively long line in one row should be sent by chunks
 	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
 	line = <-p.inputChan
 	assert.Equal(t, contentLenLimit, len(line.content))
@@ -97,7 +97,7 @@ func TestDecodeIncomingData(t *testing.T) {
 	assert.Equal(t, strings.Repeat("a", 10), string(line.content))
 	assert.Equal(t, 11, line.rawDataLen)
 
-	// too long line in multiple rows should be sent by chuncks
+	// excessively long line in multiple rows should be sent by chunks
 	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit-5)))
 	d.decodeIncomingData([]byte(strings.Repeat("a", 15) + "\n"))
 	line = <-p.inputChan

--- a/pkg/logs/decoder/decoder_test.go
+++ b/pkg/logs/decoder/decoder_test.go
@@ -49,58 +49,75 @@ func TestDecodeIncomingData(t *testing.T) {
 	d.decodeIncomingData([]byte("helloworld\n"))
 	line = <-p.inputChan
 	assert.Equal(t, "helloworld", string(line.content))
+	assert.Equal(t, len("helloworld\n"), line.rawDataLen)
 	assert.Equal(t, "", d.lineBuffer.String())
 
 	// multiple lines in one raw should be sent
 	d.decodeIncomingData([]byte("helloworld\nhowayou\ngoodandyou"))
+	l := 0
 	line = <-p.inputChan
+	l += line.rawDataLen
 	assert.Equal(t, "helloworld", string(line.content))
 	line = <-p.inputChan
+	l += line.rawDataLen
 	assert.Equal(t, "howayou", string(line.content))
 	assert.Equal(t, "goodandyou", d.lineBuffer.String())
+	assert.Equal(t, len("helloworld\nhowayou\n"), l)
 	d.lineBuffer.Reset()
+	d.rawDataLen, l = 0, 0
 
 	// multiple lines in multiple rows should be sent
 	d.decodeIncomingData([]byte("helloworld\nthisisa"))
 	line = <-p.inputChan
+	l += line.rawDataLen
 	assert.Equal(t, "helloworld", string(line.content))
 	assert.Equal(t, "thisisa", d.lineBuffer.String())
 	d.decodeIncomingData([]byte("longinput\nindeed"))
 	line = <-p.inputChan
+	l += line.rawDataLen
 	assert.Equal(t, "thisisalonginput", string(line.content))
 	assert.Equal(t, "indeed", d.lineBuffer.String())
+	assert.Equal(t, len("helloworld\nthisisalonginput\n"), l)
 	d.lineBuffer.Reset()
+	d.rawDataLen = 0
 
 	// one line in multiple rows should be sent
 	d.decodeIncomingData([]byte("hello world"))
 	d.decodeIncomingData([]byte("!\n"))
 	line = <-p.inputChan
 	assert.Equal(t, "hello world!", string(line.content))
+	assert.Equal(t, len("hello world!\n"), line.rawDataLen)
 
 	// too long line in one raw should be sent by chuncks
 	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
 	line = <-p.inputChan
 	assert.Equal(t, contentLenLimit, len(line.content))
+	assert.Equal(t, contentLenLimit, line.rawDataLen)
 	line = <-p.inputChan
 	assert.Equal(t, strings.Repeat("a", 10), string(line.content))
+	assert.Equal(t, 11, line.rawDataLen)
 
 	// too long line in multiple rows should be sent by chuncks
 	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit-5)))
 	d.decodeIncomingData([]byte(strings.Repeat("a", 15) + "\n"))
 	line = <-p.inputChan
 	assert.Equal(t, contentLenLimit, len(line.content))
+	assert.Equal(t, contentLenLimit, line.rawDataLen)
 	line = <-p.inputChan
 	assert.Equal(t, strings.Repeat("a", 10), string(line.content))
+	assert.Equal(t, 11, line.rawDataLen)
 
 	// empty lines should be sent
 	d.decodeIncomingData([]byte("\n"))
 	line = <-p.inputChan
 	assert.Equal(t, "", string(line.content))
 	assert.Equal(t, "", d.lineBuffer.String())
+	assert.Equal(t, 1, line.rawDataLen)
 
 	// empty message should not change anything
 	d.decodeIncomingData([]byte(""))
 	assert.Equal(t, "", d.lineBuffer.String())
+	assert.Equal(t, 0, d.rawDataLen)
 }
 
 func TestDecodeIncomingDataWithCustomSequence(t *testing.T) {
@@ -225,10 +242,12 @@ func TestDecoderInputNotDockerHeader(t *testing.T) {
 	output = <-h.inputChan
 	expected1 := append([]byte("hello"), []byte{1, 0, 0, 0, 0}...)
 	assert.Equal(t, expected1, output.content)
+	assert.Equal(t, len(expected1)+1, output.rawDataLen)
 
 	output = <-h.inputChan
 	expected2 := append([]byte{0, 0}, []byte("2018-06-14T18:27:03.246999277Z app logs")...)
 	assert.Equal(t, expected2, output.content)
+	assert.Equal(t, len(expected2)+1, output.rawDataLen)
 	d.Stop()
 }
 
@@ -245,13 +264,17 @@ func TestDecoderWithDockerHeader(t *testing.T) {
 	var output *Message
 	output = <-d.OutputChan
 	assert.Equal(t, "hello", string(output.Content))
+	assert.Equal(t, len("hello")+1, output.RawDataLen)
 
 	output = <-d.OutputChan
 	expected := []byte{1, 0, 0, 0, 0}
 	assert.Equal(t, expected, output.Content)
+	assert.Equal(t, 6, output.RawDataLen)
 
 	output = <-d.OutputChan
 	expected = append([]byte{0, 0}, []byte("2018-06-14T18:27:03.246999277Z app logs")...)
 	assert.Equal(t, expected, output.Content)
+	assert.Equal(t, len(expected)+1, output.RawDataLen)
+
 	d.Stop()
 }

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -9,8 +9,6 @@ import (
 	"bytes"
 	"regexp"
 	"time"
-
-	"github.com/DataDog/datadog-agent/pkg/logs/parser"
 )
 
 // truncatedFlag is the flag that is added at the beginning
@@ -36,16 +34,14 @@ type SingleLineHandler struct {
 	inputChan      chan *Message
 	outputChan     chan *Message
 	shouldTruncate bool
-	parser         parser.Parser
 	lineLimit      int
 }
 
 // NewSingleLineHandler returns a new SingleLineHandler.
-func NewSingleLineHandler(outputChan chan *Message, parser parser.Parser, lineLimit int) *SingleLineHandler {
+func NewSingleLineHandler(outputChan chan *Message, lineLimit int) *SingleLineHandler {
 	return &SingleLineHandler{
 		inputChan:  make(chan *Message),
 		outputChan: outputChan,
-		parser:     parser,
 		lineLimit:  lineLimit,
 	}
 }
@@ -118,7 +114,6 @@ const defaultFlushTimeout = 1000 * time.Millisecond
 type MultiLineHandler struct {
 	inputChan      chan *Message
 	outputChan     chan *Message
-	parser         parser.Parser
 	newContentRe   *regexp.Regexp
 	buffer         *bytes.Buffer
 	flushTimeout   time.Duration
@@ -130,11 +125,10 @@ type MultiLineHandler struct {
 }
 
 // NewMultiLineHandler returns a new MultiLineHandler.
-func NewMultiLineHandler(outputChan chan *Message, newContentRe *regexp.Regexp, flushTimeout time.Duration, parser parser.Parser, lineLimit int) *MultiLineHandler {
+func NewMultiLineHandler(outputChan chan *Message, newContentRe *regexp.Regexp, flushTimeout time.Duration, lineLimit int) *MultiLineHandler {
 	return &MultiLineHandler{
 		inputChan:    make(chan *Message),
 		outputChan:   outputChan,
-		parser:       parser,
 		newContentRe: newContentRe,
 		buffer:       bytes.NewBuffer(nil),
 		flushTimeout: flushTimeout,
@@ -255,6 +249,6 @@ func (h *MultiLineHandler) sendBuffer() {
 	copy(content, data)
 
 	if len(content) > 0 {
-		h.outputChan <- NewOutput(content, h.status, h.linesLen, h.timestamp)
+		h.outputChan <- NewMessage(content, h.status, h.linesLen, h.timestamp)
 	}
 }

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -89,7 +89,7 @@ func (h *SingleLineHandler) process(line []byte) {
 		rawLen++
 	}
 
-	content, status, timestamp, err := h.parser.Parse(line)
+	content, status, timestamp, _, err := h.parser.Parse(line)
 	if err != nil {
 		log.Debug(err)
 	}
@@ -210,7 +210,7 @@ func (h *MultiLineHandler) run() {
 // and that the length of the lines is properly tracked
 // so that the agent restarts tailing from the right place.
 func (h *MultiLineHandler) process(line []byte) {
-	content, status, timestamp, err := h.parser.Parse(line)
+	content, status, timestamp, _, err := h.parser.Parse(line)
 	if err != nil {
 		log.Debug(err)
 	}

--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -52,11 +52,11 @@ func (u *MockFailingParser) Parse(msg []byte) ([]byte, string, string, bool, err
 }
 
 func TestSingleLineHandler(t *testing.T) {
-	outputChan := make(chan *Output, 10)
+	outputChan := make(chan *Message, 10)
 	h := NewSingleLineHandler(outputChan, parser.NoopParser, 100)
 	h.Start()
 
-	var output *Output
+	var output *Message
 	var line string
 
 	// valid line should be sent
@@ -93,11 +93,11 @@ func TestSingleLineHandler(t *testing.T) {
 }
 
 func TestTrimSingleLine(t *testing.T) {
-	outputChan := make(chan *Output, 10)
+	outputChan := make(chan *Message, 10)
 	h := NewSingleLineHandler(outputChan, parser.NoopParser, 100)
 	h.Start()
 
-	var output *Output
+	var output *Message
 	var line string
 
 	// All leading and trailing whitespace characters should be trimmed
@@ -112,11 +112,11 @@ func TestTrimSingleLine(t *testing.T) {
 
 func TestMultiLineHandler(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
-	outputChan := make(chan *Output, 10)
+	outputChan := make(chan *Message, 10)
 	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, parser.NoopParser, 20)
 	h.Start()
 
-	var output *Output
+	var output *Message
 
 	// two lines long message should be sent
 	h.Handle([]byte("1.first"))
@@ -187,11 +187,11 @@ func TestMultiLineHandler(t *testing.T) {
 
 func TestTrimMultiLine(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
-	outputChan := make(chan *Output, 10)
+	outputChan := make(chan *Message, 10)
 	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, parser.NoopParser, 100)
 	h.Start()
 
-	var output *Output
+	var output *Message
 
 	// All leading and trailing whitespace characters should be trimmed
 	h.Handle([]byte(whitespace + "foo" + whitespace + "bar" + whitespace))
@@ -211,7 +211,7 @@ func TestTrimMultiLine(t *testing.T) {
 
 func TestSingleLineHandlerDropsEmptyMessages(t *testing.T) {
 	const header = "HEADER"
-	outputChan := make(chan *Output, 10)
+	outputChan := make(chan *Message, 10)
 	h := NewSingleLineHandler(outputChan, NewMockParser(header), 100)
 	h.Start()
 
@@ -219,7 +219,7 @@ func TestSingleLineHandlerDropsEmptyMessages(t *testing.T) {
 	h.Handle([]byte(line))
 	h.Handle([]byte(line + "one message"))
 
-	var output *Output
+	var output *Message
 
 	output = <-outputChan
 	assert.Equal(t, "one message", string(output.Content))
@@ -227,7 +227,7 @@ func TestSingleLineHandlerDropsEmptyMessages(t *testing.T) {
 
 func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
 	const header = "HEADER"
-	outputChan := make(chan *Output, 10)
+	outputChan := make(chan *Message, 10)
 	re := regexp.MustCompile("[0-9]+\\.")
 	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, NewMockParser(header), 100)
 	h.Start()
@@ -237,7 +237,7 @@ func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
 	h.Handle([]byte(header + "1.third line"))
 	h.Handle([]byte("fourth line"))
 
-	var output *Output
+	var output *Message
 
 	output = <-outputChan
 	assert.Equal(t, "1.third line\\nfourth line", string(output.Content))
@@ -245,13 +245,13 @@ func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
 
 func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
 	const header = "HEADER"
-	outputChan := make(chan *Output, 10)
+	outputChan := make(chan *Message, 10)
 	h := NewSingleLineHandler(outputChan, NewMockFailingParser(header), 100)
 	h.Start()
 
 	h.Handle([]byte("one message"))
 
-	var output *Output
+	var output *Message
 
 	output = <-outputChan
 	assert.Equal(t, "one message", string(output.Content))
@@ -259,7 +259,7 @@ func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
 
 func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
 	const header = "HEADER"
-	outputChan := make(chan *Output, 10)
+	outputChan := make(chan *Message, 10)
 	re := regexp.MustCompile("[0-9]+\\.")
 	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, NewMockFailingParser(header), 100)
 	h.Start()
@@ -267,7 +267,7 @@ func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
 	h.Handle([]byte("1.third line"))
 	h.Handle([]byte("fourth line"))
 
-	var output *Output
+	var output *Message
 
 	output = <-outputChan
 	assert.Equal(t, "1.third line\\nfourth line", string(output.Content))

--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -17,46 +17,6 @@ import (
 // All valid whitespace characters
 const whitespace = "\t\n\v\f\r\u0085\u00a0 "
 
-// To be relocated in line parser test
-// MockParser mocks the logic of a Parser
-//type MockParser struct {
-//	header []byte
-//}
-
-//func NewMockParser(header string) parser.Parser {
-//	return &MockParser{header: []byte(header)}
-//}
-
-// Parse removes header from line and returns a message
-//func (u *MockParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
-//	return bytes.Replace(msg, u.header, []byte(""), 1), "", "", false, nil
-//}
-//
-//func (u *MockParser) SupportsPartialLine() bool {
-//	return false
-//}
-//
-//type MockFailingParser struct {
-//	header []byte
-//}
-
-//func NewMockFailingParser(header string) parser.Parser {
-//	return &MockFailingParser{header: []byte(header)}
-//}
-
-// Parse removes header from line and returns a message if its header matches the Parser header
-// or returns an error
-//func (u *MockFailingParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
-//	if bytes.HasPrefix(msg, u.header) {
-//		return bytes.Replace(msg, u.header, []byte(""), 1), "", "", false, nil
-//	}
-//	return msg, "", "", false, fmt.Errorf("error")
-//}
-
-//func (u *MockFailingParser) SupportsPartialLine() bool {
-//	return false
-//}
-
 func getDummyMessage(content string) *Message {
 	return NewMessage([]byte(content), "info", len(content), "2018-06-14T18:27:03.246999277Z")
 }
@@ -224,7 +184,6 @@ func TestTrimMultiLine(t *testing.T) {
 }
 
 func TestSingleLineHandlerDropsEmptyMessages(t *testing.T) {
-	// const header = "HEADER"
 	outputChan := make(chan *Message, 10)
 	h := NewSingleLineHandler(outputChan, 100)
 	h.Start()
@@ -236,10 +195,11 @@ func TestSingleLineHandlerDropsEmptyMessages(t *testing.T) {
 
 	output = <-outputChan
 	assert.Equal(t, "one message", string(output.Content))
+
+	h.Stop()
 }
 
 func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
-	// const header = "HEADER"
 	outputChan := make(chan *Message, 10)
 	re := regexp.MustCompile("[0-9]+\\.")
 	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, 100)
@@ -254,36 +214,6 @@ func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
 
 	output = <-outputChan
 	assert.Equal(t, "1.third line\\nfourth line", string(output.Content))
-}
 
-// Mostly useless in line handler context to be relocated in lineparser tests
-func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
-	// const header = "HEADER"
-	outputChan := make(chan *Message, 10)
-	h := NewSingleLineHandler(outputChan, 100)
-	h.Start()
-
-	h.Handle(getDummyMessage("one message"))
-
-	var output *Message
-
-	output = <-outputChan
-	assert.Equal(t, "one message", string(output.Content))
-}
-
-// Mostly useless in line handler context to be relocated in lineparser tests
-func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
-	//const header = "HEADER"
-	outputChan := make(chan *Message, 10)
-	re := regexp.MustCompile("[0-9]+\\.")
-	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, 100)
-	h.Start()
-
-	h.Handle(getDummyMessage("1.third line"))
-	h.Handle(getDummyMessage("fourth line"))
-
-	var output *Message
-
-	output = <-outputChan
-	assert.Equal(t, "1.third line\\nfourth line", string(output.Content))
+	h.Stop()
 }

--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -30,8 +30,8 @@ func NewMockParser(header string) parser.Parser {
 }
 
 // Parse removes header from line and returns a message
-func (u *MockParser) Parse(msg []byte) ([]byte, string, string, error) {
-	return bytes.Replace(msg, u.header, []byte(""), 1), "", "", nil
+func (u *MockParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
+	return bytes.Replace(msg, u.header, []byte(""), 1), "", "", false, nil
 }
 
 type MockFailingParser struct {
@@ -44,11 +44,11 @@ func NewMockFailingParser(header string) parser.Parser {
 
 // Parse removes header from line and returns a message if its header matches the Parser header
 // or returns an error
-func (u *MockFailingParser) Parse(msg []byte) ([]byte, string, string, error) {
+func (u *MockFailingParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 	if bytes.HasPrefix(msg, u.header) {
-		return bytes.Replace(msg, u.header, []byte(""), 1), "", "", nil
+		return bytes.Replace(msg, u.header, []byte(""), 1), "", "", false, nil
 	}
-	return msg, "", "", fmt.Errorf("error")
+	return msg, "", "", false, fmt.Errorf("error")
 }
 
 func TestSingleLineHandler(t *testing.T) {

--- a/pkg/logs/decoder/line_parser.go
+++ b/pkg/logs/decoder/line_parser.go
@@ -41,12 +41,14 @@ func (p *SingleLineParser) Handle(input *DecodedInput) {
 
 // Start starts the parser.
 func (p *SingleLineParser) Start() {
+	p.lineHandler.Start()
 	go p.run()
 }
 
 // Stop stops the parser.
 func (p *SingleLineParser) Stop() {
 	close(p.inputChan)
+	p.lineHandler.Stop()
 }
 
 // run consumes new lines and processes them.
@@ -62,5 +64,5 @@ func (p *SingleLineParser) process(input *DecodedInput) {
 	if err != nil {
 		log.Debug(err)
 	}
-	p.lineHandler.Handle(NewOutput(content, status, input.rawDataLen, timestamp))
+	p.lineHandler.Handle(NewMessage(content, status, input.rawDataLen, timestamp))
 }

--- a/pkg/logs/decoder/line_parser.go
+++ b/pkg/logs/decoder/line_parser.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package decoder
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/parser"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// LineParser e
+type LineParser interface {
+	Handle(input *DecodedInput)
+	Start()
+	Stop()
+}
+
+// SingleLineParser makes sure that multiple lines from a same content
+// are properly put together.
+type SingleLineParser struct {
+	parser      parser.Parser
+	inputChan   chan *DecodedInput
+	lineHandler LineHandler
+}
+
+// NewSingleLineParser returns a new MultiLineHandler.
+func NewSingleLineParser(parser parser.Parser, lineHandler LineHandler) *SingleLineParser {
+	return &SingleLineParser{
+		parser:      parser,
+		inputChan:   make(chan *DecodedInput),
+		lineHandler: lineHandler,
+	}
+}
+
+// Handle puts all new lines into a channel for later processing.
+func (p *SingleLineParser) Handle(input *DecodedInput) {
+	p.inputChan <- input
+}
+
+// Start starts the parser.
+func (p *SingleLineParser) Start() {
+	go p.run()
+}
+
+// Stop stops the parser.
+func (p *SingleLineParser) Stop() {
+	close(p.inputChan)
+}
+
+// run consumes new lines and processes them.
+func (p *SingleLineParser) run() {
+	for input := range p.inputChan {
+		p.process(input)
+	}
+}
+
+func (p *SingleLineParser) process(input *DecodedInput) {
+	// Just parse an pass to the next step
+	content, status, timestamp, _, err := p.parser.Parse(input.content)
+	if err != nil {
+		log.Debug(err)
+	}
+	p.lineHandler.Handle(NewOutput(content, status, input.rawDataLen, timestamp))
+}

--- a/pkg/logs/decoder/line_parser_test.go
+++ b/pkg/logs/decoder/line_parser_test.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-2020 Datadog, Inc.
+
+package decoder
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockHandler struct {
+	message *Message
+}
+
+func (h *MockHandler) Handle(input *Message) {
+	h.message = input
+}
+
+func (h *MockHandler) Start() {
+	return
+}
+
+func (h *MockHandler) Stop() {
+	return
+}
+
+type MockFailingParser struct {
+	header []byte
+}
+
+func NewMockFailingParser(header string) parser.Parser {
+	return &MockFailingParser{header: []byte(header)}
+}
+
+// Parse removes header from line and returns a message if its header matches the Parser header
+// or returns an error
+func (u *MockFailingParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
+	if bytes.HasPrefix(msg, u.header) {
+		return bytes.Replace(msg, u.header, []byte(""), 1), "", "", false, nil
+	}
+	return msg, "", "", false, fmt.Errorf("error")
+}
+
+func (u *MockFailingParser) SupportsPartialLine() bool {
+	return false
+}
+
+func TestSingleLineParser(t *testing.T) {
+	const header = "HEADER"
+	h := &MockHandler{}
+	p := NewMockFailingParser(header)
+
+	lineParser := NewSingleLineParser(p, h)
+	lineParser.Start()
+
+	line := header
+
+	lineParser.Handle(&DecodedInput{[]byte(line), 7})
+	assert.Equal(t, "", string(h.message.Content))
+	assert.Equal(t, 7, h.message.RawDataLen)
+
+	lineParser.Handle(&DecodedInput{[]byte(line + "one message"), 18})
+
+	assert.Equal(t, "one message", string(h.message.Content))
+	assert.Equal(t, 18, h.message.RawDataLen)
+
+	lineParser.Stop()
+}
+
+func TestSingleLineParserSendsRawInvalidMessages(t *testing.T) {
+	const header = "HEADER"
+	h := &MockHandler{}
+	p := NewMockFailingParser(header)
+
+	lineParser := NewSingleLineParser(p, h)
+	lineParser.Start()
+
+	lineParser.Handle(&DecodedInput{[]byte("one message"), 12})
+	assert.Equal(t, "one message", string(h.message.Content))
+
+	lineParser.Stop()
+}

--- a/pkg/logs/decoder/line_parser_test.go
+++ b/pkg/logs/decoder/line_parser_test.go
@@ -62,16 +62,17 @@ func TestSingleLineParser(t *testing.T) {
 
 	line := header
 
-	lineParser.Handle(&DecodedInput{[]byte(line), 7})
+	inputLen := len(line) + 1
+	lineParser.Handle(&DecodedInput{[]byte(line), inputLen})
 	message = <-h.ouputChan
 	assert.Equal(t, "", string(message.Content))
-	assert.Equal(t, 7, message.RawDataLen)
+	assert.Equal(t, inputLen, message.RawDataLen)
 
-	lineParser.Handle(&DecodedInput{[]byte(line + "one message"), 18})
+	inputLen = len(line+"one message") + 1
+	lineParser.Handle(&DecodedInput{[]byte(line + "one message"), inputLen})
 	message = <-h.ouputChan
-
 	assert.Equal(t, "one message", string(message.Content))
-	assert.Equal(t, 18, message.RawDataLen)
+	assert.Equal(t, inputLen, message.RawDataLen)
 
 	lineParser.Stop()
 }

--- a/pkg/logs/input/docker/decoder_test.go
+++ b/pkg/logs/input/docker/decoder_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestDecoderWithHeaderSingleline(t *testing.T) {
-	var output *decoder.Output
+	var output *decoder.Message
 	var line []byte
 	var lineLen int
 
@@ -62,7 +62,7 @@ func TestDecoderWithHeaderSingleline(t *testing.T) {
 }
 
 func TestDecoderWithHeaderMultiline(t *testing.T) {
-	var output *decoder.Output
+	var output *decoder.Message
 	var line []byte
 	var lineLen int
 
@@ -106,7 +106,7 @@ func TestDecoderWithHeaderMultiline(t *testing.T) {
 }
 
 func TestDecoderWithJSONSingleline(t *testing.T) {
-	var output *decoder.Output
+	var output *decoder.Message
 	var line []byte
 	var lineLen int
 
@@ -136,7 +136,7 @@ func TestDecoderWithJSONSingleline(t *testing.T) {
 }
 
 func TestDecoderWithJSONMultiline(t *testing.T) {
-	var output *decoder.Output
+	var output *decoder.Message
 	var line []byte
 	var lineLen int
 
@@ -180,7 +180,7 @@ func TestDecoderWithJSONMultiline(t *testing.T) {
 }
 
 func TestDecoderWithJSONSplittedByDocker(t *testing.T) {
-	var output *decoder.Output
+	var output *decoder.Message
 	var line []byte
 	var lineLen int
 

--- a/pkg/logs/input/docker/json_parser.go
+++ b/pkg/logs/input/docker/json_parser.go
@@ -58,9 +58,9 @@ func (p *jsonParser) Parse(data []byte) ([]byte, string, string, bool, error) {
 	content := []byte(log.Log)
 	length := len(content)
 	partial := false
-	if length > 0 {
-		if log.Log[length-1] == '\n' {
-			content = content[:length-1]
+	if length > 1 {
+		if log.Log[length-2:length-1] == `\n` {
+			content = content[:length-2]
 		} else {
 			partial = true
 		}

--- a/pkg/logs/input/docker/json_parser.go
+++ b/pkg/logs/input/docker/json_parser.go
@@ -58,12 +58,16 @@ func (p *jsonParser) Parse(data []byte) ([]byte, string, string, bool, error) {
 	content := []byte(log.Log)
 	length := len(content)
 	partial := false
-	if length > 1 {
-		if log.Log[length-2:length-1] == `\n` {
-			content = content[:length-2]
+	if length > 0 {
+		if log.Log[length-1] == '\n' {
+			content = content[:length-1]
 		} else {
 			partial = true
 		}
 	}
 	return content, status, log.Time, partial, nil
+}
+
+func (p *jsonParser) SupportsPartialLine() bool {
+	return true
 }

--- a/pkg/logs/input/docker/json_parser.go
+++ b/pkg/logs/input/docker/json_parser.go
@@ -42,7 +42,7 @@ func (p *jsonParser) Parse(data []byte) ([]byte, string, string, bool, error) {
 	var log *logLine
 	err := json.Unmarshal(data, &log)
 	if err != nil {
-		return data, message.StatusInfo, "", fmt.Errorf("cannot parse docker message, invalid JSON: %v", err)
+		return data, message.StatusInfo, "", false, fmt.Errorf("cannot parse docker message, invalid JSON: %v", err)
 	}
 
 	var status string

--- a/pkg/logs/input/docker/json_parser.go
+++ b/pkg/logs/input/docker/json_parser.go
@@ -38,7 +38,7 @@ type jsonParser struct{}
 // {"log":"a message","stream":"stderr","time":"2019-06-06T16:35:55.930852911Z"}
 // returns:
 // "a message", "error", "2019-06-06T16:35:55.930852911Z", nil
-func (p *jsonParser) Parse(data []byte) ([]byte, string, string, error) {
+func (p *jsonParser) Parse(data []byte) ([]byte, string, string, bool, error) {
 	var log *logLine
 	err := json.Unmarshal(data, &log)
 	if err != nil {
@@ -57,8 +57,13 @@ func (p *jsonParser) Parse(data []byte) ([]byte, string, string, error) {
 
 	content := []byte(log.Log)
 	length := len(content)
-	if length > 0 && log.Log[length-1] == '\n' {
-		content = content[:length-1]
+	partial := false
+	if length > 0 {
+		if log.Log[length-1] == '\n' {
+			content = content[:length-1]
+		} else {
+			partial = true
+		}
 	}
-	return content, status, log.Time, nil
+	return content, status, log.Time, partial, nil
 }

--- a/pkg/logs/input/docker/json_parser_test.go
+++ b/pkg/logs/input/docker/json_parser_test.go
@@ -18,42 +18,48 @@ func TestJSONParser(t *testing.T) {
 		content   []byte
 		status    string
 		timestamp string
+		partial   bool
 		err       error
 	)
 
 	parser := JSONParser
 
-	content, status, timestamp, err = parser.Parse([]byte(`{"log":"a message","stream":"stderr","time":"2019-06-06T16:35:55.930852911Z"}`))
+	content, status, timestamp, partial, err = parser.Parse([]byte(`{"log":"a message","stream":"stderr","time":"2019-06-06T16:35:55.930852911Z"}`))
 	assert.Nil(t, err)
+	assert.True(t, partial)
 	assert.Equal(t, []byte("a message"), content)
 	assert.Equal(t, message.StatusError, status)
 	assert.Equal(t, "2019-06-06T16:35:55.930852911Z", timestamp)
 
-	content, status, timestamp, err = parser.Parse([]byte(`{"log":"a second message","stream":"stdout","time":"2019-06-06T16:35:55.930852912Z"}`))
+	content, status, timestamp, partial, err = parser.Parse([]byte(`{"log":"a second message","stream":"stdout","time":"2019-06-06T16:35:55.930852912Z"}`))
 	assert.Nil(t, err)
+	assert.True(t, partial)
 	assert.Equal(t, []byte("a second message"), content)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, "2019-06-06T16:35:55.930852912Z", timestamp)
 
-	content, status, timestamp, err = parser.Parse([]byte(`{"log":"a third message\n","stream":"stdout","time":"2019-06-06T16:35:55.930852913Z"}`))
+	content, status, timestamp, partial, err = parser.Parse([]byte(`{"log":"a third message\n","stream":"stdout","time":"2019-06-06T16:35:55.930852913Z"}`))
 	assert.Nil(t, err)
+	assert.False(t, partial)
 	assert.Equal(t, []byte("a third message"), content)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, "2019-06-06T16:35:55.930852913Z", timestamp)
 
-	content, status, _, err = parser.Parse([]byte("a wrong message"))
+	content, status, _, _, err = parser.Parse([]byte("a wrong message"))
 	assert.NotNil(t, err)
 	assert.Equal(t, []byte("a wrong message"), content)
 	assert.Equal(t, message.StatusInfo, status)
 
-	content, status, timestamp, err = parser.Parse([]byte(`{"log":"","stream":"stdout","time":"2019-06-06T16:35:55.930852914Z"}`))
+	content, status, timestamp, partial, err = parser.Parse([]byte(`{"log":"","stream":"stdout","time":"2019-06-06T16:35:55.930852914Z"}`))
 	assert.Nil(t, err)
+	assert.False(t, partial)
 	assert.Equal(t, []byte(""), content)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, "2019-06-06T16:35:55.930852914Z", timestamp)
 
-	content, status, timestamp, err = parser.Parse([]byte(`{"log":"\n","stream":"stdout","time":"2019-06-06T16:35:55.930852915Z"}`))
+	content, status, timestamp, partial, err = parser.Parse([]byte(`{"log":"\n","stream":"stdout","time":"2019-06-06T16:35:55.930852915Z"}`))
 	assert.Nil(t, err)
+	assert.False(t, partial)
 	assert.Equal(t, []byte(""), content)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, "2019-06-06T16:35:55.930852915Z", timestamp)

--- a/pkg/logs/input/docker/matcher_test.go
+++ b/pkg/logs/input/docker/matcher_test.go
@@ -33,7 +33,7 @@ func TestDecoderDetectDockerHeader(t *testing.T) {
 		input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
 		d.InputChan <- decoder.NewInput(input)
 
-		var output *decoder.Output
+		var output *decoder.Message
 		output = <-d.OutputChan
 		assert.Equal(t, "hello", string(output.Content))
 
@@ -55,7 +55,7 @@ func TestDecoderDetectMultipleDockerHeader(t *testing.T) {
 	}
 	d.InputChan <- decoder.NewInput(input)
 
-	var output *decoder.Output
+	var output *decoder.Message
 	for i := 0; i < 100; i++ {
 		output = <-d.OutputChan
 		assert.Equal(t, fmt.Sprintf("app logs %d", i), string(output.Content))
@@ -86,7 +86,7 @@ func TestDecoderDetectMultipleDockerHeaderOnAChunkedLine(t *testing.T) {
 
 	d.InputChan <- decoder.NewInput(input)
 
-	var output *decoder.Output
+	var output *decoder.Message
 	output = <-d.OutputChan
 	assert.Equal(t, fmt.Sprintf(longestChunk+longestChunk+"the end"), string(output.Content))
 	output = <-d.OutputChan
@@ -105,7 +105,7 @@ func TestDecoderNoNewLineBeforeDockerHeader(t *testing.T) {
 		input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
 		d.InputChan <- decoder.NewInput(input)
 
-		var output *decoder.Output
+		var output *decoder.Message
 		output = <-d.OutputChan
 		assert.Equal(t, "app logs", string(output.Content))
 	}

--- a/pkg/logs/input/docker/parser.go
+++ b/pkg/logs/input/docker/parser.go
@@ -44,6 +44,10 @@ func (p *Parser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 	return parse(msg, p.containerID)
 }
 
+func (p *Parser) SupportsPartialLine() bool {
+	return true
+}
+
 // parse extracts the date and the status from the raw docker message
 // it returns 1. raw message 2. severity 3. timestamp, 4. is partial, 5. error
 // see https://github.com/moby/moby/blob/master/client/container_logs.go#L36

--- a/pkg/logs/input/docker/parser.go
+++ b/pkg/logs/input/docker/parser.go
@@ -45,7 +45,7 @@ func (p *Parser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 }
 
 func (p *Parser) SupportsPartialLine() bool {
-	return true
+	return false
 }
 
 // parse extracts the date and the status from the raw docker message

--- a/pkg/logs/input/docker/parser_test.go
+++ b/pkg/logs/input/docker/parser_test.go
@@ -27,15 +27,16 @@ func TestGetDockerSeverity(t *testing.T) {
 func TestDockerStandaloneParserShouldSucceedWithValidInput(t *testing.T) {
 	validMessage := dockerHeader + " " + "anything"
 	parser := NewParser("container_1")
-	content, status, timestamp, err := parser.Parse([]byte(validMessage))
+	content, status, timestamp, partial, err := parser.Parse([]byte(validMessage))
 	assert.Nil(t, err)
+	assert.False(t, partial)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", timestamp)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, []byte("anything"), content)
 }
 
 func TestDockerStandaloneParserShouldHandleEmptyMessage(t *testing.T) {
-	content, _, _, err := container1Parser.Parse([]byte(dockerHeader))
+	content, _, _, _, err := container1Parser.Parse([]byte(dockerHeader))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(content))
 }
@@ -44,25 +45,26 @@ func TestDockerStandaloneParserShouldHandleNewlineOnlyMessage(t *testing.T) {
 	emptyContent := [3]string{"\\n", "\\r", "\\r\\n"}
 
 	for _, em := range emptyContent {
-		msg, _, _, err := container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z " + em))
+		msg, _, _, _, err := container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z " + em))
 		assert.Nil(t, err)
 		assert.Equal(t, 0, len(msg))
 	}
 }
 
 func TestDockerStandaloneParserShouldHandleTtyMessage(t *testing.T) {
-	msg, status, timestamp, err := container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z foo"))
+	msg, status, timestamp, partial, err := container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z foo"))
 	assert.Nil(t, err)
+	assert.False(t, partial)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", timestamp)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, []byte("foo"), msg)
 }
 
 func TestDockerStandaloneParserShouldHandleEmptyTtyMessage(t *testing.T) {
-	msg, _, _, err := container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z"))
+	msg, _, _, _, err := container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z"))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(msg))
-	msg, _, _, err = container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z "))
+	msg, _, _, _, err = container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z "))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(msg))
 }
@@ -74,7 +76,7 @@ func TestDockerStandaloneParserShouldFailWithInvalidInput(t *testing.T) {
 	// missing dockerHeader separator
 	msg = []byte{}
 	msg = append(msg, []byte{1, 0, 0, 0, 0}...)
-	_, _, _, err = container1Parser.Parse(msg)
+	_, _, _, _, err = container1Parser.Parse(msg)
 	assert.Equal(t, errors.New("cannot parse docker message for container container_1: expected a 8 bytes header"), err)
 
 }
@@ -86,8 +88,9 @@ func TestDockerStandaloneParserShouldRemovePartialHeaders(t *testing.T) {
 	// 16kb log
 	msgToClean = []byte(buildPartialMessage('a', dockerBufferSize) + dockerHeader)
 	expectedMsg = []byte(buildMessage('a', dockerBufferSize))
-	content, status, timestamp, err := container1Parser.Parse(msgToClean)
+	content, status, timestamp, partial, err := container1Parser.Parse(msgToClean)
 	assert.Nil(t, err)
+	assert.False(t, partial)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", timestamp)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, expectedMsg, content)
@@ -96,8 +99,9 @@ func TestDockerStandaloneParserShouldRemovePartialHeaders(t *testing.T) {
 	// over 16kb
 	msgToClean = []byte(buildPartialMessage('a', dockerBufferSize) + buildPartialMessage('b', 50))
 	expectedMsg = []byte(buildMessage('a', dockerBufferSize) + buildMessage('b', 50))
-	content, status, timestamp, err = container1Parser.Parse(msgToClean)
+	content, status, timestamp, partial, err = container1Parser.Parse(msgToClean)
 	assert.Nil(t, err)
+	assert.False(t, partial)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", timestamp)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, expectedMsg, content)
@@ -106,8 +110,9 @@ func TestDockerStandaloneParserShouldRemovePartialHeaders(t *testing.T) {
 	// three times over 16kb
 	msgToClean = []byte(buildPartialMessage('a', dockerBufferSize) + buildPartialMessage('a', dockerBufferSize) + buildPartialMessage('a', dockerBufferSize) + buildPartialMessage('b', 50))
 	expectedMsg = []byte(buildMessage('a', 3*dockerBufferSize) + buildMessage('b', 50))
-	content, status, timestamp, err = container1Parser.Parse(msgToClean)
+	content, status, timestamp, partial, err = container1Parser.Parse(msgToClean)
 	assert.Nil(t, err)
+	assert.False(t, partial)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", timestamp)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, expectedMsg, content)

--- a/pkg/logs/input/kubernetes/decoder_test.go
+++ b/pkg/logs/input/kubernetes/decoder_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestDecoderWithSingleline(t *testing.T) {
-	var output *decoder.Output
+	var output *decoder.Message
 	var line []byte
 	var lineLen int
 
@@ -47,7 +47,7 @@ func TestDecoderWithSingleline(t *testing.T) {
 }
 
 func TestDecoderWithMultiline(t *testing.T) {
-	var output *decoder.Output
+	var output *decoder.Message
 	var line []byte
 	var lineLen int
 

--- a/pkg/logs/input/kubernetes/parser.go
+++ b/pkg/logs/input/kubernetes/parser.go
@@ -42,6 +42,10 @@ func (p *parser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 	return content, status, timestamp, isPartial(flag), err
 }
 
+func (p *parser) SupportsPartialLine() bool {
+	return true
+}
+
 func parse(msg []byte) ([]byte, string, string, string, error) {
 	var status = message.StatusInfo
 	var flag string

--- a/pkg/logs/input/kubernetes/parser.go
+++ b/pkg/logs/input/kubernetes/parser.go
@@ -8,6 +8,7 @@ package kubernetes
 import (
 	"bytes"
 	"errors"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	lineParser "github.com/DataDog/datadog-agent/pkg/logs/parser"
 )
@@ -36,9 +37,9 @@ type parser struct {
 // see https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/logs/logs.go
 // Example:
 // 2018-09-20T11:54:11.753589172Z stdout F This is my message
-func (p *parser) Parse(msg []byte) ([]byte, string, string, error) {
-	content, status, timestamp, _, err := parse(msg)
-	return content, status, timestamp, err
+func (p *parser) Parse(msg []byte) ([]byte, string, string, bool, error) {
+	content, status, timestamp, flag, err := parse(msg)
+	return content, status, timestamp, isPartial(flag), err
 }
 
 func parse(msg []byte) ([]byte, string, string, string, error) {
@@ -57,6 +58,13 @@ func parse(msg []byte) ([]byte, string, string, string, error) {
 	timestamp = string(components[0])
 	flag = string(components[2])
 	return content, status, timestamp, flag, nil
+}
+
+func isPartial(flag string) bool {
+	if flag == "P" {
+		return true
+	}
+	return false
 }
 
 // getStatus returns the status of the message based on

--- a/pkg/logs/input/kubernetes/parser.go
+++ b/pkg/logs/input/kubernetes/parser.go
@@ -65,10 +65,7 @@ func parse(msg []byte) ([]byte, string, string, string, error) {
 }
 
 func isPartial(flag string) bool {
-	if flag == "P" {
-		return true
-	}
-	return false
+	return flag == "P"
 }
 
 // getStatus returns the status of the message based on

--- a/pkg/logs/input/kubernetes/parser_test.go
+++ b/pkg/logs/input/kubernetes/parser_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var containerdHeaderOut = "2018-09-20T11:54:11.753589172Z stdout F"
+var partialContainerdHeaderOut = "2018-09-20T11:54:11.753589172Z stdout P"
 
 func TestGetKubernetesSeverity(t *testing.T) {
 	assert.Equal(t, message.StatusInfo, getStatus([]byte("stdout")))
@@ -22,16 +23,26 @@ func TestGetKubernetesSeverity(t *testing.T) {
 
 func TestParserShouldSucceedWithValidInput(t *testing.T) {
 	validMessage := containerdHeaderOut + " " + "anything"
-	content, status, _, err := Parser.Parse([]byte(validMessage))
+	content, status, _, partial, err := Parser.Parse([]byte(validMessage))
 	assert.Nil(t, err)
+	assert.False(t, partial)
+	assert.Equal(t, message.StatusInfo, status)
+	assert.Equal(t, []byte("anything"), content)
+}
+func TestParserShouldSucceedWithPartialFlag(t *testing.T) {
+	validMessage := partialContainerdHeaderOut + " " + "anything"
+	content, status, _, partial, err := Parser.Parse([]byte(validMessage))
+	assert.Nil(t, err)
+	assert.True(t, partial)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, []byte("anything"), content)
 }
 
 func TestParserShouldHandleEmptyMessage(t *testing.T) {
-	msg, status, timestamp, err := Parser.Parse([]byte(containerdHeaderOut))
+	msg, status, timestamp, partial, err := Parser.Parse([]byte(containerdHeaderOut))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(msg))
+	assert.False(t, partial)
 	assert.Equal(t, message.StatusInfo, status)
 	assert.Equal(t, "2018-09-20T11:54:11.753589172Z", timestamp)
 }
@@ -40,7 +51,8 @@ func TestParserShouldFailWithInvalidInput(t *testing.T) {
 	// Only timestamp
 	var err error
 	log := []byte("2018-09-20T11:54:11.753589172Z foo")
-	msg, status, timestamp, err := Parser.Parse(log)
+	msg, status, timestamp, partial, err := Parser.Parse(log)
+	assert.False(t, partial)
 	assert.NotNil(t, err)
 	assert.Equal(t, log, msg)
 	assert.Equal(t, message.StatusInfo, status)
@@ -49,6 +61,6 @@ func TestParserShouldFailWithInvalidInput(t *testing.T) {
 	// Missing timestamp but with 3 spaces, the message is valid
 	// FIXME: We might want to handle that
 	log = []byte("stdout F foo bar")
-	_, _, _, err = Parser.Parse(log)
+	_, _, _, _, err = Parser.Parse(log)
 	assert.Nil(t, err)
 }

--- a/pkg/logs/parser/parser.go
+++ b/pkg/logs/parser/parser.go
@@ -50,6 +50,7 @@ type DecodingParser struct {
 	Parser
 }
 
+// Parse pases the incoming message with the decoder
 func (p *DecodingParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 	decoded, _, err := transform.Bytes(p.decoder, msg)
 	return decoded, "", "", false, err

--- a/pkg/logs/parser/parser.go
+++ b/pkg/logs/parser/parser.go
@@ -26,7 +26,7 @@ const (
 
 // Parser parse messages
 type Parser interface {
-	// Returns : messages, status, timestamp, isPartial, error
+	// It returns 1. raw message, 2. severity, 3. timestamp, 4. partial, 5. error
 	Parse([]byte) ([]byte, string, string, bool, error)
 }
 

--- a/pkg/logs/parser/parser.go
+++ b/pkg/logs/parser/parser.go
@@ -28,6 +28,7 @@ const (
 type Parser interface {
 	// It returns 1. raw message, 2. severity, 3. timestamp, 4. partial, 5. error
 	Parse([]byte) ([]byte, string, string, bool, error)
+	SupportsPartialLine() bool
 }
 
 type noopParser struct {
@@ -39,16 +40,19 @@ func (p *noopParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 	return msg, "", "", false, nil
 }
 
+func (p *noopParser) SupportsPartialLine() bool {
+	return false
+}
+
 // DecodingParser a generic decoding Parser
 type DecodingParser struct {
 	decoder *encoding.Decoder
 	Parser
 }
 
-// Parse does nothing for NoopParser
-func (p *DecodingParser) Parse(msg []byte) ([]byte, string, string, error) {
+func (p *DecodingParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 	decoded, _, err := transform.Bytes(p.decoder, msg)
-	return decoded, "", "", err
+	return decoded, "", "", false, err
 }
 
 // NewDecodingParser build a new DecodingParser

--- a/pkg/logs/parser/parser.go
+++ b/pkg/logs/parser/parser.go
@@ -26,7 +26,8 @@ const (
 
 // Parser parse messages
 type Parser interface {
-	Parse([]byte) ([]byte, string, string, error)
+	// Returns : messages, status, timestamp, isPartial, error
+	Parse([]byte) ([]byte, string, string, bool, error)
 }
 
 type noopParser struct {
@@ -34,8 +35,8 @@ type noopParser struct {
 }
 
 // Parse does nothing for NoopParser
-func (p *noopParser) Parse(msg []byte) ([]byte, string, string, error) {
-	return msg, "", "", nil
+func (p *noopParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
+	return msg, "", "", false, nil
 }
 
 // DecodingParser a generic decoding Parser

--- a/pkg/logs/parser/parser_test.go
+++ b/pkg/logs/parser/parser_test.go
@@ -23,19 +23,19 @@ func TestNoopParserHandleMessages(t *testing.T) {
 func TestUTF16LEParserHandleMessages(t *testing.T) {
 	parser := NewDecodingParser(UTF16LE)
 	testMsg := []byte{'F', 0x0, 'o', 0x0, 'o', 0x0}
-	msg, _, _, err := parser.Parse(testMsg)
+	msg, _, _, _, err := parser.Parse(testMsg)
 	assert.Nil(t, err)
 	assert.Equal(t, "Foo", string(msg))
 
 	// We should support BOM
 	testMsg = []byte{0xFF, 0xFE, 'F', 0x0, 'o', 0x0, 'o', 0x0}
-	msg, _, _, err = parser.Parse(testMsg)
+	msg, _, _, _, err = parser.Parse(testMsg)
 	assert.Nil(t, err)
 	assert.Equal(t, "Foo", string(msg))
 
 	// BOM overrides endianness
 	testMsg = []byte{0xFE, 0xFF, 0x0, 'F', 0x0, 'o', 0x0, 'o'}
-	msg, _, _, err = parser.Parse(testMsg)
+	msg, _, _, _, err = parser.Parse(testMsg)
 	assert.Nil(t, err)
 	assert.Equal(t, "Foo", string(msg))
 }
@@ -43,19 +43,19 @@ func TestUTF16LEParserHandleMessages(t *testing.T) {
 func TestUTF16BEParserHandleMessages(t *testing.T) {
 	parser := NewDecodingParser(UTF16BE)
 	testMsg := []byte{0x0, 'F', 0x0, 'o', 0x0, 'o'}
-	msg, _, _, err := parser.Parse(testMsg)
+	msg, _, _, _, err := parser.Parse(testMsg)
 	assert.Nil(t, err)
 	assert.Equal(t, "Foo", string(msg))
 
 	// We should support BOM
 	testMsg = []byte{0xFE, 0xFF, 0x0, 'F', 0x0, 'o', 0x0, 'o'}
-	msg, _, _, err = parser.Parse(testMsg)
+	msg, _, _, _, err = parser.Parse(testMsg)
 	assert.Nil(t, err)
 	assert.Equal(t, "Foo", string(msg))
 
 	// BOM overrides endianness
 	testMsg = []byte{0xFF, 0xFE, 'F', 0x0, 'o', 0x0, 'o', 0x0}
-	msg, _, _, err = parser.Parse(testMsg)
+	msg, _, _, _, err = parser.Parse(testMsg)
 	assert.Nil(t, err)
 	assert.Equal(t, "Foo", string(msg))
 }

--- a/pkg/logs/parser/parser_test.go
+++ b/pkg/logs/parser/parser_test.go
@@ -14,8 +14,9 @@ import (
 func TestNoopParserHandleMessages(t *testing.T) {
 	parser := NoopParser
 	testMsg := []byte("Foo")
-	msg, _, _, err := parser.Parse(testMsg)
+	msg, _, _, partial, err := parser.Parse(testMsg)
 	assert.Nil(t, err)
+	assert.False(t, partial)
 	assert.Equal(t, testMsg, msg)
 }
 


### PR DESCRIPTION
### What does this PR do?
It isolates the parsing logic in the log pipeline (when tailing from file):
It changes
```
[...] -> decoder -> line_handler -> [...]
```
by
```
[...] -> decoder -> line_parser -> line_handler -> [...]
```

### Motivation
Make room for additional parsing+buffering logic to support split lines (usecase: log tailing in a k8s environment with explicit tailing from file, lines are split in 16k chunks) and keeps other feature intact.

### Additional Notes
It will add a slight overhead.
See subsequent PR #6266 for the release note.

### Describe your test plan
Existing UT adjusted.
New UT.
IRL tests.
