### PR TITLE
[macos] Make unversioned python binaries of Agent 6 point to Py2

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -52,7 +52,9 @@ build do
             delete "#{install_dir}/bin/agent/dist/*.conf*"
             delete "#{install_dir}/bin/agent/dist/*.yaml"
             command "del /q /s #{windows_safe_path(install_dir)}\\*.pyc"
-        elsif linux? || osx?
+        end
+
+        if linux? || osx?
             # Setup script aliases, e.g. `/opt/datadog-agent/embedded/bin/pip` will
             # default to `pip2` if the default Python runtime is Python 2.
             if with_python_runtime? "2"
@@ -74,142 +76,143 @@ build do
                 delete "#{install_dir}/embedded/bin/2to3"
                 link "#{install_dir}/embedded/bin/2to3-3.8", "#{install_dir}/embedded/bin/2to3"
             end
+        end
 
-            if linux?
-                # Fix pip after building on extended toolchain in CentOS builder
-                if redhat?
-                  unless arm?
-                    rhel_toolchain_root = "/opt/centos/devtoolset-1.1/root"
-                    # lets be cautious - we first search for the expected toolchain path, if its not there, bail out
-                    command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec grep -inH '#{rhel_toolchain_root}' {} \\; |  egrep '.*'"
-                    # replace paths with expected target toolchain location
-                    command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec sed -i 's##{rhel_toolchain_root}##g' {} \\;"
-                  end
-                end
+        if linux?
+            # Fix pip after building on extended toolchain in CentOS builder
+            if redhat?
+              unless arm?
+                rhel_toolchain_root = "/opt/centos/devtoolset-1.1/root"
+                # lets be cautious - we first search for the expected toolchain path, if its not there, bail out
+                command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec grep -inH '#{rhel_toolchain_root}' {} \\; |  egrep '.*'"
+                # replace paths with expected target toolchain location
+                command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec sed -i 's##{rhel_toolchain_root}##g' {} \\;"
+              end
+            end
 
-                # Move system service files
-                mkdir "/etc/init"
-                move "#{install_dir}/scripts/datadog-agent.conf", "/etc/init"
-                move "#{install_dir}/scripts/datadog-agent-trace.conf", "/etc/init"
-                move "#{install_dir}/scripts/datadog-agent-process.conf", "/etc/init"
-                move "#{install_dir}/scripts/datadog-agent-sysprobe.conf", "/etc/init"
-                move "#{install_dir}/scripts/datadog-agent-security.conf", "/etc/init"
-                systemd_directory = "/usr/lib/systemd/system"
-                if debian?
-                    # debian recommends using a different directory for systemd unit files
-                    systemd_directory = "/lib/systemd/system"
+            # Move system service files
+            mkdir "/etc/init"
+            move "#{install_dir}/scripts/datadog-agent.conf", "/etc/init"
+            move "#{install_dir}/scripts/datadog-agent-trace.conf", "/etc/init"
+            move "#{install_dir}/scripts/datadog-agent-process.conf", "/etc/init"
+            move "#{install_dir}/scripts/datadog-agent-sysprobe.conf", "/etc/init"
+            move "#{install_dir}/scripts/datadog-agent-security.conf", "/etc/init"
+            systemd_directory = "/usr/lib/systemd/system"
+            if debian?
+                # debian recommends using a different directory for systemd unit files
+                systemd_directory = "/lib/systemd/system"
 
