### PR TITLE
pkg/trace/obfuscate: optimize the SQL obfuscator

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -265,17 +265,16 @@ func (oq *ObfuscatedQuery) Cost() int64 {
 // attemptObfuscation attempts to obfuscate the SQL query loaded into the tokenizer, using the
 // given set of filters.
 func attemptObfuscation(tokenizer *SQLTokenizer) (*ObfuscatedQuery, error) {
-	tableFinder := &tableFinderFilter{}
-	filterTableFinder := config.HasFeature("table_names")
 	var (
-		out       = *bytes.NewBuffer(make([]byte, 0, len(tokenizer.buf)))
-		err       error
-		lastToken TokenKind
-		discard   discardFilter
-		replace   replaceFilter
-		grouping  groupingFilter
+		tableFinder       = &tableFinderFilter{}
+		filterTableFinder = config.HasFeature("table_names")
+		out               = *bytes.NewBuffer(make([]byte, 0, len(tokenizer.buf)))
+		err               error
+		lastToken         TokenKind
+		discard           discardFilter
+		replace           replaceFilter
+		grouping          groupingFilter
 	)
-
 	// call Scan() function until tokens are available or if a LEX_ERROR is raised. After
 	// retrieving a token, send it to the tokenFilter chains so that the token is discarded
 	// or replaced.

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -266,14 +266,14 @@ func (oq *ObfuscatedQuery) Cost() int64 {
 // given set of filters.
 func attemptObfuscation(tokenizer *SQLTokenizer) (*ObfuscatedQuery, error) {
 	var (
-		tableFinder       = &tableFinderFilter{}
-		filterTableFinder = config.HasFeature("table_names")
-		out               = *bytes.NewBuffer(make([]byte, 0, len(tokenizer.buf)))
-		err               error
-		lastToken         TokenKind
-		discard           discardFilter
-		replace           replaceFilter
-		grouping          groupingFilter
+		tableFinder    = &tableFinderFilter{}
+		useTableFinder = config.HasFeature("table_names")
+		out            = *bytes.NewBuffer(make([]byte, 0, len(tokenizer.buf)))
+		err            error
+		lastToken      TokenKind
+		discard        discardFilter
+		replace        replaceFilter
+		grouping       groupingFilter
 	)
 	// call Scan() function until tokens are available or if a LEX_ERROR is raised. After
 	// retrieving a token, send it to the tokenFilter chains so that the token is discarded
@@ -296,7 +296,7 @@ func attemptObfuscation(tokenizer *SQLTokenizer) (*ObfuscatedQuery, error) {
 		if token, buff, err = grouping.Filter(token, lastToken, buff); err != nil {
 			return nil, err
 		}
-		if filterTableFinder {
+		if useTableFinder {
 			if token, buff, err = tableFinder.Filter(token, lastToken, buff); err != nil {
 				return nil, err
 			}

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -268,7 +268,7 @@ func attemptObfuscation(tokenizer *SQLTokenizer) (*ObfuscatedQuery, error) {
 	tableFinder := &tableFinderFilter{}
 	filterTableFinder := config.HasFeature("table_names")
 	var (
-		out       bytes.Buffer = *bytes.NewBuffer(make([]byte, 0, len(tokenizer.buf)))
+		out       = *bytes.NewBuffer(make([]byte, 0, len(tokenizer.buf)))
 		err       error
 		lastToken TokenKind
 		discard   discardFilter

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -265,20 +265,17 @@ func (oq *ObfuscatedQuery) Cost() int64 {
 // attemptObfuscation attempts to obfuscate the SQL query loaded into the tokenizer, using the
 // given set of filters.
 func attemptObfuscation(tokenizer *SQLTokenizer) (*ObfuscatedQuery, error) {
-	filters := []tokenFilter{
-		&discardFilter{},
-		&replaceFilter{},
-		&groupingFilter{},
-	}
 	tableFinder := &tableFinderFilter{}
-	if config.HasFeature("table_names") {
-		filters = append(filters, tableFinder)
-	}
+	filterTableFinder := config.HasFeature("table_names")
 	var (
-		out       bytes.Buffer
+		out       bytes.Buffer = *bytes.NewBuffer(make([]byte, 0, len(tokenizer.buf)))
 		err       error
 		lastToken TokenKind
+		discard   discardFilter
+		replace   replaceFilter
+		grouping  groupingFilter
 	)
+
 	// call Scan() function until tokens are available or if a LEX_ERROR is raised. After
 	// retrieving a token, send it to the tokenFilter chains so that the token is discarded
 	// or replaced.
@@ -290,8 +287,18 @@ func attemptObfuscation(tokenizer *SQLTokenizer) (*ObfuscatedQuery, error) {
 		if token == LexError {
 			return nil, fmt.Errorf("%v", tokenizer.Err())
 		}
-		for _, f := range filters {
-			if token, buff, err = f.Filter(token, lastToken, buff); err != nil {
+
+		if token, buff, err = discard.Filter(token, lastToken, buff); err != nil {
+			return nil, err
+		}
+		if token, buff, err = replace.Filter(token, lastToken, buff); err != nil {
+			return nil, err
+		}
+		if token, buff, err = grouping.Filter(token, lastToken, buff); err != nil {
+			return nil, err
+		}
+		if filterTableFinder {
+			if token, buff, err = tableFinder.Filter(token, lastToken, buff); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -1013,6 +1013,7 @@ func TestLiteralEscapesUpdates(t *testing.T) {
 	}
 }
 
+// query1 is sourced from https://stackoverflow.com/questions/12607667/issues-with-a-very-large-sql-query/12711494
 var query1 = `SELECT '%c%' as Chapter,
 (SELECT count(ticket.id) AS Matches FROM engine.ticket INNER JOIN engine.ticket_custom ON ticket.id = ticket_custom.ticket
 WHERE ticket_custom.name='chapter' AND ticket_custom.value LIKE '%c%' AND type='New material' AND milestone='1.1.12' AND component NOT LIKE 'internal_engine' AND ticket.status IN ('new','assigned') ) AS 'New',
@@ -1047,6 +1048,7 @@ FROM engine.ticket
 INNER JOIN engine.ticket_custom ON ticket.id = ticket_custom.ticket
 WHERE ticket_custom.name='chapter' AND ticket_custom.value LIKE '%c%' AND type='New material' AND milestone='1.1.12' AND component NOT LIKE 'internal_engine'`
 
+// query3 is sourced from https://www.ibm.com/support/knowledgecenter/SSCRJT_6.0.0/com.ibm.swg.im.bigsql.doc/doc/tut_bsql_uc_complex_query.html
 var query3 = `WITH
  sales AS
  (SELECT sf.*

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -8,7 +8,6 @@ package obfuscate
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"unicode"
 	"unicode/utf8"
 )
@@ -80,10 +79,11 @@ const escapeCharacter = '\\'
 // SQLTokenizer is the struct used to generate SQL
 // tokens for the parser.
 type SQLTokenizer struct {
-	rd       *strings.Reader // the "rune" reader
-	pos      int             // byte offset of lastChar
-	lastChar rune            // last read rune
-	err      error           // any error occurred while reading
+	pos      int    // byte offset of lastChar
+	lastChar rune   // last read rune
+	buf      []byte // buf holds the query that we are parsing
+	index    int    // index is the index into buf where the unread portion of the query begins.
+	err      error  // any error occurred while reading
 
 	literalEscapes bool // indicates we should not treat backslashes as escape characters
 	seenEscape     bool // indicates whether this tokenizer has seen an escape character within a string
@@ -93,16 +93,17 @@ type SQLTokenizer struct {
 // whether escape characters should be treated literally or as such.
 func NewSQLTokenizer(sql string, literalEscapes bool) *SQLTokenizer {
 	return &SQLTokenizer{
-		rd:             strings.NewReader(sql),
+		buf:            []byte(sql),
 		literalEscapes: literalEscapes,
 	}
 }
 
 // Reset the underlying buffer and positions
 func (tkn *SQLTokenizer) Reset(in string) {
-	tkn.rd.Reset(in)
 	tkn.pos = 0
 	tkn.lastChar = 0
+	tkn.buf = []byte(in)
+	tkn.index = 0
 	tkn.err = nil
 }
 
@@ -159,12 +160,12 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 			}
 			fallthrough
 		case '=', ',', ';', '(', ')', '+', '*', '&', '|', '^', '~', '[', ']', '?':
-			return TokenKind(ch), runeBytes(ch)
+			return TokenKind(ch), tkn.grab()
 		case '.':
 			if isDigit(tkn.lastChar) {
 				return tkn.scanNumber(true)
 			}
-			return TokenKind(ch), runeBytes(ch)
+			return TokenKind(ch), tkn.grab()
 		case '/':
 			switch tkn.lastChar {
 			case '/':
@@ -174,14 +175,14 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 				tkn.next()
 				return tkn.scanCommentType2()
 			default:
-				return TokenKind(ch), runeBytes(ch)
+				return TokenKind(ch), tkn.grab()
 			}
 		case '-':
 			if tkn.lastChar == '-' {
 				tkn.next()
 				return tkn.scanCommentType1("--")
 			}
-			return TokenKind(ch), runeBytes(ch)
+			return TokenKind(ch), tkn.grab()
 		case '#':
 			tkn.next()
 			return tkn.scanCommentType1("#")
@@ -200,21 +201,21 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 					return LE, []byte("<=")
 				}
 			default:
-				return TokenKind(ch), runeBytes(ch)
+				return TokenKind(ch), tkn.grab()
 			}
 		case '>':
 			if tkn.lastChar == '=' {
 				tkn.next()
 				return GE, []byte(">=")
 			}
-			return TokenKind(ch), runeBytes(ch)
+			return TokenKind(ch), tkn.grab()
 		case '!':
 			if tkn.lastChar == '=' {
 				tkn.next()
 				return NE, []byte("!=")
 			}
 			tkn.setErr(`expected "=" after "!", got "%c" (%d)`, tkn.lastChar, tkn.lastChar)
-			return LexError, []byte("!")
+			return LexError, tkn.grab()
 		case '\'':
 			return tkn.scanString(ch, String)
 		case '"':
@@ -230,14 +231,14 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 				return tkn.scanFormatParameter('%')
 			}
 			// modulo operator (e.g. 'id % 8')
-			return TokenKind(ch), runeBytes(ch)
+			return TokenKind(ch), tkn.grab()
 		case '$':
 			return tkn.scanPreparedStatement('$')
 		case '{':
 			return tkn.scanEscapeSequence('{')
 		default:
 			tkn.setErr(`unexpected byte %d`, ch)
-			return LexError, runeBytes(ch)
+			return LexError, tkn.grab()
 		}
 	}
 }
@@ -246,99 +247,116 @@ func (tkn *SQLTokenizer) skipBlank() {
 	for unicode.IsSpace(tkn.lastChar) {
 		tkn.next()
 	}
+	tkn.grab()
+}
+
+// myFastToUpper returns a copy of the byte slice s with all Unicode letters mapped to
+// their upper case. It uses the array pointed to by dst as the destination if possible.
+func myFastToUpper(src, dst []byte) []byte {
+	dst = dst[:0]
+	isASCII, hasLower := true, false
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		if c >= utf8.RuneSelf {
+			isASCII = false
+			break
+		}
+		hasLower = hasLower || ('a' <= c && c <= 'z')
+	}
+	if cap(dst) < len(src) {
+		dst = make([]byte, 0, len(src))
+	}
+	if isASCII { // optimize for ASCII-only byte slices.
+		if !hasLower {
+			// Just return a copy.
+			return append(dst, src...)
+		}
+		dst = dst[:len(src)]
+		//b := make([]byte, len(src))
+		for i := 0; i < len(src); i++ {
+			c := src[i]
+			if 'a' <= c && c <= 'z' {
+				c -= 'a' - 'A'
+			}
+			dst[i] = c
+		}
+		return dst
+	}
+	// This *could* be optimized, but it's an uncommon case.
+	return bytes.Map(unicode.ToUpper, src)
 }
 
 func (tkn *SQLTokenizer) scanIdentifier() (TokenKind, []byte) {
-	buffer := &bytes.Buffer{}
-	buffer.WriteRune(tkn.lastChar)
 	tkn.next()
-
 	for isLetter(tkn.lastChar) || isDigit(tkn.lastChar) || tkn.lastChar == '.' || tkn.lastChar == '*' {
-		buffer.WriteRune(tkn.lastChar)
 		tkn.next()
 	}
-	upper := bytes.ToUpper(buffer.Bytes())
+
+	t := tkn.grab()
+	// Space allows us to upper-case identifiers 200 bytes long or less without allocating.
+	var space [200]byte
+	upper := myFastToUpper(t, space[:0])
 	if keywordID, found := keywords[string(upper)]; found {
-		return keywordID, buffer.Bytes()
+		return keywordID, t
 	}
-	return ID, buffer.Bytes()
+	return ID, t
 }
 
 func (tkn *SQLTokenizer) scanLiteralIdentifier(quote rune) (TokenKind, []byte) {
-	buffer := &bytes.Buffer{}
-	buffer.WriteRune(tkn.lastChar)
+	tkn.grab() // throw away initial quote
 	if !isLetter(tkn.lastChar) && !isDigit(tkn.lastChar) {
 		tkn.setErr(`unexpected character "%c" (%d) in literal identifier`, tkn.lastChar, tkn.lastChar)
-		return LexError, buffer.Bytes()
+		return LexError, tkn.grab()
 	}
 	for tkn.next(); skipNonLiteralIdentifier(tkn.lastChar); tkn.next() {
-		buffer.WriteRune(tkn.lastChar)
 	}
+
+	t := tkn.grab()
 	// literals identifier are enclosed between quotes
 	if tkn.lastChar != quote {
 		tkn.setErr(`literal identifiers must end in "%c", got "%c" (%d)`, quote, tkn.lastChar, tkn.lastChar)
-		return LexError, buffer.Bytes()
+		return LexError, t
 	}
 	tkn.next()
-	return ID, buffer.Bytes()
+	return ID, t
 }
 
 func (tkn *SQLTokenizer) scanVariableIdentifier(prefix rune) (TokenKind, []byte) {
-	buffer := &bytes.Buffer{}
-	buffer.WriteRune(prefix)
-	buffer.WriteRune(tkn.lastChar)
-
 	for tkn.next(); tkn.lastChar != ')' && tkn.lastChar != EOFChar; tkn.next() {
-		buffer.WriteRune(tkn.lastChar)
 	}
-
-	buffer.WriteRune(tkn.lastChar)
 	tkn.next()
-	buffer.WriteRune(tkn.lastChar)
 	if !isLetter(tkn.lastChar) {
 		tkn.setErr(`invalid character after variable identifier: "%c" (%d)`, tkn.lastChar, tkn.lastChar)
-		return LexError, buffer.Bytes()
+		return LexError, tkn.grab()
 	}
 	tkn.next()
-	return Variable, buffer.Bytes()
+	return Variable, tkn.grab()
 }
 
 func (tkn *SQLTokenizer) scanFormatParameter(prefix rune) (TokenKind, []byte) {
-	buffer := &bytes.Buffer{}
-	buffer.WriteRune(prefix)
-	buffer.WriteRune(tkn.lastChar)
-
 	tkn.next()
-	return Variable, buffer.Bytes()
+	return Variable, tkn.grab()
 }
 
 func (tkn *SQLTokenizer) scanPreparedStatement(prefix rune) (TokenKind, []byte) {
-	buffer := &bytes.Buffer{}
-
 	// a prepared statement expect a digit identifier like $1
 	if !isDigit(tkn.lastChar) {
 		tkn.setErr(`prepared statements must start with digits, got "%c" (%d)`, tkn.lastChar, tkn.lastChar)
-		return LexError, buffer.Bytes()
+		return LexError, tkn.grab()
 	}
 
+	// scanNumber keeps the prefix rune intact.
 	// read numbers and return an error if any
 	token, buff := tkn.scanNumber(false)
 	if token == LexError {
 		tkn.setErr("invalid number")
-		return LexError, buffer.Bytes()
+		return LexError, tkn.grab()
 	}
-
-	buffer.WriteRune(prefix)
-	buffer.Write(buff)
-	return PreparedStatement, buffer.Bytes()
+	return PreparedStatement, buff
 }
 
 func (tkn *SQLTokenizer) scanEscapeSequence(braces rune) (TokenKind, []byte) {
-	buffer := &bytes.Buffer{}
-	buffer.WriteRune(braces)
-
 	for tkn.lastChar != '}' && tkn.lastChar != EOFChar {
-		buffer.WriteRune(tkn.lastChar)
 		tkn.next()
 	}
 
@@ -346,62 +364,56 @@ func (tkn *SQLTokenizer) scanEscapeSequence(braces rune) (TokenKind, []byte) {
 	// the closing curly braces
 	if tkn.lastChar == EOFChar {
 		tkn.setErr("unexpected EOF in escape sequence")
-		return LexError, buffer.Bytes()
+		return LexError, tkn.grab()
 	}
 
-	buffer.WriteRune(tkn.lastChar)
 	tkn.next()
-	return EscapeSequence, buffer.Bytes()
+	return EscapeSequence, tkn.grab()
 }
 
 func (tkn *SQLTokenizer) scanBindVar() (TokenKind, []byte) {
-	buffer := bytes.NewBufferString(":")
 	token := ValueArg
 	if tkn.lastChar == ':' {
 		token = ListArg
-		buffer.WriteRune(tkn.lastChar)
 		tkn.next()
 	}
 	if !isLetter(tkn.lastChar) {
 		tkn.setErr(`bind variables should start with letters, got "%c" (%d)`, tkn.lastChar, tkn.lastChar)
-		return LexError, buffer.Bytes()
+		return LexError, tkn.grab()
 	}
 	for isLetter(tkn.lastChar) || isDigit(tkn.lastChar) || tkn.lastChar == '.' {
-		buffer.WriteRune(tkn.lastChar)
 		tkn.next()
 	}
-	return token, buffer.Bytes()
+	return token, tkn.grab()
 }
 
-func (tkn *SQLTokenizer) scanMantissa(base int, buffer *bytes.Buffer) {
+func (tkn *SQLTokenizer) scanMantissa(base int) {
 	for digitVal(tkn.lastChar) < base {
-		tkn.consumeNext(buffer)
+		tkn.next()
 	}
 }
 
 func (tkn *SQLTokenizer) scanNumber(seenDecimalPoint bool) (TokenKind, []byte) {
-	buffer := &bytes.Buffer{}
 	if seenDecimalPoint {
-		buffer.WriteByte('.')
-		tkn.scanMantissa(10, buffer)
+		tkn.scanMantissa(10)
 		goto exponent
 	}
 
 	if tkn.lastChar == '0' {
 		// int or float
-		tkn.consumeNext(buffer)
+		tkn.next()
 		if tkn.lastChar == 'x' || tkn.lastChar == 'X' {
 			// hexadecimal int
-			tkn.consumeNext(buffer)
-			tkn.scanMantissa(16, buffer)
+			tkn.next()
+			tkn.scanMantissa(16)
 		} else {
 			// octal int or float
 			seenDecimalDigit := false
-			tkn.scanMantissa(8, buffer)
+			tkn.scanMantissa(8)
 			if tkn.lastChar == '8' || tkn.lastChar == '9' {
 				// illegal octal int or float
 				seenDecimalDigit = true
-				tkn.scanMantissa(10, buffer)
+				tkn.scanMantissa(10)
 			}
 			if tkn.lastChar == '.' || tkn.lastChar == 'e' || tkn.lastChar == 'E' {
 				goto fraction
@@ -409,35 +421,36 @@ func (tkn *SQLTokenizer) scanNumber(seenDecimalPoint bool) (TokenKind, []byte) {
 			// octal int
 			if seenDecimalDigit {
 				// tkn.setErr called in caller
-				return LexError, buffer.Bytes()
+				return LexError, tkn.grab()
 			}
 		}
 		goto exit
 	}
 
 	// decimal int or float
-	tkn.scanMantissa(10, buffer)
+	tkn.scanMantissa(10)
 
 fraction:
 	if tkn.lastChar == '.' {
-		tkn.consumeNext(buffer)
-		tkn.scanMantissa(10, buffer)
+		tkn.next()
+		tkn.scanMantissa(10)
 	}
 
 exponent:
 	if tkn.lastChar == 'e' || tkn.lastChar == 'E' {
-		tkn.consumeNext(buffer)
+		tkn.next()
 		if tkn.lastChar == '+' || tkn.lastChar == '-' {
-			tkn.consumeNext(buffer)
+			tkn.next()
 		}
-		tkn.scanMantissa(10, buffer)
+		tkn.scanMantissa(10)
 	}
 
 exit:
-	if buffer.Len() == 0 {
+	t := tkn.grab()
+	if len(t) == 0 {
 		return LexError, nil
 	}
-	return Number, buffer.Bytes()
+	return Number, t
 }
 
 func (tkn *SQLTokenizer) scanString(delim rune, kind TokenKind) (TokenKind, []byte) {
@@ -480,60 +493,68 @@ func (tkn *SQLTokenizer) scanString(delim rune, kind TokenKind) (TokenKind, []by
 }
 
 func (tkn *SQLTokenizer) scanCommentType1(prefix string) (TokenKind, []byte) {
-	buffer := &bytes.Buffer{}
-	buffer.WriteString(prefix)
 	for tkn.lastChar != EOFChar {
 		if tkn.lastChar == '\n' {
-			tkn.consumeNext(buffer)
+			tkn.next()
 			break
 		}
-		tkn.consumeNext(buffer)
+		tkn.next()
 	}
-	return Comment, buffer.Bytes()
+	return Comment, tkn.grab()
 }
 
 func (tkn *SQLTokenizer) scanCommentType2() (TokenKind, []byte) {
-	buffer := &bytes.Buffer{}
-	buffer.WriteString("/*")
 	for {
 		if tkn.lastChar == '*' {
-			tkn.consumeNext(buffer)
+			tkn.next()
 			if tkn.lastChar == '/' {
-				tkn.consumeNext(buffer)
+				tkn.next()
 				break
 			}
 			continue
 		}
 		if tkn.lastChar == EOFChar {
 			tkn.setErr("unexpected EOF in comment")
-			return LexError, buffer.Bytes()
+			return LexError, tkn.grab()
 		}
-		tkn.consumeNext(buffer)
+		tkn.next()
 	}
-	return Comment, buffer.Bytes()
+	return Comment, tkn.grab()
 }
 
-func (tkn *SQLTokenizer) consumeNext(buffer *bytes.Buffer) {
-	if tkn.lastChar == EOFChar {
-		// This should never happen.
-		panic("unexpected EOF")
-	}
-	buffer.WriteRune(tkn.lastChar)
-	tkn.next()
-}
-
+// Next sets tkn.lastChar to the next rune at tkn.buf[tkn.index], and advances the tkn.pos and
+// tkn.index by its size. If next() is unable to scan a character, tkn.lastChar is set to EOFChar.
 func (tkn *SQLTokenizer) next() {
-	ch, _, err := tkn.rd.ReadRune()
+	ch, n := utf8.DecodeRune(tkn.buf[tkn.index:])
+	if ch == utf8.RuneError && n == 0 {
+		// only EOF is possible
+		tkn.pos++
+		tkn.lastChar = EOFChar
+		return
+	}
+
+	len := utf8.RuneLen(ch)
 	if tkn.lastChar != 0 || tkn.pos > 0 {
 		// we are past the first character
-		tkn.pos += utf8.RuneLen(ch)
+		tkn.pos += len
 	}
-	if err != nil {
-		// only EOF is possible
-		tkn.lastChar = EOFChar
-	} else {
-		tkn.lastChar = ch
+	tkn.index += len
+	tkn.lastChar = ch
+}
+
+// grab returns a byte slice of all the characters advanced over with next() since the last call to
+// grab.
+func (tkn *SQLTokenizer) grab() []byte {
+	if tkn.lastChar == EOFChar {
+		ret := tkn.buf[:tkn.index]
+		tkn.buf = tkn.buf[tkn.index:]
+		tkn.index = 0
+		return ret
 	}
+	ret := tkn.buf[:tkn.index-1]
+	tkn.buf = tkn.buf[tkn.index-1:]
+	tkn.index = 1
+	return ret
 }
 
 func skipNonLiteralIdentifier(ch rune) bool {

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -273,11 +273,10 @@ func toUpper(src, dst []byte) []byte {
 	}
 	if isASCII { // optimize for ASCII-only byte slices.
 		if !hasLower {
-			// Just return a copy.
-			//return append(dst, src...)
+			// Just return src.
+			return src
 		}
 		dst = dst[:len(src)]
-		//b := make([]byte, len(src))
 		for i := 0; i < len(src); i++ {
 			c := src[i]
 			if 'a' <= c && c <= 'z' {

--- a/releasenotes/notes/refactor-sql-obfuscator-3c8a0d1ef428c410.yaml
+++ b/releasenotes/notes/refactor-sql-obfuscator-3c8a0d1ef428c410.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: refactor the SQL obfuscator to be significantly more efficient.

--- a/releasenotes/notes/refactor-sql-obfuscator-3c8a0d1ef428c410.yaml
+++ b/releasenotes/notes/refactor-sql-obfuscator-3c8a0d1ef428c410.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    APM: refactor the SQL obfuscator to be significantly more efficient.
+    APM: refactored the SQL obfuscator to be significantly more efficient.


### PR DESCRIPTION
### What does this PR do?

Previously, the SQL obfuscator would build a new byte array with
bytes.Buffer for every token. This resulted in a lot of allocations. The
new obfuscator returns slices into the original query rather than new
allocations, saving a lot of work. Comparing to the previous obfuscator,
the new one is significantly better in both space and time.
```
% benchcmp master.bench new.bench
benchmark                                      old ns/op     new ns/op     delta
BenchmarkObfuscateSQLString/query1/3694-8     119274        76567         -35.81%
BenchmarkObfuscateSQLString/query3/980-8      34102         20726         -39.22%
BenchmarkObfuscateSQLString/Escaping/512-8     12644         8888          -29.71%
BenchmarkObfuscateSQLString/Grouping/199-8     6353          4858          -23.53%
BenchmarkObfuscateSQLString/random-8           1929          1378          -28.56%

benchmark                                      old allocs     new allocs     delta
BenchmarkObfuscateSQLString/query1/3694-8     912            83             -90.90%
BenchmarkObfuscateSQLString/query3/980-8      242            6              -97.52%
BenchmarkObfuscateSQLString/Escaping/512-8     93             12             -87.10%
BenchmarkObfuscateSQLString/Grouping/199-8     74             10             -86.49%
BenchmarkObfuscateSQLString/random-8           24             8              -66.67%

benchmark                                      old bytes     new bytes     delta
BenchmarkObfuscateSQLString/query1/3694-8     43489         16256         -62.62%
BenchmarkObfuscateSQLString/query3/980-8      11264         3008          -73.30%
BenchmarkObfuscateSQLString/Escaping/512-8     3264          1936          -40.69%
BenchmarkObfuscateSQLString/Grouping/199-8     1920          816           -57.50%
BenchmarkObfuscateSQLString/random-8           752           248           -67.02%
```

### Motivation

The SQL obfuscator has been the source of frequent performance issues. 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

The test suite passes, but since this is a large change we probably want to do some testing against real applications.