### PR TITLE
Add output of `lodctr -q` to flare, to make sure counters are enabled

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -264,6 +264,10 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 	if err != nil {
 		log.Errorf("Could not write typeperf data: %s", err)
 	}
+	err = zipLodctrOutput(tempDir, hostname)
+	if err != nil {
+		log.Errorf("Could not write lodctr data: %s", err)
+	}
 
 	err = zipCounterStrings(tempDir, hostname)
 	if err != nil {

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -26,6 +26,9 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 
+func zipLodctrOutput(tempDir, hostname string) error {
+	return nil
+}
 func zipWindowsEventLogs(tempDir, hostname string) error {
 	return nil
 }

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -100,6 +100,29 @@ func zipTypeperfData(tempDir, hostname string) error {
 	}
 	return nil
 }
+func zipLodctrOutput(tempDir, hostname string) error {
+	cmd := exec.Command("lodctr", "/q")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		log.Warnf("Error running lodctr command %v", err);
+	}
+	f := filepath.Join(tempDir, hostname, "lodctr.txt")
+	err = ensureParentDirsExist(f)
+	if err != nil {
+		log.Warnf("Error in ensureParentDirsExist %v", err)
+		return err
+	}
+
+	err = ioutil.WriteFile(f, out.Bytes(), os.ModePerm)
+	if err != nil {
+		log.Warnf("Error writing file %v", err)
+		return err
+	}
+	return nil
+}
+
 
 // zipWindowsEventLogs exports Windows event logs.
 func zipWindowsEventLogs(tempDir, hostname string) error {

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -106,7 +106,7 @@ func zipLodctrOutput(tempDir, hostname string) error {
 	cmd.Stdout = &out
 	err := cmd.Run()
 	if err != nil {
-		log.Warnf("Error running lodctr command %v", err);
+		log.Warnf("Error running lodctr command %v", err)
 	}
 	f := filepath.Join(tempDir, hostname, "lodctr.txt")
 	err = ensureParentDirsExist(f)
@@ -122,7 +122,6 @@ func zipLodctrOutput(tempDir, hostname string) error {
 	}
 	return nil
 }
-
 
 // zipWindowsEventLogs exports Windows event logs.
 func zipWindowsEventLogs(tempDir, hostname string) error {

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -31,7 +31,7 @@ var (
 		"Application": "Event/System/Provider[@Name=\"datadog-trace-agent\"]",
 		"Microsoft-Windows-WMI-Activity/Operational": "*",
 	}
-	execTimeoutInSeconds = 30 * time.Second
+	execTimeout = 30 * time.Second
 )
 
 const (
@@ -84,7 +84,7 @@ func zipCounterStrings(tempDir, hostname string) error {
 }
 
 func zipTypeperfData(tempDir, hostname string) error {
-	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds)
+	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeout)
 	defer cancelfunc()
 
 	cmd := exec.CommandContext(cancelctx, "typeperf", "-qx")
@@ -108,7 +108,7 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 func zipLodctrOutput(tempDir, hostname string) error {
-	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds)
+	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeout)
 	defer cancelfunc()
 
 	cmd := exec.CommandContext(cancelctx, "lodctr.exe", "/q")

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -84,7 +84,7 @@ func zipCounterStrings(tempDir, hostname string) error {
 }
 
 func zipTypeperfData(tempDir, hostname string) error {
-	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds * time.Second)
+	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds*time.Second)
 	defer cancelfunc()
 
 	cmd := exec.CommandContext(cancelctx, "typeperf", "-qx")
@@ -108,17 +108,19 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 func zipLodctrOutput(tempDir, hostname string) error {
-	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds * time.Second)
+	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds*time.Second)
 	defer cancelfunc()
 
-	cmd := exec.CommandContext(cancelctx, "lodctr", "/q")
+	cmd := exec.CommandContext(cancelctx, "lodctr.exe", "/q")
 
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()
 	if err != nil {
 		log.Warnf("Error running lodctr command %v", err)
-		return err
+		// for some reason the lodctr command returns error 259 even when
+		// it succeeds.  Log the error in case it's some other error,
+		// but continue on.
 	}
 	f := filepath.Join(tempDir, hostname, "lodctr.txt")
 	err = ensureParentDirsExist(f)

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -31,7 +31,7 @@ var (
 		"Application": "Event/System/Provider[@Name=\"datadog-trace-agent\"]",
 		"Microsoft-Windows-WMI-Activity/Operational": "*",
 	}
-	execTimeoutInSeconds = time.Duration(30)
+	execTimeoutInSeconds = 30 * time.Second
 )
 
 const (
@@ -84,7 +84,7 @@ func zipCounterStrings(tempDir, hostname string) error {
 }
 
 func zipTypeperfData(tempDir, hostname string) error {
-	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds*time.Second)
+	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds)
 	defer cancelfunc()
 
 	cmd := exec.CommandContext(cancelctx, "typeperf", "-qx")
@@ -108,7 +108,7 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 func zipLodctrOutput(tempDir, hostname string) error {
-	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds*time.Second)
+	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeoutInSeconds)
 	defer cancelfunc()
 
 	cmd := exec.CommandContext(cancelctx, "lodctr.exe", "/q")


### PR DESCRIPTION
### What does this PR do?

on windows, add output of `lodctr -q` to flare.  Additional debugging to troubleshoot
perf counter problems.

### Motivation

get add'l information without pestering customer

