### PR TITLE
Allow `agent integration install` to work when the configuration file is missing

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -142,7 +142,7 @@ func loadPythonInfo() error {
 		rootDir = parentDir
 	}
 
-	if err := common.SetupConfig(confFilePath); err != nil {
+	if err := common.SetupConfigIfExist(confFilePath); err != nil {
 		fmt.Printf("Cannot setup config, exiting: %v\n", err)
 		return err
 	}

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -65,7 +65,7 @@ func setupConfig(confFilePath string, configName string, withoutSecrets bool, fa
 	}
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
 	var e viper.ConfigFileNotFoundError
-	if err != nil && !(!failOnMissingFile && errors.As(err, &e) && confFilePath == "") {
+	if err != nil && (failOnMissingFile || !errors.As(err, &e) || confFilePath != "") {
 		return warnings, fmt.Errorf("unable to load Datadog config file: %w", err)
 	}
 	return warnings, nil

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -6,10 +6,12 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/spf13/viper"
 )
 
 // SetupConfig fires up the configuration system
@@ -20,16 +22,24 @@ func SetupConfig(confFilePath string) error {
 
 // SetupConfigWithWarnings fires up the configuration system and returns warnings if any.
 func SetupConfigWithWarnings(confFilePath, configName string) (*config.Warnings, error) {
-	return setupConfig(confFilePath, configName, false)
+	return setupConfig(confFilePath, configName, false, true)
 }
 
 // SetupConfigWithoutSecrets fires up the configuration system without secrets support
 func SetupConfigWithoutSecrets(confFilePath string, configName string) error {
-	_, err := setupConfig(confFilePath, configName, true)
+	_, err := setupConfig(confFilePath, configName, true, true)
 	return err
 }
 
-func setupConfig(confFilePath string, configName string, withoutSecrets bool) (*config.Warnings, error) {
+// SetupConfigIfExist fires up the configuration system but
+// doesn't raise an error if the configuration file is the default one
+// and it doesn't exist.
+func SetupConfigIfExist(confFilePath string) error {
+	_, err := setupConfig(confFilePath, "", false, false)
+	return err
+}
+
+func setupConfig(confFilePath string, configName string, withoutSecrets bool, failOnMissingFile bool) (*config.Warnings, error) {
 	if configName != "" {
 		config.Datadog.SetConfigName(configName)
 	}
@@ -53,8 +63,10 @@ func setupConfig(confFilePath string, configName string, withoutSecrets bool) (*
 	} else {
 		warnings, err = config.Load()
 	}
-	if err != nil {
-		return warnings, fmt.Errorf("unable to load Datadog config file: %s", err)
+	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
+	var e viper.ConfigFileNotFoundError
+	if err != nil && !(!failOnMissingFile && errors.As(err, &e) && confFilePath == "") {
+		return warnings, fmt.Errorf("unable to load Datadog config file: %w", err)
 	}
 	return warnings, nil
 }

--- a/releasenotes/notes/Fix-agent_integration_install-inside-a-Dockerfile-269ff9f12a297794.yaml
+++ b/releasenotes/notes/Fix-agent_integration_install-inside-a-Dockerfile-269ff9f12a297794.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Allow `agent integration install` to work even if the datadog agent
+    configuration file doesn't exist.
+    This is typically the case when this command is run from a Dockerfile
+    in order to build a custom image from the datadog official one.


### PR DESCRIPTION
### What does this PR do?

Ignore missing configuration file if:
— the configuration file is the default one and has not been explicitly set;
— the command run is `agent integration install`.

### Motivation

In order to add custom checks to a datadog agent docker image, the procedure involves running `agent integration install` inside a Dockerfile: [Community integration installation](https://docs.datadoghq.com/agent/guide/community-integrations-installation-with-docker-agent/?tab=docker).
The issue is that the datadog agent docker image doesn't have a `/etc/datadog-agent/datadog.yaml` file. Instead, it dynamically creates it at Kubernetes pod start: https://github.com/DataDog/datadog-agent/blob/fc7b205536a8f5fa16d814ed934ad76dfe4816e8/Dockerfiles/agent/entrypoint/51-docker.sh#L16-L19

As this init script isn’t run in the context of a `docker build` used to build a custom image, `agent integration install` fails.

### Additional Notes

As a short-term workaround, the doc has been amended to add an explicit specification of a datadog configuration file in this context: https://github.com/DataDog/documentation/pull/7208

This workaround can now be reverted: https://github.com/DataDog/documentation/pull/8480

### Describe your test plan

Try to build a custom image with this Dockerfile:
```dockerfile
FROM python:3.8 AS wheel_builder
WORKDIR /wheels
RUN pip install "datadog-checks-dev[cli]"
RUN git clone https://github.com/DataDog/integrations-extras.git
RUN ddev config set extras ./integrations-extras
RUN ddev -e release build bind9

FROM datadog/agent:latest
COPY --from=wheel_builder /wheels/integrations-extras/bind9/dist/ /dist
RUN agent integration install -r -w /dist/*.whl
```

With `FROM datadog/agent:7.22.0`, we got:
```
Step 9/9 : RUN agent integration install -r -w /dist/*.whl
 ---> Running in 58acaac2acdd
Cannot setup config, exiting: unable to load Datadog config file: Config File "datadog" Not Found in "[/etc/datadog-agent]"
Error: unable to load Datadog config file: Config File "datadog" Not Found in "[/etc/datadog-agent]"
The command '/bin/sh -c agent integration install -r -w /dist/*.whl' returned a non-zero code: 255
```

With `FROM datadog/agent:7.23.0-rc.1`, we should get:
```
Step 9/9 : RUN agent integration install -r -w /dist/*.whl
 ---> Running in 1d1e2e2fb374
For your security, only use this to install wheels containing an Agent integration and coming from a known source. The Agent cannot perform any verification on local wheels.
Processing /dist/datadog_bind9-1.0.0-py2.py3-none-any.whl
Installing collected packages: datadog-bind9
Successfully installed datadog-bind9-1.0.0
Successfully copied configuration file conf.yaml.example
Successfully completed the installation of datadog-bind9
Removing intermediate container 1d1e2e2fb374
 ---> db02d569ec3d
Successfully built db02d569ec3d
```