### PR TITLE
Auto-exclude pause containers based on container labels

### DIFF
--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
@@ -264,6 +265,9 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 }
 
 func isExcluded(ctn containers.Container, fil *ddContainers.Filter) bool {
+	if config.Datadog.GetBool("exclude_pause_container") && ddContainers.IsPauseContainer(ctn.Labels) {
+		return true
+	}
 	// The container name is not available in Containerd, we only rely on image name and kube namespace based exclusion
 	return fil.IsExcluded("", ctn.Image, ctn.Labels["io.kubernetes.pod.namespace"])
 }

--- a/pkg/collector/corechecks/containers/containerd_test.go
+++ b/pkg/collector/corechecks/containers/containerd_test.go
@@ -481,4 +481,13 @@ func TestIsExcluded(t *testing.T) {
 		},
 	}
 	require.True(t, isExcluded(c, containerdCheck.filters))
+
+	// Pause container filtering
+	c = containers.Container{
+		Image: "foo",
+		Labels: map[string]string{
+			"io.kubernetes.pod.name": "foo",
+		},
+	}
+	require.True(t, isExcluded(c, containerdCheck.filters))
 }

--- a/pkg/collector/corechecks/containers/cri.go
+++ b/pkg/collector/corechecks/containers/cri.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -150,6 +151,10 @@ func (c *CRICheck) computeContainerUptime(sender aggregator.Sender, currentTime 
 
 // isExcluded returns whether a container should be excluded based on its image, name and namespace
 func (c *CRICheck) isExcluded(ctr *pb.ContainerStatus) bool {
+	if config.Datadog.GetBool("exclude_pause_container") && containers.IsPauseContainer(ctr.Labels) {
+		return true
+	}
+
 	name := ""
 	if meta := ctr.GetMetadata(); meta != nil {
 		name = meta.GetName()

--- a/pkg/collector/corechecks/containers/cri_test.go
+++ b/pkg/collector/corechecks/containers/cri_test.go
@@ -69,6 +69,12 @@ func TestExcludedContainers(t *testing.T) {
 		Metadata: &pb.ContainerMetadata{Name: "foo-name"},
 	}
 
+	pauseCtr := &pb.ContainerStatus{
+		Labels:   map[string]string{"io.kubernetes.container.name": "POD"},
+		Image:    &pb.ImageSpec{Image: "pod"},
+		Metadata: &pb.ContainerMetadata{Name: "pod"},
+	}
+
 	// Namespace based exclusion
 	config.Datadog.Set("container_exclude", "kube_namespace:foo*")
 	containers.ResetSharedFilter()
@@ -86,6 +92,9 @@ func TestExcludedContainers(t *testing.T) {
 	containers.ResetSharedFilter()
 	criCheck.filter, _ = containers.GetSharedMetricFilter()
 	require.True(t, criCheck.isExcluded(ctr))
+
+	// Pause container exclusion
+	require.True(t, criCheck.isExcluded(pauseCtr))
 
 	// Container not excluded
 	config.Datadog.Set("container_exclude", "image:bar* name:bar* kube_namespace:bar*")

--- a/pkg/util/containers/pause.go
+++ b/pkg/util/containers/pause.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package containers
+
+const containerNameLabel = "io.kubernetes.container.name"
+const podNameLabel = "io.kubernetes.pod.name"
+const pauseContainerNameValue = "POD"
+
+// IsPauseContainer returns whether a container is a pause container based on the container labels
+// This util can be used to exclude pause container in best-effort
+// Note: Pause containers can still be excluded based on the image name via the container filtering module
+func IsPauseContainer(labels map[string]string) bool {
+	ctr, ctrFound := labels[containerNameLabel]
+	if ctr == pauseContainerNameValue {
+		return true
+	}
+
+	// Pause containers don't have a "io.kubernetes.container.name" label in containerd
+	// they only have io.kubernetes.pod.name
+	// See https://github.com/containerd/cri/issues/922
+	_, podFound := labels[podNameLabel]
+	return !ctrFound && podFound
+}

--- a/pkg/util/containers/pause_test.go
+++ b/pkg/util/containers/pause_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPauseContainer(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{
+			name: "docker & crio pause container",
+			labels: map[string]string{
+				"io.kubernetes.container.name": "POD",
+				"io.kubernetes.pod.name":       "coredns-66bff467f8-qjf22",
+				"io.kubernetes.pod.namespace":  "kube-system",
+				"io.kubernetes.pod.uid":        "0adb6ccb-2024-43de-b5a2-6fb0c7f3dc5f",
+				"k8s-app":                      "kube-dns",
+				"pod-template-hash":            "66bff467f8",
+			},
+			want: true,
+		},
+		{
+			name: "docker & crio regular container",
+			labels: map[string]string{
+				"io.kubernetes.container.name": "storage-provisioner",
+				"io.kubernetes.pod.name":       "storage-provisioner",
+				"io.kubernetes.pod.namespace":  "kube-system",
+				"io.kubernetes.pod.uid":        "72e546dc-6977-430e-8e7d-99b61c45eab7",
+			},
+			want: false,
+		},
+		{
+			name: "containerd pause container",
+			labels: map[string]string{
+				"controller-revision-hash":    "c8bb659c5",
+				"io.kubernetes.pod.name":      "kube-proxy-f5dvk",
+				"io.kubernetes.pod.namespace": "kube-system",
+				"io.kubernetes.pod.uid":       "180db9cf-e5c0-4d5f-9bbe-505df6c63791",
+				"k8s-app":                     "kube-proxy",
+				"pod-template-generation":     "1",
+			},
+			want: true,
+		},
+		{
+			name: "containerd regular container",
+			labels: map[string]string{
+				"io.kubernetes.container.name": "redis-ctr",
+				"io.kubernetes.pod.name":       "redis",
+				"io.kubernetes.pod.namespace":  "default",
+				"io.kubernetes.pod.uid":        "c83e3e11-263c-4467-9efd-bcb6a314a1f8",
+			},
+			want: false,
+		},
+		{
+			name:   "empty labels",
+			labels: map[string]string{},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsPauseContainer(tt.labels))
+		})
+	}
+}

--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
@@ -226,7 +227,8 @@ func (d *DockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*containers.C
 			log.Warnf("Can't resolve image name %s: %s", c.Image, err)
 		}
 
-		excluded := d.cfg.filter.IsExcluded(c.Names[0], image, c.Labels["io.kubernetes.pod.namespace"])
+		pauseContainerExcluded := config.Datadog.GetBool("exclude_pause_container") && containers.IsPauseContainer(c.Labels)
+		excluded := pauseContainerExcluded || d.cfg.filter.IsExcluded(c.Names[0], image, c.Labels["io.kubernetes.pod.namespace"])
 		if excluded && !cfg.FlagExcluded {
 			continue
 		}

--- a/releasenotes/notes/auto-exclude-pause-containers-e8cbe84dc6ab3fbe.yaml
+++ b/releasenotes/notes/auto-exclude-pause-containers-e8cbe84dc6ab3fbe.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Pause containers are now detected and auto excluded based on the `io.kubernetes` container labels.


### PR DESCRIPTION
### What does this PR do?

Identify pause containers using the container labels and exclude them automatically

### Motivation

Image name filtering is not enough, even though we exclude a large set of pause containers using the container image, we might miss other images.

### Additional Notes

As opposed to `crio` and `docker`, `containerd` doesn't add a `io.kubernetes.container.name=POD` label on pause containers, so the pause containers are identified by the absence of that label + the presence of `io.kubernetes.pod.name`

### Describe your test plan

Should be tested this with `crio` `docker` and `containerd`, it's difficult to QA it without adding extra logging though.
