### PR TITLE
Fix racy test

### DIFF
--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -409,6 +409,7 @@ func TestDebugStatsSpike(t *testing.T) {
 
 	// stop the debug loop to avoid data race
 	s.DisableMetricsStats()
+	time.Sleep(500 * time.Millisecond)
 	assert.True(s.hasSpike())
 
 	s.EnableMetricsStats()
@@ -417,6 +418,7 @@ func TestDebugStatsSpike(t *testing.T) {
 
 	// stop the debug loop to avoid data race
 	s.DisableMetricsStats()
+	time.Sleep(500 * time.Millisecond)
 	// it is no more considered a spike because we had another second with 500 metrics
 	assert.False(s.hasSpike())
 }


### PR DESCRIPTION
### What does this PR do?

`DisableMetricsStats` closes the channel, but that doesn't guarantee that
the values sent there have been read yet. Wait a bit to increase the
chances that they have been picked up.

### Motivation

Should fix https://app.circleci.com/pipelines/github/DataDog/datadog-agent/8646/workflows/be5e7c46-b308-45d4-aadf-77db01042718/jobs/286070

