### PR TITLE
Add periodic cleanup of kitchen leftovers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4492,7 +4492,7 @@ periodic_kitchen_cleanup_s3:
   tags: [ "runner:main", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   rules:
-    - <<: *if_deploy_on_nightly
+    - if: $DEPLOY_AGENT == "true" && $RELEASE_VERSION_6 == "nightly" && $RELEASE_VERSION_7 == "nightly-a7" && $TESTING_CLEANUP == "true"
   script:
     - aws s3 rm --recursive s3://$DEB_TESTING_S3_BUCKET/pool
     - aws s3 rm --recursive s3://$DEB_TESTING_S3_BUCKET/dists
@@ -4507,7 +4507,7 @@ periodic_kitchen_cleanup_azure:
   tags: [ "runner:main", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   rules:
-    - <<: *if_deploy_on_nightly
+    - if: $DEPLOY_AGENT == "true" && $RELEASE_VERSION_6 == "nightly" && $RELEASE_VERSION_7 == "nightly-a7" && $TESTING_CLEANUP == "true"
   script:
     - export ARM_SUBSCRIPTION_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_subscription_id --with-decryption --query "Parameter.Value" --out text`
     - export ARM_CLIENT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_client_id --with-decryption --query "Parameter.Value" --out text`

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ variables:
   RELEASE_VERSION_6: nightly
   RELEASE_VERSION_7: nightly-a7
   DATADOG_AGENT_BUILDIMAGES: v2894686-d80c3ce
-  DATADOG_AGENT_BUILDERS: v2894668-736db00
+  DATADOG_AGENT_BUILDERS: v3299433-d824e87
   DATADOG_AGENT_WINBUILDIMAGES: v3283120-ecb88be
   DATADOG_AGENT_ARMBUILDIMAGES: v2894686-d80c3ce
   DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v2894686-d80c3ce
@@ -4484,6 +4484,36 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish gcr.io/datadoghq/dogstatsd:${NEW_LATEST_RELEASE_7} gcr.io/datadoghq/dogstatsd:latest
     - inv -e docker.publish gcr.io/datadoghq/dogstatsd:${NEW_LATEST_RELEASE_7} gcr.io/datadoghq/dogstatsd:7
+
+# Once a day, before the nightly build, cleans up the artifacts used during kitchen tests which might have been left over
+# This can happen when a kitchen test fails and is never retried, since that pipeline's cleanup job won't run
+periodic_kitchen_cleanup_s3:
+  stage: maintenance_jobs
+  tags: [ "runner:main", "size:large" ]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
+  rules:
+    - <<: *if_deploy_on_nightly
+  script:
+    - aws s3 rm --recursive s3://$DEB_TESTING_S3_BUCKET/pool
+    - aws s3 rm --recursive s3://$DEB_TESTING_S3_BUCKET/dists
+    - aws s3 rm --recursive s3://$RPM_TESTING_S3_BUCKET/testing/
+    - aws s3 rm --recursive s3://$RPM_TESTING_S3_BUCKET/suse/testing/
+    - aws s3 rm --recursive s3://$WIN_S3_BUCKET/pipelines/A6/
+    - aws s3 rm --recursive s3://$WIN_S3_BUCKET/pipelines/A7/
+
+# Once a day, before the nightly build, kills any VMs that might have been left over by kitchen
+periodic_kitchen_cleanup_azure:
+  stage: maintenance_jobs
+  tags: [ "runner:main", "size:large" ]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
+  rules:
+    - <<: *if_deploy_on_nightly
+  script:
+    - export ARM_SUBSCRIPTION_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_subscription_id --with-decryption --query "Parameter.Value" --out text`
+    - export ARM_CLIENT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_client_id --with-decryption --query "Parameter.Value" --out text`
+    - export ARM_CLIENT_SECRET=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_client_secret --with-decryption --query "Parameter.Value" --out text`
+    - export ARM_TENANT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_tenant_id --with-decryption --query "Parameter.Value" --out text`
+    - python3 ~/deploy_scripts/cleanup_azure.py
 
 #
 # Use this step to delete a tag of a given image


### PR DESCRIPTION
### What does this PR do?

Before each nightly build, this job removes stray kitchen VMs and leftover
test builds from the testing S3 buckets.

### Motivation

This was previously done by a different pipeline (minus the cleanup of the
Windows buckets which was missing) but I think it makes more sense to have
it here.
