### PR TITLE
[windows] Enable system-probe and process-agent with new flags

### DIFF
--- a/cmd/agent/app/dependent_services.go
+++ b/cmd/agent/app/dependent_services.go
@@ -10,11 +10,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// start various subservices (apm, logs, process) based on the config file settings
+// start various subservices (apm, logs, process, system-probe) based on the config file settings
 
 // IsEnabled checks to see if a given service should be started
 func (s *Servicedef) IsEnabled() bool {
-	return config.Datadog.GetBool(s.configKey)
+	for _, configKey := range s.configKeys {
+		if config.Datadog.GetBool(configKey) {
+			return true
+		}
+	}
+	return false
 }
 
 func startDependentServices() {

--- a/cmd/agent/app/dependent_services_nix.go
+++ b/cmd/agent/app/dependent_services_nix.go
@@ -8,8 +8,8 @@ package app
 
 // Servicedef defines a service
 type Servicedef struct {
-	name      string
-	configKey string
+	name       string
+	configKeys []string
 }
 
 var subservices = []Servicedef{}

--- a/cmd/agent/app/dependent_services_windows.go
+++ b/cmd/agent/app/dependent_services_windows.go
@@ -29,19 +29,19 @@ type Servicedef struct {
 var subservices = []Servicedef{
 	{
 		name:        "apm",
-		configKeys:   []string{"apm_config.enabled"},
+		configKeys:  []string{"apm_config.enabled"},
 		serviceName: "datadog-trace-agent",
 		serviceInit: apmInit,
 	},
 	{
 		name:        "process",
-		configKeys:   []string{"process_config.enabled", "network_config.enabled", "system_probe.enabled"},
+		configKeys:  []string{"process_config.enabled", "network_config.enabled", "system_probe.enabled"},
 		serviceName: "datadog-process-agent",
 		serviceInit: processInit,
 	},
 	{
 		name:        "sysprobe",
-		configKeys:   []string{"system_probe_config.enabled", "network_config.enabled"},
+		configKeys:  []string{"system_probe_config.enabled", "network_config.enabled"},
 		serviceName: "datadog-system-probe",
 		serviceInit: sysprobeInit,
 	}}

--- a/cmd/agent/app/dependent_services_windows.go
+++ b/cmd/agent/app/dependent_services_windows.go
@@ -19,8 +19,8 @@ type serviceInitFunc func() (err error)
 
 // Servicedef defines a service
 type Servicedef struct {
-	name      string
-	configKey string
+	name       string
+	configKeys []string
 
 	serviceName string
 	serviceInit serviceInitFunc
@@ -29,19 +29,19 @@ type Servicedef struct {
 var subservices = []Servicedef{
 	{
 		name:        "apm",
-		configKey:   "apm_config.enabled",
+		configKeys:   []string{"apm_config.enabled"},
 		serviceName: "datadog-trace-agent",
 		serviceInit: apmInit,
 	},
 	{
 		name:        "process",
-		configKey:   "process_config.enabled",
+		configKeys:   []string{"process_config.enabled", "network_config.enabled", "system_probe.enabled"},
 		serviceName: "datadog-process-agent",
 		serviceInit: processInit,
 	},
 	{
 		name:        "sysprobe",
-		configKey:   "system_probe_config.enabled",
+		configKeys:   []string{"system_probe_config.enabled", "network_config.enabled"},
 		serviceName: "datadog-system-probe",
 		serviceInit: sysprobeInit,
 	}}

--- a/tasks/winbuildscripts/buildlocal.bat
+++ b/tasks/winbuildscripts/buildlocal.bat
@@ -29,13 +29,10 @@ SET PATH=%PATH%;%GOPATH%/bin
 @echo VSTUDIO_ROOT %VSTUDIO_ROOT%
 @echo TARGET_ARCH %TARGET_ARCH%
 
-REM Section to pre-install libyajl2 gem with fix for gcc10 compatibility
-Powershell -C "ridk enable; ./tasks/winbuildscripts/libyajl2_install.ps1"
-
-
+REM Equivalent to the "ridk enable" command, but without the exit
 if "%TARGET_ARCH%" == "x64" (
     @echo IN x64 BRANCH
-    call ridk enable
+    @for /f "delims=" %%x in ('"ruby" --disable-gems -x '%RIDK%' enable') do set "%%x"
 )
 
 if "%TARGET_ARCH%" == "x86" (
@@ -44,8 +41,7 @@ if "%TARGET_ARCH%" == "x86" (
     Powershell -C "ridk enable; cd omnibus; bundle install"
 )
 
-pip3 install -r requirements.txt || exit /b 4
-
+pip install -r requirements.txt || exit /b 4
 
 inv -e deps --verbose || exit /b 5
 

--- a/tasks/winbuildscripts/buildlocal.bat
+++ b/tasks/winbuildscripts/buildlocal.bat
@@ -29,10 +29,13 @@ SET PATH=%PATH%;%GOPATH%/bin
 @echo VSTUDIO_ROOT %VSTUDIO_ROOT%
 @echo TARGET_ARCH %TARGET_ARCH%
 
-REM Equivalent to the "ridk enable" command, but without the exit
+REM Section to pre-install libyajl2 gem with fix for gcc10 compatibility
+Powershell -C "ridk enable; ./tasks/winbuildscripts/libyajl2_install.ps1"
+
+
 if "%TARGET_ARCH%" == "x64" (
     @echo IN x64 BRANCH
-    @for /f "delims=" %%x in ('"ruby" --disable-gems -x '%RIDK%' enable') do set "%%x"
+    call ridk enable
 )
 
 if "%TARGET_ARCH%" == "x86" (
@@ -41,7 +44,8 @@ if "%TARGET_ARCH%" == "x86" (
     Powershell -C "ridk enable; cd omnibus; bundle install"
 )
 
-pip install -r requirements.txt || exit /b 4
+pip3 install -r requirements.txt || exit /b 4
+
 
 inv -e deps --verbose || exit /b 5
 


### PR DESCRIPTION
### What does this PR do?

Both the process-agent and system-probe should start up if any of several flags are set to true. This commit changes the dependent_services logic for windows so one of several commands can enable the system-probe and process-agent.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

* install an MSI with the system-probe driver module enabled on a windows box set up to test the system-probe. 
* check that network_config.enabled will turn on the system-probe
  * set `network_config.enabled`  to true in `C:\ProgramData\Datadog\system-probe.yaml`
  * restart the agent ` & 'C:\Program Files\Datadog\Datadog Agent\bin\agent.exe' restart-service ` in powershell
   * make sure the system-probe and connection check are running  ` Get-Content -Wait C:\ProgramData\Datadog\logs\system-probe.log ` in powershell, look for log lines about the `/connection` endpoint

* check that the process_agent can still be enabled in isolation
  * set network_config.enabled=false and process_config.enabled=true in `C:\ProgramData\Datadog\datadog.yaml`
  * restart the agent
  * make sure the system-probe is not running (`Get-Process -Name system-probe` should fail in powershell)
  * make sure the process-agent is running (` Get-Content -Wait C:\ProgramData\Datadog\logs\process-agent.log `) 


