### PR TITLE
[install_script] Add retries to apt-key --recv-keys

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -6,7 +6,7 @@
 # using the package manager and Datadog repositories.
 
 set -e
-install_script_version=1.0.1
+install_script_version=1.0.2
 logfile="ddagent-install.log"
 
 LEGACY_ETCDIR="/etc/dd-agent"
@@ -126,6 +126,7 @@ else
 fi
 
 keyserver="hkp://keyserver.ubuntu.com:80"
+backup_keyserver="hkp://pool.sks-keyservers.net:80"
 # use this env var to specify another key server, such as
 # hkp://p80.pool.sks-keyservers.net:80 for example.
 if [ -n "$DD_KEYSERVER" ]; then
@@ -220,7 +221,26 @@ elif [ "$OS" = "Debian" ]; then
     fi
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
     $sudo_cmd sh -c "echo 'deb https://${apt_url}/ ${apt_repo_version}' > /etc/apt/sources.list.d/datadog.list"
-    $sudo_cmd apt-key adv --recv-keys --keyserver "${keyserver}" A2923DFF56EDA6E76E55E492D3A80E30382E94DE
+    retries=0
+    while [ "$retries" -le 4 ]; do
+      $sudo_cmd apt-key adv --recv-keys --keyserver "${keyserver}" A2923DFF56EDA6E76E55E492D3A80E30382E94DE && break
+      if [ "$retries" -eq 4 ]; then
+        ERROR_MESSAGE="ERROR
+Couldn't fetch Datadog public key.
+This might be due to a connectivity error with the key server
+or a temporary service interruption.
+*****
+"
+        false
+      fi
+      printf "\033[31m\napt-key failed to retrieve Datadog's public key, retrying in 5 seconds...\n\033[0m\n"
+      sleep 5
+      if [ "$retries" -eq 1 ]; then
+        printf "\033[31mSwitching to backup keyserver\n\033[0m\n"
+        keyserver="${backup_keyserver}"
+      fi
+      retries=$((retries+1))
+    done
 
     printf "\033[34m\n* Installing the Datadog Agent package\n\033[0m\n"
     ERROR_MESSAGE="ERROR

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -221,8 +221,7 @@ elif [ "$OS" = "Debian" ]; then
     fi
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
     $sudo_cmd sh -c "echo 'deb https://${apt_url}/ ${apt_repo_version}' > /etc/apt/sources.list.d/datadog.list"
-    retries=0
-    while [ "$retries" -le 4 ]; do
+    for retries in {0..4}; do
       $sudo_cmd apt-key adv --recv-keys --keyserver "${keyserver}" A2923DFF56EDA6E76E55E492D3A80E30382E94DE && break
       if [ "$retries" -eq 4 ]; then
         ERROR_MESSAGE="ERROR
@@ -233,13 +232,12 @@ or a temporary service interruption.
 "
         false
       fi
-      printf "\033[31m\napt-key failed to retrieve Datadog's public key, retrying in 5 seconds...\n\033[0m\n"
+      printf "\033[33m\napt-key failed to retrieve Datadog's public key, retrying in 5 seconds...\n\033[0m\n"
       sleep 5
       if [ "$retries" -eq 1 ]; then
-        printf "\033[31mSwitching to backup keyserver\n\033[0m\n"
+        printf "\033[34mSwitching to backup keyserver\n\033[0m\n"
         keyserver="${backup_keyserver}"
       fi
-      retries=$((retries+1))
     done
 
     printf "\033[34m\n* Installing the Datadog Agent package\n\033[0m\n"


### PR DESCRIPTION
### What does this PR do?
- Retry fetching the public key if it fails the first time.
- Use a backup server if we still fail with the main one after 2 tries
- When all retries fail, print an error message and quit.

### Motivation

Errors fetching the keys seem to be common.

### Describe your test plan

Happy case output:

```
* Installing APT package sources for Datadog

Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.OzdifUvv54/gpg.1.sh --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
gpg: key D3A80E30382E94DE: "Datadog, Inc <package@datadoghq.com>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
```

Output when nothing works:

```
Installing APT package sources for Datadog

Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.0VrYLz84GP/gpg.1.sh --recv-keys --keyserver hkp://potatoes.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
gpg: keyserver receive failed: No name

apt-key failed to retrieve Datadog's public key, retrying in 5 seconds...

Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.ikZtPn0NrI/gpg.1.sh --recv-keys --keyserver hkp://potatoes.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
gpg: keyserver receive failed: No name

apt-key failed to retrieve Datadog's public key, retrying in 5 seconds...

Switching to backup keyserver

Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.pVbEi5XsbR/gpg.1.sh --recv-keys --keyserver hkp://aybabtu.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
gpg: keyserver receive failed: No name

apt-key failed to retrieve Datadog's public key, retrying in 5 seconds...

Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.IWufy6bd2C/gpg.1.sh --recv-keys --keyserver hkp://aybabtu.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
gpg: keyserver receive failed: No name

apt-key failed to retrieve Datadog's public key, retrying in 5 seconds...

Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.yAI0xLA6ut/gpg.1.sh --recv-keys --keyserver hkp://aybabtu.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
gpg: keyserver receive failed: No name
ERROR
Couldn't fetch Datadog public key.
This might be due to a connectivity error with the key server
or a temporary service interruption.
*****

It looks like you hit an issue when trying to install the Agent.

Troubleshooting and basic usage information for the Agent are available at:

    https://docs.datadoghq.com/agent/basic_agent_usage/

If you're still having problems, please send an email to support@datadoghq.com
with the contents of ddagent-install.log and we'll do our very best to help you
solve your problem.
```

Output if only the backup works:


```
* Installing APT package sources for Datadog

Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.ehhApe8Qiw/gpg.1.sh --recv-keys --keyserver hkp://potatoes.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
gpg: keyserver receive failed: No name

apt-key failed to retrieve Datadog's public key, retrying in 5 seconds...

Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.WO3Fne400H/gpg.1.sh --recv-keys --keyserver hkp://potatoes.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
gpg: keyserver receive failed: No name

apt-key failed to retrieve Datadog's public key, retrying in 5 seconds...

Switching to backup keyserver

Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.GPkpGOaxFi/gpg.1.sh --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
gpg: key D3A80E30382E94DE: "Datadog, Inc <package@datadoghq.com>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
```