### PR TITLE
Supporting secrets in JSON payload set in env vars

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -47,11 +47,34 @@ func Init(command string, arguments []string, timeout int, maxSize int) {
 
 type walkerCallback func(string) (string, error)
 
+// Viper support setting chunk of configuration through env variable using
+// Yaml/json. Sadly those are loaded on the fly when querying the
+// configuration, the underlying type remain a string. In order to support
+// nested `ENC` in JSON payload we try to unmarshal each string. This is costly
+// but only done once when loading the configuration when the agent starts.
+func handleString(str string, callback walkerCallback) (interface{}, error) {
+	var data interface{}
+	err := yaml.Unmarshal([]byte(str), &data)
+
+	if err == nil {
+		switch v := data.(type) {
+		case map[interface{}]interface{}:
+			err = walkHash(v, callback)
+			return v, err
+		case []interface{}:
+			err = walkSlice(v, callback)
+			return v, err
+		}
+	}
+
+	return callback(str)
+}
+
 func walkSlice(data []interface{}, callback walkerCallback) error {
 	for idx, k := range data {
 		switch v := k.(type) {
 		case string:
-			newValue, err := callback(v)
+			newValue, err := handleString(v, callback)
 			if err != nil {
 				return err
 			}
@@ -73,7 +96,7 @@ func walkHash(data map[interface{}]interface{}, callback walkerCallback) error {
 	for k := range data {
 		switch v := data[k].(type) {
 		case string:
-			newValue, err := callback(v)
+			newValue, err := handleString(v, callback)
 			if err != nil {
 				return err
 			}
@@ -96,7 +119,7 @@ func walkHash(data map[interface{}]interface{}, callback walkerCallback) error {
 func walk(data *interface{}, callback walkerCallback) error {
 	switch v := (*data).(type) {
 	case string:
-		newValue, err := callback(v)
+		newValue, err := handleString(v, callback)
 		if err != nil {
 			return err
 		}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -61,6 +61,13 @@ instances:
 - password: ENC[pass2]
 `)
 
+	testConfJSON = []byte(`---
+instances:
+- "{\"password\": \"ENC[pass1]\", \"user\": \"test\"}"
+- password: ENC[pass2]
+  user: test2
+`)
+
 	testConfDecrypted = []byte(`instances:
 - password: password1
   user: test
@@ -205,6 +212,34 @@ func TestDecryptSecretNoCache(t *testing.T) {
 	}
 
 	newConf, err := Decrypt(testConf, "test")
+	require.Nil(t, err)
+	assert.Equal(t, string(testConfDecrypted), string(newConf))
+}
+
+func TestDecryptSecretNestedJSON(t *testing.T) {
+	secretBackendCommand = "some_command"
+
+	defer func() {
+		secretBackendCommand = ""
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+		secretFetcher = fetchSecret
+	}()
+
+	secretFetcher = func(secrets []string, origin string) (map[string]string, error) {
+		sort.Strings(secrets)
+		assert.Equal(t, []string{
+			"pass1",
+			"pass2",
+		}, secrets)
+
+		return map[string]string{
+			"pass1": "password1",
+			"pass2": "password2",
+		}, nil
+	}
+
+	newConf, err := Decrypt(testConfJSON, "test")
 	require.Nil(t, err)
 	assert.Equal(t, string(testConfDecrypted), string(newConf))
 }

--- a/releasenotes/notes/support-secrets-in-json-in-env-7221222ffa7c245c.yaml
+++ b/releasenotes/notes/support-secrets-in-json-in-env-7221222ffa7c245c.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Secrets handles are not supported inside JSON value set through environment variables.
+    For example setting a secret in a list
+    `DD_FLARE_STRIPPED_KEYS='["ENC[auth_token_name]"]' datadog-agent run`


### PR DESCRIPTION
### What does this PR do?

Viper support setting chunk of configuration through env variable using
Yaml/json. Sadly those are loaded on the fly when querying the
configuration, the underlying type remain a string. In order to support
nested `ENC` in JSON payload we try to unmarshal each string. This is
costly but only done once when loading the configuration when the agent
starts.