### PR TITLE
pkg/trace/{api,config}: allow read & write timeouts to be configured separately

### DIFF
--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -56,6 +56,8 @@ func setupAPM(config Config) {
 	config.BindEnvAndSetDefault("apm_config.remote_tagger", false, "DD_APM_REMOTE_TAGGER")                                                    //nolint:errcheck
 
 	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")                             //nolint:errcheck
+	config.BindEnv("apm_config.receiver_write_timeout", "DD_APM_RECEIVER_WRITE_TIMEOUT")                 //nolint:errcheck
+	config.BindEnv("apm_config.receiver_read_timeout", "DD_APM_RECEIVER_READ_TIMEOUT")                   //nolint:errcheck
 	config.BindEnv("apm_config.max_payload_size", "DD_APM_MAX_PAYLOAD_SIZE")                             //nolint:errcheck
 	config.BindEnv("apm_config.log_file", "DD_APM_LOG_FILE")                                             //nolint:errcheck
 	config.BindEnv("apm_config.max_events_per_second", "DD_APM_MAX_EPS", "DD_MAX_EPS")                   //nolint:errcheck

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -128,18 +128,10 @@ func (r *HTTPReceiver) buildMux() *http.ServeMux {
 func (r *HTTPReceiver) Start() {
 	mux := r.buildMux()
 
-	readTimeout := 5 * time.Second
-	if r.conf.ReceiverReadTimeout > 0 {
-		readTimeout = time.Duration(r.conf.ReceiverReadTimeout) * time.Second
-	}
-	writeTimeout := 15 * time.Second
-	if r.conf.ReceiverWriteTimeout > 0 {
-		writeTimeout = time.Duration(r.conf.ReceiverWriteTimeout) * time.Second
-	}
 	httpLogger := logutil.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
 	r.server = &http.Server{
-		ReadTimeout:  readTimeout,
-		WriteTimeout: writeTimeout,
+		ReadTimeout:  r.conf.ReceiverReadTimeout,
+		WriteTimeout: r.conf.ReceiverWriteTimeout,
 		ErrorLog:     stdlog.New(httpLogger, "http.Server: ", 0),
 		Handler:      mux,
 	}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -132,7 +132,7 @@ func (r *HTTPReceiver) Start() {
 	if r.conf.ReceiverReadTimeout > 0 {
 		readTimeout = time.Duration(r.conf.ReceiverReadTimeout) * time.Second
 	}
-	writeTimeout := 5 * time.Second
+	writeTimeout := 15 * time.Second
 	if r.conf.ReceiverWriteTimeout > 0 {
 		writeTimeout = time.Duration(r.conf.ReceiverWriteTimeout) * time.Second
 	}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -128,14 +128,18 @@ func (r *HTTPReceiver) buildMux() *http.ServeMux {
 func (r *HTTPReceiver) Start() {
 	mux := r.buildMux()
 
-	timeout := 5 * time.Second
-	if r.conf.ReceiverTimeout > 0 {
-		timeout = time.Duration(r.conf.ReceiverTimeout) * time.Second
+	readTimeout := 5 * time.Second
+	if r.conf.ReceiverReadTimeout > 0 {
+		readTimeout = time.Duration(r.conf.ReceiverReadTimeout) * time.Second
+	}
+	writeTimeout := 5 * time.Second
+	if r.conf.ReceiverWriteTimeout > 0 {
+		writeTimeout = time.Duration(r.conf.ReceiverWriteTimeout) * time.Second
 	}
 	httpLogger := logutil.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
 	r.server = &http.Server{
-		ReadTimeout:  timeout,
-		WriteTimeout: timeout,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
 		ErrorLog:     stdlog.New(httpLogger, "http.Server: ", 0),
 		Handler:      mux,
 	}

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -931,6 +931,23 @@ func BenchmarkWatchdog(b *testing.B) {
 	}
 }
 
+func TestReceiverTimeoutConfig(t *testing.T) {
+	tcs := [][]int{{1, 2, 1, 2}, {1, 0, 1, 5}, {0, 1, 5, 1}, {0, 0, 5, 5}}
+	for _, tc := range tcs {
+		t.Run("receiver timeout", func(t *testing.T) {
+			c := config.New()
+			c.ReceiverReadTimeout = tc[0]
+			c.ReceiverWriteTimeout = tc[1]
+
+			r := newTestReceiverFromConfig(c)
+			r.Start()
+			defer r.Stop()
+			assert.Equal(t, time.Duration(tc[2])*time.Second, r.server.ReadTimeout)
+			assert.Equal(t, time.Duration(tc[3])*time.Second, r.server.WriteTimeout)
+		})
+	}
+}
+
 func TestReplyOKV5(t *testing.T) {
 	r := newTestReceiverFromConfig(config.New())
 	r.Start()

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -934,9 +934,9 @@ func BenchmarkWatchdog(b *testing.B) {
 func TestReceiverTimeoutConfig(t *testing.T) {
 	tcs := [][]int{
 		{1, 2, 1, 2},
-		{1, 0, 1, 15},
+		{1, 0, 1, 5},
 		{0, 1, 5, 1},
-		{0, 0, 5, 15},
+		{0, 0, 5, 5},
 	}
 	for _, tc := range tcs {
 		t.Run("", func(t *testing.T) {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -932,12 +932,21 @@ func BenchmarkWatchdog(b *testing.B) {
 }
 
 func TestReceiverTimeoutConfig(t *testing.T) {
-	tcs := [][]int{{1, 2, 1, 2}, {1, 0, 1, 15}, {0, 1, 5, 1}, {0, 0, 5, 15}}
+	tcs := [][]int{
+		{1, 2, 1, 2},
+		{1, 0, 1, 15},
+		{0, 1, 5, 1},
+		{0, 0, 5, 15},
+	}
 	for _, tc := range tcs {
-		t.Run("receiver timeout", func(t *testing.T) {
+		t.Run("", func(t *testing.T) {
 			c := config.New()
-			c.ReceiverReadTimeout = tc[0]
-			c.ReceiverWriteTimeout = tc[1]
+			if tc[0] != 0 {
+				c.ReceiverReadTimeout = time.Duration(tc[0]) * time.Second
+			}
+			if tc[1] != 0 {
+				c.ReceiverWriteTimeout = time.Duration(tc[1]) * time.Second
+			}
 
 			r := newTestReceiverFromConfig(c)
 			r.Start()

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -932,7 +932,7 @@ func BenchmarkWatchdog(b *testing.B) {
 }
 
 func TestReceiverTimeoutConfig(t *testing.T) {
-	tcs := [][]int{{1, 2, 1, 2}, {1, 0, 1, 5}, {0, 1, 5, 1}, {0, 0, 5, 5}}
+	tcs := [][]int{{1, 2, 1, 2}, {1, 0, 1, 15}, {0, 1, 5, 1}, {0, 0, 5, 15}}
 	for _, tc := range tcs {
 		t.Run("receiver timeout", func(t *testing.T) {
 			c := config.New()

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -57,6 +57,9 @@ func profilingEndpoints(apiKey string) (urls []*url.URL, apiKeys []string, err e
 			}
 		}
 	}
+	for i, u := range urls {
+		log.Debugf("Set profiling intake URL [%d]:%s", i, u)
+	}
 	return urls, apiKeys, nil
 }
 

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -353,7 +353,14 @@ func (c *AgentConfig) loadDeprecatedValues() error {
 		c.BucketInterval = d * time.Second
 	}
 	if cfg.IsSet("apm_config.receiver_timeout") {
-		c.ReceiverTimeout = cfg.GetInt("apm_config.receiver_timeout")
+		c.ReceiverReadTimeout = cfg.GetInt("apm_config.receiver_timeout")
+		c.ReceiverWriteTimeout = cfg.GetInt("apm_config.receiver_timeout")
+	}
+	if cfg.IsSet("apm_config.receiver_read_timeout") {
+		c.ReceiverReadTimeout = cfg.GetInt("apm_config.receiver_read_timeout")
+	}
+	if cfg.IsSet("apm_config.receiver_write_timeout") {
+		c.ReceiverWriteTimeout = cfg.GetInt("apm_config.receiver_write_timeout")
 	}
 	if cfg.IsSet("apm_config.watchdog_check_delay") {
 		d := time.Duration(cfg.GetInt("apm_config.watchdog_check_delay"))

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -358,12 +358,10 @@ func (c *AgentConfig) loadDeprecatedValues() error {
 		c.ReceiverWriteTimeout = d * time.Second
 	}
 	if cfg.IsSet("apm_config.receiver_read_timeout") {
-		d := time.Duration(cfg.GetInt("apm_config.receiver_read_timeout"))
-		c.ReceiverReadTimeout = d * time.Second
+		c.ReceiverReadTimeout = time.Duration(cfg.GetInt("apm_config.receiver_read_timeout")) * time.Second
 	}
 	if cfg.IsSet("apm_config.receiver_write_timeout") {
-		d := time.Duration(cfg.GetInt("apm_config.receiver_write_timeout"))
-		c.ReceiverWriteTimeout = d * time.Second
+		c.ReceiverWriteTimeout = time.Duration(cfg.GetInt("apm_config.receiver_write_timeout")) * time.Second
 	}
 	if cfg.IsSet("apm_config.watchdog_check_delay") {
 		d := time.Duration(cfg.GetInt("apm_config.watchdog_check_delay"))

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -353,14 +353,17 @@ func (c *AgentConfig) loadDeprecatedValues() error {
 		c.BucketInterval = d * time.Second
 	}
 	if cfg.IsSet("apm_config.receiver_timeout") {
-		c.ReceiverReadTimeout = cfg.GetInt("apm_config.receiver_timeout")
-		c.ReceiverWriteTimeout = cfg.GetInt("apm_config.receiver_timeout")
+		d := time.Duration(cfg.GetInt("apm_config.receiver_timeout"))
+		c.ReceiverReadTimeout = d * time.Second
+		c.ReceiverWriteTimeout = d * time.Second
 	}
 	if cfg.IsSet("apm_config.receiver_read_timeout") {
-		c.ReceiverReadTimeout = cfg.GetInt("apm_config.receiver_read_timeout")
+		d := time.Duration(cfg.GetInt("apm_config.receiver_read_timeout"))
+		c.ReceiverReadTimeout = d * time.Second
 	}
 	if cfg.IsSet("apm_config.receiver_write_timeout") {
-		c.ReceiverWriteTimeout = cfg.GetInt("apm_config.receiver_write_timeout")
+		d := time.Duration(cfg.GetInt("apm_config.receiver_write_timeout"))
+		c.ReceiverWriteTimeout = d * time.Second
 	}
 	if cfg.IsSet("apm_config.watchdog_check_delay") {
 		d := time.Duration(cfg.GetInt("apm_config.watchdog_check_delay"))

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -70,13 +70,14 @@ type AgentConfig struct {
 	MaxEPS          float64
 
 	// Receiver
-	ReceiverHost         string
-	ReceiverPort         int
-	ReceiverSocket       string // if not empty, UDS will be enabled on unix://<receiver_socket>
-	ConnectionLimit      int    // for rate-limiting, how many unique connections to allow in a lease period (30s)
-	ReceiverReadTimeout  int    // timeout for receiving data from clients (seconds)
-	ReceiverWriteTimeout int    // timeout for sending data to clients (seconds)
-	MaxRequestBytes      int64  // specifies the maximum allowed request size for incoming trace payloads
+	ReceiverHost    string
+	ReceiverPort    int
+	ReceiverSocket  string // if not empty, UDS will be enabled on unix://<receiver_socket>
+	ConnectionLimit int    // for rate-limiting, how many unique connections to allow in a lease period (30s)
+	MaxRequestBytes int64  // specifies the maximum allowed request size for incoming trace payloads
+
+	ReceiverReadTimeout  time.Duration // timeout for receiving data from clients
+	ReceiverWriteTimeout time.Duration // timeout for sending data to clients
 
 	// Writers
 	StatsWriter             *WriterConfig
@@ -135,6 +136,9 @@ func New() *AgentConfig {
 		ReceiverHost:    "localhost",
 		ReceiverPort:    8126,
 		MaxRequestBytes: 50 * 1024 * 1024, // 50MB
+
+		ReceiverReadTimeout:  time.Duration(5) * time.Second,
+		ReceiverWriteTimeout: time.Duration(15) * time.Second,
 
 		StatsWriter:             new(WriterConfig),
 		TraceWriter:             new(WriterConfig),

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -70,12 +70,13 @@ type AgentConfig struct {
 	MaxEPS          float64
 
 	// Receiver
-	ReceiverHost    string
-	ReceiverPort    int
-	ReceiverSocket  string // if not empty, UDS will be enabled on unix://<receiver_socket>
-	ConnectionLimit int    // for rate-limiting, how many unique connections to allow in a lease period (30s)
-	ReceiverTimeout int
-	MaxRequestBytes int64 // specifies the maximum allowed request size for incoming trace payloads
+	ReceiverHost         string
+	ReceiverPort         int
+	ReceiverSocket       string // if not empty, UDS will be enabled on unix://<receiver_socket>
+	ConnectionLimit      int    // for rate-limiting, how many unique connections to allow in a lease period (30s)
+	ReceiverReadTimeout  int    // timeout for receiving data from clients (seconds)
+	ReceiverWriteTimeout int    // timeout for sending data to clients (seconds)
+	MaxRequestBytes      int64  // specifies the maximum allowed request size for incoming trace payloads
 
 	// Writers
 	StatsWriter             *WriterConfig

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -137,8 +137,8 @@ func New() *AgentConfig {
 		ReceiverPort:    8126,
 		MaxRequestBytes: 50 * 1024 * 1024, // 50MB
 
-		ReceiverReadTimeout:  time.Duration(5) * time.Second,
-		ReceiverWriteTimeout: time.Duration(5) * time.Second,
+		ReceiverReadTimeout:  5 * time.Second,
+		ReceiverWriteTimeout: 5 * time.Second,
 
 		StatsWriter:             new(WriterConfig),
 		TraceWriter:             new(WriterConfig),

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -138,7 +138,7 @@ func New() *AgentConfig {
 		MaxRequestBytes: 50 * 1024 * 1024, // 50MB
 
 		ReceiverReadTimeout:  time.Duration(5) * time.Second,
-		ReceiverWriteTimeout: time.Duration(15) * time.Second,
+		ReceiverWriteTimeout: time.Duration(5) * time.Second,
 
 		StatsWriter:             new(WriterConfig),
 		TraceWriter:             new(WriterConfig),

--- a/releasenotes/notes/apm-receiver-timeout-config-6c66ef404b36b766.yaml
+++ b/releasenotes/notes/apm-receiver-timeout-config-6c66ef404b36b766.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Allow configuring read and write timeouts for the trace-agent HTTP
+    receiver separately using apm_config.receiver_write_timeout and
+    apm_config.receiver_read_timeout.
+


### PR DESCRIPTION
### What does this PR do?

This PR allows the read and write timeouts for the HTTP server in the APM trace-agent 
to be configured separately. Eventually, we may want to increase the default write timeout,
but this PR only changes the configuration mechanism, it does not change any of the 
existing defaults.

### Motivation

Customers have reported that they see warnings for profile upload
failures in their application logs, coming from `dd-trace-java`.
However, the data is uploaded successfully and is available in the
Datadog app.

We see a similar behaviour internally with services configured to
send profiling data to multiple targets, we see failure warnings
in the logs, but the data is uploaded successfully and available
in the UI.

The cause of the problem is the timeout changed by this PR - whenever
the profile upload request takes longer than the 5s timeout we have
configured at present, the http server in `datadog-agent` gracefully
closes the connection, `dd-trace-java` sees an empty reply from
server and triggers the UnexpectedEndOfStream exception which is logged.

This is more likely to happen for customers that have large profiles or
slow network connections to our intake.

We've changed the logging in dd-trace-java to use a friendlier message
(e.g. 'WARN ProfileUploader - No reply from server, please check upload
status' instead of 'Failed to upload') and we will not log the stacktrace
for these exceptions as they're not useful.

However, since for some customers this can be logged every five minutes,
ideally we would eliminate the error altogether. This change allows configuring 
read and write timeouts separately so we can increase the default write 
timeout in the future.

### Additional Notes

Alternatively, we could return a 200 OK from the agent immediately after we
receive the profiling data from the application, so the client app logs will
not see any errors. However, even though errors would be available in the
datadog-agent logs, I'm not sure customers would look there so this could mask
real upload problems (bad api key, bad config etc).

### Describe your test plan

We have automated tests for the bits of configuration changed in this PR.