### PR TITLE
Collect system-wide context switches

### DIFF
--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -101,9 +101,7 @@ func (c *CPUCheck) readCtxSwitches() (ctxSwitches int64, err error) {
 	for scanner.Scan() {
 		txt := scanner.Text()
 		if strings.HasPrefix(txt, "ctxt") {
-			fmt.Printf("LINE = %s\n", txt)
 			elemts := strings.Split(txt, " ")
-			fmt.Printf("ELEMTS = %v\n", elemts)
 			ctxSwitches, err = strconv.ParseInt(elemts[1], 10, 64)
 			if err != nil {
 				return 0, err

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -38,10 +38,11 @@ func (c *CPUCheck) Run() error {
 		return err
 	}
 
-	err = c.collectCtxSwitches()
+	err = c.collectCtxSwitches(sender)
 	if err != nil {
-		log.Warnf("system.CPUCheck could not read context switches: %s", err.Error())
-		return err
+		log.Debugf("system.CPUCheck could not read context switches: %s", err.Error())
+		// Don't return here, we still want to collect the CPU metrics even if we could not
+		// read the context switches
 	}
 
 	cpuTimes, err := times(false)

--- a/pkg/collector/corechecks/system/cpu_ctx_switches.go
+++ b/pkg/collector/corechecks/system/cpu_ctx_switches.go
@@ -1,8 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
 // +build !linux
 
 package system
 
-func (c *CPUCheck) collectCtxSwitches() error {
+import "github.com/DataDog/datadog-agent/pkg/aggregator"
+
+func (c *CPUCheck) collectCtxSwitches(sender aggregator.Sender) error {
 	// On non-linux systems, do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/cpu_ctx_switches.go
+++ b/pkg/collector/corechecks/system/cpu_ctx_switches.go
@@ -1,0 +1,8 @@
+// +build !linux
+
+package system
+
+func (c *CPUCheck) collectCtxSwitches() error {
+	// On non-linux systems, do nothing
+	return nil
+}

--- a/pkg/collector/corechecks/system/cpu_ctx_switches_linux.go
+++ b/pkg/collector/corechecks/system/cpu_ctx_switches_linux.go
@@ -1,0 +1,37 @@
+// +build linux
+
+package system
+
+func readCtxSwitches(procStatPath string) (ctxSwitches int64, err error) {
+	file, err := os.Open(procStatPath)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		txt := scanner.Text()
+		if strings.HasPrefix(txt, "ctxt") {
+			elemts := strings.Split(txt, " ")
+			ctxSwitches, err = strconv.ParseInt(elemts[1], 10, 64)
+			if err != nil {
+				return 0, err
+			}
+			return ctxSwitches, nil
+		}
+	}
+
+	return 0, fmt.Errorf("could not find the context switches in stat file")
+}
+
+func (c *CPUCheck) collectCtxSwitches() error {
+	// TODO: Make me configurable
+	ctxSwitches, err := readCtxSwitches("/proc/stat")
+	if err != nil {
+		log.Warnf("system.CPUCheck could not read context switches: %s", err.Error())
+		return err
+	}
+	sender.MonotonicCount("system.linux.context_switches", float64(ctxSwitches), "", nil)
+	return nil
+}

--- a/pkg/collector/corechecks/system/cpu_ctx_switches_linux.go
+++ b/pkg/collector/corechecks/system/cpu_ctx_switches_linux.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -44,7 +45,7 @@ func (c *CPUCheck) collectCtxSwitches(sender aggregator.Sender) error {
 	if config.Datadog.IsSet("procfs_path") {
 		procfsPath = config.Datadog.GetString("procfs_path")
 	}
-	ctxSwitches, err := readCtxSwitches(procfsPath + "/stat")
+	ctxSwitches, err := readCtxSwitches(filepath.Join(procfsPath, "/stat"))
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu_ctx_switches_linux.go
+++ b/pkg/collector/corechecks/system/cpu_ctx_switches_linux.go
@@ -24,13 +24,13 @@ func readCtxSwitches(procStatPath string) (ctxSwitches int64, err error) {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
+	for i := 0; scanner.Scan(); i++ {
 		txt := scanner.Text()
 		if strings.HasPrefix(txt, "ctxt") {
 			elemts := strings.Split(txt, " ")
 			ctxSwitches, err = strconv.ParseInt(elemts[1], 10, 64)
 			if err != nil {
-				return 0, err
+				return 0, fmt.Errorf("%s in '%s' at line %d", err, procStatPath, i)
 			}
 			return ctxSwitches, nil
 		}

--- a/pkg/collector/corechecks/system/cpu_ctx_switches_linux.go
+++ b/pkg/collector/corechecks/system/cpu_ctx_switches_linux.go
@@ -2,6 +2,14 @@
 
 package system
 
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
 func readCtxSwitches(procStatPath string) (ctxSwitches int64, err error) {
 	file, err := os.Open(procStatPath)
 	if err != nil {

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/shirou/gopsutil/cpu"
+	"github.com/stretchr/testify/mock"
 )
 
 var (
@@ -79,42 +80,42 @@ func TestCPUCheckLinux(t *testing.T) {
 	cpuCheck := new(CPUCheck)
 	cpuCheck.Configure(nil, nil, "test")
 
-	mock := mocksender.NewMockSender(cpuCheck.ID())
-	mock.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	m := mocksender.NewMockSender(cpuCheck.ID())
+	m.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
 	if runtime.GOOS == "linux" {
-		mock.On(metrics.MonotonicCountType.String(), "system.cpu.context_switches", 3, "", []string(nil)).Return().Times(1)
+		m.On(metrics.MonotonicCountType.String(), "system.cpu.context_switches", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
 	}
 
-	mock.On("Commit").Return().Times(1)
+	m.On("Commit").Return().Times(1)
 
 	sample = firstSample
 	cpuCheck.Run()
 
-	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, metrics.GaugeType.String(), 1)
+	m.AssertExpectations(t)
+	m.AssertNumberOfCalls(t, metrics.GaugeType.String(), 1)
 	if runtime.GOOS == "linux" {
-		mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
+		m.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
 	}
-	mock.AssertNumberOfCalls(t, "Commit", 1)
+	m.AssertNumberOfCalls(t, "Commit", 1)
 
 	sample = secondSample
-	mock.On(metrics.GaugeType.String(), "system.cpu.user", 0.1913803067769472, "", []string(nil)).Return().Times(1)
-	mock.On(metrics.GaugeType.String(), "system.cpu.system", 5.026101621048045, "", []string(nil)).Return().Times(1)
-	mock.On(metrics.GaugeType.String(), "system.cpu.iowait", 0.03789709045088063, "", []string(nil)).Return().Times(1)
-	mock.On(metrics.GaugeType.String(), "system.cpu.idle", 94.74272612720159, "", []string(nil)).Return().Times(1)
-	mock.On(metrics.GaugeType.String(), "system.cpu.stolen", 0.0018948545225440318, "", []string(nil)).Return().Times(1)
-	mock.On(metrics.GaugeType.String(), "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
-	mock.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.user", 0.1913803067769472, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.system", 5.026101621048045, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.iowait", 0.03789709045088063, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.idle", 94.74272612720159, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.stolen", 0.0018948545225440318, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
 	if runtime.GOOS == "linux" {
-		mock.On(metrics.MonotonicCountType.String(), "system.cpu.context_switches", 32768, "", []string(nil)).Return().Times(1)
+		m.On(metrics.MonotonicCountType.String(), "system.cpu.context_switches", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
 	}
-	mock.On("Commit").Return().Times(1)
+	m.On("Commit").Return().Times(1)
 	cpuCheck.Run()
 
-	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, metrics.GaugeType.String(), 8)
+	m.AssertExpectations(t)
+	m.AssertNumberOfCalls(t, metrics.GaugeType.String(), 8)
 	if runtime.GOOS == "linux" {
-		mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
+		m.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
 	}
-	mock.AssertNumberOfCalls(t, "Commit", 2)
+	m.AssertNumberOfCalls(t, "Commit", 2)
 }

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -115,7 +115,7 @@ func TestCPUCheckLinux(t *testing.T) {
 	m.AssertExpectations(t)
 	m.AssertNumberOfCalls(t, metrics.GaugeType.String(), 8)
 	if runtime.GOOS == "linux" {
-		m.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
+		m.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 2)
 	}
 	m.AssertNumberOfCalls(t, "Commit", 2)
 }

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -81,7 +81,7 @@ func TestCPUCheckLinux(t *testing.T) {
 
 	mock := mocksender.NewMockSender(cpuCheck.ID())
 	mock.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
-	if (runtime.GOOS == "linux") {
+	if runtime.GOOS == "linux" {
 		mock.On(metrics.MonotonicCountType.String(), "system.cpu.context_switches", 3, "", []string(nil)).Return().Times(1)
 	}
 
@@ -92,7 +92,7 @@ func TestCPUCheckLinux(t *testing.T) {
 
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, metrics.GaugeType.String(), 1)
-	if (runtime.GOOS == "linux") {
+	if runtime.GOOS == "linux" {
 		mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
 	}
 	mock.AssertNumberOfCalls(t, "Commit", 1)
@@ -105,7 +105,7 @@ func TestCPUCheckLinux(t *testing.T) {
 	mock.On(metrics.GaugeType.String(), "system.cpu.stolen", 0.0018948545225440318, "", []string(nil)).Return().Times(1)
 	mock.On(metrics.GaugeType.String(), "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
 	mock.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
-	if (runtime.GOOS == "linux") {
+	if runtime.GOOS == "linux" {
 		mock.On(metrics.MonotonicCountType.String(), "system.cpu.context_switches", 32768, "", []string(nil)).Return().Times(1)
 	}
 	mock.On("Commit").Return().Times(1)
@@ -113,7 +113,7 @@ func TestCPUCheckLinux(t *testing.T) {
 
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, metrics.GaugeType.String(), 8)
-	if (runtime.GOOS == "linux") {
+	if runtime.GOOS == "linux" {
 		mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
 	}
 	mock.AssertNumberOfCalls(t, "Commit", 2)

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -79,7 +79,8 @@ func TestCPUCheckLinux(t *testing.T) {
 	cpuCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(cpuCheck.ID())
-	mock.On("Gauge", "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.MonotonicCountType.String(), "system.cpu.ctx_switches", 3, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)
 
 	sample = firstSample
@@ -87,6 +88,7 @@ func TestCPUCheckLinux(t *testing.T) {
 
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, metrics.GaugeType.String(), 1)
+	mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 
 	sample = secondSample

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -8,7 +8,7 @@ package system
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"golang.org/x/tools/go/ssa/interp/testdata/src/runtime"
+	"runtime"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -8,6 +8,7 @@ package system
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"golang.org/x/tools/go/ssa/interp/testdata/src/runtime"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -80,7 +81,10 @@ func TestCPUCheckLinux(t *testing.T) {
 
 	mock := mocksender.NewMockSender(cpuCheck.ID())
 	mock.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
-	mock.On(metrics.MonotonicCountType.String(), "system.cpu.ctx_switches", 3, "", []string(nil)).Return().Times(1)
+	if (runtime.GOOS == "linux") {
+		mock.On(metrics.MonotonicCountType.String(), "system.cpu.context_switches", 3, "", []string(nil)).Return().Times(1)
+	}
+
 	mock.On("Commit").Return().Times(1)
 
 	sample = firstSample
@@ -88,7 +92,9 @@ func TestCPUCheckLinux(t *testing.T) {
 
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, metrics.GaugeType.String(), 1)
-	mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
+	if (runtime.GOOS == "linux") {
+		mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
+	}
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 
 	sample = secondSample
@@ -99,12 +105,16 @@ func TestCPUCheckLinux(t *testing.T) {
 	mock.On(metrics.GaugeType.String(), "system.cpu.stolen", 0.0018948545225440318, "", []string(nil)).Return().Times(1)
 	mock.On(metrics.GaugeType.String(), "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
 	mock.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
-	mock.On(metrics.MonotonicCountType.String(), "system.cpu.ctx_switches", 32768, "", []string(nil)).Return().Times(1)
+	if (runtime.GOOS == "linux") {
+		mock.On(metrics.MonotonicCountType.String(), "system.cpu.context_switches", 32768, "", []string(nil)).Return().Times(1)
+	}
 	mock.On("Commit").Return().Times(1)
 	cpuCheck.Run()
 
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, metrics.GaugeType.String(), 8)
-	mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
+	if (runtime.GOOS == "linux") {
+		mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
+	}
 	mock.AssertNumberOfCalls(t, "Commit", 2)
 }

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -7,6 +7,7 @@
 package system
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -85,21 +86,23 @@ func TestCPUCheckLinux(t *testing.T) {
 	cpuCheck.Run()
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 1)
+	mock.AssertNumberOfCalls(t, metrics.GaugeType.String(), 1)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 
 	sample = secondSample
-	mock.On("Gauge", "system.cpu.user", 0.1913803067769472, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.cpu.system", 5.026101621048045, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.cpu.iowait", 0.03789709045088063, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.cpu.idle", 94.74272612720159, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.cpu.stolen", 0.0018948545225440318, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.GaugeType.String(), "system.cpu.user", 0.1913803067769472, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.GaugeType.String(), "system.cpu.system", 5.026101621048045, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.GaugeType.String(), "system.cpu.iowait", 0.03789709045088063, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.GaugeType.String(), "system.cpu.idle", 94.74272612720159, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.GaugeType.String(), "system.cpu.stolen", 0.0018948545225440318, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.GaugeType.String(), "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	mock.On(metrics.MonotonicCountType.String(), "system.cpu.ctx_switches", 32768, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)
 	cpuCheck.Run()
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 8)
+	mock.AssertNumberOfCalls(t, metrics.GaugeType.String(), 8)
+	mock.AssertNumberOfCalls(t, metrics.MonotonicCountType.String(), 1)
 	mock.AssertNumberOfCalls(t, "Commit", 2)
 }

--- a/releasenotes/notes/system_wide_ctx_switches-8785fb458ac869a1.yaml
+++ b/releasenotes/notes/system_wide_ctx_switches-8785fb458ac869a1.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    The CPU check now collect system-wide context switches on Linux.

--- a/releasenotes/notes/system_wide_ctx_switches-8785fb458ac869a1.yaml
+++ b/releasenotes/notes/system_wide_ctx_switches-8785fb458ac869a1.yaml
@@ -1,3 +1,3 @@
 enhancements:
   - |
-    The CPU check now collect system-wide context switches on Linux.
+    The CPU check now collects system-wide context switches on Linux.


### PR DESCRIPTION
### What does this PR do?

This PR adds support for collecting system-wide context switches count from the CPU check.

### Motivation

Not many people know about the `linux_proc_extras` integration (which collects this metric).
Having that metric collected by a core Go check makes sense for distributions of the Agent without Python (IoT Agent).

### Describe your test plan

1. Run the check on an IoT Agent and check in Datadog that the metric `system.cpu.context_switches` is correctly reported.
2. Update `procfs_path` in `datadog.yaml` to an invalid path, and set log level to debug. Run the Agent and ensure that it reports the invalid path as debug, e.g.:
`2020-11-06 18:54:42 CET | CORE | DEBUG | (pkg/collector/corechecks/system/cpu.go:43 in Run) | system.CPUCheck could not read context switches: open /toto/stat: no such file or directory`
The metric `system.cpu.context_switches` should not be visible in Datadog, but the CPU check **should still report metrics.**
3. Create a file on the filesystem, say `/test/stat` with the content of `/proc/stat`. Edit that file to introduce an error (letter, invalid character etc...) on the same line of `ctxt 1234567890` (for example `ctxt x1234567890`). Point `procfs_path` to that file and check the DEBUG log. A log similar to this should appear:
`2020-11-10 15:41:22 CET | CORE | DEBUG | (pkg/collector/corechecks/system/cpu.go:43 in Run) | system.CPUCheck could not read context switches: strconv.ParseInt: parsing "x1057989461": invalid syntax in '/test/stat' at line 6`
The metrics for the CPU *should still* appear in Datadog.