### PR TITLE
Failed transactions: removal policy

### DIFF
--- a/pkg/forwarder/failed_transaction_removal_policy.go
+++ b/pkg/forwarder/failed_transaction_removal_policy.go
@@ -1,0 +1,138 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package forwarder
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util"
+)
+
+type failedTransactionRemovalPolicy struct {
+	rootPath           string
+	knownDomainFolders map[string]struct{}
+	outdatedFileTime   time.Time
+}
+
+func newFailedTransactionRemovalPolicy(rootPath string, outdatedFileDayCount int) (*failedTransactionRemovalPolicy, error) {
+	if err := os.MkdirAll(rootPath, 0755); err != nil {
+		return nil, err
+	}
+
+	return &failedTransactionRemovalPolicy{
+		rootPath:           rootPath,
+		knownDomainFolders: make(map[string]struct{}),
+		outdatedFileTime:   time.Now().Add(time.Duration(-outdatedFileDayCount*24) * time.Hour),
+	}, nil
+}
+
+// RegisterDomain registers a domain name.
+func (p *failedTransactionRemovalPolicy) RegisterDomain(domainName string) (string, error) {
+	folder, err := p.getFolderPathForDomain(domainName)
+	if err != nil {
+		return "", err
+	}
+
+	p.knownDomainFolders[folder] = struct{}{}
+	return folder, nil
+}
+
+// RemoveOutdatedFiles removes the outdated files.
+// It removes files with extension retryTransactionsExtension:
+// - For domains not registered
+// - When a file is older than outDatedFileDayCount days
+func (p *failedTransactionRemovalPolicy) RemoveOutdatedFiles() ([]string, error) {
+	entries, err := ioutil.ReadDir(p.rootPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var filesRemoved []string
+	for _, domain := range entries {
+		if domain.Mode().IsDir() {
+			folderPath := path.Join(p.rootPath, domain.Name())
+			var files []string
+			if _, found := p.knownDomainFolders[folderPath]; found {
+				files, err = p.removeOutdatedFiles(folderPath)
+			} else {
+				files, err = p.removeUnknownDomain(folderPath)
+			}
+			if err != nil {
+				return nil, err
+			}
+			filesRemoved = append(filesRemoved, files...)
+		}
+	}
+	return filesRemoved, nil
+}
+
+func (p *failedTransactionRemovalPolicy) getFolderPathForDomain(domainName string) (string, error) {
+	// Use md5 for the folder name as the domainName is an url which can contain invalid charaters for a file path.
+	h := md5.New()
+	if _, err := io.WriteString(h, domainName); err != nil {
+		return "", err
+	}
+	folder := fmt.Sprintf("%x", h.Sum(nil))
+
+	return path.Join(p.rootPath, folder), nil
+}
+
+func (p *failedTransactionRemovalPolicy) removeUnknownDomain(folderPath string) ([]string, error) {
+	files, err := p.removeRetryFiles(folderPath, func(filename string) bool { return true })
+
+	// Try to remove the folder if it is empty
+	_ = os.Remove(folderPath)
+	return files, err
+}
+
+func (p *failedTransactionRemovalPolicy) removeOutdatedFiles(folderPath string) ([]string, error) {
+	return p.removeRetryFiles(folderPath, func(filename string) bool {
+		modTime, err := util.GetFileModTime(filename)
+		if err != nil {
+			return false
+		}
+		return modTime.Before(p.outdatedFileTime)
+	})
+}
+
+func (p *failedTransactionRemovalPolicy) removeRetryFiles(folderPath string, predicate func(string) bool) ([]string, error) {
+	files, err := p.getRetryFiles(folderPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var filesRemoved []string
+	for _, f := range files {
+		if predicate(f) {
+			if err = os.Remove(f); err != nil {
+				return nil, err
+			}
+			filesRemoved = append(filesRemoved, f)
+		}
+	}
+	return filesRemoved, nil
+}
+
+func (p *failedTransactionRemovalPolicy) getRetryFiles(folder string) ([]string, error) {
+	entries, err := ioutil.ReadDir(folder)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, entry := range entries {
+		if entry.Mode().IsRegular() && filepath.Ext(entry.Name()) == retryTransactionsExtension {
+			files = append(files, path.Join(folder, entry.Name()))
+		}
+	}
+	return files, nil
+}

--- a/pkg/forwarder/failed_transaction_removal_policy_test.go
+++ b/pkg/forwarder/failed_transaction_removal_policy_test.go
@@ -1,0 +1,101 @@
+package forwarder
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFailedTransactionRemovalPolicyUnknownDomain(t *testing.T) {
+	a := assert.New(t)
+	root, clean := createTmpFolder(a)
+	defer clean()
+	p, err := newFailedTransactionRemovalPolicy(root, 1)
+	a.NoError(err)
+
+	domain1, err := p.RegisterDomain("domain1")
+	a.NoError(err)
+	domain2, err := p.RegisterDomain("domain2")
+	a.NoError(err)
+
+	file1 := createRetryFile(a, domain1, "file1")
+	file2 := createRetryFile(a, domain2, "file2")
+	file3 := createRetryFile(a, root+"/unknownDomain", "file3")
+	file4 := createFile(a, root+"/unknownDomain", "notRetryFileMustNotBeRemoved")
+
+	pathsRemoved, err := p.RemoveOutdatedFiles()
+	a.NoError(err)
+	a.EqualValues([]string{file3}, pathsRemoved)
+	a.EqualValues([]string{file1, file2, file4}, getRemainingFiles(a, root))
+}
+
+func TestFailedTransactionRemovalPolicyOutdatedFiles(t *testing.T) {
+	a := assert.New(t)
+	root, clean := createTmpFolder(a)
+	defer clean()
+	outDatedFileDayCount := 2
+	p, err := newFailedTransactionRemovalPolicy(root, outDatedFileDayCount)
+	a.NoError(err)
+
+	domain, err := p.RegisterDomain("domain")
+	a.NoError(err)
+
+	file1 := createRetryFile(a, domain, "file1")
+	file2 := createRetryFile(a, domain, "file2")
+	file3 := createRetryFile(a, domain, "file3")
+
+	modTime := time.Now().Add(time.Duration(-3*24) * time.Hour)
+	a.NoError(os.Chtimes(file2, modTime, modTime))
+
+	modTime = time.Now().Add(time.Duration(-1*24) * time.Hour)
+	a.NoError(os.Chtimes(file3, modTime, modTime))
+
+	pathsRemoved, err := p.RemoveOutdatedFiles()
+	a.NoError(err)
+	a.EqualValues([]string{file2}, pathsRemoved)
+	a.EqualValues([]string{file1, file3}, getRemainingFiles(a, root))
+}
+
+func TestFailedTransactionRemovalPolicyExistingDomain(t *testing.T) {
+	a := assert.New(t)
+	root, clean := createTmpFolder(a)
+	defer clean()
+	_, err := newFailedTransactionRemovalPolicy(root, 1)
+	a.NoError(err)
+
+	// No error if the folder already exits.
+	_, err = newFailedTransactionRemovalPolicy(root, 1)
+	a.NoError(err)
+}
+
+func createRetryFile(a *assert.Assertions, root string, filename string) string {
+	return createFile(a, root, filename+retryTransactionsExtension)
+}
+
+func createFile(a *assert.Assertions, root string, filename string) string {
+	a.NoError(os.MkdirAll(root, 0755))
+	fullPath := path.Join(root, filename)
+	a.NoError(ioutil.WriteFile(fullPath, []byte{1, 2, 3}, 0644))
+	return fullPath
+}
+
+func getRemainingFiles(a *assert.Assertions, folder string) []string {
+	var files []string
+	a.NoError(filepath.Walk(folder,
+		func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.Mode().IsRegular() {
+				files = append(files, p)
+			}
+			return nil
+		}))
+
+	return files
+}

--- a/pkg/forwarder/transaction_container_test.go
+++ b/pkg/forwarder/transaction_container_test.go
@@ -10,7 +10,8 @@ func TestTransactionContainerAdd(t *testing.T) {
 	a := assert.New(t)
 	path, clean := createTmpFolder(a)
 	defer clean()
-	s := newTransactionsFileStorage(NewTransactionsSerializer(), path, 1000)
+	s, err := newTransactionsFileStorage(NewTransactionsSerializer(), path, 1000)
+	a.NoError(err)
 	container := newTransactionContainer(s, 100, 0.6)
 
 	// When adding the last element `15`, the buffer becomes full and the first 3
@@ -34,7 +35,8 @@ func TestTransactionContainerSeveralFlushToDisk(t *testing.T) {
 	a := assert.New(t)
 	path, clean := createTmpFolder(a)
 	defer clean()
-	s := newTransactionsFileStorage(NewTransactionsSerializer(), path, 1000)
+	s, err := newTransactionsFileStorage(NewTransactionsSerializer(), path, 1000)
+	a.NoError(err)
 	container := newTransactionContainer(s, 50, 0.1)
 
 	// Flush to disk when adding `40`

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -121,19 +121,34 @@ func CopyDir(src, dst string) error {
 
 // GetFileSize gets the file size
 func GetFileSize(path string) (int64, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = file.Close() }()
-
-	stat, err := file.Stat()
+	stat, err := getFileStat(path)
 
 	if err != nil {
 		return 0, err
 	}
 
 	return stat.Size(), nil
+}
+
+// GetFileModTime gets the modification time
+func GetFileModTime(path string) (time.Time, error) {
+	stat, err := getFileStat(path)
+
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return stat.ModTime(), nil
+}
+
+func getFileStat(path string) (os.FileInfo, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	return file.Stat()
 }
 
 // EnsureParentDirsExist makes a path immediately available for


### PR DESCRIPTION
### What does this PR do?

This PR is part of **persisting failed transactions on disk when in-mem buffer is full.**
See #6867 for more context.

This PR removes deprecate files. It removes files with extension `retryTransactionsExtension`:
- For domains not registered
- When a file is older than `outDatedFileDayCount` days

Existing retry files are reloaded in `transactionsFileStorage`.

### Motivation

### Additional Notes

The code is not already used.

### Describe your test plan