### PR TITLE
[compliance] Check if a file is present before checking audit rule

### DIFF
--- a/pkg/compliance/checks/audit_check.go
+++ b/pkg/compliance/checks/audit_check.go
@@ -8,6 +8,7 @@ package checks
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
@@ -37,6 +38,11 @@ func resolveAudit(_ context.Context, e env.Env, ruleID string, res compliance.Re
 	path, err := resolvePath(e, audit.Path)
 	if err != nil {
 		return nil, err
+	}
+
+	normPath := e.NormalizeToHostRoot(path)
+	if _, err := os.Stat(normPath); err != nil && os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s: audit resource path does not exist", ruleID)
 	}
 
 	paths := []string{path}


### PR DESCRIPTION
### What does this PR do?

Improves compliance check for audit rules by verifying the targeted file exists on the host, if it doesn't reports an error accordingly.

### Motivation

Resolve potential confusion due to the source of error (missing file path vs missing audit rule).

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Configure an audit resource in compliance check to target a file that is not available in the system, confirm the reported error specifies the missing path rather than missing audit rule.