### PR TITLE
Update storedTags on adds to every source

### DIFF
--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -108,9 +108,6 @@ func (s *tagStore) processTagInfo(tagInfos []*collectors.TagInfo) {
 			eventType = EventTypeAdded
 			storedTags = newEntityTags(info.Entity)
 			s.store[info.Entity] = storedTags
-
-			prefix, _ := containers.SplitEntityName(info.Entity)
-			storedEntities.Inc(info.Source, prefix)
 		}
 
 		// TODO: check if real change
@@ -135,10 +132,16 @@ func (s *tagStore) processTagInfo(tagInfos []*collectors.TagInfo) {
 func updateStoredTags(storedTags *entityTags, info *collectors.TagInfo) error {
 	storedTags.Lock()
 	defer storedTags.Unlock()
+
 	_, found := storedTags.sourceTags[info.Source]
 	if found && info.CacheMiss {
 		// check if the source tags is already present for this entry
 		return fmt.Errorf("try to overwrite an existing entry with and empty cache-miss entry, info.Source: %s, info.Entity: %s", info.Source, info.Entity)
+	}
+
+	if !found {
+		prefix, _ := containers.SplitEntityName(info.Entity)
+		storedEntities.Inc(info.Source, prefix)
 	}
 
 	storedTags.cacheValid = false


### PR DESCRIPTION
### What does this PR do?

Previously, because of the old telemetry that didn't have a breakdown
per source, storedTags was only updated when an entity didn't exist at
all in the store. When we started breaking down how many entities we
have stored per source, we'd actually just count the first source to
have seen the entity. This caused deletions, which did delete tags for
each source, to eventually bring the number of stored entities below
zero.

Now, each new source counts as an add, which will finally get us the
correct number of stored entities.

### Describe your test plan

Can be tested together with #6881. You'll need to test that the telemetry data matches the number of entities in the store. The entities in the store can be seen by using `agent tagger-list`, and you'll need to take into account the prefix for each entity (so `container_id://foobar`'s prefix is `container_id`) and each source. The telemetry data can be obtained by using `curl http://localhost:5000/telemetry | grep stored_entities`.