### PR TITLE
[Tagger][Aggregator] Add Agent tagger tags to telemetry metrics submitted by the Aggregator

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/serializer/split"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -209,6 +211,9 @@ type BufferedAggregator struct {
 	stopChan           chan struct{}
 	health             *health.Handle
 	agentName          string // Name of the agent for telemetry metrics
+
+	tlmContainerTagsEnabled bool                                              // Whether we should call the tagger to tag agent telemetry metrics
+	agentTags               func(collectors.TagCardinality) ([]string, error) // This function gets the agent tags from the tagger (defined as a struct field to ease testing)
 }
 
 // NewBufferedAggregator instantiates a BufferedAggregator
@@ -239,16 +244,18 @@ func NewBufferedAggregator(s serializer.MetricSerializer, hostname string, flush
 
 		MetricSamplePool: metrics.NewMetricSamplePool(MetricSamplePoolBatchSize),
 
-		statsdSampler:      *NewTimeSampler(bucketSize),
-		checkSamplers:      make(map[check.ID]*CheckSampler),
-		flushInterval:      flushInterval,
-		serializer:         s,
-		hostname:           hostname,
-		hostnameUpdate:     make(chan string),
-		hostnameUpdateDone: make(chan struct{}),
-		stopChan:           make(chan struct{}),
-		health:             health.RegisterLiveness("aggregator"),
-		agentName:          agentName,
+		statsdSampler:           *NewTimeSampler(bucketSize),
+		checkSamplers:           make(map[check.ID]*CheckSampler),
+		flushInterval:           flushInterval,
+		serializer:              s,
+		hostname:                hostname,
+		hostnameUpdate:          make(chan string),
+		hostnameUpdateDone:      make(chan struct{}),
+		stopChan:                make(chan struct{}),
+		health:                  health.RegisterLiveness("aggregator"),
+		agentName:               agentName,
+		tlmContainerTagsEnabled: config.Datadog.GetBool("basic_telemetry_add_container_tags"),
+		agentTags:               tagger.AgentTags,
 	}
 
 	return aggregator
@@ -293,7 +300,7 @@ func (agg *BufferedAggregator) AddAgentStartupTelemetry(agentVersion string) {
 	metric := &metrics.MetricSample{
 		Name:       fmt.Sprintf("datadog.%s.started", agg.agentName),
 		Value:      1,
-		Tags:       []string{fmt.Sprintf("version:%s", version.AgentVersion)},
+		Tags:       agg.tags(true),
 		Host:       agg.hostname,
 		Mtype:      metrics.CountType,
 		SampleRate: 1,
@@ -434,9 +441,10 @@ func (agg *BufferedAggregator) sendSeries(start time.Time, series metrics.Series
 			extra.SourceTypeName = "System"
 		}
 
+		tags := append(extra.Tags, agg.tags(false)...)
 		newSerie := &metrics.Serie{
 			Name:           extra.Name,
-			Tags:           extra.Tags,
+			Tags:           tags,
 			Host:           extra.Host,
 			MType:          extra.MType,
 			SourceTypeName: extra.SourceTypeName,
@@ -461,7 +469,7 @@ func (agg *BufferedAggregator) sendSeries(start time.Time, series metrics.Series
 	series = append(series, &metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", agg.agentName),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           []string{fmt.Sprintf("version:%s", version.AgentVersion)},
+		Tags:           agg.tags(true),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
@@ -471,6 +479,7 @@ func (agg *BufferedAggregator) sendSeries(start time.Time, series metrics.Series
 	series = append(series, &metrics.Serie{
 		Name:           fmt.Sprintf("n_o_i_n_d_e_x.datadog.%s.payload.dropped", agg.agentName),
 		Points:         []metrics.Point{{Value: float64(split.GetPayloadDrops()), Ts: float64(start.Unix())}},
+		Tags:           agg.tags(false),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
@@ -540,6 +549,7 @@ func (agg *BufferedAggregator) flushServiceChecks(start time.Time, waitForSerial
 	agg.addServiceCheck(metrics.ServiceCheck{
 		CheckName: "datadog.agent.up",
 		Status:    metrics.ServiceCheckOK,
+		Tags:      agg.tags(false),
 		Host:      agg.hostname,
 	})
 
@@ -703,4 +713,21 @@ func (agg *BufferedAggregator) run() {
 			agg.hostnameUpdateDone <- struct{}{}
 		}
 	}
+}
+
+// tags returns the list of tags that should be added to the agent telemetry metrics
+// Container agent tags may be missing in the first seconds after agent startup
+func (agg *BufferedAggregator) tags(withVersion bool) []string {
+	tags := []string{}
+	if agg.tlmContainerTagsEnabled {
+		var err error
+		tags, err = agg.agentTags(tagger.ChecksCardinality)
+		if err != nil {
+			log.Debugf("Couldn't get Agent tags: %v", err)
+		}
+	}
+	if withVersion {
+		return append(tags, "version:"+version.AgentVersion)
+	}
+	return tags
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -281,6 +281,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("histogram_percentiles", []string{"0.95"})
 	config.BindEnvAndSetDefault("aggregator_stop_timeout", 2)
 	config.BindEnvAndSetDefault("aggregator_buffer_size", 100)
+	config.BindEnvAndSetDefault("basic_telemetry_add_container_tags", false) // configure adding the agent container tags to the basic agent telemetry metrics (e.g. `datadog.agent.running`)
 	// Serializer
 	config.BindEnvAndSetDefault("enable_stream_payload_serialization", true)
 	config.BindEnvAndSetDefault("enable_service_checks_stream_payload_serialization", true)

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -11,6 +11,8 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -59,6 +61,18 @@ func Tag(entity string, cardinality collectors.TagCardinality) ([]string, error)
 // standard tags (env, version, service) from cache or sources.
 func StandardTags(entity string) ([]string, error) {
 	return defaultTagger.Standard(entity)
+}
+
+// AgentTags returns the agent tags
+// It relies on the container provider utils to get the Agent container ID
+func AgentTags(cardinality collectors.TagCardinality) ([]string, error) {
+	ctrID, err := providers.ContainerImpl().GetAgentCID()
+	if err != nil {
+		return nil, err
+	}
+
+	entityID := containers.BuildTaggerEntityName(ctrID)
+	return Tag(entityID, cardinality)
 }
 
 // OrchestratorScopeTag queries tags for orchestrator scope (e.g. task_arn in ECS Fargate)


### PR DESCRIPTION
### What does this PR do?

- Expose a new tagger function `AgentTags` to collect Agent tags
- Add Agent tags to the telemetry metrics submitted by the Aggregator

### Motivation

It's useful to have container/pod tags attached to following metrics:
- `datadog.agent.running`
- `datadog.agent.started`
- `datadog.agent.up` (service check)
- `datadog.agent.python.version`

### Additional Notes

- Needs to be enabled via `basic_telemetry_add_container_tags` 
- The added tags respect the `ChecksCardinality` config

### Describe your test plan

Enable the feature and check whether the pod tags were added
