### PR TITLE
Add ability to retry host tags providers and set Kubernetes retry to 10s

### DIFF
--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -88,7 +88,7 @@ func (mr *MetricsRetriever) retrieveMetricsValues() {
 		}
 
 		if queryResult, found := results[datadogMetric.Query]; found {
-			log.Debug("QueryResult from DD: %v", queryResult)
+			log.Debugf("QueryResult from DD: %v", queryResult)
 
 			if queryResult.Valid {
 				datadogMetricFromStore.Value = queryResult.Value

--- a/pkg/metadata/host/host_tags_test.go
+++ b/pkg/metadata/host/host_tags_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func init() {
+	retrySleepTime = 0
+}
+
 func TestGetHostTags(t *testing.T) {
 	mockConfig := config.Mock()
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3"})

--- a/releasenotes/notes/fix-missing-host-tags-7662be0de55b5493.yaml
+++ b/releasenotes/notes/fix-missing-host-tags-7662be0de55b5493.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add retries to Kubernetes host tags retrievals, minimize the chance of missing/changing host tags every 30mins


### PR DESCRIPTION
### What does this PR do?

Add possibility to retry the host tags providers, using for K8S with 10 retries (every second). Useful to avoid random loss of host tags when refresh happens (every 30mins).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Failure do not happen very often, so not easy to reproduce. One way may be to delay Cluster Agent start time (e.g. some sleep in init script or init container) and make sure we still retrieve host tags on first points by comparing metrics for a host with and without a node_labels_as_tags.
