### PR TITLE
[agent] Check for hidepid=2 on proc mount and report in logs

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/app/settings"
 	"github.com/DataDog/datadog-agent/cmd/agent/clcrunnerapi"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/agent/common/misconfig"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -323,6 +324,9 @@ func StartAgent() error {
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 	// start the autoconfig, this will immediately run any configured check
 	common.StartAutoConfig()
+
+	// check for common misconfigurations and report them to log
+	misconfig.ToLog()
 
 	// setup the metadata collector
 	common.MetadataScheduler = metadata.NewScheduler(s)

--- a/cmd/agent/common/misconfig/global.go
+++ b/cmd/agent/common/misconfig/global.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package misconfig
+
+import "github.com/DataDog/datadog-agent/pkg/util/log"
+
+func ToLog() {
+	for name, check := range checks {
+		if err := check(); err != nil {
+			log.Warnf("misconfig: %s: %v", name, err)
+		}
+	}
+}
+
+type checkFn func() error
+
+var checks = map[string]checkFn{
+	"proc mount": procMount,
+}

--- a/cmd/agent/common/misconfig/global.go
+++ b/cmd/agent/common/misconfig/global.go
@@ -7,6 +7,7 @@ package misconfig
 
 import "github.com/DataDog/datadog-agent/pkg/util/log"
 
