### PR TITLE
Add profiler to system-probe if enabled

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -21,6 +21,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 // All System Probe modules should register their factories here
@@ -85,6 +87,14 @@ func runAgent(exit <-chan struct{}) {
 		gracefulExit()
 	}
 
+	if cfg.ProfilingEnabled {
+		if err := enableProfiling(cfg); err != nil {
+			log.Criticalf("failed to enable profiling: %s", err)
+			cleanupAndExit(1)
+		}
+		defer profiling.Stop()
+	}
+
 	log.Infof("running system-probe with version: %s", versionString(", "))
 
 	// configure statsd
@@ -146,6 +156,28 @@ func runAgent(exit <-chan struct{}) {
 
 	log.Infof("system probe successfully started")
 	<-exit
+}
+
+func enableProfiling(cfg *config.AgentConfig) error {
+	// allow full url override for development use
+	s := ddconfig.DefaultSite
+	if cfg.ProfilingSite != "" {
+		s = cfg.ProfilingSite
+	}
+
+	site := fmt.Sprintf(profiling.ProfileURLTemplate, s)
+	if cfg.ProfilingURL != "" {
+		site = cfg.ProfilingURL
+	}
+
+	v, _ := version.Agent()
+	return profiling.Start(
+		cfg.ProfilingAPIKey,
+		site,
+		cfg.ProfilingEnvironment,
+		"system-probe",
+		fmt.Sprintf("version:%v", v),
+	)
 }
 
 func gracefulExit() {

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -89,8 +89,7 @@ func runAgent(exit <-chan struct{}) {
 
 	if cfg.ProfilingEnabled {
 		if err := enableProfiling(cfg); err != nil {
-			log.Criticalf("failed to enable profiling: %s", err)
-			cleanupAndExit(1)
+			log.Warnf("failed to enable profiling: %s", err)
 		}
 		defer profiling.Stop()
 	}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -920,6 +920,25 @@ api_key:
   #
   # log_file: /var/log/datadog/system-probe.log
 
+{{- if .Profiling -}}
+  ## @param profiling - custom object - optional
+  ## Enter specific configurations for profiling.
+  ## Uncomment this parameter and the one below to enable profiling.
+  ## See https://docs.datadoghq.com/tracing/profiling/
+  #
+  ## NOTE: If enabled this option may incur billing charges or other
+  ##       unexpected side-effects (ie. system probe profiles showing with your
+  ##       services).
+  #
+  # profiling:
+  #
+    ## @param enabled - boolean - optional - default: false
+    ## Enable profiling for the System Probe process.
+    #
+    # enabled: false
+
+{{ end }}
+
 {{- if .NetworkModule }}
 
 ########################################

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -56,24 +56,29 @@ type WindowsConfig struct {
 // AgentConfig is the global config for the process-agent. This information
 // is sourced from config files and the environment variables.
 type AgentConfig struct {
-	Enabled            bool
-	HostName           string
-	APIEndpoints       []api.Endpoint
-	LogFile            string
-	LogLevel           string
-	LogToConsole       bool
-	QueueSize          int // The number of items allowed in each delivery queue.
-	ProcessQueueBytes  int // The total number of bytes that can be enqueued for delivery to the process intake endpoint
-	Blacklist          []*regexp.Regexp
-	Scrubber           *DataScrubber
-	MaxPerMessage      int
-	MaxConnsPerMessage int
-	AllowRealTime      bool
-	Transport          *http.Transport `json:"-"`
-	DDAgentBin         string
-	StatsdHost         string
-	StatsdPort         int
-	ProcessExpVarPort  int
+	Enabled              bool
+	HostName             string
+	APIEndpoints         []api.Endpoint
+	LogFile              string
+	LogLevel             string
+	LogToConsole         bool
+	QueueSize            int // The number of items allowed in each delivery queue.
+	ProcessQueueBytes    int // The total number of bytes that can be enqueued for delivery to the process intake endpoint
+	Blacklist            []*regexp.Regexp
+	Scrubber             *DataScrubber
+	MaxPerMessage        int
+	MaxConnsPerMessage   int
+	AllowRealTime        bool
+	Transport            *http.Transport `json:"-"`
+	DDAgentBin           string
+	StatsdHost           string
+	StatsdPort           int
+	ProcessExpVarPort    int
+	ProfilingEnabled     bool
+	ProfilingSite        string
+	ProfilingURL         string
+	ProfilingAPIKey      string
+	ProfilingEnvironment string
 	// host type of the agent, used to populate container payload with additional host information
 	ContainerHostType model.ContainerHostType
 
@@ -488,6 +493,11 @@ func loadSysProbeEnvVariables() {
 		{"DD_DISABLE_DNS_INSPECTION", "system_probe_config.disable_dns_inspection"},
 		{"DD_COLLECT_LOCAL_DNS", "system_probe_config.collect_local_dns"},
 		{"DD_COLLECT_DNS_STATS", "system_probe_config.collect_dns_stats"},
+		{"DD_SYSTEM_PROBE_PROFILING_ENABLED", "system_probe_config.profiling.enabled"},
+		{"DD_SITE", "system_probe_config.profiling.site"},
+		{"DD_APM_PROFILING_DD_URL", "system_probe_config.profiling.profile_dd_url"},
+		{"DD_API_KEY", "system_probe_config.profiling.api_key"},
+		{"DD_ENV", "system_probe_config.profiling.env"},
 	} {
 		if v, ok := os.LookupEnv(variable.env); ok {
 			config.Datadog.Set(variable.cfg, v)

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -195,6 +195,14 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		a.Enabled = true
 	}
 
+	if config.Datadog.IsSet(key(spNS, "profiling_enabled")) {
+		a.ProfilingEnabled = config.Datadog.GetBool(key(spNS, "profiling.enabled"))
+		a.ProfilingSite = config.Datadog.GetString(key(spNS, "profiling.site"))
+		a.ProfilingURL = config.Datadog.GetString(key(spNS, "profiling.profile_dd_url"))
+		a.ProfilingAPIKey = config.Datadog.GetString(key(spNS, "profiling.api_key"))
+		a.ProfilingEnvironment = config.Datadog.GetString(key(spNS, "profiling.env"))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds the ability for the system-probe to have profiling turned on.

### Motivation

The ability to investigate performance issues in the Windows system-probe.

### Additional Notes

The `api_key`, `env`, `site`, and `profile_dd_url` vars are **not** read from the main agent config, since this is something not currently done by the system-probe and it would complicate setup to add.

### Describe your test plan

Turn on profiling using the config vars in `system-probe.yaml` and ensure data flows to APM.
