### PR TITLE
[runtime-security] remove the wilcard suffix limitation

### DIFF
--- a/pkg/security/probe/kfilters_test.go
+++ b/pkg/security/probe/kfilters_test.go
@@ -96,4 +96,32 @@ func TestIsParentDiscarder(t *testing.T) {
 	if is, _ := isParentPathDiscarder(rs, FileRenameEventType, "rename.old.filename", "/etc/nginx/nginx.conf"); !is {
 		t.Fatal("should be a parent discarder")
 	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename =~ "/etc/conf.d/*"`)
+
+	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/sys.d/nginx.conf"); !is {
+		t.Fatal("should be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename =~ "*/conf.*"`)
+
+	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+		t.Fatal("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename =~ "*/conf.d"`)
+
+	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+		t.Fatal("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename =~ "/etc/*"`)
+
+	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/cron.d/log"); is {
+		t.Fatal("shouldn't be a parent discarder")
+	}
 }

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build linux_bpf
+// +build linux
 
 package probe
 
@@ -11,6 +11,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
 func TestMkdirJSON(t *testing.T) {
@@ -20,7 +22,6 @@ func TestMkdirJSON(t *testing.T) {
 	}
 	e := NewEvent(&Resolvers{TimeResolver: tr})
 	e.Process = ProcessEvent{
-		Pidns:   333,
 		Comm:    "aaa",
 		TTYName: "bbb",
 		Pid:     123,
@@ -48,5 +49,24 @@ func TestMkdirJSON(t *testing.T) {
 	err = d.Decode(&i)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAbsolutePath(t *testing.T) {
+	model := &Model{}
+	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "/var/log/*"}); err != nil {
+		t.Fatalf("shouldn't return an error: %s", err)
+	}
+	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "~/apache/httpd.conf"}); err == nil {
+		t.Fatal("should return an error")
+	}
+	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "../../../etc/apache/httpd.conf"}); err == nil {
+		t.Fatal("should return an error")
+	}
+	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "/etc/apache/./httpd.conf"}); err == nil {
+		t.Fatal("should return an error")
+	}
+	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "*/"}); err == nil {
+		t.Fatal("should return an error")
 	}
 }

--- a/pkg/security/secl/eval/eval.go
+++ b/pkg/security/secl/eval/eval.go
@@ -10,6 +10,7 @@ package eval
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 
 	"github.com/alecthomas/participle/lexer"
@@ -39,6 +40,8 @@ const (
 type FieldValue struct {
 	Value interface{}
 	Type  FieldValueType
+
+	Regex *regexp.Regexp
 }
 
 // Opts are the options to be passed to the evaluator

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -269,7 +269,10 @@ func TestRegexp(t *testing.T) {
 		{Expr: `process.name !~ "/usr/sbin/*"`, Expected: true},
 		{Expr: `process.name =~ "/bin/"`, Expected: false},
 		{Expr: `process.name =~ "/bin/*"`, Expected: false},
-		{Expr: `process.name =~ ""`, Expected: false},
+		{Expr: `process.name =~ "*/bin/*"`, Expected: true},
+		{Expr: `process.name =~ "*/bin"`, Expected: false},
+		{Expr: `process.name =~ "/usr/*/c$t"`, Expected: true},
+		{Expr: `process.name =~ "/usr/*/bin/*"`, Expected: false},
 	}
 
 	for _, test := range tests {

--- a/pkg/security/secl/eval/operators.go
+++ b/pkg/security/secl/eval/operators.go
@@ -39,8 +39,8 @@ func IntNot(a *IntEvaluator, opts *Opts, state *state) *IntEvaluator {
 }
 
 func patternToRegexp(pattern string) (*regexp.Regexp, error) {
-	// only accept suffix wilcard, ex: /etc/* or /etc/*.conf
-	if matched, err := regexp.Match(`\*.*/`, []byte(pattern)); err != nil || matched {
+	// do not accept full wildcard value
+	if matched, err := regexp.Match(`[a-zA-Z0-9\.]+`, []byte(pattern)); err != nil || !matched {
 		return nil, &ErrInvalidPattern{Pattern: pattern}
 	}
 
@@ -73,7 +73,7 @@ func StringMatches(a *StringEvaluator, b *StringEvaluator, not bool, opts *Opts,
 	}
 
 	if a.Field != "" {
-		if err := state.UpdateFieldValues(a.Field, FieldValue{Value: b.Value, Type: PatternValueType}); err != nil {
+		if err := state.UpdateFieldValues(a.Field, FieldValue{Value: b.Value, Type: PatternValueType, Regex: re}); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/security/secl/eval/operators_test.go
+++ b/pkg/security/secl/eval/operators_test.go
@@ -19,11 +19,7 @@ func TestPatternValue(t *testing.T) {
 		t.Fatalf("expected regexp not found: %s", re.String())
 	}
 
-	if _, err = patternToRegexp("*/passwd"); err == nil {
-		t.Fatal("only suffix wildcard are accepted")
-	}
-
-	if _, err = patternToRegexp("/etc/*/passwd"); err == nil {
-		t.Fatal("only suffix wildcard are accepted")
+	if _, err = patternToRegexp("*"); err == nil {
+		t.Fatal("wildcard only pattern is not supported")
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR allow to write rules/macros with wildcard not only limited to suffix. Wildcard can be placed anywhere in the path string. The only limitation is that we can't write a rule matching anything like: open.filename == "*"

### Motivation

This allow to write rule such as open.filename == "*/.ssh/*"

### Additional Notes

### Describe your test plan

Unit tests have been added
