### PR TITLE
Change metric value from float to doble

### DIFF
--- a/pkg/collector/python/aggregator.go
+++ b/pkg/collector/python/aggregator.go
@@ -23,7 +23,7 @@ import "C"
 
 // SubmitMetric is the method exposed to Python scripts to submit metrics
 //export SubmitMetric
-func SubmitMetric(checkID *C.char, metricType C.metric_type_t, metricName *C.char, value C.float, tags **C.char, hostname *C.char) {
+func SubmitMetric(checkID *C.char, metricType C.metric_type_t, metricName *C.char, value C.double, tags **C.char, hostname *C.char) {
 	goCheckID := C.GoString(checkID)
 
 	sender, err := aggregator.GetSender(chk.ID(goCheckID))

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -106,7 +106,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 // aggregator module
 //
 
-void SubmitMetric(char *, metric_type_t, char *, float, char **, int, char *);
+void SubmitMetric(char *, metric_type_t, char *, double, char **, int, char *);
 void SubmitServiceCheck(char *, char *, int, char **, int, char *, char *);
 void SubmitEvent(char *, event_t *, int);
 void SubmitHistogramBucket(char *, char *, long long, float, float, int, char *, char **);

--- a/pkg/collector/python/test_aggregator.go
+++ b/pkg/collector/python/test_aggregator.go
@@ -26,43 +26,43 @@ func testSubmitMetric(t *testing.T) {
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_GAUGE,
 		C.CString("test_gauge"),
-		C.float(21),
+		C.double(21),
 		&cTags[0],
 		C.CString("my_hostname"))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_RATE,
 		C.CString("test_rate"),
-		C.float(21),
+		C.double(21),
 		&cTags[0],
 		C.CString("my_hostname"))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_COUNT,
 		C.CString("test_count"),
-		C.float(21),
+		C.double(21),
 		&cTags[0],
 		C.CString("my_hostname"))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_MONOTONIC_COUNT,
 		C.CString("test_monotonic_count"),
-		C.float(21),
+		C.double(21),
 		&cTags[0],
 		C.CString("my_hostname"))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_COUNTER,
 		C.CString("test_counter"),
-		C.float(21),
+		C.double(21),
 		&cTags[0],
 		C.CString("my_hostname"))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_HISTOGRAM,
 		C.CString("test_histogram"),
-		C.float(21),
+		C.double(21),
 		&cTags[0],
 		C.CString("my_hostname"))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_HISTORATE,
 		C.CString("test_historate"),
-		C.float(21),
+		C.double(21),
 		&cTags[0],
 		C.CString("my_hostname"))
 
@@ -83,7 +83,7 @@ func testSubmitMetricEmptyTags(t *testing.T) {
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_GAUGE,
 		C.CString("test_gauge"),
-		C.float(21),
+		C.double(21),
 		&cTags[0],
 		C.CString("my_hostname"))
 
@@ -98,7 +98,7 @@ func testSubmitMetricEmptyHostname(t *testing.T) {
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_GAUGE,
 		C.CString("test_gauge"),
-		C.float(21),
+		C.double(21),
 		&cTags[0],
 		nil)
 

--- a/releasenotes/notes/python-use-double-metric-values-b053c9127ae2ea49.yaml
+++ b/releasenotes/notes/python-use-double-metric-values-b053c9127ae2ea49.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Use double-precision floats for metric values submitted from Python checks.

--- a/rtloader/common/builtins/aggregator.c
+++ b/rtloader/common/builtins/aggregator.c
@@ -188,7 +188,7 @@ static PyObject *submit_metric(PyObject *self, PyObject *args)
     char *check_id = NULL;
     char **tags = NULL;
     int mt;
