### PR TITLE
[AD] Cleanup prometheus AD

### DIFF
--- a/pkg/autodiscovery/common/prometheus.go
+++ b/pkg/autodiscovery/common/prometheus.go
@@ -96,7 +96,6 @@ type LabelJoinsConfig struct {
 
 // ADConfig contains the autodiscovery configuration data for a PrometheusCheck
 type ADConfig struct {
-	ExcludeAutoconf    *bool     `mapstructure:"exclude_autoconfig_files"`
 	KubeAnnotations    *InclExcl `mapstructure:"kubernetes_annotations"`
 	KubeContainerNames []string  `mapstructure:"kubernetes_container_names"`
 	ContainersRe       *regexp.Regexp
@@ -209,11 +208,6 @@ func (ad *ADConfig) GetExcludeAnnotations() map[string]string {
 
 // defaultAD defaults the values of the autodiscovery structure
 func (ad *ADConfig) defaultAD() {
-	if ad.ExcludeAutoconf == nil {
-		// TODO: Implement OOTB autoconf exclusion
-		ad.ExcludeAutoconf = boolPointer(true)
-	}
-
 	if ad.KubeContainerNames == nil {
 		ad.KubeContainerNames = []string{}
 	}
@@ -271,7 +265,6 @@ var DefaultPrometheusCheck = &PrometheusCheck{
 		},
 	},
 	AD: &ADConfig{
-		ExcludeAutoconf: boolPointer(true),
 		KubeAnnotations: &InclExcl{
 			Excl: map[string]string{PrometheusScrapeAnnotation: "false"},
 			Incl: map[string]string{PrometheusScrapeAnnotation: "true"},
@@ -294,8 +287,4 @@ func buildURL(annotations map[string]string) string {
 	}
 
 	return openmetricsURLPrefix + port + path
-}
-
-func boolPointer(b bool) *bool {
-	return &b
 }

--- a/pkg/autodiscovery/providers/prometheus_common_test.go
+++ b/pkg/autodiscovery/providers/prometheus_common_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestSetupConfigs(t *testing.T) {
-	trueVar := true
-	falseVar := false
 	tests := []struct {
 		name       string
 		config     []*common.PrometheusCheck
@@ -36,7 +34,6 @@ func TestSetupConfigs(t *testing.T) {
 						},
 					},
 					AD: &common.ADConfig{
-						ExcludeAutoconf: &trueVar,
 						KubeAnnotations: &common.InclExcl{
 							Excl: map[string]string{"prometheus.io/scrape": "false"},
 							Incl: map[string]string{"prometheus.io/scrape": "true"},
@@ -68,7 +65,6 @@ func TestSetupConfigs(t *testing.T) {
 						},
 					},
 					AD: &common.ADConfig{
-						ExcludeAutoconf: &trueVar,
 						KubeAnnotations: &common.InclExcl{
 							Excl: map[string]string{"prometheus.io/scrape": "false"},
 							Incl: map[string]string{"prometheus.io/scrape": "true"},
@@ -100,7 +96,6 @@ func TestSetupConfigs(t *testing.T) {
 						},
 					},
 					AD: &common.ADConfig{
-						ExcludeAutoconf: &trueVar,
 						KubeAnnotations: &common.InclExcl{
 							Excl: map[string]string{"custom/annotation": "exclude"},
 							Incl: map[string]string{"prometheus.io/scrape": "true"},
@@ -124,7 +119,6 @@ func TestSetupConfigs(t *testing.T) {
 						},
 					},
 					AD: &common.ADConfig{
-						ExcludeAutoconf: &falseVar,
 						KubeAnnotations: &common.InclExcl{
 							Incl: map[string]string{"custom/annotation": "include"},
 							Excl: map[string]string{"custom/annotation": "exclude"},
@@ -143,7 +137,6 @@ func TestSetupConfigs(t *testing.T) {
 						},
 					},
 					AD: &common.ADConfig{
-						ExcludeAutoconf: &falseVar,
 						KubeAnnotations: &common.InclExcl{
 							Incl: map[string]string{"custom/annotation": "include"},
 							Excl: map[string]string{"custom/annotation": "exclude"},
@@ -189,7 +182,6 @@ func TestSetupConfigs(t *testing.T) {
 						},
 					},
 					AD: &common.ADConfig{
-						ExcludeAutoconf: &trueVar,
 						KubeAnnotations: &common.InclExcl{
 							Excl: map[string]string{"prometheus.io/scrape": "false"},
 							Incl: map[string]string{"prometheus.io/scrape": "true"},


### PR DESCRIPTION
### What does this PR do?

Remove `ExcludeAutoconf` config from the Prometheus config provider

### Motivation

OOTB autoconf exclusion is now possible (and not limited to Prometheus) via https://github.com/DataDog/datadog-agent/pull/6509

### Describe your test plan

Should be a no op because `ExcludeAutoconf` wasn't implemented