-                    # sysvinit support for debian only for now
-                    mkdir "/etc/init.d"
-                    move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
-                    move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
-                    move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
-                    move "#{install_dir}/scripts/datadog-agent-security", "/etc/init.d"
-                end
-                if suse?
-                    mkdir "/etc/init.d"
-                    move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
-                    move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
-                    move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
-                    move "#{install_dir}/scripts/datadog-agent-security", "/etc/init.d"
-                end
-                mkdir systemd_directory
-                move "#{install_dir}/scripts/datadog-agent.service", systemd_directory
-                move "#{install_dir}/scripts/datadog-agent-trace.service", systemd_directory
-                move "#{install_dir}/scripts/datadog-agent-process.service", systemd_directory
-                move "#{install_dir}/scripts/datadog-agent-sysprobe.service", systemd_directory
-                move "#{install_dir}/scripts/datadog-agent-security.service", systemd_directory
+                # sysvinit support for debian only for now
+                mkdir "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent-security", "/etc/init.d"
+            end
+            if suse?
+                mkdir "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent-security", "/etc/init.d"
+            end
+            mkdir systemd_directory
+            move "#{install_dir}/scripts/datadog-agent.service", systemd_directory
+            move "#{install_dir}/scripts/datadog-agent-trace.service", systemd_directory
+            move "#{install_dir}/scripts/datadog-agent-process.service", systemd_directory
+            move "#{install_dir}/scripts/datadog-agent-sysprobe.service", systemd_directory
+            move "#{install_dir}/scripts/datadog-agent-security.service", systemd_directory
 
-                # Move configuration files
-                mkdir "/etc/datadog-agent"
-                move "#{install_dir}/bin/agent/dd-agent", "/usr/bin/dd-agent"
-                move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "/etc/datadog-agent"
-                move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "/etc/datadog-agent"
-                move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent", :force=>true
-                move "#{install_dir}/etc/datadog-agent/runtime-security.d", "/etc/datadog-agent", :force=>true
-                move "#{install_dir}/etc/datadog-agent/compliance.d", "/etc/datadog-agent"
+            # Move configuration files
+            mkdir "/etc/datadog-agent"
+            move "#{install_dir}/bin/agent/dd-agent", "/usr/bin/dd-agent"
+            move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "/etc/datadog-agent"
+            move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "/etc/datadog-agent"
+            move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent", :force=>true
+            move "#{install_dir}/etc/datadog-agent/runtime-security.d", "/etc/datadog-agent", :force=>true
+            move "#{install_dir}/etc/datadog-agent/compliance.d", "/etc/datadog-agent"
 
-                # Move SELinux policy
-                if debian? || redhat?
-                  move "#{install_dir}/etc/datadog-agent/selinux", "/etc/datadog-agent/selinux"
-                end
+            # Move SELinux policy
+            if debian? || redhat?
+              move "#{install_dir}/etc/datadog-agent/selinux", "/etc/datadog-agent/selinux"
+            end
 
-                # Create empty directories so that they're owned by the package
-                # (also requires `extra_package_file` directive in project def)
-                mkdir "/etc/datadog-agent/checks.d"
-                mkdir "/var/log/datadog"
+            # Create empty directories so that they're owned by the package
+            # (also requires `extra_package_file` directive in project def)
+            mkdir "/etc/datadog-agent/checks.d"
+            mkdir "/var/log/datadog"
 
-                # remove unused configs
-                delete "/etc/datadog-agent/conf.d/apm.yaml.default"
-                delete "/etc/datadog-agent/conf.d/process_agent.yaml.default"
+            # remove unused configs
+            delete "/etc/datadog-agent/conf.d/apm.yaml.default"
+            delete "/etc/datadog-agent/conf.d/process_agent.yaml.default"
 
-                # remove windows specific configs
-                delete "/etc/datadog-agent/conf.d/winproc.d"
+            # remove windows specific configs
+            delete "/etc/datadog-agent/conf.d/winproc.d"
 
-                # cleanup clutter
-                delete "#{install_dir}/etc"
+            # cleanup clutter
+            delete "#{install_dir}/etc"
 
-                # The prerm script of the package should use this list to remove the pyc/pyo files
-                command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.py_compiled_files.txt"
-                command "find #{install_dir}/embedded '(' -name '*.pyc' -o -name '*.pyo' ')' -type f -delete -print >> #{install_dir}/embedded/.py_compiled_files.txt"
+            # The prerm script of the package should use this list to remove the pyc/pyo files
+            command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.py_compiled_files.txt"
+            command "find #{install_dir}/embedded '(' -name '*.pyc' -o -name '*.pyo' ')' -type f -delete -print >> #{install_dir}/embedded/.py_compiled_files.txt"
 
