### PR TITLE
Use run_path as the path for the version-history.json file

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -608,7 +608,7 @@ func zipRegistryJSON(tempDir, hostname string) error {
 }
 
 func zipVersionHistory(tempDir, hostname string) error {
-	originalPath := filepath.Join(config.Datadog.GetString("logs_config.run_path"), "version-history.json")
+	originalPath := filepath.Join(config.Datadog.GetString("run_path"), "version-history.json")
 	original, err := os.Open(originalPath)
 	if err != nil {
 		return err

--- a/pkg/util/version_history.go
+++ b/pkg/util/version_history.go
@@ -30,7 +30,7 @@ const maxVersionHistoryEntries = 60
 // LogVersionHistory loads version history file, append new entry if agent version is different than the last entry in the
 // JSON file, trim the file if too many entries then save the file.
 func LogVersionHistory() {
-	versionHistoryFilePath := filepath.Join(config.Datadog.GetString("logs_config.run_path"), "version-history.json")
+	versionHistoryFilePath := filepath.Join(config.Datadog.GetString("run_path"), "version-history.json")
 	logVersionHistoryToFile(versionHistoryFilePath, version.AgentVersion, time.Now().UTC())
 }
 


### PR DESCRIPTION
### What does this PR do?

It changes the path of the `version-history.json` file from `logs_config.run_path` to just `run_path` as this file is created by the agent outside the logs agent.

### Motivation

We modified this entry in the Heroku buildpack only if the customer had logs enabled, so with the latest release we got ne bug reports that this file wasn't being created successfully for those who didn't have logs enabled.


