### PR TITLE
[Windows] Fix windows install on child domains

### DIFF
--- a/releasenotes/notes/support_child_domain-24f6e6f71d38f573.yaml
+++ b/releasenotes/notes/support_child_domain-24f6e6f71d38f573.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    During a domain installation in a child domain, the Windows installer can now use a user from a parent domain.

--- a/tools/windows/install-help/cal/Error.cpp
+++ b/tools/windows/install-help/cal/Error.cpp
@@ -6,6 +6,8 @@ std::wstring FormatErrorMessage(DWORD error)
     buf.resize(1024);
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, error, 0, buf.data(), 1023, nullptr);
     std::wstringstream sstream;
+    buf.erase(std::remove(buf.begin(), buf.end(), '\n'), buf.end());
+    buf.erase(std::remove(buf.begin(), buf.end(), '\r'), buf.end());
     sstream << buf.data() << L" (" << std::hex << L"0x" << error << L")" << std::endl;
     return sstream.str();
 }

--- a/tools/windows/install-help/cal/Error.cpp
+++ b/tools/windows/install-help/cal/Error.cpp
@@ -1,0 +1,11 @@
+#include "stdafx.h"
+
+std::wstring FormatErrorMessage(DWORD error)
+{
+    std::wstring buf;
+    buf.resize(1024);
+    FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, error, 0, buf.data(), 1023, nullptr);
+    std::wstringstream sstream;
+    sstream << buf.data() << L" (" << std::hex << L"0x" << error << L")" << std::endl;
+    return sstream.str();
+}

--- a/tools/windows/install-help/cal/Error.h
+++ b/tools/windows/install-help/cal/Error.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+#include "lmerr_str.h"
+
+std::wstring FormatErrorMessage(DWORD error);

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -1,19 +1,18 @@
 #include "stdafx.h"
 #include "TargetMachine.h"
 
