### PR TITLE
[ecs] Add ecs_metadata_timeout config setting

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -476,6 +476,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected
 	config.BindEnvAndSetDefault("ecs_agent_container_name", "ecs-agent")
 	config.BindEnvAndSetDefault("ecs_collect_resource_tags_ec2", false)
+	config.BindEnvAndSetDefault("ecs_metadata_timeout", 500) // value in milliseconds
 
 	// GCE
 	config.BindEnvAndSetDefault("collect_gce_tags", true)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1598,6 +1598,11 @@ api_key:
 #
 # ecs_collect_resource_tags_ec2: false
 
+## @param ecs_metadata_timeout - integer - optional - default: 500
+## Timeout in milliseconds on calls to the AWS ECS metadata endpoints.
+#
+# ecs_metadata_timeout: 500
+
 {{ end -}}
 {{- if .CRI }}
 

--- a/pkg/util/ecs/common/common.go
+++ b/pkg/util/ecs/common/common.go
@@ -5,5 +5,16 @@
 
 package common
 
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
 // CloudProviderName contains the inventory name of for ECS
 const CloudProviderName = "AWS"
+
+// MetadataTimeout defines timeout for ECS metadata endpoints
+func MetadataTimeout() time.Duration {
+	return time.Duration(config.Datadog.GetInt("ecs_metadata_timeout")) * time.Millisecond
+}

--- a/pkg/util/ecs/common/common.go
+++ b/pkg/util/ecs/common/common.go
@@ -16,5 +16,5 @@ const CloudProviderName = "AWS"
 
 // MetadataTimeout defines timeout for ECS metadata endpoints
 func MetadataTimeout() time.Duration {
-	return time.Duration(config.Datadog.GetInt("ecs_metadata_timeout")) * time.Millisecond
+	return config.Datadog.GetDuration("ecs_metadata_timeout") * time.Millisecond
 }

--- a/pkg/util/ecs/metadata/v1/client.go
+++ b/pkg/util/ecs/metadata/v1/client.go
@@ -14,7 +14,8 @@ import (
 	"net/url"
 	"path"
 	"reflect"
-	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
 )
 
 const (
@@ -24,9 +25,6 @@ const (
 	// Metadata v1 API paths
 	instancePath     = "/metadata"
 	taskMetadataPath = "/tasks"
-
-	// Default client configuration
-	endpointTimeout = 500 * time.Millisecond
 )
 
 // Client represents a client for a metadata v1 API endpoint.
@@ -69,7 +67,7 @@ func (c *Client) makeURL(requestPath string) (string, error) {
 }
 
 func (c *Client) get(path string, v interface{}) error {
-	client := http.Client{Timeout: endpointTimeout}
+	client := http.Client{Timeout: common.MetadataTimeout()}
 	url, err := c.makeURL(path)
 	if err != nil {
 		return fmt.Errorf("Error constructing metadata request URL: %s", err)

--- a/pkg/util/ecs/metadata/v2/client.go
+++ b/pkg/util/ecs/metadata/v2/client.go
@@ -15,7 +15,8 @@ import (
 	"net/url"
 	"path"
 	"reflect"
-	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
 )
 
 const (
@@ -26,9 +27,6 @@ const (
 	taskMetadataPath         = "/metadata"
 	taskMetadataWithTagsPath = "/metadataWithTags"
 	containerStatsPath       = "/stats"
-
-	// Default client configuration
-	endpointTimeout = 500 * time.Millisecond
 )
 
 // Client represents a client for a metadata v2 API endpoint.
@@ -75,7 +73,7 @@ func (c *Client) GetTaskWithTags() (*Task, error) {
 }
 
 func (c *Client) get(path string, v interface{}) error {
-	client := http.Client{Timeout: endpointTimeout}
+	client := http.Client{Timeout: common.MetadataTimeout()}
 	url, err := c.makeURL(path)
 	if err != nil {
 		return fmt.Errorf("Error constructing metadata request URL: %s", err)

--- a/pkg/util/ecs/metadata/v3/client.go
+++ b/pkg/util/ecs/metadata/v3/client.go
@@ -14,7 +14,8 @@ import (
 	"net/url"
 	"path"
 	"reflect"
-	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
 )
 
 const (
@@ -24,9 +25,6 @@ const (
 	// Metadata v3 API paths
 	taskMetadataPath         = "/task"
 	taskMetadataWithTagsPath = "/taskWithTags"
-
-	// Default client configuration
-	endpointTimeout = 500 * time.Millisecond
 )
 
 // Client represents a client for a metadata v3 API endpoint.
@@ -61,7 +59,7 @@ func (c *Client) GetTaskWithTags() (*Task, error) {
 }
 
 func (c *Client) get(path string, v interface{}) error {
-	client := http.Client{Timeout: endpointTimeout}
+	client := http.Client{Timeout: common.MetadataTimeout()}
 	url, err := c.makeURL(path)
 	if err != nil {
 		return fmt.Errorf("Error constructing metadata request URL: %s", err)

--- a/releasenotes/notes/add-ecs-metadata-timeout-config-setting-54eea3e21e54421b.yaml
+++ b/releasenotes/notes/add-ecs-metadata-timeout-config-setting-54eea3e21e54421b.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Adds config setting for ECS metadata endpoint client timeout (ecs_metadata_timeout).
+    Adds config setting for ECS metadata endpoint client timeout (ecs_metadata_timeout), value in milliseconds.

--- a/releasenotes/notes/add-ecs-metadata-timeout-config-setting-54eea3e21e54421b.yaml
+++ b/releasenotes/notes/add-ecs-metadata-timeout-config-setting-54eea3e21e54421b.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adds config setting for ECS metadata endpoint client timeout (ecs_metadata_timeout).


### PR DESCRIPTION
### What does this PR do?

Add `ecs_metadata_timeout` config setting controlling metadata endpoint client timeout.

### Describe your test plan

Make sure ECS metadata client honors config setting and tags work as expected 