### PR TITLE
Perform type coercion on values for apm_config.analyzed_spans

### DIFF
--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -288,7 +289,9 @@ func (c *AgentConfig) applyDatadogConfig() error {
 				log.Errorf("Error parsing names: %v", err)
 				continue
 			}
-			if floatrate, ok := rate.(float64); ok {
+			if floatrate, err := toFloat64(rate); err != nil {
+				log.Errorf("Invalid value (%v) for apm_config.analyzed_spans: %v", rate, err)
+			} else {
 				if _, ok := c.AnalyzedSpansByService[serviceName]; !ok {
 					c.AnalyzedSpansByService[serviceName] = make(map[string]float64)
 				}
@@ -395,6 +398,30 @@ func parseServiceAndOp(name string) (string, string, error) {
 		return "", "", fmt.Errorf("Bad format for operation name and service name in: %s, it should have format: service_name|operation_name", name)
 	}
 	return splits[0], splits[1], nil
+}
+
+func toFloat64(i interface{}) (float64, error) {
+	switch v := i.(type) {
+	case float64:
+		return v, nil
+	case float32:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case int32:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case uint:
+		return float64(v), nil
+	case uint32:
+		return float64(v), nil
+	case uint64:
+		return float64(v), nil
+	case string:
+		return strconv.ParseFloat(v, 64)
+	}
+	return 0, fmt.Errorf("%v cannot be converted to float64", i)
 }
 
 func splitString(s string, sep rune) ([]string, error) {

--- a/releasenotes/notes/apm-analyzed-spans-float64-bug-ce0c77adb2a874d6.yaml
+++ b/releasenotes/notes/apm-analyzed-spans-float64-bug-ce0c77adb2a874d6.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix a regression where non-float64 numeric values in apm_config.analyzed_spans would disable the functionality.


### PR DESCRIPTION
### What does this PR do?

This restores the float64 type coercion mitchellh/mapstructure was performing on Viper's behalf, save for json.Number to float64.

### Motivation

tl;dr; - Analyzed Traces in the UI _*recently*_ broke because we used `1` instead of `1.0` as a value in the `analyzed_spans` configuration, and a recent refactoring led to no longer getting the weak type coercion from the mitchellh/mapstructure library by way of Viper's `UnmarshalStruct`.

Prior to the September 2020 refactoring of how configuration for APM is handled, Viper performed type coercion from int, uint, float32, string, bool, and json.Number to float64 via mapstructure.

After the refactoring, all non-float64 values were silently dropped when parsing the configuration. This led to a lot of back and forth between us and support to track down why we weren't seeing Analyzed Traces in the DataDog UI after an agent upgrade. This regression was discovered independent of DataDog support.

### Additional Notes

I didn't include `json.Number` support because I've never seen the DataDog agent configured with json files.