### PR TITLE
change default tag template comment to `env`

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -64,7 +64,7 @@ api_key:
 ## Learn more about tagging: https://docs.datadoghq.com/tagging/
 #
 # tags:
-#   - environment:dev
+#   - env:dev
 #   - <TAG_KEY>:<TAG_VALUE>
 
 ## @param env - string - optional

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -64,7 +64,7 @@ api_key:
 ## Learn more about tagging: https://docs.datadoghq.com/tagging/
 #
 # tags:
-#   - env:dev
+#   - team:infra
 #   - <TAG_KEY>:<TAG_VALUE>
 
 ## @param env - string - optional


### PR DESCRIPTION
We provide the default tag name of `environment` when according to our unified tagging docs we recommend `env` https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#overview

### What does this PR do?

changes default tag template comment to `env`

### Motivation

I see a lot of customers using `environment` when they probably shouldn't, and i think this example tag contributes.