### PR TITLE
[runtime-security] Fix parent filename discarder as regular expression

### DIFF
--- a/pkg/security/probe/discarders_bpf.go
+++ b/pkg/security/probe/discarders_bpf.go
@@ -84,7 +84,7 @@ func (p *Probe) discardInode(eventType EventType, mountID uint32, inode uint64) 
 }
 
 func (p *Probe) discardParentInode(rs *rules.RuleSet, eventType EventType, field eval.Field, filename string, mountID uint32, inode uint64, pathID uint32) (bool, uint32, uint64, error) {
-	isDiscarder, err := isParentPathDiscarder(rs, eventType, field, filename)
+	isDiscarder, err := isParentPathDiscarder(rs, p.regexCache, eventType, field, filename)
 	if !isDiscarder {
 		return false, 0, 0, err
 	}

--- a/pkg/security/probe/kfilters_test.go
+++ b/pkg/security/probe/kfilters_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
+	"github.com/hashicorp/golang-lru/simplelru"
 )
 
 func addRuleExpr(t *testing.T, rs *rules.RuleSet, exprs ...string) {
@@ -33,95 +34,114 @@ func addRuleExpr(t *testing.T, rs *rules.RuleSet, exprs ...string) {
 }
 
 func TestIsParentDiscarder(t *testing.T) {
+	regexCache, err := simplelru.NewLRU(64, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.filename != "/var/log/datadog/system-probe.log"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/var/log/datadog/system-probe.log"); is {
-		t.Fatal("shouldn't be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/var/log/datadog/system-probe.log"); is {
+		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.filename != "/var/log/datadog/system-probe.log"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/var/lib/datadog/system-probe.sock"); !is {
-		t.Fatal("should be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/var/lib/datadog/system-probe.sock"); !is {
+		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename == "/var/log/datadog/system-probe.log"`, `unlink.basename == "datadog"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/var/log/datadog/datadog-agent.log"); is {
-		t.Fatal("shouldn't be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/var/log/datadog/datadog-agent.log"); is {
+		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.basename =~ ".*"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/var/lib/.runc/1234"); !is {
-		t.Fatal("should be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/var/lib/.runc/1234"); !is {
+		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename == "/etc/conf.d/httpd.conf" || unlink.basename == "conf.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/nginx.conf"); is {
-		t.Fatal("shouldn't be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/nginx.conf"); is {
+		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename == "/etc/conf.d/httpd.conf" || unlink.basename == "sys.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/sys.d/nginx.conf"); is {
-		t.Fatal("shouldn't be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/etc/sys.d/nginx.conf"); is {
+		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.basename == "conf.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/nginx.conf"); is {
-		t.Fatal("shouldn't be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/nginx.conf"); is {
+		t.Error("shouldn't be a parent discarder")
 	}
 
 	// field that doesn't exists shouldn't return any discarders
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `rename.old.filename == "/etc/conf.d/abc"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileRenameEventType, "rename.filename", "/etc/conf.d/nginx.conf"); is {
-		t.Fatal("shouldn't be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileRenameEventType, "rename.filename", "/etc/conf.d/nginx.conf"); is {
+		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `rename.old.filename == "/etc/conf.d/abc"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileRenameEventType, "rename.old.filename", "/etc/nginx/nginx.conf"); !is {
-		t.Fatal("should be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileRenameEventType, "rename.old.filename", "/etc/nginx/nginx.conf"); !is {
+		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename =~ "/etc/conf.d/*"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/sys.d/nginx.conf"); !is {
-		t.Fatal("should be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/etc/sys.d/nginx.conf"); !is {
+		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename =~ "*/conf.*"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
-		t.Fatal("shouldn't be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+		t.Error("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename =~ "/etc/conf.d/ab*"`)
+
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+		t.Error("shouldn't be a parent discarder")
+	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
+	addRuleExpr(t, rs, `unlink.filename =~ "*/conf.d/ab*"`)
+
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename =~ "*/conf.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
-		t.Fatal("shouldn't be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(SECLConstants, nil))
 	addRuleExpr(t, rs, `unlink.filename =~ "/etc/*"`)
 
-	if is, _ := isParentPathDiscarder(rs, FileUnlinkEventType, "unlink.filename", "/etc/cron.d/log"); is {
-		t.Fatal("shouldn't be a parent discarder")
+	if is, _ := isParentPathDiscarder(rs, regexCache, FileUnlinkEventType, "unlink.filename", "/etc/cron.d/log"); is {
+		t.Error("shouldn't be a parent discarder")
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Avoid pushing a wrong parent discarder.

### Motivation

The recent change that loosed the constraints on wildcards in filename caused some discarders
to be pushed that would invalidate some rules.