### PR TITLE
pkg/trace/agent: do not stop processing after finding a filtered trace

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -180,7 +180,7 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 			log.Debugf("Trace rejected by blacklister. root: %v", root)
 			atomic.AddInt64(&ts.TracesFiltered, 1)
 			atomic.AddInt64(&ts.SpansFiltered, tracen)
-			return
+			continue
 		}
 
 		// Extra sanitization steps of the trace.

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -147,6 +147,52 @@ func TestProcess(t *testing.T) {
 		assert.EqualValues(2, want.SpansFiltered)
 	})
 
+	t.Run("BlacklistPayload", func(t *testing.T) {
+		// Regression test for  DataDog/datadog-agent#6500
+		cfg := config.New()
+		cfg.Endpoints[0].APIKey = "test"
+		cfg.Ignore["resource"] = []string{"^INSERT.*"}
+		ctx, cancel := context.WithCancel(context.Background())
+		agnt := NewAgent(ctx, cfg)
+		defer cancel()
+
+		now := time.Now()
+		spanValid := &pb.Span{
+			TraceID:  1,
+			SpanID:   1,
+			Resource: "SELECT name FROM people WHERE age = 42 AND extra = 55",
+			Type:     "sql",
+			Start:    now.Add(-time.Second).UnixNano(),
+			Duration: (500 * time.Millisecond).Nanoseconds(),
+		}
+		spanInvalid := &pb.Span{
+			TraceID:  1,
+			SpanID:   1,
+			Resource: "INSERT INTO db VALUES (1, 2, 3)",
+			Type:     "sql",
+			Start:    now.Add(-time.Second).UnixNano(),
+			Duration: (500 * time.Millisecond).Nanoseconds(),
+		}
+
+		want := agnt.Receiver.Stats.GetTagStats(info.Tags{})
+		assert := assert.New(t)
+
+		agnt.Process(&api.Payload{
+			Traces: pb.Traces{{spanInvalid, spanInvalid}, {spanValid}},
+			Source: want,
+		}, stats.NewSublayerCalculator())
+		assert.EqualValues(1, want.TracesFiltered)
+		assert.EqualValues(2, want.SpansFiltered)
+		var span *pb.Span
+		select {
+		case ss := <-agnt.Out:
+			span = ss.Traces[0].Spans[0]
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout: Expected one valid trace, but none were received.")
+		}
+		assert.Equal("unnamed_operation", span.Name)
+	})
+
 	t.Run("ContainerTags", func(t *testing.T) {
 		cfg := config.New()
 		cfg.Endpoints[0].APIKey = "test"

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -148,7 +148,7 @@ func TestProcess(t *testing.T) {
 	})
 
 	t.Run("BlacklistPayload", func(t *testing.T) {
-		// Regression test for  DataDog/datadog-agent#6500
+		// Regression test for DataDog/datadog-agent#6500
 		cfg := config.New()
 		cfg.Endpoints[0].APIKey = "test"
 		cfg.Ignore["resource"] = []string{"^INSERT.*"}


### PR DESCRIPTION
### What does this PR do?

Starting in #6020 (*Agent).Process processes whole payloads, not individual
traces. This means Process cannot return after finding a trace that should
be filtered. Instead, it should continue to process the other traces in the
payload.


### Motivation

This is a bug that causes traces to be lost.

