### PR TITLE
[ecs] Only log when there's an error

### DIFF
--- a/pkg/util/ecs/detection.go
+++ b/pkg/util/ecs/detection.go
@@ -87,7 +87,9 @@ func HasEC2ResourceTags() bool {
 			return false, hasEC2ResourceTagsCacheExpiry
 		}
 		_, err = client.GetTaskWithTags()
-		log.Debugf("failed to get task with tags: %s", err)
+		if err != nil {
+			log.Debugf("failed to get task with tags: %s", err)
+		}
 		return err == nil, hasEC2ResourceTagsCacheExpiry
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Only output Debug log on error to fetch tasks with tags.

### Describe your test plan

Ensure there are no Debug logs output in this path on error.
