### PR TITLE
[docker log] Adjust matcher for corner cases + UT

### DIFF
--- a/pkg/logs/input/docker/matcher.go
+++ b/pkg/logs/input/docker/matcher.go
@@ -51,10 +51,11 @@ func (s *headerMatcher) matchHeader(exists []byte, bs []byte) bool {
 			// less than 4 + i bytes
 			continue
 		}
-		if s.getByte(exists, bs, idx) == 1 || s.getByte(exists, bs, idx) == 2 {
-			if s.getByte(exists, bs, idx+1) == 0 &&
-				s.getByte(exists, bs, idx+2) == 0 &&
-				s.getByte(exists, bs, idx+3) == 0 {
+		// We test for {1, 0, 0, 0} (stdout log) and {2, 0, 0, 0} (stderr)
+		if s.checkByte(exists, bs, idx, 1) || s.checkByte(exists, bs, idx, 2) {
+			if s.checkByte(exists, bs, idx+1, 0) &&
+				s.checkByte(exists, bs, idx+2, 0) &&
+				s.checkByte(exists, bs, idx+3, 0) {
 				return true
 			}
 		}
@@ -62,13 +63,13 @@ func (s *headerMatcher) matchHeader(exists []byte, bs []byte) bool {
 	return false
 }
 
-func (s *headerMatcher) getByte(exists []byte, bs []byte, i int) byte {
+func (s *headerMatcher) checkByte(exists []byte, bs []byte, i int, val byte) bool {
 	l := len(exists) + len(bs)
 	if i < l {
 		if i < len(exists) {
-			return exists[i]
+			return exists[i] == val
 		}
-		return bs[i-len(exists)]
+		return bs[i-len(exists)] == val
 	}
-	return 0xFF
+	return false
 }

--- a/pkg/logs/input/docker/matcher.go
+++ b/pkg/logs/input/docker/matcher.go
@@ -7,7 +7,6 @@
 package docker
 
 import (
-	"bytes"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 )
@@ -47,10 +46,36 @@ func (s *headerMatcher) Match(exists []byte, appender []byte, start int, end int
 // case [1|2 0 0 0 size1 size2 size3 10]
 func (s *headerMatcher) matchHeader(exists []byte, bs []byte) bool {
 	l := len(exists) + len(bs)
-	if l >= headerLength || l < headerPrefixLength {
+	if l < headerPrefixLength {
 		return false
 	}
-	h := append(exists, bs...)
-	return bytes.HasPrefix(h, headerStdoutPrefix) ||
-		bytes.HasPrefix(h, headerStderrPrefix)
+
+	for i := 0; i < 4; i++ {
+		// possible start of header offset
+		idx := l - (headerPrefixLength + i)
+		if idx < 0 {
+			// less than 4 + i bytes
+			continue
+		}
+		if s.getByte(exists, bs, idx) == 1 || s.getByte(exists, bs, idx) == 2 {
+			if s.getByte(exists, bs, idx+1) == 0 &&
+				s.getByte(exists, bs, idx+2) == 0 &&
+				s.getByte(exists, bs, idx+3) == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *headerMatcher) getByte(exists []byte, bs []byte, i int) byte {
+	l := len(exists) + len(bs)
+	if i < l {
+		if i < len(exists) {
+			return exists[i]
+		} else {
+			return bs[i-len(exists)]
+		}
+	}
+	return 0xFF
 }

--- a/pkg/logs/input/docker/matcher.go
+++ b/pkg/logs/input/docker/matcher.go
@@ -17,13 +17,7 @@ func InitializeDecoder(source *config.LogSource, containerID string) *decoder.De
 }
 
 const (
-	headerLength       = 8
 	headerPrefixLength = 4
-)
-
-var (
-	headerStdoutPrefix = []byte{1, 0, 0, 0}
-	headerStderrPrefix = []byte{2, 0, 0, 0}
 )
 
 type headerMatcher struct {
@@ -73,9 +67,8 @@ func (s *headerMatcher) getByte(exists []byte, bs []byte, i int) byte {
 	if i < l {
 		if i < len(exists) {
 			return exists[i]
-		} else {
-			return bs[i-len(exists)]
 		}
+		return bs[i-len(exists)]
 	}
 	return 0xFF
 }

--- a/pkg/logs/input/docker/matcher_test.go
+++ b/pkg/logs/input/docker/matcher_test.go
@@ -7,28 +7,91 @@
 package docker
 
 import (
+	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
+
+func getDummyHeader(i int) []byte {
+	hdr := []byte{1, 0, 0, 0, 0, 0, 0, 0}
+	hdr[i] = 10
+	return hdr
+}
 
 func TestDecoderDetectDockerHeader(t *testing.T) {
 	source := config.NewLogSource("config", &config.LogsConfig{})
 	d := InitializeDecoder(source, "container1")
 	d.Start()
 
-	input := []byte("hello\n")
-	input = append(input, []byte{1, 0, 0, 0, 0, 10, 0, 0}...) // docker header
-	input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
+	for i := 4; i < 8; i++ {
+		input := []byte("hello\n")
+		input = append(input, getDummyHeader(i)...) // docker header
+		input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
+		d.InputChan <- decoder.NewInput(input)
+
+		var output *decoder.Message
+		output = <-d.OutputChan
+		assert.Equal(t, "hello", string(output.Content))
+
+		output = <-d.OutputChan
+		assert.Equal(t, "app logs", string(output.Content))
+	}
+	d.Stop()
+}
+
+func TestDecoderDetectMultipleDockerHeader(t *testing.T) {
+	source := config.NewLogSource("config", &config.LogsConfig{})
+	d := InitializeDecoder(source, "container1")
+	d.Start()
+
+	var input []byte
+	for i := 0; i < 100; i++ {
+		input = append(input, getDummyHeader(4+i%4)...) // docker header
+		input = append(input, []byte(fmt.Sprintf("2018-06-14T18:27:03.246999277Z app logs %d\n", i))...)
+	}
+	d.InputChan <- decoder.NewInput(input)
+
+	var output *decoder.Output
+	for i := 0; i < 100; i++ {
+		output = <-d.OutputChan
+		assert.Equal(t, fmt.Sprintf("app logs %d", i), string(output.Content))
+	}
+
+	d.Stop()
+}
+
+func TestDecoderDetectMultipleDockerHeaderOnAChunkedLine(t *testing.T) {
+	source := config.NewLogSource("config", &config.LogsConfig{})
+	longestChunk := strings.Repeat("A", 16384)
+	d := InitializeDecoder(source, "container1")
+	d.Start()
+
+	var input []byte
+	input = append(input, getDummyHeader(5)...)
+	input = append(input, []byte("2018-06-14T18:27:03.246999277Z "+longestChunk)...)
+	input = append(input, getDummyHeader(6)...)
+	input = append(input, []byte("2018-06-14T18:27:03.246999277Z "+longestChunk)...)
+	input = append(input, getDummyHeader(7)...)
+	input = append(input, []byte("2018-06-14T18:27:03.246999277Z the end\n")...)
+	input = append(input, getDummyHeader(5)...)
+	input = append(input, []byte("2018-06-14T18:27:03.246999277Z "+longestChunk)...)
+	input = append(input, getDummyHeader(6)...)
+	input = append(input, []byte("2018-06-14T18:27:03.246999277Z "+longestChunk)...)
+	input = append(input, getDummyHeader(7)...)
+	input = append(input, []byte("2018-06-14T18:27:03.246999277Z the very end\n")...)
+
 	d.InputChan <- decoder.NewInput(input)
 
 	var output *decoder.Output
 	output = <-d.OutputChan
-	assert.Equal(t, "hello", string(output.Content))
-
+	assert.Equal(t, fmt.Sprintf(longestChunk+longestChunk+"the end"), string(output.Content))
 	output = <-d.OutputChan
-	assert.Equal(t, "app logs", string(output.Content))
+	assert.Equal(t, fmt.Sprintf(longestChunk+longestChunk+"the very end"), string(output.Content))
+
 	d.Stop()
 }
 
@@ -36,22 +99,23 @@ func TestDecoderNoNewLineBeforeDockerHeader(t *testing.T) {
 	source := config.NewLogSource("config", &config.LogsConfig{})
 	d := InitializeDecoder(source, "container1")
 	d.Start()
+	for i := 4; i < 8; i++ {
+		input := []byte("hello")
+		input = append(input, getDummyHeader(i)...) // docker header
+		input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
+		d.InputChan <- decoder.NewInput(input)
 
-	input := []byte("hello")
-	input = append(input, []byte{1, 0, 0, 0, 0, 10, 0, 0}...)
-	input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
-	d.InputChan <- decoder.NewInput(input)
+		var output *decoder.Output
 
-	var output *decoder.Output
+		// expected output content is discarded from SingleLineHandler (line #96)
+		// due to docker.parser line#80 condition not-match
 
-	// expected output content is discarded from SingleLineHandler (line #96)
-	// due to docker.parser line#80 condition not-match
+		//output =<- d.OutputChan
+		//expected := append([]byte("hello"), []byte{1, 0, 0, 0, 0}...)
+		//assert.Equal(t, expected, output.Content)
 
-	//output =<- d.OutputChan
-	//expected := append([]byte("hello"), []byte{1, 0, 0, 0, 0}...)
-	//assert.Equal(t, expected, output.Content)
-
-	output = <-d.OutputChan
-	assert.Equal(t, "app logs", string(output.Content))
+		output = <-d.OutputChan
+		assert.Equal(t, "app logs", string(output.Content))
+	}
 	d.Stop()
 }

--- a/pkg/logs/input/docker/matcher_test.go
+++ b/pkg/logs/input/docker/matcher_test.go
@@ -33,7 +33,7 @@ func TestDecoderDetectDockerHeader(t *testing.T) {
 		input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
 		d.InputChan <- decoder.NewInput(input)
 
-		var output *decoder.Message
+		var output *decoder.Output
 		output = <-d.OutputChan
 		assert.Equal(t, "hello", string(output.Content))
 

--- a/pkg/logs/input/docker/matcher_test.go
+++ b/pkg/logs/input/docker/matcher_test.go
@@ -106,14 +106,6 @@ func TestDecoderNoNewLineBeforeDockerHeader(t *testing.T) {
 		d.InputChan <- decoder.NewInput(input)
 
 		var output *decoder.Output
-
-		// expected output content is discarded from SingleLineHandler (line #96)
-		// due to docker.parser line#80 condition not-match
-
-		//output =<- d.OutputChan
-		//expected := append([]byte("hello"), []byte{1, 0, 0, 0, 0}...)
-		//assert.Equal(t, expected, output.Content)
-
 		output = <-d.OutputChan
 		assert.Equal(t, "app logs", string(output.Content))
 	}


### PR DESCRIPTION
### What does this PR do?

Rewrite the tailing-from-docker-socket-end-of-line-matcher

### Motivation

The old implementation was missing some cases leading to split lines.
It was also doing `append(...)` on potentially large chunk of data.

### Additional Notes

Not 100% sure, but when tailing from the docker socket, instead of
splitting message based on `\n` it may sound better to split message
every docker header and do the line re-assembling later (as it may
be required in other cases, as per #6265 & #6266)

### Describe your test plan

Added various UT, attempted to cover most of realistic use cases.
See AC-184 for a Dockerfile that was exhibiting the issue and gets fixed by this PR.