### PR TITLE
Add manual stage to build ebpf-only clang 11

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,7 @@ variables:
   S3_CP_OPTIONS: --only-show-errors --region us-east-1 --sse AES256
   S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
   S3_ARTIFACTS_URI: s3://dd-ci-artefacts-build-stable/$CI_PROJECT_NAME/$CI_PIPELINE_ID
+  S3_PERMANENT_ARTIFACTS_URI: s3://dd-ci-persistent-artefacts-build-stable/$CI_PROJECT_NAME
 ## comment out both lines below (S3_OMNIBUS_CACHE_BUCKET and USE_S3_CACHING) to allow
 ## build to succeed with S3 caching disabled.
   S3_OMNIBUS_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-cache-build-stable
@@ -95,7 +96,7 @@ variables:
   DATADOG_AGENT_BUILDERS: v3399751-fc72c60
   DATADOG_AGENT_WINBUILDIMAGES: v3283120-ecb88be
   DATADOG_AGENT_ARMBUILDIMAGES: v2894686-d80c3ce
-  DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v2894686-d80c3ce
+  DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v3384103-12f9098
   BCC_VERSION: v0.12.0
   SYSTEM_PROBE_GO_VERSION: 1.14.7
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded
@@ -383,8 +384,10 @@ tests_ebpf:
     - python3 -m pip install -r requirements.txt
     # Retrieve libbcc from S3
     - $S3_CP_CMD $S3_ARTIFACTS_URI/libbcc-amd64.tar.xz /tmp/libbcc.tar.xz
-    - mkdir /opt/libbcc
-    - tar -xvf /tmp/libbcc.tar.xz -C /opt/libbcc
+    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-amd64-11.0.0.tar.xz /tmp/clang.tar.xz
+    - mkdir -p $DATADOG_AGENT_EMBEDDED_PATH
+    - tar -xvf /tmp/libbcc.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
+    - tar -xvf /tmp/clang.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
   after_script:
     - cd $SRC_PATH
     - cp ./pkg/ebpf/bytecode/build/tracer-ebpf.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer-ebpf.o
@@ -394,7 +397,7 @@ tests_ebpf:
   tags: [ "runner:main", "size:large" ]
   script:
     # For now only check bpf bytes since we don't have a way to run eBPF tests without mounting a debugfs
-    - CGO_CFLAGS='-I/opt/libbcc/include' CGO_LDFLAGS='-Wl,-rpath,/opt/libbcc/lib -L/opt/libbcc/lib' inv -e system-probe.test --only-check-bpf-bytes
+    - inv -e system-probe.test --only-check-bpf-bytes
     # Compile runtime security functional tests to be executed in kitchen tests
     - inv -e security-agent.functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite
 
@@ -681,6 +684,53 @@ dogstatsd_arm64_size_test:
   script:
     - inv -e dogstatsd.size-test --skip-build
 
+.build_clang_common:
+  rules:
+    - when: manual
+      allow_failure: true
+  stage: deps_build
+  timeout: 2h 00m
+  script:
+    - wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang-11.0.0.src.tar.xz -O clang.src.tar.xz
+    - wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-11.0.0.src.tar.xz -O llvm.src.tar.xz
+    - mkdir clang && tar xf clang.src.tar.xz --strip-components=1 --no-same-owner -C clang
+    - mkdir llvm && tar xf llvm.src.tar.xz --strip-components=1 --no-same-owner -C llvm
+    - mkdir build && cd build
+    - |
+      cmake -DLLVM_ENABLE_PROJECTS=clang \
+      -DLLVM_TARGETS_TO_BUILD="BPF" \
+      -DCMAKE_INSTALL_PREFIX=$DATADOG_AGENT_EMBEDDED_PATH \
+      -G "Ninja" \
+      -DCMAKE_BUILD_TYPE=MinSizeRel \
+      -DLLVM_BUILD_TOOLS=OFF \
+      -DLLVM_INCLUDE_EXAMPLES=OFF \
+      -DLLVM_INCLUDE_TESTS=OFF \
+      -DLLVM_INCLUDE_BENCHMARKS=OFF \
+      -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
+      -DLLVM_ENABLE_BINDINGS=OFF \
+      -DLLVM_PARALLEL_COMPILE_JOBS=4 \
+      -DLLVM_PARALLEL_LINK_JOBS=4 \
+      ../llvm
+    - cmake --build . --target install
+    - cd $DATADOG_AGENT_EMBEDDED_PATH
+    - rm -rf bin share libexec lib/clang lib/cmake lib/*.so*
+    - tar cvaf /tmp/clang.tar.xz .
+    - $S3_CP_CMD /tmp/clang.tar.xz $S3_PERMANENT_ARTIFACTS_URI/clang-$ARCH-11.0.0.tar.xz
+
+build_clang_x64:
+  extends: .build_clang_common
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: [ "runner:main", "size:2xlarge" ]
+  variables:
+    ARCH: amd64
+
+build_clang_arm64:
+  extends: .build_clang_common
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: [ "runner:docker-arm", "platform:arm64" ]
+  variables:
+    ARCH: arm64
+
 .system-probe_build_common:
   before_script:
     # Hack to work around the cloning issue with arm runners
@@ -695,8 +745,10 @@ dogstatsd_arm64_size_test:
     - inv -e deps --verbose
     # Retrieve libbcc from S3
     - $S3_CP_CMD $S3_ARTIFACTS_URI/libbcc-$ARCH.tar.xz /tmp/libbcc.tar.xz
+    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$ARCH-11.0.0.tar.xz /tmp/clang.tar.xz
     - mkdir -p $DATADOG_AGENT_EMBEDDED_PATH
     - tar -xvf /tmp/libbcc.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
+    - tar -xvf /tmp/clang.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
 
   script:
     - inv -e system-probe.build --go-version=$SYSTEM_PROBE_GO_VERSION --embedded-path=$DATADOG_AGENT_EMBEDDED_PATH


### PR DESCRIPTION
### What does this PR do?

Adds a manually triggered stage to build a static version of clang 11 with only the eBPF backend. It stores the artifacts in S3 for later use.

### Motivation

This will be used with upcoming runtime compilation feature in the system-probe.

### Additional Notes

This also updates the system-probe build image to use clang 11.

### Describe your test plan

I manually triggered the stage and it completed successfully.