### PR TITLE
Add us3.datadoghq.com site option to Windows installer

### DIFF
--- a/omnibus/resources/agent/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/agent/msi/assets/sitedlg.wxi
@@ -1,7 +1,8 @@
 <Include>
   <ComboBox Property="SITE">
-    <ListItem Text="Datadog US (datadoghq.com)" Value="datadoghq.com"/>
-    <ListItem Text="Datadog EU (datadoghq.eu)" Value="datadoghq.eu"/>
+    <ListItem Text="datadoghq.com" Value="datadoghq.com"/>
+    <ListItem Text="datadoghq.eu" Value="datadoghq.eu"/>
+    <ListItem Text="us3.datadoghq.com" Value="us3.datadoghq.com"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
   <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>

--- a/omnibus/resources/dogstatsd/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/dogstatsd/msi/assets/sitedlg.wxi
@@ -1,7 +1,8 @@
 <Include>
   <ComboBox Property="SITE">
-    <ListItem Text="Datadog US (datadoghq.com)" Value="datadoghq.com"/>
-    <ListItem Text="Datadog EU (datadoghq.eu)" Value="datadoghq.eu"/>
+    <ListItem Text="datadoghq.com" Value="datadoghq.com"/>
+    <ListItem Text="datadoghq.eu" Value="datadoghq.eu"/>
+    <ListItem Text="us3.datadoghq.com" Value="us3.datadoghq.com"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
   <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>

--- a/omnibus/resources/iot/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/iot/msi/assets/sitedlg.wxi
@@ -1,7 +1,8 @@
 <Include>
   <ComboBox Property="SITE">
-    <ListItem Text="Datadog US (datadoghq.com)" Value="datadoghq.com"/>
-    <ListItem Text="Datadog EU (datadoghq.eu)" Value="datadoghq.eu"/>
+    <ListItem Text="datadoghq.com" Value="datadoghq.com"/>
+    <ListItem Text="datadoghq.eu" Value="datadoghq.eu"/>
+    <ListItem Text="us3.datadoghq.com" Value="us3.datadoghq.com"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
   <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>

--- a/releasenotes/notes/windows-installer-us3-option-1eef1d7008f7d02a.yaml
+++ b/releasenotes/notes/windows-installer-us3-option-1eef1d7008f7d02a.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Support the us3.datadoghq.com site option in the Windows
+    GUI installer.


### PR DESCRIPTION
### What does this PR do?

Adds us3.datadoghq.com as a new site option in the Windows installer GUI.

### Motivation

Support new site option.

### Additional notes

Does this need a release note?