### PR TITLE
[DCA] Prometheus endpoint checks in service config provider

### DIFF
--- a/pkg/autodiscovery/common/prometheus_apiserver.go
+++ b/pkg/autodiscovery/common/prometheus_apiserver.go
@@ -14,8 +14,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	kubePodKind   = "Pod"
+	KubePodPrefix = "kubernetes_pod://"
 )
 
 // ConfigsForService returns the openmetrics configurations for a given service if it matches the AD configuration
@@ -41,4 +47,59 @@ func (pc *PrometheusCheck) ConfigsForService(svc *v1.Service) []integration.Conf
 	}
 
 	return configs
+}
+
+// ConfigsForServiceEndpoints returns the openmetrics configurations for a given endpoints if it matches the AD
+// configuration for related service
+func (pc *PrometheusCheck) ConfigsForServiceEndpoints(svc *v1.Service, ep *v1.Endpoints) []integration.Config {
+	var configs []integration.Config
+	namespacedName := fmt.Sprintf("%s/%s", svc.GetNamespace(), svc.GetName())
+	if pc.isExcluded(svc.GetAnnotations(), namespacedName) {
+		return configs
+	}
+
+	instances, found := pc.buildInstances(svc.GetAnnotations(), namespacedName)
+	if found {
+		for _, subset := range ep.Subsets {
+			for _, address := range subset.Addresses {
+				endpointsID := apiserver.EntityForEndpoints(ep.GetNamespace(), ep.GetName(), address.IP)
+
+				epConfig := integration.Config{
+					Name:          openmetricsCheckName,
+					InitConfig:    integration.Data(openmetricsInitConfig),
+					Instances:     instances,
+					ClusterCheck:  true,
+					Provider:      names.PrometheusServices,
+					Source:        "prometheus_services:" + endpointsID,
+					ADIdentifiers: []string{endpointsID},
+				}
+
+				ResolveEndpointConfigAuto(&epConfig, address)
+				configs = append(configs, epConfig)
+			}
+		}
+	}
+
+	return configs
+}
+
+// ResolveEndpointConfigAuto automatically resolves endpoint pod and node information if available
+func ResolveEndpointConfigAuto(conf *integration.Config, addr v1.EndpointAddress) {
+	log.Debugf("using 'auto' resolve for config: %s, entity: %s", conf.Name, conf.Entity)
+	if targetRef := addr.TargetRef; targetRef != nil && targetRef.Kind == kubePodKind {
+		// The endpoint is backed by a pod.
+		// We add the pod uid as AD identifiers so the check can get the pod tags.
+		podUID := string(targetRef.UID)
+		conf.ADIdentifiers = append(conf.ADIdentifiers, getPodEntity(podUID))
+		if nodeName := addr.NodeName; nodeName != nil {
+			// Set the node name to schedule the endpoint check on the correct node.
+			// This field needs to be set only when the endpoint is backed by a pod.
+			conf.NodeName = *nodeName
+		}
+	}
+}
+
+// getPodEntity returns pod entity
+func getPodEntity(podUID string) string {
+	return KubePodPrefix + podUID
 }

--- a/pkg/autodiscovery/common/prometheus_apiserver.go
+++ b/pkg/autodiscovery/common/prometheus_apiserver.go
@@ -65,6 +65,7 @@ func (pc *PrometheusCheck) ConfigsForServiceEndpoints(svc *v1.Service, ep *v1.En
 				endpointsID := apiserver.EntityForEndpoints(ep.GetNamespace(), ep.GetName(), address.IP)
 
 				epConfig := integration.Config{
+					Entity:        endpointsID,
 					Name:          openmetricsCheckName,
 					InitConfig:    integration.Data(openmetricsInitConfig),
 					Instances:     instances,

--- a/pkg/autodiscovery/common/prometheus_test.go
+++ b/pkg/autodiscovery/common/prometheus_test.go
@@ -8,6 +8,7 @@ package common
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -76,4 +77,98 @@ func TestContainerRegex(t *testing.T) {
 	assert.NotNil(t, ad.ContainersRe)
 	assert.True(t, ad.matchContainer("foo"))
 	assert.True(t, ad.matchContainer("bar"))
+}
+
+func TestGetPrometheusIncludeAnnotations(t *testing.T) {
+	tests := []struct {
+		name   string
+		config []*PrometheusCheck
+		want   map[string]string
+	}{
+		{
+			name:   "empty config, default",
+			config: []*PrometheusCheck{},
+			want:   PrometheusAnnotations{"prometheus.io/scrape": "true"},
+		},
+		{
+			name:   "custom config",
+			config: []*PrometheusCheck{{AD: &ADConfig{KubeAnnotations: &InclExcl{Incl: map[string]string{"include": "true"}}}}},
+			want:   PrometheusAnnotations{"include": "true"},
+		},
+		{
+			name: "multiple configs",
+			config: []*PrometheusCheck{
+				{
+					AD: &ADConfig{KubeAnnotations: &InclExcl{Incl: map[string]string{"foo": "bar"}}},
+				},
+				{
+					AD: &ADConfig{KubeAnnotations: &InclExcl{Incl: map[string]string{"baz": "tar"}}},
+				},
+			},
+			want: PrometheusAnnotations{"foo": "bar", "baz": "tar"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.Datadog.Set("prometheus_scrape.checks", tt.config)
+			assert.EqualValues(t, tt.want, GetPrometheusIncludeAnnotations())
+		})
+	}
+}
+
+func TestPrometheusIsMatchingAnnotations(t *testing.T) {
+	tests := []struct {
+		name           string
+		promInclAnnot  PrometheusAnnotations
+		svcAnnotations map[string]string
+		want           bool
+	}{
+		{
+			name:           "is prom service",
+			promInclAnnot:  PrometheusAnnotations{"prometheus.io/scrape": "true"},
+			svcAnnotations: map[string]string{"prometheus.io/scrape": "true", "foo": "bar"},
+			want:           true,
+		},
+		{
+			name:           "is not prom service",
+			promInclAnnot:  PrometheusAnnotations{"prometheus.io/scrape": "true"},
+			svcAnnotations: map[string]string{"foo": "bar"},
+			want:           false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.promInclAnnot.IsMatchingAnnotations(tt.svcAnnotations))
+		})
+	}
+}
+
+func TestPrometheusAnnotationsDiffer(t *testing.T) {
+	tests := []struct {
+		name          string
+		promInclAnnot PrometheusAnnotations
+		first         map[string]string
+		second        map[string]string
+		want          bool
+	}{
+		{
+			name:          "differ",
+			promInclAnnot: PrometheusAnnotations{"prometheus.io/scrape": "true"},
+			first:         map[string]string{"prometheus.io/scrape": "true", "foo": "bar"},
+			second:        map[string]string{"prometheus.io/scrape": "false", "foo": "bar"},
+			want:          true,
+		},
+		{
+			name:          "no differ",
+			promInclAnnot: PrometheusAnnotations{"prometheus.io/scrape": "true"},
+			first:         map[string]string{"prometheus.io/scrape": "true", "foo": "bar"},
+			second:        map[string]string{"prometheus.io/scrape": "true", "baz": "tar"},
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.promInclAnnot.AnnotationsDiffer(tt.first, tt.second))
+		})
+	}
 }

