### PR TITLE
[logs/file tailer] Update the source of existing file tailers

### DIFF
--- a/pkg/logs/input/file/scanner.go
+++ b/pkg/logs/input/file/scanner.go
@@ -192,7 +192,10 @@ func (s *Scanner) launchTailers(source *config.LogSource) {
 		if len(s.tailers) >= s.tailingLimit {
 			return
 		}
-		if _, isTailed := s.tailers[buildTailerKey(file)]; isTailed {
+		if tailer, isTailed := s.tailers[buildTailerKey(file)]; isTailed {
+			// the file is already tailed, update the existing tailer's source so that the tailer
+			// uses this new source going forward
+			tailer.ReplaceSource(source)
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do?

When a new source coming from AD matches existing file tailers, update
these file tailers' source so that the file tailers actually update
the new source, instead of updating the older source that may not be
tracked anymore by the logs agent's scheduler.

### Motivation

This fixes a display issue on the status page where a k8s container being tailed with a file tailer would show with status `Pending` forever if there was an unschedule/reschedule event for the pod. For example, consider this scenario:
1. container A in a pod is tailed with a file tailer
2. one of the other containers in the pod changes (example: another container stops), leading to consecutive unschedule and schedule events for all the containers in the pod. For container A that we're interested in: the unschedule event removes the old log source, and the new scheduling event creates a new log source. Even though we're on k8s, container's A ID is unchanged since container A wasn't actually stopped and recreated.
3. the new source will generally not lead to the creation of a new file tailer since the existing file tailer was likely not entirely stopped yet (~it is kept around until a timeout to collect any late log~ _update: there's no timeout for late logs for file tailers scheduled from containers, not sure how this impacts the likelihood of this scenario_) and container's A ID is the same.
   Therefore, if the new source is not set on the existing file tailer, the tailer will forever update the old (removed) source, and the new source will remain in `Pending` state forever.

### Additional Notes

* The `tagProvider` on the file tailer isn't updated when the source changes. I believe this is OK since on k8s each file tailer is tracked by the scanner with a unique key that includes the container ID, so the source is updated on existing file tailer only if the container ID is unchanged. However (1) I might be missing something and (2) this might be a non-intuitive design edge case that could come back to bite us in the future. Comments welcome.
* Not sure if this change may cause additional edge cases if we start tailing from files directly on plain Docker environments.
* This is still a draft. I'm not very happy with the code changes cleanness, and I'm unsure of the side effects of always updating the source of existing file tailers in other scenarios. For example, is there a scenario with regular log file tailing where this new behavior is undesirable?
* needs a release note

### Describe your test plan

No testing done yet, and I don't have a reproduction setup yet. TODO.
