### PR TITLE
[ecs] Expire cache key for availability of ECS EC2 resource tags

### DIFF
--- a/releasenotes/notes/expire-cache-key-for-ec2-resource-tags-in-ecs-e8ff361c6bf62a4c.yaml
+++ b/releasenotes/notes/expire-cache-key-for-ec2-resource-tags-in-ecs-e8ff361c6bf62a4c.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Expires the cache key for availability of ECS metadata endpoint used to fetch
+    EC2 resource tags every 5 minutes.


### PR DESCRIPTION
### What does this PR do?

Expires the cache key for availability of ECS metadata endpoint used to fetch EC2 resource tags every 5 minutes.

### Motivation

Stop-gap for https://github.com/DataDog/datadog-agent/issues/6758 along with configurable timeout implemented in https://github.com/DataDog/datadog-agent/pull/6828.

### Describe your test plan

Ensure we are able to survive temporary failures of ECS metadata endpoint.