-UINT doFinalizeInstall(CustomActionData &data)
+UINT doFinalizeInstall(CustomActionData& data)
 {
     HRESULT hr = S_OK;
     UINT er = ERROR_SUCCESS;
 
-    int ddUserExists = 0;
+    bool ddUserExists;
     int ddServiceExists = 0;
     int passbuflen = 0;
-    wchar_t *passbuf = NULL;
-    const wchar_t * passToUse = NULL;
-    
+    wchar_t* passbuf = NULL;
+    const wchar_t* passToUse = NULL;
+
     std::wstring providedPassword;
-    PSID sid = NULL;
     LSA_HANDLE hLsa = NULL;
     std::wstring propval;
     ddRegKey regkeybase;
@@ -21,21 +20,60 @@ UINT doFinalizeInstall(CustomActionData &data)
     DWORD nErr = NERR_Success;
     bool bResetPassword = false;
 
-
     std::wstring waitval;
     regkeybase.deleteSubKey(strRollbackKeyName.c_str());
     regkeybase.createSubKey(strRollbackKeyName.c_str(), keyRollback, REG_OPTION_VOLATILE);
     regkeybase.createSubKey(strUninstallKeyName.c_str(), keyInstall);
 
-    // check to see if the supplied dd-agent-user exists
-    WcaLog(LOGMSG_STANDARD, "checking to see if the user is already present");
-    if ((ddUserExists = doesUserExist(data, data.GetTargetMachine().IsDomainController())) == -1) {
-        er = ERROR_INSTALL_FAILURE;
-        goto LExit;
+    // First check to see if the supplied dd-agent-user exists
+    WcaLog(LOGMSG_STANDARD, "Checking to see if the user \"%S\" is already present in \"%S\"",
+           data.UnqualifiedUsername().c_str(), data.Domain().c_str());
+    auto [sid, err] = GetSidForUser(nullptr, data.Username().c_str());
+    if (err == ERROR_NONE_MAPPED)
+    {
+        // The DNS domain name can be != from the joined domain name (if pre-Windows 2000 domain name was set differently)
+        // so we'll try by swapping the domain name for the joined domain.
+        if (data.GetTargetMachine().IsDomainJoined() &&
+            _wcsicmp(data.GetTargetMachine().JoinedDomainName().c_str(), data.Domain().c_str()) != 0)
+        {
+            std::wstring joinedDomainUser = data.GetTargetMachine().JoinedDomainName() + L"\\" + data.UnqualifiedUsername();
+            WcaLog(LOGMSG_STANDARD, "None found. Checking to see if the user \"%S\" is already present in joined domain \"%S\"",
+                   data.UnqualifiedUsername().c_str(), data.GetTargetMachine().JoinedDomainName().c_str());
+            auto [newsid, newerr] = GetSidForUser(nullptr, joinedDomainUser.c_str());
+            err = newerr;
+            if (err == S_OK)
+            {
+                // We found the user, use that one in the subsequent calls
+                sid.reset(newsid.release());
+                data.Domain(data.GetTargetMachine().JoinedDomainName());
+            }
+        }
     }
+
+    if (err == ERROR_NONE_MAPPED)
+    {
+        WcaLog(LOGMSG_STANDARD, "User not found.");
+        ddUserExists = false;
+    }
+    else if (err != ERROR_NONE_MAPPED)
+    {
+        if (sid != nullptr)
+        {
+            WcaLog(LOGMSG_STANDARD, "User found.");
+            ddUserExists = true;
+        }
+        else
+        {
+            WcaLog(LOGMSG_STANDARD, "Failed to lookup account name: %d", GetLastError());
+            er = ERROR_INSTALL_FAILURE;
+            goto LExit;
+        }
+    }
+
     // check to see if the service is already installed
     WcaLog(LOGMSG_STANDARD, "checking to see if the service is installed");
-    if ((ddServiceExists = doesServiceExist(agentService)) == -1) {
+    if ((ddServiceExists = doesServiceExist(agentService)) == -1)
+    {
         er = ERROR_INSTALL_FAILURE;
         goto LExit;
     }
@@ -44,7 +82,8 @@ UINT doFinalizeInstall(CustomActionData &data)
     // new installation or an upgrade, and what steps need to be taken
 
 
-    if (!canInstall(data.GetTargetMachine().IsDomainController(), ddUserExists, ddServiceExists, data, bResetPassword)) {
+    if (!canInstall(data.GetTargetMachine().IsDomainController(), ddUserExists, ddServiceExists, data, bResetPassword))
+    {
         er = ERROR_INSTALL_FAILURE;
         goto LExit;
     }
@@ -52,44 +91,63 @@ UINT doFinalizeInstall(CustomActionData &data)
     // ok.  If we get here, we should be in a sane state (all installation conditions met)
     WcaLog(LOGMSG_STANDARD, "custom action initialization complete.  Processing");
     // first, let's decide if we need to create the dd-agent-user
-    if (!ddUserExists || bResetPassword) {
+    if (!ddUserExists || bResetPassword)
+    {
         // that was easy.  Need to create the user.  See if we have a password, or need to
         // generate one
         passbuflen = MAX_PASS_LEN + 2;
 
-        if (data.value(propertyDDAgentUserPassword, providedPassword)) {
+        if (data.value(propertyDDAgentUserPassword, providedPassword))
+        {
             passToUse = providedPassword.c_str();
         }
-        else {
+        else
+        {
             passbuf = new wchar_t[passbuflen];
-            if (!generatePassword(passbuf, passbuflen)) {
+            if (!generatePassword(passbuf, passbuflen))
+            {
                 WcaLog(LOGMSG_STANDARD, "failed to generate password");
                 er = ERROR_INSTALL_FAILURE;
                 goto LExit;
             }
             passToUse = passbuf;
         }
-        if (bResetPassword) {
+        if (bResetPassword)
+        {
             DWORD ret = doSetUserPassword(data.UnqualifiedUsername(), passToUse);
-            if (ret != 0) {
+            if (ret != 0)
+            {
                 WcaLog(LOGMSG_STANDARD, "Failed to set DD user password");
                 er = ERROR_INSTALL_FAILURE;
                 goto LExit;
             }
         }
-        else {
+        else
+        {
             DWORD nErr = 0;
             DWORD ret = doCreateUser(data.UnqualifiedUsername(), ddAgentUserDescription, passToUse);
-            if (ret != 0) {
+            if (ret != 0)
+            {
                 WcaLog(LOGMSG_STANDARD, "Failed to create DD user");
                 er = ERROR_INSTALL_FAILURE;
                 goto LExit;
             }
+
+            auto&& [newsid, newerr] = GetSidForUser(nullptr, data.UnqualifiedUsername().c_str());
+            if (newerr != S_OK)
+            {
+                WcaLog(LOGMSG_STANDARD, "Failed to lookup account name: %d", GetLastError());
+                er = ERROR_INSTALL_FAILURE;
+                goto LExit;
+            }
+            sid = std::move(newsid);
+
             // store that we created the user, and store the username so we can
             // delete on rollback/uninstall
             keyRollback.setStringValue(installCreatedDDUser.c_str(), data.Username().c_str());
             keyInstall.setStringValue(installCreatedDDUser.c_str(), data.Username().c_str());
-            if (data.isUserDomainUser()) {
+            if (data.isUserDomainUser())
+            {
                 keyRollback.setStringValue(installCreatedDDDomain.c_str(), data.Domain().c_str());
                 keyInstall.setStringValue(installCreatedDDDomain.c_str(), data.Domain().c_str());
             }
@@ -101,51 +159,57 @@ UINT doFinalizeInstall(CustomActionData &data)
     // set the account privileges regardless; if they're already set the OS will silently
     // ignore the request.    
     hr = -1;
-    sid = GetSidForUser(NULL, data.Username().c_str());
-    if (!sid) {
-        WcaLog(LOGMSG_STANDARD, "Failed to get SID for %S (%d)", data.Username().c_str(), GetLastError());
-        goto LExit;
-    }
-    if ((hLsa = GetPolicyHandle()) == NULL) {
+    if ((hLsa = GetPolicyHandle()) == NULL)
+    {
         WcaLog(LOGMSG_STANDARD, "Failed to get policy handle for %S", data.Username().c_str());
         goto LExit;
     }
-    if (!AddPrivileges(sid, hLsa, SE_DENY_INTERACTIVE_LOGON_NAME)) {
+    if (!AddPrivileges(sid.get(), hLsa, SE_DENY_INTERACTIVE_LOGON_NAME))
+    {
         WcaLog(LOGMSG_STANDARD, "failed to add deny interactive login right");
         goto LExit;
     }
 
-    if (!AddPrivileges(sid, hLsa, SE_DENY_NETWORK_LOGON_NAME)) {
+    if (!AddPrivileges(sid.get(), hLsa, SE_DENY_NETWORK_LOGON_NAME))
+    {
         WcaLog(LOGMSG_STANDARD, "failed to add deny network login right");
         goto LExit;
     }
-    if (!AddPrivileges(sid, hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME)) {
+    if (!AddPrivileges(sid.get(), hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME))
+    {
         WcaLog(LOGMSG_STANDARD, "failed to add deny remote interactive login right");
         goto LExit;
     }
-    if (!AddPrivileges(sid, hLsa, SE_SERVICE_LOGON_NAME)) {
+    if (!AddPrivileges(sid.get(), hLsa, SE_SERVICE_LOGON_NAME))
+    {
         WcaLog(LOGMSG_STANDARD, "failed to add service login right");
         goto LExit;
     }
     hr = 0;
 
-    if (!data.GetTargetMachine().IsReadOnlyDomainController()) {
-        er = AddUserToGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
-        if (er != NERR_Success) {
+    if (!data.GetTargetMachine().IsReadOnlyDomainController())
+    {
+        er = AddUserToGroup(sid.get(), L"S-1-5-32-558", L"Performance Monitor Users");
+        if (er != NERR_Success)
+        {
             WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", er);
             goto LExit;
         }
-        er = AddUserToGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
-        if (er != NERR_Success) {
+        er = AddUserToGroup(sid.get(), L"S-1-5-32-573", L"Event Log Readers");
+        if (er != NERR_Success)
+        {
             WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", er);
             goto LExit;
         }
     }
 
-    if (!ddServiceExists) {
+    if (!ddServiceExists)
+    {
         WcaLog(LOGMSG_STANDARD, "attempting to install services");
-        if (!passToUse) {
-            if (!data.value(propertyDDAgentUserPassword, providedPassword)) {
+        if (!passToUse)
+        {
+            if (!data.value(propertyDDAgentUserPassword, providedPassword))
+            {
                 // given all the error conditions checked above, this should *never*
                 // happen.  But we'll check anyway
                 WcaLog(LOGMSG_STANDARD, "Don't have password to register service");
@@ -154,47 +218,51 @@ UINT doFinalizeInstall(CustomActionData &data)
             }
             passToUse = providedPassword.c_str();
         }
-        int ret = installServices(data, passToUse);
+        int ret = installServices(data, sid.get(), passToUse);
 
-        if (ret != 0) {
+        if (ret != 0)
+        {
             WcaLog(LOGMSG_STANDARD, "Failed to create install services");
             er = ERROR_INSTALL_FAILURE;
             goto LExit;
         }
         keyRollback.setStringValue(installInstalledServices.c_str(), L"true");
         keyInstall.setStringValue(installInstalledServices.c_str(), L"true");
-
     }
-    else {
+    else
+    {
         WcaLog(LOGMSG_STANDARD, "updating existing service record");
         int ret = verifyServices(data);
-        if (ret != 0) {
+        if (ret != 0)
+        {
             WcaLog(LOGMSG_STANDARD, "Failed to updated existing services");
             er = ERROR_INSTALL_FAILURE;
             goto LExit;
         }
     }
-    er = addDdUserPermsToFile(data, programdataroot);
+    er = addDdUserPermsToFile(sid.get(), programdataroot);
     WcaLog(LOGMSG_STANDARD, "%d setting programdata dir perms", er);
-    er = addDdUserPermsToFile(data, embedded2Dir);
+    er = addDdUserPermsToFile(sid.get(), embedded2Dir);
     WcaLog(LOGMSG_STANDARD, "%d setting embedded2Dir dir perms", er);
-    er = addDdUserPermsToFile(data, embedded3Dir);
+    er = addDdUserPermsToFile(sid.get(), embedded3Dir);
     WcaLog(LOGMSG_STANDARD, "%d setting embedded3Dir dir perms", er);
-    er = addDdUserPermsToFile(data, logfilename);
+    er = addDdUserPermsToFile(sid.get(), logfilename);
     WcaLog(LOGMSG_STANDARD, "%d setting log file perms", er);
-    er = addDdUserPermsToFile(data, authtokenfilename);
+    er = addDdUserPermsToFile(sid.get(), authtokenfilename);
     WcaLog(LOGMSG_STANDARD, "%d setting token file perms", er);
-    er = addDdUserPermsToFile(data, datadogyamlfile);
+    er = addDdUserPermsToFile(sid.get(), datadogyamlfile);
     WcaLog(LOGMSG_STANDARD, "%d setting datadog.yaml file perms", er);
-    er = addDdUserPermsToFile(data, confddir);
+    er = addDdUserPermsToFile(sid.get(), confddir);
     WcaLog(LOGMSG_STANDARD, "%d setting confd dir perms", er);
-    er = addDdUserPermsToFile(data, logdir);
+    er = addDdUserPermsToFile(sid.get(), logdir);
     WcaLog(LOGMSG_STANDARD, "%d setting log dir perms", er);
 
-    if (0 == changeRegistryAcls(data, datadog_acl_key_datadog.c_str())) {
+    if (0 == changeRegistryAcls(sid.get(), datadog_acl_key_datadog.c_str()))
+    {
         WcaLog(LOGMSG_STANDARD, "registry perms updated");
     }
-    else {
+    else
+    {
         WcaLog(LOGMSG_STANDARD, "registry perm update failed");
         er = ERROR_INSTALL_FAILURE;
     }
@@ -216,14 +284,13 @@ UINT doFinalizeInstall(CustomActionData &data)
         }
     }
 LExit:
-    if (sid) {
-        delete[](BYTE *) sid;
-    }
-    if (passbuf) {
+    if (passbuf)
+    {
         memset(passbuf, 0, sizeof(wchar_t) * passbuflen);
         delete[] passbuf;
     }
-    if (er == ERROR_SUCCESS) {
+    if (er == ERROR_SUCCESS)
+    {
         er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
     }
     return er;

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -69,7 +69,7 @@ UINT doFinalizeInstall(CustomActionData& data)
         }
         if (bResetPassword)
         {
-            DWORD ret = doSetUserPassword(data.Username(), passToUse);
+            DWORD ret = doSetUserPassword(data.UnqualifiedUsername(), passToUse);
             if (ret != 0)
             {
                 WcaLog(LOGMSG_STANDARD, "Failed to set DD user password");
@@ -79,8 +79,7 @@ UINT doFinalizeInstall(CustomActionData& data)
         }
         else
         {
-            DWORD nErr = 0;
-            DWORD ret = doCreateUser(data.Username(), ddAgentUserDescription, passToUse);
+            DWORD ret = doCreateUser(data.UnqualifiedUsername(), ddAgentUserDescription, passToUse);
             if (ret != 0)
             {
                 WcaLog(LOGMSG_STANDARD, "Failed to create DD user");

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -1,16 +1,16 @@
 #include "stdafx.h"
 #include "TargetMachine.h"
 
-UINT doFinalizeInstall(CustomActionData& data)
+UINT doFinalizeInstall(CustomActionData &data)
 {
     HRESULT hr = S_OK;
     UINT er = ERROR_SUCCESS;
 
-    bool ddUserExists;
+    bool ddUserExists = false;
     int ddServiceExists = 0;
     int passbuflen = 0;
-    wchar_t* passbuf = NULL;
-    const wchar_t* passToUse = NULL;
+    wchar_t *passbuf = NULL;
+    const wchar_t * passToUse = NULL;
 
     std::wstring providedPassword;
     LSA_HANDLE hLsa = NULL;

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -27,8 +27,7 @@ UINT doFinalizeInstall(CustomActionData& data)
 
     // check to see if the service is already installed
     WcaLog(LOGMSG_STANDARD, "checking to see if the service is installed");
-    if ((ddServiceExists = doesServiceExist(agentService)) == -1)
-    {
+    if ((ddServiceExists = doesServiceExist(agentService)) == -1) {
         er = ERROR_INSTALL_FAILURE;
         goto LExit;
     }
@@ -37,8 +36,7 @@ UINT doFinalizeInstall(CustomActionData& data)
     // new installation or an upgrade, and what steps need to be taken
     ddUserExists = data.DoesUserExists();
 
-    if (!canInstall(data.GetTargetMachine().IsDomainController(), ddUserExists, ddServiceExists, data, bResetPassword))
-    {
+    if (!canInstall(data.GetTargetMachine().IsDomainController(), ddUserExists, ddServiceExists, data, bResetPassword)) {
         er = ERROR_INSTALL_FAILURE;
         goto LExit;
     }
@@ -46,42 +44,34 @@ UINT doFinalizeInstall(CustomActionData& data)
     // ok.  If we get here, we should be in a sane state (all installation conditions met)
     WcaLog(LOGMSG_STANDARD, "custom action initialization complete.  Processing");
     // first, let's decide if we need to create the dd-agent-user
-    if (!ddUserExists || bResetPassword)
-    {
+    if (!ddUserExists || bResetPassword) {
         // that was easy.  Need to create the user.  See if we have a password, or need to
         // generate one
         passbuflen = MAX_PASS_LEN + 2;
 
-        if (data.value(propertyDDAgentUserPassword, providedPassword))
-        {
+        if (data.value(propertyDDAgentUserPassword, providedPassword)) {
             passToUse = providedPassword.c_str();
         }
-        else
-        {
+        else {
             passbuf = new wchar_t[passbuflen];
-            if (!generatePassword(passbuf, passbuflen))
-            {
+            if (!generatePassword(passbuf, passbuflen)) {
                 WcaLog(LOGMSG_STANDARD, "failed to generate password");
                 er = ERROR_INSTALL_FAILURE;
                 goto LExit;
             }
             passToUse = passbuf;
         }
-        if (bResetPassword)
-        {
+        if (bResetPassword) {
             DWORD ret = doSetUserPassword(data.UnqualifiedUsername(), passToUse);
-            if (ret != 0)
-            {
+            if (ret != 0) {
                 WcaLog(LOGMSG_STANDARD, "Failed to set DD user password");
                 er = ERROR_INSTALL_FAILURE;
                 goto LExit;
             }
         }
-        else
-        {
+        else {
             DWORD ret = doCreateUser(data.UnqualifiedUsername(), ddAgentUserDescription, passToUse);
-            if (ret != 0)
-            {
+            if (ret != 0) {
                 WcaLog(LOGMSG_STANDARD, "Failed to create DD user");
                 er = ERROR_INSTALL_FAILURE;
                 goto LExit;
@@ -100,8 +90,7 @@ UINT doFinalizeInstall(CustomActionData& data)
             // delete on rollback/uninstall
             keyRollback.setStringValue(installCreatedDDUser.c_str(), data.Username().c_str());
             keyInstall.setStringValue(installCreatedDDUser.c_str(), data.Username().c_str());
-            if (data.isUserDomainUser())
-            {
+            if (data.isUserDomainUser()) {
                 keyRollback.setStringValue(installCreatedDDDomain.c_str(), data.Domain().c_str());
                 keyInstall.setStringValue(installCreatedDDDomain.c_str(), data.Domain().c_str());
             }
@@ -114,57 +103,49 @@ UINT doFinalizeInstall(CustomActionData& data)
     // set the account privileges regardless; if they're already set the OS will silently
     // ignore the request.    
     hr = -1;
-    if ((hLsa = GetPolicyHandle()) == NULL)
-    {
+    if ((hLsa = GetPolicyHandle()) == NULL) {
         WcaLog(LOGMSG_STANDARD, "Failed to get policy handle for %S", data.Username().c_str());
         goto LExit;
     }
-    if (!AddPrivileges(sid, hLsa, SE_DENY_INTERACTIVE_LOGON_NAME))
-    {
+
+    if (!AddPrivileges(sid, hLsa, SE_DENY_INTERACTIVE_LOGON_NAME)) {
         WcaLog(LOGMSG_STANDARD, "failed to add deny interactive login right");
         goto LExit;
     }
 
-    if (!AddPrivileges(sid, hLsa, SE_DENY_NETWORK_LOGON_NAME))
-    {
+    if (!AddPrivileges(sid, hLsa, SE_DENY_NETWORK_LOGON_NAME)) {
         WcaLog(LOGMSG_STANDARD, "failed to add deny network login right");
         goto LExit;
     }
-    if (!AddPrivileges(sid, hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME))
-    {
+
+    if (!AddPrivileges(sid, hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME)) {
         WcaLog(LOGMSG_STANDARD, "failed to add deny remote interactive login right");
         goto LExit;
     }
-    if (!AddPrivileges(sid, hLsa, SE_SERVICE_LOGON_NAME))
-    {
+
+    if (!AddPrivileges(sid, hLsa, SE_SERVICE_LOGON_NAME)) {
         WcaLog(LOGMSG_STANDARD, "failed to add service login right");
         goto LExit;
     }
     hr = 0;
 
-    if (!data.GetTargetMachine().IsReadOnlyDomainController())
-    {
+    if (!data.GetTargetMachine().IsReadOnlyDomainController()) {
         er = AddUserToGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
-        if (er != NERR_Success)
-        {
+        if (er != NERR_Success) {
             WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", er);
             goto LExit;
         }
         er = AddUserToGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
-        if (er != NERR_Success)
-        {
+        if (er != NERR_Success) {
             WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", er);
             goto LExit;
         }
     }
 
-    if (!ddServiceExists)
-    {
+    if (!ddServiceExists) {
         WcaLog(LOGMSG_STANDARD, "attempting to install services");
-        if (!passToUse)
-        {
-            if (!data.value(propertyDDAgentUserPassword, providedPassword))
-            {
+        if (!passToUse) {
+            if (!data.value(propertyDDAgentUserPassword, providedPassword)) {
                 // given all the error conditions checked above, this should *never*
                 // happen.  But we'll check anyway
                 WcaLog(LOGMSG_STANDARD, "Don't have password to register service");
@@ -175,8 +156,7 @@ UINT doFinalizeInstall(CustomActionData& data)
         }
         int ret = installServices(data, sid, passToUse);
 
-        if (ret != 0)
-        {
+        if (ret != 0) {
             WcaLog(LOGMSG_STANDARD, "Failed to create install services");
             er = ERROR_INSTALL_FAILURE;
             goto LExit;
@@ -184,12 +164,10 @@ UINT doFinalizeInstall(CustomActionData& data)
         keyRollback.setStringValue(installInstalledServices.c_str(), L"true");
         keyInstall.setStringValue(installInstalledServices.c_str(), L"true");
     }
-    else
-    {
+    else {
         WcaLog(LOGMSG_STANDARD, "updating existing service record");
         int ret = verifyServices(data);
-        if (ret != 0)
-        {
+        if (ret != 0) {
             WcaLog(LOGMSG_STANDARD, "Failed to updated existing services");
             er = ERROR_INSTALL_FAILURE;
             goto LExit;
@@ -212,12 +190,10 @@ UINT doFinalizeInstall(CustomActionData& data)
     er = addDdUserPermsToFile(sid, logdir);
     WcaLog(LOGMSG_STANDARD, "%d setting log dir perms", er);
 
-    if (0 == changeRegistryAcls(sid, datadog_acl_key_datadog.c_str()))
-    {
+    if (0 == changeRegistryAcls(sid, datadog_acl_key_datadog.c_str())) {
         WcaLog(LOGMSG_STANDARD, "registry perms updated");
     }
-    else
-    {
+    else {
         WcaLog(LOGMSG_STANDARD, "registry perm update failed");
         er = ERROR_INSTALL_FAILURE;
     }
@@ -227,25 +203,21 @@ UINT doFinalizeInstall(CustomActionData& data)
         std::wstring embedded = installdir + L"\\embedded";
         std::wstring bindir = installdir + L"\\bin";
         BOOL bRet = CreateSymbolicLink(embedded.c_str(), bindir.c_str(), SYMBOLIC_LINK_FLAG_DIRECTORY);
-        if (!bRet)
-        {
+        if (!bRet) {
             DWORD lastErr = GetLastError();
             std::string lastErrStr = GetErrorMessageStr(lastErr);
             WcaLog(LOGMSG_STANDARD, "CreateSymbolicLink: %s (%d)", lastErrStr.c_str(), lastErr);
         }
-        else
-        {
+        else {
             WcaLog(LOGMSG_STANDARD, "CreateSymbolicLink");
         }
     }
 LExit:
-    if (passbuf)
-    {
+    if (passbuf) {
         memset(passbuf, 0, sizeof(wchar_t) * passbuflen);
         delete[] passbuf;
     }
-    if (er == ERROR_SUCCESS)
-    {
+    if (er == ERROR_SUCCESS) {
         er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
     }
     return er;

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -97,8 +97,6 @@ UINT doFinalizeInstall(CustomActionData &data)
         }
     }
 
-    auto sid = data.Sid();
-
     // add all the rights we want to the user (either existing or newly created)
     // set the account privileges regardless; if they're already set the OS will silently
     // ignore the request.    
@@ -108,34 +106,34 @@ UINT doFinalizeInstall(CustomActionData &data)
         goto LExit;
     }
 
-    if (!AddPrivileges(sid, hLsa, SE_DENY_INTERACTIVE_LOGON_NAME)) {
+    if (!AddPrivileges(data.Sid(), hLsa, SE_DENY_INTERACTIVE_LOGON_NAME)) {
         WcaLog(LOGMSG_STANDARD, "failed to add deny interactive login right");
         goto LExit;
     }
 
-    if (!AddPrivileges(sid, hLsa, SE_DENY_NETWORK_LOGON_NAME)) {
+    if (!AddPrivileges(data.Sid(), hLsa, SE_DENY_NETWORK_LOGON_NAME)) {
         WcaLog(LOGMSG_STANDARD, "failed to add deny network login right");
         goto LExit;
     }
 
-    if (!AddPrivileges(sid, hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME)) {
+    if (!AddPrivileges(data.Sid(), hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME)) {
         WcaLog(LOGMSG_STANDARD, "failed to add deny remote interactive login right");
         goto LExit;
     }
 
-    if (!AddPrivileges(sid, hLsa, SE_SERVICE_LOGON_NAME)) {
+    if (!AddPrivileges(data.Sid(), hLsa, SE_SERVICE_LOGON_NAME)) {
         WcaLog(LOGMSG_STANDARD, "failed to add service login right");
         goto LExit;
     }
     hr = 0;
 
     if (!data.GetTargetMachine().IsReadOnlyDomainController()) {
-        er = AddUserToGroup(sid, L"S-1-5-32-558", L"Performance Monitor Users");
+        er = AddUserToGroup(data.Sid(), L"S-1-5-32-558", L"Performance Monitor Users");
         if (er != NERR_Success) {
             WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", er);
             goto LExit;
         }
-        er = AddUserToGroup(sid, L"S-1-5-32-573", L"Event Log Readers");
+        er = AddUserToGroup(data.Sid(), L"S-1-5-32-573", L"Event Log Readers");
         if (er != NERR_Success) {
             WcaLog(LOGMSG_STANDARD, "Unexpected error adding user to group %d", er);
             goto LExit;
@@ -154,7 +152,7 @@ UINT doFinalizeInstall(CustomActionData &data)
             }
             passToUse = providedPassword.c_str();
         }
-        int ret = installServices(data, sid, passToUse);
+        int ret = installServices(data, data.Sid(), passToUse);
 
         if (ret != 0) {
             WcaLog(LOGMSG_STANDARD, "Failed to create install services");
@@ -173,24 +171,24 @@ UINT doFinalizeInstall(CustomActionData &data)
             goto LExit;
         }
     }
-    er = addDdUserPermsToFile(sid, programdataroot);
+    er = addDdUserPermsToFile(data.Sid(), programdataroot);
     WcaLog(LOGMSG_STANDARD, "%d setting programdata dir perms", er);
-    er = addDdUserPermsToFile(sid, embedded2Dir);
+    er = addDdUserPermsToFile(data.Sid(), embedded2Dir);
     WcaLog(LOGMSG_STANDARD, "%d setting embedded2Dir dir perms", er);
-    er = addDdUserPermsToFile(sid, embedded3Dir);
+    er = addDdUserPermsToFile(data.Sid(), embedded3Dir);
     WcaLog(LOGMSG_STANDARD, "%d setting embedded3Dir dir perms", er);
-    er = addDdUserPermsToFile(sid, logfilename);
+    er = addDdUserPermsToFile(data.Sid(), logfilename);
     WcaLog(LOGMSG_STANDARD, "%d setting log file perms", er);
-    er = addDdUserPermsToFile(sid, authtokenfilename);
+    er = addDdUserPermsToFile(data.Sid(), authtokenfilename);
     WcaLog(LOGMSG_STANDARD, "%d setting token file perms", er);
-    er = addDdUserPermsToFile(sid, datadogyamlfile);
+    er = addDdUserPermsToFile(data.Sid(), datadogyamlfile);
     WcaLog(LOGMSG_STANDARD, "%d setting datadog.yaml file perms", er);
-    er = addDdUserPermsToFile(sid, confddir);
+    er = addDdUserPermsToFile(data.Sid(), confddir);
     WcaLog(LOGMSG_STANDARD, "%d setting confd dir perms", er);
-    er = addDdUserPermsToFile(sid, logdir);
+    er = addDdUserPermsToFile(data.Sid(), logdir);
     WcaLog(LOGMSG_STANDARD, "%d setting log dir perms", er);
 
-    if (0 == changeRegistryAcls(sid, datadog_acl_key_datadog.c_str())) {
+    if (0 == changeRegistryAcls(data.Sid(), datadog_acl_key_datadog.c_str())) {
         WcaLog(LOGMSG_STANDARD, "registry perms updated");
     }
     else {

--- a/tools/windows/install-help/cal/SID.h
+++ b/tools/windows/install-help/cal/SID.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <memory>
+#include <heapapi.h>
+
+template <class P>
+struct heap_deleter
+{
+    typedef P* pointer;
+
+    void operator()(pointer ptr) const
+    {
+        HeapFree(GetProcessHeap(), 0, ptr);
+    }
+};
+typedef std::unique_ptr<SID, heap_deleter<SID>> sid_ptr;
+
+inline sid_ptr make_sid(size_t sidLength)
+{
+    return sid_ptr(static_cast<sid_ptr::pointer>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sidLength)));
+}

--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -155,7 +155,6 @@ DWORD TargetMachine::DetectDomainInformation()
     DWORD nErr = NetGetJoinInformation(nullptr, &name, &st);
     if (nErr == NERR_Success)
     {
-        _wcslwr_s(name, wcslen(name) + 1);
         _joinedDomain = name;
         (void)NetApiBufferFree(name);
     }

--- a/tools/windows/install-help/cal/TargetMachine.h
+++ b/tools/windows/install-help/cal/TargetMachine.h
@@ -6,8 +6,9 @@ private:
     DWORD _serverType;
     DWORD _dcFlags;
     std::wstring _machineName;
-    std::wstring _domain;
+    std::wstring _joinedDomain;
     bool _isDomainJoined;
+    std::wstring _dnsDomainName;
 
     DWORD DetectMachineType();
     bool DetectComputerName(COMPUTER_NAME_FORMAT fmt, std::wstring& result);
@@ -19,11 +20,65 @@ public:
 
     DWORD Detect();
 
+    /// <summary>
+    /// Get the name of the computer.
+    /// </summary>
+    /// <returns>The name of the computer.</returns>
     std::wstring GetMachineName() const;
-    std::wstring GetDomain() const;
+
+    /// <summary>
+    /// Returns the name of the domain this computer is joined to.
+    /// It should also match the pre-Windows 2000 name of the domain, which
+    /// can be different from the DNS name of the domain returned by <see cref="DnsDomainName"/>
+    ///
+    /// For example the DNS domain "datadohq.com" can have a pre-Windows 2000
+    /// name of "DDOG" and this method would return "DDOG".
+    /// </summary>
+    /// <returns>A wide string with the name of the domain this computer is joined to.</returns>
+    std::wstring JoinedDomainName() const;
+
+    /// <summary>
+    /// Returns the DNS name of the domain this computer is joined to.
+    /// It can be different from the pre-Windows 2000 domain name returned by <see cref="JoinedDomainName"/>.
+    ///
+    /// For example the DNS domain "datadohq.com" can have a pre-Windows 2000
+    /// name of "DDOG" and this method would return "datadoghq.com".
+    /// </summary>
+    /// <remarks>
+    /// When creating a user with the domain name returned by this method, the subsequent call to
+    /// <see cref="LookupAccountName"/> can fail with code 1332 (NONE_MAPPED).
+    /// </remarks>
+    /// <returns>A wide string with the DNS name of the domain this computer is joined to.</returns>
+    std::wstring DnsDomainName() const;
+
+    /// <summary>
+    /// Check if the computer is part of a domain or is a standalone machine.
+    /// </summary>
+    /// <returns>True if the computer is joined to a domain, false otherwise.</returns>
     bool IsDomainJoined() const;
+
+    /// <summary>
+    /// Check if the computer is a workstation or a server.
+    /// </summary>
+    /// <returns>True if the computer is a server, false otherwise.</returns>
     bool IsServer() const;
+
+    /// <summary>
+    /// Check if the computer is a domain controller.
+    /// </summary>
+    /// <returns>True if the computer is a domain controller, false otherwise.</returns>
     bool IsDomainController() const;
+
+    /// <summary>
+    /// Check if the computer is a backup domain controller.
+    /// </summary>
+    /// <returns>True if the computer is a domain controller, false otherwise.</returns>
     bool IsBackupDomainController() const;
+
+    /// <summary>
+    /// Chef if the computer is a read-only domain controller.
+    /// </summary>
+    /// <remarks>It is not possible to create users on a read-only domain controller.</remarks>
+    /// <returns>True if the computer is a read-only domain controller.</returns>
     bool IsReadOnlyDomainController() const;
 };

--- a/tools/windows/install-help/cal/caninstall.cpp
+++ b/tools/windows/install-help/cal/caninstall.cpp
@@ -72,14 +72,18 @@ bool canInstall(BOOL isDC, int ddUserExists, int ddServiceExists, const CustomAc
                 bRet = false;
             }
         }
-        if(!ddUserExists &&
-            (_wcsicmp(data.Domain().c_str(), data.GetTargetMachine().GetDomain().c_str())))
+        if (!ddUserExists
+            && _wcsicmp(data.Domain().c_str(), data.GetTargetMachine().JoinedDomainName().c_str()) != 0
+            && _wcsicmp(data.Domain().c_str(), data.GetTargetMachine().DnsDomainName().c_str()) != 0
+        )
         {
             // on a domain controller, we can only create a user in this controller's domain.
             // check and reject an attempt to create a user not in this domain
-            WcaLog(LOGMSG_STANDARD, "(Configuration Error)  Can't create a user that's not in this domain: %S (asked for %S)",
-                data.GetTargetMachine().GetDomain().c_str(), data.Domain().c_str());
-                bRet = false;
+            WcaLog(LOGMSG_STANDARD, "(Configuration Error) Can't create a user that's not in this domain: %S (%S) (asked for %S)",
+                data.GetTargetMachine().DnsDomainName().c_str(),
+                data.GetTargetMachine().JoinedDomainName().c_str(),
+                data.Domain().c_str());
+            bRet = false;
         }
     }
     else {

--- a/tools/windows/install-help/cal/caninstall.cpp
+++ b/tools/windows/install-help/cal/caninstall.cpp
@@ -72,19 +72,6 @@ bool canInstall(BOOL isDC, int ddUserExists, int ddServiceExists, const CustomAc
                 bRet = false;
             }
         }
-        if (!ddUserExists
-            && _wcsicmp(data.Domain().c_str(), data.GetTargetMachine().JoinedDomainName().c_str()) != 0
-            && _wcsicmp(data.Domain().c_str(), data.GetTargetMachine().DnsDomainName().c_str()) != 0
-        )
-        {
-            // on a domain controller, we can only create a user in this controller's domain.
-            // check and reject an attempt to create a user not in this domain
-            WcaLog(LOGMSG_STANDARD, "(Configuration Error) Can't create a user that's not in this domain: %S (%S) (asked for %S)",
-                data.GetTargetMachine().DnsDomainName().c_str(),
-                data.GetTargetMachine().JoinedDomainName().c_str(),
-                data.Domain().c_str());
-            bRet = false;
-        }
     }
     else {
         if(!ddUserExists && data.isUserDomainUser()) {

--- a/tools/windows/install-help/cal/caninstall.cpp
+++ b/tools/windows/install-help/cal/caninstall.cpp
@@ -72,6 +72,16 @@ bool canInstall(BOOL isDC, int ddUserExists, int ddServiceExists, const CustomAc
                 bRet = false;
             }
         }
+
+        if (!ddUserExists && data.GetTargetMachine().IsDomainController() &&
+            _wcsicmp(data.Domain().c_str(), data.GetTargetMachine().JoinedDomainName().c_str()) != 0)
+        {
+            // on a domain controller, we can only create a user in this controller's domain.
+            // check and reject an attempt to create a user not in this domain
+            
+            WcaLog(LOGMSG_STANDARD, "(Configuration Error) Can't create a user that's not in this Domain Controller's domain.");
+            bRet = false;
+        }
     }
     else {
         if(!ddUserExists && data.isUserDomainUser()) {

--- a/tools/windows/install-help/cal/customaction.h
+++ b/tools/windows/install-help/cal/customaction.h
@@ -1,13 +1,30 @@
 #pragma once
 #define MIN_PASS_LEN 12
 #define MAX_PASS_LEN 18
+
+template <class P>
+struct heap_deleter
+{
+    typedef P* pointer;
+
+    void operator()(pointer ptr) const
+    {
+        HeapFree(GetProcessHeap(), 0, ptr);
+    }
+};
+typedef std::unique_ptr<SID, heap_deleter<SID>> sid_ptr;
+
+inline sid_ptr make_sid(size_t sidLength)
+{
+    return sid_ptr(static_cast<sid_ptr::pointer>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sidLength)));
+}
+
 // usercreate.cpp
 bool generatePassword(wchar_t* passbuf, int passbuflen);
 int doCreateUser(const std::wstring& name, const std::wstring& comment, const wchar_t* passbuf);
 int doSetUserPassword(const std::wstring& name, const wchar_t* passbuf);
-DWORD changeRegistryAcls(CustomActionData& data, const wchar_t* name);
-DWORD addDdUserPermsToFile(CustomActionData& data, std::wstring &filename);
-int doesUserExist(const CustomActionData& data, bool isDC = false);
+DWORD changeRegistryAcls(PSID sid, const wchar_t* name);
+DWORD addDdUserPermsToFile(PSID sid, std::wstring &filename);
 
 void removeUserPermsFromFile(std::wstring &filename, PSID sidremove);
 
@@ -16,14 +33,22 @@ DWORD DeleteUser(const wchar_t* host, const wchar_t* name);
 
 bool AddPrivileges(PSID AccountSID, LSA_HANDLE PolicyHandle, LPCWSTR rightToAdd);
 bool RemovePrivileges(PSID AccountSID, LSA_HANDLE PolicyHandle, LPCWSTR rightToAdd);
-int EnableServiceForUser(CustomActionData& data, const std::wstring& service);
+int EnableServiceForUser(PSID sid, const std::wstring& service);
 DWORD AddUserToGroup(PSID userSid, wchar_t* groupSidString, wchar_t* defaultGroupName);
 DWORD DelUserFromGroup(PSID userSid, wchar_t* groupSidString, wchar_t* defaultGroupName);
 bool InitLsaString(
 	PLSA_UNICODE_STRING pLsaString,
 	LPCWSTR pwszString);
 
-PSID GetSidForUser(LPCWSTR host, LPCWSTR user);
+/// <summary>
+/// Retrives the Security Identifier Descriptor of the specified user.
+/// </summary>
+/// <param name="host">The host to search on.</param>
+/// <param name="user">The username to look for.</param>
+/// <returns>A tuple containing a pointer to the SID of the user and and error code.
+/// If no user is found, the pointer to the SID will be NULL and the DWORD will contain  the result of <see cref="GetLastError">.</returns>
+std::tuple<sid_ptr, DWORD>  GetSidForUser(LPCWSTR host, LPCWSTR user);
+
 bool GetNameForSid(LPCWSTR host, PSID sid, std::wstring& namestr);
 
 LSA_HANDLE GetPolicyHandle();
@@ -34,7 +59,7 @@ LSA_HANDLE GetPolicyHandle();
 VOID  DoStopSvc(std::wstring &svcName);
 DWORD DoStartSvc(std::wstring &svcName);
 int doesServiceExist(std::wstring& svcName);
-int installServices(CustomActionData& data, const wchar_t *password);
+int installServices(CustomActionData& data, PSID sid, const wchar_t *password);
 int uninstallServices(CustomActionData& data);
 int verifyServices(CustomActionData& data);
 

--- a/tools/windows/install-help/cal/customaction.vcxproj
+++ b/tools/windows/install-help/cal/customaction.vcxproj
@@ -158,6 +158,7 @@
     <ClCompile Include="ddreg.cpp" />
     <ClCompile Include="delfiles.cpp" />
     <ClCompile Include="doUninstall.cpp" />
+    <ClCompile Include="Error.cpp" />
     <ClCompile Include="FinalizeInstall.cpp" />
     <ClCompile Include="rollback.cpp" />
     <ClCompile Include="TargetMachine.cpp" />
@@ -180,6 +181,7 @@
   <ItemGroup>
     <ClInclude Include="customactiondata.h" />
     <ClInclude Include="ddreg.h" />
+    <ClInclude Include="Error.h" />
     <ClInclude Include="lmerr_str.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="SID.h" />

--- a/tools/windows/install-help/cal/customaction.vcxproj
+++ b/tools/windows/install-help/cal/customaction.vcxproj
@@ -182,6 +182,7 @@
     <ClInclude Include="ddreg.h" />
     <ClInclude Include="lmerr_str.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="SID.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="strings.h" />
     <ClInclude Include="TargetMachine.h" />

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -193,12 +193,12 @@ bool CustomActionData::parseUsernameData()
         }
         else if (0 == _wcsicmp(computed_domain.c_str(), machine.DnsDomainName().c_str()))
         {
-            WcaLog(LOGMSG_STANDARD, "Supplied domain name %S %S", computed_domain.c_str(), machine.DnsDomainName().c_str());
+            WcaLog(LOGMSG_STANDARD, "Supplied domain name %\"S\"", computed_domain.c_str());
             domainUser = true;
         }
         else
         {
-            WcaLog(LOGMSG_STANDARD, "Warning: Supplied user in different domain (%S != %S)", computed_domain.c_str(), machine.DnsDomainName().c_str());
+            WcaLog(LOGMSG_STANDARD, "Warning: Supplied user in different domain (\"%S\" != \"%S\")", computed_domain.c_str(), machine.DnsDomainName().c_str());
             domainUser = true;
         }
     }

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -27,7 +27,7 @@ bool CustomActionData::init(const std::wstring& data)
     DWORD errCode = machine.Detect();
     if (errCode != ERROR_SUCCESS)
     {
-        WcaLog(LOGMSG_STANDARD, "Could not determine machine information: %d", errCode);
+        WcaLog(LOGMSG_STANDARD, "Could not determine machine information: %S", FormatErrorMessage(errCode).c_str());
         return false;
     }
 
@@ -167,12 +167,6 @@ bool CustomActionData::parseUsernameData()
         }
     }
     auto sidResult = GetSidForUser(nullptr, tmpName.c_str());
-    if (sidResult.Result != ERROR_SUCCESS)
-    {
-        WcaLog(LOGMSG_STANDARD, "Could not get SID for user %S: %d", tmpName.c_str(), sidResult.Result);
-        return false;
-    }
-
     if (sidResult.Result == ERROR_NONE_MAPPED)
     {
         WcaLog(LOGMSG_STANDARD, "User not found.");
@@ -188,12 +182,12 @@ bool CustomActionData::parseUsernameData()
         }
         else
         {
-            WcaLog(LOGMSG_STANDARD, "Failed to lookup account name: %d", GetLastError());
+            WcaLog(LOGMSG_STANDARD, "Could not get SID for user %S: %S", tmpName.c_str(), FormatErrorMessage(sidResult.Result).c_str());
             return false;
         }
     }
 
-    // The domnain can be the local computer
+    // The domain can be the local computer
     _domain = sidResult.Domain;
 
     // We're on a domain AND the user specified on the command line is not the local machine name

--- a/tools/windows/install-help/cal/customactiondata.h
+++ b/tools/windows/install-help/cal/customactiondata.h
@@ -15,38 +15,28 @@ class CustomActionData
         bool present(const std::wstring& key) const;
         bool value(const std::wstring& key, std::wstring &val) const;
 
-        bool isUserDomainUser() const {
-            return domainUser;
-        }
-        bool isUserLocalUser() const {
-            return !domainUser;
-        }
+        bool isUserDomainUser() const;
 
-        const std::wstring& Username() const {
-            return this->username;
-        }
-        const std::wstring& UnqualifiedUsername() const {
-            return this->uqusername;
-        }
-        const std::wstring& Domain() const {
-            return this->domain;
-        }
+        bool isUserLocalUser() const;
 
-        bool installSysprobe() const {
-            return doInstallSysprobe;
-        }
+        const std::wstring& UnqualifiedUsername() const;
 
-        const TargetMachine& GetTargetMachine() const {
-            return machine;
-        }
+        const std::wstring& Username() const;
+
+        const std::wstring& Domain() const;
+        void Domain(const std::wstring& domain);
+
+        bool installSysprobe() const;
+
+        const TargetMachine& GetTargetMachine() const;
     private:
         MSIHANDLE hInstall;
         TargetMachine machine;
         bool domainUser;
         std::map< std::wstring, std::wstring> values;
-        std::wstring username; // qualified
-        std::wstring uqusername;// unqualified
-        std::wstring domain;
+        std::wstring _unqualifiedUsername;
+        std::wstring _domain;
+        std::wstring _fqUsernameFromCli;
         bool doInstallSysprobe;
 
         bool parseUsernameData();

--- a/tools/windows/install-help/cal/customactiondata.h
+++ b/tools/windows/install-help/cal/customactiondata.h
@@ -2,6 +2,7 @@
 #include <map>
 #include <string>
 #include "TargetMachine.h"
+#include "SID.h"
 
 class CustomActionData
 {
@@ -19,16 +20,21 @@ class CustomActionData
 
         bool isUserLocalUser() const;
 
+        bool DoesUserExists() const;
+
         const std::wstring& UnqualifiedUsername() const;
 
         const std::wstring& Username() const;
 
         const std::wstring& Domain() const;
-        void Domain(const std::wstring& domain);
+
+        PSID  Sid() const;
+        void Sid(sid_ptr& sid);
 
         bool installSysprobe() const;
 
         const TargetMachine& GetTargetMachine() const;
+        
     private:
         MSIHANDLE hInstall;
         TargetMachine machine;
@@ -36,8 +42,10 @@ class CustomActionData
         std::map< std::wstring, std::wstring> values;
         std::wstring _unqualifiedUsername;
         std::wstring _domain;
-        std::wstring _fqUsernameFromCli;
+        std::wstring _fqUsername;
+        sid_ptr _sid;
         bool doInstallSysprobe;
+        bool _ddUserExists;
 
         bool parseUsernameData();
         bool parseSysprobeData();

--- a/tools/windows/install-help/cal/doUninstall.cpp
+++ b/tools/windows/install-help/cal/doUninstall.cpp
@@ -63,12 +63,10 @@ UINT doUninstallAs(UNINSTALL_TYPE t)
 
     if (willDeleteUser)
     {
-        auto sidResult = GetSidForUser(NULL, installedComplete.c_str());
+        auto [sid, err] = GetSidForUser(nullptr, installedComplete.c_str());
 
         // Do not try to do anything if we don't find the user.
-        if (std::get<1>(sidResult) == S_OK) {
-            const auto & sid = std::get<0>(sidResult);
-
+        if (err == S_OK) {
             // remove dd user from programdata root
             removeUserPermsFromFile(programdataroot, sid.get());
 

--- a/tools/windows/install-help/cal/doUninstall.cpp
+++ b/tools/windows/install-help/cal/doUninstall.cpp
@@ -63,25 +63,25 @@ UINT doUninstallAs(UNINSTALL_TYPE t)
 
     if (willDeleteUser)
     {
-        auto [sid, err] = GetSidForUser(nullptr, installedComplete.c_str());
+        auto sidResult = GetSidForUser(nullptr, installedComplete.c_str());
 
         // Do not try to do anything if we don't find the user.
-        if (err == S_OK) {
+        if (sidResult.Result == ERROR_SUCCESS) {
             // remove dd user from programdata root
-            removeUserPermsFromFile(programdataroot, sid.get());
+            removeUserPermsFromFile(programdataroot, sidResult.Sid.get());
 
             // remove dd user from log directory
-            removeUserPermsFromFile(logdir, sid.get());
+            removeUserPermsFromFile(logdir, sidResult.Sid.get());
 
             // remove dd user from conf directory
-            removeUserPermsFromFile(confddir, sid.get());
+            removeUserPermsFromFile(confddir, sidResult.Sid.get());
 
             // remove dd user from datadog.yaml
-            removeUserPermsFromFile(datadogyamlfile, sid.get());
+            removeUserPermsFromFile(datadogyamlfile, sidResult.Sid.get());
 
             // remove dd user from Performance monitor users
-            DelUserFromGroup(sid.get(), L"S-1-5-32-558", L"Performance Monitor Users");
-            DelUserFromGroup(sid.get(), L"S-1-5-32-573", L"Event Log Readers");
+            DelUserFromGroup(sidResult.Sid.get(), L"S-1-5-32-558", L"Performance Monitor Users");
+            DelUserFromGroup(sidResult.Sid.get(), L"S-1-5-32-573", L"Event Log Readers");
 
             // remove dd user right for
             //   SE_SERVICE_LOGON NAME
@@ -89,17 +89,17 @@ UINT doUninstallAs(UNINSTALL_TYPE t)
             //   SE_DENY_NETWORK_LOGIN_NAME
             //   SE_DENY_INTERACTIVE_LOGIN_NAME
             if ((hLsa = GetPolicyHandle()) != NULL) {
-                if (!RemovePrivileges(sid.get(), hLsa, SE_DENY_INTERACTIVE_LOGON_NAME)) {
+                if (!RemovePrivileges(sidResult.Sid.get(), hLsa, SE_DENY_INTERACTIVE_LOGON_NAME)) {
                     WcaLog(LOGMSG_STANDARD, "failed to remove deny interactive login right");
                 }
 
-                if (!RemovePrivileges(sid.get(), hLsa, SE_DENY_NETWORK_LOGON_NAME)) {
+                if (!RemovePrivileges(sidResult.Sid.get(), hLsa, SE_DENY_NETWORK_LOGON_NAME)) {
                     WcaLog(LOGMSG_STANDARD, "failed to remove deny network login right");
                 }
-                if (!RemovePrivileges(sid.get(), hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME)) {
+                if (!RemovePrivileges(sidResult.Sid.get(), hLsa, SE_DENY_REMOTE_INTERACTIVE_LOGON_NAME)) {
                     WcaLog(LOGMSG_STANDARD, "failed to remove deny remote interactive login right");
                 }
-                if (!RemovePrivileges(sid.get(), hLsa, SE_SERVICE_LOGON_NAME)) {
+                if (!RemovePrivileges(sidResult.Sid.get(), hLsa, SE_SERVICE_LOGON_NAME)) {
                     WcaLog(LOGMSG_STANDARD, "failed to remove service login right");
                 }
             }
@@ -113,7 +113,7 @@ UINT doUninstallAs(UNINSTALL_TYPE t)
             }
             else {
                 // delete the home directory that was left behind
-                DeleteHomeDirectory(installedUser, sid.get());
+                DeleteHomeDirectory(installedUser, sidResult.Sid.get());
             }
         }
     }

--- a/tools/windows/install-help/cal/stdafx.h
+++ b/tools/windows/install-help/cal/stdafx.h
@@ -40,7 +40,7 @@
 #include "customaction.h"
 #include "strings.h"
 #include "ddreg.h"
-
+#include "Error.h"
 #include "resource.h"
 
 #ifdef _WIN64

--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -733,7 +733,7 @@ public:
     }
 };
 
-int installServices(CustomActionData& data, const wchar_t *password) {
+int installServices(CustomActionData& data, PSID sid, const wchar_t *password) {
     SC_HANDLE hScManager = NULL;
     SC_HANDLE hService = NULL;
     int retval = 0;
@@ -801,23 +801,23 @@ int installServices(CustomActionData& data, const wchar_t *password) {
         }
     }
     WcaLog(LOGMSG_STANDARD, "done installing services");
-    UINT er = EnableServiceForUser(data, traceService);
+    UINT er = EnableServiceForUser(sid, traceService);
     if (0 != er) {
         WcaLog(LOGMSG_STANDARD, "Warning, unable to enable trace service for dd user %d", er);
     }
-    er = EnableServiceForUser(data, processService);
+    er = EnableServiceForUser(sid, processService);
     if (0 != er) {
         WcaLog(LOGMSG_STANDARD, "Warning, unable to enable process service for dd user %d", er);
     }
     if(data.installSysprobe()){
-        er = EnableServiceForUser(data, systemProbeService);
+        er = EnableServiceForUser(sid, systemProbeService);
         if (0 != er) {
             WcaLog(LOGMSG_STANDARD, "Warning, unable to enable system probe service for dd user %d", er);
         }
     }
     // need to enable user rights for the datadogagent service (main service)
     // so that it can restart itself
-    er = EnableServiceForUser(data, agentService);
+    er = EnableServiceForUser(sid, agentService);
     if (0 != er) {
         WcaLog(LOGMSG_STANDARD, "Warning, unable to enable agent service for dd user %d", er);
     }

--- a/tools/windows/install-help/cal/usercreate.cpp
+++ b/tools/windows/install-help/cal/usercreate.cpp
@@ -1,5 +1,4 @@
 #include "stdafx.h"
-#include "lmerr_str.h"
 #pragma comment(lib, "shlwapi.lib")
 
 

--- a/tools/windows/install-help/cal/usercreate.cpp
+++ b/tools/windows/install-help/cal/usercreate.cpp
@@ -227,13 +227,12 @@ int doCreateUser(const std::wstring& name, const std::wstring& comment, const wc
     ui.usri1_priv = USER_PRIV_USER;
     ui.usri1_comment = (LPWSTR)comment.c_str();
     ui.usri1_flags = UF_DONT_EXPIRE_PASSWD;
-    DWORD ret = 0;
-    
-    WcaLog(LOGMSG_STANDARD, "Calling NetUserAdd.");
-    ret = NetUserAdd(nullptr, // LOCAL_MACHINE
-                     1, // indicates we're using a USER_INFO_1
-                     reinterpret_cast<LPBYTE>(&ui),
-                     nullptr);
+
+    WcaLog(LOGMSG_STANDARD, "Adding user %S", name.c_str());
+    DWORD ret = NetUserAdd(nullptr, // LOCAL_MACHINE
+                           1, // indicates we're using a USER_INFO_1
+                           reinterpret_cast<LPBYTE>(&ui),
+                           nullptr);
     /*
      * If the function fails, the return value can be one of the following error codes.
      *   - ERROR_ACCESS_DENIED

--- a/tools/windows/install-help/cal/userrights.cpp
+++ b/tools/windows/install-help/cal/userrights.cpp
@@ -13,13 +13,14 @@ std::tuple<sid_ptr, DWORD> GetSidForUser(LPCWSTR host, LPCWSTR user) {
 	{
 		return std::make_tuple(nullptr, GetLastError());
 	}
-
+	WcaLog(LOGMSG_VERBOSE, "Got SID from %S", refDomain.get());
 	if (!IsValidSid(newsid.get()))
 	{
+		WcaLog(LOGMSG_STANDARD, "New SID is invalid");
 		return std::make_tuple(nullptr, ERROR_INVALID_SID);
 	}
 
-	return std::make_tuple(std::move(newsid), S_OK);
+	return std::make_tuple(std::move(newsid), ERROR_SUCCESS);
 }
 
 bool GetNameForSid(LPCWSTR host, PSID sid, std::wstring& namestr) 

--- a/tools/windows/install-help/cal/userrights.cpp
+++ b/tools/windows/install-help/cal/userrights.cpp
@@ -1,54 +1,25 @@
 #include "stdafx.h"
 
-
-
-PSID GetSidForUser(LPCWSTR host, LPCWSTR user) {
-	SID *newsid = NULL;
+std::tuple<sid_ptr, DWORD> GetSidForUser(LPCWSTR host, LPCWSTR user) {
+	
 	DWORD cbSid = 0;
-	LPWSTR refDomain = NULL;
 	DWORD cchRefDomain = 0;
 	SID_NAME_USE use;
-	BOOL bRet = LookupAccountName(host, user, newsid, &cbSid, refDomain, &cchRefDomain, &use);
-	if (bRet) {
-		// this should *never* happen, because we didn't pass in a buffer large enough for
-		// the sid or the domain name.
-		return NULL;
-	}
-	DWORD err = GetLastError();
-	if (ERROR_INSUFFICIENT_BUFFER != err) {
-		// we don't know what happened
-		WcaLog(LOGMSG_STANDARD, "First call to LookupAccountName failed with %d", err);
-		return NULL;
-	}
-	newsid = (SID *) new BYTE[cbSid];
-	ZeroMemory(newsid, cbSid);
 
-	refDomain = new wchar_t[cchRefDomain + 1];
-	ZeroMemory(refDomain, (cchRefDomain + 1) * sizeof(wchar_t));
+	LookupAccountName(host, user, nullptr, &cbSid, nullptr, &cchRefDomain, &use);
+	sid_ptr newsid = make_sid(cbSid);
+	std::unique_ptr<wchar_t[]> refDomain(new wchar_t[cchRefDomain + 1]);
+	if (!LookupAccountName(host, user, newsid.get(), &cbSid, refDomain.get(), &cchRefDomain, &use))
+	{
+		return std::make_tuple(nullptr, GetLastError());
+	}
 
-	// try it again
-	bRet = LookupAccountName(NULL, user, newsid, &cbSid, refDomain, &cchRefDomain, &use);
-	if (!bRet) {
-		WcaLog(LOGMSG_STANDARD, "Failed to lookup account name %d", GetLastError());
-		goto cleanAndFail;
+	if (!IsValidSid(newsid.get()))
+	{
+		return std::make_tuple(nullptr, ERROR_INVALID_SID);
 	}
-	if (!IsValidSid(newsid)) {
-		WcaLog(LOGMSG_STANDARD, "New SID is invalid");
-		goto cleanAndFail;
-	}
-	
-	WcaLog(LOGMSG_STANDARD, "Got SID from %S", refDomain);
-	delete[] refDomain;
-	return newsid;
 
-cleanAndFail:
-	if (newsid) {
-		delete[](BYTE*)newsid;
-	}
-	if (refDomain) {
-		delete[] refDomain;
-	}
-	return NULL;
+	return std::make_tuple(std::move(newsid), S_OK);
 }
 
 bool GetNameForSid(LPCWSTR host, PSID sid, std::wstring& namestr) 
@@ -231,7 +202,7 @@ void BuildExplicitAccessWithSid(EXPLICIT_ACCESS_W &data, PSID pSID, DWORD perms,
 	data.Trustee.ptstrName = (LPTSTR)pSID;
 }
 
-int EnableServiceForUser(CustomActionData& data, const std::wstring& service)
+int EnableServiceForUser(PSID sid, const std::wstring& service)
 {
     int ret = 0;
     SC_HANDLE hscm = OpenSCManager(NULL, NULL, SC_MANAGER_ALL_ACCESS | GENERIC_ALL | READ_CONTROL);
@@ -245,7 +216,6 @@ int EnableServiceForUser(CustomActionData& data, const std::wstring& service)
 	BYTE bigbuf[8192];
 	DWORD pcbBytes = 8192;
 	char *ssec = NULL;
-	PSID sid = NULL;
 	PSECURITY_DESCRIPTOR psec = (PSECURITY_DESCRIPTOR)bigbuf;
 	EXPLICIT_ACCESSW ea;
 	memset(&ea, 0, sizeof(EXPLICIT_ACCESSW));
@@ -264,10 +234,6 @@ int EnableServiceForUser(CustomActionData& data, const std::wstring& service)
 	
 	if (!QueryServiceObjectSecurity(hService, DACL_SECURITY_INFORMATION , psec, 8192, &pcbBytes)) {
 		WcaLog(LOGMSG_STANDARD,"Failed to query security info %d\n", GetLastError());
-		goto cleanAndReturn;
-	}
-	if ((sid = GetSidForUser(NULL, data.Username().c_str())) == NULL) {
-		WcaLog(LOGMSG_STANDARD,"Failed to get sid\n");
 		goto cleanAndReturn;
 	}
 	// Get the DACL...
@@ -325,9 +291,6 @@ cleanAndReturn:
 	}
 	if (hService) {
 		CloseServiceHandle(hscm);
-	}
-	if (sid) {
-		delete[](BYTE *) sid;
 	}
     return ret;
 }

--- a/tools/windows/install-help/cal/userrights.cpp
+++ b/tools/windows/install-help/cal/userrights.cpp
@@ -8,20 +8,20 @@ SidResult GetSidForUser(LPCWSTR host, LPCWSTR user) {
 
 	LookupAccountName(host, user, nullptr, &cbSid, nullptr, &cchRefDomain, &use);
 	sid_ptr newsid = make_sid(cbSid);
-	std::wstring refDomain;
+	std::vector<wchar_t> refDomain;
+	// +1 in case cchRefDomain == 0
 	refDomain.resize(cchRefDomain + 1);
 	if (!LookupAccountName(host, user, newsid.get(), &cbSid, &refDomain[0], &cchRefDomain, &use))
 	{
 		return SidResult(GetLastError());
 	}
-	WcaLog(LOGMSG_VERBOSE, "Got SID from %S", refDomain.c_str());
+
 	if (!IsValidSid(newsid.get()))
 	{
-		WcaLog(LOGMSG_STANDARD, "New SID is invalid");
 		return SidResult(ERROR_INVALID_SID);
 	}
 
-	return SidResult(newsid, refDomain, ERROR_SUCCESS);
+	return SidResult(newsid, std::wstring(refDomain.data()), ERROR_SUCCESS);
 }
 
 bool GetNameForSid(LPCWSTR host, PSID sid, std::wstring& namestr) 

--- a/tools/windows/install-help/cal/userrights.cpp
+++ b/tools/windows/install-help/cal/userrights.cpp
@@ -14,7 +14,7 @@ SidResult GetSidForUser(LPCWSTR host, LPCWSTR user) {
 	{
 		return SidResult(GetLastError());
 	}
-	WcaLog(LOGMSG_VERBOSE, "Got SID from %S", refDomain);
+	WcaLog(LOGMSG_VERBOSE, "Got SID from %S", refDomain.c_str());
 	if (!IsValidSid(newsid.get()))
 	{
 		WcaLog(LOGMSG_STANDARD, "New SID is invalid");

--- a/tools/windows/install-help/cal/winacl.cpp
+++ b/tools/windows/install-help/cal/winacl.cpp
@@ -57,7 +57,6 @@ void ExplicitAccess::BuildGrantUser(LPCWSTR name, DWORD rights, DWORD inheritanc
 
 
 void ExplicitAccess::BuildGrantUser(SID *sid, DWORD rights, DWORD inheritance_flags) {
-    this->deleteSid = true;
     data.grfAccessPermissions = rights;
     data.grfAccessMode = GRANT_ACCESS;
     data.grfInheritance = inheritance_flags;

--- a/tools/windows/install-help/install-cmd/install-cmd.vcxproj
+++ b/tools/windows/install-help/install-cmd/install-cmd.vcxproj
@@ -97,6 +97,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,6 +116,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -135,6 +137,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -157,6 +160,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -176,6 +180,7 @@
     <ClCompile Include="..\cal\caninstall.cpp" />
     <ClCompile Include="..\cal\customactiondata.cpp" />
     <ClCompile Include="..\cal\ddreg.cpp" />
+    <ClCompile Include="..\cal\Error.cpp" />
     <ClCompile Include="..\cal\FinalizeInstall.cpp" />
     <ClCompile Include="..\cal\stopservices.cpp" />
     <ClCompile Include="..\cal\strings.cpp" />

--- a/tools/windows/install-help/install-cmd/stdafx.h
+++ b/tools/windows/install-help/install-cmd/stdafx.h
@@ -49,7 +49,7 @@
 #include "..\cal\customaction.h"
 #include "..\cal\strings.h"
 #include "..\cal\ddreg.h"
-
+#include "..\cal\Error.h"
 
 #include "resource.h"
 

--- a/tools/windows/install-help/uninstall-cmd/stdafx.h
+++ b/tools/windows/install-help/uninstall-cmd/stdafx.h
@@ -50,7 +50,7 @@
 #include "..\cal\customaction.h"
 #include "..\cal\strings.h"
 #include "..\cal\ddreg.h"
-
+#include "..\cal\Error.h"
 
 #include "resource.h"
 

--- a/tools/windows/install-help/uninstall-cmd/uninstall-cmd.vcxproj
+++ b/tools/windows/install-help/uninstall-cmd/uninstall-cmd.vcxproj
@@ -97,6 +97,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,6 +116,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -135,6 +137,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -157,6 +160,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(WIX)sdk\VS2017\inc</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -178,6 +182,7 @@
     <ClCompile Include="..\cal\ddreg.cpp" />
     <ClCompile Include="..\cal\delfiles.cpp" />
     <ClCompile Include="..\cal\doUninstall.cpp" />
+    <ClCompile Include="..\cal\Error.cpp" />
     <ClCompile Include="..\cal\stopservices.cpp" />
     <ClCompile Include="..\cal\strings.cpp" />
     <ClCompile Include="..\cal\TargetMachine.cpp" />


### PR DESCRIPTION
### What does this PR do?

This PR allows the MSI installer to install the Agent on child domain with a pre-existing domain user that is located in a parent domain.

### Motivation

Handle installation of the Agent on child domains properly.

### Additional Notes

The fix consists in not processing the username and instead relying on `LookupAccountName`. Previously we tried to match the domain part of the username to the joined domain and substituting if it didn't match.
This behaviour was correct most of the time, especially when the Netbios domain name is different from the DNS domain name (see #6318).
However when installing on a child domain controller with a domain user from the parent domain, this would create a new user in the child domain.

### Describe your test plan

1) Setup a parent and child domain
2) Create a user in the parent domain
3) Install the Agent on the DC of the child domain, specifying the user from the parent domain
4) Check that no new user was created in the child domain and that the installation succeeds
