### PR TITLE
Revert "[ad] Increase log level in Config.Digest() (#6355)"

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -289,7 +289,7 @@ func (c *Config) Digest() string {
 			// identical configs with the same tags but with different order
 			tagsInterface, ok := val.([]interface{})
 			if !ok {
-				log.Debug("Error while calculating config digest for %s, skipping: cannot read tags from config", c.Name)
+				log.Debugf("Error while calculating config digest for %s, skipping: cannot read tags from config", c.Name)
 				continue
 			}
 			tags := make([]string, len(tagsInterface))

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -281,7 +281,7 @@ func (c *Config) Digest() string {
 		inst := RawMap{}
 		err := yaml.Unmarshal(i, &inst)
 		if err != nil {
-			log.Infof("Error while calculating config digest for %s, skipping: %v", c.Name, err)
+			log.Debugf("Error while calculating config digest for %s, skipping: %v", c.Name, err)
 			continue
 		}
 		if val, found := inst["tags"]; found {
@@ -289,7 +289,7 @@ func (c *Config) Digest() string {
 			// identical configs with the same tags but with different order
 			tagsInterface, ok := val.([]interface{})
 			if !ok {
-				log.Infof("Error while calculating config digest for %s, skipping: cannot read tags from config", c.Name)
+				log.Debug("Error while calculating config digest for %s, skipping: cannot read tags from config", c.Name)
 				continue
 			}
 			tags := make([]string, len(tagsInterface))
@@ -301,7 +301,7 @@ func (c *Config) Digest() string {
 		}
 		out, err := yaml.Marshal(&inst)
 		if err != nil {
-			log.Infof("Error while calculating config digest for %s, skipping: %v", c.Name, err)
+			log.Debugf("Error while calculating config digest for %s, skipping: %v", c.Name, err)
 			continue
 		}
 		h.Write(out) //nolint:errcheck


### PR DESCRIPTION
### What does this PR do?
This reverts commit c78a4525c1abc697d6ec0d4fab25c724f8fd30db.

### Motivation
The reverted commit was generating too many logs.
Check deserialisation error will be reported in `agent status` in a foreseeable future to avoid generating to many log and still report the issue.

### Additional Notes
N/A

### Describe your test plan

Write there any instructions and details you may have to test your PR.