### PR TITLE
Start the security-agent binary if security-agent.yaml is not present

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -128,7 +128,7 @@ func start(cmd *cobra.Command, args []string) error {
 	defer log.Flush()
 
 	// Read configuration files received from the command line arguments '-c'
-	if err := common.MergeConfigurationFiles("datadog", confPathArray); err != nil {
+	if err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
 		return err
 	}
 

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -62,7 +62,7 @@ func init() {
 
 func eventRun(cmd *cobra.Command, args []string) error {
 	// Read configuration files received from the command line arguments '-c'
-	if err := secagentcommon.MergeConfigurationFiles("datadog", confPathArray); err != nil {
+	if err := secagentcommon.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
 		return err
 	}
 

--- a/cmd/security-agent/app/config.go
+++ b/cmd/security-agent/app/config.go
@@ -33,7 +33,7 @@ var configCommand = &cobra.Command{
 		}
 
 		// Read configuration files received from the command line arguments '-c'
-		err := common.MergeConfigurationFiles("datadog", confPathArray)
+		err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed)
 		if err != nil {
 			return err
 		}

--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -43,7 +43,7 @@ var flareCmd = &cobra.Command{
 		}
 
 		// Read configuration files received from the command line arguments '-c'
-		err := secagentcommon.MergeConfigurationFiles("datadog", confPathArray)
+		err := secagentcommon.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed)
 		if err != nil {
 			return err
 		}

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -49,7 +49,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Read configuration files received from the command line arguments '-c'
-	err := common.MergeConfigurationFiles("datadog", confPathArray)
+	err := common.MergeConfigurationFiles("datadog", confPathArray, cmd.Flags().Lookup("cfgpath").Changed)
 	if err != nil {
 		return err
 	}

--- a/cmd/security-agent/common/check_command.go
+++ b/cmd/security-agent/common/check_command.go
@@ -69,7 +69,7 @@ func runCheck(cmd *cobra.Command, confPathArray []string, args []string) error {
 	}
 
 	// Read configuration files received from the command line arguments '-c'
-	if err := MergeConfigurationFiles(configName, confPathArray); err != nil {
+	if err := MergeConfigurationFiles(configName, confPathArray, cmd.Flags().Lookup("cfgpath").Changed); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR makes the security-agent binary evaluates all provided configuration files, and does not mandate that the `security-agent.yaml` file exists.

### Motivation

`security-agent status` does not work if `/etc/datadog-agent/security-agent.yaml` does not exist.

### Additional Notes

When files do not exist, the output differs when `-c`is specified by the user or not.

Here is the error message when no filenames are specified:
```
security-agent status 
Error: Unable to load any configuration file from [/etc/datadog-agent/datadog.yaml /etc/datadog-agent/security-agent.yaml]
```

When `-c` is used:
```
security-agent/security-agent status -c /etc/datadog-agent/datadog.yaml -c /etc/datadog-agent/security-agent.yaml
Warning: unable to access /etc/datadog-agent/datadog.yaml
Warning: unable to access /etc/datadog-agent/security-agent.yaml
Error: Unable to load any configuration file from [/etc/datadog-agent/datadog.yaml /etc/datadog-agent/security-agent.yaml]
```


