### PR TITLE
pkg/trace/obfuscate: introduce an SQL query cache

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1095,3 +1095,6 @@ core,"google.golang.org/appengine/datastore/internal/cloudkey",Apache-2.0
 core,"google.golang.org/appengine/datastore/internal/cloudpb",Apache-2.0
 core,"google.golang.org/appengine/internal/app_identity",Apache-2.0
 core,"google.golang.org/appengine/internal/modules",Apache-2.0
+core,"github.com/cespare/xxhash",MIT
+core,"github.com/dgraph-io/ristretto",Apache-2.0
+core,"github.com/dgraph-io/ristretto/z",Apache-2.0

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a
 	github.com/davecgh/go-spew v1.1.1
+	github.com/dgraph-io/ristretto v0.0.3
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,7 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c/go.mod h1:Xe6ZsFhtM8HrDku0pxJ3/Lr51rwykrzgFwpmTzleatY=
 github.com/cespare/xxhash v0.0.0-20181017004759-096ff4a8a059/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
@@ -346,8 +347,11 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC4G4As=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
+github.com/dgraph-io/ristretto v0.0.3 h1:jh22xisGBjrEVnRZ1DVTpBVQm0Xndu8sMl0CWDzSIBI=
+github.com/dgraph-io/ristretto v0.0.3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-jump v0.0.0-20170409065014-e1f439676b57 h1:qZNIK8jjHgLFHAW2wzCWPEv0ZIgcBhU7X3oDt/p3Sv0=
 github.com/dgryski/go-jump v0.0.0-20170409065014-e1f439676b57/go.mod h1:4hKCXuwrJoYvHZxJ86+bRVTOMyJ0Ej+RqfSm8mHi6KA=
 github.com/dgryski/go-sip13 v0.0.0-20190329191031-25c5027a8c7b/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -141,6 +141,7 @@ func (a *Agent) loop() {
 			a.ErrorsScoreSampler.Stop()
 			a.PrioritySampler.Stop()
 			a.EventProcessor.Stop()
+			a.obfuscator.Stop()
 			return
 		}
 	}

--- a/pkg/trace/obfuscate/cache.go
+++ b/pkg/trace/obfuscate/cache.go
@@ -1,0 +1,80 @@
+package obfuscate
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+
+	"github.com/dgraph-io/ristretto"
+)
+
+// measuredCache is a wrapper on top of *ristretto.Cache which additionally
+// sends metrics (hits and misses) every 10 seconds.
+type measuredCache struct {
+	*ristretto.Cache
+
+	// close allows sending shutdown notification.
+	close chan struct{}
+}
+
+// Close gracefully closes the cache when active.
+func (c *measuredCache) Close() {
+	if c.Cache == nil {
+		return
+	}
+	c.close <- struct{}{}
+	<-c.close
+}
+
+func (c *measuredCache) statsLoop() {
+	defer func() {
+		c.close <- struct{}{}
+	}()
+	tick := time.NewTicker(10 * time.Second)
+	defer tick.Stop()
+	mx := c.Cache.Metrics
+	for {
+		select {
+		case <-tick.C:
+			metrics.Gauge("datadog.trace_agent.ofuscation.sql_cache.hits", float64(mx.Hits()), nil, 1)
+			metrics.Gauge("datadog.trace_agent.ofuscation.sql_cache.misses", float64(mx.Misses()), nil, 1)
+		case <-c.close:
+			c.Cache.Close()
+			return
+		}
+	}
+}
+
+// newMeasuredCache returns a new measuredCache.
+func newMeasuredCache() *measuredCache {
+	if !config.HasFeature("sql_cache") {
+		// a nil *ristretto.Cache is a no-op cache
+		return &measuredCache{}
+	}
+	cfg := &ristretto.Config{
+		Metrics: true,
+		// We know that both cache keys and values will have a maximum
+		// length of 5K, so one entry (key + value) will be 10K maximum.
+		// At worst case scenario, a 5M cache should fit at least 500 queries.
+		MaxCost: 5 * 1024 * 1024,
+		// An appromixation worst-case scenario when the cache is filled of small
+		// queries averaged as being of length 19 (SELECT * FROM users), we would
+		// be able to fit 263K of them into 5MB of cost.
+		// We multiply the value by x10 as advised in the ristretto.Config documentation.
+		NumCounters: 3 * 1000 * 1000,
+		// 64 is the recommended default value
+		BufferItems: 64,
+	}
+	cache, err := ristretto.NewCache(cfg)
+	if err != nil {
+		panic(fmt.Errorf("Error starting obfuscator query cache: %v", err))
+	}
+	c := measuredCache{
+		close: make(chan struct{}),
+		Cache: cache,
+	}
+	go c.statsLoop()
+	return &c
+}

