### PR TITLE
Adding support for multiple values per dogstatsd datagram

### DIFF
--- a/pkg/dogstatsd/README.md
+++ b/pkg/dogstatsd/README.md
@@ -24,3 +24,23 @@ Dogstatsd implementation documentation (PacketsBuffer, StringInterner, ...) is a
 in `docs/dogstatsd/internals.md`.
 
 Details on existing Dogstatsd internals tuning fields are available in `docs/dogstatsd/configuration.md`.
+
+### [Experimental] Dogstatsd protocol 1.1
+
+This feature is experimental for now and could change or be remove in futur release.
+
+Starting with agent 7.25.0/6.25.0 Dogstatsd datagram can contain multiple values using the `:` delimiter.
+
+For example, this payload contains 3 values (`1.5`, `20`, and `30`) for the metric `my_metric`:
+```
+my_metric:1.5:20:30|h|#tag1,tag2
+```
+
+All metric types except `set` support this, since `:` could be in the value of a
+set. Sets are now being aggregated on the client side, so this is not an issue.
+
+Most official Dogstatsd clients now support client-side aggregation for metrics
+type outside histograms and distributions. This evolution in the protocol allows
+clients to buffer histogram and distribution values and send them in fewer
+payload to the agent (providing a behavior close to client-side aggregation for
+those types).

--- a/pkg/dogstatsd/convert_bench_test.go
+++ b/pkg/dogstatsd/convert_bench_test.go
@@ -7,27 +7,50 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
-func buildRawSample(tagCount int) []byte {
+func buildRawSample(tagCount int, multipleValues bool) []byte {
 	tags := "tag0:val0"
 	for i := 1; i < tagCount; i++ {
 		tags += fmt.Sprintf(",tag%d:val%d", i, i)
 	}
 
+	if multipleValues {
+		return []byte(fmt.Sprintf("daemon:666:777|h|@0.5|#%s", tags))
+	}
 	return []byte(fmt.Sprintf("daemon:666|h|@0.5|#%s", tags))
 }
 
 // used to store the result and avoid optimizations
-var sample metrics.MetricSample
+var (
+	benchSamples []metrics.MetricSample
+)
 
-func BenchmarkParseMetric(b *testing.B) {
+func runParseMetricBenchmark(b *testing.B, multipleValues bool) {
+	parser := newParser(newFloat64ListPool())
+	namespaceBlacklist := []string{}
+
 	for i := 1; i < 1000; i *= 4 {
 		b.Run(fmt.Sprintf("%d-tags", i), func(sb *testing.B) {
-			rawSample := buildRawSample(i)
+			rawSample := buildRawSample(i, multipleValues)
 			sb.ResetTimer()
+			samples := make([]metrics.MetricSample, 0, 2)
 
 			for n := 0; n < sb.N; n++ {
-				sample, _ = parseAndEnrichMetricMessage(rawSample, "", []string{}, "default-hostname")
+
+				parsed, err := parser.parseMetricSample(rawSample)
+				if err != nil {
+					continue
+				}
+
+				benchSamples = enrichMetricSample(samples, parsed, "", namespaceBlacklist, "default-hostname", returnEmptyTags, true, false)
 			}
 		})
 	}
+}
+
+func BenchmarkParseMetric(b *testing.B) {
+	runParseMetricBenchmark(b, false)
+}
+
+func BenchmarkParseMultipleMetric(b *testing.B) {
+	runParseMetricBenchmark(b, true)
 }

--- a/pkg/dogstatsd/float64_list_pool.go
+++ b/pkg/dogstatsd/float64_list_pool.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package dogstatsd
+
+import (
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
+)
+
+var (
+	tlmFloat64ListPoolGet = telemetry.NewCounter("dogstatsd", "float64_list_pool_get",
+		nil, "Count of get done in the float64_list  pool")
+	tlmFloat64ListPoolPut = telemetry.NewCounter("dogstatsd", "float64_list_pool_put",
+		nil, "Count of put done in the float64_list  pool")
+	tlmFloat64ListPool = telemetry.NewGauge("dogstatsd", "float64_list_pool",
+		nil, "Usage of the float64_list pool in dogstatsd")
+)
+
+// float64ListPool wraps the sync.Pool class for []float64 type.
+// It avoids allocating a new slice for each packet received.
+//
+// Caution: as objects get reused, data in the slice will change when the
+// object is reused. You need to hold on to the object until you extracted all
+// the information needed.
+type float64ListPool struct {
+	pool sync.Pool
+	// telemetry
+	tlmEnabled bool
+}
+
+// newFloat64ListPool creates a new pool with a specified buffer size
+func newFloat64ListPool() *float64ListPool {
+	return &float64ListPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return []float64{}
+			},
+		},
+		// telemetry
+		tlmEnabled: telemetry_utils.IsEnabled(),
+	}
+}
+
+// Get gets a slice of floats ready to use.
+func (f *float64ListPool) get() []float64 {
+	if f.tlmEnabled {
+		tlmFloat64ListPoolGet.Inc()
+		tlmFloat64ListPool.Inc()
+	}
+	return f.pool.Get().([]float64)
+}
+
+// Put resets the slice of floats and puts it back in the pool.
+func (f *float64ListPool) put(list []float64) {
+	if f.tlmEnabled {
+		tlmFloat64ListPoolPut.Inc()
+		tlmFloat64ListPool.Dec()
+	}
+	// we reset the slice's length but keep the allocated buffer
+	list = list[:0]
+	f.pool.Put(list)
+}

