### PR TITLE
pkg/trace: remove custom aggregations

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -69,7 +69,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 
 	return &Agent{
 		Receiver:           api.NewHTTPReceiver(conf, dynConf, in),
-		Concentrator:       stats.NewConcentrator(conf.ExtraAggregators, conf.BucketInterval.Nanoseconds(), statsChan),
+		Concentrator:       stats.NewConcentrator(conf.BucketInterval.Nanoseconds(), statsChan),
 		Blacklister:        filters.NewBlacklister(conf.Ignore["resource"]),
 		Replacer:           filters.NewReplacer(conf.ReplaceTags),
 		ScoreSampler:       NewScoreSampler(conf),

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -329,13 +329,6 @@ func (c *AgentConfig) loadDeprecatedValues() error {
 	if cfg.IsSet("apm_config.log_level") {
 		c.LogLevel = config.Datadog.GetString("apm_config.log_level")
 	}
-	if v := cfg.GetString("apm_config.extra_aggregators"); len(v) > 0 {
-		aggs, err := splitString(v, ',')
-		if err != nil {
-			return err
-		}
-		c.ExtraAggregators = append(c.ExtraAggregators, aggs...)
-	}
 	if cfg.IsSet("apm_config.log_throttling") {
 		c.LogThrottling = cfg.GetBool("apm_config.log_throttling")
 	}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -125,8 +125,7 @@ func New() *AgentConfig {
 		DefaultEnv: "none",
 		Endpoints:  []*Endpoint{{Host: "https://trace.agent.datadoghq.com"}},
 
-		BucketInterval:   time.Duration(10) * time.Second,
-		ExtraAggregators: []string{"http.status_code", "version", "_dd.hostname"},
+		BucketInterval: time.Duration(10) * time.Second,
 
 		ExtraSampleRate: 1.0,
 		MaxTPS:          10,

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -115,8 +115,6 @@ func TestDefaultConfig(t *testing.T) {
 
 	assert.Equal("INFO", c.LogLevel)
 	assert.Equal(true, c.Enabled)
-
-	assert.Equal([]string{"http.status_code", "version", "_dd.hostname"}, c.ExtraAggregators)
 }
 
 func TestNoAPMConfig(t *testing.T) {

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -1,0 +1,97 @@
+package stats
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"strings"
+)
+
+const (
+	hostnameTag   = "_dd.hostname"
+	statusCodeTag = "http.status_code"
+	versionTag    = "version"
+)
+
+// When adding or removing fields to aggregation the methods toTags, keyLen and
+// writeKey should always be updated accordingly
+type aggregation struct {
+	Env        string
+	Resource   string
+	Service    string
+	Hostname   string
+	StatusCode string
+	Version    string
+}
+
+func newAggregationFromSpan(s *pb.Span, env string) aggregation {
+	return aggregation{
+		Env:        env,
+		Resource:   s.Resource,
+		Service:    s.Service,
+		Hostname:   s.Meta[hostnameTag],
+		StatusCode: s.Meta[statusCodeTag],
+		Version:    s.Meta[versionTag],
+	}
+}
+
+func (aggr *aggregation) toTags() TagSet {
+	tagSet := make(TagSet, 3, 7)
+	tagSet[0] = Tag{"env", aggr.Env}
+	tagSet[1] = Tag{"resource", aggr.Resource}
+	tagSet[2] = Tag{"service", aggr.Service}
+	if len(aggr.Hostname) > 0 {
+		tagSet = append(tagSet, Tag{hostnameTag, aggr.Hostname})
+	}
+	if len(aggr.StatusCode) > 0 {
+		tagSet = append(tagSet, Tag{statusCodeTag, aggr.StatusCode})
+	}
+	if len(aggr.Version) > 0 {
+		tagSet = append(tagSet, Tag{versionTag, aggr.Version})
+	}
+	return tagSet
+}
+
+func (aggr *aggregation) keyLen() int {
+	length := len("env:") + len(aggr.Env) + len(",resource:") + len(aggr.Resource) + len(",service:") + len(aggr.Service)
+	if len(aggr.Hostname) > 0 {
+		// +2 for "," and ":" separator
+		length += 1 + len(hostnameTag) + 1 + len(aggr.Hostname)
+	}
+	if len(aggr.StatusCode) > 0 {
+		// +2 for "," and ":" separator
+		length += 1 + len(statusCodeTag) + 1 + len(aggr.StatusCode)
+	}
+	if len(aggr.Version) > 0 {
+		// +2 for "," and ":" separator
+		length += 1 + len(versionTag) + 1 + len(aggr.Version)
+	}
+	return length
+}
+
+func (aggr *aggregation) writeKey(b *strings.Builder) {
+	b.WriteString("env:")
+	b.WriteString(aggr.Env)
+	b.WriteString(",resource:")
+	b.WriteString(aggr.Resource)
+	b.WriteString(",service:")
+	b.WriteString(aggr.Service)
+
+	// Keys should be written in lexicographical order of the tag name
+	if len(aggr.Hostname) > 0 {
+		b.WriteRune(',')
+		b.WriteString(hostnameTag)
+		b.WriteRune(':')
+		b.WriteString(aggr.Hostname)
+	}
+	if len(aggr.StatusCode) > 0 {
+		b.WriteRune(',')
+		b.WriteString(statusCodeTag)
+		b.WriteRune(':')
+		b.WriteString(aggr.StatusCode)
+	}
+	if len(aggr.Version) > 0 {
+		b.WriteRune(',')
+		b.WriteString(versionTag)
+		b.WriteRune(':')
+		b.WriteString(aggr.Version)
+	}
+}

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -6,12 +6,13 @@ import (
 )
 
 const (
-	hostnameTag   = "_dd.hostname"
-	statusCodeTag = "http.status_code"
-	versionTag    = "version"
+	tagHostname   = "_dd.hostname"
+	tagStatusCode = "http.status_code"
+	tagVersion    = "version"
 )
 
-// When adding or removing fields to aggregation the methods toTags, keyLen and
+// aggregation contains all the dimension on which we aggregate statistics
+// when adding or removing fields to aggregation the methods toTagSet, keyLen and
 // writeKey should always be updated accordingly
 type aggregation struct {
 	Env        string
@@ -27,25 +28,25 @@ func newAggregationFromSpan(s *pb.Span, env string) aggregation {
 		Env:        env,
 		Resource:   s.Resource,
 		Service:    s.Service,
-		Hostname:   s.Meta[hostnameTag],
-		StatusCode: s.Meta[statusCodeTag],
-		Version:    s.Meta[versionTag],
+		Hostname:   s.Meta[tagHostname],
+		StatusCode: s.Meta[tagStatusCode],
+		Version:    s.Meta[tagVersion],
 	}
 }
 
-func (aggr *aggregation) toTags() TagSet {
+func (aggr *aggregation) toTagSet() TagSet {
 	tagSet := make(TagSet, 3, 7)
 	tagSet[0] = Tag{"env", aggr.Env}
 	tagSet[1] = Tag{"resource", aggr.Resource}
 	tagSet[2] = Tag{"service", aggr.Service}
 	if len(aggr.Hostname) > 0 {
-		tagSet = append(tagSet, Tag{hostnameTag, aggr.Hostname})
+		tagSet = append(tagSet, Tag{tagHostname, aggr.Hostname})
 	}
 	if len(aggr.StatusCode) > 0 {
-		tagSet = append(tagSet, Tag{statusCodeTag, aggr.StatusCode})
+		tagSet = append(tagSet, Tag{tagStatusCode, aggr.StatusCode})
 	}
 	if len(aggr.Version) > 0 {
-		tagSet = append(tagSet, Tag{versionTag, aggr.Version})
+		tagSet = append(tagSet, Tag{tagVersion, aggr.Version})
 	}
 	return tagSet
 }
@@ -54,15 +55,15 @@ func (aggr *aggregation) keyLen() int {
 	length := len("env:") + len(aggr.Env) + len(",resource:") + len(aggr.Resource) + len(",service:") + len(aggr.Service)
 	if len(aggr.Hostname) > 0 {
 		// +2 for "," and ":" separator
-		length += 1 + len(hostnameTag) + 1 + len(aggr.Hostname)
+		length += 1 + len(tagHostname) + 1 + len(aggr.Hostname)
 	}
 	if len(aggr.StatusCode) > 0 {
 		// +2 for "," and ":" separator
-		length += 1 + len(statusCodeTag) + 1 + len(aggr.StatusCode)
+		length += 1 + len(tagStatusCode) + 1 + len(aggr.StatusCode)
 	}
 	if len(aggr.Version) > 0 {
 		// +2 for "," and ":" separator
-		length += 1 + len(versionTag) + 1 + len(aggr.Version)
+		length += 1 + len(tagVersion) + 1 + len(aggr.Version)
 	}
 	return length
 }
@@ -77,15 +78,15 @@ func (aggr *aggregation) writeKey(b *strings.Builder) {
 
 	// Keys should be written in lexicographical order of the tag name
 	if len(aggr.Hostname) > 0 {
-		b.WriteString("," + hostnameTag + ":")
+		b.WriteString("," + tagHostname + ":")
 		b.WriteString(aggr.Hostname)
 	}
 	if len(aggr.StatusCode) > 0 {
-		b.WriteString("," + statusCodeTag + ":")
+		b.WriteString("," + tagStatusCode + ":")
 		b.WriteString(aggr.StatusCode)
 	}
 	if len(aggr.Version) > 0 {
-		b.WriteString("," + versionTag + ":")
+		b.WriteString("," + tagVersion + ":")
 		b.WriteString(aggr.Version)
 	}
 }

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -77,21 +77,15 @@ func (aggr *aggregation) writeKey(b *strings.Builder) {
 
 	// Keys should be written in lexicographical order of the tag name
 	if len(aggr.Hostname) > 0 {
-		b.WriteRune(',')
-		b.WriteString(hostnameTag)
-		b.WriteRune(':')
+		b.WriteString("," + hostnameTag + ":")
 		b.WriteString(aggr.Hostname)
 	}
 	if len(aggr.StatusCode) > 0 {
-		b.WriteRune(',')
-		b.WriteString(statusCodeTag)
-		b.WriteRune(':')
+		b.WriteString("," + statusCodeTag + ":")
 		b.WriteString(aggr.StatusCode)
 	}
 	if len(aggr.Version) > 0 {
-		b.WriteRune(',')
-		b.WriteString(versionTag)
-		b.WriteRune(':')
+		b.WriteString("," + versionTag + ":")
 		b.WriteString(aggr.Version)
 	}
 }

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -6,7 +6,6 @@
 package stats
 
 import (
-	"sort"
 	"sync"
 	"time"
 
@@ -24,8 +23,6 @@ const defaultBufferLen = 2
 // Gets an imperial shitton of traces, and outputs pre-computed data structures
 // allowing to find the gold (stats) amongst the traces.
 type Concentrator struct {
-	// list of attributes to use for extra aggregation
-	aggregators []string
 	// bucket duration in nanoseconds
 	bsize int64
 	// Timestamp of the oldest time bucket for which we allow data.
@@ -48,11 +45,10 @@ type Concentrator struct {
 }
 
 // NewConcentrator initializes a new concentrator ready to be started
-func NewConcentrator(aggregators []string, bsize int64, out chan []Bucket) *Concentrator {
+func NewConcentrator(bsize int64, out chan []Bucket) *Concentrator {
 	c := Concentrator{
-		aggregators: aggregators,
-		bsize:       bsize,
-		buckets:     make(map[int64]*RawBucket),
+		bsize:   bsize,
+		buckets: make(map[int64]*RawBucket),
 		// At start, only allow stats for the current time bucket. Ensure we don't
 		// override buckets which could have been sent before an Agent restart.
 		oldestTs: alignTs(time.Now().UnixNano(), bsize),
@@ -65,7 +61,6 @@ func NewConcentrator(aggregators []string, bsize int64, out chan []Bucket) *Conc
 		exit:   make(chan struct{}),
 		exitWG: &sync.WaitGroup{},
 	}
-	sort.Strings(c.aggregators)
 	return &c
 }
 
@@ -156,7 +151,7 @@ func (c *Concentrator) addNow(i *Input) {
 		}
 
 		subs, _ := i.Sublayers[s.Span]
-		b.HandleSpan(s, i.Env, c.aggregators, subs)
+		b.HandleSpan(s, i.Env, subs)
 	}
 }
 

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -23,7 +23,7 @@ var (
 
 func NewTestConcentrator() *Concentrator {
 	statsChan := make(chan []Bucket)
-	return NewConcentrator([]string{}, time.Second.Nanoseconds(), statsChan)
+	return NewConcentrator(time.Second.Nanoseconds(), statsChan)
 }
 
 // getTsInBucket gives a timestamp in ns which is `offset` buckets late
@@ -160,7 +160,7 @@ func TestConcentratorOldestTs(t *testing.T) {
 	t.Run("cold", func(t *testing.T) {
 		// Running cold, all spans in the past should end up in the current time bucket.
 		flushTime := now
-		c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+		c := NewConcentrator(testBucketInterval, statsChan)
 		c.addNow(testTrace)
 
 		for i := 0; i < c.bufferLen; i++ {
@@ -189,7 +189,7 @@ func TestConcentratorOldestTs(t *testing.T) {
 
 	t.Run("hot", func(t *testing.T) {
 		flushTime := now
-		c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+		c := NewConcentrator(testBucketInterval, statsChan)
 		c.oldestTs = alignTs(now, c.bsize) - int64(c.bufferLen-1)*c.bsize
 		c.addNow(testTrace)
 
@@ -236,7 +236,7 @@ func TestConcentratorOldestTs(t *testing.T) {
 func TestConcentratorStatsTotals(t *testing.T) {
 	assert := assert.New(t)
 	statsChan := make(chan []Bucket)
-	c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+	c := NewConcentrator(testBucketInterval, statsChan)
 
 	now := time.Now().UnixNano()
 	alignedNow := alignTs(now, c.bsize)
@@ -299,7 +299,7 @@ func TestConcentratorStatsTotals(t *testing.T) {
 func TestConcentratorStatsCounts(t *testing.T) {
 	assert := assert.New(t)
 	statsChan := make(chan []Bucket)
-	c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+	c := NewConcentrator(testBucketInterval, statsChan)
 
 	now := time.Now().UnixNano()
 	alignedNow := alignTs(now, c.bsize)
@@ -418,7 +418,7 @@ func TestConcentratorStatsCounts(t *testing.T) {
 func TestConcentratorSublayersStatsCounts(t *testing.T) {
 	assert := assert.New(t)
 	statsChan := make(chan []Bucket)
-	c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+	c := NewConcentrator(testBucketInterval, statsChan)
 
 	now := time.Now().UnixNano()
 	alignedNow := now - now%c.bsize
@@ -582,7 +582,7 @@ func TestConcentratorAdd(t *testing.T) {
 				sublayers[subtrace.Root] = subtraceSublayers
 			}
 			testTrace.Sublayers = sublayers
-			c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+			c := NewConcentrator(testBucketInterval, statsChan)
 			c.addNow(testTrace)
 			stats := c.flushNow(now + (int64(c.bufferLen) * testBucketInterval))
 			countValsEq(t, test.out, stats[0].Counts)

--- a/pkg/trace/stats/stats.go
+++ b/pkg/trace/stats/stats.go
@@ -7,6 +7,7 @@ package stats
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/stats/quantile"
 )
@@ -64,8 +65,21 @@ type Distribution struct {
 // GrainKey generates the key used to aggregate counts and distributions
 // which is of the form: name|measure|aggr
 // for example: serve|duration|service:webserver
-func GrainKey(name, measure, aggr string) string {
-	return name + "|" + measure + "|" + aggr
+func GrainKey(name, measure string, aggr aggregation) string {
+	b := strings.Builder{}
+	// +2 for "|" separators
+	size := len(name) + 1 + len(measure) + 1
+	size += aggr.keyLen()
+	b.Grow(size)
+
+	b.WriteString(name)
+	b.WriteRune('|')
+	b.WriteString(measure)
+	b.WriteRune('|')
+
+	aggr.writeKey(&b)
+
+	return b.String()
 }
 
 // NewCount returns a new Count for a metric and a given tag set

--- a/pkg/trace/stats/stats_test.go
+++ b/pkg/trace/stats/stats_test.go
@@ -6,8 +6,6 @@
 package stats
 
 import (
-	"bytes"
-	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -23,14 +21,22 @@ import (
 
 const defaultEnv = "default"
 
-func testWeightedSpans() WeightedTrace {
+func testWeightedSpans(withVersion bool) WeightedTrace {
+	var version13 map[string]string
+	if withVersion {
+		version13 = map[string]string{"version": "1.3"}
+	}
+	var version14 map[string]string
+	if withVersion {
+		version14 = map[string]string{"version": "1.4"}
+	}
 	spans := []pb.Span{
 		{Service: "A", Name: "A.foo", Resource: "α", Duration: 1},
 		{Service: "A", Name: "A.foo", Resource: "β", Duration: 2, Error: 1},
 		{Service: "B", Name: "B.foo", Resource: "γ", Duration: 3},
 		{Service: "B", Name: "B.foo", Resource: "ε", Duration: 4, Error: 404},
-		{Service: "B", Name: "B.foo", Resource: "ζ", Duration: 5, Meta: map[string]string{"version": "1.3"}},
-		{Service: "B", Name: "sql.query", Resource: "ζ", Duration: 6, Meta: map[string]string{"version": "1.4"}},
+		{Service: "B", Name: "B.foo", Resource: "ζ", Duration: 5, Meta: version13},
+		{Service: "B", Name: "sql.query", Resource: "ζ", Duration: 6, Meta: version14},
 		{Service: "C", Name: "sql.query", Resource: "δ", Duration: 7},
 		{Service: "C", Name: "sql.query", Resource: "δ", Duration: 8},
 	}
@@ -97,8 +103,8 @@ func testTraceTopLevel() pb.Trace {
 
 func TestGrainKey(t *testing.T) {
 	assert := assert.New(t)
-	gk := GrainKey("serve", "duration", "service:webserver")
-	assert.Equal("serve|duration|service:webserver", gk)
+	gk := GrainKey("serve", "duration", aggregation{Service: "webserver", Env: "prod", Resource: "api_route"})
+	assert.Equal("serve|duration|env:prod,resource:api_route,service:webserver", gk)
 }
 
 type expectedCount struct {
@@ -116,11 +122,10 @@ func TestBucketDefault(t *testing.T) {
 
 	srb := NewRawBucket(0, 1e9)
 
-	// No custom aggregators only the defaults
-	aggr := []string{}
-	for _, s := range testWeightedSpans() {
+	// Without version tag
+	for _, s := range testWeightedSpans(false) {
 		t.Logf("weight: %f, topLevel: %v", s.Weight, s.TopLevel)
-		srb.HandleSpan(s, defaultEnv, aggr, nil)
+		srb.HandleSpan(s, defaultEnv, nil)
 	}
 	sb := srb.Export()
 
@@ -224,10 +229,9 @@ func TestBucketExtraAggregators(t *testing.T) {
 
 	srb := NewRawBucket(0, 1e9)
 
-	// one custom aggregator
-	aggr := []string{"version"}
-	for _, s := range testWeightedSpans() {
-		srb.HandleSpan(s, defaultEnv, aggr, nil)
+	// with version tag
+	for _, s := range testWeightedSpans(true) {
+		srb.HandleSpan(s, defaultEnv, nil)
 	}
 	sb := srb.Export()
 
@@ -286,12 +290,11 @@ func TestBucketMany(t *testing.T) {
 	srb := NewRawBucket(0, 1e9)
 
 	// No custom aggregators only the defaults
-	aggr := []string{}
 	for i := 0; i < n; i++ {
 		s := templateSpan
 		s.Resource = "α" + strconv.Itoa(i)
 		srbCopy := *srb
-		srbCopy.HandleSpan(s, defaultEnv, aggr, nil)
+		srbCopy.HandleSpan(s, defaultEnv, nil)
 	}
 	sb := srb.Export()
 
@@ -324,9 +327,8 @@ func TestBucketSublayers(t *testing.T) {
 	srb := NewRawBucket(0, 1e9)
 
 	// No custom aggregators only the defaults
-	aggr := []string{}
 	for _, s := range wt {
-		srb.HandleSpan(s, defaultEnv, aggr, sublayers)
+		srb.HandleSpan(s, defaultEnv, sublayers)
 	}
 	sb := srb.Export()
 
@@ -422,9 +424,8 @@ func TestBucketSublayersTopLevel(t *testing.T) {
 	srb := NewRawBucket(0, 1e9)
 
 	// No custom aggregators only the defaults
-	aggr := []string{}
 	for _, s := range wt {
-		srb.HandleSpan(s, defaultEnv, aggr, sublayers)
+		srb.HandleSpan(s, defaultEnv, sublayers)
 	}
 	sb := srb.Export()
 
@@ -527,21 +528,17 @@ func TestTsRounding(t *testing.T) {
 func BenchmarkHandleSpan(b *testing.B) {
 
 	srb := NewRawBucket(0, 1e9)
-	aggr := []string{}
-
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		for _, s := range testWeightedSpans() {
-			srb.HandleSpan(s, defaultEnv, aggr, nil)
+		for _, s := range testWeightedSpans(false) {
+			srb.HandleSpan(s, defaultEnv, nil)
 		}
 	}
 }
 
 func BenchmarkHandleSpanSublayers(b *testing.B) {
 	srb := NewRawBucket(0, 1e9)
-	aggr := []string{}
-
 	tr := testTrace()
 	sublayers := NewSublayerCalculator().ComputeSublayers(tr)
 	root := traceutil.GetRoot(tr)
@@ -553,7 +550,7 @@ func BenchmarkHandleSpanSublayers(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		for _, s := range wt {
-			srb.HandleSpan(s, defaultEnv, aggr, sublayers)
+			srb.HandleSpan(s, defaultEnv, sublayers)
 		}
 	}
 }
@@ -562,7 +559,7 @@ func BenchmarkHandleSpanSublayers(b *testing.B) {
 // else compiler performs compile-time optimization when using + with strings
 var grainName = "mysql.query"
 var grainMeasure = "duration"
-var grainAggr = "resource:SELECT * FROM stuff,service:mysql"
+var grainAggr = aggregation{Resource: "SELECT * FROM stuff", Service: "mysql"}
 
 // testing out various way of doing string ops, to check which one is most efficient
 func BenchmarkGrainKey(b *testing.B) {
@@ -570,75 +567,5 @@ func BenchmarkGrainKey(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = GrainKey(grainName, grainMeasure, grainAggr)
-	}
-}
-
-func BenchmarkStringPlus(b *testing.B) {
-	if testing.Short() {
-		return
-	}
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_ = grainName + "|" + grainMeasure + "|" + grainAggr
-	}
-}
-
-func BenchmarkSprintf(b *testing.B) {
-	if testing.Short() {
-		return
-	}
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_ = fmt.Sprintf("%s|%s|%s", grainName, grainMeasure, grainAggr)
-	}
-}
-
-func BenchmarkBufferWriteByte(b *testing.B) {
-	if testing.Short() {
-		return
-	}
-	var buf bytes.Buffer
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		buf.Reset()
-		buf.WriteString(grainName)
-		buf.WriteByte('|')
-		buf.WriteString(grainMeasure)
-		buf.WriteByte('|')
-		buf.WriteString(grainAggr)
-		_ = buf.String()
-	}
-}
-
-func BenchmarkBufferWriteRune(b *testing.B) {
-	if testing.Short() {
-		return
-	}
-	var buf bytes.Buffer
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		buf.Reset()
-		buf.WriteString(grainName)
-		buf.WriteRune('|')
-		buf.WriteString(grainMeasure)
-		buf.WriteRune('|')
-		buf.WriteString(grainAggr)
-		_ = buf.String()
-	}
-}
-
-func BenchmarkStringsJoin(b *testing.B) {
-	if testing.Short() {
-		return
-	}
-	a := []string{grainName, grainMeasure, grainAggr}
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_ = strings.Join(a, "|")
 	}
 }

--- a/pkg/trace/stats/stats_test.go
+++ b/pkg/trace/stats/stats_test.go
@@ -526,12 +526,13 @@ func TestTsRounding(t *testing.T) {
 }
 
 func BenchmarkHandleSpan(b *testing.B) {
-
 	srb := NewRawBucket(0, 1e9)
+	wt := testWeightedSpans(false)
+
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		for _, s := range testWeightedSpans(false) {
+		for _, s := range wt {
 			srb.HandleSpan(s, defaultEnv, nil)
 		}
 	}

--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -80,7 +80,7 @@ func (sb *RawBucket) Export() Bucket {
 	ret := NewBucket(sb.start, sb.duration)
 	for k, v := range sb.data {
 		hitsKey := GrainKey(k.name, HITS, k.aggr)
-		tagSet := k.aggr.toTags()
+		tagSet := k.aggr.toTagSet()
 		ret.Counts[hitsKey] = Count{
 			Key:      hitsKey,
 			Name:     k.name,
@@ -125,7 +125,7 @@ func (sb *RawBucket) Export() Bucket {
 		}
 		for sk, sv := range v.sublayerStats {
 			key := GrainKey(k.name, sk.Metric, k.aggr) + "," + sk.Tag.Name + ":" + sk.Tag.Value
-			tagSet := append(k.aggr.toTags(), sk.Tag)
+			tagSet := append(k.aggr.toTagSet(), sk.Tag)
 			ret.Counts[key] = Count{
 				Key:      key,
 				Name:     k.name,
@@ -180,8 +180,10 @@ func (sb *RawBucket) add(s *WeightedSpan, aggr aggregation, sublayers []Sublayer
 	}
 
 	for _, sub := range sublayers {
-		var ss sublayerStat
-		var ok bool
+		var (
+			ss sublayerStat
+			ok bool
+		)
 
 		sKey := sublayerKey{sub.Metric, sub.Tag}
 		if ss, ok = gs.sublayerStats[sKey]; !ok {

--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -7,7 +7,6 @@ package stats
 
 import (
 	"bytes"
-	"sort"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/stats/quantile"
 )
@@ -16,8 +15,6 @@ import (
 // is that the final data, the one with send after a call to Export(), is correct.
 
 type groupedStats struct {
-	tags TagSet
-
 	topLevel float64
 
 	hits                    float64
@@ -28,37 +25,27 @@ type groupedStats struct {
 }
 
 type sublayerStats struct {
-	tags TagSet
-
 	topLevel float64
 
 	value int64
 }
 
-func newGroupedStats(tags TagSet) groupedStats {
+func newGroupedStats() groupedStats {
 	return groupedStats{
-		tags:                    tags,
 		durationDistribution:    quantile.NewSliceSummary(),
 		errDurationDistribution: quantile.NewSliceSummary(),
 	}
 }
 
-func newSublayerStats(tags TagSet) sublayerStats {
-	return sublayerStats{
-		tags: tags,
-	}
-}
-
 type statsKey struct {
 	name string
-	aggr string
+	aggr aggregation
 }
 
 type statsSubKey struct {
-	name   string
-	metric string
-	tag    Tag
-	aggr   string
+	name string
+	sub  SublayerValue
+	aggr aggregation
 }
 
 // RawBucket is used to compute span data and aggregate it
@@ -96,11 +83,12 @@ func (sb *RawBucket) Export() Bucket {
 	ret := NewBucket(sb.start, sb.duration)
 	for k, v := range sb.data {
 		hitsKey := GrainKey(k.name, HITS, k.aggr)
+		tagSet := k.aggr.toTags()
 		ret.Counts[hitsKey] = Count{
 			Key:      hitsKey,
 			Name:     k.name,
 			Measure:  HITS,
-			TagSet:   v.tags,
+			TagSet:   tagSet,
 			TopLevel: v.topLevel,
 			Value:    float64(v.hits),
 		}
@@ -109,7 +97,7 @@ func (sb *RawBucket) Export() Bucket {
 			Key:      errorsKey,
 			Name:     k.name,
 			Measure:  ERRORS,
-			TagSet:   v.tags,
+			TagSet:   tagSet,
 			TopLevel: v.topLevel,
 			Value:    float64(v.errors),
 		}
@@ -118,7 +106,7 @@ func (sb *RawBucket) Export() Bucket {
 			Key:      durationKey,
 			Name:     k.name,
 			Measure:  DURATION,
-			TagSet:   v.tags,
+			TagSet:   tagSet,
 			TopLevel: v.topLevel,
 			Value:    float64(v.duration),
 		}
@@ -126,7 +114,7 @@ func (sb *RawBucket) Export() Bucket {
 			Key:      durationKey,
 			Name:     k.name,
 			Measure:  DURATION,
-			TagSet:   v.tags,
+			TagSet:   tagSet,
 			TopLevel: v.topLevel,
 			Summary:  v.durationDistribution,
 		}
@@ -134,18 +122,19 @@ func (sb *RawBucket) Export() Bucket {
 			Key:      durationKey,
 			Name:     k.name,
 			Measure:  DURATION,
-			TagSet:   v.tags,
+			TagSet:   tagSet,
 			TopLevel: v.topLevel,
 			Summary:  v.errDurationDistribution,
 		}
 	}
 	for k, v := range sb.sublayerData {
-		key := GrainKey(k.name, k.metric, k.aggr+","+k.tag.Name+":"+k.tag.Value)
+		key := GrainKey(k.name, k.sub.Metric, k.aggr) + "," + k.sub.Tag.Name + ":" + k.sub.Tag.Value
+		tagSet := append(k.aggr.toTags(), k.sub.Tag)
 		ret.Counts[key] = Count{
 			Key:      key,
 			Name:     k.name,
-			Measure:  k.metric,
-			TagSet:   v.tags,
+			Measure:  k.sub.Metric,
+			TagSet:   tagSet,
 			TopLevel: v.topLevel,
 			Value:    float64(v.value),
 		}
@@ -153,73 +142,27 @@ func (sb *RawBucket) Export() Bucket {
 	return ret
 }
 
-func assembleGrain(b *bytes.Buffer, env, resource, service string, m map[string]string) (string, TagSet) {
-	b.Reset()
-
-	b.WriteString("env:")
-	b.WriteString(env)
-	b.WriteString(",resource:")
-	b.WriteString(resource)
-	b.WriteString(",service:")
-	b.WriteString(service)
-
-	tagset := TagSet{{"env", env}, {"resource", resource}, {"service", service}}
-
-	if m == nil || len(m) == 0 {
-		return b.String(), tagset
-	}
-
-	keys := make([]string, len(m))
-	j := 0
-	for k := range m {
-		keys[j] = k
-		j++
-	}
-
-	sort.Strings(keys) // required else aggregations would not work
-
-	for _, key := range keys {
-		b.WriteRune(',')
-		b.WriteString(key)
-		b.WriteRune(':')
-		b.WriteString(m[key])
-		tagset = append(tagset, Tag{key, m[key]})
-	}
-
-	return b.String(), tagset
-}
-
 // HandleSpan adds the span to this bucket stats, aggregated with the finest grain matching given aggregators
-func (sb *RawBucket) HandleSpan(s *WeightedSpan, env string, aggregators []string, sublayers []SublayerValue) {
+func (sb *RawBucket) HandleSpan(s *WeightedSpan, env string, sublayers []SublayerValue) {
 	if env == "" {
 		panic("env should never be empty")
 	}
 
-	m := make(map[string]string)
-
-	for _, agg := range aggregators {
-		if agg != "env" && agg != "resource" && agg != "service" {
-			if v, ok := s.Meta[agg]; ok {
-				m[agg] = v
-			}
-		}
-	}
-
-	grain, tags := assembleGrain(&sb.keyBuf, env, s.Resource, s.Service, m)
-	sb.add(s, grain, tags)
+	aggr := newAggregationFromSpan(s.Span, env)
+	sb.add(s, aggr)
 
 	for _, sub := range sublayers {
-		sb.addSublayer(s, grain, tags, sub)
+		sb.addSublayer(s, aggr, sub)
 	}
 }
 
-func (sb *RawBucket) add(s *WeightedSpan, aggr string, tags TagSet) {
+func (sb *RawBucket) add(s *WeightedSpan, aggr aggregation) {
 	var gs groupedStats
 	var ok bool
 
 	key := statsKey{name: s.Name, aggr: aggr}
 	if gs, ok = sb.data[key]; !ok {
-		gs = newGroupedStats(tags)
+		gs = newGroupedStats()
 	}
 
 	if s.TopLevel {
@@ -244,7 +187,7 @@ func (sb *RawBucket) add(s *WeightedSpan, aggr string, tags TagSet) {
 	sb.data[key] = gs
 }
 
-func (sb *RawBucket) addSublayer(s *WeightedSpan, aggr string, tags TagSet, sub SublayerValue) {
+func (sb *RawBucket) addSublayer(s *WeightedSpan, aggr aggregation, sub SublayerValue) {
 	// This is not as efficient as a "regular" add as we don't update
 	// all sublayers at once (one call for HITS, and another one for ERRORS, DURATION...)
 	// when logically, if we have a sublayer for HITS, we also have one for DURATION,
@@ -253,13 +196,9 @@ func (sb *RawBucket) addSublayer(s *WeightedSpan, aggr string, tags TagSet, sub 
 	var ss sublayerStats
 	var ok bool
 
-	subTags := make(TagSet, len(tags)+1)
-	copy(subTags, tags)
-	subTags[len(tags)] = sub.Tag
-
-	key := statsSubKey{name: s.Name, metric: sub.Metric, tag: sub.Tag, aggr: aggr}
+	key := statsSubKey{name: s.Name, sub: sub, aggr: aggr}
 	if ss, ok = sb.sublayerData[key]; !ok {
-		ss = newSublayerStats(subTags)
+		ss = sublayerStats{}
 	}
 
 	if s.TopLevel {

--- a/pkg/trace/stats/statsraw_test.go
+++ b/pkg/trace/stats/statsraw_test.go
@@ -6,6 +6,7 @@
 package stats
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
@@ -15,31 +16,31 @@ import (
 )
 
 func TestGrain(t *testing.T) {
-	srb := NewRawBucket(0, 1e9)
 	assert := assert.New(t)
 
 	s := pb.Span{Service: "thing", Name: "other", Resource: "yo"}
-	aggr, tgs := assembleGrain(&srb.keyBuf, "default", s.Resource, s.Service, nil)
+	aggr := newAggregationFromSpan(&s, "default")
 
-	assert.Equal("env:default,resource:yo,service:thing", aggr)
-	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}}, tgs)
+	b := strings.Builder{}
+	aggr.writeKey(&b)
+	assert.Equal("env:default,resource:yo,service:thing", b.String())
+	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}}, aggr.toTags())
 }
 
 func TestGrainWithExtraTags(t *testing.T) {
-	srb := NewRawBucket(0, 1e9)
 	assert := assert.New(t)
 
-	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{"meta2": "two", "meta1": "ONE"}}
-	aggr, tgs := assembleGrain(&srb.keyBuf, "default", s.Resource, s.Service, s.Meta)
+	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{hostnameTag: "host-id", versionTag: "v0", statusCodeTag: "418"}}
+	aggr := newAggregationFromSpan(&s, "default")
 
-	assert.Equal("env:default,resource:yo,service:thing,meta1:ONE,meta2:two", aggr)
-	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}, Tag{"meta1", "ONE"}, Tag{"meta2", "two"}}, tgs)
+	b := strings.Builder{}
+	aggr.writeKey(&b)
+	assert.Equal("env:default,resource:yo,service:thing,_dd.hostname:host-id,http.status_code:418,version:v0", b.String())
+	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}, Tag{"_dd.hostname", "host-id"}, Tag{"http.status_code", "418"}, Tag{"version", "v0"}}, aggr.toTags())
 }
 
 func BenchmarkHandleSpanRandom(b *testing.B) {
 	sb := NewRawBucket(0, 1e9)
-	aggr := []string{}
-
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -47,7 +48,7 @@ func BenchmarkHandleSpanRandom(b *testing.B) {
 		traceutil.ComputeTopLevel(benchTrace)
 		wt := NewWeightedTrace(benchTrace, root)
 		for _, span := range wt {
-			sb.HandleSpan(span, "dev", aggr, nil)
+			sb.HandleSpan(span, "dev", nil)
 		}
 	}
 }

--- a/pkg/trace/stats/statsraw_test.go
+++ b/pkg/trace/stats/statsraw_test.go
@@ -24,19 +24,19 @@ func TestGrain(t *testing.T) {
 	b := strings.Builder{}
 	aggr.writeKey(&b)
 	assert.Equal("env:default,resource:yo,service:thing", b.String())
-	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}}, aggr.toTags())
+	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}}, aggr.toTagSet())
 }
 
 func TestGrainWithExtraTags(t *testing.T) {
 	assert := assert.New(t)
 
-	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{hostnameTag: "host-id", versionTag: "v0", statusCodeTag: "418"}}
+	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{tagHostname: "host-id", tagVersion: "v0", tagStatusCode: "418"}}
 	aggr := newAggregationFromSpan(&s, "default")
 
 	b := strings.Builder{}
 	aggr.writeKey(&b)
 	assert.Equal("env:default,resource:yo,service:thing,_dd.hostname:host-id,http.status_code:418,version:v0", b.String())
-	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}, Tag{"_dd.hostname", "host-id"}, Tag{"http.status_code", "418"}, Tag{"version", "v0"}}, aggr.toTags())
+	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}, Tag{"_dd.hostname", "host-id"}, Tag{"http.status_code", "418"}, Tag{"version", "v0"}}, aggr.toTagSet())
 }
 
 func BenchmarkHandleSpanRandom(b *testing.B) {

--- a/pkg/trace/test/testutil/stats.go
+++ b/pkg/trace/test/testutil/stats.go
@@ -18,7 +18,7 @@ const defaultEnv = "none"
 // TestBucket returns a fixed stats bucket to be used in unit tests
 func TestBucket() stats.Bucket {
 	srb := stats.NewRawBucket(0, 1e9)
-	srb.HandleSpan(TestWeightedSpan(), defaultEnv, defaultAggregators, nil)
+	srb.HandleSpan(TestWeightedSpan(), defaultEnv, nil)
 	sb := srb.Export()
 
 	// marshalling then unmarshalling data to:
@@ -42,7 +42,7 @@ func TestBucket() stats.Bucket {
 func BucketWithSpans(spans []*stats.WeightedSpan) stats.Bucket {
 	srb := stats.NewRawBucket(0, 1e9)
 	for _, s := range spans {
-		srb.HandleSpan(s, defaultEnv, defaultAggregators, nil)
+		srb.HandleSpan(s, defaultEnv, nil)
 	}
 	return srb.Export()
 }

--- a/releasenotes/notes/trace-agent-remove-custom-aggregations-c36ddb504d4ff147.yaml
+++ b/releasenotes/notes/trace-agent-remove-custom-aggregations-c36ddb504d4ff147.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: improve stats computation performance.
+deprecations:
+  - |
+    APM: remove the already deprecated apm_config.extra_aggregators config option.


### PR DESCRIPTION
### What does this PR do?

This PR removes `apm_config.extra_aggregators` from the configuration (it is deprecated and the feature is no longer supported). It leverages this to remove the generic behavior to compute any aggregation and hardcodes the ones we need: "http.status_code", "version", "_dd.hostname". This in turn allows to remove all the string concatenation that were previously done and use a struct instead.  

It reduces the number of allocations, but increases the cost of hashing to update the maps. To offset that cost, the data-structure has been slightly changed so that we only do one map access for each span processed (commits 
cdbd398  and 2656754).


```
name                   old time/op    new time/op    delta
HandleSpan-4             3.28µs ± 3%    1.93µs ± 1%   -41.24%  (p=0.008 n=5+5)
HandleSpanSublayers-4    11.3µs ± 2%     4.2µs ± 1%   -63.34%  (p=0.016 n=5+4)
HandleSpanRandom-4       11.3µs ± 6%     8.2µs ±24%   -27.49%  (p=0.008 n=5+5)

name                   old alloc/op   new alloc/op   delta
HandleSpan-4             1.15kB ± 0%    0.00kB       -100.00%  (p=0.008 n=5+5)
HandleSpanSublayers-4    3.70kB ± 0%    0.00kB       -100.00%  (p=0.008 n=5+5)
HandleSpanRandom-4       5.64kB ± 0%    1.22kB ± 0%   -78.30%  (p=0.008 n=5+5)

name                   old allocs/op  new allocs/op  delta
HandleSpan-4               16.0 ± 0%       0.0       -100.00%  (p=0.008 n=5+5)
HandleSpanSublayers-4      32.0 ± 0%       0.0       -100.00%  (p=0.008 n=5+5)
HandleSpanRandom-4         50.0 ± 0%      18.0 ± 0%   -64.00%  (p=0.008 n=5+5)
```


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
