### PR TITLE
[orchestrator] fix status for additional endpoints

### DIFF
--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -49,13 +49,13 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 		status["ClusterName"] = clustername.GetClusterName(hostname)
 	}
 
-	// get orchestrator endpoints, check for old keys
-	orchestratorEndpoints := config.Datadog.GetString("orchestrator_explorer.orchestrator_additional_endpoints")
-	orchestratorEndpointsOldKey := config.Datadog.GetString("process_config.orchestrator_additional_endpoints")
-	if orchestratorEndpointsOldKey != "" {
-		status["OrchestratorAdditionalEndpoints"] = orchestratorEndpointsOldKey
-	} else if orchestratorEndpoints != "" {
-		status["OrchestratorAdditionalEndpoints"] = orchestratorEndpoints
+	// get orchestrator endpoints, check for old keys, looks like this: map[endpoints] = apikey
+	newKey := "orchestrator_explorer.orchestrator_additional_endpoints"
+	oldKey := "process_config.orchestrator_additional_endpoints"
+	if config.Datadog.IsSet(newKey) {
+		status["OrchestratorAdditionalEndpoints"] = config.Datadog.GetStringMapStringSlice(newKey)
+	} else if config.Datadog.IsSet(oldKey) {
+		status["OrchestratorAdditionalEndpoints"] = config.Datadog.GetStringMapStringSlice(oldKey)
 	}
 
 	orchestratorEndpoint := config.Datadog.GetString("orchestrator_explorer.orchestrator_dd_url")

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -34,7 +34,10 @@ Orchestrator Explorer
     OrchestratorEndpoint: {{.OrchestratorEndpoint}}
 {{- end }}
 {{- if .OrchestratorAdditionalEndpoints }}
-    OrchestratorAdditionalEndpoints: {{.OrchestratorAdditionalEndpoints}}
+    {{ range $key, $value := .OrchestratorAdditionalEndpoints }}OrchestratorAdditionalEndpoint: {{$key}}
+    {{/* this line intentionally left blank */}}
+    {{- end }}
+
 {{- end }}
 
   ===============


### PR DESCRIPTION
### What does this PR do?

fix endpoint output of status.

with additional settings
```
=====================
Orchestrator Explorer
=====================
  ClusterID: dd70405a-9502-4144-9b35-2a4004da56ce
  ClusterName: nammnnammnnammnnammnnammnnammnnammnnammnnammnnam
  ContainerScrubbing: Enabled
  ======================
  Orchestrator Endpoints
  ======================
    OrchestratorEndpoint: https://orchestrator.datadoghq.com
    OrchestratorAdditionalEndpoint: https://orchestrator.datad0g.com
    OrchestratorAdditionalEndpoint: https://orchestrator.datadoghq.com


  ===============
  Forwarder Stats
  ===============
```

not with additional settings
```
  Orchestrator Endpoints
  ======================
    OrchestratorEndpoint: https://orchestrator.datadoghq.com

  ===============
  Forwarder Stats
  ===============
    Pods: 0
```

### Motivation
double shipping can lead to error in status output/log
```
2020-11-06 10:40:37 UTC | CLUSTER | WARN | (pkg/config/viper.go:99 in GetString) | failed to get configuration value for key "process_config.orchestrator_additional_endpoints": unable to cast map[string]interface {}{"https://orchestrator.datad0g.com.":[]interface {}{"***************************b0053"}, "https://orchestrator.datadoghq.com.":[]interface {}{"***************************6c5b4"}} of type map[string]interface {} to string
```
### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
