### PR TITLE
[ECS Fargate] Fix missing task_arn tag due to race condition

### DIFF
--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -22,27 +22,24 @@ import (
 // parseMetadata parses the task metadata and its container list, and returns a list of TagInfo for the new ones.
 // It also updates the lastSeen cache of the ECSFargateCollector and return the list of dead containers to be expired.
 func (c *ECSFargateCollector) parseMetadata(meta *v2.Task, parseAll bool) ([]*TagInfo, error) {
-	var output []*TagInfo
-	now := time.Now()
-
 	if meta.KnownStatus != "RUNNING" {
-		return output, fmt.Errorf("Task %s is in %s status, skipping", meta.Family, meta.KnownStatus)
+		return nil, fmt.Errorf("Task %s is in %s status, skipping", meta.Family, meta.KnownStatus)
 	}
 
-	c.doOnceOrchScope.Do(func() {
-		tags := utils.NewTagList()
-		tags.AddOrchestrator("task_arn", meta.TaskARN)
-		low, orch, high, standard := tags.Compute()
-		info := &TagInfo{
+	now := time.Now()
+	tags := utils.NewTagList()
+	tags.AddOrchestrator("task_arn", meta.TaskARN)
+	low, orch, high, standard := tags.Compute()
+	output := []*TagInfo{
+		{
 			Source:               ecsFargateCollectorName,
 			Entity:               OrchestratorScopeEntityID,
 			HighCardTags:         high,
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
-		}
-		output = append(output, info)
-	})
+		},
+	}
 
 	for _, ctr := range meta.Containers {
 		if c.expire.Update(ctr.DockerID, now) || parseAll {

--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -148,15 +148,15 @@ func TestParseMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"unknownID"}, expires)
 
-	// Diff parsing should show 0 containers
+	// Diff parsing should show 0 containers + 1 tag for task_arn
 	updates, err = collector.parseMetadata(&meta, false)
 	assert.NoError(t, err)
-	assert.Len(t, updates, 0)
+	assert.Len(t, updates, 1)
 
-	// Full parsing should show 3 containers
+	// Full parsing should show 3 containers + 1 tag for task_arn
 	updates, err = collector.parseMetadata(&meta, true)
 	assert.NoError(t, err)
-	assert.Len(t, updates, 3)
+	assert.Len(t, updates, 4)
 }
 
 func TestParseMetadataV10(t *testing.T) {

--- a/pkg/tagger/collectors/ecs_fargate_main.go
+++ b/pkg/tagger/collectors/ecs_fargate_main.go
@@ -9,7 +9,6 @@ package collectors
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/errors"
@@ -34,8 +33,6 @@ type ECSFargateCollector struct {
 	lastExpire   time.Time
 	expireFreq   time.Duration
 	labelsAsTags map[string]string
-	// Used to initialize the orchestrator scope tags which don't need to be refetched after
-	doOnceOrchScope sync.Once
 }
 
 // Detect tries to connect to the ECS metadata API

--- a/releasenotes/notes/ecs-fargate-fix-missing-task_arn-tag-c6ef09f9b82a1822.yaml
+++ b/releasenotes/notes/ecs-fargate-fix-missing-task_arn-tag-c6ef09f9b82a1822.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes an issue with not always reporting ECS Fargate task_arn tag due to a race condition in the tag collector.


### PR DESCRIPTION
### What does this PR do?

- Due to a race condition between `Fetch` and `Pull` methods in the ECS Fargate tag collector,
 the task_arn tag could be overwritten.

The solution implemented here is to drop use of `sync.Once` since the original optimization is rather minimal.

### Motivation

Working `task_arn` tag in ECS Fargate.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy an ECS task and ensure that the `task_arn` tag is reported on metrics (the issue is not always reproducible due to the nature of the race condition).
