### PR TITLE
Make Windows docker entrypoint job depend on the Windows test job.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -562,6 +562,8 @@ build_windows_container_entrypoint:
     when: on_success
   stage: binary_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
+  needs:
+    - run_tests_windows-x64
   variables:
     ARCH: "x64"
   script:


### PR DESCRIPTION
### What does this PR do?

Make Windows docker entrypoint job depend on the Windows test job.

### Motivation

Gitlab seems to skip the entrypoint job if a job in a previous stage fails, which in turn makes the docker build jobs fail.
