### PR TITLE
pkg/trace/agent: increase maximum allowed tag key length from 100 to 200

### DIFF
--- a/pkg/trace/agent/truncator.go
+++ b/pkg/trace/agent/truncator.go
@@ -23,7 +23,7 @@ func init() {
 
 const (
 	// MaxMetaKeyLen the maximum length of metadata key
-	MaxMetaKeyLen = 100
+	MaxMetaKeyLen = 200
 	// MaxMetaValLen the maximum length of metadata value
 	MaxMetaValLen = 5000
 	// MaxMetricsKeyLen the maximum length of a metric name key

--- a/releasenotes/notes/apm-max-key-len-100-to-200-31e84fcd225f8e8d.yaml
+++ b/releasenotes/notes/apm-max-key-len-100-to-200-31e84fcd225f8e8d.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: The maximum allowed key length for tags has been increased from 100 to 200.


### PR DESCRIPTION
The maximum allowed key length for meta and metrics maps has been
increased to 200 in our backend. This change reflects that.