### PR TITLE
Implement variable interpolation in the tagger when inferring the standard tags

### DIFF
--- a/releasenotes/notes/Implement-variable-interpolation-in-the-tagger-ff55c22d1aac4d2a.yaml
+++ b/releasenotes/notes/Implement-variable-interpolation-in-the-tagger-ff55c22d1aac4d2a.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Implement variable interpolation in the tagger when inferring the standard tags
+    from the ``DD_ENV``, ``DD_SERVICE`` and ``DD_VERSION`` environment variables


### PR DESCRIPTION
### What does this PR do?

Implement variable interpolation in the tagger when inferring the standard tags from the `DD_ENV`, `DD_SERVICE` and `DD_VERSION` environment variables.

### Motivation

Whereas the environment variables are properly interpolated by the kubelet, the interpolation logic was missing from the agent when it directly reads the containers spec.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Start an agent with this in its container spec:
```yaml
        - name: MY_VAR
          value: foo
        - name: MY_VAR_2
          value: $(MY_VAR) bar
        - name: DD_ENV
          value: $(MY_VAR_2)
```

and run `agent check kubelet`.

With `datadog/agent:7.22.0`, in the tag list of the metrics, we see:
```
        "env:$(MY_VAR_2)",
```

With `datadog/agent:7.23.0-rc.1`, we see:
```
        "env:foo bar",
```