### PR TITLE
pkg/trace: avoid sorting custom aggregation tags in assembleGrain

### DIFF
--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -7,7 +7,6 @@ package stats
 
 import (
 	"bytes"
-	"sort"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/stats/quantile"
 )
@@ -152,7 +151,7 @@ func (sb *RawBucket) Export() Bucket {
 	return ret
 }
 
-func assembleGrain(b *bytes.Buffer, env, resource, service string, m map[string]string) (string, TagSet) {
+func assembleGrain(b *bytes.Buffer, env, resource, service string, m []Tag) (string, TagSet) {
 	b.Reset()
 
 	b.WriteString("env:")
@@ -162,27 +161,21 @@ func assembleGrain(b *bytes.Buffer, env, resource, service string, m map[string]
 	b.WriteString(",service:")
 	b.WriteString(service)
 
-	tagset := TagSet{{"env", env}, {"resource", resource}, {"service", service}}
+	tagset := make(TagSet, 3, 3+len(m))
+	tagset[0] = Tag{"env", env}
+	tagset[1] = Tag{"resource", resource}
+	tagset[2] = Tag{"service", service}
 
 	if m == nil || len(m) == 0 {
 		return b.String(), tagset
 	}
 
-	keys := make([]string, len(m))
-	j := 0
-	for k := range m {
-		keys[j] = k
-		j++
-	}
-
-	sort.Strings(keys) // required else aggregations would not work
-
-	for _, key := range keys {
+	for _, tag := range m {
 		b.WriteRune(',')
-		b.WriteString(key)
+		b.WriteString(tag.Name)
 		b.WriteRune(':')
-		b.WriteString(m[key])
-		tagset = append(tagset, Tag{key, m[key]})
+		b.WriteString(tag.Value)
+		tagset = append(tagset, tag)
 	}
 
 	return b.String(), tagset
@@ -194,12 +187,15 @@ func (sb *RawBucket) HandleSpan(s *WeightedSpan, env string, aggregators []strin
 		panic("env should never be empty")
 	}
 
-	m := make(map[string]string)
+	m := []Tag{}
 
 	for _, agg := range aggregators {
 		if agg != "env" && agg != "resource" && agg != "service" {
 			if v, ok := s.Meta[agg]; ok {
-				m[agg] = v
+				if len(m) == 0 {
+					m = make([]Tag, 0, len(aggregators))
+				}
+				m = append(m, Tag{agg, v})
 			}
 		}
 	}

--- a/releasenotes/notes/trace-agent-no-sorting-on-custom-aggregations-6e82a90fe47508b8.yaml
+++ b/releasenotes/notes/trace-agent-no-sorting-on-custom-aggregations-6e82a90fe47508b8.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    APM: improved stats computation by removing not needed sorting step.
+    APM: improved stats computation by removing unneeded sorting step.

--- a/releasenotes/notes/trace-agent-no-sorting-on-custom-aggregations-6e82a90fe47508b8.yaml
+++ b/releasenotes/notes/trace-agent-no-sorting-on-custom-aggregations-6e82a90fe47508b8.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: improved stats computation by removing not needed sorting step.


### PR DESCRIPTION
### What does this PR do?

This PR leverages the fact that custom aggregations are already sorted (cf [here](https://github.com/DataDog/datadog-agent/blob/7ca5a98077e0f16e922a0e0bb223b862f5d1f6e2/pkg/trace/stats/concentrator.go#L68)) to avoid the sort operation on all insertions with custom aggregations and remove some allocations

**Benchmark**

Before:
BenchmarkHandleSpanRandom-4                 	  100899	     11231 ns/op	    5641 B/op	      50 allocs/op
BenchmarkHandleSpanRandomWithCustomAggr-4   	   59293	     21202 ns/op	   12620 B/op	      86 allocs/op

After:
BenchmarkHandleSpanRandom-4                 	   93445	     11684 ns/op	    5642 B/op	      50 allocs/op
BenchmarkHandleSpanRandomWithCustomAggr-4   	   79399	     15239 ns/op	   10954 B/op	      62 allocs/op

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
