### PR TITLE
Don't double convert tagger IDs

### DIFF
--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -122,15 +122,9 @@ func (c *KubeMetadataCollector) Pull() error {
 		for id, lastSeen := range c.lastSeen {
 			if now.Sub(lastSeen) >= c.expireFreq {
 				delete(c.lastSeen, id)
-				entityID, err := kubelet.KubeIDToTaggerEntityID(id)
-				if err != nil {
-					log.Warnf("error extracting tagger entity id from %q: %s", id, err)
-					continue
-				}
-
 				tagInfos = append(tagInfos, &TagInfo{
 					Source:       kubeMetadataCollectorName,
-					Entity:       entityID,
+					Entity:       id,
 					DeleteEntity: true,
 				})
 			}

--- a/releasenotes/notes/tagger-entity-leak-7f140966083ac07a.yaml
+++ b/releasenotes/notes/tagger-entity-leak-7f140966083ac07a.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The Datadog Agent had a memory leak where some tags would be collected but
+    never cleaned up after their entities were removed from a Kubernetes
+    cluster due to their IDs not being recognized. This has now been fixed, and
+    all tags are garbage collected when their entities are removed.


### PR DESCRIPTION
At this point in the collector, we're no longer dealing with raw IDs (as
in, the ones containing the actual container runtime instead of just
`container_id`), but rather already the ones converted for use in the
tagger, so that double conversion was superfluous and was actually
making the tagger leak entities since it would try to delete entities it
couldn't find.

### Describe your test plan

Create a pod, run agent tagger-list and ensure the pod and its containers have the `kube-metatada-collector` source. Then delete the pod, and ensure that after 5+ minutes the entities for the pod and its containers are gone from the list (a list of empty tags is not enough).