### PR TITLE
Pick up new pod tags

### DIFF
--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -79,18 +79,19 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 	defer w.Unlock()
 	for _, pod := range podList {
 		podEntity := PodUIDToEntityName(pod.Metadata.UID)
-		newStaticPod := false
+		newPod := false
 		_, foundPod := w.lastSeen[podEntity]
 
 		if w.isWatchingTags() && !foundPod {
 			w.tagsDigest[podEntity] = digestPodMeta(pod.Metadata)
 			w.oldPhase[podEntity] = pod.Status.Phase
+			newPod = true
 		}
 
 		// static pods are included specifically because they won't have any container
 		// as they're not updated in the pod list after creation
 		if isPodStatic(pod) && !foundPod {
-			newStaticPod = true
+			newPod = true
 		}
 
 		// Refresh last pod seen time
@@ -141,7 +142,7 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 				newPhase = true
 			}
 		}
-		if newStaticPod || updatedContainer || newLabelsOrAnnotations || newPhase {
+		if newPod || updatedContainer || newLabelsOrAnnotations || newPhase {
 			updatedPods = append(updatedPods, pod)
 		}
 	}

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -575,6 +575,24 @@ func (suite *PodwatcherTestSuite) TestPodWatcherAnnotationsValueChange() {
 	require.Len(suite.T(), changes, 2)
 }
 
+func (suite *PodwatcherTestSuite) TestPodWatcherContainerCreating() {
+	sourcePods, err := loadPodsFixture("./testdata/podlist_container_creating.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 1)
+
+	watcher := &PodWatcher{
+		lastSeen:       make(map[string]time.Time),
+		lastSeenReady:  make(map[string]time.Time),
+		tagsDigest:     make(map[string]string),
+		oldPhase:       make(map[string]string),
+		expiryDuration: 5 * time.Minute,
+	}
+
+	changes, err := watcher.computeChanges(sourcePods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 1)
+}
+
 func TestPodwatcherTestSuite(t *testing.T) {
 	suite.Run(t, new(PodwatcherTestSuite))
 }

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -583,6 +583,22 @@ func (suite *PodwatcherTestSuite) TestPodWatcherContainerCreating() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		expiryDuration: 5 * time.Minute,
+	}
+
+	changes, err := watcher.computeChanges(sourcePods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 0)
+}
+
+func (suite *PodwatcherTestSuite) TestPodWatcherContainerCreatingTags() {
+	sourcePods, err := loadPodsFixture("./testdata/podlist_container_creating.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 1)
+
+	watcher := &PodWatcher{
+		lastSeen:       make(map[string]time.Time),
+		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
 		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_container_creating.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_container_creating.json
@@ -1,0 +1,141 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "metadata": {
+        "name": "pod-containercreating",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/pod-containercreating",
+        "uid": "a7b2a624-3b27-11eb-bf0e-42010a8400c5",
+        "resourceVersion": "175060842",
+        "creationTimestamp": "2020-12-10T20:38:26Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"pod-containercreating\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"k8s.gcr.io/test-webserver\",\"name\":\"test-container\",\"volumeMounts\":[{\"mountPath\":\"/test-ebs\",\"name\":\"test-volume\"}]}],\"restartPolicy\":\"Never\",\"volumes\":[{\"hostPath\":{\"path\":\"/invalid\",\"type\":\"Directory\"},\"name\":\"test-volume\"}]}}\n",
+          "kubernetes.io/config.seen": "2020-12-10T20:38:26.836351897Z",
+          "kubernetes.io/config.source": "api",
+          "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container test-container"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "test-volume",
+            "hostPath": {
+              "path": "/invalid",
+              "type": "Directory"
+            }
+          },
+          {
+            "name": "default-token-6b2kz",
+            "secret": {
+              "secretName": "default-token-6b2kz",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "test-container",
+            "image": "k8s.gcr.io/test-webserver",
+            "resources": {
+              "requests": {
+                "cpu": "100m"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "test-volume",
+                "mountPath": "/test-ebs"
+              },
+              {
+                "name": "default-token-6b2kz",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Never",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "my-node-name",
+        "securityContext": {},
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true
+      },
+      "status": {
+        "phase": "Pending",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-12-10T20:38:26Z"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-12-10T20:38:26Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [test-container]"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-12-10T20:38:26Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [test-container]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-12-10T20:38:26Z"
+          }
+        ],
+        "hostIP": "10.132.0.98",
+        "startTime": "2020-12-10T20:38:26Z",
+        "containerStatuses": [
+          {
+            "name": "test-container",
+            "state": {
+              "waiting": {
+                "reason": "ContainerCreating"
+              }
+            },
+            "lastState": {},
+            "ready": false,
+            "restartCount": 0,
+            "image": "k8s.gcr.io/test-webserver",
+            "imageID": ""
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    }
+  ]
+}

--- a/releasenotes/notes/new-pod-tags-7fc08af62bf4170d.yaml
+++ b/releasenotes/notes/new-pod-tags-7fc08af62bf4170d.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix missing tags on pods that were not seen with a running container yet.


### PR DESCRIPTION
### What does this PR do?

It changes the pod watcher, when watching for tags, so that "new" (i.e. never seen until the agent started) pods are always picked up.

### Motivation

Pods in the pending phase that don't have any container running yet are discarded by the pod watcher. As a consequence, the kubelet tagger collector never gets a chance to see them and we are missing tags for those in the orchestrator explorer.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
