### PR TITLE
dogstatsd: allow empty message for events (resolves #6054)

### DIFF
--- a/pkg/dogstatsd/parse_events.go
+++ b/pkg/dogstatsd/parse_events.go
@@ -161,8 +161,8 @@ func (p *parser) parseEvent(message []byte) (dogstatsdEvent, error) {
 	if len(rawEvent) < header.textLength+header.titleLength+1 {
 		return dogstatsdEvent{}, fmt.Errorf("invalid event")
 	}
-	if header.titleLength == 0 || header.textLength == 0 {
-		return dogstatsdEvent{}, fmt.Errorf("invalid event: empty title or text")
+	if header.titleLength == 0 {
+		return dogstatsdEvent{}, fmt.Errorf("invalid event: empty title")
 	}
 	title := cleanEventText(rawEvent[:header.titleLength])
 	text := cleanEventText(rawEvent[header.titleLength+1 : header.titleLength+1+header.textLength])

--- a/pkg/dogstatsd/parse_events_test.go
+++ b/pkg/dogstatsd/parse_events_test.go
@@ -230,3 +230,26 @@ func TestEventMetadataMultiple(t *testing.T) {
 	assert.Equal(t, string("aggKey"), e.aggregationKey)
 	assert.Equal(t, string("source test"), e.sourceType)
 }
+
+func TestEventEmptyTitle(t *testing.T) {
+	_, err := parseEvent([]byte("_e{0,9}:|test text"))
+
+	require.Error(t, err, "invalid event: empty title")
+}
+
+func TestEventEmptyText(t *testing.T) {
+	e, err := parseEvent([]byte("_e{10,0}:test title|"))
+
+	require.NoError(t, err)
+	assert.Equal(t, string("test title"), e.title)
+	assert.Equal(t, string(""), e.text)
+}
+
+func TestEventEmptyTextWithAlertType(t *testing.T) {
+	e, err := parseEvent([]byte("_e{10,0}:test title||t:warning"))
+
+	require.NoError(t, err)
+	assert.Equal(t, string("test title"), e.title)
+	assert.Equal(t, string(""), e.text)
+	assert.Equal(t, alertTypeWarning, e.alertType)
+}

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -249,7 +249,7 @@ func TestUDPReceive(t *testing.T) {
 	}
 
 	// Test erroneous Event
-	conn.Write([]byte("_e{10,0}:test title|\n_e{11,10}:test title2|test\\ntext|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
+	conn.Write([]byte("_e{0,9}:|test text\n_e{11,10}:test title2|test\\ntext|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
 	select {
 	case res := <-eventOut:
 		assert.Equal(t, 1, len(res))

--- a/releasenotes/notes/dogstatsd-allow-empty-event-message-5e54cd17790027bf.yaml
+++ b/releasenotes/notes/dogstatsd-allow-empty-event-message-5e54cd17790027bf.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Allow empty message for DogStatsD events (e.g. "_e{10,0}:test title|")


### PR DESCRIPTION
### What does this PR do?

To be consistent with the Datadog API, allow empty message for events.

### Motivation

When the agent starts the event `HOST's Datadog Agent has started` is emitted and when I tried to emit something similar with dogstatsd I got the error `event: empty title or text`.