### PR TITLE
[runtime-security] Fix discarders with rules mixing filename and basename

### DIFF
--- a/pkg/security/probe/kfilters.go
+++ b/pkg/security/probe/kfilters.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
-	"regexp"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
@@ -38,52 +38,68 @@ func (f *FilterPolicy) Bytes() ([]byte, error) {
 	return []byte{uint8(f.Mode), uint8(f.Flags)}, nil
 }
 
-func isParentPathDiscarder(rs *rules.RuleSet, eventType eval.EventType, filename string) (bool, error) {
+func isParentPathDiscarder(rs *rules.RuleSet, eventType eval.EventType, filenameField eval.Field, filename string) (bool, error) {
 	dirname := filepath.Dir(filename)
 
-	// ensure we don't push parent discarder if there is another rule relying on the parent path
-	// ex: rule      open.filename == "/etc/passwd"
-	//     discarder /etc/fstab
-	// /etc/fstab is a discarder but not the parent
-	re, err := regexp.Compile("^" + dirname + "/.*$")
-	if err != nil {
-		return false, err
+	bucket := rs.GetBucket(eventType)
+	if bucket == nil {
+		return false, nil
 	}
 
-	values := rs.GetFieldValues(eventType + ".filename")
-	for _, value := range values {
-		if re.MatchString(value.Value.(string)) {
-			return false, nil
+	basenameField := strings.Replace(filenameField, ".filename", ".basename", 1)
+
+	event := NewEvent(nil)
+	if _, err := event.GetFieldType(filenameField); err != nil {
+		return false, nil
+	}
+
+	if _, err := event.GetFieldType(basenameField); err != nil {
+		return false, nil
+	}
+
+	for _, rule := range bucket.GetRules() {
+		// ensure we don't push parent discarder if there is another rule relying on the parent path
+
+		// first case: rule contains a filename field
+		// ex: rule		open.filename == "/etc/passwd"
+		//     discarder /etc/fstab
+		// /etc/fstab is a discarder but not the parent
+
+		// second case: rule doesn't contain a filename field but a basename field
+		// ex: rule	 	open.basename == "conf.d"
+		//     discarder /etc/conf.d/httpd.conf
+		// /etc/conf.d/httpd.conf is a discarder but not the parent
+
+		// check filename
+		if values := rule.GetFieldValues(filenameField); len(values) > 0 {
+			for _, value := range values {
+				if strings.HasPrefix(value.Value.(string), dirname) {
+					return false, nil
+				}
+			}
+
+			if err := event.SetFieldValue(filenameField, dirname); err != nil {
+				return false, err
+			}
+
+			if isDiscarder, _ := rs.IsDiscarder(event, filenameField); isDiscarder {
+				return true, nil
+			}
 		}
-	}
 
-	// check basename, assuming there is a basename field
-	// ensure that we don't discard a parent that matches a basename rule
-	// ex: rule     open.basename == ".ssh"
-	//     discader /root/.ssh/id_rsa
-	// we can't discard /root/.ssh as basename rule matches it
-	// Note: This shouldn't happen we can't have a discarder working on multiple fields.
-	//       ex: open.filename == "/etc/passwd"
-	//           open.basename == "shadow"
-	//       These rules won't return any discarder
-	var isDiscarder bool
+		// check basename
+		if values := rule.GetFieldValues(basenameField); len(values) > 0 {
+			if err := event.SetFieldValue(basenameField, path.Base(dirname)); err != nil {
+				return false, err
+			}
 
-	field := eventType + ".basename"
-	if values := rs.GetFieldValues(field); len(values) == 0 {
-		isDiscarder = true
-	} else {
-		isDiscarder, err = rs.IsDiscarder(field, path.Base(dirname))
-		if err != nil {
-			if _, ok := err.(*eval.ErrFieldNotFound); ok {
-				// no basename rule so we can discard
-				isDiscarder = true
+			if isDiscarder, _ := rs.IsDiscarder(event, basenameField); !isDiscarder {
+				return false, nil
 			}
 		}
 	}
 
-	if isDiscarder {
-		log.Tracef("`%s` discovered as parent discarder", dirname)
-	}
+	log.Tracef("`%s` discovered as parent discarder", dirname)
 
-	return isDiscarder, nil
+	return true, nil
 }

--- a/pkg/security/probe/kfilters_bpf.go
+++ b/pkg/security/probe/kfilters_bpf.go
@@ -32,8 +32,8 @@ func discardInode(probe *Probe, mountID uint32, inode uint64, tableName string) 
 	return true, nil
 }
 
-func discardParentInode(probe *Probe, rs *rules.RuleSet, eventType eval.EventType, filename string, mountID uint32, inode uint64, tableName string) (bool, error) {
-	isDiscarder, err := isParentPathDiscarder(rs, eventType, filename)
+func discardParentInode(probe *Probe, rs *rules.RuleSet, eventType eval.EventType, field eval.Field, filename string, mountID uint32, inode uint64, tableName string) (bool, error) {
+	isDiscarder, err := isParentPathDiscarder(rs, eventType, field, filename)
 	if !isDiscarder {
 		return false, err
 	}

--- a/pkg/security/probe/kfilters_test.go
+++ b/pkg/security/probe/kfilters_test.go
@@ -34,10 +34,66 @@ func addRuleExpr(t *testing.T, rs *rules.RuleSet, exprs ...string) {
 
 func TestIsParentDiscarder(t *testing.T) {
 	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
-
 	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.filename != "/var/log/datadog/system-probe.log"`)
 
-	if is, _ := isParentPathDiscarder(rs, "unlink", "/var/log/datadog/system-probe.log"); is {
+	if is, _ := isParentPathDiscarder(rs, "unlink", "unlink.filename", "/var/log/datadog/system-probe.log"); is {
 		t.Fatal("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.filename != "/var/log/datadog/system-probe.log"`)
+
+	if is, _ := isParentPathDiscarder(rs, "unlink", "unlink.filename", "/var/lib/datadog/system-probe.sock"); !is {
+		t.Fatal("should be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename == "/var/log/datadog/system-probe.log"`, `unlink.basename == "datadog"`)
+
+	if is, _ := isParentPathDiscarder(rs, "unlink", "unlink.filename", "/var/log/datadog/datadog-agent.log"); is {
+		t.Fatal("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.basename =~ ".*"`)
+
+	if is, _ := isParentPathDiscarder(rs, "unlink", "unlink.filename", "/var/lib/.runc/1234"); !is {
+		t.Fatal("should be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename == "/etc/conf.d/httpd.conf" || unlink.basename == "conf.d"`)
+
+	if is, _ := isParentPathDiscarder(rs, "unlink", "unlink.filename", "/etc/conf.d/nginx.conf"); is {
+		t.Fatal("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename == "/etc/conf.d/httpd.conf" || unlink.basename == "sys.d"`)
+
+	if is, _ := isParentPathDiscarder(rs, "unlink", "unlink.filename", "/etc/sys.d/nginx.conf"); is {
+		t.Fatal("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.basename == "conf.d"`)
+
+	if is, _ := isParentPathDiscarder(rs, "unlink", "unlink.filename", "/etc/conf.d/nginx.conf"); is {
+		t.Fatal("shouldn't be a parent discarder")
+	}
+
+	// field that doesn't exists shouldn't return any discarders
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
+	addRuleExpr(t, rs, `rename.old.filename == "/etc/conf.d/abc"`)
+
+	if is, _ := isParentPathDiscarder(rs, "rename", "rename.filename", "/etc/conf.d/nginx.conf"); is {
+		t.Fatal("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(true, SECLConstants, nil))
+	addRuleExpr(t, rs, `rename.old.filename == "/etc/conf.d/abc"`)
+
+	if is, _ := isParentPathDiscarder(rs, "rename", "rename.old.filename", "/etc/nginx/nginx.conf"); !is {
+		t.Fatal("should be a parent discarder")
 	}
 }

--- a/pkg/security/probe/open_bpf.go
+++ b/pkg/security/probe/open_bpf.go
@@ -81,7 +81,7 @@ func openOnNewDiscarder(rs *rules.RuleSet, event *Event, probe *Probe, discarder
 			return nil
 		}
 
-		isDiscarded, err := discardParentInode(probe, rs, "open", value, fsEvent.MountID, fsEvent.Inode, table)
+		isDiscarded, err := discardParentInode(probe, rs, "open", "open.filename", value, fsEvent.MountID, fsEvent.Inode, table)
 		if !isDiscarded {
 			if _, ok := err.(*ErrInvalidKeyPath); !ok {
 				// not able to discard the parent then only discard the filename

--- a/pkg/security/probe/unlink_bpf.go
+++ b/pkg/security/probe/unlink_bpf.go
@@ -28,7 +28,7 @@ func unlinkOnNewDiscarder(rs *rules.RuleSet, event *Event, probe *Probe, discard
 			return nil
 		}
 
-		_, err := discardParentInode(probe, rs, "unlink", value, fsEvent.MountID, fsEvent.Inode, table)
+		_, err := discardParentInode(probe, rs, "unlink", "unlink.filename", value, fsEvent.MountID, fsEvent.Inode, table)
 		return err
 	}
 	return &ErrDiscarderNotSupported{Field: field}


### PR DESCRIPTION
### What does this PR do?

These PR fix the parent discarder discovery mechanism that were failing with rules mixing filename and basename.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test have been added
