### PR TITLE
pkg/trace/agent: update top_level field set by tracer

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -185,6 +185,9 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 		for _, span := range t {
 			a.obfuscator.Obfuscate(span)
 			Truncate(span)
+			if p.ClientComputedTopLevel {
+				traceutil.UpdateTracerTopLevel(span)
+			}
 		}
 		a.Replacer.Replace(t)
 

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -423,22 +423,20 @@ func TestClientComputedTopLevel(t *testing.T) {
 		Metrics:  map[string]float64{sampler.KeySamplingPriority: 2},
 	}}}
 
-	t.Run("on", func(t *testing.T) {
+	t.Run("onNotTop", func(t *testing.T) {
 		go agnt.Process(&api.Payload{
 			Traces:                 traces,
 			Source:                 agnt.Receiver.Stats.GetTagStats(info.Tags{}),
 			ClientComputedTopLevel: true,
 		}, stats.NewSublayerCalculator())
 		timeout := time.After(time.Second)
-		for {
-			select {
-			case ss := <-agnt.TraceWriter.In:
-				_, ok := ss.Traces[0].Spans[0].Metrics["_top_level"]
-				assert.False(t, ok)
-				return
-			case <-timeout:
-				t.Fatal("timed out waiting for input")
-			}
+		select {
+		case ss := <-agnt.TraceWriter.In:
+			_, ok := ss.Traces[0].Spans[0].Metrics["_top_level"]
+			assert.False(t, ok)
+			return
+		case <-timeout:
+			t.Fatal("timed out waiting for input")
 		}
 	})
 
@@ -449,15 +447,33 @@ func TestClientComputedTopLevel(t *testing.T) {
 			ClientComputedTopLevel: false,
 		}, stats.NewSublayerCalculator())
 		timeout := time.After(time.Second)
-		for {
-			select {
-			case ss := <-agnt.TraceWriter.In:
-				_, ok := ss.Traces[0].Spans[0].Metrics["_top_level"]
-				assert.True(t, ok)
-				return
-			case <-timeout:
-				t.Fatal("timed out waiting for input")
-			}
+		select {
+		case ss := <-agnt.TraceWriter.In:
+			_, ok := ss.Traces[0].Spans[0].Metrics["_top_level"]
+			assert.True(t, ok)
+			return
+		case <-timeout:
+			t.Fatal("timed out waiting for input")
+		}
+	})
+
+	t.Run("onTop", func(t *testing.T) {
+		traces[0][0].Metrics["_dd.top_level"] = 1
+		go agnt.Process(&api.Payload{
+			Traces:                 traces,
+			Source:                 agnt.Receiver.Stats.GetTagStats(info.Tags{}),
+			ClientComputedTopLevel: true,
+		}, stats.NewSublayerCalculator())
+		timeout := time.After(time.Second)
+		select {
+		case ss := <-agnt.TraceWriter.In:
+			_, ok := ss.Traces[0].Spans[0].Metrics["_top_level"]
+			assert.True(t, ok)
+			_, ok = ss.Traces[0].Spans[0].Metrics["_dd.top_level"]
+			assert.True(t, ok)
+			return
+		case <-timeout:
+			t.Fatal("timed out waiting for input")
 		}
 	})
 }

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -13,11 +13,20 @@ const (
 
 	// measuredKey is a special metric flag that marks a span for trace metrics calculation.
 	measuredKey = "_dd.measured"
+	// tracerTopLevelKey is a metric flag set by tracers on top_level spans
+	tracerTopLevelKey = "_dd.top_level"
 )
 
 // HasTopLevel returns true if span is top-level.
 func HasTopLevel(s *pb.Span) bool {
 	return s.Metrics[topLevelKey] == 1
+}
+
+// UpdateTracerTopLevel sets _top_level tag on spans flagged by the tracer
+func UpdateTracerTopLevel(s *pb.Span) {
+	if s.Metrics[tracerTopLevelKey] == 1 {
+		SetMetric(s, topLevelKey, 1)
+	}
 }
 
 // IsMeasured returns true if a span should be measured (i.e., it should get trace metrics calculated).


### PR DESCRIPTION
Tracers marking spans as top levels set span.Metrics["_dd.top_level"] = 1.
Translating it to `_top_level` in the 7.25 agent version to keep compatibility.
`_dd.top_level` metric is kept to track when the property is set by tracers.
