### PR TITLE
[ad] Support instance tags defined in a map

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -295,13 +295,15 @@ func (c *Config) Digest() string {
 					if valueStr := fmt.Sprint(v); len(valueStr) > 0 {
 						tags = append(tags, fmt.Sprintf("%v:%s", k, valueStr))
 					} else {
-						tags = append(tags, fmt.Sprintf("%s", k))
+						tags = append(tags, fmt.Sprint(k))
 					}
 				}
 			} else {
 				log.Infof("Error while calculating config digest for %s, skipping: cannot read tags from config", c.Name)
 				continue
 			}
+			// sort the list of tags so the digest stays stable for
+			// identical configs with the same tags but with different order
 			sort.Strings(tags)
 			inst["tags"] = tags
 		}

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -54,7 +54,35 @@ func TestConfigEqual(t *testing.T) {
 		Instances:  []Data{Data("tags: [\"foo:bar\", \"bar:foo\"]")},
 		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 	}
+
 	assert.Equal(t, checkConfigWithOrderedTags.Digest(), checkConfigWithUnorderedTags.Digest())
+}
+
+func TestConfigTagsEqual(t *testing.T) {
+
+	checkConfigWithTagsInList := &Config{
+		Name:       "test",
+		InitConfig: Data("{foo}"),
+		Instances:  []Data{Data("tags: [\"bar:foo\", \"baz\", \"foo:bar\"]")},
+		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
+	}
+
+	checkConfigWithTagsInMap := &Config{
+		Name:       "test",
+		InitConfig: Data("{foo}"),
+		Instances:  []Data{Data("tags: { foo: bar, bar: foo, baz: \"\" }")},
+		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
+	}
+
+	checkConfigWithTagsReorderedInMap := &Config{
+		Name:       "test",
+		InitConfig: Data("{foo}"),
+		Instances:  []Data{Data("tags: { bar: foo, foo: bar, baz: \"\" }")},
+		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
+	}
+
+	assert.Equal(t, checkConfigWithTagsInList.Digest(), checkConfigWithTagsInMap.Digest())
+	assert.Equal(t, checkConfigWithTagsInList.Digest(), checkConfigWithTagsReorderedInMap.Digest())
 }
 
 func TestIsLogConfig(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Modify the  Digest(...) function so it is able to deserialize tags
stored in map (new) and in a list. Tags in a map are supported by
jmxfetch and are in use out there.

### Motivation
Prevent log with severity lowered in #6355 to appear too many time
in many situation were everything is fine.

### Additional Notes
N/A

### Describe your test plan
Test IRL with AD/k8s pods annotations, jmx integration config file having tags
defined in a map.

Write there any instructions and details you may have to test your PR.