### PR TITLE
Prevent clobbering of return value from `State.Connections()`

### DIFF
--- a/pkg/ebpf/tracer_test.go
+++ b/pkg/ebpf/tracer_test.go
@@ -1759,8 +1759,8 @@ func TestConnectionClobber(t *testing.T) {
 	// Create TCP Server which, for every line, sends back a message with size=serverMessageSize
 	srvRecvBuf := make([]byte, 4)
 	server := NewTCPServer(func(c net.Conn) {
-		io.ReadFull(c, srvRecvBuf)
-		c.Write(srvRecvBuf)
+		_, _ = io.ReadFull(c, srvRecvBuf)
+		_, _ = c.Write(srvRecvBuf)
 	})
 	doneChan := make(chan struct{})
 	server.Run(doneChan)
@@ -1789,7 +1789,7 @@ func TestConnectionClobber(t *testing.T) {
 				if _, err = c.Write(sendBuf); err != nil {
 					t.Fatal(err)
 				}
-				io.ReadFull(c, recvBuf)
+				_, _ = io.ReadFull(c, recvBuf)
 				sendWg.Done()
 				<-closeCh
 			}()

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -159,7 +159,10 @@ func (ns *networkState) Connections(
 			ns.storeDNSStats(dnsStats)
 			ns.addDNSStats(id, latestConns)
 		}
-		return latestConns
+		// copy to ensure return value doesn't get clobbered
+		conns := make([]ConnectionStats, len(latestConns))
+		copy(conns, latestConns)
+		return conns
 	}
 
 	// Update all connections with relevant up-to-date stats for client


### PR DESCRIPTION
### What does this PR do?

If there is no buffer resize between the first and second calls to `State.Connections()`, then the returned slice from the first call could be clobbered because the buffer is passed through untouched in the first call.

This does a copy only in the first call instance to ensure this cannot happen.

### Motivation

This discussion on another PR: https://github.com/DataDog/datadog-agent/pull/6359#discussion_r486497206


