### PR TITLE
[runtime-security] Fix resolved mount points for non-overlayfs filesystem

### DIFF
--- a/pkg/security/probe/mount.go
+++ b/pkg/security/probe/mount.go
@@ -155,6 +155,15 @@ func (mr *MountResolver) Insert(e MountEvent) {
 }
 
 func (mr *MountResolver) insert(e MountEvent) {
+	// Retrieve the parent paths and strip it from the event
+	p, ok := mr.mounts[e.ParentMountID]
+	if ok {
+		prefix := mr.getParentPath(p.MountID)
+		if len(prefix) > 0 && prefix != "/" {
+			e.MountPointStr = strings.TrimPrefix(e.MountPointStr, prefix)
+		}
+	}
+
 	mounts := mr.devices[e.Device]
 	if mounts == nil {
 		mounts = make(map[uint32]*MountEvent)
@@ -236,7 +245,7 @@ func (mr *MountResolver) GetMountPath(mountID uint32) (string, string, string, e
 		ref = ancestor
 	}
 
-	return mr.getOverlayPath(ref), mount.MountPointStr, mount.RootStr, nil
+	return mr.getOverlayPath(ref), mr.getParentPath(mountID), mount.RootStr, nil
 }
 
 // NewMountResolver instantiates a new mount resolver

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -8,13 +8,13 @@
 package tests
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"os"
-	"strings"
+	"path"
 	"syscall"
 	"testing"
 	"time"
-
-	"github.com/DataDog/datadog-agent/pkg/security/rules"
+	"unsafe"
 )
 
 func TestMount(t *testing.T) {
@@ -23,20 +23,26 @@ func TestMount(t *testing.T) {
 		Expression: `utimes.filename == "{{.Root}}/test-mount"`,
 	}
 
-	test, err := newTestProbe(nil, []*rules.RuleDefinition{rule}, testOpts{})
+	testDrive, err := newTestDrive("ext4", []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	test, err := newTestProbe(nil, []*rules.RuleDefinition{rule}, testOpts{testDir: testDrive.Root()})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer test.Close()
 
-	mntPath, _, err := test.Path("test-mount")
+	mntPath, _, err := testDrive.Path("test-mount")
 	if err != nil {
 		t.Fatal(err)
 	}
 	os.MkdirAll(mntPath, 0755)
 	defer os.RemoveAll(mntPath)
 
-	dstMntPath, _, err := test.Path("test-dest-mount")
+	dstMntBasename := "test-dest-mount"
+	dstMntPath, _, err := testDrive.Path(dstMntBasename)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,10 +64,8 @@ func TestMount(t *testing.T) {
 				t.Errorf("expected mount event, got %s", event.GetType())
 			}
 
-			p := event.Mount.MountPointStr
-			p = strings.Replace(p, "/tmp", "", 1)
-			if p != strings.Replace(dstMntPath, "/tmp", "", 1) {
-				t.Errorf("expected %v for ParentPathStr, got %v", mntPath, p)
+			if event.Mount.MountPointStr != "/"+dstMntBasename {
+				t.Errorf("expected %v for ParentPathStr, got %v", dstMntPath, event.Mount.MountPointStr)
 			}
 
 			// use accessor to parse properly the mount type
@@ -69,6 +73,45 @@ func TestMount(t *testing.T) {
 				t.Errorf("expected a bind mount, got %v", fs)
 			}
 			mntID = event.Mount.MountID
+		}
+	})
+
+	t.Run("mount_resolver", func(t *testing.T) {
+		utimFile, utimFilePtr, err := testDrive.Path(path.Join(dstMntBasename, "test-utime"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		f, err := os.Create(utimFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(utimFile)
+
+		utimbuf := &syscall.Utimbuf{
+			Actime:  123,
+			Modtime: 456,
+		}
+
+		if _, _, errno := syscall.Syscall(syscall.SYS_UTIME, uintptr(utimFilePtr), uintptr(unsafe.Pointer(utimbuf)), 0); errno != 0 {
+			t.Fatal(errno)
+		}
+
+		event, err := test.GetEvent(3*time.Second, "utimes")
+		if err != nil {
+			t.Error(err)
+		} else {
+			if event.GetType() != "utimes" {
+				t.Errorf("expected utimes event, got %s", event.GetType())
+			}
+
+			if event.Utimes.PathnameStr != utimFile {
+				t.Errorf("expected %v for PathnameStr, got %v", utimFile, event.Utimes.PathnameStr)
+			}
 		}
 	})
 

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -42,6 +42,10 @@ func (td *testDrive) Path(filename string) (string, unsafe.Pointer, error) {
 }
 
 func newTestDrive(fsType string, mountOpts []string) (*testDrive, error) {
+	return newTestDriveWithMountPoint(fsType, mountOpts, "")
+}
+
+func newTestDriveWithMountPoint(fsType string, mountOpts []string, mountPoint string) (*testDrive, error) {
 	backingFile, err := ioutil.TempFile("", "secagent-testdrive-")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create testdrive backing file")
@@ -51,10 +55,12 @@ func newTestDrive(fsType string, mountOpts []string) (*testDrive, error) {
 		return nil, errors.Wrap(err, "failed to close testdrive backing file")
 	}
 
-	mountPoint, err := ioutil.TempDir("", "secagent-testdrive-")
-	if err != nil {
-		os.Remove(backingFile.Name())
-		return nil, errors.Wrap(err, "failed to create testdrive mount point")
+	if len(mountPoint) == 0 {
+		mountPoint, err = ioutil.TempDir("", "secagent-testdrive-")
+		if err != nil {
+			os.Remove(backingFile.Name())
+			return nil, errors.Wrap(err, "failed to create testdrive mount point")
+		}
 	}
 
 	if err := os.Truncate(backingFile.Name(), 1*1024*1024); err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR trims the `MountPointStr` path of `MountEvents` so that they contain their relative paths to their immediate parent, regardless of what generated the event (the snapshot or an eBPF probe).

### Motivation

The mount resolver is currently struggling to resolve nested mount points that are not part of a container path. This is only true for mount points dynamically detected by our mount probes as the mount points resolved in the snapshot seem to work properly. The underlying issue is caused by the fact that the snapshot emits `MountEvents` with fully resolved `MountPointStr` paths. However the dynamically generated `MountEvents` contain relative paths to the immediate parent of the mount point.

### Additional Notes

We might improve the `MountResolver` to compute the resolved paths (container path + `MountPointStr`) when a `MountEvent` is inserted, instead of resolving those paths at runtime on evaluation. This change might be introduced in 7.25, but for now we want to introduce as little new code as possible to fix 7.24.

### Describe your test plan

`TestMount` has been updated so that we can test that the `MountResolver` is fixed.
