### PR TITLE
[ec2] Account for IMDSv2 config flag when requesting EC2 tags

### DIFF
--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -219,7 +219,7 @@ func doHTTPRequest(url string, method string, headers map[string]string, useToke
 	if useToken {
 		token, err := getToken()
 		if err != nil {
-			log.Warnf("ec2_prefer_imdsv2 is set to true in configuration but the agent was unable to get a token: %s", err)
+			log.Warnf("ec2_prefer_imdsv2 is set to true in configuration but was unable to proceed: %s", err)
 		} else {
 			headers["X-aws-ec2-metadata-token"] = token
 		}

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -219,7 +219,7 @@ func doHTTPRequest(url string, method string, headers map[string]string, useToke
 	if useToken {
 		token, err := getToken()
 		if err != nil {
-			log.Warnf("ec2_prefer_imdsv2 is set to true in configuration but was unable to proceed: %s", err)
+			log.Warnf("ec2_prefer_imdsv2 is set to true in the configuration but the agent was unable to proceed: %s", err)
 		} else {
 			headers["X-aws-ec2-metadata-token"] = token
 		}

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -104,7 +104,7 @@ type ec2Identity struct {
 func getInstanceIdentity() (*ec2Identity, error) {
 	instanceIdentity := &ec2Identity{}
 
-	res, err := doHTTPRequest(instanceIdentityURL, http.MethodGet, map[string]string{}, true)
+	res, err := doHTTPRequest(instanceIdentityURL, http.MethodGet, map[string]string{}, config.Datadog.GetBool("ec2_prefer_imdsv2"))
 	if err != nil {
 		return instanceIdentity, fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}
@@ -137,7 +137,7 @@ func getSecurityCreds() (*ec2SecurityCred, error) {
 		return iamParams, err
 	}
 
-	res, err := doHTTPRequest(metadataURL+"/iam/security-credentials/"+iamRole, http.MethodGet, map[string]string{}, true)
+	res, err := doHTTPRequest(metadataURL+"/iam/security-credentials/"+iamRole, http.MethodGet, map[string]string{}, config.Datadog.GetBool("ec2_prefer_imdsv2"))
 	if err != nil {
 		return iamParams, fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}
@@ -156,7 +156,7 @@ func getSecurityCreds() (*ec2SecurityCred, error) {
 }
 
 func getIAMRole() (string, error) {
-	res, err := doHTTPRequest(metadataURL+"/iam/security-credentials/", http.MethodGet, map[string]string{}, true)
+	res, err := doHTTPRequest(metadataURL+"/iam/security-credentials/", http.MethodGet, map[string]string{}, config.Datadog.GetBool("ec2_prefer_imdsv2"))
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}

--- a/releasenotes/notes/fix-imdsv2-ignored-setting-c79fdd188cd12f9b.yaml
+++ b/releasenotes/notes/fix-imdsv2-ignored-setting-c79fdd188cd12f9b.yaml
@@ -10,5 +10,5 @@ fixes:
   - |
     The ``ec2_prefer_imdsv2`` parameter was ignored when fetching
     EC2 tags from the metadata endpoint. This fixes situations were
-    EC2 tags could not be fetched by a dockerized agent running
+    EC2 tags could not be fetched by a containerized agent running
     on an EC2 instance.

--- a/releasenotes/notes/fix-imdsv2-ignored-setting-c79fdd188cd12f9b.yaml
+++ b/releasenotes/notes/fix-imdsv2-ignored-setting-c79fdd188cd12f9b.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The ``ec2_prefer_imdsv2`` parameter was ignored when fetching
+    EC2 tags from the metadata endpoint. This fixes situations were
+    EC2 tags could not be fetched by a dockerized agent running
+    on an EC2 instance.


### PR DESCRIPTION
### What does this PR do?
When fetchin ec2 tags/IAM profile from ec2 medatada endpoint only
uses token/IMDSv2 when specified in config.

### Motivation
Fix a missing change that should have been included in #6033.

### Additional Notes
N/A.

### Describe your test plan
N/A.