### PR TITLE
[logs/AD] Logs tailing from docker label

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -291,6 +291,7 @@
         <span class="stat_subtitle">{{ .name }}</span>
         <span class="stat_subdata">
           {{- range .sources }}
+            <span class="stat_subdata">
             Type: {{ .type }}</br>
             {{- range $key, $value := .configuration }}
             {{$key}}: {{$value}}</br>
@@ -313,7 +314,7 @@
               </span>
             {{- end }}
             {{- end }}
-            BytesRead: {{ .bytes_read }}</br>
+            </span>
           {{- end }}
         </span>
       {{- end }}

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -17,6 +17,7 @@ import (
 
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	lineParser "github.com/DataDog/datadog-agent/pkg/logs/parser"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -85,8 +86,9 @@ func NewTailer(outputChan chan *message.Message, source *config.LogSource, path 
 	}
 
 	var tagProvider tag.Provider
+
 	if source.Config.Identifier != "" {
-		tagProvider = tag.NewProvider(source.Config.Identifier)
+		tagProvider = tag.NewProvider(containers.BuildTaggerEntityName(source.Config.Identifier))
 	} else {
 		tagProvider = tag.NoopProvider
 	}

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -214,7 +214,7 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 	}
 	cfg.Type = config.FileType
 	cfg.Path = l.getPath(basePath, pod, container)
-	cfg.Identifier = getTaggerEntityID(container.ID)
+	cfg.Identifier = kubelet.TrimRuntimeFromCID(container.ID)
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid kubernetes annotation: %v", err)
 	}

--- a/pkg/logs/input/kubernetes/launcher_test.go
+++ b/pkg/logs/input/kubernetes/launcher_test.go
@@ -189,21 +189,21 @@ func TestContainerCollectAll(t *testing.T) {
 
 	source, err := launcherCollectAll.getSource(podFoo, containerFoo)
 	assert.Nil(t, err)
-	assert.Equal(t, "container_id://fooID", source.Config.Identifier)
+	assert.Equal(t, "fooID", source.Config.Identifier)
 	source, err = launcherCollectAll.getSource(podBar, containerBar)
 	assert.Nil(t, err)
-	assert.Equal(t, "container_id://barID", source.Config.Identifier)
+	assert.Equal(t, "barID", source.Config.Identifier)
 
 	source, err = launcherCollectAllDisabled.getSource(podFoo, containerFoo)
 	assert.Nil(t, err)
-	assert.Equal(t, "container_id://fooID", source.Config.Identifier)
+	assert.Equal(t, "fooID", source.Config.Identifier)
 	source, err = launcherCollectAllDisabled.getSource(podBar, containerBar)
 	assert.Equal(t, errCollectAllDisabled, err)
 	assert.Nil(t, source)
 
 	source, err = launcherCollectAll.getSource(podBaz, containerBaz)
 	assert.Nil(t, err)
-	assert.Equal(t, "container_id://bazID", source.Config.Identifier)
+	assert.Equal(t, "bazID", source.Config.Identifier)
 }
 
 func TestGetPath(t *testing.T) {

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -112,9 +112,8 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 				log.Warnf("Invalid configuration: %v", err)
 				continue
 			}
-
 			for _, source := range s.sources.GetSources() {
-				if identifier == source.Config.Identifier {
+				if identifier == source.Config.Identifier || dockerutil.ContainerIDToTaggerEntityName(identifier) == source.Config.Identifier {
 					s.sources.RemoveSource(source)
 				}
 			}

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -16,7 +16,6 @@ import (
 	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
-	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -113,7 +112,7 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 				continue
 			}
 			for _, source := range s.sources.GetSources() {
-				if identifier == source.Config.Identifier || dockerutil.ContainerIDToTaggerEntityName(identifier) == source.Config.Identifier {
+				if identifier == source.Config.Identifier {
 					s.sources.RemoveSource(source)
 				}
 			}
@@ -218,7 +217,9 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 			// a config defined in a docker label or a pod annotation does not always contain a type,
 			// override it here to ensure that the config won't be dropped at validation.
 			if cfg.Type == logsConfig.FileType && service.Type == "docker" {
-				cfg.Identifier = dockerutil.ContainerIDToTaggerEntityName(service.Identifier)
+				// cfg.Type is not overwritten as tailing a file from a docker AD configuration
+				// is explicitly supported
+				cfg.Identifier = service.Identifier
 			} else {
 				cfg.Type = service.Type
 				cfg.Identifier = service.Identifier // used for matching a source with a service

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -11,12 +11,12 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -175,6 +175,7 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 	case config.FileType:
 		dictionary["Path"] = c.Path
 		dictionary["TailingMode"] = c.TailingMode
+		dictionary["Identifier"] = c.Identifier
 	case config.DockerType:
 		dictionary["Image"] = c.Image
 		dictionary["Label"] = c.Label

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -52,24 +52,24 @@ Logs Agent
   {{ .name }}
   {{ printDashes .name "-" }}
   {{- range .sources }}
-    Type: {{ .type }}
-    {{- range $key, $value := .configuration }}
-    {{$key}}: {{$value}}
-    {{- end }}
-    Status: {{ .status }}
-    {{- range $message := .messages }}
-      {{ $message }}
-    {{- end }}
-    {{- if .inputs }}
-    Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}
-    {{- end }}
-    BytesRead: {{ .bytes_read }}
-    {{- if .info }}
-    Container Info:
-    {{- range $inf := .info }}
-      {{ $inf }}
-    {{- end }}
-    {{- end }}
+    - Type: {{ .type }}
+      {{- range $key, $value := .configuration }}
+      {{$key}}: {{$value}}
+      {{- end }}
+      Status: {{ .status }}
+      {{- range $message := .messages }}
+        {{ $message }}
+      {{- end }}
+      {{- if .inputs }}
+      Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}
+      {{- end }}
+      BytesRead: {{ .bytes_read }}
+      {{- if .info }}
+      Container Info:
+      {{- range $inf := .info }}
+        {{ $inf }}
+      {{- end }}
+      {{- end }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### What does this PR do?
Support file tailing logs config coming from docker label.

### Motivation
Extend supported logs config coming from AD.

### Additional Notes
Checklist:
* Better `agent status` output & GUI ✅ 
* Better harmonization of `Identifier` value, stick to `<container_id>` ~or `container_id://<container_id>` and stop using the other~ ✅ 

Note: file path shall be relative to where the agent is running.  
Note #2: registry key are not impacted by the small rework on how `Identifier` is populated (the registry uses the tailer identifier that is not impacted by the change) 

### Describe your test plan
Manual test on K8s ✅ 
