### PR TITLE
[compliance] Fix truncated status in compliance checks

### DIFF
--- a/pkg/status/templates/compliance.tmpl
+++ b/pkg/status/templates/compliance.tmpl
@@ -15,7 +15,7 @@ Compliance Checks
     Report:
       Result: {{ complianceResult $Check.LastEvent.result }}
       Data:
-      {{- range $k, $v := index $Check.LastEvent.data }}
+      {{- range $k, $v := $Check.LastEvent.data }}
         {{ $k }}: {{ $v }}
       {{- end }}
   {{- end }}

--- a/releasenotes/notes/fix-truncated-compliance-status-output-ec5f92b3751d1d00.yaml
+++ b/releasenotes/notes/fix-truncated-compliance-status-output-ec5f92b3751d1d00.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes truncated output for status of compliance checks in Security Agent.


### PR DESCRIPTION
### What does this PR do?

- Fix template formatting for checks that do not provide data fields in reported results (e.g. audit checks in failed status).

### Motivation

Working status in security agent.

### Describe your test plan

Confirm status is showing valid info for all enabled compliance checks.
```
security-agent status
```
