### PR TITLE
Add telemetry for secret backend execution time

### DIFF
--- a/pkg/collector/check/stats.go
+++ b/pkg/collector/check/stats.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 )
 
 var (
@@ -60,7 +61,7 @@ func NewStats(c Check) *Stats {
 		CheckName:         c.String(),
 		CheckVersion:      c.Version(),
 		CheckConfigSource: c.ConfigSource(),
-		telemetry:         telemetry.IsCheckEnabled(c.String()),
+		telemetry:         telemetry_utils.IsCheckEnabled(c.String()),
 	}
 }
 

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -57,7 +57,7 @@ func NewCheckBaseWithInterval(name string, defaultInterval time.Duration) CheckB
 		checkName:     name,
 		checkID:       check.ID(name),
 		checkInterval: defaultInterval,
-		telemetry:     telemetry.IsCheckEnabled(name),
+		telemetry:     telemetry_utils.IsCheckEnabled(name),
 	}
 }
 

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 	"github.com/DataDog/datadog-agent/pkg/util"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -171,7 +171,7 @@ func (c *APMCheck) Configure(data integration.Data, initConfig integration.Data,
 	}
 
 	c.source = source
-	c.telemetry = telemetry.IsCheckEnabled("apm")
+	c.telemetry = telemetry_utils.IsCheckEnabled("apm")
 	return nil
 }
 

--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -33,7 +33,7 @@ func newJMXCheck(config integration.Config, source string) *JMXCheck {
 		name:      config.Name,
 		id:        check.ID(fmt.Sprintf("%v_%v", config.Name, config.Digest())),
 		source:    source,
-		telemetry: telemetry.IsCheckEnabled("jmx"),
+		telemetry: telemetry_utils.IsCheckEnabled("jmx"),
 	}
 	check.Configure(config.InitConfig, config.MetricConfig, source) //nolint:errcheck
 

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -23,7 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -165,7 +165,7 @@ func (c *ProcessAgentCheck) Configure(data integration.Data, initConfig integrat
 	}
 
 	c.source = source
-	c.telemetry = telemetry.IsCheckEnabled("process_agent")
+	c.telemetry = telemetry_utils.IsCheckEnabled("process_agent")
 	return nil
 }
 

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -58,7 +58,7 @@ func NewPythonCheck(name string, class *C.rtloader_pyobject_t) *PythonCheck {
 		class:        class,
 		interval:     defaults.DefaultCheckInterval,
 		lastWarnings: []error{},
-		telemetry:    telemetry.IsCheckEnabled(name),
+		telemetry:    telemetry_utils.IsCheckEnabled(name),
 	}
 	runtime.SetFinalizer(pyCheck, pythonCheckFinalizer)
 	return pyCheck

--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -2,6 +2,7 @@ package dogstatsd
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -28,7 +29,7 @@ func newStringInterner(maxSize int) *stringInterner {
 	return &stringInterner{
 		strings:    make(map[string]string),
 		maxSize:    maxSize,
-		tlmEnabled: telemetry.IsEnabled(),
+		tlmEnabled: telemetry_utils.IsEnabled(),
 	}
 }
 

--- a/pkg/dogstatsd/listeners/packet_pool.go
+++ b/pkg/dogstatsd/listeners/packet_pool.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 )
 
 var (
@@ -50,7 +51,7 @@ func NewPacketPool(bufferSize int) *PacketPool {
 			},
 		},
 		// telemetry
