### PR TITLE
pkg/trace/api: improve rate limiting

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -341,15 +341,23 @@ func (r *HTTPReceiver) replyOK(v Version, w http.ResponseWriter) {
 	}
 }
 
+// rateLimited reports whether n number of traces should be rejected by the API.
+func (r *HTTPReceiver) rateLimited(n int64) bool {
+	if n == 0 {
+		return false
+	}
+	if r.conf.MaxMemory == 0 && r.conf.MaxCPU == 0 {
+		// rate limiting is off
+		return false
+	}
+	return !r.RateLimiter.Permits(n)
+}
+
 // handleTraces knows how to handle a bunch of traces
 func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.Request) {
 	ts := r.tagStats(v, req)
-	traceCount, err := traceCount(req)
-	if err != nil {
-		log.Warnf("Error getting trace count: %q. Functionality may be limited.", err)
-	}
-
-	if !r.RateLimiter.Permits(traceCount) {
+	tracen, err := traceCount(req)
+	if err == nil && r.rateLimited(tracen) {
 		// this payload can not be accepted
 		io.Copy(ioutil.Discard, req.Body)
 		w.WriteHeader(r.rateLimiterResponse)
@@ -362,9 +370,9 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	if err != nil {
 		httpDecodingError(err, []string{"handler:traces", fmt.Sprintf("v:%s", v)}, w)
 		if err == ErrLimitedReaderLimitReached {
-			atomic.AddInt64(&ts.TracesDropped.PayloadTooLarge, traceCount)
+			atomic.AddInt64(&ts.TracesDropped.PayloadTooLarge, tracen)
 		} else {
-			atomic.AddInt64(&ts.TracesDropped.DecodingError, traceCount)
+			atomic.AddInt64(&ts.TracesDropped.DecodingError, tracen)
 		}
 		log.Errorf("Cannot decode %s traces payload: %v", v, err)
 		return

--- a/pkg/trace/traceutil/trace.go
+++ b/pkg/trace/traceutil/trace.go
@@ -12,15 +12,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// GetEnv returns the meta value for the "env" key for
-// the first trace it finds or an empty string
+// GetEnv returns the first "env" tag found in trace t.
 func GetEnv(t pb.Trace) string {
-	// exit this on first success
 	for _, s := range t {
-		for k, v := range s.Meta {
-			if k == "env" {
-				return v
-			}
+		if v, ok := s.Meta["env"]; ok {
+			// exit this on first success
+			return v
 		}
 	}
 	return ""


### PR DESCRIPTION
This change contains multiple improvements:
* Avoid calling the rate limiter (which has a mutex) when it is disabled (both max_cpu and max_memory are 0)
* Remove the spammy X-Datadog-Trace-Count header warning (support tickets asking about it) ([APMAGENT-5](https://datadoghq.atlassian.net/browse/APMAGENT-5))
* Simplify `GetEnv`