### PR TITLE
[FLare] Fix missing env vars in the flare

### DIFF
--- a/releasenotes/notes/fix-flare-envvars-482c475e00e55803.yaml
+++ b/releasenotes/notes/fix-flare-envvars-482c475e00e55803.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed missing some Agent environment variables in the flare


### PR DESCRIPTION
### What does this PR do?

- Consider the env vars corresponding to nested config fields
- Replace some non-inclusive terminology

### Motivation

The flare must include all the agent config env variables

### Additional Notes

The bug affects the DCA as well

### Describe your test plan

Compare the output of `env | grep DD_` to what the flare contains, nested configs like `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL` (corresponds to `logs_config.container_collect_all`) must appear in the flare (if set)
