### PR TITLE
[pkg/network] Fix TestDNSOverIPv6

### DIFF
--- a/pkg/network/dns_snooper_test.go
+++ b/pkg/network/dns_snooper_test.go
@@ -467,7 +467,7 @@ func TestParsingError(t *testing.T) {
 }
 
 func TestDNSOverIPv6(t *testing.T) {
-	m, reverseDNS := initDNSTests(t, true)
+	m, reverseDNS := initDNSTestsWithDomainCollection(t, true)
 	defer m.Stop(manager.CleanAll)
 	defer reverseDNS.Close()
 
@@ -483,7 +483,7 @@ func TestDNSOverIPv6(t *testing.T) {
 	key := getKey(queryIP, queryPort, serverIP, UDP)
 	require.Contains(t, allStats, key)
 
-	stats := allStats[key]
+	stats := allStats[key]["nxdomain-123.com"]
 	assert.Equal(t, 1, len(stats.countByRcode))
 	assert.Equal(t, uint32(1), stats.countByRcode[uint8(layers.DNSResponseCodeNXDomain)])
 }


### PR DESCRIPTION
### What does this PR do?

Fixes `TestDNSOverIPv6`.

### Motivation

Two conflicting PRs (https://github.com/DataDog/datadog-agent/pull/6717 and https://github.com/DataDog/datadog-agent/pull/6944) got merged around the same time, causing failures in ebpf tests.

### Describe your test plan

Pipeline passes.
