### PR TITLE
[cmd/agent] During Logs Agent startup, wait for the AutoConfig to run before starting ContainerCollectAll.

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -300,8 +300,7 @@ func StartAgent() error {
 		if config.Datadog.GetBool("log_enabled") {
 			log.Warn(`"log_enabled" is deprecated, use "logs_enabled" instead`)
 		}
-		err := logs.Start()
-		if err != nil {
+		if err := logs.Start(); err != nil {
 			log.Error("Could not start logs-agent: ", err)
 		}
 	} else {

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/jmx"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
@@ -300,7 +301,7 @@ func StartAgent() error {
 		if config.Datadog.GetBool("log_enabled") {
 			log.Warn(`"log_enabled" is deprecated, use "logs_enabled" instead`)
 		}
-		if err := logs.Start(); err != nil {
+		if err := logs.Start(func() *autodiscovery.AutoConfig { return common.AC }); err != nil {
 			log.Error("Could not start logs-agent: ", err)
 		}
 	} else {

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -110,17 +110,17 @@ func StartAutoConfig() {
 	AC.LoadAndRun()
 }
 
-// BlockUntilAutoConfigRunnedOnce blocks until the AutoConfig has been runned once.
+// BlockUntilAutoConfigRanOnce blocks until the AutoConfig has been ran once.
 // It also returns after the given timeout.
-func BlockUntilAutoConfigRunnedOnce(timeout time.Duration) {
+func BlockUntilAutoConfigRanOnce(timeout time.Duration) {
 	now := time.Now()
 	for {
 		time.Sleep(100 * time.Millisecond) // don't hog the CPU
-		if AC.HasRunnedOnce() {
+		if AC.HasRanOnce() {
 			return
 		}
 		if time.Since(now) > timeout {
-			log.Warn("BlockUntilAutoConfigRunnedOnce timeout after", timeout)
+			log.Warn("BlockUntilAutoConfigRanOnce timeout after", timeout)
 			return
 		}
 	}

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -120,7 +120,7 @@ func BlockUntilAutoConfigRanOnce(timeout time.Duration) {
 			return
 		}
 		if time.Since(now) > timeout {
-			log.Warn("BlockUntilAutoConfigRanOnce timeout after", timeout)
+			log.Error("BlockUntilAutoConfigRanOnce timeout after", timeout)
 			return
 		}
 	}

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -7,7 +7,6 @@ package common
 
 import (
 	"path/filepath"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
@@ -108,20 +107,4 @@ func SetupAutoConfig(confdPath string) {
 //   2. run all the Checks for each configuration found
 func StartAutoConfig() {
 	AC.LoadAndRun()
-}
-
-// BlockUntilAutoConfigRanOnce blocks until the AutoConfig has been ran once.
-// It also returns after the given timeout.
-func BlockUntilAutoConfigRanOnce(timeout time.Duration) {
-	now := time.Now()
-	for {
-		time.Sleep(100 * time.Millisecond) // don't hog the CPU
-		if AC.HasRanOnce() {
-			return
-		}
-		if time.Since(now) > timeout {
-			log.Error("BlockUntilAutoConfigRanOnce timeout after", timeout)
-			return
-		}
-	}
 }

--- a/cmd/agent/common/autoconfig_test.go
+++ b/cmd/agent/common/autoconfig_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package common
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBlockUntilAutoConfigRunnedOnce(t *testing.T) {
+	SetupAutoConfig("/tmp")
+	start := time.Now()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		AC.LoadAndRun()
+	}()
+	BlockUntilAutoConfigRunnedOnce(2 * time.Second)
+	if time.Since(start) > 500*time.Millisecond {
+		t.Fatalf("should not have timeout")
+	}
+}
+
+func TestBlockUntilAutoConfigRunnedOnceTimeout(t *testing.T) {
+	SetupAutoConfig("/tmp")
+	start := time.Now()
+	BlockUntilAutoConfigRunnedOnce(3 * time.Second)
+	if time.Since(start) < 2500*time.Millisecond {
+		t.Fatalf("should have timeout")
+	}
+}

--- a/cmd/agent/common/autoconfig_test.go
+++ b/cmd/agent/common/autoconfig_test.go
@@ -10,23 +10,23 @@ import (
 	"time"
 )
 
-func TestBlockUntilAutoConfigRunnedOnce(t *testing.T) {
+func TestBlockUntilAutoConfigRanOnce(t *testing.T) {
 	SetupAutoConfig("/tmp")
 	start := time.Now()
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		AC.LoadAndRun()
 	}()
-	BlockUntilAutoConfigRunnedOnce(2 * time.Second)
+	BlockUntilAutoConfigRanOnce(2 * time.Second)
 	if time.Since(start) > 500*time.Millisecond {
 		t.Fatalf("should not have timeout")
 	}
 }
 
-func TestBlockUntilAutoConfigRunnedOnceTimeout(t *testing.T) {
+func TestBlockUntilAutoConfigRanOnceTimeout(t *testing.T) {
 	SetupAutoConfig("/tmp")
 	start := time.Now()
-	BlockUntilAutoConfigRunnedOnce(3 * time.Second)
+	BlockUntilAutoConfigRanOnce(3 * time.Second)
 	if time.Since(start) < 2500*time.Millisecond {
 		t.Fatalf("should have timeout")
 	}

--- a/cmd/agent/common/autoconfig_test.go
+++ b/cmd/agent/common/autoconfig_test.go
@@ -8,6 +8,9 @@ package common
 import (
 	"testing"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/logs"
 )
 
 func TestBlockUntilAutoConfigRanOnce(t *testing.T) {
@@ -17,7 +20,7 @@ func TestBlockUntilAutoConfigRanOnce(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		AC.LoadAndRun()
 	}()
-	BlockUntilAutoConfigRanOnce(2 * time.Second)
+	logs.BlockUntilAutoConfigRanOnce(func() *autodiscovery.AutoConfig { return AC }, 2*time.Second)
 	if time.Since(start) > 500*time.Millisecond {
 		t.Fatalf("should not have timeout")
 	}
@@ -26,7 +29,7 @@ func TestBlockUntilAutoConfigRanOnce(t *testing.T) {
 func TestBlockUntilAutoConfigRanOnceTimeout(t *testing.T) {
 	SetupAutoConfig("/tmp")
 	start := time.Now()
-	BlockUntilAutoConfigRanOnce(3 * time.Second)
+	logs.BlockUntilAutoConfigRanOnce(func() *autodiscovery.AutoConfig { return AC }, 3*time.Second)
 	if time.Since(start) < 2500*time.Millisecond {
 		t.Fatalf("should have timeout")
 	}

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -66,8 +66,8 @@ type AutoConfig struct {
 	delService         chan listeners.Service
 	store              *store
 	m                  sync.RWMutex
-	// runnedOnce is an atomic uint32 set to 1 once the AutoConfig has been executed
-	runnedOnce uint32
+	// ranOnce is an atomic uint32 set to 1 once the AutoConfig has been executed
+	ranOnce uint32
 }
 
 // NewAutoConfig creates an AutoConfig instance.
@@ -193,16 +193,16 @@ func (ac *AutoConfig) AddConfigProvider(provider providers.ConfigProvider, shoul
 func (ac *AutoConfig) LoadAndRun() {
 	resolvedConfigs := ac.GetAllConfigs()
 	ac.schedule(resolvedConfigs)
-	atomic.StoreUint32(&ac.runnedOnce, 1)
+	atomic.StoreUint32(&ac.ranOnce, 1)
 	log.Debug("LoadAndRun done.")
 }
 
-// HasRunnedOnce returns true if the AutoConfig has runned once.
-func (ac *AutoConfig) HasRunnedOnce() bool {
+// HasRanOnce returns true if the AutoConfig has ran once.
+func (ac *AutoConfig) HasRanOnce() bool {
 	if ac == nil {
 		return false
 	}
-	return atomic.LoadUint32(&ac.runnedOnce) == 1
+	return atomic.LoadUint32(&ac.ranOnce) == 1
 }
 
 // GetAllConfigs queries all the providers and returns all the integration

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -197,8 +197,8 @@ func (ac *AutoConfig) LoadAndRun() {
 	log.Debug("LoadAndRun done.")
 }
 
-// HasRanOnce returns true if the AutoConfig has ran once.
-func (ac *AutoConfig) HasRanOnce() bool {
+// HasRunOnce returns true if the AutoConfig has ran once.
+func (ac *AutoConfig) HasRunOnce() bool {
 	if ac == nil {
 		return false
 	}

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -9,6 +9,7 @@ import (
 	"expvar"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/configresolver"
@@ -65,6 +66,8 @@ type AutoConfig struct {
 	delService         chan listeners.Service
 	store              *store
 	m                  sync.RWMutex
+	// runnedOnce is an atomic uint32 set to 1 once the AutoConfig has been executed
+	runnedOnce uint32
 }
 
 // NewAutoConfig creates an AutoConfig instance.
@@ -190,6 +193,16 @@ func (ac *AutoConfig) AddConfigProvider(provider providers.ConfigProvider, shoul
 func (ac *AutoConfig) LoadAndRun() {
 	resolvedConfigs := ac.GetAllConfigs()
 	ac.schedule(resolvedConfigs)
+	atomic.StoreUint32(&ac.runnedOnce, 1)
+	log.Debug("LoadAndRun done.")
+}
+
+// HasRunnedOnce returns true if the AutoConfig has runned once.
+func (ac *AutoConfig) HasRunnedOnce() bool {
+	if ac == nil {
+		return false
+	}
+	return atomic.LoadUint32(&ac.runnedOnce) == 1
 }
 
 // GetAllConfigs queries all the providers and returns all the integration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -353,6 +353,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("exclude_pause_container", true)
 	config.BindEnvAndSetDefault("ac_include", []string{})
 	config.BindEnvAndSetDefault("ac_exclude", []string{})
+	// ac_load_timeout is used to delay the introduction of sources other than
+	// the ones automatically loaded by the AC, into the logs agent.
+	// It is mainly here to delay the introduction of the container_collect_all
+	// in the logs agent, to avoid it to tail all the available containers.
+	config.BindEnvAndSetDefault("ac_load_timeout", 30000) // in milliseconds
 	config.BindEnvAndSetDefault("container_include", []string{})
 	config.BindEnvAndSetDefault("container_exclude", []string{})
 	config.BindEnvAndSetDefault("container_include_metrics", []string{})

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -47,31 +47,30 @@ var (
 	HTTPConnectivityFailure HTTPConnectivity = false
 )
 
-// DefaultSources returns the default log sources that can be directly set from the datadog.yaml or through environment variables.
-func DefaultSources() []*LogSource {
-	var sources []*LogSource
-
+// ContainerCollectAllSource returns a source to collect all logs from all containers.
+func ContainerCollectAllSource() *LogSource {
 	if coreConfig.Datadog.GetBool("logs_config.container_collect_all") {
-		// append a new source to collect all logs from all containers
-		source := NewLogSource(ContainerCollectAll, &LogsConfig{
+		// source to collect all logs from all containers
+		return NewLogSource(ContainerCollectAll, &LogsConfig{
 			Type:    DockerType,
 			Service: "docker",
 			Source:  "docker",
 		})
-		sources = append(sources, source)
 	}
+	return nil
+}
 
+// SNMPTrapsSource returs a source to forward SNMP traps as logs.
+func SNMPTrapsSource() *LogSource {
 	if traps.IsEnabled() && traps.IsRunning() {
-		// Append a new source to forward SNMP traps as logs.
-		source := NewLogSource(SnmpTraps, &LogsConfig{
+		// source to forward SNMP traps as logs.
+		return NewLogSource(SnmpTraps, &LogsConfig{
 			Type:    SnmpTrapsType,
 			Service: "snmp",
 			Source:  "snmp",
 		})
-		sources = append(sources, source)
 	}
-
-	return sources
+	return nil
 }
 
 // GlobalProcessingRules returns the global processing rules to apply to all logs.

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -46,15 +46,16 @@ func (suite *ConfigTestSuite) TestDefaultDatadogConfig() {
 }
 
 func (suite *ConfigTestSuite) TestDefaultSources() {
-	var sources []*LogSource
-	var source *LogSource
+	// container collect all source
+
+	source := ContainerCollectAllSource()
+	suite.Nil(source)
 
 	suite.config.Set("logs_config.container_collect_all", true)
 
-	sources = DefaultSources()
-	suite.Equal(1, len(sources))
+	source = ContainerCollectAllSource()
+	suite.NotNil(source)
 
-	source = sources[0]
 	suite.Equal("container_collect_all", source.Name)
 	suite.Equal(DockerType, source.Config.Type)
 	suite.Equal("docker", source.Config.Source)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -106,7 +106,7 @@ func Start(getAC func() *autodiscovery.AutoConfig) error {
 	return nil
 }
 
-// BlockUntilAutoConfigRanOnce blocks until the AutoConfig has been ran once.
+// BlockUntilAutoConfigRanOnce blocks until the AutoConfig has been run once.
 // It also returns after the given timeout.
 func BlockUntilAutoConfigRanOnce(getAC func() *autodiscovery.AutoConfig, timeout time.Duration) {
 	now := time.Now()
@@ -115,7 +115,7 @@ func BlockUntilAutoConfigRanOnce(getAC func() *autodiscovery.AutoConfig, timeout
 		if getAC() == nil {
 			continue
 		}
-		if getAC().HasRanOnce() {
+		if getAC().HasRunOnce() {
 			return
 		}
 		if time.Since(now) > timeout {

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -112,9 +112,6 @@ func BlockUntilAutoConfigRanOnce(getAC func() *autodiscovery.AutoConfig, timeout
 	now := time.Now()
 	for {
 		time.Sleep(100 * time.Millisecond) // don't hog the CPU
-		if getAC() == nil {
-			continue
-		}
 		if getAC().HasRunOnce() {
 			return
 		}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -86,7 +87,7 @@ func Start() error {
 	// add the default sources after the AutoConfig has been executed once because
 	// we don't want the container_collect_all to reap all containers ownership
 	go func() {
-		common.BlockUntilAutoConfigRanOnce(time.Second * 30)
+		common.BlockUntilAutoConfigRanOnce(time.Millisecond * time.Duration(coreConfig.Datadog.GetInt("ac_load_timeout")))
 		log.Debug("Adding DefaultSources to the Logs Agent")
 		for _, source := range config.DefaultSources() {
 			sources.AddSource(source)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -83,10 +83,10 @@ func Start() error {
 	atomic.StoreInt32(&isRunning, 1)
 	log.Info("logs-agent started")
 
-	// add the default sources after the AutoConfig has been runned once because
+	// add the default sources after the AutoConfig has been executed once because
 	// we don't want the container_collect_all to reap all containers ownership
 	go func() {
-		common.BlockUntilAutoConfigRunnedOnce(time.Second * 30)
+		common.BlockUntilAutoConfigRanOnce(time.Second * 30)
 		log.Debug("Adding DefaultSources to the Logs Agent")
 		for _, source := range config.DefaultSources() {
 			sources.AddSource(source)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -87,7 +87,7 @@ func Start() error {
 	// add the default sources after the AutoConfig has been executed once because
 	// we don't want the container_collect_all to reap all containers ownership
 	go func() {
-		common.BlockUntilAutoConfigRanOnce(time.Millisecond * time.Duration(coreConfig.Datadog.GetInt("ac_load_timeout")))
+		common.BlockUntilAutoConfigRanOnce(time.Millisecond * coreConfig.Datadog.GetDuration("ac_load_timeout"))
 		log.Debug("Adding DefaultSources to the Logs Agent")
 		for _, source := range config.DefaultSources() {
 			sources.AddSource(source)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -87,7 +87,7 @@ func Start() error {
 	// add the default sources after the AutoConfig has been executed once because
 	// we don't want the container_collect_all to reap all containers ownership
 	go func() {
-		common.BlockUntilAutoConfigRanOnce(time.Millisecond * coreConfig.Datadog.GetDuration("ac_load_timeout"))
+		common.BlockUntilAutoConfigRanOnce(time.Millisecond * time.Duration(coreConfig.Datadog.GetInt("ac_load_timeout")))
 		log.Debug("Adding DefaultSources to the Logs Agent")
 		for _, source := range config.DefaultSources() {
 			sources.AddSource(source)

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -19,6 +19,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+var (
+	// scheduler is plugged to autodiscovery to collect integration configs
+	// and schedule log collection for different kind of inputs
+	adScheduler *Scheduler
+)
+
 // Scheduler creates and deletes new sources and services to start or stop
 // log collection on different kind of inputs.
 // A source represents a logs-config that can be defined either in a configuration file,
@@ -29,16 +35,18 @@ type Scheduler struct {
 	services *service.Services
 }
 
-// NewScheduler returns a new scheduler.
-func NewScheduler(sources *logsConfig.LogSources, services *service.Services) *Scheduler {
-	return &Scheduler{
+// CreateScheduler creates the scheduler.
+func CreateScheduler(sources *logsConfig.LogSources, services *service.Services) {
+	adScheduler = &Scheduler{
 		sources:  sources,
 		services: services,
 	}
 }
 
 // Stop does nothing.
-func (s *Scheduler) Stop() {}
+func (s *Scheduler) Stop() {
+	adScheduler = nil
+}
 
 // Schedule creates new sources and services from a list of integration configs.
 // An integration config can be mapped to a list of sources when it contains a Provider,
@@ -252,4 +260,9 @@ var integrationToServiceCRTime = map[integration.CreationTime]service.CreationTi
 // getCreationTime returns the service creation time for the integration configuration.
 func (s *Scheduler) getCreationTime(config integration.Config) service.CreationTime {
 	return integrationToServiceCRTime[config.CreationTime]
+}
+
+// GetScheduler returns the logs-config scheduler if set.
+func GetScheduler() *Scheduler {
+	return adScheduler
 }

--- a/pkg/logs/scheduler/scheduler_test.go
+++ b/pkg/logs/scheduler/scheduler_test.go
@@ -19,7 +19,7 @@ import (
 func TestScheduleConfigCreatesNewSource(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	scheduler := NewScheduler(logSources, services)
+	CreateScheduler(logSources, services)
 
 	logSourcesStream := logSources.GetAddedForType(config.DockerType)
 
@@ -33,7 +33,7 @@ func TestScheduleConfigCreatesNewSource(t *testing.T) {
 		CreationTime:  0,
 	}
 
-	go scheduler.Schedule([]integration.Config{configSource})
+	go adScheduler.Schedule([]integration.Config{configSource})
 	logSource := <-logSourcesStream
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
@@ -47,7 +47,7 @@ func TestScheduleConfigCreatesNewSource(t *testing.T) {
 func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	scheduler := NewScheduler(logSources, services)
+	CreateScheduler(logSources, services)
 
 	logSourcesStream := logSources.GetAddedForType(config.DockerType)
 
@@ -62,7 +62,7 @@ func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 		CreationTime:  0,
 	}
 
-	go scheduler.Schedule([]integration.Config{configSource})
+	go adScheduler.Schedule([]integration.Config{configSource})
 	logSource := <-logSourcesStream
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
@@ -76,7 +76,7 @@ func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	scheduler := NewScheduler(logSources, services)
+	CreateScheduler(logSources, services)
 
 	logSourcesStream := logSources.GetAddedForType(config.DockerType)
 
@@ -91,7 +91,7 @@ func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 		CreationTime:  0,
 	}
 
-	go scheduler.Schedule([]integration.Config{configSource})
+	go adScheduler.Schedule([]integration.Config{configSource})
 	logSource := <-logSourcesStream
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
@@ -105,7 +105,7 @@ func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 func TestScheduleConfigCreatesNewService(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	scheduler := NewScheduler(logSources, services)
+	CreateScheduler(logSources, services)
 
 	servicesStream := services.GetAddedServicesForType(config.DockerType)
 
@@ -117,7 +117,7 @@ func TestScheduleConfigCreatesNewService(t *testing.T) {
 		CreationTime: 0,
 	}
 
-	go scheduler.Schedule([]integration.Config{configService})
+	go adScheduler.Schedule([]integration.Config{configService})
 	svc := <-servicesStream
 	assert.Equal(t, configService.Entity, svc.GetEntityID())
 
@@ -129,7 +129,7 @@ func TestScheduleConfigCreatesNewService(t *testing.T) {
 		ClusterCheck: false,
 		CreationTime: 0,
 	}
-	go scheduler.Schedule([]integration.Config{configService})
+	go adScheduler.Schedule([]integration.Config{configService})
 	select {
 	case <-servicesStream:
 		assert.Fail(t, "Pod should be ignored")
@@ -141,7 +141,7 @@ func TestScheduleConfigCreatesNewService(t *testing.T) {
 func TestUnscheduleConfigRemovesSource(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	scheduler := NewScheduler(logSources, services)
+	CreateScheduler(logSources, services)
 	logSourcesStream := logSources.GetRemovedForType(config.DockerType)
 
 	configSource := integration.Config{
@@ -155,10 +155,10 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 	}
 
 	// We need to have a source to remove
-	sources, _ := scheduler.toSources(configSource)
+	sources, _ := adScheduler.toSources(configSource)
 	logSources.AddSource(sources[0])
 
-	go scheduler.Unschedule([]integration.Config{configSource})
+	go adScheduler.Unschedule([]integration.Config{configSource})
 	logSource := <-logSourcesStream
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
@@ -172,7 +172,7 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 func TestUnscheduleConfigRemovesService(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	scheduler := NewScheduler(logSources, services)
+	CreateScheduler(logSources, services)
 	servicesStream := services.GetRemovedServicesForType(config.DockerType)
 
 	configService := integration.Config{
@@ -183,7 +183,7 @@ func TestUnscheduleConfigRemovesService(t *testing.T) {
 		CreationTime: 0,
 	}
 
-	go scheduler.Unschedule([]integration.Config{configService})
+	go adScheduler.Unschedule([]integration.Config{configService})
 	svc := <-servicesStream
 	assert.Equal(t, configService.Entity, svc.GetEntityID())
 
@@ -196,7 +196,7 @@ func TestUnscheduleConfigRemovesService(t *testing.T) {
 		CreationTime: 0,
 	}
 
-	go scheduler.Unschedule([]integration.Config{configService})
+	go adScheduler.Unschedule([]integration.Config{configService})
 	select {
 	case <-servicesStream:
 		assert.Fail(t, "Pod should be ignored")
@@ -208,7 +208,7 @@ func TestUnscheduleConfigRemovesService(t *testing.T) {
 func TestIgnoreConfigIfLogsExcluded(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	scheduler := NewScheduler(logSources, services)
+	CreateScheduler(logSources, services)
 	servicesStreamIn := services.GetAddedServicesForType(config.DockerType)
 	servicesStreamOut := services.GetRemovedServicesForType(config.DockerType)
 
@@ -221,7 +221,7 @@ func TestIgnoreConfigIfLogsExcluded(t *testing.T) {
 		LogsExcluded: true,
 	}
 
-	go scheduler.Schedule([]integration.Config{configService})
+	go adScheduler.Schedule([]integration.Config{configService})
 	select {
 	case <-servicesStreamIn:
 		assert.Fail(t, "config must be ignored")
@@ -229,7 +229,7 @@ func TestIgnoreConfigIfLogsExcluded(t *testing.T) {
 		break
 	}
 
-	go scheduler.Unschedule([]integration.Config{configService})
+	go adScheduler.Unschedule([]integration.Config{configService})
 	select {
 	case <-servicesStreamOut:
 		assert.Fail(t, "config must be ignored")

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -13,10 +13,23 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
+// Transport is the transport used by logs-agent, i.e TCP or HTTP
+type Transport string
+
+const (
+	// TransportHTTP indicates logs-agent is using HTTP transport
+	TransportHTTP Transport = "HTTP"
+	// TransportTCP indicates logs-agent is using TCP transport
+	TransportTCP Transport = "TCP"
+)
+
 var (
 	builder  *Builder
 	warnings *config.Messages
 	errors   *config.Messages
+
+	// CurrentTransport is the current transport used by logs-agent, i.e TCP or HTTP
+	CurrentTransport Transport
 )
 
 // Source provides some information about a logs source.

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/alibaba"
@@ -26,8 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
 	kubelet "github.com/DataDog/datadog-agent/pkg/util/hostname/kubelet"
-
-	"github.com/DataDog/datadog-agent/pkg/logs"
 
 	"io/ioutil"
 
@@ -235,7 +234,7 @@ func getContainerMeta(timeout time.Duration) map[string]string {
 }
 
 func getLogsMeta() *LogsMeta {
-	return &LogsMeta{Transport: string(logs.CurrentTransport)}
+	return &LogsMeta{Transport: string(status.CurrentTransport)}
 }
 
 func buildKey(key string) string {

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/logs"
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -106,15 +106,15 @@ func TestGetContainerMetaTimeout(t *testing.T) {
 
 func TestGetLogsMeta(t *testing.T) {
 	// No transport
-	logs.CurrentTransport = ""
+	status.CurrentTransport = ""
 	meta := getLogsMeta()
 	assert.Equal(t, &LogsMeta{Transport: ""}, meta)
 	// TCP transport
-	logs.CurrentTransport = logs.TransportTCP
+	status.CurrentTransport = status.TransportTCP
 	meta = getLogsMeta()
 	assert.Equal(t, &LogsMeta{Transport: "TCP"}, meta)
 	// HTTP transport
-	logs.CurrentTransport = logs.TransportHTTP
+	status.CurrentTransport = status.TransportHTTP
 	meta = getLogsMeta()
 	assert.Equal(t, &LogsMeta{Transport: "HTTP"}, meta)
 }


### PR DESCRIPTION
### What does this PR do?

The ContainerCollectAll virtual configuration of the Logs Agent can start before any configuration file is processed, meaning that it would reap the tailing ownership of every running containers, even if a configuration file has been created through a ConfigMap to tail some containers.

This PR delays the introduction of the ContainerCollectAll source until the AutoConfig has been executed.

### Additional Notes

Some refactoring has been done because the main logs package contained some global variables which had to be contained in a more precise package.

### Describe your test plan

In a k8s cluster, enable the `logs_config.container_collect_all` flag and use a ConfigMap to add a configuration file tailing logs of a container. Validate that the logs from the configuration file is properly tailed by the custom config.
Feel free to ping me for questions.