### PR TITLE
Fix snmp listener subnet loop

### DIFF
--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -230,6 +230,7 @@ func (l *SNMPListener) checkDevices() {
 	for {
 		var subnet *snmpSubnet
 		for i := range subnets {
+			// Use `&subnets[i]` to pass the correct pointer address to snmpJob{}
 			subnet = &subnets[i]
 			startingIP := make(net.IP, len(subnet.startingIP))
 			copy(startingIP, subnet.startingIP)
@@ -242,7 +243,6 @@ func (l *SNMPListener) checkDevices() {
 				jobIP := make(net.IP, len(currentIP))
 				copy(jobIP, currentIP)
 				job := snmpJob{
-					// Use `&subnets[i]` (not `&subnet`) to pass the correct pointer address
 					subnet:    subnet,
 					currentIP: jobIP,
 				}

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -240,6 +240,7 @@ func (l *SNMPListener) checkDevices() {
 				jobIP := make(net.IP, len(currentIP))
 				copy(jobIP, currentIP)
 				job := snmpJob{
+					// Use `&subnets[i]` (not `&subnet`) to pass the correct pointer address
 					subnet:    &subnets[i],
 					currentIP: jobIP,
 				}

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -228,7 +228,8 @@ func (l *SNMPListener) checkDevices() {
 	discoveryTicker := time.NewTicker(time.Duration(l.config.DiscoveryInterval) * time.Second)
 
 	for {
-		for _, subnet := range subnets {
+		for i := range subnets {
+			subnet := subnets[i]
 			startingIP := make(net.IP, len(subnet.startingIP))
 			copy(startingIP, subnet.startingIP)
 			for currentIP := startingIP; subnet.network.Contains(currentIP); incrementIP(currentIP) {

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -228,8 +228,7 @@ func (l *SNMPListener) checkDevices() {
 	discoveryTicker := time.NewTicker(time.Duration(l.config.DiscoveryInterval) * time.Second)
 
 	for {
-		for i := range subnets {
-			subnet := subnets[i]
+		for i, subnet := range subnets {
 			startingIP := make(net.IP, len(subnet.startingIP))
 			copy(startingIP, subnet.startingIP)
 			for currentIP := startingIP; subnet.network.Contains(currentIP); incrementIP(currentIP) {
@@ -241,7 +240,7 @@ func (l *SNMPListener) checkDevices() {
 				jobIP := make(net.IP, len(currentIP))
 				copy(jobIP, currentIP)
 				job := snmpJob{
-					subnet:    &subnet,
+					subnet:    &subnets[i],
 					currentIP: jobIP,
 				}
 				jobs <- job

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -228,7 +228,9 @@ func (l *SNMPListener) checkDevices() {
 	discoveryTicker := time.NewTicker(time.Duration(l.config.DiscoveryInterval) * time.Second)
 
 	for {
-		for i, subnet := range subnets {
+		var subnet *snmpSubnet
+		for i := range subnets {
+			subnet = &subnets[i]
 			startingIP := make(net.IP, len(subnet.startingIP))
 			copy(startingIP, subnet.startingIP)
 			for currentIP := startingIP; subnet.network.Contains(currentIP); incrementIP(currentIP) {
@@ -241,7 +243,7 @@ func (l *SNMPListener) checkDevices() {
 				copy(jobIP, currentIP)
 				job := snmpJob{
 					// Use `&subnets[i]` (not `&subnet`) to pass the correct pointer address
-					subnet:    &subnets[i],
+					subnet:    subnet,
 					currentIP: jobIP,
 				}
 				jobs <- job

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -6,7 +6,9 @@
 package listeners
 
 import (
+	"strconv"
 	"testing"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 
@@ -55,6 +57,62 @@ func TestSNMPListener(t *testing.T) {
 	job = <-testChan
 	assert.Equal(t, "192.168.0.1", job.currentIP.String())
 	assert.Equal(t, "192.168.0.0", job.subnet.startingIP.String())
+}
+
+func TestSNMPListenerSubnets(t *testing.T) {
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	testChan := make(chan snmpJob)
+
+	listenerConfig := snmp.ListenerConfig{
+		Configs: []snmp.Config{},
+		Workers: 10,
+	}
+
+	for i := 0; i < 100; i++ {
+		snmpConfig := snmp.Config{
+			Network:     "172.18.0.0/30",
+			Community:   "f5-big-ip",
+			Port:        1161,
+			ContextName: "context" + strconv.Itoa(i),
+		}
+		listenerConfig.Configs = append(listenerConfig.Configs, snmpConfig)
+	}
+
+	mockConfig := config.Mock()
+	mockConfig.Set("snmp_listener", listenerConfig)
+
+	worker = func(l *SNMPListener, jobs <-chan snmpJob) {
+		for {
+			job := <-jobs
+			testChan <- job
+		}
+	}
+
+	snmpListenerConfig, err := snmp.NewListenerConfig()
+	assert.Equal(t, nil, err)
+
+	services := map[string]Service{}
+	l := &SNMPListener{
+		services: services,
+		stop:     make(chan bool),
+		config:   snmpListenerConfig,
+	}
+
+	l.Listen(newSvc, delSvc)
+
+	subnets := make(map[uintptr]bool)
+	entities := make(map[string]bool)
+
+	for i := 0; i < 400; i++ {
+		job := <-testChan
+		subnets[uintptr(unsafe.Pointer(job.subnet))] = true
+		entities[job.subnet.config.Digest(job.currentIP.String())] = true
+	}
+
+	// make sure we have 100 subnets and 400 different entity hashes
+	assert.Equal(t, 100, len(subnets))
+	assert.Equal(t, 400, len(entities))
 }
 
 func TestSNMPListenerIgnoredAdresses(t *testing.T) {

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -6,11 +6,10 @@
 package listeners
 
 import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"strconv"
 	"testing"
-	"unsafe"
-
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/snmp"
@@ -101,12 +100,12 @@ func TestSNMPListenerSubnets(t *testing.T) {
 
 	l.Listen(newSvc, delSvc)
 
-	subnets := make(map[uintptr]bool)
+	subnets := make(map[string]bool)
 	entities := make(map[string]bool)
 
 	for i := 0; i < 400; i++ {
 		job := <-testChan
-		subnets[uintptr(unsafe.Pointer(job.subnet))] = true
+		subnets[fmt.Sprintf("%p", job.subnet)] = true
 		entities[job.subnet.config.Digest(job.currentIP.String())] = true
 	}
 

--- a/releasenotes/notes/snmp_listener_fix_subnets_loop-c870ab18d3fac9fd.yaml
+++ b/releasenotes/notes/snmp_listener_fix_subnets_loop-c870ab18d3fac9fd.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix snmp listener subnet loop to use correct subnet pointer
+    when creating snmpJob object.


### PR DESCRIPTION
### What does this PR do?

Fix snmp listener subnet loop to use correct subnet pointer when creating snmpJob object.

### Motivation

This bug lead to wrong services being scheduled (duplicate services for same device ip and/or missing service for discovered device) making the feature unreliable.

### Additional Notes


### Describe your test plan

Use snmp listener with at least 10 subnets that discovers 2 or more 

Example manual testing using k8s + helm chart: https://gist.github.com/AlexandreYang/de88d56b53766fb7557bdb2fb1102e62

```
helm install datadog-monitoring --set datadog.apiKey=XXXXXXXXXXX -f cluster-agent-values_snmp_listener.yaml datadog/datadog
```

You might need to run first:

```
helm repo add datadog https://helm.datadoghq.com
helm repo add stable https://charts.helm.sh/stable
helm repo update
```
