### PR TITLE
Add ddog-gov.com site option to Windows installer

### DIFF
--- a/omnibus/resources/agent/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/agent/msi/assets/sitedlg.wxi
@@ -3,6 +3,7 @@
     <ListItem Text="datadoghq.com" Value="datadoghq.com"/>
     <ListItem Text="datadoghq.eu" Value="datadoghq.eu"/>
     <ListItem Text="us3.datadoghq.com" Value="us3.datadoghq.com"/>
+    <ListItem Text="ddog-gov.com" Value="ddog-gov.com"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
   <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>

--- a/omnibus/resources/dogstatsd/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/dogstatsd/msi/assets/sitedlg.wxi
@@ -3,6 +3,7 @@
     <ListItem Text="datadoghq.com" Value="datadoghq.com"/>
     <ListItem Text="datadoghq.eu" Value="datadoghq.eu"/>
     <ListItem Text="us3.datadoghq.com" Value="us3.datadoghq.com"/>
+    <ListItem Text="ddog-gov.com" Value="ddog-gov.com"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
   <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>

--- a/omnibus/resources/iot/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/iot/msi/assets/sitedlg.wxi
@@ -3,6 +3,7 @@
     <ListItem Text="datadoghq.com" Value="datadoghq.com"/>
     <ListItem Text="datadoghq.eu" Value="datadoghq.eu"/>
     <ListItem Text="us3.datadoghq.com" Value="us3.datadoghq.com"/>
+    <ListItem Text="ddog-gov.com" Value="ddog-gov.com"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">
   <Control Id="SiteFromDefault" Type="ComboBox" ComboList="no" Height="15" Width="320" X="25" Y="148" Property="SITE"/>

--- a/releasenotes/notes/add-ddgov-e6247cff63b3951b.yaml
+++ b/releasenotes/notes/add-ddgov-e6247cff63b3951b.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  - |
+    Support the ddog-gov.com site option in the Windows
+    GUI installer.


### PR DESCRIPTION
### What does this PR do?

Adds ddog-gov.com as a new site option in the Windows installer GUI.

### Motivation

Support new site option.
