### PR TITLE
Add conntrack sampling percent metric to system probe telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.42.0+incompatible
+	github.com/DataDog/agent-payload v4.43.0+incompatible
 	github.com/DataDog/datadog-go v3.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200527110245-7850164045c8
 	github.com/DataDog/ebpf v0.0.0-20200825200022-7a8f7d072a50

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload v4.42.0+incompatible h1:mLPrI/Mp/rqEphv1Gxy0bXV04U+NQUttBcPDZlPfA/s=
 github.com/DataDog/agent-payload v4.42.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.43.0+incompatible h1:SH3YqDkd2guUFGybpH2nAZNA7WlDRa/MeVhNdjA+c2A=
+github.com/DataDog/agent-payload v4.43.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/pkg/ebpf/bytecode/tracer-ebpf.go
+++ b/pkg/ebpf/bytecode/tracer-ebpf.go
@@ -596,7 +596,7 @@ func bindataPkgEbpfCTracerebpfo() (*asset, error) {
 		name:        "pkg/ebpf/c/tracer-ebpf.o",
 		size:        41280,
 		md5checksum: "",
-		mode:        os.FileMode(420),
+		mode:        os.FileMode(436),
 		modTime:     time.Unix(1, 0),
 	}
 
@@ -1027,7 +1027,7 @@ func bindataPkgEbpfCTracerebpfdebugo() (*asset, error) {
 		name:        "pkg/ebpf/c/tracer-ebpf-debug.o",
 		size:        66704,
 		md5checksum: "",
-		mode:        os.FileMode(420),
+		mode:        os.FileMode(436),
 		modTime:     time.Unix(1, 0),
 	}
 
@@ -1114,7 +1114,7 @@ func bindataPkgEbpfCOffsetguesso() (*asset, error) {
 		name:        "pkg/ebpf/c/offset-guess.o",
 		size:        8328,
 		md5checksum: "",
-		mode:        os.FileMode(420),
+		mode:        os.FileMode(436),
 		modTime:     time.Unix(1, 0),
 	}
 
@@ -1201,7 +1201,7 @@ func bindataPkgEbpfCOffsetguessdebugo() (*asset, error) {
 		name:        "pkg/ebpf/c/offset-guess-debug.o",
 		size:        8328,
 		md5checksum: "",
-		mode:        os.FileMode(420),
+		mode:        os.FileMode(436),
 		modTime:     time.Unix(1, 0),
 	}
 
@@ -2793,7 +2793,7 @@ func bindataPkgSecurityEbpfCRuntimesecurityo() (*asset, error) {
 		name:        "pkg/security/ebpf/c/runtime-security.o",
 		size:        485024,
 		md5checksum: "",
-		mode:        os.FileMode(420),
+		mode:        os.FileMode(436),
 		modTime:     time.Unix(1, 0),
 	}
 
@@ -4390,7 +4390,7 @@ func bindataPkgSecurityEbpfCRuntimesecuritysyscallwrappero() (*asset, error) {
 		name:        "pkg/security/ebpf/c/runtime-security-syscall-wrapper.o",
 		size:        486280,
 		md5checksum: "",
-		mode:        os.FileMode(420),
+		mode:        os.FileMode(436),
 		modTime:     time.Unix(1, 0),
 	}
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -458,6 +458,9 @@ func (t *Tracer) getConnTelemetry(mapSize int) *network.ConnectionsTelemetry {
 	if rtd, ok := conntrackStats["registers_dropped"]; ok {
 		tm.MonotonicConntrackRegistersDropped = rtd
 	}
+	if sp, ok := conntrackStats["sampling_pct"]; ok {
+		tm.ConntrackSamplingPercent = sp
+	}
 
 	dnsStats := t.reverseDNS.GetStats()
 	if pp, ok := dnsStats["packets_processed"]; ok {

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -64,6 +64,7 @@ func FormatTelemetry(tel *network.ConnectionsTelemetry) *model.ConnectionsTeleme
 		ConnsBpfMapSize:                    tel.ConnsBpfMapSize,
 		MonotonicUdpSendsProcessed:         tel.MonotonicUDPSendsProcessed,
 		MonotonicUdpSendsMissed:            tel.MonotonicUDPSendsMissed,
+		ConntrackSamplingPercent:           tel.ConntrackSamplingPercent,
 	}
 }
 

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -88,6 +88,7 @@ type ConnectionsTelemetry struct {
 	ConnsBpfMapSize                    int64
 	MonotonicUDPSendsProcessed         int64
 	MonotonicUDPSendsMissed            int64
+	ConntrackSamplingPercent           int64
 }
 
 // ConnectionStats stores statistics for a single connection.  Field order in the struct should be 8-byte aligned

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -136,6 +136,7 @@ func (c *ConnectionsCheck) diffTelemetry(tel *model.ConnectionsTelemetry) *model
 		ConnsBpfMapSize:           tel.ConnsBpfMapSize,
 		UdpSendsProcessed:         tel.MonotonicUdpSendsProcessed - c.lastTelemetry.UdpSendsProcessed,
 		UdpSendsMissed:            tel.MonotonicUdpSendsMissed - c.lastTelemetry.UdpSendsMissed,
+		ConntrackSamplingPercent:  tel.ConntrackSamplingPercent,
 	}
 	c.saveTelemetry(tel)
 	return cct


### PR DESCRIPTION
### What does this PR do?

Adds conntrack sampling rate (as a percentage) to the telemetry generated by the system probe by adding a field to the `ConnectionsTelemetry` struct and populating it with data from the eBPF tracer.

### Motivation

[Jira Ticket NET-690](https://datadoghq.atlassian.net/browse/NET-690)

### Additional Notes

Depends on [agent-payload #66]( https://github.com/DataDog/agent-payload/pull/66 )

### Describe your test plan

I ran the process-agent and system probe in the agent VM, then used the following commands to check
a) that the metric was being reported:

`curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/connections?client_id=1 | jq '.'`:
```
"telemetry": {
    ...
    "conntrackSamplingPercent": "100"
  }
```
and b) that the value of the metric matched the value being reported by the conntrack consumer:

`curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/stats | jq '.[] | {conntrack}'`:
```
{
  "conntrack": {
    ...
    "sampling_pct": 100,
    ...
  }
}
```

If anyone wants to test this themselves, you can checkout the branch `isabelle.sauve/testing-conntrack-sampling` - it contains the changes below along with the changes to `go.mod` and `go.sum` which will allow you to build the agents before the related `agent-payload` changes have been merged.

