### PR TITLE
Log unhealthy agent components as info instead of debug

### DIFF
--- a/pkg/api/healthprobe/healthprobe.go
+++ b/pkg/api/healthprobe/healthprobe.go
@@ -69,7 +69,7 @@ func healthHandler(getStatusNonBlocking func() (health.Status, error), w http.Re
 
 	if len(health.Unhealthy) > 0 {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Debugf("Healthcheck failed on: %v", health.Unhealthy)
+		log.Infof("Healthcheck failed on: %v", health.Unhealthy)
 	}
 
 	jsonHealth, err := json.Marshal(health)


### PR DESCRIPTION
### What does this PR do?

Log the unhealthy components at info level when the health probe servers returns a `500`

### Motivation

This is a crucial information, it helps debugging a failing agent liveness probe

### Additional Notes

Changing the agent log level at runtime can be an alternative, but most of the time we need this information when the agent is in bad shape (CLB), it can be even impossible to exec into the agent container to change the log level. 

### Describe your test plan

Deploy an unhealthy agent in k8s (force a wrong kubelet address for examlpe) with liveness probe enabled, make sure it logs the unhealthy components 
