### PR TITLE
[IoT] Allow collecting Nvidia Jetson metrics with sudo

### DIFF
--- a/cmd/agent/dist/conf.d/jetson.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/jetson.d/conf.yaml.example
@@ -1,3 +1,7 @@
+## This file is overwritten upon Agent upgrade.
+## To make modifications to the check configuration, please copy this file
+## to `conf.yaml` and make your changes on that file.
+#
 instances:
   ## @param tegrastats_path - string - optional
   ## Path to the tegrastats binary.
@@ -5,9 +9,10 @@ instances:
   #
   # - tegrastats_path: <PATH_TO_TEGRASTATS_UTILITY>
   #
-  ## @param use_sudo - boolean - optional
-  ## Certain metrics require super-user privileges, such as the CPU/GPU frequency, the Audio-Processing Engine usage,
-  ## and IRAM values.
-  #
+  ## @param use_sudo - boolean - optional - default: false
+  ## Certain metrics require super-user privileges, such as the CPU/GPU frequency,
+  ## the Audio-Processing Engine usage, and IRAM values.
+  ## Set this to `true` to allow collecting these metrics.
+  ## Note that an entry needs to be added to the sudoers file for the dd-agent user.
   # - use_sudo: false
   #

--- a/cmd/agent/dist/conf.d/jetson.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/jetson.d/conf.yaml.example
@@ -4,3 +4,10 @@ instances:
   ## Defaults to `/usr/bin/tegrastats`
   #
   # - tegrastats_path: <PATH_TO_TEGRASTATS_UTILITY>
+  #
+  ## @param use_sudo - boolean - optional
+  ## Certain metrics require super-user privileges, such as the CPU/GPU frequency, the Audio-Processing Engine usage,
+  ## and IRAM values.
+  #
+  # - use_sudo: false
+  #

--- a/pkg/collector/corechecks/system/gpu/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/system/gpu/nvidia/jetson/jetson.go
@@ -37,7 +37,7 @@ const (
 // The configuration for the jetson check
 type checkCfg struct {
 	TegraStatsPath string `yaml:"tegrastats_path,omitempty"`
-	UseSudo	bool `yaml:"use_sudo,omitempty"`
+	UseSudo        bool   `yaml:"use_sudo,omitempty"`
 }
 
 // JetsonCheck contains the field for the JetsonCheck
@@ -120,7 +120,7 @@ func (c *JetsonCheck) processTegraStatsOutput(tegraStatsOuptut string) error {
 // Run executes the check
 func (c *JetsonCheck) Run() error {
 	tegraStatsCmd := fmt.Sprintf("%s %s", c.tegraStatsPath, strings.Join(c.commandOpts, " "))
-	cmdStr := fmt.Sprintf("(%s) & pid=$!; (sleep %d && kill -9 $pid)", tegraStatsCmd, int((2*tegraStatsInterval).Seconds()))
+	cmdStr := fmt.Sprintf("(%s) & pid=$!; (sleep %d && kill -9 $pid)", tegraStatsCmd, int((2 * tegraStatsInterval).Seconds()))
 	var cmd *exec.Cmd
 	if c.useSudo {
 		// -n, non-interactive mode, no prompts are used
@@ -144,7 +144,7 @@ func (c *JetsonCheck) Run() error {
 	}
 	log.Debugf("tegrastats output = %s\n", tegrastatsOutput)
 	if err := c.processTegraStatsOutput(string(tegrastatsOutput)); err != nil {
-		return fmt.Errorf("error processing tegrastats output: %s",  err)
+		return fmt.Errorf("error processing tegrastats output: %s", err)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/system/gpu/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/system/gpu/nvidia/jetson/jetson.go
@@ -134,7 +134,7 @@ func (c *JetsonCheck) Run() error {
 		switch err := err.(type) {
 		case *exec.ExitError:
 			if len(tegrastatsOutput) <= 0 {
-				return fmt.Errorf("tegrastats did not produce any output: %s\n", err)
+				return fmt.Errorf("tegrastats did not produce any output: %s", err)
 			}
 			// We kill the process, so ExitError is expected - as long as
 			// we got our output.


### PR DESCRIPTION
### What does this PR do?

Add support for collecting additional metrics on the Nvidia Jetsons' boards.
This PR adds a new flag in the Jetson check, `use_sudo` which instructs the check to run the `tegrastats` with sudo.

### Motivation

CPU frequency, GPU frequency, IRAM usage and Audio Processing Engine usage are only available if the `tegrastats` process runs as root.

### Additional Notes

The `dd-agent` user must be in the `sudoers` file, like so:
```
dd-agent ALL=(ALL) NOPASSWD: /bin/sh
```

### Describe your test plan

Set the `use_sudo` flag to false on a Jetson Nano, check on Datadog that the CPU/GPU frequency and IRAM stats are missing.
Set the `use_sudo` flag to true (while making sure the sudoers entry is correct), check on Datadog that the CPU/GPU frequency and IRAM stats are present.
