### PR TITLE
[orchestrator] scrub args as well

### DIFF
--- a/pkg/orchestrator/pod.go
+++ b/pkg/orchestrator/pod.go
@@ -133,10 +133,13 @@ func ScrubContainer(c *v1.Container, scrubber *DataScrubber) {
 	for _, cmd := range c.Command {
 		words += len(strings.Split(cmd, " "))
 	}
+
 	scrubbedMergedCommand, changed := scrubber.ScrubSimpleCommand(merged) // return value is split if has been changed
 	if !changed {
 		return // no change has happened, no need to go further down the line
 	}
+
+	// if part of the merged command got scrubbed the updated value will be split, even for e.g. c.Args only if the c.Command got scrubbed
 	if len(c.Command) > 0 {
 		c.Command = scrubbedMergedCommand[:words]
 	}

--- a/pkg/orchestrator/pod.go
+++ b/pkg/orchestrator/pod.go
@@ -127,6 +127,10 @@ func ScrubContainer(c *v1.Container, scrubber *DataScrubber) {
 		}
 	}()
 
+	// scrub args
+	scrubbedArgs, _ := scrubber.ScrubSimpleCommand(c.Args)
+	c.Args = scrubbedArgs
+
 	// scrub command line
 	scrubbedCmd, _ := scrubber.ScrubSimpleCommand(c.Command)
 	c.Command = scrubbedCmd

--- a/pkg/orchestrator/pod_test.go
+++ b/pkg/orchestrator/pod_test.go
@@ -548,10 +548,20 @@ func getScrubCases() map[string]struct {
 		},
 		"sensitive arg": {
 			input: v1.Container{
-				Args: []string{"mysql", "--password", "afztyerbzio1234"},
+				Command: []string{"mysql"},
+				Args:    []string{"--password", "afztyerbzio1234"},
 			},
 			expected: v1.Container{
-				Args: []string{"mysql", "--password", "********"},
+				Command: []string{"mysql"},
+				Args:    []string{"--password", "********"},
+			},
+		},
+		"sensitive arg no command": {
+			input: v1.Container{
+				Args: []string{"password", "--password", "afztyerbzio1234"},
+			},
+			expected: v1.Container{
+				Args: []string{"password", "--password", "********"},
 			},
 		},
 		"sensitive arg joined": {
@@ -571,7 +581,7 @@ func getScrubCases() map[string]struct {
 					{Name: "hostname", Value: "password"},
 					{Name: "pwd", Value: "yolo"},
 				},
-				Args: []string{"mysql", "--password", "afztyerbzio1234"},
+				Args: []string{"--password", "afztyerbzio1234"},
 			},
 			expected: v1.Container{
 				Name:    "test container",
@@ -581,7 +591,7 @@ func getScrubCases() map[string]struct {
 					{Name: "hostname", Value: "password"},
 					{Name: "pwd", Value: "********"},
 				},
-				Args: []string{"mysql", "--password", "********"},
+				Args: []string{"--password", "********"},
 			},
 		},
 	}

--- a/pkg/orchestrator/pod_test.go
+++ b/pkg/orchestrator/pod_test.go
@@ -514,12 +514,36 @@ func getScrubCases() map[string]struct {
 				Command: []string{"mysql", "--password", "********"},
 			},
 		},
