### PR TITLE
Add libssl-dev to Docker image explicitly

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -100,7 +100,8 @@ RUN apt update \
   # Install iproute2 package for the ss utility that is used by the network check.
   # When the network check will have switched from using ss to directly parsing /proc/net/tcp,
   # this can be removed
-  && apt install -y iproute2 \
+  # Install libssl-dev as it's required by some Python checks and we rely on system version
+  && apt install -y iproute2 libssl-dev \
   # https://security-tracker.debian.org/tracker/CVE-2016-2779
   && rm -f /usr/sbin/runuser \
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6954

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -100,7 +100,8 @@ RUN apt update \
   # Install iproute2 package for the ss utility that is used by the network check.
   # When the network check will have switched from using ss to directly parsing /proc/net/tcp,
   # this can be removed
-  && apt install -y iproute2 \
+  # Install libssl-dev as it's required by some Python checks and we rely on system version
+  && apt install -y iproute2 libssl-dev \
   # https://security-tracker.debian.org/tracker/CVE-2016-2779
   && rm -f /usr/sbin/runuser \
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6954


### PR DESCRIPTION
### What does this PR do?

From 7.25 testing, we saw that `libcrypto.so` was not present anymore in base image, adding it explicitly to our Dockerfiles.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Check presence of `/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1` in generated Docker image
