### PR TITLE
Fix issue with external metrics when several HPAs use the same query

### DIFF
--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -122,10 +122,14 @@ func (p *Processor) UpdateExternalMetrics(emList map[string]custommetrics.Extern
 	var err error
 	updated = make(map[string]custommetrics.ExternalMetricValue)
 
-	batch := []string{}
+	uniqueQueries := make(map[string]struct{}, len(emList))
+	batch := make([]string, 0, len(emList))
 	for _, e := range emList {
 		q := getKey(e.MetricName, e.Labels, aggregator, rollup)
-		batch = append(batch, q)
+		if _, found := uniqueQueries[q]; !found {
+			uniqueQueries[q] = struct{}{}
+			batch = append(batch, q)
+		}
 	}
 
 	metrics, err := p.QueryExternalMetric(batch)

--- a/pkg/util/kubernetes/autoscalers/processor_test.go
+++ b/pkg/util/kubernetes/autoscalers/processor_test.go
@@ -108,6 +108,46 @@ func TestProcessor_UpdateExternalMetrics(t *testing.T) {
 			},
 		},
 		{
+			"perform unique from list of input externalMetrics",
+			map[string]custommetrics.ExternalMetricValue{
+				"id1": {
+					MetricName: metricName,
+					Labels:     map[string]string{"foo": "bar"},
+					Valid:      false,
+				},
+				"id2": {
+					MetricName: metricName,
+					Labels:     map[string]string{"foo": "bar"},
+					Valid:      false,
+				},
+			},
+			[]datadog.Series{
+				{
+					Metric: &metricName,
+					Points: []datadog.DataPoint{
+						makePoints(1531492452000, 12),
+						makePoints(penTime, 14), // Force the penultimate point to be considered fresh at all time(< externalMaxAge)
+						makePoints(0, 27),
+					},
+					Scope: makePtr("foo:bar"),
+				},
+			},
+			map[string]custommetrics.ExternalMetricValue{
+				"id1": {
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"foo": "bar"},
+					Value:      14,
+					Valid:      true,
+				},
+				"id2": {
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"foo": "bar"},
+					Value:      14,
+					Valid:      true,
+				},
+			},
+		},
+		{
 			"do not update valid sparse metric",
 			map[string]custommetrics.ExternalMetricValue{
 				"id2": {

--- a/releasenotes-dca/notes/fix-duplicate-queries-external-metrics-a9489dd3eb4d2ca8.yaml
+++ b/releasenotes-dca/notes/fix-duplicate-queries-external-metrics-a9489dd3eb4d2ca8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix issue in Cluster Agent when using external metrics without DatadogMetrics where multiple HPAs using the same metricName + Labels would prevent all HPAs (except 1st one) to get values from Datadog


### PR DESCRIPTION
### What does this PR do?

Fix issue in Cluster Agent when using external metrics without DatadogMetrics where multiple HPAs using the same metricName + Labels would prevent all HPAs (except 1st one) to get values from Datadog

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Install DCA with ExternalMetrics (without DatadogMetrics). Create 2 HPAs with the same metric name and labels. Both of them should work normally
