### PR TITLE
Introduce a gRPC Tagger service

### DIFF
--- a/cmd/agent/api/grpc.go
+++ b/cmd/agent/api/grpc.go
@@ -12,17 +12,18 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	pb "github.com/DataDog/datadog-agent/cmd/agent/api/pb"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	hostutil "github.com/DataDog/datadog-agent/pkg/util"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-// EnableExperimentalEndpoints enables experimental endpoints (set via -X)
-var EnableExperimentalEndpoints bool
 
 type server struct {
 	pb.UnimplementedAgentServer
@@ -30,6 +31,11 @@ type server struct {
 
 type serverSecure struct {
 	pb.UnimplementedAgentServer
+
+	// NOTE: tagger.Tagger is a concrete type that makes testing harder
+	// than it should be. We should make that concrete type private, and
+	// create a new tagger.Tagger interface that replicates it.
+	tagger *tagger.Tagger
 }
 
 func (s *server) GetHostname(ctx context.Context, in *pb.HostnameRequest) (*pb.HostnameReply, error) {
@@ -48,12 +54,118 @@ func (s *server) AuthFuncOverride(ctx context.Context, fullMethodName string) (c
 	return ctx, nil
 }
 
-func (s *serverSecure) GetTags(ctx context.Context, in *pb.TagRequest) (*pb.TagReply, error) {
-	if EnableExperimentalEndpoints {
-		tags, _ := tagger.Tag(in.GetEntity(), collectors.HighCardinality)
-		return &pb.TagReply{Tags: tags}, nil
+// StreamTags subscribes to added, removed, or changed entities in the Tagger
+// and streams them to clients as pb.StreamTagsResponse events. Filtering is as
+// of yet not implemented.
+func (s *serverSecure) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecure_TaggerStreamEntitiesServer) error {
+	cardinality, err := pb2taggerCardinality(in.Cardinality)
+	if err != nil {
+		return err
 	}
 
-	return nil, status.Errorf(codes.PermissionDenied,
-		"This is an experimental endpoint and has been disabled in this build")
+	// NOTE: StreamTagsRequest can specify filters, but they cannot be
+	// implemented since the tagger has no concept of container metadata.
+	// these filters will be introduced when we implement a container
+	// metadata service that can receive them as is from the tagger.
+
+	eventCh := s.tagger.Subscribe(cardinality)
+	defer s.tagger.Unsubscribe(eventCh)
+
+	for events := range eventCh {
+		for _, event := range events {
+			response, err := tagger2pbEntityEvent(event)
+			if err != nil {
+				log.Warnf("can't convert tagger entity to protobuf: %s", err)
+				continue
+			}
+
+			err = out.Send(response)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// FetchEntity fetches an entity from the Tagger with the desired cardinality tags.
+func (s *serverSecure) TaggerFetchEntity(ctx context.Context, in *pb.FetchEntityRequest) (*pb.FetchEntityResponse, error) {
+	if in.Id == nil {
+		return nil, status.Errorf(codes.InvalidArgument, `missing "id" parameter`)
+	}
+
+	entityID := fmt.Sprintf("%s://%s", in.Id.Prefix, in.Id.Uid)
+	cardinality, err := pb2taggerCardinality(in.Cardinality)
+	if err != nil {
+		return nil, err
+	}
+
+	tags, err := s.tagger.Tag(entityID, cardinality)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+	}
+
+	return &pb.FetchEntityResponse{
+		Id:          in.Id,
+		Cardinality: in.Cardinality,
+		Tags:        tags,
+	}, nil
+}
+
+func tagger2pbEntityID(entityID string) (*pb.EntityId, error) {
+	parts := strings.SplitN(entityID, "://", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid entity id %q", entityID)
+	}
+
+	return &pb.EntityId{
+		Prefix: parts[0],
+		Uid:    parts[1],
+	}, nil
+}
+
+func tagger2pbEntityEvent(event tagger.EntityEvent) (*pb.StreamTagsResponse, error) {
+	entity := event.Entity
+	entityID, err := tagger2pbEntityID(entity.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	var eventType pb.EventType
+	switch event.EventType {
+	case tagger.EventTypeAdded:
+		eventType = pb.EventType_ADDED
+	case tagger.EventTypeModified:
+		eventType = pb.EventType_MODIFIED
+	case tagger.EventTypeDeleted:
+		eventType = pb.EventType_DELETED
+	default:
+		return nil, fmt.Errorf("invalid event type %q", event.EventType)
+	}
+
+	return &pb.StreamTagsResponse{
+		Type: eventType,
+		Entity: &pb.Entity{
+			Id:                          entityID,
+			Hash:                        entity.Hash,
+			HighCardinalityTags:         entity.HighCardinalityTags,
+			OrchestratorCardinalityTags: entity.OrchestratorCardinalityTags,
+			LowCardinalityTags:          entity.LowCardinalityTags,
+			StandardTags:                entity.StandardTags,
+		},
+	}, nil
+}
+
+func pb2taggerCardinality(pbCardinality pb.TagCardinality) (collectors.TagCardinality, error) {
+	switch pbCardinality {
+	case pb.TagCardinality_LOW:
+		return collectors.LowCardinality, nil
+	case pb.TagCardinality_ORCHESTRATOR:
+		return collectors.OrchestratorCardinality, nil
+	case pb.TagCardinality_HIGH:
+		return collectors.HighCardinality, nil
+	}
+
+	return 0, status.Errorf(codes.InvalidArgument, "invalid cardinality %q", pbCardinality)
 }

--- a/cmd/agent/api/pb/api.pb.go
+++ b/cmd/agent/api/pb/api.pb.go
@@ -25,6 +25,62 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
+type EventType int32
+
+const (
+	EventType_ADDED    EventType = 0
+	EventType_MODIFIED EventType = 1
+	EventType_DELETED  EventType = 2
+)
+
+var EventType_name = map[int32]string{
+	0: "ADDED",
+	1: "MODIFIED",
+	2: "DELETED",
+}
+
+var EventType_value = map[string]int32{
+	"ADDED":    0,
+	"MODIFIED": 1,
+	"DELETED":  2,
+}
+
+func (x EventType) String() string {
+	return proto.EnumName(EventType_name, int32(x))
+}
+
+func (EventType) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_00212fb1f9d3bf1c, []int{0}
+}
+
+type TagCardinality int32
+
+const (
+	TagCardinality_LOW          TagCardinality = 0
+	TagCardinality_ORCHESTRATOR TagCardinality = 1
+	TagCardinality_HIGH         TagCardinality = 2
+)
+
+var TagCardinality_name = map[int32]string{
+	0: "LOW",
+	1: "ORCHESTRATOR",
+	2: "HIGH",
+}
+
+var TagCardinality_value = map[string]int32{
+	"LOW":          0,
+	"ORCHESTRATOR": 1,
+	"HIGH":         2,
+}
+
+func (x TagCardinality) String() string {
+	return proto.EnumName(TagCardinality_name, int32(x))
+}
+
+func (TagCardinality) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_00212fb1f9d3bf1c, []int{1}
+}
+
 type HostnameRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -96,114 +152,453 @@ func (m *HostnameReply) GetHostname() string {
 	return ""
 }
 
-// The request message containing the tag list for an entity.
-type TagRequest struct {
-	Entity               string   `protobuf:"bytes,1,opt,name=entity,proto3" json:"entity,omitempty"`
+type StreamTagsRequest struct {
+	Cardinality          TagCardinality `protobuf:"varint,1,opt,name=cardinality,proto3,enum=pb.TagCardinality" json:"cardinality,omitempty"`
+	IncludeFilter        *Filter        `protobuf:"bytes,2,opt,name=includeFilter,proto3" json:"includeFilter,omitempty"`
+	ExcludeFilter        *Filter        `protobuf:"bytes,3,opt,name=excludeFilter,proto3" json:"excludeFilter,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
+	XXX_unrecognized     []byte         `json:"-"`
+	XXX_sizecache        int32          `json:"-"`
+}
+
+func (m *StreamTagsRequest) Reset()         { *m = StreamTagsRequest{} }
+func (m *StreamTagsRequest) String() string { return proto.CompactTextString(m) }
+func (*StreamTagsRequest) ProtoMessage()    {}
+func (*StreamTagsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_00212fb1f9d3bf1c, []int{2}
+}
+
+func (m *StreamTagsRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StreamTagsRequest.Unmarshal(m, b)
+}
+func (m *StreamTagsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StreamTagsRequest.Marshal(b, m, deterministic)
+}
+func (m *StreamTagsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StreamTagsRequest.Merge(m, src)
+}
+func (m *StreamTagsRequest) XXX_Size() int {
+	return xxx_messageInfo_StreamTagsRequest.Size(m)
+}
+func (m *StreamTagsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_StreamTagsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StreamTagsRequest proto.InternalMessageInfo
+
+func (m *StreamTagsRequest) GetCardinality() TagCardinality {
+	if m != nil {
+		return m.Cardinality
+	}
+	return TagCardinality_LOW
+}
+
+func (m *StreamTagsRequest) GetIncludeFilter() *Filter {
+	if m != nil {
+		return m.IncludeFilter
+	}
+	return nil
+}
+
+func (m *StreamTagsRequest) GetExcludeFilter() *Filter {
+	if m != nil {
+		return m.ExcludeFilter
+	}
+	return nil
+}
+
+type StreamTagsResponse struct {
+	Type                 EventType `protobuf:"varint,1,opt,name=type,proto3,enum=pb.EventType" json:"type,omitempty"`
+	Entity               *Entity   `protobuf:"bytes,2,opt,name=entity,proto3" json:"entity,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
+	XXX_unrecognized     []byte    `json:"-"`
+	XXX_sizecache        int32     `json:"-"`
+}
+
+func (m *StreamTagsResponse) Reset()         { *m = StreamTagsResponse{} }
+func (m *StreamTagsResponse) String() string { return proto.CompactTextString(m) }
+func (*StreamTagsResponse) ProtoMessage()    {}
+func (*StreamTagsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_00212fb1f9d3bf1c, []int{3}
+}
+
+func (m *StreamTagsResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StreamTagsResponse.Unmarshal(m, b)
+}
+func (m *StreamTagsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StreamTagsResponse.Marshal(b, m, deterministic)
+}
+func (m *StreamTagsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StreamTagsResponse.Merge(m, src)
+}
+func (m *StreamTagsResponse) XXX_Size() int {
+	return xxx_messageInfo_StreamTagsResponse.Size(m)
+}
+func (m *StreamTagsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_StreamTagsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StreamTagsResponse proto.InternalMessageInfo
+
+func (m *StreamTagsResponse) GetType() EventType {
+	if m != nil {
+		return m.Type
+	}
+	return EventType_ADDED
+}
+
+func (m *StreamTagsResponse) GetEntity() *Entity {
+	if m != nil {
+		return m.Entity
+	}
+	return nil
+}
+
+type Filter struct {
+	KubeNamespace        string   `protobuf:"bytes,1,opt,name=kubeNamespace,proto3" json:"kubeNamespace,omitempty"`
+	Image                string   `protobuf:"bytes,2,opt,name=image,proto3" json:"image,omitempty"`
+	ContainerName        string   `protobuf:"bytes,3,opt,name=containerName,proto3" json:"containerName,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *TagRequest) Reset()         { *m = TagRequest{} }
-func (m *TagRequest) String() string { return proto.CompactTextString(m) }
-func (*TagRequest) ProtoMessage()    {}
-func (*TagRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{2}
+func (m *Filter) Reset()         { *m = Filter{} }
+func (m *Filter) String() string { return proto.CompactTextString(m) }
+func (*Filter) ProtoMessage()    {}
+func (*Filter) Descriptor() ([]byte, []int) {
+	return fileDescriptor_00212fb1f9d3bf1c, []int{4}
 }
 
-func (m *TagRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_TagRequest.Unmarshal(m, b)
+func (m *Filter) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Filter.Unmarshal(m, b)
 }
-func (m *TagRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_TagRequest.Marshal(b, m, deterministic)
+func (m *Filter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Filter.Marshal(b, m, deterministic)
 }
-func (m *TagRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TagRequest.Merge(m, src)
+func (m *Filter) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Filter.Merge(m, src)
 }
-func (m *TagRequest) XXX_Size() int {
-	return xxx_messageInfo_TagRequest.Size(m)
+func (m *Filter) XXX_Size() int {
+	return xxx_messageInfo_Filter.Size(m)
 }
-func (m *TagRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_TagRequest.DiscardUnknown(m)
+func (m *Filter) XXX_DiscardUnknown() {
+	xxx_messageInfo_Filter.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_TagRequest proto.InternalMessageInfo
+var xxx_messageInfo_Filter proto.InternalMessageInfo
 
-func (m *TagRequest) GetEntity() string {
+func (m *Filter) GetKubeNamespace() string {
 	if m != nil {
-		return m.Entity
+		return m.KubeNamespace
 	}
 	return ""
 }
 
-// The response message containing the tagger reply
-type TagReply struct {
-	Tags                 []string `protobuf:"bytes,1,rep,name=tags,proto3" json:"tags,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+func (m *Filter) GetImage() string {
+	if m != nil {
+		return m.Image
+	}
+	return ""
 }
 
-func (m *TagReply) Reset()         { *m = TagReply{} }
-func (m *TagReply) String() string { return proto.CompactTextString(m) }
-func (*TagReply) ProtoMessage()    {}
-func (*TagReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{3}
+func (m *Filter) GetContainerName() string {
+	if m != nil {
+		return m.ContainerName
+	}
+	return ""
 }
 
-func (m *TagReply) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_TagReply.Unmarshal(m, b)
-}
-func (m *TagReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_TagReply.Marshal(b, m, deterministic)
-}
-func (m *TagReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TagReply.Merge(m, src)
-}
-func (m *TagReply) XXX_Size() int {
-	return xxx_messageInfo_TagReply.Size(m)
-}
-func (m *TagReply) XXX_DiscardUnknown() {
-	xxx_messageInfo_TagReply.DiscardUnknown(m)
+type Entity struct {
+	Id                          *EntityId `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Hash                        string    `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
+	HighCardinalityTags         []string  `protobuf:"bytes,3,rep,name=highCardinalityTags,proto3" json:"highCardinalityTags,omitempty"`
+	OrchestratorCardinalityTags []string  `protobuf:"bytes,4,rep,name=orchestratorCardinalityTags,proto3" json:"orchestratorCardinalityTags,omitempty"`
+	LowCardinalityTags          []string  `protobuf:"bytes,5,rep,name=lowCardinalityTags,proto3" json:"lowCardinalityTags,omitempty"`
+	StandardTags                []string  `protobuf:"bytes,6,rep,name=standardTags,proto3" json:"standardTags,omitempty"`
+	XXX_NoUnkeyedLiteral        struct{}  `json:"-"`
+	XXX_unrecognized            []byte    `json:"-"`
+	XXX_sizecache               int32     `json:"-"`
 }
 
-var xxx_messageInfo_TagReply proto.InternalMessageInfo
+func (m *Entity) Reset()         { *m = Entity{} }
+func (m *Entity) String() string { return proto.CompactTextString(m) }
+func (*Entity) ProtoMessage()    {}
+func (*Entity) Descriptor() ([]byte, []int) {
+	return fileDescriptor_00212fb1f9d3bf1c, []int{5}
+}
 
-func (m *TagReply) GetTags() []string {
+func (m *Entity) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Entity.Unmarshal(m, b)
+}
+func (m *Entity) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Entity.Marshal(b, m, deterministic)
+}
+func (m *Entity) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Entity.Merge(m, src)
+}
+func (m *Entity) XXX_Size() int {
+	return xxx_messageInfo_Entity.Size(m)
+}
+func (m *Entity) XXX_DiscardUnknown() {
+	xxx_messageInfo_Entity.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Entity proto.InternalMessageInfo
+
+func (m *Entity) GetId() *EntityId {
+	if m != nil {
+		return m.Id
+	}
+	return nil
+}
+
+func (m *Entity) GetHash() string {
+	if m != nil {
+		return m.Hash
+	}
+	return ""
+}
+
+func (m *Entity) GetHighCardinalityTags() []string {
+	if m != nil {
+		return m.HighCardinalityTags
+	}
+	return nil
+}
+
+func (m *Entity) GetOrchestratorCardinalityTags() []string {
+	if m != nil {
+		return m.OrchestratorCardinalityTags
+	}
+	return nil
+}
+
+func (m *Entity) GetLowCardinalityTags() []string {
+	if m != nil {
+		return m.LowCardinalityTags
+	}
+	return nil
+}
+
+func (m *Entity) GetStandardTags() []string {
+	if m != nil {
+		return m.StandardTags
+	}
+	return nil
+}
+
+type FetchEntityRequest struct {
+	Id                   *EntityId      `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Cardinality          TagCardinality `protobuf:"varint,2,opt,name=cardinality,proto3,enum=pb.TagCardinality" json:"cardinality,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
+	XXX_unrecognized     []byte         `json:"-"`
+	XXX_sizecache        int32          `json:"-"`
+}
+
+func (m *FetchEntityRequest) Reset()         { *m = FetchEntityRequest{} }
+func (m *FetchEntityRequest) String() string { return proto.CompactTextString(m) }
+func (*FetchEntityRequest) ProtoMessage()    {}
+func (*FetchEntityRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_00212fb1f9d3bf1c, []int{6}
+}
+
+func (m *FetchEntityRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchEntityRequest.Unmarshal(m, b)
+}
+func (m *FetchEntityRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchEntityRequest.Marshal(b, m, deterministic)
+}
+func (m *FetchEntityRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchEntityRequest.Merge(m, src)
+}
+func (m *FetchEntityRequest) XXX_Size() int {
+	return xxx_messageInfo_FetchEntityRequest.Size(m)
+}
+func (m *FetchEntityRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchEntityRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchEntityRequest proto.InternalMessageInfo
+
+func (m *FetchEntityRequest) GetId() *EntityId {
+	if m != nil {
+		return m.Id
+	}
+	return nil
+}
+
+func (m *FetchEntityRequest) GetCardinality() TagCardinality {
+	if m != nil {
+		return m.Cardinality
+	}
+	return TagCardinality_LOW
+}
+
+type FetchEntityResponse struct {
+	Id                   *EntityId      `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Cardinality          TagCardinality `protobuf:"varint,2,opt,name=cardinality,proto3,enum=pb.TagCardinality" json:"cardinality,omitempty"`
+	Tags                 []string       `protobuf:"bytes,3,rep,name=tags,proto3" json:"tags,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
+	XXX_unrecognized     []byte         `json:"-"`
+	XXX_sizecache        int32          `json:"-"`
+}
+
+func (m *FetchEntityResponse) Reset()         { *m = FetchEntityResponse{} }
+func (m *FetchEntityResponse) String() string { return proto.CompactTextString(m) }
+func (*FetchEntityResponse) ProtoMessage()    {}
+func (*FetchEntityResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_00212fb1f9d3bf1c, []int{7}
+}
+
+func (m *FetchEntityResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchEntityResponse.Unmarshal(m, b)
+}
+func (m *FetchEntityResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchEntityResponse.Marshal(b, m, deterministic)
+}
+func (m *FetchEntityResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchEntityResponse.Merge(m, src)
+}
+func (m *FetchEntityResponse) XXX_Size() int {
+	return xxx_messageInfo_FetchEntityResponse.Size(m)
+}
+func (m *FetchEntityResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchEntityResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchEntityResponse proto.InternalMessageInfo
+
+func (m *FetchEntityResponse) GetId() *EntityId {
+	if m != nil {
+		return m.Id
+	}
+	return nil
+}
+
+func (m *FetchEntityResponse) GetCardinality() TagCardinality {
+	if m != nil {
+		return m.Cardinality
+	}
+	return TagCardinality_LOW
+}
+
+func (m *FetchEntityResponse) GetTags() []string {
 	if m != nil {
 		return m.Tags
 	}
 	return nil
 }
 
+type EntityId struct {
+	Prefix               string   `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	Uid                  string   `protobuf:"bytes,2,opt,name=uid,proto3" json:"uid,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *EntityId) Reset()         { *m = EntityId{} }
+func (m *EntityId) String() string { return proto.CompactTextString(m) }
+func (*EntityId) ProtoMessage()    {}
+func (*EntityId) Descriptor() ([]byte, []int) {
+	return fileDescriptor_00212fb1f9d3bf1c, []int{8}
+}
+
+func (m *EntityId) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_EntityId.Unmarshal(m, b)
+}
+func (m *EntityId) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_EntityId.Marshal(b, m, deterministic)
+}
+func (m *EntityId) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EntityId.Merge(m, src)
+}
+func (m *EntityId) XXX_Size() int {
+	return xxx_messageInfo_EntityId.Size(m)
+}
+func (m *EntityId) XXX_DiscardUnknown() {
+	xxx_messageInfo_EntityId.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_EntityId proto.InternalMessageInfo
+
+func (m *EntityId) GetPrefix() string {
+	if m != nil {
+		return m.Prefix
+	}
+	return ""
+}
+
+func (m *EntityId) GetUid() string {
+	if m != nil {
+		return m.Uid
+	}
+	return ""
+}
+
 func init() {
+	proto.RegisterEnum("pb.EventType", EventType_name, EventType_value)
+	proto.RegisterEnum("pb.TagCardinality", TagCardinality_name, TagCardinality_value)
 	proto.RegisterType((*HostnameRequest)(nil), "pb.HostnameRequest")
 	proto.RegisterType((*HostnameReply)(nil), "pb.HostnameReply")
-	proto.RegisterType((*TagRequest)(nil), "pb.TagRequest")
-	proto.RegisterType((*TagReply)(nil), "pb.TagReply")
+	proto.RegisterType((*StreamTagsRequest)(nil), "pb.StreamTagsRequest")
+	proto.RegisterType((*StreamTagsResponse)(nil), "pb.StreamTagsResponse")
+	proto.RegisterType((*Filter)(nil), "pb.Filter")
+	proto.RegisterType((*Entity)(nil), "pb.Entity")
+	proto.RegisterType((*FetchEntityRequest)(nil), "pb.FetchEntityRequest")
+	proto.RegisterType((*FetchEntityResponse)(nil), "pb.FetchEntityResponse")
+	proto.RegisterType((*EntityId)(nil), "pb.EntityId")
 }
 
 func init() { proto.RegisterFile("api.proto", fileDescriptor_00212fb1f9d3bf1c) }
 
 var fileDescriptor_00212fb1f9d3bf1c = []byte{
-	// 262 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x5c, 0x90, 0x41, 0x4a, 0xc3, 0x40,
-	0x14, 0x86, 0x49, 0xd5, 0xda, 0xbc, 0x5a, 0x4b, 0x9f, 0x28, 0x21, 0x88, 0x94, 0xc1, 0x45, 0x51,
-	0x48, 0xb0, 0xee, 0xdc, 0x75, 0x55, 0x17, 0x2e, 0x24, 0xd6, 0x03, 0x4c, 0xca, 0x63, 0x0c, 0xc4,
-	0x99, 0x31, 0x79, 0x15, 0xb2, 0xf5, 0x0a, 0x1e, 0xcd, 0x2b, 0x78, 0x10, 0x99, 0x31, 0x36, 0xd8,
-	0xdd, 0xfc, 0x3f, 0xff, 0x7c, 0xf3, 0x31, 0x10, 0x4a, 0x5b, 0x24, 0xb6, 0x32, 0x6c, 0xb0, 0x67,
-	0xf3, 0xf8, 0x5c, 0x19, 0xa3, 0x4a, 0x4a, 0xa5, 0x2d, 0x52, 0xa9, 0xb5, 0x61, 0xc9, 0x85, 0xd1,
-	0xf5, 0xef, 0x42, 0x4c, 0x60, 0x7c, 0x6f, 0x6a, 0xd6, 0xf2, 0x95, 0x32, 0x7a, 0xdb, 0x50, 0xcd,
-	0xe2, 0x1a, 0x46, 0x5d, 0x65, 0xcb, 0x06, 0x63, 0x18, 0xbc, 0xb4, 0x45, 0x14, 0x4c, 0x83, 0x59,
-	0x98, 0x6d, 0xb3, 0xb8, 0x04, 0x58, 0x49, 0xd5, 0x5e, 0xc5, 0x33, 0xe8, 0x93, 0xe6, 0x82, 0x9b,
-	0x76, 0xd7, 0x26, 0x71, 0x01, 0x03, 0xbf, 0x72, 0x34, 0x84, 0x7d, 0x96, 0xaa, 0x8e, 0x82, 0xe9,
-	0xde, 0x2c, 0xcc, 0xfc, 0x79, 0xfe, 0x0c, 0x07, 0x0b, 0x45, 0x9a, 0xf1, 0x01, 0x86, 0x4b, 0xe2,
-	0xbf, 0xe7, 0xf1, 0x24, 0xb1, 0x79, 0xb2, 0xe3, 0x17, 0x4f, 0xfe, 0x97, 0xb6, 0x6c, 0xc4, 0xe9,
-	0xc7, 0xd7, 0xf7, 0x67, 0x6f, 0x8c, 0xa3, 0xf4, 0xfd, 0x26, 0x55, 0x95, 0x5d, 0xa7, 0x4e, 0x70,
-	0xfe, 0x08, 0x43, 0x8f, 0x7d, 0xa2, 0xf5, 0xa6, 0x22, 0x5c, 0xc0, 0xe1, 0x92, 0x78, 0x25, 0x55,
-	0x8d, 0xc7, 0x8e, 0xd1, 0x89, 0xc7, 0x47, 0xdb, 0xec, 0x70, 0x91, 0xc7, 0xa1, 0xe8, 0x70, 0xce,
-	0xf2, 0x2e, 0xb8, 0xca, 0xfb, 0xfe, 0xd7, 0x6e, 0x7f, 0x02, 0x00, 0x00, 0xff, 0xff, 0x95, 0x07,
-	0x12, 0xc5, 0x64, 0x01, 0x00, 0x00,
+	// 699 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x54, 0xcd, 0x4e, 0xdb, 0x4a,
+	0x14, 0xc6, 0xce, 0x0f, 0xc9, 0x49, 0x02, 0xce, 0xe1, 0xe7, 0xa2, 0x5c, 0xa4, 0x0b, 0x23, 0xa4,
+	0x8b, 0x72, 0xa5, 0x04, 0x72, 0xe9, 0x86, 0x55, 0x11, 0x31, 0x24, 0x12, 0x6d, 0x24, 0x93, 0xaa,
+	0x8b, 0x2e, 0xaa, 0x89, 0x3d, 0xd8, 0xd3, 0x3a, 0xb6, 0x6b, 0x4f, 0x28, 0x59, 0x74, 0xc3, 0x2b,
+	0xf4, 0x39, 0xfa, 0x34, 0x7d, 0x85, 0xbe, 0x40, 0xdf, 0xa0, 0xf2, 0xd8, 0x90, 0x38, 0x41, 0xa8,
+	0x9b, 0xee, 0x3c, 0xdf, 0xf9, 0xbe, 0xf3, 0x9d, 0x99, 0x73, 0x7c, 0xa0, 0x4c, 0x03, 0xde, 0x0a,
+	0x42, 0x5f, 0xf8, 0xa8, 0x06, 0xa3, 0xc6, 0xae, 0xed, 0xfb, 0xb6, 0xcb, 0xda, 0x34, 0xe0, 0x6d,
+	0xea, 0x79, 0xbe, 0xa0, 0x82, 0xfb, 0x5e, 0x94, 0x30, 0x48, 0x1d, 0xd6, 0x7b, 0x7e, 0x24, 0x3c,
+	0x3a, 0x66, 0x06, 0xfb, 0x34, 0x61, 0x91, 0x20, 0xff, 0x41, 0x6d, 0x06, 0x05, 0xee, 0x14, 0x1b,
+	0x50, 0x72, 0x52, 0x60, 0x47, 0xd9, 0x53, 0x0e, 0xcb, 0xc6, 0xe3, 0x99, 0x7c, 0x53, 0xa0, 0x7e,
+	0x2d, 0x42, 0x46, 0xc7, 0x43, 0x6a, 0x47, 0x69, 0x0a, 0x3c, 0x81, 0x8a, 0x49, 0x43, 0x8b, 0x7b,
+	0xd4, 0xe5, 0x62, 0x2a, 0x45, 0x6b, 0x1d, 0x6c, 0x05, 0xa3, 0xd6, 0x90, 0xda, 0xe7, 0xb3, 0x88,
+	0x31, 0x4f, 0xc3, 0x23, 0xa8, 0x71, 0xcf, 0x74, 0x27, 0x16, 0xbb, 0xe0, 0xae, 0x60, 0xe1, 0x8e,
+	0xba, 0xa7, 0x1c, 0x56, 0x3a, 0x10, 0xeb, 0x12, 0xc4, 0xc8, 0x12, 0x62, 0x05, 0xbb, 0x9b, 0x57,
+	0xe4, 0x96, 0x15, 0x19, 0x02, 0x79, 0x07, 0x38, 0x5f, 0x6e, 0x14, 0xf8, 0x5e, 0xc4, 0x70, 0x1f,
+	0xf2, 0x62, 0x1a, 0xb0, 0xb4, 0xd0, 0x5a, 0x2c, 0xd7, 0x6f, 0x99, 0x27, 0x86, 0xd3, 0x80, 0x19,
+	0x32, 0x84, 0x04, 0x8a, 0xcc, 0x13, 0xf1, 0x6d, 0xe6, 0xaa, 0xd2, 0x25, 0x62, 0xa4, 0x11, 0xf2,
+	0x01, 0x8a, 0x69, 0x61, 0x07, 0x50, 0xfb, 0x38, 0x19, 0xb1, 0xd7, 0x74, 0xcc, 0xa2, 0x80, 0x9a,
+	0x0f, 0xef, 0x96, 0x05, 0x71, 0x13, 0x0a, 0x7c, 0x4c, 0x6d, 0x26, 0x53, 0x96, 0x8d, 0xe4, 0x10,
+	0x6b, 0x4d, 0xdf, 0x13, 0x94, 0x7b, 0x2c, 0x8c, 0xb9, 0xf2, 0x52, 0x65, 0x23, 0x0b, 0x92, 0x7b,
+	0x15, 0x8a, 0x89, 0x3d, 0xee, 0x82, 0xca, 0x2d, 0xe9, 0x50, 0xe9, 0x54, 0x67, 0x65, 0xf5, 0x2d,
+	0x43, 0xe5, 0x16, 0x22, 0xe4, 0x1d, 0x1a, 0x39, 0xa9, 0x87, 0xfc, 0xc6, 0x23, 0xd8, 0x70, 0xb8,
+	0xed, 0xcc, 0x75, 0x22, 0x7e, 0x8e, 0x9d, 0xdc, 0x5e, 0xee, 0xb0, 0x6c, 0x3c, 0x15, 0xc2, 0x97,
+	0xf0, 0xb7, 0x1f, 0x9a, 0x0e, 0x8b, 0x44, 0x48, 0x85, 0x1f, 0x2e, 0x2a, 0xf3, 0x52, 0xf9, 0x1c,
+	0x05, 0x5b, 0x80, 0xae, 0xff, 0x79, 0x51, 0x58, 0x90, 0xc2, 0x27, 0x22, 0x48, 0xa0, 0x1a, 0x09,
+	0xea, 0x59, 0x34, 0xb4, 0x24, 0xb3, 0x28, 0x99, 0x19, 0x8c, 0x38, 0x80, 0x17, 0x4c, 0x98, 0x4e,
+	0xda, 0x87, 0x74, 0xfa, 0x9e, 0x7f, 0x8f, 0x85, 0xd9, 0x54, 0x7f, 0x6b, 0x36, 0xc9, 0x17, 0xd8,
+	0xc8, 0x38, 0xa5, 0x83, 0xf3, 0x07, 0xac, 0xe2, 0x86, 0x89, 0x59, 0x37, 0xe4, 0x37, 0x39, 0x81,
+	0xd2, 0x43, 0x66, 0xdc, 0x86, 0x62, 0x10, 0xb2, 0x1b, 0x7e, 0x97, 0x0e, 0x55, 0x7a, 0x42, 0x0d,
+	0x72, 0x13, 0x6e, 0xa5, 0x7d, 0x8e, 0x3f, 0x9b, 0xc7, 0x50, 0x7e, 0x1c, 0x63, 0x2c, 0x43, 0xe1,
+	0xac, 0xdb, 0xd5, 0xbb, 0xda, 0x0a, 0x56, 0xa1, 0xf4, 0x6a, 0xd0, 0xed, 0x5f, 0xf4, 0xf5, 0xae,
+	0xa6, 0x60, 0x05, 0x56, 0xbb, 0xfa, 0x95, 0x3e, 0xd4, 0xbb, 0x9a, 0xda, 0x7c, 0x01, 0x6b, 0xd9,
+	0xda, 0x70, 0x15, 0x72, 0x57, 0x83, 0xb7, 0xda, 0x0a, 0x6a, 0x50, 0x1d, 0x18, 0xe7, 0x3d, 0xfd,
+	0x7a, 0x68, 0x9c, 0x0d, 0x07, 0x86, 0xa6, 0x60, 0x09, 0xf2, 0xbd, 0xfe, 0x65, 0x4f, 0x53, 0x3b,
+	0x6f, 0xa0, 0x70, 0x66, 0x33, 0x4f, 0xe0, 0x15, 0x54, 0x2e, 0x99, 0x78, 0xd8, 0x1f, 0xb8, 0x11,
+	0x5f, 0x76, 0x61, 0xc1, 0x34, 0xea, 0x59, 0x30, 0x70, 0xa7, 0x64, 0xeb, 0xfe, 0xfb, 0x8f, 0xaf,
+	0xea, 0x3a, 0xd6, 0xda, 0xb7, 0xc7, 0x6d, 0x3b, 0x0c, 0xcc, 0x76, 0xbc, 0x61, 0x3a, 0x3f, 0x15,
+	0xa8, 0xc8, 0xbc, 0xd7, 0xcc, 0x9c, 0x84, 0x0c, 0x23, 0xd8, 0x1c, 0x52, 0xdb, 0x66, 0x61, 0xf2,
+	0x0f, 0xcb, 0x27, 0xe1, 0x2c, 0xc2, 0xad, 0x38, 0xe3, 0xd2, 0x1a, 0x6a, 0x6c, 0x2f, 0xc2, 0x49,
+	0xd7, 0x48, 0x53, 0xba, 0x1d, 0x90, 0x7f, 0x1e, 0xdd, 0x84, 0xcc, 0xda, 0x8e, 0x24, 0xf7, 0x3d,
+	0x4b, 0xf3, 0x9e, 0x2a, 0xcd, 0x23, 0x05, 0xc7, 0x50, 0x4f, 0x4c, 0xe7, 0x06, 0x00, 0x65, 0xea,
+	0xe5, 0xd9, 0x6b, 0xfc, 0xb5, 0x84, 0xa7, 0x9e, 0xff, 0x4a, 0xcf, 0x7d, 0xb2, 0xbb, 0xe8, 0x79,
+	0x13, 0x93, 0x13, 0xcb, 0xe9, 0xa9, 0xd2, 0x1c, 0x15, 0xe5, 0x62, 0xfe, 0xff, 0x57, 0x00, 0x00,
+	0x00, 0xff, 0xff, 0xb4, 0x39, 0x18, 0xbb, 0xc7, 0x05, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -292,7 +687,8 @@ var _Agent_serviceDesc = grpc.ServiceDesc{
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type AgentSecureClient interface {
-	GetTags(ctx context.Context, in *TagRequest, opts ...grpc.CallOption) (*TagReply, error)
+	TaggerStreamEntities(ctx context.Context, in *StreamTagsRequest, opts ...grpc.CallOption) (AgentSecure_TaggerStreamEntitiesClient, error)
+	TaggerFetchEntity(ctx context.Context, in *FetchEntityRequest, opts ...grpc.CallOption) (*FetchEntityResponse, error)
 }
 
 type agentSecureClient struct {
@@ -303,9 +699,41 @@ func NewAgentSecureClient(cc *grpc.ClientConn) AgentSecureClient {
 	return &agentSecureClient{cc}
 }
 
-func (c *agentSecureClient) GetTags(ctx context.Context, in *TagRequest, opts ...grpc.CallOption) (*TagReply, error) {
-	out := new(TagReply)
-	err := c.cc.Invoke(ctx, "/pb.AgentSecure/GetTags", in, out, opts...)
+func (c *agentSecureClient) TaggerStreamEntities(ctx context.Context, in *StreamTagsRequest, opts ...grpc.CallOption) (AgentSecure_TaggerStreamEntitiesClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_AgentSecure_serviceDesc.Streams[0], "/pb.AgentSecure/TaggerStreamEntities", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &agentSecureTaggerStreamEntitiesClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type AgentSecure_TaggerStreamEntitiesClient interface {
+	Recv() (*StreamTagsResponse, error)
+	grpc.ClientStream
+}
+
+type agentSecureTaggerStreamEntitiesClient struct {
+	grpc.ClientStream
+}
+
+func (x *agentSecureTaggerStreamEntitiesClient) Recv() (*StreamTagsResponse, error) {
+	m := new(StreamTagsResponse)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (c *agentSecureClient) TaggerFetchEntity(ctx context.Context, in *FetchEntityRequest, opts ...grpc.CallOption) (*FetchEntityResponse, error) {
+	out := new(FetchEntityResponse)
+	err := c.cc.Invoke(ctx, "/pb.AgentSecure/TaggerFetchEntity", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -314,35 +742,60 @@ func (c *agentSecureClient) GetTags(ctx context.Context, in *TagRequest, opts ..
 
 // AgentSecureServer is the server API for AgentSecure service.
 type AgentSecureServer interface {
-	GetTags(context.Context, *TagRequest) (*TagReply, error)
+	TaggerStreamEntities(*StreamTagsRequest, AgentSecure_TaggerStreamEntitiesServer) error
+	TaggerFetchEntity(context.Context, *FetchEntityRequest) (*FetchEntityResponse, error)
 }
 
 // UnimplementedAgentSecureServer can be embedded to have forward compatible implementations.
 type UnimplementedAgentSecureServer struct {
 }
 
-func (*UnimplementedAgentSecureServer) GetTags(ctx context.Context, req *TagRequest) (*TagReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetTags not implemented")
+func (*UnimplementedAgentSecureServer) TaggerStreamEntities(req *StreamTagsRequest, srv AgentSecure_TaggerStreamEntitiesServer) error {
+	return status.Errorf(codes.Unimplemented, "method TaggerStreamEntities not implemented")
+}
+func (*UnimplementedAgentSecureServer) TaggerFetchEntity(ctx context.Context, req *FetchEntityRequest) (*FetchEntityResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method TaggerFetchEntity not implemented")
 }
 
 func RegisterAgentSecureServer(s *grpc.Server, srv AgentSecureServer) {
 	s.RegisterService(&_AgentSecure_serviceDesc, srv)
 }
 
-func _AgentSecure_GetTags_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(TagRequest)
+func _AgentSecure_TaggerStreamEntities_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(StreamTagsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(AgentSecureServer).TaggerStreamEntities(m, &agentSecureTaggerStreamEntitiesServer{stream})
+}
+
+type AgentSecure_TaggerStreamEntitiesServer interface {
+	Send(*StreamTagsResponse) error
+	grpc.ServerStream
+}
+
+type agentSecureTaggerStreamEntitiesServer struct {
+	grpc.ServerStream
+}
+
+func (x *agentSecureTaggerStreamEntitiesServer) Send(m *StreamTagsResponse) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func _AgentSecure_TaggerFetchEntity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(FetchEntityRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(AgentSecureServer).GetTags(ctx, in)
+		return srv.(AgentSecureServer).TaggerFetchEntity(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/pb.AgentSecure/GetTags",
+		FullMethod: "/pb.AgentSecure/TaggerFetchEntity",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AgentSecureServer).GetTags(ctx, req.(*TagRequest))
+		return srv.(AgentSecureServer).TaggerFetchEntity(ctx, req.(*FetchEntityRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -352,10 +805,16 @@ var _AgentSecure_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*AgentSecureServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "GetTags",
-			Handler:    _AgentSecure_GetTags_Handler,
+			MethodName: "TaggerFetchEntity",
+			Handler:    _AgentSecure_TaggerFetchEntity_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "TaggerStreamEntities",
+			Handler:       _AgentSecure_TaggerStreamEntities_Handler,
+			ServerStreams: true,
+		},
+	},
 	Metadata: "api.proto",
 }

--- a/cmd/agent/api/pb/api.pb.gw.go
+++ b/cmd/agent/api/pb/api.pb.gw.go
@@ -49,8 +49,8 @@ func local_request_Agent_GetHostname_0(ctx context.Context, marshaler runtime.Ma
 
 }
 
-func request_AgentSecure_GetTags_0(ctx context.Context, marshaler runtime.Marshaler, client AgentSecureClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq TagRequest
+func request_AgentSecure_TaggerStreamEntities_0(ctx context.Context, marshaler runtime.Marshaler, client AgentSecureClient, req *http.Request, pathParams map[string]string) (AgentSecure_TaggerStreamEntitiesClient, runtime.ServerMetadata, error) {
+	var protoReq StreamTagsRequest
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -61,13 +61,38 @@ func request_AgentSecure_GetTags_0(ctx context.Context, marshaler runtime.Marsha
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	msg, err := client.GetTags(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	stream, err := client.TaggerStreamEntities(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
+}
+
+func request_AgentSecure_TaggerFetchEntity_0(ctx context.Context, marshaler runtime.Marshaler, client AgentSecureClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq FetchEntityRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.TaggerFetchEntity(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
 }
 
-func local_request_AgentSecure_GetTags_0(ctx context.Context, marshaler runtime.Marshaler, server AgentSecureServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq TagRequest
+func local_request_AgentSecure_TaggerFetchEntity_0(ctx context.Context, marshaler runtime.Marshaler, server AgentSecureServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq FetchEntityRequest
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -78,7 +103,7 @@ func local_request_AgentSecure_GetTags_0(ctx context.Context, marshaler runtime.
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	msg, err := server.GetTags(ctx, &protoReq)
+	msg, err := server.TaggerFetchEntity(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -116,7 +141,14 @@ func RegisterAgentHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
 func RegisterAgentSecureHandlerServer(ctx context.Context, mux *runtime.ServeMux, server AgentSecureServer) error {
 
-	mux.Handle("POST", pattern_AgentSecure_GetTags_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("POST", pattern_AgentSecure_TaggerStreamEntities_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
+		_, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+		return
+	})
+
+	mux.Handle("POST", pattern_AgentSecure_TaggerFetchEntity_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
@@ -125,14 +157,14 @@ func RegisterAgentSecureHandlerServer(ctx context.Context, mux *runtime.ServeMux
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_AgentSecure_GetTags_0(rctx, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_AgentSecure_TaggerFetchEntity_0(rctx, inboundMarshaler, server, req, pathParams)
 		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
 
-		forward_AgentSecure_GetTags_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_AgentSecure_TaggerFetchEntity_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -246,7 +278,7 @@ func RegisterAgentSecureHandler(ctx context.Context, mux *runtime.ServeMux, conn
 // "AgentSecureClient" to call the correct interceptors.
 func RegisterAgentSecureHandlerClient(ctx context.Context, mux *runtime.ServeMux, client AgentSecureClient) error {
 
-	mux.Handle("POST", pattern_AgentSecure_GetTags_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("POST", pattern_AgentSecure_TaggerStreamEntities_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
@@ -255,14 +287,34 @@ func RegisterAgentSecureHandlerClient(ctx context.Context, mux *runtime.ServeMux
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_AgentSecure_GetTags_0(rctx, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_AgentSecure_TaggerStreamEntities_0(rctx, inboundMarshaler, client, req, pathParams)
 		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
 
-		forward_AgentSecure_GetTags_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_AgentSecure_TaggerStreamEntities_0(ctx, mux, outboundMarshaler, w, req, func() (proto.Message, error) { return resp.Recv() }, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_AgentSecure_TaggerFetchEntity_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AgentSecure_TaggerFetchEntity_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_AgentSecure_TaggerFetchEntity_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -270,9 +322,13 @@ func RegisterAgentSecureHandlerClient(ctx context.Context, mux *runtime.ServeMux
 }
 
 var (
-	pattern_AgentSecure_GetTags_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "grpc", "tags"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_AgentSecure_TaggerStreamEntities_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "grpc", "tagger", "stream_entities"}, "", runtime.AssumeColonVerbOpt(true)))
+
+	pattern_AgentSecure_TaggerFetchEntity_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "grpc", "tagger", "fetch_entity"}, "", runtime.AssumeColonVerbOpt(true)))
 )
 
 var (
-	forward_AgentSecure_GetTags_0 = runtime.ForwardResponseMessage
+	forward_AgentSecure_TaggerStreamEntities_0 = runtime.ForwardResponseStream
+
+	forward_AgentSecure_TaggerFetchEntity_0 = runtime.ForwardResponseMessage
 )

--- a/cmd/agent/api/pb/api.proto
+++ b/cmd/agent/api/pb/api.proto
@@ -15,12 +15,57 @@ service Agent {
 }
 
 service AgentSecure {
-    rpc GetTags (TagRequest) returns (TagReply) {
+    // subscribes to added, removed, or changed entities in the Tagger
+    // and streams them to clients as events.
+    // can be called through the HTTP gateway, and events will be streamed as JSON:
+    //   $  curl -H "authorization: Bearer $(cat /etc/datadog-agent/auth_token)" \
+    //      -XPOST -k https://localhost:5001/v1/grpc/tagger/stream_entities
+    //   {
+    //    "result": {
+    //        "entity": {
+    //            "id": {
+    //                "prefix": "kubernetes_pod_uid",
+    //                "uid": "4025461f832caf3fceb7fc2a32f879c6"
+    //            },
+    //            "hash": "cad4fc8fc409fcc1",
+    //            "lowCardinalityTags": [
+    //                "kube_namespace:kube-system",
+    //                "pod_phase:running"
+    //            ]
+    //        }
+    //    }
+    //}
+    rpc TaggerStreamEntities(StreamTagsRequest) returns (stream StreamTagsResponse) {
         option (google.api.http) = {
-            post: "/v1/grpc/tags"
+            post: "/v1/grpc/tagger/stream_entities"
             body: "*"
         };
-    }
+    };
+
+    // fetches an entity from the Tagger with the desired cardinality tags.
+    // can be called through the HTTP gateway, and entity will be returned as JSON:
+    //   $ curl -H "authorization: Bearer $(cat /etc/datadog-agent/auth_token)" \
+    //      -XPOST -k -H "Content-Type: application/json" \
+    //      --data '{"id":{"prefix":"kubernetes_pod_uid","uid":"d575fb58-82dc-418e-bfb1-aececc9bc507"}}' \
+    //      https://localhost:5001/v1/grpc/tagger/fetch_entity 
+    //   {
+    //    "id": {
+    //        "prefix": "kubernetes_pod_uid",
+    //        "uid": "d575fb58-82dc-418e-bfb1-aececc9bc507"
+    //    },
+    //    "tags": [
+    //        "kube_namespace:kube-system",
+    //        "pod_phase:running",
+    //        "kube_deployment:coredns",
+    //        "kube_service:kube-dns"
+    //    ]
+    //}
+    rpc TaggerFetchEntity(FetchEntityRequest) returns (FetchEntityResponse) {
+        option (google.api.http) = {
+            post: "/v1/grpc/tagger/fetch_entity"
+            body: "*"
+        };
+    };
 }
 
 message HostnameRequest {}
@@ -30,12 +75,56 @@ message HostnameReply {
     string hostname = 1;
 }
 
-// The request message containing the tag list for an entity.
-message TagRequest {
-    string entity = 1;
+message StreamTagsRequest {
+    TagCardinality cardinality = 1;
+    Filter includeFilter = 2;
+    Filter excludeFilter = 3;
 }
 
-// The response message containing the tagger reply
-message TagReply {
-    repeated string tags = 1;
+message StreamTagsResponse {
+    EventType type = 1;
+    Entity entity = 2;
+}
+
+enum EventType {
+    ADDED = 0;
+    MODIFIED = 1;
+    DELETED = 2;
+}
+
+enum TagCardinality {
+    LOW = 0;
+    ORCHESTRATOR = 1;
+    HIGH = 2;
+}
+
+message Filter {
+    string kubeNamespace = 1;
+    string image = 2;
+    string containerName = 3;
+}
+
+message Entity {
+    EntityId id = 1;
+    string hash = 2;
+    repeated string highCardinalityTags = 3;
+    repeated string orchestratorCardinalityTags = 4;
+    repeated string lowCardinalityTags = 5;
+    repeated string standardTags = 6;
+}
+
+message FetchEntityRequest {
+    EntityId id = 1;
+    TagCardinality cardinality = 2;
+}
+
+message FetchEntityResponse {
+    EntityId id = 1;
+    TagCardinality cardinality = 2;
+    repeated string tags = 3;
+}
+
+message EntityId {
+    string prefix = 1;
+    string uid = 2;
 }

--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -30,6 +30,7 @@ import (
 	pb "github.com/DataDog/datadog-agent/cmd/agent/api/pb"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
 	gorilla "github.com/gorilla/mux"
 )
 
@@ -80,7 +81,9 @@ func StartServer() error {
 
 	s := grpc.NewServer(opts...)
 	pb.RegisterAgentServer(s, &server{})
-	pb.RegisterAgentSecureServer(s, &serverSecure{})
+	pb.RegisterAgentSecureServer(s, &serverSecure{
+		tagger: tagger.GetDefaultTagger(),
+	})
 
 	dcreds := credentials.NewTLS(&tls.Config{
 		ServerName: tlsAddr,

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -95,6 +95,11 @@ func GetEntityHash(entity string) string {
 	return defaultTagger.GetEntityHash(entity)
 }
 
+// GetDefaultTagger returns the global Tagger instance
+func GetDefaultTagger() *Tagger {
+	return defaultTagger
+}
+
 func init() {
 	defaultTagger = newTagger()
 }

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -109,9 +109,7 @@ func (t *Tagger) run() error {
 			return nil
 		case <-t.health.C:
 		case msg := <-t.infoIn:
-			for _, info := range msg {
-				t.tagStore.processTagInfo(info) //nolint:errcheck
-			}
+			t.tagStore.processTagInfo(msg)
 		case <-t.retryTicker.C:
 			go t.startCollectors()
 		case <-t.pullTicker.C:
@@ -270,13 +268,15 @@ IterCollectors:
 			tagArrays = append(tagArrays, high)
 		}
 		// Submit to cache for next lookup
-		t.tagStore.processTagInfo(&collectors.TagInfo{ //nolint:errcheck
-			Entity:               entity,
-			Source:               name,
-			LowCardTags:          low,
-			OrchestratorCardTags: orch,
-			HighCardTags:         high,
-			CacheMiss:            cacheMiss,
+		t.tagStore.processTagInfo([]*collectors.TagInfo{
+			{
+				Entity:               entity,
+				Source:               name,
+				LowCardTags:          low,
+				OrchestratorCardTags: orch,
+				HighCardTags:         high,
+				CacheMiss:            cacheMiss,
+			},
 		})
 	}
 	t.RUnlock()
@@ -307,8 +307,8 @@ func (t *Tagger) List(cardinality collectors.TagCardinality) response.TaggerList
 		Entities: make(map[string]response.TaggerListEntity),
 	}
 
-	t.tagStore.storeMutex.RLock()
-	defer t.tagStore.storeMutex.RUnlock()
+	t.tagStore.RLock()
+	defer t.tagStore.RUnlock()
 	for entityID, et := range t.tagStore.store {
 		entity := response.TaggerListEntity{}
 		tags, sources, _ := et.get(cardinality)
@@ -318,6 +318,18 @@ func (t *Tagger) List(cardinality collectors.TagCardinality) response.TaggerList
 	}
 
 	return r
+}
+
+// Subscribe returns a list of existing entities in the store, alongside a
+// channel that receives events whenever an entity is added, modified or
+// deleted.
+func (t *Tagger) Subscribe(cardinality collectors.TagCardinality) chan []EntityEvent {
+	return t.tagStore.subscribe(cardinality)
+}
+
+// Unsubscribe ends a subscription to entity events and closes its channel.
+func (t *Tagger) Unsubscribe(ch chan []EntityEvent) {
+	t.tagStore.unsubscribe(ch)
 }
 
 // copyArray makes sure the tagger does not return internal slices

--- a/pkg/tagger/tagger_test.go
+++ b/pkg/tagger/tagger_test.go
@@ -127,16 +127,18 @@ func TestFetchAllCached(t *testing.T) {
 	tagger.Init(catalog)
 	defer tagger.Stop()
 
-	tagger.tagStore.processTagInfo(&collectors.TagInfo{
-		Entity:       "entity_name",
-		Source:       "stream",
-		LowCardTags:  []string{"low1"},
-		HighCardTags: []string{"high"},
-	})
-	tagger.tagStore.processTagInfo(&collectors.TagInfo{
-		Entity:      "entity_name",
-		Source:      "pull",
-		LowCardTags: []string{"low2"},
+	tagger.tagStore.processTagInfo([]*collectors.TagInfo{
+		{
+			Entity:       "entity_name",
+			Source:       "stream",
+			LowCardTags:  []string{"low1"},
+			HighCardTags: []string{"high"},
+		},
+		{
+			Entity:      "entity_name",
+			Source:      "pull",
+			LowCardTags: []string{"low2"},
+		},
 	})
 
 	streamer := tagger.streamers["stream"].(*DummyCollector)
@@ -172,10 +174,12 @@ func TestFetchOneCached(t *testing.T) {
 	tagger.Init(catalog)
 	defer tagger.Stop()
 
-	tagger.tagStore.processTagInfo(&collectors.TagInfo{
-		Entity:      "entity_name",
-		Source:      "stream",
-		LowCardTags: []string{"low1"},
+	tagger.tagStore.processTagInfo([]*collectors.TagInfo{
+		{
+			Entity:      "entity_name",
+			Source:      "stream",
+			LowCardTags: []string{"low1"},
+		},
 	})
 
 	streamer := tagger.streamers["stream"].(*DummyCollector)
@@ -207,10 +211,12 @@ func TestEmptyEntity(t *testing.T) {
 	tagger.Init(catalog)
 	defer tagger.Stop()
 
-	tagger.tagStore.processTagInfo(&collectors.TagInfo{
-		Entity:      "entity_name",
-		Source:      "stream",
-		LowCardTags: []string{"low1"},
+	tagger.tagStore.processTagInfo([]*collectors.TagInfo{
+		{
+			Entity:      "entity_name",
+			Source:      "stream",
+			LowCardTags: []string{"low1"},
+		},
 	})
 
 	tags, err := tagger.Tag("", collectors.HighCardinality)
@@ -297,10 +303,12 @@ func TestSafeCache(t *testing.T) {
 	tagger.Init(catalog)
 	defer tagger.Stop()
 
-	tagger.tagStore.processTagInfo(&collectors.TagInfo{
-		Entity:      "entity_name",
-		Source:      "pull",
-		LowCardTags: []string{"low1", "low2", "low3"},
+	tagger.tagStore.processTagInfo([]*collectors.TagInfo{
+		{
+			Entity:      "entity_name",
+			Source:      "pull",
+			LowCardTags: []string{"low1", "low2", "low3"},
+		},
 	})
 
 	// First lookup

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // entityTags holds the tag information for a given entity
 type entityTags struct {
 	sync.RWMutex
+	entityID           string
 	sourceTags         map[string]sourceTags
 	cacheValid         bool
 	cachedSource       []string
@@ -26,8 +26,9 @@ type entityTags struct {
 	toDelete           map[string]struct{}
 }
 
-func newEntityTags() *entityTags {
+func newEntityTags(entityID string) *entityTags {
 	return &entityTags{
+		entityID:   entityID,
 		sourceTags: make(map[string]sourceTags),
 		toDelete:   make(map[string]struct{}),
 	}
@@ -42,70 +43,100 @@ type sourceTags struct {
 	standardTags         []string
 }
 
+type entityEvent struct {
+	eventType  EventType
+	storedTags *entityTags
+}
+
 // tagStore stores entity tags in memory and handles search and collation.
 // Queries should go through the Tagger for cache-miss handling
 type tagStore struct {
-	storeMutex    sync.RWMutex
-	store         map[string]*entityTags
-	toDeleteMutex sync.RWMutex
-	toDelete      map[string]struct{} // set emulation
+	sync.RWMutex
+
+	store    map[string]*entityTags
+	toDelete map[string]struct{} // set emulation
+
+	subscribersMutex sync.RWMutex
+	subscribers      map[chan []EntityEvent]collectors.TagCardinality
 }
 
 func newTagStore() *tagStore {
 	return &tagStore{
-		store:    make(map[string]*entityTags),
-		toDelete: make(map[string]struct{}),
+		store:       make(map[string]*entityTags),
+		toDelete:    make(map[string]struct{}),
+		subscribers: make(map[chan []EntityEvent]collectors.TagCardinality),
 	}
 }
 
-func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
-	if info == nil {
-		return fmt.Errorf("skipping nil message")
-	}
-	if info.Entity == "" {
-		return fmt.Errorf("empty entity name, skipping message")
-	}
-	if info.Source == "" {
-		return fmt.Errorf("empty source name, skipping message")
-	}
+func (s *tagStore) processTagInfo(xyz []*collectors.TagInfo) {
+	events := []entityEvent{}
 
-	s.storeMutex.Lock()
-	defer s.storeMutex.Unlock()
-	storedTags, exist := s.store[info.Entity]
+	s.Lock()
+	defer s.Unlock()
 
-	if info.DeleteEntity {
-		if exist {
-			storedTags.Lock()
-			defer storedTags.Unlock()
-			s.toDeleteMutex.Lock()
-			defer s.toDeleteMutex.Unlock()
-
-			s.toDelete[info.Entity] = struct{}{}
-			storedTags.toDelete[info.Source] = struct{}{}
+	for _, info := range xyz {
+		if info == nil {
+			log.Tracef("processTagInfo err: skipping nil message")
+			continue
+		}
+		if info.Entity == "" {
+			log.Tracef("processTagInfo err: empty entity name, skipping message")
+			continue
+		}
+		if info.Source == "" {
+			log.Tracef("processTagInfo err: empty source name, skipping message")
+			continue
 		}
 
-		return nil
+		storedTags, exist := s.store[info.Entity]
+
+		if info.DeleteEntity {
+			if exist {
+				s.toDelete[info.Entity] = struct{}{}
+
+				storedTags.Lock()
+				storedTags.toDelete[info.Source] = struct{}{}
+				storedTags.Unlock()
+			}
+
+			continue
+		}
+
+		eventType := EventTypeModified
+		if !exist {
+			eventType = EventTypeAdded
+			storedTags = newEntityTags(info.Entity)
+			s.store[info.Entity] = storedTags
+
+			storedEntities.Inc()
+		}
+
+		// TODO: check if real change
+
+		updatedEntities.Inc()
+
+		err := updateStoredTags(storedTags, info)
+		if err != nil {
+			log.Tracef("processTagInfo err: %v", err)
+			continue
+		}
+
+		events = append(events, entityEvent{
+			eventType:  eventType,
+			storedTags: storedTags,
+		})
 	}
 
-	if !exist {
-		storedTags = newEntityTags()
-		s.store[info.Entity] = storedTags
+	s.notifySubscribers(events)
+}
 
-		storedEntities.Inc()
-	}
-
-	// TODO: check if real change
-
-	updatedEntities.Inc()
-
+func updateStoredTags(storedTags *entityTags, info *collectors.TagInfo) error {
 	storedTags.Lock()
 	defer storedTags.Unlock()
 	_, found := storedTags.sourceTags[info.Source]
 	if found && info.CacheMiss {
 		// check if the source tags is already present for this entry
-		err := fmt.Errorf("try to overwrite an existing entry with and empty cache-miss entry, info.Source: %s, info.Entity: %s", info.Source, info.Entity)
-		log.Tracef("processTagInfo err: %v", err)
-		return err
+		return fmt.Errorf("try to overwrite an existing entry with and empty cache-miss entry, info.Source: %s, info.Entity: %s", info.Source, info.Entity)
 	}
 
 	storedTags.cacheValid = false
@@ -117,6 +148,109 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 	}
 
 	return nil
+}
+
+// Entity is an entity ID + tags.
+type Entity struct {
+	ID                          string
+	Hash                        string
+	HighCardinalityTags         []string
+	OrchestratorCardinalityTags []string
+	LowCardinalityTags          []string
+	StandardTags                []string
+}
+
+// EventType is a type of event, triggered when an entity is added, modified or
+// deleted.
+type EventType int
+
+const (
+	// EventTypeAdded means an entity was added.
+	EventTypeAdded EventType = iota
+	// EventTypeModified means an entity was modified.
+	EventTypeModified
+	// EventTypeDeleted means an entity was deleted.
+	EventTypeDeleted
+)
+
+// EntityEvent is an event generated when an entity is added, modified or
+// deleted. It contains the event type and the new entity.
+type EntityEvent struct {
+	EventType EventType
+	Entity    Entity
+}
+
+// subscribe returns a channel that receives a slice of events whenever an entity is
+// added, modified or deleted.
+func (s *tagStore) subscribe(cardinality collectors.TagCardinality) chan []EntityEvent {
+	// this buffer size is an educated guess, as we know the rate of
+	// updates, but not how fast these can be streamed out yet. it most
+	// likely should be configurable.
+	bufferSize := 100
+
+	// this is a `ch []EntityEvent` instead of a `ch EntityEvent` to
+	// improve throughput, as bursts of events are as likely to occur as
+	// isolated events, especially at startup or with the kubelet
+	// collector, since it's a collector that periodically pulls changes.
+	ch := make(chan []EntityEvent, bufferSize)
+
+	s.RLock()
+	defer s.RUnlock()
+	events := make([]EntityEvent, 0, len(s.store))
+	for _, storedTags := range s.store {
+		events = append(events, EntityEvent{
+			EventType: EventTypeAdded,
+			Entity:    storedTags.toEntity(cardinality),
+		})
+	}
+
+	s.subscribersMutex.Lock()
+	defer s.subscribersMutex.Unlock()
+	s.subscribers[ch] = cardinality
+
+	ch <- events
+
+	return ch
+}
+
+// unsubscribe ends a subscription to entity events and closes its channel.
+func (s *tagStore) unsubscribe(ch chan []EntityEvent) {
+	s.subscribersMutex.Lock()
+	defer s.subscribersMutex.Unlock()
+
+	delete(s.subscribers, ch)
+	close(ch)
+}
+
+// notifySubscribers sends a slice of EntityEvents of a certain type for the
+// passed entities all registered subscribers.
+func (s *tagStore) notifySubscribers(events []entityEvent) {
+	s.subscribersMutex.RLock()
+	defer s.subscribersMutex.RUnlock()
+
+	// NOTE: we need to add some telemetry on the amount of subscribers and
+	// notifications being sent, and at which cardinality
+
+	for ch, cardinality := range s.subscribers {
+		subscriberEvents := make([]EntityEvent, 0, len(events))
+
+		for _, event := range events {
+			var entity Entity
+
+			if event.eventType != EventTypeDeleted {
+				entity = event.storedTags.toEntity(cardinality)
+			} else {
+				entity = Entity{ID: event.storedTags.entityID}
+			}
+
+			subscriberEvents = append(subscriberEvents, EntityEvent{
+				EventType: event.eventType,
+				Entity:    entity,
+			})
+		}
+
+		ch <- subscriberEvents
+	}
 }
 
 func computeTagsHash(tags []string) string {
@@ -137,15 +271,15 @@ func computeTagsHash(tags []string) string {
 // prune will lock the store and delete tags for the entity previously
 // passed as delete. This is to be called regularly from the user class.
 func (s *tagStore) prune() error {
-	s.toDeleteMutex.Lock()
-	defer s.toDeleteMutex.Unlock()
+	s.Lock()
+	defer s.Unlock()
 
 	if len(s.toDelete) == 0 {
 		return nil
 	}
 
-	s.storeMutex.Lock()
-	defer s.storeMutex.Unlock()
+	events := []entityEvent{}
+
 	for entity := range s.toDelete {
 		storedTags, ok := s.store[entity]
 		if !ok {
@@ -160,9 +294,17 @@ func (s *tagStore) prune() error {
 
 		if len(storedTags.sourceTags) == 0 {
 			delete(s.store, entity)
+			events = append(events, entityEvent{
+				eventType:  EventTypeDeleted,
+				storedTags: storedTags,
+			})
 		} else {
 			storedTags.cacheValid = false
 			storedTags.toDelete = make(map[string]struct{})
+			events = append(events, entityEvent{
+				eventType:  EventTypeModified,
+				storedTags: storedTags,
+			})
 		}
 
 		storedTags.Unlock()
@@ -174,6 +316,7 @@ func (s *tagStore) prune() error {
 	// Start fresh
 	s.toDelete = make(map[string]struct{})
 
+	s.notifySubscribers(events)
 	storedEntities.Set(float64(remainingEntities))
 
 	return nil
@@ -184,8 +327,8 @@ func (s *tagStore) prune() error {
 // client to trigger manual lookups on missing sources, the last string
 // is the tags hash to have a snapshot digest of all the tags.
 func (s *tagStore) lookup(entity string, cardinality collectors.TagCardinality) ([]string, []string, string) {
-	s.storeMutex.RLock()
-	defer s.storeMutex.RUnlock()
+	s.RLock()
+	defer s.RUnlock()
 	storedTags, present := s.store[entity]
 
 	if present == false {
@@ -196,8 +339,8 @@ func (s *tagStore) lookup(entity string, cardinality collectors.TagCardinality) 
 
 // lookupStandard returns the standard tags recorded for a given entity
 func (s *tagStore) lookupStandard(entity string) ([]string, error) {
-	s.storeMutex.RLock()
-	defer s.storeMutex.RUnlock()
+	s.RLock()
+	defer s.RUnlock()
 	storedTags, present := s.store[entity]
 	if present == false {
 		return nil, fmt.Errorf("entity %s not found", entity)
@@ -222,20 +365,55 @@ type tagPriority struct {
 }
 
 func (e *entityTags) get(cardinality collectors.TagCardinality) ([]string, []string, string) {
+	e.computeCache()
+
 	e.Lock()
 	defer e.Unlock()
 
-	// Cache hit
-	if e.cacheValid {
-		if cardinality == collectors.HighCardinality {
-			return e.cachedAll, e.cachedSource, e.tagsHash
-		} else if cardinality == collectors.OrchestratorCardinality {
-			return e.cachedOrchestrator, e.cachedSource, e.tagsHash
-		}
-		return e.cachedLow, e.cachedSource, e.tagsHash
+	if cardinality == collectors.HighCardinality {
+		return e.cachedAll, e.cachedSource, e.tagsHash
+	} else if cardinality == collectors.OrchestratorCardinality {
+		return e.cachedOrchestrator, e.cachedSource, e.tagsHash
+	}
+	return e.cachedLow, e.cachedSource, e.tagsHash
+}
+
+func (e *entityTags) toEntity(cardinality collectors.TagCardinality) Entity {
+	e.computeCache()
+
+	standardTags := e.getStandard()
+
+	e.RLock()
+	defer e.RUnlock()
+
+	entity := Entity{
+		ID:           e.entityID,
+		Hash:         e.tagsHash,
+		StandardTags: standardTags,
 	}
 
-	// Cache miss
+	switch cardinality {
+	case collectors.HighCardinality:
+		entity.HighCardinalityTags = e.cachedAll[len(e.cachedOrchestrator):]
+		fallthrough
+	case collectors.OrchestratorCardinality:
+		entity.OrchestratorCardinalityTags = e.cachedOrchestrator[len(e.cachedLow):]
+		fallthrough
+	case collectors.LowCardinality:
+		entity.LowCardinalityTags = e.cachedLow
+	}
+
+	return entity
+}
+
+func (e *entityTags) computeCache() {
+	e.Lock()
+	defer e.Unlock()
+
+	if e.cacheValid {
+		return
+	}
+
 	var sources []string
 	tagPrioMapper := make(map[string][]tagPriority)
 
@@ -283,13 +461,6 @@ func (e *entityTags) get(cardinality collectors.TagCardinality) ([]string, []str
 	e.cachedLow = e.cachedAll[:len(lowCardTags)]
 	e.cachedOrchestrator = e.cachedAll[:len(lowCardTags)+len(orchestratorCardTags)]
 	e.tagsHash = computeTagsHash(e.cachedAll)
-
-	if cardinality == collectors.HighCardinality {
-		return tags, sources, e.tagsHash
-	} else if cardinality == collectors.OrchestratorCardinality {
-		return e.cachedOrchestrator, sources, e.tagsHash
-	}
-	return lowCardTags, sources, e.tagsHash
 }
 
 func insertWithPriority(tagPrioMapper map[string][]tagPriority, tags []string, source string, cardinality collectors.TagCardinality) {

--- a/pkg/tagger/tagstore_bench_test.go
+++ b/pkg/tagger/tagstore_bench_test.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package tagger
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+)
+
+const (
+	batchSize = 100
+	nMaxTags  = 5
+	nSources  = 10
+	nEntities = 1000
+)
+
+var (
+	sources []string
+	ids     []string
+)
+
+func init() {
+	sources = make([]string, 0, nSources)
+	for i := 0; i < nSources; i++ {
+		sources = append(sources, fmt.Sprintf("source_%d", i))
+	}
+
+	ids = make([]string, 0, nEntities)
+	for i := 0; i < nEntities; i++ {
+		ids = append(ids, strconv.FormatInt(rand.Int63(), 16))
+	}
+}
+
+func BenchmarkTagStoreThroughput(b *testing.B) {
+	store := newTagStore()
+
+	doneCh := make(chan struct{})
+	pruneTicker := time.NewTicker(time.Second)
+
+	go func() {
+		select {
+		case <-pruneTicker.C:
+			store.prune()
+		case <-doneCh:
+			return
+		}
+	}()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			for i := 0; i < 100; i++ {
+				processRandomTagInfoBatch(store)
+			}
+			wg.Done()
+		}()
+
+		go func() {
+			for i := 0; i < 1000; i++ {
+				id := ids[rand.Intn(nEntities)]
+				store.lookup(id, collectors.HighCardinality)
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+	}
+
+	close(doneCh)
+}
+
+// BenchmarkTagStore_processTagInfo benchmarks how fast the tagStore can ingest
+// changes to entities. It does not do so concurrently, as even though the
+// store is thread-safe, processTagInfo is always used synchronously by the
+// tagger at the moment.
+func BenchmarkTagStore_processTagInfo(b *testing.B) {
+	store := newTagStore()
+
+	for i := 0; i < b.N; i++ {
+		processRandomTagInfoBatch(store)
+	}
+}
+
+func generateRandomTagInfo() *collectors.TagInfo {
+	id := ids[rand.Intn(nEntities)]
+	source := sources[rand.Intn(nSources)]
+	return &collectors.TagInfo{
+		Entity:               id,
+		Source:               source,
+		LowCardTags:          generateRandomTags(),
+		OrchestratorCardTags: generateRandomTags(),
+		HighCardTags:         generateRandomTags(),
+		StandardTags:         generateRandomTags(),
+	}
+}
+
+func generateRandomTags() []string {
+	nTags := rand.Intn(nMaxTags)
+	tags := make([]string, 0, nTags)
+	for i := 0; i < nTags; i++ {
+		tags = append(tags, strconv.FormatInt(rand.Int63(), 16))
+	}
+
+	return tags
+}
+
+func processRandomTagInfoBatch(store *tagStore) {
+	tagInfos := make([]*collectors.TagInfo, 0, batchSize)
+	for i := 0; i < batchSize; i++ {
+		tagInfos = append(tagInfos, generateRandomTagInfo())
+	}
+
+	store.processTagInfo(tagInfos)
+}


### PR DESCRIPTION
### What does this PR do?

This PR introduces a gRPC interface that wraps the Tagger and exposes two RPCs: `StreamTags` to watch and stream changes to entities in a "push" model, and `FetchEntity` to pull the current tags for one entity.

### Motivation

This is the first part in an epic that aims to centralize the Tagger into a single agent, instead of having one per agent.

### Describe your test plan

There is an HTTP/JSON gateway already configured in the agent, so the changes here can be tested with `curl` easily:

```
$  curl -H "authorization: Bearer $(cat /etc/datadog-agent/auth_token)" \
   -XPOST -k https://localhost:5001/v1/grpc/tagger/stream_entities

$ curl -H "authorization: Bearer $(cat /etc/datadog-agent/auth_token)" \
   -XPOST -k -H "Content-Type: application/json" \
   --data '{"id":{"prefix":"kubernetes_pod_uid","uid":"d575fb58-82dc-418e-bfb1-aececc9bc507"}}' \
   https://localhost:5001/v1/grpc/tagger/fetch_entity 
```