--- a/pkg/autodiscovery/listeners/kube_endpoints.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -37,6 +38,7 @@ type KubeEndpointsListener struct {
 	serviceInformer   infov1.ServiceInformer
 	serviceLister     listv1.ServiceLister
 	endpoints         map[types.UID][]*KubeEndpointService
+	promInclAnnot     common.PrometheusAnnotations
 	newService        chan<- Service
 	delService        chan<- Service
 	m                 sync.RWMutex
@@ -80,6 +82,7 @@ func NewKubeEndpointsListener() (ServiceListener, error) {
 		endpointsLister:   endpointsInformer.Lister(),
 		serviceInformer:   serviceInformer,
 		serviceLister:     serviceInformer.Lister(),
+		promInclAnnot:     common.GetPrometheusIncludeAnnotations(),
 	}, nil
 }
 
@@ -250,7 +253,7 @@ func (l *KubeEndpointsListener) isEndpointsAnnotated(kep *v1.Endpoints) bool {
 	if err != nil {
 		log.Tracef("Cannot get Kubernetes service: %s", err)
 	}
-	return isServiceAnnotated(ksvc, kubeEndpointsAnnotationFormat)
+	return isServiceAnnotated(ksvc, kubeEndpointsAnnotationFormat) || l.promInclAnnot.IsMatchingAnnotations(ksvc.GetAnnotations())
 }
 
 func (l *KubeEndpointsListener) createService(kep *v1.Endpoints, alreadyExistingService, checkServiceAnnotations bool) {

--- a/pkg/autodiscovery/listeners/kube_services.go
+++ b/pkg/autodiscovery/listeners/kube_services.go
@@ -34,7 +34,7 @@ const (
 type KubeServiceListener struct {
 	informer      infov1.ServiceInformer
 	services      map[types.UID]Service
-	promInclAnnot map[string]string
+	promInclAnnot common.PrometheusAnnotations
 	newService    chan<- Service
 	delService    chan<- Service
 	m             sync.RWMutex
@@ -70,7 +70,7 @@ func NewKubeServiceListener() (ServiceListener, error) {
 	return &KubeServiceListener{
 		services:      make(map[types.UID]Service),
 		informer:      servicesInformer,
-		promInclAnnot: getPrometheusInclAnnotations(),
+		promInclAnnot: common.GetPrometheusIncludeAnnotations(),
 	}, nil
 }
 
@@ -132,7 +132,7 @@ func (l *KubeServiceListener) updated(old, obj interface{}) {
 		l.createService(castedObj, false)
 		return
 	}
-	if servicesDiffer(castedObj, castedOld) || l.prometheusAnnotDiffer(castedObj.GetAnnotations(), castedOld.GetAnnotations()) {
+	if servicesDiffer(castedObj, castedOld) || l.promInclAnnot.AnnotationsDiffer(castedObj.GetAnnotations(), castedOld.GetAnnotations()) {
 		l.removeService(castedObj)
 		l.createService(castedObj, false)
 	}
@@ -179,7 +179,7 @@ func (l *KubeServiceListener) createService(ksvc *v1.Service, firstRun bool) {
 		return
 	}
 
-	if !isServiceAnnotated(ksvc, kubeServiceAnnotationFormat) && !l.isPrometheusService(ksvc.GetAnnotations()) {
+	if !isServiceAnnotated(ksvc, kubeServiceAnnotationFormat) && !l.promInclAnnot.IsMatchingAnnotations(ksvc.GetAnnotations()) {
 		// Ignore services with no AD or Prometheus AD include annotation
 		return
 	}
@@ -248,53 +248,6 @@ func (l *KubeServiceListener) removeService(ksvc *v1.Service) {
 	} else {
 		log.Debugf("Entity %s not found, not removing", ksvc.UID)
 	}
-}
-
-// isPrometheusService returns whether a service matches the AD include rules for Prometheus
-func (l *KubeServiceListener) isPrometheusService(svcAnnotations map[string]string) bool {
-	for k, v := range l.promInclAnnot {
-		if svcAnnotations[k] == v {
-			return true
-		}
-	}
-	return false
-}
-
-// prometheusAnnotDiffer returns whether the Prometheus AD include annotations have changed
-func (l *KubeServiceListener) prometheusAnnotDiffer(first, second map[string]string) bool {
-	for k := range l.promInclAnnot {
-		if first[k] != second[k] {
-			return true
-		}
-	}
-	return false
-}
-
-// getPrometheusInclAnnotations returns the Prometheus AD include annotations based on the Prometheus config
-func getPrometheusInclAnnotations() map[string]string {
-	annotations := map[string]string{}
-	checks, err := common.ReadPrometheusChecksConfig()
-	if err != nil {
-		log.Warnf("Couldn't get configurations from 'prometheus_scrape.checks': %v", err)
-		return annotations
-	}
-
-	if len(checks) == 0 {
-		annotations[common.PrometheusScrapeAnnotation] = "true"
-		return annotations
-	}
-
-	for _, check := range checks {
-		if err := check.Init(); err != nil {
-			log.Errorf("Couldn't init check configuration: %v", err)
-			continue
-		}
-		for k, v := range check.AD.GetIncludeAnnotations() {
-			annotations[k] = v
-		}
-	}
-
-	return annotations
 }
 
 // GetEntity returns the unique entity name linked to that service

--- a/pkg/autodiscovery/listeners/kube_services_test.go
+++ b/pkg/autodiscovery/listeners/kube_services_test.go
@@ -12,9 +12,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/config"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -349,102 +347,6 @@ func TestServicesDiffer(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.result, servicesDiffer(tc.first, tc.second))
-		})
-	}
-}
-
-func TestGetPrometheusInclAnnotations(t *testing.T) {
-	tests := []struct {
-		name   string
-		config []*common.PrometheusCheck
-		want   map[string]string
-	}{
-		{
-			name:   "empty config, default",
-			config: []*common.PrometheusCheck{},
-			want:   map[string]string{"prometheus.io/scrape": "true"},
-		},
-		{
-			name:   "custom config",
-			config: []*common.PrometheusCheck{{AD: &common.ADConfig{KubeAnnotations: &common.InclExcl{Incl: map[string]string{"include": "true"}}}}},
-			want:   map[string]string{"include": "true"},
-		},
-		{
-			name: "multiple configs",
-			config: []*common.PrometheusCheck{
-				{
-					AD: &common.ADConfig{KubeAnnotations: &common.InclExcl{Incl: map[string]string{"foo": "bar"}}},
-				},
-				{
-					AD: &common.ADConfig{KubeAnnotations: &common.InclExcl{Incl: map[string]string{"baz": "tar"}}},
-				},
-			},
-			want: map[string]string{"foo": "bar", "baz": "tar"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config.Datadog.Set("prometheus_scrape.checks", tt.config)
-			assert.EqualValues(t, tt.want, getPrometheusInclAnnotations())
-		})
-	}
-}
-
-func TestIsPrometheusService(t *testing.T) {
-	tests := []struct {
-		name           string
-		promInclAnnot  map[string]string
-		svcAnnotations map[string]string
-		want           bool
-	}{
-		{
-			name:           "is prom service",
-			promInclAnnot:  map[string]string{"prometheus.io/scrape": "true"},
-			svcAnnotations: map[string]string{"prometheus.io/scrape": "true", "foo": "bar"},
-			want:           true,
-		},
-		{
-			name:           "is not prom service",
-			promInclAnnot:  map[string]string{"prometheus.io/scrape": "true"},
-			svcAnnotations: map[string]string{"foo": "bar"},
-			want:           false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			l := &KubeServiceListener{promInclAnnot: tt.promInclAnnot}
-			assert.Equal(t, tt.want, l.isPrometheusService(tt.svcAnnotations))
-		})
-	}
-}
-
-func TestPrometheusAnnotDiffer(t *testing.T) {
-	tests := []struct {
-		name          string
-		promInclAnnot map[string]string
-		first         map[string]string
-		second        map[string]string
-		want          bool
-	}{
-		{
-			name:          "differ",
-			promInclAnnot: map[string]string{"prometheus.io/scrape": "true"},
-			first:         map[string]string{"prometheus.io/scrape": "true", "foo": "bar"},
-			second:        map[string]string{"prometheus.io/scrape": "false", "foo": "bar"},
-			want:          true,
-		},
-		{
-			name:          "no differ",
-			promInclAnnot: map[string]string{"prometheus.io/scrape": "true"},
-			first:         map[string]string{"prometheus.io/scrape": "true", "foo": "bar"},
-			second:        map[string]string{"prometheus.io/scrape": "true", "baz": "tar"},
-			want:          false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			l := &KubeServiceListener{promInclAnnot: tt.promInclAnnot}
-			assert.Equal(t, tt.want, l.prometheusAnnotDiffer(tt.first, tt.second))
 		})
 	}
 }

