### PR TITLE
[oom kill/tcp queue length] Fix off-by-one in cgroup name copy

### DIFF
--- a/pkg/ebpf/oom-kill-kern-user.h
+++ b/pkg/ebpf/oom-kill-kern-user.h
@@ -8,7 +8,7 @@
 #endif
 
 struct oom_stats {
-  char cgroup_name[65];
+  char cgroup_name[129];
   // Pid of triggering process
   __u32 pid;
   // Pid of killed process

--- a/pkg/ebpf/oom-kill-kern-user.h
+++ b/pkg/ebpf/oom-kill-kern-user.h
@@ -8,7 +8,7 @@
 #endif
 
 struct oom_stats {
-  char cgroup_name[64];
+  char cgroup_name[65];
   // Pid of triggering process
   __u32 pid;
   // Pid of killed process

--- a/pkg/ebpf/tcp-queue-length-kern-user.h
+++ b/pkg/ebpf/tcp-queue-length-kern-user.h
@@ -18,7 +18,7 @@ struct conn {
 
 struct stats {
   __u32 pid;
-  char cgroup_name[65];
+  char cgroup_name[129];
   struct conn conn;
   struct queue_length rqueue;
   struct queue_length wqueue;

--- a/pkg/ebpf/tcp-queue-length-kern-user.h
+++ b/pkg/ebpf/tcp-queue-length-kern-user.h
@@ -18,7 +18,7 @@ struct conn {
 
 struct stats {
   __u32 pid;
-  char cgroup_name[64];
+  char cgroup_name[65];
   struct conn conn;
   struct queue_length rqueue;
   struct queue_length wqueue;

--- a/releasenotes/notes/oom-kill-tcp-queue-length-off-by-one-cgroup-name-e2e79dc3890d347d.yaml
+++ b/releasenotes/notes/oom-kill-tcp-queue-length-off-by-one-cgroup-name-e2e79dc3890d347d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix truncated cgroup name on copy with bpf_probe_read_str in OOM kill and TCP queue length checks.
+


### PR DESCRIPTION
### What does this PR do?

Fix truncated cgroup name on copy with `bpf_probe_read_str` - since the buffer is 64 bytes (passed as `sz` argument to this helper), the copy operation results in truncation with the terminating NULL, which results in the wrong container ID used in these checks.

Per [docs](https://man7.org/linux/man-pages/man7/bpf-helpers.7.html):
```
       int bpf_probe_read_str(void *dst, u32 size, const void *unsafe_ptr)

              Description
                     Copy a NUL terminated string from an unsafe kernel
                     address unsafe_ptr to dst. See
                     bpf_probe_read_kernel_str() for more details.
...
              Return On success, the strictly positive length of the string,
                     including the trailing NUL character. On error, a
                     negative value.
```


### Motivation

Working tags on container metrics from OOM kill probe.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test OOMKilled containers with tags.