### PR TITLE
[release] 7.24.0-rc.10 release entry

### DIFF
--- a/release.json
+++ b/release.json
@@ -22,6 +22,24 @@
         "WINDOWS_DDNPM_SHASUM": "4ca09e6a029dc1db2f2313b6a1ebf770ee3e733dcf500c770e9cd154490d0435",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
+    "6.24.0-rc.10": {
+        "INTEGRATIONS_CORE_VERSION": "7.24.0-rc.10",
+        "OMNIBUS_SOFTWARE_VERSION": "7.24.x",
+        "OMNIBUS_RUBY_VERSION": "7.24.x",
+        "JMXFETCH_VERSION": "0.40.3",
+        "JMXFETCH_HASH": "6e8984c4b65cc553ab22b907b7947e00cd007c7aad7e85ef1799a1b532d52bee",
+        "MACOS_BUILD_VERSION": "6.24.0-rc.1",
+        "SECURITY_AGENT_POLICIES_VERSION": "v0.5"
+    },
+    "7.24.0-rc.10": {
+        "INTEGRATIONS_CORE_VERSION": "7.24.0-rc.10",
+        "OMNIBUS_SOFTWARE_VERSION": "7.24.x",
+        "OMNIBUS_RUBY_VERSION": "7.24.x",
+        "JMXFETCH_VERSION": "0.40.3",
+        "JMXFETCH_HASH": "6e8984c4b65cc553ab22b907b7947e00cd007c7aad7e85ef1799a1b532d52bee",
+        "MACOS_BUILD_VERSION": "7.24.0-rc.1",
+        "SECURITY_AGENT_POLICIES_VERSION": "v0.5"
+    },
     "6.24.0-rc.9": {
         "INTEGRATIONS_CORE_VERSION": "7.24.0-rc.7",
         "OMNIBUS_SOFTWARE_VERSION": "7.24.x",


### PR DESCRIPTION
Ship tag `7.24.0-rc.10` of integrations-core adding support for the network connection queues collection configuration field.