### PR TITLE
fix CPU calculation for new containers

### DIFF
--- a/pkg/process/checks/container_common.go
+++ b/pkg/process/checks/container_common.go
@@ -16,7 +16,7 @@ func calculateCtrPct(cur, prev, sys2, sys1 uint64, numCPU int, before time.Time)
 
 	// If we have system usage values then we need to calculate against those.
 	// XXX: Right now this only applies to ECS collection
-	if sys1 > 0 && sys2 > 0 && sys2 != sys1 {
+	if sys1 >= 0 && sys2 > 0 && sys2 != sys1 {
 		cpuDelta := float32(cur - prev)
 		sysDelta := float32(sys2 - sys1)
 		return (cpuDelta / sysDelta) * float32(numCPU) * 100

--- a/pkg/process/checks/container_test.go
+++ b/pkg/process/checks/container_test.go
@@ -136,6 +136,9 @@ func TestCalculateCtrPct(t *testing.T) {
 	// Div by zero on sys2/sys1, fallback to normal cpu calculation
 	assert.InEpsilon(t, 2, calculateCtrPct(3, 1, 1, 1, 1, before), epsilon)
 
+	// use cur=2, prev=0, sys1=0, sys2=2 simulating first check on new container
+	assert.InEpsilon(t, float32(200), calculateCtrPct(2, 0, 1, 0, 1, before), epsilon)
+
 	// Calculate based off cur & prev
 	assert.InEpsilon(t, 2, calculateCtrPct(3, 1, 0, 0, 1, before), epsilon)
 


### PR DESCRIPTION
### What does this PR do?

When a new container is created we don't have previous CPU time to base on while calculating CPU%. Thus the formula `float32(cur-prev) / float32(diff)` is used, which causes unreasonable CPU% metric on the first value.

### Motivation

https://datadoghq.atlassian.net/browse/CONS-3261

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
