### PR TITLE
Prevent collectors from deleting others' tags

### DIFF
--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -45,12 +45,9 @@ cache. Cache invalidation is triggered by the collectors (or source) by either:
 
 * sending new tags for the same `Entity`, all the tags from this `Source`
   will be removed and replaced by the new tags
-* sending a **TagInfo** with **DeleteEntity** set, all the entries for this
-  entity (including from other sources) will be deleted when **prune()** is
-  called.
-
-The deletions are batched so that if two sources send coliding add and delete
-messages, the delete eventually wins.
+* sending a **TagInfo** with **DeleteEntity** set, all the tags collected for
+  this entity by the specified source (but not others) will be deleted when
+  **prune()** is called.
 
 ## TagCardinality
 

--- a/releasenotes/notes/prevent-tag-deletion-from-multiple-sources-3c7182119d955f2a.yaml
+++ b/releasenotes/notes/prevent-tag-deletion-from-multiple-sources-3c7182119d955f2a.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+fixes:
+  - |
+    Under some circumstances, the Agent would delete all tags for a workload if
+    they were collected from different sources, such as the kubelet and docker,
+    but deleted from only one of them. Now, the agent keeps track of tags per
+    collector correctly.


### PR DESCRIPTION
The ability of a collector to delete another collector's tags seems to
have been designed in with good intentions, but it causes issues by
prematurely removing tags. This change lets each collector delete tags
for their own entities on their own schedule, without trampling over
each other.

### Describe your test plan

It's difficult to test that this PR does what it claims, since it's hard to reproduce the conditions that trigger the bug it aims to fix. It's important to check that it doesn't *break* the deletion though, and that can be tested by creating a pod, running `agent tagger-list` and ensuring all the tags are present, then deleting the pod, waiting 5+ minutes (deleted entities are only pruned once every 5 minutes), running `agent tagger-list` again, and checking that all tags for that pod are gone.