### PR TITLE
pkg/trace/agent: enhance test to cover non-filtered traces

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -183,14 +183,15 @@ func TestProcess(t *testing.T) {
 		}, stats.NewSublayerCalculator())
 		assert.EqualValues(1, want.TracesFiltered)
 		assert.EqualValues(2, want.SpansFiltered)
-		var span *pb.Span
+		var traces []*pb.APITrace
 		select {
 		case ss := <-agnt.Out:
-			span = ss.Traces[0].Spans[0]
+			traces = ss.Traces
 		case <-time.After(2 * time.Second):
 			t.Fatal("timeout: Expected one valid trace, but none were received.")
 		}
-		assert.Equal("unnamed_operation", span.Name)
+		assert.Equal("unnamed_operation", traces[0].Spans[0].Name)
+		assert.Len(traces, 1)
 	})
 
 	t.Run("ContainerTags", func(t *testing.T) {


### PR DESCRIPTION
This change improves the existing blacklister test to ensure that traces
coming in after ignored ones get sampled. It's a regression test
covering the bug resolved in #6500