### PR TITLE
Log timeout time is set by seconds - not nanoseconds

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -563,7 +563,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
 	config.BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
-	config.BindEnvAndSetDefault("logs_config.close_timeout", 60*time.Second)
+	config.BindEnvAndSetDefault("logs_config.close_timeout", 60)
 	config.BindEnv("logs_config.additional_endpoints") //nolint:errcheck
 
 	// The cardinality of tags to send for checks and dogstatsd respectively.

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -92,7 +92,7 @@ func NewTailer(outputChan chan *message.Message, source *config.LogSource, path 
 	}
 
 	forwardContext, stopForward := context.WithCancel(context.Background())
-	closeTimeout := coreConfig.Datadog.GetDuration("logs_config.close_timeout")
+	closeTimeout := coreConfig.Datadog.GetDuration("logs_config.close_timeout") * time.Second
 
 	return &Tailer{
 		path:           path,

--- a/pkg/logs/input/file/tailer_test.go
+++ b/pkg/logs/input/file/tailer_test.go
@@ -101,7 +101,7 @@ func (suite *TailerTestSuite) TestTialerTimeDurationConfig() {
 	tailer := NewTailer(suite.outputChan, suite.source, suite.testPath, 10*time.Millisecond, false)
 	tailer.StartFromBeginning()
 
-	suite.Equal(tailer.closeTimeout, time.Duration(42))
+	suite.Equal(tailer.closeTimeout, time.Duration(42)*time.Second)
 	tailer.Stop()
 }
 


### PR DESCRIPTION
### What does this PR do?

The log timeout should be configurable by seconds rather than nanoseconds
