### PR TITLE
[e2e tests] Enable all agents and check for pod readiness

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4616,6 +4616,7 @@ trigger_release_6:
   - python3.6 -m pip install --user -r requirements.txt
   - export DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
   - export DOCKER_REGISTRY_PWD=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+  - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
 
 pupernetes-dev:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4614,6 +4614,8 @@ trigger_release_6:
   before_script:
   - cd $SRC_PATH
   - python3.6 -m pip install --user -r requirements.txt
+  - export DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+  - export DOCKER_REGISTRY_PWD=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
 
 pupernetes-dev:
   rules:

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -21,54 +21,82 @@ spec:
           helm repo add datadog https://helm.datadoghq.com
           helm repo update
           helm --namespace {{inputs.parameters.namespace}} install \
-            --set datadog.dd_url=http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local \
-            --set datadog.apiKey=123er \
-            --set datadog.appKey=123er1 \
-            --set datadog.env[0].name=DD_HOSTNAME \
-            --set datadog.env[0].value=e2e-test \
-            --set datadog.leaderElection=true \
-            --set datadog.logs.enabled=true \
-            --set datadog.logs.containerCollectAll=true \
-            --set agents.image.repository={{inputs.parameters.agent-image-repository}} \
-            --set agents.image.tag={{inputs.parameters.agent-image-tag}} \
-            --set agents.image.doNotCheckTag=true \
-            --set clusterAgent.enabled=true \
-            --set clusterAgent.image.repository={{inputs.parameters.cluster-agent-image-repository}} \
-            --set clusterAgent.image.tag={{inputs.parameters.cluster-agent-image-tag}} \
-            --set clusterAgent.token=c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd \
-            --set clusterAgent.metricsProvider.enabled=true \
-            --set clusterAgent.env[0].name=DATADOG_HOST \
-            --set clusterAgent.env[0].value=http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local \
-            --set datadog.confd.memory\\.yaml='instances:
-            - empty_default_hostname: true
-          ' \
-            --set datadog.confd.network\\.yaml='init_config:
-          instances:
-            - collect_connection_state: false
-              excluded_interfaces:
-                - lo
-                - lo0
-            - collect_connection_state: false
-              empty_default_hostname: true
-              excluded_interfaces:
-                - lo
-                - lo0
-          ' \
-            --set datadog.confd.kubernetes_state\\.yaml='ad_identifiers:
-            - kube-state-metrics
+            --values <(cat <<EOF
+            datadog:
+              dd_url: http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local
+              apiKey: 123er
+              appKey: 123er1
+              env:
+                - name: DD_HOSTNAME
+                  value: e2e-test
+              leaderElection: true
+              logs:
+                enabled: true
+                containerCollectAll: true
+              apm:
+                enabled: true
+              processAgent:
+                enabled: true
+              systemProbe:
+                enabled: true
 
-          init_config:
+              confd:
+                memory.yaml: |
+                  init_config:
+                  instances:
+                    - empty_default_hostname: true
 
-          # Ignore tags coming from autodiscovery
-          ignore_autodiscovery_tags: true
+                network.yaml: |
+                  init_config:
+                  instances:
+                    - collect_connection_state: false
+                      excluded_interfaces:
+                        - lo
+                        - lo0
+                    - collect_connection_state: false
+                      empty_default_hostname: true
+                      excluded_interfaces:
+                        - lo
+                        - lo0
 
-          instances:
-            - kube_state_url: http://%%host%%:8080/metrics
-              hostname_override: false
-          ' \
-            --set datadog.dogstatsd.useSocketVolume=true \
-            --set datadog.dogstatsd.socketPath=/var/run/dogstatsd/dsd.socket \
-            --set datadog.dogstatsd.hostSocketPath=/var/run/dogstatsd \
+                kubernetes_state.yaml: |
+                  ad_identifiers:
+                    - kube_state_metrics
+
+                  init_config:
+
+                  # Ignore tags coming from autodiscovery
+                  ignore_autodiscovery_tags: true
+
+                  instances:
+                    - kube_state_url: http://%%host%%:8080/metrics
+                      hostname_override: false
+
+              dogstatsd:
+                useSocketVolume: true
+                socketPath: /var/run/dogstatsd/dsd.socket
+                hostSocketPath: /var/run/dogstatsd
+
+            agents:
+              image:
+                repository: {{inputs.parameters.agent-image-repository}}
+                tag: {{inputs.parameters.agent-image-tag}}
+                doNotCheckTag: true
+
+            clusterAgent:
+              enabled: true
+              image:
+                repository: {{inputs.parameters.agent-image-repository}}
+                tag: {{inputs.parameters.agent-image-tag}}
+                doNotCheckTag: true
+              token: c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd
+              metricsProvider:
+                enabled: true
+              env:
+                - name: DATADOG_HOST
+                  value: http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local
+            EOF
+            ) \
             datadog-agent datadog/datadog
 
     - name: delete
