### PR TITLE
Check error on system-probe debug server if activated as it may be scraped by an Agent check

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -101,7 +101,13 @@ func runAgent(exit <-chan struct{}) {
 
 	// if a debug port is specified, we expose the default handler to that port
 	if cfg.SystemProbeDebugPort > 0 {
-		go http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.SystemProbeDebugPort), http.DefaultServeMux) //nolint:errcheck
+		go func() {
+			err := http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.SystemProbeDebugPort), http.DefaultServeMux)
+			if err != nil && err != http.ErrServerClosed {
+				log.Criticalf("Error creating debug HTTP server: %v", err)
+				cleanupAndExit(1)
+			}
+		}()
 	}
 
 	loader := NewLoader()


### PR DESCRIPTION
### What does this PR do?

Make sure system-probe debug server starts if activated.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Run an application listening on port XYZ. Start system-probe with debug server activated on port XYZ, system-probe should fail starting.