### PR TITLE
[Windows][Entrypoint] Exit container if init script returns exit code != 0

### DIFF
--- a/Dockerfiles/agent/windows/entrypoint/entrypoint.cpp
+++ b/Dockerfiles/agent/windows/entrypoint/entrypoint.cpp
@@ -67,7 +67,7 @@ void ExecuteInitScripts()
         if (exitCode != 0)
         {
             std::stringstream sstream;
-            sstream << script.path() << " exited with code [" << std::hex << exitCode << "]";
+            sstream << script.path() << " exited with code " << FormatErrorCode(exitCode);
             throw std::exception(sstream.str().c_str());
         }
     }

--- a/Dockerfiles/agent/windows/entrypoint/entrypoint.cpp
+++ b/Dockerfiles/agent/windows/entrypoint/entrypoint.cpp
@@ -68,7 +68,7 @@ void ExecuteInitScripts()
         {
             std::stringstream sstream;
             sstream << script.path() << " exited with code [" << std::hex << exitCode << "]";
-            throw std::exception(sstream.str());
+            throw std::exception(sstream.str().c_str());
         }
     }
 }

--- a/Dockerfiles/agent/windows/entrypoint/entrypoint.cpp
+++ b/Dockerfiles/agent/windows/entrypoint/entrypoint.cpp
@@ -66,7 +66,9 @@ void ExecuteInitScripts()
         DWORD exitCode = pwsh.WaitForExit();
         if (exitCode != 0)
         {
-            std::cout << "[ENTRYPOINT][WARNING] " << script.path() << " exited with code [" << std::hex << exitCode << "]" << std::endl;
+            std::stringstream sstream;
+            sstream << script.path() << " exited with code [" << std::hex << exitCode << "]";
+            throw std::exception(sstream.str());
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR makes the Agent container entrypoint for Windows exit if any of its init scripts returns an error code different from 0.

### Motivation

The container should exit if any of its init scripts fail.

### Describe your test plan

Run the agent without the API_KEY set, the folllowing error should appear and the container should exit:

```
==================================================================================
You must set an DD_API_KEY environment variable to run the Datadog Agent container
==================================================================================

[ENTRYPOINT][ERROR] "entrypoint-ps1\\01-check-apikey.ps1" exited with code [1]
```