### PR TITLE
[jmxfetch] Fix identical config file related crash

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/state.go
+++ b/pkg/collector/corechecks/embed/jmx/state.go
@@ -26,7 +26,14 @@ type jmxState struct {
 }
 
 var state jmxState = jmxState{
-	configs:     cache.NewBasicCache(),
+	configs: cache.NewBasicCacheWithEqualityFunc(func(a, b interface{}) bool {
+		cfgA, okA := a.(integration.Config)
+		cfgB, okB := b.(integration.Config)
+		if !(okA && okB) {
+			return false
+		}
+		return cfgA.Equal(&cfgB)
+	}),
 	runnerError: make(chan struct{}),
 	runner:      &runner{},
 	lock:        &sync.Mutex{},

--- a/pkg/collector/corechecks/embed/jmx/state.go
+++ b/pkg/collector/corechecks/embed/jmx/state.go
@@ -26,14 +26,7 @@ type jmxState struct {
 }
 
 var state jmxState = jmxState{
-	configs: cache.NewBasicCacheWithEqualityFunc(func(a, b interface{}) bool {
-		cfgA, okA := a.(integration.Config)
-		cfgB, okB := b.(integration.Config)
-		if !(okA && okB) {
-			return false
-		}
-		return cfgA.Equal(&cfgB)
-	}),
+	configs:     cache.NewBasicCache(),
 	runnerError: make(chan struct{}),
 	runner:      &runner{},
 	lock:        &sync.Mutex{},

--- a/pkg/util/cache/basic_cache.go
+++ b/pkg/util/cache/basic_cache.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"reflect"
 	"sync"
 	"time"
 )
@@ -11,36 +10,23 @@ type BasicCache struct {
 	m        sync.RWMutex
 	cache    map[string]interface{}
 	modified int64
-	eqFunc   func(interface{}, interface{}) bool
 }
 
 // NewBasicCache Creates new BasicCache
 func NewBasicCache() *BasicCache {
-	return NewBasicCacheWithEqualityFunc(func(a, b interface{}) bool { return reflect.DeepEqual(a, b) })
-}
-
-// NewBasicCacheWithEqualityFunc Creates new BasicCache with custom equality function
-func NewBasicCacheWithEqualityFunc(f func(interface{}, interface{}) bool) *BasicCache {
 	return &BasicCache{
-		cache:  make(map[string]interface{}),
-		eqFunc: f,
+		cache: make(map[string]interface{}),
 	}
 }
 
 // Add adds value to cache for specified key
-// Returns true if the value was added/changed, or false if it was already there.
-// If the value was added/changed, it updates the modified timestamp
-func (b *BasicCache) Add(k string, v interface{}) bool {
+// It will overwrite any existing value
+func (b *BasicCache) Add(k string, v interface{}) {
 	b.m.Lock()
 	defer b.m.Unlock()
 
-	current, found := b.cache[k]
-	if !found || !b.eqFunc(current, v) {
-		b.cache[k] = v
-		b.modified = time.Now().Unix()
-		return true
-	}
-	return false
+	b.cache[k] = v
+	b.modified = time.Now().Unix()
 }
 
 // Get gets interface for specified key and a boolean that's false when the key is not found

--- a/pkg/util/cache/basic_cache.go
+++ b/pkg/util/cache/basic_cache.go
@@ -16,10 +16,7 @@ type BasicCache struct {
 
 // NewBasicCache Creates new BasicCache
 func NewBasicCache() *BasicCache {
-	return &BasicCache{
-		cache:  make(map[string]interface{}),
-		eqFunc: func(a, b interface{}) bool { return reflect.DeepEqual(a, b) },
-	}
+	return NewBasicCacheWithEqualityFunc(func(a, b interface{}) bool { return reflect.DeepEqual(a, b) })
 }
 
 // NewBasicCacheWithEqualityFunc Creates new BasicCache with custom equality function

--- a/pkg/util/cache/basic_cache_test.go
+++ b/pkg/util/cache/basic_cache_test.go
@@ -11,6 +11,7 @@ func TestBasicCache(t *testing.T) {
 		"a": 1,
 		"b": "dos",
 		"c": struct{}{},
+		"d": []string{"42", "platypus"},
 	}
 
 	c := NewBasicCache()
@@ -37,7 +38,41 @@ func TestBasicCache(t *testing.T) {
 		assert.Equal(t, m[k], v)
 	}
 
+	added = c.Add("d", []string{"56", "wombat"})
+	assert.True(t, added) // Update there
+
 	for k := range m {
+		c.Remove(k)
+	}
+	assert.Equal(t, 0, c.Size())
+}
+
+func TestBasicCacheWithCustomEqFunc(t *testing.T) {
+	data := map[string]interface{}{
+		"1": 1,
+		"2": "2",
+		"3": struct{}{},
+		"4": "four",
+	}
+
+	c := NewBasicCacheWithEqualityFunc(func(a, b interface{}) bool { return true })
+	for k, v := range data {
+		added := c.Add(k, v)
+		assert.True(t, added)
+	}
+
+	assert.Equal(t, len(data), c.Size())
+	m := c.GetModified()
+
+	for k, v := range data {
+		added := c.Add(k, "koala")
+		assert.False(t, added)              // Already there and equal given the custom equalitfy func
+		assert.Equal(t, m, c.GetModified()) // Thus the cache should not have been updated
+		val, _ := c.Get(k)
+		assert.Equal(t, v, val)
+	}
+
+	for k := range data {
 		c.Remove(k)
 	}
 	assert.Equal(t, 0, c.Size())

--- a/pkg/util/cache/basic_cache_test.go
+++ b/pkg/util/cache/basic_cache_test.go
@@ -41,8 +41,6 @@ func TestBasicCache(t *testing.T) {
 	cached, found := c.Get("d")
 	assert.True(t, found)
 	assert.Equal(t, cached, wombat)
-	// Timestamp was reset to 0 before calling .Add, so equality
-	// also means that the timestamp was updated
 	assert.GreaterOrEqual(t, c.GetModified(), initialTimestamp)
 
 	for k := range m {


### PR DESCRIPTION
### What does this PR do?
Fix crashes that occurs if /etc/datadog-agent/conf.d/jmx.d contains 2 files ending with .yaml with the very same content, running `datadog-agent check jmx` or `datadog-agent jmx collect` was leading to a crash because equality assertion on  `integration.Config` struct that is an uncomparable type.

### Motivation
Fix a crash situation.

### Additional Notes
N/A.

### Describe your test plan

UT covering the case that was triggering the failure + manual tests (`datadog-agent check jmx` and `datadog-agent jmx collect`) with twin config files.