### PR TITLE
pkg/trace/agent: improve normalizer

### DIFF
--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -508,6 +508,7 @@ func BenchmarkNormalization(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ts := newTagStats()
 		span := newTestSpan()
+		ts.Lang = "go"
 
 		normalize(ts, span)
 	}

--- a/releasenotes/notes/apm-normalize-sprintf-48dc737513d0a1e5.yaml
+++ b/releasenotes/notes/apm-normalize-sprintf-48dc737513d0a1e5.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Span normalization speed has been increased by 15%.


### PR DESCRIPTION
This change improves the normalization speed for a span by 18%

     name             old time/op    new time/op    delta
     Normalization-8     850ns ± 0%     693ns ± 0%  -18.47%

     name             old alloc/op   new alloc/op   delta
     Normalization-8    1.00kB ± 0%    0.95kB ± 0%   -4.80%

     name             old allocs/op  new allocs/op  delta
     Normalization-8      12.0 ± 0%      10.0 ± 0%  -16.67%
