### PR TITLE
Support wildcard in k8s node labels and pod annotations as tags 

### DIFF
--- a/pkg/tagger/collectors/common.go
+++ b/pkg/tagger/collectors/common.go
@@ -9,15 +9,10 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
 )
 
 // OrchestratorScopeEntityID defines the orchestrator scope entity ID
 const OrchestratorScopeEntityID = "internal:orchestrator-scope-entity-id"
-
-var templateVariables = map[string]struct{}{
-	"label": {},
-}
 
 // retrieveMappingFromConfig gets a stringmapstring config key and
 // lowercases all map keys to make envvar and yaml sources consistent
@@ -29,17 +24,4 @@ func retrieveMappingFromConfig(configKey string) map[string]string {
 	}
 
 	return labelsList
-}
-
-func resolveTag(tmpl, label string) string {
-	vars := tmplvar.ParseString(tmpl)
-	tagName := tmpl
-	for _, v := range vars {
-		if _, ok := templateVariables[string(v.Name)]; ok {
-			tagName = strings.Replace(tagName, string(v.Raw), label, -1)
-			continue
-		}
-		tagName = strings.Replace(tagName, string(v.Raw), "", -1)
-	}
-	return tagName
 }

--- a/pkg/tagger/collectors/common_test.go
+++ b/pkg/tagger/collectors/common_test.go
@@ -6,7 +6,6 @@
 package collectors
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 
@@ -62,34 +61,5 @@ func assertTagInfoListEqual(t *testing.T, expectedUpdates []*TagInfo, updates []
 	assert.Equal(t, len(expectedUpdates), len(updates))
 	for i := 0; i < len(expectedUpdates); i++ {
 		assertTagInfoEqual(t, expectedUpdates[i], updates[i])
-	}
-}
-
-func TestResolveTag(t *testing.T) {
-	testCases := []struct {
-		tmpl, label, expected string
-	}{
-		{
-			"kube_%%label%%", "app", "kube_app",
-		},
-		{
-			"foo_%%label%%_bar", "app", "foo_app_bar",
-		},
-		{
-			"%%label%%%%label%%", "app", "appapp",
-		},
-		{
-			"kube_", "app", "kube_", // no template variable
-		},
-		{
-			"kube_%%foo%%", "app", "kube_", // unsupported template variable
-		},
-	}
-
-	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			tagName := resolveTag(testCase.tmpl, testCase.label)
-			assert.Equal(t, testCase.expected, tagName)
-		})
 	}
 }

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -71,25 +71,16 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 			case kubernetes.KubeAppManagedByLabelKey:
 				tags.AddLow(tagKeyKubeAppManagedBy, value)
 			}
-			for pattern, tmpl := range c.labelsAsTags {
-				n := strings.ToLower(name)
-				if g, ok := c.globMap[pattern]; ok {
-					if !g.Match(n) {
-						continue
-					}
-				} else if pattern != n {
-					continue
-				}
-				tags.AddAuto(resolveTag(tmpl, name), value)
-			}
+
+			// Pod labels as tags
+			utils.AddMetadataAsTags(name, value, c.labelsAsTags, c.globLabels, tags)
 		}
 
-		// Pod annotations
+		// Pod annotations as tags
 		for name, value := range pod.Metadata.Annotations {
-			if tagName, found := c.annotationsAsTags[strings.ToLower(name)]; found {
-				tags.AddAuto(tagName, value)
-			}
+			utils.AddMetadataAsTags(name, value, c.annotationsAsTags, c.globAnnotations, tags)
 		}
