### PR TITLE
autodiscovery: avoid double-discovery & double-reporting

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -577,7 +577,12 @@ func GetResolveWarnings() map[string][]string {
 // processNewService takes a service, tries to match it against templates and
 // triggers scheduling events if it finds a valid config for it.
 func (ac *AutoConfig) processNewService(svc listeners.Service) {
-	// in any case, register the service and store its tag hash
+	// Remove any old service for this entity.
+	if old := ac.store.getServiceForEntity(svc.GetEntity()); old != nil {
+		ac.processDelService(old)
+	}
+
+	// Register the service and store its tag hash
 	ac.store.setServiceForEntity(svc, svc.GetEntity())
 	ac.store.setTagsHashForService(
 		svc.GetTaggerEntity(),


### PR DESCRIPTION
### What does this PR do?

The existing implementation of kubelet autodiscovery permits discovering
the same container in a pod more than once. This can happen if a pod
containing multiple containers is performing autodiscovery based on
container A and observes a restart of container B within the same pod.

Pods are autodiscovered based on the implementation in
pkg/util/kubernetes/kubelet/podwatcher.go#computeChanges. If any
container restarts, receiving a new container.ID, the pod is returned.
Inside autodiscovery/listeners/kubelet.go, every container within that
pod that is not pending is autodiscovered. In our case, container B is
restarted, so any service on A or B is respawned.

Inside pkg/autodiscovery/autoconfig.go, the new service is handled by
scheduling all integrations that are autodiscovered based on the
autodiscovered attributes.

In no place (podwatcher, listener/kubelet.go, or
autodiscovery/autoconfig.go) is there deduplication with or deleting of
the previous configuration for the service on the entity.

This is different from the handling inside checkTagFreshness, where the
previous service configuration is deleted before reconfiguring a
service.

This behavior appears to be an oversight. The effect of this is that we
observe multiple instances of checks spawned by the kubelet listener for
the same exact pod if a different container restarts. These create
multiple datapoints per 15 second check interval, which corrupts all
measured counts in that pod.

### Motivation

Our throughput metrics were incorrectly reported for our service mesh. I debugged it down to incorrect handling of container restarts on proxy version 7.22.0.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- I tested this patch on our internal infrastructure. I was able to confirm the fix.