### PR TITLE
[system-probe] Do not delete dest conntrack entry when deleteing source entry

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -623,6 +623,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-jsonnet v0.14.0/go.mod h1:zPGC9lj/TbjkBtUACIvYR/ILHrFqKRhxeEA+bLyeMnY=

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -168,42 +168,24 @@ func (ctr *realConntracker) DeleteTranslation(c network.ConnectionStats) {
 	ctr.Lock()
 	defer ctr.Unlock()
 
-	keys := []connKey{
-		{
-			srcIP:     c.Source,
-			srcPort:   c.SPort,
-			dstIP:     c.Dest,
-			dstPort:   c.DPort,
-			transport: c.Type,
-		},
-		{
-			srcIP:     c.Dest,
-			srcPort:   c.DPort,
-			dstIP:     c.Source,
-			dstPort:   c.SPort,
-			transport: c.Type,
-		},
+	k := connKey{
+		srcIP:     c.Source,
+		srcPort:   c.SPort,
+		dstIP:     c.Dest,
+		dstPort:   c.DPort,
+		transport: c.Type,
 	}
 
-	deleteTrans := func(k connKey) bool {
-		t, ok := ctr.state[k]
-		if !ok {
-			log.Tracef("not deleting %+v from conntrack", k)
-			return false
-		}
-
-		delete(ctr.state, k)
-		delete(ctr.state, ipTranslationToConnKey(k.transport, t))
-		log.Tracef("deleted %+v from conntrack", k)
-		return true
+	t, ok := ctr.state[k]
+	if !ok {
+		log.Tracef("not deleting %+v from conntrack", k)
+		return
 	}
 
-	for _, k := range keys {
-		if ok := deleteTrans(k); ok {
-			atomic.AddInt64(&ctr.stats.unregisters, 1)
-			break
-		}
-	}
+	delete(ctr.state, k)
+	delete(ctr.state, ipTranslationToConnKey(k.transport, t))
+	log.Tracef("deleted %+v from conntrack", k)
+	atomic.AddInt64(&ctr.stats.unregisters, 1)
 }
 
 func (ctr *realConntracker) Close() {


### PR DESCRIPTION
### What does this PR do?

Do not delete conntrack entry for dest when source is being deleted. This was a carryover from when we were not deleting the "reply" entry from the conntrack table. That has been fixed by deleting both the conntrack entry and its translation at the same time.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
