### PR TITLE
pkg/trace/agent: replace custom UTF-8 validation in normalization with std lib

### DIFF
--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -450,7 +450,7 @@ func TestNormalizeInvalidUTF8(t *testing.T) {
 		err := normalize(ts, span)
 
 		assert.Nil(err)
-		assert.Equal("test��", span.Resource)
+		assert.Equal("test�", span.Resource)
 	})
 
 	t.Run("name", func(t *testing.T) {
@@ -478,7 +478,7 @@ func TestNormalizeInvalidUTF8(t *testing.T) {
 		err := normalize(ts, span)
 
 		assert.Nil(err)
-		assert.Equal("test��", span.Type)
+		assert.Equal("test�", span.Type)
 	})
 
 	t.Run("meta", func(t *testing.T) {
@@ -496,9 +496,29 @@ func TestNormalizeInvalidUTF8(t *testing.T) {
 
 		assert.Nil(err)
 		assert.EqualValues(map[string]string{
-			"test��": "test1",
-			"test2":  "test��",
+			"test�": "test1",
+			"test2": "test�",
 		}, span.Meta)
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		assert := assert.New(t)
+
+		ts := newTagStats()
+		span := newTestSpan()
+
+		span.Metrics = map[string]float64{
+			invalidUTF8: 1 / 5,
+			"test2":     2 / 5,
+		}
+
+		err := normalize(ts, span)
+
+		assert.Nil(err)
+		assert.EqualValues(map[string]float64{
+			"test�": 1 / 5,
+			"test2": 2 / 5,
+		}, span.Metrics)
 	})
 }
 

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -621,7 +621,7 @@ func benchToUTF8(s string) func(b *testing.B) {
 }
 
 func BenchmarkToUTF8(b *testing.B) {
-	b.Run("valid ascii", benchNormalizeTag("valid UTF8"))
-	b.Run("valid utf8", benchNormalizeTag("Data🐨dog🐶 繋がっ⛰てて"))
+	b.Run("ascii", benchNormalizeTag("valid UTF8"))
+	b.Run("utf8", benchNormalizeTag("Data🐨dog🐶 繋がっ⛰てて"))
 	b.Run("invalid", benchNormalizeTag("test\x99\x8f"))
 }

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -610,3 +610,18 @@ func BenchmarkNormalizeTag(b *testing.B) {
 	b.Run("plenty", benchNormalizeTag("fun:ky_ta@#g/1"))
 	b.Run("more", benchNormalizeTag("fun:k####y_ta@#g/1_@@#"))
 }
+
+func benchToUTF8(s string) func(b *testing.B) {
+	return func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			toUTF8(s)
+		}
+	}
+}
+
+func BenchmarkToUTF8(b *testing.B) {
+	b.Run("valid ascii", benchNormalizeTag("valid UTF8"))
+	b.Run("valid utf8", benchNormalizeTag("Data🐨dog🐶 繋がっ⛰てて"))
+	b.Run("invalid", benchNormalizeTag("test\x99\x8f"))
+}


### PR DESCRIPTION
### What does this PR do?

Replaces custom UTF8 validation/replacement with the std library one.

Additionally, the span `metrics` map keys are also added to the UTF8
normalizer.