### PR TITLE
[config_template] Update docs of collect_ec2_tags option

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -212,6 +212,9 @@ api_key:
 
 ## @param collect_ec2_tags - boolean - optional - default: false
 ## Collect AWS EC2 custom tags as host tags.
+## Requires the EC2 instance to have an IAM role with the `EC2:DescribeTags`
+## permission. See docs for further details:
+## https://docs.datadoghq.com/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration/
 #
 # collect_ec2_tags: false
 


### PR DESCRIPTION
### What does this PR do?

Adds more details on IAM role and permission required for the `collect_ec2_tags` option, in `datadog.yaml`.

### Additional Notes

Related to https://github.com/DataDog/documentation/pull/8841 which updates the docs.

### Describe your test plan

I've confirmed only this permission is needed to collect ec2 instance tags from the Agent.