--- a/pkg/autodiscovery/providers/prometheus_pods.go
+++ b/pkg/autodiscovery/providers/prometheus_pods.go
@@ -8,6 +8,7 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -17,15 +18,23 @@ import (
 // PrometheusPodsConfigProvider implements the ConfigProvider interface for prometheus pods.
 type PrometheusPodsConfigProvider struct {
 	kubelet kubelet.KubeUtilInterface
-	PrometheusConfigProvider
+
+	checks []*common.PrometheusCheck
 }
 
 // NewPrometheusPodsConfigProvider returns a new Prometheus ConfigProvider connected to kubelet.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
 func NewPrometheusPodsConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
-	p := &PrometheusPodsConfigProvider{}
-	err := p.setupConfigs()
-	return p, err
+	configProvider := &PrometheusConfigProvider{}
+	err := configProvider.setupConfigs()
+	if err != nil {
+		return nil, err
+	}
+
+	p := &PrometheusPodsConfigProvider{
+		checks: configProvider.checks,
+	}
+	return p, nil
 }
 
 // String returns a string representation of the PrometheusPodsConfigProvider

--- a/pkg/autodiscovery/providers/prometheus_services.go
+++ b/pkg/autodiscovery/providers/prometheus_services.go
@@ -11,6 +11,7 @@ package providers
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -20,20 +21,47 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/labels"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
+type ServiceAPI interface {
+	// List lists all Services
+	ListServices() ([]*v1.Service, error)
+	// GetEndpoints gets Endpoints by namespace and name
+	GetEndpoints(namespace, name string) (*v1.Endpoints, error)
+}
+
+type svcAPI struct {
+	serviceLister   listersv1.ServiceLister
+	endpointsLister listersv1.EndpointsLister
+}
+
+func (api *svcAPI) ListServices() ([]*v1.Service, error) {
+	return api.serviceLister.List(labels.Everything())
+}
+
+func (api *svcAPI) GetEndpoints(namespace, name string) (*v1.Endpoints, error) {
+	return api.endpointsLister.Endpoints(namespace).Get(name)
+}
+
 // PrometheusServicesConfigProvider implements the ConfigProvider interface for prometheus services
 type PrometheusServicesConfigProvider struct {
-	lister   listersv1.ServiceLister
+	sync.RWMutex
+
+	api      ServiceAPI
 	upToDate bool
-	PrometheusConfigProvider
+
+	collectEndpoints   bool
+	monitoredEndpoints map[string]bool
+
+	checks []*common.PrometheusCheck
 }
 
 // NewPrometheusServicesConfigProvider returns a new Prometheus ConfigProvider connected to kube apiserver
