### PR TITLE
[KSMv2] Target standard tags only in label joins

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
@@ -139,6 +139,12 @@ var (
 		"kube_pod_container_status_last_terminated_reason": {},
 	}
 
+	defaultStandardLabels = []string{
+		"label_tags_datadoghq_com_env",
+		"label_tags_datadoghq_com_service",
+		"label_tags_datadoghq_com_version",
+	}
+
 	// defaultLabelJoins contains the default label joins configuration
 	defaultLabelJoins = map[string]*JoinsConfig{
 		"kube_pod_status_phase": {
@@ -159,27 +165,27 @@ var (
 		},
 		"kube_pod_labels": {
 			LabelsToMatch: []string{"pod", "namespace"},
-			GetAllLabels:  true,
+			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_deployment_labels": {
 			LabelsToMatch: []string{"deployment", "namespace"},
-			GetAllLabels:  true,
+			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_replicaset_labels": {
 			LabelsToMatch: []string{"replicaset", "namespace"},
-			GetAllLabels:  true,
+			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_daemonset_labels": {
 			LabelsToMatch: []string{"daemonset", "namespace"},
-			GetAllLabels:  true,
+			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_statefulset_labels": {
 			LabelsToMatch: []string{"statefulset", "namespace"},
-			GetAllLabels:  true,
+			LabelsToGet:   defaultStandardLabels,
 		},
 		"kube_job_labels": {
 			LabelsToMatch: []string{"job_name", "namespace"},
-			GetAllLabels:  true,
+			LabelsToGet:   defaultStandardLabels,
 		},
 	}
 )

--- a/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
@@ -224,10 +224,9 @@ func validateJob(val float64, tags []string) ([]string, bool) {
 
 	for i, tag := range tags {
 		split := strings.Split(tag, ":")
-		if len(split) == 2 && split[0] == "job" || split[0] == "job_name" {
+		if len(split) == 2 && split[0] == "kube_job" || split[0] == "job" || split[0] == "job_name" {
 			// Trim the timestamp suffix to avoid high cardinality
 			tags[i] = fmt.Sprintf("%s:%s", split[0], trimJobTag(split[1]))
-			return tags, true
 		}
 	}
 
@@ -254,8 +253,6 @@ func jobStatusFailedTransformer(s aggregator.Sender, name string, metric ksmstor
 // jobMetric sends a gauge for job status
 func jobMetric(s aggregator.Sender, metric ksmstore.DDMetric, metricName string, hostname string, tags []string) {
 	if strippedTags, valid := validateJob(metric.Val, tags); valid {
-		// TODO: Many problems have been reported about job metrics in the v1 check
-		// This is different compared to what we do in the v1 check already but let's investigate more
 		s.Gauge(metricName, 1, hostname, strippedTags)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

- Restrict the default label joins to target the datadog standard labels only (reduce high cardinality risk)
- Validate/strip the `kube_job` tag value which contains a timestamp suffix for cronjobs

### Motivation

Lower the metrics cardinality (align with the ksm v1)

### Describe your test plan

Only the standard labels should be added from label joins
