### PR TITLE
Refactor build batch files so that there's a file for building locally

### DIFF
--- a/tasks/winbuildscripts/buildlocal.bat
+++ b/tasks/winbuildscripts/buildlocal.bat
@@ -2,63 +2,15 @@
 @echo MAJOR_VERSION %MAJOR_VERSION%
 @echo PY_RUNTIMES %PY_RUNTIMES%
 
+REM set up variables for local build.
+REM assumes attempting to build A7/x64 nightly
+REM assumes target directory is mounted in the container 
+REM (vs. copied in as in CI build)
 if NOT DEFINED RELEASE_VERSION set RELEASE_VERSION=nightly
 if NOT DEFINED MAJOR_VERSION set MAJOR_VERSION=7
 if NOT DEFINED PY_RUNTIMES set PY_RUNTIMES="3"
 if NOT DEFINED CI_JOB_ID set CI_JOB_ID=1
 if NOT DEFINED TARGET_ARCH set TARGET_ARCH=x64
 
-REM don't use `OUTDIR` as an environment variable. It will confuse the VC build
-set PKG_OUTDIR=c:\mnt\build-out\%CI_JOB_ID%
-
-set OMNIBUS_BUILD=agent.omnibus-build
-set OMNIBUS_ARGS=--python-runtimes "%PY_RUNTIMES%"
-
-if "%OMNIBUS_TARGET%" == "iot" set OMNIBUS_ARGS=--iot
-if "%OMNIBUS_TARGET%" == "dogstatsd" set OMNIBUS_BUILD=dogstatsd.omnibus-build && set OMNIBUS_ARGS=
-if "%OMNIBUS_TARGET%" == "agent_binaries" set OMNIBUS_ARGS=%OMNIBUS_ARGS% --agent-binaries
-
-if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 1
-cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 2
-
-SET PATH=%PATH%;%GOPATH%/bin
-
-@echo GOPATH %GOPATH%
-@echo PATH %PATH%
-@echo VSTUDIO_ROOT %VSTUDIO_ROOT%
-@echo TARGET_ARCH %TARGET_ARCH%
-
-REM Equivalent to the "ridk enable" command, but without the exit
-if "%TARGET_ARCH%" == "x64" (
-    @echo IN x64 BRANCH
-    @for /f "delims=" %%x in ('"ruby" --disable-gems -x '%RIDK%' enable') do set "%%x"
-)
-
-if "%TARGET_ARCH%" == "x86" (
-    @echo IN x86 BRANCH
-    REM Use 64-bit toolchain to build gems
-    Powershell -C "ridk enable; cd omnibus; bundle install"
-)
-
-pip install -r requirements.txt || exit /b 4
-
-inv -e deps --verbose || exit /b 5
-
-@echo "inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION%"
-inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 6
-
-dir \omnibus\pkg
-
-dir \omnibus-ruby\pkg\
-
-if not exist %PKG_OUTDIR% mkdir %PKG_OUTDIR% || exit /b 7
-if exist \omnibus-ruby\pkg\*.msi copy \omnibus-ruby\pkg\*.msi %PKG_OUTDIR% || exit /b 8
-if exist \omnibus-ruby\pkg\*.zip copy \omnibus-ruby\pkg\*.zip %PKG_OUTDIR% || exit /b 9
-
-goto :EOF
-
-:nomntdir
-@echo directory not mounted, parameters incorrect
-exit /b 1
-goto :EOF
+call %~dp0dobuild.bat || @echo "Build failed %ERRORLEVEL%"
 

--- a/tasks/winbuildscripts/buildwin.bat
+++ b/tasks/winbuildscripts/buildwin.bat
@@ -1,63 +1,24 @@
 if not exist c:\mnt\ goto nomntdir
 
 @echo c:\mnt found, continuing
-@echo PARAMS %*
-@echo RELEASE_VERSION %RELEASE_VERSION%
-@echo MAJOR_VERSION %MAJOR_VERSION%
-@echo PY_RUNTIMES %PY_RUNTIMES%
-
-if NOT DEFINED RELEASE_VERSION set RELEASE_VERSION=%~1
-if NOT DEFINED MAJOR_VERSION set MAJOR_VERSION=%~2
-if NOT DEFINED PY_RUNTIMES set PY_RUNTIMES=%~3
-
-REM don't use `OUTDIR` as an environment variable. It will confuse the VC build
-set PKG_OUTDIR=c:\mnt\build-out\%CI_JOB_ID%
-
-set OMNIBUS_BUILD=agent.omnibus-build
-set OMNIBUS_ARGS=--python-runtimes "%PY_RUNTIMES%"
-
-if "%OMNIBUS_TARGET%" == "iot" set OMNIBUS_ARGS=--iot
-if "%OMNIBUS_TARGET%" == "dogstatsd" set OMNIBUS_BUILD=dogstatsd.omnibus-build && set OMNIBUS_ARGS=
-if "%OMNIBUS_TARGET%" == "agent_binaries" set OMNIBUS_ARGS=%OMNIBUS_ARGS% --agent-binaries
 
 mkdir \dev\go\src\github.com\DataDog\datadog-agent
 if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 1
 cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 2
 xcopy /e/s/h/q c:\mnt\*.* || exit /b 3
 
