### PR TITLE
Add .gitattributes to exclude generated files from diff and statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.pb.go -diff -merge
+*.pb.go linguist-generated=true
+*.pb.gw.go -diff -merge
+*.pb.gw.go linguist-generated=true
+pkg/ebpf/bytecode/tracer-ebpf.go -diff -merge
+pkg/ebpf/bytecode/tracer-ebpf.go linguist-generated=true


### PR DESCRIPTION
### What does this PR do?

Add a .gitattributes files

### Motivation

PRs and `git diff` commands may be flooded by diffs of generated files. Same thing happens with Github statistics.
Adding generated files to .gitattributes still make the generated file appear in `git diff` and PRs, but hides the content by default, making the changes easier to review