### PR TITLE
[runtime-security] Isolate mount point events handler

### DIFF
--- a/pkg/security/probe/mount.go
+++ b/pkg/security/probe/mount.go
@@ -92,7 +92,7 @@ func (mr *MountResolver) SyncCache(pid uint32) error {
 			return err
 		}
 
-		mr.insert(e)
+		mr.insert(*e)
 	}
 
 	return nil
@@ -148,21 +148,21 @@ func (mr *MountResolver) Delete(mountID uint32) error {
 }
 
 // Insert a new mount point in the cache
-func (mr *MountResolver) Insert(e *MountEvent) {
+func (mr *MountResolver) Insert(e MountEvent) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 	mr.insert(e)
 }
 
-func (mr *MountResolver) insert(e *MountEvent) {
+func (mr *MountResolver) insert(e MountEvent) {
 	mounts := mr.devices[e.Device]
 	if mounts == nil {
 		mounts = make(map[uint32]*MountEvent)
 		mr.devices[e.Device] = mounts
 	}
-	mounts[e.MountID] = e
+	mounts[e.MountID] = &e
 
-	mr.mounts[e.MountID] = e
+	mr.mounts[e.MountID] = &e
 }
 
 func (mr *MountResolver) getParentPath(mountID uint32) string {

--- a/pkg/security/probe/mount_test.go
+++ b/pkg/security/probe/mount_test.go
@@ -325,7 +325,7 @@ func TestMountResolver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, evt := range tt.args.events {
 				if evt.mount != nil {
-					mr.Insert(evt.mount)
+					mr.Insert(*evt.mount)
 				}
 				if evt.umount != nil {
 					if err := mr.Delete(evt.umount.MountID); err != nil {

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -311,6 +311,7 @@ func (p *Probe) handleMountEvent(CPU int, data []byte, perfMap *manager.PerfMap,
 	}
 
 	p.eventsStats.CountEventType(eventType, 1)
+	p.DispatchEvent(event)
 }
 
 func (p *Probe) handleEvent(CPU int, data []byte, perfMap *manager.PerfMap, manager *manager.Manager) {

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -78,7 +78,7 @@ func TestMount(t *testing.T) {
 			t.Fatalf("could not unmount test-mount: %s", err)
 		}
 
-		event, err := test.GetEvent(3 * time.Second)
+		event, err := test.GetEvent(3*time.Second, "umount")
 		if err != nil {
 			t.Error(err)
 		} else {


### PR DESCRIPTION
### What does this PR do?

This PR introduces 2 changes:

- change the `MountEvent` given to the `MountResolver.Insert` method from a pointer to an object.
- introduce a user space events handler dedicated to the `mountpoins_events` perf map.

### Motivation

- Since the same `MountEvent` instance is used to parse all the `mount` / `umount` events from the kernel, the current mount resolver stores a pointer to the same structure over and over again. When a container starts, this introduces an infinite loop when a path within the container is resolved (the resolver tries to resolve the parent of the same `MountEvent` over and over again). It was not caught by our functional tests because we do not start a container during our functional tests.

- For each perf map, a separate goroutine is started by the perf reader of `Datadog/ebpf`, that will detect new events from the kernel and call the configured events handler. Since we currently use the same `handleEvents` handler, that ultimately populates the same `Event` instance, there is a race condition where an event from the `events` perf map can be mixed up with an event from the `mountpoints_events` perf map. This explains why we sometimes get `mount` events that look like `open` events.

### Anything else ?

We'll create a functional test that starts a new container later: we don't exactly know what we want to test with it yet.