### PR TITLE
pkg/trace/{agent,writer}: simplify channels

### DIFF
--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -194,7 +194,7 @@ func testStatsWriter() (*StatsWriter, chan []stats.Bucket, *testServer) {
 		Endpoints:   []*config.Endpoint{{Host: srv.URL, APIKey: "123"}},
 		StatsWriter: &config.WriterConfig{ConnectionLimit: 20, QueueSize: 20},
 	}
-	return NewStatsWriter(cfg, in, nil), in, srv
+	return NewStatsWriter(cfg, in), in, srv
 }
 
 func removeDuplicateEntries(stats []stats.Bucket) int {


### PR DESCRIPTION
This change ensures that incoming client buckets get the same treatment as concentrator generated buckets. Additionally, it simplifies channel use.

Follows from #6870 