### PR TITLE
pkg/trace/agent: do not stop processing after finding a filtered trace

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -179,7 +179,7 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 			log.Debugf("Trace rejected by blacklister. root: %v", root)
 			atomic.AddInt64(&ts.TracesFiltered, 1)
 			atomic.AddInt64(&ts.SpansFiltered, tracen)
-			return
+			continue
 		}
 
 		// Extra sanitization steps of the trace.


### PR DESCRIPTION
Backport to 7.22.x for #6500 
### What does this PR do?

Starting in #6020 (*Agent).Process processes whole payloads, not individual
traces. This means Process cannot return after finding a trace that should
be filtered. Instead, it should continue to process the other traces in the
payload.

A brief description of the change being made with this pull request.

### Motivation

This is a bug that causes traces to be lost.