+		"sensitive CLI joined": {
+			input: v1.Container{
+				Command: []string{"mysql --password afztyerbzio1234"},
+			},
+			expected: v1.Container{
+				Command: []string{"mysql", "--password", "********"},
+			},
+		},
 		"sensitive env var": {
 			input: v1.Container{
 				Env: []v1.EnvVar{{Name: "password", Value: "kqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAOLJ"}},
 			},
 			expected: v1.Container{
 				Env: []v1.EnvVar{{Name: "password", Value: "********"}},
+			},
+		},
+		"sensitive arg": {
+			input: v1.Container{
+				Args: []string{"mysql", "--password", "afztyerbzio1234"},
+			},
+			expected: v1.Container{
+				Args: []string{"mysql", "--password", "********"},
+			},
+		},
+		"sensitive arg joined": {
+			input: v1.Container{
+				Args: []string{"pwd pwd afztyerbzio1234 --password 1234"},
+			},
+			expected: v1.Container{
+				Args: []string{"pwd", "pwd", "********", "--password", "********"},
 			},
 		},
 		"sensitive container": {
@@ -531,6 +555,7 @@ func getScrubCases() map[string]struct {
 					{Name: "hostname", Value: "password"},
 					{Name: "pwd", Value: "yolo"},
 				},
+				Args: []string{"mysql", "--password", "afztyerbzio1234"},
 			},
 			expected: v1.Container{
 				Name:    "test container",
@@ -540,6 +565,7 @@ func getScrubCases() map[string]struct {
 					{Name: "hostname", Value: "password"},
 					{Name: "pwd", Value: "********"},
 				},
+				Args: []string{"mysql", "--password", "********"},
 			},
 		},
 	}

--- a/pkg/orchestrator/pod_test.go
+++ b/pkg/orchestrator/pod_test.go
@@ -514,6 +514,20 @@ func getScrubCases() map[string]struct {
 				Command: []string{"mysql", "--password", "********"},
 			},
 		},
