### PR TITLE
Add AD container label tags in Fargate env

### DIFF
--- a/pkg/tagger/collectors/common.go
+++ b/pkg/tagger/collectors/common.go
@@ -6,13 +6,20 @@
 package collectors
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// OrchestratorScopeEntityID defines the orchestrator scope entity ID
-const OrchestratorScopeEntityID = "internal:orchestrator-scope-entity-id"
+const (
+	// OrchestratorScopeEntityID defines the orchestrator scope entity ID
+	OrchestratorScopeEntityID = "internal:orchestrator-scope-entity-id"
+
+	autodiscoveryLabelTagsKey = "com.datadoghq.ad.tags"
+)
 
 // retrieveMappingFromConfig gets a stringmapstring config key and
 // lowercases all map keys to make envvar and yaml sources consistent
@@ -24,4 +31,21 @@ func retrieveMappingFromConfig(configKey string) map[string]string {
 	}
 
 	return labelsList
+}
+
+func parseContainerADTagsLabels(tags *utils.TagList, labelValue string) {
+	tagNames := []string{}
+	err := json.Unmarshal([]byte(labelValue), &tagNames)
+	if err != nil {
+		log.Debugf("Cannot unmarshal AD tags: %s", err)
+	}
+	for _, tag := range tagNames {
+		tagParts := strings.Split(tag, ":")
+		// skip if tag is not in expected k:v format
+		if len(tagParts) != 2 {
+			log.Debugf("Tag '%s' is not in k:v format", tag)
+			continue
+		}
+		tags.AddHigh(tagParts[0], tagParts[1])
+	}
 }

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -8,7 +8,6 @@
 package collectors
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -114,22 +113,8 @@ func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string,
 			tags.AddStandard(tagKeyService, labelValue)
 
 		// Custom labels as tags
-		case "com.datadoghq.ad.tags":
-			tagNames := []string{}
-			err := json.Unmarshal([]byte(labelValue), &tagNames)
-			if err != nil {
-				log.Debugf("Cannot unmarshal AD tags: %s", err)
-			}
-			for _, tag := range tagNames {
-				tagParts := strings.Split(tag, ":")
-				// skip if tag is not in expected k:v format
-				if len(tagParts) != 2 {
-					log.Debugf("Tag '%s' is not in k:v format", tag)
-					continue
-				}
-				tags.AddHigh(tagParts[0], tagParts[1])
-			}
-
+		case autodiscoveryLabelTagsKey:
+			parseContainerADTagsLabels(tags, labelValue)
 		default:
 			if tagName, found := labelsAsTags[strings.ToLower(labelName)]; found {
 				tags.AddAuto(tagName, labelValue)

--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -91,12 +91,18 @@ func (c *ECSFargateCollector) parseMetadata(meta *v2.Task, parseAll bool) ([]*Ta
 
 			for labelName, labelValue := range ctr.Labels {
 				switch labelName {
+
+				// Standard tags
 				case dockerLabelEnv:
 					tags.AddStandard(tagKeyEnv, labelValue)
 				case dockerLabelVersion:
 					tags.AddStandard(tagKeyVersion, labelValue)
 				case dockerLabelService:
 					tags.AddStandard(tagKeyService, labelValue)
+
+				// Custom labels as tags
+				case autodiscoveryLabelTagsKey:
+					parseContainerADTagsLabels(tags, labelValue)
 				}
 
 				if tagName, found := c.labelsAsTags[strings.ToLower(labelName)]; found {

--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -128,6 +128,8 @@ func TestParseMetadata(t *testing.T) {
 				"container_name:ecs-redis-datadog-3-redis-f6eedfd8b18a8fbe1d00",
 				"hightag:value2",
 				"container_id:0fc5bb7a1b29adc30997eabae1415a98fe85591eb7432c23349703a53aa43280",
+				"env:staging",
+				"service:backend",
 			},
 			StandardTags: []string{
 				"service:redis",

--- a/pkg/tagger/collectors/testdata/fargate_meta.json
+++ b/pkg/tagger/collectors/testdata/fargate_meta.json
@@ -83,6 +83,7 @@
         "com.datadoghq.ad.check_names": "[\"redisdb\"]",
         "com.datadoghq.ad.init_configs": "[{}]",
         "com.datadoghq.ad.instances": "[{\"host\": \"%%host%%\", \"port\": 6379}]",
+        "com.datadoghq.ad.tags": "[\"env:staging\", \"service:backend\"]",
         "com.datadoghq.tags.service": "redis",
         "com.datadoghq.tags.env": "prod",
         "com.datadoghq.tags.version": "1.0",

--- a/releasenotes/notes/ad-tags-support-fargate-38b3cf09163b1265.yaml
+++ b/releasenotes/notes/ad-tags-support-fargate-38b3cf09163b1265.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add `com.datadoghq.ad.tags` container auto-discovery label in AWS Fargate environment.


### PR DESCRIPTION
### What does this PR do?

This PR is the continuation of #5779

The pull request adds support to Autodiscover tags from the `com.datadoghq.ad.tags` Docker label on ECS Fargate environments.

### Motivation

> Since Agent v7.20+, a containerized Agent can Autodiscover tags from Docker labels. But this doesn't work on Fargate.
> https://docs.datadoghq.com/agent/docker/tag/?tab=containerizedagent#extract-environment-variables-as-tags.
> 
> What inspired you to submit this pull request?
> 
> I was trying to add custom tags to one of my Fargate containers. However, after looking at the code, I noticed that it wasn't supported. So here is a fix that should add support for that.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy a Fargate task with a docker container image that contains the label `com.datadoghq.ad.tags`. Tags present in the label value should be attached to the fargate task metrics.