--- a/pkg/trace/obfuscate/cache_test.go
+++ b/pkg/trace/obfuscate/cache_test.go
@@ -1,0 +1,16 @@
+package obfuscate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMeasuredCacheNoPanic(t *testing.T) {
+	// this test mostly ensures that a nil cache creates no panic
+	c := measuredCache{Cache: nil}
+	ok := c.Set("a", 1, 1)
+	assert.False(t, ok)
+	_, ok = c.Get("a")
+	assert.False(t, ok)
+}

--- a/pkg/trace/obfuscate/obfuscate.go
+++ b/pkg/trace/obfuscate/obfuscate.go
@@ -26,6 +26,8 @@ type Obfuscator struct {
 	// to be generic.
 	// Not safe for concurrent use.
 	sqlLiteralEscapes int32
+	// queryCache keeps a cache of already obfuscated queries.
+	queryCache *measuredCache
 }
 
 // SetSQLLiteralEscapes sets whether or not escape characters should be treated literally by the SQL obfuscator.
@@ -47,7 +49,10 @@ func NewObfuscator(cfg *config.ObfuscationConfig) *Obfuscator {
 	if cfg == nil {
 		cfg = new(config.ObfuscationConfig)
 	}
-	o := Obfuscator{opts: cfg}
+	o := Obfuscator{
+		opts:       cfg,
+		queryCache: newMeasuredCache(),
+	}
 	if cfg.ES.Enabled {
 		o.es = newJSONObfuscator(&cfg.ES)
 	}
@@ -56,6 +61,9 @@ func NewObfuscator(cfg *config.ObfuscationConfig) *Obfuscator {
 	}
 	return &o
 }
+
+// Stop cleans up after a finished Obfuscator.
+func (o *Obfuscator) Stop() { o.queryCache.Close() }
 
 // Obfuscate may obfuscate span's properties based on its type and on the Obfuscator's
 // configuration.

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -172,8 +172,7 @@ func (o *Obfuscator) ObfuscateSQLString(in string) (*ObfuscatedQuery, error) {
 	if err != nil {
 		return oq, err
 	}
-	cost := len(in) + len(oq.Query) + len(oq.TablesCSV)
-	o.queryCache.Set(in, oq, int64(cost))
+	o.queryCache.Set(in, oq, oq.Cost())
 	return oq, nil
 }
 
@@ -255,6 +254,12 @@ func (f *tableFinderFilter) Reset() {
 type ObfuscatedQuery struct {
 	Query     string // the obfuscated SQL query
 	TablesCSV string // comma-separated list of tables that the query addresses
+}
+
+// Cost returns the number of bytes needed to store all the fields
+// of this ObfuscatedQuery.
+func (oq *ObfuscatedQuery) Cost() int64 {
+	return int64(len(oq.Query) + len(oq.TablesCSV))
 }
 
 // attemptObfuscation attempts to obfuscate the SQL query loaded into the tokenizer, using the

--- a/releasenotes/notes/apm-sql-cache-03c32a5e90b21674.yaml
+++ b/releasenotes/notes/apm-sql-cache-03c32a5e90b21674.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: An SQL query obfuscation cache was added under the feature flag
+    DD_APM_FEATURES=sql_cache. In most cases where SQL queries are repeated
+    or prepared, this can significantly reduce CPU work.


### PR DESCRIPTION
This change introduces a string cache which stores obfuscation results. It is limited to 5MB.

⚠️ This feature is disabled by default. To enable it, a feature flag is needed to be set (`DD_APM_FEATURES=sql_cache`). The motivations for this are partially explained in https://github.com/DataDog/datadog-agent/pull/6320#pullrequestreview-484100736

Closes https://github.com/DataDog/datadog-agent/issues/6289