### PR TITLE
Dedicated logs endpoints for the security-agent

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -127,15 +127,15 @@ func newLogContext(logsConfig config.LogsConfigKeys, endpointPrefix string) (*co
 
 func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, error) {
 	logsConfigComplianceKeys := config.LogsConfigKeys{
-		UseCompression:          "compliance_config.logs_config.use_compression",
-		CompressionLevel:        "compliance_config.logs_config.compression_level",
-		ConnectionResetInterval: "compliance_config.logs_config.connection_reset_interval",
-		LogsDDURL:               "compliance_config.logs_config.logs_dd_url",
-		LogsNoSSL:               "compliance_config.logs_config.logs_no_ssl",
-		DDURL:                   "compliance_config.logs_config.dd_url",
-		DevModeNoSSL:            "compliance_config.logs_config.dev_mode_no_ssl",
-		AdditionalEndpoints:     "compliance_config.logs_config.additional_endpoints",
-		BatchWait:               "compliance_config.logs_config.batch_wait",
+		UseCompression:          "compliance_config.endpoints.use_compression",
+		CompressionLevel:        "compliance_config.endpoints.compression_level",
+		ConnectionResetInterval: "compliance_config.endpoints.connection_reset_interval",
+		LogsDDURL:               "compliance_config.endpoints.logs_dd_url",
+		LogsNoSSL:               "compliance_config.endpoints.logs_no_ssl",
+		DDURL:                   "compliance_config.endpoints.dd_url",
+		DevModeNoSSL:            "compliance_config.endpoints.dev_mode_no_ssl",
+		AdditionalEndpoints:     "compliance_config.endpoints.additional_endpoints",
+		BatchWait:               "compliance_config.endpoints.batch_wait",
 	}
 	return newLogContext(logsConfigComplianceKeys, "agent-http-intake.logs.")
 }
@@ -143,15 +143,15 @@ func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, 
 // This function will only be used on Linux. The only platforms where the runtime agent runs
 func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) { // nolint: deadcode, unused
 	logsConfigRuntimeKeys := config.LogsConfigKeys{
-		UseCompression:          "runtime_security_config.logs_config.use_compression",
-		CompressionLevel:        "runtime_security_config.logs_config.compression_level",
-		ConnectionResetInterval: "runtime_security_config.logs_config.connection_reset_interval",
-		LogsDDURL:               "runtime_security_config.logs_config.logs_dd_url",
-		LogsNoSSL:               "runtime_security_config.logs_config.logs_no_ssl",
-		DDURL:                   "runtime_security_config.logs_config.dd_url",
-		DevModeNoSSL:            "runtime_security_config.logs_config.dev_mode_no_ssl",
-		AdditionalEndpoints:     "runtime_security_config.logs_config.additional_endpoints",
-		BatchWait:               "runtime_security_config.logs_config.batch_wait",
+		UseCompression:          "runtime_security_config.endpoints.use_compression",
+		CompressionLevel:        "runtime_security_config.endpoints.compression_level",
+		ConnectionResetInterval: "runtime_security_config.endpoints.connection_reset_interval",
+		LogsDDURL:               "runtime_security_config.endpoints.logs_dd_url",
+		LogsNoSSL:               "runtime_security_config.endpoints.logs_no_ssl",
+		DDURL:                   "runtime_security_config.endpoints.dd_url",
+		DevModeNoSSL:            "runtime_security_config.endpoints.dev_mode_no_ssl",
+		AdditionalEndpoints:     "runtime_security_config.endpoints.additional_endpoints",
+		BatchWait:               "runtime_security_config.endpoints.batch_wait",
 	}
 	return newLogContext(logsConfigRuntimeKeys, "agent-http-intake.logs.")
 }

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -140,7 +140,8 @@ func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, 
 	return newLogContext(logsConfigComplianceKeys, "agent-http-intake.logs.")
 }
 
