### PR TITLE
[logs] Aggregates long lines when tailing in a k8s env - part #2

### DIFF
--- a/pkg/logs/decoder/decoder.go
+++ b/pkg/logs/decoder/decoder.go
@@ -96,7 +96,7 @@ func NewDecoderWithEndLineMatcher(source *config.LogSource, parser parser.Parser
 	}
 
 	if parser.SupportsPartialLine() {
-		lineParser = NewSingleLineParser(parser, lineHandler)
+		lineParser = NewMultiLineParser(defaultFlushTimeout, parser, lineHandler, lineLimit)
 	} else {
 		lineParser = NewSingleLineParser(parser, lineHandler)
 	}

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -248,7 +248,7 @@ func (h *MultiLineHandler) sendBuffer() {
 	content := make([]byte, len(data))
 	copy(content, data)
 
-	if len(content) > 0 {
+	if len(content) > 0 || h.linesLen > 0 {
 		h.outputChan <- NewMessage(content, h.status, h.linesLen, h.timestamp)
 	}
 }

--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -217,3 +217,31 @@ func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
 
 	h.Stop()
 }
+
+func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
+	outputChan := make(chan *Message, 10)
+	h := NewSingleLineHandler(outputChan, 100)
+	h.Start()
+
+	h.Handle(getDummyMessage("one message"))
+
+	var output *Message
+
+	output = <-outputChan
+	assert.Equal(t, "one message", string(output.Content))
+}
+
+func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
+	outputChan := make(chan *Message, 10)
+	re := regexp.MustCompile("[0-9]+\\.")
+	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, 100)
+	h.Start()
+
+	h.Handle(getDummyMessage("1.third line"))
+	h.Handle(getDummyMessage("fourth line"))
+
+	var output *Message
+
+	output = <-outputChan
+	assert.Equal(t, "1.third line\\nfourth line", string(output.Content))
+}

--- a/pkg/logs/decoder/line_parser.go
+++ b/pkg/logs/decoder/line_parser.go
@@ -6,6 +6,9 @@
 package decoder
 
 import (
+	"bytes"
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/parser"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -48,7 +51,6 @@ func (p *SingleLineParser) Start() {
 // Stop stops the parser.
 func (p *SingleLineParser) Stop() {
 	close(p.inputChan)
-	p.lineHandler.Stop()
 }
 
 // run consumes new lines and processes them.
@@ -56,6 +58,7 @@ func (p *SingleLineParser) run() {
 	for input := range p.inputChan {
 		p.process(input)
 	}
+	p.lineHandler.Stop()
 }
 
 func (p *SingleLineParser) process(input *DecodedInput) {
@@ -65,4 +68,117 @@ func (p *SingleLineParser) process(input *DecodedInput) {
 		log.Debug(err)
 	}
 	p.lineHandler.Handle(NewMessage(content, status, input.rawDataLen, timestamp))
+}
+
+// MultiLineParser makes sure that chunked lines are properly put together.
+type MultiLineParser struct {
+	buffer       *bytes.Buffer
+	flushTimeout time.Duration
+	inputChan    chan *DecodedInput
+	lineHandler  LineHandler
+	parser       parser.Parser
+	rawDataLen   int
+	lineLimit    int
+	status       string
+	timestamp    string
+}
+
+// NewMultiLineParser returns a new MultiLineHandler.
+func NewMultiLineParser(flushTimeout time.Duration, parser parser.Parser, lineHandler LineHandler, lineLimit int) *MultiLineParser {
+	return &MultiLineParser{
+		inputChan:    make(chan *DecodedInput),
+		buffer:       bytes.NewBuffer(nil),
+		flushTimeout: flushTimeout,
+		lineHandler:  lineHandler,
+		lineLimit:    lineLimit,
+		parser:       parser,
+	}
+}
+
+// Handle forward lines to lineChan to process them.
+func (p *MultiLineParser) Handle(input *DecodedInput) {
+	p.inputChan <- input
+}
+
+// Stop stops the handler.
+func (p *MultiLineParser) Stop() {
+	close(p.inputChan)
+}
+
+// Start starts the handler.
+func (p *MultiLineParser) Start() {
+	p.lineHandler.Start()
+	go p.run()
+}
+
+// run processes new lines from the channel and makes sur the content is properly sent when
+// it stayed for too long in the buffer.
+func (p *MultiLineParser) run() {
+	flushTimer := time.NewTimer(p.flushTimeout)
+	defer func() {
+		flushTimer.Stop()
+		// make sure the content stored in the buffer gets sent,
+		// this can happen when the stop is called in between two timer ticks.
+		p.sendLine()
+		p.lineHandler.Stop()
+	}()
+	for {
+		select {
+		case message, isOpen := <-p.inputChan:
+			if !isOpen {
+				//  inputChan has been closed, no more lines are expected
+				return
+			}
+			// process the new line and restart the timeout
+			if !flushTimer.Stop() {
+				// timer stop doesn't not prevent the timer to tick,
+				// makes sure the event is consumed to avoid sending
+				// just one piece of the content.
+				select {
+				case <-flushTimer.C:
+				default:
+				}
+			}
+			p.process(message)
+			flushTimer.Reset(p.flushTimeout)
+		case <-flushTimer.C:
+			// no chunk has been collected since a while,
+			// the content is supposed to be complete.
+			p.sendLine()
+		}
+	}
+}
+
+// process buffers and aggregates partial lines
+func (p *MultiLineParser) process(input *DecodedInput) {
+	content, status, timestamp, partial, err := p.parser.Parse(input.content)
+	if err != nil {
+		log.Debug(err)
+	}
+	// track the raw data length and the timestamp so that the agent tails
+	// from the right place at restart
+	p.rawDataLen += input.rawDataLen
+	p.timestamp = timestamp
+	p.status = status
+	p.buffer.Write(content)
+
+	if !partial || p.buffer.Len() >= p.lineLimit {
+		// the current chunk marks the end of an aggregated line
+		p.sendLine()
+	}
+}
+
+// sendBuffer forwards the content stored in the buffer
+// to the output channel.
+func (p *MultiLineParser) sendLine() {
+	defer func() {
+		p.buffer.Reset()
+		p.rawDataLen = 0
+	}()
+
+	content := make([]byte, p.buffer.Len())
+	copy(content, p.buffer.Bytes())
+	if len(content) > 0 || p.rawDataLen > 0 {
+		p.lineHandler.Handle(NewMessage(content, p.status, p.rawDataLen, p.timestamp))
+	}
 }

--- a/pkg/logs/decoder/line_parser_test.go
+++ b/pkg/logs/decoder/line_parser_test.go
@@ -8,11 +8,15 @@ package decoder
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/parser"
 	"github.com/stretchr/testify/assert"
 )
