### PR TITLE
[gitlab] Implicitly declare pupernetes-dev dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4179,9 +4179,13 @@ pupernetes-dev:
     - when: manual
       allow_failure: true
   <<: *pupernetes_template
-  needs: 
-  - dev_branch_docker_hub-a6
-  - dev_branch_docker_hub-a7
+  # Note: pupernetes-dev requires the below jobs to work. However,
+  # we can't explicitly define the dependencies because the required jobs are manual.
+  # Adding these lines would result in pipelines remaining in a "Running" state forever,
+  # as the pupernetes-dev job waits for jobs that may never be triggered.
+  # needs:
+  #   - dev_branch_docker_hub-a6
+  #   - dev_branch_docker_hub-a7
   script:
   - inv -e e2e-tests --image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py2
   - inv -e e2e-tests --image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4180,12 +4180,16 @@ pupernetes-dev:
       allow_failure: true
   <<: *pupernetes_template
   # Note: pupernetes-dev requires the below jobs to work. However,
-  # we can't explicitly define the dependencies because the required jobs are manual.
-  # Adding these lines would result in pipelines remaining in a "Running" state forever,
-  # as the pupernetes-dev job waits for jobs that may never be triggered.
+  # we can't explicitly define the dependencies because a job cannot depend on other manual jobs.
+  # Adding the following lines would result in pipelines remaining in a "Running" state forever,
+  # as the pupernetes-dev job waits for manual jobs that may never be triggered.
   # needs:
   #   - dev_branch_docker_hub-a6
   #   - dev_branch_docker_hub-a7
+  # We still want to make the job available as soon as possible. In this case, since it's manual
+  # and requires other manual jobs, it's reasonable make it available from the beginning and let
+  # engineers trigger the correct sequence of jobs when needed.
+  needs: []
   script:
   - inv -e e2e-tests --image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py2
   - inv -e e2e-tests --image=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3


### PR DESCRIPTION
### What does this PR do?

Makes the `pupernetes-dev` dependencies implicit. Explicitly declaring a dependency on a manual job gives weird results (in this case, the job stays in a "created" state until the manual jobs are run, leaving our pipelines in a "Running" state).

On the other hand, that means people who want to run this job have to remember that they need to run the dependencies before running `pupernetes-dev`.

### Motivation

Clean up gitlab pipelines.

### Additional Notes

An alternative would be to have the required jobs automatically run, but that would dramatically increase the number of pushes to dockerhub, which we probably want to avoid.
