### PR TITLE
Failed transactions: In memory buffer uses disk serialization

### DIFF
--- a/pkg/forwarder/transaction_container.go
+++ b/pkg/forwarder/transaction_container.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package forwarder
+
+import (
+	"fmt"
+)
+
+type transactionStorage interface {
+	Serialize([]Transaction) error
+	Deserialize() ([]Transaction, error)
+}
+
+// transactionContainer stores transactions in memory and flush them to disk when the memory
+// limit is exceeded.
+type transactionContainer struct {
+	transactions          []Transaction
+	currentMemSizeInBytes int
+	maxMemSizeInBytes     int
+	flushToStorageRatio   float32
+	transactionStorage    transactionStorage
+}
+
+func newTransactionContainer(
+	transactionStorage transactionStorage,
+	maxMemSizeInBytes int,
+	flushToStorageRatio float32) *transactionContainer {
+	return &transactionContainer{
+		maxMemSizeInBytes:   maxMemSizeInBytes,
+		flushToStorageRatio: flushToStorageRatio,
+		transactionStorage:  transactionStorage,
+	}
+}
+
+// Add adds a new transaction and flush transactions to disk if the memory limit is exceeded.
+// The amount of transactions flushed to disk is control by
+// `flushToStorageRatio` which is the ratio of the transactions to be flushed.
+// Consider the following payload sizes 10, 20, 30, 40, 15 with `maxMemSizeInBytes=100` and
+// `flushToStorageRatio=0.6`
+// When adding the last payload `15`, the buffer becomes full (10+20+30+40+15 > 100) and
+// 100*0.6=60 bytes must be flushed on disk.
+// The first 3 transactions are flushed to the disk as 10 + 20 + 30 >= 60
+func (f *transactionContainer) Add(t Transaction) error {
+	payloadSize := t.GetPayloadSize()
+	if err := f.makeRoomFor(payloadSize); err != nil {
+		return fmt.Errorf("Not enough space for the payload %v %v", t.GetTarget(), err)
+	}
+
+	f.transactions = append(f.transactions, t)
+	f.currentMemSizeInBytes += payloadSize
+	return nil
+}
+
+// ExtractTransactions extracts transactions from the container.
+// If some transactions exist in memory extract them otherwise extract transactions
+// from the disk.
+// No transactions are in memory after calling this method.
+func (f *transactionContainer) ExtractTransactions() ([]Transaction, error) {
+	var transactions []Transaction
+	var err error
+	if len(f.transactions) > 0 {
+		transactions = f.transactions
+		f.transactions = nil
+	} else {
+		transactions, err = f.transactionStorage.Deserialize()
+		if err != nil {
+			return nil, err
+		}
+	}
+	f.currentMemSizeInBytes = 0
+	return transactions, nil
+}
+
+// GetCurrentMemSizeInBytes gets the current memory usage in bytes
+func (f *transactionContainer) GetCurrentMemSizeInBytes() int {
+	return f.currentMemSizeInBytes
+}
+
+func (f *transactionContainer) makeRoomFor(payloadSize int) error {
+	for f.currentMemSizeInBytes+payloadSize > f.maxMemSizeInBytes && len(f.transactions) > 0 {
+		if err := f.flushToStorage(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *transactionContainer) flushToStorage() error {
+	sizeInBytesFlushed := 0
+	var payloadsToFlush []Transaction
+
+	i := 0
+	sizeInBytesToFlush := int(float32(f.maxMemSizeInBytes) * f.flushToStorageRatio)
+	// Flush the N first transactions whose payload size sum is greater than `sizeInBytesToFlush`
+	for ; i < len(f.transactions) && sizeInBytesFlushed < sizeInBytesToFlush; i++ {
+		transaction := f.transactions[i]
+		sizeInBytesFlushed += transaction.GetPayloadSize()
+		payloadsToFlush = append(payloadsToFlush, transaction)
+	}
+
+	if len(payloadsToFlush) > 0 {
+		err := f.transactionStorage.Serialize(payloadsToFlush)
+		if err != nil {
+			return err
+		}
+		f.transactions = f.transactions[i:]
+		f.currentMemSizeInBytes -= sizeInBytesFlushed
+	}
+
+	return nil
+}

--- a/pkg/forwarder/transaction_container_test.go
+++ b/pkg/forwarder/transaction_container_test.go
@@ -1,0 +1,76 @@
+package forwarder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransactionContainerAdd(t *testing.T) {
+	a := assert.New(t)
+	path, clean := createTmpFolder(a)
+	defer clean()
+	s := newTransactionsFileStorage(NewTransactionsSerializer(), path, 1000)
+	container := newTransactionContainer(s, 100, 0.6)
+
+	// When adding the last element `15`, the buffer becomes full and the first 3
+	// transactions are flushed to the disk as 10 + 20 + 30 >= 100 * 0.6
+	for _, payloadSize := range []int{10, 20, 30, 40, 15} {
+		container.Add(createTransactionWithPayloadSize(payloadSize))
+	}
+	a.Equal(40+15, container.GetCurrentMemSizeInBytes())
+
+	assertPayloadSizeFromExtractTransactions(a, container, []int{40, 15})
+
+	container.Add(createTransactionWithPayloadSize(5))
+	a.Equal(5, container.GetCurrentMemSizeInBytes())
+
+	assertPayloadSizeFromExtractTransactions(a, container, []int{5})
+	assertPayloadSizeFromExtractTransactions(a, container, []int{10, 20, 30})
+	assertPayloadSizeFromExtractTransactions(a, container, nil)
+}
+
+func TestTransactionContainerSeveralFlushToDisk(t *testing.T) {
+	a := assert.New(t)
+	path, clean := createTmpFolder(a)
+	defer clean()
+	s := newTransactionsFileStorage(NewTransactionsSerializer(), path, 1000)
+	container := newTransactionContainer(s, 50, 0.1)
+
+	// Flush to disk when adding `40`
+	for _, payloadSize := range []int{9, 10, 11, 40} {
+		container.Add(createTransactionWithPayloadSize(payloadSize))
+	}
+	a.Equal(40, container.GetCurrentMemSizeInBytes())
+	a.Equal(3, s.GetFilesCount())
+
+	assertPayloadSizeFromExtractTransactions(a, container, []int{40})
+	assertPayloadSizeFromExtractTransactions(a, container, []int{11})
+	assertPayloadSizeFromExtractTransactions(a, container, []int{10})
+	assertPayloadSizeFromExtractTransactions(a, container, []int{9})
+	a.Equal(0, s.GetFilesCount())
+	a.Equal(int64(0), s.GetCurrentSizeInBytes())
+}
+
+func createTransactionWithPayloadSize(payloadSize int) *HTTPTransaction {
+	tr := NewHTTPTransaction()
+	payload := make([]byte, payloadSize)
+	tr.Payload = &payload
+	return tr
+}
+
+func assertPayloadSizeFromExtractTransactions(
+	a *assert.Assertions,
+	container *transactionContainer,
+	expectedPayloadSize []int) {
+
+	transactions, err := container.ExtractTransactions()
+	a.NoError(err)
+	a.Equal(0, container.GetCurrentMemSizeInBytes())
+
+	var payloadSizes []int
+	for _, t := range transactions {
+		payloadSizes = append(payloadSizes, t.GetPayloadSize())
+	}
+	a.EqualValues(expectedPayloadSize, payloadSizes)
+}


### PR DESCRIPTION
### What does this PR do?

This PR is part of persisting failed transactions on disk when in-mem buffer is full.
See https://github.com/DataDog/datadog-agent/pull/6867 for more context.

This PR provides a way store transactions in memory and flush them to the disk when the memory limit is reach.

`transactionContainer` from this PR is an improvement of `retryTransactionsCollection` from #6496.
### Motivation

### Additional Notes

The code is not already used.

### Describe your test plan

QA should be done at the same time as https://github.com/DataDog/datadog-agent/pull/6867.
