### PR TITLE
[AD] Add prometheus-pods config provider

### DIFF
--- a/pkg/autodiscovery/providers/names/provider_names.go
+++ b/pkg/autodiscovery/providers/names/provider_names.go
@@ -18,6 +18,7 @@ const (
 	Kubernetes      = "kubernetes"
 	KubeServices    = "kubernetes-services"
 	KubeEndpoints   = "kubernetes-endpoints"
+	Prometheus      = "prometheus"
 	SNMP            = "snmp"
 	Zookeeper       = "zookeeper"
 )

--- a/pkg/autodiscovery/providers/prometheus_common.go
+++ b/pkg/autodiscovery/providers/prometheus_common.go
@@ -1,0 +1,226 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package providers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// Default openmetrics check configuration values
+	openmetricsCheckName   = "openmetrics"
+	openmetricsInitConfig  = "{}"
+	openmetricsURLPrefix   = "http://%%host%%:"
+	openmetricsDefaultPort = "%%port%%"
+	openmetricsDefaultPath = "/metrics"
+	openmetricsDefaultNS   = ""
+
+	// Prometheus annnotation keys
+	prometheusScrapeAnnotation = "prometheus.io/scrape"
+	prometheusPathAnnotation   = "prometheus.io/path"
+	prometheusPortAnnotation   = "prometheus.io/port"
+)
+
+var (
+	openmetricsDefaultMetrics = []string{"*"}
+)
+
+// PrometheusCheck represents the openmetrics check instances and the corresponding autodiscovery rules
+type PrometheusCheck struct {
+	Instances []*OpenmetricsInstance `mapstructure:"configurations"`
+	AD        *ADConfig              `mapstructure:"autodiscovery"`
+}
+
+// OpenmetricsInstance contains the openmetrics check instance fields
+type OpenmetricsInstance struct {
+	URL                           string                      `mapstructure:"prometheus_url" json:"prometheus_url,omitempty"`
+	Namespace                     string                      `mapstructure:"namespace" json:"namespace"`
+	Metrics                       []string                    `mapstructure:"metrics" json:"metrics,omitempty"`
+	Prefix                        string                      `mapstructure:"prometheus_metrics_prefix" json:"prometheus_metrics_prefix,omitempty"`
+	HealthCheck                   bool                        `mapstructure:"health_service_check" json:"health_service_check,omitempty"`
+	LabelToHostname               bool                        `mapstructure:"label_to_hostname" json:"label_to_hostname,omitempty"`
+	LabelJoins                    map[string]LabelJoinsConfig `mapstructure:"label_joins" json:"label_joins,omitempty"`
+	LabelsMapper                  map[string]string           `mapstructure:"labels_mapper" json:"labels_mapper,omitempty"`
+	TypeOverride                  map[string]string           `mapstructure:"type_overrides" json:"type_overrides,omitempty"`
+	HistogramBuckets              bool                        `mapstructure:"send_histograms_buckets" json:"send_histograms_buckets,omitempty"`
+	DistribuitionBuckets          bool                        `mapstructure:"send_distribution_buckets" json:"send_distribution_buckets,omitempty"`
+	MonotonicCounter              bool                        `mapstructure:"send_monotonic_counter" json:"send_monotonic_counter,omitempty"`
+	DistributionCountsAsMonotonic bool                        `mapstructure:"send_distribution_counts_as_monotonic" json:"send_distribution_counts_as_monotonic,omitempty"`
+	DistributionSumsAsMonotonic   bool                        `mapstructure:"send_distribution_sums_as_monotonic" json:"send_distribution_sums_as_monotonic,omitempty"`
+	ExcludeLabels                 []string                    `mapstructure:"exclude_labels" json:"exclude_labels,omitempty"`
+	BearerTokenAuth               bool                        `mapstructure:"bearer_token_auth" json:"bearer_token_auth,omitempty"`
+	BearerTokenPath               string                      `mapstructure:"bearer_token_path" json:"bearer_token_path,omitempty"`
+	IgnoreMetrics                 []string                    `mapstructure:"ignore_metrics" json:"ignore_metrics,omitempty"`
+	Proxy                         map[string]string           `mapstructure:"proxy" json:"proxy,omitempty"`
+	SkipProxy                     bool                        `mapstructure:"skip_proxy" json:"skip_proxy,omitempty"`
+	Username                      string                      `mapstructure:"username" json:"username,omitempty"`
+	Password                      string                      `mapstructure:"password" json:"password,omitempty"`
+	TLSVerify                     bool                        `mapstructure:"tls_verify" json:"tls_verify,omitempty"`
+	TLSHostHeader                 bool                        `mapstructure:"tls_use_host_header" json:"tls_use_host_header,omitempty"`
+	TLSIgnoreWarn                 bool                        `mapstructure:"tls_ignore_warning" json:"tls_ignore_warning,omitempty"`
+	TLSCert                       string                      `mapstructure:"tls_cert" json:"tls_cert,omitempty"`
+	TLSPrivateKey                 string                      `mapstructure:"tls_private_key" json:"tls_private_key,omitempty"`
+	TLSCACert                     string                      `mapstructure:"tls_ca_cert" json:"tls_ca_cert,omitempty"`
+	Headers                       map[string]string           `mapstructure:"headers" json:"headers,omitempty"`
+	ExtraHeaders                  map[string]string           `mapstructure:"extra_headers" json:"extra_headers,omitempty"`
+	Timeout                       int                         `mapstructure:"timeout" json:"timeout,omitempty"`
+	Tags                          []string                    `mapstructure:"tags" json:"tags,omitempty"`
+	Service                       string                      `mapstructure:"service" json:"service,omitempty"`
+	MinCollectInterval            int                         `mapstructure:"min_collection_interval" json:"min_collection_interval,omitempty"`
+	EmptyDefaultHost              bool                        `mapstructure:"empty_default_hostname" json:"empty_default_hostname,omitempty"`
+}
+
+// LabelJoinsConfig contains the label join configuration fields
+type LabelJoinsConfig struct {
+	LabelsToMatch []string `mapstructure:"labels_to_match" json:"labels_to_match"`
+	LabelsToGet   []string `mapstructure:"labels_to_get" json:"labels_to_get"`
+}
+
+// ADConfig contains the autodiscovery configuration data for a PrometheusCheck
+type ADConfig struct {
+	ExcludeAutoconf    *bool     `mapstructure:"exclude_autoconfig_files"`
+	KubeAnnotations    *InclExcl `mapstructure:"kubernetes_annotations"`
+	KubeContainerNames []string  `mapstructure:"kubernetes_container_names"`
+	containersRe       *regexp.Regexp
+}
+
+// InclExcl contains the include/exclude data structure
+type InclExcl struct {
+	Incl map[string]string `mapstructure:"include"`
+	Excl map[string]string `mapstructure:"exclude"`
+}
+
+// defaultCheck has the default openmetrics check values
+// To be used when the checks configuration is empty
+var defaultCheck = &PrometheusCheck{
+	Instances: []*OpenmetricsInstance{
+		{
+			Metrics:   openmetricsDefaultMetrics,
+			Namespace: openmetricsDefaultNS,
+		},
+	},
+	AD: &ADConfig{
+		ExcludeAutoconf: boolPointer(true),
+		KubeAnnotations: &InclExcl{
+			Excl: map[string]string{prometheusScrapeAnnotation: "false"},
+			Incl: map[string]string{prometheusScrapeAnnotation: "true"},
+		},
+		KubeContainerNames: []string{},
+	},
+}
+
+// init prepares the PrometheusCheck structure and defaults its values
+// init must be called only once
+func (pc *PrometheusCheck) init() error {
+	pc.initInstances()
+	return pc.initAD()
+}
+
+// initInstances defaults the Instances field in PrometheusCheck
+func (pc *PrometheusCheck) initInstances() {
+	if len(pc.Instances) == 0 {
+		// Put a default config
+		pc.Instances = append(pc.Instances, &OpenmetricsInstance{
+			Metrics:   openmetricsDefaultMetrics,
+			Namespace: openmetricsDefaultNS,
+		})
+		return
+	}
+
+	for _, instance := range pc.Instances {
+		// Default the required config values if not set
+		if len(instance.Metrics) == 0 {
+			instance.Metrics = openmetricsDefaultMetrics
+		}
+	}
+}
+
+// initAD defaults the AD field in PrometheusCheck
+// It also prepares the regex to match the containers by name
+func (pc *PrometheusCheck) initAD() error {
+	if pc.AD == nil {
+		pc.AD = &ADConfig{}
+	}
+
+	pc.AD.defaultAD()
+	return pc.AD.setContainersRegex()
+}
+
+// defaultAD defaults the values of the autodiscovery structure
+func (ad *ADConfig) defaultAD() {
+	if ad.ExcludeAutoconf == nil {
+		// TODO: Implement OOTB autoconf exclusion
+		ad.ExcludeAutoconf = boolPointer(true)
+	}
+
+	if ad.KubeContainerNames == nil {
+		ad.KubeContainerNames = []string{}
+	}
+
+	if ad.KubeAnnotations == nil {
+		ad.KubeAnnotations = &InclExcl{
+			Excl: map[string]string{prometheusScrapeAnnotation: "false"},
+			Incl: map[string]string{prometheusScrapeAnnotation: "true"},
+		}
+		return
+	}
+
+	if ad.KubeAnnotations.Excl == nil {
+		ad.KubeAnnotations.Excl = map[string]string{prometheusScrapeAnnotation: "false"}
+	}
+
+	if ad.KubeAnnotations.Incl == nil {
+		ad.KubeAnnotations.Incl = map[string]string{prometheusScrapeAnnotation: "true"}
+	}
+}
+
+// setContainersRegex precompiles the regex to match the container names for autodiscovery
+// returns an error if the container names cannot be converted to a valid regex
+func (ad *ADConfig) setContainersRegex() error {
+	ad.containersRe = nil
+	if len(ad.KubeContainerNames) == 0 {
+		return nil
+	}
+
+	regexString := strings.Join(ad.KubeContainerNames, "|")
+	re, err := regexp.Compile(regexString)
+	if err != nil {
+		return fmt.Errorf("Invalid container names - regex: '%s': %v", regexString, err)
+	}
+
+	ad.containersRe = re
+	return nil
+}
+
+// matchContainer returns whether a container name matches the 'kubernetes_container_names' configuration
+func (ad *ADConfig) matchContainer(name string) bool {
+	if ad.containersRe == nil {
+		return true
+	}
+	return ad.containersRe.MatchString(name)
+}
+
+// buildURL returns the 'prometheus_url' based on the default values
+// and the prometheus path and port annotations
+func buildURL(annotations map[string]string) string {
+	port := openmetricsDefaultPort
+	if portFromAnnotation, found := annotations[prometheusPortAnnotation]; found {
+		port = portFromAnnotation
+	}
+
+	path := openmetricsDefaultPath
+	if pathFromAnnotation, found := annotations[prometheusPathAnnotation]; found {
+		path = pathFromAnnotation
+	}
+
+	return openmetricsURLPrefix + port + path
+}
+
+func boolPointer(b bool) *bool {
+	return &b
+}

