### PR TITLE
pkg/trace/{agent,api}: allow client to override top-level computation 

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -204,9 +204,11 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 				traceutil.SetMeta(root, tagContainersTags, p.ContainerTags)
 			}
 		}
-		// Figure out the top-level spans and sublayers now as it involves modifying the Metrics map
-		// which is not thread-safe while samplers and Concentrator might modify it too.
-		traceutil.ComputeTopLevel(t)
+		if !p.ClientComputedTopLevel {
+			// Figure out the top-level spans and sublayers now as it involves modifying the Metrics map
+			// which is not thread-safe while samplers and Concentrator might modify it too.
+			traceutil.ComputeTopLevel(t)
+		}
 
 		env := a.conf.DefaultEnv
 		if v := traceutil.GetEnv(t); v != "" {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -404,6 +404,62 @@ func TestProcess(t *testing.T) {
 	})
 }
 
+func TestClientComputedTopLevel(t *testing.T) {
+	cfg := config.New()
+	cfg.Endpoints[0].APIKey = "test"
+	ctx, cancel := context.WithCancel(context.Background())
+	agnt := NewAgent(ctx, cfg)
+	defer cancel()
+	traces := pb.Traces{{{
+		Service:  "something &&<@# that should be a metric!",
+		TraceID:  1,
+		SpanID:   1,
+		Resource: "SELECT name FROM people WHERE age = 42 AND extra = 55",
+		Type:     "sql",
+		Start:    time.Now().Add(-time.Second).UnixNano(),
+		Duration: (500 * time.Millisecond).Nanoseconds(),
+		Metrics:  map[string]float64{sampler.KeySamplingPriority: 2},
+	}}}
+
+	t.Run("on", func(t *testing.T) {
+		go agnt.Process(&api.Payload{
+			Traces:                 traces,
+			Source:                 agnt.Receiver.Stats.GetTagStats(info.Tags{}),
+			ClientComputedTopLevel: true,
+		}, stats.NewSublayerCalculator())
+		timeout := time.After(time.Second)
+		for {
+			select {
+			case ss := <-agnt.Out:
+				_, ok := ss.Traces[0].Spans[0].Metrics["_top_level"]
+				assert.False(t, ok)
+				return
+			case <-timeout:
+				t.Fatal("timed out waiting for input")
+			}
+		}
+	})
+
+	t.Run("off", func(t *testing.T) {
+		go agnt.Process(&api.Payload{
+			Traces:                 traces,
+			Source:                 agnt.Receiver.Stats.GetTagStats(info.Tags{}),
+			ClientComputedTopLevel: false,
+		}, stats.NewSublayerCalculator())
+		timeout := time.After(time.Second)
+		for {
+			select {
+			case ss := <-agnt.Out:
+				_, ok := ss.Traces[0].Spans[0].Metrics["_top_level"]
+				assert.True(t, ok)
+				return
+			case <-timeout:
+				t.Fatal("timed out waiting for input")
+			}
+		}
+	})
+}
+
 func TestSampling(t *testing.T) {
 	for name, tt := range map[string]struct {
 		// hasErrors will be true if the input trace should have errors

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -569,6 +569,54 @@ func (sr *chunkedReader) Read(p []byte) (n int, err error) {
 	return sr.reader.Read(buf)
 }
 
+func TestClientComputedTopLevel(t *testing.T) {
+	conf := newTestReceiverConfig()
+	rcv := newTestReceiverFromConfig(conf)
+	rcv.Start()
+	defer rcv.Stop()
+
+	// run runs the test with ClientComputedStats turned on.
+	run := func(on bool) func(t *testing.T) {
+		return func(t *testing.T) {
+			var buf bytes.Buffer
+			msgp.Encode(&buf, testutil.GetTestTraces(10, 10, true))
+
+			req, _ := http.NewRequest("POST", "http://127.0.0.1:8126/v0.4/traces", &buf)
+			req.Header.Set("Content-Type", "application/msgpack")
+			req.Header.Set(headerLang, "lang1")
+			if on {
+				req.Header.Set(headerComputedTopLevel, "yes")
+			}
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if resp.StatusCode != 200 {
+					t.Fatal(resp.StatusCode)
+				}
+			}()
+			timeout := time.After(time.Second)
+			for {
+				select {
+				case p := <-rcv.out:
+					assert.Equal(t, p.ClientComputedTopLevel, on)
+					wg.Wait()
+					return
+				case <-timeout:
+					t.Fatal("no output")
+				}
+			}
+		}
+	}
+
+	t.Run("on", run(true))
+	t.Run("off", run(false))
+}
+
 func TestReceiverRateLimiterCancel(t *testing.T) {
 	assert := assert.New(t)
 

--- a/releasenotes/notes/apm-client-computed-top-level-96f21b29ee88d9ca.yaml
+++ b/releasenotes/notes/apm-client-computed-top-level-96f21b29ee88d9ca.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: The agent is now able to skip top-level span computation in cases when
+    the client has marked them by means of the Datadog-Client-Computed-Top-Level
+    header.


### PR DESCRIPTION
This change introduces a new header which causes the agent to skip
top-level computation. This is used when the client has marked top-level
spans.

The header is "Datadog-Client-Computed-Top-Level" and will signify "yes"
on any non-empty value.