### PR TITLE
pkg/trace: Trim unused sublayer tags set on spans

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -227,7 +227,7 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 		for _, subtrace := range subtraces {
 			subtraceSublayers := sublayerCalculator.ComputeSublayers(subtrace.Trace)
 			pt.Sublayers[subtrace.Root] = subtraceSublayers
-			if keep || len(events) > 0 {
+			if keep {
 				stats.SetSublayersOnSpan(subtrace.Root, subtraceSublayers)
 			}
 		}

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -362,7 +362,9 @@ func TestProcess(t *testing.T) {
 						Metrics:  map[string]float64{sampler.KeySamplingPriority: 2},
 					},
 				},
-				f: func(t *testing.T, spans []*pb.Span) { assert.Equal(t, 2.0, spans[0].Metrics["_sublayers.span_count"]) },
+				f: func(t *testing.T, spans []*pb.Span) {
+					assert.Equal(t, float64(0), spans[0].Metrics["_sublayers.duration.by_service.sublayer_service:unnamed-service"])
+				},
 			},
 			{
 				trace: pb.Trace{
@@ -378,7 +380,9 @@ func TestProcess(t *testing.T) {
 						Metrics:  map[string]float64{sampler.KeySamplingPriority: -1},
 					},
 				},
-				f: func(t *testing.T, spans []*pb.Span) { assert.NotContains(t, spans[0].Metrics, "_sublayers.span_count") },
+				f: func(t *testing.T, spans []*pb.Span) {
+					assert.NotContains(t, spans[0].Metrics, "_sublayers.duration.by_service.sublayer_service:unnamed-service")
+				},
 			},
 		} {
 			t.Run("", func(t *testing.T) {

--- a/pkg/trace/stats/sublayers.go
+++ b/pkg/trace/stats/sublayers.go
@@ -311,12 +311,11 @@ func SetSublayersOnSpan(span *pb.Span, values []SublayerValue) {
 	}
 
 	for _, value := range values {
-		name := value.Metric
-
-		if value.Tag.Name != "" {
-			name = name + "." + value.Tag.Name + ":" + value.Tag.Value
+		if value.Metric != "_sublayers.duration.by_service" && value.Tag.Name != "sublayer_service" {
+			continue
 		}
 
-		span.Metrics[name] = value.Value
+		key := value.Metric + "." + value.Tag.Name + ":" + value.Tag.Value
+		span.Metrics[key] = value.Value
 	}
 }

--- a/pkg/trace/stats/sublayers.go
+++ b/pkg/trace/stats/sublayers.go
@@ -311,6 +311,7 @@ func SetSublayersOnSpan(span *pb.Span, values []SublayerValue) {
 	}
 
 	for _, value := range values {
+		// filtering out sublayer metrics that are not used on spans
 		if value.Metric != "_sublayers.duration.by_service" && value.Tag.Name != "sublayer_service" {
 			continue
 		}

--- a/pkg/trace/stats/sublayers_test.go
+++ b/pkg/trace/stats/sublayers_test.go
@@ -279,8 +279,6 @@ func TestSetSublayersOnSpan(t *testing.T) {
 	SetSublayersOnSpan(&span, values)
 
 	assert.Equal(map[string]float64{
-		"_sublayers.span_count":                                      2.0,
-		"_sublayers.duration.by_type.sublayer_type:db":               30.0,
 		"_sublayers.duration.by_service.sublayer_service:pgsql":      30.0,
 		"_sublayers.duration.by_service.sublayer_service:pgsql-read": 20.0,
 	}, span.Metrics)

--- a/pkg/trace/test/testsuite/sublayers_test.go
+++ b/pkg/trace/test/testsuite/sublayers_test.go
@@ -12,10 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/test"
-	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
-	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
 type BySpanID []*pb.Span
@@ -23,53 +20,6 @@ type BySpanID []*pb.Span
 func (s BySpanID) Len() int           { return len(s) }
 func (s BySpanID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s BySpanID) Less(i, j int) bool { return s[i].SpanID < s[j].SpanID }
-
-func TestSublayerCounts(t *testing.T) {
-	r := test.Runner{Verbose: true}
-	if err := r.Start(); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := r.Shutdown(time.Second); err != nil {
-			t.Log("shutdown: ", err)
-		}
-	}()
-	if err := r.RunAgent(nil); err != nil {
-		t.Fatal(err)
-	}
-	defer r.KillAgent()
-
-	span1 := testutil.TestSpan()
-	span1.SpanID = 1
-	span2 := testutil.TestSpan()
-	span2.SpanID = 2
-	span2.TraceID = span1.TraceID
-	span2.ParentID = span1.SpanID
-	span3 := testutil.TestSpan()
-	span3.SpanID = 3
-	span3.TraceID = span1.TraceID
-	span3.ParentID = span2.SpanID
-	traceutil.SetTopLevel(span1, true)
-	payload := pb.Traces{pb.Trace{span1, span2, span3}, pb.Trace{testutil.RandomSpan()}}
-	payload[0][0].Metrics[sampler.KeySamplingPriority] = 2
-	payload[1][0].Metrics[sampler.KeySamplingPriority] = -1
-	if err := r.Post(payload); err != nil {
-		t.Fatal(err)
-	}
-	waitForTrace(t, &r, func(v pb.TracePayload) {
-		if n := len(v.Traces); n != 1 {
-			t.Fatalf("expected %d traces, got %d", 1, n)
-		}
-		if n := len(v.Traces[0].Spans); n != len(payload[0]) {
-			t.Fatalf("expected %d spans, got %d", len(payload[0]), n)
-		}
-		sort.Sort(BySpanID(v.Traces[0].Spans))
-		span := v.Traces[0].Spans[0]
-		if n := span.Metrics["_sublayers.span_count"]; n != float64(len(payload[0])) {
-			t.Fatalf(`expected span.Metrics["_sublayers.span_count"] == %d, but was got %f`, len(payload[0]), n)
-		}
-	})
-}
 
 func TestSublayerDurations(t *testing.T) {
 	r := test.Runner{Verbose: true}
@@ -133,16 +83,10 @@ func TestSublayerDurations(t *testing.T) {
 			{0, "_sublayers.duration.by_service.sublayer_service:redis", 28.0},
 			{0, "_sublayers.duration.by_service.sublayer_service:rpc1", 30.0},
 			{0, "_sublayers.duration.by_service.sublayer_service:alert", 35.0},
-			{0, "_sublayers.duration.by_type.sublayer_type:cache", 28.0},
-			{0, "_sublayers.duration.by_type.sublayer_type:db", 28.0},
-			{0, "_sublayers.duration.by_type.sublayer_type:rpc", 65.0},
-			{0, "_sublayers.duration.by_type.sublayer_type:web", 30.0},
 			{1, "_sublayers.duration.by_service.sublayer_service:pg", 20.0},
 			{1, "_sublayers.duration.by_service.sublayer_service:pg-read", 30.0},
-			{1, "_sublayers.duration.by_type.sublayer_type:db", 50.0},
 			{5, "_sublayers.duration.by_service.sublayer_service:rpc1", 50.0},
 			{5, "_sublayers.duration.by_service.sublayer_service:alert", 40.0},
-			{5, "_sublayers.duration.by_type.sublayer_type:rpc", 90.0},
 		} {
 			val, ok := spans[tt.spanIndex].Metrics[tt.metric]
 			if !ok {

--- a/releasenotes/notes/apm-remove-analytics-sublayers-737fa4255043ff02.yaml
+++ b/releasenotes/notes/apm-remove-analytics-sublayers-737fa4255043ff02.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Lowered CPU usage when using analytics.


### PR DESCRIPTION
### What does this PR do?

Sublayers are only set for on spans with the trace chunk sampled. We don't use sublayer tags on single analytic spans.

Trim all sublayer tags that do not match `_sublayers.duration.by_service.sublayer_service` as they are not used

### Motivation

Reduces overhead of setting sublayers on spans. When analytic_enabled is set at 100% for a service, the sublayers are always attached to the single events forwarded.

Under constant throughput of 7k traces with 4 spans, set sublayers takes over 7% of CPU
![image](https://user-images.githubusercontent.com/22001182/97615233-59ebd900-1a1b-11eb-8a85-03613f98e4a4.png)