-                # The prerm and preinst scripts of the package will use this list to detect which files
-                # have been setup by the installer, this way, on removal, we'll be able to delete only files
-                # which have not been created by the package.
-                command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.installed_by_pkg.txt"
-                command "find . -path './embedded/lib/python*/site-packages/*' >> #{install_dir}/embedded/.installed_by_pkg.txt", cwd: install_dir
+            # The prerm and preinst scripts of the package will use this list to detect which files
+            # have been setup by the installer, this way, on removal, we'll be able to delete only files
+            # which have not been created by the package.
+            command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.installed_by_pkg.txt"
+            command "find . -path './embedded/lib/python*/site-packages/*' >> #{install_dir}/embedded/.installed_by_pkg.txt", cwd: install_dir
 
-                # removing the doc from the embedded folder to reduce package size by ~3MB
-                delete "#{install_dir}/embedded/share/doc"
+            # removing the doc from the embedded folder to reduce package size by ~3MB
+            delete "#{install_dir}/embedded/share/doc"
 
-                # removing the terminfo db from the embedded folder to reduce package size by ~7MB
-                delete "#{install_dir}/embedded/share/terminfo"
-                # removing the symlink too
-                delete "#{install_dir}/embedded/lib/terminfo"
+            # removing the terminfo db from the embedded folder to reduce package size by ~7MB
+            delete "#{install_dir}/embedded/share/terminfo"
+            # removing the symlink too
+            delete "#{install_dir}/embedded/lib/terminfo"
 
-                # removing useless folder
-                delete "#{install_dir}/embedded/share/aclocal"
-                delete "#{install_dir}/embedded/share/examples"
+            # removing useless folder
+            delete "#{install_dir}/embedded/share/aclocal"
+            delete "#{install_dir}/embedded/share/examples"
 
-                # removing the man pages from the embedded folder to reduce package size by ~4MB
-                delete "#{install_dir}/embedded/man"
-                delete "#{install_dir}/embedded/share/man"
+            # removing the man pages from the embedded folder to reduce package size by ~4MB
+            delete "#{install_dir}/embedded/man"
+            delete "#{install_dir}/embedded/share/man"
 
-                # linux build will be stripped - but psycopg2 affected by bug in the way binutils
-                # and patchelf work together:
-                #    https://github.com/pypa/manylinux/issues/119
-                #    https://github.com/NixOS/patchelf
-                #
-                # Only affects psycopg2 - any binary whose path matches the pattern will be
-                # skipped.
-                strip_exclude("*psycopg2*")
-                strip_exclude("*cffi_backend*")
+            # linux build will be stripped - but psycopg2 affected by bug in the way binutils
+            # and patchelf work together:
+            #    https://github.com/pypa/manylinux/issues/119
+            #    https://github.com/NixOS/patchelf
+            #
+            # Only affects psycopg2 - any binary whose path matches the pattern will be
+            # skipped.
+            strip_exclude("*psycopg2*")
+            strip_exclude("*cffi_backend*")
 
-                # Do not strip eBPF programs
-                strip_exclude("*tracer-ebpf*")
-                strip_exclude("*offset-guess*")
-                strip_exclude("*runtime-security*")
+            # Do not strip eBPF programs
+            strip_exclude("*tracer-ebpf*")
+            strip_exclude("*offset-guess*")
+            strip_exclude("*runtime-security*")
+        end
 
-            elsif osx?
-                # Remove linux specific configs
-                delete "#{install_dir}/etc/conf.d/file_handle.d"
+        if osx?
+            # Remove linux specific configs
+            delete "#{install_dir}/etc/conf.d/file_handle.d"
 
