### PR TITLE
[System Probe][Windows] Fix regression that exported IsTracerSupportedByOS to a separate repo

### DIFF
--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -3,30 +3,13 @@ package ebpf
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
-	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf"
 	"github.com/pkg/errors"
 )
-
-// Feature versions sourced from: https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md
-var requiredKernelFuncs = []string{
-	// Maps (3.18)
-	"bpf_map_lookup_elem",
-	"bpf_map_update_elem",
-	"bpf_map_delete_elem",
-	// bpf_probe_read intentionally omitted since it was renamed in kernel 5.5
-	// Perf events (4.4)
-	"bpf_perf_event_output",
-	"bpf_perf_event_read",
-}
 
 var (
 	// ErrNotImplemented will be returned on non-linux environments like Windows and Mac OSX
@@ -35,63 +18,6 @@ var (
 	// CIncludePattern is the regex for #include headers of C files
 	CIncludePattern = `^\s*#\s*include\s+"(.*)"$`
 )
-
-// IsTracerSupportedByOS returns whether or not the current kernel version supports tracer functionality
-// along with some context on why it's not supported
-func IsTracerSupportedByOS(exclusionList []string) (bool, string) {
-	currentKernelCode, err := ebpf.CurrentKernelVersion()
-	if err == ErrNotImplemented {
-		log.Infof("Could not detect OS, will assume supported.")
-	} else if err != nil {
-		return false, fmt.Sprintf("could not get kernel version: %s", err)
-	}
-
-	platform, err := util.GetPlatform()
-	if err != nil {
-		log.Warnf("error retrieving current platform: %s", err)
-	} else {
-		log.Infof("running on platform: %s", platform)
-	}
-	return verifyOSVersion(currentKernelCode, platform, exclusionList)
-}
-
-func verifyKernelFuncs(path string) ([]string, error) {
-	// Will hold the found functions
-	found := make(map[string]bool, len(requiredKernelFuncs))
-	for _, f := range requiredKernelFuncs {
-		found[f] = false
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading kallsyms file from: %s", path)
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Split(bufio.ScanLines)
-
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) < 3 {
-			continue
-		}
-
-		name := fields[2]
-		if _, ok := found[name]; ok {
-			found[name] = true
-		}
-	}
-
-	missing := []string{}
-	for probe, b := range found {
-		if !b {
-			missing = append(missing, probe)
-		}
-	}
-
-	return missing, nil
-}
 
 // snakeToCapInitialCamel converts a snake case to Camel case with capital initial
 func snakeToCapInitialCamel(s string) string {

--- a/pkg/ebpf/common_test.go
+++ b/pkg/ebpf/common_test.go
@@ -6,23 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVerifyKernelFuncs(t *testing.T) {
-	missing, err := verifyKernelFuncs("./testdata/kallsyms.supported")
-	assert.Empty(t, missing)
-	assert.Empty(t, err)
-
-	missing, err = verifyKernelFuncs("./testdata/kallsyms.unsupported")
-	assert.NotEmpty(t, missing)
-	assert.Empty(t, err)
-
-	missing, err = verifyKernelFuncs("./testdata/kallsyms.empty")
-	assert.NotEmpty(t, missing)
-	assert.Empty(t, err)
-
-	_, err = verifyKernelFuncs("./testdata/kallsyms.d_o_n_o_t_e_x_i_s_t")
-	assert.NotEmpty(t, err)
-}
-
 func TestSnakeToCamel(t *testing.T) {
 	for test, exp := range map[string]string{
 		"closed_conn_dropped":      "ClosedConnDropped",

--- a/pkg/ebpf/utils_linux.go
+++ b/pkg/ebpf/utils_linux.go
@@ -5,10 +5,11 @@ package ebpf
 import (
 	"bufio"
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/DataDog/ebpf"
 

--- a/pkg/ebpf/utils_linux_test.go
+++ b/pkg/ebpf/utils_linux_test.go
@@ -54,3 +54,20 @@ func TestExcludedKernelVersion(t *testing.T) {
 	assert.True(t, ok)
 	assert.Empty(t, msg)
 }
+
+func TestVerifyKernelFuncs(t *testing.T) {
+	missing, err := verifyKernelFuncs("./testdata/kallsyms.supported")
+	assert.Empty(t, missing)
+	assert.Empty(t, err)
+
+	missing, err = verifyKernelFuncs("./testdata/kallsyms.unsupported")
+	assert.NotEmpty(t, missing)
+	assert.Empty(t, err)
+
+	missing, err = verifyKernelFuncs("./testdata/kallsyms.empty")
+	assert.NotEmpty(t, missing)
+	assert.Empty(t, err)
+
+	_, err = verifyKernelFuncs("./testdata/kallsyms.d_o_n_o_t_e_x_i_s_t")
+	assert.NotEmpty(t, err)
+}

--- a/pkg/ebpf/utils_unsupported.go
+++ b/pkg/ebpf/utils_unsupported.go
@@ -2,6 +2,12 @@
 
 package ebpf
 
+// IsTracerSupportedByOS returns whether or not the current kernel version supports tracer functionality
+// along with some context on why it's not supported
+func IsTracerSupportedByOS(exclusionList []string) (bool, string) {
+	return verifyOSVersion(0, "", nil)
+}
+
 func verifyOSVersion(kernelCode uint32, platform string, exclusionList []string) (bool, string) {
 	return false, "unsupported architecture"
 }

--- a/pkg/ebpf/utils_windows.go
+++ b/pkg/ebpf/utils_windows.go
@@ -2,6 +2,12 @@
 
 package ebpf
 
+// IsTracerSupportedByOS returns whether or not the current kernel version supports tracer functionality
+// along with some context on why it's not supported
+func IsTracerSupportedByOS(exclusionList []string) (bool, string) {
+	return verifyOSVersion(0, "", nil)
+}
+
 // TODO Determine which windows versions we will support, and potentially remove kernelCode from parameters list
 func verifyOSVersion(kernelCode uint32, platform string, exclusionList []string) (bool, string) {
 	return true, ""


### PR DESCRIPTION
### What does this PR do?

Adds dummy windows IsTracerSupportedByOS function and refactors code that checks this for linux. 

### Motivation

Regression caused by ebpf refactoring caused the windows system probe to not build. 