### PR TITLE
[aggregator] Fix flushed value when 2 identical values are submitted

### DIFF
--- a/pkg/metrics/monotonic_count.go
+++ b/pkg/metrics/monotonic_count.go
@@ -44,7 +44,7 @@ func (mc *MonotonicCount) addSample(sample *MetricSample, timestamp float64) {
 	// To handle cases where the samples are not monotonically increasing, we always add the difference
 	// between 2 consecutive samples to the value that'll be flushed (if the difference is >0).
 	diff := mc.currentSample - mc.previousSample
-	if (mc.hasPreviousSample || mc.flushFirstValue) && diff > 0. {
+	if (mc.hasPreviousSample || mc.flushFirstValue) && diff >= 0. {
 		mc.value += diff
 	} else if mc.flushFirstValue {
 		mc.value = mc.currentSample

--- a/pkg/metrics/monotonic_count_test.go
+++ b/pkg/metrics/monotonic_count_test.go
@@ -60,13 +60,22 @@ func TestMonotonicCountSampling(t *testing.T) {
 		assert.EqualValues(t, 80, series[0].Points[0].Ts)
 	}
 
-	// Add another sample with lower value: flush 0.
-	monotonicCount.addSample(&MetricSample{Value: 9}, 81)
+	// Add another sample with same value: flush 0.
+	monotonicCount.addSample(&MetricSample{Value: 11}, 81)
 	series, err = monotonicCount.flush(82)
 	assert.Nil(t, err)
 	if assert.Len(t, series, 1) && assert.Len(t, series[0].Points, 1) {
 		assert.Equal(t, 0., series[0].Points[0].Value)
 		assert.EqualValues(t, 82, series[0].Points[0].Ts)
+	}
+
+	// Add another sample with lower value: flush 0.
+	monotonicCount.addSample(&MetricSample{Value: 9}, 83)
+	series, err = monotonicCount.flush(84)
+	assert.Nil(t, err)
+	if assert.Len(t, series, 1) && assert.Len(t, series[0].Points, 1) {
+		assert.Equal(t, 0., series[0].Points[0].Value)
+		assert.EqualValues(t, 84, series[0].Points[0].Ts)
 	}
 
 	// Add sequence of non-monotonic samples
@@ -124,6 +133,14 @@ func TestMonotonicCount_FlushFirstValue(t *testing.T) {
 			true,
 			false,
 			2.,
+		},
+		{
+			"1: Flush after another sample with the same value and FlushFirstValue enabled: flush 0",
+			&monotonicCount1,
+			10.,
+			true,
+			false,
+			0.,
 		},
 		{
 			"1: Flush after another sample with a lower value and FlushFirstValue disabled: flush 0",


### PR DESCRIPTION
### What does this PR do?

On MonotonicCount, fix flushed value when 2 identical values are submitted: in this case, it should flush `0` (instead of the submitted value).

This was always the case with `FlushFirstValue` left to `false` (default), this PR fixes it when `FlushFirstValue` is set to `true`.

### Motivation

Fixes bug in implementation of https://github.com/DataDog/datadog-agent/pull/6663. Affects openmetrics-based checks since `openmetrics` uses `flush_first_value` since https://github.com/DataDog/integrations-core/pull/7904.

### Describe your test plan

* Added unit tests covering this.
* Bug is reproducible on the QA env (internal agent telemetry, see `ntp` check runs metric)