### PR TITLE
[kubelet] Return init containers spec

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -305,8 +305,9 @@ func (ku *KubeUtil) GetStatusForContainerID(pod *Pod, containerID string) (Conta
 }
 
 // GetSpecForContainerName returns the container spec from the pod given a name
+// It searches spec.containers then spec.initContainers
 func (ku *KubeUtil) GetSpecForContainerName(pod *Pod, containerName string) (ContainerSpec, error) {
-	for _, containerSpec := range pod.Spec.Containers {
+	for _, containerSpec := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 		if containerName == containerSpec.Name {
 			return containerSpec, nil
 		}

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -847,9 +847,21 @@ func TestGetSpecForContainerName(t *testing.T) {
 		Image: "fooPrefix:fooImage",
 	}
 
+	specC := ContainerSpec{
+		Name:  "fooInitC",
+		Image: "fooInitPrefix:fooInitImage",
+	}
+
 	pod := &Pod{
 		Spec: Spec{
 			Containers: []ContainerSpec{specA, specB},
+		},
+	}
+
+	podWithInit := &Pod{
+		Spec: Spec{
+			InitContainers: []ContainerSpec{specC},
+			Containers:     []ContainerSpec{specA, specB},
 		},
 	}
 
@@ -859,6 +871,10 @@ func TestGetSpecForContainerName(t *testing.T) {
 
 	containerSpec, err = k.GetSpecForContainerName(pod, specB.Name)
 	assert.Equal(t, specB, containerSpec)
+	assert.Nil(t, err)
+
+	containerSpec, err = k.GetSpecForContainerName(podWithInit, specC.Name)
+	assert.Equal(t, specC, containerSpec)
 	assert.Nil(t, err)
 
 	containerSpec, err = k.GetSpecForContainerName(pod, "noMatch")

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -43,10 +43,11 @@ type PodOwner struct {
 
 // Spec contains fields for unmarshalling a Pod.Spec
 type Spec struct {
-	HostNetwork bool            `json:"hostNetwork,omitempty"`
-	NodeName    string          `json:"nodeName,omitempty"`
-	Containers  []ContainerSpec `json:"containers,omitempty"`
-	Volumes     []VolumeSpec    `json:"volumes,omitempty"`
+	HostNetwork    bool            `json:"hostNetwork,omitempty"`
+	NodeName       string          `json:"nodeName,omitempty"`
+	InitContainers []ContainerSpec `json:"initContainers,omitempty"`
+	Containers     []ContainerSpec `json:"containers,omitempty"`
+	Volumes        []VolumeSpec    `json:"volumes,omitempty"`
 }
 
 // ContainerSpec contains fields for unmarshalling a Pod.Spec.Containers

--- a/releasenotes/notes/fix-init-containers-log-source-7fdbed729e5188af.yaml
+++ b/releasenotes/notes/fix-init-containers-log-source-7fdbed729e5188af.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug that prevented the logs Agent from discovering the correct init containers `source` and `service` on Kubernetes.


### PR DESCRIPTION
### What does this PR do?

`GetSpecForContainerName` now searches in `spec.initContainers` in addition to `spec.containers`

### Motivation

This was preventing the logs Agent from discovering the correct init containers `source` and `service` on Kubernetes.

### Describe your test plan

Without the fix, init containers will have `kubernetes` as source and service
