### PR TITLE
Export security_agent running metrics

### DIFF
--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	ddgostatsd "github.com/DataDog/datadog-go/statsd"
 )
 
 var (
@@ -119,7 +120,7 @@ func newComplianceReporter(stopper restart.Stopper, sourceName, sourceType strin
 	return event.NewReporter(logSource, pipelineProvider.NextPipelineChan()), nil
 }
 
-func startCompliance(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper) error {
+func startCompliance(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper, statsdClient *ddgostatsd.Client) error {
 	enabled := coreconfig.Datadog.GetBool("compliance_config.enabled")
 	if !enabled {
 		return nil
@@ -176,7 +177,7 @@ func startCompliance(hostname string, endpoints *config.Endpoints, context *clie
 	log.Infof("Running compliance checks every %s", checkInterval.String())
 
 	// Send the compliance 'running' metrics periodically
-	ticker := sendRunningMetrics("compliance")
+	ticker := sendRunningMetrics(statsdClient, "compliance")
 	stopper.Add(ticker)
 
 	return nil

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -174,5 +174,10 @@ func startCompliance(hostname string, endpoints *config.Endpoints, context *clie
 	stopper.Add(agent)
 
 	log.Infof("Running compliance checks every %s", checkInterval.String())
+
+	// Send the compliance 'running' metrics periodically
+	ticker := sendRunningMetrics("compliance")
+	stopper.Add(ticker)
+
 	return nil
 }

--- a/cmd/security-agent/app/metrics.go
+++ b/cmd/security-agent/app/metrics.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package app
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/process/statsd"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// sendRunningMetrics exports a metric to distinguish between security-agent modules that are activated
+func sendRunningMetrics(moduleName string) *time.Ticker {
+	// Retrieve the agent version using a dedicated package
+	tags := []string{fmt.Sprintf("version:%s", version.AgentVersion)}
+
+	// Send the metric regularly
+	heartbeat := time.NewTicker(15 * time.Second)
+	go func() {
+		for range heartbeat.C {
+			statsd.Client.Gauge(fmt.Sprintf("datadog.security_agent.%s.running", moduleName), 1, tags, 1) //nolint:errcheck
+		}
+	}()
+
+	return heartbeat
+}

--- a/cmd/security-agent/app/metrics.go
+++ b/cmd/security-agent/app/metrics.go
@@ -9,12 +9,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	ddgostatsd "github.com/DataDog/datadog-go/statsd"
 )
 
 // sendRunningMetrics exports a metric to distinguish between security-agent modules that are activated
-func sendRunningMetrics(moduleName string) *time.Ticker {
+func sendRunningMetrics(statsdClient *ddgostatsd.Client, moduleName string) *time.Ticker {
 	// Retrieve the agent version using a dedicated package
 	tags := []string{fmt.Sprintf("version:%s", version.AgentVersion)}
 
@@ -22,7 +22,7 @@ func sendRunningMetrics(moduleName string) *time.Ticker {
 	heartbeat := time.NewTicker(15 * time.Second)
 	go func() {
 		for range heartbeat.C {
-			statsd.Client.Gauge(fmt.Sprintf("datadog.security_agent.%s.running", moduleName), 1, tags, 1) //nolint:errcheck
+			statsdClient.Gauge(fmt.Sprintf("datadog.security_agent.%s.running", moduleName), 1, tags, 1) //nolint:errcheck
 		}
 	}()
 

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	ddgostatsd "github.com/DataDog/datadog-go/statsd"
 )
 
 var (
@@ -107,7 +108,7 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 	return event.NewReporter(logSource, pipelineProvider.NextPipelineChan()), nil
 }
 
-func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper) (*secagent.RuntimeSecurityAgent, error) {
+func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {
 	enabled := coreconfig.Datadog.GetBool("runtime_security_config.enabled")
 	if !enabled {
 		log.Info("Datadog runtime security agent disabled by config")
@@ -130,7 +131,7 @@ func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context 
 	log.Info("Datadog runtime security agent is now running")
 
 	// Send the runtime 'running' metrics periodically
-	ticker := sendRunningMetrics("runtime")
+	ticker := sendRunningMetrics(statsdClient, "runtime")
 	stopper.Add(ticker)
 
 	return agent, nil

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -129,5 +129,9 @@ func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context 
 
 	log.Info("Datadog runtime security agent is now running")
 
+	// Send the runtime 'running' metrics periodically
+	ticker := sendRunningMetrics("runtime")
+	stopper.Add(ticker)
+
 	return agent, nil
 }

--- a/cmd/security-agent/app/runtime_unsupported.go
+++ b/cmd/security-agent/app/runtime_unsupported.go
@@ -16,12 +16,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	ddgostatsd "github.com/DataDog/datadog-go/statsd"
 	"github.com/spf13/cobra"
 )
 
 var runtimeCmd *cobra.Command
 
-func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper) (*secagent.RuntimeSecurityAgent, error) {
+func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {
 	enabled := coreconfig.Datadog.GetBool("runtime_security_config.enabled")
 	if !enabled {
 		log.Info("Datadog runtime security agent disabled by config")


### PR DESCRIPTION
### What does this PR do?

This PR exports to the metrics datadog.security_agent.runtime.running and datadog.security_agent.compliance.running from the security-agent binary.

### Motivation

It is currently not possible to distinguish which parts of the product are activated.