### PR TITLE
pkg/trace/config: always activate APM non-local traffic in containerized environments if no explicit setting

### DIFF
--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -238,15 +238,20 @@ func (c *AgentConfig) applyDatadogConfig() error {
 		}
 	}
 
-	if config.Datadog.IsSet("bind_host") {
-		host := config.Datadog.GetString("bind_host")
-		c.StatsdHost = host
-		c.ReceiverHost = host
-	}
-	if config.Datadog.IsSet("apm_config.apm_non_local_traffic") {
-		if config.Datadog.GetBool("apm_config.apm_non_local_traffic") {
+	if config.Datadog.IsSet("bind_host") || config.Datadog.IsSet("apm_config.apm_non_local_traffic") {
+		if config.Datadog.IsSet("bind_host") {
+			host := config.Datadog.GetString("bind_host")
+			c.StatsdHost = host
+			c.ReceiverHost = host
+		}
+
+		if config.Datadog.IsSet("apm_config.apm_non_local_traffic") && config.Datadog.GetBool("apm_config.apm_non_local_traffic") {
 			c.ReceiverHost = "0.0.0.0"
 		}
+	} else if config.IsContainerized() {
+		// Automatically activate non local traffic in containerized environment if no explicit config set
+		log.Info("Activating non-local traffic automatically in containerized environment, trace-agent will listen on 0.0.0.0")
+		c.ReceiverHost = "0.0.0.0"
 	}
 
 	if config.Datadog.IsSet("apm_config.obfuscation") {

--- a/releasenotes/notes/apm-non-local-traffic-default-cont-f8f9277d9ce2abf1.yaml
+++ b/releasenotes/notes/apm-non-local-traffic-default-cont-f8f9277d9ce2abf1.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    APM: Automatically activate non-local trafic (i.e. listening on 0.0.0.0) for APM in containerized environment if no explicit setting is set (bind_host or apm_non_local_traffic)


### PR DESCRIPTION
### What does this PR do?

Always activate APM non-local traffic in containerized environments if no explicit setting.

### Motivation

Ease APM setup as much as possible in containerized scenarios.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy Agent in a container with APM activated but without `bind_host` or `apm_non_local_traffic`. Make sure `trace-agent` listens on `0.0.0.0`
