### PR TITLE
Fix missing userSupplied assignment

### DIFF
--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -251,6 +251,8 @@ bool CustomActionData::parseUsernameData()
     if (this->value(propertyDDAgentUserName, tmpName)) {
         if (tmpName.length() == 0) {
             tmpName = ddAgentUserName;
+        } else {
+            userSupplied = true;
         }
     }
     if (std::wstring::npos == tmpName.find(L'\\')) {


### PR DESCRIPTION
### What does this PR do?

This PR restores a line that was missed when merging #6864 

### Motivation

Without this line the user used to install the Agent during a previous install would never be used.
