### PR TITLE
Address the e2e tests failures of today

### DIFF
--- a/test/e2e/argo-workflows/templates/fake-datadog.yaml
+++ b/test/e2e/argo-workflows/templates/fake-datadog.yaml
@@ -137,6 +137,6 @@ spec:
           set -euo pipefail
           set -x
 
-          until curl -f http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local/_/reset -XPOST --connect-timeout 1; do
+          until curl -f http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local/_/reset -XPOST --max-time 1; do
             sleep 3
           done

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -36,7 +36,7 @@ until _ssh systemctl is-system-running --wait; do
         continue
     fi
     _ssh journalctl -n 30 ||:
-    _ssh systemctl list-units --failed ||:
+    _ssh LC_ALL=C systemctl list-units --failed ||:
     # Let's try to reboot until we have more clues about what can go wrong here.
     _ssh sudo systemctl reboot ||:
     sleep 5


### PR DESCRIPTION
### What does this PR do?

Address the e2e tests failures of today:
* `systemctl list-units --failed` printed utf-8 characters that are making GitLab crash.
* the `fake-dd-reset` step blocked forever. So, let’s add a timeout on `curl`.

### Motivation

Let’s fix the e2e tests flakiness!

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Launch e2e tests.
