### PR TITLE
[logs] missing method on parser.DecodingParser

### DIFF
--- a/pkg/logs/input/kubernetes/parser.go
+++ b/pkg/logs/input/kubernetes/parser.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
-	lineParser "github.com/DataDog/datadog-agent/pkg/logs/parser"
 )
 
 const (
@@ -28,9 +27,7 @@ var (
 // Parser parses Kubernetes log lines
 var Parser *parser
 
-type parser struct {
-	lineParser.Parser
-}
+type parser struct{}
 
 // Parse parses a Kubernetes log line.
 // Kubernetes log lines follow this pattern '<timestamp> <stream> <flag> <content>',

--- a/pkg/logs/parser/parser.go
+++ b/pkg/logs/parser/parser.go
@@ -18,7 +18,7 @@ var NoopParser *noopParser
 type Encoding int
 
 const (
-	// UTF16LE UTF16 little endian, most commong (windows)
+	// UTF16LE UTF16 little endian, most common (windows)
 	UTF16LE = iota
 	// UTF16BE UTF16 big endian
 	UTF16BE
@@ -54,6 +54,10 @@ type DecodingParser struct {
 func (p *DecodingParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 	decoded, _, err := transform.Bytes(p.decoder, msg)
 	return decoded, "", "", false, err
+}
+
+func (p *DecodingParser) SupportsPartialLine() bool {
+	return false
 }
 
 // NewDecodingParser build a new DecodingParser

--- a/pkg/logs/parser/parser.go
+++ b/pkg/logs/parser/parser.go
@@ -50,12 +50,13 @@ type DecodingParser struct {
 	Parser
 }
 
-// Parse pases the incoming message with the decoder
+// Parse parses the incoming message with the decoder
 func (p *DecodingParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
 	decoded, _, err := transform.Bytes(p.decoder, msg)
 	return decoded, "", "", false, err
 }
 
+// SupportsPartialLine returns false as it does not support partial lines
 func (p *DecodingParser) SupportsPartialLine() bool {
 	return false
 }

--- a/pkg/logs/parser/parser.go
+++ b/pkg/logs/parser/parser.go
@@ -31,9 +31,7 @@ type Parser interface {
 	SupportsPartialLine() bool
 }
 
-type noopParser struct {
-	Parser
-}
+type noopParser struct{}
 
 // Parse does nothing for NoopParser
 func (p *noopParser) Parse(msg []byte) ([]byte, string, string, bool, error) {
@@ -47,7 +45,6 @@ func (p *noopParser) SupportsPartialLine() bool {
 // DecodingParser a generic decoding Parser
 type DecodingParser struct {
 	decoder *encoding.Decoder
-	Parser
 }
 
 // Parse parses the incoming message with the decoder


### PR DESCRIPTION
### What does this PR do?
Add a missing method and a relevant test.
Method was missing because of a complex rebase (#6265).

### Motivation
Fix a possible crash.

### Additional Notes
N/A.

### Describe your test plan
Test that utf-16 log tailing works.