### PR TITLE
Demote emitted signal log message level from Critical to Info

### DIFF
--- a/pkg/process/util/signal_nowindows.go
+++ b/pkg/process/util/signal_nowindows.go
@@ -18,7 +18,7 @@ func HandleSignals(exit chan struct{}) {
 	for sig := range sigIn {
 		switch sig {
 		case syscall.SIGINT, syscall.SIGTERM:
-			log.Criticalf("Caught signal '%s'; terminating.", sig)
+			log.Infof("Caught signal '%s'; terminating.", sig)
 			close(exit)
 			return
 		case syscall.SIGPIPE:

--- a/pkg/process/util/signal_windows.go
+++ b/pkg/process/util/signal_windows.go
@@ -18,7 +18,7 @@ func HandleSignals(exit chan struct{}) {
 	for sig := range sigIn {
 		switch sig {
 		case syscall.SIGINT, syscall.SIGTERM:
-			log.Criticalf("Caught signal '%s'; terminating.", sig)
+			log.Infof("Caught signal '%s'; terminating.", sig)
 			close(exit)
 			return
 		}


### PR DESCRIPTION
Critical log messages are meant to indicate that the message emitted
is one that needs to be acted upon with high urgency. Syslog defines
critical level just below the alert level, which indicates that action
must be taken now but the system is still usable. In general critical
level represents a very severe logging level and often indicates that
the system is behaving in a unexpected manner that needs correcting
ASAP.

We monitor our logs and receive alerts for any message above the error
level and alert accordingly. This is logical since these types of
messages rarely to never show up unless something is wrong. So every
time we use a signal to shut down the datadog service and receive a
critical message, we have to know to ignore the alert that it causes.
Obviously this is not ideal.

Signals are a natural occurence in operation in software and as such
these log messages should be emitted at the informational level. This
patch makes this behavior a reality.