### PR TITLE
Add compliance containers running metric

### DIFF
--- a/pkg/compliance/agent/agent_test.go
+++ b/pkg/compliance/agent/agent_test.go
@@ -14,11 +14,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 	"github.com/DataDog/datadog-agent/pkg/util"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -86,6 +88,8 @@ func eventMatcher(m eventMatch) interface{} {
 
 func TestRun(t *testing.T) {
 	assert := assert.New(t)
+
+	aggregator.InitAggregator(nil, "foo")
 
 	e := enterTempEnv(t)
 	defer e.leave()
@@ -177,6 +181,8 @@ func TestRun(t *testing.T) {
 
 func TestRunChecks(t *testing.T) {
 	assert := assert.New(t)
+
+	aggregator.InitAggregator(nil, "foo")
 
 	e := enterTempEnv(t)
 	defer e.leave()

--- a/pkg/compliance/agent/telemetry.go
+++ b/pkg/compliance/agent/telemetry.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package agent
+
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	containersCountMetricName = "datadog.security_agent.compliance.containers_running"
+)
+
+// telemetry reports environment information (e.g containers running count) when the compliance component is running
+type telemetry struct {
+	sender   aggregator.Sender
+	detector collectors.DetectorInterface
+}
+
+func newTelemtry() (*telemetry, error) {
+	sender, err := aggregator.GetDefaultSender()
+	if err != nil {
+		return nil, err
+	}
+
+	return &telemetry{
+		sender:   sender,
+		detector: collectors.NewDetector(""),
+	}, nil
+}
+
+func (t *telemetry) run(ctx context.Context) {
+	log.Info("Start collecting Compliance telemetry")
+	defer log.Info("Stopping Compliance telemetry")
+
+	metricsTicker := time.NewTicker(2 * time.Minute)
+	defer metricsTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-metricsTicker.C:
+			if err := t.reportContainersCount(); err != nil {
+				log.Debugf("Couldn't report containers count: %v", err)
+			}
+		}
+	}
+}
+
+func (t *telemetry) reportContainersCount() error {
+	collector, _, err := t.detector.GetPreferred()
+	if err != nil {
+		return err
+	}
+
+	containers, err := collector.List()
+	if err != nil {
+		return err
+	}
+
+	t.sender.Gauge(containersCountMetricName, float64(len(containers)), "", []string{})
+	t.sender.Commit()
+
+	return nil
+}

--- a/pkg/compliance/agent/telemetry_test.go
+++ b/pkg/compliance/agent/telemetry_test.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package agent
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/collectors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type dummyCollector struct{ ctrCount int }
+
+func (dc *dummyCollector) Detect() error                                 { return nil }
+func (dc *dummyCollector) UpdateMetrics(c []*containers.Container) error { return nil }
+func (dc *dummyCollector) List() ([]*containers.Container, error) {
+	ctrList := []*containers.Container{}
+	for i := 0; i < dc.ctrCount; i++ {
+		ctrList = append(ctrList, &containers.Container{ID: strconv.Itoa(i)})
+	}
+	return ctrList, nil
+}
+
+type dummyDetector struct{ ctrCount int }
+
+func (dd *dummyDetector) GetPreferred() (collectors.Collector, string, error) {
+	return &dummyCollector{ctrCount: dd.ctrCount}, "dummy", nil
+}
+
+func newDummyDetector(ctrCount int) collectors.DetectorInterface {
+	return &dummyDetector{ctrCount: ctrCount}
+}
+
+func TestReportContainersCount(t *testing.T) {
+	mockSender := mocksender.NewMockSender("foo")
+	mockSender.SetupAcceptAll()
+
+	telemetry := &telemetry{sender: mockSender}
+
+	telemetry.detector = newDummyDetector(10)
+	assert.NoError(t, telemetry.reportContainersCount())
+	mockSender.AssertCalled(t, "Gauge", containersCountMetricName, 10.0, "", []string{})
+
+	telemetry.detector = newDummyDetector(100)
+	assert.NoError(t, telemetry.reportContainersCount())
+	mockSender.AssertCalled(t, "Gauge", containersCountMetricName, 100.0, "", []string{})
+}

--- a/pkg/util/containers/collectors/detector.go
+++ b/pkg/util/containers/collectors/detector.go
@@ -37,6 +37,11 @@ type Detector struct {
 	preferredName      string
 }
 
+// DetectorInterface is useful to mock the Detector in other packages
+type DetectorInterface interface {
+	GetPreferred() (Collector, string, error)
+}
+
 // NewDetector returns a Detector ready to use. If configuredName
 // is empty, autodetection is enabled. If not, only the one name
 // will be tried.


### PR DESCRIPTION
### What does this PR do?

Submit a metric `datadog.security_agent.compliance.containers_running` tagged by `host` when compliance monitoring is enabled

![image](https://user-images.githubusercontent.com/38987709/98700723-cb5f4c00-2378-11eb-8f07-e906a41fb052.png)

### Additional Notes

The metric is sent every 2 minutes

### Describe your test plan

Enable compliance
