### PR TITLE
[Chocolatey] Set the MSI url at build time

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1350,11 +1350,8 @@ agent_dmg-x64-a7:
 # The online version fetches the package from S3 so
 # it is created only when the package is pushed
 windows_choco_online_7_x64:
-  rules:
-    - <<: *if_deploy_on_tag_7
   stage: choco_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["deploy_staging_windows_tags-a7"]
   variables:
     ARCH: "x64"
   script:
@@ -4179,7 +4176,7 @@ pupernetes-dev:
     - when: manual
       allow_failure: true
   <<: *pupernetes_template
-  needs: 
+  needs:
   - dev_branch_docker_hub-a6
   - dev_branch_docker_hub-a7
   script:
@@ -4190,7 +4187,7 @@ pupernetes-master:
   <<: *pupernetes_template
   rules:
     - <<: *if_master_branch
-  needs: 
+  needs:
   - dev_master_docker_hub-a6
   - dev_master_docker_hub-a7
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1350,8 +1350,11 @@ agent_dmg-x64-a7:
 # The online version fetches the package from S3 so
 # it is created only when the package is pushed
 windows_choco_online_7_x64:
+  rules:
+    - <<: *if_deploy_on_tag_7
   stage: choco_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
+  needs: ["deploy_staging_windows_tags-a7"]
   variables:
     ARCH: "x64"
   script:
@@ -4176,7 +4179,7 @@ pupernetes-dev:
     - when: manual
       allow_failure: true
   <<: *pupernetes_template
-  needs:
+  needs: 
   - dev_branch_docker_hub-a6
   - dev_branch_docker_hub-a7
   script:
@@ -4187,7 +4190,7 @@ pupernetes-master:
   <<: *pupernetes_template
   rules:
     - <<: *if_master_branch
-  needs:
+  needs: 
   - dev_master_docker_hub-a6
   - dev_master_docker_hub-a7
   script:

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -1,14 +1,5 @@
 $ErrorActionPreference = 'Stop';
 
-$url = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($env:chocolateyPackageVersion).msi"
-# Note: match x.x.x-rc-x nuspec version format
-$releaseCandidatePattern = "(\d+\.\d+\.\d+)-rc\-(\d+)"
-if ($env:chocolateyPackageVersion -match $releaseCandidatePattern) {
-  # and turn it back into Datadog version format x.x.x-rc.x
-  $agentVersionMatches = $env:chocolateyPackageVersion | Select-String -Pattern $releaseCandidatePattern
-  $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2])-1-x86_64.msi"
-}
-
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -5,7 +5,7 @@ $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   fileType      = 'msi'
-  # Note: $__url_from_ci__ is replaced at build time with the full URL to the MSI
+  # Note: Url is replaced at build time with the full URL to the MSI
   url64bit      = $__url_from_ci__
   softwareName  = 'Datadog Agent'
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""

--- a/chocolatey/tools-online/chocolateyinstall.ps1
+++ b/chocolatey/tools-online/chocolateyinstall.ps1
@@ -5,7 +5,8 @@ $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   fileType      = 'msi'
-  url64bit      = $url
+  # Note: $__url_from_ci__ is replaced at build time with the full URL to the MSI
+  url64bit      = $__url_from_ci__
   softwareName  = 'Datadog Agent'
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
   validExitCodes= @(0, 3010, 1641)

--- a/releasenotes/notes/hardcode_msi_url_in_chocolatey_package-97846e2c2dd79a76.yaml
+++ b/releasenotes/notes/hardcode_msi_url_in_chocolatey_package-97846e2c2dd79a76.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    The Chocolatey package now uses a fixed URL to the MSI installer.

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -53,5 +53,8 @@ Write-Host "Generating Chocolatey $installMethod package version $agentVersion i
 if (!(Test-Path $outputDirectory)) {
     New-Item -ItemType Directory -Path $outputDirectory
 }
