### PR TITLE
Fix nil pointer in containerd spec read

### DIFF
--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -219,11 +219,11 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 
 		ociSpec, err := cu.Spec(ctn)
 		if err != nil {
-			log.Errorf("Could not retrieve OCI Spec from: %s: %v", ctn.ID(), err)
+			log.Warnf("Could not retrieve OCI Spec from: %s: %v", ctn.ID(), err)
 		}
 
 		var cpuLimits *specs.LinuxCPU
-		if ociSpec.Linux != nil && ociSpec.Linux.Resources != nil {
+		if ociSpec != nil && ociSpec.Linux != nil && ociSpec.Linux.Resources != nil {
 			cpuLimits = ociSpec.Linux.Resources.CPU
 		}
 		computeCPU(sender, metrics.CPU, cpuLimits, info.CreatedAt, currentTime, tags)

--- a/releasenotes/notes/fix-containerd-panic-15d508acf9a70125.yaml
+++ b/releasenotes/notes/fix-containerd-panic-15d508acf9a70125.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a panic in containerd if retrieved ociSpec is nil


### PR DESCRIPTION
### What does this PR do?

Fix a panic when ociSpec cannot be retrieved from containerd.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Panic will happen regularly on large clusters at `containerd.go:226 +0x970`. A few days on a large cluster without occurence should validate the fix.