--- a/pkg/dogstatsd/parse_events_test.go
+++ b/pkg/dogstatsd/parse_events_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func parseEvent(rawEvent []byte) (dogstatsdEvent, error) {
-	parser := newParser()
+	parser := newParser(newFloat64ListPool())
 	return parser.parseEvent(rawEvent)
 }
 

--- a/pkg/dogstatsd/parse_metrics.go
+++ b/pkg/dogstatsd/parse_metrics.go
@@ -29,8 +29,12 @@ var (
 )
 
 type dogstatsdMetricSample struct {
-	name       string
-	value      float64
+	name string
+	// use for single value messages
+	value float64
+	// use for multiple value messages
+	values []float64
+	// use to store set's values
 	setValue   string
 	metricType metricType
 	sampleRate float64
@@ -82,60 +86,4 @@ func parseMetricSampleMetricType(rawMetricType []byte) (metricType, error) {
 
 func parseMetricSampleSampleRate(rawSampleRate []byte) (float64, error) {
 	return parseFloat64(rawSampleRate)
-}
-
-func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error) {
-	// fast path to eliminate most of the gibberish
-	// especially important here since all the unidentified garbage gets
-	// identified as metrics
-	if !hasMetricSampleFormat(message) {
-		return dogstatsdMetricSample{}, fmt.Errorf("invalid dogstatsd message format")
-	}
-
-	rawNameAndValue, message := nextField(message)
-	name, rawValue, err := parseMetricSampleNameAndRawValue(rawNameAndValue)
-	if err != nil {
-		return dogstatsdMetricSample{}, err
-	}
-
-	rawMetricType, message := nextField(message)
-	metricType, err := parseMetricSampleMetricType(rawMetricType)
-	if err != nil {
-		return dogstatsdMetricSample{}, err
-	}
-
-	var setValue []byte
-	var value float64
-	if metricType == setType {
-		setValue = rawValue
-	} else {
-		value, err = parseFloat64(rawValue)
-		if err != nil {
-			return dogstatsdMetricSample{}, fmt.Errorf("could not parse dogstatsd metric value: %v", err)
-		}
-	}
-
-	sampleRate := 1.0
-	var tags []string
-	var optionalField []byte
-	for message != nil {
-		optionalField, message = nextField(message)
-		if bytes.HasPrefix(optionalField, tagsFieldPrefix) {
-			tags = p.parseTags(optionalField[1:])
-		} else if bytes.HasPrefix(optionalField, sampleRateFieldPrefix) {
-			sampleRate, err = parseMetricSampleSampleRate(optionalField[1:])
-			if err != nil {
-				return dogstatsdMetricSample{}, fmt.Errorf("could not parse dogstatsd sample rate %q", optionalField)
-			}
-		}
-	}
-
-	return dogstatsdMetricSample{
-		name:       p.interner.LoadOrStore(name),
-		value:      value,
-		setValue:   string(setValue),
-		metricType: metricType,
-		sampleRate: sampleRate,
-		tags:       tags,
-	}, nil
 }

--- a/pkg/dogstatsd/parse_service_checks_test.go
+++ b/pkg/dogstatsd/parse_service_checks_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func parseServiceCheck(rawServiceCheck []byte) (dogstatsdServiceCheck, error) {
-	parser := newParser()
+	parser := newParser(newFloat64ListPool())
 	return parser.parseServiceCheck(rawServiceCheck)
 }
 

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -72,6 +72,7 @@ type Server struct {
 
 	packetsIn                 chan listeners.Packets
 	sharedPacketPool          *listeners.PacketPool
+	sharedFloat64List         *float64ListPool
 	Statistics                *util.Stats
 	Started                   bool
 	stopChan                  chan bool
@@ -212,6 +213,7 @@ func NewServer(aggregator *aggregator.BufferedAggregator) (*Server, error) {
 		Statistics:                stats,
 		packetsIn:                 packetsChannel,
 		sharedPacketPool:          sharedPacketPool,
+		sharedFloat64List:         newFloat64ListPool(),
 		aggregator:                aggregator,
 		listeners:                 tmpListeners,
 		stopChan:                  make(chan bool),
@@ -353,7 +355,7 @@ func nextMessage(packet *[]byte) (message []byte) {
 	return message
 }
 
-func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*listeners.Packet) {
+func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*listeners.Packet, samples []metrics.MetricSample) []metrics.MetricSample {
 	for _, packet := range packets {
 		originTagger := originTags{origin: packet.Origin}
 		log.Tracef("Dogstatsd receive: %q", packet.Contents)
@@ -396,7 +398,10 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*liste
 				}
 				batcher.appendEvent(event)
 			case metricSampleType:
-				sample, err := s.parseMetricMessage(parser, message, originTagger.getTags)
+				var err error
+				samples = samples[0:0]
+
+				samples, err = s.parseMetricMessage(samples, parser, message, originTagger.getTags)
 				if err != nil {
 					originTags := originTagger.getTags()
 					if len(originTags) > 0 {
@@ -406,21 +411,24 @@ func (s *Server) parsePackets(batcher *batcher, parser *parser, packets []*liste
 					}
 					continue
 				}
-				if atomic.LoadUint64(&s.Debug.Enabled) == 1 {
-					s.storeMetricStats(sample)
-				}
-				batcher.appendSample(sample)
-				if s.histToDist && sample.Mtype == metrics.HistogramType {
-					distSample := sample.Copy()
-					distSample.Name = s.histToDistPrefix + distSample.Name
-					distSample.Mtype = metrics.DistributionType
-					batcher.appendSample(*distSample)
+				for idx := range samples {
+					if atomic.LoadUint64(&s.Debug.Enabled) == 1 {
+						s.storeMetricStats(samples[idx])
+					}
+					batcher.appendSample(samples[idx])
+					if s.histToDist && samples[idx].Mtype == metrics.HistogramType {
+						distSample := samples[idx].Copy()
+						distSample.Name = s.histToDistPrefix + distSample.Name
+						distSample.Mtype = metrics.DistributionType
+						batcher.appendSample(*distSample)
+					}
 				}
 			}
 		}
 		s.sharedPacketPool.Put(packet)
 	}
 	batcher.flush()
+	return samples
 }
 
 func (s *Server) errLog(format string, params ...interface{}) {
@@ -431,12 +439,12 @@ func (s *Server) errLog(format string, params ...interface{}) {
 	}
 }
 
-func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFunc func() []string) (metrics.MetricSample, error) {
+func (s *Server) parseMetricMessage(metricSamples []metrics.MetricSample, parser *parser, message []byte, originTagsFunc func() []string) ([]metrics.MetricSample, error) {
 	sample, err := parser.parseMetricSample(message)
 	if err != nil {
 		dogstatsdMetricParseErrors.Add(1)
 		tlmProcessed.IncWithTags(tlmProcessedErrorTags)
-		return metrics.MetricSample{}, err
+		return metricSamples, err
 	}
 	if s.mapper != nil {
 		mapResult := s.mapper.Map(sample.name)
@@ -446,12 +454,24 @@ func (s *Server) parseMetricMessage(parser *parser, message []byte, originTagsFu
 			sample.tags = append(sample.tags, mapResult.Tags...)
 		}
 	}
-	metricSample := enrichMetricSample(sample, s.metricPrefix, s.metricPrefixBlacklist, s.defaultHostname, originTagsFunc, s.entityIDPrecedenceEnabled, s.ServerlessMode)
-	metricSample.Tags = append(metricSample.Tags, s.extraTags...)
+	metricSamples = enrichMetricSample(metricSamples, sample, s.metricPrefix, s.metricPrefixBlacklist, s.defaultHostname, originTagsFunc, s.entityIDPrecedenceEnabled, s.ServerlessMode)
 
-	dogstatsdMetricPackets.Add(1)
-	tlmProcessed.IncWithTags(tlmProcessedOkTags)
-	return metricSample, nil
+	if len(sample.values) > 0 {
+		s.sharedFloat64List.put(sample.values)
+	}
+
+	for idx := range metricSamples {
+		// All metricSamples already share the same Tags slice. We can
+		// extends the first one and reuse it for the rest.
+		if idx == 0 {
+			metricSamples[idx].Tags = append(metricSamples[idx].Tags, s.extraTags...)
+		} else {
+			metricSamples[idx].Tags = metricSamples[0].Tags
+		}
+		dogstatsdMetricPackets.Add(1)
+		tlmProcessed.IncWithTags(tlmProcessedOkTags)
+	}
+	return metricSamples, nil
 }
 
 func (s *Server) parseEventMessage(parser *parser, message []byte, originTagsFunc func() []string) (*metrics.Event, error) {

--- a/pkg/dogstatsd/server_worker.go
+++ b/pkg/dogstatsd/server_worker.go
@@ -1,5 +1,14 @@
 package dogstatsd
 
+import "github.com/DataDog/datadog-agent/pkg/metrics"
+
+var (
+	// defaultSampleSize is the default allocation size used to store
+	// samples when a message contains multiple values. This will
+	// automatically be extended if needed when we append to it.
+	defaultSampleSize = 1024
+)
+
 type worker struct {
 	server *Server
 	// the batcher will be responsible of batching a few samples / events / service
@@ -7,13 +16,18 @@ type worker struct {
 	// the flushing logic to the aggregator is actually in the batcher.
 	batcher *batcher
 	parser  *parser
+	// we allocate it once per worker instead of once per packet. This will
+	// be used to store the samples out a of packets. Allocating it every
+	// time is very costly, especially on the GC.
+	samples []metrics.MetricSample
 }
 
 func newWorker(s *Server) *worker {
 	return &worker{
 		server:  s,
 		batcher: newBatcher(s.aggregator),
-		parser:  newParser(),
+		parser:  newParser(s.sharedFloat64List),
+		samples: make([]metrics.MetricSample, 0, defaultSampleSize),
 	}
 }
 
@@ -28,7 +42,10 @@ func (w *worker) run() {
 			return
 		case <-w.server.health.C:
 		case packets := <-w.server.packetsIn:
-			w.server.parsePackets(w.batcher, w.parser, packets)
+			w.samples = w.samples[0:0]
+			// we return the samples in case the slice was extended
+			// when parsing the packets
+			w.samples = w.server.parsePackets(w.batcher, w.parser, packets, w.samples)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Numerical metrics (ie: not 'set') in dogstatsd now support sending
multiple values per message. This allows client to reduce traffic usage
and enable client side aggregation for histogram and distribution.

### Performances

I tried to keep the same performance for single value messages than before. For this we allocate slice of samples as early as possible and pass them around. 

To compare to master I had to rewrite a bit some benchmark to take the GC out of it. This [PR](https://github.com/DataDog/datadog-agent/pull/6832/files) has been use as the reference for master.

Benchmarks where run with a 5s benchtime (`go test -bench=. -test.run=nothing -benchtime=5s`) on a `t2.xlarge` (4 vCPUs and 16GB or ram) on a Ubuntu with `go1.15.5`.

We have two tool to compare benchmark


#### benchstat

```
name                    old time/op    new time/op    delta
ParseMetric/1-tags-4       447ns ± 0%     469ns ± 0%   ~     (p=1.000 n=1+1)
ParseMetric/4-tags-4       694ns ± 0%     699ns ± 0%   ~     (p=1.000 n=1+1)
ParseMetric/16-tags-4     1.60µs ± 0%    1.54µs ± 0%   ~     (p=1.000 n=1+1)
ParseMetric/64-tags-4     5.06µs ± 0%    5.14µs ± 0%   ~     (p=1.000 n=1+1)
ParseMetric/256-tags-4    21.0µs ± 0%    21.7µs ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/20-tags-4       229ns ± 0%     231ns ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/40-tags-4       317ns ± 0%     320ns ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/60-tags-4       412ns ± 0%     419ns ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/80-tags-4       518ns ± 0%     522ns ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/100-tags-4      580ns ± 0%     585ns ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/120-tags-4      701ns ± 0%     710ns ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/140-tags-4      780ns ± 0%     867ns ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/160-tags-4      902ns ± 0%     976ns ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/180-tags-4     1.04µs ± 0%    0.97µs ± 0%   ~     (p=1.000 n=1+1)
EnrichTags/200-tags-4     1.08µs ± 0%    1.10µs ± 0%   ~     (p=1.000 n=1+1)
ParsePackets-4             238µs ± 0%     256µs ± 0%   ~     (p=1.000 n=1+1)
ParseMetricMessage-4       278ns ± 0%     257ns ± 0%   ~     (p=1.000 n=1+1)
WithMapper-4              4.03µs ± 0%    4.27µs ± 0%   ~     (p=1.000 n=1+1)
MapperControl-4           4.05µs ± 0%    4.31µs ± 0%   ~     (p=1.000 n=1+1)

name                    old alloc/op   new alloc/op   delta
WithMapper-4              4.59kB ± 0%    4.59kB ± 0%   ~     (all equal)
MapperControl-4           4.59kB ± 0%    4.59kB ± 0%   ~     (all equal)

name                    old allocs/op  new allocs/op  delta
WithMapper-4                14.0 ± 0%      14.0 ± 0%   ~     (all equal)
MapperControl-4             14.0 ± 0%      14.0 ± 0%   ~     (all equal)
```

#### benchcmp (deprecated)

`benchcmp` should be disregarded in favor or `benchstat` as running the benchmark on master twice can produce up to 10% difference for some bench (especially for smaller bench running around ~500ns/op).

```
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                           old ns/op     new ns/op     delta
BenchmarkParseMetric/1-tags-4       447           469           +4.92%
BenchmarkParseMetric/4-tags-4       694           699           +0.72%
BenchmarkParseMetric/16-tags-4      1599          1536          -3.94%
BenchmarkParseMetric/64-tags-4      5059          5144          +1.68%
BenchmarkParseMetric/256-tags-4     21031         21717         +3.26%
BenchmarkEnrichTags/20-tags-4       229           231           +0.87%
BenchmarkEnrichTags/40-tags-4       317           320           +0.95%
BenchmarkEnrichTags/60-tags-4       412           419           +1.70%
BenchmarkEnrichTags/80-tags-4       518           522           +0.77%
BenchmarkEnrichTags/100-tags-4      580           585           +0.86%
BenchmarkEnrichTags/120-tags-4      701           710           +1.28%
BenchmarkEnrichTags/140-tags-4      780           867           +11.15%
BenchmarkEnrichTags/160-tags-4      902           976           +8.20%
BenchmarkEnrichTags/180-tags-4      1041          967           -7.11%
BenchmarkEnrichTags/200-tags-4      1077          1095          +1.67%
BenchmarkParsePackets-4             237536        256212        +7.86%
BenchmarkParseMetricMessage-4       278           257           -7.55%
BenchmarkWithMapper-4               4029          4272          +6.03%
BenchmarkMapperControl-4            4048          4311          +6.50%

benchmark                    old allocs     new allocs     delta
BenchmarkWithMapper-4        14             14             +0.00%
BenchmarkMapperControl-4     14             14             +0.00%

benchmark                    old bytes     new bytes     delta
BenchmarkWithMapper-4        4588          4588          +0.00%
BenchmarkMapperControl-4     4588          4588          +0.00%
```
