### PR TITLE
pkg/trace/agent: add lang* tags to root tag

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -176,6 +176,9 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 
 		// Root span is used to carry some trace-level metadata, such as sampling rate and priority.
 		root := traceutil.GetRoot(t)
+		for k, v := range p.Source.Tags.KV() {
+			traceutil.SetMeta(root, k, v)
+		}
 
 		if !a.Blacklister.Allows(root) {
 			log.Debugf("Trace rejected by blacklister. root: %v", root)

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -474,3 +474,29 @@ func (t *Tags) toArray() []string {
 
 	return tags
 }
+
+// KV returns all the non-empty tags as key-value pairs.
+func (t *Tags) KV() map[string]string {
+	tags := make(map[string]string)
+	if t.Lang != "" {
+		// TODO(x): these map keys could be factored out as constants, for
+		// consistency and safety.
+		tags["lang"] = t.Lang
+	}
+	if t.LangVersion != "" {
+		tags["lang_version"] = t.LangVersion
+	}
+	if t.LangVendor != "" {
+		tags["lang_vendor"] = t.LangVendor
+	}
+	if t.Interpreter != "" {
+		tags["interpreter"] = t.Interpreter
+	}
+	if t.TracerVersion != "" {
+		tags["tracer_version"] = t.TracerVersion
+	}
+	if t.EndpointVersion != "" {
+		tags["endpoint_version"] = t.EndpointVersion
+	}
+	return tags
+}

--- a/pkg/trace/info/stats_test.go
+++ b/pkg/trace/info/stats_test.go
@@ -69,19 +69,39 @@ func TestSpansMalformed(t *testing.T) {
 }
 
 func TestStatsTags(t *testing.T) {
-	assert.Equal(t, (&Tags{
-		Lang:            "go",
-		LangVersion:     "1.14",
-		LangVendor:      "gov",
-		Interpreter:     "goi",
-		TracerVersion:   "1.21.0",
-		EndpointVersion: "v0.4",
-	}).toArray(), []string{
-		"lang:go",
-		"lang_version:1.14",
-		"lang_vendor:gov",
-		"interpreter:goi",
-		"tracer_version:1.21.0",
-		"endpoint_version:v0.4",
+	t.Run("toArray", func(t *testing.T) {
+		assert.Equal(t, (&Tags{
+			Lang:            "go",
+			LangVersion:     "1.14",
+			LangVendor:      "gov",
+			Interpreter:     "goi",
+			TracerVersion:   "1.21.0",
+			EndpointVersion: "v0.4",
+		}).toArray(), []string{
+			"lang:go",
+			"lang_version:1.14",
+			"lang_vendor:gov",
+			"interpreter:goi",
+			"tracer_version:1.21.0",
+			"endpoint_version:v0.4",
+		})
+	})
+
+	t.Run("KV", func(t *testing.T) {
+		assert.Equal(t, (&Tags{
+			Lang:            "go",
+			LangVersion:     "1.14",
+			LangVendor:      "gov",
+			Interpreter:     "goi",
+			TracerVersion:   "1.21.0",
+			EndpointVersion: "v0.4",
+		}).KV(), map[string]string{
+			"lang":             "go",
+			"lang_version":     "1.14",
+			"lang_vendor":      "gov",
+			"interpreter":      "goi",
+			"tracer_version":   "1.21.0",
+			"endpoint_version": "v0.4",
+		})
 	})
 }

--- a/releasenotes/notes/apm-root-lang-tags-157c388fa843a5ef.yaml
+++ b/releasenotes/notes/apm-root-lang-tags-157c388fa843a5ef.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Root tags now contain information about source language, tracer version, interpreter, etc.


### PR DESCRIPTION
This change ensures that values sent by the tracer via X-Datadog-* HTTP
headers are added onto the root tag as metadata (lang, vendor,
interpreter, etc.)