+		"empty container": {
+			input:    v1.Container{},
+			expected: v1.Container{},
+		},
+		"empty container empty slices": {
+			input: v1.Container{
+				Command: []string{},
+				Args:    []string{},
+			},
+			expected: v1.Container{
+				Command: []string{},
+				Args:    []string{},
+			},
+		},
 		"non sensitive CLI": {
 			input: v1.Container{
 				Command: []string{"mysql", "--arg", "afztyerbzio1234"},
@@ -546,7 +560,7 @@ func getScrubCases() map[string]struct {
 				Env: []v1.EnvVar{{Name: "password", Value: "********"}},
 			},
 		},
-		"sensitive arg": {
+		"command with sensitive arg": {
 			input: v1.Container{
 				Command: []string{"mysql"},
 				Args:    []string{"--password", "afztyerbzio1234"},
@@ -554,6 +568,36 @@ func getScrubCases() map[string]struct {
 			expected: v1.Container{
 				Command: []string{"mysql"},
 				Args:    []string{"--password", "********"},
+			},
+		},
+		"command with no sensitive arg": {
+			input: v1.Container{
+				Command: []string{"mysql"},
+				Args:    []string{"--debug", "afztyerbzio1234"},
+			},
+			expected: v1.Container{
+				Command: []string{"mysql"},
+				Args:    []string{"--debug", "afztyerbzio1234"},
+			},
+		},
+		"sensitive command with no sensitive arg": {
+			input: v1.Container{
+				Command: []string{"mysql --password 123"},
+				Args:    []string{"--debug", "123"},
+			},
+			expected: v1.Container{
+				Command: []string{"mysql", "--password", "********"},
+				Args:    []string{"--debug", "123"},
+			},
+		},
+		"sensitive command with no sensitive arg joined": {
+			input: v1.Container{
+				Command: []string{"mysql --password 123"},
+				Args:    []string{"--debug 123"},
+			},
+			expected: v1.Container{
+				Command: []string{"mysql", "--password", "********"},
+				Args:    []string{"--debug", "123"},
 			},
 		},
 		"sensitive arg no command": {

--- a/pkg/orchestrator/pod_test.go
+++ b/pkg/orchestrator/pod_test.go
@@ -514,6 +514,22 @@ func getScrubCases() map[string]struct {
 				Command: []string{"mysql", "--password", "********"},
 			},
 		},
+		"non sensitive CLI": {
+			input: v1.Container{
+				Command: []string{"mysql", "--arg", "afztyerbzio1234"},
+			},
+			expected: v1.Container{
+				Command: []string{"mysql", "--arg", "afztyerbzio1234"},
+			},
+		},
+		"non sensitive CLI joined": {
+			input: v1.Container{
+				Command: []string{"mysql --arg afztyerbzio1234"},
+			},
+			expected: v1.Container{
+				Command: []string{"mysql --arg afztyerbzio1234"},
+			},
+		},
 		"sensitive CLI joined": {
 			input: v1.Container{
 				Command: []string{"mysql --password afztyerbzio1234"},

--- a/pkg/orchestrator/pod_test.go
+++ b/pkg/orchestrator/pod_test.go
@@ -600,6 +600,36 @@ func getScrubCases() map[string]struct {
 				Args:    []string{"--debug", "123"},
 			},
 		},
+		"sensitive command with no sensitive arg split": {
+			input: v1.Container{
+				Command: []string{"mysql", "--password", "123"},
+				Args:    []string{"--debug", "123"},
+			},
+			expected: v1.Container{
+				Command: []string{"mysql", "--password", "********"},
+				Args:    []string{"--debug", "123"},
+			},
+		},
+		"sensitive command with no sensitive arg mixed": {
+			input: v1.Container{
+				Command: []string{"mysql", "--password", "123"},
+				Args:    []string{"--debug", "123"},
+			},
+			expected: v1.Container{
+				Command: []string{"mysql", "--password", "********"},
+				Args:    []string{"--debug", "123"},
+			},
+		},
+		"sensitive pass in args": {
+			input: v1.Container{
+				Command: []string{"agent --password"},
+				Args:    []string{"token123"},
+			},
+			expected: v1.Container{
+				Command: []string{"agent", "--password"},
+				Args:    []string{"********"},
+			},
+		},
 		"sensitive arg no command": {
 			input: v1.Container{
 				Args: []string{"password", "--password", "afztyerbzio1234"},

--- a/pkg/process/config/data_scrubber_test.go
+++ b/pkg/process/config/data_scrubber_test.go
@@ -58,6 +58,7 @@ type testProcess struct {
 
 func setupSensitiveCmdlines() []testCase {
 	return []testCase{
+		{[]string{"agent", "password", "-token", "1234"}, []string{"agent", "password", "********", "1234"}},
 		{[]string{"agent", "-password", "1234"}, []string{"agent", "-password", "********"}},
 		{[]string{"agent --password > /password/secret; agent --password echo >> /etc"}, []string{"agent", "--password", "********", "/password/secret;", "agent", "--password", "********", ">>", "/etc"}},
 		{[]string{"agent --password > /password/secret; ls"}, []string{"agent", "--password", "********", "/password/secret;", "ls"}},

--- a/releasenotes/notes/scrub-args-61700bb5b32f4ef8.yaml
+++ b/releasenotes/notes/scrub-args-61700bb5b32f4ef8.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Scrub container args as well for orchestrator explorer.


### PR DESCRIPTION
### What does this PR do?

Scrubbing Args part of `v1.Container` as well.


Some Possible Cases:
```
Image Entrypoint | Image Cmd | Container command | Container args | Command run
[/ep-1] | [foo bar] | <not set> | <not set> | [ep-1 foo bar]
[/ep-1] | [foo bar] | [/ep-2] | <not set> | [ep-2]
[/ep-1] | [foo bar] | <not set> | [zoo boo] | [ep-1 zoo boo]
[/ep-1] | [foo bar] | [/ep-2] | [zoo boo] | [ep-2 zoo boo]
```

The unit tests should reflect them. Basically this PR merged Args and Commands and scrubs them together. Later it splits them again by the count of the words.
This will, if one is split to the both of them being saved split.

### Motivation

https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes
We scrub Env and Commands of Containers but not the args

### Additional Notes

I added additional tests to verify functionality.

Additionally, added some cases which shows that we replace commands from a single line to multiline. We already did this with the past regex behaviour. But the added unit tests should show it more clearly.

### Describe your test plan

- Unit tests
- Running locally and verify that args are scrubbed