### PR TITLE
[runtime-security] make use of SECL iterator to expose process ancestors

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -1037,6 +1037,22 @@ func (e *InvalidateDentryEvent) UnmarshalBinary(data []byte) (int, error) {
 	return 16, nil
 }
 
+// ProcessCacheEntry this structure holds the container context that we keep in kernel for each process
+type ProcessCacheEntry struct {
+	ContainerContext
+	ProcessContext
+
+	Parent   *ProcessCacheEntry
+	Children map[uint32]*ProcessCacheEntry
+}
+
+// NewProcessCacheEntry returns an empty instance of ProcessCacheEntry
+func NewProcessCacheEntry() *ProcessCacheEntry {
+	return &ProcessCacheEntry{
+		Children: make(map[uint32]*ProcessCacheEntry),
+	}
+}
+
 // ProcessContext holds the process context of an event
 type ProcessContext struct {
 	ExecEvent
@@ -1046,7 +1062,27 @@ type ProcessContext struct {
 	UID uint32 `field:"uid"`
 	GID uint32 `field:"gid"`
 
-	Parent *ProcessCacheEntry `field:"-"`
+	Parent *ProcessCacheEntry `field:"ancestors" iterator:"ProcessAncestorsIterator"`
+}
+
+type ProcessAncestorsIterator struct {
+	prev *ProcessCacheEntry
+}
+
+func (it *ProcessAncestorsIterator) Front(ctx *eval.Context) unsafe.Pointer {
+	if front := (*Event)(ctx.Object).Process.Parent; front != nil {
+		it.prev = front
+		return unsafe.Pointer(front)
+	}
+	return nil
+}
+
+func (it *ProcessAncestorsIterator) Next(ctx *eval.Context) unsafe.Pointer {
+	if next := (*ProcessCacheEntry)(it.prev).Parent; next != nil {
+		it.prev = next
+		return unsafe.Pointer(next)
+	}
+	return nil
 }
 
 func (p *ProcessContext) marshalJSON(event *Event) ([]byte, error) {

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -1065,10 +1065,12 @@ type ProcessContext struct {
 	Parent *ProcessCacheEntry `field:"ancestors" iterator:"ProcessAncestorsIterator"`
 }
 
+// ProcessAncestorsIterator defines an iterator of ancestors
 type ProcessAncestorsIterator struct {
 	prev *ProcessCacheEntry
 }
 
+// Front returns the first element
 func (it *ProcessAncestorsIterator) Front(ctx *eval.Context) unsafe.Pointer {
 	if front := (*Event)(ctx.Object).Process.Parent; front != nil {
 		it.prev = front
@@ -1077,8 +1079,9 @@ func (it *ProcessAncestorsIterator) Front(ctx *eval.Context) unsafe.Pointer {
 	return nil
 }
 
+// Next returns the next element
 func (it *ProcessAncestorsIterator) Next() unsafe.Pointer {
-	if next := (*ProcessCacheEntry)(it.prev).Parent; next != nil {
+	if next := it.prev.Parent; next != nil {
 		it.prev = next
 		return unsafe.Pointer(next)
 	}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -1077,7 +1077,7 @@ func (it *ProcessAncestorsIterator) Front(ctx *eval.Context) unsafe.Pointer {
 	return nil
 }
 
-func (it *ProcessAncestorsIterator) Next(ctx *eval.Context) unsafe.Pointer {
+func (it *ProcessAncestorsIterator) Next() unsafe.Pointer {
 	if next := (*ProcessCacheEntry)(it.prev).Parent; next != nil {
 		it.prev = next
 		return unsafe.Pointer(next)

--- a/pkg/security/probe/model_accessors.go
+++ b/pkg/security/probe/model_accessors.go
@@ -15,7 +15,7 @@ func (m *Model) GetIterator(field eval.Field) (eval.Iterator, error) {
 
 	}
 
-	return nil, &eval.ErrIteratorNoSupported{Field: field}
+	return nil, &eval.ErrIteratorNotSupported{Field: field}
 }
 
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
@@ -29,6 +29,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chmod.container_path":
@@ -39,6 +41,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chmod.filename":
@@ -49,6 +53,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chmod.inode":
@@ -59,6 +65,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chmod.mode":
@@ -69,6 +77,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chmod.overlay_numlower":
@@ -79,6 +89,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chmod.retval":
@@ -89,6 +101,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chown.basename":
@@ -99,6 +113,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chown.container_path":
@@ -109,6 +125,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chown.filename":
@@ -119,6 +137,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chown.gid":
@@ -129,6 +149,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chown.inode":
@@ -139,6 +161,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chown.overlay_numlower":
@@ -149,6 +173,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chown.retval":
@@ -159,6 +185,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chown.uid":
@@ -169,6 +197,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "container.id":
@@ -179,6 +209,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.AllowCacheResolution":
@@ -189,6 +221,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "exec.basename":
@@ -199,6 +233,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.container_path":
@@ -209,6 +245,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.cookie":
@@ -219,6 +257,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.filename":
@@ -229,6 +269,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.group":
@@ -239,6 +281,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.inode":
@@ -249,6 +293,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "exec.name":
@@ -259,6 +305,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.overlay_numlower":
@@ -269,6 +317,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "exec.ppid":
@@ -279,6 +329,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.tty_name":
@@ -289,6 +341,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.uid":
@@ -299,6 +353,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.user":
@@ -309,6 +365,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "link.retval":
@@ -319,6 +377,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "link.source.basename":
@@ -329,6 +389,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "link.source.container_path":
@@ -339,6 +401,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "link.source.filename":
@@ -349,6 +413,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "link.source.inode":
@@ -359,6 +425,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "link.source.overlay_numlower":
@@ -369,6 +437,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "link.target.basename":
@@ -379,6 +449,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "link.target.container_path":
@@ -389,6 +461,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "link.target.filename":
@@ -399,6 +473,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "link.target.inode":
@@ -409,6 +485,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "link.target.overlay_numlower":
@@ -419,6 +497,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "mkdir.basename":
@@ -429,6 +509,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "mkdir.container_path":
@@ -439,6 +521,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "mkdir.filename":
@@ -449,6 +533,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "mkdir.inode":
@@ -459,6 +545,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "mkdir.mode":
@@ -469,6 +557,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "mkdir.overlay_numlower":
@@ -479,6 +569,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "mkdir.retval":
@@ -489,6 +581,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "open.basename":
@@ -499,6 +593,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "open.container_path":
@@ -509,6 +605,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "open.filename":
@@ -519,6 +617,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "open.flags":
@@ -529,6 +629,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "open.inode":
@@ -539,6 +641,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "open.mode":
@@ -549,6 +653,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "open.overlay_numlower":
@@ -559,6 +665,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "open.retval":
@@ -569,6 +677,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.AllowCacheResolution":
@@ -579,6 +689,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.basename":
@@ -589,6 +701,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.container_path":
@@ -599,6 +713,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.cookie":
@@ -609,6 +725,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.filename":
@@ -619,6 +737,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.gid":
@@ -629,6 +749,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.group":
@@ -639,6 +761,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.inode":
@@ -649,6 +773,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.name":
@@ -659,6 +785,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.overlay_numlower":
@@ -669,6 +797,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.pid":
@@ -679,6 +809,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.ppid":
@@ -689,6 +821,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.tid":
@@ -699,6 +833,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.tty_name":
@@ -709,6 +845,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.uid":
@@ -719,6 +857,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.user":
@@ -729,6 +869,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "removexattr.basename":
@@ -739,6 +881,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "removexattr.container_path":
@@ -749,6 +893,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "removexattr.filename":
@@ -759,6 +905,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "removexattr.inode":
@@ -769,6 +917,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "removexattr.name":
@@ -779,6 +929,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "removexattr.namespace":
@@ -789,6 +941,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "removexattr.overlay_numlower":
@@ -799,6 +953,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "removexattr.retval":
@@ -809,6 +965,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rename.new.basename":
@@ -819,6 +977,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rename.new.container_path":
@@ -829,6 +989,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rename.new.filename":
@@ -839,6 +1001,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rename.new.inode":
@@ -849,6 +1013,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rename.new.overlay_numlower":
@@ -859,6 +1025,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rename.old.basename":
@@ -869,6 +1037,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rename.old.container_path":
@@ -879,6 +1049,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rename.old.filename":
@@ -889,6 +1061,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rename.old.inode":
@@ -899,6 +1073,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rename.old.overlay_numlower":
@@ -909,6 +1085,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rename.retval":
@@ -919,6 +1097,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rmdir.basename":
@@ -929,6 +1109,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rmdir.container_path":
@@ -939,6 +1121,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rmdir.filename":
@@ -949,6 +1133,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rmdir.inode":
@@ -959,6 +1145,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rmdir.overlay_numlower":
@@ -969,6 +1157,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rmdir.retval":
@@ -979,6 +1169,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "setxattr.basename":
@@ -989,6 +1181,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "setxattr.container_path":
@@ -999,6 +1193,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "setxattr.filename":
@@ -1009,6 +1205,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "setxattr.inode":
@@ -1019,6 +1217,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "setxattr.name":
@@ -1029,6 +1229,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "setxattr.namespace":
@@ -1039,6 +1241,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "setxattr.overlay_numlower":
@@ -1049,6 +1253,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "setxattr.retval":
@@ -1059,6 +1265,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "unlink.basename":
@@ -1069,6 +1277,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "unlink.container_path":
@@ -1079,6 +1289,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "unlink.filename":
@@ -1089,6 +1301,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "unlink.flags":
@@ -1099,6 +1313,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "unlink.inode":
@@ -1109,6 +1325,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "unlink.overlay_numlower":
@@ -1119,6 +1337,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "unlink.retval":
@@ -1129,6 +1349,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "utimes.basename":
@@ -1139,6 +1361,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "utimes.container_path":
@@ -1149,6 +1373,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "utimes.filename":
@@ -1159,6 +1385,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "utimes.inode":
@@ -1169,6 +1397,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "utimes.overlay_numlower":
@@ -1179,6 +1409,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "utimes.retval":
@@ -1189,6 +1421,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			},
 			Field: field,
+
+			Weight: eval.FunctionWeight,
 		}, nil
 
 	}

--- a/pkg/security/probe/model_accessors.go
+++ b/pkg/security/probe/model_accessors.go
@@ -6,6 +6,7 @@ package probe
 
 import (
 	"reflect"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
@@ -679,8 +680,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result string
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ResolveBasename((*Event)(ctx.Object))
 
@@ -701,8 +702,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result string
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ResolveContainerPath((*Event)(ctx.Object))
 
@@ -723,8 +724,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result int
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = int(element.ResolveCookie((*Event)(ctx.Object)))
 
@@ -745,8 +746,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result string
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ResolveInode((*Event)(ctx.Object))
 
@@ -767,8 +768,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result int
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = int(element.GID)
 
@@ -789,8 +790,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result string
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ResolveGroup((*Event)(ctx.Object))
 
@@ -811,8 +812,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result string
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ResolveContainerID((*Event)(ctx.Object))
 
@@ -833,8 +834,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result int
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = int(element.Inode)
 
@@ -855,8 +856,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result string
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ResolveComm((*Event)(ctx.Object))
 
@@ -877,8 +878,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result int
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = int(element.OverlayNumLower)
 
@@ -899,8 +900,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result int
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = int(element.Pid)
 
@@ -921,8 +922,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result int
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = int(element.ResolvePPID((*Event)(ctx.Object)))
 
@@ -943,8 +944,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result int
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = int(element.Tid)
 
@@ -965,8 +966,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result string
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ResolveTTY((*Event)(ctx.Object))
 
@@ -987,8 +988,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result int
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = int(element.UID)
 
@@ -1009,8 +1010,8 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				var result string
 
 				reg := ctx.Registers[regID]
-				element := (*ProcessCacheEntry)(reg.Value)
-				if element != nil {
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ResolveUser((*Event)(ctx.Object))
 
@@ -1982,67 +1983,355 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "process.ancestors.basename":
 
-		return e.Process.Parent.ResolveBasename(e), nil
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ResolveBasename((*Event)(ctx.Object))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.container_path":
 
-		return e.Process.Parent.ResolveContainerPath(e), nil
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ResolveContainerPath((*Event)(ctx.Object))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.cookie":
 
-		return int(e.Process.Parent.ResolveCookie(e)), nil
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ResolveCookie((*Event)(ctx.Object)))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.filename":
 
-		return e.Process.Parent.ResolveInode(e), nil
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ResolveInode((*Event)(ctx.Object))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.gid":
 
-		return int(e.Process.Parent.GID), nil
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.GID)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.group":
 
-		return e.Process.Parent.ResolveGroup(e), nil
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ResolveGroup((*Event)(ctx.Object))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.id":
 
-		return e.Process.Parent.ResolveContainerID(e), nil
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ResolveContainerID((*Event)(ctx.Object))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.inode":
 
-		return int(e.Process.Parent.Inode), nil
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.Inode)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.name":
 
-		return e.Process.Parent.ResolveComm(e), nil
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ResolveComm((*Event)(ctx.Object))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.overlay_numlower":
 
-		return int(e.Process.Parent.OverlayNumLower), nil
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.OverlayNumLower)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.pid":
 
-		return int(e.Process.Parent.Pid), nil
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.Pid)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.ppid":
 
-		return int(e.Process.Parent.ResolvePPID(e)), nil
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ResolvePPID((*Event)(ctx.Object)))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.tid":
 
-		return int(e.Process.Parent.Tid), nil
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.Tid)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.tty_name":
 
