### PR TITLE
[AD][Tagger] Fix potential inconsistent tags hash

### DIFF
--- a/pkg/autodiscovery/common_test.go
+++ b/pkg/autodiscovery/common_test.go
@@ -48,8 +48,8 @@ func (s *dummyService) GetPorts() ([]listeners.ContainerPort, error) {
 }
 
 // GetTags returns mil
-func (s *dummyService) GetTags() ([]string, error) {
-	return nil, nil
+func (s *dummyService) GetTags() ([]string, string, error) {
+	return nil, "", nil
 }
 
 // GetPid return a dummy pid

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -59,8 +59,8 @@ func (s *dummyService) GetPorts() ([]listeners.ContainerPort, error) {
 }
 
 // GetTags returns mil
-func (s *dummyService) GetTags() ([]string, error) {
-	return nil, nil
+func (s *dummyService) GetTags() ([]string, string, error) {
+	return nil, "", nil
 }
 
 // GetPid return a dummy pid
@@ -566,7 +566,7 @@ func TestResolve(t *testing.T) {
 			// Make sure we don't modify the template object
 			checksum := tc.tpl.Digest()
 
-			cfg, err := Resolve(tc.tpl, tc.svc)
+			cfg, _, err := Resolve(tc.tpl, tc.svc)
 			if tc.errorString != "" {
 				assert.EqualError(t, err, tc.errorString)
 			} else {

--- a/pkg/autodiscovery/listeners/cloudfoundry.go
+++ b/pkg/autodiscovery/listeners/cloudfoundry.go
@@ -227,8 +227,8 @@ func (s *CloudFoundryService) GetPorts() ([]ContainerPort, error) {
 }
 
 // GetTags returns the list of container tags
-func (s *CloudFoundryService) GetTags() ([]string, error) {
-	return s.tags, nil
+func (s *CloudFoundryService) GetTags() ([]string, string, error) {
+	return s.tags, "", nil
 }
 
 // GetPid returns nil and an error because pids are currently not supported in CF

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -292,7 +292,7 @@ func (l *DockerListener) createService(cID string) {
 	if err != nil {
 		log.Errorf("Failed to inspect container %s - %s", cID[:12], err)
 	}
-	_, err = svc.GetTags()
+	_, _, err = svc.GetTags()
 	if err != nil {
 		log.Errorf("Failed to inspect container %s - %s", cID[:12], err)
 	}
@@ -551,13 +551,8 @@ func parseDockerPort(port nat.Port) ([]ContainerPort, error) {
 }
 
 // GetTags retrieves tags using the Tagger
-func (s *DockerService) GetTags() ([]string, error) {
-	tags, err := tagger.Tag(s.GetTaggerEntity(), tagger.ChecksCardinality)
-	if err != nil {
-		return []string{}, err
-	}
-
-	return tags, nil
+func (s *DockerService) GetTags() ([]string, string, error) {
+	return tagger.TagWithHash(s.GetTaggerEntity(), tagger.ChecksCardinality)
 }
 
 // GetPid inspect the container an return its pid

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -43,7 +43,6 @@ type ECSService struct {
 	runtime         string
 	ADIdentifiers   []string
 	hosts           map[string]string
-	tags            []string
 	clusterName     string
 	taskFamily      string
 	taskVersion     string
@@ -201,13 +200,6 @@ func (l *ECSListener) createService(c v2.Container, firstRun bool) (ECSService, 
 	}
 	svc.hosts = ips
 
-	// Tags
-	tags, err := tagger.Tag(svc.GetTaggerEntity(), tagger.ChecksCardinality)
-	if err != nil {
-		log.Errorf("Failed to extract tags for container %s - %s", c.DockerID[:12], err)
-	}
-	svc.tags = tags
-
 	// Detect metrics or logs exclusion
 	svc.metricsExcluded = l.filters.IsExcluded(containers.MetricsFilter, c.DockerName, c.Image, "")
 	svc.logsExcluded = l.filters.IsExcluded(containers.LogsFilter, c.DockerName, c.Image, "")
@@ -251,8 +243,8 @@ func (s *ECSService) GetPorts() ([]ContainerPort, error) {
 }
 
 // GetTags retrieves a container's tags
-func (s *ECSService) GetTags() ([]string, error) {
-	return s.tags, nil
+func (s *ECSService) GetTags() ([]string, string, error) {
+	return tagger.TagWithHash(s.GetTaggerEntity(), tagger.ChecksCardinality)
 }
 
 // GetPid inspect the container and return its pid

--- a/pkg/autodiscovery/listeners/kube_endpoints.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints.go
@@ -394,11 +394,11 @@ func (s *KubeEndpointService) GetPorts() ([]ContainerPort, error) {
 }
 
 // GetTags retrieves tags
-func (s *KubeEndpointService) GetTags() ([]string, error) {
+func (s *KubeEndpointService) GetTags() ([]string, string, error) {
 	if s.tags == nil {
-		return []string{}, nil
+		return []string{}, "", nil
 	}
-	return s.tags, nil
+	return s.tags, "", nil
 }
 
 // GetHostname returns nil and an error because port is not supported in Kubelet

--- a/pkg/autodiscovery/listeners/kube_endpoints_test.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints_test.go
@@ -73,7 +73,7 @@ func TestProcessEndpoints(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []ContainerPort{{123, "port123"}, {126, "port126"}}, ports)
 
-	tags, err := eps[0].GetTags()
+	tags, _, err := eps[0].GetTags()
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"kube_service:myservice", "kube_namespace:default", "kube_endpoint_ip:10.0.0.1", "foo:bar"}, tags)
 
@@ -92,7 +92,7 @@ func TestProcessEndpoints(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []ContainerPort{{123, "port123"}, {126, "port126"}}, ports)
 
-	tags, err = eps[1].GetTags()
+	tags, _, err = eps[1].GetTags()
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"kube_service:myservice", "kube_namespace:default", "kube_endpoint_ip:10.0.0.2", "foo:bar"}, tags)
 

--- a/pkg/autodiscovery/listeners/kube_services.go
+++ b/pkg/autodiscovery/listeners/kube_services.go
@@ -329,8 +329,8 @@ func (s *KubeServiceService) GetPorts() ([]ContainerPort, error) {
 }
 
 // GetTags retrieves tags
-func (s *KubeServiceService) GetTags() ([]string, error) {
-	return s.tags, nil
+func (s *KubeServiceService) GetTags() ([]string, string, error) {
+	return s.tags, "", nil
 }
 
 // GetHostname returns nil and an error because port is not supported in Kubelet

--- a/pkg/autodiscovery/listeners/kube_services_test.go
+++ b/pkg/autodiscovery/listeners/kube_services_test.go
@@ -65,7 +65,7 @@ func TestProcessService(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []ContainerPort{{123, "test1"}, {126, "test2"}}, ports)
 
-	tags, err := svc.GetTags()
+	tags, _, err := svc.GetTags()
 	assert.NoError(t, err)
 	expectedTags := []string{
 		"kube_service:myservice",

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -436,8 +436,8 @@ func (s *KubeContainerService) GetPorts() ([]ContainerPort, error) {
 }
 
 // GetTags retrieves tags using the Tagger
-func (s *KubeContainerService) GetTags() ([]string, error) {
-	return tagger.Tag(s.GetTaggerEntity(), tagger.ChecksCardinality)
+func (s *KubeContainerService) GetTags() ([]string, string, error) {
+	return tagger.TagWithHash(s.GetTaggerEntity(), tagger.ChecksCardinality)
 }
 
 // GetHostname returns nil and an error because port is not supported in Kubelet
@@ -512,8 +512,8 @@ func (s *KubePodService) GetPorts() ([]ContainerPort, error) {
 }
 
 // GetTags retrieves tags using the Tagger
-func (s *KubePodService) GetTags() ([]string, error) {
-	return tagger.Tag(s.GetTaggerEntity(), tagger.ChecksCardinality)
+func (s *KubePodService) GetTags() ([]string, string, error) {
+	return tagger.TagWithHash(s.GetTaggerEntity(), tagger.ChecksCardinality)
 }
 
 // GetHostname returns nil and an error because port is not supported in Kubelet

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -349,8 +349,8 @@ func (s *SNMPService) GetPorts() ([]ContainerPort, error) {
 }
 
 // GetTags returns the list of container tags - currently always empty
-func (s *SNMPService) GetTags() ([]string, error) {
-	return []string{}, nil
+func (s *SNMPService) GetTags() ([]string, string, error) {
+	return []string{}, "", nil
 }
 
 // GetPid returns nil and an error because pids are currently not supported

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -31,7 +31,7 @@ type Service interface {
 	GetADIdentifiers() ([]string, error)       // identifiers on which templates will be matched
 	GetHosts() (map[string]string, error)      // network --> IP address
 	GetPorts() ([]ContainerPort, error)        // network ports
-	GetTags() ([]string, error)                // tags
+	GetTags() ([]string, string, error)        // tags and tags hash
 	GetPid() (int, error)                      // process identifier
 	GetHostname() (string, error)              // hostname.domainname for the entity
 	GetCreationTime() integration.CreationTime // created before or after the agent start

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -57,6 +57,22 @@ func Tag(entity string, cardinality collectors.TagCardinality) ([]string, error)
 	return defaultTagger.Tag(entity, cardinality)
 }
 
+// TagWithHash is similar to Tag but it also computes and returns the hash of the tags found
+func TagWithHash(entity string, cardinality collectors.TagCardinality) ([]string, string, error) {
+	tags, err := Tag(entity, cardinality)
+	if err != nil {
+		return tags, "", err
+	}
+	return tags, computeTagsHash(tags), nil
+}
+
+// GetEntityHash returns the hash for the tags associated with the given entity
+// Returns an empty string if the tags lookup fails
+func GetEntityHash(entity string, cardinality collectors.TagCardinality) string {
+	_, hash, _ := TagWithHash(entity, cardinality)
+	return hash
+}
+
 // StandardTags queries the defaultTagger to get entity
 // standard tags (env, version, service) from cache or sources.
 func StandardTags(entity string) ([]string, error) {
@@ -88,11 +104,6 @@ func Stop() error {
 // List the content of the defaulTagger
 func List(cardinality collectors.TagCardinality) response.TaggerListResponse {
 	return defaultTagger.List(cardinality)
-}
-
-// GetEntityHash returns the hash for the tags associated with the given entity
-func GetEntityHash(entity string) string {
-	return defaultTagger.GetEntityHash(entity)
 }
 
 // GetDefaultTagger returns the global Tagger instance

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -218,12 +218,6 @@ func (t *Tagger) Stop() error {
 	return nil
 }
 
-// GetEntityHash returns the tags hash of an entity
-func (t *Tagger) GetEntityHash(entity string) string {
-	_, _, tagsHash := t.tagStore.lookup(entity, collectors.HighCardinality)
-	return tagsHash
-}
-
 // Tag returns tags for a given entity
 func (t *Tagger) Tag(entity string, cardinality collectors.TagCardinality) ([]string, error) {
 	queries.Inc(tagCardinalityToString(cardinality))
@@ -292,7 +286,7 @@ func (t *Tagger) Standard(entity string) ([]string, error) {
 	if entity == "" {
 		return nil, fmt.Errorf("empty entity ID")
 	}
-	if hash := t.GetEntityHash(entity); hash == "" {
+	if _, _, hash := t.tagStore.lookup(entity, collectors.HighCardinality); hash == "" {
 		// entity not found yet in the tagger
 		// trigger tagger fetch operations
 		log.Debugf("Entity '%s' not found in tagger cache, will try to fetch it", entity)

--- a/releasenotes/notes/fix-tags-race-5d9e6ebad31c97aa.yaml
+++ b/releasenotes/notes/fix-tags-race-5d9e6ebad31c97aa.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a bug that could potentially cause missing container tags for check metrics.

--- a/test/integration/listeners/docker/docker_listener_test.go
+++ b/test/integration/listeners/docker/docker_listener_test.go
@@ -212,8 +212,9 @@ func (suite *DockerListenerTestSuite) commonSection(containerIDs []string) {
 		expectedTags, found := expectedADIDs[entity]
 		assert.True(suite.T(), found, "entity not found in expected ones")
 
-		tags, err := service.GetTags()
+		tags, hash, err := service.GetTags()
 		assert.Nil(suite.T(), err)
+		assert.NotEqual(suite.T(), "", hash)
 		assert.Contains(suite.T(), tags, "docker_image:datadog/docker-library:redis_3_2_11-alpine")
 		assert.Contains(suite.T(), tags, "image_name:datadog/docker-library")
 		assert.Contains(suite.T(), tags, "image_tag:redis_3_2_11-alpine")


### PR DESCRIPTION
### What does this PR do?

Make sure the tags hash and the tags cached in the AD store are consistent.
Now instead of fetching the tags twice, we fetch the tags once and we compute the hash based on the result we get from the tagger.

### Motivation

Before this PR, the following scenario can happen:
- Collect tags: got `a:b`, `c:d`
- Compute tags hash by fetching the tags again, in the meantime the tags might have changed: we get and store a tags hash for `a:b`, `c:d`, `x:y`

Later, the refresh tags mechanism will call the tagger again and compare the stored hash to the new tags hash, and will find that the tags are fresh which is incorrect. the check will miss the `x:y` tag.

### Describe your test plan

Not obvious how to reproduce this, we need to make sure this change doesn't break anything (e.g we can try adding/deleting container/pod tags dynamically and see how AD reacts)