### PR TITLE
pkg/trace/api: better responses

### DIFF
--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -40,26 +40,22 @@ func httpFormatError(w http.ResponseWriter, v Version, err error) {
 func httpDecodingError(err error, tags []string, w http.ResponseWriter) {
 	status := http.StatusBadRequest
 	errtag := "decoding-error"
-	msg := err.Error()
 
 	switch err {
 	case ErrLimitedReaderLimitReached:
 		status = http.StatusRequestEntityTooLarge
 		errtag = "payload-too-large"
-		msg = errtag
 	case io.EOF, io.ErrUnexpectedEOF:
 		errtag = "unexpected-eof"
-		msg = errtag
 	}
 	if err, ok := err.(net.Error); ok && err.Timeout() {
 		status = http.StatusRequestTimeout
 		errtag = "timeout"
-		msg = errtag
 	}
 
 	tags = append(tags, fmt.Sprintf("error:%s", errtag))
 	metrics.Count(receiverErrorKey, 1, tags, 1)
-	http.Error(w, msg, status)
+	http.Error(w, fmt.Sprintf("%s:%v", errtag, err), status)
 }
 
 // httpOK is a dumb response for when things are a OK

--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -55,7 +55,7 @@ func httpDecodingError(err error, tags []string, w http.ResponseWriter) {
 
 	tags = append(tags, fmt.Sprintf("error:%s", errtag))
 	metrics.Count(receiverErrorKey, 1, tags, 1)
-	http.Error(w, fmt.Sprintf("%s:%v", errtag, err), status)
+	http.Error(w, fmt.Sprintf("%s: %v", errtag, err), status)
 }
 
 // httpOK is a dumb response for when things are a OK

--- a/releasenotes/notes/apm-error-response-9b041ddd069bd1d4.yaml
+++ b/releasenotes/notes/apm-error-response-9b041ddd069bd1d4.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Non-200 client responses now contain more information about
+    decoding errors.


### PR DESCRIPTION
This change improves the responses given to clients in case of decoding
errors. Whereas previously we had a response saying simply
`decoding-error`, now the response will be `decoding-error:
{actual_error}`.