### PR TITLE
[runtime-security] Fix rule tags load, copy ruleDef.Tags to secl.Rule

### DIFF
--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -152,9 +152,15 @@ func (rs *RuleSet) AddRule(ruleDef *RuleDefinition) (*eval.Rule, error) {
 		return nil, fmt.Errorf("found multiple definition of the rule '%s'", ruleDef.ID)
 	}
 
+	var tags []string
+	for k, v := range ruleDef.Tags {
+		tags = append(tags, k+":"+v)
+	}
+
 	rule := &eval.Rule{
 		ID:         ruleDef.ID,
 		Expression: ruleDef.Expression,
+		Tags:       tags,
 	}
 
 	if err := rule.Parse(); err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR fixes custom tags report. Without this patch rules tags are not sent to the backend. This PR copy ruleDef.Tags to secl.Rule.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Add custom tags in the policy file and check that the tags are properly reported in the backend
