### PR TITLE
When upgrading from the NPM beta to 7.24 (which doesn't include npm),

### DIFF
--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -887,6 +887,7 @@ int verifyServices(CustomActionData& data)
     // Get a handle to the SCM database. 
 #ifdef __REGISTER_ALL_SERVICES
   #define NUM_SERVICES 4
+  #define SYSPROBE_INDEX 3
     serviceDef services[NUM_SERVICES] = {
         serviceDef(agentService.c_str(), L"Datadog Agent", L"Send metrics to Datadog",
                    agent_exe.c_str(),
@@ -934,6 +935,16 @@ int verifyServices(CustomActionData& data)
         if (retval != 0) {
             WcaLog(LOGMSG_STANDARD, "Failed to verify service %d %d 0x%x, rolling back", i, retval, retval);
             break;
+        }
+    }
+    if(!data.installSysprobe()) {
+        retval = services[SYSPROBE_INDEX].destroy(hScManager);
+        if(0 == retval) {
+            WcaLog(LOGMSG_STANDARD, "Removed system probe service");
+        } else if ( ERROR_SERVICE_DOES_NOT_EXIST == retval ) {
+            WcaLog(LOGMSG_STANDARD, "system probe not present");
+        } else {
+            WcaLog(LOGMSG_STANDARD, "Error removing system probe service %d", retval);
         }
     }
     WcaLog(LOGMSG_STANDARD, "done updating services");


### PR DESCRIPTION
upgrade was leaving a service configured, pointing to a binary that no
longer exists.


A brief description of the change being made with this pull request.

### Motivation

Leave a clean machine when upgrading

