### PR TITLE
[loader/jmx] Report jmx loading error in agent status

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/fixtures/jmx.yaml
+++ b/pkg/collector/corechecks/embed/jmx/fixtures/jmx.yaml
@@ -2,7 +2,7 @@ instances:
   - host: localhost
     port: 9999 # This is the JMX port on which Kafka exposes its metrics (usually 9999)
     tags:
-      env: test
+      - env:test
 
 init_config:
   is_jmx: true

--- a/pkg/collector/corechecks/embed/jmx/fixtures/kafka.yaml
+++ b/pkg/collector/corechecks/embed/jmx/fixtures/kafka.yaml
@@ -9,7 +9,7 @@ instances:
   - host: localhost
     port: 9999 # This is the JMX port on which Kafka exposes its metrics (usually 9999)
     tags:
-      kafka: broker
+      - kafka:broker
       # env: stage
       # newTag: test
     # user: username

--- a/pkg/collector/corechecks/embed/jmx/loader.go
+++ b/pkg/collector/corechecks/embed/jmx/loader.go
@@ -10,6 +10,8 @@ package jmx
 import (
 	"errors"
 
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
@@ -38,6 +40,13 @@ func (jl *JMXCheckLoader) Load(config integration.Config, instance integration.D
 		return c, err
 	}
 
+	// Validate common instance structure
+	commonOptions := integration.CommonInstanceConfig{}
+	err := yaml.Unmarshal(instance, &commonOptions)
+	if err != nil {
+		log.Debugf("jmx.loader: invalid instance for check %s: %s", config.Name, err)
+	}
+
 	cf := integration.Config{
 		ADIdentifiers: config.ADIdentifiers,
 		InitConfig:    config.InitConfig,
@@ -49,7 +58,7 @@ func (jl *JMXCheckLoader) Load(config integration.Config, instance integration.D
 	}
 	c = newJMXCheck(cf, config.Source)
 
-	return c, nil
+	return c, err
 }
 
 func (jl *JMXCheckLoader) String() string {

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -144,6 +144,14 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 				errorStats.removeLoaderErrors(config.Name)
 				checks = append(checks, c)
 				break
+			} else if c != nil && check.IsJMXInstance(config.Name, instance, config.InitConfig) {
+				// JMXfetch is more permissive than the agent regarding instance configuration. It
+				// accepts tags as a map and a list whether the agent only accepts tags as a list
+				// we still attempt to schedule the check but we save the error.
+				log.Debugf("%v: loading issue for JMX check '%s', the agent will still attempt to schedule it", loader, config.Name)
+				errorStats.setLoaderError(config.Name, fmt.Sprintf("%v", loader), err.Error())
+				checks = append(checks, c)
+				break
 			} else {
 				errorStats.setLoaderError(config.Name, fmt.Sprintf("%v", loader), err.Error())
 				errors = append(errors, fmt.Sprintf("%v: %s", loader, err))


### PR DESCRIPTION
### What does this PR do?
Following #6355  & #6435 this PR proposes to:
* Keep previously working situation still functional (e.g. tags defined in a map - valid from a jmxfecht standpoint, invalid from the agent standpoint, works with a single instance, causes trouble with more than one instance, see AGENT-2006 for additional details)
* Expose instance unmarshalling error for JMX checks in `agent status`

### Motivation
JMX checks are more or less working when tags are defined as a map. This is unsupported and cause problem when multiple instances are defined in a single configuration file and use map to define tags.

### Additional Notes
N/A

### Describe your test plan
Validate that a  config like the one below shows a loading error but still get scheduled and report jvm metrics :
```
init_config:
  is_jmx: true
instances:
  - host: localhost
    port: 11000
    name: plop
    tags:
      env: prod
      user: john_doe
```