### PR TITLE
Update zypper flag

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -282,7 +282,7 @@ elif [ "$OS" = "SUSE" ]; then
   $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://${yum_url}/suse/${yum_version_path}/${ARCHI}\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=${gpgkeys}' > /etc/zypp/repos.d/datadog.repo"
 
   echo -e "\033[34m\n* Refreshing repositories\n\033[0m"
-  $sudo_cmd zypper --non-interactive --no-gpg-check refresh datadog
+  $sudo_cmd zypper --non-interactive --no-gpg-checks refresh datadog
 
   echo -e "\033[34m\n* Installing Datadog Agent\n\033[0m"
   $sudo_cmd zypper --non-interactive install "$agent_flavor"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -6,7 +6,7 @@
 # using the package manager and Datadog repositories.
 
 set -e
-install_script_version=1.0.0
+install_script_version=1.0.1
 logfile="ddagent-install.log"
 
 LEGACY_ETCDIR="/etc/dd-agent"


### PR DESCRIPTION
### What does this PR do?

Correct Zypper No GPG Check flag

Zypper in previous SUSE approximates `--no-gpg-check` to `--no-gpg-checks` but the latter is the correct one.

### Motivation

SUSE/SLES 15 now fails and throws `The flag --no-gpg-check is not known.`
https://datadoghq.atlassian.net/browse/AGENT-4882

### Additional Notes

I've checked `--help` in both SLES 11 and 12, the flag is `--no-gpg-checks` but does not throw errors when using `--no-gpg-check`

### Describe your test plan

Write there any instructions and details you may have to test your PR.
