### PR TITLE
[AD][kubelet] Support custom check ad-identifier

### DIFF
--- a/pkg/autodiscovery/common/kubelet.go
+++ b/pkg/autodiscovery/common/kubelet.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package common
+
+import "fmt"
+
+const (
+	checkIDAnnotationFormat = "ad.datadoghq.com/%s.check.id"
+)
+
+// GetCustomCheckID returns whether there is a custom check ID for a given container based on the pod annotations
+func GetCustomCheckID(annotations map[string]string, containerName string) (string, bool) {
+	id, found := annotations[fmt.Sprintf(checkIDAnnotationFormat, containerName)]
+	return id, found
+}

--- a/pkg/autodiscovery/common/kubelet_test.go
+++ b/pkg/autodiscovery/common/kubelet_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCustomCheckID(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		containerName string
+		want          string
+		found         bool
+	}{
+		{
+			name:          "found",
+			annotations:   map[string]string{"ad.datadoghq.com/foo.check.id": "bar"},
+			containerName: "foo",
+			want:          "bar",
+			found:         true,
+		},
+		{
+			name:          "not found",
+			annotations:   map[string]string{"ad.datadoghq.com/foo.check.id": "bar"},
+			containerName: "baz",
+			want:          "",
+			found:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := GetCustomCheckID(tt.annotations, tt.containerName)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.found, found)
+		})
+	}
+}

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -243,15 +244,24 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 			svc.metricsExcluded = l.filters.IsExcluded(containers.MetricsFilter, container.Name, containerImage, pod.Metadata.Namespace)
 			svc.logsExcluded = l.filters.IsExcluded(containers.LogsFilter, container.Name, containerImage, pod.Metadata.Namespace)
 
+			// Cache the container name to get the corresponding ports after breaking the for-loop
 			containerName = container.Name
+
+			// Check for custom AD identifiers
+			adIdentifier := containerName
+			if customADIdentifier, customIDFound := common.GetCustomCheckID(pod.Metadata.Annotations, containerName); customIDFound {
+				adIdentifier = customADIdentifier
+				// Add custom check ID as AD identifier
+				svc.adIdentifiers = append(svc.adIdentifiers, customADIdentifier)
+			}
 
 			// Add container uid as ID
 			svc.adIdentifiers = append(svc.adIdentifiers, entity)
 
 			// Cache check names if the pod template is annotated
-			if podHasADTemplate(pod.Metadata.Annotations, containerName) {
+			if podHasADTemplate(pod.Metadata.Annotations, adIdentifier) {
 				var err error
-				svc.checkNames, err = getCheckNamesFromAnnotations(pod.Metadata.Annotations, containerName)
+				svc.checkNames, err = getCheckNamesFromAnnotations(pod.Metadata.Annotations, adIdentifier)
 				if err != nil {
 					log.Error(err.Error())
 				}

--- a/pkg/autodiscovery/providers/kubelet_test.go
+++ b/pkg/autodiscovery/providers/kubelet_test.go
@@ -178,6 +178,42 @@ func TestParseKubeletPodlist(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Custom check ID",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/nginx.check.id":            "nginx-custom",
+						"ad.datadoghq.com/nginx-custom.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/nginx-custom.init_configs": "[{}]",
+						"ad.datadoghq.com/nginx-custom.instances":    "[{\"name\": \"Other service\", \"url\": \"http://%%host_external%%\", \"timeout\": 1}]",
+					},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "nginx",
+							ID:   "container_id://4ac8352d70bf1",
+						},
+					},
+					AllContainers: []kubelet.ContainerStatus{
+						{
+							Name: "nginx",
+							ID:   "container_id://4ac8352d70bf1",
+						},
+					},
+				},
+			},
+			expectedCfg: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"container_id://4ac8352d70bf1"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
+					Source:        "kubelet:container_id://4ac8352d70bf1",
+				},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {
 			checks, err := parseKubeletPodlist([]*kubelet.Pod{tc.pod})

--- a/releasenotes/notes/support-custom-k8s-ad-id-4d7084e1125b7c2a.yaml
+++ b/releasenotes/notes/support-custom-k8s-ad-id-4d7084e1125b7c2a.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Support custom autodiscovery identifiers on Kubernetes using the `ad.datadoghq.com/<container_name>.check.id` pod annotation.


### PR DESCRIPTION
### What does this PR do?

- Support custom autodiscovery identifiers on Kubernetes using the `ad.datadoghq.com/<container_name>.check.id` pod annotation.

### Motivation

- Feature parity with [Docker AD](https://docs.datadoghq.com/agent/guide/ad_identifiers/#custom-autodiscovery-container-identifiers)
- Enables targeting a specific container in a multi-containers pod when the containers are using the same image (e.g the Datadog Agent pod)

### Describe your test plan

A. Config Map
1. Annotate the pod `ad.datadoghq.com/<container_name>.check.id=<custom_id>`
2. Use a config map to define a check targeting the container with `<custom_id>` used as `ad_identifiers` instead of the image name
Example
```yaml
      annotations:
        ad.datadoghq.com/nginx.check.id: 'custom-nginx'
```
```yaml
  confd:
    nginx.yaml: |-
      ad_identifiers:
        - custom-nginx
      init_config:
      instances:
        - nginx_status_url: http://%%host%%/nginx_status/
          name: nginx
```

B. Pod Annotations
1. Annotate the pod `ad.datadoghq.com/<container_name>.check.id=<custom_id>`
2. Use pod annotations to define a check targeting the container with `<custom_id>` instead of the container name .
Example
```yaml
      annotations:
        ad.datadoghq.com/nginx.check.id: 'custom-nginx'
        ad.datadoghq.com/custom-nginx.check_names: '["nginx"]'
        ad.datadoghq.com/custom-nginx.init_configs: '[{}]'
        ad.datadoghq.com/custom-nginx.instances: |
          [
            {
              "name": "nginx",
              "nginx_status_url": "http://%%host%%/nginx_status/"
            }
          ]
```