### PR TITLE
Fix parsing of pre-release versions for integrations

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -48,9 +48,9 @@ except pkg_resources.DistributionNotFound:
 var (
 	datadogPkgNameRe      = regexp.MustCompile("datadog-.*")
 	yamlFileNameRe        = regexp.MustCompile("[\\w_]+\\.yaml.*")
-	wheelPackageNameRe    = regexp.MustCompile("Name: (\\S+)")                                                                                // e.g. Name: datadog-postgres
-	versionSpecifiersRe   = regexp.MustCompile("([><=!]{1,2})([0-9.]*)")                                                                      // Matches version specifiers defined in https://packaging.python.org/specifications/core-metadata/#requires-dist-multiple-use
-	pep440VersionStringRe = regexp.MustCompile("^(?P<release>\\d+\\.\\d+\\.\\d+)(?:(?P<preReleaseType>a|b|rc)(?P<preReleaseNumber>\\d+)?)?$") // e.g. 1.3.4b1, simplified form of: https://www.python.org/dev/peps/pep-0440
+	wheelPackageNameRe    = regexp.MustCompile("Name: (\\S+)")                                                                                   // e.g. Name: datadog-postgres
+	versionSpecifiersRe   = regexp.MustCompile("([><=!]{1,2})([0-9.]*)")                                                                         // Matches version specifiers defined in https://packaging.python.org/specifications/core-metadata/#requires-dist-multiple-use
+	pep440VersionStringRe = regexp.MustCompile("^(?P<release>\\d+\\.\\d+\\.\\d+)(?:(?P<preReleaseType>[a-zA-Z]+)(?P<preReleaseNumber>\\d+)?)?$") // e.g. 1.3.4b1, simplified form of: https://www.python.org/dev/peps/pep-0440
 
 	allowRoot           bool
 	verbose             int
@@ -228,16 +228,16 @@ func PEP440ToSemver(pep440 string) (*semver.Version, error) {
 	preReleaseType := matches[2]
 	preReleaseNumber := matches[3]
 	if preReleaseType != "" {
+		if preReleaseNumber == "" {
+			preReleaseNumber = "0"
+		}
 		switch preReleaseType {
 		case "a":
-			versionString = fmt.Sprintf("%s-alpha", versionString)
+			versionString = fmt.Sprintf("%s-alpha.%s", versionString, preReleaseNumber)
 		case "b":
-			versionString = fmt.Sprintf("%s-beta", versionString)
+			versionString = fmt.Sprintf("%s-beta.%s", versionString, preReleaseNumber)
 		default:
-			versionString = fmt.Sprintf("%s-%s", versionString, preReleaseType)
-		}
-		if preReleaseNumber != "" {
-			versionString = fmt.Sprintf("%s.%s", versionString, preReleaseNumber)
+			versionString = fmt.Sprintf("%s-%s.%s", versionString, preReleaseType, preReleaseNumber)
 		}
 	}
 	return semver.NewVersion(versionString)

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -169,8 +169,14 @@ func TestPEP440ToSemver(t *testing.T) {
 	version, _ = PEP440ToSemver("1.3.4b12")
 	assert.Equal(t, version.String(), "1.3.4-beta.12")
 
+	// PEP440 allows this: https://www.python.org/dev/peps/pep-0440/#implicit-pre-release-number
+	// We don't ship versions like this, but we support this in case we do in the future.
 	version, _ = PEP440ToSemver("1.3.4b")
-	assert.Equal(t, version.String(), "1.3.4-beta")
+	assert.Equal(t, version.String(), "1.3.4-beta.0")
+
+	// Other identifiers are passed-through, for resiliency.
+	version, _ = PEP440ToSemver("1.3.4dev1")
+	assert.Equal(t, version.String(), "1.3.4-dev.1")
 }
 
 func TestGetIntegrationName(t *testing.T) {

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -144,6 +144,35 @@ func TestSemverToPEP440(t *testing.T) {
 	assert.Equal(t, semverToPEP440(semver.New("1.3.4-beta")), "1.3.4b")
 }
 
+func TestPEP440ToSemver(t *testing.T) {
+	version, _ := PEP440ToSemver("1.3.4")
+	assert.Equal(t, version.String(), "1.3.4")
+
+	version, _ = PEP440ToSemver("12.3.4")
+	assert.Equal(t, version.String(), "12.3.4")
+
+	version, _ = PEP440ToSemver("1.32.4")
+	assert.Equal(t, version.String(), "1.32.4")
+
+	version, _ = PEP440ToSemver("1.3.42")
+	assert.Equal(t, version.String(), "1.3.42")
+
+	version, _ = PEP440ToSemver("1.3.4rc1")
+	assert.Equal(t, version.String(), "1.3.4-rc.1")
+
+	version, _ = PEP440ToSemver("1.3.4a1")
+	assert.Equal(t, version.String(), "1.3.4-alpha.1")
+
+	version, _ = PEP440ToSemver("1.3.4b1")
+	assert.Equal(t, version.String(), "1.3.4-beta.1")
+
+	version, _ = PEP440ToSemver("1.3.4b12")
+	assert.Equal(t, version.String(), "1.3.4-beta.12")
+
+	version, _ = PEP440ToSemver("1.3.4b")
+	assert.Equal(t, version.String(), "1.3.4-beta")
+}
+
 func TestGetIntegrationName(t *testing.T) {
 	assert.Equal(t, getIntegrationName("datadog-checks-base"), "base")
 	assert.Equal(t, getIntegrationName("datadog-checks-downloader"), "downloader")

--- a/releasenotes/notes/fix-integration-prerelease-parsing-dd5e4ae9f865bdb8.yaml
+++ b/releasenotes/notes/fix-integration-prerelease-parsing-dd5e4ae9f865bdb8.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug when parsing the current version of an integration that prevented
+    upgrading from an alpha or beta prerelease version.


### PR DESCRIPTION
### What does this PR do?
Follow-up to #1637

- Fix bug that prevents upgrading an integration (or showing its version) when an `alpha` or `beta` version is installed.
- Add unit tests to prevent regressions.

### Motivation

PR #6137 tried to modify the parsing of versions of currently installed integrations so that prereleases (alpha, beta, RCs) are also supported. However the logic was wrong for `alpha` and `beta`: PEP440 defines them as `a` and `b`.

In practice, it means that version parsing will fail when an alpha or beta is installed, which prevents upgrading through the regular `install datadog-<check>=...` method (installing through wheels via `-w` still works in this case).

I discovered this through a customer case: they had a beta that was half-installed due to permission errors, and they could not reinstall it:

```console
$ sudo -u dd-agent -- datadog-agent integration install datadog-voltdb==0.1.0-beta.2 
Error: could not get current version of datadog-voltdb: error parsing version <nil>: strconv.ParseInt: parsing "0b2": invalid syntax
```

### Additional Notes
I could have hot-fixed the code based on `strings.NewReplacer` but I figured a proper parsing similar to `SemverToPEP440()` would be appropriate.

Meant to target 7.24.1 (there is a known workaround: install from wheel, and this is an old bug, so not fit for a new RC).

### Describe your test plan

In addition to checking the PR code, try upgrading from a beta:

- Install a beta: `datadog-agent integration install datadog-voltdb==0.1.0-beta.2`.
- Install it again. (This should do nothing, but this is where the parsing used to fail.)
- Validate that `datadog-agent integration show datadog-voltdb` succeeds.