-    float value;
+    double value;
 
     // Python call: aggregator.submit_metric(self, check_id, aggregator.metric_type.GAUGE, name, value, tags, hostname)
     if (!PyArg_ParseTuple(args, "OsisfOs", &check, &check_id, &mt, &name, &value, &py_tags, &hostname)) {

--- a/rtloader/common/builtins/aggregator.c
+++ b/rtloader/common/builtins/aggregator.c
@@ -191,7 +191,7 @@ static PyObject *submit_metric(PyObject *self, PyObject *args)
     double value;
 
     // Python call: aggregator.submit_metric(self, check_id, aggregator.metric_type.GAUGE, name, value, tags, hostname)
-    if (!PyArg_ParseTuple(args, "OsisfOs", &check, &check_id, &mt, &name, &value, &py_tags, &hostname)) {
+    if (!PyArg_ParseTuple(args, "OsisdOs", &check, &check_id, &mt, &name, &value, &py_tags, &hostname)) {
         goto error;
     }
 

--- a/rtloader/demo/main.c
+++ b/rtloader/demo/main.c
@@ -26,7 +26,7 @@ char **get_tags(char *id, int highCard)
     return data;
 }
 
-void submitMetric(char *id, metric_type_t mt, char *name, float val, char **tags,  char *hostname)
+void submitMetric(char *id, metric_type_t mt, char *name, double val, char **tags,  char *hostname)
 {
     printf("I'm extending Python providing aggregator.submit_metric:\n");
     printf("Check id: %s\n", id);

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -93,7 +93,7 @@ typedef enum {
 // aggregator
 //
 // (id, metric_type, metric_name, value, tags, hostname)
-typedef void (*cb_submit_metric_t)(char *, metric_type_t, char *, float, char **, char *);
+typedef void (*cb_submit_metric_t)(char *, metric_type_t, char *, double, char **, char *);
 // (id, sc_name, status, tags, hostname, message)
 typedef void (*cb_submit_service_check_t)(char *, char *, int, char **, char *, char *);
 // (id, event)

--- a/rtloader/test/aggregator/aggregator.go
+++ b/rtloader/test/aggregator/aggregator.go
@@ -17,7 +17,7 @@ import (
 #include "rtloader_mem.h"
 #include "datadog_agent_rtloader.h"
 
-extern void submitMetric(char *, metric_type_t, double *, float, char **, char *);
+extern void submitMetric(char *, metric_type_t, char *, double, char **, char *);
 extern void submitServiceCheck(char *, char *, int, char **, char *, char *);
 extern void submitEvent(char*, event_t*);
 extern void submitHistogramBucket(char *, char *, long long, float, float, int, char *, char **);

--- a/rtloader/test/aggregator/aggregator.go
+++ b/rtloader/test/aggregator/aggregator.go
@@ -17,7 +17,7 @@ import (
 #include "rtloader_mem.h"
 #include "datadog_agent_rtloader.h"
 
-extern void submitMetric(char *, metric_type_t, char *, float, char **, char *);
+extern void submitMetric(char *, metric_type_t, double *, float, char **, char *);
 extern void submitServiceCheck(char *, char *, int, char **, char *, char *);
 extern void submitEvent(char*, event_t*);
 extern void submitHistogramBucket(char *, char *, long long, float, float, int, char *, char **);
@@ -151,7 +151,7 @@ func charArrayToSlice(array **C.char) (res []string) {
 }
 
 //export submitMetric
-func submitMetric(id *C.char, mt C.metric_type_t, mname *C.char, val C.float, t **C.char, hname *C.char) {
+func submitMetric(id *C.char, mt C.metric_type_t, mname *C.char, val C.double, t **C.char, hname *C.char) {
 	checkID = C.GoString(id)
 	metricType = int(mt)
 	name = C.GoString(mname)


### PR DESCRIPTION
### What does this PR do?

It changes the metric submission type in the rt_loader from float to double

### Motivation
This customer has some big number metrics missing: https://github.com/DataDog/integrations-core/issues/7476

looks like Python automatically handles big nums
> Python supports a "bignum" integer type which can work with arbitrarily large numbers. In Python 2.5+, this type is called long and is separate from the int type, but the interpreter will automatically use whichever is more appropriate. In Python 3.0+, the int type has been dropped completely.

But we're limited by the c binding.
