### PR TITLE
[agent/tcp_queue_length] Rename tcp_queue_length metrics

### DIFF
--- a/pkg/collector/corechecks/ebpf/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcp_queue_length.go
@@ -115,8 +115,8 @@ func (t *TCPQueueLengthCheck) Run() error {
 			}
 		}
 
-		sender.Gauge("tcp_queue.read_buffer_max_fill_rate", float64(v.ReadBufferMaxFillRate)/1000.0, "", tags)
-		sender.Gauge("tcp_queue.write_buffer_max_fill_rate", float64(v.WriteBufferMaxFillRate)/1000.0, "", tags)
+		sender.Gauge("tcp_queue.read_buffer_max_usage_pct", float64(v.ReadBufferMaxUsage)/1000.0, "", tags)
+		sender.Gauge("tcp_queue.write_buffer_max_usage_pct", float64(v.WriteBufferMaxUsage)/1000.0, "", tags)
 	}
 
 	sender.Commit()

--- a/pkg/ebpf/c/tcp-queue-length-kern.c
+++ b/pkg/ebpf/c/tcp-queue-length-kern.c
@@ -24,8 +24,8 @@ BPF_HASH(who_sendmsg, u64, struct sock*, 100);
 // TODO: replace all `bpf_probe_read` by `bpf_probe_read_kernel` once we can assume that we have at least kernel 5.5
 static inline int check_sock(struct sock* sk) {
     struct stats_value zero = {
-        .read_buffer_max_fill_rate = 0,
-        .write_buffer_max_fill_rate = 0
+        .read_buffer_max_usage = 0,
+        .write_buffer_max_usage = 0
     };
 
     struct stats_key k;
@@ -51,13 +51,13 @@ static inline int check_sock(struct sock* sk) {
         rqueue = 0;
     u32 wqueue = write_seq - snd_una;
 
-    u32 rqueue_fill_rate = 1000 * rqueue / rqueue_size;
-    u32 wqueue_fill_rate = 1000 * wqueue / wqueue_size;
+    u32 rqueue_usage = 1000 * rqueue / rqueue_size;
+    u32 wqueue_usage = 1000 * wqueue / wqueue_size;
 
-    if (rqueue_fill_rate > v->read_buffer_max_fill_rate)
-        v->read_buffer_max_fill_rate = rqueue_fill_rate;
-    if (wqueue_fill_rate > v->write_buffer_max_fill_rate)
-        v->write_buffer_max_fill_rate = wqueue_fill_rate;
+    if (rqueue_usage > v->read_buffer_max_usage)
+        v->read_buffer_max_usage = rqueue_usage;
+    if (wqueue_usage > v->write_buffer_max_usage)
+        v->write_buffer_max_usage = wqueue_usage;
 
     return 0;
 }

--- a/pkg/ebpf/tcp-queue-length-kern-user.h
+++ b/pkg/ebpf/tcp-queue-length-kern-user.h
@@ -8,8 +8,8 @@ struct stats_key {
 };
 
 struct stats_value {
-  __u32 read_buffer_max_fill_rate;
-  __u32 write_buffer_max_fill_rate;
+  __u32 read_buffer_max_usage;
+  __u32 write_buffer_max_usage;
 };
 
 #endif /* defined(TCP_QUEUE_LENGTH_KERN_USER_H) */

--- a/pkg/ebpf/tcp_queue_length.go
+++ b/pkg/ebpf/tcp_queue_length.go
@@ -112,11 +112,11 @@ func (t *TCPQueueLengthTracer) Get() tcpqueuelength.Stats {
 				log.Error("Too many CPUs")
 				continue
 			}
-			if uint32(statsValue[cpu].read_buffer_max_fill_rate) > max.ReadBufferMaxFillRate {
-				max.ReadBufferMaxFillRate = uint32(statsValue[cpu].read_buffer_max_fill_rate)
+			if uint32(statsValue[cpu].read_buffer_max_usage) > max.ReadBufferMaxUsage {
+				max.ReadBufferMaxUsage = uint32(statsValue[cpu].read_buffer_max_usage)
 			}
-			if uint32(statsValue[cpu].write_buffer_max_fill_rate) > max.WriteBufferMaxFillRate {
-				max.WriteBufferMaxFillRate = uint32(statsValue[cpu].write_buffer_max_fill_rate)
+			if uint32(statsValue[cpu].write_buffer_max_usage) > max.WriteBufferMaxUsage {
+				max.WriteBufferMaxUsage = uint32(statsValue[cpu].write_buffer_max_usage)
 			}
 		}
 		result[containerID] = max

--- a/pkg/ebpf/tcpqueuelength/types.go
+++ b/pkg/ebpf/tcpqueuelength/types.go
@@ -7,8 +7,8 @@ type StatsKey struct {
 
 // StatsValue is the type of the `Stats` map value: the maximum fill rate of busiest read and write buffers
 type StatsValue struct {
-	ReadBufferMaxFillRate  uint32 `json:"read_buffer_max_fill_rate"`
-	WriteBufferMaxFillRate uint32 `json:"write_buffer_max_fill_rate"`
+	ReadBufferMaxUsage  uint32 `json:"read_buffer_max_usage"`
+	WriteBufferMaxUsage uint32 `json:"write_buffer_max_usage"`
 }
 
 // Stats is the map of the maximum fill rate of the read and write buffers per container

--- a/releasenotes/notes/tcp-queue-length-max-fill-rate-492a5b1a6444a609.yaml
+++ b/releasenotes/notes/tcp-queue-length-max-fill-rate-492a5b1a6444a609.yaml
@@ -9,6 +9,6 @@
 upgrade:
   - |
     tcp_queue_length check: the previous metrics reported by this check (``tcp_queue.rqueue.size``, ``tcp_queue.rqueue.min``, ``tcp_queue.rqueue.max``, ``tcp_queue.wqueue.size``, ``tcp_queue.wqueue.min``, ``tcp_queue.wqueue.max``) were generating too much data because there was one time series generated per TCP connection.
-    Those metrics have been replaced by ``tcp_queue.read_buffer_max_fill_rate``, ``tcp_queue.write_buffer_max_fill_rate`` which are aggregating all the connections of a container.
-    These metrics are reporting the maximum fill rate (amount of data divided by the queue capacity) of the busiest buffer.
-    Additionally, `only_count_nb_context` option from the `tcp_queue_length` check configuration has been removed and will be ignore from now on.
+    Those metrics have been replaced by ``tcp_queue.read_buffer_max_usage_pct``, ``tcp_queue.write_buffer_max_usage_pct`` which are aggregating all the connections of a container.
+    These metrics are reporting the maximum usage in percent (amount of data divided by the queue capacity) of the busiest buffer.
+    Additionally, `only_count_nb_context` option from the `tcp_queue_length` check configuration has been removed and will be ignored from now on.


### PR DESCRIPTION
### What does this PR do?

This renames the following metrics reported by the `tcp_queue_length` check:
- `tcp_queue.read_buffer_max_fill_rate` => `tcp_queue.read_buffer_max_usage_pct`
- `tcp_queue.write_buffer_max_fill_rate` => `tcp_queue.write_buffer_max_usage_pct`

### Motivation

Better readability and clarity about what these metrics represent

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy a pod running two netcat containers (server and client), enable the `tcp_queue_length` check and make sure the metrics are reported with the correct names.
