### PR TITLE
[system-probe] Increase loop timeout so that it is greater than DNS timeout

### DIFF
--- a/pkg/network/dns_snooper_test.go
+++ b/pkg/network/dns_snooper_test.go
@@ -264,7 +264,9 @@ func getStats(
 	snooper *SocketFilterSnooper,
 	expectedCount int,
 ) map[dnsKey]map[string]dnsStats {
-	timeout := time.After(1 * time.Second)
+	// DNS timeout is set to 1 second for the tests.
+	// So a 3-second timeout here should provide enough time for an unanswered DNS query to be considered as a timeout.
+	timeout := time.After(3 * time.Second)
 Loop:
 	// Wait until DNS stats becomes available
 	for {


### PR DESCRIPTION
### What does this PR do?

In `dns_snooper_test`, we set the the `DNS timeout` to `1 sec`.

That means if a DNS query remains unanswered for `1 second` , it would be considered a `timeout`.
We have a function `getStats` where we wait for all DNS stats to be available before query for the stats.
That loop also had a timeout of `1 second`.
As a result, we were sometimes breaking out from that loop before the expiry of the `DNS timeout`. As a result, a couple of tests for `timeouts` were failing intermittently.

This PR increases the loop timeout `3x` to give enough time for a timeout to be counted. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
