### PR TITLE
Bumping datadog-go (DogStatsD Go client) to 4.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	github.com/DataDog/agent-payload v4.47.0+incompatible
-	github.com/DataDog/datadog-go v3.5.0+incompatible
+	github.com/DataDog/datadog-go v4.2.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
 	github.com/DataDog/ebpf v0.0.0-20201120093539-d2690c373d70
 	github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v3.5.0+incompatible h1:AShr9cqkF+taHjyQgcBcQUt/ZNK+iPq4ROaZwSX5c/U=
 github.com/DataDog/datadog-go v3.5.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/datadog-go v4.2.0+incompatible h1:Q73jzyKHwyA04Gf4SSukRF+KR4wJEimU6tAuU0B8Y4Y=
+github.com/DataDog/datadog-go v4.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822 h1:E5WNl43j4mpE3V35QySkRnP/m9pjXOnEZD6eyTK7Qvk=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822/go.mod h1:a5NqgPglcSct+NwO9gPvVhoL5V6G1+gHbRaRnU8U54M=
 github.com/DataDog/ebpf v0.0.0-20201120093539-d2690c373d70 h1:NdZRtbZ0ToAL5nfqCbDQXQsIgP/6D/5uymRkTYgGXQw=

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -238,9 +237,7 @@ func (m *Module) GetRuleSet() *rules.RuleSet {
 func NewModule(cfg *config.Config) (api.Module, error) {
 	var statsdClient *statsd.Client
 	var err error
-	// statsd segfaults on 386 because of atomic primitive usage with wrong alignment
-	// https://github.com/golang/go/issues/37262
-	if runtime.GOARCH != "386" && cfg != nil {
+	if cfg != nil {
 		statsdAddr := os.Getenv("STATSD_URL")
 		if statsdAddr == "" {
 			statsdAddr = cfg.StatsdAddr

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -18,11 +18,10 @@ import (
 
 // Configure creates a statsd client for the given agent's configuration, using the specified global tags.
 func Configure(conf *config.AgentConfig, tags []string) error {
-	client, err := statsd.New(fmt.Sprintf("%s:%d", conf.StatsdHost, conf.StatsdPort))
+	client, err := statsd.New(fmt.Sprintf("%s:%d", conf.StatsdHost, conf.StatsdPort), statsd.WithTags(tags))
 	if err != nil {
 		return err
 	}
-	client.Tags = tags
 	Client = client
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Bumping datadog-go (DogStatsD Go client) to `4.2.0`

### Motivation

New version brings improvement in performances and fixes.

### Additional Notes
