### PR TITLE
Add docker authentication for docker build in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2653,6 +2653,10 @@ send_pkg_size-a7:
 
 .docker_build_job_definition: &docker_build_job_definition
   stage: image_build
+  variables:
+    DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
+    DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
+    DOCKER_REGISTRY_URL: docker.io
   script:
     - aws s3 sync --only-show-errors $S3_ARTIFACTS_URI $BUILD_CONTEXT
     - TAG_SUFFIX=${TAG_SUFFIX:-}
@@ -2660,6 +2664,10 @@ send_pkg_size-a7:
     - TARGET_TAG=$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX-$ARCH
     # Pull base image(s) with content trust enabled
     - python3 -m pip install -r requirements.txt
+    # DockerHub login event for build to limit rate limit when pulling base images
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    # Pull base images
     - inv -e docker.pull-base-images --signed-pull $BUILD_CONTEXT/$ARCH/Dockerfile
     # Build testing stage if provided
     - test "$TESTING_ARG" && docker build --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,6 +101,10 @@ variables:
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded
   RPM_GPG_KEY_SSM_NAME: ci.datadog-agent.rpm_signing_private_key_e09422b3
   RPM_SIGNING_PASSPHRASE_SSM_NAME: ci.datadog-agent.rpm_signing_key_passphrase_e09422b3
+  # docker.io authentication
+  DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
+  DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
+  DOCKER_REGISTRY_URL: docker.io
 
 #
 # Condition mixins for simplification of rules
@@ -2653,10 +2657,6 @@ send_pkg_size-a7:
 
 .docker_build_job_definition: &docker_build_job_definition
   stage: image_build
-  variables:
-    DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
-    DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
-    DOCKER_REGISTRY_URL: docker.io
   script:
     - aws s3 sync --only-show-errors $S3_ARTIFACTS_URI $BUILD_CONTEXT
     - TAG_SUFFIX=${TAG_SUFFIX:-}
@@ -2664,7 +2664,7 @@ send_pkg_size-a7:
     - TARGET_TAG=$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX-$ARCH
     # Pull base image(s) with content trust enabled
     - python3 -m pip install -r requirements.txt
-    # DockerHub login event for build to limit rate limit when pulling base images
+    # DockerHub login for build to limit rate limit when pulling base images
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Pull base images

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2840,22 +2840,100 @@ docker_build_agent7_jmx_arm64:
     BUILD_ARG: --target release --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
     TESTING_ARG:  --target testing --build-arg WITH_JMX=true --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_arm64.deb
 
+
+.docker_hub_variables: &docker_hub_variables
+  DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
+  DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
+  DELEGATION_KEY_SSM_KEY: docker_hub_signing_key
+  DELEGATION_PASS_SSM_KEY: docker_hub_signing_pass
+  DOCKER_REGISTRY_URL: docker.io
+  SRC_AGENT: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
+  SRC_DSD: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
+  SRC_DCA: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
+
+
+.docker_build_windows_job_definition: &docker_build_windows_job_definition
+  stage: image_deploy
+  variables:
+    <<: *docker_hub_variables
+  before_script:
+    - $ErrorActionPreference = "Stop"
+    - mkdir ci-scripts
+    - |
+      @"
+      Set-PSDebug -Trace 1
+      `$ErrorActionPreference = "Stop"
+      pip3 install -r requirements.txt
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      # ECR Login
+      `$AWS_ECR_PASSWORD = aws ecr get-login-password --region us-east-1
+      docker login --username AWS --password "`${AWS_ECR_PASSWORD}" 486234852809.dkr.ecr.us-east-1.amazonaws.com
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      # DockerHub login
+      `$DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_LOGIN_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
+      `$DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_PWD_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
+      docker login --username "`${DOCKER_REGISTRY_LOGIN}" --password "`${DOCKER_REGISTRY_PWD}" "${DOCKER_REGISTRY_URL}"
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      "@ | out-file ci-scripts/docker-login.ps1
+
+
+.docker_tag_windows_job_definition: &docker_tag_windows_job_definition
+  stage: image_deploy
+  variables:
+    <<: *docker_hub_variables
+  before_script:
+    - $ErrorActionPreference = "Stop"
+    - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
+    - $SRC_TAG = "v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}"
+    - mkdir ci-scripts
+    - |
+      @"
+      Set-PSDebug -Trace 1
+      `$ErrorActionPreference = "Stop"
+      pip3 install -r requirements.txt
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      # ECR Login
+      `$AWS_ECR_PASSWORD = aws ecr get-login-password --region us-east-1
+      docker login --username AWS --password "`${AWS_ECR_PASSWORD}" 486234852809.dkr.ecr.us-east-1.amazonaws.com
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      # DockerHub login
+      `$DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_LOGIN_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
+      `$DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_PWD_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
+      docker login --username "`${DOCKER_REGISTRY_LOGIN}" --password "`${DOCKER_REGISTRY_PWD}" "${DOCKER_REGISTRY_URL}"
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      # DockerHub image signing
+      `$Env:DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DELEGATION_PASS_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
+      `$Env:NOTARY_DELEGATION_PASSPHRASE = `$Env:DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE
+      `$Env:NOTARY_AUTH = "`${DOCKER_REGISTRY_LOGIN}:`${DOCKER_REGISTRY_PWD}"
+      `$bytes = [System.Text.Encoding]::Unicode.GetBytes(`$Env:NOTARY_AUTH)
+      `$Env:NOTARY_AUTH = [Convert]::ToBase64String(`$bytes)
+      aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DELEGATION_KEY_SSM_KEY} --with-decryption --query "Parameter.Value" --out text | Set-Content -Encoding ASCII docker.key
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      docker trust key load `$PWD\docker.key
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      Remove-Item `$PWD\docker.key
+      ridk enable # This is only needed because invoke docker.publish-manifest calls "cat" which doesn't exist on Windows
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      "@ | out-file ci-scripts/docker-publish.ps1
+
+
 # build agent7_windows image
 docker_build_agent7_windows1809:
   rules:
     - <<: *if_version_7
       when: on_success
   stage: image_build
