### PR TITLE
Set Agent Platform as code owners of Jetson integration configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,7 @@
 /cmd/trace-agent/                       @DataDog/agent-apm
 /cmd/agent/app/integrations*.go         @trishankatdatadog @DataDog/agent-integrations @DataDog/agent-core
 /cmd/agent/clcrunnerapi/                @DataDog/container-integrations @DataDog/agent-core
+/cmd/agent/dist/conf.d/jetson.d         @DataDog/agent-platform
 /cmd/agent/*.manifest                   @DataDog/agent-platform
 /cmd/agent/*.mc                         @DataDog/agent-platform
 /cmd/agent/*.rc                         @DataDog/agent-platform


### PR DESCRIPTION
### What does this PR do?

This PR chnanges the configuration for the Nvidia Jetson integration to Agent Platform

### Motivation

Better codeowners distribution