### PR TITLE
Do not treat config already being set as an error

### DIFF
--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -164,8 +164,8 @@ func ImportRegistryConfig() error {
 	datadogYamlPath := config.Datadog.ConfigFileUsed()
 
 	if config.Datadog.GetString("api_key") != "" {
-		return fmt.Errorf("%s seems to contain a valid configuration, not overwriting config",
-			datadogYamlPath)
+		log.Infof("%s seems to contain a valid configuration, not overwriting config", datadogYamlPath)
+		return nil
 	}
 
 	overrides := make(map[string]interface{})


### PR DESCRIPTION
### What does this PR do?

Do not treat config already being set as an error. Print an info message instead.

### Motivation

Warning was too scary.

