### PR TITLE
[circleci] Update XCode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
 
   macos_tests:
     macos:
-      xcode: 10.1.0
+      xcode: 11.7.0
     environment:
       BUILDIMAGES_VERSION: "a8226a8e78774afad285e7372fe8c6c179340dd9" # datadog-agent-buildimages commit to fetch to get the MacOS scripts
     working_directory: ~/go/src/github.com/DataDog/datadog-agent


### PR DESCRIPTION
### What does this PR do?

Updates the XCode version used in the CI to 11.7.0, which updates the underlying MacOS image (from 10.13 to 10.15).

### Motivation

MacOS 10.13 is too old and not supported by brew anymore. Some new brew updates broke it on 10.13.

### Describe your test plan

Check CircleCI tests.