### PR TITLE
add new config options and stats from driver

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -697,6 +697,8 @@ func InitConfig(config Config) {
 	config.SetKnown("system_probe_config.enable_tracepoints")
 	config.SetKnown("system_probe_config.windows.enable_monotonic_count")
 	config.SetKnown("system_probe_config.windows.driver_buffer_size")
+	config.SetKnown("system_probe_config.windows.enable_flow_read_hint")
+	config.SetKnown("system_probe_config.windows.enable_flow_context_cache")
 
 	// Network
 	config.BindEnv("network.id") //nolint:errcheck

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -104,6 +104,11 @@ type Config struct {
 
 	// DriverBufferSize (Windows only) determines the size (in bytes) of the buffer we pass to the driver when reading flows
 	DriverBufferSize int
+	// EnableFlowReadHint (Windows only) determines if the flow read optimization is enabled in the driver
+	EnableFlowReadHint bool
+
+	// EnableFlowContextCache (Windows only) determines if the flow contexts are cached or return to the heap
+	EnableFlowContextCache bool
 }
 
 // NewDefaultConfig enables traffic collection for all connection types

--- a/pkg/ebpf/tracer_windows.go
+++ b/pkg/ebpf/tracer_windows.go
@@ -44,8 +44,8 @@ type Tracer struct {
 
 // NewTracer returns an initialized tracer struct
 func NewTracer(config *Config) (*Tracer, error) {
-	di, err := network.NewDriverInterface(config.EnableMonotonicCount,
-										  config.DriverBufferSize,
+	di, err := network.NewDriverInterface(config.DriverBufferSize,
+										  config.EnableMonotonicCount,
 										  config.EnableFlowReadHint,
 										  config.EnableFlowContextCache)
 	if err != nil {

--- a/pkg/ebpf/tracer_windows.go
+++ b/pkg/ebpf/tracer_windows.go
@@ -44,7 +44,10 @@ type Tracer struct {
 
 // NewTracer returns an initialized tracer struct
 func NewTracer(config *Config) (*Tracer, error) {
-	di, err := network.NewDriverInterface(config.EnableMonotonicCount, config.DriverBufferSize)
+	di, err := network.NewDriverInterface(config.EnableMonotonicCount,
+										  config.DriverBufferSize,
+										  config.EnableFlowReadHint,
+										  config.EnableFlowContextCache)
 	if err != nil {
 		return nil, fmt.Errorf("could not create windows driver controller: %v", err)
 	}

--- a/pkg/network/ddnpmapi.h
+++ b/pkg/network/ddnpmapi.h
@@ -12,11 +12,12 @@ typedef unsigned short      uint16_t;
 typedef __int64 LONG64;
 #endif
 
+
 // this type doesn't seem to be defined anyway
 typedef unsigned char       uint8_t;
 
 // define a version signature so that the driver won't load out of date structures, etc.
-#define DD_NPMDRIVER_VERSION       0x05
+#define DD_NPMDRIVER_VERSION       0x06
 #define DD_NPMDRIVER_SIGNATURE     ((uint64_t)0xDDFD << 32 | DD_NPMDRIVER_VERSION)
 
 // for more information on defining control codes, see
@@ -48,6 +49,22 @@ typedef unsigned char       uint8_t;
                                               0x805, \
                                               METHOD_BUFFERED,\
                                               FILE_ANY_ACCESS)
+
+#define DDNPMDRIVER_IOCTL_GET_FLOW_COUNT  CTL_CODE(FILE_DEVICE_NETWORK, \
+                                              0x806, \
+                                              METHOD_BUFFERED,\
+                                              FILE_ANY_ACCESS)
+
+#define DDNPMDRIVER_IOCTL_ENABLE_FLOWREAD_HINT  CTL_CODE(FILE_DEVICE_NETWORK, \
+                                              0x807, \
+                                              METHOD_BUFFERED,\
+                                              FILE_ANY_ACCESS)
+
+#define DDNPMDRIVER_IOCTL_ENABLE_FLOW_CONTEXT_CACHE  CTL_CODE(FILE_DEVICE_NETWORK, \
+                                              0x808, \
+                                              METHOD_BUFFERED,\
+                                              FILE_ANY_ACCESS)
+
 #pragma pack(1)
 
 /*!
@@ -79,6 +96,10 @@ typedef struct _flow_handle_stats {
     volatile LONG64         num_flow_search_misses; // number of times we missed a flow even after searching the list
 
     volatile LONG64         num_flow_collisions;
+
+    volatile LONG64         num_flow_contexts_allocated;
+    volatile LONG64         num_flow_contexts_from_cache;
+    volatile LONG64         num_flow_contexts_in_free_cache;
 } FLOW_STATS;
 
 typedef struct _transport_handle_stats {

--- a/pkg/network/ddnpmapi.h
+++ b/pkg/network/ddnpmapi.h
@@ -100,6 +100,9 @@ typedef struct _flow_handle_stats {
     volatile LONG64         num_flow_contexts_allocated;
     volatile LONG64         num_flow_contexts_from_cache;
     volatile LONG64         num_flow_contexts_in_free_cache;
+
+    volatile LONG64         num_flow_read_context_hints_used;
+    volatile LONG64         num_flow_read_list_searches;
 } FLOW_STATS;
 
 typedef struct _transport_handle_stats {

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -378,6 +378,8 @@ func (dh *DriverHandle) getStatsForHandle() (map[string]int64, error) {
 			"num_flow_contexts_allocated": int64(stats.handle.flow_stats.num_flow_contexts_allocated),
 			"num_flow_contexts_from_cache": int64(stats.handle.flow_stats.num_flow_contexts_from_cache),
 			"num_flow_contexts_in_free_cache": int64(stats.handle.flow_stats.num_flow_contexts_in_free_cache),
+			"num_flow_read_context_hints_used": int64(stats.handle.flow_stats.num_flow_read_context_hints_used),
+			"num_flow_read_list_searches": int64(stats.handle.flow_stats.num_flow_read_list_searches),
 
 		}, nil
 	// A DataHandle handle returns transfer stats specific to this handle

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -50,6 +50,12 @@ type WindowsConfig struct {
 
 	// DriverBufferSize (bytes) determines the size of the buffer we pass to the driver when reading flows
 	DriverBufferSize int
+	// EnableFlowReadHint (Windows only) determines if the flow read optimization is enabled in the driver
+	EnableFlowReadHint bool
+
+	// EnableFlowContextCache (Windows only) determines if the flow contexts are cached or return to the heap
+	EnableFlowContextCache bool
+	
 }
 
 // AgentConfig is the global config for the process-agent. This information

--- a/pkg/process/config/tracer_config.go
+++ b/pkg/process/config/tracer_config.go
@@ -82,6 +82,8 @@ func SysProbeConfigFromConfig(cfg *AgentConfig) *ebpf.Config {
 
 	tracerConfig.EnableMonotonicCount = cfg.Windows.EnableMonotonicCount
 	tracerConfig.DriverBufferSize = cfg.Windows.DriverBufferSize
+	tracerConfig.EnableFlowReadHint = cfg.Windows.EnableFlowReadHint
+	tracerConfig.EnableFlowContextCache = cfg.Windows.EnableFlowContextCache
 
 	return tracerConfig
 }

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -162,6 +162,8 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	}
 
 	a.Windows.EnableMonotonicCount = config.Datadog.GetBool(key(spNS, "windows", "enable_monotonic_count"))
+	a.Windows.EnableFlowReadHint = config.Datadog.GetBool(key(spNS, "windows", "enable_flow_read_hint"))
+	a.Windows.EnableFlowContextCache = config.Datadog.GetBool(key(spNS, "windows", "enable_flow_context_cache"))
 
 	if driverBufferSize := config.Datadog.GetInt(key(spNS, "windows", "driver_buffer_size")); driverBufferSize > 0 {
 		a.Windows.DriverBufferSize = driverBufferSize

--- a/release.json
+++ b/release.json
@@ -6,8 +6,8 @@
         "JMXFETCH_VERSION": "0.38.2",
         "JMXFETCH_HASH": "9a344b7cc76c9e9ab1171073e3e46656a8c1097273f72aee30f3564ed815b681",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "0.98.2.git.12.54ae2bc",
-        "WINDOWS_DDNPM_SHASUM": "ded26e4905378dbc18173635d3366eaa4cbf94eb0da172353b3c7eef3145824f"
+        "WINDOWS_DDNPM_VERSION": "0.98.2.git.18.ffb2503",
+        "WINDOWS_DDNPM_SHASUM": "f38ec7d835bbda1c45ab22f397e93b64816196c5d6fcc5fb8f4cb90c2b1c4bf6"
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
@@ -16,8 +16,8 @@
         "JMXFETCH_VERSION": "0.38.2",
         "JMXFETCH_HASH": "9a344b7cc76c9e9ab1171073e3e46656a8c1097273f72aee30f3564ed815b681",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "0.98.2.git.12.54ae2bc",
-        "WINDOWS_DDNPM_SHASUM": "ded26e4905378dbc18173635d3366eaa4cbf94eb0da172353b3c7eef3145824f",
+        "WINDOWS_DDNPM_VERSION": "0.98.2.git.18.ffb2503",
+        "WINDOWS_DDNPM_SHASUM": "f38ec7d835bbda1c45ab22f397e93b64816196c5d6fcc5fb8f4cb90c2b1c4bf6",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "6.22.0": {

--- a/release.json
+++ b/release.json
@@ -6,8 +6,8 @@
         "JMXFETCH_VERSION": "0.38.2",
         "JMXFETCH_HASH": "9a344b7cc76c9e9ab1171073e3e46656a8c1097273f72aee30f3564ed815b681",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "0.98.2.git.18.ffb2503",
-        "WINDOWS_DDNPM_SHASUM": "f38ec7d835bbda1c45ab22f397e93b64816196c5d6fcc5fb8f4cb90c2b1c4bf6"
+        "WINDOWS_DDNPM_VERSION": "0.98.2.git.19.660ce25",
+        "WINDOWS_DDNPM_SHASUM": "8ae9441e96f6a3f22b16cfb72c8bbcfc4d5072f1e26c126c1df43c442ee1cb1c"
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
@@ -16,8 +16,8 @@
         "JMXFETCH_VERSION": "0.38.2",
         "JMXFETCH_HASH": "9a344b7cc76c9e9ab1171073e3e46656a8c1097273f72aee30f3564ed815b681",
         "WINDOWS_DDNPM_DRIVER": "testsigned",
-        "WINDOWS_DDNPM_VERSION": "0.98.2.git.18.ffb2503",
-        "WINDOWS_DDNPM_SHASUM": "f38ec7d835bbda1c45ab22f397e93b64816196c5d6fcc5fb8f4cb90c2b1c4bf6",
+        "WINDOWS_DDNPM_VERSION": "0.98.2.git.19.660ce25",
+        "WINDOWS_DDNPM_SHASUM": "8ae9441e96f6a3f22b16cfb72c8bbcfc4d5072f1e26c126c1df43c442ee1cb1c",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "6.22.0": {


### PR DESCRIPTION
### What does this PR do?

Adds new configuration options (to match new options in driver) and new stats from driver to add to go expvar.

Note that since the stats structure changes size, this needs a specific driver build.  Chosing to remove any of the stats in the driver will necessitate modifying this PR to match.

