### PR TITLE
Add unit-test in pkg/config for tag_value_split_separator

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -88,7 +88,7 @@ api_key:
 ##  results in the raw tag being transformed into "foo:1", "foo:2", "foo:3" tags
 #
 # tag_value_split_separator:
-#   - <TAG_KEY>: <SEPARATOR>
+#   <TAG_KEY>: <SEPARATOR>
 
 ## @param checks_tag_cardinality - string - optional - default: low
 ## Configure the level of granularity of tags to send for checks metrics and events. Choices are:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -887,3 +887,17 @@ dogstatsd_mapper_profiles:
 	assert.Contains(t, err.Error(), expectedErrorMsg)
 	assert.Empty(t, profiles)
 }
+
+func TestTagSplitValue(t *testing.T) {
+	datadogYaml := `
+tag_value_split_separator:
+  kafka_partition: "-"
+  grain: "-"
+`
+	testConfig := setupConfFromYAML(datadogYaml)
+	separatorConfig := testConfig.GetStringMapString("tag_value_split_separator")
+	kafkaSeparator, find := separatorConfig["kafka_partition"]
+	assert.True(t, find, "`kafka_partition` key should exist")
+	assert.Equal(t, "-", kafkaSeparator, "should be equal")
+	assert.Equal(t, "-", separatorConfig["grain"], "should be equal")
+}


### PR DESCRIPTION
### What does this PR do?

Add a unit-test in `pkg/config` to test how `tag_value_split_separator` is decoded.

### Motivation

It looks like we have an issue this configuration parameter in 7.22.x.
This unit-test show that it seams to work properly.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
