### PR TITLE
Fixes bug introduced by #6694.  Install would fail when upgrading fro…

### DIFF
--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -946,6 +946,9 @@ int verifyServices(CustomActionData& data)
         } else {
             WcaLog(LOGMSG_STANDARD, "Error removing system probe service %d", retval);
         }
+        // reset retval to zero.  If we were unable to remove the system-probe service,
+        // and it's not present anyway, don't cause the entire install to fail
+        retval = 0;
     }
     WcaLog(LOGMSG_STANDARD, "done updating services");
    


### PR DESCRIPTION
…m an install that didn't already have system-probe

### What does this PR do?

Fixes PR #6694 

That PR introduced a bug that iupon upgrade from an install that didn't have system probe, the upgrade
would fail.  Fixes that bug