+
+const header = "HEADER"
 
 type MockHandler struct {
 	ouputChan chan *Message
@@ -38,21 +42,25 @@ func NewMockFailingParser(header string) parser.Parser {
 	return &MockFailingParser{header: []byte(header)}
 }
 
-// Parse removes header from line and returns a message if its header matches the Parser header
-// or returns an error
+// Parse removes header from line, returns a message if its header matches the Parser header
+// or returns an error and flags the line as partial if it does not end up by \n
 func (u *MockFailingParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 	if bytes.HasPrefix(msg, u.header) {
-		return bytes.Replace(msg, u.header, []byte(""), 1), "", "", false, nil
+		msg := bytes.Replace(msg, u.header, []byte(""), 1)
+		l := len(msg)
+		if l > 1 && msg[l-2] == '\\' && msg[l-1] == 'n' {
+			return msg[:l-2], "", "", false, nil
+		}
+		return msg, "", "", true, nil
 	}
 	return msg, "", "", false, fmt.Errorf("error")
 }
 
 func (u *MockFailingParser) SupportsPartialLine() bool {
-	return false
+	return true
 }
 
 func TestSingleLineParser(t *testing.T) {
-	const header = "HEADER"
 	var message *Message
 	h := &MockHandler{make(chan *Message)}
 	p := NewMockFailingParser(header)
@@ -78,7 +86,6 @@ func TestSingleLineParser(t *testing.T) {
 }
 
 func TestSingleLineParserSendsRawInvalidMessages(t *testing.T) {
-	const header = "HEADER"
 
 	h := &MockHandler{make(chan *Message)}
 	p := NewMockFailingParser(header)
@@ -89,6 +96,76 @@ func TestSingleLineParserSendsRawInvalidMessages(t *testing.T) {
 	lineParser.Handle(&DecodedInput{[]byte("one message"), 12})
 	message := <-h.ouputChan
 	assert.Equal(t, "one message", string(message.Content))
+
+	lineParser.Stop()
+}
+
+func TestMultilineParser(t *testing.T) {
+	h := &MockHandler{make(chan *Message)}
+	p := NewMockFailingParser(header)
+	timeout := 1000 * time.Millisecond
+	contentLenLimit := 256 * 100
+
+	lineParser := NewMultiLineParser(timeout, p, h, contentLenLimit)
+	lineParser.Start()
+
+	lineParser.Handle(&DecodedInput{[]byte(header + "one "), 11})
+	lineParser.Handle(&DecodedInput{[]byte(header + "long "), 12})
+	lineParser.Handle(&DecodedInput{[]byte(header + "line\\n"), 14})
+
+	message := <-h.ouputChan
+
+	assert.Equal(t, "one long line", string(message.Content))
+	assert.Equal(t, message.RawDataLen, 11+12+14)
+
+	lineParser.Stop()
+}
+
+func TestMultilineParserTimeout(t *testing.T) {
+	h := &MockHandler{make(chan *Message)}
+	p := NewMockFailingParser(header)
+	timeout := 100 * time.Millisecond
+	contentLenLimit := 256 * 100
+
+	lineParser := NewMultiLineParser(timeout, p, h, contentLenLimit)
+	lineParser.Start()
+
+	lineParser.Handle(&DecodedInput{[]byte(header + "message"), 14})
+
+	message := <-h.ouputChan
+
+	assert.Equal(t, "message", string(message.Content))
+	assert.Equal(t, message.RawDataLen, 14)
+
+	lineParser.Stop()
+}
+
+func TestMultilineParserLimit(t *testing.T) {
+	// Allow buffering to ensure the line_parser does not timeout
+	h := &MockHandler{make(chan *Message, 10)}
+	p := NewMockFailingParser(header)
+	timeout := 1000 * time.Millisecond
+	contentLenLimit := 64
+	var message *Message
+	line := strings.Repeat("a", contentLenLimit)
+
+	lineParser := NewMultiLineParser(timeout, p, h, contentLenLimit)
+	lineParser.Start()
+
+	for i := 0; i < 10; i++ {
+		lineParser.Handle(&DecodedInput{[]byte(header + line), 7 + len(line)})
+	}
+	lineParser.Handle(&DecodedInput{[]byte(header + "aaaa\\n"), 13})
+
+	for i := 0; i < 10; i++ {
+		message = <-h.ouputChan
+		assert.Equal(t, line, string(message.Content))
+		assert.Equal(t, message.RawDataLen, 7+len(line))
+	}
+
+	message = <-h.ouputChan
+	assert.Equal(t, "aaaa", string(message.Content))
+	assert.Equal(t, message.RawDataLen, 13)
 
 	lineParser.Stop()
 }

--- a/pkg/logs/input/docker/decoder_test.go
+++ b/pkg/logs/input/docker/decoder_test.go
@@ -182,39 +182,24 @@ func TestDecoderWithJSONMultiline(t *testing.T) {
 func TestDecoderWithJSONSplittedByDocker(t *testing.T) {
 	var output *decoder.Message
 	var line []byte
-	var lineLen int
 
 	d := decoder.InitializeDecoder(config.NewLogSource("", &config.LogsConfig{}), JSONParser)
 	d.Start()
 	defer d.Stop()
 
 	line = []byte(`{"log":"part1","stream":"stdout","time":"2019-06-06T16:35:55.930852911Z"}` + "\n")
-	lineLen = len(line)
+	rawLen := len(line)
 	d.InputChan <- decoder.NewInput(line)
 
 	line = []byte(`{"log":"part2\n","stream":"stdout","time":"2019-06-06T16:35:55.930852912Z"}` + "\n")
+	rawLen += len(line)
 	d.InputChan <- decoder.NewInput(line)
 
 	// We don't reaggregate partial messages but we expect content of line not finishing with a '\n' character to be reconciliated
 	// with the next line.
-	// TODO: merge partial messages for JSON docker messages.
-	// output = <-d.OutputChan
-	// assert.Equal(t, []byte("part1part2\\n"), output.Content)
-	// assert.Equal(t, lineLen, output.RawDataLen)
-	// assert.Equal(t, message.StatusInfo, output.Status)
-	// assert.Equal(t, "2019-06-06T16:35:55.930852911Z", output.Timestamp)
-
 	output = <-d.OutputChan
-	assert.Equal(t, []byte("part1"), output.Content)
-	assert.Equal(t, lineLen, output.RawDataLen)
-	assert.Equal(t, message.StatusInfo, output.Status)
-	assert.Equal(t, "2019-06-06T16:35:55.930852911Z", output.Timestamp)
-
-	lineLen = len(line)
-
-	output = <-d.OutputChan
-	assert.Equal(t, []byte("part2"), output.Content)
-	assert.Equal(t, lineLen, output.RawDataLen)
+	assert.Equal(t, []byte("part1part2"), output.Content)
+	assert.Equal(t, rawLen, output.RawDataLen)
 	assert.Equal(t, message.StatusInfo, output.Status)
 	assert.Equal(t, "2019-06-06T16:35:55.930852912Z", output.Timestamp)
 }

--- a/releasenotes/notes/long-log-lines-reconciliation-a79d1871b6a6a581.yaml
+++ b/releasenotes/notes/long-log-lines-reconciliation-a79d1871b6a6a581.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When tailing logs from container in a kubernetes environment
+    long lines (>16kB usually) that got split by the container
+    runtime (docker & containerd at least) are now reassembled
+    pending they do not exceed the upper message length limit
+    (256kB).


### PR DESCRIPTION
### What does this PR do?
Enable buffering+concatenation for split lines.
Useful in k8s env when tailing from file (`logs_config.k8s_container_use_file: true`)

### Motivation
Get entire log line show in log explorer when lines are longer tha 16kB.

### Additional Notes
Depends on #6265 

### Describe your test plan
UT
IRL tests : agent running in k8s with different container runtime (at least containerd and docker) and  `logs_config.k8s_container_use_file: true` :
- minikube + docker ✅ 
- minikube + containerd ✅ 