### PR TITLE
[KSMv2] Change check name and force building a unique ID

### DIFF
--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -26,7 +26,7 @@ import (
 // NewCheckBase() in your factory, plus:
 // - long-running checks must override Stop() and Interval()
 // - checks supporting multiple instances must call BuildID() from
-// their Config() method
+// their Configure() method
 // - after optionally building a unique ID, CommonConfigure() must
 // be called from the Config() method to handle the common instance
 // fields

--- a/pkg/collector/corechecks/cluster/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	// TODO rename correctly once we deprecate the python check
-	kubeStateMetricsCheckName = "kubernetes_state-alpha"
+	kubeStateMetricsCheckName = "kubernetes_state_core"
 	defaultResyncPeriod       = 30
 )
 
@@ -129,6 +128,8 @@ func (k *KSMCheck) Configure(config, initConfig integration.Data, source string)
 	if err != nil {
 		return err
 	}
+
+	k.BuildID(config, initConfig)
 
 	err = k.instance.parse(config)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

- Rename `kubernetes_state-alpha` to `kubernetes_state_core`
- Call `k.BuildID` from the base class

### Motivation

- It's expected to have multiple instances of this check, each instance must have a unique ID

### Describe your test plan

Configure multiple instances on the same Agent, the status page must show multiple instances