### PR TITLE
[AD] Allow ignoring auto_config.yaml files

### DIFF
--- a/pkg/autodiscovery/providers/file_test.go
+++ b/pkg/autodiscovery/providers/file_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,6 +73,7 @@ func TestNewYamlConfigProvider(t *testing.T) {
 }
 
 func TestCollect(t *testing.T) {
+	config.Datadog.Set("ignore_autoconf", []string{"ignored"})
 	paths := []string{"tests", "foo/bar"}
 	provider := NewFileConfigProvider(paths)
 	configs, err := provider.Collect()
@@ -120,6 +122,9 @@ func TestCollect(t *testing.T) {
 
 	// logs files collected in root directory
 	assert.Equal(t, 1, len(get("logs-agent_only")))
+
+	// ignored autoconf file not collected
+	assert.Equal(t, 0, len(get("ignored")))
 
 	// total number of configurations found
 	assert.Equal(t, 15, len(configs))

--- a/pkg/autodiscovery/providers/tests/ignored.d/auto_conf.yaml
+++ b/pkg/autodiscovery/providers/tests/ignored.d/auto_conf.yaml
@@ -1,0 +1,7 @@
+ad_identifiers:
+  - foo
+
+init_config:
+
+instances:
+  - host: '%%host%%'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -370,6 +370,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ad_config_poll_interval", int64(10)) // in seconds
 	config.BindEnvAndSetDefault("extra_listeners", []string{})
 	config.BindEnvAndSetDefault("extra_config_providers", []string{})
+	config.BindEnvAndSetDefault("ignore_autoconf", []string{})
 
 	// Docker
 	config.BindEnvAndSetDefault("docker_query_timeout", int64(5))

--- a/releasenotes/notes/allow-ignoring-autoconf-files-e3068d17b5d2f2a4.yaml
+++ b/releasenotes/notes/allow-ignoring-autoconf-files-e3068d17b5d2f2a4.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    It's possible to ignore ``auto_conf.yaml`` configuration files using ``ignore_autoconf`` or ``DD_IGNORE_AUTOCONF``.
+    Example: DD_IGNORE_AUTOCONF="redisdb kubernetes_state"


### PR DESCRIPTION
### What does this PR do?

Add the `ignore_autoconf` config to allow ignoring `auto_conf.yaml` files

### Motivation

Provide an easy way to disable OOTB configurations

### Describe your test plan

`DD_IGNORE_AUTOCONF="redisdb kubernetes_state"` + deploy ksm and redis => the checks shouldn't be picked