-func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) {
+// This function will only be used on Linux. The only platforms where the runtime agent runs
+func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) { // nolint: deadcode, unused
 	logsConfigRuntimeKeys := config.LogsConfigKeys{
 		UseCompression:          "runtime_security_config.logs_config.use_compression",
 		CompressionLevel:        "runtime_security_config.logs_config.compression_level",

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -127,11 +127,9 @@ func newLogContext(logsConfig config.LogsConfigKeys, endpointPrefix string) (*co
 
 func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, error) {
 	logsConfigComplianceKeys := config.LogsConfigKeys{
-		UseCompression:          "compliance_config.endpoints.use_compression",
 		CompressionLevel:        "compliance_config.endpoints.compression_level",
 		ConnectionResetInterval: "compliance_config.endpoints.connection_reset_interval",
 		LogsDDURL:               "compliance_config.endpoints.logs_dd_url",
-		LogsNoSSL:               "compliance_config.endpoints.logs_no_ssl",
 		DDURL:                   "compliance_config.endpoints.dd_url",
 		DevModeNoSSL:            "compliance_config.endpoints.dev_mode_no_ssl",
 		AdditionalEndpoints:     "compliance_config.endpoints.additional_endpoints",
@@ -143,11 +141,9 @@ func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, 
 // This function will only be used on Linux. The only platforms where the runtime agent runs
 func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) { // nolint: deadcode, unused
 	logsConfigRuntimeKeys := config.LogsConfigKeys{
-		UseCompression:          "runtime_security_config.endpoints.use_compression",
 		CompressionLevel:        "runtime_security_config.endpoints.compression_level",
 		ConnectionResetInterval: "runtime_security_config.endpoints.connection_reset_interval",
 		LogsDDURL:               "runtime_security_config.endpoints.logs_dd_url",
-		LogsNoSSL:               "runtime_security_config.endpoints.logs_no_ssl",
 		DDURL:                   "runtime_security_config.endpoints.dd_url",
 		DevModeNoSSL:            "runtime_security_config.endpoints.dev_mode_no_ssl",
 		AdditionalEndpoints:     "runtime_security_config.endpoints.additional_endpoints",

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -135,7 +135,7 @@ func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, 
 		AdditionalEndpoints:     "compliance_config.endpoints.additional_endpoints",
 		BatchWait:               "compliance_config.endpoints.batch_wait",
 	}
-	return newLogContext(logsConfigComplianceKeys, "agent-http-intake.logs.")
+	return newLogContext(logsConfigComplianceKeys, "compliance-http-intake.logs.")
 }
 
 // This function will only be used on Linux. The only platforms where the runtime agent runs
@@ -149,7 +149,7 @@ func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, err
 		AdditionalEndpoints:     "runtime_security_config.endpoints.additional_endpoints",
 		BatchWait:               "runtime_security_config.endpoints.batch_wait",
 	}
-	return newLogContext(logsConfigRuntimeKeys, "agent-http-intake.logs.")
+	return newLogContext(logsConfigRuntimeKeys, "runtime-security-http-intake.logs.")
 }
 
 func start(cmd *cobra.Command, args []string) error {

--- a/cmd/security-agent/app/runtime_unsupported.go
+++ b/cmd/security-agent/app/runtime_unsupported.go
@@ -11,8 +11,6 @@ import (
 	"errors"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/logs/client"
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -22,7 +20,7 @@ import (
 
 var runtimeCmd *cobra.Command
 
-func startRuntimeSecurity(hostname string, endpoints *config.Endpoints, context *client.DestinationsContext, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {
+func startRuntimeSecurity(hostname string, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {
 	enabled := coreconfig.Datadog.GetBool("runtime_security_config.enabled")
 	if !enabled {
 		log.Info("Datadog runtime security agent disabled by config")

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -176,51 +176,85 @@ func buildTCPEndpoints() (*Endpoints, error) {
 	return NewEndpoints(main, additionals, useProto, false, 0), nil
 }
 
+// LogsConfigKeys stores logs configuration keys stored in YAML configuration files
+type LogsConfigKeys struct {
+	UseCompression          string
+	CompressionLevel        string
+	ConnectionResetInterval string
+	LogsDDURL               string
+	LogsNoSSL               string
+	DDURL                   string
+	DevModeNoSSL            string
+	AdditionalEndpoints     string
+	BatchWait               string
+}
+
+var logsConfigDefaultKeys = LogsConfigKeys{
+	UseCompression:          "logs_config.use_compression",
+	CompressionLevel:        "logs_config.compression_level",
+	ConnectionResetInterval: "logs_config.connection_reset_interval",
+	LogsDDURL:               "logs_config.logs_dd_url",
+	LogsNoSSL:               "logs_config.logs_no_ssl",
+	DDURL:                   "logs_config.dd_url",
+	DevModeNoSSL:            "logs_config.dev_mode_no_ssl",
+	AdditionalEndpoints:     "logs_config.additional_endpoints",
+	BatchWait:               "logs_config.batch_wait",
+}
+
 // BuildHTTPEndpoints returns the HTTP endpoints to send logs to.
 func BuildHTTPEndpoints() (*Endpoints, error) {
+	return BuildHTTPEndpointsWithConfig(logsConfigDefaultKeys, httpEndpointPrefix)
+}
+
+// BuildHTTPEndpointsWithConfig uses two arguments that instructs it how to access configuration parameters, then returns the HTTP endpoints to send logs to.
+func BuildHTTPEndpointsWithConfig(logsConfig LogsConfigKeys, endpointPrefix string) (*Endpoints, error) {
 	main := Endpoint{
 		APIKey:                  getLogsAPIKey(coreConfig.Datadog),
-		UseCompression:          coreConfig.Datadog.GetBool("logs_config.use_compression"),
-		CompressionLevel:        coreConfig.Datadog.GetInt("logs_config.compression_level"),
-		ConnectionResetInterval: time.Duration(coreConfig.Datadog.GetInt("logs_config.connection_reset_interval")) * time.Second,
+		UseCompression:          coreConfig.Datadog.GetBool(logsConfig.UseCompression),
+		CompressionLevel:        coreConfig.Datadog.GetInt(logsConfig.CompressionLevel),
+		ConnectionResetInterval: time.Duration(coreConfig.Datadog.GetInt(logsConfig.ConnectionResetInterval)) * time.Second,
 	}
 
 	switch {
-	case isSetAndNotEmpty(coreConfig.Datadog, "logs_config.logs_dd_url"):
-		host, port, err := parseAddress(coreConfig.Datadog.GetString("logs_config.logs_dd_url"))
+	case isSetAndNotEmpty(coreConfig.Datadog, logsConfig.LogsDDURL):
+		host, port, err := parseAddress(coreConfig.Datadog.GetString(logsConfig.LogsDDURL))
 		if err != nil {
 			return nil, fmt.Errorf("could not parse logs_dd_url: %v", err)
 		}
 		main.Host = host
 		main.Port = port
-		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.logs_no_ssl")
+		main.UseSSL = !coreConfig.Datadog.GetBool(logsConfig.LogsNoSSL)
 	default:
-		main.Host = coreConfig.GetMainEndpoint(httpEndpointPrefix, "logs_config.dd_url")
-		main.UseSSL = !coreConfig.Datadog.GetBool("logs_config.dev_mode_no_ssl")
+		main.Host = coreConfig.GetMainEndpoint(endpointPrefix, logsConfig.DDURL)
+		main.UseSSL = !coreConfig.Datadog.GetBool(logsConfig.DevModeNoSSL)
 	}
 
-	additionals := getAdditionalEndpoints()
+	additionals := getAdditionalEndpointsFromKey(logsConfig.AdditionalEndpoints)
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
 		additionals[i].APIKey = coreConfig.SanitizeAPIKey(additionals[i].APIKey)
 	}
 
-	batchWait := batchWait(coreConfig.Datadog)
+	batchWait := batchWaitFromKey(coreConfig.Datadog, logsConfig.BatchWait)
 
 	return NewEndpoints(main, additionals, false, true, batchWait), nil
 }
 
 func getAdditionalEndpoints() []Endpoint {
+	return getAdditionalEndpointsFromKey("logs_config.additional_endpoints")
+}
+
+func getAdditionalEndpointsFromKey(additionalEndpointsParameter string) []Endpoint {
 	var endpoints []Endpoint
 	var err error
-	raw := coreConfig.Datadog.Get("logs_config.additional_endpoints")
+	raw := coreConfig.Datadog.Get(additionalEndpointsParameter)
 	if raw == nil {
 		return endpoints
 	}
 	if s, ok := raw.(string); ok && s != "" {
 		err = json.Unmarshal([]byte(s), &endpoints)
 	} else {
-		err = coreConfig.Datadog.UnmarshalKey("logs_config.additional_endpoints", &endpoints)
+		err = coreConfig.Datadog.UnmarshalKey(additionalEndpointsParameter, &endpoints)
 	}
 	if err != nil {
 		log.Warnf("Could not parse additional_endpoints for logs: %v", err)
@@ -253,8 +287,8 @@ func parseAddress(address string) (string, int, error) {
 	return host, port, nil
 }
 
-func batchWait(config coreConfig.Config) time.Duration {
-	batchWait := coreConfig.Datadog.GetInt("logs_config.batch_wait")
+func batchWaitFromKey(config coreConfig.Config, batchWaitKey string) time.Duration {
+	batchWait := coreConfig.Datadog.GetInt(batchWaitKey)
 	if batchWait < 1 || 10 < batchWait {
 		log.Warnf("Invalid batch_wait: %v should be in [1, 10], fallback on %v", batchWait, coreConfig.DefaultBatchWait)
 		return coreConfig.DefaultBatchWait * time.Second

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -189,6 +189,7 @@ type LogsConfigKeys struct {
 	BatchWait               string
 }
 
+// logsConfigDefaultKeys defines the default YAML keys used to retrieve logs configuration
 var logsConfigDefaultKeys = LogsConfigKeys{
 	UseCompression:          "logs_config.use_compression",
 	CompressionLevel:        "logs_config.compression_level",

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -207,7 +207,7 @@ func BuildHTTPEndpoints() (*Endpoints, error) {
 	return BuildHTTPEndpointsWithConfig(logsConfigDefaultKeys, httpEndpointPrefix)
 }
 
-// BuildHTTPEndpointsWithConfig uses two arguments that instructs it how to access configuration parameters, then returns the HTTP endpoints to send logs to.
+// BuildHTTPEndpointsWithConfig uses two arguments that instructs it how to access configuration parameters, then returns the HTTP endpoints to send logs to. This function is able to default to the 'classic' BuildHTTPEndpoints() when passed the default variables logsConfigDefaultKeys and httpEndpointPrefix
 func BuildHTTPEndpointsWithConfig(logsConfig LogsConfigKeys, endpointPrefix string) (*Endpoints, error) {
 	main := Endpoint{
 		APIKey:                  getLogsAPIKey(coreConfig.Datadog),


### PR DESCRIPTION
### What does this PR do?

The security-agent will soon need to send logs to two new endpoints to the ease differentiate the source of events.

This PR prepares the code to support these two endpoints:
1. It makes the BuildHTTPEndpoint() function accept an argument that abstracts the name of configuration parameter
2. It makes the compliance and runtime parts of the security agent send logs independently.

As soon as the endpoints are ready, a subsequent PR will change the endpoints names in the newReporterCompliance() and newReporterRuntime() functions.
