### PR TITLE
[jmxfetch] Timeout harmonization

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -482,7 +482,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("jmx_reconnection_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_collection_timeout", 60)
 	config.BindEnvAndSetDefault("jmx_check_period", int(defaults.DefaultCheckInterval/time.Millisecond))
-	config.BindEnvAndSetDefault("jmx_reconnection_timeout", 10)
+	config.BindEnvAndSetDefault("jmx_reconnection_timeout", 60)
 
 	// Go_expvar server port
 	config.BindEnvAndSetDefault("expvar_port", "5000")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1197,10 +1197,10 @@ api_key:
 #
 # jmx_reconnection_thread_pool_size: 3
 
-## @param jmx_reconnection_timeout - integer - optional - default: 10
+## @param jmx_reconnection_timeout - integer - optional - default: 60
 ## Determines the maximum waiting period in seconds before timing up on instance reconnection.
 #
-# jmx_reconnection_timeout: 10
+# jmx_reconnection_timeout: 60
 
 {{ end -}}
 {{- if .Logging }}


### PR DESCRIPTION
### What does this PR do?

Harmonize timeout in jmxfetch.

### Motivation

Consistency between initial JMX connection and reconnection attempts.

### Additional Notes

See https://github.com/DataDog/jmxfetch/pull/317 for additional details

### Describe your test plan
Check that jmxfetch child process gets the correct config value.