-SET PATH=%PATH%;%GOPATH%/bin
+REM
+REM after copying files in from the host, execute the build
+REM using `dobuild.bat`
+REM
+call %~p0dobuild.bat %* || exit /b %ERRORLEVEL%
 
-@echo GOPATH %GOPATH%
-@echo PATH %PATH%
-@echo VSTUDIO_ROOT %VSTUDIO_ROOT%
-@echo TARGET_ARCH %TARGET_ARCH%
-
-REM Section to pre-install libyajl2 gem with fix for gcc10 compatibility
-Powershell -C "ridk enable; ./tasks/winbuildscripts/libyajl2_install.ps1"
-
-
-if "%TARGET_ARCH%" == "x64" (
-    @echo IN x64 BRANCH
-    call ridk enable
-)
-
-if "%TARGET_ARCH%" == "x86" (
-    @echo IN x86 BRANCH
-    REM Use 64-bit toolchain to build gems
-    Powershell -C "ridk enable; cd omnibus; bundle install"
-)
-
-pip3 install -r requirements.txt || exit /b 4
-
-inv -e deps --verbose || exit /b 5
-
-@echo "inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION%"
-inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 6
-
+REM show output directories (for debugging)
 dir \omnibus\pkg
 
 dir \omnibus-ruby\pkg\
 
+REM copy resulting packages to expected location for collection by gitlab.
 if not exist %PKG_OUTDIR% mkdir %PKG_OUTDIR% || exit /b 7
 if exist \omnibus-ruby\pkg\*.msi copy \omnibus-ruby\pkg\*.msi %PKG_OUTDIR% || exit /b 8
 if exist \omnibus-ruby\pkg\*.zip copy \omnibus-ruby\pkg\*.zip %PKG_OUTDIR% || exit /b 9

--- a/tasks/winbuildscripts/dobuild.bat
+++ b/tasks/winbuildscripts/dobuild.bat
@@ -1,0 +1,51 @@
+@echo PARAMS %*
+@echo RELEASE_VERSION %RELEASE_VERSION%
+@echo MAJOR_VERSION %MAJOR_VERSION%
+@echo PY_RUNTIMES %PY_RUNTIMES%
+
+if NOT DEFINED RELEASE_VERSION set RELEASE_VERSION=%~1
+if NOT DEFINED MAJOR_VERSION set MAJOR_VERSION=%~2
+if NOT DEFINED PY_RUNTIMES set PY_RUNTIMES=%~3
+
+REM don't use `OUTDIR` as an environment variable. It will confuse the VC build
+set PKG_OUTDIR=c:\mnt\build-out\%CI_JOB_ID%
+
+set OMNIBUS_BUILD=agent.omnibus-build
+set OMNIBUS_ARGS=--python-runtimes "%PY_RUNTIMES%"
+
+if "%OMNIBUS_TARGET%" == "iot" set OMNIBUS_ARGS=--iot
+if "%OMNIBUS_TARGET%" == "dogstatsd" set OMNIBUS_BUILD=dogstatsd.omnibus-build && set OMNIBUS_ARGS=
+if "%OMNIBUS_TARGET%" == "agent_binaries" set OMNIBUS_ARGS=%OMNIBUS_ARGS% --agent-binaries
+
+SET PATH=%PATH%;%GOPATH%/bin
+
+@echo GOPATH %GOPATH%
+@echo PATH %PATH%
+@echo VSTUDIO_ROOT %VSTUDIO_ROOT%
+@echo TARGET_ARCH %TARGET_ARCH%
+
+REM Section to pre-install libyajl2 gem with fix for gcc10 compatibility
+Powershell -C "ridk enable; ./tasks/winbuildscripts/libyajl2_install.ps1"
+
+
+if "%TARGET_ARCH%" == "x64" (
+    @echo IN x64 BRANCH
+    call ridk enable
+)
+
+if "%TARGET_ARCH%" == "x86" (
+    @echo IN x86 BRANCH
+    REM Use 64-bit toolchain to build gems
+    Powershell -C "ridk enable; cd omnibus; bundle install"
+)
+
+if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 1
+cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 2
+
+
+pip3 install -r requirements.txt || exit /b 4
+
+inv -e deps --verbose || exit /b 5
+
+@echo "inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION%"
+inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 6


### PR DESCRIPTION
(development cycle) and file for CI, and they share the build steps

### What does this PR do?

Makes as much of the build steps shared as possible between the batch file that does the CI build and the batch file that's present to allow daily development

### Motivation

Not duplicating maintenance

