### PR TITLE
Fix agent payload version check

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -143,13 +143,15 @@ def get_payload_version():
                 continue
             pkgname = whitespace_split[0]
             if pkgname == "github.com/DataDog/agent-payload":
-                # Example of line: github.com/DataDog/agent-payload v4.40.0+incompatible
+                # Example of line
+                # github.com/DataDog/agent-payload v4.40.0+incompatible
+                # github.com/DataDog/agent-payload v4.42.1-0.20200826134834-1ddcfb686e3f+incompatible
                 version_split = re.split(r'[ +]', line)
                 if len(version_split) < 2:
                     raise Exception(
                         "Versioning of agent-payload in go.mod has changed, the version logic needs to be updated"
                     )
-                version = version_split[1].strip()
+                version = version_split[1].split("-")[0].strip()
                 if not re.search(r"^v\d+(\.\d+){2}$", version):
                     raise Exception("Version of agent-payload in go.mod is invalid: '{}'".format(version))
                 return version

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -149,7 +149,7 @@ def get_payload_version():
                     raise Exception(
                         "Versioning of agent-payload in go.mod has changed, the version logic needs to be updated"
                     )
-                version = version_split[1].strip()
+                version = version_split[1].split("-")[0].strip()
                 if not re.search(r"^v\d+(\.\d+){2}$", version):
                     raise Exception("Version of agent-payload in go.mod is invalid: '{}'".format(version))
                 return version


### PR DESCRIPTION
### What does this PR do?

If we are making changes in `agent-payload`, we sometimes need to use a specific version of that module in the `agent-repo` based on a commit hash. That breaks the _version extraction_ code. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

```python
>>> import re
>>> line1 = "github.com/DataDog/agent-payload v4.40.0+incompatible"
>>> line2 = "github.com/DataDog/agent-payload v4.42.1-0.20200826134834-1ddcfb686e3f+incompatible"
>>> version_split = re.split(r'[ +]', line1)
>>> version = version_split[1].split("-")[0].strip()
>>> re.search(r"^v\d+(\.\d+){2}$", version)
<_sre.SRE_Match object at 0x1097904b0>
>>> version
'v4.40.0'
>>> version_split = re.split(r'[ +]', line2)
>>> version = version_split[1].split("-")[0].strip()
>>> re.search(r"^v\d+(\.\d+){2}$", version)
<_sre.SRE_Match object at 0x1097904b0>
>>> version
'v4.42.1'
```