-		tlmEnabled: telemetry.IsEnabled(),
+		tlmEnabled: telemetry_utils.IsEnabled(),
 	}
 }
 

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -211,7 +212,7 @@ func NewServer(aggregator *aggregator.BufferedAggregator) (*Server, error) {
 		histToDist:                histToDist,
 		histToDistPrefix:          histToDistPrefix,
 		extraTags:                 extraTags,
-		telemetryEnabled:          telemetry.IsEnabled(),
+		telemetryEnabled:          telemetry_utils.IsEnabled(),
 		entityIDPrecedenceEnabled: entityIDPrecedenceEnabled,
 		disableVerboseLogs:        config.Datadog.GetBool("dogstatsd_disable_verbose_logs"),
 		Debug: &dsdServerDebug{

--- a/pkg/metrics/metric_sample_pool.go
+++ b/pkg/metrics/metric_sample_pool.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 )
 
 var (
@@ -31,7 +32,7 @@ func NewMetricSamplePool(batchSize int) *MetricSamplePool {
 			},
 		},
 		// telemetry
-		tlmEnabled: telemetry.IsEnabled(),
+		tlmEnabled: telemetry_utils.IsEnabled(),
 	}
 }
 

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -11,17 +11,24 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // PayloadVersion defines the current payload version sent to a secret backend
 const PayloadVersion = "1.0"
+
+var (
+	tlmSecretBackendElapsed = telemetry.NewGauge("secret_backend", "elapsed_ms", []string{"command", "exit_code"}, "Elapsed time of secret backend invocation")
+)
 
 type limitBuffer struct {
 	max int
@@ -58,15 +65,29 @@ func execCommand(inputPayload string) ([]byte, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
+	start := time.Now()
 	err := cmd.Run()
+	elapsed := time.Since(start)
+	log.Debugf("secret_backend_command '%s' completed in %d ms", secretBackendCommand, elapsed.Milliseconds())
+
 	if err != nil {
 		log.Errorf("secret_backend_command stderr: %s", stderr.buf.String())
+
+		exitCode := "unknown"
+		var e *exec.ExitError
+		if errors.As(err, &e) {
+			exitCode = strconv.Itoa(e.ExitCode())
+		} else if ctx.Err() == context.DeadlineExceeded {
+			exitCode = "timeout"
+		}
+		tlmSecretBackendElapsed.Add(float64(elapsed.Milliseconds()), secretBackendCommand, exitCode)
 
 		if ctx.Err() == context.DeadlineExceeded {
 			return nil, fmt.Errorf("error while running '%s': command timeout", secretBackendCommand)
 		}
 		return nil, fmt.Errorf("error while running '%s': %s", secretBackendCommand, err)
 	}
+	tlmSecretBackendElapsed.Add(float64(elapsed.Milliseconds()), secretBackendCommand, "0")
 	return stdout.buf.Bytes(), nil
 }
 

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -68,7 +68,7 @@ func execCommand(inputPayload string) ([]byte, error) {
 	start := time.Now()
 	err := cmd.Run()
 	elapsed := time.Since(start)
-	log.Debugf("secret_backend_command '%s' completed in %d ms", secretBackendCommand, elapsed.Milliseconds())
+	log.Debugf("secret_backend_command '%s' completed in %s", secretBackendCommand, elapsed)
 
 	if err != nil {
 		log.Errorf("secret_backend_command stderr: %s", stderr.buf.String())

--- a/pkg/telemetry/utils/utils.go
+++ b/pkg/telemetry/utils/utils.go
@@ -1,4 +1,4 @@
-package telemetry
+package utils
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/config"

--- a/pkg/telemetry/utils/utils_test.go
+++ b/pkg/telemetry/utils/utils_test.go
@@ -1,4 +1,4 @@
-package telemetry
+package utils
 
 import (
 	"testing"


### PR DESCRIPTION
### What does this PR do?

Add telemetry measure for secret backend execution time.

### Motivation

We sometimes have agents failing to start because of timeouts while decoding secrets via the secret backend.
This PR allows to monitor the secret backend execution time so that we can notice when it becomes abnormally slow even if it doesn’t time out.

### Additional Notes

### Describe your test plan

Start an agent with telemetry enabled and a secret in its config:
```yaml
app_key: ENC[foo]
telemetry:
  enabled: true
```

And check the telemetry gauge:
```shell
$ docker exec -ti datadog-agent curl http://localhost:5000/telemetry | grep secret

# HELP secret_backend__elapsed_ms Elapsed time of secret backend invocation
# TYPE secret_backend__elapsed_ms gauge
secret_backend__elapsed_ms{command="/readsecret.sh",exit_code="0"} 2047
```