### PR TITLE
[tagger] Fix concurrent map access in KubeMetadataCollector

### DIFF
--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -28,8 +28,6 @@ const (
 )
 
 type KubeMetadataCollector struct {
-	sync.RWMutex
-
 	kubeUtil            kubelet.KubeUtilInterface
 	apiClient           *apiserver.APIClient
 	infoOut             chan<- []*TagInfo
@@ -38,6 +36,7 @@ type KubeMetadataCollector struct {
 	updateFreq          time.Duration
 	expireFreq          time.Duration
 
+	m sync.RWMutex
 	// used to set a custom delay
 	lastUpdate time.Time
 	lastExpire time.Time
@@ -121,16 +120,16 @@ func (c *KubeMetadataCollector) Pull() error {
 }
 
 func (c *KubeMetadataCollector) getLastUpdate() time.Time {
-	c.RLock()
-	defer c.RUnlock()
+	c.m.RLock()
+	defer c.m.RUnlock()
 	return c.lastUpdate
 }
 
 func (c *KubeMetadataCollector) collectUpdates(pods []*kubelet.Pod) []*TagInfo {
 	tagInfos := c.getTagInfos(pods)
 
-	c.Lock()
-	defer c.Unlock()
+	c.m.Lock()
+	defer c.m.Unlock()
 
 	now := time.Now()
 

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -9,6 +9,7 @@ package collectors
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -27,19 +28,20 @@ const (
 )
 
 type KubeMetadataCollector struct {
-	kubeUtil  kubelet.KubeUtilInterface
-	apiClient *apiserver.APIClient
-	infoOut   chan<- []*TagInfo
-	dcaClient clusteragent.DCAClientInterface
+	sync.RWMutex
+
+	kubeUtil            kubelet.KubeUtilInterface
+	apiClient           *apiserver.APIClient
+	infoOut             chan<- []*TagInfo
+	dcaClient           clusteragent.DCAClientInterface
+	clusterAgentEnabled bool
+	updateFreq          time.Duration
+	expireFreq          time.Duration
+
 	// used to set a custom delay
 	lastUpdate time.Time
-	updateFreq time.Duration
-
 	lastExpire time.Time
 	lastSeen   map[string]time.Time
-	expireFreq time.Duration
-
-	clusterAgentEnabled bool
 }
 
 // Detect tries to connect to the kubelet and the API Server if the DCA is not used or the DCA.
@@ -93,7 +95,7 @@ func (c *KubeMetadataCollector) Detect(out chan<- []*TagInfo) (CollectionMode, e
 // Pull implements an additional time constraints to avoid exhausting the kube-apiserver
 func (c *KubeMetadataCollector) Pull() error {
 	// Time constraints, get the delta in seconds to display it in the logs:
-	timeDelta := c.lastUpdate.Add(c.updateFreq).Unix() - time.Now().Unix()
+	timeDelta := c.getLastUpdate().Add(c.updateFreq).Unix() - time.Now().Unix()
 	if timeDelta > 0 {
 		log.Tracef("skipping, next effective Pull will be in %d seconds", timeDelta)
 		return nil
@@ -111,7 +113,25 @@ func (c *KubeMetadataCollector) Pull() error {
 		}
 	}
 
+	tagInfos := c.collectUpdates(pods)
+
+	c.infoOut <- tagInfos
+
+	return nil
+}
+
+func (c *KubeMetadataCollector) getLastUpdate() time.Time {
+	c.RLock()
+	defer c.RUnlock()
+	return c.lastUpdate
+}
+
+func (c *KubeMetadataCollector) collectUpdates(pods []*kubelet.Pod) []*TagInfo {
 	tagInfos := c.getTagInfos(pods)
+
+	c.Lock()
+	defer c.Unlock()
+
 	now := time.Now()
 
 	for _, tagInfo := range tagInfos {
@@ -134,9 +154,7 @@ func (c *KubeMetadataCollector) Pull() error {
 	}
 
 	c.lastUpdate = now
-	c.infoOut <- tagInfos
-
-	return nil
+	return tagInfos
 }
 
 // Fetch fetches tags for a given entity by iterating on the whole podlist and

--- a/releasenotes/notes/fix-panic-in-kubernetes-metadata.yaml
+++ b/releasenotes/notes/fix-panic-in-kubernetes-metadata.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes panic on concurrent map access in Kubernetes metadata tag collector.
+


### PR DESCRIPTION
### What does this PR do?

Fixes concurrent map access in KubeMetadataCollector.lastSeen.

Concurrent calls to the Pull method happen from periodic pull and init in the tagger:

```
fatal error: concurrent map writes
goroutine 178 [running]:
runtime.throw(0x25c2fc5, 0x15)
        /root/.gimme/versions/go1.14.12.linux.amd64/src/runtime/panic.go:1116 +0x72 fp=0xc0009d1d58 sp=0xc0009d1d28 pc=0x439342
runtime.mapassign_faststr(0x21d5c80, 0xc000262600, 0xc000bc2a50, 0x4f, 0xc000bcc400)
        /root/.gimme/versions/go1.14.12.linux.amd64/src/runtime/map_faststr.go:211 +0x3f7 fp=0xc0009d1dc0 sp=0xc0009d1d58 pc=0x417c47
github.com/DataDog/datadog-agent/pkg/tagger/collectors.(*KubeMetadataCollector).Pull(0xc00050bd80, 0x0, 0x0)
        /.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/tagger/collectors/kubernetes_main.go:118 +0x317 fp=0xc0009d1f28 sp=0xc0009d1dc0 pc=0x1beecc7
github.com/DataDog/datadog-agent/pkg/tagger.(*Tagger).pull(0xc00057acb0)
        /.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/tagger/tagger.go:207 +0xbf fp=0xc0009d1fd8 sp=0xc0009d1f28 pc=0x1bf3caf
runtime.goexit()
        /root/.gimme/versions/go1.14.12.linux.amd64/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc0009d1fe0 sp=0xc0009d1fd8 pc=0x46bfb1
created by github.com/DataDog/datadog-agent/pkg/tagger.(*Tagger).Init
        /.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/tagger/tagger.go:90 +0x1c5
```

and

```
goroutine 176 [runnable]:
github.com/DataDog/datadog-agent/pkg/tagger/collectors.(*KubeMetadataCollector).Pull(0xc00050bd80, 0x0, 0x0)
        /.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/tagger/collectors/kubernetes_main.go:118 +0x317
github.com/DataDog/datadog-agent/pkg/tagger.(*Tagger).pull(0xc00057acb0)
        /.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/tagger/tagger.go:207 +0xbf
created by github.com/DataDog/datadog-agent/pkg/tagger.(*Tagger).run
        /.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/tagger/tagger.go:116 +0x1ba
```

### Motivation

Crash-free metadata tagging.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Ensure metadata tag collection still works for Pods when `kubernetes_collect_metadata_tags` is configured
