### PR TITLE
pkg/trace: remove allocations for stats.Input in process

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -157,7 +157,7 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 	defer timing.Since("datadog.trace_agent.internal.process_payload_ms", time.Now())
 	ts := p.Source
 	ss := new(writer.SampledSpans)
-	sinputs := make([]*stats.Input, 0, len(p.Traces))
+	sinputs := make([]stats.Input, 0, len(p.Traces))
 	for _, t := range p.Traces {
 		if len(t) == 0 {
 			log.Debugf("Skipping received empty trace")
@@ -231,7 +231,7 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 				stats.SetSublayersOnSpan(subtrace.Root, subtraceSublayers)
 			}
 		}
-		sinputs = append(sinputs, &stats.Input{
+		sinputs = append(sinputs, stats.Input{
 			Trace:     pt.WeightedTrace,
 			Sublayers: pt.Sublayers,
 			Env:       pt.Env,

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -37,7 +37,7 @@ type Concentrator struct {
 	// This only applies to past buckets. Stats buckets in the future are allowed with no restriction.
 	bufferLen int
 
-	In  chan []*Input
+	In  chan []Input
 	Out chan []Bucket
 
 	exit   chan struct{}
@@ -59,7 +59,7 @@ func NewConcentrator(aggregators []string, bsize int64, out chan []Bucket) *Conc
 		// TODO: Move to configuration.
 		bufferLen: defaultBufferLen,
 
-		In:  make(chan []*Input, 100),
+		In:  make(chan []Input, 100),
 		Out: out,
 
 		exit:   make(chan struct{}),
@@ -126,10 +126,10 @@ type Input struct {
 }
 
 // Add applies the given input to the concentrator.
-func (c *Concentrator) Add(inputs []*Input) {
+func (c *Concentrator) Add(inputs []Input) {
 	c.mu.Lock()
-	for _, i := range inputs {
-		c.addNow(i)
+	for i := range inputs {
+		c.addNow(&inputs[i])
 	}
 	c.mu.Unlock()
 }

--- a/releasenotes/notes/trace-agent-less-allocs-in-processing-e6801581437368f8.yaml
+++ b/releasenotes/notes/trace-agent-less-allocs-in-processing-e6801581437368f8.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: improve performance of trace processing by removing some heap allocations.


### PR DESCRIPTION
### What does this PR do?

Use an array of objects instead of an array of pointers to avoid allocations for each stats.Input in the Process function.

It's not our largest allocation source but it shows on profiles:

<img width="342" alt="image" src="https://user-images.githubusercontent.com/425368/99792659-b2e4f380-2b27-11eb-84f1-cca6f2a3798c.png">

<img width="806" alt="image" src="https://user-images.githubusercontent.com/425368/99792618-a52f6e00-2b27-11eb-8542-c6f319b87575.png">


### Motivation

Improve performance

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
