### PR TITLE
Move functional tests to the end of the pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,8 +18,6 @@ stages:
   - deps_build
   - deps_fetch
   - source_test
-  - functional_test
-  - functional_test_cleanup
   - binary_build
   - integration_test
   - package_build
@@ -38,6 +36,8 @@ stages:
   - trigger_release
   - e2e
   - testkitchen_cleanup
+  - functional_test
+  - functional_test_cleanup
   - notify
 
 variables:
@@ -1942,16 +1942,6 @@ deploy_windows_testing-a7:
     - .kitchen_datadog_iot_agent_flavor
     - .kitchen_azure_location_north_central_us
 
-trigger_kitchen_functional_test:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
-  tags: [ "runner:docker", "size:large" ]
-  rules:
-    - when: manual
-      allow_failure: true
-  needs: []
-  script: [ "# noop" ]
-  stage: source_test
-
 .kitchen_test_security_agent:
   script:
     - bash -l tasks/run-test-kitchen.sh security-agent-test $AGENT_MAJOR_VERSION
@@ -1960,9 +1950,9 @@ trigger_kitchen_functional_test:
     - .kitchen_azure_location_north_central_us
   <<: *kitchen_common
   rules:
-    - when: always
+    - when: manual
       allow_failure: true
-  needs: [ "trigger_kitchen_functional_test", "tests_ebpf" ]
+  needs: [  "tests_ebpf" ]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -2183,7 +2173,6 @@ kitchen_centos_upgrade7_iot_agent-a7:
     - .kitchen_test_upgrade7_iot_agent
 
 kitchen_centos_security_agent:
-  allow_failure: false
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export TEST_PLATFORMS="centos-77,urn,OpenLogic:CentOS:7.7:7.7.201912090"
@@ -2273,7 +2262,6 @@ kitchen_ubuntu_upgrade7_iot_agent-a7:
     - .kitchen_test_upgrade7_iot_agent
 
 kitchen_ubuntu_security_agent:
-  allow_failure: false
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export TEST_PLATFORMS="ubuntu-18-04,urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040"
@@ -2362,7 +2350,6 @@ kitchen_suse_upgrade7_iot_agent-a7:
     - .kitchen_test_upgrade7_iot_agent
 
 kitchen_suse_security_agent:
-  allow_failure: false
   extends:
     - .kitchen_os_suse
     - .kitchen_test_security_agent
@@ -2447,7 +2434,6 @@ kitchen_debian_upgrade7_iot_agent-a7:
     - .kitchen_test_upgrade7_iot_agent
 
 kitchen_debian_security_agent:
-  allow_failure: false
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export TEST_PLATFORMS="debian-10,urn,Debian:debian-10:10:0.20200610.293"
@@ -2529,14 +2515,10 @@ testkitchen_cleanup_azure-a7:
 cleanup_kitchen_functional_test:
   <<: *kitchen_cleanup_azure_common
   rules:
-    - when: always
+    - when: manual
       allow_failure: true
   stage: functional_test_cleanup
-  needs:
-    - kitchen_centos_security_agent
-    - kitchen_debian_security_agent
-    - kitchen_suse_security_agent
-    - kitchen_ubuntu_security_agent
+  needs: [  "tests_ebpf" ]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
 


### PR DESCRIPTION
### What does this PR do?

Move functional test jobs to the end of the pipeline

### Motivation

The newly introduced functional test jobs are manual and therefore block jobs that don't have any `need` or `dependency` attribute