-  before_script: [ "# noop" ] # Override top level entry
   needs:
     - windows_msi_and_bosh_zip_x64-a7
     - build_windows_container_entrypoint
   tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .docker_build_windows_job_definition
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
     BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1809 --build-arg WITH_JMX=false
+    VARIANT: 1809
   script:
     - $ErrorActionPreference = "Stop"
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
@@ -2863,6 +2941,10 @@ docker_build_agent7_windows1809:
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip
     - cp entrypoint.exe ${BUILD_CONTEXT}/entrypoint.exe
     - get-childitem ${BUILD_CONTEXT}
+      # Docker setup
+    - cat ci-scripts/docker-login.ps1
+    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64:${Env:DATADOG_AGENT_WINBUILDIMAGES} powershell -C C:\mnt\ci-scripts\docker-login.ps1
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker push ${TARGET_TAG}
@@ -2875,16 +2957,17 @@ docker_build_agent7_windows1809_jmx:
     - <<: *if_version_7
       when: on_success
   stage: image_build
-  before_script: [ "# noop" ] # Override top level entry
   needs:
     - windows_msi_and_bosh_zip_x64-a7
     - build_windows_container_entrypoint
   tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .docker_build_windows_job_definition
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
     BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1809 --build-arg WITH_JMX=true
+    VARIANT: 1809
   script:
     - $ErrorActionPreference = "Stop"
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
@@ -2892,6 +2975,10 @@ docker_build_agent7_windows1809_jmx:
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip
     - cp entrypoint.exe ${BUILD_CONTEXT}/entrypoint.exe
     - get-childitem ${BUILD_CONTEXT}
+      # Docker setup
+    - cat ci-scripts/docker-login.ps1
+    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64:${Env:DATADOG_AGENT_WINBUILDIMAGES} powershell -C C:\mnt\ci-scripts\docker-login.ps1
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker push ${TARGET_TAG}
@@ -2905,16 +2992,17 @@ docker_build_agent7_windows1909:
     - <<: *if_version_7
       when: on_success
   stage: image_build
-  before_script: [ "# noop" ] # Override top level entry
   needs:
     - windows_msi_and_bosh_zip_x64-a7
     - build_windows_container_entrypoint
   tags: ["runner:windows-docker", "windowsversion:1909"]
+  extends: .docker_build_windows_job_definition
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
     BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1909 --build-arg WITH_JMX=false
+    VARIANT: 1909
   script:
     - $ErrorActionPreference = "Stop"
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
@@ -2922,6 +3010,10 @@ docker_build_agent7_windows1909:
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip
     - cp entrypoint.exe ${BUILD_CONTEXT}/entrypoint.exe
     - get-childitem ${BUILD_CONTEXT}
+      # Docker setup
+    - cat ci-scripts/docker-login.ps1
+    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64:${Env:DATADOG_AGENT_WINBUILDIMAGES} powershell -C C:\mnt\ci-scripts\docker-login.ps1
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker push ${TARGET_TAG}
@@ -2934,16 +3026,17 @@ docker_build_agent7_windows1909_jmx:
     - <<: *if_version_7
       when: on_success
   stage: image_build
