### PR TITLE
Add additional pause container regex filter

### DIFF
--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -23,11 +23,18 @@ const (
 	pauseContainerOpenshift  = "image:openshift/origin-pod"
 	pauseContainerOpenshift3 = "image:.*rhel7/pod-infrastructure"
 
+	// - asia.gcr.io/google-containers/pause-amd64
+	// - gcr.io/google-containers/pause
+	// - *.gcr.io/google_containers/pause
+	// - *.jfrog.io/google_containers/pause
+	pauseContainerGoogle = "image:google(_|-)containers/pause.*"
+
 	// - k8s.gcr.io/pause-amd64:3.1
 	// - asia.gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/gke-release/pause-win:1.1.0
 	// - eu.gcr.io/k8s-artifacts-prod/pause:3.3
+	// - k8s.gcr.io/pause
 	pauseContainerGCR = `image:.*gcr\.io(.*)/pause.*`
 
 	// - k8s-gcrio.azureedge.net/pause-amd64
@@ -47,6 +54,8 @@ const (
 	pauseContainerWin = `image:kubeletwin/pause.*`
 	// - ecr.us-east-1.amazonaws.com/pause
 	pauseContainerECR = `image:ecr(.*)amazonaws\.com/pause.*`
+	// - *.ecr.us-east-1.amazonaws.com/upstream/pause
+	pauseContainerUpstream = `image:upstream/pause.*`
 )
 
 // Filter holds the state for the container filtering logic
@@ -161,6 +170,7 @@ func newMetricFilterFromConfig() (*Filter, error) {
 			pauseContainerOpenshift,
 			pauseContainerOpenshift3,
 			pauseContainerKubernetes,
+			pauseContainerGoogle,
 			pauseContainerAzure,
 			pauseContainerECS,
 			pauseContainerEKS,
@@ -169,6 +179,7 @@ func newMetricFilterFromConfig() (*Filter, error) {
 			pauseContainerWin,
 			pauseContainerAKS,
 			pauseContainerECR,
+			pauseContainerUpstream,
 		)
 	}
 	return NewFilter(includeList, excludeList)

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -203,6 +203,22 @@ func TestFilter(t *testing.T) {
 			},
 			ns: "default",
 		},
+		{
+			c: Container{
+				ID:    "26",
+				Name:  "private_jfrog",
+				Image: "foo.jfrog.io/google_containers/pause",
+			},
+			ns: "default",
+		},
+		{
+			c: Container{
+				ID:    "27",
+				Name:  "private_ecr_upstream",
+				Image: "2342834325.ecr.us-east-1.amazonaws.com/upstream/pause",
+			},
+			ns: "default",
+		},
 	}
 
 	for i, tc := range []struct {
@@ -211,25 +227,25 @@ func TestFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27"},
 		},
 		{
 			excludeList: []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25"},
+			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27"},
 		},
 		{
 			excludeList: []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27"},
 		},
 		{
 			includeList: []string{},
 			excludeList: []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25"},
+			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27"},
 		},
 		{
 			includeList: []string{"name:mysql"},
 			excludeList: []string{"name:dd"},
-			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19", "20", "23", "24", "25"},
+			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27"},
 		},
 		{
 			excludeList: []string{"kube_namespace:.*"},
@@ -238,7 +254,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			excludeList: []string{"kube_namespace:bar"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19", "20", "23", "24", "25"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19", "20", "23", "24", "25", "26", "27"},
 		},
 		// Test kubernetes defaults
 		{
@@ -247,6 +263,7 @@ func TestFilter(t *testing.T) {
 				pauseContainerOpenshift,
 				pauseContainerOpenshift3,
 				pauseContainerKubernetes,
+				pauseContainerGoogle,
 				pauseContainerAzure,
 				pauseContainerECS,
 				pauseContainerEKS,
@@ -255,6 +272,7 @@ func TestFilter(t *testing.T) {
 				pauseContainerWin,
 				pauseContainerAKS,
 				pauseContainerECR,
+				pauseContainerUpstream,
 			},
 			expectedIDs: []string{"1", "2", "3", "4", "5", "14", "15"},
 		},

--- a/releasenotes/notes/add-additional-pause-container-filters-xok77yd3ez5dxstw.yaml
+++ b/releasenotes/notes/add-additional-pause-container-filters-xok77yd3ez5dxstw.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Expand pause container image filter


### PR DESCRIPTION
### What does this PR do?

Add Additional Kubernetes pause container regex in `filter.go`

### Motivation

Support more kubernetes distribution/configuration, exclude these pause containers from metrics.

### Additional Notes

N/A

### Describe your test plan

Start/restart a kubelet with the option `--pod-infra-container-image` set with a specific image name. doc [here](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
