### PR TITLE
add entity to jmx config

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/loader.go
+++ b/pkg/collector/corechecks/embed/jmx/loader.go
@@ -40,6 +40,7 @@ func (jl *JMXCheckLoader) Load(config integration.Config, instance integration.D
 
 	cf := integration.Config{
 		ADIdentifiers: config.ADIdentifiers,
+		Entity:        config.Entity,
 		InitConfig:    config.InitConfig,
 		Instances:     []integration.Data{instance},
 		LogsConfig:    config.LogsConfig,


### PR DESCRIPTION
### What does this PR do?

Incorporate Entity ID into JMX config to utilize change made in #5409 for JMX checks

### Motivation

To have previous change made to prevent check ID clashes apply to JMX checks as well

### Additional Notes


### Describe your test plan

In a Kubernetes environment, monitor a JMX application pod (via deployment) with the agent JMX check. Delete the application pod and make sure the agent can monitor the new pod without issue.