-                # remove windows specific configs
-                delete "#{install_dir}/etc/conf.d/winproc.d"
+            # remove windows specific configs
+            delete "#{install_dir}/etc/conf.d/winproc.d"
 
-                if ENV['HARDENED_RUNTIME_MAC'] == 'true'
-                    hardened_runtime = "-o runtime --entitlements #{entitlements_file} "
-                else
-                    hardened_runtime = ""
-                end
+            if ENV['HARDENED_RUNTIME_MAC'] == 'true'
+                hardened_runtime = "-o runtime --entitlements #{entitlements_file} "
+            else
+                hardened_runtime = ""
+            end
 
-                if code_signing_identity
-                    # Codesign everything
-                    command "find #{install_dir} -type f | grep -E '(\\.so|\\.dylib)' | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
-                    command "find #{install_dir}/embedded/bin -perm +111 -type f | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
-                    command "find #{install_dir}/bin -perm +111 -type f | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
-                    command "codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '#{install_dir}/Datadog Agent.app'"
-                end
+            if code_signing_identity
+                # Codesign everything
+                command "find #{install_dir} -type f | grep -E '(\\.so|\\.dylib)' | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
+                command "find #{install_dir}/embedded/bin -perm +111 -type f | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
+                command "find #{install_dir}/bin -perm +111 -type f | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
+                command "codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '#{install_dir}/Datadog Agent.app'"
             end
         end
     end

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -52,102 +52,7 @@ build do
             delete "#{install_dir}/bin/agent/dist/*.conf*"
             delete "#{install_dir}/bin/agent/dist/*.yaml"
             command "del /q /s #{windows_safe_path(install_dir)}\\*.pyc"
