### PR TITLE
[process-agent] don't send payloads for the first 3 container checks

### DIFF
--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -20,7 +20,7 @@ import (
 
 // Container is a singleton ContainerCheck.
 var (
-	Container = &ContainerCheck{}
+	Container    = &ContainerCheck{}
 	checksToSkip = 3
 )
 


### PR DESCRIPTION
### What does this PR do?

In some cases, especially in ECS/Fargate environment where container tags are collected by pulling information from API, the tagger runs tag collection asynchronously in the background and the API call returns slower than container check. This causes the first several checks to miss container tags. Therefore we need to skip sending payloads for the first three payloads. This PR should fix the UI inconsistency because we only update container metadata periodically, so for quite some time the new container in the UI would show incomplete info, until next metadata update happens. By delaying three checks, we wait on the tag latency so that the information is already correct the first time we send containers to Datadog.

### Motivation

https://datadoghq.atlassian.net/browse/CONS-3261 describes the UI behavior, the most obvious inconsistency is that the container would initially show as a fargate task arn. After a while(10-15 minutes) it populates the correct name.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