-		return e.Process.Parent.ResolveTTY(e), nil
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ResolveTTY((*Event)(ctx.Object))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.uid":
 
-		return int(e.Process.Parent.UID), nil
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.UID)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.ancestors.user":
 
-		return e.Process.Parent.ResolveUser(e), nil
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ResolveUser((*Event)(ctx.Object))
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
 
 	case "process.basename":
 
@@ -2915,67 +3204,67 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 	case "process.ancestors.basename":
 
-		return reflect.String, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.container_path":
 
-		return reflect.String, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.cookie":
 
-		return reflect.Int, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.filename":
 
-		return reflect.String, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.gid":
 
-		return reflect.Int, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.group":
 
-		return reflect.String, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.id":
 
-		return reflect.String, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.inode":
 
-		return reflect.Int, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.name":
 
-		return reflect.String, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.overlay_numlower":
 
-		return reflect.Int, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.pid":
 
-		return reflect.Int, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.ppid":
 
-		return reflect.Int, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.tid":
 
-		return reflect.Int, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.tty_name":
 
-		return reflect.String, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.uid":
 
-		return reflect.Int, nil
+		return reflect.Slice, nil
 
 	case "process.ancestors.user":
 
-		return reflect.String, nil
+		return reflect.Slice, nil
 
 	case "process.basename":
 

--- a/pkg/security/probe/model_accessors.go
+++ b/pkg/security/probe/model_accessors.go
@@ -13,6 +13,9 @@ import (
 func (m *Model) GetIterator(field eval.Field) (eval.Iterator, error) {
 	switch field {
 
+	case "process.ancestors":
+		return &ProcessAncestorsIterator{}, nil
+
 	}
 
 	return nil, &eval.ErrIteratorNotSupported{Field: field}
@@ -211,18 +214,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "exec.AllowCacheResolution":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
-
-				return (*Event)(ctx.Object).Exec.AllowCacheResolution
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "exec.basename":
@@ -681,16 +672,356 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "process.AllowCacheResolution":
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool {
+	case "process.ancestors.basename":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Process.AllowCacheResolution
+				var result string
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = element.ResolveBasename((*Event)(ctx.Object))
+
+				}
+
+				return result
 
 			},
 			Field: field,
 
-			Weight: eval.FunctionWeight,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = element.ResolveContainerPath((*Event)(ctx.Object))
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.cookie":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = int(element.ResolveCookie((*Event)(ctx.Object)))
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.filename":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = element.ResolveInode((*Event)(ctx.Object))
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = int(element.GID)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = element.ResolveGroup((*Event)(ctx.Object))
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.id":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = element.ResolveContainerID((*Event)(ctx.Object))
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = int(element.Inode)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = element.ResolveComm((*Event)(ctx.Object))
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = int(element.OverlayNumLower)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.pid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = int(element.Pid)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.ppid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = int(element.ResolvePPID((*Event)(ctx.Object)))
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.tid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = int(element.Tid)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.tty_name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = element.ResolveTTY((*Event)(ctx.Object))
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = int(element.UID)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				element := (*ProcessCacheEntry)(reg.Value)
+				if element != nil {
+
+					result = element.ResolveUser((*Event)(ctx.Object))
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
 		}, nil
 
 	case "process.basename":
@@ -1497,10 +1828,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Container.ResolveContainerID(e), nil
 
-	case "exec.AllowCacheResolution":
-
-		return e.Exec.AllowCacheResolution, nil
-
 	case "exec.basename":
 
 		return e.Exec.ResolveBasename(e), nil
@@ -1653,9 +1980,69 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Open.Retval), nil
 
-	case "process.AllowCacheResolution":
+	case "process.ancestors.basename":
 
-		return e.Process.AllowCacheResolution, nil
+		return e.Process.Parent.ResolveBasename(e), nil
+
+	case "process.ancestors.container_path":
+
+		return e.Process.Parent.ResolveContainerPath(e), nil
+
+	case "process.ancestors.cookie":
+
+		return int(e.Process.Parent.ResolveCookie(e)), nil
+
+	case "process.ancestors.filename":
+
+		return e.Process.Parent.ResolveInode(e), nil
+
+	case "process.ancestors.gid":
+
+		return int(e.Process.Parent.GID), nil
+
+	case "process.ancestors.group":
+
+		return e.Process.Parent.ResolveGroup(e), nil
+
+	case "process.ancestors.id":
+
+		return e.Process.Parent.ResolveContainerID(e), nil
+
+	case "process.ancestors.inode":
+
+		return int(e.Process.Parent.Inode), nil
+
+	case "process.ancestors.name":
+
+		return e.Process.Parent.ResolveComm(e), nil
+
+	case "process.ancestors.overlay_numlower":
+
+		return int(e.Process.Parent.OverlayNumLower), nil
+
+	case "process.ancestors.pid":
+
+		return int(e.Process.Parent.Pid), nil
+
+	case "process.ancestors.ppid":
+
+		return int(e.Process.Parent.ResolvePPID(e)), nil
+
+	case "process.ancestors.tid":
+
+		return int(e.Process.Parent.Tid), nil
+
+	case "process.ancestors.tty_name":
+
+		return e.Process.Parent.ResolveTTY(e), nil
+
+	case "process.ancestors.uid":
+
+		return int(e.Process.Parent.UID), nil
+
+	case "process.ancestors.user":
+
+		return e.Process.Parent.ResolveUser(e), nil
 
 	case "process.basename":
 
@@ -1957,9 +2344,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "container.id":
 		return "*", nil
 
-	case "exec.AllowCacheResolution":
-		return "exec", nil
-
 	case "exec.basename":
 		return "exec", nil
 
@@ -2074,7 +2458,52 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "open.retval":
 		return "open", nil
 
-	case "process.AllowCacheResolution":
+	case "process.ancestors.basename":
+		return "*", nil
+
+	case "process.ancestors.container_path":
+		return "*", nil
+
+	case "process.ancestors.cookie":
+		return "*", nil
+
+	case "process.ancestors.filename":
+		return "*", nil
+
+	case "process.ancestors.gid":
+		return "*", nil
+
+	case "process.ancestors.group":
+		return "*", nil
+
+	case "process.ancestors.id":
+		return "*", nil
+
+	case "process.ancestors.inode":
+		return "*", nil
+
+	case "process.ancestors.name":
+		return "*", nil
+
+	case "process.ancestors.overlay_numlower":
+		return "*", nil
+
+	case "process.ancestors.pid":
+		return "*", nil
+
+	case "process.ancestors.ppid":
+		return "*", nil
+
+	case "process.ancestors.tid":
+		return "*", nil
+
+	case "process.ancestors.tty_name":
+		return "*", nil
+
+	case "process.ancestors.uid":
+		return "*", nil
+
+	case "process.ancestors.user":
 		return "*", nil
 
 	case "process.basename":
@@ -2332,10 +2761,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "exec.AllowCacheResolution":
-
-		return reflect.Bool, nil
-
 	case "exec.basename":
 
 		return reflect.String, nil
@@ -2488,9 +2913,69 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
-	case "process.AllowCacheResolution":
+	case "process.ancestors.basename":
 
-		return reflect.Bool, nil
+		return reflect.String, nil
+
+	case "process.ancestors.container_path":
+
+		return reflect.String, nil
+
+	case "process.ancestors.cookie":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.filename":
+
+		return reflect.String, nil
+
+	case "process.ancestors.gid":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.group":
+
+		return reflect.String, nil
+
+	case "process.ancestors.id":
+
+		return reflect.String, nil
+
+	case "process.ancestors.inode":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.name":
+
+		return reflect.String, nil
+
+	case "process.ancestors.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.pid":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.ppid":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.tid":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.tty_name":
+
+		return reflect.String, nil
+
+	case "process.ancestors.uid":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.user":
+
+		return reflect.String, nil
 
 	case "process.basename":
 
@@ -2875,13 +3360,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "exec.AllowCacheResolution":
-
-		if e.Exec.AllowCacheResolution, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.AllowCacheResolution"}
-		}
-		return nil
-
 	case "exec.basename":
 
 		if e.Exec.BasenameStr, ok = value.(string); !ok {
@@ -3184,13 +3662,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Open.Retval"}
 		}
 		e.Open.Retval = int64(v)
-		return nil
-
-	case "process.AllowCacheResolution":
-
-		if e.Process.AllowCacheResolution, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.AllowCacheResolution"}
-		}
 		return nil
 
 	case "process.basename":