-        elsif linux?
-            # Fix pip after building on extended toolchain in CentOS builder
-            if redhat?
-              unless arm?
-                rhel_toolchain_root = "/opt/centos/devtoolset-1.1/root"
-                # lets be cautious - we first search for the expected toolchain path, if its not there, bail out
-                command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec grep -inH '#{rhel_toolchain_root}' {} \\; |  egrep '.*'"
-                # replace paths with expected target toolchain location
-                command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec sed -i 's##{rhel_toolchain_root}##g' {} \\;"
-              end
-            end
-
-            # Move system service files
-            mkdir "/etc/init"
-            move "#{install_dir}/scripts/datadog-agent.conf", "/etc/init"
-            move "#{install_dir}/scripts/datadog-agent-trace.conf", "/etc/init"
-            move "#{install_dir}/scripts/datadog-agent-process.conf", "/etc/init"
-            move "#{install_dir}/scripts/datadog-agent-sysprobe.conf", "/etc/init"
-            move "#{install_dir}/scripts/datadog-agent-security.conf", "/etc/init"
-            systemd_directory = "/usr/lib/systemd/system"
-            if debian?
-                # debian recommends using a different directory for systemd unit files
-                systemd_directory = "/lib/systemd/system"
-
-                # sysvinit support for debian only for now
-                mkdir "/etc/init.d"
-                move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
-                move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
-                move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
-                move "#{install_dir}/scripts/datadog-agent-security", "/etc/init.d"
-            end
-            if suse?
-                mkdir "/etc/init.d"
-                move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
-                move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
-                move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
-                move "#{install_dir}/scripts/datadog-agent-security", "/etc/init.d"
-            end
-            mkdir systemd_directory
-            move "#{install_dir}/scripts/datadog-agent.service", systemd_directory
-            move "#{install_dir}/scripts/datadog-agent-trace.service", systemd_directory
-            move "#{install_dir}/scripts/datadog-agent-process.service", systemd_directory
-            move "#{install_dir}/scripts/datadog-agent-sysprobe.service", systemd_directory
-            move "#{install_dir}/scripts/datadog-agent-security.service", systemd_directory
-
-            # Move configuration files
-            mkdir "/etc/datadog-agent"
-            move "#{install_dir}/bin/agent/dd-agent", "/usr/bin/dd-agent"
-            move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "/etc/datadog-agent"
-            move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "/etc/datadog-agent"
-            move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent", :force=>true
-            move "#{install_dir}/etc/datadog-agent/runtime-security.d", "/etc/datadog-agent", :force=>true
-            move "#{install_dir}/etc/datadog-agent/compliance.d", "/etc/datadog-agent"
-
-            # Move SELinux policy
-            if debian? || redhat?
-              move "#{install_dir}/etc/datadog-agent/selinux", "/etc/datadog-agent/selinux"
-            end
-
-            # Create empty directories so that they're owned by the package
-            # (also requires `extra_package_file` directive in project def)
-            mkdir "/etc/datadog-agent/checks.d"
-            mkdir "/var/log/datadog"
-
-            # remove unused configs
-            delete "/etc/datadog-agent/conf.d/apm.yaml.default"
-            delete "/etc/datadog-agent/conf.d/process_agent.yaml.default"
-
-            # remove windows specific configs
-            delete "/etc/datadog-agent/conf.d/winproc.d"
-
-            # cleanup clutter
-            delete "#{install_dir}/etc"
-
-            # The prerm script of the package should use this list to remove the pyc/pyo files
-            command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.py_compiled_files.txt"
-            command "find #{install_dir}/embedded '(' -name '*.pyc' -o -name '*.pyo' ')' -type f -delete -print >> #{install_dir}/embedded/.py_compiled_files.txt"
-
-            # The prerm and preinst scripts of the package will use this list to detect which files
-            # have been setup by the installer, this way, on removal, we'll be able to delete only files
-            # which have not been created by the package.
-            command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.installed_by_pkg.txt"
-            command "find . -path './embedded/lib/python*/site-packages/*' >> #{install_dir}/embedded/.installed_by_pkg.txt", cwd: install_dir
-
-            # removing the doc from the embedded folder to reduce package size by ~3MB
-            delete "#{install_dir}/embedded/share/doc"
-
-            # removing the terminfo db from the embedded folder to reduce package size by ~7MB
-            delete "#{install_dir}/embedded/share/terminfo"
-            # removing the symlink too
-            delete "#{install_dir}/embedded/lib/terminfo"
-
-            # removing useless folder
-            delete "#{install_dir}/embedded/share/aclocal"
-            delete "#{install_dir}/embedded/share/examples"
-
+        elsif linux? || osx?
             # Setup script aliases, e.g. `/opt/datadog-agent/embedded/bin/pip` will
             # default to `pip2` if the default Python runtime is Python 2.
             if with_python_runtime? "2"
@@ -170,44 +75,141 @@ build do
                 link "#{install_dir}/embedded/bin/2to3-3.8", "#{install_dir}/embedded/bin/2to3"
             end
 
-            # removing the man pages from the embedded folder to reduce package size by ~4MB
-            delete "#{install_dir}/embedded/man"
-            delete "#{install_dir}/embedded/share/man"
+            if linux?
+                # Fix pip after building on extended toolchain in CentOS builder
+                if redhat?
+                  unless arm?
+                    rhel_toolchain_root = "/opt/centos/devtoolset-1.1/root"
+                    # lets be cautious - we first search for the expected toolchain path, if its not there, bail out
+                    command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec grep -inH '#{rhel_toolchain_root}' {} \\; |  egrep '.*'"
+                    # replace paths with expected target toolchain location
+                    command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec sed -i 's##{rhel_toolchain_root}##g' {} \\;"
+                  end
+                end
 