-
+if ($installMethod -eq "online") {
+    (Get-Content $nuspecFile).replace('$($env:chocolateyPackageVersion)', $agentVersion)
+                             .replace('$env:chocolateyPackageVersion', $agentVersion) | Set-Content $nuspecFile
+}
 choco pack --out=$outputDirectory $nuspecFile package_version=$agentVersion release_notes=$releaseNotes copyright=$copyright

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -54,7 +54,7 @@ if (!(Test-Path $outputDirectory)) {
     New-Item -ItemType Directory -Path $outputDirectory
 }
 if ($installMethod -eq "online") {
-    (Get-Content $nuspecFile).replace('$($env:chocolateyPackageVersion)', $agentVersion)
-                             .replace('$env:chocolateyPackageVersion', $agentVersion) | Set-Content $nuspecFile
+    (Get-Content $nuspecFile).replace('$($env:chocolateyPackageVersion)', $agentVersion).
+                              replace('$env:chocolateyPackageVersion', $agentVersion) | Set-Content $nuspecFile
 }
 choco pack --out=$outputDirectory $nuspecFile package_version=$agentVersion release_notes=$releaseNotes copyright=$copyright

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -33,7 +33,7 @@ if ($rawAgentVersion -match $releaseCandidatePattern) {
     $agentVersion = "{0}-rc-{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2].Value
     # We don't have release notes for RCs but this way the user can always see what commits are included in this RC
     $releaseNotes = "https://github.com/DataDog/datadog-agent/releases/tag/{0}-rc.{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2]
-    $url = "`"https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2])-1-x86_64.msi`""
+    $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2])-1-x86_64.msi"
 } elseif ($rawAgentVersion -match $develPattern) {
     if ($installMethod -eq "online") {
         # We don't publish online chocolatey packages for dev branches, error out
@@ -48,7 +48,7 @@ if ($rawAgentVersion -match $releaseCandidatePattern) {
     $agentVersionMatches = $rawAgentVersion | Select-String -Pattern $releasePattern
     $agentVersion = $agentVersionMatches.Matches.Groups[1].Value
     $releaseNotes = "https://github.com/DataDog/datadog-agent/releases/tag/$agentVersion"
-    $url = "`"https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi`""
+    $url = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi"
 } else {
     Write-Host "Unknown agent version '$rawAgentVersion', aborting"
     exit 3
@@ -64,7 +64,7 @@ if (!(Test-Path $outputDirectory)) {
 
 if ($installMethod -eq "online") {
     # Set the $url in the install script
-    (Get-Content $installScript).replace('$url', $url) | Set-Content $installScript
+    (Get-Content $installScript).replace('__url_from_ci__', '"' +  $url  + '"') | Set-Content $installScript
 }
 
 choco pack --out=$outputDirectory $nuspecFile package_version=$agentVersion release_notes=$releaseNotes copyright=$copyright

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -33,7 +33,7 @@ if ($rawAgentVersion -match $releaseCandidatePattern) {
     $agentVersion = "{0}-rc-{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2].Value
     # We don't have release notes for RCs but this way the user can always see what commits are included in this RC
     $releaseNotes = "https://github.com/DataDog/datadog-agent/releases/tag/{0}-rc.{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2]
-    $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2])-1-x86_64.msi"
+    $url = "`"https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2])-1-x86_64.msi`""
 } elseif ($rawAgentVersion -match $develPattern) {
     if ($installMethod -eq "online") {
         # We don't publish online chocolatey packages for dev branches, error out
@@ -48,7 +48,7 @@ if ($rawAgentVersion -match $releaseCandidatePattern) {
     $agentVersionMatches = $rawAgentVersion | Select-String -Pattern $releasePattern
     $agentVersion = $agentVersionMatches.Matches.Groups[1].Value
     $releaseNotes = "https://github.com/DataDog/datadog-agent/releases/tag/$agentVersion"
-    $url = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi"
+    $url = "`"https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi`""
 } else {
     Write-Host "Unknown agent version '$rawAgentVersion', aborting"
     exit 3

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -64,7 +64,7 @@ if (!(Test-Path $outputDirectory)) {
 
 if ($installMethod -eq "online") {
     # Set the $url in the install script
-    (Get-Content $installScript).replace('__url_from_ci__', '"' +  $url  + '"') | Set-Content $installScript
+    (Get-Content $installScript).replace('$__url_from_ci__', '"' +  $url  + '"') | Set-Content $installScript
 }
 
 choco pack --out=$outputDirectory $nuspecFile package_version=$agentVersion release_notes=$releaseNotes copyright=$copyright

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -21,6 +21,7 @@ $develPattern = "(\d+\.\d+\.\d+)-devel\+git\.\d+\.(.+)"
 
 $nuspecFile = "c:\mnt\chocolatey\datadog-agent-online.nuspec"
 $licensePath = "c:\mnt\chocolatey\tools-online\LICENSE.txt"
+$installScript = "c:\mnt\chocolatey\tools-online\chocolateyinstall.ps1"
 
 if ($installMethod -eq "offline") {
     $nuspecFile = "c:\mnt\chocolatey\datadog-agent-offline.nuspec"
@@ -32,7 +33,13 @@ if ($rawAgentVersion -match $releaseCandidatePattern) {
     $agentVersion = "{0}-rc-{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2].Value
     # We don't have release notes for RCs but this way the user can always see what commits are included in this RC
     $releaseNotes = "https://github.com/DataDog/datadog-agent/releases/tag/{0}-rc.{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2]
+    $url = "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-$($agentVersionMatches.Matches.Groups[1])-rc.$($agentVersionMatches.Matches.Groups[2])-1-x86_64.msi"
 } elseif ($rawAgentVersion -match $develPattern) {
+    if ($installMethod -eq "online") {
+        # We don't publish online chocolatey packages for dev branches, error out
+        Write-Host "Chocolatey packages are not built for dev branches aborting"
+        exit 2
+    }
     $agentVersionMatches = $rawAgentVersion | Select-String -Pattern $develPattern
     $agentVersion = "{0}-devel-{1}" -f $agentVersionMatches.Matches.Groups[1], $agentVersionMatches.Matches.Groups[2].Value
     # We don't have release notes for devel, so point it to the generic url
@@ -41,9 +48,10 @@ if ($rawAgentVersion -match $releaseCandidatePattern) {
     $agentVersionMatches = $rawAgentVersion | Select-String -Pattern $releasePattern
     $agentVersion = $agentVersionMatches.Matches.Groups[1].Value
     $releaseNotes = "https://github.com/DataDog/datadog-agent/releases/tag/$agentVersion"
+    $url = "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi"
 } else {
     Write-Host "Unknown agent version '$rawAgentVersion', aborting"
-    exit 2
+    exit 3
 }
 
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/DataDog/datadog-agent/master/LICENSE" -OutFile $licensePath
@@ -53,8 +61,10 @@ Write-Host "Generating Chocolatey $installMethod package version $agentVersion i
 if (!(Test-Path $outputDirectory)) {
     New-Item -ItemType Directory -Path $outputDirectory
 }
+
 if ($installMethod -eq "online") {
-    (Get-Content $nuspecFile).replace('$($env:chocolateyPackageVersion)', $agentVersion).
-                              replace('$env:chocolateyPackageVersion', $agentVersion) | Set-Content $nuspecFile
+    # Set the $url in the install script
+    (Get-Content $installScript).replace('$url', $url) | Set-Content $installScript
 }
+
 choco pack --out=$outputDirectory $nuspecFile package_version=$agentVersion release_notes=$releaseNotes copyright=$copyright


### PR DESCRIPTION
### What does this PR do?

This PR sets the MSI url in the Chocolatey package at build time.

### Motivation

Chocolatey's PackageInternalizer doesn't support environment variables within strings (see https://github.com/chocolatey/chocolatey-licensed-issues/issues/177), so it's not possible to internalize our Chocolatey package .

### Describe your test plan

Install the Chocolatey package, the agent should be installed.
Ensure that the `chocolateyinstall.ps1` has a direct ULR to the MSI package, and does not contain any environment variable.
