### PR TITLE
[system-probe] Remove dependency on gopacket layer in state.go

### DIFF
--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -18,6 +18,7 @@ const (
 	// DEBUGCLIENT is the ClientID for debugging
 	DEBUGCLIENT = "-1"
 
+	// DNSResponseCodeNoError is the value that indicates that the DNS reply contains no errors.
 	// We could have used layers.DNSResponseCodeNoErr here. But importing the gopacket library only for this
 	// constant is not worth the increased memory cost.
 	DNSResponseCodeNoError = 0

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/gopacket/layers"
-
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -204,7 +202,7 @@ func (ns *networkState) addDNSStats(id string, conns []ConnectionStats) {
 
 		if dnsStats, ok := ns.clients[id].dnsStats[key]; ok {
 			conn.DNSTimeouts = dnsStats.timeouts
-			conn.DNSSuccessfulResponses = dnsStats.countByRcode[uint8(layers.DNSResponseCodeNoErr)]
+			conn.DNSSuccessfulResponses = dnsStats.countByRcode[0] // 0 means No Error
 			conn.DNSSuccessLatencySum = dnsStats.successLatencySum
 			conn.DNSFailureLatencySum = dnsStats.failureLatencySum
 			conn.DNSCountByRcode = make(map[uint32]uint32)

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -17,6 +17,10 @@ var (
 const (
 	// DEBUGCLIENT is the ClientID for debugging
 	DEBUGCLIENT = "-1"
+
+	// We could have used layers.DNSResponseCodeNoErr here. But importing the gopacket library only for this
+	// constant is not worth the increased memory cost.
+	DNSResponseCodeNoError = 0
 )
 
 // State takes care of handling the logic for:
@@ -202,7 +206,7 @@ func (ns *networkState) addDNSStats(id string, conns []ConnectionStats) {
 
 		if dnsStats, ok := ns.clients[id].dnsStats[key]; ok {
 			conn.DNSTimeouts = dnsStats.timeouts
-			conn.DNSSuccessfulResponses = dnsStats.countByRcode[0] // 0 means No Error
+			conn.DNSSuccessfulResponses = dnsStats.countByRcode[DNSResponseCodeNoError]
 			conn.DNSSuccessLatencySum = dnsStats.successLatencySum
 			conn.DNSFailureLatencySum = dnsStats.failureLatencySum
 			conn.DNSCountByRcode = make(map[uint32]uint32)

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket/layers"
-
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 
 	"github.com/stretchr/testify/assert"
@@ -1151,7 +1149,7 @@ func TestDNSStatsWithMultipleClients(t *testing.T) {
 	getStats := func() map[dnsKey]dnsStats {
 		stats := make(map[dnsKey]dnsStats)
 		countByRcode := make(map[uint8]uint32)
-		countByRcode[uint8(layers.DNSResponseCodeNoErr)] = 1
+		countByRcode[uint8(DNSResponseCodeNoError)] = 1
 		stats[dKey] = dnsStats{countByRcode: countByRcode}
 		return stats
 	}
@@ -1198,7 +1196,7 @@ func TestDNSStatsPIDCollisions(t *testing.T) {
 	dKey := dnsKey{clientIP: c.Source, clientPort: c.SPort, serverIP: c.Dest, protocol: c.Type}
 	stats := make(map[dnsKey]dnsStats)
 	countByRcode := make(map[uint8]uint32)
-	countByRcode[uint8(layers.DNSResponseCodeNoErr)] = 1
+	countByRcode[DNSResponseCodeNoError] = 1
 	stats[dKey] = dnsStats{countByRcode: countByRcode}
 
 	client := "client"


### PR DESCRIPTION
## Issue

The import of `github.com/google/gopacket/layers` in `pkg/network/state.go` caused the baseline RSS of the core agent to increase by 5- 10 MB.

## Fix

The import was done only for the constant `DNSResponseCodeNoErr`. It is a DNS response code with value 0 and denotes a successful response. The PR replaces the constant directly with `0`. 