### PR TITLE
[omnibus, MacOS] Blacklist snowflake on Python 2

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -82,12 +82,14 @@ if osx?
   # Blacklist ibm_was, which depends on lxml
   blacklist_folders.push('ibm_was')
 
-  # Blacklist ijson as it fails MacOS notarization: the _yajl2.so binary inside was built with a
+  # Blacklist snowflake-connector-python as it makes MacOS notarization fail.
+  # It pulls the ijson package, which contains a _yajl2.so binary that was built with a
   # MacOS SDK lower than 10.9. The Python 3 counterpart of the same package is not affected (it
   # doesn't ship this file).
+  blacklist_packages.push(/^snowflake-connector-python==/)
   blacklist_packages.push(/^ijson==/)
 
-  # Blacklist snowflake, which depends on lxml
+  # Blacklist snowflake, which depends on snowflake-connector-python
   blacklist_folders.push('snowflake')
 
   # Blacklist aerospike, new version 3.10 is not supported on MacOS yet

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -87,7 +87,6 @@ if osx?
   # MacOS SDK lower than 10.9. The Python 3 counterpart of the same package is not affected (it
   # doesn't ship this file).
   blacklist_packages.push(/^snowflake-connector-python==/)
-  blacklist_packages.push(/^ijson==/)
 
   # Blacklist snowflake, which depends on snowflake-connector-python
   blacklist_folders.push('snowflake')

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -78,8 +78,17 @@ if osx?
   # binaries were built with a MacOS SDK lower than 10.9.
   # This can be removed once a new lxml version with binaries built with a newer SDK is available.
   blacklist_packages.push(/^lxml==/)
+
   # Blacklist ibm_was, which depends on lxml
   blacklist_folders.push('ibm_was')
+
+  # Blacklist ijson as it fails MacOS notarization: the _yajl2.so binary inside was built with a
+  # MacOS SDK lower than 10.9. The Python 3 counterpart of the same package is not affected (it
+  # doesn't ship this file).
+  blacklist_packages.push(/^ijson==/)
+
+  # Blacklist snowflake, which depends on lxml
+  blacklist_folders.push('snowflake')
 
   # Blacklist aerospike, new version 3.10 is not supported on MacOS yet
   blacklist_folders.push('aerospike')


### PR DESCRIPTION
### What does this PR do?

Blacklists the snowflake integration in the Python 2 environment.

### Motivation

`snowflake-connector-python`, one of the snowflake integration dependencies, makes MacOS notarization fail. It pulls the `ijson` package, which contains a `_yajl2.so` binary that was built with a MacOS SDK lower than 10.9.

### Additional Notes

Does this need a release note?

### Describe your test plan

MacOS build succeeds and passes notarization.