### PR TITLE
[logs/auditor] Make auditor's TTL configurable

### DIFF
--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -60,7 +60,7 @@ func startCompliance(stopper restart.Stopper, apiCl *apiserver.APIClient, isLead
 	health := health.RegisterLiveness("compliance")
 
 	// setup the auditor
-	auditor := auditor.New(coreconfig.Datadog.GetString("compliance_config.run_path"), "compliance-cluster-registry.json", health)
+	auditor := auditor.New(coreconfig.Datadog.GetString("compliance_config.run_path"), "compliance-cluster-registry.json", coreconfig.DefaultAuditorTTL, health)
 	auditor.Start()
 	stopper.Add(auditor)
 

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -98,7 +98,7 @@ func newComplianceReporter(stopper restart.Stopper, sourceName, sourceType strin
 	health := health.RegisterLiveness("compliance")
 
 	// setup the auditor
-	auditor := auditor.New(coreconfig.Datadog.GetString("compliance_config.run_path"), "compliance-registry.json", health)
+	auditor := auditor.New(coreconfig.Datadog.GetString("compliance_config.run_path"), "compliance-registry.json", coreconfig.DefaultAuditorTTL, health)
 	auditor.Start()
 	stopper.Add(auditor)
 

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -88,7 +88,7 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 	health := health.RegisterLiveness("runtime-security")
 
 	// setup the auditor
-	auditor := auditor.New(coreconfig.Datadog.GetString("runtime_security_config.run_path"), "runtime-security-registry.json", health)
+	auditor := auditor.New(coreconfig.Datadog.GetString("runtime_security_config.run_path"), "runtime-security-registry.json", coreconfig.DefaultAuditorTTL, health)
 	auditor.Start()
 	stopper.Add(auditor)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,9 @@ const (
 	// DefaultBatchWait is the default HTTP batch wait in second for logs
 	DefaultBatchWait = 5
 
+	// DefaultAuditorTTL is the default logs auditor TTL in hours
+	DefaultAuditorTTL = 23
+
 	// ClusterIDCacheKey is the key name for the orchestrator cluster id in the agent in-mem cache
 	ClusterIDCacheKey = "orchestratorClusterID"
 
@@ -589,7 +592,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
 	config.BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
 	config.BindEnvAndSetDefault("logs_config.close_timeout", 60)
-	config.BindEnv("logs_config.additional_endpoints") //nolint:errcheck
+	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL) // in hours
+	config.BindEnv("logs_config.additional_endpoints")                        //nolint:errcheck
 
 	// The cardinality of tags to send for checks and dogstatsd respectively.
 	// Choices are: low, orchestrator, high.

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -49,7 +49,8 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 	// setup the auditor
 	// We pass the health handle to the auditor because it's the end of the pipeline and the most
 	// critical part. Arguably it could also be plugged to the destination.
-	auditor := auditor.New(coreConfig.Datadog.GetString("logs_config.run_path"), auditor.DefaultRegistryFilename, health)
+	auditorTTL := time.Duration(coreConfig.Datadog.GetInt("logs_config.auditor_ttl")) * time.Hour
+	auditor := auditor.New(coreConfig.Datadog.GetString("logs_config.run_path"), auditor.DefaultRegistryFilename, auditorTTL, health)
 	destinationsCtx := client.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender

--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -26,7 +26,6 @@ const DefaultRegistryFilename = "registry.json"
 
 const defaultFlushPeriod = 1 * time.Second
 const defaultCleanupPeriod = 300 * time.Second
-const defaultTTL = 23 * time.Hour
 
 // latest version of the API used by the auditor to retrieve the registry from disk.
 const registryAPIVersion = 2
@@ -74,11 +73,11 @@ type Auditor struct {
 }
 
 // New returns an initialized Auditor
-func New(runPath string, filename string, health *health.Handle) *Auditor {
+func New(runPath string, filename string, ttl time.Duration, health *health.Handle) *Auditor {
 	return &Auditor{
 		health:       health,
 		registryPath: filepath.Join(runPath, filename),
-		entryTTL:     defaultTTL,
+		entryTTL:     ttl,
 	}
 }
 

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -42,7 +42,7 @@ func (suite *AuditorTestSuite) SetupTest() {
 	_, err = os.Create(suite.testPath)
 	suite.Nil(err)
 
-	suite.a = New("", DefaultRegistryFilename, health.RegisterLiveness("fake"))
+	suite.a = New("", DefaultRegistryFilename, time.Hour, health.RegisterLiveness("fake"))
 	suite.a.registryPath = suite.testPath
 	suite.source = config.NewLogSource("", &config.LogsConfig{Path: testpath})
 }

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -7,6 +7,7 @@ package pipeline
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 
@@ -24,7 +25,7 @@ type ProviderTestSuite struct {
 }
 
 func (suite *ProviderTestSuite) SetupTest() {
-	suite.a = auditor.New("", auditor.DefaultRegistryFilename, health.RegisterLiveness("fake"))
+	suite.a = auditor.New("", auditor.DefaultRegistryFilename, time.Hour, health.RegisterLiveness("fake"))
 	suite.p = &provider{
 		numberOfPipelines: 3,
 		auditor:           suite.a,


### PR DESCRIPTION
### What does this PR do?

Makes the auditor's TTL configurable (`logs_config.auditor_ttl`).

### Motivation

Allow for longer TTLs to be set, useful when some inputs don't emit logs for longer than the default of 23h, which causes the logs agent to miss (if tailing from the end of input) or re-send logs (if tailing from the beginning of input) if the inputs are then re-instantiated (because of an agent restart or source unschedule/reschedule).

This is a mitigation, actual fix on the auditor will require large code changes and will be tracked separately.

### Additional notes

* Leaving the option undocumented since it's a knob most users shouldn't have to use (and that may disappear when root issue is fixed).
* Configuration doesn't change the config of auditors used in other agent components (cluster-agent, security-agent). If it makes sense to have them configurable as well, it should be done with separate config options.

### Describe your test plan

The code change is trivial, but just to check the option works:
1. make the logs agent tail a container's logs, configure the TTL to `1` hour
2. stop the container (check that the container is still tracked in `registry.json`)
3. wait 1 hour (+ 5 min for registry cleanup logic to kick in)
4. container entry should have disappeared from `registry.json`.