### PR TITLE
add NET_BROADCAST to allowedCaapbilities section

### DIFF
--- a/Dockerfiles/manifests/openshift/scc.yaml
+++ b/Dockerfiles/manifests/openshift/scc.yaml
@@ -40,6 +40,7 @@ allowedCapabilities:
 - SYS_RESOURCE
 - SYS_PTRACE
 - NET_ADMIN
+- NET_BROADCAST
 - IPC_LOCK
 #
 # The rest is copied from restricted SCC


### PR DESCRIPTION
### What does this PR do?

Existing SCC does not include the `NET_BROADCAST` capability which is required if you want to use NPM on OpenShift. If this capability is not added, the agent will not deploy at all. See example from a local deployment where I used the Operator: 

Without `NET_BROADCAST`
```
[morgan.lupton@COMP10906:~/repos/operator-example-with-everything/manifests] (master)$ oc get pods 
NAME                                     READY   STATUS    RESTARTS   AGE
datadog-cluster-agent-64d774fc8d-9mzqs   1/1     Running   0          8m9s

```

With `NET_BROADCAST`
```
[morgan.lupton@COMP10906:~/repos/operator-example-with-everything/manifests] (master)$ oc get pods
NAME                                     READY   STATUS    RESTARTS   AGE
datadog-agent-zvrdd                      4/4     Running   0          20m
datadog-cluster-agent-64d774fc8d-9mzqs   1/1     Running   0          28m
```

Screenshot of working NPM configuration: https://a.cl.ly/yAub52qg

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
