### PR TITLE
Avoid hammering the Kubernetes API server

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_eventbundle.go
@@ -106,12 +106,17 @@ func (b *kubernetesEventBundle) formatEvents(clusterName string, providerIDCache
 		// Find provider ID from cache or find via node spec from APIserver
 		hostProviderID, hit := providerIDCache.Get(b.nodename)
 		if hit {
-			tags = append(tags, fmt.Sprintf("host_provider_id:%s", hostProviderID))
+			if hostProviderID != "" {
+				tags = append(tags, fmt.Sprintf("host_provider_id:%s", hostProviderID))
+			}
 		} else {
 			hostProviderID := getHostProviderID(b.nodename)
 			if hostProviderID != "" {
 				providerIDCache.Set(b.nodename, hostProviderID, cache.NoExpiration)
 				tags = append(tags, fmt.Sprintf("host_provider_id:%s", hostProviderID))
+			} else {
+				log.Debugf("Failed to find the host provider ID for node %s. Caching this negative result for 1 min", b.nodename)
+				providerIDCache.Set(b.nodename, "", 1*time.Minute)
 			}
 		}
 	}

--- a/releasenotes-dca/notes/avoid_hammering_api_server-7fa7152c927e0fa4.yaml
+++ b/releasenotes-dca/notes/avoid_hammering_api_server-7fa7152c927e0fa4.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    When a new node starts, the DCA might receive Kubernetes events before the API server can GET it.
+    In this case, the DCA will keep on querying the API server for each event it receives until it succeeds.
+    In order to not hammer the API server, the DCA will now query the API server to get the node info at most once every minutes per node.


### PR DESCRIPTION
### What does this PR do?

When a new node starts, the DCA might receive Kubernetes events before the API server can GET it.
In this case, the DCA will keep on querying the API server for each event it receives until it succeeds.
In order to not hammer the API server, the DCA will now query the API server to get the node info at most once every minutes per node.

### Motivation

Avoid a storm of the following logs:
```
2020-10-29 01:08:56 UTC | CLUSTER | WARN | (pkg/collector/corechecks/cluster/kubernetes_eventbundle.go:161 in getHostProviderID) | Can't get node from API Server: nodes "ip-10-145-105-226" not found
2020-10-29 01:08:56 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/apiserver/apiserver.go:564 in GetNode) | Can't get node from the API server: nodes "ip-10-145-105-226" not found
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Trigger a cluster scale-up, watch the DCA logs and look for the above mentioned logs. We should have much fewer of them.