-            # linux build will be stripped - but psycopg2 affected by bug in the way binutils
-            # and patchelf work together:
-            #    https://github.com/pypa/manylinux/issues/119
-            #    https://github.com/NixOS/patchelf
-            #
-            # Only affects psycopg2 - any binary whose path matches the pattern will be
-            # skipped.
-            strip_exclude("*psycopg2*")
-            strip_exclude("*cffi_backend*")
+                # Move system service files
+                mkdir "/etc/init"
+                move "#{install_dir}/scripts/datadog-agent.conf", "/etc/init"
+                move "#{install_dir}/scripts/datadog-agent-trace.conf", "/etc/init"
+                move "#{install_dir}/scripts/datadog-agent-process.conf", "/etc/init"
+                move "#{install_dir}/scripts/datadog-agent-sysprobe.conf", "/etc/init"
+                move "#{install_dir}/scripts/datadog-agent-security.conf", "/etc/init"
+                systemd_directory = "/usr/lib/systemd/system"
+                if debian?
+                    # debian recommends using a different directory for systemd unit files
+                    systemd_directory = "/lib/systemd/system"
 
-            # Do not strip eBPF programs
-            strip_exclude("*tracer-ebpf*")
-            strip_exclude("*offset-guess*")
-            strip_exclude("*runtime-security*")
+                    # sysvinit support for debian only for now
+                    mkdir "/etc/init.d"
+                    move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
+                    move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
+                    move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
+                    move "#{install_dir}/scripts/datadog-agent-security", "/etc/init.d"
+                end
+                if suse?
+                    mkdir "/etc/init.d"
+                    move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
+                    move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
+                    move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
+                    move "#{install_dir}/scripts/datadog-agent-security", "/etc/init.d"
+                end
+                mkdir systemd_directory
+                move "#{install_dir}/scripts/datadog-agent.service", systemd_directory
+                move "#{install_dir}/scripts/datadog-agent-trace.service", systemd_directory
+                move "#{install_dir}/scripts/datadog-agent-process.service", systemd_directory
+                move "#{install_dir}/scripts/datadog-agent-sysprobe.service", systemd_directory
+                move "#{install_dir}/scripts/datadog-agent-security.service", systemd_directory
 
-        elsif osx?
-            # Remove linux specific configs
-            delete "#{install_dir}/etc/conf.d/file_handle.d"
+                # Move configuration files
+                mkdir "/etc/datadog-agent"
+                move "#{install_dir}/bin/agent/dd-agent", "/usr/bin/dd-agent"
+                move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "/etc/datadog-agent"
+                move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "/etc/datadog-agent"
+                move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent", :force=>true
+                move "#{install_dir}/etc/datadog-agent/runtime-security.d", "/etc/datadog-agent", :force=>true
+                move "#{install_dir}/etc/datadog-agent/compliance.d", "/etc/datadog-agent"
 
-            # remove windows specific configs
-            delete "#{install_dir}/etc/conf.d/winproc.d"
+                # Move SELinux policy
+                if debian? || redhat?
+                  move "#{install_dir}/etc/datadog-agent/selinux", "/etc/datadog-agent/selinux"
+                end
 
-            if ENV['HARDENED_RUNTIME_MAC'] == 'true'
-                hardened_runtime = "-o runtime --entitlements #{entitlements_file} "
-            else
-                hardened_runtime = ""
-            end
+                # Create empty directories so that they're owned by the package
+                # (also requires `extra_package_file` directive in project def)
+                mkdir "/etc/datadog-agent/checks.d"
+                mkdir "/var/log/datadog"
 
