### PR TITLE
Revert "Supporting secrets in JSON payload set in env vars" (#6589)

### DIFF
--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -61,13 +61,6 @@ instances:
 - password: ENC[pass2]
 `)
 
-	testConfJSON = []byte(`---
-instances:
-- "{\"password\": \"ENC[pass1]\", \"user\": \"test\"}"
-- password: ENC[pass2]
-  user: test2
-`)
-
 	testConfDecrypted = []byte(`instances:
 - password: password1
   user: test
@@ -212,34 +205,6 @@ func TestDecryptSecretNoCache(t *testing.T) {
 	}
 
 	newConf, err := Decrypt(testConf, "test")
-	require.Nil(t, err)
-	assert.Equal(t, string(testConfDecrypted), string(newConf))
-}
-
-func TestDecryptSecretNestedJSON(t *testing.T) {
-	secretBackendCommand = "some_command"
-
-	defer func() {
-		secretBackendCommand = ""
-		secretCache = map[string]string{}
-		secretOrigin = map[string]common.StringSet{}
-		secretFetcher = fetchSecret
-	}()
-
-	secretFetcher = func(secrets []string, origin string) (map[string]string, error) {
-		sort.Strings(secrets)
-		assert.Equal(t, []string{
-			"pass1",
-			"pass2",
-		}, secrets)
-
-		return map[string]string{
-			"pass1": "password1",
-			"pass2": "password2",
-		}, nil
-	}
-
-	newConf, err := Decrypt(testConfJSON, "test")
 	require.Nil(t, err)
 	assert.Equal(t, string(testConfDecrypted), string(newConf))
 }

--- a/releasenotes/notes/revert-yaml-in-secret-a2f8b0b7fbe6a820.yaml
+++ b/releasenotes/notes/revert-yaml-in-secret-a2f8b0b7fbe6a820.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Support of secrets in JSON environment variables, added in `7.23.0`, is
+    reverted due to a side effect (e.g. a string value of `"-"` would be loaded as a list). This
+    feature will be fixed and added again in a future release.

--- a/releasenotes/notes/support-secrets-in-json-in-env-7221222ffa7c245c.yaml
+++ b/releasenotes/notes/support-secrets-in-json-in-env-7221222ffa7c245c.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    Secrets handles are not supported inside JSON value set through environment variables.
-    For example setting a secret in a list
-    `DD_FLARE_STRIPPED_KEYS='["ENC[auth_token_name]"]' datadog-agent run`


### PR DESCRIPTION
### What does this PR do?

Reverts https://github.com/DataDog/datadog-agent/pull/6285 on master. Cherry-pick of the revert on `7.23.x`: #6589. See that PR for details.