### PR TITLE
Fix random Kubelet panic in searchPodForContainerID

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -171,10 +171,11 @@ func getMockedPods() []*kubelet.Pod {
 		},
 	}
 	kubeletStatus := kubelet.Status{
-		Phase:      "Running",
-		PodIP:      "127.0.0.1",
-		HostIP:     "127.0.0.2",
-		Containers: containerStatuses,
+		Phase:         "Running",
+		PodIP:         "127.0.0.1",
+		HostIP:        "127.0.0.2",
+		Containers:    containerStatuses,
+		AllContainers: containerStatuses,
 	}
 	return []*kubelet.Pod{
 		{

--- a/pkg/autodiscovery/providers/kubelet_test.go
+++ b/pkg/autodiscovery/providers/kubelet_test.go
@@ -35,6 +35,12 @@ func TestParseKubeletPodlist(t *testing.T) {
 							ID:   "testID",
 						},
 					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "testName",
+							ID:   "testID",
+						},
+					},
 				},
 			},
 			expectedCfg: nil,
@@ -54,6 +60,12 @@ func TestParseKubeletPodlist(t *testing.T) {
 				},
 				Status: kubelet.Status{
 					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "apache",
+							ID:   "container_id://3b8efe0c50e8",
+						},
+					},
+					AllContainers: []kubelet.ContainerStatus{
 						{
 							Name: "apache",
 							ID:   "container_id://3b8efe0c50e8",
@@ -95,6 +107,16 @@ func TestParseKubeletPodlist(t *testing.T) {
 							ID:   "container_id://4ac8352d70bf1",
 						},
 					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "apache",
+							ID:   "container_id://3b8efe0c50e8",
+						},
+						{
+							Name: "nginx",
+							ID:   "container_id://4ac8352d70bf1",
+						},
+					},
 				},
 			},
 			expectedCfg: []integration.Config{
@@ -126,6 +148,12 @@ func TestParseKubeletPodlist(t *testing.T) {
 				},
 				Status: kubelet.Status{
 					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "apache",
+							ID:   "container_id://3b8efe0c50e8",
+						},
+					},
+					AllContainers: []kubelet.ContainerStatus{
 						{
 							Name: "apache",
 							ID:   "container_id://3b8efe0c50e8",

--- a/pkg/autodiscovery/providers/prometheus_pods_test.go
+++ b/pkg/autodiscovery/providers/prometheus_pods_test.go
@@ -239,6 +239,12 @@ func TestConfigsForPod(t *testing.T) {
 							ID:   "foo-ctr-id",
 						},
 					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
 				},
 			},
 			want: []integration.Config{
@@ -275,6 +281,12 @@ func TestConfigsForPod(t *testing.T) {
 							ID:   "foo-ctr-id",
 						},
 					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
 				},
 			},
 			want: []integration.Config{
@@ -303,6 +315,12 @@ func TestConfigsForPod(t *testing.T) {
 							ID:   "foo-ctr-id",
 						},
 					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
 				},
 			},
 			want: nil,
@@ -322,6 +340,12 @@ func TestConfigsForPod(t *testing.T) {
 							ID:   "foo-ctr-id",
 						},
 					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
 				},
 			},
 			want: nil,
@@ -336,6 +360,16 @@ func TestConfigsForPod(t *testing.T) {
 				},
 				Status: kubelet.Status{
 					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr1",
+							ID:   "foo-ctr1-id",
+						},
+						{
+							Name: "foo-ctr2",
+							ID:   "foo-ctr2-id",
+						},
+					},
+					AllContainers: []kubelet.ContainerStatus{
 						{
 							Name: "foo-ctr1",
 							ID:   "foo-ctr1-id",
@@ -389,6 +423,16 @@ func TestConfigsForPod(t *testing.T) {
 							ID:   "foo-ctr2-id",
 						},
 					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr1",
+							ID:   "foo-ctr1-id",
+						},
+						{
+							Name: "foo-ctr2",
+							ID:   "foo-ctr2-id",
+						},
+					},
 				},
 			},
 			want: []integration.Config{
@@ -421,6 +465,12 @@ func TestConfigsForPod(t *testing.T) {
 							ID:   "foo-ctr-id",
 						},
 					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
 				},
 			},
 			want: nil,
@@ -439,6 +489,12 @@ func TestConfigsForPod(t *testing.T) {
 				},
 				Status: kubelet.Status{
 					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "foo-ctr",
+							ID:   "foo-ctr-id",
+						},
+					},
+					AllContainers: []kubelet.ContainerStatus{
 						{
 							Name: "foo-ctr",
 							ID:   "foo-ctr-id",

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -26,6 +26,13 @@ func TestParsePods(t *testing.T) {
 				Name:  "dd-agent",
 			},
 		},
+		AllContainers: []kubelet.ContainerStatus{
+			{
+				ID:    dockerEntityID,
+				Image: "datadog/docker-dd-agent:latest5",
+				Name:  "dd-agent",
+			},
+		},
 		Phase: "Running",
 	}
 	dockerContainerSpec := kubelet.Spec{
@@ -115,6 +122,18 @@ func TestParsePods(t *testing.T) {
 				Name:  "filter",
 			},
 		},
