### PR TITLE
Monitor dogstatsd buffer usage

### DIFF
--- a/docs/dogstatsd/internals.md
+++ b/docs/dogstatsd/internals.md
@@ -41,7 +41,7 @@ or
 
 The PacketBuffer sends it in a Go buffered channel to the worker / parser, meaning that the channels can buffer the Packets on their own while waiting for the worker to read and process them.
 
-In theory, the max memory usage of the PacketBuffer is:
+In theory, the max memory usage of this Go buffered channel is:
 * packet buffer size * packet size * channel buffer size
 * `dogstatsd_packer_buffer_size` * `dogstatsd_buffer_size` * `dogstatsd_queue_size`
 * 32 * 8192 * 1024 =  256MB

--- a/pkg/dogstatsd/listeners/packet_assembler_test.go
+++ b/pkg/dogstatsd/listeners/packet_assembler_test.go
@@ -127,3 +127,20 @@ func TestPacketBufferEmptySecond(t *testing.T) {
 	assert.Len(t, packets, 1)
 	assert.Equal(t, []byte("test1\n"), packets[0].Contents)
 }
+
+func BenchmarkPacketsBufferFlush(b *testing.B) {
+	packet := generateRandomPacket(4)
+
+	for i := 0; i < b.N; i++ {
+		pb, out := buildPacketAssembler()
+
+		for i := 0; i < 100; i++ {
+			pb.addMessage(packet)
+
+			// let's empty the packets channel to make sure it is not blocking
+			for len(out) > 0 {
+				<-out
+			}
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds instrumentation to dogstats `PacketBuffer` flush events and packets channel size (see https://github.com/DataDog/datadog-agent/blob/master/docs/dogstatsd/internals.md):

- Fix documentation mistake on dogstatsd memory usage
- Add a metric to count the number of objects in the packets channel (`packets_channel size`)
- Add two metrics to monitor the packets buffer flush events: number of flush triggered by the timer (`packets_buffer_flush_timer`) vs number of flush triggered because the buffer is full (`packets_buffer_flush_full`)

### Motivation

We want to understand what is the margin on the memory allocated to the agent, most of it being requested for this packets channel. From [the doc](https://github.com/DataDog/datadog-agent/blob/master/docs/dogstatsd/internals.md#packetbuffer):
> In theory, the max memory usage of this Go buffered channel is:
> * packet buffer size * packet size * channel buffer size
> * `dogstatsd_packer_buffer_size` * `dogstatsd_buffer_size` * `dogstatsd_queue_size`
> * 32 * 8192 * 1024 =  256MB

The goal is to know the `dogstatsd_queue_size` parameter (the size of the packets channel) optimal value.

### Additional Notes

### Describe your test plan

This was tested using benchmark scripts to send 10K metrics/s to the agent, and adding intentional delay in the packets parsing in [this loop](https://github.com/DataDog/datadog-agent/blob/49e3c1d0df537d309156996f2ff72cd80ec23ff2/pkg/dogstatsd/server.go#L349) to check that the packets channel gets filled:
```diff
func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*listeners.Packet) {
    for _, packet := range packets {
+        time.Sleep(1 * time.Second)
        // ...
```

### Performance
The performance impact of this PR was evaluated by running each version against the proposed `BenchmarkPacketsBufferFlush`, here are the results:
```shell
$ benchstat old.txt new.txt
name                  old time/op  new time/op  delta
PacketsBufferFlush-8  20.9µs ± 8%  22.0µs ± 7%  +5.03%  (p=0.015 n=10+10)
```
So this PR causes a statistically significant (p < 0.05) increase of ~ **5%** computation time. :rocket:

As discussed we also compared the performance when adding tags to the `packets_buffer_flush_timer` and `packets_buffer_flush_full` metrics, but this results in a ~ **20%** computation time increase:
```shell
benchstat old.txt new-with-tags.txt
name                  old time/op  new time/op  delta
PacketsBufferFlush-8  20.9µs ± 8%  25.2µs ±10%  +20.32%  (p=0.000 n=10+10)
```

<br/>

*Note: The code modification to add tags looks like:*
```diff
- tlmPacketsBufferFlushedFull.Inc()
+ tlmPacketsBufferFlushedFull.IncWithTags(pb.protocolTag)
```
*with*
```go
pb.protocolTag: map[string]string{"protocol": protocol}
```
*computed in the `newPacketsBuffer` function.*