### PR TITLE
[logging] Fix logger initialization

### DIFF
--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -105,6 +105,7 @@ func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, sys
 		return err
 	}
 	loggerInterface, err := GenerateLoggerInterface(seelogConfig)
+	_ = seelog.ReplaceLogger(loggerInterface)
 	log.SetupLogger(loggerInterface, seelogLogLevel)
 	log.AddStrippedKeys(Datadog.GetStringSlice("flare_stripped_keys"))
 	return err

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -43,6 +43,7 @@ type DatadogLogger struct {
 
 // SetupLogger setup agent wide logger
 func SetupLogger(i seelog.LoggerInterface, level string) {
+	seelog.ReplaceLogger(i)
 	logger = setupCommonLogger(i, level)
 }
 

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -43,7 +43,7 @@ type DatadogLogger struct {
 
 // SetupLogger setup agent wide logger
 func SetupLogger(i seelog.LoggerInterface, level string) {
-	seelog.ReplaceLogger(i)
+	_ = seelog.ReplaceLogger(i)
 	logger = setupCommonLogger(i, level)
 }
 

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -43,7 +43,6 @@ type DatadogLogger struct {
 
 // SetupLogger setup agent wide logger
 func SetupLogger(i seelog.LoggerInterface, level string) {
-	_ = seelog.ReplaceLogger(i)
 	logger = setupCommonLogger(i, level)
 }
 


### PR DESCRIPTION
### What does this PR do?
Fix logger initialization (for 3rd party lib).
Was broken by #5671.

### Motivation
Fix flooging that's happening with trace log level
from gopsutil.

### Additional Notes
At runtime broken build can be set back on previous behaviour
by using `agent config set log_level <log_level>` because the
missing call will be called (https://github.com/DataDog/datadog-agent/blob/master/pkg/config/log.go#L456)

### Describe your test plan
QA on env that exhibited the issue and ensure it's gone.