+		AllContainers: []kubelet.ContainerStatus{
+			{
+				ID:    dockerEntityID,
+				Image: "datadog/docker-dd-agent:latest5",
+				Name:  "dd-agent",
+			},
+			{
+				ID:    dockerEntityID2,
+				Image: "datadog/docker-filter:latest",
+				Name:  "filter",
+			},
+		},
 		Phase: "Pending",
 	}
 	dockerTwoContainersSpec := kubelet.Spec{
@@ -133,6 +152,13 @@ func TestParsePods(t *testing.T) {
 	dockerEntityIDCassandra := "container_id://6eaa4782de428f5ea639e33a837ed47aa9fa9e6969f8cb23e39ff788a751ce7d"
 	dockerContainerStatusCassandra := kubelet.Status{
 		Containers: []kubelet.ContainerStatus{
+			{
+				ID:    dockerEntityIDCassandra,
+				Image: "gcr.io/google-samples/cassandra:v13",
+				Name:  "cassandra",
+			},
+		},
+		AllContainers: []kubelet.ContainerStatus{
 			{
 				ID:    dockerEntityIDCassandra,
 				Image: "gcr.io/google-samples/cassandra:v13",
@@ -184,6 +210,13 @@ func TestParsePods(t *testing.T) {
 	criEntityID := "container_id://acbe44ff07525934cab9bf7c38c6627d64fd0952d8e6b87535d57092bfa6e9d1"
 	criContainerStatus := kubelet.Status{
 		Containers: []kubelet.ContainerStatus{
+			{
+				ID:    criEntityID,
+				Image: "sha256:0f006d265944c984e05200fab1c14ac54163cbcd4e8ae0ba3b35eb46fc559823",
+				Name:  "redis-master",
+			},
+		},
+		AllContainers: []kubelet.ContainerStatus{
 			{
 				ID:    criEntityID,
 				Image: "sha256:0f006d265944c984e05200fab1c14ac54163cbcd4e8ae0ba3b35eb46fc559823",

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -193,6 +193,10 @@ func (ku *KubeUtil) GetLocalPodList() ([]*Pod, error) {
 	tmpSlice := make([]*Pod, 0, len(pods.Items))
 	for _, pod := range pods.Items {
 		if pod != nil {
+			allContainers := make([]ContainerStatus, 0, len(pod.Status.InitContainers)+len(pod.Status.Containers))
+			allContainers = append(allContainers, pod.Status.InitContainers...)
+			allContainers = append(allContainers, pod.Status.Containers...)
+			pod.Status.AllContainers = allContainers
 			tmpSlice = append(tmpSlice, pod)
 		}
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet_common_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common_test.go
@@ -49,6 +49,12 @@ func loadPodsFixture(path string) ([]*Pod, error) {
 	if err != nil {
 		return nil, err
 	}
+	for _, pod := range podList.Items {
+		allContainers := make([]ContainerStatus, 0, len(pod.Status.InitContainers)+len(pod.Status.Containers))
+		allContainers = append(allContainers, pod.Status.InitContainers...)
+		allContainers = append(allContainers, pod.Status.Containers...)
+		pod.Status.AllContainers = allContainers
+	}
 	return podList.Items, nil
 }
 

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -813,7 +813,8 @@ func TestGetStatusForContainerID(t *testing.T) {
 			},
 		},
 		Status: Status{
-			Containers: []ContainerStatus{containerFoo, containerBar},
+			Containers:    []ContainerStatus{containerFoo, containerBar},
+			AllContainers: []ContainerStatus{containerFoo, containerBar},
 		},
 	}
 

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -69,8 +69,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChanges() {
 
 	// A new container ID in an existing pod should trigger
 	remainingPods[0].Status.Containers[0].ID = "testNewID"
-	// we're modifying the container list here, we need to reset the lazy all containers list
-	remainingPods[0].Status.AllContainers = []ContainerStatus{}
+	remainingPods[0].Status.AllContainers[0].ID = "testNewID"
 	changes, err = watcher.computeChanges(remainingPods)
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), changes, 1)

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -105,10 +105,6 @@ type Status struct {
 // GetAllContainers returns the list of init and regular containers
 // the list is created lazily assuming container statuses are not modified
 func (s *Status) GetAllContainers() []ContainerStatus {
-	if len(s.AllContainers) > 0 {
-		return s.AllContainers
-	}
-	s.AllContainers = append(s.InitContainers, s.Containers...)
 	return s.AllContainers
 }
 

--- a/releasenotes/notes/fix-kubelet-panic-f99149eb00b1d59a.yaml
+++ b/releasenotes/notes/fix-kubelet-panic-f99149eb00b1d59a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix random panic in Kubelet searchPodForContainerID due to concurrent modification of pod.Status.AllContainers


### PR DESCRIPTION
### What does this PR do?

Fix a panic due to concurrent calls to `searchPodForContainerID`

Remove lazy computation as it would require a lock, which is not practical to put in place as `Status` is a plain struct (issues with copying the lock).

Pre-computing it when generating Pod list. We're already going through the Pod list to remove `nil` Pods, so no overhead for core agent (`GetAllContainers` was always called at least once), minor overhead for other agents.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Not easy to reproduce. On a large-ish cluster, you can consider that not having a panic in `searchPodForContainerID` for 2 days means the fix is working.