### PR TITLE
Fix segfault when listing garden containers in error state (#6357)

### DIFF
--- a/pkg/util/cloudfoundry/garden.go
+++ b/pkg/util/cloudfoundry/garden.go
@@ -87,7 +87,7 @@ func (gu *GardenUtil) ListContainers() ([]*containers.Container, error) {
 		return nil, fmt.Errorf("error listing garden containers: %v", err)
 	}
 
-	var cList = make([]*containers.Container, len(gardenContainers))
+	var cList = make([]*containers.Container, 0, len(gardenContainers))
 	handles := make([]string, len(gardenContainers))
 	for i, gardenContainer := range gardenContainers {
 		handles[i] = gardenContainer.Handle()
@@ -101,7 +101,7 @@ func (gu *GardenUtil) ListContainers() ([]*containers.Container, error) {
 		return nil, fmt.Errorf("error getting metrics for garden containers: %v", err)
 	}
 
-	for i, handle := range handles {
+	for _, handle := range handles {
 		infoEntry := gardenContainerInfo[handle]
 		if err := infoEntry.Err; err != nil {
 			log.Debugf("could not get info for container %s: %v", handle, err)
@@ -121,7 +121,7 @@ func (gu *GardenUtil) ListContainers() ([]*containers.Container, error) {
 			Created:     time.Now().Add(-metricsEntry.Metrics.Age).Unix(),
 			AddressList: parseContainerPorts(infoEntry.Info),
 		}
-		cList[i] = &container
+		cList = append(cList, &container)
 	}
 
 	for _, container := range cList {

--- a/pkg/util/cloudfoundry/garden_test.go
+++ b/pkg/util/cloudfoundry/garden_test.go
@@ -1,6 +1,9 @@
 package cloudfoundry
 
 import (
+	"code.cloudfoundry.org/garden/gardenfakes"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
 	"net"
 	"testing"
 
@@ -37,4 +40,107 @@ func TestParseContainerPorts(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, addresses)
+}
+
+type fakeContainerImpl struct {
+}
+
+func (f fakeContainerImpl) Prefetch() error {
+	return nil
+}
+
+func (f fakeContainerImpl) ContainerExists(containerID string) bool {
+	return true
+}
+
+func (f fakeContainerImpl) GetContainerStartTime(containerID string) (int64, error) {
+	panic("implement me")
+}
+
+func (f fakeContainerImpl) DetectNetworkDestinations(pid int) ([]containers.NetworkDestination, error) {
+	panic("implement me")
+}
+
+func (f fakeContainerImpl) GetAgentCID() (string, error) {
+	panic("implement me")
+}
+
+func (f fakeContainerImpl) GetPIDs(containerID string) ([]int32, error) {
+	return []int32{123}, nil
+}
+
+func (f fakeContainerImpl) ContainerIDForPID(pid int) (string, error) {
+	panic("implement me")
+}
+
+func (f fakeContainerImpl) GetDefaultGateway() (net.IP, error) {
+	panic("implement me")
+}
+
+func (f fakeContainerImpl) GetDefaultHostIPs() ([]string, error) {
+	panic("implement me")
+}
+
+func (f fakeContainerImpl) GetContainerMetrics(containerID string) (*metrics.ContainerMetrics, error) {
+	return nil, nil
+}
+
+func (f fakeContainerImpl) GetContainerLimits(containerID string) (*metrics.ContainerLimits, error) {
+	return nil, nil
+}
+
+func (f fakeContainerImpl) GetNetworkMetrics(containerID string, networks map[string]string) (metrics.ContainerNetStats, error) {
+	return nil, nil
+}
+
+func TestListContainers(t *testing.T) {
+	defer providers.Deregister()
+	providers.Register(fakeContainerImpl{})
+	cli := gardenfakes.FakeClient{}
+	bulkContainers := map[string]garden.ContainerInfoEntry{
+		"ok": {
+			Info: garden.ContainerInfo{
+				State: "active",
+			},
+			Err: nil,
+		},
+		"ok err metrics": {
+			Info: garden.ContainerInfo{
+				State: "active",
+			},
+			Err: nil,
+		},
+		"not ok": {
+			Info: garden.ContainerInfo{
+				State: "on fire",
+			},
+			Err: garden.NewError("problem!"),
+		},
+	}
+	metrics := map[string]garden.ContainerMetricsEntry{
+		"ok":             {},
+		"ok err metrics": {Err: garden.NewError("another problem!")},
+		"not ok":         {},
+	}
+	okc := gardenfakes.FakeContainer{}
+	okc.HandleReturns("ok")
+	oknometricsc := gardenfakes.FakeContainer{}
+	oknometricsc.HandleReturns("ok err metrics")
+	nokc := gardenfakes.FakeContainer{}
+	nokc.HandleReturns("not ok")
+	containers := []garden.Container{
+		&okc, &oknometricsc, &nokc,
+	}
+
+	cli.BulkInfoReturns(bulkContainers, nil)
+	cli.BulkMetricsReturns(metrics, nil)
+	cli.ContainersReturns(containers, nil)
+	gu := GardenUtil{
+		cli: &cli,
+	}
+
+	result, err := gu.ListContainers()
+	assert.Nil(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "ok", result[0].ID)
 }

--- a/pkg/util/containers/providers/provider.go
+++ b/pkg/util/containers/providers/provider.go
@@ -31,3 +31,9 @@ func Register(impl containers.ContainerImplementation) {
 		log.Critical("Trying to set multiple ContainerImplementation")
 	}
 }
+
+// Deregister allows to unset a ContainerImplementation
+// this should only be used in tests to clean the global state
+func Deregister() {
+	containerImpl = nil
+}

--- a/releasenotes/notes/fix-garden-listcontainers-segfault-e208c9ab68dbc944.yaml
+++ b/releasenotes/notes/fix-garden-listcontainers-segfault-e208c9ab68dbc944.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix segfault when listing Garden containers that are in error state.


### PR DESCRIPTION
### What does this PR do?

Fixes a segfault for ListContainers for Garden when containers are in error state. (This is same as #6357, just cherry-picked for 7.22.x branch).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
