### PR TITLE
[networks] Add OS telemetry for `CollectorConnections`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.46.1-0.20201112171416-f39b1422df74+incompatible
+	github.com/DataDog/agent-payload v4.47.0+incompatible
 	github.com/DataDog/datadog-go v3.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
 	github.com/DataDog/ebpf v0.0.0-20201015152207-a91a2d800994

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.46.0+incompatible
+	github.com/DataDog/agent-payload v4.46.1-0.20201112171416-f39b1422df74+incompatible
 	github.com/DataDog/datadog-go v3.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
 	github.com/DataDog/ebpf v0.0.0-20201015152207-a91a2d800994

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload v4.46.0+incompatible h1:K6E0ikU5xBdSwahp+CtTJpUOO76+G4p+Xr1EJlWqm80=
 github.com/DataDog/agent-payload v4.46.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
-github.com/DataDog/agent-payload v4.46.1-0.20201109210321-dc09c7893394+incompatible h1:S4soW57HjbY5TLXgY8SiG6Usg1+YOQe+PhGZ5FgSh/k=
-github.com/DataDog/agent-payload v4.46.1-0.20201109210321-dc09c7893394+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
-github.com/DataDog/agent-payload v4.46.1-0.20201112171416-f39b1422df74+incompatible h1:gv4CGPD2OOGS058WrqMTcKn3M/swbPz97puSbPRc5Cc=
-github.com/DataDog/agent-payload v4.46.1-0.20201112171416-f39b1422df74+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.47.0+incompatible h1:R2Lzbg3j+vzajMt4nq/srOCzf+ButJrmlJGpjjqx3hk=
+github.com/DataDog/agent-payload v4.47.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,10 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload v4.46.0+incompatible h1:K6E0ikU5xBdSwahp+CtTJpUOO76+G4p+Xr1EJlWqm80=
 github.com/DataDog/agent-payload v4.46.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.46.1-0.20201109210321-dc09c7893394+incompatible h1:S4soW57HjbY5TLXgY8SiG6Usg1+YOQe+PhGZ5FgSh/k=
+github.com/DataDog/agent-payload v4.46.1-0.20201109210321-dc09c7893394+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.46.1-0.20201112171416-f39b1422df74+incompatible h1:gv4CGPD2OOGS058WrqMTcKn3M/swbPz97puSbPRc5Cc=
+github.com/DataDog/agent-payload v4.46.1-0.20201112171416-f39b1422df74+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/pkg/metadata/host/host_windows.go
+++ b/pkg/metadata/host/host_windows.go
@@ -43,6 +43,7 @@ type InfoStat struct {
 	PlatformFamily       string `json:"platformFamily"`  // ex: debian, rhel
 	PlatformVersion      string `json:"platformVersion"` // version of the complete OS
 	KernelVersion        string `json:"kernelVersion"`   // version of the OS kernel (if available)
+	KernelArch           string `json:"kernelArch"`
 	VirtualizationSystem string `json:"virtualizationSystem"`
 	VirtualizationRole   string `json:"virtualizationRole"` // guest or host
 	HostID               string `json:"hostid"`             // ex: uuid
@@ -119,6 +120,8 @@ func getHostInfo() *InfoStat {
 	pids, _ := Pids()
 	info.Procs = uint64(len(pids))
 	info.OS = runtime.GOOS
+
+	info.KernelArch = runtime.GOARCH
 
 	pi, _ := platform.GetArchInfo()
 	info.Platform = pi["os"].(string)

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -9,6 +9,7 @@ import (
 
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/dockerproxy"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
@@ -208,6 +209,15 @@ func batchConnections(
 			EncodedDNS:        dnsEncoder.Encode(batchDNS),
 			ContainerHostType: cfg.ContainerHostType,
 		}
+
+		// Add OS telemetry
+		if hostInfo := host.GetStatusInformation(); hostInfo != nil {
+			cc.KernelVersion = hostInfo.KernelVersion
+			cc.Architecture = hostInfo.KernelArch
+			cc.Platform = hostInfo.Platform
+			cc.PlatformVersion = hostInfo.PlatformVersion
+		}
+
 		// only add the telemetry to the first message to prevent double counting
 		if len(batches) == 0 {
 			cc.Telemetry = telemetry


### PR DESCRIPTION
### What does this PR do?

Embed the following bits of OS telemetry in the `CollectorConnections` payload:

* KernelVersion
* KernelArchitecture
* Platform
* PlatformVersion

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Verify via `procq` that the new fields are present:
```
sudog procq consumer -t network_raw -n 1
```