### PR TITLE
Add snowflake-connector-python dep patch

### DIFF
--- a/omnibus/config/patches/snowflake-connector-python/snowflake-connector-python-cryptography.patch
+++ b/omnibus/config/patches/snowflake-connector-python/snowflake-connector-python-cryptography.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 0da6a8a..6c7e91b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -189,7 +189,7 @@ setup(
+         'pycryptodomex>=3.2,!=3.5.0,<4.0.0',
+         'pyOpenSSL>=16.2.0,<21.0.0',
+         'cffi>=1.9,<1.14',
+-        'cryptography>=1.8.2,<3.0.0',
++        'cryptography>=1.8.2',
+         'ijson<3.0.0',
+         'pyjwt<2.0.0',
+         'idna<3.0.0',

--- a/omnibus/config/patches/snowflake-connector-python/snowflake-connector-python-cryptography.patch
+++ b/omnibus/config/patches/snowflake-connector-python/snowflake-connector-python-cryptography.patch
@@ -1,12 +1,14 @@
 diff --git a/setup.py b/setup.py
-index 0da6a8a..6c7e91b 100644
+index 0da6a8a..9df4fb5 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -189,7 +189,7 @@ setup(
+@@ -188,8 +188,8 @@ setup(
+         'pytz<2021.0',
          'pycryptodomex>=3.2,!=3.5.0,<4.0.0',
          'pyOpenSSL>=16.2.0,<21.0.0',
-         'cffi>=1.9,<1.14',
+-        'cffi>=1.9,<1.14',
 -        'cryptography>=1.8.2,<3.0.0',
++        'cffi>=1.9,<1.15',
 +        'cryptography>=1.8.2',
          'ijson<3.0.0',
          'pyjwt<2.0.0',

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -10,7 +10,8 @@ name 'datadog-agent-integrations-py2'
 
 dependency 'datadog-agent'
 dependency 'pip2'
-dependency 'snowflake-connector-python'
+
+dependency 'snowflake-connector-python-py2'
 
 if arm?
   # psycopg2 doesn't come with pre-built wheel on the arm architecture.

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -70,6 +70,7 @@ blacklist_packages = Array.new
 
 # We build these manually
 blacklist_packages.push(/^aerospike==/)
+blacklist_packages.push(/^snowflake-connector-python==/)
 
 if suse?
   blacklist_folders.push('aerospike')  # Temporarily blacklist Aerospike until builder supports new dependency
@@ -299,12 +300,12 @@ build do
 
   end
 
-  # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
-  if windows?
-    command "#{python} -m pip check"
-  else
-    command "#{pip} check"
-  end
+    # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
+    if windows?
+      command "#{python} -m pip check"
+    else
+      command "#{pip} check"
+    end
 
   # Ship `requirements-agent-release.txt` file containing the versions of every check shipped with the agent
   # Used by the `datadog-agent integration` command to prevent downgrading a check to a version

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -10,6 +10,7 @@ name 'datadog-agent-integrations-py2'
 
 dependency 'datadog-agent'
 dependency 'pip2'
+dependency 'snowflake-connector-python'
 
 if arm?
   # psycopg2 doesn't come with pre-built wheel on the arm architecture.

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -298,7 +298,6 @@ build do
       patch :source => "create-regex-at-runtime.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/yaml/reader.py"
     end
 
-  end
 
     # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
     if windows?
@@ -306,6 +305,7 @@ build do
     else
       command "#{pip} check"
     end
+  end
 
   # Ship `requirements-agent-release.txt` file containing the versions of every check shipped with the agent
   # Used by the `datadog-agent integration` command to prevent downgrading a check to a version

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -10,6 +10,7 @@ name 'datadog-agent-integrations-py3'
 
 dependency 'datadog-agent'
 dependency 'pip3'
+dependency 'snowflake-connector-python'
 
 if arm?
   # psycopg2 doesn't come with pre-built wheel on the arm architecture.

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -10,7 +10,8 @@ name 'datadog-agent-integrations-py3'
 
 dependency 'datadog-agent'
 dependency 'pip3'
-dependency 'snowflake-connector-python'
+
+dependency 'snowflake-connector-python-py3'
 
 if arm?
   # psycopg2 doesn't come with pre-built wheel on the arm architecture.

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -284,14 +284,13 @@ build do
         command "#{pip} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
       end
     end
-  end
-
     # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
     if windows?
       command "#{python} -m pip check"
     else
       command "#{pip} check"
     end
+  end
 
   # Ship `requirements-agent-release.txt` file containing the versions of every check shipped with the agent
   # Used by the `datadog-agent integration` command to prevent downgrading a check to a version

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -71,6 +71,7 @@ blacklist_packages = Array.new
 
 # We build these manually
 blacklist_packages.push(/^aerospike==/)
+blacklist_packages.push(/^snowflake-connector-python==/)
 
 if suse?
   blacklist_folders.push('aerospike')  # Temporarily blacklist Aerospike until builder supports new dependency
@@ -285,12 +286,12 @@ build do
     end
   end
 
-  # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
-  if windows?
-    command "#{python} -m pip check"
-  else
-    command "#{pip} check"
-  end
+    # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
+    if windows?
+      command "#{python} -m pip check"
+    else
+      command "#{pip} check"
+    end
 
   # Ship `requirements-agent-release.txt` file containing the versions of every check shipped with the agent
   # Used by the `datadog-agent integration` command to prevent downgrading a check to a version

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -1,14 +1,8 @@
-name "snowflake-connector-python"
-
-default_version "2.1.3"
-relative_path "snowflake-connector-python-#{version}"
+name "snowflake-connector-python-py2"
 
 dependency "pip2"
-dependency "cython"
 
-source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/v#{version}.tar.gz",
-       :sha256 => "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
-       :extract => :seven_zip
+dependency "snowflake-connector-python"
 
 build do
   ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -7,5 +7,5 @@ dependency "snowflake-connector-python"
 version "2.1.3"
 
 build do
-  command "#{install_dir}/embedded/bin/pip2 install --no-deps #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"
+  command "#{install_dir}/embedded/bin/pip2 install --no-deps #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-2.1.3"
 end

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -1,0 +1,16 @@
+name "snowflake-connector-python"
+
+default_version "2.1.3"
+
+dependency "pip2"
+dependency "cython"
+
+source url: "https://github.com/snowflakedb/snowflake-connector-python/archive/v#{version}.tar.gz",
+       sha256: "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
+       extract: :seven_zip
+
+build do
+  ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
+  patch source: "snowflake-connector-python-cryptography.patch", target: "setup.py", plevel: 0
+  command "#{install_dir}/embedded/bin/pip2 install ."
+end

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -8,5 +8,5 @@ default_version "2.1.3"
 relative_path "snowflake-connector-python-#{version}"
 
 build do
-  command "#{install_dir}/embedded/bin/pip3 install #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"
+  command "#{install_dir}/embedded/bin/pip2 install #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"
 end

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -4,8 +4,7 @@ dependency "pip2"
 
 dependency "snowflake-connector-python"
 
-default_version "2.1.3"
-relative_path "snowflake-connector-python-#{version}"
+version "2.1.3"
 
 build do
   command "#{install_dir}/embedded/bin/pip2 install --no-deps #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -5,12 +5,12 @@ default_version "2.1.3"
 dependency "pip2"
 dependency "cython"
 
-source url: "https://github.com/snowflakedb/snowflake-connector-python/archive/v#{version}.tar.gz",
-       sha256: "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
-       extract: :seven_zip
+source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/v#{version}.tar.gz",
+       :sha256 => "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
+       :extract => :seven_zip
 
 build do
   ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
-  patch source: "snowflake-connector-python-cryptography.patch", target: "setup.py", plevel: 0
+  patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py", :plevel => 0
   command "#{install_dir}/embedded/bin/pip2 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -1,6 +1,7 @@
 name "snowflake-connector-python"
 
 default_version "2.1.3"
+relative_path "snowflake-connector-python-#{version}"
 
 dependency "pip2"
 dependency "cython"

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -8,5 +8,5 @@ default_version "2.1.3"
 relative_path "snowflake-connector-python-#{version}"
 
 build do
-  command "#{install_dir}/embedded/bin/pip2 install #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"
+  command "#{install_dir}/embedded/bin/pip2 install --no-deps #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"
 end

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -11,6 +11,6 @@ source :url => "https://github.com/snowflakedb/snowflake-connector-python/archiv
 
 build do
   ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
-  patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py", :plevel => 0
+  patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py"
   command "#{install_dir}/embedded/bin/pip2 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -4,6 +4,9 @@ dependency "pip2"
 
 dependency "snowflake-connector-python"
 
+default_version "2.1.3"
+relative_path "snowflake-connector-python-#{version}"
+
 build do
   command "#{install_dir}/embedded/bin/pip2 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -5,7 +5,5 @@ dependency "pip2"
 dependency "snowflake-connector-python"
 
 build do
-  ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
-  patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py"
   command "#{install_dir}/embedded/bin/pip2 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -8,5 +8,5 @@ default_version "2.1.3"
 relative_path "snowflake-connector-python-#{version}"
 
 build do
-  command "#{install_dir}/embedded/bin/pip2 install ."
+  command "#{install_dir}/embedded/bin/pip3 install #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -1,12 +1,9 @@
-name "snowflake-connector-python-py3"
+name "snowflake-connector-python-py2"
 
-dependency "pip3"
+dependency "pip2"
 
 dependency "snowflake-connector-python"
 
-default_version "2.1.3"
-relative_path "snowflake-connector-python-#{version}"
-
 build do
-  command "#{install_dir}/embedded/bin/pip3 install ."
+  command "cd #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-2.1.3 && #{install_dir}/embedded/bin/pip2 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -1,9 +1,9 @@
-name "snowflake-connector-python-py2"
+name "snowflake-connector-python-py3"
 
-dependency "pip2"
+dependency "pip3"
 
 dependency "snowflake-connector-python"
 
 build do
-  command "cd #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-2.1.3 && #{install_dir}/embedded/bin/pip2 install ."
+  command "cd #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-2.1.3 && #{install_dir}/embedded/bin/pip3 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -1,14 +1,8 @@
-name "snowflake-connector-python"
-
-default_version "2.1.3"
-relative_path "snowflake-connector-python-#{version}"
+name "snowflake-connector-python-py3"
 
 dependency "pip3"
-dependency "cython"
 
-source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/v#{version}.tar.gz",
-       :sha256 => "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
-       :extract => :seven_zip
+dependency "snowflake-connector-python"
 
 build do
   ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -4,6 +4,8 @@ dependency "pip3"
 
 dependency "snowflake-connector-python"
 
+default_version "2.1.3"
+
 build do
   command "#{install_dir}/embedded/bin/pip3 install --no-deps #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -5,7 +5,5 @@ dependency "pip3"
 dependency "snowflake-connector-python"
 
 build do
-  ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
-  patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py"
   command "#{install_dir}/embedded/bin/pip3 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -4,7 +4,7 @@ dependency "pip3"
 
 dependency "snowflake-connector-python"
 
-default_version "2.1.3"
+version "2.1.3"
 
 build do
   command "#{install_dir}/embedded/bin/pip3 install --no-deps #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -5,5 +5,5 @@ dependency "pip3"
 dependency "snowflake-connector-python"
 
 build do
-  command "cd #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-2.1.3 && #{install_dir}/embedded/bin/pip3 install ."
+  command "#{install_dir}/embedded/bin/pip3 install --no-deps #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -1,6 +1,7 @@
 name "snowflake-connector-python"
 
 default_version "2.1.3"
+relative_path "snowflake-connector-python-#{version}"
 
 dependency "pip3"
 dependency "cython"

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -5,12 +5,12 @@ default_version "2.1.3"
 dependency "pip3"
 dependency "cython"
 
-source url: "https://github.com/snowflakedb/snowflake-connector-python/archive/v#{version}.tar.gz",
-       sha256: "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
-       extract: :seven_zip
+source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/v#{version}.tar.gz",
+       :sha256 => "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
+       :extract => :seven_zip
 
 build do
   ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
-  patch source: "snowflake-connector-python-cryptography.patch", target: "setup.py", plevel: 0
+  patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py", :plevel => 0
   command "#{install_dir}/embedded/bin/pip3 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -4,8 +4,6 @@ dependency "pip3"
 
 dependency "snowflake-connector-python"
 
-version "2.1.3"
-
 build do
-  command "#{install_dir}/embedded/bin/pip3 install --no-deps #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-#{version}"
+  command "#{install_dir}/embedded/bin/pip3 install --no-deps #{Omnibus::Config.source_dir()}/snowflake-connector-python/snowflake-connector-python-2.1.3"
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -1,0 +1,16 @@
+name "snowflake-connector-python"
+
+default_version "2.1.3"
+
+dependency "pip3"
+dependency "cython"
+
+source url: "https://github.com/snowflakedb/snowflake-connector-python/archive/v#{version}.tar.gz",
+       sha256: "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
+       extract: :seven_zip
+
+build do
+  ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
+  patch source: "snowflake-connector-python-cryptography.patch", target: "setup.py", plevel: 0
+  command "#{install_dir}/embedded/bin/pip3 install ."
+end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -4,6 +4,8 @@ dependency "pip3"
 
 dependency "snowflake-connector-python"
 
+relative_path "snowflake-connector-python-#{version}"
+
 build do
   command "#{install_dir}/embedded/bin/pip3 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -11,6 +11,6 @@ source :url => "https://github.com/snowflakedb/snowflake-connector-python/archiv
 
 build do
   ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
-  patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py", :plevel => 0
+  patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py"
   command "#{install_dir}/embedded/bin/pip3 install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -4,6 +4,7 @@ dependency "pip3"
 
 dependency "snowflake-connector-python"
 
+default_version "2.1.3"
 relative_path "snowflake-connector-python-#{version}"
 
 build do

--- a/omnibus/config/software/snowflake-connector-python.rb
+++ b/omnibus/config/software/snowflake-connector-python.rb
@@ -9,5 +9,7 @@ source :url => "https://github.com/snowflakedb/snowflake-connector-python/archiv
        :sha256 => "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
        :extract => :seven_zip
 
-ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
-patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py"
+build do
+    ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
+    patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py"
+end

--- a/omnibus/config/software/snowflake-connector-python.rb
+++ b/omnibus/config/software/snowflake-connector-python.rb
@@ -12,4 +12,3 @@ source :url => "https://github.com/snowflakedb/snowflake-connector-python/archiv
 build do
     ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
     patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py"
-end

--- a/omnibus/config/software/snowflake-connector-python.rb
+++ b/omnibus/config/software/snowflake-connector-python.rb
@@ -1,0 +1,11 @@
+name "snowflake-connector-python"
+
+default_version "2.1.3"
+relative_path "snowflake-connector-python-#{version}"
+
+dependency "cython"
+
+source :url => "https://github.com/snowflakedb/snowflake-connector-python/archive/v#{version}.tar.gz",
+       :sha256 => "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
+       :extract => :seven_zip
+

--- a/omnibus/config/software/snowflake-connector-python.rb
+++ b/omnibus/config/software/snowflake-connector-python.rb
@@ -9,3 +9,5 @@ source :url => "https://github.com/snowflakedb/snowflake-connector-python/archiv
        :sha256 => "855ffb93a09c3cd994dab8af7c87a46038bbba103928c5948a0edcd2500f4e1a",
        :extract => :seven_zip
 
+ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
+patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py"

--- a/omnibus/config/software/snowflake-connector-python.rb
+++ b/omnibus/config/software/snowflake-connector-python.rb
@@ -12,3 +12,4 @@ source :url => "https://github.com/snowflakedb/snowflake-connector-python/archiv
 build do
     ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
     patch :source => "snowflake-connector-python-cryptography.patch", :target => "setup.py"
+end

--- a/release.json
+++ b/release.json
@@ -1,7 +1,7 @@
 {
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",
-        "OMNIBUS_SOFTWARE_VERSION": "master",
+        "OMNIBUS_SOFTWARE_VERSION": "cc/snowflake-patch",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.39.2",
         "JMXFETCH_HASH": "c59021fa9a02102ffb8a28e9083007aed5e11f6eef2b199f5446533d3a89ede4",
@@ -12,7 +12,7 @@
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
-        "OMNIBUS_SOFTWARE_VERSION": "master",
+        "OMNIBUS_SOFTWARE_VERSION": "cc/snowflake-patch",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.39.2",
         "JMXFETCH_HASH": "c59021fa9a02102ffb8a28e9083007aed5e11f6eef2b199f5446533d3a89ede4",

--- a/release.json
+++ b/release.json
@@ -1,7 +1,7 @@
 {
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",
-        "OMNIBUS_SOFTWARE_VERSION": "cc/snowflake-patch",
+        "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.39.2",
         "JMXFETCH_HASH": "c59021fa9a02102ffb8a28e9083007aed5e11f6eef2b199f5446533d3a89ede4",
@@ -12,7 +12,7 @@
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
-        "OMNIBUS_SOFTWARE_VERSION": "cc/snowflake-patch",
+        "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.39.2",
         "JMXFETCH_HASH": "c59021fa9a02102ffb8a28e9083007aed5e11f6eef2b199f5446533d3a89ede4",


### PR DESCRIPTION
### What does this PR do?
Updates the cryptography pin in snowflake-connector-python https://github.com/DataDog/omnibus-software/pull/381
### Motivation
snowflake-connector-python is pinned to 2.1.3 for python2 compatibility, but not compatible with latest cryptography release.

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
