### PR TITLE
Use Map.IterateFrom to prevent problems on older kernels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/DataDog/agent-payload v4.40.0+incompatible
 	github.com/DataDog/datadog-go v3.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200527110245-7850164045c8
-	github.com/DataDog/ebpf v0.0.0-20200813173322-0c621fa94637
+	github.com/DataDog/ebpf v0.0.0-20200825200022-7a8f7d072a50
 	github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect
@@ -153,7 +153,7 @@ require (
 	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d
+	golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,10 @@ github.com/DataDog/ebpf v0.0.0-20200810204017-170f39a7810a h1:oFmjBcE1Oq3YyWfs8K
 github.com/DataDog/ebpf v0.0.0-20200810204017-170f39a7810a/go.mod h1:KNnyHMGc9auLVSPvYY8ws1BRvZP5THoxJuhfEOsuW7U=
 github.com/DataDog/ebpf v0.0.0-20200813173322-0c621fa94637 h1:JsOzZpmDuaPP7tBqeNoPGbb+yYz4BtPa/gZci3TxZIs=
 github.com/DataDog/ebpf v0.0.0-20200813173322-0c621fa94637/go.mod h1:KNnyHMGc9auLVSPvYY8ws1BRvZP5THoxJuhfEOsuW7U=
+github.com/DataDog/ebpf v0.0.0-20200825172706-b86dd82d5a08 h1:C75xwpqf39k2J69yawGNK9uAs/67i7dbHJvHZYI8iDY=
+github.com/DataDog/ebpf v0.0.0-20200825172706-b86dd82d5a08/go.mod h1:KNnyHMGc9auLVSPvYY8ws1BRvZP5THoxJuhfEOsuW7U=
+github.com/DataDog/ebpf v0.0.0-20200825200022-7a8f7d072a50 h1:SDv8tEPuNd5sSIDksVwvwcgXP3ElGaQSuCB7Mtfluf8=
+github.com/DataDog/ebpf v0.0.0-20200825200022-7a8f7d072a50/go.mod h1:KNnyHMGc9auLVSPvYY8ws1BRvZP5THoxJuhfEOsuW7U=
 github.com/DataDog/gobpf v0.0.0-20200131184214-6763fd92fd3f h1:vPk11ERhqpKweLLyXanBlUwKFdkpqDTEDWanr/fLZok=
 github.com/DataDog/gobpf v0.0.0-20200131184214-6763fd92fd3f/go.mod h1:rNvi5cSHdpxN6495MOYAWN3yukac8lORoluL+9Osrsw=
 github.com/DataDog/gobpf v0.0.0-20200728095841-88e65b29b186 h1:M/TmXm0VnfBmg9zkqdz+JQpaPgdgohQ81UE+tClyGiQ=
@@ -1556,6 +1560,8 @@ golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed h1:WBkVNH1zd9jg/dK4HCM4lNANn
 golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d h1:QQrM/CCYEzTs91GZylDCQjGHudbPTxF/1fvXdVh5lMo=
 golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8 h1:AvbQYmiaaaza3cW3QXRyPo5kYgpFIzOAfeAAN7m3qQ4=
+golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180805044716-cb6730876b98/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -521,7 +521,7 @@ func (t *Tracer) getConnections(active []network.ConnectionStats) ([]network.Con
 	key, stats := &ConnTuple{}, &ConnStatsWithTimestamp{}
 	seen := make(map[ConnTuple]struct{})
 	var expired []*ConnTuple
-	entries := mp.Iterate()
+	entries := mp.IterateFrom(unsafe.Pointer(&ConnTuple{}))
 	for entries.Next(unsafe.Pointer(key), unsafe.Pointer(stats)) {
 		if stats.isExpired(latestTime, t.timeoutForConn(key)) {
 			expired = append(expired, key.copy())
@@ -754,12 +754,12 @@ func (t *Tracer) DebugNetworkMaps() (*network.Connections, error) {
 // the map will be one of port_bindings  or udp_port_bindings, and the mapping will be one of tracer#portMapping
 // tracer#udpPortMapping respectively.
 func (t *Tracer) populatePortMapping(mp *ebpf.Map, mapping *network.PortMapping) ([]uint16, error) {
-	var key uint16
+	var key, emptyKey uint16
 	var state uint8
 
 	closedPortBindings := make([]uint16, 0)
 
-	entries := mp.Iterate()
+	entries := mp.IterateFrom(unsafe.Pointer(&emptyKey))
 	for entries.Next(unsafe.Pointer(&key), unsafe.Pointer(&state)) {
 		port := key
 


### PR DESCRIPTION
### What does this PR do?

Use eBPF map workaround to prevent problems with map iteration on older kennels.

### Motivation

Kernels older than `4.4.132` (or linux ubuntu aws < `4.4.0-1062`) do not support calling `bpf` syscall, command `BPF_MAP_GET_NEXT_KEY` with a `NULL` key. Instead we use a non-existing key for the initial call.

This error would show up in the logs as `unable to retrieve connections: error retrieving connections: unable to iterate connection map: next key failed: bad address` whenever `process-agent` tried to retrieve the connections list from `system-probe`.

### Describe your test plan

I reproduced the issue with a Vagrant VM using `bento/ubuntu-16.04 box-version 201803.24.0` which is kernel version `4.4.0-87-generic`, by installing `7.22.0-rc.6`. I confirmed this fix worked on the same VM by replacing `system-probe` with a newly built version (without bcc).