-func NewPrometheusServicesConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+func NewPrometheusServicesConfigProvider(configProviders config.ConfigurationProviders) (ConfigProvider, error) {
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)
@@ -41,12 +69,34 @@ func NewPrometheusServicesConfigProvider(config config.ConfigurationProviders) (
 
 	servicesInformer := ac.InformerFactory.Core().V1().Services()
 	if servicesInformer == nil {
-		return nil, errors.New("cannot get service informer")
+		return nil, errors.New("cannot get services informer")
 	}
 
-	p := &PrometheusServicesConfigProvider{
-		lister: servicesInformer.Lister(),
+	var endpointsLister listersv1.EndpointsLister
+
+	collectEndpoints := config.Datadog.GetBool("prometheus_scrape.service_endpoints")
+	endpointsInformer := ac.InformerFactory.Core().V1().Endpoints()
+	if collectEndpoints {
+		if endpointsInformer == nil {
+			return nil, errors.New("cannot get endpoints informer")
+		}
+		endpointsLister = endpointsInformer.Lister()
+
 	}
+
+	api := &svcAPI{
+		serviceLister:   servicesInformer.Lister(),
+		endpointsLister: endpointsLister,
+	}
+
+	// TODO: refactor PrometheusConfigProvider to be an init once helper
+	configProvider := &PrometheusConfigProvider{}
+	err = configProvider.setupConfigs()
+	if err != nil {
+		return nil, err
+	}
+
+	p := newPromServicesProvider(configProvider.checks, api, collectEndpoints)
 
 	servicesInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    p.invalidate,
@@ -54,8 +104,21 @@ func NewPrometheusServicesConfigProvider(config config.ConfigurationProviders) (
 		DeleteFunc: p.invalidate,
 	})
 
-	err = p.setupConfigs()
-	return p, err
+	if collectEndpoints {
+		endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			UpdateFunc: p.invalidateIfChangedEndpoints,
+		})
+	}
+	return p, nil
+}
+
+func newPromServicesProvider(checks []*common.PrometheusCheck, api ServiceAPI, collectEndpoints bool) *PrometheusServicesConfigProvider {
+	return &PrometheusServicesConfigProvider{
+		checks:             checks,
+		api:                api,
+		collectEndpoints:   collectEndpoints,
+		monitoredEndpoints: make(map[string]bool),
+	}
 }
 
 // String returns a string representation of the PrometheusServicesConfigProvider
