### PR TITLE
[KSMv2] Make KSMv2 a long-running CoreCheck

### DIFF
--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -25,10 +25,11 @@ import (
 // To use it, you need to embed it in your check struct, by calling
 // NewCheckBase() in your factory, plus:
 // - long-running checks must override Stop() and Interval()
+// - long-running checks can call runner.AddWorkStats() to register their stats
 // - checks supporting multiple instances must call BuildID() from
 // their Configure() method
 // - after optionally building a unique ID, CommonConfigure() must
-// be called from the Config() method to handle the common instance
+// be called from the Configure() method to handle the common instance
 // fields
 //
 // Integration warnings are handled via the Warn and Warnf methods

--- a/pkg/collector/runner/check_stats.go
+++ b/pkg/collector/runner/check_stats.go
@@ -1,0 +1,118 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package runner
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// How long is the first series of check runs we want to log
+	firstRunSeries uint64 = 5
+)
+
+var checkStats *runnerCheckStats
+
+func init() {
+	checkStats = &runnerCheckStats{
+		Stats: make(map[string]map[check.ID]*check.Stats),
+	}
+}
+
+// runnerCheckStats holds the stats from the running checks
+type runnerCheckStats struct {
+	Stats map[string]map[check.ID]*check.Stats
+	M     sync.RWMutex
+}
+
+// AddWorkStats updates the stats of a given check, should be called after every check run
+// The runner.work() method calls this function to collect regular-corecheck stats
+// Long-running corechecks should explicitly call this function to register and update their stats
+func AddWorkStats(c check.Check, execTime time.Duration, err error, warnings []error, mStats map[string]int64) {
+	var s *check.Stats
+	var found bool
+
+	checkStats.M.Lock()
+	log.Tracef("Add stats for %s", string(c.ID()))
+	stats, found := checkStats.Stats[c.String()]
+	if !found {
+		stats = make(map[check.ID]*check.Stats)
+		checkStats.Stats[c.String()] = stats
+	}
+	s, found = stats[c.ID()]
+	if !found {
+		s = check.NewStats(c)
+		stats[c.ID()] = s
+	}
+	checkStats.M.Unlock()
+
+	s.Add(execTime, err, warnings, mStats)
+}
+
+// GetCheckStats returns the check stats map
+func GetCheckStats() map[string]map[check.ID]*check.Stats {
+	checkStats.M.RLock()
+	defer checkStats.M.RUnlock()
+
+	return checkStats.Stats
+}
+
+// RemoveCheckStats removes a check from the check stats map
+func RemoveCheckStats(checkID check.ID) {
+	checkStats.M.Lock()
+	defer checkStats.M.Unlock()
+	log.Debugf("Remove stats for %s", string(checkID))
+
+	checkName := strings.Split(string(checkID), ":")[0]
+	stats, found := checkStats.Stats[checkName]
+	if found {
+		delete(stats, checkID)
+		if len(stats) == 0 {
+			delete(checkStats.Stats, checkName)
+		}
+	}
+}
+
+func shouldLog(id check.ID) (doLog bool, lastLog bool) {
+	checkStats.M.RLock()
+	defer checkStats.M.RUnlock()
+
+	var nameFound, idFound bool
+	var s *check.Stats
+
+	loggingFrequency := uint64(config.Datadog.GetInt64("logging_frequency"))
+	name := strings.Split(string(id), ":")[0]
+
+	stats, nameFound := checkStats.Stats[name]
+	if nameFound {
+		s, idFound = stats[id]
+	}
+	// this is the first time we see the check, log it
+	if !idFound {
+		doLog = true
+		lastLog = false
+		return
+	}
+
+	// we log the first firstRunSeries times, then every loggingFrequency times
+	doLog = s.TotalRuns <= firstRunSeries || s.TotalRuns%loggingFrequency == 0
+	// we print a special message when we change logging frequency
+	lastLog = s.TotalRuns == firstRunSeries
+	return
+}
+
+func expCheckStats() interface{} {
+	checkStats.M.RLock()
+	defer checkStats.M.RUnlock()
+
+	return checkStats.Stats
+}

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -8,7 +8,6 @@ package runner
 import (
 	"expvar"
 	"fmt"
-	"strings"
 
 	"strconv"
 	"sync"
@@ -29,29 +28,17 @@ const (
 	stopCheckTimeout time.Duration = 500 * time.Millisecond
 	// Time to wait for all checks to stop
 	stopAllChecksTimeout time.Duration = 2 * time.Second
-	// How long is the first series of check runs we want to log
-	firstRunSeries uint64 = 5
 )
 
 var (
 	// TestWg is used for testing the number of check workers
 	TestWg      sync.WaitGroup
 	runnerStats *expvar.Map
-	checkStats  *runnerCheckStats
 )
 
 func init() {
 	runnerStats = expvar.NewMap("runner")
 	runnerStats.Set("Checks", expvar.Func(expCheckStats))
-	checkStats = &runnerCheckStats{
-		Stats: make(map[string]map[check.ID]*check.Stats),
-	}
-}
-
-// checkStats holds the stats from the running checks
-type runnerCheckStats struct {
-	Stats map[string]map[check.ID]*check.Stats
-	M     sync.RWMutex
 }
 
 // Runner ...
@@ -314,7 +301,7 @@ func (r *Runner) work() {
 			// otherwise only do so if the check is in the scheduler
 			if r.scheduler == nil || r.scheduler.IsCheckScheduled(check.ID()) {
 				mStats, _ := check.GetMetricStats()
-				addWorkStats(check, time.Since(t0), err, warnings, mStats)
+				AddWorkStats(check, time.Since(t0), err, warnings, mStats)
 			}
 		}
 		r.m.Unlock()
@@ -336,86 +323,6 @@ func (r *Runner) work() {
 	}
 
 	log.Debug("Finished processing checks.")
-}
-
-func shouldLog(id check.ID) (doLog bool, lastLog bool) {
-	checkStats.M.RLock()
-	defer checkStats.M.RUnlock()
-
-	var nameFound, idFound bool
-	var s *check.Stats
-
-	loggingFrequency := uint64(config.Datadog.GetInt64("logging_frequency"))
-	name := strings.Split(string(id), ":")[0]
-
-	stats, nameFound := checkStats.Stats[name]
-	if nameFound {
-		s, idFound = stats[id]
-	}
-	// this is the first time we see the check, log it
-	if !idFound {
-		doLog = true
-		lastLog = false
-		return
-	}
-
-	// we log the first firstRunSeries times, then every loggingFrequency times
-	doLog = s.TotalRuns <= firstRunSeries || s.TotalRuns%loggingFrequency == 0
-	// we print a special message when we change logging frequency
-	lastLog = s.TotalRuns == firstRunSeries
-	return
-}
-
-func addWorkStats(c check.Check, execTime time.Duration, err error, warnings []error, mStats map[string]int64) {
-	var s *check.Stats
-	var found bool
-
-	checkStats.M.Lock()
-	log.Tracef("Add stats for %s", string(c.ID()))
-	stats, found := checkStats.Stats[c.String()]
-	if !found {
-		stats = make(map[check.ID]*check.Stats)
-		checkStats.Stats[c.String()] = stats
-	}
-	s, found = stats[c.ID()]
-	if !found {
-		s = check.NewStats(c)
-		stats[c.ID()] = s
-	}
-	checkStats.M.Unlock()
-
-	s.Add(execTime, err, warnings, mStats)
-}
-
-func expCheckStats() interface{} {
-	checkStats.M.RLock()
-	defer checkStats.M.RUnlock()
-
-	return checkStats.Stats
-}
-
-// GetCheckStats returns the check stats map
-func GetCheckStats() map[string]map[check.ID]*check.Stats {
-	checkStats.M.RLock()
-	defer checkStats.M.RUnlock()
-
-	return checkStats.Stats
-}
-
-// RemoveCheckStats removes a check from the check stats map
-func RemoveCheckStats(checkID check.ID) {
-	checkStats.M.Lock()
-	defer checkStats.M.Unlock()
-	log.Debugf("Remove stats for %s", string(checkID))
-
-	checkName := strings.Split(string(checkID), ":")[0]
-	stats, found := checkStats.Stats[checkName]
-	if found {
-		delete(stats, checkID)
-		if len(stats) == 0 {
-			delete(checkStats.Stats, checkName)
-		}
-	}
 }
 
 func getHostname() string {


### PR DESCRIPTION
### What does this PR do?

- Make KSMv2 a long-running check (i.e the `Interval()` method always returns `0`)
- Make the check collection interval configurable via `collection_interval` 
- Implement the `Stop()` method to shutdown the KSM informers when the check is unscheduled: The `Stop()` method cancels the context used to build the KSM store and sends a signal to the main `Run()` method to stop collecting metrics
- Make `AddWorkStats` a public function
- Small refactoring of the `collector/runner` package

### Motivation

- KSMv2 should be a long-running check because the KSM informers keep running asynchronously and keep watching resources and generating metrics between the check runs, it's required to shutdown the informers gracefully when unscheduling the check
- By making KSMv2 a long-running check, we guarantee that the `Stop()` is called when the check is unscheduled, this is critical - the KSM informers must stop when the check is unscheduled. As opposed to regular checks where the `Stop` method is only called if the check is being unscheduled during a not-finished check run execution.
- The refactoring of the `collector/runner` package is not necessary, but it would make more sense to have all the functions handling the `checkStats` variable together in a single file (`check_stats.go`), since it already exposes functions like `GetCheckStats` and `RemoveCheckStats` to other packages. The real change in this package is making `AddWorkStats` accessible by other packages (needed by the long-running check to update the stats in this case)
- Without calling `AddWorkStats`, the long-running check will never appear in the `agent status` output

### Additional Notes

Understanding long-running checks and how they're handled by the Scheduler/Collector would help reviewing this PR, here is a TL;DR:
- The collector will call the long-running check Run method only once, the long running check has to implement a `Stop()` method which will be called by the collector when unscheduling the check.
- In contrast, the regular checks are expected to be stateless, the collector calls their Run method regularly (every 15s), they can implement a `Stop()` method but it’s called only if the check is running while unscheduling it, i.e the `Stop()` method will only be called if `Unschedule()` is called while `Run()` didn’t finish yet which is very very unlikely.
- The `Interval()` method must return `0` to tell the Scheduler when it's a long-running check.

### Describe your test plan

1. Schedule/Unschedule multiple KSM check v2 dynamically without restarting the Agent, the KSM informers in question must stop when a check is unscheduled
2. The check checks must appear on the `status` page
3. The check must honour the `collection_interval ` config, fallback to `15s` when not defined