+
 		if podTags, found := extractTagsFromMap(podTagsAnnotation, pod.Metadata.Annotations); found {
 			for tagName, values := range podTags {
 				for _, val := range values {

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -1126,6 +1126,47 @@ func TestParsePods(t *testing.T) {
 				StandardTags: []string{},
 			}},
 		},
+		{
+			desc: "pod annotations as tags with wildcards",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Annotations: map[string]string{
+						"component":                    "kube-proxy",
+						"tier":                         "node",
+						"k8s-app":                      "kubernetes-dashboard",
+						"pod-template-hash":            "490794276",
+						"app.kubernetes.io/managed-by": "spinnaker",
+					},
+				},
+				Status: dockerContainerStatus,
+				Spec:   dockerContainerSpec,
+			},
+			annotationsAsTags: map[string]string{
+				"*":         "foo_%%annotation%%",
+				"component": "component",
+			},
+			labelsAsTags: map[string]string{},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"foo_component:kube-proxy",
+					"component:kube-proxy",
+					"foo_tier:node",
+					"foo_k8s-app:kubernetes-dashboard",
+					"foo_pod-template-hash:490794276",
+					"foo_app.kubernetes.io/managed-by:spinnaker",
+					"image_name:datadog/docker-dd-agent",
+					"image_tag:latest5",
+					"kube_container_name:dd-agent",
+					"short_image:docker-dd-agent",
+					"pod_phase:running",
+				},
+				OrchestratorCardTags: []string{},
+				HighCardTags:         []string{"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f"},
+				StandardTags:         []string{},
+			}},
+		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {
 			if tc.skip {

--- a/pkg/tagger/utils/k8s_metadata.go
+++ b/pkg/tagger/utils/k8s_metadata.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package utils
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
+
+	"github.com/gobwas/glob"
+)
+
+// InitMetadataAsTags prepares labels and annotations as tags
+// - It lower-case all the labels in metadataAsTags
+// - It compiles all the patterns and stores them in a map of glob.Glob objects
+func InitMetadataAsTags(metadataAsTags map[string]string) (map[string]string, map[string]glob.Glob) {
+	// We lower-case the values collected by viper as well as the ones from inspecting the pod labels/annotations.
+	globMap := map[string]glob.Glob{}
+	for label, value := range metadataAsTags {
+		delete(metadataAsTags, label)
+		pattern := strings.ToLower(label)
+		metadataAsTags[pattern] = value
+		if strings.Index(pattern, "*") != -1 {
+			g, err := glob.Compile(pattern)
+			if err != nil {
+				log.Errorf("Failed to compile glob for [%s]: %v", pattern, err)
+				continue
+			}
+			globMap[pattern] = g
+		}
+	}
+	return metadataAsTags, globMap
+}
+
+// AddMetadataAsTags converts name and value into tags based on the metadata as tags configuration and patterns
+func AddMetadataAsTags(name, value string, metadataAsTags map[string]string, glob map[string]glob.Glob, tags *TagList) {
+	for pattern, tmpl := range metadataAsTags {
+		n := strings.ToLower(name)
+		if g, ok := glob[pattern]; ok {
+			if !g.Match(n) {
+				continue
+			}
+		} else if pattern != n {
+			continue
+		}
+		tags.AddAuto(resolveTag(tmpl, name), value)
+	}
+}
+
+var templateVariables = map[string]struct{}{
+	"label":      {},
+	"annotation": {},
+}
+
+// resolveTag replaces %%label%% and %%annotation%% by their values
+func resolveTag(tmpl, label string) string {
+	vars := tmplvar.ParseString(tmpl)
+	tagName := tmpl
+	for _, v := range vars {
+		if _, ok := templateVariables[string(v.Name)]; ok {
+			tagName = strings.Replace(tagName, string(v.Raw), label, -1)
+			continue
+		}
+		tagName = strings.Replace(tagName, string(v.Raw), "", -1)
+	}
+	return tagName
+}

--- a/pkg/tagger/utils/k8s_metadata_test.go
+++ b/pkg/tagger/utils/k8s_metadata_test.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetadataAsTags(t *testing.T) {
+	tests := []struct {
+		name           string
+		k              string
+		v              string
+		metadataAsTags map[string]string
+		want           []string
+	}{
+		{
+			name:           "nominal case",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "foo"},
+			want:           []string{"foo:bar"},
+		},
+		{
+			name:           "label tpl var",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "%%label%%"},
+			want:           []string{"foo:bar"},
+		},
+		{
+			name:           "annotation tpl var",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "%%annotation%%"},
+			want:           []string{"foo:bar"},
+		},
+		{
+			name:           "label tpl var with prefix",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "prefix_%%label%%"},
+			want:           []string{"prefix_foo:bar"},
+		},
+		{
+			name:           "annotation tpl var with suffix",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "%%annotation%%_suffix"},
+			want:           []string{"foo_suffix:bar"},
+		},
+		{
+			name:           "with wildcard",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"fo*": "baz"},
+			want:           []string{"baz:bar"},
+		},
+		{
+			name:           "match all labels",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"*": "%%label%%"},
+			want:           []string{"foo:bar"},
+		},
+		{
+			name:           "match all annotations",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"*": "%%annotation%%"},
+			want:           []string{"foo:bar"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tagList := NewTagList()
+			m, g := InitMetadataAsTags(tt.metadataAsTags)
+			AddMetadataAsTags(tt.k, tt.v, m, g, tagList)
+			tags, _, _, _ := tagList.Compute()
+			assert.ElementsMatch(t, tt.want, tags)
+		})
+	}
+}
+
+func TestResolveTag(t *testing.T) {
+	testCases := []struct {
+		tmpl, label, expected string
+	}{
+		{
+			"kube_%%label%%", "app", "kube_app",
+		},
+		{
+			"foo_%%label%%_bar", "app", "foo_app_bar",
+		},
+		{
+			"%%label%%%%label%%", "app", "appapp",
+		},
+		{
+			"kube_%%annotation%%", "app", "kube_app",
+		},
+		{
+			"foo_%%annotation%%_bar", "app", "foo_app_bar",
+		},
+		{
+			"%%annotation%%%%annotation%%", "app", "appapp",
+		},
+		{
+			"kube_", "app", "kube_", // no template variable
+		},
+		{
+			"kube_%%foo%%", "app", "kube_", // unsupported template variable
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			tagName := resolveTag(testCase.tmpl, testCase.label)
+			assert.Equal(t, testCase.expected, tagName)
+		})
+	}
+}

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -48,13 +48,10 @@ func getLabelsToTags() map[string]string {
 
 func extractTags(nodeLabels, labelsToTags map[string]string) []string {
 	tagList := utils.NewTagList()
-
+	labelsToTags, glob := utils.InitMetadataAsTags(labelsToTags)
 	for labelName, labelValue := range nodeLabels {
 		labelName, labelValue := LabelPreprocessor(labelName, labelValue)
-
-		if tagName, found := labelsToTags[strings.ToLower(labelName)]; found {
-			tagList.AddLow(tagName, labelValue)
-		}
+		utils.AddMetadataAsTags(labelName, labelValue, labelsToTags, glob, tagList)
 	}
 
 	tags, _, _, _ := tagList.Compute()

--- a/pkg/util/kubernetes/hostinfo/tags_test.go
+++ b/pkg/util/kubernetes/hostinfo/tags_test.go
@@ -30,6 +30,14 @@ func TestExtractTags(t *testing.T) {
 		"node-role.kubernetes.io/foo":          "bar",
 	}
 
+	gkeLabelsWithRole := map[string]string{
+		"beta.kubernetes.io/arch":       "amd64",
+		"beta.kubernetes.io/os":         "linux",
+		"cloud.google.com/gke-nodepool": "default-pool",
+		"kubernetes.io/hostname":        "gke-dummy-18-default-pool-6888842e-hcv0",
+		"kubernetes.io/role":            "foo",
+	}
+
 	for _, tc := range []struct {
 		nodeLabels   map[string]string
 		labelsToTags map[string]string
@@ -83,6 +91,19 @@ func TestExtractTags(t *testing.T) {
 				"kube_node_role:9090-090-9",
 				"kube_node_role:compute-node",
 				"kube_node_role:foo",
+			},
+		},
+		{
+			nodeLabels: gkeLabelsWithRole,
+			labelsToTags: map[string]string{
+				"*": "foo_%%label%%",
+			},
+			expectedTags: []string{
+				"foo_beta.kubernetes.io/arch:amd64",
+				"foo_beta.kubernetes.io/os:linux",
+				"foo_cloud.google.com/gke-nodepool:default-pool",
+				"foo_kubernetes.io/hostname:gke-dummy-18-default-pool-6888842e-hcv0",
+				"foo_kubernetes.io/role:foo",
 			},
 		},
 	} {

--- a/releasenotes/notes/k8s-wildcard-tags-528c933cfbf00a35.yaml
+++ b/releasenotes/notes/k8s-wildcard-tags-528c933cfbf00a35.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    ``kubernetes_pod_annotations_as_tags`` (``DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS``) now support regex wildcards:
+    ``'{"*":"<PREFIX>_%%annotation%%"}'`` can be used as value to collect all pod annotations as tags.
+    ``kubernetes_node_labels_as_tags`` (``DD_KUBERNETES_NODE_LABELS_AS_TAGS``) now support regex wildcards:
+    ``'{"*":"<PREFIX>_%%label%%"}'`` can be used as value to collect all node labels as tags.
+    Note: ``kubernetes_pod_labels_as_tags`` (``DD_KUBERNETES_POD_LABELS_AS_TAGS``) supports this already.


### PR DESCRIPTION
### What does this PR do?

- Make `kubernetes_pod_annotations_as_tags` support `%%annotation%%` and `*`
- Make `kubernetes_node_labels_as_tags` support `%%label%%` and `*`

### Motivation

- FR
- Feature parity with `kubernetes_pod_labels_as_tags` 

### Describe your test plan

```
      - name: DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS
        value: '{"*":"podannotation_%%annotation%%"}'
      - name: DD_KUBERNETES_POD_LABELS_AS_TAGS
        value: '{"*":"podlabel_%%label%%"}'
      - name: DD_KUBERNETES_NODE_LABELS_AS_TAGS
        value: '{"*":"nodelabel_%%label%%"}'
```
