### PR TITLE
remove namespace from nginx configmap

### DIFF
--- a/Dockerfiles/manifests/cluster-agent/hpa-example/nginx.yaml
+++ b/Dockerfiles/manifests/cluster-agent/hpa-example/nginx.yaml
@@ -53,7 +53,6 @@ data:
 kind: ConfigMap
 metadata:
   name: nginxconfig
-  namespace: default
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
### What does this PR do?

Removes the namespace from the configmap for the nginx deployment in the hpa walkthrough files

### Motivation

If you are trying to follow [this walkthrough](https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/) in a non-default namespace, the nginx pod won't start as it won't be able to find the configmap.

### Describe your test plan

Making this change allowed me to continue the walkthrough while using a non-default namespace. 
