### PR TITLE
[System Probe][Windows] Move ConnectionStats buffers to tracer to limit resizing

### DIFF
--- a/pkg/ebpf/tracer_windows.go
+++ b/pkg/ebpf/tracer_windows.go
@@ -149,7 +149,7 @@ func (t *Tracer) resizeBuffer(compareSize int, buffer []network.ConnectionStats)
 		return make([]network.ConnectionStats, 0, cap(buffer)*2)
 	} else if compareSize <= cap(buffer)/2 {
 		// Take the max of buffer/2 and compareSize to limit future array resizes
-		return make([]network.ConnectionStats, 0, math.Max(float64(cap(buffer)/2), float64(compareSize)))
+		return make([]network.ConnectionStats, 0, int(math.Max(float64(cap(buffer)/2), float64(compareSize))))
 	}
 	return buffer
 }

--- a/pkg/ebpf/tracer_windows.go
+++ b/pkg/ebpf/tracer_windows.go
@@ -5,6 +5,7 @@ package ebpf
 import (
 	"expvar"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -147,7 +148,8 @@ func (t *Tracer) resizeBuffer(compareSize int, buffer []network.ConnectionStats)
 	if compareSize >= cap(buffer)*2 {
 		return make([]network.ConnectionStats, 0, cap(buffer)*2)
 	} else if compareSize <= cap(buffer)/2 {
-		return make([]network.ConnectionStats, 0, cap(buffer)/2)
+		// Take the max of buffer/2 and compareSize to limit future array resizes
+		return make([]network.ConnectionStats, 0, math.Max(float64(cap(buffer)/2), float64(compareSize)))
 	}
 	return buffer
 }


### PR DESCRIPTION
### What does this PR do?

This has us not need to reallocate/resize a slice we are using to store active and closed connections each time we pull flows from the driver. 

### Motivation

CPU and performance issues within the tracer code when we reached around 1.5m connections/minute. 
