### PR TITLE
[runtime-security] make sure arm64 is not interpreted as ia32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/DataDog/agent-payload v4.46.0+incompatible
 	github.com/DataDog/datadog-go v3.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
-	github.com/DataDog/ebpf v0.0.0-20201015152207-a91a2d800994
+	github.com/DataDog/ebpf v0.0.0-20201116165404-c4cbb9e2e108
 	github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/DataDog/datadog-go v3.5.0+incompatible h1:AShr9cqkF+taHjyQgcBcQUt/ZNK
 github.com/DataDog/datadog-go v3.5.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822 h1:E5WNl43j4mpE3V35QySkRnP/m9pjXOnEZD6eyTK7Qvk=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822/go.mod h1:a5NqgPglcSct+NwO9gPvVhoL5V6G1+gHbRaRnU8U54M=
-github.com/DataDog/ebpf v0.0.0-20201015152207-a91a2d800994 h1:dbl6KbfE4EGBoTV/c1lhshLCAQbYP34vSHkU3zX8QRY=
-github.com/DataDog/ebpf v0.0.0-20201015152207-a91a2d800994/go.mod h1:rIVS3jqxhqtYJtznvFI8qtCbYG1M7WQZS4Z15/nCmOI=
+github.com/DataDog/ebpf v0.0.0-20201116165404-c4cbb9e2e108 h1:AKqxL/BBv6exUCY1Ihuhxt/9AcO7w0mC+NkZ0EajBIU=
+github.com/DataDog/ebpf v0.0.0-20201116165404-c4cbb9e2e108/go.mod h1:rIVS3jqxhqtYJtznvFI8qtCbYG1M7WQZS4Z15/nCmOI=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71 h1:0TOAH3X9tEvMBVQ1HYrQfrnAUcSS1mfMrhqeN+spV1s=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71/go.mod h1:rNvi5cSHdpxN6495MOYAWN3yukac8lORoluL+9Osrsw=
 github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a h1:BkU6uq4Ib7Kp1zP7MT33IdHZQazC+kxbuTyEmgePyyA=

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -28,6 +28,8 @@ func resolveRuntimeArch() {
 	switch string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]) {
 	case "x86_64":
 		RuntimeArch = "x64"
+	case "aarch64":
+		RuntimeArch = "arm64"
 	default:
 		RuntimeArch = "ia32"
 	}


### PR DESCRIPTION
### What does this PR do?

When the system is not x64, we assume that it's an intel 32 bits system. But it could be something else like arm64 now that we have arm builds. 
I suppose we could also add a case like, but I wasn't too sure about the specifics so I didn't do it

```go
	case "armv7l":
		RuntimeArch = "arm" // Not sure which value to put here
```

It should be a no-op because we only do something if `RuntimeArch == "x64"`, but I think it's worth adding another case here in case `ia32` is used for something

It also updates ebpf dependency to the lastest version, that include a fix for a panic 

### Motivation

I was running the agent agent on arm64 (image `datadog/agent-arm64:7.24.0-rc.5-jmx` on a raspberry pi, with ubuntu 64bits) and got into this issue https://github.com/DataDog/datadog-agent/issues/6418. 
I've seen the code has been moved to our eBPF repo so I made a PR https://github.com/DataDog/ebpf/pull/25

I went a bit up on the call stack to see if there was any obvious things that would broke and notice this potential problem

### Additional Notes

Sorry I couldn't put up labels and milestone and all, it looks like I lost my rights on the repo (also why I had to fork it on my own github account)

### Describe your test plan

Does the CI generates a binary ? i'd be happy to test it on my RPi 
