### PR TITLE
[logs/tcp] Allow recreating tcp connections at configurable interval

### DIFF
--- a/pkg/logs/client/tcp/connection_manager.go
+++ b/pkg/logs/client/tcp/connection_manager.go
@@ -144,6 +144,12 @@ func (cm *ConnectionManager) address() string {
 	return net.JoinHostPort(cm.endpoint.Host, strconv.Itoa(cm.endpoint.Port))
 }
 
+// ShouldReset returns whether the connection should be reset, depending on the endpoint's config
+// and the passed connection creation time.
+func (cm *ConnectionManager) ShouldReset(connCreationTime time.Time) bool {
+	return cm.endpoint.ConnectionResetInterval != 0 && time.Since(connCreationTime) > cm.endpoint.ConnectionResetInterval
+}
+
 // CloseConnection closes a connection on the client side
 func (cm *ConnectionManager) CloseConnection(conn net.Conn) {
 	conn.Close()

--- a/pkg/logs/client/tcp/connection_manager_test.go
+++ b/pkg/logs/client/tcp/connection_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -68,4 +69,20 @@ func TestNewConnectionReturnsWhenContextCancelled(t *testing.T) {
 
 	// Make sure NewConnection really returns.
 	wg.Wait()
+}
+
+func TestShouldReset(t *testing.T) {
+	endpoint := config.Endpoint{ConnectionResetInterval: time.Duration(10) * time.Second}
+	connManager := NewConnectionManager(endpoint)
+
+	assert.False(t, connManager.ShouldReset(time.Now().Add(-time.Duration(5)*time.Second)))
+	assert.True(t, connManager.ShouldReset(time.Now().Add(-time.Duration(20)*time.Second)))
+}
+
+func TestShouldResetDisabled(t *testing.T) {
+	endpoint := config.Endpoint{ConnectionResetInterval: 0}
+	connManager := NewConnectionManager(endpoint)
+
+	assert.False(t, connManager.ShouldReset(time.Now().Add(-time.Duration(5)*time.Second)))
+	assert.False(t, connManager.ShouldReset(time.Now().Add(-time.Duration(20)*time.Second)))
 }

--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -9,6 +9,7 @@ import (
 	"expvar"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -27,6 +28,8 @@ type Destination struct {
 	connManager         *ConnectionManager
 	destinationsContext *client.DestinationsContext
 	conn                net.Conn
+	connResetInterval   time.Duration
+	connCreationTime    time.Time
 	inputChan           chan []byte
 	once                sync.Once
 }
@@ -39,6 +42,7 @@ func NewDestination(endpoint config.Endpoint, useProto bool, destinationsContext
 		delimiter:           NewDelimiter(useProto),
 		connManager:         NewConnectionManager(endpoint),
 		destinationsContext: destinationsContext,
+		connResetInterval:   endpoint.ConnectionResetInterval,
 	}
 }
 
@@ -55,6 +59,7 @@ func (d *Destination) Send(payload []byte) error {
 			// this can happen only when the context is cancelled.
 			return err
 		}
+		d.connCreationTime = time.Now()
 	}
 
 	metrics.BytesSent.Add(int64(len(payload)))
@@ -74,6 +79,12 @@ func (d *Destination) Send(payload []byte) error {
 		d.connManager.CloseConnection(d.conn)
 		d.conn = nil
 		return client.NewRetryableError(err)
+	}
+
+	if d.connResetInterval != 0 && time.Since(d.connCreationTime) > d.connResetInterval {
+		log.Debug("Resetting TCP connection")
+		d.connManager.CloseConnection(d.conn)
+		d.conn = nil
 	}
 
 	return nil

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -135,8 +135,9 @@ func buildTCPEndpoints() (*Endpoints, error) {
 	useProto := coreConfig.Datadog.GetBool("logs_config.dev_mode_use_proto")
 	proxyAddress := coreConfig.Datadog.GetString("logs_config.socks5_proxy_address")
 	main := Endpoint{
-		APIKey:       getLogsAPIKey(coreConfig.Datadog),
-		ProxyAddress: proxyAddress,
+		APIKey:                  getLogsAPIKey(coreConfig.Datadog),
+		ProxyAddress:            proxyAddress,
+		ConnectionResetInterval: time.Duration(coreConfig.Datadog.GetInt("logs_config.connection_reset_interval")) * time.Second,
 	}
 	switch {
 	case isSetAndNotEmpty(coreConfig.Datadog, "logs_config.logs_dd_url"):


### PR DESCRIPTION
### What does this PR do?

Allows recreating tcp connections at configurable interval (using the same config option as in HTTP mode -- `logs_config.connection_reset_interval`).

Disabled by default, no-op if left disabled.

Includes a small change on the `ConnectionManager` to avoid logging a warning when `handleServerClose` is actually detecting that the connection was already closed.

### Describe your test plan

No unit tests on `Destination` (there were no existing ones), ideally we should write a few (but requires bootstrapping a tcp server, etc).

Tested on a dev build: no-op when option is left to default value (no connection re-creation, nothing in logs), connections are properly re-created (message logged, and agent process uses new connections) at configured interval under `logs_config.connection_reset_interval`.
