### PR TITLE
Improve FreeBSD support.

### DIFF
--- a/cmd/agent/common/common_freebsd.go
+++ b/cmd/agent/common/common_freebsd.go
@@ -3,21 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build netbsd openbsd solaris dragonfly linux
-// +build !freebsd !android
-
 package common
 
 import (
 	"path/filepath"
-
-	// Init packages
-	_ "github.com/DataDog/datadog-agent/pkg/util/containers/providers/cgroup"
 )
 
 const (
 	// DefaultConfPath points to the folder containing datadog.yaml
-	DefaultConfPath = "/etc/datadog-agent"
+	DefaultConfPath = "/usr/local/etc/datadog-agent"
 	// DefaultLogFile points to the log file that will be used if not configured
 	DefaultLogFile = "/var/log/datadog/agent.log"
 	// DefaultDCALogFile points to the log file that will be used if not configured

--- a/pkg/collector/corechecks/system/file_handles.go
+++ b/pkg/collector/corechecks/system/file_handles.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 // +build !windows
+// +build !freebsd
 
 package system
 

--- a/pkg/collector/corechecks/system/file_handles_freebsd.go
+++ b/pkg/collector/corechecks/system/file_handles_freebsd.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+// +build freebsd
+
+package system
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/blabber/go-freebsd-sysctl/sysctl"
+)
+
+const fileHandlesCheckName = "file_handle"
+
+type fhCheck struct {
+	core.CheckBase
+}
+
+// Run executes the check
+func (c *fhCheck) Run() error {
+
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+	openFh, err := sysctl.GetInt64("kern.openfiles")
+	if err != nil {
+		log.Warnf("Error getting kern.openfiles value %v", err)
+		return err
+	}
+	maxFh, err := sysctl.GetInt64("kern.maxfiles")
+	if err != nil {
+		log.Warnf("Error getting kern.maxfiles value %v", err)
+		return err
+	}
+	log.Debugf("Submitting kern.openfiles %v", openFh)
+	log.Debugf("Submitting kern.maxfiles %v", maxFh)
+	sender.Gauge("system.fs.file_handles.in_use", float64(openFh), "", nil)
+	sender.Gauge("system.fs.file_handles.max", float64(maxFh), "", nil)
+	sender.Commit()
+
+	return nil
+}
+
+// The check doesn't need configuration
+func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data, source string) (err error) {
+	if err := c.CommonConfigure(data, source); err != nil {
+		return err
+	}
+
+	return err
+}
+
+func fhFactory() check.Check {
+	return &fhCheck{
+		CheckBase: core.NewCheckBase(fileHandlesCheckName),
+	}
+}
+
+func init() {
+	core.RegisterCheck(fileHandlesCheckName, fhFactory)
+}

--- a/pkg/collector/corechecks/system/file_handles_freebsd.go
+++ b/pkg/collector/corechecks/system/file_handles_freebsd.go
@@ -7,11 +7,11 @@
 package system
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/blabber/go-freebsd-sysctl/sysctl"
 )
 

--- a/pkg/collector/corechecks/system/file_handles_freebsd_test.go
+++ b/pkg/collector/corechecks/system/file_handles_freebsd_test.go
@@ -7,8 +7,8 @@
 package system
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -23,7 +23,9 @@ func TestFhCheckFreeBSD(t *testing.T) {
 	fileHandleCheck.Configure(nil, nil, "test")
 
 	monkey.PatchInstanceMethod(reflect.TypeOf(sysctl), "GetInt64", func(name string) (value int64, err error) {
-		return (65534, nil)
+		value = 65534
+		err = nil
+		return
 	})
 
 	mock := mocksender.NewMockSender(fileHandleCheck.ID())

--- a/pkg/collector/corechecks/system/file_handles_freebsd_test.go
+++ b/pkg/collector/corechecks/system/file_handles_freebsd_test.go
@@ -8,9 +8,11 @@ package system
 
 import (
 	"testing"
+	"reflect"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/blabber/go-freebsd-sysctl/sysctl"
 
 	"bou.ke/monkey"
 )
@@ -20,7 +22,7 @@ func TestFhCheckFreeBSD(t *testing.T) {
 	fileHandleCheck := new(fhCheck)
 	fileHandleCheck.Configure(nil, nil, "test")
 
-	monkey.PatchInstanceMethod(sysctl.GetInt64, (name string, err error)) {
+	monkey.PatchInstanceMethod(reflect.TypeOf(sysctl), "GetInt64", func(name string) (value int64, err error) {
 		return (65534, nil)
 	})
 

--- a/pkg/collector/corechecks/system/file_handles_freebsd_test.go
+++ b/pkg/collector/corechecks/system/file_handles_freebsd_test.go
@@ -2,7 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
-// +build !freebsd
+// +build freebsd
 
 package system
 

--- a/pkg/collector/corechecks/system/file_handles_freebsd_test.go
+++ b/pkg/collector/corechecks/system/file_handles_freebsd_test.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+// +build !freebsd
+
+package system
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"bou.ke/monkey"
+)
+
+func TestFhCheckFreeBSD(t *testing.T) {
+
+	fileHandleCheck := new(fhCheck)
+	fileHandleCheck.Configure(nil, nil, "test")
+
+	monkey.PatchInstanceMethod(sysctl.GetInt64, (name string, err error)) {
+		return (65534, nil)
+	})
+
+	mock := mocksender.NewMockSender(fileHandleCheck.ID())
+
+	mock.On("Gauge", "system.fs.file_handles.in_use", 421, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.max", 65534, "", []string(nil)).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
+	fileHandleCheck.Run()
+
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 2)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+
+}

--- a/rtloader/rtloader/CMakeLists.txt
+++ b/rtloader/rtloader/CMakeLists.txt
@@ -35,6 +35,12 @@ if(EXECINFO)
 endif()
 endif()
 
+## Backtrace
+if(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
+  find_package(Backtrace REQUIRED)
+  target_link_libraries(datadog-agent-rtloader ${Backtrace_LIBRARIES})
+endif()
+
 set_target_properties(datadog-agent-rtloader PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION 1

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -36,6 +36,9 @@
 #elif __APPLE__
 #    define DATADOG_AGENT_TWO "libdatadog-agent-two.dylib"
 #    define DATADOG_AGENT_THREE "libdatadog-agent-three.dylib"
+#elif __FreeBSD__
+#    define DATADOG_AGENT_TWO "libdatadog-agent-two.so"
+#    define DATADOG_AGENT_THREE "libdatadog-agent-three.so"
 #elif _WIN32
 #    define DATADOG_AGENT_TWO "libdatadog-agent-two.dll"
 #    define DATADOG_AGENT_THREE "libdatadog-agent-three.dll"


### PR DESCRIPTION
### What does this PR do?

This changes add better FreeBSD support and replace patches used in FreeBSD ports system

### Motivation

I'm a maintainer off FreeBSD port and this is backport of what I need to change to build datadog-agent on FreeBSD
