### PR TITLE
[runtime-security] Preset resolvers of event zero to avoid race

### DIFF
--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -274,13 +274,11 @@ var eventZero Event
 
 func (p *Probe) zeroEvent() *Event {
 	*p.event = eventZero
-	p.event.resolvers = p.resolvers
 	return p.event
 }
 
 func (p *Probe) zeroMountEvent() *Event {
 	*p.mountEvent = eventZero
-	p.event.resolvers = p.resolvers
 	return p.mountEvent
 }
 
@@ -625,6 +623,8 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 		return nil, err
 	}
 
+	eventZero.resolvers = p.resolvers
+
 	return p, nil
 }
 
@@ -672,7 +672,7 @@ func filenameDiscarderWrapper(eventType EventType, fnc onDiscarderFnc, getter in
 				return nil
 			}
 
-			isDiscarded, err := discardParentInode(probe, rs, eventType, field, filename, mountID, inode, pathID)
+			isDiscarded, _, parentInode, err := discardParentInode(probe, rs, eventType, field, filename, mountID, inode, pathID)
 			if !isDiscarded && !isDeleted {
 				if _, ok := err.(*ErrInvalidKeyPath); !ok {
 					log.Tracef("apply `%s.filename` inode discarder for event `%s`, inode: %d", eventType, eventType, inode)
@@ -685,7 +685,7 @@ func filenameDiscarderWrapper(eventType EventType, fnc onDiscarderFnc, getter in
 			}
 
 			if err != nil {
-				err = errors.Wrapf(err, "unable to set inode discarders for `%s` for event `%s`", filename, eventType)
+				err = errors.Wrapf(err, "unable to set inode discarders for `%s` for event `%s`, inode: %d", filename, eventType, parentInode)
 			}
 
 			return err

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -9,6 +9,7 @@ package tests
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -140,7 +141,10 @@ func TestOpenParentDiscarderFilter(t *testing.T) {
 	defer os.Remove(testFile1)
 
 	if _, err := waitForOpenDiscarder(test, testFile1); err != nil {
-		t.Fatal(err)
+		inode := getInode(t, testFile1)
+		parentInode := getInode(t, path.Dir(testFile1))
+
+		t.Fatalf("not able to get the expected event inode: %d, parent inode: %d", inode, parentInode)
 	}
 
 	fd2, testFile2, err := openTestFile(test, "test-obd-2", syscall.O_CREAT|syscall.O_SYNC)


### PR DESCRIPTION
### What does this PR do?

Currently there is a race between Clone call in tests and the zeroing and the set of the resolvers. This PR preset the resolvers to avoid the race.

### Motivation

Some CI tests where failing with a stack trace due to nil pointer.

### Additional Notes

Improve a bit the log in case of error for filter tests.

### Describe your test plan

Functional tests triggered the issue, with this fix we shouldn't see any stack trace
