### PR TITLE
[runtime-security] remove outdated inode discarders

### DIFF
--- a/pkg/security/ebpf/c/filters.h
+++ b/pkg/security/ebpf/c/filters.h
@@ -26,4 +26,6 @@ struct filter_t {
     char value;
 };
 
+void __attribute__((always_inline)) remove_inode_discarders(struct file_t *file);
+
 #endif

--- a/pkg/security/ebpf/c/probe.c
+++ b/pkg/security/ebpf/c/probe.c
@@ -29,6 +29,16 @@
 #include "getattr.h"
 #include "setxattr.h"
 
+void __attribute__((always_inline)) remove_inode_discarders(struct file_t *file) {
+    struct path_key_t path_key = {
+        .ino = file->inode,
+        .mount_id = file->mount_id,
+    };
+
+    bpf_map_delete_elem(&open_path_inode_discarders, &path_key);
+    bpf_map_delete_elem(&unlink_path_inode_discarders, &path_key);
+}
+
 __u32 _version SEC("version") = 0xFFFFFFFE;
 
 char LICENSE[] SEC("license") = "GPL";

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -90,6 +90,9 @@ int __attribute__((always_inline)) trace__sys_rename_ret(struct pt_regs *ctx) {
 
     resolve_dentry(syscall->rename.src_dentry, syscall->rename.target_key, NULL);
 
+    // as old and new have are the same files, only one is needed
+    remove_inode_discarders(&event.new);
+
     send_event(ctx, event);
 
     return 0;

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -84,6 +84,8 @@ SYSCALL_KRETPROBE(rmdir) {
     struct proc_cache_t *entry = fill_process_data(&event.process);
     fill_container_data(entry, &event.container);
 
+    remove_inode_discarders(&event.file);
+
     send_event(ctx, event);
 
     return 0;

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -98,6 +98,8 @@ int __attribute__((always_inline)) trace__sys_unlink_ret(struct pt_regs *ctx) {
     struct proc_cache_t *entry = fill_process_data(&event.process);
     fill_container_data(entry, &event.container);
 
+    remove_inode_discarders(&event.file);
+
     send_event(ctx, event);
 
     return 0;

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -118,7 +118,7 @@ func (m *Module) RuleMatch(rule *eval.Rule, event eval.Event) {
 // EventDiscarderFound is called by the ruleset when a new discarder discovered
 func (m *Module) EventDiscarderFound(rs *rules.RuleSet, event eval.Event, field string) {
 	if err := m.probe.OnNewDiscarder(rs, event.(*sprobe.Event), field); err != nil {
-		log.Debug(err)
+		log.Trace(err)
 	}
 }
 

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -160,7 +160,7 @@ func (e *FileEvent) ResolveContainerPath(resolvers *Resolvers) string {
 		}
 		if len(containerPath) == 0 && len(e.PathnameStr) == 0 {
 			// The container path might be included in the pathname. The container path will be set there.
-			_ = e.ResolveInode(resolvers)
+			e.ResolveInode(resolvers)
 		}
 	}
 	return e.ContainerPath

--- a/pkg/security/probe/open_bpf.go
+++ b/pkg/security/probe/open_bpf.go
@@ -85,11 +85,16 @@ func openOnNewDiscarder(rs *rules.RuleSet, event *Event, probe *Probe, discarder
 	case "open.filename":
 		fsEvent := event.Open
 		table := "open_path_inode_discarders"
+		value := discarder.Value.(string)
 
-		isDiscarded, err := discardParentInode(probe, rs, "open", discarder.Value.(string), fsEvent.MountID, fsEvent.Inode, table)
+		isDiscarded, err := discardParentInode(probe, rs, "open", value, fsEvent.MountID, fsEvent.Inode, table)
 		if !isDiscarded || err != nil {
 			// not able to discard the parent then only discard the filename
 			_, err = discardInode(probe, fsEvent.MountID, fsEvent.Inode, table)
+		}
+
+		if err != nil {
+			err = errors.Wrapf(err, "unable to set inode discarders for `%s`", value)
 		}
 
 		return err

--- a/pkg/security/probe/open_bpf.go
+++ b/pkg/security/probe/open_bpf.go
@@ -87,10 +87,16 @@ func openOnNewDiscarder(rs *rules.RuleSet, event *Event, probe *Probe, discarder
 		table := "open_path_inode_discarders"
 		value := discarder.Value.(string)
 
+		if value == "" {
+			return nil
+		}
+
 		isDiscarded, err := discardParentInode(probe, rs, "open", value, fsEvent.MountID, fsEvent.Inode, table)
-		if !isDiscarded || err != nil {
-			// not able to discard the parent then only discard the filename
-			_, err = discardInode(probe, fsEvent.MountID, fsEvent.Inode, table)
+		if !isDiscarded {
+			if _, ok := err.(*ErrInvalidKeyPath); !ok {
+				// not able to discard the parent then only discard the filename
+				_, err = discardInode(probe, fsEvent.MountID, fsEvent.Inode, table)
+			}
 		}
 
 		if err != nil {

--- a/pkg/security/probe/unlink_bpf.go
+++ b/pkg/security/probe/unlink_bpf.go
@@ -22,13 +22,13 @@ func unlinkOnNewDiscarder(rs *rules.RuleSet, event *Event, probe *Probe, discard
 	case "unlink.filename":
 		fsEvent := event.Unlink
 		table := "unlink_path_inode_discarders"
+		value := discarder.Value.(string)
 
-		isDiscarded, err := discardParentInode(probe, rs, "unlink", discarder.Value.(string), fsEvent.MountID, fsEvent.Inode, table)
-		if !isDiscarded || err != nil {
-			// not able to discard the parent then only discard the filename
-			_, err = discardInode(probe, fsEvent.MountID, fsEvent.Inode, table)
+		if value == "" {
+			return nil
 		}
 
+		_, err := discardParentInode(probe, rs, "unlink", value, fsEvent.MountID, fsEvent.Inode, table)
 		return err
 	}
 	return &ErrDiscarderNotSupported{Field: field}


### PR DESCRIPTION
### What does this PR do?

This PR removes the outdated inode discarders.

### Motivation

A file renamed can currently be discarded even if the file name matches a rule because the inode will remains discarded.
An inode can be reused after an unlink by another filename.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan
