### PR TITLE
Inject netns listeners into containers for UDP origin detection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -335,6 +335,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_socket", "") // Notice: empty means feature disabled
 	config.BindEnvAndSetDefault("dogstatsd_stats_port", 5000)
 	config.BindEnvAndSetDefault("dogstatsd_stats_enable", false)
+	config.BindEnvAndSetDefault("dogstatsd_netns_listeners_enable", false)
 	config.BindEnvAndSetDefault("dogstatsd_stats_buffer", 10)
 	config.BindEnvAndSetDefault("dogstatsd_expiry_seconds", 300)
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -172,7 +172,7 @@ api_key:
 
 ## @param forwarder_retry_queue_payloads_max_size - integer - optional - default: 31457280 (30Mb)
 ## It defines the maximum size in bytes of all the payloads in the forwarder's retry queue.
-## If "forwarder_retry_queue_max_size" is greater than 0, this parameter is ignored. 
+## If "forwarder_retry_queue_max_size" is greater than 0, this parameter is ignored.
 #
 # forwarder_retry_queue_payloads_max_size: 31457280
 
@@ -1040,6 +1040,11 @@ api_key:
 ## Publish DogStatsD's internal stats as Go expvars.
 #
 # dogstatsd_stats_enable: false
+
+## @param dogstatsd_netns_listeners_enable - boolean - optional - default: false
+## Inject UDP listeners in containers' network namespaces.
+#
+# dogstatsd_netns_listeners_enable: false
 
 ## @param dogstatsd_queue_size - integer - optional - default: 1024
 ## Configure the internal queue size of the Dogstatsd server.

--- a/pkg/dogstatsd/listeners/packet_assembler.go
+++ b/pkg/dogstatsd/listeners/packet_assembler.go
@@ -22,6 +22,7 @@ type packetAssembler struct {
 	sharedPacketPool *PacketPool
 	flushTimer       *time.Ticker
 	closeChannel     chan struct{}
+	Origin           string
 	sync.Mutex
 }
 