@@ -105,6 +133,26 @@ spec:
             exit 0
           done
 
+    - name: ready
+      inputs:
+        parameters:
+          - name: namespace
+      activeDeadlineSeconds: 200
+      script:
+        image: argoproj/argoexec:latest
+        command: [bash]
+        source: |
+          set -euo pipefail
+          set -x
+
+          until kubectl --namespace {{inputs.parameters.namespace}} get pods -l app=datadog-agent; do
+            sleep 1
+          done
+
+          until ! kubectl --namespace {{inputs.parameters.namespace}} get pod -l app=datadog-agent -o custom-columns=ready:status.conditions[?(.type==\"Ready\")].status --no-headers | grep -v True; do
+            sleep 1
+          done
+
     - name: leader
       inputs:
         parameters:
@@ -128,6 +176,12 @@ spec:
       steps:
         - - name: health
             template: health
+            arguments:
+              parameters:
+                - name: namespace
+                  value: "{{inputs.parameters.namespace}}"
+          - name: ready
+            template: ready
             arguments:
               parameters:
                 - name: namespace

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -36,6 +36,11 @@ spec:
               enabled: true
             systemProbe:
               enabled: true
+            securityAgent:
+              compliance:
+                enabled: true
+              runtime:
+                enabled: true
 
             confd:
               memory.yaml: |
@@ -155,6 +160,7 @@ spec:
           done
 
           until ! kubectl --namespace {{inputs.parameters.namespace}} get pod -l app=datadog-agent -o custom-columns=ready:status.conditions[?\(.type==\"Ready\"\)].status --no-headers | grep -v True; do
+            kubectl --namespace {{inputs.parameters.namespace}} get pod -l app=datadog-agent
             sleep 1
           done
 

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -58,7 +58,7 @@ spec:
 
               kubernetes_state.yaml: |
                 ad_identifiers:
-                  - kube_state_metrics
+                  - kube-state-metrics
 
                 init_config:
 
@@ -85,8 +85,8 @@ spec:
           clusterAgent:
             enabled: true
             image:
-              repository: {{inputs.parameters.agent-image-repository}}
-              tag: {{inputs.parameters.agent-image-tag}}
+              repository: {{inputs.parameters.cluster-agent-image-repository}}
+              tag: {{inputs.parameters.cluster-agent-image-tag}}
               doNotCheckTag: true
               pullSecrets:
                 - name: docker-registry
@@ -154,7 +154,7 @@ spec:
             sleep 1
           done
 
-          until ! kubectl --namespace {{inputs.parameters.namespace}} get pod -l app=datadog-agent -o custom-columns=ready:status.conditions[?(.type==\"Ready\")].status --no-headers | grep -v True; do
+          until ! kubectl --namespace {{inputs.parameters.namespace}} get pod -l app=datadog-agent -o custom-columns=ready:status.conditions[?\(.type==\"Ready\"\)].status --no-headers | grep -v True; do
             sleep 1
           done
 

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -18,85 +18,90 @@ spec:
         source: |
           set -euo pipefail
 
+          cat > /tmp/values.yaml <<EOF
+          datadog:
+            dd_url: http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local
+            apiKey: 123er
+            appKey: 123er1
+            env:
+              - name: DD_HOSTNAME
+                value: e2e-test
+            leaderElection: true
+            logs:
+              enabled: true
+              containerCollectAll: true
+            apm:
+              enabled: true
+            processAgent:
+              enabled: true
+            systemProbe:
+              enabled: true
+
+            confd:
+              memory.yaml: |
+                init_config:
+                instances:
+                  - empty_default_hostname: true
+
+              network.yaml: |
+                init_config:
+                instances:
+                  - collect_connection_state: false
+                    excluded_interfaces:
+                      - lo
+                      - lo0
+                  - collect_connection_state: false
+                    empty_default_hostname: true
+                    excluded_interfaces:
+                      - lo
+                      - lo0
+
+              kubernetes_state.yaml: |
+                ad_identifiers:
+                  - kube_state_metrics
+
+                init_config:
+
+                # Ignore tags coming from autodiscovery
+                ignore_autodiscovery_tags: true
+
+                instances:
+                  - kube_state_url: http://%%host%%:8080/metrics
+                    hostname_override: false
+
+            dogstatsd:
+              useSocketVolume: true
+              socketPath: /var/run/dogstatsd/dsd.socket
+              hostSocketPath: /var/run/dogstatsd
+
+          agents:
+            image:
+              repository: {{inputs.parameters.agent-image-repository}}
+              tag: {{inputs.parameters.agent-image-tag}}
+              doNotCheckTag: true
+              pullSecrets:
+                - name: docker-registry
+
+          clusterAgent:
+            enabled: true
+            image:
+              repository: {{inputs.parameters.agent-image-repository}}
+              tag: {{inputs.parameters.agent-image-tag}}
+              doNotCheckTag: true
+              pullSecrets:
+                - name: docker-registry
+            token: c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd
+            metricsProvider:
+              enabled: true
+            env:
+              - name: DATADOG_HOST
+                value: http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local
+          EOF
+
           helm repo add datadog https://helm.datadoghq.com
           helm repo update
           helm --namespace {{inputs.parameters.namespace}} install \
-            --values <(cat <<EOF
-            datadog:
-              dd_url: http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local
-              apiKey: 123er
-              appKey: 123er1
-              env:
-                - name: DD_HOSTNAME
-                  value: e2e-test
-              leaderElection: true
-              logs:
-                enabled: true
-                containerCollectAll: true
-              apm:
-                enabled: true
-              processAgent:
-                enabled: true
-              systemProbe:
-                enabled: true
-
-              confd:
-                memory.yaml: |
-                  init_config:
-                  instances:
-                    - empty_default_hostname: true
-
-                network.yaml: |
-                  init_config:
-                  instances:
-                    - collect_connection_state: false
-                      excluded_interfaces:
-                        - lo
-                        - lo0
-                    - collect_connection_state: false
-                      empty_default_hostname: true
-                      excluded_interfaces:
-                        - lo
-                        - lo0
-
-                kubernetes_state.yaml: |
-                  ad_identifiers:
-                    - kube_state_metrics
-
-                  init_config:
-
-                  # Ignore tags coming from autodiscovery
-                  ignore_autodiscovery_tags: true
-
-                  instances:
-                    - kube_state_url: http://%%host%%:8080/metrics
-                      hostname_override: false
-
-              dogstatsd:
-                useSocketVolume: true
-                socketPath: /var/run/dogstatsd/dsd.socket
-                hostSocketPath: /var/run/dogstatsd
-
-            agents:
-              image:
-                repository: {{inputs.parameters.agent-image-repository}}
-                tag: {{inputs.parameters.agent-image-tag}}
-                doNotCheckTag: true
-
-            clusterAgent:
-              enabled: true
-              image:
-                repository: {{inputs.parameters.agent-image-repository}}
-                tag: {{inputs.parameters.agent-image-tag}}
-                doNotCheckTag: true
-              token: c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd
-              metricsProvider:
-                enabled: true
-              env:
-                - name: DATADOG_HOST
-                  value: http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local
-            EOF
-            ) \
+            --values /tmp/values.yaml \
             datadog-agent datadog/datadog
 
     - name: delete

--- a/test/e2e/scripts/run-instance/21-argo-setup.sh
+++ b/test/e2e/scripts/run-instance/21-argo-setup.sh
@@ -15,7 +15,15 @@ done
 set -e
 
 /opt/bin/kubectl create namespace argo
-/opt/bin/kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/stable/manifests/install.yaml
+/opt/bin/kubectl --namespace argo apply -f https://raw.githubusercontent.com/argoproj/argo/stable/manifests/install.yaml
+
+if [[ -n ${DOCKER_REGISTRY_URL+x} ]] && [[ -n ${DOCKER_REGISTRY_LOGIN+x} ]] && [[ -n ${DOCKER_REGISTRY_PWD+x} ]]; then
+    oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
+    /opt/bin/kubectl --namespace argo create secret docker-registry docker-registry --docker-server="$DOCKER_REGISTRY_URL" --docker-username="$DOCKER_REGISTRY_LOGIN" --docker-password="$DOCKER_REGISTRY_PWD"
+    eval "$oldstate"
+    /opt/bin/kubectl --namespace argo patch deployment.apps/argo-server         --type json --patch $'[{"op": "add", "path": "/spec/template/spec/imagePullSecrets", "value": [{"name": "docker-registry"}]}]'
+    /opt/bin/kubectl --namespace argo patch deployment.apps/workflow-controller --type json --patch $'[{"op": "add", "path": "/spec/template/spec/imagePullSecrets", "value": [{"name": "docker-registry"}]}]'
+fi
 
 # TODO use a more restrictive SA
 /opt/bin/kubectl apply -f - << EOF

--- a/test/e2e/scripts/run-instance/21-argo-setup.sh
+++ b/test/e2e/scripts/run-instance/21-argo-setup.sh
@@ -18,7 +18,7 @@ set -e
 /opt/bin/kubectl --namespace argo apply -f https://raw.githubusercontent.com/argoproj/argo/stable/manifests/install.yaml
 
 if [[ -n ${DOCKER_REGISTRY_URL+x} ]] && [[ -n ${DOCKER_REGISTRY_LOGIN+x} ]] && [[ -n ${DOCKER_REGISTRY_PWD+x} ]]; then
-    oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
+    oldstate=$(shopt -po xtrace ||:); set +x  # Do not log credentials
     /opt/bin/kubectl --namespace argo create secret docker-registry docker-registry --docker-server="$DOCKER_REGISTRY_URL" --docker-username="$DOCKER_REGISTRY_LOGIN" --docker-password="$DOCKER_REGISTRY_PWD"
     eval "$oldstate"
     /opt/bin/kubectl --namespace argo patch deployment.apps/argo-server         --type json --patch $'[{"op": "add", "path": "/spec/template/spec/imagePullSecrets", "value": [{"name": "docker-registry"}]}]'

--- a/test/e2e/scripts/run-instance/22-argo-submit.sh
+++ b/test/e2e/scripts/run-instance/22-argo-submit.sh
@@ -15,6 +15,12 @@ echo "DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE}"
 
 cd "$(dirname "$0")"
 
+if [[ -n ${DOCKER_REGISTRY_URL+x} ]] && [[ -n ${DOCKER_REGISTRY_LOGIN+x} ]] && [[ -n ${DOCKER_REGISTRY_PWD+x} ]]; then
+    oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
+    /opt/bin/kubectl create secret docker-registry docker-registry --docker-server="$DOCKER_REGISTRY_URL" --docker-username="$DOCKER_REGISTRY_LOGIN" --docker-password="$DOCKER_REGISTRY_PWD"
+    eval "$oldstate"
+fi
+
 # TODO run all workflows ?
 
 ./argo template create ../../argo-workflows/templates/*.yaml

--- a/test/e2e/scripts/run-instance/22-argo-submit.sh
+++ b/test/e2e/scripts/run-instance/22-argo-submit.sh
@@ -16,7 +16,7 @@ echo "DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE}"
 cd "$(dirname "$0")"
 
 if [[ -n ${DOCKER_REGISTRY_URL+x} ]] && [[ -n ${DOCKER_REGISTRY_LOGIN+x} ]] && [[ -n ${DOCKER_REGISTRY_PWD+x} ]]; then
-    oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
+    oldstate=$(shopt -po xtrace ||:); set +x  # Do not log credentials
     /opt/bin/kubectl create secret docker-registry docker-registry --docker-server="$DOCKER_REGISTRY_URL" --docker-username="$DOCKER_REGISTRY_LOGIN" --docker-password="$DOCKER_REGISTRY_PWD"
     eval "$oldstate"
 fi

--- a/test/e2e/scripts/run-instance/23-argo-get.sh
+++ b/test/e2e/scripts/run-instance/23-argo-get.sh
@@ -72,37 +72,4 @@ LOCAL_IP=$(curl -s http://169.254.169.254/2020-10-27/meta-data/local-ipv4)
 
 echo "The Argo UI will remain available at http://${LOCAL_IP} until ${TIME_LEFT}"
 
-set -x
-
-if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
-    if [[ $EXIT_CODE -eq 0 ]]; then
-        event="{
-\"title\": \"e2e tests result\",
-\"text\": \"E2e tests succeeded:\n${CI_JOB_URL}\",
-\"alert_type\": \"success\",
-\"tags\": [
-  \"app:agent-e2e-tests\",
-  \"datadog-agent-image:$DATADOG_AGENT_IMAGE\",
-  \"datadog-cluster-agent-image:$DATADOG_CLUSTER_AGENT_IMAGE\"
-]
-}"
-    else
-        event="{
-\"title\": \"e2e tests result\",
-\"text\": \"E2e tests failed:\n${CI_JOB_URL}\",
-\"alert_type\": \"error\",
-\"tags\": [
-  \"app:agent-e2e-tests\",
-  \"datadog-agent-image:$DATADOG_AGENT_IMAGE\",
-  \"datadog-cluster-agent-image:$DATADOG_CLUSTER_AGENT_IMAGE\"
-]
-}"
-    fi
-    oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
-    curl -X POST "https://api.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}" \
-         -H "Content-Type: application/json" \
-         -d "$event"
-    eval "$oldstate"
-fi
-
 exit ${EXIT_CODE}

--- a/test/e2e/scripts/run-instance/23-argo-get.sh
+++ b/test/e2e/scripts/run-instance/23-argo-get.sh
@@ -52,7 +52,7 @@ for workflow in $(./argo list -l workflows.argoproj.io/phase=Failed -o name); do
 done
 
 # Make the Argo UI available from the user
-/opt/bin/kubectl patch svc -n argo argo-server --type json --patch $'[{"op": "replace", "path": "/spec/type", "value": "NodePort"}]'
+/opt/bin/kubectl --namespace argo patch service/argo-server --type json --patch $'[{"op": "replace", "path": "/spec/type", "value": "NodePort"}]'
 
 # The goal of the following iptables magic is to make the `argo-server` NodePort service available on port 80.
 # We cannot do it with Kube since 80 isn’t in the NodePort service range and yet, 80 is a convenient port for an HTTP UI.

--- a/test/e2e/scripts/run-instance/23-argo-get.sh
+++ b/test/e2e/scripts/run-instance/23-argo-get.sh
@@ -67,6 +67,13 @@ sudo iptables -w -t nat -A HACK -m comment --comment 'argo/argo-server:web' -p t
 sudo iptables -w -t nat -A PREROUTING -m addrtype --dst-type LOCAL -j HACK
 sudo iptables -w -t nat -A OUTPUT     -m addrtype --dst-type LOCAL -j HACK
 
+# In case of failure, let's keep the VM for 1 day instead of 2 hours for investigation
+if [[ $EXIT_CODE != 0 ]]; then
+    sudo sed -i 's/^OnBootSec=.*/OnBootSec=86400/' /etc/systemd/system/terminate.timer
+    sudo systemctl daemon-reload
+    sudo systemctl restart terminate.timer
+fi
+
 TIME_LEFT=$(systemctl status terminate.timer | awk '$1 == "Trigger:" {print gensub(/ *Trigger: (.*)/, "\\1", 1)}')
 LOCAL_IP=$(curl -s http://169.254.169.254/2020-10-27/meta-data/local-ipv4)
 

--- a/test/e2e/scripts/run-instance/23-argo-get.sh
+++ b/test/e2e/scripts/run-instance/23-argo-get.sh
@@ -77,6 +77,6 @@ fi
 TIME_LEFT=$(systemctl status terminate.timer | awk '$1 == "Trigger:" {print gensub(/ *Trigger: (.*)/, "\\1", 1)}')
 LOCAL_IP=$(curl -s http://169.254.169.254/2020-10-27/meta-data/local-ipv4)
 
-echo "The Argo UI will remain available at http://${LOCAL_IP} until ${TIME_LEFT}"
+printf "\033[1mThe Argo UI will remain available at \033[1;34mhttp://%s\033[0m until \033[1;33m%s\033[0m.\n" "$LOCAL_IP" "$TIME_LEFT"
 
 exit ${EXIT_CODE}

--- a/test/e2e/scripts/run-instance/23-argo-get.sh
+++ b/test/e2e/scripts/run-instance/23-argo-get.sh
@@ -72,6 +72,8 @@ LOCAL_IP=$(curl -s http://169.254.169.254/2020-10-27/meta-data/local-ipv4)
 
 echo "The Argo UI will remain available at http://${LOCAL_IP} until ${TIME_LEFT}"
 
+set -x
+
 if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
     if [[ $EXIT_CODE -eq 0 ]]; then
         event="{

--- a/test/e2e/scripts/run-instance/23-argo-get.sh
+++ b/test/e2e/scripts/run-instance/23-argo-get.sh
@@ -72,4 +72,35 @@ LOCAL_IP=$(curl -s http://169.254.169.254/2020-10-27/meta-data/local-ipv4)
 
 echo "The Argo UI will remain available at http://${LOCAL_IP} until ${TIME_LEFT}"
 
+if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
+    if [[ $EXIT_CODE -eq 0 ]]; then
+        event="{
+\"title\": \"e2e tests result\",
+\"text\": \"E2e tests succeeded:\n${CI_JOB_URL}\",
+\"alert_type\": \"success\",
+\"tags\": [
+  \"app:agent-e2e-tests\",
+  \"datadog-agent-image:$DATADOG_AGENT_IMAGE\",
+  \"datadog-cluster-agent-image:$DATADOG_CLUSTER_AGENT_IMAGE\"
+]
+}"
+    else
+        event="{
+\"title\": \"e2e tests result\",
+\"text\": \"E2e tests failed:\n${CI_JOB_URL}\",
+\"alert_type\": \"error\",
+\"tags\": [
+  \"app:agent-e2e-tests\",
+  \"datadog-agent-image:$DATADOG_AGENT_IMAGE\",
+  \"datadog-cluster-agent-image:$DATADOG_CLUSTER_AGENT_IMAGE\"
+]
+}"
+    fi
+    oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
+    curl -X POST "https://api.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}" \
+         -H "Content-Type: application/json" \
+         -d "$event"
+    eval "$oldstate"
+fi
+
 exit ${EXIT_CODE}

--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -112,5 +112,5 @@ storage:
     - path: /etc/ssh/sshd_config.d/99-datadog.conf
       mode: 0400
       contents:
-        source: "data:,AcceptEnv%20DATADOG%5F%2AAGENT%5FIMAGE%0A"
+        source: "data:,AcceptEnv%20DOCKER%5FREGISTRY%5F%2A%20DATADOG%5F%2AAGENT%5FIMAGE%0A"
 EOF

--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -112,5 +112,5 @@ storage:
     - path: /etc/ssh/sshd_config.d/99-datadog.conf
       mode: 0400
       contents:
-        source: "data:,AcceptEnv%20DOCKER%5FREGISTRY%5F%2A%20DATADOG%5F%2AAGENT%5FIMAGE%20CI%5FJOB%5FURL%0A"
+        source: "data:,AcceptEnv%20DOCKER%5FREGISTRY%5F%2A%20DATADOG%5F%2AAGENT%5FIMAGE%0A"
 EOF

--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -112,5 +112,5 @@ storage:
     - path: /etc/ssh/sshd_config.d/99-datadog.conf
       mode: 0400
       contents:
-        source: "data:,AcceptEnv%20DOCKER%5FREGISTRY%5F%2A%20DATADOG%5F%2AAGENT%5FIMAGE%0A"
+        source: "data:,AcceptEnv%20DOCKER%5FREGISTRY%5F%2A%20DATADOG%5F%2AAGENT%5FIMAGE%20CI%5FJOB%5FURL%0A"
 EOF

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -30,7 +30,15 @@ until _ssh /bin/true; do
     sleep 5
 done
 
-until _ssh systemctl is-system-running; do
+until _ssh systemctl is-system-running --wait; do
+    if [[ $? -eq 255 ]]; then
+        sleep 5
+        continue
+    fi
+    _ssh journalctl -n 30 ||:
+    _ssh systemctl list-units --failed ||:
+    # Let's try to reboot until we have more clues about what can go wrong here.
+    _ssh sudo systemctl reboot ||:
     sleep 5
 done
 

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -54,7 +54,7 @@ _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/10-pupernetes
 _ssh timeout 120 /home/core/datadog-agent/test/e2e/scripts/run-instance/11-pupernetes-ready.sh
 if [[ -n ${DOCKER_REGISTRY_URL+x} ]] && [[ -n ${DOCKER_REGISTRY_LOGIN+x} ]] && [[ -n ${DOCKER_REGISTRY_PWD+x} ]]; then
     oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
-    _ssh_logged sudo docker login --username "${DOCKER_REGISTRY_LOGIN}" --password "${DOCKER_REGISTRY_PWD}" "${DOCKER_REGISTRY_URL}"
+    _ssh_logged \"sudo docker login --username \\\"${DOCKER_REGISTRY_LOGIN}\\\" --password \\\"${DOCKER_REGISTRY_PWD}\\\" \\\"${DOCKER_REGISTRY_URL}\\\"\"
     eval "$oldstate"
 fi
 

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -16,7 +16,7 @@ test "${COMMIT_ID}" || {
     COMMIT_ID=$(git rev-parse --verify HEAD)
 }
 
-SSH_OPTS=("-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master} DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master} CI_JOB_URL")
+SSH_OPTS=("-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master} DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master}")
 
 function _ssh() {
     ssh "${SSH_OPTS[@]}" -lcore "${MACHINE}" "$@"
@@ -65,4 +65,8 @@ _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/20-argo-downl
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/21-argo-setup.sh
 
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/22-argo-submit.sh
+set +e
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/23-argo-get.sh
+EXIT_CODE=$?
+set -e
+./04-send-dd-event.sh $EXIT_CODE

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -65,7 +65,7 @@ _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/20-argo-downl
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/21-argo-setup.sh
 
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/22-argo-submit.sh
-set +xe
+set +e
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/23-argo-get.sh
 EXIT_CODE=$?
 set -e

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -53,7 +53,7 @@ _ssh git -C /home/core/datadog-agent checkout "${COMMIT_ID}"
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/10-pupernetes-wait.sh
 _ssh timeout 120 /home/core/datadog-agent/test/e2e/scripts/run-instance/11-pupernetes-ready.sh
 if [[ -n ${DOCKER_REGISTRY_URL+x} ]] && [[ -n ${DOCKER_REGISTRY_LOGIN+x} ]] && [[ -n ${DOCKER_REGISTRY_PWD+x} ]]; then
-    oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
+    oldstate=$(shopt -po xtrace ||:); set +x  # Do not log credentials
     _ssh_logged \"sudo docker login --username \\\"${DOCKER_REGISTRY_LOGIN}\\\" --password \\\"${DOCKER_REGISTRY_PWD}\\\" \\\"${DOCKER_REGISTRY_URL}\\\"\"
     eval "$oldstate"
     _ssh_logged \"sudo cp /root/.docker/config.json /var/lib/p8s-kubelet\"

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -16,7 +16,7 @@ test "${COMMIT_ID}" || {
     COMMIT_ID=$(git rev-parse --verify HEAD)
 }
 
-SSH_OPTS=("-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master} DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master}")
+SSH_OPTS=("-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master} DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master} CI_JOB_URL")
 
 function _ssh() {
     ssh "${SSH_OPTS[@]}" -lcore "${MACHINE}" "$@"
@@ -56,6 +56,7 @@ if [[ -n ${DOCKER_REGISTRY_URL+x} ]] && [[ -n ${DOCKER_REGISTRY_LOGIN+x} ]] && [
     oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
     _ssh_logged \"sudo docker login --username \\\"${DOCKER_REGISTRY_LOGIN}\\\" --password \\\"${DOCKER_REGISTRY_PWD}\\\" \\\"${DOCKER_REGISTRY_URL}\\\"\"
     eval "$oldstate"
+    _ssh_logged \"sudo cp /root/.docker/config.json /var/lib/p8s-kubelet\"
 fi
 
 

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -69,4 +69,5 @@ set +e
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/23-argo-get.sh
 EXIT_CODE=$?
 set -e
+export MACHINE
 ./04-send-dd-event.sh $EXIT_CODE

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -65,7 +65,7 @@ _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/20-argo-downl
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/21-argo-setup.sh
 
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/22-argo-submit.sh
-set +e
+set +xe
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/23-argo-get.sh
 EXIT_CODE=$?
 set -e

--- a/test/e2e/scripts/setup-instance/04-send-dd-event.sh
+++ b/test/e2e/scripts/setup-instance/04-send-dd-event.sh
@@ -18,7 +18,7 @@ if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
          -d @- <<EOF
 {
   "title": "datadog-agent e2e tests result",
-  "text": "# E2e tests ${succeeded_or_failed}\ndatadog-agent image: ${DATADOG_AGENT_IMAGE}\ndatadog-cluster-agent image: ${DATADOG_CLUSTER_AGENT_IMAGE}\nCommit: ${CI_COMMIT_SHORT_SHA}\n\nGitLab job: ${CI_JOB_URL}\nArgo UI: http://${MACHINE}",
+  "text": "E2e tests ${succeeded_or_failed}\ndatadog-agent image: ${DATADOG_AGENT_IMAGE}\ndatadog-cluster-agent image: ${DATADOG_CLUSTER_AGENT_IMAGE}\nCommit: ${CI_COMMIT_SHORT_SHA}\n\nGitLab job: ${CI_JOB_URL}\nArgo UI: http://${MACHINE}",
   "alert_type": "${alert_type}",
   "tags": [
     "app:agent-e2e-tests",

--- a/test/e2e/scripts/setup-instance/04-send-dd-event.sh
+++ b/test/e2e/scripts/setup-instance/04-send-dd-event.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-set -x
-
 EXIT_CODE=$1
 
 if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then

--- a/test/e2e/scripts/setup-instance/04-send-dd-event.sh
+++ b/test/e2e/scripts/setup-instance/04-send-dd-event.sh
@@ -1,38 +1,32 @@
 #!/bin/bash
 set -euo pipefail
 
-set -x
-
 EXIT_CODE=$1
 
 if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
     if [[ $EXIT_CODE -eq 0 ]]; then
-        event="{
-\"title\": \"e2e tests result\",
-\"text\": \"E2e tests succeeded:\n${CI_JOB_URL}\",
-\"alert_type\": \"success\",
-\"tags\": [
-  \"app:agent-e2e-tests\",
-  \"datadog-agent-image:$DATADOG_AGENT_IMAGE\",
-  \"datadog-cluster-agent-image:$DATADOG_CLUSTER_AGENT_IMAGE\"
-]
-}"
+        succeeded_or_failed='succeeded :-D'
+        alert_type=success
     else
-        event="{
-\"title\": \"e2e tests result\",
-\"text\": \"E2e tests failed:\n${CI_JOB_URL}\",
-\"alert_type\": \"error\",
-\"tags\": [
-  \"app:agent-e2e-tests\",
-  \"datadog-agent-image:$DATADOG_AGENT_IMAGE\",
-  \"datadog-cluster-agent-image:$DATADOG_CLUSTER_AGENT_IMAGE\"
-]
-}"
+        succeeded_or_failed='failed ;-('
+        alert_type=error
     fi
+
     oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
     curl -s -X POST "https://api.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}" \
          -H "Content-Type: application/json" \
-         -d "$event"
+         -d @- <<EOF
+{
+  "title": "datadog-agent e2e tests result",
+  "text": "# E2e tests ${succeeded_or_failed}\ndatadog-agent image: ${DATADOG_AGENT_IMAGE}\ndatadog-cluster-agent image: ${DATADOG_CLUSTER_AGENT}\n\nGitLab job: ${CI_JOB_URL}\nArgo UI: http://${MACHINE}",
+  "alert_type": "${alert_type}",
+  "tags": [
+    "app:agent-e2e-tests",
+    "datadog-agent-image:$DATADOG_AGENT_IMAGE",
+    "datadog-cluster-agent-image:$DATADOG_CLUSTER_AGENT_IMAGE"
+  ]
+}
+EOF
     eval "$oldstate"
 fi
 

--- a/test/e2e/scripts/setup-instance/04-send-dd-event.sh
+++ b/test/e2e/scripts/setup-instance/04-send-dd-event.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+set -x
+
 EXIT_CODE=$1
 
 if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then

--- a/test/e2e/scripts/setup-instance/04-send-dd-event.sh
+++ b/test/e2e/scripts/setup-instance/04-send-dd-event.sh
@@ -18,7 +18,7 @@ if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
          -d @- <<EOF
 {
   "title": "datadog-agent e2e tests result",
-  "text": "# E2e tests ${succeeded_or_failed}\ndatadog-agent image: ${DATADOG_AGENT_IMAGE}\ndatadog-cluster-agent image: ${DATADOG_CLUSTER_AGENT}\n\nGitLab job: ${CI_JOB_URL}\nArgo UI: http://${MACHINE}",
+  "text": "# E2e tests ${succeeded_or_failed}\ndatadog-agent image: ${DATADOG_AGENT_IMAGE}\ndatadog-cluster-agent image: ${DATADOG_CLUSTER_AGENT_IMAGE}\nCommit: ${CI_COMMIT_SHORT_SHA}\n\nGitLab job: ${CI_JOB_URL}\nArgo UI: http://${MACHINE}",
   "alert_type": "${alert_type}",
   "tags": [
     "app:agent-e2e-tests",

--- a/test/e2e/scripts/setup-instance/04-send-dd-event.sh
+++ b/test/e2e/scripts/setup-instance/04-send-dd-event.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+EXIT_CODE=$1
+
+if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
+    if [[ $EXIT_CODE -eq 0 ]]; then
+        event="{
+\"title\": \"e2e tests result\",
+\"text\": \"E2e tests succeeded:\n${CI_JOB_URL}\",
+\"alert_type\": \"success\",
+\"tags\": [
+  \"app:agent-e2e-tests\",
+  \"datadog-agent-image:$DATADOG_AGENT_IMAGE\",
+  \"datadog-cluster-agent-image:$DATADOG_CLUSTER_AGENT_IMAGE\"
+]
+}"
+    else
+        event="{
+\"title\": \"e2e tests result\",
+\"text\": \"E2e tests failed:\n${CI_JOB_URL}\",
+\"alert_type\": \"error\",
+\"tags\": [
+  \"app:agent-e2e-tests\",
+  \"datadog-agent-image:$DATADOG_AGENT_IMAGE\",
+  \"datadog-cluster-agent-image:$DATADOG_CLUSTER_AGENT_IMAGE\"
+]
+}"
+    fi
+    oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
+    curl -X POST "https://api.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}" \
+         -H "Content-Type: application/json" \
+         -d "$event"
+    eval "$oldstate"
+fi
+
+exit "$EXIT_CODE"

--- a/test/e2e/scripts/setup-instance/04-send-dd-event.sh
+++ b/test/e2e/scripts/setup-instance/04-send-dd-event.sh
@@ -28,7 +28,7 @@ if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
 }"
     fi
     oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
-    curl -X POST "https://api.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}" \
+    curl -s -X POST "https://api.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}" \
          -H "Content-Type: application/json" \
          -d "$event"
     eval "$oldstate"

--- a/test/e2e/scripts/setup-instance/04-send-dd-event.sh
+++ b/test/e2e/scripts/setup-instance/04-send-dd-event.sh
@@ -12,7 +12,7 @@ if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
         alert_type=error
     fi
 
-    oldstate=$(shopt -po xtrace); set +x  # Do not log credentials
+    oldstate=$(shopt -po xtrace ||:); set +x  # Do not log credentials
     curl -s -X POST "https://api.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}" \
          -H "Content-Type: application/json" \
          -d @- <<EOF


### PR DESCRIPTION
### What does this PR do?

In the e2e tests:
* Enable all the agents;
* Check for pod readiness;
* Use docker authentification to workaround image pull rate limiting;
* Generate a DD event at the end of the e2e job to allow the creation of a monitor.

### Motivation

Even if the e2e tests are not actively testing the `process-agent` and `trace-agent` yet, this would allow us to catch panics at boot earlier than at release time.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Check that the e2e tests are launched daily with the nightly build
