### PR TITLE
[DCA] External Metrics Server Configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ require (
 	gopkg.in/zorkian/go-datadog-api.v2 v2.29.0
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
-	k8s.io/apiserver v0.17.4
+	k8s.io/apiserver v0.17.4 // indirect
 	k8s.io/autoscaler/vertical-pod-autoscaler v0.0.0-20200123122250-fa95810cfc1e
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/cri-api v0.0.0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -581,6 +581,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics_provider.use_datadogmetric_crd", false) // Use DatadogMetric CRD with custom Datadog Queries instead of ConfigMap
 	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)               // timeout between two successful event collections in milliseconds.
 	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)               // value in seconds. Default to 5 minutes
+	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})  // list of options that can be used to configure the external metrics server
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30)  // value in seconds
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)

--- a/test/e2e/argo-workflows/cluster-agent.yaml
+++ b/test/e2e/argo-workflows/cluster-agent.yaml
@@ -158,6 +158,8 @@ spec:
               auth_token: "c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd"
             external_metrics_provider:
               enabled: true
+              config:
+                secure-port: 6443
 
     - name: cluster-agent-deployment
       value: |
@@ -240,7 +242,7 @@ spec:
           ports:
           - protocol: TCP
             port: 443
-            targetPort: 443
+            targetPort: 6443
 
     - name: nginx-hpa
       value: |


### PR DESCRIPTION
### What does this PR do?

The Datadog Cluster Agent implements the External Metrics Server api and its associated featureset.
Up until now, it was not possible to configure the flags of this server.
Such flags include, but are not limited to:

```
--requestheader-allowed-names strings                     List of client certificate common names to allow to provide usernames in headers specified by --requestheader-username-headers. If empty, any client certificate validated by the authorities in --requestheader-client-ca-file is allowed.
--requestheader-client-ca-file string                     Root certificate bundle to use to verify client certificates on incoming requests before trusting usernames in headers specified by --requestheader-username-headers. WARNING: generally do not depend on authorization being already done for incoming requests.
--requestheader-extra-headers-prefix strings              List of request header prefixes to inspect. X-Remote-Extra- is suggested. (default [x-remote-extra-])
--requestheader-group-headers strings                     List of request headers to inspect for groups. X-Remote-Group is suggested. (default [x-remote-group])
--authentication-skip-lookup                              If false, the authentication-kubeconfig will be used to lookup missing authentication configuration from the cluster.
--lister-kubeconfig string                                kubeconfig file pointing at the 'core' kubernetes server with enough rights to list any described objects
```

With this bit of logic, one can specify the headers required to inquire external metrics.

### Motivation

Having the ability to configure the request headers, the certificates, the kubeconfig to use for out-of-clusters set ups is a security requirement.

### Additional Notes

Still need to add tests (e2e ideally)

### Describe your test plan

Several ways to test this:
1/
```
            - name: DD_EXTERNAL_METRICS_PROVIDER_CONFIG
              value: '{"cert-dir": "/etc/datadog-agent", "requestheader-group-headers": "X-Remote-Group", "secure-port": "8443"}'
```
Verify that:
- The server is running and serving correctly 
```
root@datadog-cluster-agent-XXX:/# curl -k -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" --header "X-Remote-Group: system:unauthenticated" --cert /etc/datadog-agent/apiserver.crt --key /etc/datadog-agent/apiserver.key https://127.0.0.1:8443/apis/external.metrics.k8s.io/v1beta1
{
  "kind": "APIResourceList",
  "apiVersion": "v1",
  "groupVersion": "external.metrics.k8s.io/v1beta1",
  "resources": []
```

2/ Soon to come: specify the certificates in the external metrics provider.
Something like 
```
external_metrics_provider.config:
   requestheader-group-headers: X-Remote-Group
   requestheader-username-headers: X-Remote-User 
   client-ca-file: client-ca.crt
   requestheader-allowed-names: front-proxy-client
   requestheader-client-ca-file: front-proxy-ca.crt
   secure-port: 6443
```
and verify that you can only query the API with the proper conf (similar to the API Server).

### Todo 
- [ ] Test 