### PR TITLE
Add clang-format to format Windows installer code

### DIFF
--- a/tools/windows/install-help/.clang-format
+++ b/tools/windows/install-help/.clang-format
@@ -1,0 +1,137 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Microsoft
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      false
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/tools/windows/install-help/Format-Source.ps1
+++ b/tools/windows/install-help/Format-Source.ps1
@@ -1,0 +1,69 @@
+$ErrorActionPreference = 'Stop'
+function Invoke-Process {
+    [CmdletBinding(SupportsShouldProcess)]
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FilePath,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$ArgumentList
+    )
+    try {
+        $stdOutTempFile = "$env:TEMP\$((New-Guid).Guid)"
+        $stdErrTempFile = "$env:TEMP\$((New-Guid).Guid)"
+
+        $startProcessParams = @{
+            FilePath               = $FilePath
+            ArgumentList           = $ArgumentList
+            RedirectStandardError  = $stdErrTempFile
+            RedirectStandardOutput = $stdOutTempFile
+            Wait                   = $true;
+            PassThru               = $true;
+            NoNewWindow            = $true;
+        }
+        $cmd = Start-Process @startProcessParams
+        $cmdOutput = Get-Content -Path $stdOutTempFile -Raw
+        $cmdError = Get-Content -Path $stdErrTempFile -Raw
+        if ($cmd.ExitCode -ne 0) {
+            if ($cmdError) {
+                throw $cmdError.Trim()
+            }
+            if ($cmdOutput) {
+                throw $cmdOutput.Trim()
+            }
+        } else {
+            if ([string]::IsNullOrEmpty($cmdOutput) -eq $false) {
+                Write-Output -InputObject $cmdOutput
+            }
+        }
+    } catch {
+        $PSCmdlet.ThrowTerminatingError($_)
+    } finally {
+        Remove-Item -Path $stdOutTempFile, $stdErrTempFile -Force -ErrorAction Ignore
+    }
+}
+
+function Format-Source {
+    Param(
+        $clang_format_path,
+        $source_dir
+    )
+    Write-Host ("Formatting code in {0}" -f $source_dir)
+    @("*.h", "*.hpp", "*.cpp") | ForEach-Object {
+        Get-ChildItem -Recurse $source_dir -Filter $PSItem | ForEach-Object {
+            if (!$_.Directory.FullName.StartsWith("$source_dir\cal\packages")) {
+                Write-Host ("Formatting {0}" -f $_.FullName)
+                Invoke-Process $clang_format_path ("-i {0}" -f $_.FullName)
+            }
+        }
+    }
+}
+$clang_format_config_path = "{0}\.clang-format" -f (Get-Location)
+# Make sure to call this from the location where .clang-format is located
+if (![System.IO.File]::Exists($clang_format_config_path)) {
+    Write-Host ("No .clang-format file found at {0}, using default configuration" -f $clang_format_config_path)
+}
+Format-Source "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\vc\Tools\Llvm\bin\clang-format.exe" (Get-Location)

--- a/tools/windows/install-help/Format-Source.ps1
+++ b/tools/windows/install-help/Format-Source.ps1
@@ -52,14 +52,16 @@ function Format-Source {
         $source_dir
     )
     Write-Host ("Formatting code in {0}" -f $source_dir)
+    $source_files = [System.Collections.ArrayList]@()
     @("*.h", "*.hpp", "*.cpp") | ForEach-Object {
         Get-ChildItem -Recurse $source_dir -Filter $PSItem | ForEach-Object {
             if (!$_.Directory.FullName.StartsWith("$source_dir\cal\packages")) {
-                Write-Host ("Formatting {0}" -f $_.FullName)
-                Invoke-Process $clang_format_path ("-i {0}" -f $_.FullName)
+                Write-Host ($_.FullName)
+                [void]::($source_files.Add($_.FullName))
             }
         }
     }
+    Invoke-Process $clang_format_path ("-i {0}" -f ($source_files -join ' '))
 }
 $clang_format_config_path = "{0}\.clang-format" -f (Get-Location)
 # Make sure to call this from the location where .clang-format is located


### PR DESCRIPTION
### What does this PR do?

This PR adds a clang-format configuration and a script to formalise the code-style of the Windows installer code.

### Motivation

Legibility and consistency of the code base.

### Additional Notes

The script has to be run manually at the moment, and it takes a while to go through every file. A better option would be to format the files that changed only and to run the script automatically for each commit.

