### PR TITLE
Improve the kubelet check error reporting in the output of `agent status`

### DIFF
--- a/pkg/collector/python/kubeutil.go
+++ b/pkg/collector/python/kubeutil.go
@@ -8,6 +8,7 @@
 package python
 
 import (
+	"errors"
 	"time"
 
 	yaml "gopkg.in/yaml.v2"
@@ -37,7 +38,8 @@ func getConnections() map[string]string {
 	if err != nil {
 		// Connection to the kubelet fail, return the error
 		log.Errorf("connection to kubelet failed: %v", err)
-		if e, ok := err.(*retry.Error); ok {
+		var e *retry.Error
+		if errors.As(err, &e) {
 			return map[string]string{"err": e.Unwrap().Error()}
 		}
 		return map[string]string{"err": err.Error()}

--- a/pkg/util/retry/error.go
+++ b/pkg/util/retry/error.go
@@ -13,6 +13,7 @@ var statusFormats map[Status]string
 // you can get its Status with IsRetryError()
 type Error struct {
 	LogicError    error
+	LastTryError  error
 	RessourceName string
 	RetryStatus   Status
 }
@@ -24,6 +25,11 @@ func (e *Error) Error() string {
 		format = "error in %s: %s"
 	}
 	return fmt.Sprintf(format, e.RessourceName, e.LogicError)
+}
+
+// Unwrap implements the Go 1.13 unwrap convention
+func (e *Error) Unwrap() error {
+	return e.LastTryError
 }
 
 // IsRetryError checks an `error` object to tell if it's a Retry.Error

--- a/pkg/util/retry/retrier.go
+++ b/pkg/util/retry/retrier.go
@@ -105,10 +105,11 @@ func (r *Retrier) doTry() *Error {
 	}
 	method := r.cfg.AttemptMethod
 	r.RUnlock()
-	r.lastTryError = method()
+	err := method()
 
 	r.Lock()
-	if r.lastTryError == nil {
+	r.lastTryError = err
+	if err == nil {
 		r.status = OK
 	} else {
 		switch r.cfg.Strategy {
@@ -135,7 +136,7 @@ func (r *Retrier) doTry() *Error {
 	}
 	r.Unlock()
 
-	return r.wrapError(r.lastTryError)
+	return r.wrapError(err)
 }
 
 func (r *Retrier) errorf(format string, a ...interface{}) *Error {

--- a/releasenotes/notes/better-kubelet-check-error-reporting-in-agent-status-5d6b694d00963830.yaml
+++ b/releasenotes/notes/better-kubelet-check-error-reporting-in-agent-status-5d6b694d00963830.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve the ``kubelet`` check error reporting in the output of ``agent status`` in the case where the agent cannot properly connect to the kubelet.


### PR DESCRIPTION
### What does this PR do?

In combination with DataDog/integrations-core#7495 , this change improves the `kubelet` check error reported in the output of `agent status` when the agent cannot properly connect to the kubelet.

### Motivation

In case the agent cannot properly connect to the kubelet, the useful details were in the logs but the output of the `agent status` command gave no clue about the reasons.

Here is an example of the `agent status` output in such a case:
```
$ agent status
[…]

=========
Collector
=========

  Running Checks
  ==============

    kubelet (4.1.1)
    ---------------
      Instance ID: kubelet:d884b5186b651429 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 2ms
      Last Execution Date : 2020-09-03 11:40:31.000000 UTC
      Last Successful Execution Date : Never
      Error: Unable to detect the kubelet URL automatically.
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 827, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/kubelet/kubelet.py", line 297, in check
          raise CheckException("Unable to detect the kubelet URL automatically.")
      datadog_checks.base.errors.CheckException: Unable to detect the kubelet URL automatically.
```

Here is what the output becomes with this PR:

```
$ agent status
[…]

=========
Collector
=========

  Running Checks
  ==============

    kubelet (4.1.1)
    ---------------
      Instance ID: kubelet:d884b5186b651429 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 3ms
      Last Execution Date : 2020-09-03 11:14:20.000000 UTC
      Last Successful Execution Date : Never
      Error: Unable to detect the kubelet URL automatically: cannot set a valid kubelet host: cannot connect to kubelet using any of the given hosts: [1.2.3.4] [], Errors: [Get https://1.2.3.4:10250/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) cannot connect: http: "Get http://1.2.3.4:10255/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"]
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 827, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/kubelet/kubelet.py", line 297, in check
          raise CheckException("Unable to detect the kubelet URL automatically: " + kubelet_conn_info.get('err'))
      datadog_checks.base.errors.CheckException: Unable to detect the kubelet URL automatically: cannot set a valid kubelet host: cannot connect to kubelet using any of the given hosts: [1.2.3.4] [], Errors: [Get https://1.2.3.4:10250/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) cannot connect: http: "Get http://1.2.3.4:10255/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"]
```

### Additional Notes

This would help the investigation of issues like DataDog/integrations-core#2582.

### Describe your test plan

Start the agent in a context where it schedules the `kubelet` check, but it cannot connect to it:
```shell
docker run --rm --name datadog-agent -e DD_API_KEY=$DD_API_KEY -e KUBERNETES=yes -e DD_KUBERNETES_KUBELET_HOST=1.2.3.4 datadog/agent:7.23.0
```
