### PR TITLE
Finer checking of GetEvents() rate limiting

### DIFF
--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -34,12 +34,16 @@ type EventServer struct {
 
 // GetEvents waits for security events
 func (e *EventServer) GetEvents(params *api.GetParams, stream api.SecurityModule_GetEventsServer) error {
+	// Read 10 security events per call
 	msgs := 10
-	if !e.rate.limiter.AllowN(time.Now(), msgs) {
-		return nil
-	}
 LOOP:
 	for {
+		// Check that the limit is not reached
+		if !e.rate.limiter.Allow() {
+			return nil
+		}
+
+		// Read on message
 		select {
 		case msg := <-e.msgs:
 			if err := stream.Send(msg); err != nil {
@@ -50,6 +54,7 @@ LOOP:
 			break LOOP
 		}
 
+		// Stop the loop when 10 messages were retrieved
 		if msgs <= 0 {
 			break
 		}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -81,7 +81,7 @@ func (e *EventServer) SendEvent(rule *eval.Rule, event eval.Event) {
 	default:
 		// The channel is full, consume the oldest event
 		oldestMsg := <-e.msgs
-		// Try to send the send the event again
+		// Try to send the event again
 		select {
 		case e.msgs <- msg:
 			break


### PR DESCRIPTION
### What does this PR do?

This PR allows the `GetEvents()` method to retrieve messages when the rate limit is almost reached.

### Motivation

Currently `GetEvents()` checks if 10 messages can be retrieved with a single call to `AllowN()`, that could fail if a smaller number is allowed.

### Additional Notes

The first commit fixes a typo.
