### PR TITLE
[aggregator] Better support monotonic counts from openmetrics

### DIFF
--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -30,6 +30,12 @@ func (m *MockSender) AssertMetric(t *testing.T, method string, metric string, va
 	return m.Mock.AssertCalled(t, method, metric, value, hostname, MatchTagsContains(tags))
 }
 
+// AssertMonotonicCount allows to assert a monotonic count was emitted with given parameters.
+// Additional tags over the ones specified don't make it fail
+func (m *MockSender) AssertMonotonicCount(t *testing.T, method string, metric string, value float64, hostname string, tags []string, flushFirstValue bool) bool {
+	return m.Mock.AssertCalled(t, method, metric, value, hostname, MatchTagsContains(tags), flushFirstValue)
+}
+
 // AssertHistogramBucket allows to assert a histogram bucket was emitted with given parameters.
 // Additional tags over the ones specified don't make it fail
 func (m *MockSender) AssertHistogramBucket(t *testing.T, method string, metric string, value int64, lowerBound float64, upperBound float64, monotonic bool, hostname string, tags []string) bool {

--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -24,6 +24,11 @@ func (m *MockSender) MonotonicCount(metric string, value float64, hostname strin
 	m.Called(metric, value, hostname, tags)
 }
 
+//MonotonicCountWithFlushFirstValue adds a monotonic count type to the mock calls with flushFirstValue parameter
+func (m *MockSender) MonotonicCountWithFlushFirstValue(metric string, value float64, hostname string, tags []string, flushFirstValue bool) {
+	m.Called(metric, value, hostname, tags, flushFirstValue)
+}
+
 //Counter adds a counter type to the mock calls.
 func (m *MockSender) Counter(metric string, value float64, hostname string, tags []string) {
 	m.Called(metric, value, hostname, tags)

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -46,6 +46,13 @@ func (m *MockSender) SetupAcceptAll() {
 			mock.AnythingOfType("[]string"), // Tags
 		).Return()
 	}
+	m.On("MonotonicCountWithFlushFirstValue",
+		mock.AnythingOfType("string"),   // Metric
+		mock.AnythingOfType("float64"),  // Value
+		mock.AnythingOfType("string"),   // Hostname
+		mock.AnythingOfType("[]string"), // Tags
+		mock.AnythingOfType("bool"),     // FlushFirstValue
+	).Return()
 	m.On("ServiceCheck",
 		mock.AnythingOfType("string"),                     // checkName (e.g: docker.exit)
 		mock.AnythingOfType("metrics.ServiceCheckStatus"), // (e.g: metrics.ServiceCheckOK)

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -28,6 +28,7 @@ type Sender interface {
 	Rate(metric string, value float64, hostname string, tags []string)
 	Count(metric string, value float64, hostname string, tags []string)
 	MonotonicCount(metric string, value float64, hostname string, tags []string)
+	MonotonicCountWithFlushFirstValue(metric string, value float64, hostname string, tags []string, flushFirstValue bool)
 	Counter(metric string, value float64, hostname string, tags []string)
 	Histogram(metric string, value float64, hostname string, tags []string)
 	Historate(metric string, value float64, hostname string, tags []string)
@@ -227,19 +228,20 @@ func (s *checkSender) SendRawMetricSample(sample *metrics.MetricSample) {
 	s.smsOut <- senderMetricSample{s.id, sample, false}
 }
 
-func (s *checkSender) sendMetricSample(metric string, value float64, hostname string, tags []string, mType metrics.MetricType) {
+func (s *checkSender) sendMetricSample(metric string, value float64, hostname string, tags []string, mType metrics.MetricType, flushFirstValue bool) {
 	tags = append(tags, s.checkTags...)
 
 	log.Trace(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
 
 	metricSample := &metrics.MetricSample{
-		Name:       metric,
-		Value:      value,
-		Mtype:      mType,
-		Tags:       tags,
-		Host:       hostname,
-		SampleRate: 1,
-		Timestamp:  timeNowNano(),
+		Name:            metric,
+		Value:           value,
+		Mtype:           mType,
+		Tags:            tags,
+		Host:            hostname,
+		SampleRate:      1,
+		Timestamp:       timeNowNano(),
+		FlushFirstValue: flushFirstValue,
 	}
 
 	if hostname == "" && !s.defaultHostnameDisabled {
@@ -255,35 +257,41 @@ func (s *checkSender) sendMetricSample(metric string, value float64, hostname st
 
 // Gauge should be used to send a simple gauge value to the aggregator. Only the last value sampled is kept at commit time.
 func (s *checkSender) Gauge(metric string, value float64, hostname string, tags []string) {
-	s.sendMetricSample(metric, value, hostname, tags, metrics.GaugeType)
+	s.sendMetricSample(metric, value, hostname, tags, metrics.GaugeType, false)
 }
 
 // Rate should be used to track the rate of a metric over each check run
 func (s *checkSender) Rate(metric string, value float64, hostname string, tags []string) {
-	s.sendMetricSample(metric, value, hostname, tags, metrics.RateType)
+	s.sendMetricSample(metric, value, hostname, tags, metrics.RateType, false)
 }
 
 // Count should be used to count a number of events that occurred during the check run
 func (s *checkSender) Count(metric string, value float64, hostname string, tags []string) {
-	s.sendMetricSample(metric, value, hostname, tags, metrics.CountType)
+	s.sendMetricSample(metric, value, hostname, tags, metrics.CountType, false)
 }
 
 // MonotonicCount should be used to track the increase of a monotonic raw counter
 func (s *checkSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
-	s.sendMetricSample(metric, value, hostname, tags, metrics.MonotonicCountType)
+	s.sendMetricSample(metric, value, hostname, tags, metrics.MonotonicCountType, false)
+}
+
+// MonotonicCountWithFlushFirstValue should be used to track the increase of a monotonic raw counter,
+// and allows specifying whether the aggregator should flush the first sampled value as-is.
+func (s *checkSender) MonotonicCountWithFlushFirstValue(metric string, value float64, hostname string, tags []string, flushFirstValue bool) {
+	s.sendMetricSample(metric, value, hostname, tags, metrics.MonotonicCountType, flushFirstValue)
 }
 
 // Counter is DEPRECATED and only implemented to preserve backward compatibility with python checks. Prefer using either:
 // * `Gauge` if you're counting states
 // * `Count` if you're counting events
 func (s *checkSender) Counter(metric string, value float64, hostname string, tags []string) {
-	s.sendMetricSample(metric, value, hostname, tags, metrics.CounterType)
+	s.sendMetricSample(metric, value, hostname, tags, metrics.CounterType, false)
 }
 
 // Histogram should be used to track the statistical distribution of a set of values during a check run
 // Should be called multiple times on the same (metric, hostname, tags) so that a distribution can be computed
 func (s *checkSender) Histogram(metric string, value float64, hostname string, tags []string) {
-	s.sendMetricSample(metric, value, hostname, tags, metrics.HistogramType)
+	s.sendMetricSample(metric, value, hostname, tags, metrics.HistogramType, false)
 }
 
 // HistogramBucket should be called to directly send raw buckets to be submitted as distribution metrics
@@ -326,7 +334,7 @@ func (s *checkSender) HistogramBucket(metric string, value int64, lowerBound, up
 // Historate should be used to create a histogram metric for "rate" like metrics.
 // Warning this doesn't use the harmonic mean, beware of what it means when using it.
 func (s *checkSender) Historate(metric string, value float64, hostname string, tags []string) {
-	s.sendMetricSample(metric, value, hostname, tags, metrics.HistorateType)
+	s.sendMetricSample(metric, value, hostname, tags, metrics.HistorateType, false)
 }
 
 // SendRawServiceCheck sends the raw service check

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -153,7 +153,7 @@ func TestGetSenderServiceTagMetrics(t *testing.T) {
 	// only tags added by the check
 	checkSender.SetCheckService("")
 	checkSender.FinalizeCheckServiceTag()
-	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", checkTags, metrics.CounterType)
+	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", checkTags, metrics.CounterType, false)
 	sms := <-senderMetricSampleChan
 	assert.Equal(t, checkTags, sms.metricSample.Tags)
 
@@ -161,7 +161,7 @@ func TestGetSenderServiceTagMetrics(t *testing.T) {
 	checkSender.SetCheckService("service1")
 	checkSender.SetCheckService("service2")
 	checkSender.FinalizeCheckServiceTag()
-	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", checkTags, metrics.CounterType)
+	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", checkTags, metrics.CounterType, false)
 	sms = <-senderMetricSampleChan
 	assert.Equal(t, append(checkTags, "service:service2"), sms.metricSample.Tags)
 }
@@ -239,13 +239,13 @@ func TestGetSenderAddCheckCustomTagsMetrics(t *testing.T) {
 	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan)
 
 	// no custom tags
-	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", nil, metrics.CounterType)
+	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", nil, metrics.CounterType, false)
 	sms := <-senderMetricSampleChan
 	assert.Nil(t, sms.metricSample.Tags)
 
 	// only tags added by the check
 	checkTags := []string{"check:tag1", "check:tag2"}
-	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", checkTags, metrics.CounterType)
+	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", checkTags, metrics.CounterType, false)
 	sms = <-senderMetricSampleChan
 	assert.Equal(t, checkTags, sms.metricSample.Tags)
 
@@ -255,12 +255,12 @@ func TestGetSenderAddCheckCustomTagsMetrics(t *testing.T) {
 	assert.Len(t, checkSender.checkTags, 2)
 
 	// only tags coming from the configuration file
-	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", nil, metrics.CounterType)
+	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", nil, metrics.CounterType, false)
 	sms = <-senderMetricSampleChan
 	assert.Equal(t, customTags, sms.metricSample.Tags)
 
 	// tags added by the check + tags coming from the configuration file
-	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", checkTags, metrics.CounterType)
+	checkSender.sendMetricSample("metric.test", 42.0, "testhostname", checkTags, metrics.CounterType, false)
 	sms = <-senderMetricSampleChan
 	assert.Equal(t, append(checkTags, customTags...), sms.metricSample.Tags)
 }
@@ -397,6 +397,7 @@ func TestCheckSenderInterface(t *testing.T) {
 	checkSender.Rate("my.rate_metric", 2.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Count("my.count_metric", 123.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.MonotonicCount("my.monotonic_count_metric", 12.0, "my-hostname", []string{"foo", "bar"})
+	checkSender.MonotonicCountWithFlushFirstValue("my.monotonic_count_metric", 12.0, "my-hostname", []string{"foo", "bar"}, true)
 	checkSender.Counter("my.counter_metric", 1.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Histogram("my.histo_metric", 3.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.HistogramBucket("my.histogram_bucket", 42, 1.0, 2.0, true, "my-hostname", []string{"foo", "bar"})
@@ -435,6 +436,12 @@ func TestCheckSenderInterface(t *testing.T) {
 	assert.EqualValues(t, checkID1, monotonicCountSenderSample.id)
 	assert.Equal(t, metrics.MonotonicCountType, monotonicCountSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, monotonicCountSenderSample.commit)
+
+	monotonicCountWithFlushFirstValueSenderSample := <-senderMetricSampleChan
+	assert.EqualValues(t, checkID1, monotonicCountWithFlushFirstValueSenderSample.id)
+	assert.Equal(t, metrics.MonotonicCountType, monotonicCountWithFlushFirstValueSenderSample.metricSample.Mtype)
+	assert.Equal(t, true, monotonicCountWithFlushFirstValueSenderSample.metricSample.FlushFirstValue)
+	assert.Equal(t, false, monotonicCountWithFlushFirstValueSenderSample.commit)
 
 	CounterSenderSample := <-senderMetricSampleChan
 	assert.EqualValues(t, checkID1, CounterSenderSample.id)

--- a/pkg/collector/python/aggregator.go
+++ b/pkg/collector/python/aggregator.go
@@ -23,7 +23,7 @@ import "C"
 
 // SubmitMetric is the method exposed to Python scripts to submit metrics
 //export SubmitMetric
-func SubmitMetric(checkID *C.char, metricType C.metric_type_t, metricName *C.char, value C.double, tags **C.char, hostname *C.char) {
+func SubmitMetric(checkID *C.char, metricType C.metric_type_t, metricName *C.char, value C.double, tags **C.char, hostname *C.char, flushFirstValue C.bool) {
 	goCheckID := C.GoString(checkID)
 
 	sender, err := aggregator.GetSender(chk.ID(goCheckID))
@@ -36,6 +36,7 @@ func SubmitMetric(checkID *C.char, metricType C.metric_type_t, metricName *C.cha
 	_value := float64(value)
 	_hostname := C.GoString(hostname)
 	_tags := cStringArrayToSlice(tags)
+	_flushFirstValue := bool(flushFirstValue)
 
 	switch metricType {
 	case C.DATADOG_AGENT_RTLOADER_GAUGE:
@@ -45,7 +46,7 @@ func SubmitMetric(checkID *C.char, metricType C.metric_type_t, metricName *C.cha
 	case C.DATADOG_AGENT_RTLOADER_COUNT:
 		sender.Count(_name, _value, _hostname, _tags)
 	case C.DATADOG_AGENT_RTLOADER_MONOTONIC_COUNT:
-		sender.MonotonicCount(_name, _value, _hostname, _tags)
+		sender.MonotonicCountWithFlushFirstValue(_name, _value, _hostname, _tags, _flushFirstValue)
 	case C.DATADOG_AGENT_RTLOADER_COUNTER:
 		sender.Counter(_name, _value, _hostname, _tags)
 	case C.DATADOG_AGENT_RTLOADER_HISTOGRAM:

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -106,7 +106,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 // aggregator module
 //
 
-void SubmitMetric(char *, metric_type_t, char *, double, char **, char *);
+void SubmitMetric(char *, metric_type_t, char *, double, char **, char *, bool);
 void SubmitServiceCheck(char *, char *, int, char **, char *, char *);
 void SubmitEvent(char *, event_t *);
 void SubmitHistogramBucket(char *, char *, long long, float, float, int, char *, char **);

--- a/pkg/collector/python/test_aggregator.go
+++ b/pkg/collector/python/test_aggregator.go
@@ -28,48 +28,63 @@ func testSubmitMetric(t *testing.T) {
 		C.CString("test_gauge"),
 		C.double(21),
 		&cTags[0],
-		C.CString("my_hostname"))
+		C.CString("my_hostname"),
+		C.bool(false))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_RATE,
 		C.CString("test_rate"),
 		C.double(21),
 		&cTags[0],
-		C.CString("my_hostname"))
+		C.CString("my_hostname"),
+		C.bool(false))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_COUNT,
 		C.CString("test_count"),
 		C.double(21),
 		&cTags[0],
-		C.CString("my_hostname"))
+		C.CString("my_hostname"),
+		C.bool(false))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_MONOTONIC_COUNT,
 		C.CString("test_monotonic_count"),
 		C.double(21),
 		&cTags[0],
-		C.CString("my_hostname"))
+		C.CString("my_hostname"),
+		C.bool(false))
+	SubmitMetric(C.CString("testID"),
+		C.DATADOG_AGENT_RTLOADER_MONOTONIC_COUNT,
+		C.CString("test_monotonic_count_flush_first_value"),
+		C.double(21),
+		&cTags[0],
+		C.CString("my_hostname"),
+		C.bool(true))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_COUNTER,
 		C.CString("test_counter"),
 		C.double(21),
 		&cTags[0],
-		C.CString("my_hostname"))
+		C.CString("my_hostname"),
+		C.bool(false))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_HISTOGRAM,
 		C.CString("test_histogram"),
 		C.double(21),
 		&cTags[0],
-		C.CString("my_hostname"))
+		C.CString("my_hostname"),
+		C.bool(false))
 	SubmitMetric(C.CString("testID"),
 		C.DATADOG_AGENT_RTLOADER_HISTORATE,
 		C.CString("test_historate"),
 		C.double(21),
 		&cTags[0],
-		C.CString("my_hostname"))
+		C.CString("my_hostname"),
+		C.bool(false))
 
 	sender.AssertMetric(t, "Gauge", "test_gauge", 21, "my_hostname", []string{"tag1", "tag2"})
 	sender.AssertMetric(t, "Rate", "test_rate", 21, "my_hostname", []string{"tag1", "tag2"})
 	sender.AssertMetric(t, "Count", "test_count", 21, "my_hostname", []string{"tag1", "tag2"})
-	sender.AssertMetric(t, "MonotonicCount", "test_monotonic_count", 21, "my_hostname", []string{"tag1", "tag2"})
+	sender.AssertMonotonicCount(t, "MonotonicCountWithFlushFirstValue", "test_monotonic_count", 21, "my_hostname", []string{"tag1", "tag2"}, false)
+	sender.AssertMonotonicCount(t, "MonotonicCountWithFlushFirstValue", "test_monotonic_count_flush_first_value", 21, "my_hostname", []string{"tag1", "tag2"}, true)
 	sender.AssertMetric(t, "Counter", "test_counter", 21, "my_hostname", []string{"tag1", "tag2"})
 	sender.AssertMetric(t, "Histogram", "test_histogram", 21, "my_hostname", []string{"tag1", "tag2"})
 	sender.AssertMetric(t, "Historate", "test_historate", 21, "my_hostname", []string{"tag1", "tag2"})
@@ -85,7 +100,8 @@ func testSubmitMetricEmptyTags(t *testing.T) {
 		C.CString("test_gauge"),
 		C.double(21),
 		&cTags[0],
-		C.CString("my_hostname"))
+		C.CString("my_hostname"),
+		C.bool(false))
 
 	sender.AssertMetric(t, "Gauge", "test_gauge", 21, "my_hostname", nil)
 }
@@ -100,7 +116,8 @@ func testSubmitMetricEmptyHostname(t *testing.T) {
 		C.CString("test_gauge"),
 		C.double(21),
 		&cTags[0],
-		nil)
+		nil,
+		C.bool(false))
 
 	sender.AssertMetric(t, "Gauge", "test_gauge", 21, "", nil)
 }

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -62,14 +62,15 @@ type MetricSampleContext interface {
 
 // MetricSample represents a raw metric sample
 type MetricSample struct {
-	Name       string
-	Value      float64
-	RawValue   string
-	Mtype      MetricType
-	Tags       []string
-	Host       string
-	SampleRate float64
-	Timestamp  float64
+	Name            string
+	Value           float64
+	RawValue        string
+	Mtype           MetricType
+	Tags            []string
+	Host            string
+	SampleRate      float64
+	Timestamp       float64
+	FlushFirstValue bool
 }
 
 // Implement the MetricSampleContext interface

--- a/pkg/metrics/monotonic_count.go
+++ b/pkg/metrics/monotonic_count.go
@@ -31,7 +31,7 @@ func (mc *MonotonicCount) addSample(sample *MetricSample, timestamp float64) {
 	// To handle cases where the samples are not monotonically increasing, we always add the difference
 	// between 2 consecutive samples to the value that'll be flushed (if the difference is >0).
 	diff := mc.currentSample - mc.previousSample
-	if mc.sampledSinceLastFlush && mc.hasPreviousSample && diff > 0. {
+	if mc.hasPreviousSample && diff > 0. {
 		mc.value += diff
 	}
 }
@@ -44,6 +44,7 @@ func (mc *MonotonicCount) flush(timestamp float64) ([]*Serie, error) {
 	value := mc.value
 	// reset struct fields
 	mc.previousSample, mc.currentSample, mc.value = mc.currentSample, 0., 0.
+	mc.hasPreviousSample = true
 	mc.sampledSinceLastFlush = false
 
 	return []*Serie{

--- a/rtloader/common/builtins/aggregator.c
+++ b/rtloader/common/builtins/aggregator.c
@@ -189,7 +189,7 @@ static PyObject *submit_metric(PyObject *self, PyObject *args)
     char **tags = NULL;
     int mt;
     double value;
-    bool flush_first_value;
+    bool flush_first_value = false;
 
     // Python call: aggregator.submit_metric(self, check_id, aggregator.metric_type.GAUGE, name, value, tags, hostname, flush_first_value)
     if (!PyArg_ParseTuple(args, "OsisdOs|i", &check, &check_id, &mt, &name, &value, &py_tags, &hostname, &flush_first_value)) {

--- a/rtloader/common/builtins/aggregator.c
+++ b/rtloader/common/builtins/aggregator.c
@@ -189,16 +189,17 @@ static PyObject *submit_metric(PyObject *self, PyObject *args)
     char **tags = NULL;
     int mt;
     double value;
+    bool flush_first_value;
 
-    // Python call: aggregator.submit_metric(self, check_id, aggregator.metric_type.GAUGE, name, value, tags, hostname)
-    if (!PyArg_ParseTuple(args, "OsisdOs", &check, &check_id, &mt, &name, &value, &py_tags, &hostname)) {
+    // Python call: aggregator.submit_metric(self, check_id, aggregator.metric_type.GAUGE, name, value, tags, hostname, flush_first_value)
+    if (!PyArg_ParseTuple(args, "OsisdOs|i", &check, &check_id, &mt, &name, &value, &py_tags, &hostname, &flush_first_value)) {
         goto error;
     }
 
     if ((tags = py_tag_to_c(py_tags)) == NULL)
         goto error;
 
-    cb_submit_metric(check_id, mt, name, value, tags, hostname);
+    cb_submit_metric(check_id, mt, name, value, tags, hostname, flush_first_value);
 
     free_tags(tags);
 

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -92,8 +92,8 @@ typedef enum {
 
 // aggregator
 //
-// (id, metric_type, metric_name, value, tags, hostname)
-typedef void (*cb_submit_metric_t)(char *, metric_type_t, char *, double, char **, char *);
+// (id, metric_type, metric_name, value, tags, hostname, flush_first_value)
+typedef void (*cb_submit_metric_t)(char *, metric_type_t, char *, double, char **, char *, bool);
 // (id, sc_name, status, tags, hostname, message)
 typedef void (*cb_submit_service_check_t)(char *, char *, int, char **, char *, char *);
 // (id, event)

--- a/rtloader/test/aggregator/aggregator.go
+++ b/rtloader/test/aggregator/aggregator.go
@@ -17,7 +17,7 @@ import (
 #include "rtloader_mem.h"
 #include "datadog_agent_rtloader.h"
 
-extern void submitMetric(char *, metric_type_t, char *, double, char **, char *);
+extern void submitMetric(char *, metric_type_t, char *, double, char **, char *, bool);
 extern void submitServiceCheck(char *, char *, int, char **, char *, char *);
 extern void submitEvent(char*, event_t*);
 extern void submitHistogramBucket(char *, char *, long long, float, float, int, char *, char **);
@@ -32,21 +32,22 @@ static void initAggregatorTests(rtloader_t *rtloader) {
 import "C"
 
 var (
-	rtloader   *C.rtloader_t
-	checkID    string
-	metricType int
-	name       string
-	value      float64
-	tags       []string
-	hostname   string
-	scLevel    int
-	scName     string
-	scMessage  string
-	_event     *event
-	intValue   int
-	lowerBound float64
-	upperBound float64
-	monotonic  bool
+	rtloader        *C.rtloader_t
+	checkID         string
+	metricType      int
+	name            string
+	value           float64
+	tags            []string
+	hostname        string
+	flushFirstValue bool
+	scLevel         int
+	scName          string
+	scMessage       string
+	_event          *event
+	intValue        int
+	lowerBound      float64
+	upperBound      float64
+	monotonic       bool
 )
 
 type event struct {
@@ -151,7 +152,7 @@ func charArrayToSlice(array **C.char) (res []string) {
 }
 
 //export submitMetric
-func submitMetric(id *C.char, mt C.metric_type_t, mname *C.char, val C.double, t **C.char, hname *C.char) {
+func submitMetric(id *C.char, mt C.metric_type_t, mname *C.char, val C.double, t **C.char, hname *C.char, fFirstValue C.bool) {
 	checkID = C.GoString(id)
 	metricType = int(mt)
 	name = C.GoString(mname)
@@ -160,6 +161,7 @@ func submitMetric(id *C.char, mt C.metric_type_t, mname *C.char, val C.double, t
 	if t != nil {
 		tags = append(tags, charArrayToSlice(t)...)
 	}
+	flushFirstValue = bool(fFirstValue)
 }
 
 //export submitServiceCheck

--- a/rtloader/test/aggregator/aggregator_test.go
+++ b/rtloader/test/aggregator/aggregator_test.go
@@ -52,6 +52,50 @@ func TestSubmitMetric(t *testing.T) {
 	if tags[0] != "foo" || tags[1] != "bar" {
 		t.Fatalf("Unexpected tags: %v", tags)
 	}
+	if flushFirstValue != false {
+		t.Fatalf("Unexpected flushFirstValue: %v", flushFirstValue)
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}
+
+func TestSubmitMetric_FlushFirstValue(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	out, err := run(`aggregator.submit_metric(None, 'id', aggregator.GAUGE, 'name', -99.0, ['foo', 21, 'bar', ["hey"]], 'myhost', True)`)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "" {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+	if checkID != "id" {
+		t.Fatalf("Unexpected id value: %s", checkID)
+	}
+	if metricType != 0 {
+		t.Fatalf("Unexpected metricType value: %d", metricType)
+	}
+	if name != "name" {
+		t.Fatalf("Unexpected name value: %s", name)
+	}
+	if value != -99.0 {
+		t.Fatalf("Unexpected value: %f", value)
+	}
+	if hostname != "myhost" {
+		t.Fatalf("Unexpected hostname value: %s", hostname)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("Unexpected tags length: %d", len(tags))
+	}
+	if tags[0] != "foo" || tags[1] != "bar" {
+		t.Fatalf("Unexpected tags: %v", tags)
+	}
+	if flushFirstValue != true {
+		t.Fatalf("Unexpected flushFirstValue: %v", flushFirstValue)
+	}
 
 	// Check for leaks
 	helpers.AssertMemoryUsage(t)


### PR DESCRIPTION
### What does this PR do?

Adds a boolean on the `MetricSample` struct (`FlushFirstValue`), which is only taken into account in
`MonotonicCount`. When the boolean is set to `true` on a `MetricSample`, it makes the `MonotonicCount`:

1. flush the first sampled value as-is on the 1st flush, instead of flushing nothing on the 1st flush.
2. flush a sampled value as-is when it's lower than the previously-sampled value.

Adds related code on the `Sender` and in `rtloader` so that python code can use this boolean. From Python, this is exposed as the last (and optional) parameter of `submit_metric`. Pseudo-code:

```python
import aggregator
aggregator.submit_metric(self, check_id, aggregator.metric_type.MONOTONIC_COUNT, metric_name, value, tags, hostname, flush_first_value)
```

### Motivation

This boolean will be useful for the openmetrics check, where the assumptions that make this new behavior better can be verified by the check. It will submit monotonic counts from openmetrics with this boolean set to `true` when it can tell that the submitted monotonic_count value can be flushed as-is if it's on a new (metric_name, tag set). For the openmetrics check, this condition is met starting with the 2nd successful scrape of the openmetrics endpoint.

### Additional Notes

By default, when this boolean is not set on a `MetricSample`, the code is mostly a no-op . The only differences are:

1. there may be minor added overhead of the new `bool` field on the struct
2. the first commit makes a small change on the behavior of `MonotonicCount` (see commit description), that I think is very safe to make.

Reviewers: to make the review easier, each commit should be reviewed individually.

### Describe your test plan

* Added a bunch of unit tests on all the modified parts.
* Tested on locally-built agent with a simple custom check submitting `monotonic_count` with and without this boolean set to `True`.
* This should be tested with the related changes on openmetrics, when they're ready.
