### PR TITLE
Adding a secondary endpoint to dogstatsd for telemetry

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -352,6 +352,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_entity_id_precedence", false)
 	// Sends Dogstatsd parse errors to the Debug level instead of the Error level
 	config.BindEnvAndSetDefault("dogstatsd_disable_verbose_logs", false)
+	config.BindEnvAndSetDefault("dogstatsd_telemetry_listener", "")
 
 	_ = config.BindEnv("dogstatsd_mapper_profiles")
 	config.SetEnvKeyTransformer("dogstatsd_mapper_profiles", func(in string) interface{} {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1013,6 +1013,20 @@ api_key:
 #
 # dogstatsd_socket: ""
 
+## @param dogstatsd_telemetry_listener - string - optional - default: ""
+## Add an extra listener for the telemetry from DogStatsD clients. By default,
+## clients send telemetry to the main dogstatsd destination, but some clients can
+## be configured to send their telemetry to another destination than the main
+## data. This option allows the Agent to listen to the telemetry from those
+## clients.
+## This is useful in high throughput scenarios to avoid dropping telemetry metrics
+## which prevents users from troubleshooting issues. See each client
+## configuration to know how to send their telemetry to a different destination.
+##
+## Use "unix://<path_to_socket>" for UDS or "<port_number>" for UDP.
+#
+# dogstatsd_telemetry_listener: ""
+
 ## @param dogstatsd_origin_detection - boolean - optional - default: false
 ## When using Unix Socket, DogStatsD can tag metrics with container metadata.
 ## If running DogStatsD in a container, host PID mode (e.g. with --pid=host) is required.

--- a/pkg/dogstatsd/listeners/named_pipe_nowindows.go
+++ b/pkg/dogstatsd/listeners/named_pipe_nowindows.go
@@ -13,6 +13,9 @@ import (
 // NamedPipeListener implements the StatsdListener interface for named pipe protocol.
 type NamedPipeListener struct{}
 
+// IsNamedPipeEndpoint detects if the endpoint has the named pipe prefix
+func IsNamedPipeEndpoint(endpoint string) bool { return false }
+
 // NewNamedPipeListener returns an named pipe Statsd listener
 func NewNamedPipeListener(pipeName string, packetOut chan Packets, sharedPacketPool *PacketPool) (*NamedPipeListener, error) {
 	return nil, errors.New("named pipe is only supported on Windows")

--- a/pkg/dogstatsd/listeners/named_pipe_windows.go
+++ b/pkg/dogstatsd/listeners/named_pipe_windows.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"io"
 	"net"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -52,8 +53,11 @@ func newNamedPipeListener(
 		InputBufferSize:  int32(bufferSize),
 		OutputBufferSize: 0,
 	}
-	pipePath := pipeNamePrefix + pipeName
-	pipe, err := winio.ListenPipe(pipePath, &config)
+
+	if !strings.HasPrefix(pipeName, pipeNamePrefix) {
+		pipeName = pipeNamePrefix + pipeName
+	}
+	pipe, err := winio.ListenPipe(pipeName, &config)
 
 	if err != nil {
 		return nil, err
@@ -73,6 +77,11 @@ func newNamedPipeListener(
 
 	log.Debugf("dogstatsd-named-pipes: %s successfully initialized", pipe.Addr())
 	return listener, nil
+}
+
+// IsNamedPipeEndpoint detects if the endpoint has the named pipe prefix
+func IsNamedPipeEndpoint(endpoint string) bool {
+	return strings.HasPrefix(endpoint, pipeNamePrefix)
 }
 
 type namedPipeConnections struct {

--- a/pkg/dogstatsd/listeners/named_pipe_windows_test.go
+++ b/pkg/dogstatsd/listeners/named_pipe_windows_test.go
@@ -21,6 +21,12 @@ const pipeName = "TestPipeName"
 const maxPipeMessageCount = 1000
 const namedPipeBufferSize = 13
 
+func TestIsNamedPipeEndpoint(t *testing.T) {
+	assert.False(t, IsNamedPipeEndpoint(""))
+	assert.False(t, IsNamedPipeEndpoint("some_pipe"))
+	assert.True(t, IsNamedPipeEndpoint(`\\.\pipe\`+"some_pipe"))
+}
+
 func TestNamedPipeListen(t *testing.T) {
 	listener := newNamedPipeListenerTest(t)
 	defer listener.Stop()

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -9,6 +9,7 @@ import (
 	"expvar"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
@@ -47,15 +48,15 @@ type UDPListener struct {
 }
 
 // NewUDPListener returns an idle UDP Statsd listener
-func NewUDPListener(packetOut chan Packets, sharedPacketPool *PacketPool) (*UDPListener, error) {
+func NewUDPListener(portNumber int, packetOut chan Packets, sharedPacketPool *PacketPool) (*UDPListener, error) {
 	var err error
 	var url string
 
 	if config.Datadog.GetBool("dogstatsd_non_local_traffic") == true {
 		// Listen to all network interfaces
-		url = fmt.Sprintf(":%d", config.Datadog.GetInt("dogstatsd_port"))
+		url = fmt.Sprintf(":%d", portNumber)
 	} else {
-		url = net.JoinHostPort(config.Datadog.GetString("bind_host"), config.Datadog.GetString("dogstatsd_port"))
+		url = net.JoinHostPort(config.Datadog.GetString("bind_host"), strconv.Itoa(portNumber))
 	}
 
 	addr, err := net.ResolveUDPAddr("udp", url)

--- a/pkg/dogstatsd/listeners/udp_test.go
+++ b/pkg/dogstatsd/listeners/udp_test.go
@@ -22,7 +22,7 @@ import (
 var packetPoolUDP = NewPacketPool(config.Datadog.GetInt("dogstatsd_buffer_size"))
 
 func TestNewUDPListener(t *testing.T) {
-	s, err := NewUDPListener(nil, packetPoolUDP)
+	s, err := NewUDPListener(8125, nil, packetPoolUDP)
 	assert.NotNil(t, s)
 	assert.Nil(t, err)
 
@@ -32,9 +32,8 @@ func TestNewUDPListener(t *testing.T) {
 func TestStartStopUDPListener(t *testing.T) {
 	port, err := getAvailableUDPPort()
 	require.Nil(t, err)
-	config.Datadog.SetDefault("dogstatsd_port", port)
 	config.Datadog.SetDefault("dogstatsd_non_local_traffic", false)
-	s, err := NewUDPListener(nil, packetPoolUDP)
+	s, err := NewUDPListener(port, nil, packetPoolUDP)
 	require.NotNil(t, s)
 
 	assert.Nil(t, err)
@@ -63,9 +62,8 @@ func TestStartStopUDPListener(t *testing.T) {
 func TestUDPNonLocal(t *testing.T) {
 	port, err := getAvailableUDPPort()
 	require.Nil(t, err)
-	config.Datadog.SetDefault("dogstatsd_port", port)
 	config.Datadog.SetDefault("dogstatsd_non_local_traffic", true)
-	s, err := NewUDPListener(nil, packetPoolUDP)
+	s, err := NewUDPListener(port, nil, packetPoolUDP)
 	assert.Nil(t, err)
 	require.NotNil(t, s)
 
@@ -87,9 +85,8 @@ func TestUDPNonLocal(t *testing.T) {
 func TestUDPLocalOnly(t *testing.T) {
 	port, err := getAvailableUDPPort()
 	require.Nil(t, err)
-	config.Datadog.SetDefault("dogstatsd_port", port)
 	config.Datadog.SetDefault("dogstatsd_non_local_traffic", false)
-	s, err := NewUDPListener(nil, packetPoolUDP)
+	s, err := NewUDPListener(port, nil, packetPoolUDP)
 	assert.Nil(t, err)
 	require.NotNil(t, s)
 
@@ -114,10 +111,9 @@ func TestUDPReceive(t *testing.T) {
 	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
 	port, err := getAvailableUDPPort()
 	require.Nil(t, err)
-	config.Datadog.SetDefault("dogstatsd_port", port)
 
 	packetChannel := make(chan Packets)
-	s, err := NewUDPListener(packetChannel, packetPoolUDP)
+	s, err := NewUDPListener(port, packetChannel, packetPoolUDP)
 	require.NotNil(t, s)
 	assert.Nil(t, err)
 

--- a/pkg/dogstatsd/listeners/uds_linux_test.go
+++ b/pkg/dogstatsd/listeners/uds_linux_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"golang.org/x/sys/unix"
 )
 
@@ -29,11 +28,7 @@ func TestUDSPassCred(t *testing.T) {
 	defer os.RemoveAll(dir) // clean up
 	socketPath := filepath.Join(dir, "dsd.socket")
 
-	mockConfig := config.Mock()
-	mockConfig.Set("dogstatsd_socket", socketPath)
-	mockConfig.Set("dogstatsd_origin_detection", true)
-
-	s, err := NewUDSListener(nil, NewPacketPool(512))
+	s, err := NewUDSListener(socketPath, true, nil, NewPacketPool(512))
 	defer s.Stop()
 
 	assert.Nil(t, err)

--- a/releasenotes/notes/secondary-uds-endpoint-0e8eae5f55670a0c.yaml
+++ b/releasenotes/notes/secondary-uds-endpoint-0e8eae5f55670a0c.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Adding a secondary endpoint to DogStatsD dedicated to telemetry metrics.
+    This is useful in high throughput scenarios to avoid dropping telemetry
+    metrics which prevents users from troubleshooting issues. The new option is
+    "dogstatsd_telemetry_listener", supports UDS/UDP and is disabled by default.
+    This also requires the DogStatsD client to send telemetry to a custom
+    endpoint, see the clients documentation for more details.

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners"
 	"github.com/DataDog/datadog-agent/test/integration/utils"
 )
@@ -33,8 +32,6 @@ const (
 // we can't just `netcat` to the socket, that's why we run a custom python
 // script that will stay up after sending packets.
 func testUDSOriginDetection(t *testing.T) {
-	mockConfig := config.Mock()
-
 	// Detect whether we are containerised and set the socket path accordingly
 	var socketVolume string
 	var composeFile string
@@ -52,13 +49,11 @@ func testUDSOriginDetection(t *testing.T) {
 		composeFile = "mount_volume.compose"
 	}
 	socketPath := filepath.Join(dir, "dsd.socket")
-	mockConfig.Set("dogstatsd_socket", socketPath)
-	mockConfig.Set("dogstatsd_origin_detection", true)
 
 	// Start DSD
 	packetsChannel := make(chan listeners.Packets)
 	sharedPacketPool := listeners.NewPacketPool(32)
-	s, err := listeners.NewUDSListener(packetsChannel, sharedPacketPool)
+	s, err := listeners.NewUDSListener(socketPath, true, packetsChannel, sharedPacketPool)
 	require.Nil(t, err)
 
 	go s.Listen()


### PR DESCRIPTION
### What does this PR do?

When used in high throughput scenario the dropping telemetry metrics
prevent users from troubleshooting issues. Adding a secondary UDS
endpoint to prevent droping those.