-            if code_signing_identity
-                # Codesign everything
-                command "find #{install_dir} -type f | grep -E '(\\.so|\\.dylib)' | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
-                command "find #{install_dir}/embedded/bin -perm +111 -type f | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
-                command "find #{install_dir}/bin -perm +111 -type f | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
-                command "codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '#{install_dir}/Datadog Agent.app'"
+                # remove unused configs
+                delete "/etc/datadog-agent/conf.d/apm.yaml.default"
+                delete "/etc/datadog-agent/conf.d/process_agent.yaml.default"
+
+                # remove windows specific configs
+                delete "/etc/datadog-agent/conf.d/winproc.d"
+
+                # cleanup clutter
+                delete "#{install_dir}/etc"
+
+                # The prerm script of the package should use this list to remove the pyc/pyo files
+                command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.py_compiled_files.txt"
+                command "find #{install_dir}/embedded '(' -name '*.pyc' -o -name '*.pyo' ')' -type f -delete -print >> #{install_dir}/embedded/.py_compiled_files.txt"
+
+                # The prerm and preinst scripts of the package will use this list to detect which files
+                # have been setup by the installer, this way, on removal, we'll be able to delete only files
+                # which have not been created by the package.
+                command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.installed_by_pkg.txt"
+                command "find . -path './embedded/lib/python*/site-packages/*' >> #{install_dir}/embedded/.installed_by_pkg.txt", cwd: install_dir
+
+                # removing the doc from the embedded folder to reduce package size by ~3MB
+                delete "#{install_dir}/embedded/share/doc"
+
+                # removing the terminfo db from the embedded folder to reduce package size by ~7MB
+                delete "#{install_dir}/embedded/share/terminfo"
+                # removing the symlink too
+                delete "#{install_dir}/embedded/lib/terminfo"
+
+                # removing useless folder
+                delete "#{install_dir}/embedded/share/aclocal"
+                delete "#{install_dir}/embedded/share/examples"
+
+                # removing the man pages from the embedded folder to reduce package size by ~4MB
+                delete "#{install_dir}/embedded/man"
+                delete "#{install_dir}/embedded/share/man"
+
+                # linux build will be stripped - but psycopg2 affected by bug in the way binutils
+                # and patchelf work together:
+                #    https://github.com/pypa/manylinux/issues/119
+                #    https://github.com/NixOS/patchelf
+                #
+                # Only affects psycopg2 - any binary whose path matches the pattern will be
+                # skipped.
+                strip_exclude("*psycopg2*")
+                strip_exclude("*cffi_backend*")
+
+                # Do not strip eBPF programs
+                strip_exclude("*tracer-ebpf*")
+                strip_exclude("*offset-guess*")
+                strip_exclude("*runtime-security*")
+
+            elsif osx?
+                # Remove linux specific configs
+                delete "#{install_dir}/etc/conf.d/file_handle.d"
+
+                # remove windows specific configs
+                delete "#{install_dir}/etc/conf.d/winproc.d"
+
+                if ENV['HARDENED_RUNTIME_MAC'] == 'true'
+                    hardened_runtime = "-o runtime --entitlements #{entitlements_file} "
+                else
+                    hardened_runtime = ""
+                end
+
+                if code_signing_identity
+                    # Codesign everything
+                    command "find #{install_dir} -type f | grep -E '(\\.so|\\.dylib)' | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
+                    command "find #{install_dir}/embedded/bin -perm +111 -type f | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
+                    command "find #{install_dir}/bin -perm +111 -type f | xargs -I{} codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'"
+                    command "codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '#{install_dir}/Datadog Agent.app'"
+                end
             end
         end
     end

--- a/releasenotes/notes/macos-a6-default-to-py2-binaries-e952a6531185c343.yaml
+++ b/releasenotes/notes/macos-a6-default-to-py2-binaries-e952a6531185c343.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On macOS, in Agent v6, the unversioned python binaries in
+    ``/opt/datadog-agent/embedded/bin`` (example: ``python``, ``pip``) now correctly
+    point to the Python 2 binaries.


### PR DESCRIPTION
### What does this PR do?

Apply similar logic as on Linux to the macOS package, i.e. make the unversioned python binaries of Agent 6 (`python`, `pip`, `2to3`) point to python 2 binaries instead of python 3 binaries.

### Motivation

Consistency with Linux packages, and what the defaults of Agent v6 should be. And customer request.

### Additional notes

The git diff is large, but the only change I made was to move the section that modifies the python binaries in a common `if linux? || osx?` block.

### Describe your test plan

Verified on a DMG built from this branch that the `python`, `pip` and `2to3` binaries on v6 are links pointing to the python 2 binaries; and that agent still runs fine.
