### PR TITLE
[gitlab] Clean runner before fetching deps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1431,6 +1431,11 @@ agent_android_apk:
     - echo running android before_script
     - cd $SRC_PATH
     - python3 -m pip install -r requirements.txt
+    # HACK: empty the build directory cache (that can come from previous runs)
+    #       to not have remainders of previous runs, which can make our deps bootstrapping logic fail.
+    # TODO: remove this once we switch to k8s runners, they won't have this problem
+    - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -depth # -delete implies -depth
+    - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -delete || true # Allow failure, we can't remove parent folders of datadog-agent
     - inv -e deps --android
     # Some Android license has changed, we have to accept the new version.
     # But on top of that, there is a bug in sdkmanager not updating correctly

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,8 +235,11 @@ build_libbcc_arm64:
   stage: deps_fetch
   needs: []
   script:
-    - find "$GOPATH" ! -path '*DataDog/datadog-agent*' -depth
-    - find "$GOPATH" ! -path '*DataDog/datadog-agent*' -delete || true # Allow failure, we can't remove parent folders of datadog-agent
+    # HACK: empty the build directory cache (that can come from previous runs)
+    #       to not have remainders of previous runs, which can make our deps bootstrapping logic fail.
+    # TODO: remove this once we switch to k8s runners, they won't have this problem
+    - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -depth # -delete implies -depth
+    - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -delete || true # Allow failure, we can't remove parent folders of datadog-agent
     - inv -e deps --verbose
     - cd $GOPATH/pkg && tar czf $CI_PROJECT_DIR/go-pkg.tar.gz .
     - cd $GOPATH/bin && tar czf $CI_PROJECT_DIR/go-bin.tar.gz .
@@ -673,8 +676,11 @@ dogstatsd_arm64_size_test:
     - mkdir -p $GOPATH/src/github.com/DataDog
     - '[[ "$ARCH" == arm64 ]] && cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog'
     - cd $SRC_PATH
-    - find "$GOPATH" ! -path '*DataDog/datadog-agent*' -depth
-    - find "$GOPATH" ! -path '*DataDog/datadog-agent*' -delete || true # Allow failure, we can't remove parent folders of datadog-agent
+    # HACK: empty the build directory cache (that can come from previous runs)
+    #       to not have remainders of previous runs, which can make our deps bootstrapping logic fail.
+    # TODO: remove this once we switch to k8s runners, they won't have this problem
+    - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -depth # -delete implies -depth
+    - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -delete || true # Allow failure, we can't remove parent folders of datadog-agent
     - inv -e deps --verbose
     # Retrieve libbcc from S3
     - $S3_CP_CMD $S3_ARTIFACTS_URI/libbcc-$ARCH.tar.xz /tmp/libbcc.tar.xz

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,6 +235,8 @@ build_libbcc_arm64:
   stage: deps_fetch
   needs: []
   script:
+    - ls -la $GOPATH/src/golang.org/ || true
+    - ls -la $GOPATH/src/github.com/ || true
     - inv -e deps --verbose
     - cd $GOPATH/pkg && tar czf $CI_PROJECT_DIR/go-pkg.tar.gz .
     - cd $GOPATH/bin && tar czf $CI_PROJECT_DIR/go-bin.tar.gz .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,8 +235,8 @@ build_libbcc_arm64:
   stage: deps_fetch
   needs: []
   script:
-    - ls -la $GOPATH/src/golang.org/ || true
-    - ls -la $GOPATH/src/github.com/ || true
+    - find "$GOPATH" ! -path '*DataDog/datadog-agent*' -depth
+    - find "$GOPATH" ! -path '*DataDog/datadog-agent*' -delete || true # Allow failure, we can't remove parent folders of datadog-agent
     - inv -e deps --verbose
     - cd $GOPATH/pkg && tar czf $CI_PROJECT_DIR/go-pkg.tar.gz .
     - cd $GOPATH/bin && tar czf $CI_PROJECT_DIR/go-bin.tar.gz .
@@ -673,6 +673,8 @@ dogstatsd_arm64_size_test:
     - mkdir -p $GOPATH/src/github.com/DataDog
     - '[[ "$ARCH" == arm64 ]] && cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog'
     - cd $SRC_PATH
+    - find "$GOPATH" ! -path '*DataDog/datadog-agent*' -depth
+    - find "$GOPATH" ! -path '*DataDog/datadog-agent*' -delete || true # Allow failure, we can't remove parent folders of datadog-agent
     - inv -e deps --verbose
     # Retrieve libbcc from S3
     - $S3_CP_CMD $S3_ARTIFACTS_URI/libbcc-$ARCH.tar.xz /tmp/libbcc.tar.xz

--- a/tasks/bootstrap.py
+++ b/tasks/bootstrap.py
@@ -47,6 +47,8 @@ def process_deps(ctx, target, version, kind, step, cmd=None, verbose=False):
         if step == "checkout":
             # download tools
             path = os.path.join(get_gopath(ctx), 'src', target)
+            if os.path.exists(path):
+                ctx.run("ls -la {}".format(path))
             if not os.path.exists(path):
                 ctx.run("go get{} -d -u {}".format(verbosity, target), env={'GO111MODULE': 'off'})
 

--- a/tasks/bootstrap.py
+++ b/tasks/bootstrap.py
@@ -47,8 +47,6 @@ def process_deps(ctx, target, version, kind, step, cmd=None, verbose=False):
         if step == "checkout":
             # download tools
             path = os.path.join(get_gopath(ctx), 'src', target)
-            if os.path.exists(path):
-                ctx.run("ls -la {}".format(path))
             if not os.path.exists(path):
                 ctx.run("go get{} -d -u {}".format(verbosity, target), env={'GO111MODULE': 'off'})
 


### PR DESCRIPTION
### What does this PR do?

Empty the `$CI_BUILDS_DIR` (except the datadog-agent folder) before fetching deps to ensure what we start in a clean state.

### Motivation

Prevent flakes due to inconsistent starting state of runners.
