### PR TITLE
[runtime-security] Export concurrent syscalls count metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/DataDog/agent-payload v4.49.0+incompatible
 	github.com/DataDog/datadog-go v4.2.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
-	github.com/DataDog/ebpf v0.0.0-20210104093318-524278fe0bfe
+	github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d
 	github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,10 @@ github.com/DataDog/datadog-go v4.2.0+incompatible h1:Q73jzyKHwyA04Gf4SSukRF+KR4w
 github.com/DataDog/datadog-go v4.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822 h1:E5WNl43j4mpE3V35QySkRnP/m9pjXOnEZD6eyTK7Qvk=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822/go.mod h1:a5NqgPglcSct+NwO9gPvVhoL5V6G1+gHbRaRnU8U54M=
-github.com/DataDog/ebpf v0.0.0-20201229144711-5db4ced1a6dd h1:0bpIuKLtroTz2YlM44K1gQc88rcmMxHgptWIaop6sQA=
-github.com/DataDog/ebpf v0.0.0-20201229144711-5db4ced1a6dd/go.mod h1:rIVS3jqxhqtYJtznvFI8qtCbYG1M7WQZS4Z15/nCmOI=
 github.com/DataDog/ebpf v0.0.0-20210104093318-524278fe0bfe h1:xIQF3z6+bD1Q+K7TCAIAIeK0aBZMQ3thVGqzQxzQjaU=
 github.com/DataDog/ebpf v0.0.0-20210104093318-524278fe0bfe/go.mod h1:rIVS3jqxhqtYJtznvFI8qtCbYG1M7WQZS4Z15/nCmOI=
+github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d h1:FCSp3GWrMD+dTCinb/E5JrV5z9xBB/2wDHZVG9CoWq4=
+github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d/go.mod h1:VSpIdBT/hwSbP3xKa5eYtiiBN2E37YePfTuyQVzSSig=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71 h1:0TOAH3X9tEvMBVQ1HYrQfrnAUcSS1mfMrhqeN+spV1s=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71/go.mod h1:rNvi5cSHdpxN6495MOYAWN3yukac8lORoluL+9Osrsw=
 github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a h1:BkU6uq4Ib7Kp1zP7MT33IdHZQazC+kxbuTyEmgePyyA=

--- a/pkg/security/ebpf/c/raw_syscalls.h
+++ b/pkg/security/ebpf/c/raw_syscalls.h
@@ -13,6 +13,28 @@ struct _tracepoint_raw_syscalls_sys_enter
   unsigned long args[6];
 };
 
+struct bpf_map_def SEC("maps/concurrent_syscalls") concurrent_syscalls = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(long),
+    .max_entries = 1,
+    .pinning = 0,
+    .namespace = "",
+};
+
+#define CONCURRENT_SYSCALLS_COUNTER 0
+
+struct _tracepoint_raw_syscalls_sys_exit
+{
+    unsigned short common_type;
+    unsigned char common_flags;
+    unsigned char common_preempt_count;
+    int common_pid;
+
+    long id;
+    long ret;
+};
+
 struct process_syscall_t {
     char comm[TASK_COMM_LEN];
     int pid;
@@ -55,6 +77,28 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     }
 
     __sync_fetch_and_add(count, 1);
+
+    u32 key = CONCURRENT_SYSCALLS_COUNTER;
+    long *concurrent_syscalls_counter = bpf_map_lookup_elem(&concurrent_syscalls, &key);
+    if (concurrent_syscalls_counter == NULL)
+        return 0;
+
+    __sync_fetch_and_add(concurrent_syscalls_counter, 1);
+
+    return 0;
+}
+
+SEC("tracepoint/raw_syscalls/sys_exit")
+int sys_exit(struct _tracepoint_raw_syscalls_sys_exit *args) {
+    u32 key = CONCURRENT_SYSCALLS_COUNTER;
+    long *concurrent_syscalls_counter = bpf_map_lookup_elem(&concurrent_syscalls, &key);
+    if (concurrent_syscalls_counter == NULL)
+        return 0;
+
+    __sync_fetch_and_add(concurrent_syscalls_counter, -1);
+    if (*concurrent_syscalls_counter < 0) {
+        __sync_fetch_and_add(concurrent_syscalls_counter, 1);
+    }
 
     return 0;
 }

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -38,6 +38,10 @@ func AllProbes() []*manager.Probe {
 		},
 		&manager.Probe{
 			UID:     SecurityAgentUID,
+			Section: "tracepoint/raw_syscalls/sys_exit",
+		},
+		&manager.Probe{
+			UID:     SecurityAgentUID,
 			Section: "tracepoint/sched/sched_process_exec",
 		},
 		// Snapshot probe

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -16,6 +16,7 @@ import (
 // SyscallMonitorSelectors is the list of probes that should be activated for the syscall monitor feature
 var SyscallMonitorSelectors = []manager.ProbesSelector{
 	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/raw_syscalls/sys_enter"}},
+	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/raw_syscalls/sys_exit"}},
 	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/sched/sched_process_exec"}},
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR introduces the `datadog.runtime_security.concurrent_syscalls` metric that counts the number of concurrent syscalls currently being executed. It also fixes a small bug that prevented the syscall monitor from starting.

### Motivation

We currently use an in-kernel LRU cache to prepare the data we ship back to user space. This cache currently has a size of 1024 and is indexed by `pid_tid`. This means that if there is more that `1024` concurrent syscalls being executed on the host, we'll loose context for some of them, which will ultimately make us drop an event without any warning. This new metric will help evaluate if `1024` is large enough so that this does not happen.

### Additional Notes

N/A

### Describe your test plan

This feature is only activated when the syscall monitor is activated. It should not interfere with the rest of the runtime security module.