### PR TITLE
Add defaults to containerized Agent in CI environments

### DIFF
--- a/Dockerfiles/agent/datadog-ci.yaml
+++ b/Dockerfiles/agent/datadog-ci.yaml
@@ -1,0 +1,6 @@
+## Provides defaults for CI environments,
+## please see datadog.yaml.example for all supported options
+
+apm_config:
+  enabled: true
+  apm_non_local_traffic: true

--- a/Dockerfiles/agent/entrypoint-ps1/50-ci.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/50-ci.ps1
@@ -10,4 +10,4 @@ if (-not (Test-Path C:\ProgramData\Datadog\datadog.yaml)) {
 }
 
 # Remove all default checks
-Get-ChildItem C:\ProgramData\Datadog\conf.d -Include *.yaml.default -Recurse | Remove-Item -WhatIf
+Get-ChildItem C:\ProgramData\Datadog\conf.d -Include *.yaml.default -Recurse | Remove-Item

--- a/Dockerfiles/agent/entrypoint-ps1/50-ci.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/50-ci.ps1
@@ -1,0 +1,13 @@
+
+if (-not (Test-Path env:DD_INSIDE_CI)) {
+    exit 0
+}
+
+# Set a default config for CI environments
+# Don't override datadog.yaml if it exists
+if (-not (Test-Path C:\ProgramData\Datadog\datadog.yaml)) {
+   cp C:\ProgramData\Datadog\datadog-ci.yaml C:\ProgramData\Datadog\datadog.yaml
+}
+
+# Remove all default checks
+Get-ChildItem C:\ProgramData\Datadog\conf.d -Include *.yaml.default -Recurse | Remove-Item -WhatIf

--- a/Dockerfiles/agent/entrypoint-ps1/60-disable-infra.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/60-disable-infra.ps1
@@ -1,10 +1,19 @@
 
-# Disable infra checks that would report metrics from the container (instead of the host)
-Remove-Item C:\ProgramData\Datadog\conf.d\disk.d\conf.yaml.default
-Remove-Item C:\ProgramData\Datadog\conf.d\network.d\conf.yaml.default
-Remove-Item C:\ProgramData\Datadog\conf.d\winproc.d\conf.yaml.default
-Remove-Item C:\ProgramData\Datadog\conf.d\file_handle.d\conf.yaml.default
+# Disable infra checks that would report metrics from the container (instead of the host),
+# if they're not already disabled
 
-# TODO: Conditionally enable the IO check if the host drives are mounted in the container
-Remove-Item C:\ProgramData\Datadog\conf.d\io.d\conf.yaml.default
+$defaultChecks = @(
+    "disk",
+    "network",
+    "winproc",
+    "file_handle",
+    # TODO: Conditionally enable the IO check if the host drives are mounted in the container
+    "io"
+)
 
+ForEach ($defaultCheck in $defaultChecks) {
+    $confPath = "C:\ProgramData\Datadog\conf.d\$defaultCheck.d\conf.yaml.default"
+    if (Test-Path $confPath) {
+        Remove-Item $confPath
+    }
+}

--- a/Dockerfiles/agent/entrypoint/50-ci.sh
+++ b/Dockerfiles/agent/entrypoint/50-ci.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [[ -z "${DD_INSIDE_CI}" ]]; then
+    exit 0
+fi
+
+# Set a default config for CI environments
+# Don't override /etc/datadog-agent/datadog.yaml if it exists
+if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
+    ln -s  /etc/datadog-agent/datadog-ci.yaml \
+           /etc/datadog-agent/datadog.yaml
+fi
+
+# Remove all default checks
+find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete

--- a/Dockerfiles/agent/entrypoint/50-ci.sh
+++ b/Dockerfiles/agent/entrypoint/50-ci.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [[ -z "${DD_INSIDE_CI}" ]]; then
     exit 0


### PR DESCRIPTION
### What does this PR do?

Add defaults to containerized Agent in CI environments (i.e. when `DD_INSIDE_CI` is set):

* enable APM, listening on non-local traffic
* disable all default checks

### Additional Notes

The only logic change to `60-disable-infra.ps1` is to check if the file exists before removing it.

### Describe your test plan

I've tested the script changes (linux shell and powershell), but haven't tested the resulting image.
To test, run the resulting image (Linux and Windows) with and without `DD_INSIDE_CI` set.