+// ToLog outputs warnings about common misconfigurations in the logs
 func ToLog() {
 	for name, check := range checks {
 		if err := check(); err != nil {
@@ -17,6 +18,8 @@ func ToLog() {
 
 type checkFn func() error
 
-var checks = map[string]checkFn{
-	"proc mount": procMount,
+var checks = map[string]checkFn{}
+
+func registerCheck(name string, c checkFn) {
+	checks[name] = c
 }

--- a/cmd/agent/common/misconfig/global.go
+++ b/cmd/agent/common/misconfig/global.go
@@ -20,6 +20,7 @@ type checkFn func() error
 
 var checks = map[string]checkFn{}
 
+// nolint: deadcode, unused
 func registerCheck(name string, c checkFn) {
 	checks[name] = c
 }

--- a/cmd/agent/common/misconfig/mounts.go
+++ b/cmd/agent/common/misconfig/mounts.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package misconfig
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func procMount() error {
+	groups, err := os.Getgroups()
+	if err != nil {
+		return fmt.Errorf("failed to get process groups: %v", err)
+	}
+	return checkProcMountHidePid("/host/proc/1/mounts", groups)
+}
+
+func checkProcMountHidePid(path string, groups []int) error {
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to open %s", path)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 6 ||
+			fields[0] != "proc" || fields[1] != "/proc" {
+			continue
+		}
+		mountOpts := strings.Split(fields[3], ",")
+		mountOptsLookup := map[string]bool{}
+		for _, opt := range mountOpts {
+			mountOptsLookup[opt] = true
+		}
+
+		if ok, _ := mountOptsLookup["hidepid=2"]; !ok {
+			// hidepid is not set, no further checks necessary
+			return nil
+		}
+
+		for _, gid := range groups {
+			gidOpt := fmt.Sprintf("gid=%d", gid)
+			if ok, _ := mountOptsLookup[gidOpt]; ok {
+				// While hidepid=2 is set, one of the groups is enabled
+				return nil
+			}
+		}
+
+		return fmt.Errorf("hidepid=2 option detected in %s - will prevent procfs inspection", path)
+	}
+
+	return errors.Wrapf(scanner.Err(), "failed to scan %s", path)
+}

--- a/cmd/agent/common/misconfig/mounts.go
+++ b/cmd/agent/common/misconfig/mounts.go
@@ -3,31 +3,42 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
+// +build !windows
+
 package misconfig
 
 import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	registerCheck("proc mount", procMount)
+}
 
 func procMount() error {
 	groups, err := os.Getgroups()
 	if err != nil {
 		return fmt.Errorf("failed to get process groups: %v", err)
 	}
-	return checkProcMountHidePid("/host/proc/1/mounts", groups)
+	path := config.Datadog.GetString("container_proc_root")
+	if config.IsContainerized() && path != "/proc" {
+		path = filepath.Join(path, "1/mounts")
+	} else {
+		path = filepath.Join(path, "mounts")
+	}
+	return checkProcMountHidePid(path, groups)
 }
 
 func checkProcMountHidePid(path string, groups []int) error {
 	file, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
 		return errors.Wrapf(err, "failed to open %s", path)
 	}
 	defer file.Close()
@@ -36,29 +47,29 @@ func checkProcMountHidePid(path string, groups []int) error {
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
 		if len(fields) != 6 ||
-			fields[0] != "proc" || fields[1] != "/proc" {
+			fields[1] != "/proc" || fields[2] != "proc" {
 			continue
 		}
 		mountOpts := strings.Split(fields[3], ",")
-		mountOptsLookup := map[string]bool{}
+		mountOptsLookup := map[string]struct{}{}
 		for _, opt := range mountOpts {
-			mountOptsLookup[opt] = true
+			mountOptsLookup[opt] = struct{}{}
 		}
 
-		if ok, _ := mountOptsLookup["hidepid=2"]; !ok {
+		if _, ok := mountOptsLookup["hidepid=2"]; !ok {
 			// hidepid is not set, no further checks necessary
 			return nil
 		}
 
 		for _, gid := range groups {
 			gidOpt := fmt.Sprintf("gid=%d", gid)
-			if ok, _ := mountOptsLookup[gidOpt]; ok {
+			if _, ok := mountOptsLookup[gidOpt]; ok {
 				// While hidepid=2 is set, one of the groups is enabled
 				return nil
 			}
 		}
 
-		return fmt.Errorf("hidepid=2 option detected in %s - will prevent procfs inspection", path)
+		return fmt.Errorf("hidepid=2 option detected in %s - will prevent inspection of proc fs", path)
 	}
 
 	return errors.Wrapf(scanner.Err(), "failed to scan %s", path)

--- a/cmd/agent/common/misconfig/mounts_test.go
+++ b/cmd/agent/common/misconfig/mounts_test.go
@@ -23,13 +23,14 @@ func TestCheckProcMountHidePid(t *testing.T) {
 		expectError string
 	}{
 		{
-			name: "missing file",
-			file: "./proc-mounts-not-here",
+			name:        "missing file",
+			file:        "./proc-mounts-not-here",
+			expectError: "failed to open ./proc-mounts-not-here: open ./proc-mounts-not-here: no such file or directory",
 		},
 		{
 			name:        "hidepid with no groups",
 			file:        "./tests/proc-mounts-hidepid-2",
-			expectError: "hidepid=2 option detected in ./tests/proc-mounts-hidepid-2 - will prevent inspection of procfs",
+			expectError: "hidepid=2 option detected in ./tests/proc-mounts-hidepid-2 - will prevent inspection of proc fs",
 		},
 		{
 			name:   "hidepid with no groups",

--- a/cmd/agent/common/misconfig/mounts_test.go
+++ b/cmd/agent/common/misconfig/mounts_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build !windows
+
+package misconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckProcMountHidePid(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name        string
+		file        string
+		groups      []int
+		expectError string
+	}{
+		{
+			name: "missing file",
+			file: "./proc-mounts-not-here",
+		},
+		{
+			name:        "hidepid with no groups",
+			file:        "./tests/proc-mounts-hidepid-2",
+			expectError: "hidepid=2 option detected in ./tests/proc-mounts-hidepid-2 - will prevent inspection of procfs",
+		},
+		{
+			name:   "hidepid with no groups",
+			file:   "./tests/proc-mounts-hidepid-2",
+			groups: []int{234, 4242},
+		},
+		{
+			name: "no hidepid",
+			file: "./tests/proc-mounts-no-hidepid",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkProcMountHidePid(test.file, test.groups)
+			if test.expectError != "" {
+				assert.EqualError(err, test.expectError)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}

--- a/cmd/agent/common/misconfig/mounts_test.go
+++ b/cmd/agent/common/misconfig/mounts_test.go
@@ -19,33 +19,46 @@ func TestCheckProcMountHidePid(t *testing.T) {
 	tests := []struct {
 		name        string
 		file        string
+		uid         int
 		groups      []int
 		expectError string
 	}{
 		{
 			name:        "missing file",
 			file:        "./proc-mounts-not-here",
-			expectError: "failed to open ./proc-mounts-not-here: open ./proc-mounts-not-here: no such file or directory",
+			expectError: "failed to open ./proc-mounts-not-here - proc fs inspection may not work: open ./proc-mounts-not-here: no such file or directory",
 		},
 		{
-			name:        "hidepid with no groups",
-			file:        "./tests/proc-mounts-hidepid-2",
-			expectError: "hidepid=2 option detected in ./tests/proc-mounts-hidepid-2 - will prevent inspection of proc fs",
+			name:        "non-root with hidepid without groups",
+			uid:         1001,
+			file:        "./tests/proc-mounts-hidepid-2-groups",
+			expectError: "hidepid=2 option detected in ./tests/proc-mounts-hidepid-2-groups - proc fs inspection may not work",
 		},
 		{
-			name:   "hidepid with no groups",
-			file:   "./tests/proc-mounts-hidepid-2",
+			name:   "non-root with hidepid and groups",
+			uid:    1001,
+			file:   "./tests/proc-mounts-hidepid-2-groups",
 			groups: []int{234, 4242},
 		},
 		{
-			name: "no hidepid",
+			name: "root with hidepid without groups",
+			file: "./tests/proc-mounts-hidepid-2",
+		},
+		{
+			name:   "root with hidepid and groups",
+			file:   "./tests/proc-mounts-hidepid-2-groups",
+			groups: []int{234, 4242},
+		},
+		{
+			name: "non-root with no hidepid",
+			uid:  1001,
 			file: "./tests/proc-mounts-no-hidepid",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := checkProcMountHidePid(test.file, test.groups)
+			err := checkProcMountHidePid(test.file, test.uid, test.groups)
 			if test.expectError != "" {
 				assert.EqualError(err, test.expectError)
 			} else {

--- a/cmd/agent/common/misconfig/mounts_test.go
+++ b/cmd/agent/common/misconfig/mounts_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build !windows
+// +build linux
 
 package misconfig
 
@@ -19,7 +19,6 @@ func TestCheckProcMountHidePid(t *testing.T) {
 	tests := []struct {
 		name        string
 		file        string
-		uid         int
 		groups      []int
 		expectError string
 	}{
@@ -29,36 +28,24 @@ func TestCheckProcMountHidePid(t *testing.T) {
 			expectError: "failed to open ./proc-mounts-not-here - proc fs inspection may not work: open ./proc-mounts-not-here: no such file or directory",
 		},
 		{
-			name:        "non-root with hidepid without groups",
-			uid:         1001,
+			name:        "hidepid without groups",
 			file:        "./tests/proc-mounts-hidepid-2-groups",
 			expectError: "hidepid=2 option detected in ./tests/proc-mounts-hidepid-2-groups - proc fs inspection may not work",
 		},
 		{
-			name:   "non-root with hidepid and groups",
-			uid:    1001,
+			name:   "hidepid and groups",
 			file:   "./tests/proc-mounts-hidepid-2-groups",
 			groups: []int{234, 4242},
 		},
 		{
-			name: "root with hidepid without groups",
-			file: "./tests/proc-mounts-hidepid-2",
-		},
-		{
-			name:   "root with hidepid and groups",
-			file:   "./tests/proc-mounts-hidepid-2-groups",
-			groups: []int{234, 4242},
-		},
-		{
-			name: "non-root with no hidepid",
-			uid:  1001,
+			name: "no hidepid",
 			file: "./tests/proc-mounts-no-hidepid",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := checkProcMountHidePid(test.file, test.uid, test.groups)
+			err := checkProcMountHidePid(test.file, test.groups)
 			if test.expectError != "" {
 				assert.EqualError(err, test.expectError)
 			} else {

--- a/cmd/agent/common/misconfig/mounts_test.go
+++ b/cmd/agent/common/misconfig/mounts_test.go
@@ -29,8 +29,14 @@ func TestCheckProcMountHidePid(t *testing.T) {
 		},
 		{
 			name:        "hidepid without groups",
-			file:        "./tests/proc-mounts-hidepid-2-groups",
-			expectError: "hidepid=2 option detected in ./tests/proc-mounts-hidepid-2-groups - proc fs inspection may not work",
+			file:        "./tests/proc-mounts-hidepid-2",
+			groups:      []int{1, 2, 3},
+			expectError: "hidepid=2 option detected in ./tests/proc-mounts-hidepid-2 (options=defaults,hidepid=2) - proc fs inspection may not work (uid=1001, groups=[1,2,3])",
+		},
+		{
+			name:   "hidepid without groups user has root group",
+			file:   "./tests/proc-mounts-hidepid-2",
+			groups: []int{0},
 		},
 		{
 			name:   "hidepid and groups",
@@ -45,7 +51,7 @@ func TestCheckProcMountHidePid(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := checkProcMountHidePid(test.file, test.groups)
+			err := checkProcMountHidePid(test.file, 1001, test.groups)
 			if test.expectError != "" {
 				assert.EqualError(err, test.expectError)
 			} else {

--- a/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-2
+++ b/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-2
@@ -1,0 +1,1 @@
+proc	/proc	proc	defaults,hidepid=2,gid=4242	0 0

--- a/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-2
+++ b/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-2
@@ -1,1 +1,1 @@
-proc	/proc	proc	defaults,hidepid=2,gid=4242	0 0
+proc	/proc	proc	defaults,hidepid=2	0 0

--- a/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-2-groups
+++ b/cmd/agent/common/misconfig/tests/proc-mounts-hidepid-2-groups
@@ -1,0 +1,1 @@
+proc	/proc	proc	defaults,hidepid=2,gid=4242	0 0

--- a/cmd/agent/common/misconfig/tests/proc-mounts-no-hidepid
+++ b/cmd/agent/common/misconfig/tests/proc-mounts-no-hidepid
@@ -1,0 +1,1 @@
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0

--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.1
-	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 // indirect
+	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00 // indirect
 	github.com/tinylib/msgp v1.1.2
 	github.com/twmb/murmur3 v1.1.3

--- a/releasenotes/notes/add-misconfig-check-for-hidepid=2-option-135228c24e86e227.yaml
+++ b/releasenotes/notes/add-misconfig-check-for-hidepid=2-option-135228c24e86e227.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adds misconfig check for hidepid=2 option on proc mount.


### PR DESCRIPTION
### What does this PR do?

With `hidepid=2` on proc mount the Agent will not be able to see other processes. This adds a warning in the logs so that we can detect these configurations. In the future we can expose this in the agent status as well.

More info on [hidepid](https://man7.org/linux/man-pages/man5/proc.5.html).

### Motivation

Detecting `hidepid=2` configuration.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Harden the host with `hidepid=2,gid=..` and test that the message is shown in the logs.
