### PR TITLE
Fix the file and line number reported in logs

### DIFF
--- a/cmd/cluster-agent/klog.go
+++ b/cmd/cluster-agent/klog.go
@@ -47,15 +47,15 @@ func (l redirectLogger) Write(b []byte) (int, error) {
 
 	switch b[0] {
 	case 'I':
-		log.Info(msg)
+		log.InfoStackDepth(5, msg)
 	case 'W':
-		log.Warn(msg)
+		log.WarnStackDepth(5, msg)
 	case 'E':
-		log.Error(msg)
+		log.ErrorStackDepth(5, msg)
 	case 'F':
-		log.Critical(msg)
+		log.CriticalStackDepth(5, msg)
 	default:
-		log.Info(msg)
+		log.InfoStackDepth(5, msg)
 	}
 
 	return 0, nil

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -195,6 +195,21 @@ func (sw *DatadogLogger) info(s string) {
 	}
 }
 
+// info logs at the info level and the current stack depth plus the additional given one
+func (sw *DatadogLogger) infoStackDepth(s string, depth int) {
+	sw.l.Lock()
+	defer sw.l.Unlock()
+
+	scrubbed := sw.scrub(s)
+	sw.inner.SetAdditionalStackDepth(defaultStackDepth + depth) //nolint:errcheck
+	sw.inner.Info(scrubbed)
+	sw.inner.SetAdditionalStackDepth(defaultStackDepth) //nolint:errcheck
+
+	for _, l := range sw.extra {
+		l.Info(scrubbed) //nolint:errcheck
+	}
+}
+
 // warn logs at the warn level
 func (sw *DatadogLogger) warn(s string) error {
 	sw.l.Lock()
@@ -202,6 +217,23 @@ func (sw *DatadogLogger) warn(s string) error {
 
 	scrubbed := sw.scrub(s)
 	err := sw.inner.Warn(scrubbed)
+
+	for _, l := range sw.extra {
+		l.Warn(scrubbed) //nolint:errcheck
+	}
+
+	return err
+}
+
+// error logs at the error level and the current stack depth plus the additional given one
+func (sw *DatadogLogger) warnStackDepth(s string, depth int) error {
+	sw.l.Lock()
+	defer sw.l.Unlock()
+
+	scrubbed := sw.scrub(s)
+	sw.inner.SetAdditionalStackDepth(defaultStackDepth + depth) //nolint:errcheck
+	err := sw.inner.Warn(scrubbed)
+	sw.inner.SetAdditionalStackDepth(defaultStackDepth) //nolint:errcheck
 
 	for _, l := range sw.extra {
 		l.Warn(scrubbed) //nolint:errcheck
@@ -249,6 +281,23 @@ func (sw *DatadogLogger) critical(s string) error {
 
 	scrubbed := sw.scrub(s)
 	err := sw.inner.Critical(scrubbed)
+
+	for _, l := range sw.extra {
+		l.Critical(scrubbed) //nolint:errcheck
+	}
+
+	return err
+}
+
+// critical logs at the critical level and the current stack depth plus the additional given one
+func (sw *DatadogLogger) criticalStackDepth(s string, depth int) error {
+	sw.l.Lock()
+	defer sw.l.Unlock()
+
+	scrubbed := sw.scrub(s)
+	sw.inner.SetAdditionalStackDepth(defaultStackDepth + depth) //nolint:errcheck
+	err := sw.inner.Critical(scrubbed)
+	sw.inner.SetAdditionalStackDepth(defaultStackDepth) //nolint:errcheck
 
 	for _, l := range sw.extra {
 		l.Critical(scrubbed) //nolint:errcheck
@@ -511,10 +560,31 @@ func Criticalf(format string, params ...interface{}) error {
 	return logFormatWithError(seelog.CriticalLvl, func() { Criticalf(format, params...) }, logger.criticalf, format, true, params...)
 }
 
+// InfoStackDepth logs at the info level and the current stack depth plus the additional given one
+func InfoStackDepth(depth int, v ...interface{}) {
+	log(seelog.InfoLvl, func() { InfoStackDepth(depth, v...) }, func(s string) {
+		logger.infoStackDepth(s, depth)
+	}, v...)
+}
+
+// WarnStackDepth logs at the warn level and the current stack depth plus the additional given one and returns an error containing the formated log message
+func WarnStackDepth(depth int, v ...interface{}) error {
+	return logWithError(seelog.WarnLvl, func() { WarnStackDepth(depth, v...) }, func(s string) error {
+		return logger.warnStackDepth(s, depth)
+	}, false, v...)
+}
+
 // ErrorStackDepth logs at the error level and the current stack depth plus the additional given one and returns an error containing the formated log message
 func ErrorStackDepth(depth int, v ...interface{}) error {
 	return logWithError(seelog.ErrorLvl, func() { ErrorStackDepth(depth, v...) }, func(s string) error {
 		return logger.errorStackDepth(s, depth)
+	}, true, v...)
+}
+
+// CriticalStackDepth logs at the critical level and the current stack depth plus the additional given one and returns an error containing the formated log message
+func CriticalStackDepth(depth int, v ...interface{}) error {
+	return logWithError(seelog.CriticalLvl, func() { CriticalStackDepth(depth, v...) }, func(s string) error {
+		return logger.criticalStackDepth(s, depth)
 	}, true, v...)
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix the file and line number reported in logs

### Motivation

Prior to #6614, the DCA was producing logs like this:
```
E1029 17:02:20.829015       1 event.go:293] Could not construct reference to: '&v1.ConfigMap{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"datadog-leader-election", GenerateName:"", Namespace:"datadog-agent", SelfLink:"/api/v1/namespaces/datadog-agent/configmaps/datadog-leader-election", UID:"7b02925d-6734-11e9-8014-0a864aa02990", ResourceVersion:"6584986744", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63691777871, loc:(*time.Location)(0x40b4840)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string{"control-plane.alpha.kubernetes.io/leader":"{\"holderIdentity\":\"datadog-cluster-agent-6b447f9975-flnnh\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2020-10-29T17:02:20Z\",\"renewTime\":\"2020-10-29T17:02:20Z\",\"leaderTransitions\":431}"}, OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Data:map[string]string(nil), BinaryData:map[string][]uint8(nil)}' due to: 'no kind is registered for the type v1.ConfigMap in scheme "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:100"'. Will not report event: 'Normal' 'LeaderElection' 'datadog-cluster-agent-6b447f9975-flnnh became leader'
I1008 18:50:04.110779       1 serving.go:312] Generated self-signed cert (/etc/datadog-agent/certificates/apiserver.crt, /etc/datadog-agent/certificates/apiserver.key)
I1008 18:50:04.888375       1 secure_serving.go:123] Serving securely on 0.0.0.0:443
```

Those logs were not respecting the agent log format.
Thanks to #6614, those logs are now in the proper format:
```
2020-11-05 10:32:00 UTC | CLUSTER | ERROR | (klog.go:54 in Write) | Could not construct reference to: '&v1.ConfigMap{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"datadog-leader-election", GenerateName:"", Namespace:"datadog-agent-helm", SelfLink:"/api/v1/namespaces/datadog-agent-helm/configmaps/datadog-leader-election", UID:"f0e3e01a-606f-4524-821b-b4484051b881", ResourceVersion:"11561", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63740169120, loc:(*time.Location)(0x40ce280)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string{"control-plane.alpha.kubernetes.io/leader":"{\"holderIdentity\":\"datadog-agent-docker-cluster-agent-7bf785dc55-bvp69\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2020-11-05T10:32:00Z\",\"renewTime\":\"2020-11-05T10:32:00Z\",\"leaderTransitions\":1}"}, OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Data:map[string]string(nil), BinaryData:map[string][]uint8(nil)}' due to: 'no kind is registered for the type v1.ConfigMap in scheme "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:100"'. Will not report event: 'Normal' 'LeaderElection' 'datadog-agent-docker-cluster-agent-7bf785dc55-bvp69 became leader'
2020-11-05 10:32:01 UTC | CLUSTER | INFO | (klog.go:50 in Write) | Generated self-signed cert (/etc/datadog-agent/certificates/apiserver.crt, /etc/datadog-agent/certificates/apiserver.key)
2020-11-05 10:32:02 UTC | CLUSTER | INFO | (klog.go:50 in Write) | Serving securely on [::]:8443
```

But the file and line number that is reported (always `klog.go:50 in Write`) isn’t correct.

With this PR, the files and line numbers are now correct:
```
2020-11-06 09:05:52 UTC | CLUSTER | ERROR | (vendor/k8s.io/client-go/tools/record/event.go:293 in generateEvent) | Could not construct reference to: '&v1.ConfigMap{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"datadog-leader-election", GenerateName:"", Namespace:"datadog-agent-helm", SelfLink:"/api/v1/namespaces/datadog-agent-helm/configmaps/datadog-leader-election", UID:"f0e3e01a-606f-4524-821b-b4484051b881", ResourceVersion:"559186", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63740169120, loc:(*time.Location)(0x3fe9320)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string{"control-plane.alpha.kubernetes.io/leader":"{\"holderIdentity\":\"datadog-agent-docker-cluster-agent-8456fbf4b7-nvvp7\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2020-11-06T09:05:52Z\",\"renewTime\":\"2020-11-06T09:05:52Z\",\"leaderTransitions\":7}"}, OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Data:map[string]string(nil), BinaryData:map[string][]uint8(nil)}' due to: 'no kind is registered for the type v1.ConfigMap in scheme "pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:100"'. Will not report event: 'Normal' 'LeaderElection' 'datadog-agent-docker-cluster-agent-8456fbf4b7-nvvp7 became leader'
2020-11-06 09:05:37 UTC | CLUSTER | INFO | (vendor/k8s.io/apiserver/pkg/server/options/serving.go:312 in MaybeDefaultWithSelfSignedCerts) | Generated self-signed cert (/etc/datadog-agent/certificates/apiserver.crt, /etc/datadog-agent/certificates/apiserver.key)
2020-11-06 09:05:38 UTC | CLUSTER | INFO | (vendor/k8s.io/apiserver/pkg/server/secure_serving.go:123 in Serve) | Serving securely on [::]:8443
```

### Additional Notes

### Describe your test plan

Start the DCA, look for the above mentioned logs and check the file and line number.
