### PR TITLE
pkg/trace: optimize ExtractSubtraces

### DIFF
--- a/pkg/trace/stats/subtrace.go
+++ b/pkg/trace/stats/subtrace.go
@@ -49,8 +49,9 @@ func (s *stack) Pop() *spanAndAncestors {
 // ExtractSubtraces extracts all subtraces rooted in top-level/measured spans.
 // ComputeTopLevel should be called before so that top-level spans are identified.
 func ExtractSubtraces(t pb.Trace, root *pb.Span) []Subtrace {
-	if root == nil {
-		return []Subtrace{}
+	// if there is no root or a single span no need to compute anything
+	if root == nil || len(t) < 2 {
+		return nil
 	}
 	childrenMap := traceutil.ChildrenMap(t)
 

--- a/pkg/trace/stats/subtrace_test.go
+++ b/pkg/trace/stats/subtrace_test.go
@@ -13,6 +13,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestExtractSubtracesWithSingleSpan(t *testing.T) {
+	assert := assert.New(t)
+
+	trace := pb.Trace{
+		&pb.Span{SpanID: 1, ParentID: 0, Service: "s1"},
+	}
+
+	traceutil.ComputeTopLevel(trace)
+	subtraces := ExtractSubtraces(trace, trace[0])
+
+	assert.Equal(0, len(subtraces))
+}
+
 func TestExtractSubtracesWithSimpleTrace(t *testing.T) {
 	assert := assert.New(t)
 
@@ -166,16 +179,16 @@ func BenchmarkExtractSubtraceLarge(b *testing.B) {
 		&pb.Span{SpanID: 7, ParentID: 1, Service: "s4"},
 	}
 
-	nextId := trace[len(trace)-1].SpanID + 1
+	nextID := trace[len(trace)-1].SpanID + 1
 
 	for i := 0; i < 1000; i++ {
-		trace = append(trace, &pb.Span{SpanID: nextId, ParentID: 6, Service: "s3"})
-		nextId++
+		trace = append(trace, &pb.Span{SpanID: nextID, ParentID: 6, Service: "s3"})
+		nextID++
 	}
 
 	for i := 0; i < 1000; i++ {
-		trace = append(trace, &pb.Span{SpanID: nextId, ParentID: 7, Service: "s4"})
-		nextId++
+		trace = append(trace, &pb.Span{SpanID: nextID, ParentID: 7, Service: "s4"})
+		nextID++
 	}
 
 	traceutil.ComputeTopLevel(trace)

--- a/pkg/trace/traceutil/trace.go
+++ b/pkg/trace/traceutil/trace.go
@@ -95,17 +95,7 @@ func ChildrenMap(t pb.Trace) map[uint64][]*pb.Span {
 		if span.ParentID == 0 {
 			continue
 		}
-		_, ok := childrenMap[span.SpanID]
-		if !ok {
-			childrenMap[span.SpanID] = []*pb.Span{}
-		}
-		children, ok := childrenMap[span.ParentID]
-		if ok {
-			children = append(children, span)
-		} else {
-			children = []*pb.Span{span}
-		}
-		childrenMap[span.ParentID] = children
+		childrenMap[span.ParentID] = append(childrenMap[span.ParentID], span)
 	}
 
 	return childrenMap

--- a/pkg/trace/traceutil/trace_test.go
+++ b/pkg/trace/traceutil/trace_test.go
@@ -56,6 +56,6 @@ func TestTraceChildrenMap(t *testing.T) {
 	assert.Equal([]*pb.Span{trace[3]}, childrenMap[2])
 	assert.Equal([]*pb.Span{trace[4]}, childrenMap[3])
 	assert.Equal([]*pb.Span{trace[5]}, childrenMap[4])
-	assert.Equal([]*pb.Span{}, childrenMap[5])
-	assert.Equal([]*pb.Span{}, childrenMap[6])
+	assert.Equal(nil, childrenMap[5])
+	assert.Equal(nil, childrenMap[6])
 }

--- a/pkg/trace/traceutil/trace_test.go
+++ b/pkg/trace/traceutil/trace_test.go
@@ -56,6 +56,6 @@ func TestTraceChildrenMap(t *testing.T) {
 	assert.Equal([]*pb.Span{trace[3]}, childrenMap[2])
 	assert.Equal([]*pb.Span{trace[4]}, childrenMap[3])
 	assert.Equal([]*pb.Span{trace[5]}, childrenMap[4])
-	assert.Equal(nil, childrenMap[5])
-	assert.Equal(nil, childrenMap[6])
+	assert.Equal([]*pb.Span(nil), childrenMap[5])
+	assert.Equal([]*pb.Span(nil), childrenMap[6])
 }

--- a/releasenotes/notes/trace-agent-less-allocs-in-subtrace-extraction-34ab013fefa0ecbe.yaml
+++ b/releasenotes/notes/trace-agent-less-allocs-in-subtrace-extraction-34ab013fefa0ecbe.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: improve sublayer computation performance by reducing the number of heap allocations.


### PR DESCRIPTION
### What does this PR do?

This PR makes several improvements to the ExtractSubtraces:
- use an array instead of a linked list for the stack to avoid heap allocations
- remove useless operations from ChildrenMap
- early return for single span traces

```
name                    old time/op    new time/op    delta
ExtractSubtraceSmall-4    2.03µs ± 3%    1.56µs ± 1%  -23.21%  (p=0.008 n=5+5)
ExtractSubtraceLarge-4     890µs ± 4%     346µs ± 1%  -61.08%  (p=0.008 n=5+5)

name                    old alloc/op   new alloc/op   delta
ExtractSubtraceSmall-4      912B ± 0%      800B ± 0%  -12.28%  (p=0.008 n=5+5)
ExtractSubtraceLarge-4     595kB ± 0%     239kB ± 0%  -59.75%  (p=0.008 n=5+5)

name                    old allocs/op  new allocs/op  delta
ExtractSubtraceSmall-4      27.0 ± 0%      17.0 ± 0%  -37.04%  (p=0.008 n=5+5)
ExtractSubtraceLarge-4     4.13k ± 0%     0.08k ± 0%  -98.16%  (p=0.008 n=5+5)
```

### Motivation

Improve performance

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
