### PR TITLE
pkg/trace/info: ensure stats always get reset

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -466,7 +466,7 @@ func (r *HTTPReceiver) loop() {
 				// We expose the stats accumulated to expvar
 				info.UpdateReceiverStats(accStats)
 
-				accStats.LogStats()
+				accStats.LogAndResetStats()
 
 				lastLog = now
 

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -462,17 +462,12 @@ func (r *HTTPReceiver) loop() {
 			// Publish the stats accumulated during the last flush
 			r.Stats.Publish()
 
-			// We reset the stats accumulated during the last 10s.
-			r.Stats.Reset()
-
 			if now.Sub(lastLog) >= time.Minute {
 				// We expose the stats accumulated to expvar
 				info.UpdateReceiverStats(accStats)
 
 				accStats.LogStats()
 
-				// We reset the stats accumulated during the last minute
-				accStats.Reset()
 				lastLog = now
 
 				// Also publish rates by service (they are updated by receiver)

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -78,10 +78,10 @@ func (rs *ReceiverStats) Languages() []string {
 	return langs
 }
 
-// LogStats logs one-line summaries of ReceiverStats. Problematic stats are logged as warnings.
-func (rs *ReceiverStats) LogStats() {
-	rs.RLock()
-	defer rs.RUnlock()
+// LogAndResetStats logs one-line summaries of ReceiverStats. Problematic stats are logged as warnings.
+func (rs *ReceiverStats) LogAndResetStats() {
+	rs.Lock()
+	defer rs.Unlock()
 
 	if len(rs.Stats) == 0 {
 		log.Info("No data received")


### PR DESCRIPTION
This change ensures that stats always get reset whenever published to
avoid bugs where new added stats forget to be reset.