### PR TITLE
[macos] Keep excluding snowflake

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -12,7 +12,7 @@ dependency 'datadog-agent'
 dependency 'pip2'
 
 unless osx?
-  # Blacklist snowflake-connector-python as it makes MacOS notarization fail.
+  # Exclude snowflake-connector-python as it makes MacOS notarization fail.
   # It pulls the ijson package, which contains a _yajl2.so binary that was built with a
   # MacOS SDK lower than 10.9. The Python 3 counterpart of the same package is not affected (it
   # doesn't ship this file).
@@ -91,7 +91,7 @@ if osx?
   # Blacklist ibm_was, which depends on lxml
   blacklist_folders.push('ibm_was')
 
-  # Blacklist snowflake, which depends on snowflake-connector-python (which we don't build on MacOS, see above)
+  # Exclude snowflake, which depends on snowflake-connector-python (which we don't build on MacOS, see above)
   blacklist_folders.push('snowflake')
 
   # Blacklist aerospike, new version 3.10 is not supported on MacOS yet

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -11,7 +11,13 @@ name 'datadog-agent-integrations-py2'
 dependency 'datadog-agent'
 dependency 'pip2'
 
-dependency 'snowflake-connector-python-py2'
+unless osx?
+  # Blacklist snowflake-connector-python as it makes MacOS notarization fail.
+  # It pulls the ijson package, which contains a _yajl2.so binary that was built with a
+  # MacOS SDK lower than 10.9. The Python 3 counterpart of the same package is not affected (it
+  # doesn't ship this file).
+  dependency 'snowflake-connector-python-py2'
+end
 
 if arm?
   # psycopg2 doesn't come with pre-built wheel on the arm architecture.
@@ -85,13 +91,7 @@ if osx?
   # Blacklist ibm_was, which depends on lxml
   blacklist_folders.push('ibm_was')
 
-  # Blacklist snowflake-connector-python as it makes MacOS notarization fail.
-  # It pulls the ijson package, which contains a _yajl2.so binary that was built with a
-  # MacOS SDK lower than 10.9. The Python 3 counterpart of the same package is not affected (it
-  # doesn't ship this file).
-  blacklist_packages.push(/^snowflake-connector-python==/)
-
-  # Blacklist snowflake, which depends on snowflake-connector-python
+  # Blacklist snowflake, which depends on snowflake-connector-python (which we don't build on MacOS, see above)
   blacklist_folders.push('snowflake')
 
   # Blacklist aerospike, new version 3.10 is not supported on MacOS yet


### PR DESCRIPTION
### What does this PR do?

Adds a condition to not run the `snowflake-connector-python-py2` software definition on MacOS, as it makes notarization fail.

### Motivation

In #6391, snowflake was excluded from the Python 2 env on MacOS because it made notarization fail. #6666 changed the way we build `snowflake-connector-python` (it's now directly built during the omnibus build). However, that changes makes us build `snowflake-connector-python` even on MacOS (which we do not want).

### Testing plan

MacOS builds succeeded.