### PR TITLE
Introduce Tagger telemetry metrics

### DIFF
--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -6,8 +6,6 @@
 package tagger
 
 import (
-	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
@@ -81,21 +79,6 @@ func List(cardinality collectors.TagCardinality) response.TaggerListResponse {
 // GetEntityHash returns the hash for the tags associated with the given entity
 func GetEntityHash(entity string) string {
 	return defaultTagger.GetEntityHash(entity)
-}
-
-// stringToTagCardinality extracts a TagCardinality from a string.
-// In case of failure to parse, returns an error and defaults to Low.
-func stringToTagCardinality(c string) (collectors.TagCardinality, error) {
-	switch strings.ToLower(c) {
-	case "high":
-		return collectors.HighCardinality, nil
-	case "orchestrator":
-		return collectors.OrchestratorCardinality, nil
-	case "low":
-		return collectors.LowCardinality, nil
-	default:
-		return collectors.LowCardinality, fmt.Errorf("unsupported value %s received for tag cardinality", c)
-	}
 }
 
 func init() {

--- a/pkg/tagger/metrics.go
+++ b/pkg/tagger/metrics.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package tagger
+
+import "github.com/DataDog/datadog-agent/pkg/telemetry"
+
+var (
+	storedEntities = telemetry.NewGaugeWithOpts("tagger", "stored_entities",
+		[]string{}, "Number of entities in the store.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	updatedEntities = telemetry.NewCounterWithOpts("tagger", "updated_entities",
+		[]string{}, "Number of updates made to entities.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	queries = telemetry.NewCounterWithOpts("tagger", "queries",
+		[]string{"cardinality"}, "Queries made against the tagger.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+)

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -228,6 +228,8 @@ func (t *Tagger) GetEntityHash(entity string) string {
 
 // Tag returns tags for a given entity
 func (t *Tagger) Tag(entity string, cardinality collectors.TagCardinality) ([]string, error) {
+	queries.Inc(tagCardinalityToString(cardinality))
+
 	if entity == "" {
 		return nil, fmt.Errorf("empty entity ID")
 	}

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -73,7 +73,11 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 			standardTags:         make(map[string][]string),
 		}
 		s.store[info.Entity] = storedTags
+
+		storedEntities.Inc()
 	}
+
+	updatedEntities.Inc()
 
 	storedTags.Lock()
 	defer storedTags.Unlock()
@@ -125,10 +129,13 @@ func (s *tagStore) prune() error {
 		delete(s.store, entity)
 	}
 
-	log.Debugf("pruned %d removed entities, %d remaining", len(s.toDelete), len(s.store))
+	remainingEntities := len(s.store)
+	log.Debugf("pruned %d removed entities, %d remaining", len(s.toDelete), remainingEntities)
 
 	// Start fresh
 	s.toDelete = make(map[string]struct{})
+
+	storedEntities.Set(float64(remainingEntities))
 
 	return nil
 }

--- a/pkg/tagger/utils.go
+++ b/pkg/tagger/utils.go
@@ -1,0 +1,45 @@
+package tagger
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+)
+
+const (
+	lowCardinalityString          = "low"
+	orchestratorCardinalityString = "orchestrator"
+	highCardinalityString         = "high"
+	unknownCardinalityString      = "unknown"
+)
+
+// stringToTagCardinality extracts a TagCardinality from a string.
+// In case of failure to parse, returns an error and defaults to Low.
+func stringToTagCardinality(c string) (collectors.TagCardinality, error) {
+	switch strings.ToLower(c) {
+	case highCardinalityString:
+		return collectors.HighCardinality, nil
+	case orchestratorCardinalityString:
+		return collectors.OrchestratorCardinality, nil
+	case lowCardinalityString:
+		return collectors.LowCardinality, nil
+	default:
+		return collectors.LowCardinality, fmt.Errorf("unsupported value %s received for tag cardinality", c)
+	}
+}
+
+// tagCardinalityToString returns a string representation of a TagCardinality
+// value.
+func tagCardinalityToString(c collectors.TagCardinality) string {
+	switch c {
+	case collectors.HighCardinality:
+		return highCardinalityString
+	case collectors.OrchestratorCardinality:
+		return orchestratorCardinalityString
+	case collectors.LowCardinality:
+		return lowCardinalityString
+	default:
+		return unknownCardinalityString
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Introduce telemetry metrics for tagger to measure how often it is queried and updated, and how many entities are in the store.

### Motivation

We're doing a tagger overhaul in the near future, and one of the things we're doing is extracting it into a single tagger shared between agents. Having this telemetry will inform decisions that can impact throughput because of the introduced network boundary.