### PR TITLE
add dev_branch_google_container_registry gitlab job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2978,6 +2978,12 @@ twistlock_scan-7:
   DOCKER_REGISTRY_PWD_SSM_KEY: quay_pwd
   DOCKER_REGISTRY_URL: quay.io
 
+.google_container_registry_variables: &google_container_registry_variables
+  <<: *docker_hub_variables
+  DOCKER_REGISTRY_LOGIN_SSM_KEY: gcr_login
+  DOCKER_REGISTRY_PWD_SSM_KEY: gcr_pwd
+  GOOGLE_PROJECT_ID: datadoghq
+
 .docker_tag_job_definition: &docker_tag_job_definition
   stage: image_deploy
   tags: [ "runner:docker", "size:large" ]
@@ -3036,6 +3042,21 @@ twistlock_scan-7:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | out-file ci-scripts/docker-publish.ps1
 
+.google_container_registry_tag_job_definition: &google_container_registry_tag_job_definition
+  stage: image_deploy
+  tags: [ "runner:docker", "size:large" ]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-push:1.5.0
+  variables:
+    <<: *google_container_registry_variables
+  before_script:
+    - export SRC_TAG=v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text > /tmp/gcr_key.json
+    - gcloud auth activate-service-account "$DOCKER_REGISTRY_LOGIN" --key-file=/tmp/gcr_key.json
+    - gcloud config set project $GOOGLE_PROJECT_ID
+    - gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://gcr.io
+    - python3 -m pip install -r requirements.txt
+
 dev_branch_docker_hub-a6:
   rules:
     - <<: *if_version_6
@@ -3075,6 +3096,19 @@ dev_branch_docker_hub-a7:
   script:
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-amd64             datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-amd64         datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx
+
+dev_branch_google_container_registry-a7:
+  rules:
+    - <<: *if_version_7
+      when: manual
+      allow_failure: true
+  <<: *google_container_registry_tag_job_definition
+  needs:
+    - docker_build_agent7
+    - docker_build_agent7_jmx
+  script:
+    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG}-7-amd64             gcr.io/datadoghq/agent-dev:${CI_COMMIT_REF_SLUG}-py3
+    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG}-7-jmx-amd64         gcr.io/datadoghq/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx
 
 dev_branch_docker_hub-a7-windows:
   rules:
@@ -4198,7 +4232,7 @@ pupernetes-master:
   <<: *pupernetes_template
   rules:
     - <<: *if_master_branch
-  needs: 
+  needs:
   - dev_master_docker_hub-a6
   - dev_master_docker_hub-a7
   script:


### PR DESCRIPTION
### What does this PR do?

Adds Gitlab job to push a dev agent image to `gcr.io/datadoghq/agent-dev` . (A subsequent PR is planned to add a `tag_release` job to GCR.)

### Motivation

The first step towards setting up another public registry for agent images, outside of Docker.

### Additional Notes

### Describe your test plan

Manually run the `dev_branch_google_container_registry-a7` job and verify it runs without issue, and the image exists in the repository.