--- a/pkg/security/probe/model_accessors.go
+++ b/pkg/security/probe/model_accessors.go
@@ -10,996 +10,1184 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
-func (m *Model) GetEvaluator(field eval.Field) (eval.Evaluator, error) {
+func (m *Model) GetIterator(field eval.Field) (eval.Iterator, error) {
+	switch field {
+
+	}
+
+	return nil, &eval.ErrIteratorNoSupported{Field: field}
+}
+
+func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
 
 	case "chmod.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Chmod.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Chmod.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "chmod.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Chmod.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Chmod.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "chmod.filename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Chmod.ResolveInode((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Chmod.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "chmod.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Chmod.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Chmod.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "chmod.mode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Chmod.Mode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Chmod.Mode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "chmod.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Chmod.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Chmod.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "chmod.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Chmod.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Chmod.Retval)
+
+			},
 			Field: field,
 		}, nil
 
 	case "chown.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Chown.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Chown.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "chown.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Chown.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Chown.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "chown.filename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Chown.ResolveInode((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Chown.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "chown.gid":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Chown.GID) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Chown.GID)
+
+			},
 			Field: field,
 		}, nil
 
 	case "chown.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Chown.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Chown.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "chown.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Chown.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Chown.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "chown.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Chown.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Chown.Retval)
+
+			},
 			Field: field,
 		}, nil
 
 	case "chown.uid":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Chown.UID) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Chown.UID)
+
+			},
 			Field: field,
 		}, nil
 
 	case "container.id":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Container.ResolveContainerID((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Container.ResolveContainerID((*Event)(ctx.Object))
+
+			},
+			Field: field,
+		}, nil
+
+	case "exec.AllowCacheResolution":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Exec.AllowCacheResolution
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.basename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Exec.ResolveBasename((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Exec.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Exec.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Exec.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.cookie":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Exec.ResolveCookie((*Event)(ctx.Object))) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Exec.ResolveCookie((*Event)(ctx.Object)))
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.filename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Exec.ResolveInode((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Exec.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.group":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Exec.ResolveGroup((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Exec.ResolveGroup((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Exec.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Exec.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.name":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Exec.ResolveComm((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Exec.ResolveComm((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Exec.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Exec.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.ppid":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Exec.ResolvePPID((*Event)(ctx.Object))) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Exec.ResolvePPID((*Event)(ctx.Object)))
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.tty_name":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Exec.ResolveTTY((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Exec.ResolveTTY((*Event)(ctx.Object))
+
+			},
+			Field: field,
+		}, nil
+
+	case "exec.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.ResolveGID((*Event)(ctx.Object)))
+
+			},
 			Field: field,
 		}, nil
 
 	case "exec.user":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Exec.ResolveUser((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Exec.ResolveUser((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Link.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Link.Retval)
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.source.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Link.Source.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Link.Source.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.source.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Link.Source.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Link.Source.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.source.filename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Link.Source.ResolveInode((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Link.Source.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.source.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Link.Source.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Link.Source.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.source.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Link.Source.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Link.Source.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.target.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Link.Target.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Link.Target.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.target.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Link.Target.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Link.Target.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.target.filename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Link.Target.ResolveInode((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Link.Target.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.target.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Link.Target.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Link.Target.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "link.target.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Link.Target.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Link.Target.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "mkdir.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Mkdir.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Mkdir.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "mkdir.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Mkdir.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Mkdir.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "mkdir.filename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Mkdir.ResolveInode((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Mkdir.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "mkdir.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Mkdir.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Mkdir.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "mkdir.mode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Mkdir.Mode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Mkdir.Mode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "mkdir.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Mkdir.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Mkdir.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "mkdir.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Mkdir.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Mkdir.Retval)
+
+			},
 			Field: field,
 		}, nil
 
 	case "open.basename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Open.ResolveBasename((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Open.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "open.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Open.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Open.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "open.filename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Open.ResolveInode((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Open.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "open.flags":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Open.Flags) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Open.Flags)
+
+			},
 			Field: field,
 		}, nil
 
 	case "open.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Open.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Open.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "open.mode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Open.Mode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Open.Mode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "open.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Open.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Open.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "open.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Open.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Open.Retval)
+
+			},
+			Field: field,
+		}, nil
+
+	case "process.AllowCacheResolution":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Process.AllowCacheResolution
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Process.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Process.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Process.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Process.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.cookie":
-
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Process.ResolveCookie((*Event)(ctx.Object)))
-			},
 
+				return int((*Event)(ctx.Object).Process.ResolveCookie((*Event)(ctx.Object)))
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.filename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Process.ResolveInode((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Process.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.gid":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Process.GID) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Process.GID)
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.group":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Process.ResolveGroup((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Process.ResolveGroup((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Process.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Process.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.name":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Process.ResolveComm((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Process.ResolveComm((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Process.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Process.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.pid":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Process.Pid) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Process.Pid)
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.ppid":
-
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).Process.ResolvePPID((*Event)(ctx.Object)))
-			},
 
+				return int((*Event)(ctx.Object).Process.ResolvePPID((*Event)(ctx.Object)))
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.tid":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Process.Tid) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Process.Tid)
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.tty_name":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Process.ResolveTTY((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Process.ResolveTTY((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.uid":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Process.UID) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Process.UID)
+
+			},
 			Field: field,
 		}, nil
 
 	case "process.user":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Process.ResolveUser((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Process.ResolveUser((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "removexattr.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).RemoveXAttr.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).RemoveXAttr.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "removexattr.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).RemoveXAttr.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).RemoveXAttr.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "removexattr.filename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).RemoveXAttr.ResolveInode((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).RemoveXAttr.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "removexattr.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).RemoveXAttr.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).RemoveXAttr.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "removexattr.name":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).RemoveXAttr.GetName((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).RemoveXAttr.GetName((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "removexattr.namespace":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).RemoveXAttr.GetNamespace((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).RemoveXAttr.GetNamespace((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "removexattr.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).RemoveXAttr.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).RemoveXAttr.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "removexattr.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).RemoveXAttr.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).RemoveXAttr.Retval)
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.new.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Rename.New.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Rename.New.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.new.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Rename.New.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Rename.New.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.new.filename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Rename.New.ResolveInode((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Rename.New.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.new.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Rename.New.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Rename.New.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.new.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Rename.New.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Rename.New.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.old.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Rename.Old.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Rename.Old.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.old.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Rename.Old.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Rename.Old.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.old.filename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Rename.Old.ResolveInode((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Rename.Old.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.old.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Rename.Old.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Rename.Old.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.old.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Rename.Old.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Rename.Old.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "rename.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Rename.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Rename.Retval)
+
+			},
 			Field: field,
 		}, nil
 
 	case "rmdir.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Rmdir.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Rmdir.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "rmdir.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Rmdir.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Rmdir.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "rmdir.filename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Rmdir.ResolveInode((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Rmdir.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "rmdir.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Rmdir.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Rmdir.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "rmdir.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Rmdir.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Rmdir.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "rmdir.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Rmdir.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Rmdir.Retval)
+
+			},
 			Field: field,
 		}, nil
 
 	case "setxattr.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).SetXAttr.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).SetXAttr.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "setxattr.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).SetXAttr.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).SetXAttr.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "setxattr.filename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).SetXAttr.ResolveInode((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).SetXAttr.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "setxattr.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).SetXAttr.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).SetXAttr.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "setxattr.name":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).SetXAttr.GetName((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).SetXAttr.GetName((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "setxattr.namespace":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).SetXAttr.GetNamespace((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).SetXAttr.GetNamespace((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "setxattr.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).SetXAttr.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).SetXAttr.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "setxattr.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).SetXAttr.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).SetXAttr.Retval)
+
+			},
 			Field: field,
 		}, nil
 
 	case "unlink.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Unlink.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Unlink.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "unlink.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Unlink.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Unlink.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "unlink.filename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Unlink.ResolveInode((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Unlink.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "unlink.flags":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Unlink.Flags) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Unlink.Flags)
+
+			},
 			Field: field,
 		}, nil
 
 	case "unlink.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Unlink.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Unlink.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "unlink.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Unlink.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Unlink.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "unlink.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Unlink.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Unlink.Retval)
+
+			},
 			Field: field,
 		}, nil
 
 	case "utimes.basename":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Utimes.ResolveBasename((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Utimes.ResolveBasename((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "utimes.container_path":
-
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				return (*Event)(ctx.Object).Utimes.ResolveContainerPath((*Event)(ctx.Object))
-			},
 
+				return (*Event)(ctx.Object).Utimes.ResolveContainerPath((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "utimes.filename":
-
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return (*Event)(ctx.Object).Utimes.ResolveInode((*Event)(ctx.Object)) },
+			EvalFnc: func(ctx *eval.Context) string {
 
+				return (*Event)(ctx.Object).Utimes.ResolveInode((*Event)(ctx.Object))
+
+			},
 			Field: field,
 		}, nil
 
 	case "utimes.inode":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Utimes.Inode) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Utimes.Inode)
+
+			},
 			Field: field,
 		}, nil
 
 	case "utimes.overlay_numlower":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Utimes.OverlayNumLower) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Utimes.OverlayNumLower)
+
+			},
 			Field: field,
 		}, nil
 
 	case "utimes.retval":
-
 		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int((*Event)(ctx.Object).Utimes.Retval) },
+			EvalFnc: func(ctx *eval.Context) int {
 
+				return int((*Event)(ctx.Object).Utimes.Retval)
+
+			},
 			Field: field,
 		}, nil
 
@@ -1075,6 +1263,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Container.ResolveContainerID(e), nil
 
+	case "exec.AllowCacheResolution":
+
+		return e.Exec.AllowCacheResolution, nil
+
 	case "exec.basename":
 
 		return e.Exec.ResolveBasename(e), nil
@@ -1114,6 +1306,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "exec.tty_name":
 
 		return e.Exec.ResolveTTY(e), nil
+
+	case "exec.uid":
+
+		return int(e.Exec.ResolveGID(e)), nil
 
 	case "exec.user":
 
@@ -1222,6 +1418,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "open.retval":
 
 		return int(e.Open.Retval), nil
+
+	case "process.AllowCacheResolution":
+
+		return e.Process.AllowCacheResolution, nil
 
 	case "process.basename":
 
@@ -1523,6 +1723,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "container.id":
 		return "*", nil
 
+	case "exec.AllowCacheResolution":
+		return "exec", nil
+
 	case "exec.basename":
 		return "exec", nil
 
@@ -1551,6 +1754,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 
 	case "exec.tty_name":
+		return "exec", nil
+
+	case "exec.uid":
 		return "exec", nil
 
 	case "exec.user":
@@ -1633,6 +1839,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 
 	case "open.retval":
 		return "open", nil
+
+	case "process.AllowCacheResolution":
+		return "*", nil
 
 	case "process.basename":
 		return "*", nil
@@ -1889,6 +2098,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.AllowCacheResolution":
+
+		return reflect.Bool, nil
+
 	case "exec.basename":
 
 		return reflect.String, nil
@@ -1928,6 +2141,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "exec.tty_name":
 
 		return reflect.String, nil
+
+	case "exec.uid":
+
+		return reflect.Int, nil
 
 	case "exec.user":
 
