### PR TITLE
[runtime-security] Re-enable runtime policy tags

### DIFF
--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -116,6 +116,7 @@ func (rsa *RuntimeSecurityAgent) SendSecurityEvent(evt *api.SecurityEventMessage
 		AgentRuleID:  evt.RuleID,
 		ResourceID:   rsa.hostname,
 		ResourceType: "host",
+		Tags:         evt.Tags,
 		Data:         json.RawMessage(evt.GetData()),
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR re-enables runtime policy tags. Tags can once again be defined on an agent rule basis and the alerts sent to the backend will be tagged appropriately.

### Motivation

This will support future use cases where tagging a rule might be required.

### Additional Notes

This PR is related to https://github.com/DataDog/security-agent-policies/pull/10 which is meant to remove the MITRE tags added to the default rules. Those tags are already added by the backend rules and do not need to be shipped twice.