### PR TITLE
Add `container_id` tag to `compliance.containers_running` metric

### DIFF
--- a/pkg/compliance/agent/telemetry_test.go
+++ b/pkg/compliance/agent/telemetry_test.go
@@ -44,11 +44,11 @@ func TestReportContainersCount(t *testing.T) {
 
 	telemetry := &telemetry{sender: mockSender}
 
-	telemetry.detector = newDummyDetector(10)
-	assert.NoError(t, telemetry.reportContainersCount())
-	mockSender.AssertCalled(t, "Gauge", containersCountMetricName, 10.0, "", []string{})
-
-	telemetry.detector = newDummyDetector(100)
-	assert.NoError(t, telemetry.reportContainersCount())
-	mockSender.AssertCalled(t, "Gauge", containersCountMetricName, 100.0, "", []string{})
+	containersCount := 10
+	telemetry.detector = newDummyDetector(containersCount)
+	assert.NoError(t, telemetry.reportContainers())
+	mockSender.AssertNumberOfCalls(t, "Gauge", containersCount)
+	for i := 0; i < containersCount; i++ {
+		mockSender.AssertCalled(t, "Gauge", containersCountMetricName, 1.0, "", []string{"container_id:" + strconv.Itoa(i)})
+	}
 }


### PR DESCRIPTION
### What does this PR do?

`datadog.security_agent.compliance.containers_running` will report a constant value `1` tagged by `container_id`

### Additional Notes

Related to https://github.com/DataDog/datadog-agent/pull/6734

### Describe your test plan

![image](https://user-images.githubusercontent.com/38987709/100230346-eb207380-2f25-11eb-8c91-509f630b476b.png)

![image](https://user-images.githubusercontent.com/38987709/100230410-fffd0700-2f25-11eb-889e-3e86540b601f.png)