@@ -2036,6 +2253,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "open.retval":
 
 		return reflect.Int, nil
+
+	case "process.AllowCacheResolution":
+
+		return reflect.Bool, nil
 
 	case "process.basename":
 
@@ -2420,6 +2641,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
+	case "exec.AllowCacheResolution":
+
+		if e.Exec.AllowCacheResolution, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.AllowCacheResolution"}
+		}
+		return nil
+
 	case "exec.basename":
 
 		if e.Exec.BasenameStr, ok = value.(string); !ok {
@@ -2496,6 +2724,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if e.Exec.TTYName, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.TTYName"}
 		}
+		return nil
+
+	case "exec.uid":
+
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.GID"}
+		}
+		e.Exec.GID = uint32(v)
 		return nil
 
 	case "exec.user":
@@ -2713,6 +2950,13 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Open.Retval"}
 		}
 		e.Open.Retval = int64(v)
+		return nil
+
+	case "process.AllowCacheResolution":
+
+		if e.Process.AllowCacheResolution, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.AllowCacheResolution"}
+		}
 		return nil
 
 	case "process.basename":

--- a/pkg/security/probe/process_cache_entry.go
+++ b/pkg/security/probe/process_cache_entry.go
@@ -12,22 +12,6 @@ import (
 	"fmt"
 )
 
-// ProcessCacheEntry this structure holds the container context that we keep in kernel for each process
-type ProcessCacheEntry struct {
-	ContainerContext
-	ProcessContext
-
-	Parent   *ProcessCacheEntry
-	Children map[uint32]*ProcessCacheEntry
-}
-
-// NewProcessCacheEntry returns an empty instance of ProcessCacheEntry
-func NewProcessCacheEntry() *ProcessCacheEntry {
-	return &ProcessCacheEntry{
-		Children: make(map[uint32]*ProcessCacheEntry),
-	}
-}
-
 // Copy returns a copy of the current ProcessCacheEntry
 func (pc *ProcessCacheEntry) Copy() *ProcessCacheEntry {
 	dup := *pc

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/gopsutil/process"
 )
 
