### PR TITLE
Check ListenAndServe return status

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -235,7 +235,12 @@ func StartAgent() error {
 	if config.Datadog.GetBool("telemetry.enabled") {
 		http.Handle("/telemetry", telemetry.Handler())
 	}
-	go http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux) //nolint:errcheck
+	go func() {
+		err := http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux)
+		if err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating expvar server: %v", err)
+		}
+	}()
 
 	// Setup healthcheck port
 	var healthPort = config.Datadog.GetInt("health_port")

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -238,7 +238,7 @@ func StartAgent() error {
 	go func() {
 		err := http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux)
 		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server: %v", err)
+			log.Errorf("Error creating expvar server on port %v: %v", port, err)
 		}
 	}()
 

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -35,7 +35,13 @@ func main() {
 
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", telemetry.Handler())
-	go http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", config.Datadog.GetInt("metrics_port")), nil) //nolint:errcheck
+	go func() {
+		port := config.Datadog.GetInt("metrics_port")
+		err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil)
+		if err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating expvar server: %v", err)
+		}
+	}()
 
 	if err := app.ClusterAgentCmd.Execute(); err != nil {
 		log.Error(err)

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -39,7 +39,7 @@ func main() {
 		port := config.Datadog.GetInt("metrics_port")
 		err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil)
 		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server: %v", err)
+			log.Errorf("Error creating expvar server on port %v: %v", port, err)
 		}
 	}()
 

--- a/cmd/dogstatsd/main_nix.go
+++ b/cmd/dogstatsd/main_nix.go
@@ -24,9 +24,13 @@ func main() {
 	flavor.SetFlavor(flavor.Dogstatsd)
 
 	// go_expvar server
-	go http.ListenAndServe( //nolint:errcheck
-		fmt.Sprintf("127.0.0.1:%d", config.Datadog.GetInt("dogstatsd_stats_port")),
-		http.DefaultServeMux)
+	go func() {
+		port := config.Datadog.GetInt("dogstatsd_stats_port")
+		err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), http.DefaultServeMux)
+		if err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating expvar server: %v", err)
+		}
+	}()
 
 	if err := dogstatsdCmd.Execute(); err != nil {
 		log.Error(err)

--- a/cmd/dogstatsd/main_nix.go
+++ b/cmd/dogstatsd/main_nix.go
@@ -28,7 +28,7 @@ func main() {
 		port := config.Datadog.GetInt("dogstatsd_stats_port")
 		err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), http.DefaultServeMux)
 		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server: %v", err)
+			log.Errorf("Error creating expvar server on port %v: %v", port, err)
 		}
 	}()
 

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -69,9 +69,13 @@ func main() {
 	config.Datadog.AddConfigPath(DefaultConfPath)
 
 	// go_expvar server
-	go http.ListenAndServe(
-		fmt.Sprintf("127.0.0.1:%d", config.Datadog.GetInt("dogstatsd_stats_port")),
-		http.DefaultServeMux)
+	go func() {
+		port := config.Datadog.GetInt("dogstatsd_stats_port")
+		err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), http.DefaultServeMux)
+		if err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating expvar server: %v", err)
+		}
+	}()
 
 	isIntSess, err := svc.IsAnInteractiveSession()
 	if err != nil {

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -73,7 +73,7 @@ func main() {
 		port := config.Datadog.GetInt("dogstatsd_stats_port")
 		err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), http.DefaultServeMux)
 		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server: %v", err)
+			log.Errorf("Error creating expvar server on port %v: %v", port, err)
 		}
 	}()
 

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -183,7 +183,10 @@ func runAgent(exit chan struct{}) {
 		if ddconfig.Datadog.GetBool("telemetry.enabled") {
 			http.Handle("/telemetry", telemetry.Handler())
 		}
-		http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.ProcessExpVarPort), nil) //nolint:errcheck
+		err := http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.ProcessExpVarPort), nil)
+		if err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating expvar server: %v", err)
+		}
 	}()
 
 	cl, err := NewCollector(cfg)

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -185,7 +185,7 @@ func runAgent(exit chan struct{}) {
 		}
 		err := http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.ProcessExpVarPort), nil)
 		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server: %v", err)
+			log.Errorf("Error creating expvar server on port %v: %v", port, err)
 		}
 	}()
 

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -213,7 +213,12 @@ func start(cmd *cobra.Command, args []string) error {
 	if coreconfig.Datadog.GetBool("telemetry.enabled") {
 		http.Handle("/telemetry", telemetry.Handler())
 	}
-	go http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux) //nolint:errcheck
+	go func() {
+		err := http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux)
+		if err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating expvar server: %v", err)
+		}
+	}()
 
 	// get hostname
 	// FIXME: use gRPC cross-agent communication API to retrieve hostname

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -216,7 +216,7 @@ func start(cmd *cobra.Command, args []string) error {
 	go func() {
 		err := http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux)
 		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server: %v", err)
+			log.Errorf("Error creating expvar server on port %v: %v", port, err)
 		}
 	}()
 

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -111,9 +111,13 @@ func main() {
 	flavor.SetFlavor(flavor.ServerlessAgent)
 
 	// go_expvar server // TODO(remy): shouldn't we remove that for the serverless agent?
-	go http.ListenAndServe( //nolint:errcheck
-		fmt.Sprintf("127.0.0.1:%d", config.Datadog.GetInt("dogstatsd_stats_port")),
-		http.DefaultServeMux)
+	go func() {
+		port := config.Datadog.GetInt("dogstatsd_stats_port")
+		err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), http.DefaultServeMux)
+		if err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating expvar server: %v", err)
+		}
+	}()
 
 	// if not command has been provided, run the agent
 	if len(os.Args) == 1 {

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -115,7 +115,7 @@ func main() {
 		port := config.Datadog.GetInt("dogstatsd_stats_port")
 		err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), http.DefaultServeMux)
 		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server: %v", err)
+			log.Errorf("Error creating expvar server on port %v: %v", port, err)
 		}
 	}()
 


### PR DESCRIPTION
### What does this PR do?

Remove the `nolint` annotation and print the error if any.

### Motivation

If the port was in use and the server couldn't be created, we would not print anything.

### Additional Notes

The amount of code duplication we have (with superfluous variations like using `Sprintf` vs concatenation with `+`, or `localhost` vs `127.0.0.1`) is epic.