-  before_script: [ "# noop" ] # Override top level entry
   needs:
     - windows_msi_and_bosh_zip_x64-a7
     - build_windows_container_entrypoint
   tags: ["runner:windows-docker", "windowsversion:1909"]
+  extends: .docker_build_windows_job_definition
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
     BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-1909 --build-arg WITH_JMX=true
+    VARIANT: 1909
   script:
     - $ErrorActionPreference = "Stop"
     - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
@@ -2951,6 +3044,10 @@ docker_build_agent7_windows1909_jmx:
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip
     - cp entrypoint.exe ${BUILD_CONTEXT}/entrypoint.exe
     - get-childitem ${BUILD_CONTEXT}
+      # Docker setup
+    - cat ci-scripts/docker-login.ps1
+    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64:${Env:DATADOG_AGENT_WINBUILDIMAGES} powershell -C C:\mnt\ci-scripts\docker-login.ps1
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - powershell -Command "docker build ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker push ${TARGET_TAG}
@@ -3038,16 +3135,6 @@ twistlock_scan-7:
     - scan ${SRC_AGENT}:${SRC_TAG}-7-amd64
     - scan ${SRC_AGENT}:${SRC_TAG}-7-jmx-amd64
 
-.docker_hub_variables: &docker_hub_variables
-  DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
-  DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
-  DELEGATION_KEY_SSM_KEY: docker_hub_signing_key
-  DELEGATION_PASS_SSM_KEY: docker_hub_signing_pass
-  DOCKER_REGISTRY_URL: docker.io
-  SRC_AGENT: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
-  SRC_DSD: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
-  SRC_DCA: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/cluster-agent
-
 .quay_variables: &quay_variables
   <<: *docker_hub_variables
   DOCKER_REGISTRY_LOGIN_SSM_KEY: quay_login
@@ -3078,45 +3165,6 @@ twistlock_scan-7:
     - export NOTARY_DELEGATION_PASSPHRASE="$DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE"
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DELEGATION_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text > /tmp/docker.key
     - notary -d ~/.docker/trust key import /tmp/docker.key; rm /tmp/docker.key
-
-.docker_tag_windows_job_definition: &docker_tag_windows_job_definition
-  stage: image_deploy
-  variables:
-    <<: *docker_hub_variables
-  before_script:
-    - $ErrorActionPreference = "Stop"
-    - $SHORT_CI_COMMIT_SHA = ${CI_COMMIT_SHA}.Substring(0,7)
-    - $SRC_TAG = "v${CI_PIPELINE_ID}-${SHORT_CI_COMMIT_SHA}"
-    - mkdir ci-scripts
-    - |
-      @"
-      Set-PSDebug -Trace 1
-      `$ErrorActionPreference = "Stop"
-      pip3 install -r requirements.txt
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      # ECR Login
-      `$AWS_ECR_PASSWORD = aws ecr get-login-password --region us-east-1
-      docker login --username AWS --password "`${AWS_ECR_PASSWORD}" 486234852809.dkr.ecr.us-east-1.amazonaws.com
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      # DockerHub login
-      `$DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_LOGIN_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
-      `$DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DOCKER_REGISTRY_PWD_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
-      docker login --username "`${DOCKER_REGISTRY_LOGIN}" --password "`${DOCKER_REGISTRY_PWD}" "${DOCKER_REGISTRY_URL}"
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      # DockerHub image signing
-      `$Env:DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DELEGATION_PASS_SSM_KEY} --with-decryption --query "Parameter.Value" --out text
-      `$Env:NOTARY_DELEGATION_PASSPHRASE = `$Env:DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE
-      `$Env:NOTARY_AUTH = "`${DOCKER_REGISTRY_LOGIN}:`${DOCKER_REGISTRY_PWD}"
-      `$bytes = [System.Text.Encoding]::Unicode.GetBytes(`$Env:NOTARY_AUTH)
-      `$Env:NOTARY_AUTH = [Convert]::ToBase64String(`$bytes)
-      aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.${DELEGATION_KEY_SSM_KEY} --with-decryption --query "Parameter.Value" --out text | Set-Content -Encoding ASCII docker.key
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      docker trust key load `$PWD\docker.key
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      Remove-Item `$PWD\docker.key
-      ridk enable # This is only needed because invoke docker.publish-manifest calls "cat" which doesn't exist on Windows
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      "@ | out-file ci-scripts/docker-publish.ps1
 
 .google_container_registry_tag_job_definition: &google_container_registry_tag_job_definition
   stage: image_deploy


### PR DESCRIPTION
### What does this PR do?

Add "docker login" step before `docker pull,build` images since our base image are stored in docker hub

### Motivation

Limit the risque to be rate limited when a CI job do a `docker build` and `docker pull`
It is linked to the new docker hub rate limit policy

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