--- a/pkg/autodiscovery/providers/prometheus_common_test.go
+++ b/pkg/autodiscovery/providers/prometheus_common_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        string
+	}{
+		{
+			name: "nominal case",
+			annotations: map[string]string{
+				"foo": "bar",
+			},
+			want: "http://%%host%%:%%port%%/metrics",
+		},
+		{
+			name: "custom port",
+			annotations: map[string]string{
+				"foo":                "bar",
+				"prometheus.io/port": "1337",
+			},
+			want: "http://%%host%%:1337/metrics",
+		},
+		{
+			name: "custom path",
+			annotations: map[string]string{
+				"foo":                "bar",
+				"prometheus.io/path": "/metrix",
+			},
+			want: "http://%%host%%:%%port%%/metrix",
+		},
+		{
+			name: "custom port and path",
+			annotations: map[string]string{
+				"foo":                "bar",
+				"prometheus.io/port": "1337",
+				"prometheus.io/path": "/metrix",
+			},
+			want: "http://%%host%%:1337/metrix",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildURL(tt.annotations); got != tt.want {
+				t.Errorf("buildURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainerRegex(t *testing.T) {
+	ad := &ADConfig{}
+	ad.setContainersRegex()
+	assert.Nil(t, ad.containersRe)
+	assert.True(t, ad.matchContainer("a-random-string"))
+
+	ad = &ADConfig{KubeContainerNames: []string{"foo"}}
+	ad.setContainersRegex()
+	assert.NotNil(t, ad.containersRe)
+	assert.True(t, ad.matchContainer("foo"))
+	assert.False(t, ad.matchContainer("bar"))
+
+	ad = &ADConfig{KubeContainerNames: []string{"foo", "b*"}}
+	ad.setContainersRegex()
+	assert.NotNil(t, ad.containersRe)
+	assert.True(t, ad.matchContainer("foo"))
+	assert.True(t, ad.matchContainer("bar"))
+}

--- a/pkg/autodiscovery/providers/prometheus_pods.go
+++ b/pkg/autodiscovery/providers/prometheus_pods.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build kubelet
+
+package providers
+
+import (
+	"encoding/json"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// PrometheusPodsConfigProvider implements the ConfigProvider interface for prometheus pods.
+type PrometheusPodsConfigProvider struct {
+	kubelet kubelet.KubeUtilInterface
+	checks  []*PrometheusCheck
+}
+
+// NewPrometheusPodsConfigProvider returns a new Prometheus ConfigProvider connected to kubelet.
+// Connectivity is not checked at this stage to allow for retries, Collect will do it.
+func NewPrometheusPodsConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+	p := &PrometheusPodsConfigProvider{}
+	err := p.setupConfigs()
+	return p, err
+}
+
+// setupConfigs reads and initializes the checks from the configuration
+// It defines a default openmetrics instances with default AD if the checks configuration is empty
+func (p *PrometheusPodsConfigProvider) setupConfigs() error {
+	checks := []*PrometheusCheck{}
+	if err := config.Datadog.UnmarshalKey("prometheus_scrape.checks", &checks); err != nil {
+		return err
+	}
+
+	if len(checks) == 0 {
+		log.Info("The 'prometheus_scrape.checks' configuration is empty, a default openmetrics check configuration will be used")
+		p.checks = []*PrometheusCheck{defaultCheck}
+		return nil
+	}
+
+	for i, check := range checks {
+		if err := check.init(); err != nil {
+			log.Errorf("Ignoring check configuration (# %d): %v", i+1, err)
+			continue
+		}
+		p.checks = append(p.checks, check)
+	}
+
+	return nil
+}
+
+// String returns a string representation of the PrometheusPodsConfigProvider
+func (p *PrometheusPodsConfigProvider) String() string {
+	return names.Prometheus
+}
+
+// Collect retrieves templates from the kubelet's podlist, builds config objects and returns them
+func (p *PrometheusPodsConfigProvider) Collect() ([]integration.Config, error) {
+	var err error
+	if p.kubelet == nil {
+		p.kubelet, err = kubelet.GetKubeUtil()
+		if err != nil {
+			return []integration.Config{}, err
+		}
+	}
+
+	pods, err := p.kubelet.GetLocalPodList()
+	if err != nil {
+		return []integration.Config{}, err
+	}
+
+	return p.parsePodlist(pods), nil
+}
+
+// IsUpToDate always return false to poll new data from kubelet
+func (p *PrometheusPodsConfigProvider) IsUpToDate() (bool, error) {
+	return false, nil
+}
+
+// parsePodlist searches for pods that match the AD configuration
+func (p *PrometheusPodsConfigProvider) parsePodlist(podlist []*kubelet.Pod) []integration.Config {
+	var configs []integration.Config
+	for _, pod := range podlist {
+		for _, check := range p.checks {
+			configs = append(configs, check.configsForPod(pod)...)
+		}
+	}
+	return configs
+}
+
+// configsForPod returns the openmetrics configurations for a given pod if it matches the AD configuration
+func (pc *PrometheusCheck) configsForPod(pod *kubelet.Pod) []integration.Config {
+	var configs []integration.Config
+	for k, v := range pc.AD.KubeAnnotations.Excl {
+		if pod.Metadata.Annotations[k] == v {
+			log.Debugf("Pod '%s' matched the exclusion annotation '%s=%s' ignoring it", pod.Metadata.Name, k, v)
+			return configs
+		}
+	}
+
+	for k, v := range pc.AD.KubeAnnotations.Incl {
+		if pod.Metadata.Annotations[k] == v {
+			log.Debugf("Pod '%s' matched the annotation '%s=%s' to schedule an openmetrics check", pod.Metadata.Name, k, v)
+			instances := []integration.Data{}
+			for _, instance := range pc.Instances {
+				instanceValues := *instance
+				if instanceValues.URL == "" {
+					instanceValues.URL = buildURL(pod.Metadata.Annotations)
+				}
+				instanceJSON, err := json.Marshal(instanceValues)
+				if err != nil {
+					log.Warnf("Error processing prometheus configuration: %v", err)
+					continue
+				}
+				instances = append(instances, instanceJSON)
+			}
+
+			for _, container := range pod.Status.GetAllContainers() {
+				if !pc.AD.matchContainer(container.Name) {
+					log.Debugf("Container '%s' doesn't match the AD configuration 'kubernetes_container_names', ignoring it", container.Name)
+					continue
+				}
+				configs = append(configs, integration.Config{
+					Name:          openmetricsCheckName,
+					InitConfig:    integration.Data(openmetricsInitConfig),
+					Instances:     instances,
+					Provider:      names.Prometheus,
+					Source:        "kubelet:" + container.ID,
+					ADIdentifiers: []string{container.ID},
+				})
+			}
+
+			return configs
+		}
+	}
+
+	// TODO: Support AD matching based on label selectors
+
+	return configs
+}
+
+func init() {
+	RegisterProvider("prometheus-pods", NewPrometheusPodsConfigProvider)
+}

--- a/pkg/autodiscovery/providers/prometheus_pods_test.go
+++ b/pkg/autodiscovery/providers/prometheus_pods_test.go
@@ -1,0 +1,468 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build kubelet
+
+package providers
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetupConfigs(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     []*PrometheusCheck
+		wantChecks []*PrometheusCheck
+		wantErr    bool
+	}{
+		{
+			name:   "empty config, default check",
+			config: []*PrometheusCheck{},
+			wantChecks: []*PrometheusCheck{
+				{
+					Instances: []*OpenmetricsInstance{
+						{
+							Metrics:   []string{"*"},
+							Namespace: "",
+						},
+					},
+					AD: &ADConfig{
+						ExcludeAutoconf: boolPointer(true),
+						KubeAnnotations: &InclExcl{
+							Excl: map[string]string{"prometheus.io/scrape": "false"},
+							Incl: map[string]string{"prometheus.io/scrape": "true"},
+						},
+						KubeContainerNames: []string{},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom instance, set required fields",
+			config: []*PrometheusCheck{
+				{
+					Instances: []*OpenmetricsInstance{
+						{
+							Timeout: 20,
+						},
+					},
+				},
+			},
+			wantChecks: []*PrometheusCheck{
+				{
+					Instances: []*OpenmetricsInstance{
+						{
+							Metrics:   []string{"*"},
+							Namespace: "",
+							Timeout:   20,
+						},
+					},
+					AD: &ADConfig{
+						ExcludeAutoconf: boolPointer(true),
+						KubeAnnotations: &InclExcl{
+							Excl: map[string]string{"prometheus.io/scrape": "false"},
+							Incl: map[string]string{"prometheus.io/scrape": "true"},
+						},
+						KubeContainerNames: []string{},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom AD, set required fields",
+			config: []*PrometheusCheck{
+				{
+					AD: &ADConfig{
+						KubeAnnotations: &InclExcl{
+							Excl: map[string]string{"custom/annotation": "exclude"},
+						},
+						KubeContainerNames: []string{"foo*"},
+					},
+				},
+			},
+			wantChecks: []*PrometheusCheck{
+				{
+					Instances: []*OpenmetricsInstance{
+						{
+							Metrics:   []string{"*"},
+							Namespace: "",
+						},
+					},
+					AD: &ADConfig{
+						ExcludeAutoconf: boolPointer(true),
+						KubeAnnotations: &InclExcl{
+							Excl: map[string]string{"custom/annotation": "exclude"},
+							Incl: map[string]string{"prometheus.io/scrape": "true"},
+						},
+						KubeContainerNames: []string{"foo*"},
+						containersRe:       regexp.MustCompile("foo*"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom instances and AD",
+			config: []*PrometheusCheck{
+				{
+					Instances: []*OpenmetricsInstance{
+						{
+							Metrics:       []string{"foo", "bar"},
+							Namespace:     "custom_ns",
+							IgnoreMetrics: []string{"baz"},
+						},
+					},
+					AD: &ADConfig{
+						ExcludeAutoconf: boolPointer(false),
+						KubeAnnotations: &InclExcl{
+							Incl: map[string]string{"custom/annotation": "include"},
+							Excl: map[string]string{"custom/annotation": "exclude"},
+						},
+						KubeContainerNames: []string{},
+					},
+				},
+			},
+			wantChecks: []*PrometheusCheck{
+				{
+					Instances: []*OpenmetricsInstance{
+						{
+							Metrics:       []string{"foo", "bar"},
+							Namespace:     "custom_ns",
+							IgnoreMetrics: []string{"baz"},
+						},
+					},
+					AD: &ADConfig{
+						ExcludeAutoconf: boolPointer(false),
+						KubeAnnotations: &InclExcl{
+							Incl: map[string]string{"custom/annotation": "include"},
+							Excl: map[string]string{"custom/annotation": "exclude"},
+						},
+						KubeContainerNames: []string{},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid check",
+			config: []*PrometheusCheck{
+				{
+					AD: &ADConfig{
+						KubeContainerNames: []string{"*"},
+					},
+				},
+			},
+			wantChecks: nil,
+			wantErr:    false,
+		},
+		{
+			name: "two checks, one invalid check",
+			config: []*PrometheusCheck{
+				{
+					AD: &ADConfig{
+						KubeContainerNames: []string{"*"},
+					},
+				},
+				{
+					AD: &ADConfig{
+						KubeContainerNames: []string{"foo", "bar"},
+					},
+				},
+			},
+			wantChecks: []*PrometheusCheck{
+				{
+					Instances: []*OpenmetricsInstance{
+						{
+							Metrics:   []string{"*"},
+							Namespace: "",
+						},
+					},
+					AD: &ADConfig{
+						ExcludeAutoconf: boolPointer(true),
+						KubeAnnotations: &InclExcl{
+							Excl: map[string]string{"prometheus.io/scrape": "false"},
+							Incl: map[string]string{"prometheus.io/scrape": "true"},
+						},
+						KubeContainerNames: []string{"foo", "bar"},
+						containersRe:       regexp.MustCompile("foo|bar"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PrometheusPodsConfigProvider{}
+			config.Datadog.Set("prometheus_scrape.checks", tt.config)
+			if err := p.setupConfigs(); (err != nil) != tt.wantErr {
+				t.Errorf("PrometheusPodsConfigProvider.setupConfigs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.EqualValues(t, tt.wantChecks, p.checks)
+		})
+	}
+}
+
+func TestConfigsForPod(t *testing.T) {
+	tests := []struct {
+		name    string
+		check   *PrometheusCheck
+		pod     *kubelet.Pod
+		want    []integration.Config
+		matched bool
+	}{
+		{
+			name:  "nominal case",
+			check: defaultCheck,
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:        "foo-pod",
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
+				},
+			},
+			want: []integration.Config{
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"prometheus_url\":\"http://%%host%%:%%port%%/metrics\",\"namespace\":\"\",\"metrics\":[\"*\"]}")},
+					Provider:      names.Prometheus,
+					Source:        "kubelet:foo-ctr-id",
+					ADIdentifiers: []string{"foo-ctr-id"},
+				},
+			},
+		},
+		{
+			name: "custom prometheus_url",
+			check: &PrometheusCheck{
+				Instances: []*OpenmetricsInstance{
+					{
+						URL:       "foo/bar",
+						Metrics:   []string{"*"},
+						Namespace: "",
+					},
+				},
+			},
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:        "foo-pod",
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
+				},
+			},
+			want: []integration.Config{
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"prometheus_url\":\"foo/bar\",\"namespace\":\"\",\"metrics\":[\"*\"]}")},
+					Provider:      names.Prometheus,
+					Source:        "kubelet:foo-ctr-id",
+					ADIdentifiers: []string{"foo-ctr-id"},
+				},
+			},
+		},
+		{
+			name:  "excluded",
+			check: defaultCheck,
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:        "foo-pod",
+					Annotations: map[string]string{"prometheus.io/scrape": "false"},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name:  "no match",
+			check: defaultCheck,
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:        "foo-pod",
+					Annotations: map[string]string{"foo": "bar"},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name:  "multi containers, match all",
+			check: defaultCheck,
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:        "foo-pod",
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr1",
+							ID:   "foo-ctr1-id",
+						},
+						{
+							Name: "foo-ctr2",
+							ID:   "foo-ctr2-id",
+						},
+					},
+				},
+			},
+			want: []integration.Config{
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"prometheus_url\":\"http://%%host%%:%%port%%/metrics\",\"namespace\":\"\",\"metrics\":[\"*\"]}")},
+					Provider:      names.Prometheus,
+					Source:        "kubelet:foo-ctr1-id",
+					ADIdentifiers: []string{"foo-ctr1-id"},
+				},
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"prometheus_url\":\"http://%%host%%:%%port%%/metrics\",\"namespace\":\"\",\"metrics\":[\"*\"]}")},
+					Provider:      names.Prometheus,
+					Source:        "kubelet:foo-ctr2-id",
+					ADIdentifiers: []string{"foo-ctr2-id"},
+				},
+			},
+		},
+		{
+			name: "multi containers, match one container",
+			check: &PrometheusCheck{
+				AD: &ADConfig{
+					KubeContainerNames: []string{"foo-ctr1"},
+				},
+			},
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:        "foo-pod",
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr1",
+							ID:   "foo-ctr1-id",
+						},
+						{
+							Name: "foo-ctr2",
+							ID:   "foo-ctr2-id",
+						},
+					},
+				},
+			},
+			want: []integration.Config{
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"prometheus_url\":\"http://%%host%%:%%port%%/metrics\",\"namespace\":\"\",\"metrics\":[\"*\"]}")},
+					Provider:      names.Prometheus,
+					Source:        "kubelet:foo-ctr1-id",
+					ADIdentifiers: []string{"foo-ctr1-id"},
+				},
+			},
+		},
+		{
+			name: "container name mismatch",
+			check: &PrometheusCheck{
+				AD: &ADConfig{
+					KubeContainerNames: []string{"bar"},
+				},
+			},
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:        "foo-pod",
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "container name regex",
+			check: &PrometheusCheck{
+				AD: &ADConfig{
+					KubeContainerNames: []string{"bar", "*o-c*"},
+				},
+			},
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:        "foo-pod",
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
+				},
+			},
+			want: []integration.Config{
+				{
+					Name:          "openmetrics",
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"prometheus_url\":\"http://%%host%%:%%port%%/metrics\",\"namespace\":\"\",\"metrics\":[\"*\"]}")},
+					Provider:      names.Prometheus,
+					Source:        "kubelet:foo-ctr-id",
+					ADIdentifiers: []string{"foo-ctr-id"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check.init()
+			configs := tt.check.configsForPod(tt.pod)
+			assert.ElementsMatch(t, configs, tt.want)
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -414,6 +414,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
 	config.BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
 
+	config.SetKnown("prometheus_scrape.checks") // defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
+
 	// SNMP
 	config.SetKnown("snmp_listener.discovery_interval")
 	config.SetKnown("snmp_listener.allowed_failures")


### PR DESCRIPTION
### What does this PR do?

- Prometheus-pods autodiscovery (essential features)
- Prepare the shared code with Prometheus-services (DCA)

### Motivation

Better Prometheus autodiscovery

### Additional Notes

AD config `exclude_autoconfig_files` and `kubernetes_label_selector` support will be implemented in other PRs

### Describe your test plan

Deploy various combinations of the agent `prometheus_scrape` config + Prometheus k8s annotations
