### PR TITLE
pkg/trace/test: ensure that each run installs a fresh agent

### DIFF
--- a/pkg/trace/test/runner.go
+++ b/pkg/trace/test/runner.go
@@ -55,7 +55,7 @@ func (s *Runner) Shutdown(wait time.Duration) error {
 	if s.agent == nil || s.backend == nil {
 		return ErrNotStarted
 	}
-	s.agent.Kill()
+	s.agent.cleanup()
 	if err := s.backend.Shutdown(wait); err != nil {
 		return err
 	}


### PR DESCRIPTION
This change ensures that each integration test run installs a fresh
agent in a temporary directory as opposed to using or installing
whatever is found in the environments $GOPATH/bin/trace-agent