### PR TITLE
[Windows] Detect read-only domain controller

### DIFF
--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -129,15 +129,15 @@ UINT doFinalizeInstall(CustomActionData &data)
     }
     hr = 0;
 
-    if (!data.GetTargetMachine().IsBackupDomainController()) {
-        DWORD errCode = AddUserToGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
-        if (errCode != NERR_Success) {
-            WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", errCode);
+    if (!data.GetTargetMachine().IsReadOnlyDomainController()) {
+        er = AddUserToGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
+        if (er != NERR_Success) {
+            WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", er);
             goto LExit;
         }
-        errCode = AddUserToGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
-        if (errCode != NERR_Success) {
-            WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", errCode);
+        er = AddUserToGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
+        if (er != NERR_Success) {
+            WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", er);
             goto LExit;
         }
     }

--- a/tools/windows/install-help/cal/TargetMachine.h
+++ b/tools/windows/install-help/cal/TargetMachine.h
@@ -3,7 +3,8 @@
 class TargetMachine
 {
 private:
-    DWORD  _serverType;
+    DWORD _serverType;
+    DWORD _dcFlags;
     std::wstring _machineName;
     std::wstring _domain;
     bool _isDomainJoined;
@@ -24,4 +25,5 @@ public:
     bool IsServer() const;
     bool IsDomainController() const;
     bool IsBackupDomainController() const;
+    bool IsReadOnlyDomainController() const;
 };


### PR DESCRIPTION
### What does this PR do?

Add detection for Read-Only domain controllers and skip adding the Agent user to local groups in that case.

### Motivation

https://github.com/DataDog/datadog-agent/pull/6318 adds the Agent user to a group only if it's not a backup controller, which is not correct since backup controller can also write to the domain directory if they have the "Writable" flag.

### Describe your test plan

1) Install on a backup domain controller using a custom `DDAGENTUSER_NAME` and `DDAGENTUSER_PASSWORD`. Check that the Agent user is correctly added to the groups.
2) Then install in a read-only domain controller using the user created in step 1. The install should succeed as well.
