### PR TITLE
Fix offset guessing on linux kernel 5.8

### DIFF
--- a/bootstrap.json
+++ b/bootstrap.json
@@ -76,7 +76,7 @@
             "type": "go"
         },
         "github.com/golang/perf/cmd/benchstat": {
-            "version": "9c9101da83161dff5e53fc89bf35ed49ea286db8",
+            "version": "d949658356f9a1d750bdabd650745c5bd5f1cfa4",
             "type": "go"
         }
     }

--- a/pkg/ebpf/bytecode/manager.go
+++ b/pkg/ebpf/bytecode/manager.go
@@ -22,7 +22,7 @@ func NewOffsetManager() *manager.Manager {
 		},
 		PerfMaps: []*manager.PerfMap{},
 		Probes: []*manager.Probe{
-			{Section: string(TCPGetInfo)},
+			{Section: string(TCPGetSockOpt)},
 			{Section: string(TCPv6Connect)},
 			{Section: string(IPMakeSkb)},
 			{Section: string(TCPv6ConnectReturn), KProbeMaxActive: maxActive},

--- a/pkg/ebpf/bytecode/types.go
+++ b/pkg/ebpf/bytecode/types.go
@@ -28,9 +28,9 @@ const (
 	// by the tcp_sendmsg func (so we can have a # of tcp sent bytes we miscounted)
 	TCPSendMsgReturn ProbeName = "kretprobe/tcp_sendmsg"
 
-	// TCPGetInfo traces the tcp_get_info() system call
+	// TCPGetSockOpt traces the tcp_getsockopt() kernel function
 	// This probe is used for offset guessing only
-	TCPGetInfo ProbeName = "kprobe/tcp_get_info"
+	TCPGetSockOpt ProbeName = "kprobe/tcp_getsockopt"
 
 	// TCPSetState traces the tcp_set_state() kernel function
 	TCPSetState ProbeName = "kprobe/tcp_set_state"

--- a/pkg/ebpf/offsetguess.go
+++ b/pkg/ebpf/offsetguess.go
@@ -100,13 +100,13 @@ var whatString = map[C.__u64]string{
 }
 
 const (
-	tcpInfoKProbeNotCalled C.__u64 = 0
-	tcpInfoKProbeCalled            = 1
+	tcpGetSockOptKProbeNotCalled C.__u64 = 0
+	tcpGetSockOptKProbeCalled            = 1
 )
 
 var tcpKprobeCalledString = map[C.__u64]string{
-	tcpInfoKProbeNotCalled: "tcp_get_info kprobe not executed",
-	tcpInfoKProbeCalled:    "tcp_get_info kprobe executed",
+	tcpGetSockOptKProbeNotCalled: "tcp_getsockopt kprobe not executed",
+	tcpGetSockOptKProbeCalled:    "tcp_getsockopt kprobe executed",
 }
 
 const listenIP = "127.0.0.2"
@@ -214,8 +214,8 @@ func waitUntilStable(conn net.Conn, window time.Duration, attempts int) (*fieldV
 
 func offsetGuessProbes(c *Config) map[bytecode.ProbeName]struct{} {
 	probes := map[bytecode.ProbeName]struct{}{
-		bytecode.TCPGetInfo: {},
-		bytecode.IPMakeSkb:  {},
+		bytecode.TCPGetSockOpt: {},
+		bytecode.IPMakeSkb:     {},
 	}
 
 	if c.CollectIPv6Conns {
@@ -438,7 +438,7 @@ func setReadyState(mp *ebpf.Map, status *tracerStatus) error {
 // To guess the offsets, we create connections from localhost (127.0.0.1) to
 // 127.0.0.2:$PORT, where we have a server listening. We store the current
 // possible offset and expected value of each field in a eBPF map. In kernel-space
-// we rely on two different kprobes: `tcp_get_info` and `tcp_connect_v6`. When they're
+// we rely on two different kprobes: `tcp_getsockopt` and `tcp_connect_v6`. When they're
 // are triggered, we store the value of
 //     (struct sock *)skp + possible_offset
 // in the eBPF map. Then, back in userspace (checkAndUpdateCurrentOffset()), we
@@ -611,7 +611,7 @@ func (e *eventGenerator) Generate(status *tracerStatus, expected *fieldValues) e
 		return err
 	}
 
-	// This triggers the KProbe handler attached to `tcp_get_info`
+	// This triggers the KProbe handler attached to `tcp_getsockopt`
 	_, err := tcpGetInfo(e.conn)
 	return err
 }

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -299,7 +299,7 @@ func runOffsetGuessing(config *Config, buf bytecode.AssetReader) ([]manager.Cons
 	start := time.Now()
 	editors, err := guessOffsets(offsetMgr, config)
 	if err != nil {
-		return nil, fmt.Errorf("error guessing offsets: %v", err)
+		return nil, err
 	}
 	log.Infof("socket struct offset guessing complete (took %v)", time.Since(start))
 	return editors, nil


### PR DESCRIPTION
### What does this PR do?

The previous kprobe function `tcp_get_info` was not being triggered, but rather `tcp_get_info.part.0` was. This moves the kprobe up a level to `tcp_getsockopt` which should be more stable.

### Motivation

The system-probe failed to start on Ubuntu 20.10 which runs linux kernel 5.8. Thanks @ISauve for the bug report.

Note: Ubuntu 20.10 is scheduled to release before the 7.24 agent release, so this should land in 7.23.

### Describe your test plan

All automated eBPF tests pass on Agent VM and Ubuntu 20.10. Further testing can be done by attempting to start `system-probe` since offset guessing happens upon startup.

Please test on CentOS 7.6 and Ubuntu Xenial/16.04 (kernel 4.4)