### PR TITLE
[collector] Add `Cancel` to the `check.Check` interface

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -17,7 +17,11 @@ type Check interface {
 	Run() error
 	// Stop stops the check if it's running
 	Stop()
-	// String provide a printable version of the check name
+	// Cancel cancels the check. Cancel is called when the check is unscheduled:
+	// - unlike Stop, it is called even if the check is not running when it's unscheduled
+	// - if the check is running, Cancel is called after Stop and may be called before the call to Stop completes
+	Cancel()
+	// String provides a printable version of the check name
 	String() string
 	// Configure configures the check
 	Configure(config, initConfig integration.Data, source string) error

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -13,15 +13,26 @@ import (
 
 // Check is an interface for types capable to run checks
 type Check interface {
-	Run() error                                                         // run the check
-	Stop()                                                              // stop the check if it's running
-	String() string                                                     // provide a printable version of the check name
-	Configure(config, initConfig integration.Data, source string) error // configure the check from the outside
-	Interval() time.Duration                                            // return the interval time for the check
-	ID() ID                                                             // provide a unique identifier for every check instance
-	GetWarnings() []error                                               // return the last warning registered by the check
-	GetMetricStats() (map[string]int64, error)                          // get metric stats from the sender
-	Version() string                                                    // return the version of the check if available
-	ConfigSource() string                                               // return the configuration source of the check
-	IsTelemetryEnabled() bool                                           // return if telemetry is enabled for this check
+	// Run runs the check
+	Run() error
+	// Stop stops the check if it's running
+	Stop()
+	// String provide a printable version of the check name
+	String() string
+	// Configure configures the check
+	Configure(config, initConfig integration.Data, source string) error
+	// Interval returns the interval time for the check
+	Interval() time.Duration
+	// ID provides a unique identifier for every check instance
+	ID() ID
+	// GetWarnings returns the last warning registered by the check
+	GetWarnings() []error
+	// GetMetricStats gets metric stats from the sender
+	GetMetricStats() (map[string]int64, error)
+	// Version returns the version of the check if available
+	Version() string
+	// ConfigSource returns the configuration source of the check
+	ConfigSource() string
+	// IsTelemetryEnabled returns if telemetry is enabled for this check
+	IsTelemetryEnabled() bool
 }

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -8,29 +8,13 @@ package check
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/stretchr/testify/assert"
 )
 
-// FIXTURE
-type TestCheck struct{}
-
-func (c *TestCheck) String() string                                             { return "TestCheck" }
-func (c *TestCheck) Version() string                                            { return "" }
-func (c *TestCheck) ConfigSource() string                                       { return "" }
-func (c *TestCheck) Stop()                                                      {}
-func (c *TestCheck) Configure(integration.Data, integration.Data, string) error { return nil }
-func (c *TestCheck) Interval() time.Duration                                    { return 1 }
-func (c *TestCheck) Run() error                                                 { return nil }
-func (c *TestCheck) ID() ID                                                     { return ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                                       { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error)                  { return make(map[string]int64), nil }
-func (c *TestCheck) IsTelemetryEnabled() bool                                   { return false }
-
 func TestIdentify(t *testing.T) {
-	testCheck := &TestCheck{}
+	testCheck := &StubCheck{}
 
 	instance1 := integration.Data("key1:value1\nkey2:value2")
 	initConfig1 := integration.Data("key:value")

--- a/pkg/collector/check/stub.go
+++ b/pkg/collector/check/stub.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package check
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+)
+
+// StubCheck stubs a check, should only be used in tests
+type StubCheck struct{}
+
+func (c *StubCheck) String() string                                             { return "StubCheck" }
+func (c *StubCheck) Version() string                                            { return "" }
+func (c *StubCheck) ConfigSource() string                                       { return "" }
+func (c *StubCheck) Stop()                                                      {}
+func (c *StubCheck) Configure(integration.Data, integration.Data, string) error { return nil }
+func (c *StubCheck) Interval() time.Duration                                    { return 1 * time.Second }
+func (c *StubCheck) Run() error                                                 { return nil }
+func (c *StubCheck) ID() ID                                                     { return ID(c.String()) }
+func (c *StubCheck) GetWarnings() []error                                       { return []error{} }
+func (c *StubCheck) GetMetricStats() (map[string]int64, error)                  { return make(map[string]int64), nil }
+func (c *StubCheck) IsTelemetryEnabled() bool                                   { return false }

--- a/pkg/collector/check/stub.go
+++ b/pkg/collector/check/stub.go
@@ -14,14 +14,38 @@ import (
 // StubCheck stubs a check, should only be used in tests
 type StubCheck struct{}
 
-func (c *StubCheck) String() string                                             { return "StubCheck" }
-func (c *StubCheck) Version() string                                            { return "" }
-func (c *StubCheck) ConfigSource() string                                       { return "" }
-func (c *StubCheck) Stop()                                                      {}
+// String provides a printable version of the check name
+func (c *StubCheck) String() string { return "StubCheck" }
+
+// Version returns the empty string
+func (c *StubCheck) Version() string { return "" }
+
+// ConfigSource returns the empty string
+func (c *StubCheck) ConfigSource() string { return "" }
+
+// Stop is a noop
+func (c *StubCheck) Stop() {}
+
+// Cancel is a noop
+func (c *StubCheck) Cancel() {}
+
+// Configure is a noop
 func (c *StubCheck) Configure(integration.Data, integration.Data, string) error { return nil }
-func (c *StubCheck) Interval() time.Duration                                    { return 1 * time.Second }
-func (c *StubCheck) Run() error                                                 { return nil }
-func (c *StubCheck) ID() ID                                                     { return ID(c.String()) }
-func (c *StubCheck) GetWarnings() []error                                       { return []error{} }
-func (c *StubCheck) GetMetricStats() (map[string]int64, error)                  { return make(map[string]int64), nil }
-func (c *StubCheck) IsTelemetryEnabled() bool                                   { return false }
+
+// Interval returns a duration of one second
+func (c *StubCheck) Interval() time.Duration { return 1 * time.Second }
+
+// Run is a noop
+func (c *StubCheck) Run() error { return nil }
+
+// ID returns the check name
+func (c *StubCheck) ID() ID { return ID(c.String()) }
+
+// GetWarnings returns an empty slice
+func (c *StubCheck) GetWarnings() []error { return []error{} }
+
+// GetMetricStats returns an empty map
+func (c *StubCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
+
+// IsTelemetryEnabled returns false
+func (c *StubCheck) IsTelemetryEnabled() bool { return false }

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -183,8 +183,8 @@ func (c *Collector) get(id check.ID) (check.Check, bool) {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	ch, err := c.checks[id]
-	return ch, err
+	ch, found := c.checks[id]
+	return ch, found
 }
 
 // remove the check from the list

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -172,6 +172,11 @@ func (c *CheckBase) Warnf(format string, params ...interface{}) error {
 // long-running checks (persisting after Run() exits)
 func (c *CheckBase) Stop() {}
 
+// Cancel does nothing by default, you need to implement it if
+// your check has background resources that need to be cleaned up
+// when the check is unscheduled.
+func (c *CheckBase) Cancel() {}
+
 // Interval returns the scheduling time for the check.
 // Long-running checks should override to return 0.
 func (c *CheckBase) Interval() time.Duration {

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -202,6 +202,9 @@ func (c *APMCheck) Stop() {
 	<-c.stopDone
 }
 
+// Cancel does nothing
+func (c *APMCheck) Cancel() {}
+
 // GetWarnings does not return anything in APM
 func (c *APMCheck) GetWarnings() []error {
 	return []error{}

--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -61,6 +61,8 @@ func (c *JMXCheck) Stop() {
 	state.unscheduleCheck(c)
 }
 
+func (c *JMXCheck) Cancel() {}
+
 func (c *JMXCheck) String() string {
 	return c.name
 }

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -199,6 +199,9 @@ func (c *ProcessAgentCheck) Stop() {
 	<-c.stopDone
 }
 
+// Cancel does nothing
+func (c *ProcessAgentCheck) Cancel() {}
+
 // GetMetricStats returns the stats from the last run of the check, but there aren't any yet
 func (c *ProcessAgentCheck) GetMetricStats() (map[string]int64, error) {
 	return make(map[string]int64), nil

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -8,25 +8,16 @@ package corechecks
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 )
 
 // FIXTURE
-type TestCheck struct{}
+type TestCheck struct {
+	check.StubCheck
+}
 
-func (c *TestCheck) String() string                            { return "TestCheck" }
-func (c *TestCheck) Version() string                           { return "" }
-func (c *TestCheck) ConfigSource() string                      { return "" }
-func (c *TestCheck) Run() error                                { return nil }
-func (c *TestCheck) Stop()                                     {}
-func (c *TestCheck) Interval() time.Duration                   { return 1 }
-func (c *TestCheck) ID() check.ID                              { return check.ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                      { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
-func (c *TestCheck) IsTelemetryEnabled() bool                  { return false }
 func (c *TestCheck) Configure(data integration.Data, initData integration.Data, source string) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -111,6 +111,10 @@ func (c *PythonCheck) RunSimple() error {
 // Stop does nothing
 func (c *PythonCheck) Stop() {}
 
+// Cancel does nothing
+// TODO: implement Cancel for python checks
+func (c *PythonCheck) Cancel() {}
+
 // String representation (for debug and logging)
 func (c *PythonCheck) String() string {
 	return c.ModuleName

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // FIXTURE
 type TestCheck struct {
+	check.StubCheck
 	sync.Mutex
 	doErr  bool
 	hasRun bool
@@ -38,13 +38,6 @@ func newTestCheck(doErr bool, id string) *TestCheck {
 	}
 }
 
-func (c *TestCheck) String() string                                             { return "TestCheck" }
-func (c *TestCheck) Version() string                                            { return "" }
-func (c *TestCheck) ConfigSource() string                                       { return "" }
-func (c *TestCheck) Stop()                                                      {}
-func (c *TestCheck) Configure(integration.Data, integration.Data, string) error { return nil }
-func (c *TestCheck) Interval() time.Duration                                    { return 1 }
-func (c *TestCheck) IsTelemetryEnabled() bool                                   { return false }
 func (c *TestCheck) Run() error {
 	c.Lock()
 	defer c.Unlock()
@@ -56,6 +49,9 @@ func (c *TestCheck) Run() error {
 
 	c.hasRun = true
 	return nil
+}
+func (c *TestCheck) String() string {
+	return "TestCheck"
 }
 func (c *TestCheck) ID() check.ID {
 	c.Lock()

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -9,25 +9,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 )
 
 // FIXTURE
-type TestCheck struct{ intl time.Duration }
+type TestCheck struct {
+	check.StubCheck
+	intl time.Duration
+}
 
-func (c *TestCheck) String() string                                             { return "TestCheck" }
-func (c *TestCheck) Version() string                                            { return "" }
-func (c *TestCheck) ConfigSource() string                                       { return "" }
-func (c *TestCheck) Configure(integration.Data, integration.Data, string) error { return nil }
-func (c *TestCheck) Interval() time.Duration                                    { return c.intl }
-func (c *TestCheck) Run() error                                                 { return nil }
-func (c *TestCheck) Stop()                                                      {}
-func (c *TestCheck) ID() check.ID                                               { return check.ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                                       { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error)                  { return make(map[string]int64), nil }
-func (c *TestCheck) IsTelemetryEnabled() bool                                   { return false }
+func (c *TestCheck) Interval() time.Duration { return c.intl }
 
 var initialMinAllowedInterval = minAllowedInterval
 

--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -40,6 +40,9 @@ type complianceCheck struct {
 func (c *complianceCheck) Stop() {
 }
 
+func (c *complianceCheck) Cancel() {
+}
+
 func (c *complianceCheck) String() string {
 	return compliance.CheckName(c.ruleID, c.description)
 }


### PR DESCRIPTION
### What does this PR do?

* [1st commit, code cleanup] Remove unused (and probably broken) `Collector.ReloadCheck` function, and create a `check.StubCheck` to factorize the tests' code that uses stub checks.
* [**2nd commit, actual functionality**] Adds `Cancel` to the `check.Check`, always called by the collector when the check is unscheduled. This allows checks that implement `Cancel` to stop and clean up background resources (for example the KSM check v2). A timeout of 500ms is applied on the call to `Cancel` (similar timeout as `Stop`).

### Motivation

`Check.Stop` is only called by the collector's `runner` package if the check is actually running when it's unscheduled. This doesn't allow checks to actually clean up resources they may hold in the background.

Use cases:

* new KSM check v2: it has KSM informers running in the background (watching resources and generating metrics between check runs) and which needs to clean up these informers when it's unscheduled. For the KSM check v2's use case, the alternative to this PR is to implement it as a long-running check (as proposed in the initial version of https://github.com/DataDog/datadog-agent/pull/6540)
* once this is implemented for python checks (in a future PR), some existing python integrations that keep background threads/resources could benefit from it as well, for example `vsphere` and `snmp`.

### Additional Notes

* Not implemented in python checks for now: will be done in a future PR.
* Called this method `Cancel`, but open to other naming proposals.

### Describe your test plan

Updated basic unit tests.

This should be tested with checks actually implementing `Cancel`.
