### PR TITLE
[DCA] Fix cluster agent commands

### DIFF
--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -31,6 +31,9 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 
 ENV PATH="/opt/datadog-agent/bin/:$PATH"
 
+# Allow User Group to exec the secret backend script.
+ENV DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"
+
 RUN apt-get update \
     && apt full-upgrade -y \
     && apt-get install --no-install-recommends -y ca-certificates curl \

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -30,6 +30,9 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 
 ENV PATH="/opt/datadog-agent/bin/:$PATH"
 
+# Allow User Group to exec the secret backend script.
+ENV DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"
+
 RUN apt-get update \
     && apt full-upgrade -y \
     && apt-get install --no-install-recommends -y ca-certificates curl \

--- a/Dockerfiles/cluster-agent/entrypoint.sh
+++ b/Dockerfiles/cluster-agent/entrypoint.sh
@@ -16,9 +16,6 @@ fi
 ##### Copy the custom confs #####
 find /conf.d -name '*.yaml' -exec cp --parents -fv {} /etc/datadog-agent/ \;
 
-##### Allow User Group to exec the secret backend script.
-export DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"
-
 ##### Starting up #####
 export PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/":$PATH
 


### PR DESCRIPTION
### What does this PR do?

Define `DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"` in the Dockerfile instead of the entrypoint script

### Motivation

`DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"` should be exposed to the `agent` commands (`status`, `config` etc) not only the main DCA process. Otherwise we'll get the error:

```
# agent status
Error: unable to set up global cluster agent configuration: unable to load Datadog config file: unable to decrypt secret from datadog.yaml: invalid executable ‘/readsecret.sh’, ‘group’ or ‘others’ have rights on it
```

A possible workaround is to do `DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM=true  agent status` but that's not great.

### Additional Notes

see https://github.com/DataDog/datadog-agent/pull/6298

### Describe your test plan

Agent commands must work as usual when the `readsecret.sh` script is used