### PR TITLE
[system-probe] Add build digest script

### DIFF
--- a/pkg/ebpf/bytecode/.build_digest
+++ b/pkg/ebpf/bytecode/.build_digest
@@ -1,0 +1,12 @@
+// This file is used for the purpose of diagnosing diffs in object files
+// Contents are based on the host to last run `system-probe.build` task
+DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=19.10
+DISTRIB_CODENAME=eoan
+DISTRIB_DESCRIPTION="Ubuntu 19.10"
+5.3.0-55-generic
+clang version 8.0.0 (tags/RELEASE_800/final)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /opt/clang/bin
+llvm-version: 8.0.0


### PR DESCRIPTION
### What does this PR do?

Generates a build digest file with environment info when `system-probe.build` is invoked.
The main motivation is to help diagnose changes in the object files when folks open PRs inadvertently changing them. Often times that is caused by a an outdated agent VM which should be explicit by the contents of the `.build_digest` file. 
Example output:

**pkg/ebpf/bytecode/.build_digest**
```
// This file is used for the purpose of diagnosing diffs in object files
// Contents are based on the host to last run `system-probe.build` task
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=19.10
DISTRIB_CODENAME=eoan
DISTRIB_DESCRIPTION="Ubuntu 19.10"
5.3.0-55-generic
clang version 8.0.0 (tags/RELEASE_800/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/clang/bin
llvm-version: 8.0.0
```` 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
