### PR TITLE
[DCA] Scrub creds in `agent config` output

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -182,5 +182,14 @@ func getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, string(body), 500)
 		return
 	}
-	w.Write(runtimeConfig)
+
+	scrubbed, err := log.CredentialsCleanerBytes(runtimeConfig)
+	if err != nil {
+		log.Errorf("Unable to scrub sensitive data from runtime config: %s", err)
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 500)
+		return
+	}
+
+	w.Write(scrubbed)
 }


### PR DESCRIPTION
### What does this PR do?

Call `CredentialsCleanerBytes` before printing the `agent config` output

### Describe your test plan

`agent config` won't show plaintext values for `api_key` and `app_key`
