### PR TITLE
[circleci] Run MacOS jobs at the same time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,9 +302,7 @@ workflows:
     jobs:
       - checkout_code
       - macos_tests
-      - macos_build:
-          requires:
-            - macos_tests
+      - macos_build
       - dependencies:
           requires:
             - checkout_code


### PR DESCRIPTION
### What does this PR do?

Runs `macos_tests` and `macos_build` at the same time in CircleCI. 

### Motivation

Reduce the time spent waiting for the MacOS jobs.
