### PR TITLE
[orchestrator] fix edge cases container scrubber

### DIFF
--- a/pkg/orchestrator/data_scrubber.go
+++ b/pkg/orchestrator/data_scrubber.go
@@ -102,7 +102,7 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmdline []string) ([]string, bool) {
 
 	for _, index := range wordReplacesIndexes {
 		// we only want to replace words, hence we jump to the next index and try to scrub that instead
-		for newCmdline[index] == "" {
+		for index < len(newCmdline) && newCmdline[index] == "" {
 			index++
 		}
 		if index < len(newCmdline) {

--- a/pkg/orchestrator/data_scrubber.go
+++ b/pkg/orchestrator/data_scrubber.go
@@ -79,20 +79,42 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmdline []string) ([]string, bool) {
 	// the first index can be skipped because it should be the program name.
 	for index := 1; index < len(newCmdline); index++ {
 		cmd := newCmdline[index]
-		for _, pattern := range ds.LiteralSensitivePatterns { // this can be optimized
-			// if we found a word from the list, it means that either the current or next word should be a password we want to replace.
-			if strings.Contains(strings.ToLower(cmd), pattern) { // password=1234
-				changed = true
+		for _, pattern := range ds.LiteralSensitivePatterns {
+			// if we found a word from the list,
+			// it means either:
+			// - the current after a delimiter should be a password we want to replace e.g. "agent --secret=<replace-me>" (1)
+			// - the next word should be replaced.  e.g. "agent --secret <replace-me>" (1)
+			// - the word is part of a special list of words, contains multiple supportedEnds and can be ignored e.g. "agent > /secret/secret" should not match (3)
+			matchIndex := strings.Index(strings.ToLower(cmd), pattern)
+			// password<delimiter>1234 || password || (ignore<delimiter>me<delimiter>password e.g ignore:me:password ignore/me/password)
+			// agent --password======test
+			// agent > /password/secret ==> agent > /password/secret
+			// agent --password > /password/secret ==> agent > --password ******** /password/secret
+
+			if matchIndex >= 0 {
+				before := cmd[:matchIndex] // /etc/vaultd/ from /etc/vaultd/secret/haproxy-crt.pem
+				// /etc/vaultd/secrets/haproxy-crt.pem -> we don't want to match if one of the below chars are in before
+				if strings.IndexAny(before, "/:=$") >= 0 {
+					break
+				}
+
 				v := strings.IndexAny(cmd, "=:")
-				if v > 1 {
+				if v >= 0 {
+					// skip paths
+					changed = true
+
 					// password:1234  password=1234 ==> password=****** || password:******
+					// password::::====1234 ==> password:******
 					newCmdline[index] = cmd[:v+1] + "********"
 					// replace from v to end of string with ********
 					break
 				} else {
+					changed = true
+					// password 1234 password ******
 					nextReplacementIndex := index + 1
 					if nextReplacementIndex < len(newCmdline) {
 						wordReplacesIndexes = append(wordReplacesIndexes, nextReplacementIndex)
+						index += 1
 					}
 					break
 				}

--- a/pkg/orchestrator/data_scrubber.go
+++ b/pkg/orchestrator/data_scrubber.go
@@ -93,28 +93,25 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmdline []string) ([]string, bool) {
 
 			if matchIndex >= 0 {
 				before := cmd[:matchIndex] // /etc/vaultd/ from /etc/vaultd/secret/haproxy-crt.pem
-				// /etc/vaultd/secrets/haproxy-crt.pem -> we don't want to match if one of the below chars are in before
+				// skip paths /etc/vaultd/secrets/haproxy-crt.pem -> we don't want to match if one of the below chars are in before
 				if strings.IndexAny(before, "/:=$") >= 0 {
 					break
 				}
 
+				changed = true
 				v := strings.IndexAny(cmd, "=:")
 				if v >= 0 {
-					// skip paths
-					changed = true
-
 					// password:1234  password=1234 ==> password=****** || password:******
 					// password::::====1234 ==> password:******
 					newCmdline[index] = cmd[:v+1] + "********"
 					// replace from v to end of string with ********
 					break
 				} else {
-					changed = true
 					// password 1234 password ******
 					nextReplacementIndex := index + 1
 					if nextReplacementIndex < len(newCmdline) {
 						wordReplacesIndexes = append(wordReplacesIndexes, nextReplacementIndex)
-						index += 1
+						index++
 					}
 					break
 				}

--- a/pkg/orchestrator/data_scrubber.go
+++ b/pkg/orchestrator/data_scrubber.go
@@ -90,8 +90,9 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmdline []string) ([]string, bool) {
 					// replace from v to end of string with ********
 					break
 				} else {
-					if index < len(newCmdline) {
-						wordReplacesIndexes = append(wordReplacesIndexes, index+1)
+					nextReplacementIndex := index + 1
+					if nextReplacementIndex < len(newCmdline) {
+						wordReplacesIndexes = append(wordReplacesIndexes, nextReplacementIndex)
 					}
 					break
 				}

--- a/pkg/orchestrator/data_scrubber_test.go
+++ b/pkg/orchestrator/data_scrubber_test.go
@@ -230,6 +230,9 @@ type testCase struct {
 
 func setupSensitiveCmdLines() []testCase {
 	return []testCase{
+		{[]string{"/bin/bash", "-c", "find /tmp/datadog-agent/conf.d -name '*.yaml' | xargs -I % sh -c 'cp -vr $(dirname\n      %) /etc/datadog-agent-dest/conf.d/$(echo % | cut -d'/' -f6)'; cp -vR /etc/datadog-agent/conf.d/*\n      /etc/datadog-agent-dest/conf.d/"}, []string{"/bin/bash", "-c", "find /tmp/datadog-agent/conf.d -name '*.yaml' | xargs -I % sh -c 'cp -vr $(dirname\n      %) /etc/datadog-agent-dest/conf.d/$(echo % | cut -d'/' -f6)'; cp -vR /etc/datadog-agent/conf.d/*\n      /etc/datadog-agent-dest/conf.d/"}},
+		{[]string{""}, []string{""}},
+		{[]string{"", ""}, []string{"", ""}},
 		{[]string{"agent", "password"}, []string{"agent", "password"}},
 		{[]string{"agent", "-password"}, []string{"agent", "-password"}},
 		{[]string{"agent -password"}, []string{"agent", "-password"}},

--- a/pkg/orchestrator/data_scrubber_test.go
+++ b/pkg/orchestrator/data_scrubber_test.go
@@ -29,10 +29,14 @@ func BenchmarkRegexMatchingCustom1000(b *testing.B) { benchmarkMatchingCustomReg
 //goland:noinspection ALL
 var avoidOptimization bool
 
+//goland:noinspection ALL
+var avoidOptContainer v1.Container
+
 func benchmarkMatching(nbContainers int, b *testing.B) {
 	containersBenchmarks := make([]v1.Container, nbContainers)
 	containersToBenchmark := make([]v1.Container, nbContainers)
-	var changed bool
+	c := v1.Container{}
+
 	scrubber := NewDefaultDataScrubber()
 	for _, testCase := range getScrubCases() {
 		containersToBenchmark = append(containersToBenchmark, testCase.input)
@@ -45,19 +49,17 @@ func benchmarkMatching(nbContainers int, b *testing.B) {
 	b.Run(fmt.Sprintf("simplified"), func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			for _, c := range containersBenchmarks {
-				changed = ScrubContainer(&c, scrubber)
+				ScrubContainer(&c, scrubber)
 			}
 		}
 	})
-
-	avoidOptimization = changed
+	avoidOptContainer = c
 }
 
 func benchmarkMatchingCustomRegex(nbContainers int, b *testing.B) {
-	var changed bool
-
 	var containersBenchmarks []v1.Container
 	var containersToBenchmark []v1.Container
+	c := v1.Container{}
 
 	customRegs := []string{"pwd*", "*test"}
 	cfg := config.NewDefaultAgentConfig(true)
@@ -76,12 +78,12 @@ func benchmarkMatchingCustomRegex(nbContainers int, b *testing.B) {
 	b.Run(fmt.Sprintf("simplified"), func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			for _, c := range containersBenchmarks {
-				changed = ScrubContainer(&c, scrubber)
+				ScrubContainer(&c, scrubber)
 			}
 		}
 	})
 
-	avoidOptimization = changed
+	avoidOptContainer = c
 }
 
 func TestMatchSimpleCommand(t *testing.T) {

--- a/pkg/orchestrator/data_scrubber_test.go
+++ b/pkg/orchestrator/data_scrubber_test.go
@@ -86,7 +86,7 @@ func benchmarkMatchingCustomRegex(nbContainers int, b *testing.B) {
 }
 
 func TestMatchSimpleCommand(t *testing.T) {
-	cases := setupSensitiveCmdlines()
+	cases := setupSensitiveCmdLines()
 	customSensitiveWords := []string{
 		"consul_token",
 		"dd_password",
@@ -228,8 +228,11 @@ type testCase struct {
 	parsedCmdline []string
 }
 
-func setupSensitiveCmdlines() []testCase {
+func setupSensitiveCmdLines() []testCase {
 	return []testCase{
+		{[]string{"agent", "password"}, []string{"agent", "password"}},
+		{[]string{"agent", "-password"}, []string{"agent", "-password"}},
+		{[]string{"agent -password"}, []string{"agent", "-password"}},
 		{[]string{"agent", "-password", "1234"}, []string{"agent", "-password", "********"}},
 		{[]string{"agent", "--password", "1234"}, []string{"agent", "--password", "********"}},
 		{[]string{"agent", "-password=1234"}, []string{"agent", "-password=********"}},

--- a/pkg/orchestrator/data_scrubber_test.go
+++ b/pkg/orchestrator/data_scrubber_test.go
@@ -233,6 +233,9 @@ func setupSensitiveCmdLines() []testCase {
 		{[]string{"/bin/bash", "-c", "find /tmp/datadog-agent/conf.d -name '*.yaml' | xargs -I % sh -c 'cp -vr $(dirname\n      %) /etc/datadog-agent-dest/conf.d/$(echo % | cut -d'/' -f6)'; cp -vR /etc/datadog-agent/conf.d/*\n      /etc/datadog-agent-dest/conf.d/"}, []string{"/bin/bash", "-c", "find /tmp/datadog-agent/conf.d -name '*.yaml' | xargs -I % sh -c 'cp -vr $(dirname\n      %) /etc/datadog-agent-dest/conf.d/$(echo % | cut -d'/' -f6)'; cp -vR /etc/datadog-agent/conf.d/*\n      /etc/datadog-agent-dest/conf.d/"}},
 		{[]string{""}, []string{""}},
 		{[]string{"", ""}, []string{"", ""}},
+		// in case the "password" only consist of whitespaces we can assume that it is not something we need to mask
+		{[]string{"agent password    "}, []string{"agent", "password", "", "", "", ""}},
+		{[]string{"agent", "password", ""}, []string{"agent", "password", ""}},
 		{[]string{"agent", "password"}, []string{"agent", "password"}},
 		{[]string{"agent", "-password"}, []string{"agent", "-password"}},
 		{[]string{"agent -password"}, []string{"agent", "-password"}},

--- a/pkg/orchestrator/pod.go
+++ b/pkg/orchestrator/pod.go
@@ -112,16 +112,25 @@ func ProcessPodList(podList []*v1.Pod, groupID int32, hostName string, clusterNa
 
 // ScrubContainer scrubs sensitive information in the command line & env vars
 func ScrubContainer(c *v1.Container, scrubber *DataScrubber) bool {
-	// scrub command line
-	scrubbedCmd, changed := scrubber.ScrubSimpleCommand(c.Command)
-	c.Command = scrubbedCmd
 	// scrub env vars
 	for e := 0; e < len(c.Env); e++ {
 		if scrubber.ContainsSensitiveWord(c.Env[e].Name) {
 			c.Env[e].Value = redactedValue
-			changed = true
 		}
 	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("failed to parse cmd from pod, obscuring whole command")
+			// we still want to obscure to be safe
+			c.Command = []string{redactedValue}
+		}
+	}()
+
+	// scrub command line
+	scrubbedCmd, changed := scrubber.ScrubSimpleCommand(c.Command)
+	c.Command = scrubbedCmd
+
 	return changed
 }
 

--- a/pkg/orchestrator/pod.go
+++ b/pkg/orchestrator/pod.go
@@ -111,7 +111,7 @@ func ProcessPodList(podList []*v1.Pod, groupID int32, hostName string, clusterNa
 }
 
 // ScrubContainer scrubs sensitive information in the command line & env vars
-func ScrubContainer(c *v1.Container, scrubber *DataScrubber) bool {
+func ScrubContainer(c *v1.Container, scrubber *DataScrubber) {
 	// scrub env vars
 	for e := 0; e < len(c.Env); e++ {
 		if scrubber.ContainsSensitiveWord(c.Env[e].Name) {
@@ -128,10 +128,9 @@ func ScrubContainer(c *v1.Container, scrubber *DataScrubber) bool {
 	}()
 
 	// scrub command line
-	scrubbedCmd, changed := scrubber.ScrubSimpleCommand(c.Command)
+	scrubbedCmd, _ := scrubber.ScrubSimpleCommand(c.Command)
 	c.Command = scrubbedCmd
 
-	return changed
 }
 
 // chunkPods formats and chunks the pods into a slice of chunks using a specific number of chunks.

--- a/pkg/process/config/data_scrubber_test.go
+++ b/pkg/process/config/data_scrubber_test.go
@@ -59,6 +59,18 @@ type testProcess struct {
 func setupSensitiveCmdlines() []testCase {
 	return []testCase{
 		{[]string{"agent", "-password", "1234"}, []string{"agent", "-password", "********"}},
+		{[]string{"agent --password > /password/secret; agent --password echo >> /etc"}, []string{"agent", "--password", "********", "/password/secret;", "agent", "--password", "********", ">>", "/etc"}},
+		{[]string{"agent --password > /password/secret; ls"}, []string{"agent", "--password", "********", "/password/secret;", "ls"}},
+		{[]string{"agent", "-password=========123"}, []string{"agent", "-password=********"}},
+		{[]string{"agent", "-password/123"}, []string{"agent", "-password/123"}},
+		{[]string{"agent", "-password:123"}, []string{"agent", "-password:********"}},
+		{[]string{"agent", "password/test:123"}, []string{"agent", "password/test:********"}},
+		{[]string{"agent", "-password////:123"}, []string{"agent", "-password////:********"}},
+		{[]string{"agent", "-password", "-password"}, []string{"agent", "-password", "********"}},
+		{[]string{"/usr/local/bin/bash -c cat /etc/vaultd/secrets/haproxy-crt.pem > /etc/vaultd/secrets/haproxy.pem; echo >> /etc/vaultd/secrets/haproxy.pem; cat /etc/vaultd/secrets/haproxy-key.pem >> /etc/vaultd/secrets/haproxy.pem"},
+			[]string{"/usr/local/bin/bash -c cat /etc/vaultd/secrets/haproxy-crt.pem > /etc/vaultd/secrets/haproxy.pem; echo >> /etc/vaultd/secrets/haproxy.pem; cat /etc/vaultd/secrets/haproxy-key.pem >> /etc/vaultd/secrets/haproxy.pem"}},
+		{[]string{":usr:local:bin:bash -c cat :etc:vaultd:secrets:haproxy-crt.pem > :etc:vaultd:secrets:haproxy.pem; echo >> :etc:vaultd:secrets:haproxy.pem; cat :etc:vaultd:secrets:haproxy-key.pem >> :etc:vaultd:secrets:haproxy.pem"},
+			[]string{":usr:local:bin:bash -c cat :etc:vaultd:secrets:haproxy-crt.pem > :etc:vaultd:secrets:haproxy.pem; echo >> :etc:vaultd:secrets:haproxy.pem; cat :etc:vaultd:secrets:haproxy-key.pem >> :etc:vaultd:secrets:haproxy.pem"}},
 		{[]string{"agent", "--password", "1234"}, []string{"agent", "--password", "********"}},
 		{[]string{"agent", "-password=1234"}, []string{"agent", "-password=********"}},
 		{[]string{"agent", "--password=1234"}, []string{"agent", "--password=********"}},

--- a/pkg/process/config/data_scrubber_test.go
+++ b/pkg/process/config/data_scrubber_test.go
@@ -62,15 +62,10 @@ func setupSensitiveCmdlines() []testCase {
 		{[]string{"agent --password > /password/secret; agent --password echo >> /etc"}, []string{"agent", "--password", "********", "/password/secret;", "agent", "--password", "********", ">>", "/etc"}},
 		{[]string{"agent --password > /password/secret; ls"}, []string{"agent", "--password", "********", "/password/secret;", "ls"}},
 		{[]string{"agent", "-password=========123"}, []string{"agent", "-password=********"}},
-		{[]string{"agent", "-password/123"}, []string{"agent", "-password/123"}},
 		{[]string{"agent", "-password:123"}, []string{"agent", "-password:********"}},
 		{[]string{"agent", "password/test:123"}, []string{"agent", "password/test:********"}},
 		{[]string{"agent", "-password////:123"}, []string{"agent", "-password////:********"}},
 		{[]string{"agent", "-password", "-password"}, []string{"agent", "-password", "********"}},
-		{[]string{"/usr/local/bin/bash -c cat /etc/vaultd/secrets/haproxy-crt.pem > /etc/vaultd/secrets/haproxy.pem; echo >> /etc/vaultd/secrets/haproxy.pem; cat /etc/vaultd/secrets/haproxy-key.pem >> /etc/vaultd/secrets/haproxy.pem"},
-			[]string{"/usr/local/bin/bash -c cat /etc/vaultd/secrets/haproxy-crt.pem > /etc/vaultd/secrets/haproxy.pem; echo >> /etc/vaultd/secrets/haproxy.pem; cat /etc/vaultd/secrets/haproxy-key.pem >> /etc/vaultd/secrets/haproxy.pem"}},
-		{[]string{":usr:local:bin:bash -c cat :etc:vaultd:secrets:haproxy-crt.pem > :etc:vaultd:secrets:haproxy.pem; echo >> :etc:vaultd:secrets:haproxy.pem; cat :etc:vaultd:secrets:haproxy-key.pem >> :etc:vaultd:secrets:haproxy.pem"},
-			[]string{":usr:local:bin:bash -c cat :etc:vaultd:secrets:haproxy-crt.pem > :etc:vaultd:secrets:haproxy.pem; echo >> :etc:vaultd:secrets:haproxy.pem; cat :etc:vaultd:secrets:haproxy-key.pem >> :etc:vaultd:secrets:haproxy.pem"}},
 		{[]string{"agent", "--password", "1234"}, []string{"agent", "--password", "********"}},
 		{[]string{"agent", "-password=1234"}, []string{"agent", "-password=********"}},
 		{[]string{"agent", "--password=1234"}, []string{"agent", "--password=********"}},
@@ -108,6 +103,11 @@ func setupSensitiveCmdlines() []testCase {
 
 func setupInsensitiveCmdlines() []testCase {
 	return []testCase{
+		{[]string{"agent", "-password/123"}, []string{"agent", "-password/123"}},
+		{[]string{"/usr/local/bin/bash -c cat /etc/vaultd/secrets/haproxy-crt.pem > /etc/vaultd/secrets/haproxy.pem; echo >> /etc/vaultd/secrets/haproxy.pem; cat /etc/vaultd/secrets/haproxy-key.pem >> /etc/vaultd/secrets/haproxy.pem"},
+			[]string{"/usr/local/bin/bash -c cat /etc/vaultd/secrets/haproxy-crt.pem > /etc/vaultd/secrets/haproxy.pem; echo >> /etc/vaultd/secrets/haproxy.pem; cat /etc/vaultd/secrets/haproxy-key.pem >> /etc/vaultd/secrets/haproxy.pem"}},
+		{[]string{":usr:local:bin:bash -c cat :etc:vaultd:secrets:haproxy-crt.pem > :etc:vaultd:secrets:haproxy.pem; echo >> :etc:vaultd:secrets:haproxy.pem; cat :etc:vaultd:secrets:haproxy-key.pem >> :etc:vaultd:secrets:haproxy.pem"},
+			[]string{":usr:local:bin:bash -c cat :etc:vaultd:secrets:haproxy-crt.pem > :etc:vaultd:secrets:haproxy.pem; echo >> :etc:vaultd:secrets:haproxy.pem; cat :etc:vaultd:secrets:haproxy-key.pem >> :etc:vaultd:secrets:haproxy.pem"}},
 		{[]string{"spidly", "--debug_port=2043"}, []string{"spidly", "--debug_port=2043"}},
 		{[]string{"agent", "start", "-p", "config.cfg"}, []string{"agent", "start", "-p", "config.cfg"}},
 		{[]string{"p1", "-user=admin"}, []string{"p1", "-user=admin"}},


### PR DESCRIPTION
### What does this PR do?
changed the following cases:

- fixed: words which finishes with sensitive words e.g. `java --password` should stay as `java --password`, the algorithm had a bug which tried to replace the next index, which does not necessary have to exist (was a bug because we did check for this, but used the wrong index).

- added: will not match if the lines before the matched sensitive word contains `/:$`. This is to mirror the old scrubbing behaviour which was there to e.g match paths.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Added unit tests