### PR TITLE
pkg/trace: precompute aggregation key length to minimize allocations

### DIFF
--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -158,6 +158,7 @@ func AssembleGrain(b *strings.Builder, env, resource, service string, m map[stri
 	b.Reset()
 	size := len("env:") + len(env) + len(",resource:") + len(resource) + len(",service:") + len(service)
 	for k, v := range m {
+		// Adds 2 additional chars for each tag to account for the "," and ":" separators in the resulting string
 		size += len(k) + len(v) + 2
 	}
 	b.Grow(size)

--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -156,6 +156,11 @@ func (sb *RawBucket) Export() Bucket {
 // service and any additional tags specified by m. It uses b as the buffer to write to.
 func AssembleGrain(b *strings.Builder, env, resource, service string, m map[string]string) (string, TagSet) {
 	b.Reset()
+	size := len("env:") + len(env) + len(",resource:") + len(resource) + len(",service:") + len(service)
+	for k, v := range m {
+		size += len(k) + len(v) + 2
+	}
+	b.Grow(size)
 
 	b.WriteString("env:")
 	b.WriteString(env)


### PR DESCRIPTION
### What does this PR do?

Resetting the strings builder drops the capacity to 0 and this change avoids having to allocate several intermediate buffers when we already know the total length of the aggregation key.

Before:

BenchmarkHandleSpanRandom-4   	   93958	     12228 ns/op	    6730 B/op	      85 allocs/op


After:

BenchmarkHandleSpanRandom-4   	   99148	     11434 ns/op	    5642 B/op	      50 allocs/op

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
