### PR TITLE
Support arbitrary tag values on the forwarder behind a feature flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,6 +179,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
+	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 
 	// overridden in IoT Agent main
 	config.BindEnvAndSetDefault("iot_host", false)

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -359,6 +359,8 @@ func (f *DefaultForwarder) createHTTPTransactions(endpoint endpoint, payloads Pa
 
 func (f *DefaultForwarder) createPriorityHTTPTransactions(endpoint endpoint, payloads Payloads, apiKeyInQueryString bool, extra http.Header, priority TransactionPriority) []*HTTPTransaction {
 	transactions := make([]*HTTPTransaction, 0, len(payloads)*len(f.keysPerDomains))
+	allowArbitraryTags := config.Datadog.GetBool("allow_arbitrary_tags")
+
 	for _, payload := range payloads {
 		for domain, apiKeys := range f.keysPerDomains {
 			for _, apiKey := range apiKeys {
@@ -374,7 +376,7 @@ func (f *DefaultForwarder) createPriorityHTTPTransactions(endpoint endpoint, pay
 				t.Headers.Set(apiHTTPHeaderKey, apiKey)
 				t.Headers.Set(versionHTTPHeaderKey, version.AgentVersion)
 				t.Headers.Set(useragentHTTPHeaderKey, fmt.Sprintf("datadog-agent/%s", version.AgentVersion))
-				if config.Datadog.GetBool("allow_arbitrary_tags") {
+				if allowArbitraryTags {
 					t.Headers.Set(arbitraryTagHTTPHeaderKey, "true")
 				}
 

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -124,9 +124,10 @@ const (
 )
 
 const (
-	apiHTTPHeaderKey       = "DD-Api-Key"
-	versionHTTPHeaderKey   = "DD-Agent-Version"
-	useragentHTTPHeaderKey = "User-Agent"
+	apiHTTPHeaderKey          = "DD-Api-Key"
+	versionHTTPHeaderKey      = "DD-Agent-Version"
+	useragentHTTPHeaderKey    = "User-Agent"
+	arbitraryTagHTTPHeaderKey = "Allow-Arbitrary-Tag-Value"
 )
 
 // The amount of time the forwarder will wait to receive process-like response payloads before giving up
@@ -373,6 +374,9 @@ func (f *DefaultForwarder) createPriorityHTTPTransactions(endpoint endpoint, pay
 				t.Headers.Set(apiHTTPHeaderKey, apiKey)
 				t.Headers.Set(versionHTTPHeaderKey, version.AgentVersion)
 				t.Headers.Set(useragentHTTPHeaderKey, fmt.Sprintf("datadog-agent/%s", version.AgentVersion))
+				if config.Datadog.GetBool("allow_arbitrary_tags") {
+					t.Headers.Set(arbitraryTagHTTPHeaderKey, "true")
+				}
 
 				if f.completionHandler != nil {
 					t.completionHandler = f.completionHandler

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -132,6 +132,7 @@ func TestCreateHTTPTransactions(t *testing.T) {
 	assert.NotEmpty(t, transactions[0].Headers.Get("HTTP-MAGIC"))
 	assert.Equal(t, version.AgentVersion, transactions[0].Headers.Get("DD-Agent-Version"))
 	assert.Equal(t, "datadog-agent/"+version.AgentVersion, transactions[0].Headers.Get("User-Agent"))
+	assert.Equal(t, "", transactions[0].Headers.Get(arbitraryTagHTTPHeaderKey))
 	assert.Equal(t, p1, *(transactions[0].Payload))
 	assert.Equal(t, p1, *(transactions[1].Payload))
 	assert.Equal(t, p2, *(transactions[2].Payload))
@@ -143,6 +144,21 @@ func TestCreateHTTPTransactions(t *testing.T) {
 	assert.Contains(t, transactions[1].Endpoint, "api_key=api-key-2")
 	assert.Contains(t, transactions[2].Endpoint, "api_key=api-key-1")
 	assert.Contains(t, transactions[3].Endpoint, "api_key=api-key-2")
+}
+
+func TestArbitraryTagsHTTPHeader(t *testing.T) {
+	mockConfig := config.Mock()
+	mockConfig.Set("allow_arbitrary_tags", true)
+	defer mockConfig.Set("allow_arbitrary_tags", false)
+
+	forwarder := NewDefaultForwarder(NewOptions(keysPerDomains))
+	endpoint := endpoint{"/api/foo", "foo"}
+	payload := []byte("A payload")
+	headers := make(http.Header)
+
+	transactions := forwarder.createHTTPTransactions(endpoint, Payloads{&payload}, false, headers)
+	require.True(t, len(transactions) > 0)
+	assert.Equal(t, "true", transactions[0].Headers.Get(arbitraryTagHTTPHeaderKey))
 }
 
 func TestSendHTTPTransactions(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This adds a config option to submit arbitrary tag values, which will allow setting tags like `query:select * from mytable`.

For additional context, see the integrations changes which will be submitting query text as tags:

* MySQL: https://github.com/DataDog/integrations-core/pull/7851
* Postgres: https://github.com/DataDog/integrations-core/pull/7852

This feature flag should only explicitly set the header when the customer specifies it in their config. Otherwise, we want to default to the default backend behavior to allow migration to making this behavior GA. This flag is essentially an early opt-in for beta customers.

### Motivation

For beta customers using database statement-level metrics, the agent needs to submit metrics tagged by the first 200 characters of the query text. Note that this feature will only work for the beta customers with the feature flag set on the backend as well.

### Additional Notes

### Describe your test plan

Unit tests. We have also been using this on dev builds for a couple of months on production databases.
