### PR TITLE
Add jmxfetch version and java runtime version info status page

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -116,6 +116,12 @@
         {{- if and (not .timestamp) (not .checks)}}
           No JMX status available
         {{- else }}
+          <span class="stat_subtitle">Information</span>
+          <span class="stat_subdata">
+            {{- range $k,$v := .info }}
+              {{ $k }} : {{ $v }}<br>
+            {{- end }}
+          </span>
           <span class="stat_subtitle">Initialized Checks</span>
           <span class="stat_subdata">
             {{- if (not .checks.initialized_checks)}}

--- a/pkg/status/jmx_status.go
+++ b/pkg/status/jmx_status.go
@@ -16,8 +16,9 @@ type jmxCheckStatus struct {
 
 // JMXStatus holds status for JMX checks
 type JMXStatus struct {
-	ChecksStatus jmxCheckStatus `json:"checks"`
-	Timestamp    int64          `json:"timestamp"`
+	Info         map[string]interface{} `json:"info"`
+	ChecksStatus jmxCheckStatus         `json:"checks"`
+	Timestamp    int64                  `json:"timestamp"`
 }
 
 // JMXStartupError holds startup status and errors

--- a/pkg/status/templates/jmxfetch.tmpl
+++ b/pkg/status/templates/jmxfetch.tmpl
@@ -11,6 +11,11 @@ JMXFetch
     Date: {{ formatUnixTime .JMXStartupError.Timestamp }}
 {{ end -}}
 {{ with .JMXStatus }}
+  Information
+  ==================
+  {{- range $k,$v := .info }}
+    {{ $k }} : {{ $v }}
+  {{- end }}
   {{- if and (not .timestamp) (not .checks) }}
   no JMX status available
   {{- else }}

--- a/releasenotes/notes/jmx-version-info-0b1084933da786bf.yaml
+++ b/releasenotes/notes/jmx-version-info-0b1084933da786bf.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added JMX version and java runtime version to agent status page


### PR DESCRIPTION
### What does this PR do?

The agent status page (both `agent status` and GUI now show the java runtime version and the jmxfetch version. 

Screenshot of GUI change: 

![Screen Shot 2020-09-21 at 4 55 27 PM](https://user-images.githubusercontent.com/959778/93820958-e7255c00-fc2b-11ea-8a72-395f38e2a8f6.png)

### Describe your test plan

Tested manually