### PR TITLE
pkg/trace/agent: use automaxprocs

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1112,4 +1112,9 @@ core,"sigs.k8s.io/structured-merge-diff/schema",Apache-2.0
 core,"sigs.k8s.io/structured-merge-diff/typed",Apache-2.0
 core,"sigs.k8s.io/structured-merge-diff/value",Apache-2.0
 core,"sigs.k8s.io/yaml",MIT
+core,"go.uber.org/automaxprocs",MIT
+core,"go.uber.org/automaxprocs/maxprocs",MIT
+core,"go.uber.org/automaxprocs/internal/cgroups",MIT
+core,"go.uber.org/automaxprocs/internal/runtime",MIT
+core,"go.uber.org/automaxprocs/maxprocs",MIT
 core,go.opencensus.io,Apache-2.0

--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	_ "go.uber.org/automaxprocs"
 )
 
 // handleSignal closes a channel to exit cleanly from routines

--- a/go.mod
+++ b/go.mod
@@ -154,6 +154,7 @@ require (
 	github.com/zorkian/go-datadog-api v2.28.0+incompatible // indirect
 	go.etcd.io/bbolt v1.3.4 // indirect
 	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
+	go.uber.org/automaxprocs v1.2.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
 	golang.org/x/net v0.0.0-20200822124328-c89045814202

--- a/go.sum
+++ b/go.sum
@@ -1358,6 +1358,7 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/automaxprocs v1.2.0 h1:+RUihKM+nmYUoB9w0D0Ov5TJ2PpFO2FgenTxMJiZBZA=
 go.uber.org/automaxprocs v1.2.0/go.mod h1:YfO3fm683kQpzETxlTGZhGIVmXAhaw3gxeBADbpZtnU=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=

--- a/releasenotes/notes/apm-automaxprocs-41ca2da9b16c36e3.yaml
+++ b/releasenotes/notes/apm-automaxprocs-41ca2da9b16c36e3.yaml
@@ -9,5 +9,5 @@
 enhancements:
   - |
     APM: The trace-agent now automatically sets the GOMAXPROCS value in
-    Linux containers to whatever the container has allocated, as opposed
-    to the machine node value.
+    Linux containers to match allocated CPU quota, as opposed to the matching
+    the entire node's quota.

--- a/releasenotes/notes/apm-automaxprocs-41ca2da9b16c36e3.yaml
+++ b/releasenotes/notes/apm-automaxprocs-41ca2da9b16c36e3.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: The trace-agent now automatically sets the GOMAXPROCS value in
+    Linux containers to whatever the container has allocated, as opposed
+    to the machine node value.


### PR DESCRIPTION
This change uses https://github.com/uber-go/automaxprocs to automatically set the `GOMAXPROCS` value to whatever the (Linux) container has allocated, as opposed to the machine's CPU count which could lead to be counterproductive in some cases (e.g. container has 2 CPUs allocated and the node has 96 CPUs)