### PR TITLE
[ksmv2] Add cronjob metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
@@ -107,6 +107,7 @@ var (
 		"kube_verticalpodautoscaler_spec_updatepolicy_updatemode":                                  "vpa.update_mode",
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed":             "vpa.spec_container_minallowed",
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed":             "vpa.spec_container_maxallowed",
+		"kube_cronjob_spec_suspend":                                                                "cronjob.spec_suspend",
 	}
 
 	// metadata metrics are useful for label joins
@@ -125,7 +126,6 @@ var (
 		"kube_cronjob_status_active":                       {},
 		"kube_namespace_status_phase":                      {},
 		"kube_node_status_phase":                           {},
-		"kube_cronjob_spec_suspend":                        {},
 		"kube_cronjob_spec_starting_deadline_seconds":      {},
 		"kube_job_spec_active_dealine_seconds":             {},
 		"kube_job_spec_completions":                        {},
@@ -185,6 +185,10 @@ var (
 		},
 		"kube_job_labels": {
 			LabelsToMatch: []string{"job_name", "namespace"},
+			LabelsToGet:   defaultStandardLabels,
+		},
+		"kube_cronjob_labels": {
+			LabelsToMatch: []string{"cronjob", "namespace"},
 			LabelsToGet:   defaultStandardLabels,
 		},
 	}

--- a/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_transformers.go
@@ -32,6 +32,7 @@ var (
 		"kube_pod_container_status_waiting_reason":    containerWaitingReasonTransformer,
 		"kube_pod_container_status_terminated_reason": containerTerminatedReasonTransformer,
 		"kube_cronjob_next_schedule_time":             cronJobNextScheduleTransformer,
+		"kube_cronjob_status_last_schedule_time":      cronJobLastScheduleTransformer,
 		"kube_job_complete":                           jobCompleteTransformer,
 		"kube_job_failed":                             jobFailedTransformer,
 		"kube_job_status_failed":                      jobStatusFailedTransformer,
@@ -192,6 +193,11 @@ func cronJobNextScheduleTransformer(s aggregator.Sender, name string, metric ksm
 		message = fmt.Sprintf("The cron job check scheduled at %s is %d seconds late", time.Unix(int64(metric.Val), 0).UTC(), -timeDiff)
 	}
 	s.ServiceCheck(ksmMetricPrefix+"cronjob.on_schedule_check", status, hostname, tags, message)
+}
+
+// cronJobLastScheduleTransformer sends the duration since the last time the cronjob was scheduled
+func cronJobLastScheduleTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+	s.Gauge(ksmMetricPrefix+"cronjob.duration_since_last_schedule", float64(now().Unix())-metric.Val, hostname, tags)
 }
 
 // jobCompleteTransformer sends a service check based on kube_job_complete


### PR DESCRIPTION
### What does this PR do?

Allow collecting the cron job metrics: 
- kube_cronjob_spec_suspend
- kube_cronjob_status_last_schedule_time
