### PR TITLE
[runtime-security] Ignore self generated events

### DIFF
--- a/pkg/security/ebpf/c/filters.h
+++ b/pkg/security/ebpf/c/filters.h
@@ -42,6 +42,12 @@ struct inode_discarder_t {
     u32 padding;
 };
 
+static __always_inline u32 get_system_probe_pid() {
+    u64 val = 0;
+    LOAD_CONSTANT("system_probe_pid", val);
+    return val;
+}
+
 struct bpf_map_def SEC("maps/inode_discarders") inode_discarders = {
     .type = BPF_MAP_TYPE_LRU_HASH,
     .key_size = sizeof(struct inode_discarder_t),
@@ -140,6 +146,11 @@ struct bpf_map_def SEC("maps/pid_discarders") pid_discarders = { \
 };
 
 int __attribute__((always_inline)) discarded_by_pid(u64 event_type, u32 tgid) {
+    u32 system_probe_pid = get_system_probe_pid();
+    if (system_probe_pid && system_probe_pid == tgid) {
+        return 1;
+    }
+
     struct pid_discarder_t key = {
         .tgid = tgid,
     };

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -147,6 +148,13 @@ func (p *Probe) Init() error {
 				LostHandler: p.handleLostEvents,
 			}
 		}
+	}
+
+	if os.Getenv("RUNTIME_SECURITY_TESTSUITE") != "true" {
+		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, manager.ConstantEditor{
+			Name:  "system_probe_pid",
+			Value: uint64(os.Getpid()),
+		})
 	}
 
 	if selectors, exists := probes.SelectorsPerEventType["*"]; exists {

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -581,6 +581,7 @@ func TestMain(m *testing.M) {
 }
 
 func init() {
+	os.Setenv("RUNTIME_SECURITY_TESTSUITE", "true")
 	flag.StringVar(&testEnvironment, "env", HostEnvironment, "environment used to run the test suite: ex: host, docker")
 	flag.BoolVar(&useReload, "reload", true, "reload rules instead of stopping/starting the agent for every test")
 }


### PR DESCRIPTION
### What does this PR do?

Ignore file events generated by system-probe

### Motivation

Resolving events may involve generating file events so would increase the load.