### PR TITLE
Reduce allocations in windows system-probe to reduce CPU usage

### DIFF
--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -423,7 +423,7 @@ func (t *Tracer) storeClosedConn(cs network.ConnectionStats) {
 
 	atomic.AddInt64(&t.closedConns, 1)
 	cs.IPTranslation = t.conntracker.GetTranslationForConn(cs)
-	t.state.StoreClosedConnection(cs)
+	t.state.StoreClosedConnection(&cs)
 	if cs.IPTranslation != nil {
 		t.conntracker.DeleteTranslation(cs)
 	}

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -3,7 +3,6 @@
 package ebpf
 
 import (
-	"bytes"
 	"expvar"
 	"fmt"
 	"math"
@@ -77,7 +76,7 @@ type Tracer struct {
 	bufferLock sync.Mutex
 
 	// Internal buffer used to compute bytekeys
-	buf *bytes.Buffer
+	buf [network.ConnectionByteKeyMaxLen]byte
 
 	// Connections for the tracer to blacklist
 	sourceExcludes []*network.ConnectionFilter
@@ -237,7 +236,6 @@ func NewTracer(config *Config) (*Tracer, error) {
 		udpPortMapping: udpPortMapping,
 		reverseDNS:     reverseDNS,
 		buffer:         make([]network.ConnectionStats, 0, 512),
-		buf:            &bytes.Buffer{},
 		conntracker:    conntracker,
 		sourceExcludes: network.ParseConnectionFilters(config.ExcludedSourceConnections),
 		destExcludes:   network.ParseConnectionFilters(config.ExcludedDestinationConnections),

--- a/pkg/ebpf/tracer_windows.go
+++ b/pkg/ebpf/tracer_windows.go
@@ -150,10 +150,8 @@ func (t *Tracer) GetStats() (map[string]interface{}, error) {
 
 	return map[string]interface{}{
 		"state":                    stateStats,
-		"total_flows":              driverStats["total_flows"],
-		"open_flows":               driverStats["open_flows"],
-		"closed_flows":             driverStats["closed_flows"],
-		"more_data_errors":         driverStats["more_data_errors"],
+		"flows":                    driverStats["flows"],
+		"driver":                   driverStats["driver"],
 		"driver_total_flow_stats":  driverStats["driver_total_flow_stats"],
 		"driver_flow_handle_stats": driverStats["driver_flow_handle_stats"],
 	}, nil

--- a/pkg/ebpf/tracer_windows.go
+++ b/pkg/ebpf/tracer_windows.go
@@ -130,7 +130,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	}
 
 	for _, connStat := range closedConnStats {
-		t.state.StoreClosedConnection(connStat)
+		t.state.StoreClosedConnection(&connStat)
 	}
 
 	// check for expired clients in the state

--- a/pkg/network/driver_buffer.go
+++ b/pkg/network/driver_buffer.go
@@ -6,18 +6,20 @@ import "math"
 
 const minBufferSize = 256
 
-type driverBuffer struct {
+// DriverBuffer encapsulates a resizing buffer for providing ConnectionStat pointers
+// to read from the windows driver
+type DriverBuffer struct {
 	buf []ConnectionStats
 	off int
 }
 
-func newDriverBuffer(size int) *driverBuffer {
-	return &driverBuffer{
+func NewDriverBuffer(size int) *DriverBuffer {
+	return &DriverBuffer{
 		buf: make([]ConnectionStats, int(math.Max(float64(size), minBufferSize))),
 	}
 }
 
-func (d *driverBuffer) Next() *ConnectionStats {
+func (d *DriverBuffer) Next() *ConnectionStats {
 	// double size of buffer if necessary
 	if d.off >= len(d.buf) {
 		d.buf = append(d.buf, make([]ConnectionStats, len(d.buf))...)
@@ -27,11 +29,15 @@ func (d *driverBuffer) Next() *ConnectionStats {
 	return c
 }
 
-func (d *driverBuffer) Connections() []ConnectionStats {
+func (d *DriverBuffer) Connections() []ConnectionStats {
 	return d.buf[:d.off]
 }
 
-func (d *driverBuffer) Reset() {
+func (d *DriverBuffer) Len() int {
+	return d.off
+}
+
+func (d *DriverBuffer) Reset() {
 	// shrink buffer if less than half used
 	half := len(d.buf) / 2
 	if d.off <= half && half >= minBufferSize {

--- a/pkg/network/driver_buffer.go
+++ b/pkg/network/driver_buffer.go
@@ -1,0 +1,41 @@
+// +build windows
+
+package network
+
+import "math"
+
+const minBufferSize = 256
+
+type driverBuffer struct {
+	buf []ConnectionStats
+	off int
+}
+
+func newDriverBuffer(size int) *driverBuffer {
+	return &driverBuffer{
+		buf: make([]ConnectionStats, int(math.Max(float64(size), minBufferSize))),
+	}
+}
+
+func (d *driverBuffer) Next() *ConnectionStats {
+	// double size of buffer if necessary
+	if d.off >= len(d.buf) {
+		d.buf = append(d.buf, make([]ConnectionStats, len(d.buf))...)
+	}
+	c := &d.buf[d.off]
+	d.off++
+	return c
+}
+
+func (d *driverBuffer) Connections() []ConnectionStats {
+	return d.buf[:d.off]
+}
+
+func (d *driverBuffer) Reset() {
+	// shrink buffer if less than half used
+	half := len(d.buf) / 2
+	if d.off <= half && half >= minBufferSize {
+		d.buf = make([]ConnectionStats, half)
+	}
+	d.off = 0
+}

--- a/pkg/network/driver_buffer.go
+++ b/pkg/network/driver_buffer.go
@@ -13,12 +13,15 @@ type DriverBuffer struct {
 	off int
 }
 
+// NewDriverBuffer creates a DriverBuffer with initial size `size`.
 func NewDriverBuffer(size int) *DriverBuffer {
 	return &DriverBuffer{
 		buf: make([]ConnectionStats, int(math.Max(float64(size), minBufferSize))),
 	}
 }
 
+// Next returns the next `ConnectionStats` object available for writing.
+// It will resize the internal buffer if necessary.
 func (d *DriverBuffer) Next() *ConnectionStats {
 	// double size of buffer if necessary
 	if d.off >= len(d.buf) {
@@ -29,14 +32,18 @@ func (d *DriverBuffer) Next() *ConnectionStats {
 	return c
 }
 
+// Connections returns a slice of all the `ConnectionStats` objects returned via `Next`
+// since the last `Reset`.
 func (d *DriverBuffer) Connections() []ConnectionStats {
 	return d.buf[:d.off]
 }
 
+// Len returns the count of the number of written `ConnectionStats` objects since last `Reset`.
 func (d *DriverBuffer) Len() int {
 	return d.off
 }
 
+// Reset returns the written object count back to zero. It may resize the internal buffer based on past usage.
 func (d *DriverBuffer) Reset() {
 	// shrink buffer if less than half used
 	half := len(d.buf) / 2

--- a/pkg/network/encoding/json.go
+++ b/pkg/network/encoding/json.go
@@ -20,9 +20,15 @@ func (j jsonSerializer) Marshal(conns *network.Connections) ([]byte, error) {
 	for i, conn := range conns.Conns {
 		agentConns[i] = FormatConnection(conn)
 	}
-	payload := &model.Connections{Conns: agentConns, Dns: FormatDNS(conns.DNS), Telemetry: FormatTelemetry(conns.Telemetry)}
+
+	payload := connsPool.Get().(*model.Connections)
+	payload.Conns = agentConns
+	payload.Dns = FormatDNS(conns.DNS)
+	payload.Telemetry = FormatTelemetry(conns.Telemetry)
+
 	writer := new(bytes.Buffer)
 	err := j.marshaller.Marshal(writer, payload)
+	returnToPool(payload)
 	return writer.Bytes(), err
 }
 

--- a/pkg/network/encoding/protobuf.go
+++ b/pkg/network/encoding/protobuf.go
@@ -18,13 +18,14 @@ func (protoSerializer) Marshal(conns *network.Connections) ([]byte, error) {
 		agentConns[i] = FormatConnection(conn)
 	}
 
-	payload := &model.Connections{
-		Conns:     agentConns,
-		Dns:       FormatDNS(conns.DNS),
-		Telemetry: FormatTelemetry(conns.Telemetry),
-	}
+	payload := connsPool.Get().(*model.Connections)
+	payload.Conns = agentConns
+	payload.Dns = FormatDNS(conns.DNS)
+	payload.Telemetry = FormatTelemetry(conns.Telemetry)
 
-	return proto.Marshal(payload)
+	buf, err := proto.Marshal(payload)
+	returnToPool(payload)
+	return buf, err
 }
 
 func (protoSerializer) Unmarshal(blob []byte) (*model.Connections, error) {

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -157,7 +157,7 @@ type IPTranslation struct {
 }
 
 func (c ConnectionStats) String() string {
-	return ConnectionSummary(c, nil)
+	return ConnectionSummary(&c, nil)
 }
 
 // ByteKey returns a unique key for this connection represented as a byte array
@@ -233,7 +233,7 @@ func BeautifyKey(key string) string {
 }
 
 // ConnectionSummary returns a string summarizing a connection
-func ConnectionSummary(c ConnectionStats, names map[util.Address][]string) string {
+func ConnectionSummary(c *ConnectionStats, names map[util.Address][]string) string {
 	str := fmt.Sprintf(
 		"[%s] [PID: %d] [%v:%d ⇄ %v:%d] (%s) %s sent (+%s), %s received (+%s)",
 		c.Type,

--- a/pkg/network/event_test.go
+++ b/pkg/network/event_test.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"testing"
@@ -27,7 +26,7 @@ var (
 )
 
 func TestBeautifyKey(t *testing.T) {
-	buf := &bytes.Buffer{}
+	var buf [ConnectionByteKeyMaxLen]byte
 	for _, c := range []ConnectionStats{
 		testConn,
 		{
@@ -58,7 +57,7 @@ func TestBeautifyKey(t *testing.T) {
 }
 
 func TestConnStatsByteKey(t *testing.T) {
-	buf := new(bytes.Buffer)
+	var buf [ConnectionByteKeyMaxLen]byte
 	addrA := util.AddressFromString("127.0.0.1")
 	addrB := util.AddressFromString("127.0.0.2")
 

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -100,7 +100,7 @@ func monotonicOrTransportBytes(useMonotonicCounts bool, monotonic C.uint64_t, tr
 }
 
 // FlowToConnStat converts a C.struct__perFlowData into a ConnectionStats struct for use with the tracer
-func FlowToConnStat(flow *C.struct__perFlowData, enableMonotonicCounts bool) ConnectionStats {
+func FlowToConnStat(cs *ConnectionStats, flow *C.struct__perFlowData, enableMonotonicCounts bool) {
 	var (
 		family         ConnectionFamily
 		srcAddr        util.Address
@@ -118,23 +118,42 @@ func FlowToConnStat(flow *C.struct__perFlowData, enableMonotonicCounts bool) Con
 		srcAddr, dstAddr = convertV6Addr(flow.localAddress), convertV6Addr(flow.remoteAddress)
 	}
 
-	cs := ConnectionStats{
-		Source: srcAddr,
-		Dest:   dstAddr,
-		// after lengthy discussion, use the transport bytes in/out.  monotonic
-		// RecvBytes/SentBytes includes the size of the IP header and transport
-		// header, transportBytes is the raw transport data.  At present,
-		// the linux probe only reports the raw transport data.  So do that by default.
-		MonotonicSentBytes: monotonicOrTransportBytes(enableMonotonicCounts, flow.monotonicSentBytes, flow.transportBytesOut),
-		MonotonicRecvBytes: monotonicOrTransportBytes(enableMonotonicCounts, flow.monotonicRecvBytes, flow.transportBytesIn),
-		LastUpdateEpoch:    uint64(flow.timestamp),
-		Pid:                uint32(flow.processId),
-		SPort:              uint16(flow.localPort),
-		DPort:              uint16(flow.remotePort),
-		Type:               connectionType,
-		Family:             family,
-		Direction:          connDirection(flow.flags),
-	}
+	cs.Source = srcAddr
+	cs.Dest = dstAddr
+	// after lengthy discussion, use the transport bytes in/out.  monotonic
+	// RecvBytes/SentBytes includes the size of the IP header and transport
+	// header, transportBytes is the raw transport data.  At present,
+	// the linux probe only reports the raw transport data.  So do that by default.
+	cs.MonotonicSentBytes = monotonicOrTransportBytes(enableMonotonicCounts, flow.monotonicSentBytes, flow.transportBytesOut)
+	cs.MonotonicRecvBytes = monotonicOrTransportBytes(enableMonotonicCounts, flow.monotonicRecvBytes, flow.transportBytesIn)
+	cs.LastUpdateEpoch = uint64(flow.timestamp)
+	cs.Pid = uint32(flow.processId)
+	cs.SPort = uint16(flow.localPort)
+	cs.DPort = uint16(flow.remotePort)
+	cs.Type = connectionType
+	cs.Family = family
+	cs.Direction = connDirection(flow.flags)
+
+	// reset other fields to default values
+	cs.NetNS = 0
+	cs.IPTranslation = nil
+	cs.IntraHost = false
+	cs.DNSSuccessfulResponses = 0
+	cs.DNSFailedResponses = 0
+	cs.DNSTimeouts = 0
+	cs.DNSSuccessLatencySum = 0
+	cs.DNSFailureLatencySum = 0
+	cs.DNSCountByRcode = make(map[uint32]uint32)
+	cs.LastSentBytes = 0
+	cs.LastRecvBytes = 0
+	cs.MonotonicRetransmits = 0
+	cs.LastRetransmits = 0
+	cs.MonotonicTCPEstablished = 0
+	cs.LastTCPEstablished = 0
+	cs.MonotonicTCPClosed = 0
+	cs.LastTCPClosed = 0
+	cs.RTT = 0
+	cs.RTTVar = 0
 
 	if connectionType == TCP {
 		cs.MonotonicRetransmits = uint32(C.getTcp_retransmitCount(flow))
@@ -148,5 +167,4 @@ func FlowToConnStat(flow *C.struct__perFlowData, enableMonotonicCounts bool) Con
 			cs.MonotonicTCPClosed = 1
 		}
 	}
-	return cs
 }

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -143,7 +143,7 @@ func FlowToConnStat(cs *ConnectionStats, flow *C.struct__perFlowData, enableMono
 	cs.DNSTimeouts = 0
 	cs.DNSSuccessLatencySum = 0
 	cs.DNSFailureLatencySum = 0
-	cs.DNSCountByRcode = make(map[uint32]uint32)
+	cs.DNSCountByRcode = nil
 	cs.LastSentBytes = 0
 	cs.LastRecvBytes = 0
 	cs.MonotonicRetransmits = 0

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -81,12 +81,12 @@ func isTCPFlowEstablished(flags C.uint32_t) bool {
 
 func convertV4Addr(addr [16]C.uint8_t) util.Address {
 	// We only read the first 4 bytes for v4 address
-	return util.V4AddressFromBytes(C.GoBytes(unsafe.Pointer(&addr), net.IPv4len))
+	return util.V4AddressFromBytes((*[16]byte)(unsafe.Pointer(&addr))[:net.IPv4len])
 }
 
 func convertV6Addr(addr [16]C.uint8_t) util.Address {
 	// We read all 16 bytes for v6 address
-	return util.V6AddressFromBytes(C.GoBytes(unsafe.Pointer(&addr), net.IPv6len))
+	return util.V4AddressFromBytes((*[16]byte)(unsafe.Pointer(&addr))[:net.IPv6len])
 }
 
 // Monotonic values include retransmits and headers, while transport does not. We default to using transport

--- a/pkg/network/nettop/main.go
+++ b/pkg/network/nettop/main.go
@@ -46,7 +46,7 @@ func main() {
 			fmt.Println(err)
 		}
 		for _, c := range cs.Conns {
-			fmt.Println(network.ConnectionSummary(c, cs.DNS))
+			fmt.Println(network.ConnectionSummary(&c, cs.DNS))
 		}
 	}
 

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"bytes"
 	"sync"
 	"time"
 
@@ -22,6 +21,9 @@ const (
 	// We could have used layers.DNSResponseCodeNoErr here. But importing the gopacket library only for this
 	// constant is not worth the increased memory cost.
 	DNSResponseCodeNoError = 0
+
+	// ConnectionByteKeyMaxLen represents the maximum size in bytes of a connection byte key
+	ConnectionByteKeyMaxLen = 41
 )
 
 // State takes care of handling the logic for:
@@ -87,7 +89,7 @@ type networkState struct {
 	clients   map[string]*client
 	telemetry telemetry
 
-	buf             *bytes.Buffer // Shared buffer
+	buf             [ConnectionByteKeyMaxLen]byte // Shared buffer
 	latestTimeEpoch uint64
 
 	// Network state configuration
@@ -106,7 +108,6 @@ func NewState(clientExpiry time.Duration, maxClosedConns, maxClientStats int, ma
 		maxClosedConns: maxClosedConns,
 		maxClientStats: maxClientStats,
 		maxDNSStats:    maxDNSStats,
-		buf:            &bytes.Buffer{},
 	}
 }
 
@@ -229,7 +230,7 @@ func (ns *networkState) addDNSStats(id string, conns []ConnectionStats) {
 }
 
 // getConnsByKey returns a mapping of byte-key -> connection for easier access + manipulation
-func getConnsByKey(conns []ConnectionStats, buf *bytes.Buffer) map[string]*ConnectionStats {
+func getConnsByKey(conns []ConnectionStats, buf [ConnectionByteKeyMaxLen]byte) map[string]*ConnectionStats {
 	connsByKey := make(map[string]*ConnectionStats, len(conns))
 	for i, c := range conns {
 		key, err := c.ByteKey(buf)

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -564,7 +564,6 @@ func (ns *networkState) DumpState(clientID string) map[string]interface{} {
 }
 
 func (ns *networkState) determineConnectionIntraHost(connections []ConnectionStats) {
-
 	type connKey struct {
 		Address util.Address
 		Port    uint16
@@ -588,20 +587,18 @@ func (ns *networkState) determineConnectionIntraHost(connections []ConnectionSta
 		return key
 	}
 
-	lAddrs := make(map[connKey]struct{})
+	lAddrs := make(map[connKey]struct{}, len(connections))
 	for _, conn := range connections {
 		lAddrs[newConnKey(&conn, false)] = struct{}{}
 	}
 
-	for i := range connections {
-		conn := &connections[i]
-		keyWithRAddr := newConnKey(conn, true)
-
+	for _, conn := range connections {
 		if conn.Source == conn.Dest || (conn.Source.IsLoopback() && conn.Dest.IsLoopback()) {
 			conn.IntraHost = true
 			continue
 		}
 
+		keyWithRAddr := newConnKey(&conn, true)
 		_, ok := lAddrs[keyWithRAddr]
 		if ok {
 			conn.IntraHost = true

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -37,7 +37,7 @@ type State interface {
 	) []ConnectionStats
 
 	// StoreClosedConnection stores a new closed connection
-	StoreClosedConnection(conn ConnectionStats)
+	StoreClosedConnection(conn *ConnectionStats)
 
 	// RemoveClient stops tracking stateful data for a given client
 	RemoveClient(clientID string)
@@ -243,7 +243,7 @@ func getConnsByKey(conns []ConnectionStats, buf *bytes.Buffer) map[string]*Conne
 }
 
 // StoreClosedConnection stores the given connection for every client
-func (ns *networkState) StoreClosedConnection(conn ConnectionStats) {
+func (ns *networkState) StoreClosedConnection(conn *ConnectionStats) {
 	ns.Lock()
 	defer ns.Unlock()
 
@@ -275,7 +275,7 @@ func (ns *networkState) StoreClosedConnection(conn ConnectionStats) {
 			ns.telemetry.closedConnDropped++
 			continue
 		} else {
-			client.closedConnections[string(key)] = conn
+			client.closedConnections[string(key)] = *conn
 		}
 	}
 }

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -593,13 +593,15 @@ func (ns *networkState) determineConnectionIntraHost(connections []ConnectionSta
 		lAddrs[newConnKey(&conn, false)] = struct{}{}
 	}
 
-	for _, conn := range connections {
+	// do not use range value here since it will create a copy of the ConnectionStats object
+	for i := range connections {
+		conn := &connections[i]
 		if conn.Source == conn.Dest || (conn.Source.IsLoopback() && conn.Dest.IsLoopback()) {
 			conn.IntraHost = true
 			continue
 		}
 
-		keyWithRAddr := newConnKey(&conn, true)
+		keyWithRAddr := newConnKey(conn, true)
 		_, ok := lAddrs[keyWithRAddr]
 		if ok {
 			conn.IntraHost = true

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -43,7 +43,7 @@ func BenchmarkStoreClosedConnection(b *testing.B) {
 
 			for n := 0; n < b.N; n++ {
 				for _, c := range conns[:bench.connCount] {
-					ns.StoreClosedConnection(c)
+					ns.StoreClosedConnection(&c)
 				}
 			}
 		})
@@ -114,7 +114,7 @@ func BenchmarkConnectionsGet(b *testing.B) {
 			ns.Connections(DEBUGCLIENT, latestTime, nil, nil)
 
 			for _, c := range closed[:bench.closedCount] {
-				ns.StoreClosedConnection(c)
+				ns.StoreClosedConnection(&c)
 			}
 
 			b.ResetTimer()
@@ -186,7 +186,7 @@ func TestRetrieveClosedConnection(t *testing.T) {
 
 	t.Run("without prior registration", func(t *testing.T) {
 		state := newDefaultState()
-		state.StoreClosedConnection(conn)
+		state.StoreClosedConnection(&conn)
 		conns := state.Connections(clientID, latestEpochTime(), nil, nil)
 
 		assert.Equal(t, 0, len(conns))
@@ -198,7 +198,7 @@ func TestRetrieveClosedConnection(t *testing.T) {
 		conns := state.Connections(clientID, latestEpochTime(), nil, nil)
 		assert.Equal(t, 0, len(conns))
 
-		state.StoreClosedConnection(conn)
+		state.StoreClosedConnection(&conn)
 
 		conns = state.Connections(clientID, latestEpochTime(), nil, nil)
 		assert.Equal(t, 1, len(conns))
@@ -359,7 +359,7 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 	assert.Equal(t, conn.MonotonicRecvBytes, conns[0].MonotonicRecvBytes)
 	assert.Equal(t, conn.MonotonicRetransmits, conns[0].MonotonicRetransmits)
 
-	state.StoreClosedConnection(conn2)
+	state.StoreClosedConnection(&conn2)
 
 	// We should have one connection with last stats
 	conns = state.Connections(clientID, latestEpochTime(), nil, nil)
@@ -456,7 +456,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
-		state.StoreClosedConnection(conn)
+		state.StoreClosedConnection(&conn)
 
 		// Second get, we should have monotonic and last stats = 3
 		conns = state.Connections(client, latestEpochTime(), nil, nil)
@@ -485,13 +485,13 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
-		state.StoreClosedConnection(conn)
+		state.StoreClosedConnection(&conn)
 
 		conn2 := conn
 		conn2.MonotonicSentBytes = 5
 		conn2.LastUpdateEpoch++
 		// Store the connection another time
-		state.StoreClosedConnection(conn2)
+		state.StoreClosedConnection(&conn2)
 
 		// Second get, we should have monotonic and last stats = 8
 		conns = state.Connections(client, latestEpochTime(), nil, nil)
@@ -541,7 +541,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		// Store the connection as closed
 		conn.MonotonicSentBytes++
 		conn.LastUpdateEpoch = latestEpochTime()
-		state.StoreClosedConnection(conn)
+		state.StoreClosedConnection(&conn)
 
 		conn.MonotonicSentBytes = 1
 		conn.LastUpdateEpoch = latestEpochTime()
@@ -554,7 +554,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn.MonotonicSentBytes++
 		conn.LastUpdateEpoch = latestEpochTime()
 		// Store the connection as closed
-		state.StoreClosedConnection(conn)
+		state.StoreClosedConnection(&conn)
 
 		conns = state.Connections(client, latestEpochTime(), nil, nil)
 		require.Len(t, conns, 1)
@@ -584,7 +584,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
-		state.StoreClosedConnection(conn)
+		state.StoreClosedConnection(&conn)
 
 		conn2 := conn
 		conn2.MonotonicSentBytes = 2
@@ -601,7 +601,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		// Store the connection as closed
 		conn2.MonotonicSentBytes += 3
 		conn2.LastUpdateEpoch++
-		state.StoreClosedConnection(conn2)
+		state.StoreClosedConnection(&conn2)
 
 		// Store the connection again
 		conn3 := conn2
@@ -617,7 +617,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 
 		// Store the connection as closed
 		conn3.MonotonicSentBytes += 2
-		state.StoreClosedConnection(conn3)
+		state.StoreClosedConnection(&conn3)
 
 		// 4th get, we should have monotonic = 3 and last stats = 2
 		conns = state.Connections(client, latestEpochTime(), nil, nil)
@@ -657,7 +657,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		// Store the connection as closed
 		conn2 := conn
 		conn2.MonotonicSentBytes = 8
-		state.StoreClosedConnection(conn2)
+		state.StoreClosedConnection(&conn2)
 
 		// Second get, we should have monotonic = 8 and last stats = 5
 		conns = state.Connections(client, latestEpochTime(), nil, nil)
@@ -708,7 +708,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
-		state.StoreClosedConnection(conn)
+		state.StoreClosedConnection(&conn)
 
 		// Second get for client d we should have monotonic and last stats = 3
 		conns = state.Connections(clientD, latestEpochTime(), nil, nil)
@@ -742,7 +742,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		// Store the connection as closed
 		conn2.MonotonicSentBytes += 2
 		conn2.LastUpdateEpoch++
-		state.StoreClosedConnection(conn2)
+		state.StoreClosedConnection(&conn2)
 
 		// Store the connection again
 		conn3 := conn2
@@ -770,7 +770,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		// Store the connection as closed
 		conn3.MonotonicSentBytes++
 		conn3.LastUpdateEpoch++
-		state.StoreClosedConnection(conn3)
+		state.StoreClosedConnection(&conn3)
 
 		// 4th get, for client c we should have monotonic = 3 and last stats = 2
 		conns = state.Connections(client, latestEpochTime(), nil, nil)
@@ -852,7 +852,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		// Store the connection as closed
 		conn.MonotonicSentBytes++
 		conn.LastUpdateEpoch++
-		state.StoreClosedConnection(conn)
+		state.StoreClosedConnection(&conn)
 
 		// Second get for client d we should have monotonic and last stats = 3
 		conns = state.Connections(clientD, latestEpochTime(), nil, nil)
@@ -892,7 +892,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		// Store the connection as closed
 		conn2.MonotonicSentBytes += 2
 		conn2.LastUpdateEpoch++
-		state.StoreClosedConnection(conn2)
+		state.StoreClosedConnection(&conn2)
 
 		// 4th get, for client e we should have monotonic = 5 and last stats = 5
 		conns = state.Connections(clientE, latestEpochTime(), nil, nil)
@@ -1035,9 +1035,9 @@ func TestDoubleCloseOnTwoClients(t *testing.T) {
 	assert.Len(t, state.Connections(client2, latestEpochTime(), nil, nil), 0)
 
 	// Store the closed connection twice
-	state.StoreClosedConnection(conn)
+	state.StoreClosedConnection(&conn)
 	conn.LastUpdateEpoch++
-	state.StoreClosedConnection(conn)
+	state.StoreClosedConnection(&conn)
 
 	expectedConn.LastUpdateEpoch = conn.LastUpdateEpoch
 	// Get the connections for client1 we should have only one with stats = 2*conn
@@ -1072,7 +1072,7 @@ func TestUnorderedCloseEvent(t *testing.T) {
 	conn.LastUpdateEpoch = latestEpochTime() + 1
 	conn.MonotonicSentBytes++
 	conn.MonotonicRecvBytes = 1
-	state.StoreClosedConnection(conn)
+	state.StoreClosedConnection(&conn)
 
 	conn.LastUpdateEpoch--
 	conn.MonotonicSentBytes--
@@ -1090,7 +1090,7 @@ func TestUnorderedCloseEvent(t *testing.T) {
 	// Simulate having the connection getting active again
 	conn.LastUpdateEpoch = latestEpochTime()
 	conn.MonotonicSentBytes--
-	state.StoreClosedConnection(conn)
+	state.StoreClosedConnection(&conn)
 
 	conns = state.Connections(client, latestEpochTime(), nil, nil)
 	require.Len(t, conns, 1)
@@ -1121,13 +1121,13 @@ func TestAggregateClosedConnectionsTimestamp(t *testing.T) {
 	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil), 0)
 
 	conn.LastUpdateEpoch = latestEpochTime()
-	state.StoreClosedConnection(conn)
+	state.StoreClosedConnection(&conn)
 
 	conn.LastUpdateEpoch = latestEpochTime()
-	state.StoreClosedConnection(conn)
+	state.StoreClosedConnection(&conn)
 
 	conn.LastUpdateEpoch = latestEpochTime()
-	state.StoreClosedConnection(conn)
+	state.StoreClosedConnection(&conn)
 
 	// Make sure the connections we get has the latest timestamp
 	assert.Equal(t, conn.LastUpdateEpoch, state.Connections(client, latestEpochTime(), nil, nil)[0].LastUpdateEpoch)
@@ -1164,7 +1164,7 @@ func TestDNSStatsWithMultipleClients(t *testing.T) {
 	assert.Len(t, state.Connections(client2, latestEpochTime(), nil, nil), 0)
 
 	c.LastUpdateEpoch = latestEpochTime()
-	state.StoreClosedConnection(c)
+	state.StoreClosedConnection(&c)
 
 	conns := state.Connections(client1, latestEpochTime(), nil, getStats())
 	require.Len(t, conns, 1)
@@ -1206,11 +1206,11 @@ func TestDNSStatsPIDCollisions(t *testing.T) {
 	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil), 0)
 
 	c.LastUpdateEpoch = latestEpochTime()
-	state.StoreClosedConnection(c)
+	state.StoreClosedConnection(&c)
 
 	// Store another connection with same dnsKey but different PID
 	c.Pid++
-	state.StoreClosedConnection(c)
+	state.StoreClosedConnection(&c)
 
 	conns := state.Connections(client, latestEpochTime(), nil, stats)
 	require.Len(t, conns, 2)

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"math/rand"
@@ -145,7 +144,8 @@ func TestRemoveConnections(t *testing.T) {
 		IntraHost:            true,
 	}
 
-	key, err := conn.ByteKey(&bytes.Buffer{})
+	var buf [ConnectionByteKeyMaxLen]byte
+	key, err := conn.ByteKey(buf)
 	require.NoError(t, err)
 
 	clientID := "1"


### PR DESCRIPTION
### What does this PR do?

Reduces the number of allocations during the main driver->system-probe->process-agent pathway for connection information. This ultimately reduces the CPU usage.

### Motivation

Performance improvements for Windows system-probe.

