### PR TITLE
Squash docker image layers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2659,7 +2659,6 @@ send_pkg_size-a7:
     - test "$TESTING_ARG" && docker build --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT
     # Build release stage and push to ECR
     - docker build $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --tag ${TARGET_TAG}-unsquashed $BUILD_CONTEXT
-    - pip install docker-squash
     - docker-squash ${TARGET_TAG}-unsquashed -t ${TARGET_TAG}
     - docker push $TARGET_TAG
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2658,7 +2658,7 @@ send_pkg_size-a7:
     # Build testing stage if provided
     - test "$TESTING_ARG" && docker build --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT
     # Build release stage and push to ECR
-    - docker build $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --squash=true --tag $TARGET_TAG $BUILD_CONTEXT
+    - docker build $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --tag $TARGET_TAG $BUILD_CONTEXT
     - docker push $TARGET_TAG
 
 .docker_build_job_definition_amd64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2658,7 +2658,7 @@ send_pkg_size-a7:
     # Build testing stage if provided
     - test "$TESTING_ARG" && docker build --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT
     # Build release stage and push to ECR
-    - docker build $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --tag $TARGET_TAG $BUILD_CONTEXT
+    - docker build $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --squash=true --tag $TARGET_TAG $BUILD_CONTEXT
     - docker push $TARGET_TAG
 
 .docker_build_job_definition_amd64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2658,7 +2658,9 @@ send_pkg_size-a7:
     # Build testing stage if provided
     - test "$TESTING_ARG" && docker build --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT
     # Build release stage and push to ECR
-    - docker build $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --tag $TARGET_TAG $BUILD_CONTEXT
+    - docker build $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --tag ${TARGET_TAG}-unsquashed $BUILD_CONTEXT
+    - pip install docker-squash
+    - docker-squash ${TARGET_TAG}-unsquashed -t ${TARGET_TAG}
     - docker push $TARGET_TAG
 
 .docker_build_job_definition_amd64:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 invoke==1.4.1
 reno==3.1.0
 docker==3.7.3
+docker-squash==1.0.8
 requests==2.23.0
 PyYAML==5.3.1
 toml==0.9.4

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -278,7 +278,7 @@ def system_tests(ctx):
 
 
 @task
-def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_tests=False):
+def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_tests=False, squash="false"):
     """
     Build the docker image
     """
@@ -312,7 +312,7 @@ def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_
         ctx.run("docker build {} --target testing {}".format(common_build_opts, build_context))
 
     # Build with the release target
-    ctx.run("docker build {} --target release {}".format(common_build_opts, build_context))
+    ctx.run("docker build {} --target release --squash={} {}".format(common_build_opts, squash, build_context))
     ctx.run("rm {}/{}".format(build_context, deb_glob))
 
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -278,7 +278,7 @@ def system_tests(ctx):
 
 
 @task
-def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_tests=False, squash="false"):
+def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_tests=False):
     """
     Build the docker image
     """
@@ -312,7 +312,7 @@ def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_
         ctx.run("docker build {} --target testing {}".format(common_build_opts, build_context))
 
     # Build with the release target
-    ctx.run("docker build {} --target release --squash={} {}".format(common_build_opts, squash, build_context))
+    ctx.run("docker build {} --target release {}".format(common_build_opts, build_context))
     ctx.run("rm {}/{}".format(build_context, deb_glob))
 
 


### PR DESCRIPTION
### What does this PR do?

Squash Datadog agent docker image layers.

### Motivation

As each Datadog agent release is based on the latest Debian base image, which is updated more often than Datadog agent releases, the docker images of two consecutive Datadog agent release are sharing no common layer.
So, the layering of the Datadog agent docker images is providing no gain.

### Additional Notes

I would have preferred to use `docker build --squash=true …` rather than a 3rd party tool but the docker daemon of the GitLab CI doesn’t have experimental features enabled.

### Describe your test plan

Check that the Datadog docker images is mono-layer with `docker history`.