### PR TITLE
Fix scheduling of autodiscovery checks with custom identifiers (JMX)

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -503,8 +503,6 @@ func (ac *AutoConfig) resolveTemplate(tpl integration.Config) []integration.Conf
 		}
 
 		for serviceID := range serviceIds {
-			// CELENE there is a bug here. even though we potentially store multiple services for an AD ID, we only store one service per entity.
-			// so we may not get the right one. is this a problem though? from looking at configresolver.Resolve it seems pretty innocuous.
 			svc := ac.store.getServiceForEntity(serviceID)
 			if svc == nil {
 				log.Warnf("Service %s was removed before we could resolve its config", serviceID)
@@ -581,7 +579,7 @@ func GetResolveWarnings() map[string][]string {
 func (ac *AutoConfig) processNewService(svc listeners.Service) {
 	// in any case, register the service and store its tag hash
 	entity := svc.GetEntity()
-	ac.store.setServiceForEntity(svc, entity) // CELENE i think this is detrimental that we overwrite the service . but maybe all we need is the AD identifier?... and account for it in the other line.
+	ac.store.setServiceForEntity(svc, entity)
 	ac.store.setTagsHashForService(
 		svc.GetTaggerEntity(),
 		tagger.GetEntityHash(svc.GetTaggerEntity()),
@@ -590,17 +588,12 @@ func (ac *AutoConfig) processNewService(svc listeners.Service) {
 	if err != nil {
 		log.Errorf("Failed to get AD identifiers for service %s: %s", entity, err)
 	} else {
-		ac.store.setADIdentifiersForEntity(entity, adIds) // CELENE
-		log.Debugf("CELENE set AD Identifiers %v for entity %s", adIds, entity)
+		ac.store.setADIdentifiersForEntity(entity, adIds)
+		log.Debugf("Set AD Identifiers %v for entity %s", adIds, entity)
 	}
 
 	// get all the templates matching service identifiers
 	var templates []integration.Config
-	// ADIdentifiers, err := svc.GetADIdentifiers() CELENE
-	// if err != nil {
-	// 	log.Errorf("Failed to get AD identifiers for service %s, it will not be monitored - %s", svc.GetEntity(), err)
-	// 	return
-	// }
 	ADIdentifiers, found := ac.store.getADIdentifiersForEntity(entity)
 	if !found {
 		log.Errorf("Failed to get AD identifiers for service %s, it will not be monitored - %s", entity, err)

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -21,6 +21,7 @@ type store struct {
 	nameToJMXMetrics  map[string]integration.Data
 	adIDToServices    map[string]map[string]bool
 	entityToService   map[string]listeners.Service
+	entityToAdIDs     map[string][]string
 	templateCache     *TemplateCache
 	m                 sync.RWMutex
 }
@@ -35,6 +36,7 @@ func newStore() *store {
 		nameToJMXMetrics:  make(map[string]integration.Data),
 		adIDToServices:    make(map[string]map[string]bool),
 		entityToService:   make(map[string]listeners.Service),
+		entityToAdIDs:     make(map[string][]string),
 		templateCache:     NewTemplateCache(),
 	}
 
@@ -186,4 +188,21 @@ func (s *store) getServiceEntitiesForADID(adID string) (map[string]bool, bool) {
 	defer s.m.Unlock()
 	services, found := s.adIDToServices[adID]
 	return services, found
+}
+
+func (s *store) setADIdentifiersForEntity(entity string, adIDs []string) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	if _, ok := s.entityToAdIDs[entity]; ok {
+		s.entityToAdIDs[entity] = append(s.entityToAdIDs[entity], adIDs...)
+	} else {
+		s.entityToAdIDs[entity] = adIDs
+	}
+}
+
+func (s *store) getADIdentifiersForEntity(entity string) ([]string, bool) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	adIDs, found := s.entityToAdIDs[entity]
+	return adIDs, found
 }

--- a/pkg/autodiscovery/store_test.go
+++ b/pkg/autodiscovery/store_test.go
@@ -45,3 +45,15 @@ func TestTemplateToConfig(t *testing.T) {
 	assert.Len(t, s.getConfigsForTemplate("digest1"), 1)
 	assert.Len(t, s.getConfigsForTemplate("digest2"), 1)
 }
+
+func TestSetGetADIdentifiersForEntity(t *testing.T) {
+	s := newStore()
+	s.setADIdentifiersForEntity("entity1", []string{"ad_id1", "ad_id2"})
+
+	result, found := s.getADIdentifiersForEntity("entity1")
+	assert.Len(t, result, 2)
+	assert.True(t, found)
+	result, found = s.getADIdentifiersForEntity("entity2")
+	assert.Len(t, result, 0)
+	assert.False(t, found)
+}

--- a/pkg/collector/corechecks/embed/jmx/loader.go
+++ b/pkg/collector/corechecks/embed/jmx/loader.go
@@ -40,6 +40,7 @@ func (jl *JMXCheckLoader) Load(config integration.Config, instance integration.D
 
 	cf := integration.Config{
 		ADIdentifiers: config.ADIdentifiers,
+		Entity:        config.Entity,
 		InitConfig:    config.InitConfig,
 		Instances:     []integration.Data{instance},
 		LogsConfig:    config.LogsConfig,

--- a/releasenotes/notes/fix-autodiscovery-ad-identifiers-af8947f693f276ff.yaml
+++ b/releasenotes/notes/fix-autodiscovery-ad-identifiers-af8947f693f276ff.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an issue where Autodiscovery (AD) checks may not be scheduled due to AD identifiers being unavailable


### PR DESCRIPTION
### What does this PR do?

Addresses two issues noticed related to Autodiscovery processing of new services

1. Incorporate Entity ID into JMX config to utilize change made in https://github.com/DataDog/datadog-agent/pull/5409 for JMX checks

2. Fix issue where checks that were unscheduled after a pod restart or change of tags due to tagger delays (due to Kubelet delays) are properly rescheduled

Explanation for the second issue, as I understand it:
- In this test scenario, the Datadog agent is run while monitoring a Tomcat pod (deployment). The Tomcat Docker image has a custom AD identifier label. The Tomcat pod is deleted after a few minutes, and it is expected that the Datadog agent monitor the new pod without issue.
- In an environment such as GKE with Docker, there can be two listeners: the Docker and Kubelet. Following the restart, the Docker listener reports right away, with the correct information, where as the Kubelet listener initially reports the stale pod ID but eventually is correct
- Since the Docker listener reports the service before the service is ready, the new AD service cannot schedule when `processNewService` is called.
- Since the Kubelet listener reports subsequently, this service is what is stored in [`entityToService`](https://github.com/DataDog/datadog-agent/blob/1c76b8381a195a0b0f629011a6225e936fe1d37a/pkg/autodiscovery/store.go#L160).
- The Kubelet listener service does not have the AD Identifier required to resolve the config, so it does not schedule when`processNewService` is called.
(- When the Kubelet + Tagger catches up and finds updated tags for the pod, the service tries to schedule again but fails because `checkTagFreshness` uses the service persisted in `s.entityToService`, which is the Kubelet service.)

This fix persists AD identifiers for a service entity so they can be used regardless of which listener service is stored. As far as I can tell, this is the only parameter where it matters which listener is the one persisted in `entityToService`; the other necessary info appear to be shared.

### Motivation

Degradation of behavior

### Additional Notes

I suspect this particularly affects JMX checks because of the time it takes to detect the service being ready, but I'm not sure.


### Describe your test plan

Run Datadog agent (DEBUG mode recommended) that monitors a Tomcat pod with a custom Docker label AD identifier. Check `agent status` that the JMX check is running. Restart the Tomcat pod after a few minutes, and ensure that the check is properly scheduled (logs and `agent status`).