### PR TITLE
[runtime-security] Add perf buffer usage metrics

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -780,7 +780,6 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.enable_kernel_filters", true)
 	config.BindEnvAndSetDefault("runtime_security_config.flush_discarder_window", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.syscall_monitor.enabled", false)
-	config.BindEnvAndSetDefault("runtime_security_config.perf_buffer_monitor.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.events_stats.polling_interval", 20)
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -780,6 +780,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.enable_kernel_filters", true)
 	config.BindEnvAndSetDefault("runtime_security_config.flush_discarder_window", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.syscall_monitor.enabled", false)
+	config.BindEnvAndSetDefault("runtime_security_config.perf_buffer_monitor.enabled", false)
+	config.BindEnvAndSetDefault("runtime_security_config.events_stats.polling_interval", 20)
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.rate", 10)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -780,7 +780,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.enable_kernel_filters", true)
 	config.BindEnvAndSetDefault("runtime_security_config.flush_discarder_window", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.syscall_monitor.enabled", false)
-	config.BindEnvAndSetDefault("runtime_security_config.perf_buffer_monitor.enabled", false)
+	config.BindEnvAndSetDefault("runtime_security_config.perf_buffer_monitor.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.events_stats.polling_interval", 20)
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)

--- a/pkg/ebpf/bytecode/bindata/.gitignore
+++ b/pkg/ebpf/bytecode/bindata/.gitignore
@@ -1,0 +1,2 @@
+bindataRuntimesecurityO.go
+bindataRuntimesecuritysyscallwrapperO.go

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -54,7 +54,11 @@ type Config struct {
 	// LoadControllerControlPeriod defines the period at which the load controller will empty the user space counter used
 	// to evaluate the amount of events brought back to user space
 	LoadControllerControlPeriod time.Duration
-	// StatsAddr defines the statsd address
+	// PerfBufferMonitor activates the perf ring buffer monitor
+	PerfBufferMonitor bool
+	// EventsStatsPollingInterval determines how often metrics should be polled
+	EventsStatsPollingInterval time.Duration
+	// StatsdAddr defines the statsd address
 	StatsdAddr string
 }
 
@@ -75,6 +79,8 @@ func NewConfig(cfg *config.AgentConfig) (*Config, error) {
 		LoadControllerEventsCountThreshold: int64(aconfig.Datadog.GetInt("runtime_security_config.load_controller.events_count_threshold")),
 		LoadControllerDiscarderTimeout:     time.Duration(aconfig.Datadog.GetInt("runtime_security_config.load_controller.discarder_timeout")) * time.Second,
 		LoadControllerControlPeriod:        time.Duration(aconfig.Datadog.GetInt("runtime_security_config.load_controller.control_period")) * time.Second,
+		PerfBufferMonitor:                  aconfig.Datadog.GetBool("runtime_security_config.perf_buffer_monitor.enabled"),
+		EventsStatsPollingInterval:         time.Duration(aconfig.Datadog.GetInt("runtime_security_config.events_stats.polling_interval")) * time.Second,
 		StatsdAddr:                         fmt.Sprintf("%s:%d", cfg.StatsdHost, cfg.StatsdPort),
 	}
 

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -54,8 +54,6 @@ type Config struct {
 	// LoadControllerControlPeriod defines the period at which the load controller will empty the user space counter used
 	// to evaluate the amount of events brought back to user space
 	LoadControllerControlPeriod time.Duration
-	// PerfBufferMonitor activates the perf ring buffer monitor
-	PerfBufferMonitor bool
 	// EventsStatsPollingInterval determines how often metrics should be polled
 	EventsStatsPollingInterval time.Duration
 	// StatsdAddr defines the statsd address
@@ -79,7 +77,6 @@ func NewConfig(cfg *config.AgentConfig) (*Config, error) {
 		LoadControllerEventsCountThreshold: int64(aconfig.Datadog.GetInt("runtime_security_config.load_controller.events_count_threshold")),
 		LoadControllerDiscarderTimeout:     time.Duration(aconfig.Datadog.GetInt("runtime_security_config.load_controller.discarder_timeout")) * time.Second,
 		LoadControllerControlPeriod:        time.Duration(aconfig.Datadog.GetInt("runtime_security_config.load_controller.control_period")) * time.Second,
-		PerfBufferMonitor:                  aconfig.Datadog.GetBool("runtime_security_config.perf_buffer_monitor.enabled"),
 		EventsStatsPollingInterval:         time.Duration(aconfig.Datadog.GetInt("runtime_security_config.events_stats.polling_interval")) * time.Second,
 		StatsdAddr:                         fmt.Sprintf("%s:%d", cfg.StatsdHost, cfg.StatsdPort),
 	}

--- a/pkg/security/ebpf/c/buffer_selector.h
+++ b/pkg/security/ebpf/c/buffer_selector.h
@@ -2,12 +2,13 @@
 #define _BUFFER_SELECTOR_H
 
 #define SYSCALL_MONITOR_KEY 0
+#define PERF_BUFFER_MONITOR_KEY 1
 
 struct bpf_map_def SEC("maps/buffer_selector") buffer_selector = {
     .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 1,
+    .max_entries = 2,
     .pinning = 0,
     .namespace = "",
 };

--- a/pkg/security/ebpf/c/buffer_selector.h
+++ b/pkg/security/ebpf/c/buffer_selector.h
@@ -15,8 +15,8 @@ struct bpf_map_def SEC("maps/buffer_selector") buffer_selector = {
 
 static __attribute__((always_inline))
 struct bpf_map_def *select_buffer(struct bpf_map_def *front_buffer,
-                                  struct bpf_map_def *back_buffer) {
-    u32 selector_key = SYSCALL_MONITOR_KEY;
+                                  struct bpf_map_def *back_buffer,
+                                  u32 selector_key) {
     u32 *buffer_id = bpf_map_lookup_elem(&buffer_selector, &selector_key);
     if (buffer_id == NULL)
         return NULL;

--- a/pkg/security/ebpf/c/buffer_selector.h
+++ b/pkg/security/ebpf/c/buffer_selector.h
@@ -2,13 +2,12 @@
 #define _BUFFER_SELECTOR_H
 
 #define SYSCALL_MONITOR_KEY 0
-#define PERF_BUFFER_MONITOR_KEY 1
 
 struct bpf_map_def SEC("maps/buffer_selector") buffer_selector = {
     .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 2,
+    .max_entries = 1,
     .pinning = 0,
     .namespace = "",
 };

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -198,7 +198,7 @@ enum event_type
     EVENT_EXEC,
     EVENT_EXIT,
     EVENT_INVALIDATE_DENTRY,
-    EVENT_MAX, // has to be the last one and a power of two
+    EVENT_MAX, // has to be the last one
 };
 
 // closest power of 2 that is bigger than EVENT_MAX
@@ -305,6 +305,43 @@ static __attribute__((always_inline)) u32 is_flushing_discarders(void) {
     return prev_id != NULL && *prev_id;
 }
 
+// STATS_MAX_CPU_COUNT represent the maximum number of CPUs that the perf buffer monitoring will sample. Reduce this number
+// to monitor less CPUs and therefor reduce the in-kernel overhead.
+#define STATS_MAX_CPU_COUNT 64
+
+struct perf_map_stats_t {
+    u64 bytes;
+    u64 count;
+    u64 lost;
+};
+
+#define send_event_and_stats(ctx, kernel_event, perf_map, stats_buffer_one, stats_buffer_two)           \
+                                                                                                        \
+    u64 size = sizeof(event);                                                                           \
+    int perf_ret = bpf_perf_event_output(ctx, &perf_map, kernel_event.event.cpu, &kernel_event, size);  \
+                                                                                                        \
+    if ((kernel_event.event.cpu < STATS_MAX_CPU_COUNT) && (kernel_event.event.type < EVENT_MAX)) {      \
+        u32 buffer_key = PERF_BUFFER_MONITOR_KEY;                                                       \
+        u32 *buffer_id = bpf_map_lookup_elem(&buffer_selector, &buffer_key);                            \
+        if (buffer_id != NULL) {                                                                        \
+            u32 stats_key = kernel_event.event.type + kernel_event.event.cpu * EVENT_MAX;               \
+            struct perf_map_stats_t *stats;                                                             \
+            if (*buffer_id) {                                                                           \
+                stats = bpf_map_lookup_elem(&stats_buffer_one, &stats_key);                             \
+            } else {                                                                                    \
+                stats = bpf_map_lookup_elem(&stats_buffer_two, &stats_key);                             \
+            }                                                                                           \
+            if (stats != NULL) {                                                                        \
+                if (!perf_ret) {                                                                        \
+                    __sync_fetch_and_add(&stats->bytes, size + 4);                                      \
+                    __sync_fetch_and_add(&stats->count, 1);                                             \
+                } else {                                                                                \
+                    __sync_fetch_and_add(&stats->lost, 1);                                              \
+                }                                                                                       \
+            }                                                                                           \
+        }                                                                                               \
+    }                                                                                                   \
+
 struct bpf_map_def SEC("maps/events") events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(__u32),
@@ -314,11 +351,33 @@ struct bpf_map_def SEC("maps/events") events = {
     .namespace = "",
 };
 
-#define send_event(ctx, event_type, event) \
-    event.event.type = event_type; \
-    event.event.cpu = bpf_get_smp_processor_id(); \
-    event.event.timestamp = bpf_ktime_get_ns(); \
-    bpf_perf_event_output(ctx, &events, event.event.cpu, &event, sizeof(event))
+struct bpf_map_def SEC("maps/events_stats_one") events_stats_one = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(struct perf_map_stats_t),
+    .max_entries = EVENT_MAX * STATS_MAX_CPU_COUNT,
+    .pinning = 0,
+    .namespace = "",
+};
+
+struct bpf_map_def SEC("maps/events_stats_two") events_stats_two = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(struct perf_map_stats_t),
+    .max_entries = EVENT_MAX * STATS_MAX_CPU_COUNT,
+    .pinning = 0,
+    .namespace = "",
+};
+
+#define send_event(ctx, event_type, kernel_event)                                                        \
+    kernel_event.event.type = event_type;                                                                \
+    kernel_event.event.cpu = bpf_get_smp_processor_id();                                                 \
+    kernel_event.event.timestamp = bpf_ktime_get_ns();                                                   \
+    #if PERF_BUFFER_MONITOR == 1                                                                         \
+        send_event_and_stats(ctx, kernel_event, events, events_stats_one, events_stats_two)              \
+    #else                                                                                                \
+        bpf_perf_event_output(ctx, &events, kernel_event.event.cpu, &kernel_event, sizeof(kernel_event)) \
+    #endif                                                                                               \
 
 static __attribute__((always_inline)) u32 ord(u8 c) {
     if (c >= 49 && c <= 57) {

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -313,44 +313,6 @@ struct perf_map_stats_t {
     u64 lost;
 };
 
-#define send_event_and_stats(ctx, kernel_event, perf_map, stats_buffer_fb, stats_buffer_bb)                                \
-    u64 size = sizeof(kernel_event);                                                                                       \
-    int perf_ret = bpf_perf_event_output(ctx, &perf_map, kernel_event.event.cpu, &kernel_event, size);                     \
-                                                                                                                           \
-    if ((kernel_event.event.cpu < STATS_MAX_CPU_COUNT) && (kernel_event.event.type < EVENT_MAX)) {                         \
-        struct bpf_map_def *stats_buffer = select_buffer(&stats_buffer_fb, &stats_buffer_bb, PERF_BUFFER_MONITOR_KEY);     \
-        if (stats_buffer != NULL) {                                                                                        \
-            u32 stats_key = kernel_event.event.type + kernel_event.event.cpu * EVENT_MAX;                                  \
-            struct perf_map_stats_t *stats = bpf_map_lookup_elem(stats_buffer, &stats_key);                                \
-            if (stats != NULL) {                                                                                           \
-                if (!perf_ret) {                                                                                           \
-                    __sync_fetch_and_add(&stats->bytes, size + 4);                                                         \
-                    __sync_fetch_and_add(&stats->count, 1);                                                                \
-                } else {                                                                                                   \
-                    __sync_fetch_and_add(&stats->lost, 1);                                                                 \
-                }                                                                                                          \
-            }                                                                                                              \
-        }                                                                                                                  \
-    }                                                                                                                      \
-
-#define send_event_and_lost(ctx, kernel_event, perf_map, stats_buffer_fb, stats_buffer_bb)                                 \
-                                                                                                                           \
-    u64 size = sizeof(kernel_event);                                                                                       \
-    int perf_ret = bpf_perf_event_output(ctx, &perf_map, kernel_event.event.cpu, &kernel_event, size);                     \
-                                                                                                                           \
-    if (perf_ret) {                                                                                                        \
-        if ((kernel_event.event.cpu < STATS_MAX_CPU_COUNT) && (kernel_event.event.type < EVENT_MAX)) {                     \
-            struct bpf_map_def *stats_buffer = select_buffer(&stats_buffer_fb, &stats_buffer_bb, PERF_BUFFER_MONITOR_KEY); \
-            if (stats_buffer != NULL) {                                                                                    \
-                u32 stats_key = kernel_event.event.type + kernel_event.event.cpu * EVENT_MAX;                              \
-                struct perf_map_stats_t *stats = bpf_map_lookup_elem(stats_buffer, &stats_key);                            \
-                if (stats != NULL) {                                                                                       \
-                    __sync_fetch_and_add(&stats->lost, 1);                                                                 \
-                }                                                                                                          \
-            }                                                                                                              \
-        }                                                                                                                  \
-    }                                                                                                                      \
-
 struct bpf_map_def SEC("maps/events") events = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
     .key_size = sizeof(__u32),
@@ -378,17 +340,29 @@ struct bpf_map_def SEC("maps/events_stats_bb") events_stats_bb = {
     .namespace = "",
 };
 
-#define send_event(ctx, event_type, kernel_event)                                                                          \
-    kernel_event.event.type = event_type;                                                                                  \
-    kernel_event.event.cpu = bpf_get_smp_processor_id();                                                                   \
-    kernel_event.event.timestamp = bpf_ktime_get_ns();                                                                     \
-    u64 perf_monitor_enabled;                                                                                              \
-    LOAD_CONSTANT("perf_monitor_enabled", perf_monitor_enabled);                                                           \
-    if (perf_monitor_enabled) {                                                                                            \
-        send_event_and_stats(ctx, kernel_event, events, events_stats_fb, events_stats_bb);                                 \
-    } else {                                                                                                               \
-        send_event_and_lost(ctx, kernel_event, events, events_stats_fb, events_stats_bb);                                  \
-    }                                                                                                                      \
+#define send_event(ctx, event_type, kernel_event)                                                                      \
+    kernel_event.event.type = event_type;                                                                              \
+    kernel_event.event.cpu = bpf_get_smp_processor_id();                                                               \
+    kernel_event.event.timestamp = bpf_ktime_get_ns();                                                                 \
+                                                                                                                       \
+    u64 size = sizeof(kernel_event);                                                                                   \
+    int perf_ret = bpf_perf_event_output(ctx, &events, kernel_event.event.cpu, &kernel_event, size);                   \
+                                                                                                                       \
+    if ((kernel_event.event.cpu < STATS_MAX_CPU_COUNT) && (kernel_event.event.type < EVENT_MAX)) {                     \
+        struct bpf_map_def *stats_buffer = select_buffer(&events_stats_fb, &events_stats_bb, PERF_BUFFER_MONITOR_KEY); \
+        if (stats_buffer != NULL) {                                                                                    \
+            u32 stats_key = kernel_event.event.type + kernel_event.event.cpu * EVENT_MAX;                              \
+            struct perf_map_stats_t *stats = bpf_map_lookup_elem(stats_buffer, &stats_key);                            \
+            if (stats != NULL) {                                                                                       \
+                if (!perf_ret) {                                                                                       \
+                    __sync_fetch_and_add(&stats->bytes, size + 4);                                                     \
+                    __sync_fetch_and_add(&stats->count, 1);                                                            \
+                } else {                                                                                               \
+                    __sync_fetch_and_add(&stats->lost, 1);                                                             \
+                }                                                                                                      \
+            }                                                                                                          \
+        }                                                                                                              \
+    }                                                                                                                  \
 
 static __attribute__((always_inline)) u32 ord(u8 c) {
     if (c >= 49 && c <= 57) {

--- a/pkg/security/ebpf/c/raw_syscalls.h
+++ b/pkg/security/ebpf/c/raw_syscalls.h
@@ -66,7 +66,7 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     bpf_probe_read(&syscall.id, sizeof(syscall.id), &args->id);
     bpf_get_current_comm(&syscall.comm, sizeof(syscall.comm));
 
-    struct bpf_map_def *noisy_processes = select_buffer(&noisy_processes_fb, &noisy_processes_bb);
+    struct bpf_map_def *noisy_processes = select_buffer(&noisy_processes_fb, &noisy_processes_bb, SYSCALL_MONITOR_KEY);
     if (noisy_processes == NULL)
         return 0;
 
@@ -148,7 +148,7 @@ int sched_process_exec(struct _tracepoint_sched_sched_process_exec *ctx) {
     struct exec_path key = {};
     bpf_probe_read_str(&key.filename, MAX_PATH_LEN, filename);
 
-    struct bpf_map_def *exec_count = select_buffer(&exec_count_fb, &exec_count_bb);
+    struct bpf_map_def *exec_count = select_buffer(&exec_count_fb, &exec_count_bb, SYSCALL_MONITOR_KEY);
     if (exec_count == NULL)
         return 0;
 

--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -27,7 +27,7 @@ func NewDefaultOptions() manager.Options {
 
 		// DefaultPerfRingBufferSize is the default buffer size of the perf buffers
 		// PLEASE NOTE: for the perf ring buffer usage metrics to be accurate, the provided value must have the
-		// following form: (1 + 2^n) * pages. See https://github.com/DataDog/ebpf/blob/master/perf/ring.go#L64
+		// following form: (1 + 2^n) * pages. Checkout https://github.com/DataDog/ebpf for more.
 		DefaultPerfRingBufferSize: 4097 * os.Getpagesize(),
 
 		// DefaultProbeAttach is the default number of attach / detach retries on error
@@ -62,12 +62,5 @@ func NewRuntimeSecurityManager() *manager.Manager {
 		Probes:   probes.AllProbes(),
 		Maps:     probes.AllMaps(),
 		PerfMaps: probes.AllPerfMaps(),
-	}
-}
-
-// GetPerfBufferStatisticsMaps returns the list of maps used to monitor the performances of each perf buffers
-func GetPerfBufferStatisticsMaps() map[string][2]string {
-	return map[string][2]string{
-		"events":             {"events_stats_one", "events_stats_two"},
 	}
 }

--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -26,7 +26,9 @@ func NewDefaultOptions() manager.Options {
 		DefaultKProbeMaxActive: 512,
 
 		// DefaultPerfRingBufferSize is the default buffer size of the perf buffers
-		DefaultPerfRingBufferSize: 4096 * os.Getpagesize(),
+		// PLEASE NOTE: for the perf ring buffer usage metrics to be accurate, the provided value must have the
+		// following form: (1 + 2^n) * pages. See https://github.com/DataDog/ebpf/blob/master/perf/ring.go#L64
+		DefaultPerfRingBufferSize: 4097 * os.Getpagesize(),
 
 		// DefaultProbeAttach is the default number of attach / detach retries on error
 		DefaultProbeRetry:      1,
@@ -60,5 +62,12 @@ func NewRuntimeSecurityManager() *manager.Manager {
 		Probes:   probes.AllProbes(),
 		Maps:     probes.AllMaps(),
 		PerfMaps: probes.AllPerfMaps(),
+	}
+}
+
+// GetPerfBufferStatisticsMaps returns the list of maps used to monitor the performances of each perf buffers
+func GetPerfBufferStatisticsMaps() map[string][2]string {
+	return map[string][2]string{
+		"events":             {"events_stats_one", "events_stats_two"},
 	}
 }

--- a/pkg/security/ebpf/map.go
+++ b/pkg/security/ebpf/map.go
@@ -81,3 +81,10 @@ var (
 	ZeroUint32MapItem = BytesMapItem([]byte{0, 0, 0, 0})
 	ZeroUint64MapItem = BytesMapItem([]byte{0, 0, 0, 0, 0, 0, 0, 0})
 )
+
+var (
+	// BufferSelectorSyscallMonitorKey is the key used to select the active syscall monitor buffer key
+	BufferSelectorSyscallMonitorKey = ZeroUint32MapItem
+	// BufferSelectorPerfBufferMonitorKey is the key used to select the active perf buffer monitoring key
+	BufferSelectorPerfBufferMonitorKey = Uint32MapItem(1)
+)

--- a/pkg/security/ebpf/map.go
+++ b/pkg/security/ebpf/map.go
@@ -85,6 +85,4 @@ var (
 var (
 	// BufferSelectorSyscallMonitorKey is the key used to select the active syscall monitor buffer key
 	BufferSelectorSyscallMonitorKey = ZeroUint32MapItem
-	// BufferSelectorPerfBufferMonitorKey is the key used to select the active perf buffer monitoring key
-	BufferSelectorPerfBufferMonitorKey = Uint32MapItem(1)
 )

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -93,8 +93,8 @@ func AllPerfMaps() []*manager.PerfMap {
 }
 
 // GetPerfBufferStatisticsMaps returns the list of maps used to monitor the performances of each perf buffers
-func GetPerfBufferStatisticsMaps() map[string][2]string {
-	return map[string][2]string{
-		"events": {"events_stats_fb", "events_stats_bb"},
+func GetPerfBufferStatisticsMaps() map[string]string {
+	return map[string]string{
+		"events": "events_stats",
 	}
 }

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -91,3 +91,10 @@ func AllPerfMaps() []*manager.PerfMap {
 		},
 	}
 }
+
+// GetPerfBufferStatisticsMaps returns the list of maps used to monitor the performances of each perf buffers
+func GetPerfBufferStatisticsMaps() map[string][2]string {
+	return map[string][2]string{
+		"events": {"events_stats_fb", "events_stats_bb"},
+	}
+}

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -196,7 +196,7 @@ func (m *Module) statsMonitor(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ticker := time.NewTicker(20 * time.Second)
+	ticker := time.NewTicker(m.config.EventsStatsPollingInterval)
 	defer ticker.Stop()
 
 	for {
@@ -219,14 +219,15 @@ func (m *Module) statsMonitor(ctx context.Context) {
 
 // GetStats returns statistics about the module
 func (m *Module) GetStats() map[string]interface{} {
-	probeStats, err := m.probe.GetStats()
-	if err != nil {
-		return nil
+	debug := map[string]interface{}{}
+
+	if m.probe != nil {
+		debug["probe"] = m.probe.GetDebugStats()
+	} else {
+		debug["probe"] = "not_running"
 	}
 
-	return map[string]interface{}{
-		"probe": probeStats,
-	}
+	return debug
 }
 
 // GetProbe returns the module's probe

--- a/pkg/security/probe/event_stats.go
+++ b/pkg/security/probe/event_stats.go
@@ -3,45 +3,525 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build linux
+// +build linux_bpf
 
 package probe
 
-import "sync/atomic"
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"sync/atomic"
+
+	"github.com/DataDog/datadog-go/statsd"
+	lib "github.com/DataDog/ebpf"
+	"github.com/DataDog/ebpf/manager"
+	"github.com/pkg/errors"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
+)
+
+// PerfMapStats contains the collected metrics for one event and one cpu in a perf buffer statistics map
+type PerfMapStats struct {
+	Bytes uint64
+	Count uint64
+	Lost  uint64
+
+	Usage   int64
+	InQueue int64
+}
+
+// UnmarshalBinary parses a map entry and populates the current PerfMapStats instance
+func (s *PerfMapStats) UnmarshalBinary(data []byte) error {
+	if len(data) < 24 {
+		return ErrNotEnoughData
+	}
+	s.Bytes = ebpf.ByteOrder.Uint64(data[0:8])
+	s.Count = ebpf.ByteOrder.Uint64(data[8:16])
+	s.Lost = ebpf.ByteOrder.Uint64(data[16:24])
+	return nil
+}
+
+// MarshalBinary encodes the relevant fields of the current PerfMapStats instance into a byte array
+func (s *PerfMapStats) MarshalBinary() ([]byte, error) {
+	b := make([]byte, 24)
+	ebpf.ByteOrder.PutUint64(b, s.Bytes)
+	ebpf.ByteOrder.PutUint64(b, s.Count)
+	ebpf.ByteOrder.PutUint64(b, s.Lost)
+	return b, nil
+}
 
 // EventsStats holds statistics about the number of lost and received events
 //nolint:structcheck,unused
 type EventsStats struct {
-	Lost         int64
-	PerEventType [maxEventType]int64
+	// config pointer to the config of the runtime security module
+	config *config.Config
+	// cpuCount holds the current count of CPU
+	cpuCount int
+	// perfBufferStatsMaps holds the pointers to the statistics kernel maps
+	perfBufferStatsMaps map[string][2]*lib.Map
+	// perfBufferSize holds the size of each perf buffer, indexed by the name of the perf buffer
+	perfBufferSize map[string]float64
+
+	// perfBufferMapNameToStatsMapsName maps a perf buffer to its statistics maps
+	perfBufferMapNameToStatsMapsName map[string][2]string
+	// statsMapsNamePerfBufferMapName maps a statistic map to its perf buffer
+	statsMapsNameToPerfBufferMapName map[string]string
+
+	// bufferSelector is the kernel map used to select the active buffer ID
+	bufferSelector *lib.Map
+	// activeMapIndex is the index of the statistic maps we are currently collecting data from
+	activeMapIndex uint32
+
+	// stats holds the collected metrics
+	stats map[string][][maxEventType]PerfMapStats
+	// readLostEvents is the count of lost events, collected by reading the perf buffer
+	readLostEvents map[string][]uint64
 }
 
-// GetLost returns the number of lost events
-func (e *EventsStats) GetLost() int64 {
-	return atomic.LoadInt64(&e.Lost)
+// NewEventsStats instantiates a new event statistics counter
+func NewEventsStats(ebpfManager *manager.Manager, options manager.Options, config *config.Config) (*EventsStats, error) {
+	es := EventsStats{
+		config:              config,
+		cpuCount:            runtime.NumCPU(),
+		perfBufferStatsMaps: make(map[string][2]*lib.Map),
+		perfBufferSize:      make(map[string]float64),
+
+		perfBufferMapNameToStatsMapsName: ebpf.GetPerfBufferStatisticsMaps(),
+		statsMapsNameToPerfBufferMapName: make(map[string]string),
+
+		stats:          make(map[string][][maxEventType]PerfMapStats),
+		readLostEvents: make(map[string][]uint64),
+	}
+
+	// compute statsMapPerfMap
+	for perfMap, statsMaps := range es.perfBufferMapNameToStatsMapsName {
+		for _, statsMap := range statsMaps {
+			es.statsMapsNameToPerfBufferMapName[statsMap] = perfMap
+		}
+	}
+
+	// Select perf buffer statistics maps
+	for perfMapName, statsMapsNames := range es.perfBufferMapNameToStatsMapsName {
+		var maps [2]*lib.Map
+		for i, statsMapName := range statsMapsNames {
+			stats, ok, err := ebpfManager.GetMap(statsMapName)
+			if !ok {
+				return nil, errors.Errorf("map %s not found", statsMapName)
+			}
+			if err != nil {
+				return nil, err
+			}
+			maps[i] = stats
+		}
+		es.perfBufferStatsMaps[perfMapName] = maps
+		// set default perf buffer size, it will be readjusted in the next loop if needed
+		es.perfBufferSize[perfMapName] = float64(options.DefaultPerfRingBufferSize)
+	}
+
+	// Prepare user space counters
+	for _, m := range ebpfManager.PerfMaps {
+		var stats [][maxEventType]PerfMapStats
+		var usrLostEvents []uint64
+
+		for i := 0; i < es.cpuCount; i++ {
+			stats = append(stats, [maxEventType]PerfMapStats{})
+			usrLostEvents = append(usrLostEvents, 0)
+		}
+
+		es.stats[m.Name] = stats
+		es.readLostEvents[m.Name] = usrLostEvents
+
+		// update perf buffer size if needed
+		if m.PerfRingBufferSize != 0 {
+			es.perfBufferSize[m.Name] = float64(m.PerfRingBufferSize)
+		}
+	}
+
+	// select the buffer selector map
+	bufferSelector, ok, err := ebpfManager.GetMap("buffer_selector")
+	if !ok {
+		return nil, errors.Errorf("map buffer_selector not found")
+	}
+	if err != nil {
+		return nil, err
+	}
+	es.bufferSelector = bufferSelector
+	return &es, nil
 }
 
-// GetAndResetLost returns the number of lost events and resets the counter
-func (e *EventsStats) GetAndResetLost() int64 {
-	return atomic.SwapInt64(&e.Lost, 0)
+// getPerfMapFromStatsMap returns the perf map associated with a stats map
+func (e *EventsStats) getPerfMapFromStatsMap(statsMap string) string {
+	perfMap, ok := e.statsMapsNameToPerfBufferMapName[statsMap]
+	if ok {
+		return perfMap
+	}
+	return fmt.Sprintf("unknown_%s", statsMap)
 }
 
-// GetEventCount returns the number of received events of the specified type
-func (e *EventsStats) GetEventCount(eventType EventType) int64 {
-	return atomic.LoadInt64(&e.PerEventType[eventType])
+// getReadLostCount is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getReadLostCount(perfMap string, cpu int) uint64 {
+	return atomic.LoadUint64(&e.readLostEvents[perfMap][cpu])
 }
 
-// GetAndResetEventCount returns the number of received events of the specified type and resets the counter
-func (e *EventsStats) GetAndResetEventCount(eventType EventType) int64 {
-	return atomic.SwapInt64(&e.PerEventType[eventType], 0)
+// GetReadLostCount returns the number of lost events for a given map and cpu. If a cpu of -1 is provided, the function will
+// return the sum of all the lost events of all the cpus.
+func (e *EventsStats) GetReadLostCount(perfMap string, cpu int) uint64 {
+	var total uint64
+
+	switch {
+	case cpu == -1:
+		for i := range e.readLostEvents[perfMap] {
+			total += e.getReadLostCount(perfMap, i)
+		}
+		break
+	case cpu >= 0:
+		if e.cpuCount <= cpu {
+			break
+		}
+		total += e.getReadLostCount(perfMap, cpu)
+	}
+
+	return total
 }
 
-// CountLost adds `count` to the counter of lost events
-func (e *EventsStats) CountLost(count int64) {
-	atomic.AddInt64(&e.Lost, count)
+// getAndResetReadLostCount is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getAndResetReadLostCount(perfMap string, cpu int) uint64 {
+	return atomic.SwapUint64(&e.readLostEvents[perfMap][cpu], 0)
+}
+
+// GetAndResetReadLostCount returns the number of lost events and resets the counter for a given map and cpu. If a cpu of -1 is
+// provided, the function will reset the counters of all the cpus for the provided map, and return the sum of all the
+// lost events of all the cpus of the provided map.
+func (e *EventsStats) GetAndResetReadLostCount(perfMap string, cpu int) uint64 {
+	var total uint64
+
+	switch {
+	case cpu == -1:
+		for i := range e.readLostEvents[perfMap] {
+			total += e.getAndResetReadLostCount(perfMap, i)
+		}
+		break
+	case cpu >= 0:
+		if e.cpuCount <= cpu {
+			break
+		}
+		total += e.getAndResetReadLostCount(perfMap, cpu)
+	}
+	return total
+}
+
+// getEventCount is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getEventCount(eventType EventType, perfMap string, cpu int) uint64 {
+	return atomic.LoadUint64(&e.stats[perfMap][cpu][eventType].Count)
+}
+
+// getEventBytes is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getEventBytes(eventType EventType, perfMap string, cpu int) uint64 {
+	return atomic.LoadUint64(&e.stats[perfMap][cpu][eventType].Bytes)
+}
+
+// getEventUsage is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getEventUsage(eventType EventType, perfMap string, cpu int) int64 {
+	return atomic.LoadInt64(&e.stats[perfMap][cpu][eventType].Usage)
+}
+
+// getEventInQueue is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getEventInQueue(eventType EventType, perfMap string, cpu int) int64 {
+	return atomic.LoadInt64(&e.stats[perfMap][cpu][eventType].InQueue)
+}
+
+// GetEventStats returns the number of received events of the specified type and resets the counter
+func (e *EventsStats) GetEventStats(eventType EventType, perfMap string, cpu int) PerfMapStats {
+	var stats PerfMapStats
+	var maps []string
+
+	if eventType >= maxEventType {
+		return stats
+	}
+
+	switch {
+	case len(perfMap) == 0:
+		for m := range e.stats {
+			maps = append(maps, m)
+		}
+		break
+	case e.stats[perfMap] != nil:
+		maps = append(maps, perfMap)
+	}
+
+	for _, m := range maps {
+
+		switch {
+		case cpu == -1:
+			for i := range e.stats[m] {
+				stats.Count += e.getEventCount(eventType, perfMap, i)
+				stats.Bytes += e.getEventBytes(eventType, perfMap, i)
+				stats.Usage += e.getEventUsage(eventType, perfMap, i)
+				stats.InQueue += e.getEventUsage(eventType, perfMap, i)
+			}
+			break
+		case cpu >= 0:
+			if e.cpuCount <= cpu {
+				break
+			}
+			stats.Count += e.getEventCount(eventType, perfMap, cpu)
+			stats.Bytes += e.getEventBytes(eventType, perfMap, cpu)
+			stats.Usage += e.getEventUsage(eventType, perfMap, cpu)
+			stats.InQueue += e.getEventUsage(eventType, perfMap, cpu)
+		}
+
+	}
+	return stats
+}
+
+// getAndResetEventCount is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getAndResetEventCount(eventType EventType, perfMap string, cpu int) uint64 {
+	return atomic.SwapUint64(&e.stats[perfMap][cpu][eventType].Count, 0)
+}
+
+// getAndResetEventBytes is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getAndResetEventBytes(eventType EventType, perfMap string, cpu int) uint64 {
+	return atomic.SwapUint64(&e.stats[perfMap][cpu][eventType].Bytes, 0)
+}
+
+// getAndResetEventUsage is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getAndResetEventUsage(eventType EventType, perfMap string, cpu int) int64 {
+	return atomic.SwapInt64(&e.stats[perfMap][cpu][eventType].Usage, 0)
+}
+
+// getAndResetEventInQueue is an internal function, it can segfault if its parameters are incorrect.
+func (e *EventsStats) getAndResetEventInQueue(eventType EventType, perfMap string, cpu int) int64 {
+	return atomic.SwapInt64(&e.stats[perfMap][cpu][eventType].InQueue, 0)
+}
+
+// GetAndResetEventStats returns the number of received events of the specified type and resets the counter
+func (e *EventsStats) GetAndResetEventStats(eventType EventType, perfMap string, cpu int) PerfMapStats {
+	var stats PerfMapStats
+	var maps []string
+
+	if eventType >= maxEventType {
+		return stats
+	}
+
+	switch {
+	case len(perfMap) == 0:
+		for m := range e.stats {
+			maps = append(maps, m)
+		}
+		break
+	case e.stats[perfMap] != nil:
+		maps = append(maps, perfMap)
+	}
+
+	for _, m := range maps {
+
+		switch {
+		case cpu == -1:
+			for i := range e.stats[m] {
+				stats.Count += e.getAndResetEventCount(eventType, perfMap, i)
+				stats.Bytes += e.getAndResetEventBytes(eventType, perfMap, i)
+				stats.Usage += e.getAndResetEventUsage(eventType, perfMap, i)
+				stats.InQueue += e.getAndResetEventInQueue(eventType, perfMap, i)
+			}
+			break
+		case cpu >= 0:
+			if e.cpuCount <= cpu {
+				break
+			}
+			stats.Count += e.getAndResetEventCount(eventType, perfMap, cpu)
+			stats.Bytes += e.getAndResetEventBytes(eventType, perfMap, cpu)
+			stats.Usage += e.getAndResetEventUsage(eventType, perfMap, cpu)
+			stats.InQueue += e.getAndResetEventInQueue(eventType, perfMap, cpu)
+		}
+
+	}
+	return stats
+}
+
+// CountLostEvent adds `count` to the counter of lost events
+func (e *EventsStats) CountLostEvent(count uint64, m *manager.PerfMap, cpu int) {
+	// sanity check
+	if (e.readLostEvents[m.Name] == nil) || (len(e.readLostEvents[m.Name]) <= cpu) {
+		return
+	}
+	atomic.AddUint64(&e.readLostEvents[m.Name][cpu], count)
 }
 
 // CountEventType adds `count` to the counter of received events of the specified type
-func (e *EventsStats) CountEventType(eventType EventType, count int64) {
-	atomic.AddInt64(&e.PerEventType[eventType], count)
+func (e *EventsStats) CountEvent(eventType EventType, count uint64, size uint64, m *manager.PerfMap, cpu int) {
+	// sanity check
+	if (e.stats[m.Name] == nil) || (len(e.stats[m.Name]) <= cpu) || (len(e.stats[m.Name][cpu]) <= int(eventType)) {
+		return
+	}
+
+	atomic.AddUint64(&e.stats[m.Name][cpu][eventType].Count, count)
+	atomic.AddUint64(&e.stats[m.Name][cpu][eventType].Bytes, size)
+
+	if e.config.PerfBufferMonitor {
+		atomic.AddInt64(&e.stats[m.Name][cpu][eventType].Usage, -int64(size))
+		atomic.AddInt64(&e.stats[m.Name][cpu][eventType].InQueue, -int64(count))
+	}
+}
+
+func (e *EventsStats) sendEventsAndBytesReadStats(client *statsd.Client) error {
+	var name string
+
+	for m := range e.stats {
+		for cpu := range e.stats[m] {
+			for eventType := range e.stats[m][cpu] {
+				evtType := EventType(eventType)
+				tags := []string{
+					fmt.Sprintf("map:%s", m),
+					fmt.Sprintf("cpu:%d", cpu),
+					fmt.Sprintf("event_type:%s", evtType),
+				}
+
+				name = MetricPrefix + ".perf_buffer.events.read"
+				if err := client.Count(name, int64(e.getAndResetEventCount(evtType, m, cpu)), tags, 1.0); err != nil {
+					return err
+				}
+
+				name = MetricPrefix + ".perf_buffer.bytes.read"
+				if err := client.Count(name, int64(e.getAndResetEventBytes(evtType, m, cpu)), tags, 1.0); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (e *EventsStats) sendLostEventsReadStats(client *statsd.Client) error {
+	name := MetricPrefix + ".perf_buffer.lost_events.read"
+	for m := range e.readLostEvents {
+		for cpu := range e.readLostEvents[m] {
+			tags := []string{
+				fmt.Sprintf("map:%s", m),
+				fmt.Sprintf("cpu:%d", cpu),
+			}
+			if err := client.Count(name, int64(e.getAndResetReadLostCount(m, cpu)), tags, 1.0); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *EventsStats) collectAndSendKernelStats(client *statsd.Client) error {
+	var (
+		id          uint32
+		stats, zero PerfMapStats
+		iterator    *lib.MapIterator
+		tags        []string
+	)
+
+	// loop through the statistics buffers of each perf map
+	for perfMapName, statsMaps := range e.perfBufferStatsMaps {
+		// select the current statistics buffer in use
+		statsMap := statsMaps[1-e.activeMapIndex]
+
+		// loop through all the values of the active buffer
+		iterator = statsMap.Iterate()
+		for iterator.Next(&id, &stats) {
+			// compute cpu and event type from id
+			cpu := int(id / uint32(maxEventType))
+			evtType := EventType(id % uint32(maxEventType))
+
+			// sanity checks:
+			//   - check if the computed cpu id is below the current cpu count
+			//   - check if we collect some data on the provided perf map
+			//   - check if the computed event id is below the current max event id
+			if (e.stats[perfMapName] == nil) || (len(e.stats[perfMapName]) <= cpu) || (len(e.stats[perfMapName][cpu]) <= int(evtType)) {
+				continue
+			}
+
+			// remove the entry from the kernel
+			if err := statsMap.Put(&id, &zero); err != nil {
+				return err
+			}
+
+			// prepare metrics tags
+			tags = []string{
+				fmt.Sprintf("map:%s", perfMapName),
+				fmt.Sprintf("cpu:%d", cpu),
+				fmt.Sprintf("event_type:%s", evtType),
+			}
+
+			if err := e.sendKernelStats(client, stats, tags, perfMapName, cpu, evtType); err != nil {
+				return err
+			}
+		}
+		if iterator.Err() != nil {
+			return errors.Wrapf(iterator.Err(), "failed to dump statistics buffer %d of map %s", 1-e.activeMapIndex, perfMapName)
+		}
+	}
+	return nil
+}
+
+func (e *EventsStats) sendKernelStats(client *statsd.Client, stats PerfMapStats, tags []string, perfMapName string, cpu int, evtType EventType) error {
+	metric := MetricPrefix + ".perf_buffer.events.write"
+	if err := client.Count(metric, int64(stats.Count), tags, 1.0); err != nil {
+		return err
+	}
+
+	metric = MetricPrefix + ".perf_buffer.bytes.write"
+	if err := client.Count(metric, int64(stats.Bytes), tags, 1.0); err != nil {
+		return err
+	}
+
+	metric = MetricPrefix + ".perf_buffer.lost_events.write"
+	if err := client.Count(metric, int64(stats.Lost), tags, 1.0); err != nil {
+		return err
+	}
+
+	// update usage metric
+	newUsage := atomic.AddInt64(&e.stats[perfMapName][cpu][evtType].Usage, int64(stats.Bytes))
+	newInQueue := atomic.AddInt64(&e.stats[perfMapName][cpu][evtType].InQueue, int64(stats.Count))
+
+	if evtType == FileOpenEventType && perfMapName == "events" {
+		metric = MetricPrefix + ".perf_buffer.usage"
+		// There is a race condition when the system is under pressure: between the time we read the perf buffer stats map
+		// and the time we reach this point, the kernel might have written more events in the perf map, and those events
+		// might have already been read in user space. In that case, usage will yield a negative value. In that case, set
+		// the map usage to 0 as it makes more sense than a negative value.
+		usage := math.Max(float64(newUsage)/e.perfBufferSize[perfMapName], 0)
+		if err := client.Gauge(metric, usage*100, tags, 1.0); err != nil {
+			return err
+		}
+
+		metric = MetricPrefix + ".perf_buffer.in_queue"
+		// There is a race condition when the system is under pressure: between the time we read the perf buffer stats map
+		// and the time we reach this point, the kernel might have written more events in the perf map, and those events
+		// might have already been read in user space. In that case, usage will yield a negative value. In that case, set
+		// the amount of queued events to 0 as it makes more sens than a negative value.
+		if err := client.Count(metric, int64(math.Max(float64(newInQueue), 0)), tags, 1.0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *EventsStats) SendStats(client *statsd.Client) error {
+	if e.config.PerfBufferMonitor {
+		if err := e.collectAndSendKernelStats(client); err != nil {
+			return err
+		}
+	}
+
+	if err := e.sendEventsAndBytesReadStats(client); err != nil {
+		return err
+	}
+
+	if err := e.sendLostEventsReadStats(client); err != nil {
+		return err
+	}
+
+	// Update the active statistics map id
+	if err := e.bufferSelector.Put(ebpf.BufferSelectorPerfBufferMonitorKey, 1-e.activeMapIndex); err != nil {
+		return err
+	}
+	atomic.SwapUint32(&e.activeMapIndex, 1-e.activeMapIndex)
+	return nil
 }

--- a/pkg/security/probe/event_stats.go
+++ b/pkg/security/probe/event_stats.go
@@ -351,10 +351,8 @@ func (e *EventsStats) CountEvent(eventType EventType, count uint64, size uint64,
 	atomic.AddUint64(&e.stats[m.Name][cpu][eventType].Count, count)
 	atomic.AddUint64(&e.stats[m.Name][cpu][eventType].Bytes, size)
 
-	if e.config.PerfBufferMonitor {
-		atomic.AddInt64(&e.stats[m.Name][cpu][eventType].Usage, -int64(size))
-		atomic.AddInt64(&e.stats[m.Name][cpu][eventType].InQueue, -int64(count))
-	}
+	atomic.AddInt64(&e.stats[m.Name][cpu][eventType].Usage, -int64(size))
+	atomic.AddInt64(&e.stats[m.Name][cpu][eventType].InQueue, -int64(count))
 }
 
 func (e *EventsStats) sendEventsAndBytesReadStats(client *statsd.Client) error {
@@ -497,10 +495,8 @@ func (e *EventsStats) sendKernelStats(client *statsd.Client, stats PerfMapStats,
 
 // SendStats send event stats using the provided statsd client
 func (e *EventsStats) SendStats(client *statsd.Client) error {
-	if e.config.PerfBufferMonitor {
-		if err := e.collectAndSendKernelStats(client); err != nil {
-			return err
-		}
+	if err := e.collectAndSendKernelStats(client); err != nil {
+		return err
 	}
 
 	if err := e.sendEventsAndBytesReadStats(client); err != nil {

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -70,6 +70,7 @@ type Probe struct {
 	config             *config.Config
 	handler            EventHandler
 	resolvers          *Resolvers
+	perfMap            *manager.PerfMap
 	pidDiscarders      *lib.Map
 	inodeDiscarders    *lib.Map
 	revisionCache      [discarderRevisionSize]uint32
@@ -82,7 +83,7 @@ type Probe struct {
 	loadController     *LoadController
 	kernelVersion      kernel.Version
 	_                  uint32 // padding for goarch=386
-	eventsStats        EventsStats
+	eventsStats        *EventsStats
 	startTime          time.Time
 	event              *Event
 	reOrderer          *ReOrderer
@@ -177,6 +178,16 @@ func (p *Probe) Init() error {
 		return err
 	}
 
+	var ok bool
+	if p.perfMap, ok = p.manager.GetPerfMap("events"); !ok {
+		return errors.New("couldn't find events perf map")
+	}
+
+	p.eventsStats, err = NewEventsStats(p.manager, p.managerOptions, p.config)
+	if err != nil {
+		return errors.Wrap(err, "couldn't create events statistics monitor")
+	}
+
 	if err := p.resolvers.Start(); err != nil {
 		return err
 	}
@@ -224,63 +235,15 @@ func (p *Probe) SendStats() error {
 		}
 	}
 
-	if err := p.statsdClient.Count(MetricPrefix+".events.lost", p.eventsStats.GetAndResetLost(), nil, 1.0); err != nil {
-		return errors.Wrap(err, "failed to send events.lost metric")
-	}
-
-	receivedEvents := MetricPrefix + ".events.received"
-	for i := range p.eventsStats.PerEventType {
-		if i == 0 {
-			continue
-		}
-
-		eventType := EventType(i)
-		tags := []string{fmt.Sprintf("event_type:%s", eventType.String())}
-		if value := p.eventsStats.GetAndResetEventCount(eventType); value > 0 {
-			if err := p.statsdClient.Count(receivedEvents, value, tags, 1.0); err != nil {
-				return errors.Wrap(err, "failed to send events.received metric")
-			}
-		}
-	}
-
 	if err := p.statsdClient.Gauge(MetricPrefix+".process_resolver.cache_size", p.resolvers.ProcessResolver.GetCacheSize(), []string{}, 1.0); err != nil {
 		return errors.Wrap(err, "failed to send process_resolver cache_size metric")
 	}
-	return nil
-}
 
-// GetStats returns Stats according to the system-probe module format
-func (p *Probe) GetStats() (map[string]interface{}, error) {
-	stats := make(map[string]interface{})
-
-	var syscalls *SyscallStats
-	var err error
-
-	if p.syscallMonitor != nil {
-		syscalls, err = p.syscallMonitor.GetStats()
-	}
-
-	stats["events"] = map[string]interface{}{
-		"lost":     p.eventsStats.GetLost(),
-		"syscalls": syscalls,
-	}
-
-	perEventType := make(map[string]int64)
-	stats["per_event_type"] = perEventType
-	for i := range p.eventsStats.PerEventType {
-		if i == 0 {
-			continue
-		}
-
-		eventType := EventType(i)
-		perEventType[eventType.String()] = p.eventsStats.GetEventCount(eventType)
-	}
-
-	return stats, err
+	return p.eventsStats.SendStats(p.statsdClient)
 }
 
 // GetEventsStats returns statistics about the events received by the probe
-func (p *Probe) GetEventsStats() EventsStats {
+func (p *Probe) GetEventsStats() *EventsStats {
 	return p.eventsStats
 }
 
@@ -311,7 +274,7 @@ func (p *Probe) initDiscarderRevision(mountEvent *MountEvent) {
 
 func (p *Probe) handleLostEvents(CPU int, count uint64, perfMap *manager.PerfMap, manager *manager.Manager) {
 	log.Tracef("lost %d events", count)
-	p.eventsStats.CountLost(int64(count))
+	p.eventsStats.CountLostEvent(count, perfMap, CPU)
 }
 
 var eventZero Event
@@ -367,7 +330,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 	}
 
 	eventType := EventType(event.Type)
-	p.eventsStats.CountEventType(eventType, 1)
+	p.eventsStats.CountEvent(eventType, 1, uint64(len(data)), p.perfMap, int(CPU))
 
 	log.Tracef("Decoding event %s(%d)", eventType, event.Type)
 
@@ -769,6 +732,14 @@ func getInvalidDiscarders() map[eval.Field]map[interface{}]bool {
 	}
 
 	return invalidDiscarders
+}
+
+func (p *Probe) GetDebugStats() map[string]interface{} {
+	debug := map[string]interface{}{
+		"start_time": p.startTime.String(),
+	}
+	// TODO(Will): add manager state
+	return debug
 }
 
 // NewProbe instantiates a new runtime security agent probe

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -162,14 +162,6 @@ func (p *Probe) Init() error {
 		p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, selectors...)
 	}
 
-	// activate perf buffer monitor
-	if p.config.PerfBufferMonitor {
-		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, manager.ConstantEditor{
-			Name:  "perf_monitor_enabled",
-			Value: uint64(1),
-		})
-	}
-
 	if err := p.manager.InitWithOptions(bytecodeReader, p.managerOptions); err != nil {
 		return errors.Wrap(err, "failed to init manager")
 	}

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -162,6 +162,14 @@ func (p *Probe) Init() error {
 		p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, selectors...)
 	}
 
+	// activate perf buffer monitor
+	if p.config.PerfBufferMonitor {
+		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, manager.ConstantEditor{
+			Name:  "perf_monitor_enabled",
+			Value: uint64(1),
+		})
+	}
+
 	if err := p.manager.InitWithOptions(bytecodeReader, p.managerOptions); err != nil {
 		return errors.Wrap(err, "failed to init manager")
 	}
@@ -734,6 +742,7 @@ func getInvalidDiscarders() map[eval.Field]map[interface{}]bool {
 	return invalidDiscarders
 }
 
+// GetDebugStats returns the debug stats
 func (p *Probe) GetDebugStats() map[string]interface{} {
 	debug := map[string]interface{}{
 		"start_time": p.startTime.String(),

--- a/pkg/security/probe/syscall_stats.go
+++ b/pkg/security/probe/syscall_stats.go
@@ -221,7 +221,7 @@ func (sm *SyscallMonitor) CollectStats(collector SyscallStatsCollector) error {
 	}
 
 	sm.activeKernelBuffer = 1 - sm.activeKernelBuffer
-	return sm.bufferSelector.Put(ebpf.ZeroUint32MapItem, sm.activeKernelBuffer)
+	return sm.bufferSelector.Put(ebpf.BufferSelectorSyscallMonitorKey, sm.activeKernelBuffer)
 }
 
 // NewSyscallMonitor instantiates a new syscall monitor

--- a/pkg/security/tests/.gitignore
+++ b/pkg/security/tests/.gitignore
@@ -1,0 +1,1 @@
+testsuite

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -54,7 +54,8 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 	}
 
 	eventsStats := test.probe.GetEventsStats()
-	eventsStats.GetAndResetReadLostCount("events", -1)
+	eventsStats.GetAndResetLostCount("events", -1)
+	eventsStats.GetAndResetKernelLostCount("events", -1)
 
 	events := 0
 	go func() {
@@ -108,7 +109,8 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 		t.Fatal(err)
 	}
 
-	report.AddMetric("lost", float64(eventsStats.GetReadLostCount("events", -1)), "lost")
+	report.AddMetric("lost", float64(eventsStats.GetLostCount("events", -1)), "lost")
+	report.AddMetric("kernel_lost", float64(eventsStats.GetAndResetKernelLostCount("events", -1)), "lost")
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 
@@ -203,7 +205,8 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 	}
 
 	eventsStats := test.probe.GetEventsStats()
-	eventsStats.GetAndResetReadLostCount("events", -1)
+	eventsStats.GetAndResetLostCount("events", -1)
+	eventsStats.GetAndResetKernelLostCount("events", -1)
 
 	events := 0
 	go func() {
@@ -248,7 +251,8 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 
 	time.Sleep(2 * time.Second)
 
-	report.AddMetric("lost", float64(eventsStats.GetReadLostCount("events", -1)), "lost")
+	report.AddMetric("lost", float64(eventsStats.GetLostCount("events", -1)), "lost")
+	report.AddMetric("kernel_lost", float64(eventsStats.GetAndResetKernelLostCount("events", -1)), "lost")
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -54,7 +54,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 	}
 
 	eventsStats := test.probe.GetEventsStats()
-	eventsStats.GetAndResetLost()
+	eventsStats.GetAndResetReadLostCount("events", -1)
 
 	events := 0
 	go func() {
@@ -108,7 +108,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 		t.Fatal(err)
 	}
 
-	report.AddMetric("lost", float64(eventsStats.GetLost()), "lost")
+	report.AddMetric("lost", float64(eventsStats.GetReadLostCount("events", -1)), "lost")
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -203,7 +203,7 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 	}
 
 	eventsStats := test.probe.GetEventsStats()
-	eventsStats.GetAndResetLost()
+	eventsStats.GetAndResetReadLostCount("events", -1)
 
 	events := 0
 	go func() {
@@ -248,7 +248,7 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 
 	time.Sleep(2 * time.Second)
 
-	report.AddMetric("lost", float64(eventsStats.GetLost()), "lost")
+	report.AddMetric("lost", float64(eventsStats.GetReadLostCount("events", -1)), "lost")
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 

--- a/releasenotes/notes/runtime-security-perf-map-monitor-741fc50bfe4f68a1.yaml
+++ b/releasenotes/notes/runtime-security-perf-map-monitor-741fc50bfe4f68a1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    New perf map usage metrics.

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -56,7 +56,6 @@ def build(
     arch="x64",
     embedded_path=DATADOG_AGENT_EMBEDDED_PATH,
     bundle_ebpf=False,
-    perf_buffer_monitor=False,
 ):
     """
     Build the system_probe
@@ -64,7 +63,7 @@ def build(
 
     # Only build ebpf files on unix
     if not windows:
-        build_object_files(ctx, bundle_ebpf=bundle_ebpf, perf_buffer_monitor=perf_buffer_monitor)
+        build_object_files(ctx, bundle_ebpf=bundle_ebpf)
 
     ldflags, gcflags, env = get_build_flags(
         ctx, major_version=major_version, python_runtimes=python_runtimes, embedded_path=embedded_path
@@ -179,7 +178,7 @@ def build_in_docker(
 
 @task
 def test(
-    ctx, packages=TEST_PACKAGES, skip_object_files=False, only_check_bpf_bytes=False, bundle_ebpf=True, output_path=None, perf_buffer_monitor=True
+    ctx, packages=TEST_PACKAGES, skip_object_files=False, only_check_bpf_bytes=False, bundle_ebpf=True, output_path=None
 ):
     """
     Run tests on eBPF parts
@@ -191,7 +190,7 @@ def test(
     """
 
     if not skip_object_files:
-        build_object_files(ctx, bundle_ebpf=bundle_ebpf, perf_buffer_monitor=perf_buffer_monitor)
+        build_object_files(ctx, bundle_ebpf=bundle_ebpf)
 
     cmd = 'go test -mod=vendor -v -tags {bpf_tag} {output_params} {pkgs}'
     if not is_root():
@@ -283,7 +282,7 @@ def nettop(ctx, incremental_build=False, go_mod="vendor"):
     """
     Build and run the `nettop` utility for testing
     """
-    build_object_files(ctx, bundle_ebpf=False, perf_buffer_monitor=False)
+    build_object_files(ctx, bundle_ebpf=False)
 
     cmd = 'go build -mod={go_mod} {build_type} -tags linux_bpf,ebpf_bindata -o {bin_path} {path}'
     bin_path = os.path.join(BIN_DIR, "nettop")
@@ -338,12 +337,12 @@ def build_dev_docker_image(ctx, image_name, push=False):
 
 
 @task
-def object_files(ctx, bundle_ebpf=True, perf_buffer_monitor=False):
+def object_files(ctx, bundle_ebpf=True):
     """object_files builds the eBPF object files"""
-    build_object_files(ctx, bundle_ebpf=bundle_ebpf, perf_buffer_monitor=perf_buffer_monitor)
+    build_object_files(ctx, bundle_ebpf=bundle_ebpf)
 
 
-def build_object_files(ctx, bundle_ebpf=False, perf_buffer_monitor=False):
+def build_object_files(ctx, bundle_ebpf=False):
     """build_object_files builds only the eBPF object
     set bundle_ebpf to False to disable replacing the assets
     """
@@ -460,10 +459,6 @@ def build_object_files(ctx, bundle_ebpf=False, perf_buffer_monitor=False):
         commands.append(llc_cmd.format(flags=" ".join(network_flags), bc_file=debug_bc_file, obj_file=debug_obj_file))
 
         bindata_files.extend([obj_file, debug_obj_file])
-
-    # Build security runtime programs
-    if perf_buffer_monitor:
-        flags.append("-DPERF_BUFFER_MONITOR=1")
 
     security_agent_c_dir = os.path.join(".", "pkg", "security", "ebpf", "c")
     security_agent_prebuilt_dir = os.path.join(security_agent_c_dir, "prebuilt")


### PR DESCRIPTION
### What does this PR do?

This PR introduces perf buffer usage metrics that can be used to monitor the perf buffers of the runtime security module. Since we now count events in kernel space as well, this PR also renames some of the metrics we use today in order to make it easier to understand what generated it:

*Renamed metrics*
- `datadog.runtime_security.events.received` -> `datadog.runtime_security.perf_buffer.events.read` (tagged with perf `map` name, `cpu` ID and `event_type`)
- `datadog.runtime_security.events.lost` -> `datadog.runtime_security.perf_buffer.lost_events.read` (tagged with perf `map` name and `cpu` ID)

*New metrics*
- `datadog.runtime_security.perf_buffer.bytes.read` : number of bytes read from the perf buffer in user space (tagged with `map`, `cpu`, `event_type`)
- `datadog.runtime_security.perf_buffer.events.write` : number of events written to the perf buffer in kernel space (tagged with `map`, `cpu`, `event_type`)
- `datadog.runtime_security.perf_buffer.bytes.write` : number of bytes written to the perf buffer in kernel space (tagged with `map`, `cpu`, `event_type`)
- `datadog.runtime_security.perf_buffer.lost_events.write` : number of lost events dropped from kernel space (tagged with `map`, `cpu`, `event_type` <- note that we do not have the `event_type` in the user space counter part)
- [removed checkout commit history] `datadog.runtime_security.perf_buffer.usage` : usage of a perf buffer in % (tagged with `map`, `cpu`, `event_type`). Keep in mind that there is one map per CPU core, so this metric can go above 100% on a host with more than 1 CPU core.
- [removed checkout commit history] `datadog.runtime_security.perf_buffer.in_queue` : number of events currently waiting to be consumed by the user space reader (tagged with `map`, `cpu`, `event_type`).

After analysis of the collected metrics, we decided to increase our perf buffer size to `4097` pages (~16MB).

### Motivation

The reason why we implemented this perf buffer monitor is to try to better understand and control when the kernel decides to drop events. Ultimately we would like to take action before events are being dropped (for example by pushing new kernel filters at runtime).