### PR TITLE
[DCA] Add `external_metrics_provider.endpoint` config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -615,9 +615,10 @@ func InitConfig(config Config) {
 
 	config.BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
 	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes
+	config.BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
 	config.BindEnvAndSetDefault("external_metrics_provider.enabled", false)
 	config.BindEnvAndSetDefault("external_metrics_provider.port", 443)
-	config.BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
+	config.BindEnvAndSetDefault("external_metrics_provider.endpoint", "")                 // Override the Datadog API endpoint to query external metrics from
 	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)           // value in seconds. Frequency of calls to Datadog to refresh metric values
 	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)             // value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)
 	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 120)                 // value in seconds. 4 cycles from the Autoscaler controller (up to Kubernetes 1.11) is enough to consider a metric stale

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -55,9 +55,10 @@ type Point struct {
 }
 
 const (
-	value         = 1
-	timestamp     = 0
-	queryEndpoint = "/api/v1/query"
+	value                 = 1
+	timestamp             = 0
+	queryEndpoint         = "/api/v1/query"
+	metricsEndpointPrefix = "https://api."
 )
 
 // queryDatadogExternal converts the metric name and labels from the Ref format into a Datadog metric.
@@ -184,17 +185,19 @@ func (p *Processor) updateRateLimitingMetrics() error {
 func NewDatadogClient() (*datadog.Client, error) {
 	apiKey := config.Datadog.GetString("api_key")
 	appKey := config.Datadog.GetString("app_key")
+	endpoint := config.GetMainEndpoint(metricsEndpointPrefix, "external_metrics_provider.endpoint")
 
 	if appKey == "" || apiKey == "" {
 		return nil, errors.New("missing the api/app key pair to query Datadog")
 	}
 
-	log.Infof("Initialized the Datadog Client for HPA")
+	log.Infof("Initialized the Datadog Client for HPA with endpoint %q", endpoint)
 
 	client := datadog.NewClient(apiKey, appKey)
 	client.HttpClient.Transport = httputils.CreateHTTPTransport()
 	client.RetryTimeout = 3 * time.Second
 	client.ExtraHeader["User-Agent"] = "Datadog-Cluster-Agent"
+	client.SetBaseUrl(endpoint)
 
 	return client, nil
 }

--- a/releasenotes-dca/notes/external-metrics-provider-endpoint-5f8ef7cd3879ecaa.yaml
+++ b/releasenotes-dca/notes/external-metrics-provider-endpoint-5f8ef7cd3879ecaa.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    Add a new external_metrics_provider.endpoint config in datadog-cluster.yaml
+    and a DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT environment variable to
+    override the default Datadog API endpoint to query external metrics from,
+    in place of the global DATADOG_HOST. It also makes the external metrics
+    provider respect DD_SITE if DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT is not
+    set.


### PR DESCRIPTION
# What does this PR do?

Add a new external_metrics_provider.endpoint config in
`datadog-cluster.yaml` and a `DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT`
environment variable to override the default Datadog API endpoint to
query external metrics from, in place of the global `DATADOG_HOST`. It
also makes the external metrics provider respect the `DD_SITE` setting if
`DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT` is not set.

# Describe your test plan

The external metrics client outputs a log line when it's initialized, in the form of `Initialized the Datadog Client for HPA with endpoint ...`. The following is expected:

* default config => `https://api.datadoghq.com`
* `DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT` set to a custom value => the value set in the env var
* site set to datadoghq.eu and without the env var above => `https://api.datadoghq.eu`