### PR TITLE
[gce] Send project host tag with `project_id:` key on top of `project:`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -457,6 +457,7 @@ func InitConfig(config Config) {
 	// GCE
 	config.BindEnvAndSetDefault("collect_gce_tags", true)
 	config.BindEnvAndSetDefault("exclude_gce_tags", []string{"kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings", "windows-startup-script-ps1", "common-psm1", "k8s-node-setup-psm1", "serial-port-logging-enable", "enable-oslogin", "disable-address-manager", "disable-legacy-endpoints", "windows-keys"})
+	config.BindEnvAndSetDefault("gce_send_project_id_tag", false)
 	config.BindEnvAndSetDefault("gce_metadata_timeout", 1000) // value in milliseconds
 
 	// Cloud Foundry

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -255,6 +255,12 @@ api_key:
 #   - "google-container-manifest"
 #   - "bosh_settings"
 
+## @param gce_send_project_id_tag - bool - optional - default: false
+## Send the project ID host tag with the `project_id:` tag key in addition to
+## the `project:` tag key.
+#
+# gce_send_project_id_tag: false
+
 ## @param gce_metadata_timeout - integer - optional - default: 1000
 ## Timeout in milliseconds on calls to the GCE metadata endpoints.
 #

--- a/pkg/util/gce/gce_tags.go
+++ b/pkg/util/gce/gce_tags.go
@@ -84,6 +84,9 @@ func GetTags() ([]string, error) {
 	}
 	if metadata.Project.ProjectID != "" {
 		tags = append(tags, fmt.Sprintf("project:%s", metadata.Project.ProjectID))
+		if config.Datadog.GetBool("gce_send_project_id_tag") {
+			tags = append(tags, fmt.Sprintf("project_id:%s", metadata.Project.ProjectID))
+		}
 	}
 	if metadata.Project.NumericProjectID != 0 {
 		tags = append(tags, fmt.Sprintf("numeric_project_id:%d", metadata.Project.NumericProjectID))

--- a/pkg/util/gce/gce_tags_test.go
+++ b/pkg/util/gce/gce_tags_test.go
@@ -38,7 +38,8 @@ var (
 		"google-compute-enable-pcid:true",
 		"instance-template:projects/111111111111/global/instanceTemplates/gke-test-cluster-default-pool-0012834b",
 	}
-	expectedExcludedTags = []string{
+	expectedTagsWithProjectID = append(expectedFullTags, "project_id:test-project")
+	expectedExcludedTags      = []string{
 		"tag",
 		"zone:us-east1-b",
 		"instance-type:n1-standard-1",
@@ -95,6 +96,17 @@ func TestGetHostTags(t *testing.T) {
 	tags, err := GetTags()
 	require.Nil(t, err)
 	testTags(t, tags, expectedFullTags)
+}
+
+func TestGetHostTagsWithProjectID(t *testing.T) {
+	server := mockMetadataRequest(t)
+	defer server.Close()
+	defer cache.Cache.Delete(tagsCacheKey)
+	config.Datadog.Set("gce_send_project_id_tag", true)
+	defer config.Datadog.Set("gce_send_project_id_tag", false)
+	tags, err := GetTags()
+	require.Nil(t, err)
+	testTags(t, tags, expectedTagsWithProjectID)
 }
 
 func TestGetHostTagsSuccessThenError(t *testing.T) {

--- a/releasenotes/notes/gce-project-id-98c846eb179e4d1b.yaml
+++ b/releasenotes/notes/gce-project-id-98c846eb179e4d1b.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allow sending the GCP project ID under the ``project_id:`` host tag key, in addition
+    to the ``project:`` host tag key, with the ``gce_send_project_id_tag`` config setting.


### PR DESCRIPTION
### What does this PR do?

Sends project host tag with `project_id:` key on top of `project:` key, when new config flag (`gce_send_project_id_tag`) is enabled.

### Motivation

GCP crawler _metrics_ are submitted with `project_id` tag key, so using the same tag key allows for better correlations in-app.

### Additional Notes

* Behind a config flag to avoid potential context churn problems on agent upgrade.
* A similar change is planned for the _host tags_ reported by GCP crawlers (which currently only send `project`)