+<<<<<<< HEAD
 var snapshotProbeIDs = []manager.ProbeIdentificationPair{
 	{
 		UID:     probes.SecurityAgentUID,
@@ -57,6 +58,11 @@ type ProcessResolver struct {
 	inodeInfoMap   *lib.Map
 	procCacheMap   *lib.Map
 	pidCookieMap   *lib.Map
+=======
+// Copy returns a copy of the current ProcessCacheEntry
+func (pc *ProcessCacheEntry) Copy() *ProcessCacheEntry {
+	dup := *pc
+>>>>>>> 9ccdee338... Add ancestors support on processes
 
 	entryCache map[uint32]*ProcessCacheEntry
 }

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DataDog/gopsutil/process"
 )
 
-<<<<<<< HEAD
 var snapshotProbeIDs = []manager.ProbeIdentificationPair{
 	{
 		UID:     probes.SecurityAgentUID,
@@ -58,11 +57,6 @@ type ProcessResolver struct {
 	inodeInfoMap   *lib.Map
 	procCacheMap   *lib.Map
 	pidCookieMap   *lib.Map
-=======
-// Copy returns a copy of the current ProcessCacheEntry
-func (pc *ProcessCacheEntry) Copy() *ProcessCacheEntry {
-	dup := *pc
->>>>>>> 9ccdee338... Add ancestors support on processes
 
 	entryCache map[uint32]*ProcessCacheEntry
 }

--- a/pkg/security/rules/model_test.go
+++ b/pkg/security/rules/model_test.go
@@ -75,7 +75,11 @@ func (m *testModel) ValidateField(key string, value eval.FieldValue) error {
 	return nil
 }
 
-func (m *testModel) GetEvaluator(key string) (eval.Evaluator, error) {
+func (m *testModel) GetIterator(field eval.Field) (eval.Iterator, error) {
+	return nil, &eval.ErrIteratorNotSupported{Field: field}
+}
+
+func (m *testModel) GetEvaluator(key string, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch key {
 
 	case "process.name":

--- a/pkg/security/rules/ruleset_test.go
+++ b/pkg/security/rules/ruleset_test.go
@@ -35,7 +35,7 @@ func (f *testHandler) EventDiscarderFound(rs *RuleSet, event eval.Event, field s
 	if !ok {
 		discarders = []interface{}{}
 	}
-	evaluator, _ := f.model.GetEvaluator(field)
+	evaluator, _ := f.model.GetEvaluator(field, "")
 
 	ctx := &eval.Context{}
 	ctx.SetObject(event.GetPointer())

--- a/pkg/security/secl/ast/secl.go
+++ b/pkg/security/secl/ast/secl.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	seclLexer = lexer.Must(ebnf.New(`
-Ident = (alpha | "_") { "_" | alpha | digit | "." } .
+Ident = (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } .
 String = "\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Int = [ "-" | "+" ] digit { digit } .
 Punct = "!"…"/" | ":"…"@" | "["…` + "\"`\"" + ` | "{"…"~" .

--- a/pkg/security/secl/ast/secl_test.go
+++ b/pkg/security/secl/ast/secl_test.go
@@ -71,6 +71,15 @@ func TestCompareComplex(t *testing.T) {
 	print(t, rule)
 }
 
+func TestRegister(t *testing.T) {
+	rule, err := ParseRule(`process.ancestors[A].filename == "/usr/bin/vipw" && process.ancestors[A].pid == 44`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
 func TestBoolAnd(t *testing.T) {
 	rule, err := ParseRule(`3 & 3`)
 	if err != nil {

--- a/pkg/security/secl/eval/context.go
+++ b/pkg/security/secl/eval/context.go
@@ -15,7 +15,7 @@ type RegisterID = string
 // Register describes a register that can be used by a set
 type Register struct {
 	ID    string
-	Value int
+	Value unsafe.Pointer
 }
 
 // Registers defines all available registers

--- a/pkg/security/secl/eval/context.go
+++ b/pkg/security/secl/eval/context.go
@@ -9,29 +9,6 @@ import (
 	"unsafe"
 )
 
-// RegisterID identify a register ID
-type RegisterID = string
-
-// Register describes a register that can be used by a set
-type Register struct {
-	ID    string
-	Value unsafe.Pointer
-}
-
-// Registers defines all available registers
-type Registers map[RegisterID]*Register
-
-// Clone returns a copy of the registers
-func (r Registers) Clone() Registers {
-	regs := make(Registers)
-
-	for k, v := range r {
-		regs[k] = v
-	}
-
-	return regs
-}
-
 // Context describes the context used during a rule evaluation
 type Context struct {
 	Object unsafe.Pointer

--- a/pkg/security/secl/eval/context.go
+++ b/pkg/security/secl/eval/context.go
@@ -36,7 +36,7 @@ func (r Registers) Clone() Registers {
 type Context struct {
 	Object unsafe.Pointer
 
-	registers Registers
+	Registers Registers
 }
 
 // SetObject set the given object to the context

--- a/pkg/security/secl/eval/context.go
+++ b/pkg/security/secl/eval/context.go
@@ -9,9 +9,34 @@ import (
 	"unsafe"
 )
 
+// RegisterID identify a register ID
+type RegisterID = string
+
+// Register describes a register that can be used by a set
+type Register struct {
+	ID    string
+	Value int
+}
+
+// Registers defines all available registers
+type Registers map[RegisterID]*Register
+
+// Clone returns a copy of the registers
+func (r Registers) Clone() Registers {
+	regs := make(Registers)
+
+	for k, v := range r {
+		regs[k] = v
+	}
+
+	return regs
+}
+
 // Context describes the context used during a rule evaluation
 type Context struct {
 	Object unsafe.Pointer
+
+	registers Registers
 }
 
 // SetObject set the given object to the context

--- a/pkg/security/secl/eval/errors.go
+++ b/pkg/security/secl/eval/errors.go
@@ -93,6 +93,15 @@ func (e ErrIteratorNotSupported) Error() string {
 	return fmt.Sprintf("field `%s` doesn't support iteration", e.Field)
 }
 
+// ErrNotSupported returned when something is not supported on a field
+type ErrNotSupported struct {
+	Field string
+}
+
+func (e ErrNotSupported) Error() string {
+	return fmt.Sprintf("not supported by field `%s`", e.Field)
+}
+
 // ErrValueTypeMismatch error when the given value is not having the correct type
 type ErrValueTypeMismatch struct {
 	Field string

--- a/pkg/security/secl/eval/errors.go
+++ b/pkg/security/secl/eval/errors.go
@@ -52,6 +52,11 @@ func NewOpError(pos lexer.Position, op string, err error) *ErrAstToEval {
 	return NewError(pos, fmt.Sprintf("operator `%s` error: %s", op, err))
 }
 
+// NewRegisterMultipleFields returns a new ErrAstToEval error when an operator was used in an invalid manner
+func NewRegisterMultipleFields(pos lexer.Position, regID RegisterID, err error) *ErrAstToEval {
+	return NewError(pos, fmt.Sprintf("register `%s` error: %s", regID, err))
+}
+
 // ErrRuleParse describes a parsing error and its position in the expression
 type ErrRuleParse struct {
 	pos  lexer.Position
@@ -79,12 +84,12 @@ func (e ErrFieldNotFound) Error() string {
 	return fmt.Sprintf("field `%s` not found", e.Field)
 }
 
-// ErrIteratorNoSupported error when a field doesn't support iteration
-type ErrIteratorNoSupported struct {
+// ErrIteratorNotSupported error when a field doesn't support iteration
+type ErrIteratorNotSupported struct {
 	Field string
 }
 
-func (e ErrIteratorNoSupported) Error() string {
+func (e ErrIteratorNotSupported) Error() string {
 	return fmt.Sprintf("field `%s` doesn't support iteration", e.Field)
 }
 

--- a/pkg/security/secl/eval/errors.go
+++ b/pkg/security/secl/eval/errors.go
@@ -79,6 +79,15 @@ func (e ErrFieldNotFound) Error() string {
 	return fmt.Sprintf("field `%s` not found", e.Field)
 }
 
+// ErrIteratorNoSupported error when a field doesn't support iteration
+type ErrIteratorNoSupported struct {
+	Field string
+}
+
+func (e ErrIteratorNoSupported) Error() string {
+	return fmt.Sprintf("field `%s` doesn't support iteration", e.Field)
+}
+
 // ErrValueTypeMismatch error when the given value is not having the correct type
 type ErrValueTypeMismatch struct {
 	Field string

--- a/pkg/security/secl/eval/eval.go
+++ b/pkg/security/secl/eval/eval.go
@@ -34,6 +34,15 @@ const (
 	BitmaskValueType FieldValueType = 4
 )
 
+// defines factor applied by specific operator
+const (
+	FunctionWeight = 5
+	InArrayWeight  = 10
+	HandlerWeight  = 50
+	PatternWeight  = 100
+	IteratorWeight = 1000
+)
+
 // FieldValue describes a field value with its type
 type FieldValue struct {
 	Value interface{}
@@ -75,6 +84,7 @@ type BoolEvaluator struct {
 	EvalFnc BoolEvalFnc
 	Field   Field
 	Value   bool
+	Weight  int
 
 	isPartial bool
 }
@@ -89,6 +99,7 @@ type IntEvaluator struct {
 	EvalFnc func(ctx *Context) int
 	Field   Field
 	Value   int
+	Weight  int
 
 	isPartial bool
 }
@@ -103,6 +114,7 @@ type StringEvaluator struct {
 	EvalFnc func(ctx *Context) string
 	Field   Field
 	Value   string
+	Weight  int
 
 	isPartial bool
 }

--- a/pkg/security/secl/eval/eval.go
+++ b/pkg/security/secl/eval/eval.go
@@ -426,12 +426,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, in
 				return nil, nil, obj.Pos, err
 			}
 
-			fnc, err := state.model.GetRegisterMaxValueFnc(field)
-			if err != nil {
-				return nil, nil, obj.Pos, err
+			if registerID != "" {
+				iterator, err := state.model.GetIterator(field)
+				if err != nil {
+					return nil, nil, obj.Pos, err
+				}
+				state.registerIterators[registerID] = iterator
 			}
-
-			state.regMaxValueFncs[registerID] = fnc
 
 			accessor, err := state.model.GetEvaluator(field, registerID)
 			if err != nil {

--- a/pkg/security/secl/eval/eval_operators.go
+++ b/pkg/security/secl/eval/eval_operators.go
@@ -33,12 +33,21 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state) (*BoolEval
 			}
 		}
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
+		if a.Weight > b.Weight {
+			tmp := ea
+			ea = eb
+			eb = tmp
+		}
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) || eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -87,6 +96,7 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state) (*BoolEval
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -116,6 +126,7 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state) (*BoolEval
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -151,12 +162,21 @@ func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state) (*BoolEva
 			}
 		}
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
+		if a.Weight > b.Weight {
+			tmp := ea
+			ea = eb
+			eb = tmp
+		}
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) && eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -205,6 +225,7 @@ func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state) (*BoolEva
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -234,6 +255,7 @@ func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state) (*BoolEva
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -256,12 +278,15 @@ func IntEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*Boo
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) == eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -290,6 +315,7 @@ func IntEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*Boo
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -308,6 +334,7 @@ func IntEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*Boo
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -330,12 +357,15 @@ func IntNotEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) != eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -364,6 +394,7 @@ func IntNotEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -382,6 +413,7 @@ func IntNotEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -404,12 +436,15 @@ func IntAnd(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*IntEva
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) int {
 			return ea(ctx) & eb(ctx)
 		}
 
 		return &IntEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -438,6 +473,7 @@ func IntAnd(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*IntEva
 
 		return &IntEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -456,6 +492,7 @@ func IntAnd(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*IntEva
 
 	return &IntEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -478,12 +515,15 @@ func IntOr(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*IntEval
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) int {
 			return ea(ctx) | eb(ctx)
 		}
 
 		return &IntEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -512,6 +552,7 @@ func IntOr(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*IntEval
 
 		return &IntEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -530,6 +571,7 @@ func IntOr(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*IntEval
 
 	return &IntEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -552,12 +594,15 @@ func IntXor(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*IntEva
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) int {
 			return ea(ctx) ^ eb(ctx)
 		}
 
 		return &IntEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -586,6 +631,7 @@ func IntXor(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*IntEva
 
 		return &IntEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -604,6 +650,7 @@ func IntXor(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*IntEva
 
 	return &IntEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -626,12 +673,15 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *sta
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) == eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -660,6 +710,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *sta
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -678,6 +729,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *sta
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -700,12 +752,15 @@ func StringNotEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) != eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -734,6 +789,7 @@ func StringNotEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -752,6 +808,7 @@ func StringNotEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -774,12 +831,15 @@ func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state) (*
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) == eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -808,6 +868,7 @@ func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state) (*
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -826,6 +887,7 @@ func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state) (*
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -848,12 +910,15 @@ func BoolNotEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state)
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) != eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -882,6 +947,7 @@ func BoolNotEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state)
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -900,6 +966,7 @@ func BoolNotEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *state)
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -922,12 +989,15 @@ func GreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*B
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) > eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -956,6 +1026,7 @@ func GreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*B
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -974,6 +1045,7 @@ func GreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*B
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -996,12 +1068,15 @@ func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *sta
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) >= eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -1030,6 +1105,7 @@ func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *sta
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -1048,6 +1124,7 @@ func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *sta
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -1070,12 +1147,15 @@ func LesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*Bo
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) < eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -1104,6 +1184,7 @@ func LesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*Bo
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -1122,6 +1203,7 @@ func LesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *state) (*Bo
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -1144,12 +1226,15 @@ func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *stat
 	if a.EvalFnc != nil && b.EvalFnc != nil {
 		ea, eb := a.EvalFnc, b.EvalFnc
 
+		// optimise the evaluation if need moving the evaluation with more weight at the right
+
 		evalFnc := func(ctx *Context) bool {
 			return ea(ctx) <= eb(ctx)
 		}
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + b.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -1178,6 +1263,7 @@ func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *stat
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -1196,6 +1282,7 @@ func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *stat
 
 	return &BoolEvaluator{
 		EvalFnc:   evalFnc,
+		Weight:    b.Weight,
 		isPartial: isPartialLeaf,
 	}, nil
 }

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -680,8 +680,8 @@ func TestRegister(t *testing.T) {
 	event.process.list.PushBack(&testItem{key: 200, value: 201})
 
 	event.process.array = []*testItem{
-		&testItem{key: 1000, value: 1001},
-		&testItem{key: 1002, value: 1003},
+		{key: 1000, value: 1001},
+		{key: 1002, value: 1003},
 	}
 
 	tests := []struct {
@@ -726,8 +726,8 @@ func TestRegisterPartial(t *testing.T) {
 	event.process.list.PushBack(&testItem{key: 200, value: 201})
 
 	event.process.array = []*testItem{
-		&testItem{key: 1000, value: 1001},
-		&testItem{key: 1002, value: 1003},
+		{key: 1000, value: 1001},
+		{key: 1002, value: 1003},
 	}
 
 	tests := []struct {

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -661,7 +661,8 @@ func TestRegister(t *testing.T) {
 		{Expr: `process.list[_].key == 9999 && process.list[_].value == 11`, Expected: false},
 		{Expr: `process.list[_].key == 100 && process.list[_].value == 101`, Expected: true},
 		{Expr: `process.list[_].key == 200 && process.list[_].value == 201`, Expected: true},
-		/*{Expr: `process.list[A].key == 200 && process.list[A].value == 201`, Expected: true},
+		/*{Expr: `process.list.key == 200 && process.list.value == 11`, Expected: true},
+		{Expr: `process.list[A].key == 200 && process.list[A].value == 201`, Expected: true},
 		{Expr: `process.list[A].key == 200 && process.list[B].value == 101`, Expected: true},
 		{Expr: `process.list[A].key == process.list && process.list[B].value == 444`, Expected: false},
 		{Expr: `process.list[A].key == 200 || process.list[B].value == 11`, Expected: true},*/

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -6,6 +6,7 @@
 package eval
 
 import (
+	"container/list"
 	"fmt"
 	"strings"
 	"syscall"
@@ -644,14 +645,13 @@ func TestFieldValidator(t *testing.T) {
 
 func TestRegister(t *testing.T) {
 	event := &testEvent{
-		process: testProcess{
-			list: []testItem{
-				{key: 10, value: 11},
-				{key: 100, value: 101},
-				{key: 200, value: 201},
-			},
-		},
+		process: testProcess{},
 	}
+
+	event.process.list = list.New()
+	event.process.list.PushBack(&testItem{key: 10, value: 11})
+	event.process.list.PushBack(&testItem{key: 100, value: 101})
+	event.process.list.PushBack(&testItem{key: 200, value: 201})
 
 	tests := []struct {
 		Expr     string
@@ -661,10 +661,10 @@ func TestRegister(t *testing.T) {
 		{Expr: `process.list[_].key == 9999 && process.list[_].value == 11`, Expected: false},
 		{Expr: `process.list[_].key == 100 && process.list[_].value == 101`, Expected: true},
 		{Expr: `process.list[_].key == 200 && process.list[_].value == 201`, Expected: true},
-		{Expr: `process.list[A].key == 200 && process.list[A].value == 201`, Expected: true},
+		/*{Expr: `process.list[A].key == 200 && process.list[A].value == 201`, Expected: true},
 		{Expr: `process.list[A].key == 200 && process.list[B].value == 101`, Expected: true},
 		{Expr: `process.list[A].key == process.list && process.list[B].value == 444`, Expected: false},
-		{Expr: `process.list[A].key == 200 || process.list[B].value == 11`, Expected: true},
+		{Expr: `process.list[A].key == 200 || process.list[B].value == 11`, Expected: true},*/
 	}
 
 	for _, test := range tests {

--- a/pkg/security/secl/eval/event.go
+++ b/pkg/security/secl/eval/event.go
@@ -29,9 +29,10 @@ type Event interface {
 	GetPointer() unsafe.Pointer
 }
 
+// Iterator interface of a field iterator
 type Iterator interface {
 	Front(ctx *Context) unsafe.Pointer
-	Next(ctx *Context) unsafe.Pointer
+	Next() unsafe.Pointer
 }
 
 func eventTypesFromFields(model Model, state *state) ([]EventType, error) {

--- a/pkg/security/secl/eval/event.go
+++ b/pkg/security/secl/eval/event.go
@@ -31,7 +31,7 @@ type Event interface {
 
 type Iterator interface {
 	Front(ctx *Context) unsafe.Pointer
-	Next(ctx *Context, prev unsafe.Pointer) unsafe.Pointer
+	Next(ctx *Context) unsafe.Pointer
 }
 
 func eventTypesFromFields(model Model, state *state) ([]EventType, error) {

--- a/pkg/security/secl/eval/event.go
+++ b/pkg/security/secl/eval/event.go
@@ -29,6 +29,11 @@ type Event interface {
 	GetPointer() unsafe.Pointer
 }
 
+type Iterator interface {
+	Front(ctx *Context) unsafe.Pointer
+	Next(ctx *Context, prev unsafe.Pointer) unsafe.Pointer
+}
+
 func eventTypesFromFields(model Model, state *state) ([]EventType, error) {
 	events := make(map[EventType]bool)
 	for field := range state.fieldValues {

--- a/pkg/security/secl/eval/model.go
+++ b/pkg/security/secl/eval/model.go
@@ -7,10 +7,12 @@ package eval
 
 // Model - interface that a model has to implement for the rule compilation
 type Model interface {
-	// GetEvaluator - Returns an evaluator for the given field
-	GetEvaluator(field Field) (Evaluator, error)
-	// ValidateField - Returns whether the value use against the field is valid, ex: for constant
+	// GetEvaluator returns an evaluator for the given field
+	GetEvaluator(field Field, regID RegisterID) (Evaluator, error)
+	// ValidateField returns whether the value use against the field is valid, ex: for constant
 	ValidateField(field Field, value FieldValue) error
-	// NewEvent - Returns a new event instance
+	// GetRegisterMaxValueFnc returns the maximun value that a register can have for the given field
+	GetRegisterMaxValueFnc(field Field) (func(ctx *Context) int, error)
+	// NewEvent returns a new event instance
 	NewEvent() Event
 }

--- a/pkg/security/secl/eval/model.go
+++ b/pkg/security/secl/eval/model.go
@@ -11,8 +11,8 @@ type Model interface {
 	GetEvaluator(field Field, regID RegisterID) (Evaluator, error)
 	// ValidateField returns whether the value use against the field is valid, ex: for constant
 	ValidateField(field Field, value FieldValue) error
-	// GetRegisterMaxValueFnc returns the maximun value that a register can have for the given field
-	GetRegisterMaxValueFnc(field Field) (func(ctx *Context) int, error)
+	// GetIterator return an iterator
+	GetIterator(field Field) (Iterator, error)
 	// NewEvent returns a new event instance
 	NewEvent() Event
 }

--- a/pkg/security/secl/eval/model_test.go
+++ b/pkg/security/secl/eval/model_test.go
@@ -41,7 +41,7 @@ func (t *testItemListIterator) Front(ctx *Context) unsafe.Pointer {
 	return nil
 }
 
-func (t *testItemListIterator) Next(ctx *Context) unsafe.Pointer {
+func (t *testItemListIterator) Next() unsafe.Pointer {
 	if next := (*list.Element)(t.prev).Next(); next != nil {
 		t.prev = next
 		return unsafe.Pointer(next)
@@ -50,10 +50,13 @@ func (t *testItemListIterator) Next(ctx *Context) unsafe.Pointer {
 }
 
 type testItemArrayIterator struct {
+	ctx   *Context
 	index int
 }
 
 func (t *testItemArrayIterator) Front(ctx *Context) unsafe.Pointer {
+	t.ctx = ctx
+
 	array := (*testEvent)(ctx.Object).process.array
 	if t.index < len(array) {
 		t.index++
@@ -62,8 +65,8 @@ func (t *testItemArrayIterator) Front(ctx *Context) unsafe.Pointer {
 	return nil
 }
 
-func (t *testItemArrayIterator) Next(ctx *Context) unsafe.Pointer {
-	array := (*testEvent)(ctx.Object).process.array
+func (t *testItemArrayIterator) Next() unsafe.Pointer {
+	array := (*testEvent)(t.ctx.Object).process.array
 	if t.index < len(array) {
 		value := array[t.index]
 		t.index++

--- a/pkg/security/secl/eval/model_test.go
+++ b/pkg/security/secl/eval/model_test.go
@@ -47,9 +47,7 @@ func (t *testItemIterator) Next(ctx *Context, prev unsafe.Pointer) unsafe.Pointe
 
 func (m *testModel) GetIterator(field Field) (Iterator, error) {
 	switch field {
-	case "process.list.key":
-		return &testItemIterator{}, nil
-	case "process.list.value":
+	case "process.list":
 		return &testItemIterator{}, nil
 	}
 
@@ -145,7 +143,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 		return &IntEvaluator{
 			EvalFnc: func(ctx *Context) int {
-				reg := ctx.registers[regID]
+				reg := ctx.Registers[regID]
 				element := (*list.Element)(reg.Value)
 				if element != nil {
 					return element.Value.(*testItem).key
@@ -160,7 +158,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 		return &IntEvaluator{
 			EvalFnc: func(ctx *Context) int {
-				reg := ctx.registers[regID]
+				reg := ctx.Registers[regID]
 				element := (*list.Element)(reg.Value)
 				if element != nil {
 					return element.Value.(*testItem).value

--- a/pkg/security/secl/eval/model_test.go
+++ b/pkg/security/secl/eval/model_test.go
@@ -92,6 +92,10 @@ type testEvent struct {
 	process testProcess
 	open    testOpen
 	mkdir   testMkdir
+
+	listEvaluated bool
+	uidEvaluated  bool
+	gidEvaluated  bool
 }
 
 type testModel struct {
@@ -152,15 +156,25 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 	case "process.uid":
 
 		return &IntEvaluator{
-			EvalFnc: func(ctx *Context) int { return (*testEvent)(ctx.Object).process.uid },
-			Field:   field,
+			EvalFnc: func(ctx *Context) int {
+				// to test optimisation
+				(*testEvent)(ctx.Object).uidEvaluated = true
+
+				return (*testEvent)(ctx.Object).process.uid
+			},
+			Field: field,
 		}, nil
 
 	case "process.gid":
 
 		return &IntEvaluator{
-			EvalFnc: func(ctx *Context) int { return (*testEvent)(ctx.Object).process.gid },
-			Field:   field,
+			EvalFnc: func(ctx *Context) int {
+				// to test optimisation
+				(*testEvent)(ctx.Object).gidEvaluated = true
+
+				return (*testEvent)(ctx.Object).process.gid
+			},
+			Field: field,
 		}, nil
 
 	case "process.is_root":
@@ -174,6 +188,9 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 		return &IntEvaluator{
 			EvalFnc: func(ctx *Context) int {
+				// to test optimisation
+				(*testEvent)(ctx.Object).listEvaluated = true
+
 				reg := ctx.Registers[regID]
 				if element := (*list.Element)(reg.Value); element != nil {
 					return element.Value.(*testItem).key
@@ -181,13 +198,17 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 				return 0
 			},
-			Field: field,
+			Field:  field,
+			Weight: IteratorWeight,
 		}, nil
 
 	case "process.list.value":
 
 		return &IntEvaluator{
 			EvalFnc: func(ctx *Context) int {
+				// to test optimisation
+				(*testEvent)(ctx.Object).listEvaluated = true
+
 				reg := ctx.Registers[regID]
 				if element := (*list.Element)(reg.Value); element != nil {
 					return element.Value.(*testItem).value
@@ -195,7 +216,8 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 				return 0
 			},
-			Field: field,
+			Field:  field,
+			Weight: IteratorWeight,
 		}, nil
 
 	case "process.array.key":
@@ -209,7 +231,8 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 				return 0
 			},
-			Field: field,
+			Field:  field,
+			Weight: IteratorWeight,
 		}, nil
 
 	case "process.array.value":
@@ -223,7 +246,8 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 				return 0
 			},
-			Field: field,
+			Field:  field,
+			Weight: IteratorWeight,
 		}, nil
 
 	case "open.filename":

--- a/pkg/security/secl/eval/model_test.go
+++ b/pkg/security/secl/eval/model_test.go
@@ -42,7 +42,7 @@ func (t *testItemListIterator) Front(ctx *Context) unsafe.Pointer {
 }
 
 func (t *testItemListIterator) Next() unsafe.Pointer {
-	if next := (*list.Element)(t.prev).Next(); next != nil {
+	if next := t.prev.Next(); next != nil {
 		t.prev = next
 		return unsafe.Pointer(next)
 	}

--- a/pkg/security/secl/eval/operators.go
+++ b/pkg/security/secl/eval/operators.go
@@ -28,6 +28,7 @@ func IntNot(a *IntEvaluator, opts *Opts, state *state) *IntEvaluator {
 
 		return &IntEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}
 	}
@@ -92,6 +93,7 @@ func StringMatches(a *StringEvaluator, b *StringEvaluator, not bool, opts *Opts,
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + PatternWeight,
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -110,6 +112,7 @@ func StringMatches(a *StringEvaluator, b *StringEvaluator, not bool, opts *Opts,
 
 	return &BoolEvaluator{
 		Value:     ea,
+		Weight:    a.Weight + PatternWeight,
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -148,6 +151,7 @@ func Not(a *BoolEvaluator, opts *Opts, state *state) *BoolEvaluator {
 
 	return &BoolEvaluator{
 		Value:     value,
+		Weight:    a.Weight,
 		isPartial: isPartialLeaf,
 	}
 }
@@ -175,6 +179,7 @@ func Minus(a *IntEvaluator, opts *Opts, state *state) *IntEvaluator {
 
 	return &IntEvaluator{
 		Value:     -a.Value,
+		Weight:    a.Weight,
 		isPartial: isPartialLeaf,
 	}
 }
@@ -225,6 +230,7 @@ func StringArrayContains(a *StringEvaluator, b *StringArray, not bool, opts *Opt
 
 	return &BoolEvaluator{
 		Value:     ea,
+		Weight:    a.Weight + InArrayWeight*len(b.Values),
 		isPartial: isPartialLeaf,
 	}, nil
 }
@@ -275,6 +281,7 @@ func IntArrayContains(a *IntEvaluator, b *IntArray, not bool, opts *Opts, state 
 
 	return &BoolEvaluator{
 		Value:     ea,
+		Weight:    a.Weight + InArrayWeight*len(b.Values),
 		isPartial: isPartialLeaf,
 	}, nil
 }

--- a/pkg/security/secl/eval/operators.go
+++ b/pkg/security/secl/eval/operators.go
@@ -34,6 +34,7 @@ func IntNot(a *IntEvaluator, opts *Opts, state *state) *IntEvaluator {
 
 	return &IntEvaluator{
 		Value:     ^a.Value,
+		Weight:    a.Weight,
 		isPartial: isPartialLeaf,
 	}
 }
@@ -101,6 +102,7 @@ func StringMatches(a *StringEvaluator, b *StringEvaluator, not bool, opts *Opts,
 		if not {
 			return &BoolEvaluator{
 				Value:     !ea,
+				Weight:    a.Weight + PatternWeight,
 				isPartial: isPartialLeaf,
 			}, nil
 		}
@@ -134,6 +136,7 @@ func Not(a *BoolEvaluator, opts *Opts, state *state) *BoolEvaluator {
 
 		return &BoolEvaluator{
 			EvalFnc:   ea,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}
 	}
@@ -165,6 +168,7 @@ func Minus(a *IntEvaluator, opts *Opts, state *state) *IntEvaluator {
 
 		return &IntEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight,
 			isPartial: isPartialLeaf,
 		}
 	}
@@ -205,6 +209,7 @@ func StringArrayContains(a *StringEvaluator, b *StringArray, not bool, opts *Opt
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + InArrayWeight*len(b.Values),
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -254,6 +259,7 @@ func IntArrayContains(a *IntEvaluator, b *IntArray, not bool, opts *Opts, state 
 
 		return &BoolEvaluator{
 			EvalFnc:   evalFnc,
+			Weight:    a.Weight + InArrayWeight*len(b.Values),
 			isPartial: isPartialLeaf,
 		}, nil
 	}

--- a/pkg/security/secl/eval/registers.go
+++ b/pkg/security/secl/eval/registers.go
@@ -14,7 +14,6 @@ type RegisterID = string
 
 // Register describes a register that can be used by a set
 type Register struct {
-	ID    string
 	Value unsafe.Pointer
 
 	iterator Iterator

--- a/pkg/security/secl/eval/registers.go
+++ b/pkg/security/secl/eval/registers.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package eval
+
+import (
+	"unsafe"
+)
+
+// RegisterID identify a register ID
+type RegisterID = string
+
+// Register describes a register that can be used by a set
+type Register struct {
+	ID    string
+	Value unsafe.Pointer
+
+	iterator Iterator
+}
+
+// Registers defines all available registers
+type Registers map[RegisterID]*Register
+
+// Clone returns a copy of the registers
+func (r Registers) Clone() Registers {
+	regs := make(Registers)
+
+	for k, v := range r {
+		regs[k] = v
+	}
+
+	return regs
+}

--- a/pkg/security/secl/eval/rule.go
+++ b/pkg/security/secl/eval/rule.go
@@ -77,7 +77,6 @@ func (r *Rule) GetFieldValues(field Field) []FieldValue {
 
 // PartialEval - Partial evaluation with the given Field
 func (r *Rule) PartialEval(ctx *Context, field Field) (bool, error) {
-	// TODO safchain
 	return r.evaluator.PartialEval(ctx, field)
 }
 

--- a/pkg/security/secl/eval/rule.go
+++ b/pkg/security/secl/eval/rule.go
@@ -180,7 +180,7 @@ func handleRegisters(evalFnc BoolEvalFnc, registersInfo map[RegisterID]*register
 				}
 				values = append(values, reg.Value)
 
-				reg.Value = reg.iterator.Next(ctx)
+				reg.Value = reg.iterator.Next()
 			}
 			registerValues[id] = values
 

--- a/pkg/security/secl/eval/state.go
+++ b/pkg/security/secl/eval/state.go
@@ -5,15 +5,17 @@
 
 package eval
 
-import "sort"
+import (
+	"sort"
+)
 
 type state struct {
-	model           Model
-	field           Field
-	events          map[EventType]bool
-	fieldValues     map[Field][]FieldValue
-	macros          map[MacroID]*MacroEvaluator
-	regMaxValueFncs map[RegisterID]func(ctx *Context) int
+	model             Model
+	field             Field
+	events            map[EventType]bool
+	fieldValues       map[Field][]FieldValue
+	macros            map[MacroID]*MacroEvaluator
+	registerIterators map[RegisterID]Iterator
 }
 
 //
@@ -49,11 +51,11 @@ func newState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *sta
 		macros = make(map[MacroID]*MacroEvaluator)
 	}
 	return &state{
-		field:           field,
-		macros:          macros,
-		model:           model,
-		events:          make(map[EventType]bool),
-		fieldValues:     make(map[Field][]FieldValue),
-		regMaxValueFncs: make(map[RegisterID]func(ctx *Context) int),
+		field:             field,
+		macros:            macros,
+		model:             model,
+		events:            make(map[EventType]bool),
+		fieldValues:       make(map[Field][]FieldValue),
+		registerIterators: make(map[RegisterID]Iterator),
 	}
 }

--- a/pkg/security/secl/eval/state.go
+++ b/pkg/security/secl/eval/state.go
@@ -9,17 +9,21 @@ import (
 	"sort"
 )
 
-type state struct {
-	model             Model
-	field             Field
-	events            map[EventType]bool
-	fieldValues       map[Field][]FieldValue
-	macros            map[MacroID]*MacroEvaluator
-	registerIterators map[RegisterID]Iterator
-	registerFields    map[RegisterID]Field
+type registerInfo struct {
+	iterator  Iterator
+	field     Field
+	subFields map[Field]bool
 }
 
-//
+type state struct {
+	model         Model
+	field         Field
+	events        map[EventType]bool
+	fieldValues   map[Field][]FieldValue
+	macros        map[MacroID]*MacroEvaluator
+	registersInfo map[RegisterID]*registerInfo
+}
+
 func (s *state) UpdateFields(field Field) {
 	if _, ok := s.fieldValues[field]; !ok {
 		s.fieldValues[field] = []FieldValue{}
@@ -52,12 +56,11 @@ func newState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *sta
 		macros = make(map[MacroID]*MacroEvaluator)
 	}
 	return &state{
-		field:             field,
-		macros:            macros,
-		model:             model,
-		events:            make(map[EventType]bool),
-		fieldValues:       make(map[Field][]FieldValue),
-		registerIterators: make(map[RegisterID]Iterator),
-		registerFields:    make(map[RegisterID]Field),
+		field:         field,
+		macros:        macros,
+		model:         model,
+		events:        make(map[EventType]bool),
+		fieldValues:   make(map[Field][]FieldValue),
+		registersInfo: make(map[RegisterID]*registerInfo),
 	}
 }

--- a/pkg/security/secl/eval/state.go
+++ b/pkg/security/secl/eval/state.go
@@ -16,6 +16,7 @@ type state struct {
 	fieldValues       map[Field][]FieldValue
 	macros            map[MacroID]*MacroEvaluator
 	registerIterators map[RegisterID]Iterator
+	registerFields    map[RegisterID]Field
 }
 
 //
@@ -57,5 +58,6 @@ func newState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *sta
 		events:            make(map[EventType]bool),
 		fieldValues:       make(map[Field][]FieldValue),
 		registerIterators: make(map[RegisterID]Iterator),
+		registerFields:    make(map[RegisterID]Field),
 	}
 }

--- a/pkg/security/secl/eval/state.go
+++ b/pkg/security/secl/eval/state.go
@@ -8,11 +8,12 @@ package eval
 import "sort"
 
 type state struct {
-	model       Model
-	field       Field
-	events      map[EventType]bool
-	fieldValues map[Field][]FieldValue
-	macros      map[MacroID]*MacroEvaluator
+	model           Model
+	field           Field
+	events          map[EventType]bool
+	fieldValues     map[Field][]FieldValue
+	macros          map[MacroID]*MacroEvaluator
+	regMaxValueFncs map[RegisterID]func(ctx *Context) int
 }
 
 //
@@ -48,10 +49,11 @@ func newState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *sta
 		macros = make(map[MacroID]*MacroEvaluator)
 	}
 	return &state{
-		field:       field,
-		macros:      macros,
-		model:       model,
-		events:      make(map[EventType]bool),
-		fieldValues: make(map[Field][]FieldValue),
+		field:           field,
+		macros:          macros,
+		model:           model,
+		events:          make(map[EventType]bool),
+		fieldValues:     make(map[Field][]FieldValue),
+		regMaxValueFncs: make(map[RegisterID]func(ctx *Context) int),
 	}
 }

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -431,6 +431,13 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				{{end}}
 			},
 			Field: field,
+			{{if $Field.Iterator}}
+				Weight: eval.IteratorWeight,
+			{{else if $Field.Handler}}
+				Weight: eval.HandlerWeight,
+			{{else}}
+				Weight: eval.FunctionWeight,
+			{{end}}
 		}, nil
 	{{end}}
 	}

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -47,6 +47,7 @@ type Module struct {
 	PkgPrefix string
 	BuildTags []string
 	Fields    map[string]*structField
+	Iterators map[string]*structField
 }
 
 var module *Module
@@ -60,6 +61,7 @@ type structField struct {
 	Event      string
 	Handler    string
 	OrigType   string
+	Iterator   *structField
 }
 
 func resolveSymbol(pkg, symbol string) (types.Object, error) {
@@ -78,12 +80,12 @@ func origTypeToBasicType(kind string) string {
 	return kind
 }
 
-func handleBasic(name, alias, kind, event string) {
+func handleBasic(name, alias, kind, event string, iterator *structField) {
 	fmt.Printf("handleBasic %s %s\n", name, kind)
 
 	switch kind {
 	case "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64":
-		module.Fields[alias] = &structField{Name: name, ReturnType: "int", Public: true, Event: event, OrigType: kind, BasicType: origTypeToBasicType(kind)}
+		module.Fields[alias] = &structField{Name: name, ReturnType: "int", Public: true, Event: event, OrigType: kind, BasicType: origTypeToBasicType(kind), Iterator: iterator}
 	default:
 		public := false
 		firstChar := strings.TrimPrefix(kind, "[]")
@@ -101,11 +103,12 @@ func handleBasic(name, alias, kind, event string) {
 			Public:     public,
 			Event:      event,
 			OrigType:   kind,
+			Iterator:   iterator,
 		}
 	}
 }
 
-func handleField(astFile *ast.File, name, alias, prefix, aliasPrefix, pkgName string, fieldType *ast.Ident, event string) error {
+func handleField(astFile *ast.File, name, alias, prefix, aliasPrefix, pkgName string, fieldType *ast.Ident, event string, iterator *structField, dejavu map[string]bool) error {
 	fmt.Printf("handleField fieldName %s, alias %s, prefix %s, aliasPrefix %s, pkgName %s, fieldType, %s\n", name, alias, prefix, aliasPrefix, pkgName, fieldType)
 
 	switch fieldType.Name {
@@ -114,7 +117,7 @@ func handleField(astFile *ast.File, name, alias, prefix, aliasPrefix, pkgName st
 			name = prefix + "." + name
 			alias = aliasPrefix + "." + alias
 		}
-		handleBasic(name, alias, fieldType.Name, event)
+		handleBasic(name, alias, fieldType.Name, event, iterator)
 	default:
 		symbol, err := resolveSymbol(pkgName, fieldType.Name)
 		if err != nil {
@@ -133,14 +136,14 @@ func handleField(astFile *ast.File, name, alias, prefix, aliasPrefix, pkgName st
 		}
 
 		spec := astFile.Scope.Lookup(fieldType.Name)
-		handleSpec(astFile, spec.Decl, prefix, aliasPrefix, event)
+		handleSpec(astFile, spec.Decl, prefix, aliasPrefix, event, iterator, dejavu)
 	}
 
 	return nil
 }
 
-func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event string) {
-	fmt.Printf("handleSpec spec: %+v, prefix: %s, aliasPrefix %s, event %s\n", spec, prefix, aliasPrefix, event)
+func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event string, iterator *structField, dejavu map[string]bool) {
+	fmt.Printf("handleSpec spec: %+v, prefix: %s, aliasPrefix %s, event %s, iterator %+v\n", spec, prefix, aliasPrefix, event, iterator)
 
 	if typeSpec, ok := spec.(*ast.TypeSpec); ok {
 		if structType, ok := typeSpec.Type.(*ast.StructType); ok {
@@ -159,11 +162,42 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 					fieldName := field.Names[0].Name
 					fieldAlias := fieldName
 
+					if dejavu[fieldName] {
+						fmt.Printf(">>>>>>>>>>>>>>: %s\n", fieldName)
+						continue
+					}
+
 					if fieldTag, found := tag.Lookup("field"); found {
 						split := strings.Split(fieldTag, ",")
 
 						if fieldAlias = split[0]; fieldAlias == "-" {
 							continue FIELD
+						}
+
+						if it, found := tag.Lookup("iterator"); found {
+							alias := fieldAlias
+							if aliasPrefix != "" {
+								alias = aliasPrefix + "." + fieldAlias
+							}
+
+							var fieldType *ast.Ident
+							if ft, ok := field.Type.(*ast.Ident); ok {
+								fieldType = ft
+							} else if ft, ok := field.Type.(*ast.StarExpr); ok {
+								if ident, ok := ft.X.(*ast.Ident); ok {
+									fieldType = ident
+								}
+							}
+
+							module.Iterators[alias] = &structField{
+								Name:       fmt.Sprintf("%s.%s", prefix, fieldName),
+								ReturnType: it,
+								Public:     true,
+								Event:      event,
+								OrigType:   fieldType.Name,
+							}
+
+							iterator = module.Iterators[alias]
 						}
 
 						if handler, found := tag.Lookup("handler"); found {
@@ -179,7 +213,6 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 
 							fieldType, ok := field.Type.(*ast.Ident)
 							if ok {
-
 								module.Fields[fieldAlias] = &structField{
 									Name:       fmt.Sprintf("%s.%s", prefix, fieldName),
 									BasicType:  origTypeToBasicType(fieldType.Name),
@@ -188,25 +221,36 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 									Public:     true,
 									Event:      event,
 									OrigType:   fieldType.Name,
+									Iterator:   iterator,
 								}
 							}
+							delete(dejavu, fieldName)
+
 							continue
 						}
 					}
 
+					dejavu[fieldName] = true
+
 					if fieldType, ok := field.Type.(*ast.Ident); ok {
-						if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, filepath.Base(pkgname), fieldType, event); err != nil {
+						if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, filepath.Base(pkgname), fieldType, event, iterator, dejavu); err != nil {
 							log.Print(err)
 						}
+						delete(dejavu, fieldName)
+
 						continue
 					} else if fieldType, ok := field.Type.(*ast.StarExpr); ok {
 						if itemIdent, ok := fieldType.X.(*ast.Ident); ok {
-							if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, filepath.Base(pkgname), itemIdent, event); err != nil {
+							if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, filepath.Base(pkgname), itemIdent, event, iterator, dejavu); err != nil {
 								log.Print(err)
 							}
+							delete(dejavu, fieldName)
+
 							continue
 						}
 					}
+
+					delete(dejavu, fieldName)
 
 					if strict {
 						log.Panicf("Don't know what to do with %s: %s", fieldName, spew.Sdump(field.Type))
@@ -224,7 +268,7 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 					if ident != nil {
 						embedded := astFile.Scope.Lookup(ident.Name)
 						if embedded != nil {
-							handleSpec(astFile, embedded.Decl, prefix, aliasPrefix, event)
+							handleSpec(astFile, embedded.Decl, prefix, aliasPrefix, event, iterator, dejavu)
 						}
 					}
 				}
@@ -281,6 +325,7 @@ func parseFile(filename string, pkgName string) (*Module, error) {
 		PkgPrefix: pkgPrefix,
 		BuildTags: buildTags,
 		Fields:    make(map[string]*structField),
+		Iterators: make(map[string]*structField),
 	}
 
 	for _, decl := range astFile.Decls {
@@ -299,7 +344,7 @@ func parseFile(filename string, pkgName string) (*Module, error) {
 
 			for _, spec := range decl.Specs {
 				if typeSpec, ok := spec.(*ast.TypeSpec); ok {
-					handleSpec(astFile, typeSpec, "", "", "")
+					handleSpec(astFile, typeSpec, "", "", "", nil, make(map[string]bool))
 				}
 			}
 		}
@@ -308,9 +353,13 @@ func parseFile(filename string, pkgName string) (*Module, error) {
 	return module, nil
 }
 
+var FuncMap = map[string]interface{}{
+	"TrimPrefix": strings.TrimPrefix,
+}
+
 func main() {
 	var err error
-	tmpl := template.Must(template.New("header").Parse(`{{- range .BuildTags }}// {{.}}{{end}}
+	tmpl := template.Must(template.New("header").Funcs(FuncMap).Parse(`{{- range .BuildTags }}// {{.}}{{end}}
 
 // Code generated - DO NOT EDIT.
 
@@ -322,25 +371,65 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
-func (m *Model) GetEvaluator(field eval.Field) (eval.Evaluator, error) {
+func (m *Model) GetIterator(field eval.Field) (eval.Iterator, error) {
+	switch field {
+	{{range $Name, $Field := .Iterators}}
+	case "{{$Name}}":
+		return &{{$Field.ReturnType}}{}, nil
+	{{end}}
+	}
+
+	return nil, &eval.ErrIteratorNoSupported{Field: field}
+}
+
+func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
 	{{range $Name, $Field := .Fields}}
-	{{$Return := $Field.Name | printf "(*Event)(ctx.Object).%s"}}
-	{{if ne $Field.Handler ""}}
-		{{$Return = $Field.Handler | printf "(*Event)(ctx.Object).%s((*Event)(ctx.Object))"}}
+	{{$EvaluatorType := "eval.StringEvaluator"}}
+	{{if eq $Field.ReturnType "int"}}
+	{{$EvaluatorType = "eval.IntEvaluator"}}
+	{{else if eq $Field.ReturnType "bool"}}
+	{{$EvaluatorType = "eval.BoolEvaluator"}}
 	{{end}}
 
 	case "{{$Name}}":
-	{{if eq $Field.ReturnType "string"}}
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return {{$Return}} },
-	{{else if eq $Field.ReturnType "int"}}
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int { return int({{$Return}}) },
-	{{else if eq $Field.ReturnType "bool"}}
-		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return {{$Return}} },
-	{{end}}
+		return &{{$EvaluatorType}}{
+			EvalFnc: func(ctx *eval.Context) {{$Field.ReturnType}} {
+				{{if $Field.Iterator}}
+					var result {{$Field.ReturnType}}
+
+					reg := ctx.Registers[regID]
+					element := (*{{$Field.Iterator.OrigType}})(reg.Value)
+					if element != nil {
+						{{$SubName := $Field.Iterator.Name | TrimPrefix $Field.Name}}
+
+						{{$Return := $SubName | printf "element%s"}}
+						{{if ne $Field.Handler ""}}
+							{{$Handler := $Field.Iterator.Name | TrimPrefix $Field.Handler}}
+							{{$Return = $Handler | printf "element%s((*Event)(ctx.Object))"}}
+						{{end}}
+
+						{{if eq $Field.ReturnType "int"}}
+							result = int({{$Return}})
+						{{else}}
+							result = {{$Return}}
+						{{end}}
+					}
+
+					return result
+				{{else}}
+					{{$Return := $Field.Name | printf "(*Event)(ctx.Object).%s"}}
+					{{if ne $Field.Handler ""}}
+						{{$Return = $Field.Handler | printf "(*Event)(ctx.Object).%s((*Event)(ctx.Object))"}}
+					{{end}}
+
+					{{if eq $Field.ReturnType "int"}}
+						return int({{$Return}})
+					{{else}}
+						return {{$Return}}
+					{{end}}
+				{{end}}
+			},
 			Field: field,
 		}, nil
 	{{end}}
@@ -404,6 +493,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	var ok bool
 	switch field {
 		{{range $Name, $Field := .Fields}}
+		{{if not $Field.Iterator}}
 		{{$FieldName := $Field.Name | printf "e.%s"}}
 		case "{{$Name}}":
 		{{if eq $Field.OrigType "string"}}
@@ -423,6 +513,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 				return &eval.ErrValueTypeMismatch{Field: "{{$Field.Name}}"}
 			}
 			return nil
+		{{end}}
 		{{end}}
 		{{end}}
 		}

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -379,7 +379,7 @@ func (m *Model) GetIterator(field eval.Field) (eval.Iterator, error) {
 	{{end}}
 	}
 
-	return nil, &eval.ErrIteratorNoSupported{Field: field}
+	return nil, &eval.ErrIteratorNotSupported{Field: field}
 }
 
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {

--- a/pkg/security/secl/generators/operators/operators.go
+++ b/pkg/security/secl/generators/operators/operators.go
@@ -46,20 +46,20 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 		{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 			if state.field != "" {
 				if a.isPartial {
-					ea = func(ctx *Context) {{ .EvalReturnType }} {
+					ea = func(ctx *Context, idx int) {{ .EvalReturnType }} {
 						return true
 					}
 				}
 				if b.isPartial {
-					eb = func(ctx *Context) {{ .EvalReturnType }} {
+					eb = func(ctx *Context, idx int) {{ .EvalReturnType }} {
 						return true
 					}
 				}
 			}
 		{{ end }}
 
-		evalFnc := func(ctx *Context) {{ .EvalReturnType }} {
-			return ea(ctx) {{ .Op }} eb(ctx)
+		evalFnc := func(ctx *Context, idx int) {{ .EvalReturnType }} {
+			return ea(ctx, idx) {{ .Op }} eb(ctx, idx)
 		}
 
 		return &{{ .FuncReturnType }}{
@@ -100,7 +100,7 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 		{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 			if state.field != "" {
 				if a.isPartial {
-					ea = func(ctx *Context) {{ .EvalReturnType }} {
+					ea = func(ctx *Context, idx int) {{ .EvalReturnType }} {
 						return true
 					}
 				}
@@ -110,8 +110,8 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 			}
 		{{ end }}
 
-		evalFnc := func(ctx *Context) {{ .EvalReturnType }} {
-			return ea(ctx) {{ .Op }} eb
+		evalFnc := func(ctx *Context, idx int) {{ .EvalReturnType }} {
+			return ea(ctx, idx) {{ .Op }} eb
 		}
 
 		return &{{ .FuncReturnType }}{
@@ -134,15 +134,15 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 				ea = true
 			}
 			if b.isPartial {
-				eb = func(ctx *Context) {{ .EvalReturnType }} {
+				eb = func(ctx *Context, idx int) {{ .EvalReturnType }} {
 					return true
 				}
 			}
 		}
 	{{ end }}
 
-	evalFnc := func(ctx *Context) {{ .EvalReturnType }} {
-		return ea {{ .Op }} eb(ctx)
+	evalFnc := func(ctx *Context, idx int) {{ .EvalReturnType }} {
+		return ea {{ .Op }} eb(ctx, idx)
 	}
 
 	return &{{ .FuncReturnType }}{

--- a/pkg/security/secl/generators/operators/operators.go
+++ b/pkg/security/secl/generators/operators/operators.go
@@ -58,7 +58,7 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 			}
 		{{ end }}
 
-		// optimise the evaluation if need moving the evaluation with more weight at the right
+		// optimize the evaluation if needed, moving the evaluation with more weight at the right
 		{{ if .Commutative }}
 			if a.Weight > b.Weight {
 				tmp := ea


### PR DESCRIPTION
### What does this PR do?

This PR introduces support of iterators in SECL which allows to write rule like :

```
process.ancestors[_].name
process.ancestors.name
process.ancestors[A].pid && process.ancestors[B].gid
```

the ident placed between brackets are used to specify a `register` where the iterator will store the current value

As it can introduces some overhead due to the iterations, this PR also introduces a naive optimizer which reorder the evalution according to "weight" of branches.

ex: 

```
process.ancestors[_].name == "sshd" && open.flags & O_CREAT > 0
````

will be compiled as it was written like this:

open.flags & O_CREAT > 0 && process.ancestors[_].name == "sshd"

### Motivation

This allow to write rules matching array, list, tree of objects. This PR uses SECL iterator to expose `process.ancestors`

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Unit and functional tests have been added