@@ -65,36 +128,79 @@ func (p *PrometheusServicesConfigProvider) String() string {
 
 // Collect retrieves services from the apiserver, builds Config objects and returns them
 func (p *PrometheusServicesConfigProvider) Collect() ([]integration.Config, error) {
-	services, err := p.lister.List(labels.Everything())
+	services, err := p.api.ListServices()
 	if err != nil {
 		return nil, err
 	}
 
-	p.upToDate = true
-	return p.parseServices(services), nil
+	var configs []integration.Config
+	for _, svc := range services {
+		for _, check := range p.checks {
+			serviceConfigs := check.ConfigsForService(svc)
+
+			if len(serviceConfigs) == 0 {
+				continue
+			}
+
+			configs = append(configs, serviceConfigs...)
+
+			if !p.collectEndpoints {
+				continue
+			}
+
+			ep, err := p.api.GetEndpoints(svc.GetNamespace(), svc.GetName())
+			if err != nil {
+				return nil, err
+			}
+
+			endpointConfigs := check.ConfigsForServiceEndpoints(svc, ep)
+
+			if len(endpointConfigs) == 0 {
+				continue
+			}
+
+			configs = append(configs, endpointConfigs...)
+
+			endpointsID := apiserver.EntityForEndpoints(ep.GetNamespace(), ep.GetName(), "")
+			p.Lock()
+			p.monitoredEndpoints[endpointsID] = true
+			p.Unlock()
+
+		}
+	}
+
+	p.setUpToDate(true)
+	return configs, nil
+}
+
+// setUpToDate is a thread-safe method to update the upToDate value
+func (p *PrometheusServicesConfigProvider) setUpToDate(v bool) {
+	p.Lock()
+	defer p.Unlock()
+	p.upToDate = v
 }
 
 // IsUpToDate allows to cache configs as long as no changes are detected in the apiserver
 func (p *PrometheusServicesConfigProvider) IsUpToDate() (bool, error) {
+	p.RLock()
+	defer p.RUnlock()
 	return p.upToDate, nil
 }
 
-// parseServices returns a list of configurations based on the service annotations
-func (p *PrometheusServicesConfigProvider) parseServices(services []*v1.Service) []integration.Config {
-	var configs []integration.Config
-	for _, svc := range services {
-		for _, check := range p.checks {
-			configs = append(configs, check.ConfigsForService(svc)...)
-		}
-	}
-	return configs
-}
-
 func (p *PrometheusServicesConfigProvider) invalidate(obj interface{}) {
-	if obj != nil {
-		log.Trace("Invalidating configs on new/deleted service")
-		p.upToDate = false
+	castedObj, ok := obj.(*v1.Service)
+	if !ok {
+		log.Errorf("Expected a Service type, got: %T", obj)
+		return
 	}
+	p.Lock()
+	defer p.Unlock()
+	if p.collectEndpoints {
+		endpointsID := apiserver.EntityForEndpoints(castedObj.Namespace, castedObj.Name, "")
+		log.Tracef("Invalidating configs on new/deleted service, endpoints entity: %s", endpointsID)
+		delete(p.monitoredEndpoints, endpointsID)
+	}
+	p.upToDate = false
 }
 
 func (p *PrometheusServicesConfigProvider) invalidateIfChanged(old, obj interface{}) {
@@ -110,7 +216,7 @@ func (p *PrometheusServicesConfigProvider) invalidateIfChanged(old, obj interfac
 	castedOld, ok := old.(*v1.Service)
 	if !ok {
 		log.Errorf("Expected a Service type, got: %T", old)
-		p.upToDate = false
+		p.setUpToDate(false)
 		return
 	}
 
@@ -122,8 +228,40 @@ func (p *PrometheusServicesConfigProvider) invalidateIfChanged(old, obj interfac
 	// Compare annotations
 	if p.promAnnotationsDiffer(castedObj.GetAnnotations(), castedOld.GetAnnotations()) {
 		log.Trace("Invalidating configs on service change")
-		p.upToDate = false
+		p.setUpToDate(false)
 		return
+	}
+}
+
+func (p *PrometheusServicesConfigProvider) invalidateIfChangedEndpoints(old, obj interface{}) {
+	// Cast the updated object, don't invalidate on casting error.
+	// nil pointers are safely handled by the casting logic.
+	castedObj, ok := obj.(*v1.Endpoints)
+	if !ok {
+		log.Errorf("Expected a Endpoints type, got: %T", obj)
+		return
+	}
+
+	// Cast the old object, invalidate on casting error
+	castedOld, ok := old.(*v1.Endpoints)
+	if !ok {
+		log.Errorf("Expected a Endpoints type, got: %T", old)
+		p.setUpToDate(false)
+		return
+	}
+
+	// Quick exit if resversion did not change
+	if castedObj.ResourceVersion == castedOld.ResourceVersion {
+		return
+	}
+
+	// Make sure we invalidate a monitored endpoints object
+	endpointsID := apiserver.EntityForEndpoints(castedObj.Namespace, castedObj.Name, "")
+	p.Lock()
+	defer p.Unlock()
+	if found := p.monitoredEndpoints[endpointsID]; found {
+		// Invalidate only when subsets change
+		p.upToDate = equality.Semantic.DeepEqual(castedObj.Subsets, castedOld.Subsets)
 	}
 }
 

--- a/pkg/autodiscovery/providers/prometheus_services_test.go
+++ b/pkg/autodiscovery/providers/prometheus_services_test.go
@@ -12,6 +12,13 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestPromAnnotationsDiffer(t *testing.T) {
@@ -107,6 +114,512 @@ func TestPromAnnotationsDiffer(t *testing.T) {
 			if got := p.promAnnotationsDiffer(tt.first, tt.second); got != tt.want {
 				t.Errorf("PrometheusServicesConfigProvider.promAnnotationsDiffer() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+type MockServiceAPI struct {
+	mock.Mock
+}
+
+func (api *MockServiceAPI) ListServices() ([]*v1.Service, error) {
+	args := api.Called()
+	return args.Get(0).([]*v1.Service), args.Error(1)
+}
+
+func (api *MockServiceAPI) GetEndpoints(namespace, name string) (*v1.Endpoints, error) {
+	args := api.Called(namespace, name)
+	return args.Get(0).(*v1.Endpoints), args.Error(1)
+}
+
+func TestPrometheusServicesCollect(t *testing.T) {
+	nodeNames := []string{
+		"node1",
+		"node2",
+	}
+
+	tests := []struct {
+		name             string
+		checks           []*common.PrometheusCheck
+		services         []*v1.Service
+		endpoints        []*v1.Endpoints
+		collectEndpoints bool
+		expectConfigs    []integration.Config
+		expectErr        error
+	}{
+		{
+			name:   "collect services only",
+			checks: []*common.PrometheusCheck{common.DefaultPrometheusCheck},
+			services: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID("test"),
+						Name:      "svc",
+						Namespace: "ns",
+						Annotations: map[string]string{
+							"prometheus.io/scrape": "true",
+							"prometheus.io/path":   "/mewtrix",
+							"prometheus.io/port":   "1234",
+						},
+					},
+				},
+			},
+			expectConfigs: []integration.Config{
+				{
+					Name:       "openmetrics",
+					InitConfig: integration.Data("{}"),
+					Instances: []integration.Data{
+						integration.Data(`{"prometheus_url":"http://%%host%%:1234/mewtrix","namespace":"","metrics":["*"]}`),
+					},
+					ADIdentifiers: []string{"kube_service_uid://test"},
+					Provider:      "prometheus-services",
+					ClusterCheck:  true,
+					Source:        "prometheus_services:kube_service_uid://test",
+				},
+			},
+		},
+		{
+			name:   "collect services and endpoints",
+			checks: []*common.PrometheusCheck{common.DefaultPrometheusCheck},
+			services: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID("test"),
+						Name:      "svc",
+						Namespace: "ns",
+						Annotations: map[string]string{
+							"prometheus.io/scrape": "true",
+							"prometheus.io/path":   "/mewtrix",
+							"prometheus.io/port":   "1234",
+						},
+					},
+				},
+			},
+			endpoints: []*v1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+					Subsets: []v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{
+								{
+									IP: "10.0.0.1",
+									TargetRef: &v1.ObjectReference{
+										Kind: "Pod",
+										UID:  "svc-pod-1",
+									},
+									NodeName: &nodeNames[0],
+								},
+								{
+									IP: "10.0.0.2",
+									TargetRef: &v1.ObjectReference{
+										Kind: "Pod",
+										UID:  "svc-pod-2",
+									},
+									NodeName: &nodeNames[1],
+								},
+							},
+						},
+					},
+				},
+			},
+			collectEndpoints: true,
+			expectConfigs: []integration.Config{
+				{
+					Name:       "openmetrics",
+					InitConfig: integration.Data("{}"),
+					Instances: []integration.Data{
+						integration.Data(`{"prometheus_url":"http://%%host%%:1234/mewtrix","namespace":"","metrics":["*"]}`),
+					},
+					ADIdentifiers: []string{"kube_service_uid://test"},
+					Provider:      "prometheus-services",
+					ClusterCheck:  true,
+					Source:        "prometheus_services:kube_service_uid://test",
+				},
+				{
+					Name:       "openmetrics",
+					InitConfig: integration.Data("{}"),
+					Instances: []integration.Data{
+						integration.Data(`{"prometheus_url":"http://%%host%%:1234/mewtrix","namespace":"","metrics":["*"]}`),
+					},
+					ADIdentifiers: []string{"kube_endpoint_uid://ns/svc/10.0.0.1", "kubernetes_pod://svc-pod-1"},
+					NodeName:      "node1",
+					Provider:      "prometheus-services",
+					ClusterCheck:  true,
+					Source:        "prometheus_services:kube_endpoint_uid://ns/svc/10.0.0.1",
+				},
+				{
+					Name:       "openmetrics",
+					InitConfig: integration.Data("{}"),
+					Instances: []integration.Data{
+						integration.Data(`{"prometheus_url":"http://%%host%%:1234/mewtrix","namespace":"","metrics":["*"]}`),
+					},
+					ADIdentifiers: []string{"kube_endpoint_uid://ns/svc/10.0.0.2", "kubernetes_pod://svc-pod-2"},
+					NodeName:      "node2",
+					Provider:      "prometheus-services",
+					ClusterCheck:  true,
+					Source:        "prometheus_services:kube_endpoint_uid://ns/svc/10.0.0.2",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			api := &MockServiceAPI{}
+			defer api.AssertExpectations(t)
+
+			api.On("ListServices").Return(test.services, nil)
+			for _, endpoint := range test.endpoints {
+				api.On("GetEndpoints", endpoint.GetNamespace(), endpoint.GetName()).Return(endpoint, nil)
+			}
+
+			for _, check := range test.checks {
+				check.Init()
+			}
+
+			p := newPromServicesProvider(test.checks, api, test.collectEndpoints)
+			configs, err := p.Collect()
+
+			assert.Equal(t, test.expectConfigs, configs)
+			assert.Equal(t, test.expectErr, err)
+		})
+	}
+}
+
+func TestPrometheusServicesInvalidate(t *testing.T) {
+	api := &MockServiceAPI{}
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID("test"),
+			Name:      "svc",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/path":   "/mewtrix",
+				"prometheus.io/port":   "1234",
+			},
+		},
+	}
+	p := newPromServicesProvider([]*common.PrometheusCheck{}, api, true)
+	p.monitoredEndpoints["kube_endpoint_uid://ns/svc/"] = true
+	p.setUpToDate(true)
+	p.invalidate(svc)
+
+	upToDate, err := p.IsUpToDate()
+	assert.NoError(t, err)
+	assert.False(t, upToDate)
+	assert.Empty(t, p.monitoredEndpoints)
+}
+
+func TestPrometheusServicesInvalidateIfChanged(t *testing.T) {
+	api := &MockServiceAPI{}
+	defer api.AssertExpectations(t)
+
+	checks := []*common.PrometheusCheck{common.DefaultPrometheusCheck}
+	for _, check := range checks {
+		check.Init()
+	}
+
+	tests := []struct {
+		name           string
+		old            *v1.Service
+		new            *v1.Service
+		expectUpToDate bool
+	}{
+		{
+			name: "no version change",
+
+			old: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:             types.UID("test"),
+					ResourceVersion: "v1",
+					Name:            "svc",
+					Namespace:       "ns",
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/mewtrix",
+						"prometheus.io/port":   "1234",
+					},
+				},
+			},
+			new: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:             types.UID("test"),
+					ResourceVersion: "v1",
+					Name:            "svc",
+					Namespace:       "ns",
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/mewtrix",
+						"prometheus.io/port":   "1234",
+					},
+				},
+			},
+			expectUpToDate: true,
+		},
+		{
+			name: "no prometheus annotation change",
+			old: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v1",
+					UID:             types.UID("test"),
+					Name:            "svc",
+					Namespace:       "ns",
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/mewtrix",
+						"prometheus.io/port":   "1234",
+					},
+				},
+			},
+			new: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:             types.UID("test"),
+					ResourceVersion: "v2",
+					Name:            "svc",
+					Namespace:       "ns",
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/mewtrix",
+						"prometheus.io/port":   "1234",
+						"something-else":       "yet",
+					},
+				},
+			},
+			expectUpToDate: true,
+		},
+		{
+			name: "prometheus annotation change",
+			old: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v1",
+					UID:             types.UID("test"),
+					Name:            "svc",
+					Namespace:       "ns",
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/mewtrix",
+						"prometheus.io/port":   "1234",
+					},
+				},
+			},
+			new: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:             types.UID("test"),
+					ResourceVersion: "v2",
+					Name:            "svc",
+					Namespace:       "ns",
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/path":   "/mewtrix",
+						"prometheus.io/port":   "1235",
+					},
+				},
+			},
+			expectUpToDate: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := newPromServicesProvider(checks, api, true)
+			p.setUpToDate(true)
+			p.invalidateIfChanged(test.old, test.new)
+
+			upToDate, err := p.IsUpToDate()
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectUpToDate, upToDate)
+		})
+	}
+
+}
+
+func TestPrometheusServicesInvalidateIfChangedEndpoints(t *testing.T) {
+	api := &MockServiceAPI{}
+	defer api.AssertExpectations(t)
+
+	checks := []*common.PrometheusCheck{common.DefaultPrometheusCheck}
+	for _, check := range checks {
+		check.Init()
+	}
+
+	node := "node1"
+	tests := []struct {
+		name               string
+		old                *v1.Endpoints
+		new                *v1.Endpoints
+		monitoredEndpoints []string
+		expectUpToDate     bool
+	}{
+		{
+			name: "no change",
+			old: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v1",
+					Name:            "svc",
+					Namespace:       "ns",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+								TargetRef: &v1.ObjectReference{
+									Kind: "Pod",
+									UID:  "svc-pod-1",
+								},
+								NodeName: &node,
+							},
+						},
+					},
+				},
+			},
+			new: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v1",
+					Name:            "svc",
+					Namespace:       "ns",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+								TargetRef: &v1.ObjectReference{
+									Kind: "Pod",
+									UID:  "svc-pod-1",
+								},
+								NodeName: &node,
+							},
+						},
+					},
+				},
+			},
+			expectUpToDate: true,
+		},
+		{
+			name: "no subsets change",
+			old: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v1",
+					Name:            "svc",
+					Namespace:       "ns",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+								TargetRef: &v1.ObjectReference{
+									Kind: "Pod",
+									UID:  "svc-pod-1",
+								},
+								NodeName: &node,
+							},
+						},
+					},
+				},
+			},
+			new: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v2",
+					Name:            "svc",
+					Namespace:       "ns",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+								TargetRef: &v1.ObjectReference{
+									Kind: "Pod",
+									UID:  "svc-pod-1",
+								},
+								NodeName: &node,
+							},
+						},
+					},
+				},
+			},
+			monitoredEndpoints: []string{
+				"kube_endpoint_uid://ns/svc/",
+			},
+			expectUpToDate: true,
+		},
+		{
+			name: "subsets change",
+			old: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v1",
+					Name:            "svc",
+					Namespace:       "ns",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+								TargetRef: &v1.ObjectReference{
+									Kind: "Pod",
+									UID:  "svc-pod-1",
+								},
+								NodeName: &node,
+							},
+						},
+					},
+				},
+			},
+			new: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "v2",
+					Name:            "svc",
+					Namespace:       "ns",
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{
+								IP: "10.0.0.1",
+								TargetRef: &v1.ObjectReference{
+									Kind: "Pod",
+									UID:  "svc-pod-1",
+								},
+								NodeName: &node,
+							},
+							{
+								IP: "10.0.0.2",
+								TargetRef: &v1.ObjectReference{
+									Kind: "Pod",
+									UID:  "svc-pod-2",
+								},
+								NodeName: &node,
+							},
+						},
+					},
+				},
+			},
+			monitoredEndpoints: []string{
+				"kube_endpoint_uid://ns/svc/",
+			},
+			expectUpToDate: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := newPromServicesProvider(checks, api, true)
+			p.setUpToDate(true)
+			for _, monitored := range test.monitoredEndpoints {
+				p.monitoredEndpoints[monitored] = true
+			}
+			p.invalidateIfChangedEndpoints(test.old, test.new)
+
+			upToDate, err := p.IsUpToDate()
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectUpToDate, upToDate)
 		})
 	}
 }

