### PR TITLE
[runtime-security] Add support for openat2 syscall

### DIFF
--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -77,6 +77,18 @@ SYSCALL_COMPAT_KPROBE4(openat, int, dirfd, const char*, filename, int, flags, um
     return trace__sys_openat(flags, mode);
 }
 
+struct openat2_open_how {
+    u64 flags;
+    u64 mode;
+    u64 resolve;
+};
+
+SYSCALL_KPROBE4(openat2, int, dirfd, const char*, filename, struct openat2_open_how*, phow, size_t, size) {
+    struct openat2_open_how how;
+    bpf_probe_read(&how, sizeof(struct openat2_open_how), phow);
+    return trace__sys_openat(how.flags, how.mode);
+}
+
 int __attribute__((always_inline)) approve_by_basename(struct syscall_cache_t *syscall) {
     struct open_basename_t basename = {};
     get_dentry_name(syscall->open.dentry, &basename, sizeof(basename));
@@ -233,6 +245,10 @@ SYSCALL_COMPAT_KRETPROBE(open) {
 }
 
 SYSCALL_COMPAT_KRETPROBE(openat) {
+    return trace__sys_open_ret(ctx);
+}
+
+SYSCALL_KRETPROBE(openat2) {
     return trace__sys_open_ret(ctx);
 }
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -205,6 +205,9 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "openat"}, EntryAndExit, true),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "openat2"}, EntryAndExit),
+		},
+		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
 			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "open_by_handle_at"}, EntryAndExit, true),
 		},
 	},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -44,5 +44,9 @@ func getOpenProbes() []*manager.Probe {
 		UID:             SecurityAgentUID,
 		SyscallFuncName: "openat",
 	}, EntryAndExit, true)...)
+	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
+		UID:             SecurityAgentUID,
+		SyscallFuncName: "openat2",
+	}, EntryAndExit)...)
 	return openProbes
 }

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -85,7 +85,7 @@ func expandSyscallSections(syscallName string, flag int, compat ...bool) []strin
 	sections := expandKprobe(getSyscallFnName(syscallName), flag)
 
 	if RuntimeArch == "x64" {
-		if len(compat) > 0 && syscallPrefix != "sys_" {
+		if len(compat) > 0 && compat[0] && syscallPrefix != "sys_" {
 			sections = append(sections, expandKprobe(getCompatSyscallFnName(syscallName), flag)...)
 		} else {
 			sections = append(sections, expandKprobe(getIA32SyscallFnName(syscallName), flag)...)

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"unsafe"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -99,6 +100,45 @@ func TestOpen(t *testing.T) {
 			}
 			if inode := getInode(t, testFile); inode != event.Open.Inode {
 				t.Logf("expected inode %d, got %d", event.Open.Inode, inode)
+			}
+
+			testContainerPath(t, event, "open.container_path")
+		}
+	})
+
+	t.Run("openat2", func(t *testing.T) {
+		openHow := unix.OpenHow{
+			Flags: unix.O_CREAT,
+			Mode:  0711,
+		}
+
+		fd, _, errno := syscall.Syscall6(unix.SYS_OPENAT2, 0, uintptr(testFilePtr), uintptr(unsafe.Pointer(&openHow)), unix.SizeofOpenHow, 0, 0)
+		if errno != 0 {
+			if errno == unix.ENOSYS {
+				t.Skip("openat2 is not supported")
+			}
+			t.Fatal(errno)
+		}
+		defer os.Remove(testFile)
+		defer syscall.Close(int(fd))
+
+		event, _, err := test.GetEvent()
+		if err != nil {
+			t.Error(err)
+		} else {
+			if event.GetType() != "open" {
+				t.Errorf("expected open event, got %s", event.GetType())
+			}
+
+			if flags := event.Open.Flags; flags != syscall.O_CREAT {
+				t.Errorf("expected open mode O_CREAT, got %d", flags)
+			}
+
+			if mode := event.Open.Mode; mode != 0711 {
+				t.Errorf("expected open mode 0711, got %#o", mode)
+			}
+			if inode := getInode(t, testFile); inode != event.Open.Inode {
+				t.Errorf("expected inode %d, got %d", event.Open.Inode, inode)
 			}
 
 			testContainerPath(t, event, "open.container_path")


### PR DESCRIPTION
### What does this PR do?

Add support for the openat2 syscall