### PR TITLE
[tasks/deploy] Bump cryptography dependency

### DIFF
--- a/tasks/deploy/requirements-github.txt
+++ b/tasks/deploy/requirements-github.txt
@@ -4,5 +4,5 @@
 #   the arm builder (and that are not needed, given we don't use cryptography in arm jobs).
 # - but adding the '; platform_machine == "x86_64"' to work around that breaks on python3.5, which some
 #   jobs still use
-cryptography==2.9
+cryptography==3.2.1
 PyJWT==1.7.1


### PR DESCRIPTION
### What does this PR do?

- Bump cryptography version dependency

### Motivation

- CVE-2020-25659