### PR TITLE
[runtime-security] Increase event server channel size and export dropped events metric

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -778,6 +778,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.enable_kernel_filters", true)
 	config.BindEnvAndSetDefault("runtime_security_config.syscall_monitor.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
+	config.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)
+	config.BindEnvAndSetDefault("runtime_security_config.event_server.rate", 10)
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	EnableDiscarders    bool
 	SocketPath          string
 	SyscallMonitor      bool
+	EventServerBurst    int
+	EventServerRate     int
 }
 
 // NewConfig returns a new Config object
@@ -41,6 +43,8 @@ func NewConfig(cfg *config.AgentConfig) (*Config, error) {
 		SocketPath:          aconfig.Datadog.GetString("runtime_security_config.socket"),
 		SyscallMonitor:      aconfig.Datadog.GetBool("runtime_security_config.syscall_monitor.enabled"),
 		PoliciesDir:         aconfig.Datadog.GetString("runtime_security_config.policies.dir"),
+		EventServerBurst:    aconfig.Datadog.GetInt("runtime_security_config.event_server.burst"),
+		EventServerRate:     aconfig.Datadog.GetInt("runtime_security_config.event_server.rate"),
 	}
 
 	if cfg != nil {

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -142,6 +142,9 @@ func (m *Module) statsMonitor(ctx context.Context) {
 			if err := m.rateLimiter.SendStats(m.statsdClient); err != nil {
 				log.Debug(err)
 			}
+			if err := m.eventServer.SendStats(m.statsdClient); err != nil {
+				log.Debug(err)
+			}
 		case <-ctx.Done():
 			return
 		}
@@ -203,7 +206,7 @@ func NewModule(cfg *aconfig.AgentConfig) (api.Module, error) {
 		config:       config,
 		probe:        probe,
 		ruleSet:      ruleSet,
-		eventServer:  NewEventServer(),
+		eventServer:  NewEventServer(ruleSet.ListRuleIDs()),
 		grpcServer:   grpc.NewServer(),
 		statsdClient: statsdClient,
 		rateLimiter:  NewRateLimiter(ruleSet.ListRuleIDs()),

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -206,7 +206,7 @@ func NewModule(cfg *aconfig.AgentConfig) (api.Module, error) {
 		config:       config,
 		probe:        probe,
 		ruleSet:      ruleSet,
-		eventServer:  NewEventServer(ruleSet.ListRuleIDs()),
+		eventServer:  NewEventServer(ruleSet.ListRuleIDs(), config),
 		grpcServer:   grpc.NewServer(),
 		statsdClient: statsdClient,
 		rateLimiter:  NewRateLimiter(ruleSet.ListRuleIDs()),

--- a/pkg/security/module/rate_limiter.go
+++ b/pkg/security/module/rate_limiter.go
@@ -25,32 +25,32 @@ const (
 	defaultBurst int = 40
 )
 
-// RuleLimiter describes an object that applies limits on
+// Limiter describes an object that applies limits on
 // the rate of triggering of a rule to ensure we don't overflow
 // with too permissive rules
-type RuleLimiter struct {
+type Limiter struct {
 	limiter *rate.Limiter
 	dropped int64
 	allowed int64
 }
 
-// NewRuleLimiter returns a new rule limiter
-func NewRuleLimiter(limit rate.Limit, burst int) *RuleLimiter {
-	return &RuleLimiter{
+// NewLimiter returns a new rule limiter
+func NewLimiter(limit rate.Limit, burst int) *Limiter {
+	return &Limiter{
 		limiter: rate.NewLimiter(limit, burst),
 	}
 }
 
 // RateLimiter describes a set of rule rate limiters
 type RateLimiter struct {
-	limiters map[string]*RuleLimiter
+	limiters map[string]*Limiter
 }
 
 // NewRateLimiter initializes an empty rate limiter
 func NewRateLimiter(ids []string) *RateLimiter {
-	limiters := make(map[string]*RuleLimiter)
+	limiters := make(map[string]*Limiter)
 	for _, id := range ids {
-		limiters[id] = NewRuleLimiter(defaultLimit, defaultBurst)
+		limiters[id] = NewLimiter(defaultLimit, defaultBurst)
 	}
 	return &RateLimiter{
 		limiters: limiters,

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -10,12 +10,14 @@ package module
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-go/statsd"
-	"math"
 	"sync/atomic"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
+	"golang.org/x/time/rate"
+
 	"github.com/DataDog/datadog-agent/pkg/security/api"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
@@ -26,12 +28,16 @@ import (
 // the runtime security system-probe module and forwards them to Datadog
 type EventServer struct {
 	msgs          chan *api.SecurityEventMessage
-	droppedEvents map[string]*int64
+	expiredEvents map[string]*int64
+	rate          *Limiter
 }
 
 // GetEvents waits for security events
 func (e *EventServer) GetEvents(params *api.GetParams, stream api.SecurityModule_GetEventsServer) error {
 	msgs := 10
+	if !e.rate.limiter.AllowN(time.Now(), msgs) {
+		return nil
+	}
 LOOP:
 	for {
 		select {
@@ -73,22 +79,37 @@ func (e *EventServer) SendEvent(rule *eval.Rule, event eval.Event) {
 	case e.msgs <- msg:
 		break
 	default:
-		// Update stats
-		eventsStat, ok := e.droppedEvents[rule.ID]
-		if ok {
-			atomic.AddInt64(eventsStat, 1)
+		// The channel is full, consume the oldest event
+		oldestMsg := <-e.msgs
+		// Try to send the send the event again
+		select {
+		case e.msgs <- msg:
+			break
+		default:
+			// Looks like the channel is full again, expire the current message too
+			e.expireEvent(msg)
+			break
 		}
-		// Do not wait for the channel to free up, we don't want to delay the processing pipeline further
-		log.Warnf("the event server channel is full, an event of ID %v was dropped", msg.RuleID)
+		e.expireEvent(oldestMsg)
 		break
 	}
 }
 
+// expireEvent updates the count of expired messages for the appropriate rule
+func (e *EventServer) expireEvent(msg *api.SecurityEventMessage) {
+	// Update metric
+	count, ok := e.expiredEvents[msg.RuleID]
+	if ok {
+		atomic.AddInt64(count, 1)
+	}
+	log.Tracef("the event server channel is full, an event of ID %v was dropped", msg.RuleID)
+}
+
 // GetStats returns a map indexed by ruleIDs that describes the amount of events
-// that were dropped because the groc channel was full
+// that were expired or rate limited before reaching
 func (e *EventServer) GetStats() map[string]int64 {
 	stats := make(map[string]int64)
-	for ruleID, val := range e.droppedEvents {
+	for ruleID, val := range e.expiredEvents {
 		stats[ruleID] = atomic.SwapInt64(val, 0)
 	}
 	return stats
@@ -99,7 +120,7 @@ func (e *EventServer) SendStats(client *statsd.Client) error {
 	for ruleID, val := range e.GetStats() {
 		tags := []string{fmt.Sprintf("rule_id:%s", ruleID)}
 		if val > 0 {
-			if err := client.Count(sprobe.MetricPrefix+".rules.event_server.drop", val, tags, 1.0); err != nil {
+			if err := client.Count(sprobe.MetricPrefix+".rules.event_server.expired", val, tags, 1.0); err != nil {
 				return err
 			}
 		}
@@ -108,14 +129,15 @@ func (e *EventServer) SendStats(client *statsd.Client) error {
 }
 
 // NewEventServer returns a new gRPC event server
-func NewEventServer(ids []string) *EventServer {
+func NewEventServer(ids []string, cfg *config.Config) *EventServer {
 	es := &EventServer{
-		msgs:          make(chan *api.SecurityEventMessage, defaultBurst*int(math.Min(float64(len(ids)), 50))),
-		droppedEvents: make(map[string]*int64),
+		msgs:          make(chan *api.SecurityEventMessage, cfg.EventServerBurst*3),
+		expiredEvents: make(map[string]*int64),
+		rate:          NewLimiter(rate.Limit(cfg.EventServerRate), cfg.EventServerBurst),
 	}
 	for _, id := range ids {
 		var val int64
-		es.droppedEvents[id] = &val
+		es.expiredEvents[id] = &val
 	}
 	return es
 }


### PR DESCRIPTION
### What does this PR do?

This PR increases the size of the events server channel that is used to send events from the runtime security module of system-probe to the security-agent. The new size is set as a multiplier of the burst size allowed for each rules.

This PR also introduces a new metric (`datadog.runtime_security.rules.event_server.expired`) to report when an event is dropped because the channel is full. When possible, only the oldest event is dropped.

### Motivation

The current limit is set to 5 events which is quickly reached today.