### PR TITLE
[SUSE, SysVInit] Run agent as dd-agent user

### DIFF
--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
@@ -69,7 +69,7 @@ do_start() {
   if [ "$?" -eq "0" ]; then
     return 0
   fi
-  startproc -f -q -p $PIDFILE $AGENTPATH $AGENT_ARGS
+  startproc -f -q -u $AGENT_USER -p $PIDFILE $AGENTPATH $AGENT_ARGS
 }
 
 start_and_wait() {

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
@@ -70,7 +70,7 @@ do_start() {
   if [ "$?" -eq "0" ]; then
     return 0
   fi
-  startproc -f -q -p $PIDFILE $AGENTPATH $AGENT_ARGS
+  startproc -f -q -u $AGENT_USER -p $PIDFILE $AGENTPATH $AGENT_ARGS
 }
 
 start_and_wait() {

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
@@ -70,7 +70,7 @@ do_start() {
   if [ "$?" -eq "0" ]; then
     return 0
   fi
-  startproc -f -q -p $PIDFILE $AGENTPATH $AGENT_ARGS
+  startproc -f -q -u $AGENT_USER -p $PIDFILE $AGENTPATH $AGENT_ARGS
 }
 
 start_and_wait() {

--- a/releasenotes/notes/fix-agent-user-suse-sysvinit-5dbbf909dbf8ef34.yaml
+++ b/releasenotes/notes/fix-agent-user-suse-sysvinit-5dbbf909dbf8ef34.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The SUSE SysVInit service now correctly starts the Agent as the
+    dd-agent user instead of root.


### PR DESCRIPTION
### What does this PR do?

Adds the missing "-u $AGENT_USER" option to startproc to correctly start the Agent as dd-agent on SUSE / SLES 11 with SysVInit.

### Motivation

The Agent service was starting the Agent as root on SUSE / SLES 11 with SysVInit.
