### PR TITLE
[forwarder] fix endpoint url building when using the additional endpoints feature.

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -340,12 +340,12 @@ func (f *DefaultForwarder) createPriorityHTTPTransactions(endpoint endpoint, pay
 	for _, payload := range payloads {
 		for domain, apiKeys := range f.keysPerDomains {
 			for _, apiKey := range apiKeys {
-				if apiKeyInQueryString {
-					endpoint.route = fmt.Sprintf("%s?api_key=%s", endpoint.route, apiKey)
-				}
 				t := NewHTTPTransaction()
 				t.Domain = domain
 				t.Endpoint = endpoint
+				if apiKeyInQueryString {
+					t.Endpoint.route = fmt.Sprintf("%s?api_key=%s", endpoint.route, apiKey)
+				}
 				t.Payload = payload
 				t.priority = priority
 				t.Headers.Set(apiHTTPHeaderKey, apiKey)


### PR DESCRIPTION
Writing the value in the `endpoint.route` was appending several apikeys in this string when the additional endpoints feature is used.

This PR is directly using the newly created endpoint to set the generated route, not modifying the one given in a parameter.

An unit test has also been added.

### Additional Notes

Fix of a bug introduced by #6491 which has not been shipped in any stable version yet.

### Describe your test plan

Use the additional endpoints feature and validate that URLs used to send data to the intake are correct.
