### PR TITLE
[runtime-security] Use kernel version to set the mount id offset

### DIFF
--- a/pkg/security/probe/consts.go
+++ b/pkg/security/probe/consts.go
@@ -17,6 +17,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	// KERNEL_VERSION(a,b,c) = (a << 16) + (b << 8) + (c)
+	kernel4_13 = (4 << 16) + (13 << 8) //nolint:deadcode,unused
+)
+
 // EventType describes the type of an event sent from the kernel
 type EventType uint64
 

--- a/pkg/security/probe/mount.go
+++ b/pkg/security/probe/mount.go
@@ -275,6 +275,7 @@ func newFSDevice() *FSDevice {
 
 // MountResolver represents a cache for mountpoints and the corresponding file systems
 type MountResolver struct {
+	probe   *Probe
 	lock    sync.RWMutex
 	devices map[uint32]*FSDevice
 	mounts  map[uint32]*Mount
@@ -391,8 +392,9 @@ func (mr *MountResolver) GetMountPath(mountID uint32, numlower int32) (string, s
 }
 
 // NewMountResolver instantiates a new mount resolver
-func NewMountResolver() *MountResolver {
+func NewMountResolver(probe *Probe) *MountResolver {
 	return &MountResolver{
+		probe:   probe,
 		lock:    sync.RWMutex{},
 		devices: make(map[uint32]*FSDevice),
 		mounts:  make(map[uint32]*Mount),

--- a/pkg/security/probe/mount_bpf.go
+++ b/pkg/security/probe/mount_bpf.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux_bpf
+
+package probe
+
+import "github.com/DataDog/datadog-agent/pkg/security/ebpf"
+
+// mountTables is the list of eBPF tables used by mount's kProbes
+var mountTables = []string{
+	"mount_id_offset",
+}
+
+func (mr *MountResolver) setMountIDOffset() error {
+	if mr.probe.kernelVersion != 0 && mr.probe.kernelVersion <= kernel4_13 {
+		offsetItem := ebpf.Uint32TableItem(268)
+		table := mr.probe.Table("mount_id_offset")
+		if err := table.Set(ebpf.ZeroUint32TableItem, offsetItem); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (mr *MountResolver) Start() error {
+	return mr.setMountIDOffset()
+}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -20,7 +20,7 @@ func NewResolvers(probe *Probe) (*Resolvers, error) {
 	return &Resolvers{
 		probe:          probe,
 		DentryResolver: dentryResolver,
-		MountResolver:  NewMountResolver(),
+		MountResolver:  NewMountResolver(probe),
 		TimeResolver:   timeResolver,
 	}, nil
 }

--- a/pkg/security/probe/resolvers_bpf.go
+++ b/pkg/security/probe/resolvers_bpf.go
@@ -76,6 +76,10 @@ func (r *Resolvers) Start() error {
 		return errors.New("pid_cookie BPF_HASH table doesn't exist")
 	}
 
+	if err := r.MountResolver.Start(); err != nil {
+		return err
+	}
+
 	return r.DentryResolver.Start()
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR uses kernel version instead of syscall wrapper macro to set the mount id offset.

### Motivation

mount id is incorrect for kernel between kernel >= 4.13 and <= 4.15 

### Additional Notes

The map array approach is a short term approach and will be replaced once we will have constant edition.

### Describe your test plan

Write there any instructions and details you may have to test your PR.
