### PR TITLE
[backport] Fix parsing of pre-release versions for integrations (#6797)

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -46,10 +46,11 @@ except pkg_resources.DistributionNotFound:
 )
 
 var (
-	datadogPkgNameRe    = regexp.MustCompile("datadog-.*")
-	yamlFileNameRe      = regexp.MustCompile("[\\w_]+\\.yaml.*")
-	wheelPackageNameRe  = regexp.MustCompile("Name: (\\S+)")           // e.g. Name: datadog-postgres
-	versionSpecifiersRe = regexp.MustCompile("([><=!]{1,2})([0-9.]*)") // Matches version specifiers defined in https://packaging.python.org/specifications/core-metadata/#requires-dist-multiple-use
+	datadogPkgNameRe      = regexp.MustCompile("datadog-.*")
+	yamlFileNameRe        = regexp.MustCompile("[\\w_]+\\.yaml.*")
+	wheelPackageNameRe    = regexp.MustCompile("Name: (\\S+)")                                                                                   // e.g. Name: datadog-postgres
+	versionSpecifiersRe   = regexp.MustCompile("([><=!]{1,2})([0-9.]*)")                                                                         // Matches version specifiers defined in https://packaging.python.org/specifications/core-metadata/#requires-dist-multiple-use
+	pep440VersionStringRe = regexp.MustCompile("^(?P<release>\\d+\\.\\d+\\.\\d+)(?:(?P<preReleaseType>[a-zA-Z]+)(?P<preReleaseNumber>\\d+)?)?$") // e.g. 1.3.4b1, simplified form of: https://www.python.org/dev/peps/pep-0440
 
 	allowRoot           bool
 	verbose             int
@@ -215,6 +216,31 @@ func semverToPEP440(version *semver.Version) string {
 		pep440 = fmt.Sprintf("%src%s", pep440, preReleaseNumber)
 	}
 	return pep440
+}
+
+func PEP440ToSemver(pep440 string) (*semver.Version, error) {
+	// Note: this is a simplified version that more closely fits how integrations are versioned.
+	matches := pep440VersionStringRe.FindStringSubmatch(pep440)
+	if matches == nil {
+		return nil, fmt.Errorf("invalid format: %s", pep440)
+	}
+	versionString := matches[1]
+	preReleaseType := matches[2]
+	preReleaseNumber := matches[3]
+	if preReleaseType != "" {
+		if preReleaseNumber == "" {
+			preReleaseNumber = "0"
+		}
+		switch preReleaseType {
+		case "a":
+			versionString = fmt.Sprintf("%s-alpha.%s", versionString, preReleaseNumber)
+		case "b":
+			versionString = fmt.Sprintf("%s-beta.%s", versionString, preReleaseNumber)
+		default:
+			versionString = fmt.Sprintf("%s-%s.%s", versionString, preReleaseType, preReleaseNumber)
+		}
+	}
+	return semver.NewVersion(versionString)
 }
 
 func getCommandPython() (string, error) {
@@ -701,10 +727,7 @@ func installedVersion(integration string) (*semver.Version, bool, error) {
 		return nil, false, nil
 	}
 
-	replacer := strings.NewReplacer("alpha", "-alpha", "beta", "-beta", "rc", "-rc")
-	normalizedVersion := replacer.Replace(outputStr)
-
-	version, err := semver.NewVersion(normalizedVersion)
+	version, err := PEP440ToSemver(outputStr)
 	if err != nil {
 		return nil, true, fmt.Errorf("error parsing version %s: %s", version, err)
 	}

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -144,6 +144,41 @@ func TestSemverToPEP440(t *testing.T) {
 	assert.Equal(t, semverToPEP440(semver.New("1.3.4-beta")), "1.3.4b")
 }
 
+func TestPEP440ToSemver(t *testing.T) {
+	version, _ := PEP440ToSemver("1.3.4")
+	assert.Equal(t, version.String(), "1.3.4")
+
+	version, _ = PEP440ToSemver("12.3.4")
+	assert.Equal(t, version.String(), "12.3.4")
+
+	version, _ = PEP440ToSemver("1.32.4")
+	assert.Equal(t, version.String(), "1.32.4")
+
+	version, _ = PEP440ToSemver("1.3.42")
+	assert.Equal(t, version.String(), "1.3.42")
+
+	version, _ = PEP440ToSemver("1.3.4rc1")
+	assert.Equal(t, version.String(), "1.3.4-rc.1")
+
+	version, _ = PEP440ToSemver("1.3.4a1")
+	assert.Equal(t, version.String(), "1.3.4-alpha.1")
+
+	version, _ = PEP440ToSemver("1.3.4b1")
+	assert.Equal(t, version.String(), "1.3.4-beta.1")
+
+	version, _ = PEP440ToSemver("1.3.4b12")
+	assert.Equal(t, version.String(), "1.3.4-beta.12")
+
+	// PEP440 allows this: https://www.python.org/dev/peps/pep-0440/#implicit-pre-release-number
+	// We don't ship versions like this, but we support this in case we do in the future.
+	version, _ = PEP440ToSemver("1.3.4b")
+	assert.Equal(t, version.String(), "1.3.4-beta.0")
+
+	// Other identifiers are passed-through, for resiliency.
+	version, _ = PEP440ToSemver("1.3.4dev1")
+	assert.Equal(t, version.String(), "1.3.4-dev.1")
+}
+
 func TestGetIntegrationName(t *testing.T) {
 	assert.Equal(t, getIntegrationName("datadog-checks-base"), "base")
 	assert.Equal(t, getIntegrationName("datadog-checks-downloader"), "downloader")

--- a/releasenotes/notes/fix-integration-prerelease-parsing-dd5e4ae9f865bdb8.yaml
+++ b/releasenotes/notes/fix-integration-prerelease-parsing-dd5e4ae9f865bdb8.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug when parsing the current version of an integration that prevented
+    upgrading from an alpha or beta prerelease version.


### PR DESCRIPTION
### What does this PR do?

Backport for `7.24.1`: #6797 

### Motivation

Bug prevented manual upgrade of integrations off of alphas and betas.

### Additional Notes

### Describe your test plan
