### PR TITLE
Only cleanup the test artifacts if the tests succeed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2467,7 +2467,7 @@ testkitchen_cleanup_s3-a6:
       when: never
     - <<: *if_not_test_kitchen_deploy
       when: never
-    - when: always
+    - when: on_success
   variables:
     AGENT_MAJOR_VERSION: 6
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -2481,7 +2481,7 @@ testkitchen_cleanup_s3-a7:
       when: never
     - <<: *if_not_test_kitchen_deploy
       when: never
-    - when: always
+    - when: on_success
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7


### PR DESCRIPTION
### Motivation

Otherwise, retrying the kitchen tests would fail because the artifacts
aren't there. This means that failed/retried pipelines will leave the test
artifacts in the test buckets, but hopefully the periodic cleanup will
take care of those.

