### PR TITLE
[logging] Fix a few small regressions

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -127,7 +127,7 @@ func StartServer() error {
 			NextProtos:   []string{"h2"},
 		},
 		ErrorLog: stdLog.New(&config.ErrorLogWriter{
-			AdditionalDepth: 4, // Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
+			AdditionalDepth: 5, // Use a stack depth of 5 on top of the default one to get a relevant filename in the stdlib
 		}, "Error from the agent http API server: ", 0), // log errors to seelog,
 		WriteTimeout: config.Datadog.GetDuration("server_timeout") * time.Second,
 	}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1180,6 +1180,11 @@ api_key:
 #
 # jmx_use_container_support: false
 
+## @param jmx_log_file - string - optional
+## Path of the log file where JMXFetch logs are written.
+#
+# jmx_log_file: <JMXFETCH_LOG_FILE_PATH>
+
 ## @param jmx_max_restarts - integer - optional - default: 3
 ## Number of JMX restarts allowed in the restart-interval before giving up.
 #

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -105,10 +105,13 @@ func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, sys
 		return err
 	}
 	loggerInterface, err := GenerateLoggerInterface(seelogConfig)
+	if err != nil {
+		return err
+	}
 	_ = seelog.ReplaceLogger(loggerInterface)
 	log.SetupLogger(loggerInterface, seelogLogLevel)
 	log.AddStrippedKeys(Datadog.GetStringSlice("flare_stripped_keys"))
-	return err
+	return nil
 }
 
 // SetupJMXLogger sets up a logger with JMX logger name and log level
@@ -125,8 +128,11 @@ func SetupJMXLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, 
 		return err
 	}
 	jmxLoggerInterface, err := GenerateLoggerInterface(jmxSeelogConfig)
+	if err != nil {
+		return err
+	}
 	log.SetupJMXLogger(jmxLoggerInterface, seelogLogLevel)
-	return err
+	return nil
 }
 
 func buildLoggerConfig(loggerName LoggerName, seelogLogLevel, logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool) (*seelogCfg.Config, error) {
@@ -169,7 +175,7 @@ func GenerateLoggerInterface(logConfig *seelogCfg.Config) (seelog.LoggerInterfac
 		return nil, err
 	}
 
-	return loggerInterface, err
+	return loggerInterface, nil
 }
 
 // ErrorLogWriter is a Writer that logs all written messages with the global seelog logger

--- a/pkg/config/log_nix_test.go
+++ b/pkg/config/log_nix_test.go
@@ -26,3 +26,12 @@ func TestGetSyslogURI(t *testing.T) {
 	mockConfig.Set("syslog_uri", "")
 	assert.Equal(GetSyslogURI(), "")
 }
+
+func TestSetupLoggingNowhere(t *testing.T) {
+	// setup logger so that it logs nowhere: i.e.  not to file, not to syslog, not to console
+	seelogConfig, _ = buildLoggerConfig("agent", "info", "", "", false, false, false)
+	loggerInterface, err := GenerateLoggerInterface(seelogConfig)
+
+	assert.Nil(t, loggerInterface)
+	assert.NotNil(t, err)
+}

--- a/releasenotes/notes/jmxfetch-log-file-8009038117c6d3c5.yaml
+++ b/releasenotes/notes/jmxfetch-log-file-8009038117c6d3c5.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When enabled, JMXFetch now logs to its own log file. Defaults to ``jmxfetch.log``
+    in the default agent log directory, and can be configured with ``jmx_log_file``.


### PR DESCRIPTION
### What does this PR do?

Addresses a couple of regressions introduced in https://github.com/DataDog/datadog-agent/pull/5671/:

1. Do not panic if the agent is configured to log nowhere (instead the agent should print an error and exit)
2. Fix the logging of log entries logged before logger init (they were not logged at all anymore)

\+ fixes a small unrelated issue with the additional stack depth of errors logged from the internal HTTP server
\+ adds a release note and documentation on the `jmx_log_file` option that that PR introduced

### Additional Notes

Each change is in its own commit.

### Describe your test plan

Unfortunately the logging logic is hard to unit test. I've done the following manual testing:
* `Do not panic if the agent is configured to log nowhere`: set the agent to log nowhere (`disable_file_logging: true` and `log_to_console: false`), the agent should exit with an error instead of crashing on a nil pointer.
* `Fix the logging of log entries logged before logger init (they were not logged at all anymore)`: put a non-existing option in `datadog.yaml` and start the agent: the agent should log `Unknown key in config file: [...]` at startup.
* `issue with the additional stack depth of errors logged from the internal HTTP server`: make the http server log an error (for example with `curl https://localhost:5001`), check the stack context in the logged error is relevant.
