### PR TITLE
[system-probe][NET-910] Log DNS stats periodically

### DIFF
--- a/pkg/network/dns_snooper.go
+++ b/pkg/network/dns_snooper.go
@@ -72,6 +72,9 @@ func NewSocketFilterSnooper(cfg *config.Config, filter *manager.Probe) (*SocketF
 	var statKeeper *dnsStatKeeper
 	if cfg.CollectDNSStats {
 		statKeeper = newDNSStatkeeper(cfg.DNSTimeout)
+		log.Infof("DNS Stats Collection has been enabled.")
+	} else {
+		log.Infof("DNS Stats Collection has been disabled.")
 	}
 	snooper := &SocketFilterSnooper{
 		source:          packetSrc,
@@ -97,6 +100,12 @@ func NewSocketFilterSnooper(cfg *config.Config, filter *manager.Probe) (*SocketF
 		snooper.wg.Done()
 	}()
 
+	// Start logging DNS stats
+	snooper.wg.Add(1)
+	go func() {
+		snooper.logDNSStats()
+		snooper.wg.Done()
+	}()
 	return snooper, nil
 }
 
@@ -120,9 +129,6 @@ func (s *SocketFilterSnooper) GetStats() map[string]int64 {
 	stats["packets_dropped"] = atomic.LoadInt64(&s.dropped)
 	stats["decoding_errors"] = atomic.LoadInt64(&s.decodingErrors)
 	stats["truncated_packets"] = atomic.LoadInt64(&s.truncatedPkts)
-	stats["queries"] = atomic.LoadInt64(&s.queries)
-	stats["successes"] = atomic.LoadInt64(&s.successes)
-	stats["errors"] = atomic.LoadInt64(&s.errors)
 	stats["timestamp_micro_secs"] = time.Now().UnixNano() / 1000
 	return stats
 }
@@ -197,6 +203,28 @@ func (s *SocketFilterSnooper) pollPackets() {
 
 		// Sleep briefly and try again
 		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func (s *SocketFilterSnooper) logDNSStats() {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+
+	var (
+		queries   int64
+		successes int64
+		errors    int64
+	)
+	for {
+		select {
+		case <-ticker.C:
+			queries = atomic.SwapInt64(&s.queries, 0)
+			successes = atomic.SwapInt64(&s.successes, 0)
+			errors = atomic.SwapInt64(&s.errors, 0)
+			log.Infof("DNS Stats. Queries :%d, Successes :%d, Errors: %d", queries, successes, errors)
+		case <-s.exit:
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

This PRs adds the ability to log `DNS stats collection` related stats every `10` minutes. 
It reuses `queries`, `errors` and `successes` counters that we already had.
Since we don't send those metrics as part of telemetry, I have removed the following lines:

```golang
stats["queries"] = atomic.LoadInt64(&s.queries)
....
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

If we run `system-probe`, we should lines like the following in the log:

```
2020-12-11 20:22:53 UTC | SYS-PROBE | INFO | (pkg/network/dns_snooper.go:75 in NewSocketFilterSnooper) | DNS Stats Collection has been enabled.
.....
2020-12-11 20:04:52 UTC | SYS-PROBE | INFO | (pkg/network/dns_snooper.go:224 in logDNSStats) | DNS Stats. Queries :0, Successes :0, Errors: 0
2020-12-11 20:05:52 UTC | SYS-PROBE | INFO | (pkg/network/dns_snooper.go:224 in logDNSStats) | DNS Stats. Queries :14, Successes :6, Errors: 8
```

