### PR TITLE
[logs] Fix registry offset issue when tailing blank lines

### DIFF
--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -78,13 +78,6 @@ func (h *SingleLineHandler) process(message *Message) {
 	h.shouldTruncate = false
 
 	message.Content = bytes.TrimSpace(message.Content)
-	if len(message.Content) == 0 {
-		// Important Note: when doing that the offset stored in registry
-		// is likely to be shifted from 1 byte as we are parsing an empty
-		// that still is one byte long.
-		// don't send empty lines
-		return
-	}
 
 	if isTruncated {
 		// the previous line has been truncated because it was too long,

--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -40,10 +40,6 @@ func TestSingleLineHandler(t *testing.T) {
 	assert.Equal(t, line, string(output.Content))
 	assert.Equal(t, len(line)+1, output.RawDataLen)
 
-	// empty line should be dropped
-	h.Handle(getDummyMessage(""))
-	assert.Equal(t, 0, len(outputChan))
-
 	// too long line should be truncated
 	line = strings.Repeat("a", contentLenLimit+10)
 	h.Handle(getDummyMessage(line))
@@ -179,22 +175,6 @@ func TestTrimMultiLine(t *testing.T) {
 	output = <-outputChan
 	assert.Equal(t, "foo"+whitespace+"\\n"+"bar", string(output.Content))
 	assert.Equal(t, len(whitespace+"foo"+whitespace)+1+len("bar"+whitespace)+1, output.RawDataLen)
-
-	h.Stop()
-}
-
-func TestSingleLineHandlerDropsEmptyMessages(t *testing.T) {
-	outputChan := make(chan *Message, 10)
-	h := NewSingleLineHandler(outputChan, 100)
-	h.Start()
-
-	h.Handle(getDummyMessageWithLF(""))
-	h.Handle(getDummyMessageWithLF("one message"))
-
-	var output *Message
-
-	output = <-outputChan
-	assert.Equal(t, "one message", string(output.Content))
 
 	h.Stop()
 }

--- a/pkg/logs/decoder/line_parser.go
+++ b/pkg/logs/decoder/line_parser.go
@@ -126,12 +126,12 @@ func (p *MultiLineParser) run() {
 		select {
 		case message, isOpen := <-p.inputChan:
 			if !isOpen {
-				//  inputChan has been closed, no more lines are expected
+				// inputChan has been closed, no more lines are expected
 				return
 			}
 			// process the new line and restart the timeout
 			if !flushTimer.Stop() {
-				// timer stop doesn't not prevent the timer to tick,
+				// flushTimer.stop() doesn't prevent the timer to tick,
 				// makes sure the event is consumed to avoid sending
 				// just one piece of the content.
 				select {

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -243,7 +243,10 @@ func (t *Tailer) forwardMessages() {
 		origin.Identifier = identifier
 		origin.Offset = strconv.FormatInt(offset, 10)
 		origin.SetTags(append(t.tags, t.tagProvider.GetTags()...))
-
+		// Ignore empty lines once the registry offset is updated
+		if len(output.Content) == 0 {
+			continue
+		}
 		// Make the write to the output chan cancellable to be able to stop the tailer
 		// after a file rotation when it is stuck on it.
 		// We don't return directly to keep the same shutdown sequence that in the

--- a/pkg/logs/input/listener/tailer.go
+++ b/pkg/logs/input/listener/tailer.go
@@ -62,7 +62,9 @@ func (t *Tailer) forwardMessages() {
 		t.done <- struct{}{}
 	}()
 	for output := range t.decoder.OutputChan {
-		t.outputChan <- message.NewMessageWithSource(output.Content, message.StatusInfo, t.source)
+		if len(output.Content) > 0 {
+			t.outputChan <- message.NewMessageWithSource(output.Content, message.StatusInfo, t.source)
+		}
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

It fixes offset misscaculation when tailing blank lines from file.
All spaces/blank lines are dropped without being accounted in the
offset calculation, ending up with a wrong value.

### Motivation

Keep the registry offset correct when tailing from file so an
agent restart will start reading at the correct offset.

### Additional Notes
N/A

### Describe your test plan
Update UT.
IRL Tests: append space only/blank lines to a log file, add a final
non empty log line restart the agent to check that nothing from the
final is tailed again.