### PR TITLE
[jmxfetch] Fix standalone jmx collect command

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -148,6 +148,10 @@ func runJmxCommandConsole(command string) error {
 		fmt.Printf("Cannot initialize command: %v\n", err)
 		return err
 	}
+	err = config.SetupJMXLogger(jmxLoggerName, logLevel, "", "", false, true, false)
+	if err != nil {
+		return fmt.Errorf("Unable to set up JMX logger: %v", err)
+	}
 
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 

--- a/cmd/agent/app/standalone/jmx.go
+++ b/cmd/agent/app/standalone/jmx.go
@@ -24,7 +24,7 @@ import (
 // reports with the ConsoleReporter to the agent's `log.Info`.
 // The common utils, including AutoConfig, must have already been initialized.
 func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel string) error {
-	return execJmxCommand(command, selectedChecks, jmxfetch.ReporterConsole, log.Info, logLevel)
+	return execJmxCommand(command, selectedChecks, jmxfetch.ReporterConsole, log.JMXInfo, logLevel)
 }
 
 // ExecJmxListWithMetricsJSON runs the JMX command with "with-metrics", reporting


### PR DESCRIPTION
### What does this PR do?

Fix `agent jmx collect` command that was broken by #5671
because jmxfetch logger was not initialised in this context
and error logging from jmxfetch were crashing the agent process.

### Motivation

Fix `agent jmx collect` command.

### Additional Notes

N/A

### Describe your test plan

Run `agent jmx collect` in a situation were error log are emitted
(having a broken jmxfetch.jar is enought) and also check that
info logs are still working.