@@ -54,6 +55,7 @@ func (p *packetAssembler) flushLoop() {
 
 func (p *packetAssembler) addMessage(message []byte) {
 	p.Lock()
+	p.packet.Origin = p.Origin
 	if p.packetLength == 0 {
 		p.packetLength = copy(p.packet.buffer, message)
 	} else if len(p.packet.buffer) >= len(message)+p.packetLength+1 {

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -44,6 +44,7 @@ type UDPListener struct {
 	packetsBuffer   *packetsBuffer
 	packetAssembler *packetAssembler
 	buffer          []byte
+	Origin          string
 }
 
 // NewUDPListener returns an idle UDP Statsd listener
@@ -115,6 +116,7 @@ func (l *UDPListener) Listen() {
 		tlmUDPPacketsBytes.Add(float64(n))
 
 		// packetAssembler merges multiple packets together and sends them when its buffer is full
+		l.packetAssembler.Origin = l.Origin
 		l.packetAssembler.addMessage(l.buffer[:n])
 	}
 }

--- a/pkg/dogstatsd/netns_listener_linux.go
+++ b/pkg/dogstatsd/netns_listener_linux.go
@@ -1,0 +1,266 @@
+// +build linux,docker
+
+package dogstatsd
+
+import (
+	"io"
+	"regexp"
+	"runtime"
+	"sync"
+
+	"github.com/docker/docker/api/types"
+	"github.com/vishvananda/netns"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	"github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// hostNetwork services run in the default netns that we cannot bind into
+var netNsBlacklist = regexp.MustCompile("^.+/docker/netns/default$")
+
+func (s *Server) setupNetNsListeners() {
+	d, err := docker.GetDockerUtil()
+	if err != nil {
+		log.Errorf("Failed to instantiate docker util - %v", err)
+		return
+	}
+
+	l := &netNsListener{
+		server:     s,
+		dockerUtil: d,
+		services:   make(map[string]*netNsMetadata),
+		stop:       make(chan bool),
+		health:     health.RegisterLiveness("netns-listener"),
+	}
+
+	l.init() // init listeners in containers that are already running
+	log.Debugf("Service Map: %+v", l.services)
+	log.Debugf("Service Map Len: %d", len(l.services))
+
+	messages, errs, err := l.dockerUtil.SubscribeToContainerEvents("netNsListener")
+	if err != nil {
+		log.Errorf("can't listen to docker events: %v", err)
+		signals.ErrorStopper <- true
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case <-l.stop:
+				log.Info("Recieved stop signal, shutting down listeners")
+				l.dockerUtil.UnsubscribeFromContainerEvents("netNsListener")
+				for sID, _ := range l.services {
+					l.removeService(sID)
+				}
+				l.health.Deregister()
+				return
+			case <-l.health.C:
+			case msg := <-messages:
+				log.Infof("Processing container event %s", msg.Action)
+				l.processEvent(msg)
+			case err := <-errs:
+				if err != nil && err != io.EOF {
+					log.Errorf("docker listener error: %v", err)
+					signals.ErrorStopper <- true
+				}
+				return
+			}
+		}
+	}()
+}
+
+// Stop queues a shutdown of netNsListener
+func (l *netNsListener) Stop() {
+	l.stop <- true
+}
+
+func (l *netNsListener) socketListen(nnm *netNsMetadata) {
+	udpListener, err := listeners.NewUDPListener(l.server.packetsIn, l.server.sharedPacketPool)
+	if err != nil {
+		log.Errorf("Cannot listen in a netNS: %v", err)
+		log.Debug("Short circuiting and skipping this container, ensuring it is not in service map")
+		l.m.Lock()
+		delete(l.services, nnm.cID)
+		l.m.Unlock()
+		return
+	}
+	udpListener.Origin = "container_id://" + nnm.cID
+	nnm.listener = udpListener
+	udpListener.Listen()
+}
+
+type netNsMetadata struct {
+	cID      string
+	path     string
+	listener *listeners.UDPListener
+}
+
+type netNsListener struct {
+	server     *Server
+	dockerUtil *docker.DockerUtil
+	services   map[string]*netNsMetadata
+	stop       chan bool
+	health     *health.Handle
+	m          sync.RWMutex
+}
+
+func (l *netNsListener) createService(cID string) {
+	var nnm netNsMetadata
+	cInspect, err := l.dockerUtil.Inspect(cID, false)
+	if err != nil {
+		log.Errorf("Failed to inspect container %s - %s", cID[:12], err)
+	} else {
+		nnm = netNsMetadata{path: cInspect.NetworkSettings.SandboxKey, cID: cID}
+	}
+
+	if cInspect.HostConfig.NetworkMode.IsContainer() {
+		return
+	}
+
+	if netNsBlacklist.Match([]byte(nnm.path)) {
+		return
+	}
+
+	l.m.Lock()
+	l.services[cID] = &nnm
+	l.m.Unlock()
+
+	log.Infof("Initializing listener in a new netns %s", nnm.path)
+	go executeWithinNetNS(&nnm, l.socketListen)
+}
+
+func (l *netNsListener) processEvent(e *docker.ContainerEvent) {
+	containers, err := l.dockerUtil.RawContainerList(types.ContainerListOptions{})
+	if err != nil {
+		log.Errorf("Couldn't retrieve container list - %s", err)
+		return
+	}
+	switch e.Action {
+	case "die":
+		// Loop service map removing any not in containers
+		containerIDs := make(map[string]bool)
+		deadIDs := make([]string, 0)
+		for _, co := range containers {
+			containerIDs[co.ID] = true
+		}
+		l.m.Lock()
+		for sID, _ := range l.services {
+			_, ok := containerIDs[sID]
+			if !ok {
+				deadIDs = append(deadIDs, sID)
+			}
+		}
+		l.m.Unlock()
+		for _, dID := range deadIDs {
+			log.Infof("Removing for id %s", dID)
+			l.removeService(dID)
+		}
+	case "start":
+		for _, co := range containers {
+			log.Debugf("Container list ID: %s\tNAMES: %s", co.ID, co.Names)
+			l.m.RLock()
+			_, found := l.services[co.ID]
+			l.m.RUnlock()
+			if !found {
+				l.createService(co.ID)
+			}
+		}
+	default:
+		log.Errorf("Expected die or start event got %s from %s", e.Action, e.ContainerID[:12])
+	}
+	log.Debugf("Service Map Len: %d", len(l.services))
+	log.Debugf("Service Map: %+v", l.services)
+}
+
+func (l *netNsListener) removeService(cID string) {
+	l.m.RLock()
+	svc, ok := l.services[cID]
+	l.m.RUnlock()
+
+	if ok {
+		log.Infof("Removing listener from a netns %s", svc.path)
+		svc.listener.Stop()
+		l.m.Lock()
+		delete(l.services, cID)
+		l.m.Unlock()
+	} else {
+		log.Errorf("Container %s not found, not removing", cID[:12])
+	}
+}
+
+func (l *netNsListener) init() {
+	l.m.Lock()
+	defer l.m.Unlock()
+
+	containers, err := l.dockerUtil.RawContainerList(types.ContainerListOptions{})
+	if err != nil {
+		log.Errorf("Couldn't retrieve container list - %s", err)
+	}
+
+	for _, c := range containers {
+		var nnm netNsMetadata
+		cInspect, err := l.dockerUtil.Inspect(c.ID, false)
+		if err != nil {
+			log.Errorf("Failed to inspect container %s - %s", c.ID[:12], err)
+		} else {
+			nnm = netNsMetadata{path: cInspect.NetworkSettings.SandboxKey, cID: c.ID}
+		}
+
+		if cInspect.HostConfig.NetworkMode.IsContainer() {
+			continue
+		}
+
+		if netNsBlacklist.Match([]byte(nnm.path)) {
+			continue
+		}
+
+		log.Infof("Initializing listener in existing netns %s", nnm.path)
+		l.services[c.ID] = &nnm
+		go executeWithinNetNS(&nnm, l.socketListen)
+	}
+}
+
+// executeWithinNetNS runs code inside a given network namespace, passing metadata
+func executeWithinNetNS(nnm *netNsMetadata, cb func(*netNsMetadata)) {
+	if nnm.path == "" {
+		log.Errorf("Target netNS is empty")
+		return
+	}
+
+	// confine this gorouting into this OS thread, so it stays in netNS
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	originalNS, err := netns.Get()
+	if err != nil {
+		log.Errorf("Cannot get current netNS: %w", err)
+		return
+	}
+	defer originalNS.Close()
+
+	targetNS, err := netns.GetFromPath(nnm.path)
+	if err != nil {
+		log.Errorf("Cannot get target netNS: %w", err)
+		return
+	}
+
+	// enter target netNS
+	if err := netns.Set(targetNS); err != nil {
+		log.Errorf("Cannot set target netNS: %w", err)
+		return
+	}
+	// later, return to original netNS
+	defer func() {
+		err := netns.Set(originalNS)
+		if err != nil {
+			log.Errorf("Cannot return to original netNS: %v", err)
+			return
+		}
+	}()
+
+	cb(nnm)
+}

--- a/pkg/dogstatsd/netns_listener_nolinux.go
+++ b/pkg/dogstatsd/netns_listener_nolinux.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package dogstatsd
+
+func (s *Server) setupNetNsListeners() {
+	// noop
+}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -246,6 +246,9 @@ func NewServer(aggregator *aggregator.BufferedAggregator) (*Server, error) {
 	// ----------------------
 
 	s.handleMessages()
+	if config.Datadog.GetBool("dogstatsd_netns_listeners_enable") == true {
+		s.setupNetNsListeners()
+	}
 
 	// start the debug loop
 	// ----------------------


### PR DESCRIPTION
### What does this PR do?

This PR adds `dogstatsd_netns_listeners_enable` option which — when enabled — would set up datadog agent to inject a `UDPListener` into container network namespace on host. Then, the injected Listener would "apply" container ID to packets coming through it to propagate custom metrics origin.

_Note: This is a proof of concept implementation to showcase the idea. (Needs tests, generic CRI support, and the docker event filtering logic can be reused from existing code._)

### Motivation

The goal here is to extend existing origin detection mechanisms for UDP to allow propagating `kube_namespace` tag on custom metrics. This is useful when for reasons, existing Origin detection mechanisms (via DD_ENTITY_ID and admission controller) cannot be used.

### Additional Notes

1. This implementation does not require extended container privileges. Existing "default" privileges/capabilities are sufficient.

1. This PR requires the following setting on datadog-agent pods (daemonset):

```
- name: DD_DOCKER_LABELS_AS_TAGS
  value: '{"io.kubernetes.pod.namespace":"kube_namespace"}'
```

### Describe your test plan

Run datadog-agent from this branch:

```bash
./bin/agent/agent run -c ./dev/dist/datadog.yaml
```

Note: datadog.yaml must contain your api_key, have `dogstatsd_netns_listeners_enable: true`, and use DOCKER_LABELS_AS_TAGS config mapping mentioned above.

Boot a container:

```bash
docker run -it --rm --label io.kubernetes.pod.namespace=ohai-testing-namespace --name ubuntu1 ubuntu
```

Send some metrics from inside `ubuntu1` container:

```bash
apt-get update && apt-get install -y netcat
echo -n "netns_test_metric_socat:10|c" | nc -q 1 -u 127.0.0.1 8125
```

/cc @rdooley @thomasbarton