### PR TITLE
Break down tagger telemetry per source and prefix

### DIFF
--- a/pkg/tagger/metrics.go
+++ b/pkg/tagger/metrics.go
@@ -9,7 +9,7 @@ import "github.com/DataDog/datadog-agent/pkg/telemetry"
 
 var (
 	storedEntities = telemetry.NewGaugeWithOpts("tagger", "stored_entities",
-		[]string{}, "Number of entities in the store.",
+		[]string{"source", "prefix"}, "Number of entities in the store.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	updatedEntities = telemetry.NewCounterWithOpts("tagger", "updated_entities",

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -68,13 +69,13 @@ func newTagStore() *tagStore {
 	}
 }
 
-func (s *tagStore) processTagInfo(xyz []*collectors.TagInfo) {
+func (s *tagStore) processTagInfo(tagInfos []*collectors.TagInfo) {
 	events := []entityEvent{}
 
 	s.Lock()
 	defer s.Unlock()
 
-	for _, info := range xyz {
+	for _, info := range tagInfos {
 		if info == nil {
 			log.Tracef("processTagInfo err: skipping nil message")
 			continue
@@ -108,7 +109,8 @@ func (s *tagStore) processTagInfo(xyz []*collectors.TagInfo) {
 			storedTags = newEntityTags(info.Entity)
 			s.store[info.Entity] = storedTags
 
-			storedEntities.Inc()
+			prefix, _ := containers.SplitEntityName(info.Entity)
+			storedEntities.Inc(info.Source, prefix)
 		}
 
 		// TODO: check if real change
@@ -288,8 +290,12 @@ func (s *tagStore) prune() error {
 
 		storedTags.Lock()
 
+		prefix, _ := containers.SplitEntityName(entity)
+
 		for source := range storedTags.toDelete {
 			delete(storedTags.sourceTags, source)
+
+			storedEntities.Dec(source, prefix)
 		}
 
 		if len(storedTags.sourceTags) == 0 {
@@ -310,14 +316,12 @@ func (s *tagStore) prune() error {
 		storedTags.Unlock()
 	}
 
-	remainingEntities := len(s.store)
-	log.Debugf("pruned %d removed entities, %d remaining", len(s.toDelete), remainingEntities)
+	log.Debugf("pruned %d removed entities, %d remaining", len(s.toDelete), len(s.store))
 
 	// Start fresh
 	s.toDelete = make(map[string]struct{})
 
 	s.notifySubscribers(events)
-	storedEntities.Set(float64(remainingEntities))
 
 	return nil
 }


### PR DESCRIPTION
We suspect that there is an entity leak in the tagger, where some
entities never get deleted, even though the actual entities (as in,
pods, containers, tasks, etc) are long gone. To help in the
investigation, we want to find out which collector and which kind of
entity is leaking, so we're adding extra telemetry to point us in the
right direction.

### Describe your test plan

After this PR, the `datadog.agent.tagger_stored_entities` metric should have `source` and `prefix` labels.