### PR TITLE
[AD][Fix] `configresolver.Resolve` must return a non-empty tags hash

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -58,9 +58,9 @@ func (s *dummyService) GetPorts() ([]listeners.ContainerPort, error) {
 	return s.Ports, nil
 }
 
-// GetTags returns mil
+// GetTags returns static tags
 func (s *dummyService) GetTags() ([]string, string, error) {
-	return nil, "", nil
+	return []string{"foo:bar"}, "hash", nil
 }
 
 // GetPid return a dummy pid
@@ -146,7 +146,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: 127.0.0.1")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.1\ntags:\n- foo:bar\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -165,7 +165,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: 127.0.0.2")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.2\ntags:\n- foo:bar\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -184,7 +184,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: 127.0.0.5")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.5\ntags:\n- foo:bar\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -203,7 +203,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: 127.0.0.3")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.3\ntags:\n- foo:bar\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -222,7 +222,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: 127.0.0.4")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.4\ntags:\n- foo:bar\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -257,7 +257,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("port: 3")},
+				Instances:     []integration.Data{integration.Data("port: 3\ntags:\n- foo:bar\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -276,7 +276,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("port: 1")},
+				Instances:     []integration.Data{integration.Data("port: 1\ntags:\n- foo:bar\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -295,7 +295,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("port: 2")},
+				Instances:     []integration.Data{integration.Data("port: 2\ntags:\n- foo:bar\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -357,7 +357,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("test: test_value")},
+				Instances:     []integration.Data{integration.Data("tags:\n- foo:bar\ntest: test_value\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -404,7 +404,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("test: imhere")},
+				Instances:     []integration.Data{integration.Data("tags:\n- foo:bar\ntest: imhere\n")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -417,14 +417,15 @@ func TestResolve(t *testing.T) {
 				Pid:           1337,
 			},
 			tpl: integration.Config{
-				Name:          "cpu",
-				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("pid: %%pid%%\ntags: [\"foo\"]")},
+				Name:                    "cpu",
+				ADIdentifiers:           []string{"redis"},
+				Instances:               []integration.Data{integration.Data("pid: %%pid%%\ntags: [\"foo\"]")},
+				IgnoreAutodiscoveryTags: true,
 			},
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("pid: 1337\ntags:\n- foo\n")},
+				Instances:     []integration.Data{integration.Data("pid: 1337\ntags: [\"foo\"]")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -508,7 +509,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "redis",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: localhost")},
+				Instances:     []integration.Data{integration.Data("host: localhost\ntags:\n- foo:bar\n")},
 				InitConfig:    integration.Data{},
 				Entity:        "a5901276aed1",
 				Source:        "file:/etc/datadog-agent/conf.d/redisdb.d/auto_conf.yaml",
@@ -532,7 +533,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "redis",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: localhost")},
+				Instances:     []integration.Data{integration.Data("host: localhost\ntags:\n- foo:bar\n")},
 				InitConfig:    integration.Data{},
 				Entity:        "a5901276aed1",
 				Source:        "file:/etc/datadog-agent/conf.d/redisdb.d/auto_conf.yaml",
@@ -554,7 +555,47 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "device",
 				ADIdentifiers: []string{"snmp"},
-				Instances:     []integration.Data{integration.Data("user: admin\nauthKey: secret")},
+				Instances:     []integration.Data{integration.Data("authKey: secret\ntags:\n- foo:bar\nuser: admin\n")},
+				Entity:        "a5901276aed1",
+			},
+		},
+		{
+			testName: "with IgnoreAutodiscoveryTags disabled",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"kube-state-metrics"},
+				Hosts:         map[string]string{"pod": "10.3.2.1"},
+			},
+			tpl: integration.Config{
+				Name:                    "ksm",
+				ADIdentifiers:           []string{"kube-state-metrics"},
+				Instances:               []integration.Data{integration.Data("host: %%host%%")},
+				IgnoreAutodiscoveryTags: false,
+			},
+			out: integration.Config{
+				Name:          "ksm",
+				ADIdentifiers: []string{"kube-state-metrics"},
+				Instances:     []integration.Data{integration.Data("host: 10.3.2.1\ntags:\n- foo:bar\n")},
+				Entity:        "a5901276aed1",
+			},
+		},
+		{
+			testName: "with IgnoreAutodiscoveryTags enabled",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"kube-state-metrics"},
+				Hosts:         map[string]string{"pod": "10.3.2.1"},
+			},
+			tpl: integration.Config{
+				Name:                    "ksm",
+				ADIdentifiers:           []string{"kube-state-metrics"},
+				Instances:               []integration.Data{integration.Data("host: %%host%%")},
+				IgnoreAutodiscoveryTags: true,
+			},
+			out: integration.Config{
+				Name:          "ksm",
+				ADIdentifiers: []string{"kube-state-metrics"},
+				Instances:     []integration.Data{integration.Data("host: 10.3.2.1")},
 				Entity:        "a5901276aed1",
 			},
 		},
@@ -566,13 +607,14 @@ func TestResolve(t *testing.T) {
 			// Make sure we don't modify the template object
 			checksum := tc.tpl.Digest()
 
-			cfg, _, err := Resolve(tc.tpl, tc.svc)
+			cfg, hash, err := Resolve(tc.tpl, tc.svc)
 			if tc.errorString != "" {
 				assert.EqualError(t, err, tc.errorString)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.out, cfg)
 				assert.Equal(t, checksum, tc.tpl.Digest())
+				assert.Equal(t, "hash", hash) // Resolve must return a non-empty hash if err == nil
 				validTemplates++
 			}
 		})


### PR DESCRIPTION
### What does this PR do?

- Fix a regression introduced by https://github.com/DataDog/datadog-agent/pull/6950 which causes continuous scheduling/unscheduling of checks with a `IgnoreAutodiscoveryTags: true` config (like [ksm](https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml#L7))
- Improve the test coverage

### Describe your test plan

Check the stability of any check that has `IgnoreAutodiscoveryTags: true` in its config
