### PR TITLE
pkg/trace/config: ensure apm_config.analyzed_spans allows non-float64

### DIFF
--- a/releasenotes/notes/apm-analyzed-spans-float64-bug-ed3f1011ef393f06.yaml
+++ b/releasenotes/notes/apm-analyzed-spans-float64-bug-ed3f1011ef393f06.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix a bug where non-float64 numeric values in apm_config.analyzed_spans
+    would disable this functionality.


### PR DESCRIPTION
This change ensures that the `apm_config.analyzed_spans` values allow
non-float64 numeric values. It fixes a bug introduced by #6347