### PR TITLE
Disable stack protector on system-probe build

### DIFF
--- a/releasenotes/notes/disable-system-probe-stack-protector-9b73b8b88b74e2ba.yaml
+++ b/releasenotes/notes/disable-system-probe-stack-protector-9b73b8b88b74e2ba.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Disable stack protector on system-probe to make it buildable on the environments which stack protector is enabled by default.
+
+    Some linux distributions like Alpine Linux enable stack protector by default which is not available on eBPF.

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -312,6 +312,8 @@ def build_object_files(ctx, bundle_ebpf=False):
         "-include {}".format(os.path.join(c_dir, "asm_goto_workaround.h")),
         '-O2',
         '-emit-llvm',
+        # Some linux distributions enable stack protector by default which is not available on eBPF
+        '-fno-stack-protector',
     ]
 
     # Mapping used by the kernel, from https://elixir.bootlin.com/linux/latest/source/scripts/subarch.include


### PR DESCRIPTION
### What does this PR do?

Make it buildable on the environments which stack protector is enabled by default.
Some linux distributions like Alpine Linux enables stack protector by default which is not available on eBPF.

### Motivation

To make system-probe buildable on Alpine Linux.
Related issues: https://github.com/DataDog/datadog-agent/issues/1788 https://github.com/DataDog/datadog-agent/issues/2669

### Additional Notes

### Describe your test plan


We made an Alpine linux based [docker images](https://github.com/orgs/seqsense/packages/container/package/datadog-agent).
```
git clone https://github.com/seqsense/datadog-agent-alpine.git
cd datadog-agent-alpine
make docker-build ENABLE_SYSTEM_PROBE=1
```
to check build on Alpine Linux.