### PR TITLE
[NET-784][process-agent] Group connections by similarity

### DIFF
--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -173,7 +173,7 @@ func batchConnections(
 	dnsEncoder := model.NewV1DNSEncoder()
 
 	if len(cxs) > cfg.MaxConnsPerMessage {
-		// Sort connections by remote IP/PID in order to be friendlier to network-resolver
+		// Sort connections by remote IP/PID for more efficient resolution
 		sort.Slice(cxs, func(i, j int) bool {
 			if cxs[i].Raddr.Ip != cxs[j].Raddr.Ip {
 				return cxs[i].Raddr.Ip < cxs[j].Raddr.Ip

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	model "github.com/DataDog/agent-payload/process"
@@ -170,6 +171,16 @@ func batchConnections(
 	batches := make([]model.MessageBody, 0, groupSize)
 
 	dnsEncoder := model.NewV1DNSEncoder()
+
+	if len(cxs) > cfg.MaxConnsPerMessage {
+		// Sort connections by remote IP/PID in order to be friendlier to network-resolver
+		sort.Slice(cxs, func(i, j int) bool {
+			if cxs[i].Raddr.Ip != cxs[j].Raddr.Ip {
+				return cxs[i].Raddr.Ip < cxs[j].Raddr.Ip
+			}
+			return cxs[i].Pid < cxs[j].Pid
+		})
+	}
 
 	for len(cxs) > 0 {
 		batchSize := min(cfg.MaxConnsPerMessage, len(cxs))

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -165,6 +165,13 @@ func TestBatchSimilarConnectionsTogether(t *testing.T) {
 		for _, cc := range connections.Connections {
 			assert.Equal(t, rAddr, cc.Raddr.Ip)
 		}
+
+		// make sure the connections with the same remote address are ordered by PID
+		lastSeenPID := connections.Connections[0].Pid
+		for _, cc := range connections.Connections {
+			assert.LessOrEqual(t, lastSeenPID, cc.Pid)
+			lastSeenPID = cc.Pid
+		}
 	}
 	assert.Equal(t, 6, total)
 }

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -101,7 +101,7 @@ func TestNetworkConnectionBatching(t *testing.T) {
 func TestNetworkConnectionBatchingWithDNS(t *testing.T) {
 	p := makeConnections(4)
 
-	p[0].Raddr.Ip = "1.1.2.3"
+	p[3].Raddr.Ip = "1.1.2.3"
 	dns := map[string]*model.DNSEntry{
 		"1.1.2.3": {Names: []string{"datacat.edu"}},
 	}

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -17,18 +17,18 @@ func makeConnection(pid int32) *model.Connection {
 	}
 }
 
+func makeConnections(n int) []*model.Connection {
+	conns := make([]*model.Connection, 0)
+	for i := 1; i <= n; i++ {
+		c := makeConnection(int32(i))
+		c.Laddr = &model.Addr{ContainerId: fmt.Sprintf("%d", c.Pid)}
+
+		conns = append(conns, c)
+	}
+	return conns
+}
+
 func TestNetworkConnectionBatching(t *testing.T) {
-	p := []*model.Connection{
-		makeConnection(1),
-		makeConnection(2),
-		makeConnection(3),
-		makeConnection(4),
-	}
-
-	for _, proc := range p {
-		proc.Laddr = &model.Addr{ContainerId: fmt.Sprintf("%d", proc.Pid)}
-	}
-
 	cfg := config.NewDefaultAgentConfig(false)
 
 	for i, tc := range []struct {
@@ -38,31 +38,31 @@ func TestNetworkConnectionBatching(t *testing.T) {
 		expectedChunks int
 	}{
 		{
-			cur:            []*model.Connection{p[0], p[1], p[2]},
+			cur:            makeConnections(3),
 			maxSize:        1,
 			expectedTotal:  3,
 			expectedChunks: 3,
 		},
 		{
-			cur:            []*model.Connection{p[0], p[1], p[2]},
+			cur:            makeConnections(3),
 			maxSize:        2,
 			expectedTotal:  3,
 			expectedChunks: 2,
 		},
 		{
-			cur:            []*model.Connection{p[0], p[1], p[2], p[3]},
+			cur:            makeConnections(4),
 			maxSize:        10,
 			expectedTotal:  4,
 			expectedChunks: 1,
 		},
 		{
-			cur:            []*model.Connection{p[0], p[1], p[2], p[3]},
+			cur:            makeConnections(4),
 			maxSize:        3,
 			expectedTotal:  4,
 			expectedChunks: 2,
 		},
 		{
-			cur:            []*model.Connection{p[0], p[1], p[2], p[3], p[2], p[3]},
+			cur:            makeConnections(6),
 			maxSize:        2,
 			expectedTotal:  6,
 			expectedChunks: 3,
@@ -99,20 +99,11 @@ func TestNetworkConnectionBatching(t *testing.T) {
 }
 
 func TestNetworkConnectionBatchingWithDNS(t *testing.T) {
-	p := []*model.Connection{
-		makeConnection(1),
-		makeConnection(2),
-		makeConnection(3),
-		makeConnection(4),
-	}
+	p := makeConnections(4)
 
 	p[0].Raddr.Ip = "1.1.2.3"
 	dns := map[string]*model.DNSEntry{
 		"1.1.2.3": {Names: []string{"datacat.edu"}},
-	}
-
-	for _, proc := range p {
-		proc.Laddr = &model.Addr{ContainerId: fmt.Sprintf("%d", proc.Pid)}
 	}
 
 	cfg := config.NewDefaultAgentConfig(false)
@@ -125,8 +116,8 @@ func TestNetworkConnectionBatchingWithDNS(t *testing.T) {
 	for i, c := range chunks {
 		connections := c.(*model.CollectorConnections)
 
-		// Only the first chunk should have a DNS mapping!
-		if i == 0 {
+		// Only the last chunk should have a DNS mapping
+		if i == 3 {
 			assert.NotEmpty(t, connections.EncodedDNS)
 		} else {
 			assert.Empty(t, connections.EncodedDNS)
@@ -144,4 +135,36 @@ func TestNetworkConnectionBatchingWithDNS(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 4, total)
+}
+
+func TestBatchSimilarConnectionsTogether(t *testing.T) {
+	p := makeConnections(6)
+
+	p[0].Raddr.Ip = "1.1.2.3"
+	p[1].Raddr.Ip = "1.2.3.4"
+	p[2].Raddr.Ip = "1.3.4.5"
+	p[3].Raddr.Ip = "1.1.2.3"
+	p[4].Raddr.Ip = "1.2.3.4"
+	p[5].Raddr.Ip = "1.3.4.5"
+
+	cfg := config.NewDefaultAgentConfig(false)
+	cfg.MaxConnsPerMessage = 2
+
+	chunks := batchConnections(cfg, 0, p, map[string]*model.DNSEntry{}, "nid", nil)
+
+	assert.Len(t, chunks, 3)
+	total := 0
+	for _, c := range chunks {
+		connections := c.(*model.CollectorConnections)
+		total += len(connections.Connections)
+		assert.Equal(t, int32(3), connections.GroupSize)
+		assert.Equal(t, 2, len(connections.Connections))
+
+		// make sure the connections with similar remote addresses were grouped together
+		rAddr := connections.Connections[0].Raddr.Ip
+		for _, cc := range connections.Connections {
+			assert.Equal(t, rAddr, cc.Raddr.Ip)
+		}
+	}
+	assert.Equal(t, 6, total)
 }


### PR DESCRIPTION
### What does this PR do?

When the `process-agent` receives a list of connections from the `system-probe`, it has to batch these connections into reasonably-sized messages for the backend to process. Currently we batch these connections in the order that we receive them; this change groups similar connections together so that messages seen by the backend are more likely to contain connections with the same remote address IP.

### Motivation

[NET-784](https://datadoghq.atlassian.net/browse/NET-784)

### Additional Notes

If there's fewer than `MaxConnsPerMessage` connections, then we don't bother doing any sorting since all the connections will be in the same batch regardless.

### Describe your test plan

I downloaded 500 sample messages and tested the old batching algorithm vs the new batching algorithm on these messages.
I found that with a `MaxConnsPerMessage` = 600 (the default value), the new batching algorithm resulted in a 75% average decrease in the number of unique rAddrs present in each message. This improvement primarily affected hosts which generated many more connections than `MaxConnsPerMessage`.