### PR TITLE
MacOS build on merges to master (Gitlab), not per PR (CircleCI)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,38 +271,12 @@ jobs:
             inv -e deps
             inv -e test --python-runtimes 3 --coverage --race --profile --fail-on-fmt --cpus 3
 
-  macos_build:
-    macos:
-      xcode: 10.1.0
-    environment:
-      BUILDIMAGES_VERSION: "f43e0e081e9a54fea3241ef0efde28374981f7a0" # datadog-agent-buildimages commit to fetch to get the MacOS scripts
-      RELEASE_VERSION: "nightly-a7"
-      AGENT_MAJOR_VERSION: "7"
-      PYTHON_RUNTIMES: "3"
-    working_directory: ~/go/src/github.com/DataDog/datadog-agent
-    steps:
-      - checkout
-      - run:
-          name: Setup builder
-          command: |
-            bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/$BUILDIMAGES_VERSION/macos/builder_setup.sh)"
-      - run:
-          name: Run omnibus build
-          no_output_timeout: 30m
-          command: |
-            export VERSION=$CIRCLE_SHA1
-            bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/$BUILDIMAGES_VERSION/macos/build_script.sh)"
-      - run: mkdir -p ~/artifacts && cp omnibus/pkg/*.dmg ~/artifacts
-      - store_artifacts:
-          path: ~/artifacts
-
 workflows:
   version: 2
   test_and_build:
     jobs:
       - checkout_code
       - macos_tests
-      - macos_build
       - dependencies:
           requires:
             - checkout_code

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1315,6 +1315,7 @@ agent_dmg-x64-a6:
   rules:
     - <<: *if_not_version_6
       when: never
+    - <<: *if_master_branch
     - <<: *if_deploy
   allow_failure: true
   stage: package_build


### PR DESCRIPTION
### What does this PR do?

- Removes macos build job from CircleCI.
- Makes macos build job in Gitlab also run for merges to master.

### Motivation

Make PR tests faster.