### PR TITLE
Set process_config.log_file as known config entry

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -674,6 +674,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.container_source")
 	config.SetKnown("process_config.intervals.connections")
 	config.SetKnown("process_config.expvar_port")
+	config.SetKnown("process_config.log_file")
 
 	// System probe
 	config.SetKnown("system_probe_config.enabled")


### PR DESCRIPTION
### What does this PR do?

Sets the config entry `process_config.log_file` as a known config option to avoid warnings

### Motivation

In the Heroku buildpack we have to modify this entry, so we always get a warning from the agent when it starts


