### PR TITLE
[networks] Improve kallsym lookup

### DIFF
--- a/pkg/ebpf/ksyms.go
+++ b/pkg/ebpf/ksyms.go
@@ -11,7 +11,6 @@ import (
 
 // VerifyKernelFuncs ensures all kernel functions exist in ksyms located at provided path.
 func VerifyKernelFuncs(path string, requiredKernelFuncs []string) ([]string, error) {
-	// Will hold the found functions
 	missing := make(util.SSBytes, len(requiredKernelFuncs))
 	for i, f := range requiredKernelFuncs {
 		missing[i] = []byte(f)

--- a/pkg/ebpf/ksyms.go
+++ b/pkg/ebpf/ksyms.go
@@ -28,9 +28,7 @@ func VerifyKernelFuncs(path string, requiredKernelFuncs []string) ([]string, err
 	scanner.Split(bufio.ScanWords)
 	for scanner.Scan() && len(missing) > 0 {
 		if i := missing.Search(scanner.Bytes()); i < len(missing) {
-			missing[0], missing[i] = missing[i], missing[0]
-			missing = missing[1:]
-			sort.Sort(missing)
+			missing = append(missing[:i], missing[i+1:]...)
 		}
 	}
 

--- a/pkg/ebpf/ksyms.go
+++ b/pkg/ebpf/ksyms.go
@@ -3,18 +3,20 @@ package ebpf
 import (
 	"bufio"
 	"os"
-	"strings"
+	"sort"
 
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/pkg/errors"
 )
 
 // VerifyKernelFuncs ensures all kernel functions exist in ksyms located at provided path.
 func VerifyKernelFuncs(path string, requiredKernelFuncs []string) ([]string, error) {
 	// Will hold the found functions
-	found := make(map[string]bool, len(requiredKernelFuncs))
-	for _, f := range requiredKernelFuncs {
-		found[f] = false
+	missing := make(util.SSBytes, len(requiredKernelFuncs))
+	for i, f := range requiredKernelFuncs {
+		missing[i] = []byte(f)
 	}
+	sort.Sort(missing)
 
 	f, err := os.Open(path)
 	if err != nil {
@@ -23,26 +25,19 @@ func VerifyKernelFuncs(path string, requiredKernelFuncs []string) ([]string, err
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
-	scanner.Split(bufio.ScanLines)
-
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) < 3 {
-			continue
-		}
-
-		name := fields[2]
-		if _, ok := found[name]; ok {
-			found[name] = true
+	scanner.Split(bufio.ScanWords)
+	for scanner.Scan() && len(missing) > 0 {
+		if i := missing.Search(scanner.Bytes()); i < len(missing) {
+			missing[0], missing[i] = missing[i], missing[0]
+			missing = missing[1:]
+			sort.Sort(missing)
 		}
 	}
 
-	var missing []string
-	for probe, b := range found {
-		if !b {
-			missing = append(missing, probe)
-		}
+	missingStrs := make([]string, len(missing))
+	for i := range missing {
+		missingStrs[i] = string(missing[i])
 	}
 
-	return missing, nil
+	return missingStrs, nil
 }

--- a/pkg/process/util/ss_bytes.go
+++ b/pkg/process/util/ss_bytes.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 )
 
+// SSBytes implements the sort.Interface for the [][]byte type
 type SSBytes [][]byte
 
 var _ sort.Interface = SSBytes{}

--- a/pkg/process/util/ss_bytes.go
+++ b/pkg/process/util/ss_bytes.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"bytes"
+	"sort"
+)
+
+type SSBytes [][]byte
+
+var _ sort.Interface = SSBytes{}
+
+func (ss SSBytes) Len() int {
+	return len(ss)
+}
+
+func (ss SSBytes) Less(i, j int) bool {
+	return bytes.Compare(ss[i], ss[j]) < 0
+}
+
+func (ss SSBytes) Swap(i, j int) {
+	ss[i], ss[j] = ss[j], ss[i]
+}
+
+// Search returns the index of element x if found or the length of the SSBytes otherwise.
+// SSBytes is expected to be sorted.
+func (ss SSBytes) Search(x []byte) int {
+	i := sort.Search(len(ss), func(i int) bool {
+		return bytes.Compare(ss[i], x) >= 0
+	})
+
+	if i < len(ss) && bytes.Compare(ss[i], x) == 0 {
+		return i
+	}
+
+	return len(ss)
+}


### PR DESCRIPTION
### What does this PR do?

Improve `VerifyKernelFuncs` perfomance. This should improve system-probe initialization, but the motivation was to reduce the time spent in one test that was taking 11s to finish:

Before
```
=== RUN   TestUbuntuKernelsNotSupported
--- PASS: TestUbuntuKernelsNotSupported (11.66s)
``` 

After
```
=== RUN   TestUbuntuKernelsNotSupported
--- PASS: TestUbuntuKernelsNotSupported (0.96s)
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
