### PR TITLE
[runtime-security] Add cached user resolver

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -40,6 +40,7 @@ type Module struct {
 	config         *config.Config
 	ruleSets       [2]*rules.RuleSet
 	currentRuleSet uint64
+	reloading      uint64
 	eventServer    *EventServer
 	grpcServer     *grpc.Server
 	listener       net.Listener
@@ -119,6 +120,9 @@ func (m *Module) Reload() error {
 	m.Lock()
 	defer m.Unlock()
 
+	atomic.StoreUint64(&m.reloading, 1)
+	defer atomic.StoreUint64(&m.reloading, 0)
+
 	rsa := sprobe.NewRuleSetApplier(m.config, m.probe)
 
 	ruleSet := m.probe.NewRuleSet(rules.NewOptsWithParams(sprobe.SECLConstants, sprobe.SupportedDiscarders))
@@ -173,6 +177,10 @@ func (m *Module) RuleMatch(rule *rules.Rule, event eval.Event) {
 
 // EventDiscarderFound is called by the ruleset when a new discarder discovered
 func (m *Module) EventDiscarderFound(rs *rules.RuleSet, event eval.Event, field eval.Field, eventType eval.EventType) {
+	if atomic.LoadUint64(&m.reloading) == 1 {
+		return
+	}
+
 	if err := m.probe.OnNewDiscarder(rs, event.(*sprobe.Event), field, eventType); err != nil {
 		log.Trace(err)
 	}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -13,10 +13,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os/user"
 	"path"
 	"regexp"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -752,10 +750,7 @@ func (e *ExecEvent) ResolveGID(event *Event) int {
 // ResolveUser resolves the user id of the process to a username
 func (e *ExecEvent) ResolveUser(event *Event) string {
 	if len(e.User) == 0 {
-		u, err := user.LookupId(strconv.Itoa(int(event.Process.UID)))
-		if err == nil {
-			e.User = u.Username
-		}
+		e.User, _ = event.resolvers.UserGroupResolver.ResolveUser(int(event.Process.UID))
 	}
 	return e.User
 }
@@ -763,10 +758,7 @@ func (e *ExecEvent) ResolveUser(event *Event) string {
 // ResolveGroup resolves the group id of the process to a group name
 func (e *ExecEvent) ResolveGroup(event *Event) string {
 	if len(e.Group) == 0 {
-		g, err := user.LookupGroupId(strconv.Itoa(int(event.Process.GID)))
-		if err == nil {
-			e.Group = g.Name
-		}
+		e.Group, _ = event.resolvers.UserGroupResolver.ResolveGroup(int(event.Process.GID))
 	}
 	return e.Group
 }
@@ -889,10 +881,7 @@ func (p *ProcessContext) UnmarshalBinary(data []byte) (int, error) {
 // ResolveUser resolves the user id of the process to a username
 func (p *ProcessContext) ResolveUser(event *Event) string {
 	if len(p.User) == 0 {
-		u, err := user.LookupId(strconv.Itoa(int(p.UID)))
-		if err == nil {
-			p.User = u.Username
-		}
+		p.User, _ = event.resolvers.UserGroupResolver.ResolveUser(int(p.UID))
 	}
 	return p.User
 }
@@ -900,10 +889,7 @@ func (p *ProcessContext) ResolveUser(event *Event) string {
 // ResolveGroup resolves the group id of the process to a group name
 func (p *ProcessContext) ResolveGroup(event *Event) string {
 	if len(p.Group) == 0 {
-		g, err := user.LookupGroupId(strconv.Itoa(int(p.GID)))
-		if err == nil {
-			p.Group = g.Name
-		}
+		p.Group, _ = event.resolvers.UserGroupResolver.ResolveGroup(int(p.GID))
 	}
 	return p.Group
 }

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -25,6 +25,7 @@ type Resolvers struct {
 	ContainerResolver *ContainerResolver
 	TimeResolver      *TimeResolver
 	ProcessResolver   *ProcessResolver
+	UserGroupResolver *UserGroupResolver
 }
 
 // NewResolvers creates a new instance of Resolvers
@@ -39,12 +40,18 @@ func NewResolvers(probe *Probe) (*Resolvers, error) {
 		return nil, err
 	}
 
+	userGroupResolver, err := NewUserGroupResolver()
+	if err != nil {
+		return nil, err
+	}
+
 	resolvers := &Resolvers{
 		probe:             probe,
 		DentryResolver:    dentryResolver,
 		MountResolver:     NewMountResolver(probe),
 		TimeResolver:      timeResolver,
 		ContainerResolver: &ContainerResolver{},
+		UserGroupResolver: userGroupResolver,
 	}
 
 	processResolver, err := NewProcessResolver(probe, resolvers)

--- a/pkg/security/probe/user_resolver.go
+++ b/pkg/security/probe/user_resolver.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux
+
+package probe
+
+import (
+	"os/user"
+	"strconv"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// UserGroupResolver resolves user and group ids to names
+type UserGroupResolver struct {
+	userCache  *simplelru.LRU
+	groupCache *simplelru.LRU
+}
+
+// ResolveUser resolves a user id to a username
+func (r *UserGroupResolver) ResolveUser(uid int) (string, error) {
+	username, found := r.userCache.Get(uid)
+	if found {
+		return username.(string), nil
+	}
+
+	u, err := user.LookupId(strconv.Itoa(uid))
+	if err == nil {
+		r.userCache.Add(uid, u.Username)
+	}
+	return u.Username, nil
+}
+
+// ResolveGroup resolves a group id to a group name
+func (r *UserGroupResolver) ResolveGroup(gid int) (string, error) {
+	groupname, found := r.groupCache.Get(gid)
+	if found {
+		return groupname.(string), nil
+	}
+
+	g, err := user.LookupGroupId(strconv.Itoa(gid))
+	if err == nil {
+		r.groupCache.Add(gid, g.Name)
+	}
+	return g.Name, nil
+}
+
+// NewUserGroupResolver instantiates a new user and group resolver
+func NewUserGroupResolver() (*UserGroupResolver, error) {
+	userCache, err := simplelru.NewLRU(64, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	groupCache, err := simplelru.NewLRU(64, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UserGroupResolver{
+		userCache:  userCache,
+		groupCache: groupCache,
+	}, nil
+}


### PR DESCRIPTION
### What does this PR do?

Add a cache for user and group resolution

### Motivation

Resolving user and group requires parsing /etc/group and /etc/passwd, which may also generate a new event.