### PR TITLE
Fix rtloader build on strict posix environment

### DIFF
--- a/releasenotes/notes/fix-rtloader-on-strict-posix-env-335e236b03ade55e.yaml
+++ b/releasenotes/notes/fix-rtloader-on-strict-posix-env-335e236b03ade55e.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix rtloader build on strict posix environment, e.g. musl libc on Alpine Linux.

--- a/rtloader/common/rtloader_mem.h
+++ b/rtloader/common/rtloader_mem.h
@@ -65,9 +65,7 @@ void *_malloc(size_t sz);
 void _free(void *ptr);
 
 #ifdef __cplusplus
-#    ifdef _WIN32
-#        define __THROW
-#    elif __APPLE__
+#    ifndef __GLIBC__
 #        define __THROW
 #    endif
 

--- a/rtloader/rtloader/CMakeLists.txt
+++ b/rtloader/rtloader/CMakeLists.txt
@@ -27,6 +27,12 @@ add_library(datadog-agent-rtloader SHARED
     rtloader.cpp
     ../common/rtloader_mem.c
 )
+
+# execinfo is not POSIX-compliant and some libc may have libexecinfo as a library.
+find_library(EXECINFO execinfo)
+if(EXECINFO)
+    target_link_libraries(datadog-agent-rtloader execinfo)
+endif()
 endif()
 
 set_target_properties(datadog-agent-rtloader PROPERTIES


### PR DESCRIPTION
### What does this PR do?

This commit enables rtloader to be built on Alpine Linux.

Update the condition to define `__THROW` macro which is a glibc extension.
Link libexecinfo if it exists as a library since the execinfo is not POSIX-compliant and some environment may have it as an indivisual library.

### Motivation

To make datadog-agent buildable on Alpine Linux.
Related issues: https://github.com/DataDog/datadog-agent/issues/1788 https://github.com/DataDog/datadog-agent/issues/2669

### Additional Notes


### Describe your test plan

We made an Alpine linux based [docker images](https://github.com/orgs/seqsense/packages/container/package/datadog-agent).
```
docker run -it --rm -e DD_API_KEY=**** ghcr.io/seqsense/datadog-agent:7-alpine
```
to run the image including this patch.