### PR TITLE
make the agent get k8s clusterID from dca API

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -130,5 +130,6 @@ func isExternalPath(path string) bool {
 		strings.HasPrefix(path, "/api/v1/tags/node/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/clusterchecks/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/endpointschecks/") && len(strings.Split(path, "/")) == 6 ||
-		strings.HasPrefix(path, "/api/v1/tags/cf/apps/") && len(strings.Split(path, "/")) == 7
+		strings.HasPrefix(path, "/api/v1/tags/cf/apps/") && len(strings.Split(path, "/")) == 7 ||
+		strings.HasPrefix(path, "/api/v1/cluster/id") && len(strings.Split(path, "/")) == 5
 }

--- a/cmd/cluster-agent/api/server_test.go
+++ b/cmd/cluster-agent/api/server_test.go
@@ -47,6 +47,11 @@ func TestValidateTokenMiddleware(t *testing.T) {
 			http.StatusOK,
 		},
 		{
+			"/api/v1/cluster/id",
+			"abc123",
+			http.StatusOK,
+		},
+		{
 			"/version",
 			"bandit!",
 			http.StatusForbidden,

--- a/cmd/cluster-agent/api/v1/cloudfoundry_metadata.go
+++ b/cmd/cluster-agent/api/v1/cloudfoundry_metadata.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017-2020 Datadog, Inc.
 
-// +build clusterchecks
+// +build clusterchecks,!kubeapiserver
 
 package v1
 
@@ -20,6 +20,8 @@ import (
 func installCloudFoundryMetadataEndpoints(r *mux.Router) {
 	r.HandleFunc("/tags/cf/apps/{nodeName}", getCFAppsMetadataForNode).Methods("GET")
 }
+
+func installKubernetesMetadataEndpoints(r *mux.Router) {}
 
 // getCFAppsMetadataForNode is only used when the node agent hits the DCA for the list of cloudfoundry applications tags
 // It return a list of tags for each application that can be directly used in the tagger

--- a/cmd/cluster-agent/api/v1/cloudfoundry_metadata_nocompile.go
+++ b/cmd/cluster-agent/api/v1/cloudfoundry_metadata_nocompile.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017-2020 Datadog, Inc.
 
-// +build !clusterchecks
+// +build !clusterchecks,!kubeapiserver
 
 package v1
 
@@ -12,3 +12,5 @@ import (
 )
 
 func installCloudFoundryMetadataEndpoints(r *mux.Router) {}
+
+func installKubernetesMetadataEndpoints(r *mux.Router) {}

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -6,7 +6,10 @@ import (
 	"net/http"
 	"strconv"
 
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/mux"
 )
@@ -16,6 +19,7 @@ func installKubernetesMetadataEndpoints(r *mux.Router) {
 	r.HandleFunc("/tags/pod/{nodeName}", getPodMetadataForNode).Methods("GET")
 	r.HandleFunc("/tags/pod", getAllMetadata).Methods("GET")
 	r.HandleFunc("/tags/node/{nodeName}", getNodeMetadata).Methods("GET")
+	r.HandleFunc("/cluster/id", getClusterID).Methods("GET")
 }
 
 // getNodeMetadata is only used when the node agent hits the DCA for the list of labels
@@ -234,6 +238,50 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	apiRequests.Inc(
 		"getAllMetadata",
 		strconv.Itoa(http.StatusNotFound),
+	)
+	return
+}
+
+// getClusterID is used by recent agents to get the cluster UUID, needed for enabling the orchestrator explorer
+func getClusterID(w http.ResponseWriter, r *http.Request) {
+	// bootstrap client
+	cl, err := as.GetAPIClient()
+	if err != nil {
+		log.Errorf("Can't create client to query the API Server: %v", err) //nolint:errcheck
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		apiRequests.Inc(
+			"getClusterID",
+			strconv.Itoa(http.StatusInternalServerError),
+		)
+		return
+	}
+	coreCl := cl.Cl.CoreV1().(*corev1.CoreV1Client)
+	// get clusterID
+	clusterID, err := apicommon.GetOrCreateClusterID(coreCl)
+	if err != nil {
+		log.Errorf("Failed to generate or retrieve the cluster ID: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		apiRequests.Inc(
+			"getClusterID",
+			strconv.Itoa(http.StatusInternalServerError),
+		)
+		return
+	}
+	// write response
+	j, err := json.Marshal(clusterID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		apiRequests.Inc(
+			"getClusterID",
+			strconv.Itoa(http.StatusInternalServerError),
+		)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(j)
+	apiRequests.Inc(
+		"getClusterID",
+		strconv.Itoa(http.StatusOK),
 	)
 	return
 }

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -274,6 +274,7 @@ func getClusterID(w http.ResponseWriter, r *http.Request) {
 	// write response
 	j, err := json.Marshal(clusterID)
 	if err != nil {
+		log.Errorf("Failed to marshal the cluster ID: %v", err) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		apiRequests.Inc(
 			"getClusterID",

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -1,3 +1,5 @@
+// +build kubeapiserver
+
 package v1
 
 import (
@@ -21,6 +23,8 @@ func installKubernetesMetadataEndpoints(r *mux.Router) {
 	r.HandleFunc("/tags/node/{nodeName}", getNodeMetadata).Methods("GET")
 	r.HandleFunc("/cluster/id", getClusterID).Methods("GET")
 }
+
+func installCloudFoundryMetadataEndpoints(r *mux.Router) {}
 
 // getNodeMetadata is only used when the node agent hits the DCA for the list of labels
 func getNodeMetadata(w http.ResponseWriter, r *http.Request) {

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -259,7 +259,7 @@ func getClusterID(w http.ResponseWriter, r *http.Request) {
 	// get clusterID
 	clusterID, err := apicommon.GetOrCreateClusterID(coreCl)
 	if err != nil {
-		log.Errorf("Failed to generate or retrieve the cluster ID: %v", err)
+		log.Errorf("Failed to generate or retrieve the cluster ID: %v", err) //nolint:errcheck
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		apiRequests.Inc(
 			"getClusterID",

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -228,6 +228,11 @@ func start(cmd *cobra.Command, args []string) error {
 			log.Errorf("Failed to generate or retrieve the cluster ID")
 		}
 
+		clusterName := clustername.GetClusterName(hostname)
+		if clusterName == "" {
+			log.Warn("Failed to auto-detect a Kubernetes cluster name. We recommend you set it manually via the cluster_name config option")
+		}
+
 		// TODO: move rest of the controllers out of the apiserver package
 		orchestratorCtx := orchestrator.ControllerContext{
 			IsLeaderFunc:                 le.IsLeader,
@@ -236,7 +241,7 @@ func start(cmd *cobra.Command, args []string) error {
 			Client:                       apiCl.Cl,
 			StopCh:                       stopCh,
 			Hostname:                     hostname,
-			ClusterName:                  clustername.GetClusterName(hostname),
+			ClusterName:                  clustername,
 			ConfigPath:                   confPath,
 		}
 		err = orchestrator.StartController(orchestratorCtx)

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -241,7 +241,7 @@ func start(cmd *cobra.Command, args []string) error {
 			Client:                       apiCl.Cl,
 			StopCh:                       stopCh,
 			Hostname:                     hostname,
-			ClusterName:                  clustername,
+			ClusterName:                  clusterName,
 			ConfigPath:                   confPath,
 		}
 		err = orchestrator.StartController(orchestratorCtx)

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -366,8 +366,12 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 	}
 
 	// activate the pod collection if enabled and we have the cluster name set
-	if cfg.Orchestrator.OrchestrationCollectionEnabled && cfg.Orchestrator.KubeClusterName != "" {
-		cfg.EnabledChecks = append(cfg.EnabledChecks, "pod")
+	if cfg.Orchestrator.OrchestrationCollectionEnabled {
+		if cfg.Orchestrator.KubeClusterName != "" {
+			cfg.EnabledChecks = append(cfg.EnabledChecks, "pod")
+		} else {
+			log.Warnf("Failed to auto-detect a Kubernetes cluster name. Pod collection will not start. To fix this, set it manually via the cluster_name config option")
+		}
 	}
 
 	return cfg, nil

--- a/pkg/tagger/collectors/garden_extract_test.go
+++ b/pkg/tagger/collectors/garden_extract_test.go
@@ -108,6 +108,10 @@ func (fakeDCAClient) GetEndpointsCheckConfigs(nodeName string) (types.ConfigResp
 	panic("implement me")
 }
 
+func (fakeDCAClient) GetKubernetesClusterID() (string, error) {
+	panic("implement me")
+}
+
 // Unused GardenUtilInterface methodes
 func (fakeGardenUtil) ListContainers() ([]*containers.Container, error) {
 	panic("implement me")

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper_test.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper_test.go
@@ -46,6 +46,9 @@ type FakeDCAClient struct {
 
 	EndpointsCheckConfigs    types.ConfigResponse
 	EndpointsCheckConfigsErr error
+
+	ClusterID    string
+	ClusterIDErr error
 }
 
 func (f *FakeDCAClient) Version() version.Version {
@@ -77,6 +80,10 @@ func (f *FakeDCAClient) GetClusterCheckConfigs(nodeName string) (types.ConfigRes
 
 func (f *FakeDCAClient) GetEndpointsCheckConfigs(nodeName string) (types.ConfigResponse, error) {
 	return f.EndpointsCheckConfigs, f.EndpointsCheckConfigsErr
+}
+
+func (f *FakeDCAClient) GetKubernetesClusterID() (string, error) {
+	return f.ClusterID, f.ClusterIDErr
 }
 
 func (f *FakeDCAClient) GetCFAppsMetadataForNode(nodename string) (map[string][]string, error) {

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -55,6 +55,7 @@ type DCAClientInterface interface {
 	PostClusterCheckStatus(nodeName string, status types.NodeStatus) (types.StatusResponse, error)
 	GetClusterCheckConfigs(nodeName string) (types.ConfigResponse, error)
 	GetEndpointsCheckConfigs(nodeName string) (types.ConfigResponse, error)
+	GetKubernetesClusterID() (string, error)
 }
 
 // DCAClient is required to query the API of Datadog cluster agent
@@ -407,4 +408,42 @@ func (c *DCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]
 	}
 
 	return metadataNames, nil
+}
+
+// GetKubernetesClusterID queries the datadog cluster agent to get the Kubernetes cluster ID
+// Prefer calling clustername.GetClusterID which has a cached response
+func (c *DCAClient) GetKubernetesClusterID() (string, error) {
+	const dcaClusterIDPath = "api/v1/cluster/id"
+	var clusterID string
+	var err error
+
+	if c == nil {
+		return "", fmt.Errorf("cluster agent's client is not properly initialized")
+	}
+
+	// https://host:port/api/v1/cluster/id
+	rawURL := fmt.Sprintf("%s/%s", c.clusterAgentAPIEndpoint, dcaClusterIDPath)
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header = c.clusterAgentAPIRequestHeaders
+
+	resp, err := c.clusterAgentAPIClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code from cluster agent: %d", resp.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	clusterID = string(b)
+
+	return clusterID, nil
 }

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -444,9 +444,5 @@ func (c *DCAClient) GetKubernetesClusterID() (string, error) {
 		return "", err
 	}
 	err = json.Unmarshal(b, &clusterID)
-	if err != nil {
-		return clusterID, err
-	}
-
-	return clusterID, nil
+	return clusterID, err
 }

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -443,7 +443,10 @@ func (c *DCAClient) GetKubernetesClusterID() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	clusterID = string(b)
+	err = json.Unmarshal(b, &clusterID)
+	if err != nil {
+		return clusterID, err
+	}
 
 	return clusterID, nil
 }

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/azure"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
@@ -138,11 +139,22 @@ func GetClusterID() (string, error) {
 		return cachedClusterID.(string), nil
 	}
 
+	// in older setups the cluster ID was exposed as an env var from a configmap created by the cluster agent
 	clusterID, found := os.LookupEnv(clusterIDEnv)
 	if !found {
-		err := fmt.Errorf("Cluster ID env variable %s is missing, kubernetes cluster cannot be identified", clusterIDEnv)
-		return "", err
-	} else if len(clusterID) != 36 {
+		log.Debugf("Cluster ID env variable %s is missing, calling the DCA directly", clusterIDEnv)
+
+		dcaClient, err := clusteragent.GetClusterAgentClient()
+		if err != nil {
+			return "", err
+		}
+		clusterID, err = dcaClient.GetKubernetesClusterID()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if len(clusterID) != 36 {
 		err := fmt.Errorf("Unexpected value %s for env variable %s, ignoring it", clusterID, clusterIDEnv)
 		return "", err
 	}

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -142,7 +142,7 @@ func GetClusterID() (string, error) {
 	// in older setups the cluster ID was exposed as an env var from a configmap created by the cluster agent
 	clusterID, found := os.LookupEnv(clusterIDEnv)
 	if !found {
-		log.Debugf("Cluster ID env variable %s is missing, calling the DCA directly", clusterIDEnv)
+		log.Debugf("Cluster ID env variable %s is missing, calling the Cluster Agent", clusterIDEnv)
 
 		dcaClient, err := clusteragent.GetClusterAgentClient()
 		if err != nil {

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -152,10 +152,11 @@ func GetClusterID() (string, error) {
 		if err != nil {
 			return "", err
 		}
+		log.Debugf("Cluster ID retrieved frm the Cluster Agent, set to %s", clusterID)
 	}
 
 	if len(clusterID) != 36 {
-		err := fmt.Errorf("Unexpected value %s for env variable %s, ignoring it", clusterID, clusterIDEnv)
+		err := fmt.Errorf("Unexpected value for Cluster ID: %s, ignoring it", clusterID)
 		return "", err
 	}
 

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -152,7 +152,7 @@ func GetClusterID() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		log.Debugf("Cluster ID retrieved frm the Cluster Agent, set to %s", clusterID)
+		log.Debugf("Cluster ID retrieved from the Cluster Agent, set to %s", clusterID)
 	}
 
 	if len(clusterID) != 36 {

--- a/releasenotes/notes/make-agents-get-k8s-clusterID-from-dca-directly-10818f07f6bd4938.yaml
+++ b/releasenotes/notes/make-agents-get-k8s-clusterID-from-dca-directly-10818f07f6bd4938.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    We improved the way Agents get the Kubernetes cluster ID from the Cluster Agent.
+    It used to be that the cluster agent would create a configmap which had to be
+    mounted as an env variable in the agent daemonset, blocking the process-agent
+    from starting if not found. Now the process-agent will start. Only the Kubernetes
+    Resources collection will be blocked.

--- a/releasenotes/notes/make-agents-get-k8s-clusterID-from-dca-directly-10818f07f6bd4938.yaml
+++ b/releasenotes/notes/make-agents-get-k8s-clusterID-from-dca-directly-10818f07f6bd4938.yaml
@@ -11,5 +11,5 @@ enhancements:
     We improved the way Agents get the Kubernetes cluster ID from the Cluster Agent.
     It used to be that the cluster agent would create a configmap which had to be
     mounted as an env variable in the agent daemonset, blocking the process-agent
-    from starting if not found. Now the process-agent will start. Only the Kubernetes
+    from starting if not found. Now the process-agent will start, only the Kubernetes
     Resources collection will be blocked.

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -54,6 +54,7 @@ AGENT_TAGS = set(
         "kubeapiserver",
         "kubelet",
         "netcgo",
+        "orchestrator",
         "process",
         "python",
         "secrets",

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -215,7 +215,7 @@ def ineffassign(ctx, targets):
 
 
 @task
-def staticcheck(ctx, targets):
+def staticcheck(ctx, targets, build_tags=None, arch="x64"):
     """
     Run staticcheck on targets.
 
@@ -230,7 +230,12 @@ def staticcheck(ctx, targets):
     # staticcheck checks recursively only if path is in "path/..." format
     go_targets = [sub + "/..." for sub in targets]
 
-    ctx.run("staticcheck -checks=SA1027 " + " ".join(go_targets))
+    tags = build_tags or get_default_build_tags(build="test", arch=arch)
+    # these two don't play well with static checking
+    tags.remove("python")
+    tags.remove("jmx")
+
+    ctx.run("staticcheck -checks=SA1027 -tags=" + ",".join(tags) + " " + " ".join(go_targets))
     # staticcheck exits with status 1 when it finds an issue, if we're here
     # everything went smooth
     print("staticcheck found no issues")

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -121,7 +121,7 @@ def test(
         lint(ctx, targets=tool_targets)
         misspell(ctx, targets=tool_targets)
         ineffassign(ctx, targets=tool_targets)
-        staticcheck(ctx, targets=tool_targets)
+        staticcheck(ctx, targets=tool_targets, build_tags=build_tags, arch=arch)
 
         # for now we only run golangci_lint on Unix as the Windows env need more work
         if sys.platform != 'win32':


### PR DESCRIPTION
### What does this PR do?

Improves the way Agents get the Kubernetes cluster ID from the Cluster Agent.

It used to be that the cluster agent would create a configmap which had to be mounted as an env variable in the agent daemonset, blocking the process-agent from starting if not found. Now the process-agent will start. Only the Kubernetes Resources collection will be blocked.

### Motivation

User misconfiguration resulting in the ConfigMap missing would make the process-agent fail to start.

### Additional Notes

The agent still looks for the env variable first, so it will not fail with older cluster agents

### Describe your test plan

Will deploy the agent and the cluster agent builds from this PR in a k8s cluster with and without the configmap to see how the failure mode looks like.
