### PR TITLE
[ad] Increase log level in Config.Digest()

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -281,7 +281,7 @@ func (c *Config) Digest() string {
 		inst := RawMap{}
 		err := yaml.Unmarshal(i, &inst)
 		if err != nil {
-			log.Debugf("Error while calculating config digest for %s, skipping: %v", c.Name, err)
+			log.Infof("Error while calculating config digest for %s, skipping: %v", c.Name, err)
 			continue
 		}
 		if val, found := inst["tags"]; found {
@@ -289,7 +289,7 @@ func (c *Config) Digest() string {
 			// identical configs with the same tags but with different order
 			tagsInterface, ok := val.([]interface{})
 			if !ok {
-				log.Debug("Error while calculating config digest for %s, skipping: cannot read tags from config", c.Name)
+				log.Infof("Error while calculating config digest for %s, skipping: cannot read tags from config", c.Name)
 				continue
 			}
 			tags := make([]string, len(tagsInterface))
@@ -301,7 +301,7 @@ func (c *Config) Digest() string {
 		}
 		out, err := yaml.Marshal(&inst)
 		if err != nil {
-			log.Debugf("Error while calculating config digest for %s, skipping: %v", c.Name, err)
+			log.Infof("Error while calculating config digest for %s, skipping: %v", c.Name, err)
 			continue
 		}
 		h.Write(out) //nolint:errcheck


### PR DESCRIPTION
### What does this PR do?

Increase log level from debug to info in the Config.Digest() function to ease troubleshooting. Open for discussion, as I may have miss a risk of getting too much log.

### Motivation
Having those log shown with the default log level would have prevented the case AGENT-2006 that ultimately lead to 2 JMX checks to get the same ID.

### Additional Notes
It should not generated too many log and it seems relevant to log something shown with default log level that there is something wrong in the check ID computation.

### Describe your test plan
Not needed.