### PR TITLE
[Fix][Unified Tagging] Use container image name as logs source

### DIFF
--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -187,23 +187,25 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 		if !l.collectAll {
 			return nil, errCollectAllDisabled
 		}
+		// The logs source is the short image name
+		logsSource := ""
+		shortImageName, err := l.getShortImageName(pod, container.Name)
+		if err != nil {
+			log.Debugf("Couldn't get short image for container '%s': %v", container.Name, err)
+			// Fallback and use `kubernetes` as source name
+			logsSource = kubernetesIntegration
+		} else {
+			logsSource = shortImageName
+		}
 		if standardService != "" {
 			cfg = &config.LogsConfig{
-				Source:  kubernetesIntegration,
+				Source:  logsSource,
 				Service: standardService,
 			}
 		} else {
-			shortImageName, err := l.getShortImageName(pod, container.Name)
-			if err != nil {
-				cfg = &config.LogsConfig{
-					Source:  kubernetesIntegration,
-					Service: kubernetesIntegration,
-				}
-			} else {
-				cfg = &config.LogsConfig{
-					Source:  shortImageName,
-					Service: shortImageName,
-				}
+			cfg = &config.LogsConfig{
+				Source:  logsSource,
+				Service: logsSource,
 			}
 		}
 	}

--- a/releasenotes/notes/fix-logs-source-value-a623c6b83dbbc0f2.yaml
+++ b/releasenotes/notes/fix-logs-source-value-a623c6b83dbbc0f2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The logs agent now uses the container image name as logs source instead of 
+    `kubernetes` when a standard service value was defined for the container.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where we use `kubernetes` as logs source instead of the container short image name, this happens only when a unified service was assigned to the container via `DD_SERVICE` or `tags.datadoghq.com/service`

### Motivation

Support escalation

### Additional Notes

The docker launcher is not impacted, only kubernetes

### Describe your test plan

- Assign a standard service to a logging container via `DD_SERVICE` or `tags.datadoghq.com/service`
- Enable logs collection + k8s files as source of logs + container collect all
- With previous agent versions, the logs source attribute/tag is `kuberentes`, with this fix it will be the short image name