### PR TITLE
Maxime/fix systray not visible

### DIFF
--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	seelog "github.com/cihub/seelog"
@@ -103,6 +104,11 @@ func onExit() {
 }
 
 func main() {
+	// Following https://github.com/lxn/win/commit/d9566253ae00d0a7dc7e4c9bda651dcfee029001
+	// it's up to the caller to lock OS threads
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	flag.BoolVar(&launchgui, "launch-gui", false, "Launch browser configuration and exit")
 	flag.Parse()
 	log.Debugf("launch-gui is %v", launchgui)

--- a/releasenotes/notes/fix-systray-lock-threads-da872033b8724292.yaml
+++ b/releasenotes/notes/fix-systray-lock-threads-da872033b8724292.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix the Windows systray not appearing sometimes (bug introduced with 6.20.0).


### PR DESCRIPTION
### What does this PR do?

Lock OS threads in the systray
    
When moving to go module for 6.20 'github.com/lxn/win' was pin to a newer version that doesn't lock OS threads anymore, 
leaving it up to the caller. Version went from 7e1250ba2e77 to 2da648fda5b4.
    
Not locking threads causes the systray to not appear sometimes.

### How to test

Install the agent as usual on a windows box. Then run the systray as administrator. The systray icon should appear in the "show hidden icons" section of the toolbar. Stop and restart the systray multiple times.