### PR TITLE
Bug fixes for log agent tracking per source bytes

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -303,8 +303,8 @@
             {{- end }}
             {{- if .inputs }}
             Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}</br>
-            BytesRead: {{ .bytes_read }}
             {{- end }}
+            BytesRead: {{ .bytes_read }}</br>
           {{- end }}
         </span>
       {{- end }}

--- a/pkg/logs/config/source.go
+++ b/pkg/logs/config/source.go
@@ -39,6 +39,8 @@ type LogSource struct {
 	// that reads log lines for this source. E.g, a sourceType == containerd and Config.Type == file means that
 	// the agent is tailing a file to read logs of a containerd container
 	sourceType SourceType
+	// In the case that the source is overridden, keep a reference to the parent for bubbling up information about the child
+	ParentSource *LogSource
 }
 
 // NewLogSource creates a new log source.

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -184,7 +184,9 @@ func (l *Launcher) overrideSource(container *Container, source *config.LogSource
 		return source
 	}
 
-	return newOverridenSource(standardService, shortName, source.Status)
+	newSource := newOverridenSource(standardService, shortName, source.Status)
+	newSource.ParentSource = source
+	return newSource
 }
 
 // newOverridenSource is separated from overrideSource for testing purpose

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -182,7 +182,12 @@ func (t *Tailer) readForever() {
 		default:
 			inBuf := make([]byte, 4096)
 			n, err := t.read(inBuf, t.readTimeout)
-			t.source.BytesRead.Add(int64(n))
+
+			if t.source.ParentSource != nil {
+				t.source.ParentSource.BytesRead.Add(int64(n))
+			} else {
+				t.source.BytesRead.Add(int64(n))
+			}
 			if err != nil { // an error occurred, stop from reading new logs
 				switch {
 				case isReaderClosed(err):

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -183,6 +183,8 @@ func (t *Tailer) readForever() {
 			inBuf := make([]byte, 4096)
 			n, err := t.read(inBuf, t.readTimeout)
 
+			// Since `container_collect_all` reports all docker logs as a single source (even though the source is overridden internally),
+			// we need to report the byte count to the parent source used to populate the status page.
 			if t.source.ParentSource != nil {
 				t.source.ParentSource.BytesRead.Add(int64(n))
 			} else {

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -123,12 +123,12 @@ func (b *Builder) getIntegrations() []Integration {
 		var sources []Source
 		for _, source := range logSources {
 			sources = append(sources, Source{
+				BytesRead:     source.BytesRead.Value(),
 				Type:          source.Config.Type,
 				Configuration: b.toDictionary(source.Config),
 				Status:        b.toString(source.Status),
 				Inputs:        source.GetInputs(),
 				Messages:      source.Messages.GetMessages(),
-				BytesRead:     source.BytesRead.Value(),
 			})
 		}
 		integrations = append(integrations, Integration{

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -34,12 +34,12 @@ var (
 
 // Source provides some information about a logs source.
 type Source struct {
+	BytesRead     int64                  `json:"bytes_read"`
 	Type          string                 `json:"type"`
 	Configuration map[string]interface{} `json:"configuration"`
 	Status        string                 `json:"status"`
 	Inputs        []string               `json:"inputs"`
 	Messages      []string               `json:"messages"`
-	BytesRead     int64                  `json:"bytes_read"`
 }
 
 // Integration provides some information about a logs integration.

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -62,8 +62,8 @@ Logs Agent
     {{- end }}
     {{- if .inputs }}
     Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}
-    BytesRead: {{ .bytes_read }}
     {{- end }}
+    BytesRead: {{ .bytes_read }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### What does this PR do?

During QA we found that some log sources do not set inputs. The fix here is to not hide the byte count when there is no input. 
There was also a bug where when collecting all container logs the byte count showed `0`. This is because the source was overridden. By keep track of a `parent` source we can report the byte count to the true source in agent status. 