### PR TITLE
[runtime-security] Pre-allocate dentry error

### DIFF
--- a/pkg/security/probe/dentry_resolver_bpf.go
+++ b/pkg/security/probe/dentry_resolver_bpf.go
@@ -36,6 +36,8 @@ func (e *ErrInvalidKeyPath) Error() string {
 	return fmt.Sprintf("invalid inode/mountID couple: %d/%d", e.Inode, e.MountID)
 }
 
+var ErrEntryNotFound = errors.New("entry not found")
+
 type PathKey struct {
 	Inode   uint64
 	MountID uint32
@@ -79,7 +81,7 @@ func (dr *DentryResolver) getNameFromCache(mountID uint32, inode uint64) (name s
 
 	entry, exists := dr.cache.Get(key)
 	if !exists {
-		return "", errors.New("entry not found")
+		return "", ErrEntryNotFound
 	}
 	path := entry.(PathValue)
 
@@ -117,7 +119,7 @@ func (dr *DentryResolver) ResolveFromCache(mountID uint32, inode uint64) (filena
 
 		entry, exists := dr.cache.Get(cacheKey)
 		if !exists {
-			return "", errors.New("entry not found")
+			return "", ErrEntryNotFound
 		}
 		path = entry.(PathValue)
 
@@ -206,7 +208,7 @@ func (dr *DentryResolver) getParentFromCache(mountID uint32, inode uint64) (uint
 
 	entry, exists := dr.cache.Get(key)
 	if !exists {
-		return 0, 0, errors.New("entry not found")
+		return 0, 0, ErrEntryNotFound
 	}
 	path := entry.(PathValue)
 


### PR DESCRIPTION
### What does this PR do?

This PR pre-allocate the dentry error object as this error can be instanced quite a lot.  

### Motivation

With a lot of fim events with dentry that were invalidated, an error is reported in order to fall back to the "kernel map" resolution. Profiling shows that the error allocation is trigger a lot.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
