### PR TITLE
[changelog] Move Windows Nano base image change to the upgrade section

### DIFF
--- a/releasenotes/notes/containerized-windows-nano-7e6157fcbe75ea7f.yaml
+++ b/releasenotes/notes/containerized-windows-nano-7e6157fcbe75ea7f.yaml
@@ -6,6 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-enhancements:
+upgrade:
   - |
     Windows Docker image is now based on Windows Server Nano instead of Windows Server Core.


### PR DESCRIPTION
### What does this PR do?

Change the release note so it appears under 'upgrade', since this could be a major change for some people.

