### PR TITLE
[mesos/dcos] Correct replacement of MARATHON_URL in the cont-init.d script

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-mesos.sh
+++ b/Dockerfiles/agent/entrypoint/50-mesos.sh
@@ -27,5 +27,5 @@ fi
 if [[ $MARATHON_URL ]] && [[ ! -e $CONFD/marathon.d/conf.yaml.default ]]; then
   mv $CONFD/marathon.d/conf.yaml.example \
      $CONFD/marathon.d/conf.yaml.default
-  sed -i -e "s@ - url: \"https://<SERVER>:<PORT>\"@- url: ${MARATHON_URL}@" $CONFD/marathon.d/conf.yaml.default
+  sed -i -E -e "s@ - url: (\")?https://<SERVER>:<PORT>(\")?@- url: ${MARATHON_URL}@" $CONFD/marathon.d/conf.yaml.default
 fi


### PR DESCRIPTION
### What does this PR do?

Corrects replacing MARATHON_URL in the marathon check at agent startup. 

Due to changes in the `conf.yaml.example` in the [integrations-core repo](https://github.com/DataDog/integrations-core/commit/2236344234ea125e556f1904a963868e12f39719#diff-0cb47d5bb76f1b50206d09d7f36f771de499dcaeb14b79b83b9dcad89a6eda8dR51) this replacement with `sed` is no longer working.

### Motivation

Correct marathon url in the check.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

```
$ export MARATHON_URL=https://leader.mesos:5050

$ echo '  - url: "https://<SERVER>:<PORT>"' | sed -E -e "s@ - url: (\")?https://<SERVER>:<PORT>(\")?@- url: ${MARATHON_URL}@"
 - url: https://leader.mesos:5050

$ echo '  - url: https://<SERVER>:<PORT>' | sed -E -e "s@ - url: (\")?https://<SERVER>:<PORT>(\")?@- url: ${MARATHON_URL}@"
 - url: https://leader.mesos:5050
```