### PR TITLE
Always use a 64K receive buffer in the UDP listener

### DIFF
--- a/docs/dogstatsd/configuration.md
+++ b/docs/dogstatsd/configuration.md
@@ -11,17 +11,9 @@ Information on DogStatsD, configuration and troubleshooting is available in the 
 
 ## `dogstatsd_buffer_size`
 
-The `dogstatsd_buffer_size` parameter configures two things in Dogstatsd:
+The `dogstatsd_buffer_size` parameter configures how many bytes maximum the PacketAssembler should put into one packet.
 
-* How many bytes must be read each time the socket is read
-* How many bytes maximum the PacketAssembler should put into one packet
-
-If you have reports of malformed or incomplete packets received by the Dogstatsd server, it could mean
-that the clients that are sending packets are larger than the size of this buffer. If the maximum size of the
-packets sent by the clients can't be changed, consider increasing the size of `dogstatsd_buffer_size`
-as a fallback.
-
-Please note that increasing this buffer size has a huge impact on the maximum memory usage:
+Please note that increasing this buffer size, together with `dogstatsd_queue_size`, has a huge impact on the maximum memory usage:
 doubling its size double the maximum memory usage.
 
 The default value of this field is `8192`.
@@ -51,9 +43,9 @@ are an issue.
 
 This parameter represents how many packet sets flushed from the packets buffer to the parser could be
 buffered. The idea is to read as fast as possible on the socket and to store packets here if the rest
-of the pipeline is having slow-down for any reasons.
+of the pipeline is having slow-down for any reasons. Each packet is of size `dogstatsd_buffer_size`.
 
-This is where most of the memory usage of Dogstatsd resides. It means that if you decrease the size of
+This queue is where most of the memory usage of Dogstatsd resides. It means that if you decrease the size of
 this queue, the maximum memory usage of Dogstatsd should decrease, however, the amount of drops can
 increase.
 

--- a/docs/dogstatsd/configuration.md
+++ b/docs/dogstatsd/configuration.md
@@ -13,7 +13,7 @@ Information on DogStatsD, configuration and troubleshooting is available in the 
 
 The `dogstatsd_buffer_size` parameter configures the maximum number of bytes the PacketAssembler should put into one packet.
 
-Please note that increasing this buffer size, together with `dogstatsd_queue_size`, has a huge impact on the maximum memory usage:
+**Note**: Increasing this buffer size, together with `dogstatsd_queue_size`, has a huge impact on the maximum memory usage:
 doubling its size double the maximum memory usage.
 
 The default value of this field is `8192`.

--- a/docs/dogstatsd/configuration.md
+++ b/docs/dogstatsd/configuration.md
@@ -11,7 +11,7 @@ Information on DogStatsD, configuration and troubleshooting is available in the 
 
 ## `dogstatsd_buffer_size`
 
-The `dogstatsd_buffer_size` parameter configures how many bytes maximum the PacketAssembler should put into one packet.
+The `dogstatsd_buffer_size` parameter configures the maximum number of bytes the PacketAssembler should put into one packet.
 
 Please note that increasing this buffer size, together with `dogstatsd_queue_size`, has a huge impact on the maximum memory usage:
 doubling its size double the maximum memory usage.
@@ -132,4 +132,3 @@ With UDS, a way to improve the CPU usage is to send the packets with a size of 8
 instance on a Dogstatsd server receiving 500k metrics per second, we can observe an
 improvement of -30% CPU usage by switching from clients sending 1.5kb packets to clients
 sending 8kb packets with the configuration above used for the server.
-

--- a/docs/dogstatsd/configuration.md
+++ b/docs/dogstatsd/configuration.md
@@ -43,7 +43,7 @@ are an issue.
 
 This parameter represents how many packet sets flushed from the packets buffer to the parser could be
 buffered. The idea is to read as fast as possible on the socket and to store packets here if the rest
-of the pipeline is having slow-down for any reasons. Each packet is of size `dogstatsd_buffer_size`.
+of the pipeline is slowing down for any reason. Each packet is of size `dogstatsd_buffer_size`.
 
 This queue is where most of the memory usage of Dogstatsd resides. It means that if you decrease the size of
 this queue, the maximum memory usage of Dogstatsd should decrease, however, the amount of drops can

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -74,11 +74,10 @@ func NewUDPListener(packetOut chan Packets, sharedPacketPool *PacketPool) (*UDPL
 		return nil, fmt.Errorf("can't listen: %s", err)
 	}
 
-	bufferSize := config.Datadog.GetInt("dogstatsd_buffer_size")
 	packetsBufferSize := config.Datadog.GetInt("dogstatsd_packet_buffer_size")
 	flushTimeout := config.Datadog.GetDuration("dogstatsd_packet_buffer_flush_timeout")
 
-	buffer := make([]byte, bufferSize)
+	buffer := make([]byte, 1<<16) // no point in using a smaller buffer here
 	packetsBuffer := newPacketsBuffer(uint(packetsBufferSize), flushTimeout, packetOut)
 	packetAssembler := newPacketAssembler(flushTimeout, packetsBuffer, sharedPacketPool)
 


### PR DESCRIPTION
### What does this PR do?

Always use a 64K buffer when receiving UDP.

### Motivation

datadog-go (and other statsd clients) allow to send much bigger UDP packets than the current default (8KB), and there is really no reason to conflate the size of the receive buffer with that of the buffers in the internal queue.

Increasing the size of the receive buffer to the maximum allowed UDP size will remove a footgun and simplifies configuration, as now the buffer size controls a single thing (the size of buffers in the queue), not two. Because there is a single receive buffer, memory increase is very limited (+56KB).

This change is discussed in https://github.com/DataDog/datadog-go/issues/168, that provides additional context why allowing bigger UDP packets *by default* makes sense.

### Additional Notes

Reading https://github.com/DataDog/datadog-go/issues/168 will help.

### Describe your test plan

The only meaningful test would be sending, to an agent with the default configuration, a statsd UDP packet of size >> 8192 bytes. If it works, all is good.

If this PR is accepted, at least in principle, I plan to add some unit tests covering this.