### PR TITLE
pkg/trace/api: distinguish timeout and EOF errors from decoding errors

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -371,6 +371,10 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		httpDecodingError(err, []string{"handler:traces", fmt.Sprintf("v:%s", v)}, w)
 		if err == ErrLimitedReaderLimitReached {
 			atomic.AddInt64(&ts.TracesDropped.PayloadTooLarge, tracen)
+		} else if err == io.EOF || err == io.ErrUnexpectedEOF {
+			atomic.AddInt64(&ts.TracesDropped.UnexpectedEOF, tracen)
+		} else if err, ok := err.(net.Error); ok && err.Timeout() {
+			atomic.AddInt64(&ts.TracesDropped.Timeout, tracen)
 		} else {
 			atomic.AddInt64(&ts.TracesDropped.DecodingError, tracen)
 		}

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -204,6 +204,11 @@ type TracesDropped struct {
 	SpanIDZero int64
 	// ForeignSpan is when a span in a trace has a TraceId that is different than the first span in the trace
 	ForeignSpan int64
+	// Timeout is when a request times out
+	Timeout int64
+	// UnexpectedEOF is when an unexpected EOF is encountered, this can happen because the client has aborted
+	// or because a bad payload (i.e. shorter than claimed in Content-Length) was sent
+	UnexpectedEOF int64
 }
 
 // tagValues converts TracesDropped into a map representation with keys matching standardized names for all reasons
@@ -215,6 +220,8 @@ func (s *TracesDropped) tagValues() map[string]int64 {
 		"trace_id_zero":     atomic.LoadInt64(&s.TraceIDZero),
 		"span_id_zero":      atomic.LoadInt64(&s.SpanIDZero),
 		"foreign_span":      atomic.LoadInt64(&s.ForeignSpan),
+		"timeout":           atomic.LoadInt64(&s.Timeout),
+		"unexpected_eof":    atomic.LoadInt64(&s.UnexpectedEOF),
 	}
 }
 

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -27,6 +27,8 @@ func TestTracesDropped(t *testing.T) {
 			"foreign_span":      1,
 			"trace_id_zero":     1,
 			"span_id_zero":      1,
+			"timeout":           0,
+			"unexpected_eof":    0,
 		}, s.tagValues())
 	})
 


### PR DESCRIPTION
### What does this PR do?

Currently timeouts and unexpected EOF (which either indicate a real problem with the payload/Content-Length combination, or are caused by the client aborting the connection) are recorded as decoding errors, but often correspond to valid payloads which could have been decoded had the trace agent been given enough resources.

### Motivation

More accurate error metrics for diagnostic purposes

### Describe your test plan

I added a case where EOF is produced. I don't know how to simulate a connection timeout in Go but was hoping someone in the agent team could add this test case.
