### PR TITLE
Update process-agent to be able to do profiling

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -21,6 +21,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const loggerName ddconfig.LoggerName = "PROCESS"
@@ -157,6 +159,13 @@ func runAgent(exit chan struct{}) {
 	// we just pass down empty string
 	updateDockerSocket(dockerSock)
 
+	if cfg.ProfilingEnabled {
+		if err := enableProfiling(cfg); err != nil {
+			log.Warnf("failed to enable profiling: %s", err)
+		}
+		defer profiling.Stop()
+	}
+
 	log.Debug("Running process-agent with DEBUG logging enabled")
 	if opts.check != "" {
 		err := debugCheckResults(cfg, opts.check)
@@ -264,4 +273,20 @@ func cleanupAndExit(status int) {
 	}
 
 	os.Exit(status)
+}
+
+func enableProfiling(cfg *config.AgentConfig) error {
+	// allow full url override for development use
+	s := ddconfig.DefaultSite
+	if cfg.ProfilingSite != "" {
+		s = cfg.ProfilingSite
+	}
+
+	site := fmt.Sprintf(profiling.ProfileURLTemplate, s)
+	if cfg.ProfilingURL != "" {
+		site = cfg.ProfilingURL
+	}
+
+	v, _ := version.Agent()
+	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", fmt.Sprintf("version:%v", v))
 }

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -162,6 +162,8 @@ func runAgent(exit chan struct{}) {
 	if cfg.ProfilingEnabled {
 		if err := enableProfiling(cfg); err != nil {
 			log.Warnf("failed to enable profiling: %s", err)
+		} else {
+			log.Info("start profiling process-agent")
 		}
 		defer profiling.Stop()
 	}
@@ -288,5 +290,6 @@ func enableProfiling(cfg *config.AgentConfig) error {
 	}
 
 	v, _ := version.Agent()
+
 	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", fmt.Sprintf("version:%v", v))
 }

--- a/go.sum
+++ b/go.sum
@@ -631,6 +631,7 @@ github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSN
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
 github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -702,7 +702,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.intervals.connections")
 	config.SetKnown("process_config.expvar_port")
 	config.SetKnown("process_config.log_file")
-	config.SetKnown("process_config.profiling_enabled")
+	config.SetKnown("process_config.profiling.enabled")
 
 	// System probe
 	config.SetKnown("system_probe_config.enabled")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -702,6 +702,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.intervals.connections")
 	config.SetKnown("process_config.expvar_port")
 	config.SetKnown("process_config.log_file")
+	config.SetKnown("process_config.profiling_enabled")
 
 	// System probe
 	config.SetKnown("system_probe_config.enabled")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -876,6 +876,24 @@ api_key:
   #   - 'sql*'
   #   - '*pass*d*'
 
+{{- if .Profiling -}}
+  ## @param profiling - custom object - optional
+  ## Enter specific configurations for profiling.
+  ## Uncomment this parameter and the one below to enable profiling.
+  ## See https://docs.datadoghq.com/tracing/profiling/
+  #
+  ## NOTE: If enabled this option may incur billing charges or other
+  ##       unexpected side-effects (ie. system probe profiles showing with your
+  ##       services).
+  #
+  # profiling:
+  #
+  ## @param enabled - boolean - optional - default: false
+  ## Enable profiling for the System Probe process.
+  #
+  # enabled: false
+
+{{ end }}
 {{ end -}}
 {{- if .Compliance }}
 #############################################

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -883,13 +883,13 @@ api_key:
   ## See https://docs.datadoghq.com/tracing/profiling/
   #
   ## NOTE: If enabled this option may incur billing charges or other
-  ##       unexpected side-effects (ie. system probe profiles showing with your
+  ##       unexpected side-effects (ie. process-agent profiles showing with your
   ##       services).
   #
   # profiling:
   #
   ## @param enabled - boolean - optional - default: false
-  ## Enable profiling for the System Probe process.
+  ## Enable profiling for the Process Agent process.
   #
   # enabled: false
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -882,8 +882,8 @@ api_key:
   ## Uncomment this parameter and the one below to enable profiling.
   ## See https://docs.datadoghq.com/tracing/profiling/
   #
-  ## NOTE: If enabled this option may incur billing charges or other
-  ##       unexpected side-effects (ie. process-agent profiles showing with your
+  ## NOTE: If you enable this option, it may impact your billing or
+  ##       other features (e.g. process-agent profiles showing with your
   ##       services).
   #
   # profiling:

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -433,7 +433,7 @@ func loadEnvVariables() {
 		{"DD_SCRUB_ARGS", "process_config.scrub_args"},
 		{"DD_STRIP_PROCESS_ARGS", "process_config.strip_proc_arguments"},
 		{"DD_PROCESS_AGENT_URL", "process_config.process_dd_url"},
-		{"DD_PROCESS_AGENT_PROFILING_ENABLED", "process_config.profiling_enabled"},
+		{"DD_PROCESS_AGENT_PROFILING_ENABLED", "process_config.profiling.enabled"},
 		{"DD_ORCHESTRATOR_URL", "orchestrator_explorer.orchestrator_dd_url"},
 		{"DD_HOSTNAME", "hostname"},
 		{"DD_DOGSTATSD_PORT", "dogstatsd_port"},

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -433,6 +433,7 @@ func loadEnvVariables() {
 		{"DD_SCRUB_ARGS", "process_config.scrub_args"},
 		{"DD_STRIP_PROCESS_ARGS", "process_config.strip_proc_arguments"},
 		{"DD_PROCESS_AGENT_URL", "process_config.process_dd_url"},
+		{"DD_PROCESS_AGENT_PROFILING_ENABLED", "process_config.profiling_enabled"},
 		{"DD_ORCHESTRATOR_URL", "orchestrator_explorer.orchestrator_dd_url"},
 		{"DD_HOSTNAME", "hostname"},
 		{"DD_DOGSTATSD_PORT", "dogstatsd_port"},

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -375,6 +375,16 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		}
 	}
 
+	// use `profiling_enabled` field in `process_config` section to enable/disable profiling for process-agent,
+	// but use the configuration from main agent to fill the settings
+	if config.Datadog.IsSet(key(ns, "profiling_enabled")) {
+		a.ProfilingEnabled = config.Datadog.GetBool(key(ns, "profiling_enabled"))
+		a.ProfilingSite = config.Datadog.GetString("site")
+		a.ProfilingURL = config.Datadog.GetString("profiling.profile_dd_url")
+		a.ProfilingAPIKey = config.Datadog.GetString("api_key")
+		a.ProfilingEnvironment = config.Datadog.GetString("env")
+	}
+
 	// Used to override container source auto-detection
 	// and to enable multiple collector sources if needed.
 	// "docker", "ecs_fargate", "kubelet", "kubelet docker", etc.

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -375,10 +375,10 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		}
 	}
 
-	// use `profiling_enabled` field in `process_config` section to enable/disable profiling for process-agent,
+	// use `profiling.enabled` field in `process_config` section to enable/disable profiling for process-agent,
 	// but use the configuration from main agent to fill the settings
-	if config.Datadog.IsSet(key(ns, "profiling_enabled")) {
-		a.ProfilingEnabled = config.Datadog.GetBool(key(ns, "profiling_enabled"))
+	if config.Datadog.IsSet(key(ns, "profiling.enabled")) {
+		a.ProfilingEnabled = config.Datadog.GetBool(key(ns, "profiling.enabled"))
 		a.ProfilingSite = config.Datadog.GetString("site")
 		a.ProfilingURL = config.Datadog.GetString("profiling.profile_dd_url")
 		a.ProfilingAPIKey = config.Datadog.GetString("api_key")


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability for process-agent to do profiling. Note that the enable/disable switch is `process_config.profiling.enabled`, but the profiling configurations are read from the main agent config.

cc: @DataDog/processes 

### Motivation

Enable process-agent to do profiling if needed.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
