### PR TITLE
[Windows] Don't override datadog.yaml file

### DIFF
--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -7,7 +7,6 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -23,7 +22,6 @@ import (
 
 	"github.com/cihub/seelog"
 	"golang.org/x/sys/windows/registry"
-	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -358,21 +356,6 @@ func ImportRegistryConfig() error {
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
-
-	// dump the current configuration to datadog.yaml
-	b, err := yaml.Marshal(config.Datadog.AllSettings())
-	if err != nil {
-		log.Errorf("unable to unmarshal config to YAML: %v", err)
-		return fmt.Errorf("unable to unmarshal config to YAML: %v", err)
-	}
-	// file permissions will be used only to create the file if doesn't exist,
-	// please note on Windows such permissions have no effect.
-	if err = ioutil.WriteFile(datadogYamlPath, b, 0640); err != nil {
-		log.Errorf("unable to unmarshal config to %s: %v", datadogYamlPath, err)
-		return fmt.Errorf("unable to unmarshal config to %s: %v", datadogYamlPath, err)
-	}
-
-	log.Debugf("Successfully wrote the config into %s\n", datadogYamlPath)
 
 	return nil
 }

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -8,7 +8,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof"
 	"net/url"
@@ -31,7 +30,6 @@ import (
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
-	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -329,29 +327,6 @@ func importRegistryConfig() error {
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
-
-	// dump the current configuration to datadog.yaml
-	b, err := yaml.Marshal(config.Datadog.AllSettings())
-	if err != nil {
-		log.Errorf("unable to unmarshal config to YAML: %v", err)
-		return fmt.Errorf("unable to unmarshal config to YAML: %v", err)
-	}
-	// file permissions will be used only to create the file if doesn't exist,
-	// please note on Windows such permissions have no effect.
-	if err = ioutil.WriteFile(datadogYamlPath, b, 0640); err != nil {
-		log.Errorf("unable to unmarshal config to %s: %v", datadogYamlPath, err)
-		return fmt.Errorf("unable to unmarshal config to %s: %v", datadogYamlPath, err)
-	}
-
-	valuenames := []string{"api_key", "tags", "hostname",
-		"proxy_host", "proxy_port", "proxy_user", "proxy_password", "cmd_port"}
-	for _, valuename := range valuenames {
-		k.DeleteValue(valuename)
-	}
-	for valuename := range subServices {
-		k.DeleteValue(valuename)
-	}
-	log.Debugf("Successfully wrote the config into %s\n", datadogYamlPath)
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

On Windows, the Agent reads some settings from the registry and writes it to the `datadog.yaml` file, overwriting it in the process. This PR aims to remove the overwriting of the `datadog.yaml`.

### Motivation

#### Specificities to the Windows Agent

When the Windows Agent starts, it can pick up settings from the registry. When it does so, it merges them with the in-memory representation of the `datadog.yaml` configuration.

#### YAML round-trip

It's hard to find a yaml library that preserves the formatting and comments of a parsed yaml file in memory.
(Ruamel.yaml seems to preserve comments)[https://stackoverflow.com/a/27103244] on round-trips, but i's a Python-only library, and it would require a significant refactoring to integrate that.

The official (Go yaml library recently added a Node)[https://godoc.org/gopkg.in/yaml.v3#Node] data-structure, but it would mean going to down to a low-level API to implement.

#### The necessity for overriding the `datadog.yaml` file

Given the above considerations, we should consider the reason to override the `datadog.yaml` in the first place.
It seems the point of the registry override is to be able to conveniently place some values in the registry and have them automatically applied to the Agent - perhaps before it is even installed.

Since the decision to put those values in the registry key is a conscious one, we can safely assume that the user who puts those values there knows it and thus there's no need to also have them transcribed in the `datadog.yaml` file.
On the other hand, even if no setting was present in the registry the Agent seems to overwrite the `datadog.yaml` file anyway. So to any user *not* using the registry to store Agent configuration, this causes a pain point.

The comments in that file represent a documentation on its own, and should not be removed.
This makes updating the `datadog.yaml` difficult and it can also overwrite manually-added content in that file.

Since we only need the override to apply at run-time, I believe it's better to keep the two representation separate and reload from registry on each Agent startup.

### Describe your test plan

- Install the Agent on a Windows host. Ensure it starts, then check the `datadog.yaml` file - it should be identical to https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
- Set some settings in the registry (for example the API key). Restart the Agent. Check the settings was applied (for example, using the `status` command). Check that the `datadog.yaml` is unchanged.
