### PR TITLE
Revert reno line about configurable log rotation timeout.

### DIFF
--- a/releasenotes/notes/tailer-log-when-unfinished-703597c1d373d539.yaml
+++ b/releasenotes/notes/tailer-log-when-unfinished-703597c1d373d539.yaml
@@ -9,5 +9,4 @@
 enhancements:
   - |
     Log a warning when a log file is rotated but has not finished tailing the file. 
-    Made the rotation stop timeout configurable. 
 


### PR DESCRIPTION
### What does this PR do?

Revert line about configurable log rotation timeout.
