### PR TITLE
Make the auto-discovery kubelet listener look for docker image in the spec

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -219,15 +219,28 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 	var containerName string
 	for _, container := range pod.Status.GetAllContainers() {
 		if container.ID == svc.entity {
+			// Get the ImageName from the `spec` because the one in `status` isn’t reliable
+			containerImage := ""
+			for _, containerSpec := range pod.Spec.Containers {
+				if containerSpec.Name == container.Name {
+					containerImage = containerSpec.Image
+					break
+				}
+			}
+			if containerImage == "" {
+				log.Debugf("couldn't find the container %s (%s) in the spec of pod %s", container.Name, container.ID, pod.Metadata.Name)
+				containerImage = container.Image
+			}
+
 			// Detect AD exclusion
-			if l.filters.IsExcluded(containers.GlobalFilter, container.Name, container.Image, pod.Metadata.Namespace) {
-				log.Debugf("container %s filtered out: name %q image %q namespace %q", container.ID, container.Name, container.Image, pod.Metadata.Namespace)
+			if l.filters.IsExcluded(containers.GlobalFilter, container.Name, containerImage, pod.Metadata.Namespace) {
+				log.Debugf("container %s filtered out: name %q image %q namespace %q", container.ID, container.Name, containerImage, pod.Metadata.Namespace)
 				return
 			}
 
 			// Detect metrics or logs exclusion
-			svc.metricsExcluded = l.filters.IsExcluded(containers.MetricsFilter, container.Name, container.Image, pod.Metadata.Namespace)
-			svc.logsExcluded = l.filters.IsExcluded(containers.LogsFilter, container.Name, container.Image, pod.Metadata.Namespace)
+			svc.metricsExcluded = l.filters.IsExcluded(containers.MetricsFilter, container.Name, containerImage, pod.Metadata.Namespace)
+			svc.logsExcluded = l.filters.IsExcluded(containers.LogsFilter, container.Name, containerImage, pod.Metadata.Namespace)
 
 			containerName = container.Name
 
@@ -244,12 +257,12 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 			}
 
 			// Add other identifiers if no template found
-			svc.adIdentifiers = append(svc.adIdentifiers, container.Image)
-			_, short, _, err := containers.SplitImageName(container.Image)
+			svc.adIdentifiers = append(svc.adIdentifiers, containerImage)
+			_, short, _, err := containers.SplitImageName(containerImage)
 			if err != nil {
 				log.Warnf("Error while spliting image name: %s", err)
 			}
-			if len(short) > 0 && short != container.Image {
+			if len(short) > 0 && short != containerImage {
 				svc.adIdentifiers = append(svc.adIdentifiers, short)
 			}
 			break

--- a/releasenotes/notes/Look-for-image-in-spec-rather-than-status-95d2402b82068d1c.yaml
+++ b/releasenotes/notes/Look-for-image-in-spec-rather-than-status-95d2402b82068d1c.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug that was causing not picking checks and logs for containers targeted
+    by container-image-based autodiscovery. Or picking checks and logs for
+    containers that were not targeted by container-image-based autodiscovery.
+    This happened when several image names were pointing to the same image digest.


### PR DESCRIPTION
### What does this PR do?

Make the auto-discovery kubelet listener look for docker image name in the pod spec rather than in the pod status.

### Motivation

This fixes unexpected AD behaviours when when several pods with different docker image name that are pointing to the same image digest are running on the same node.

If, on a node, several docker image names are aliasing the same docker image digest, the image name that is reported by Kubernetes in the pod status section can be any of those names.
On the other hand, the image name that appears in the pod spec section is the name that was entered by the user.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

* Spawn an EKS cluster
* Create two docker images with two different names that are pointing to the same digest (`docker tag <IMAGE1> <IMAGE2>`)
* Spawn two pods on the same node, using the two docker image name.
* Create an AD config that matches only one of the two docker image names.

With the old version of the agent, we would see either two or zero checks scheduled.
With this change, we should see only one check scheduled.