### PR TITLE
[runtime-security] Handle open.flags equals to only O_RDONLY

### DIFF
--- a/pkg/security/probe/consts.go
+++ b/pkg/security/probe/consts.go
@@ -243,13 +243,13 @@ var (
 		"O_DIRECTORY": syscall.O_DIRECTORY,
 		"O_DSYNC":     syscall.O_DSYNC,
 		"O_FSYNC":     syscall.O_FSYNC,
-		"O_LARGEFILE": syscall.O_LARGEFILE,
-		"O_NDELAY":    syscall.O_NDELAY,
-		"O_NOATIME":   syscall.O_NOATIME,
-		"O_NOCTTY":    syscall.O_NOCTTY,
-		"O_NOFOLLOW":  syscall.O_NOFOLLOW,
-		"O_NONBLOCK":  syscall.O_NONBLOCK,
-		"O_RSYNC":     syscall.O_RSYNC,
+		//"O_LARGEFILE": syscall.O_LARGEFILE, golang defines this as 0
+		"O_NDELAY":   syscall.O_NDELAY,
+		"O_NOATIME":  syscall.O_NOATIME,
+		"O_NOCTTY":   syscall.O_NOCTTY,
+		"O_NOFOLLOW": syscall.O_NOFOLLOW,
+		"O_NONBLOCK": syscall.O_NONBLOCK,
+		"O_RSYNC":    syscall.O_RSYNC,
 	}
 
 	chmodModeConstants = map[string]int{
@@ -370,6 +370,9 @@ func bitmaskToString(bitmask int, intToStrMap map[int]string) string {
 type OpenFlags int
 
 func (f OpenFlags) String() string {
+	if int(f) == syscall.O_RDONLY {
+		return openFlagsStrings[syscall.O_RDONLY]
+	}
 	return bitmaskToString(int(f), openFlagsStrings)
 }
 

--- a/pkg/security/probe/consts_test.go
+++ b/pkg/security/probe/consts_test.go
@@ -28,4 +28,9 @@ func TestFlagsToString(t *testing.T) {
 	if str != fmt.Sprintf("%d | O_EXCL | O_TRUNC", 1<<32) {
 		t.Errorf("expexted flags not found, got: %s", str)
 	}
+
+	str = OpenFlags(syscall.O_RDONLY).String()
+	if str != "O_RDONLY" {
+		t.Errorf("expexted flags not found, got: %s", str)
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Currently when open flags equals to O_RDONLY the event generated has the field open.flags empty. This PR fixes the issue.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

A unit test has been added
