### PR TITLE
Expose log ingestion volume per source in agent-status and expvar

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -282,6 +282,7 @@
             {{- if .inputs }}
             Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}</br>
             {{- end }}
+            BytesRead: {{ .bytes_read }}
           {{- end }}
         </span>
       {{- end }}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -281,8 +281,8 @@
             {{- end }}
             {{- if .inputs }}
             Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}</br>
-            {{- end }}
             BytesRead: {{ .bytes_read }}
+            {{- end }}
           {{- end }}
         </span>
       {{- end }}

--- a/pkg/logs/config/source.go
+++ b/pkg/logs/config/source.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"expvar"
 	"sync"
 )
 
@@ -34,17 +35,19 @@ type LogSource struct {
 	// that reads log lines for this source. E.g, a sourceType == containerd and Config.Type == file means that
 	// the agent is tailing a file to read logs of a containerd container
 	sourceType SourceType
+	BytesRead  expvar.Int
 }
 
 // NewLogSource creates a new log source.
 func NewLogSource(name string, config *LogsConfig) *LogSource {
 	return &LogSource{
-		Name:     name,
-		Config:   config,
-		Status:   NewLogStatus(),
-		inputs:   make(map[string]bool),
-		lock:     &sync.Mutex{},
-		Messages: NewMessages(),
+		Name:      name,
+		Config:    config,
+		Status:    NewLogStatus(),
+		inputs:    make(map[string]bool),
+		lock:      &sync.Mutex{},
+		Messages:  NewMessages(),
+		BytesRead: expvar.Int{},
 	}
 }
 

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -182,6 +182,7 @@ func (t *Tailer) readForever() {
 		default:
 			inBuf := make([]byte, 4096)
 			n, err := t.read(inBuf, t.readTimeout)
+			t.source.BytesRead.Add(int64(n))
 			if err != nil { // an error occurred, stop from reading new logs
 				switch {
 				case isReaderClosed(err):

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -160,10 +160,11 @@ func (t *Tailer) readForever() {
 		if err != nil {
 			return
 		}
+		t.source.BytesRead.Add(int64(n))
 
 		select {
 		case <-t.stop:
-			if n != 0 && t.didFileRotate == 1 {
+			if n != 0 && atomic.LoadInt32(&t.didFileRotate) == 1 {
 				log.Warn("Tailer stopped after rotation close timeout with remaining unread data")
 			}
 			// stop reading data from file

--- a/pkg/logs/input/journald/tailer.go
+++ b/pkg/logs/input/journald/tailer.go
@@ -135,6 +135,7 @@ func (t *Tailer) tail() {
 			return
 		default:
 			n, err := t.journal.Next()
+			t.source.BytesRead.Add(int64(n))
 			if err != nil && err != io.EOF {
 				err := fmt.Errorf("cant't tail journal %s: %s", t.journalPath(), err)
 				t.source.Status.Error(err)

--- a/pkg/logs/input/listener/tailer.go
+++ b/pkg/logs/input/listener/tailer.go
@@ -90,6 +90,7 @@ func (t *Tailer) readForever() {
 				log.Warnf("Couldn't read message from connection: %v", err)
 				return
 			}
+			t.source.BytesRead.Add(int64(len(data)))
 			t.decoder.InputChan <- decoder.NewInput(data)
 		}
 	}

--- a/pkg/logs/input/traps/tailer.go
+++ b/pkg/logs/input/traps/tailer.go
@@ -54,6 +54,7 @@ func (t *Tailer) run() {
 			log.Errorf("failed to format packet: %s", err)
 			continue
 		}
+		t.source.BytesRead.Add(int64(len(data)))
 		content, err := json.Marshal(data)
 		if err != nil {
 			log.Errorf("failed to serialize packet data to JSON: %s", err)

--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -93,6 +93,7 @@ func goNotificationCallback(handle C.ULONGLONG, ctx C.PVOID) {
 		return
 	}
 
+	t.source.BytesRead.Add(len(msg))
 	t.outputChan <- msg
 }
 
@@ -138,7 +139,6 @@ func EvtRender(h C.ULONGLONG) (richEvt *richEvent, err error) {
 	// Call will set error anyway.  Clear it so we don't return an error
 	err = nil
 
-	t.source.BytesRead.Add(int64(bufSize))
 	xml := ConvertWindowsString(buf)
 
 	richEvt = enrichEvent(h, xml)

--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -93,7 +93,7 @@ func goNotificationCallback(handle C.ULONGLONG, ctx C.PVOID) {
 		return
 	}
 
-	t.source.BytesRead.Add(len(msg.Content))
+	t.source.BytesRead.Add(int64(len(msg.Content)))
 	t.outputChan <- msg
 }
 

--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -138,6 +138,7 @@ func EvtRender(h C.ULONGLONG) (richEvt *richEvent, err error) {
 	// Call will set error anyway.  Clear it so we don't return an error
 	err = nil
 
+	t.source.BytesRead.Add(int64(bufSize))
 	xml := ConvertWindowsString(buf)
 
 	richEvt = enrichEvent(h, xml)

--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -93,7 +93,7 @@ func goNotificationCallback(handle C.ULONGLONG, ctx C.PVOID) {
 		return
 	}
 
-	t.source.BytesRead.Add(len(msg))
+	t.source.BytesRead.Add(len(msg.Content))
 	t.outputChan <- msg
 }
 

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -128,6 +128,7 @@ func (b *Builder) getIntegrations() []Integration {
 				Status:        b.toString(source.Status),
 				Inputs:        source.GetInputs(),
 				Messages:      source.Messages.GetMessages(),
+				BytesRead:     source.BytesRead.Value(),
 			})
 		}
 		integrations = append(integrations, Integration{

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -39,6 +39,7 @@ type Source struct {
 	Status        string                 `json:"status"`
 	Inputs        []string               `json:"inputs"`
 	Messages      []string               `json:"messages"`
+	BytesRead     int64                  `json:"bytes_read"`
 }
 
 // Integration provides some information about a logs integration.

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -63,6 +63,7 @@ Logs Agent
     {{- if .inputs }}
     Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}
     {{- end }}
+    BytesRead: {{ .bytes_read }}
   {{- end }}
 {{- end }}
 

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -62,8 +62,8 @@ Logs Agent
     {{- end }}
     {{- if .inputs }}
     Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}
-    {{- end }}
     BytesRead: {{ .bytes_read }}
+    {{- end }}
   {{- end }}
 {{- end }}
 

--- a/releasenotes/notes/per-source-log-volume-42a57217d16cbd11.yaml
+++ b/releasenotes/notes/per-source-log-volume-42a57217d16cbd11.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added byte count per log source and display it on the status page.


### PR DESCRIPTION
### What does this PR do?
This change makes it easier to see the log sources from which the Logs Agent processes a lot of logs. Useful to quickly debug and understand high throughput support cases. 

I am also looking for suggestions on how to report this to telemetry for internal use. However it is difficult to record this data without creating lots of contexts. 

### Describe your test plan

Manually tested by ingesting a log and viewing agent-status
