### PR TITLE
[invoke, gitlab] Use GITLAB_TOKEN in keychain if available

### DIFF
--- a/tasks/deploy/gitlab.py
+++ b/tasks/deploy/gitlab.py
@@ -1,7 +1,9 @@
 import errno
 import json
 import os
+import platform
 import re
+import subprocess
 
 from invoke.exceptions import Exit
 
@@ -166,10 +168,22 @@ class Gitlab(object):
 
     def _api_token(self):
         if "GITLAB_TOKEN" not in os.environ:
+            print("GITLAB_TOKEN not found in env. Trying keychain...")
+            if platform.system() == "Darwin":
+                try:
+                    output = subprocess.check_output(
+                        ['security', 'find-generic-password', '-a', os.environ["USER"], '-s', 'GITLAB_TOKEN', '-w']
+                    )
+                    if len(output) > 0:
+                        return output.strip()
+                except subprocess.CalledProcessError:
+                    print("GITLAB_TOKEN not found in keychain...")
+                    pass
             print(
                 "Please create an 'api' access token at "
                 "https://gitlab.ddbuild.io/profile/personal_access_tokens and "
-                "export it is as GITLAB_TOKEN from your .bashrc or equivalent."
+                "add it as GITLAB_TOKEN in your keychain "
+                "or export it from your .bashrc or equivalent."
             )
             raise Exit(code=1)
         return os.environ["GITLAB_TOKEN"]

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -61,8 +61,10 @@ def trigger(ctx, git_ref="master", release_version_6="nightly", release_version_
 
             print("Successfully cross checked v7 tag {} and git ref {}".format(tag_name, git_ref))
 
-    pipeline_id = trigger_agent_pipeline(git_ref, release_version_6, release_version_7, repo_branch, deploy=True)
-    wait_for_pipeline(project_name, pipeline_id)
+    pipeline_id = trigger_agent_pipeline(
+        gitlab, project_name, git_ref, release_version_6, release_version_7, repo_branch, deploy=True
+    )
+    wait_for_pipeline(gitlab, project_name, pipeline_id)
 
 
 @task
@@ -79,10 +81,17 @@ def run_all_tests(ctx, git_ref="master", here=False, release_version_6="nightly"
     inv pipeline.run-all-tests --git-ref my-branch
     inv pipeline.run-all-tests --here
     """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = Gitlab()
+    gitlab.test_project_found(project_name)
+
     if here:
         git_ref = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
-    pipeline_id = trigger_agent_pipeline(git_ref, release_version_6, release_version_7, "none", deploy=False)
-    wait_for_pipeline("DataDog/datadog-agent", pipeline_id)
+    pipeline_id = trigger_agent_pipeline(
+        gitlab, project_name, git_ref, release_version_6, release_version_7, "none", deploy=False
+    )
+    wait_for_pipeline(gitlab, project_name, pipeline_id)
 
 
 @task
@@ -98,19 +107,24 @@ def follow(ctx, id=None, git_ref=None, here=False):
     inv pipeline.follow --here
     inv pipeline.follow --id 1234567
     """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = Gitlab()
+    gitlab.test_project_found(project_name)
+
     if id is not None:
-        wait_for_pipeline("DataDog/datadog-agent", id)
+        wait_for_pipeline(gitlab, project_name, id)
     elif git_ref is not None:
-        wait_for_pipeline_from_ref(git_ref)
+        wait_for_pipeline_from_ref(gitlab, project_name, git_ref)
     elif here:
         git_ref = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
-        wait_for_pipeline_from_ref(git_ref)
+        wait_for_pipeline_from_ref(gitlab, project_name, git_ref)
 
 
-def wait_for_pipeline_from_ref(ref):
-    pipeline = Gitlab().last_pipeline_for_ref("DataDog/datadog-agent", ref)
+def wait_for_pipeline_from_ref(gitlab, project_name, ref):
+    pipeline = Gitlab().last_pipeline_for_ref(project_name, ref)
     if pipeline is not None:
-        wait_for_pipeline("DataDog/datadog-agent", pipeline['id'])
+        wait_for_pipeline(gitlab, project_name, pipeline['id'])
     else:
         print("No pipelines found for {ref}".format(ref=ref))
         raise Exit(code=1)


### PR DESCRIPTION
### What does this PR do?

On MacOS, when running `inv pipeline.*` commands, also try fetching the gitlab token from the keychain.
Refactor the gitlab-related tasks to use a single Gitlab instance (you get a prompt for the keychain password every time a `Gitlab` instance is created).

### Motivation

Allow people to put their tokens in keychain instead of using env vars if they want to.

### Additional Notes

I decided to try the keychain after the env var, because running the security command always prompts for the keychain password (even if the GITLAB_TOKEN entry isn't there), which gets annoying after a while for someone using the env var method.
To remove this prompt, you need to click on “Always Allow”, which isn't necessarily a good thing (and forcing the prompt in all cases might lead to people clicking on it to get rid of it, which we don't want)

### Describe your test plan

Run `invoke pipeline.trigger`:
- with GITLAB_TOKEN in keychain -> success
- without GITLAB_TOKEN in keychain -> success if GITLAB_TOKEN in env, failure otherwise
- with GITLAB_TOKEN in keychain, but denying access to the keychain -> success if GITLAB_TOKEN in env, failure otherwise
