### PR TITLE
Document new collect_default_jvm_metrics flag for JMXFetch

### DIFF
--- a/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
@@ -146,3 +146,8 @@ instances:
     #     exclude:
     #       bean_regex:
     #         - <REGEX>
+
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Collects default JVM metrics when true
+    #
+    # collect_default_jvm_metrics: false

--- a/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
@@ -148,6 +148,6 @@ instances:
     #         - <REGEX>
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics
+    ##  Configures the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true

--- a/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
@@ -148,6 +148,6 @@ instances:
     #         - <REGEX>
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Collects default JVM metrics when true
+    ## Allows disabling the collection of default JVM metrics
     #
     # collect_default_jvm_metrics: false

--- a/releasenotes/notes/collect_default_jvm_metrics-ebdc0ad0f00f6b07.yaml
+++ b/releasenotes/notes/collect_default_jvm_metrics-ebdc0ad0f00f6b07.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added new config option for JMXFetch collect_default_jvm_metrics that enables/disables
+    default JVM metric collection. 


### PR DESCRIPTION
### What does this PR do?

Added docs for `collect_default_jvm_metrics`. This flag allows users to disable default jvm metrics in JMXFetch

### Motivation

Goes with this PR: https://github.com/DataDog/jmxfetch/pull/345
