### PR TITLE
pkg/trace: remove string concatenation on sublayer insertions

### DIFF
--- a/releasenotes/notes/trace-agent-no-concatenations-on-sublayer-insert-3f931794114b7dcc.yaml
+++ b/releasenotes/notes/trace-agent-no-concatenations-on-sublayer-insert-3f931794114b7dcc.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: improved stats computation performance by removing some string concatenations.


### PR DESCRIPTION
### What does this PR do?

This PR avoids doing the concatenation of strings needed to compute the aggregation name on each paylad processed and instead does it only on flush.

### Motivation

This is an easy win to remove a operation that is visible on CPU profiles:
<img width="1514" alt="image" src="https://user-images.githubusercontent.com/425368/98945692-24eb8600-24f3-11eb-8dd0-6a9c58d2be50.png">


### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
