### PR TITLE
[config] Log dogstatsd_mapper_profiles parsing issue from env as an error

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -357,7 +357,7 @@ func InitConfig(config Config) {
 	config.SetEnvKeyTransformer("dogstatsd_mapper_profiles", func(in string) interface{} {
 		var mappings []MappingProfile
 		if err := json.Unmarshal([]byte(in), &mappings); err != nil {
-			log.Warnf(`"dogstatsd_mapper_profiles" can not be parsed: %v`, err)
+			log.Errorf(`"dogstatsd_mapper_profiles" can not be parsed: %v`, err)
 		}
 		return mappings
 	})


### PR DESCRIPTION
### What does this PR do?
Log `dogstatsd_mapper_profiles` parsing issue from env as an error.
It's now consistent with parsing from yaml file errors.

### Motivation
Behaviour consistency when reading config from yaml & env var.
Reflect the proper severity for a significant config error.

### Additional Notes
N/A

### Describe your test plan
Check that config error are logged with the correct severity.