### PR TITLE
pkg/trace/api: count EOF and timeout errors separately

### DIFF
--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
@@ -41,15 +42,23 @@ func httpDecodingError(err error, tags []string, w http.ResponseWriter) {
 	errtag := "decoding-error"
 	msg := err.Error()
 
-	if err == ErrLimitedReaderLimitReached {
+	switch err {
+	case ErrLimitedReaderLimitReached:
 		status = http.StatusRequestEntityTooLarge
-		errtag := "payload-too-large"
+		errtag = "payload-too-large"
+		msg = errtag
+	case io.EOF, io.ErrUnexpectedEOF:
+		errtag = "unexpected-eof"
+		msg = errtag
+	}
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		status = http.StatusRequestTimeout
+		errtag = "timeout"
 		msg = errtag
 	}
 
 	tags = append(tags, fmt.Sprintf("error:%s", errtag))
 	metrics.Count(receiverErrorKey, 1, tags, 1)
-
 	http.Error(w, msg, status)
 }
 

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -204,6 +204,11 @@ type TracesDropped struct {
 	SpanIDZero int64
 	// ForeignSpan is when a span in a trace has a TraceId that is different than the first span in the trace
 	ForeignSpan int64
+	// Timeout is when a request times out.
+	Timeout int64
+	// EOF is when an unexpected EOF is encountered, this can happen because the client has aborted
+	// or because a bad payload (i.e. shorter than claimed in Content-Length) was sent.
+	EOF int64
 }
 
 // tagValues converts TracesDropped into a map representation with keys matching standardized names for all reasons
@@ -215,6 +220,8 @@ func (s *TracesDropped) tagValues() map[string]int64 {
 		"trace_id_zero":     atomic.LoadInt64(&s.TraceIDZero),
 		"span_id_zero":      atomic.LoadInt64(&s.SpanIDZero),
 		"foreign_span":      atomic.LoadInt64(&s.ForeignSpan),
+		"timeout":           atomic.LoadInt64(&s.Timeout),
+		"unexpected_eof":    atomic.LoadInt64(&s.EOF),
 	}
 }
 
@@ -356,6 +363,8 @@ func (s *Stats) reset() {
 	atomic.StoreInt64(&s.TracesDropped.TraceIDZero, 0)
 	atomic.StoreInt64(&s.TracesDropped.SpanIDZero, 0)
 	atomic.StoreInt64(&s.TracesDropped.ForeignSpan, 0)
+	atomic.StoreInt64(&s.TracesDropped.Timeout, 0)
+	atomic.StoreInt64(&s.TracesDropped.EOF, 0)
 	atomic.StoreInt64(&s.SpansMalformed.DuplicateSpanID, 0)
 	atomic.StoreInt64(&s.SpansMalformed.ServiceEmpty, 0)
 	atomic.StoreInt64(&s.SpansMalformed.ServiceTruncate, 0)

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -27,6 +27,8 @@ func TestTracesDropped(t *testing.T) {
 			"foreign_span":      1,
 			"trace_id_zero":     1,
 			"span_id_zero":      1,
+			"timeout":           0,
+			"unexpected_eof":    0,
 		}, s.tagValues())
 	})
 

--- a/releasenotes/notes/apm-decoding-error-details-63d57d71f25f5505.yaml
+++ b/releasenotes/notes/apm-decoding-error-details-63d57d71f25f5505.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Decoding errors reported by the `datadog.trace-agent.receiver.error`
+    and `datadog.trace_agent.normalizer.traces_dropped` contain more detailed
+    reason tags in case of EOFs and timeouts.


### PR DESCRIPTION
Add distinction between common decoding errors and EOF/timeouts.

Follows from https://github.com/DataDog/datadog-agent/pull/6326