### PR TITLE
Fix the `security-agent runtime check-policies` command

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -50,6 +50,7 @@ var (
 		Short: "Datadog Security Agent at your service.",
 		Long: `
 Datadog Security Agent takes care of running compliance and security checks.`,
+		SilenceUsage: true, // don't print usage on errors
 	}
 
 	startCmd = &cobra.Command{

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -59,6 +59,7 @@ func checkPolicies(cmd *cobra.Command, args []string) error {
 		EnableKernelFilters: true,
 		EnableApprovers:     true,
 		EnableDiscarders:    true,
+		PIDCacheSize:        10000,
 	}
 
 	probe, err := sprobe.NewProbe(cfg, nil)

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -59,7 +59,7 @@ func checkPolicies(cmd *cobra.Command, args []string) error {
 		EnableKernelFilters: true,
 		EnableApprovers:     true,
 		EnableDiscarders:    true,
-		PIDCacheSize:        10000,
+		PIDCacheSize:        1,
 	}
 
 	probe, err := sprobe.NewProbe(cfg, nil)

--- a/cmd/security-agent/main.go
+++ b/cmd/security-agent/main.go
@@ -12,7 +12,6 @@ import (
 	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/app"
 )
@@ -22,7 +21,6 @@ func main() {
 	flavor.SetFlavor(flavor.SecurityAgent)
 
 	if err := app.SecurityAgentCmd.Execute(); err != nil {
-		log.Error(err)
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

The `security-agent runtime check-policies` command is correctly broken due to a missing configuration parameter.

### Additional Notes

This PR also fixes two other issues:
- the error message was printed twice
- the usage was always printed on error