### PR TITLE
Delete sender/checkSampler when check is unscheduled

### DIFF
--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -172,10 +172,19 @@ func (c *CheckBase) Warnf(format string, params ...interface{}) error {
 // long-running checks (persisting after Run() exits)
 func (c *CheckBase) Stop() {}
 
-// Cancel does nothing by default, you need to implement it if
+// Cancel calls CommonCancel by default. Override it if
 // your check has background resources that need to be cleaned up
-// when the check is unscheduled.
-func (c *CheckBase) Cancel() {}
+// when the check is unscheduled. Make sure to call CommonCancel from
+// your override.
+func (c *CheckBase) Cancel() {
+	c.CommonCancel()
+}
+
+// CommonCancel cleans up common resources. Must be called from Cancel
+// when checks implement it.
+func (c *CheckBase) CommonCancel() {
+	aggregator.DestroySender(c.checkID)
+}
 
 // Interval returns the scheduling time for the check.
 // Long-running checks should override to return 0.

--- a/pkg/collector/corechecks/cluster/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state.go
@@ -250,6 +250,7 @@ func (k *KSMCheck) Run() error {
 func (k *KSMCheck) Cancel() {
 	log.Infof("Shutting down informers used by the check '%s'", k.ID())
 	k.cancel()
+	k.CommonCancel()
 }
 
 // processMetrics attaches tags and forwards metrics to the aggregator

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -111,9 +111,11 @@ func (c *PythonCheck) RunSimple() error {
 // Stop does nothing
 func (c *PythonCheck) Stop() {}
 
-// Cancel does nothing
-// TODO: implement Cancel for python checks
-func (c *PythonCheck) Cancel() {}
+// Cancel deregisters the sender
+// TODO: allow python checks to implement Cancel
+func (c *PythonCheck) Cancel() {
+	aggregator.DestroySender(c.id)
+}
 
 // String representation (for debug and logging)
 func (c *PythonCheck) String() string {

--- a/releasenotes/notes/deregister-sender-check-unschedule-c21f79fda4d79c93.yaml
+++ b/releasenotes/notes/deregister-sender-check-unschedule-c21f79fda4d79c93.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix memory leak on check unscheduling, which could be noticeable for checks
+    submitting large amounts of metrics/tags.


### PR DESCRIPTION
### What does this PR do?

Deletes sender/checkSampler when check is unscheduled.

### Motivation

Fixes a memory leak on check unscheduling. 

Since the checkSampler stores metrics (and tags), not deleting it leads to a significant memory leak when checks sending lots of metrics (with lots of tags) are frequently scheduled/unscheduled. Noticeable on some nodes internally.

### Describe your test plan

Steps to reproduce leak:
1. write a custom check that submits lots of metrics with a large number of tags
2. configure the check to run frequently, and unschedule/schedule it frequently (by configuring it as container label for example)
3. observe memory leak. This PR should address the mem leak.
