### PR TITLE
Only update telemetry if source was actually deleted

### DIFF
--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -293,8 +293,11 @@ func (s *tagStore) prune() error {
 		prefix, _ := containers.SplitEntityName(entity)
 
 		for source := range storedTags.toDelete {
-			delete(storedTags.sourceTags, source)
+			if _, ok := storedTags.sourceTags[source]; !ok {
+				continue
+			}
 
+			delete(storedTags.sourceTags, source)
 			storedEntities.Dec(source, prefix)
 		}
 


### PR DESCRIPTION
The tag store previously used to always decrease the number of stored
entities even when sourceTags for a source had already been deleted
previously, causing telemetry to slowly decrease to over time to below
zero, which should be impossible. Now, telemetry is only updated if
there actually was a source to be deleted in the first place.

### Describe your test plan

Can be tested together with #6881. Probably difficult to test on a small cluster though, since the behavior is most likely triggered by race conditions to begin with.