### PR TITLE
pkg/trace: remove heap allocations in signature computations

### DIFF
--- a/pkg/trace/sampler/signature.go
+++ b/pkg/trace/sampler/signature.go
@@ -112,7 +112,7 @@ func (s *sum32a) Write(data []byte) {
 	*s = hash
 }
 
-func (s *sum32a) WriteChar(c byte) {
+func (s *sum32a) WriteByte(c byte) {
 	hash := *s
 	hash ^= sum32a(c)
 	hash *= prime32

--- a/pkg/trace/sampler/signature.go
+++ b/pkg/trace/sampler/signature.go
@@ -90,14 +90,13 @@ func computeSpanHash(span *pb.Span, env string, withResource bool) spanHash {
 	return spanHash(h.Sum32())
 }
 
-
-// The implementation of sum32a is lifted from golang fnv package but simplified
+// sum32a is lifted from golang fnv package but simplified
 // for our use case to remove interfaces which caused unnecessary allocations.
-type	sum32a  uint32
+type sum32a uint32
 
 const (
-	offset32        = 2166136261
-	prime32         = 16777619
+	offset32 = 2166136261
+	prime32  = 16777619
 )
 
 func new32a() sum32a {

--- a/pkg/trace/sampler/signature.go
+++ b/pkg/trace/sampler/signature.go
@@ -6,9 +6,10 @@
 package sampler
 
 import (
+	"sort"
+
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
-	"sort"
 )
 
 // Signature is a hash representation of trace or a service, used to identify
@@ -61,7 +62,7 @@ type ServiceSignature struct{ Name, Env string }
 func (s ServiceSignature) Hash() Signature {
 	h := new32a()
 	h.Write([]byte(s.Name))
-	h.WriteChar(',')
+	h.WriteByte(',')
 	h.Write([]byte(s.Env))
 	return Signature(h.Sum32())
 }
@@ -75,7 +76,7 @@ func computeSpanHash(span *pb.Span, env string, withResource bool) spanHash {
 	h.Write([]byte(env))
 	h.Write([]byte(span.Service))
 	h.Write([]byte(span.Name))
-	h.WriteChar(byte(span.Error))
+	h.WriteByte(byte(span.Error))
 	if withResource {
 		h.Write([]byte(span.Resource))
 	}

--- a/pkg/trace/sampler/signature.go
+++ b/pkg/trace/sampler/signature.go
@@ -90,7 +90,7 @@ func computeSpanHash(span *pb.Span, env string, withResource bool) spanHash {
 	return spanHash(h.Sum32())
 }
 
-// sum32a is lifted from golang fnv package but simplified
+// sum32a is an adaptation of https://golang.org/pkg/hash/fnv/#New32a, but simplified
 // for our use case to remove interfaces which caused unnecessary allocations.
 type sum32a uint32
 

--- a/pkg/trace/sampler/signature.go
+++ b/pkg/trace/sampler/signature.go
@@ -62,7 +62,7 @@ type ServiceSignature struct{ Name, Env string }
 func (s ServiceSignature) Hash() Signature {
 	h := new32a()
 	h.Write([]byte(s.Name))
-	h.WriteByte(',')
+	h.WriteChar(',')
 	h.Write([]byte(s.Env))
 	return Signature(h.Sum32())
 }
@@ -76,7 +76,7 @@ func computeSpanHash(span *pb.Span, env string, withResource bool) spanHash {
 	h.Write([]byte(env))
 	h.Write([]byte(span.Service))
 	h.Write([]byte(span.Name))
-	h.WriteByte(byte(span.Error))
+	h.WriteChar(byte(span.Error))
 	if withResource {
 		h.Write([]byte(span.Resource))
 	}
@@ -113,7 +113,7 @@ func (s *sum32a) Write(data []byte) {
 	*s = hash
 }
 
-func (s *sum32a) WriteByte(c byte) {
+func (s *sum32a) WriteChar(c byte) {
 	hash := *s
 	hash ^= sum32a(c)
 	hash *= prime32

--- a/pkg/trace/sampler/signature_test.go
+++ b/pkg/trace/sampler/signature_test.go
@@ -7,12 +7,13 @@ package sampler
 
 import (
 	"hash/fnv"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func testComputeSignature(trace pb.Trace) Signature {

--- a/pkg/trace/sampler/signature_test.go
+++ b/pkg/trace/sampler/signature_test.go
@@ -6,6 +6,8 @@
 package sampler
 
 import (
+	"hash/fnv"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
@@ -154,4 +156,37 @@ func TestServiceSignatureDifferentEnv(t *testing.T) {
 	}
 
 	assert.NotEqual(testComputeServiceSignature(t1), testComputeServiceSignature(t2))
+}
+
+func TestFnvImplem(t *testing.T) {
+	assert := assert.New(t)
+	testList := []string{"this", "is", "just", "a", "sanity", "check", "Съешь же ещё этих мягких французских булок да выпей чаю"}
+	for _, s := range testList {
+		h := fnv.New32a()
+		h.Write([]byte(s))
+		expected := h.Sum32()
+
+		h2 := new32a()
+		h2.Write([]byte(s))
+		actual := h2.Sum32()
+
+		assert.Equal(expected, actual)
+	}
+}
+
+func BenchmarkServiceSignature_Hash(b *testing.B) {
+	s1 := rand.String(10)
+	s2 := rand.String(10)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ServiceSignature{s1, s2}.Hash()
+	}
+}
+
+func BenchmarkComputeSpanHash(b *testing.B) {
+	span := &pb.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		computeSpanHash(span, "prod", true)
+	}
 }

--- a/pkg/trace/sampler/signature_test.go
+++ b/pkg/trace/sampler/signature_test.go
@@ -158,7 +158,7 @@ func TestServiceSignatureDifferentEnv(t *testing.T) {
 	assert.NotEqual(testComputeServiceSignature(t1), testComputeServiceSignature(t2))
 }
 
-func TestFnvImplem(t *testing.T) {
+func TestSum32a(t *testing.T) {
 	assert := assert.New(t)
 	testList := []string{"this", "is", "just", "a", "sanity", "check", "Съешь же ещё этих мягких французских булок да выпей чаю"}
 	for _, s := range testList {

--- a/releasenotes/notes/trace-agent-no-heap-allocs-in-signature-computations-5418d04185c2e1ca.yaml
+++ b/releasenotes/notes/trace-agent-no-heap-allocs-in-signature-computations-5418d04185c2e1ca.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: improved trace signature computation by avoiding heap allocations.


### PR DESCRIPTION
### What does this PR do?

We compute signatures for all toplevel spans ingested and these used to make some allocations just to copy data that is immediately discarded after the hash computation. This PR copies the code of the hash function and specializes it for our use case to remove the allocations.

Benchmarks for ServiceSignature show that allocs went from 4 and 6 to 0 depending on the hash function and execution time was reduced by 73% and 75% as a result.

 ```
name                     old time/op    new time/op    delta
ServiceSignature_Hash-4     130ns ± 2%      35ns ± 1%   -73.43%  (p=0.008 n=5+5)
ComputeSpanHash-4           180ns ±11%      45ns ± 1%   -75.09%  (p=0.008 n=5+5)

name                     old alloc/op   new alloc/op   delta
ServiceSignature_Hash-4     40.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
ComputeSpanHash-4           48.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)

name                     old allocs/op  new allocs/op  delta
ServiceSignature_Hash-4      4.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
ComputeSpanHash-4            6.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
```

On my memory profiles when benchmarking the agent with single span traces these represented ~20% of the total number of allocations:
<img width="644" alt="image" src="https://user-images.githubusercontent.com/425368/99097570-175bfc00-25d8-11eb-8c17-478b5dec2373.png">


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