--- a/pkg/autodiscovery/providers/prometheus_services_test.go
+++ b/pkg/autodiscovery/providers/prometheus_services_test.go
@@ -240,6 +240,7 @@ func TestPrometheusServicesCollect(t *testing.T) {
 				},
 				{
 					Name:       "openmetrics",
+					Entity:     "kube_endpoint_uid://ns/svc/10.0.0.1",
 					InitConfig: integration.Data("{}"),
 					Instances: []integration.Data{
 						integration.Data(`{"prometheus_url":"http://%%host%%:1234/mewtrix","namespace":"","metrics":["*"]}`),
@@ -252,6 +253,7 @@ func TestPrometheusServicesCollect(t *testing.T) {
 				},
 				{
 					Name:       "openmetrics",
+					Entity:     "kube_endpoint_uid://ns/svc/10.0.0.2",
 					InitConfig: integration.Data("{}"),
 					Instances: []integration.Data{
 						integration.Data(`{"prometheus_url":"http://%%host%%:1234/mewtrix","namespace":"","metrics":["*"]}`),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -430,7 +430,9 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
 	config.BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
 
-	config.SetKnown("prometheus_scrape.checks") // defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
+	config.BindEnvAndSetDefault("prometheus_scrape.enabled", false)           // Enables the prometheus config provider
+	config.SetKnown("prometheus_scrape.checks")                               // Defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
+	config.BindEnvAndSetDefault("prometheus_scrape.service_endpoints", false) // Enables Service Endpoints checks in the prometheus config provider
 
 	// SNMP
 	config.SetKnown("snmp_listener.discovery_interval")

--- a/releasenotes-dca/notes/endpoint-support-for-prometheus-scraping-0b219cb1328dcc06.yaml
+++ b/releasenotes-dca/notes/endpoint-support-for-prometheus-scraping-0b219cb1328dcc06.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Implementes endpoint support for Prometheus scraping in the services provider.

--- a/releasenotes-dca/notes/endpoint-support-for-prometheus-scraping-0b219cb1328dcc06.yaml
+++ b/releasenotes-dca/notes/endpoint-support-for-prometheus-scraping-0b219cb1328dcc06.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Implementes endpoint support for Prometheus scraping in the services provider.


### PR DESCRIPTION
### What does this PR do?

Implement endpoints scraping in service config provider.

### Motivation

Automatically generate Openmetrics check configurations for endpoints of annotated services based if `prometheus_scrape.service_endpoints` is enabled.

### Describe your test plan

Configure `prometheus_scrape.enabled: true` and `prometheus_scrape.service_endpoints: true`, and make sure that AD configuration is generated for endpoints of annotated services.

Note also that given the scope of refactoring here prometheus annotations should be tested for pods and services.
