### PR TITLE
[test] Fix tests_ebpf

### DIFF
--- a/pkg/security/tests/tests.go
+++ b/pkg/security/tests/tests.go
@@ -460,7 +460,7 @@ func newSimpleTest(macros []*rules.MacroDefinition, rules []*rules.RuleDefinitio
 		if err != nil {
 			return nil, err
 		}
-		log.SetupDatadogLogger(logger, logLevel.String())
+		log.SetupLogger(logger, logLevel.String())
 
 		logInitilialized = true
 	}


### PR DESCRIPTION
### What does this PR do?
Fix tests_ebpf

### Motivation
#5671 changed internal logging API, before it got merged new called to a being-renamed function were added.
This PR fixes this situation in CI test `tests_ebpf`.
### Additional Notes
N/A

### Describe your test plan
CI test `tests_ebpf` should pass.