### PR TITLE
[runtime-security] Fix a race condition in the load controller of the runtime security module

### DIFF
--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -124,7 +124,10 @@ func (lc *LoadController) discardNoisiestProcess() {
 
 // cleanup resets the internal counters
 func (lc *LoadController) cleanup() {
-	// reset ordering counts
+	lc.RLock()
+	defer lc.RUnlock()
+
+	// reset counts
 	for _, key := range lc.counters.Keys() {
 		val, ok := lc.counters.Peek(key)
 		if !ok || val == nil {


### PR DESCRIPTION
### What does this PR do?

This PR fixes a race condition in the load controller of the runtime security module. The race condition would happen when a new key would be deleted from the LRU between the call to `lc.counters.Keys()` and `lc.counters.Peek(key)`, and would eventually lead to an index out of range crash of system-probe.