### PR TITLE
pkg/trace/obfuscate: fix handling of UTF-8 encoding

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -280,7 +280,7 @@ func attemptObfuscation(tokenizer *SQLTokenizer) (*ObfuscatedQuery, error) {
 	// or replaced.
 	for {
 		token, buff := tokenizer.Scan()
-		if token == EOFChar {
+		if token == EndChar {
 			break
 		}
 		if token == LexError {

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -965,12 +965,17 @@ func TestSQLErrors(t *testing.T) {
 
 		{
 			" \x80",
-			"at position 2: invalid UTF-8 encoding beginning with 0x80",
+			"at position 1: invalid UTF-8 encoding beginning with 0x80",
 		},
 
 		{
 			"\x3a\xdb",
-			"at position 1: bind variables should start with letters, got \"�\" (1114112)",
+			"at position 1: invalid UTF-8 encoding beginning with 0xdb",
+		},
+
+		{
+			"select * from foo where bar = \"\x3a\xeb\"",
+			"at position 32: invalid UTF-8 encoding beginning with 0xeb",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -955,10 +955,12 @@ func TestSQLErrors(t *testing.T) {
 			" \x80",
 			"at position 2: unexpected byte 65533",
 		},
+
 		{
 			"\x3a\xdb",
 			"at position 1: bind variables should start with letters, got \"�\" (65533)",
 		},
+
 		{
 			"CALL p1 ('\ufffd\\\\');",
 			"at position 11: unexpected byte 239",

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -129,10 +129,6 @@ func TestSQLUTF8(t *testing.T) {
 	assert := assert.New(t)
 	for _, tt := range []struct{ in, out string }{
 		{
-			"drop database if exists `龔龖龗`;",
-			"drop database if exists 龔龖龗",
-		},
-		{
 			"SELECT Codi , Nom_CA AS Nom, Descripció_CAT AS Descripció FROM ProtValAptitud WHERE Vigent=1 ORDER BY Ordre, Codi",
 			"SELECT Codi, Nom_CA, Descripció_CAT FROM ProtValAptitud WHERE Vigent = ? ORDER BY Ordre, Codi",
 		},
@@ -151,6 +147,22 @@ func TestSQLUTF8(t *testing.T) {
 		{
 			"SELECT     Cli_Establiments.CODCLI, Cli_Establiments.Id_ESTAB_CLI As [Código Centro Trabajo], Cli_Establiments.CODIGO_CENTRO_AXAPTA As [Código C. Axapta],  Cli_Establiments.NOMESTAB As [Nombre],                                 Cli_Establiments.ADRECA As [Dirección], Cli_Establiments.CodPostal As [Código Postal], Cli_Establiments.Poblacio as [Población], Cli_Establiments.Provincia,                                Cli_Establiments.TEL As [Tel],  Cli_Establiments.EMAIL As [EMAIL],                                Cli_Establiments.PERS_CONTACTE As [Contacto], Cli_Establiments.PERS_CONTACTE_CARREC As [Cargo Contacto], Cli_Establiments.NumTreb As [Plantilla],                                Cli_Establiments.Localitzacio As [Localización], Tipus_Activitat.CNAE, Tipus_Activitat.Nom_ES As [Nombre Actividad], ACTIVO AS [Activo]                        FROM         Cli_Establiments LEFT OUTER JOIN                                    Tipus_Activitat ON Cli_Establiments.Id_ACTIVITAT = Tipus_Activitat.IdActivitat                        Where CODCLI = '01234' AND CENTRE_CORRECTE = 3 AND ACTIVO = 5                        ORDER BY Cli_Establiments.CODIGO_CENTRO_AXAPTA ",
 			"SELECT Cli_Establiments.CODCLI, Cli_Establiments.Id_ESTAB_CLI, Cli_Establiments.CODIGO_CENTRO_AXAPTA, Cli_Establiments.NOMESTAB, Cli_Establiments.ADRECA, Cli_Establiments.CodPostal, Cli_Establiments.Poblacio, Cli_Establiments.Provincia, Cli_Establiments.TEL, Cli_Establiments.EMAIL, Cli_Establiments.PERS_CONTACTE, Cli_Establiments.PERS_CONTACTE_CARREC, Cli_Establiments.NumTreb, Cli_Establiments.Localitzacio, Tipus_Activitat.CNAE, Tipus_Activitat.Nom_ES, ACTIVO FROM Cli_Establiments LEFT OUTER JOIN Tipus_Activitat ON Cli_Establiments.Id_ACTIVITAT = Tipus_Activitat.IdActivitat Where CODCLI = ? AND CENTRE_CORRECTE = ? AND ACTIVO = ? ORDER BY Cli_Establiments.CODIGO_CENTRO_AXAPTA",
+		},
+		{
+			"drop database if exists `龔龖龗`;",
+			"drop database if exists 龔龖龗",
+		},
+		{
+			"select * from names where name like '�����';",
+			"select * from names where name like ?",
+		},
+		{
+			"select replacement from table where replacement = 'i�n�t�e��rspersed';",
+			"select replacement from table where replacement = ?",
+		},
+		{
+			"CALL p1 ('\ufffd\\\\');",
+			"CALL p1 ( ? )",
 		},
 	} {
 		t.Run("", func(t *testing.T) {
@@ -953,17 +965,12 @@ func TestSQLErrors(t *testing.T) {
 
 		{
 			" \x80",
-			"at position 2: unexpected byte 65533",
+			"at position 2: invalid UTF-8 encoding beginning with 0x80",
 		},
 
 		{
 			"\x3a\xdb",
-			"at position 1: bind variables should start with letters, got \"�\" (65533)",
-		},
-
-		{
-			"CALL p1 ('\ufffd\\\\');",
-			"at position 11: unexpected byte 239",
+			"at position 1: bind variables should start with letters, got \"�\" (1114112)",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -129,6 +129,10 @@ func TestSQLUTF8(t *testing.T) {
 	assert := assert.New(t)
 	for _, tt := range []struct{ in, out string }{
 		{
+			"drop database if exists `龔龖龗`;",
+			"drop database if exists 龔龖龗",
+		},
+		{
 			"SELECT Codi , Nom_CA AS Nom, Descripció_CAT AS Descripció FROM ProtValAptitud WHERE Vigent=1 ORDER BY Ordre, Codi",
 			"SELECT Codi, Nom_CA, Descripció_CAT FROM ProtValAptitud WHERE Vigent = ? ORDER BY Ordre, Codi",
 		},

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -950,6 +950,19 @@ func TestSQLErrors(t *testing.T) {
 			"SELECT age FROM profile WHERE place='John\\'s House' and name='John\\'",
 			`at position 69: unexpected EOF in string`,
 		},
+
+		{
+			" \x80",
+			"at position 2: unexpected byte 65533",
+		},
+		{
+			"\x3a\xdb",
+			"at position 1: bind variables should start with letters, got \"�\" (65533)",
+		},
+		{
+			"CALL p1 ('\ufffd\\\\');",
+			"at position 11: unexpected byte 239",
+		},
 	}
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -149,8 +149,8 @@ func TestSQLUTF8(t *testing.T) {
 			"SELECT Cli_Establiments.CODCLI, Cli_Establiments.Id_ESTAB_CLI, Cli_Establiments.CODIGO_CENTRO_AXAPTA, Cli_Establiments.NOMESTAB, Cli_Establiments.ADRECA, Cli_Establiments.CodPostal, Cli_Establiments.Poblacio, Cli_Establiments.Provincia, Cli_Establiments.TEL, Cli_Establiments.EMAIL, Cli_Establiments.PERS_CONTACTE, Cli_Establiments.PERS_CONTACTE_CARREC, Cli_Establiments.NumTreb, Cli_Establiments.Localitzacio, Tipus_Activitat.CNAE, Tipus_Activitat.Nom_ES, ACTIVO FROM Cli_Establiments LEFT OUTER JOIN Tipus_Activitat ON Cli_Establiments.Id_ACTIVITAT = Tipus_Activitat.IdActivitat Where CODCLI = ? AND CENTRE_CORRECTE = ? AND ACTIVO = ? ORDER BY Cli_Establiments.CODIGO_CENTRO_AXAPTA",
 		},
 		{
-			"drop database if exists `龔龖龗`;",
-			"drop database if exists 龔龖龗",
+			"select * from `構わない`;",
+			"select * from 構わない",
 		},
 		{
 			"select * from names where name like '�����';",
@@ -161,8 +161,8 @@ func TestSQLUTF8(t *testing.T) {
 			"select replacement from table where replacement = ?",
 		},
 		{
-			"CALL p1 ('\ufffd\\\\');",
-			"CALL p1 ( ? )",
+			"SELECT ('\ufffd');",
+			"SELECT ( ? )",
 		},
 	} {
 		t.Run("", func(t *testing.T) {
@@ -974,8 +974,8 @@ func TestSQLErrors(t *testing.T) {
 		},
 
 		{
-			"select * from foo where bar = \"\x3a\xeb\"",
-			"at position 32: invalid UTF-8 encoding beginning with 0xeb",
+			"select * from profile where age = \"\x3a\xeb\"",
+			"at position 36: invalid UTF-8 encoding beginning with 0xeb",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -538,17 +538,16 @@ func (tkn *SQLTokenizer) advance() {
 		tkn.lastChar = EOFChar
 		return
 	}
-
-	len := utf8.RuneLen(ch)
 	if tkn.lastChar != 0 || tkn.pos > 0 {
 		// we are past the first character
-		tkn.pos += len
+		tkn.pos += n
 	}
-	tkn.off += len
+	tkn.off += n
 	tkn.lastChar = ch
 }
 
 // bytes returns all the bytes that were advanced over since its last call.
+// This excludes tkn.lastChar, which will remain in the buffer
 func (tkn *SQLTokenizer) bytes() []byte {
 	if tkn.lastChar == EOFChar {
 		ret := tkn.buf[:tkn.off]
@@ -556,9 +555,10 @@ func (tkn *SQLTokenizer) bytes() []byte {
 		tkn.off = 0
 		return ret
 	}
-	ret := tkn.buf[:tkn.off-1]
-	tkn.buf = tkn.buf[tkn.off-1:]
-	tkn.off = 1
+	lastLen := utf8.RuneLen(tkn.lastChar)
+	ret := tkn.buf[:tkn.off-lastLen]
+	tkn.buf = tkn.buf[tkn.off-lastLen:]
+	tkn.off = lastLen
 	return ret
 }
 

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -327,8 +327,12 @@ func (tkn *SQLTokenizer) scanLiteralIdentifier(quote rune) (TokenKind, []byte) {
 	return ID, t
 }
 
+func isValid(r rune) bool {
+	return r != EOFChar && r != utf8.RuneError
+}
+
 func (tkn *SQLTokenizer) scanVariableIdentifier(prefix rune) (TokenKind, []byte) {
-	for tkn.advance(); tkn.lastChar != ')' && tkn.lastChar != EOFChar; tkn.advance() {
+	for tkn.advance(); tkn.lastChar != ')' && isValid(tkn.lastChar); tkn.advance() {
 	}
 	tkn.advance()
 	if !isLetter(tkn.lastChar) {
@@ -362,7 +366,7 @@ func (tkn *SQLTokenizer) scanPreparedStatement(prefix rune) (TokenKind, []byte) 
 }
 
 func (tkn *SQLTokenizer) scanEscapeSequence(braces rune) (TokenKind, []byte) {
-	for tkn.lastChar != '}' && tkn.lastChar != EOFChar {
+	for tkn.lastChar != '}' && isValid(tkn.lastChar) {
 		tkn.advance()
 	}
 
@@ -370,6 +374,9 @@ func (tkn *SQLTokenizer) scanEscapeSequence(braces rune) (TokenKind, []byte) {
 	// the closing curly braces
 	if tkn.lastChar == EOFChar {
 		tkn.setErr("unexpected EOF in escape sequence")
+		return LexError, tkn.bytes()
+	} else if tkn.lastChar == utf8.RuneError {
+		tkn.setErr(`unexpected byte %d`, tkn.lastByte())
 		return LexError, tkn.bytes()
 	}
 
@@ -484,6 +491,9 @@ func (tkn *SQLTokenizer) scanString(delim rune, kind TokenKind) (TokenKind, []by
 		if ch == EOFChar {
 			tkn.setErr("unexpected EOF in string")
 			return LexError, buffer.Bytes()
+		} else if ch == utf8.RuneError {
+			tkn.setErr(`unexpected byte %d`, tkn.lastByte())
+			return LexError, buffer.Bytes()
 		}
 		buffer.WriteRune(ch)
 	}
@@ -499,7 +509,7 @@ func (tkn *SQLTokenizer) scanString(delim rune, kind TokenKind) (TokenKind, []by
 }
 
 func (tkn *SQLTokenizer) scanCommentType1(prefix string) (TokenKind, []byte) {
-	for tkn.lastChar != EOFChar {
+	for isValid(tkn.lastChar) {
 		if tkn.lastChar == '\n' {
 			tkn.advance()
 			break
@@ -522,20 +532,32 @@ func (tkn *SQLTokenizer) scanCommentType2() (TokenKind, []byte) {
 		if tkn.lastChar == EOFChar {
 			tkn.setErr("unexpected EOF in comment")
 			return LexError, tkn.bytes()
+		} else if tkn.lastChar == utf8.RuneError {
+			tkn.setErr(`unexpected byte %d`, tkn.lastByte())
+			return LexError, tkn.bytes()
 		}
 		tkn.advance()
 	}
 	return Comment, tkn.bytes()
 }
 
-// advance advances the tokenizer to the next rune. If this is not possible, tkn.lastChar will
+func (tkn *SQLTokenizer) lastByte() byte {
+	return tkn.buf[tkn.off]
+}
+
+// advance advances the tokenizer to the next rune. If the decoder encounters an error decoding,
+// lastChar will be set to utf8.RuneError. If the end of the buffer is reached, tkn.lastChar will
 // be set to EOFChar.
 func (tkn *SQLTokenizer) advance() {
 	ch, n := utf8.DecodeRune(tkn.buf[tkn.off:])
-	if ch == utf8.RuneError && n == 0 {
-		// only EOF is possible
+	if ch == utf8.RuneError {
 		tkn.pos++
-		tkn.lastChar = EOFChar
+		if n == 0 {
+			// only EOF is possible
+			tkn.lastChar = EOFChar
+			return
+		}
+		tkn.lastChar = utf8.RuneError
 		return
 	}
 	if tkn.lastChar != 0 || tkn.pos > 0 {
@@ -554,6 +576,9 @@ func (tkn *SQLTokenizer) bytes() []byte {
 		tkn.buf = tkn.buf[tkn.off:]
 		tkn.off = 0
 		return ret
+	}
+	if tkn.lastChar == utf8.RuneError {
+		return []byte{}
 	}
 	lastLen := utf8.RuneLen(tkn.lastChar)
 	ret := tkn.buf[:tkn.off-lastLen]

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -126,6 +126,9 @@ var keywords = map[string]TokenKind{
 func (tkn *SQLTokenizer) Err() error { return tkn.err }
 
 func (tkn *SQLTokenizer) setErr(format string, args ...interface{}) {
+	if tkn.err != nil {
+		return
+	}
 	tkn.err = fmt.Errorf("at position %d: %v", tkn.pos, fmt.Errorf(format, args...))
 }
 
@@ -147,6 +150,9 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 		return tkn.scanNumber(false)
 	default:
 		tkn.advance()
+		if tkn.lastChar == EOFChar && tkn.err != nil {
+			return LexError, nil
+		}
 		switch ch {
 		case EOFChar:
 			if tkn.err != nil {


### PR DESCRIPTION
When returning the byte slice from bytes(), it was previously incorrectly
assumed that the last character had a byte length of 1, leading to errors
when multibyte utf-8 characters were on token boundaries.

This commit calculates the correct length of the final character and slices
the buffer correctly.

This also fixes a second bug which causes the parser to panic when in encounters
invalid utf8 sequences. The length of the sequence is measured incorrectly
resulting in an out-of-bounds panic.

### Motivation
These bugs were introduced in #6480 as part of performance optimization.
This testing is being performed as part of the 7.24.0 release.

### Describe your test plan

Many thousands of queries from postgres, mariadb and elsewhere are being run against the parser to ensure it is functioning correctly. We are also using go-fuzz with the already-present SQL corpus to detect bad behavior with unexpected inputs. This is how the bugs were discovered to begin with.

Specific test cases have been added for the discovered failures.