### PR TITLE
[KubeUtil] Identify NotFound and Retriable errors

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -11,6 +11,7 @@ type errorReason int
 
 const (
 	notFoundError errorReason = iota
+	retriableError
 	unknownError
 )
 
@@ -38,6 +39,19 @@ func NewNotFound(notFoundObject string) *AgentError {
 // IsNotFound returns true if the specified error was created by NewNotFound.
 func IsNotFound(err error) bool {
 	return reasonForError(err) == notFoundError
+}
+
+// NewRetriable returns a new error which indicates that the object passed in parameter couldn't be fetched and that the query can be retried.
+func NewRetriable(retriableObj interface{}, err error) *AgentError {
+	return &AgentError{
+		message:     fmt.Sprintf("couldn't fetch %q: %v", retriableObj, err),
+		errorReason: retriableError,
+	}
+}
+
+// IsRetriable returns true if the specified error was created by NewRetriable.
+func IsRetriable(err error) bool {
+	return reasonForError(err) == retriableError
 }
 
 func reasonForError(err error) errorReason {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -6,6 +6,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -22,4 +23,17 @@ func TestNotFound(t *testing.T) {
 	require.True(t, IsNotFound(err))
 	require.False(t, IsNotFound(fmt.Errorf("fake")))
 	require.False(t, IsNotFound(fmt.Errorf(`"foo" not found`)))
+}
+
+func TestRetriable(t *testing.T) {
+	// New
+	err := NewRetriable("foo", errors.New("bar"))
+	require.Error(t, err)
+	require.Equal(t, `couldn't fetch "foo": bar`, err.Error())
+
+	// Is
+	var errFunc func() error = func() error { return NewRetriable("foo", errors.New("bar")) }
+	require.True(t, IsRetriable(errFunc()))
+	require.False(t, IsRetriable(fmt.Errorf("fake")))
+	require.False(t, IsRetriable(fmt.Errorf(`couldn't fetch "foo": bar`)))
 }

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -251,6 +251,30 @@ func (suite *KubeletTestSuite) TestGetLocalPodList() {
 	}
 }
 
+func (suite *KubeletTestSuite) TestGetLocalPodListWithBrokenKubelet() {
+	mockConfig := config.Mock()
+
+	kubelet, err := newDummyKubelet("./testdata/invalid.json")
+	require.Nil(suite.T(), err)
+	ts, kubeletPort, err := kubelet.Start()
+	defer ts.Close()
+	require.Nil(suite.T(), err)
+
+	mockConfig.Set("kubernetes_kubelet_host", "localhost")
+	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
+	mockConfig.Set("kubernetes_https_kubelet_port", -1)
+	mockConfig.Set("kubelet_tls_verify", false)
+	mockConfig.Set("kubelet_auth_token_path", "")
+
+	kubeutil := suite.getCustomKubeUtil()
+	kubelet.dropRequests() // Throwing away first GETs
+
+	pods, err := kubeutil.GetLocalPodList()
+	require.NotNil(suite.T(), err)
+	require.Len(suite.T(), pods, 0)
+	require.True(suite.T(), errors.IsRetriable(err))
+}
+
 func (suite *KubeletTestSuite) TestGetNodeInfo() {
 	mockConfig := config.Mock()
 
@@ -386,6 +410,41 @@ func (suite *KubeletTestSuite) TestGetPodForContainerID() {
 	// Valid container ID
 	pod, err = kubeutil.GetPodForContainerID("container_id://b3e4cd65204e04d1a2d4b7683cae2f59b2075700f033a6b09890bd0d3fecf6b6")
 	// The /pods request is still cached
+	require.Nil(suite.T(), err)
+	require.NotNil(suite.T(), pod)
+	require.Equal(suite.T(), "kube-proxy-rnd5q", pod.Metadata.Name)
+}
+
+func (suite *KubeletTestSuite) TestGetPodFromUID() {
+	mockConfig := config.Mock()
+
+	kubelet, err := newDummyKubelet("./testdata/podlist_1.8-2.json")
+	require.Nil(suite.T(), err)
+	ts, kubeletPort, err := kubelet.Start()
+	defer ts.Close()
+	require.Nil(suite.T(), err)
+
+	mockConfig.Set("kubernetes_kubelet_host", "localhost")
+	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
+	mockConfig.Set("kubernetes_https_kubelet_port", -1)
+
+	kubeutil := suite.getCustomKubeUtil()
+	kubelet.dropRequests() // Throwing away first GETs
+
+	// Empty Pod UID
+	pod, err := kubeutil.GetPodFromUID("")
+	require.Nil(suite.T(), pod)
+	require.NotNil(suite.T(), err)
+	require.Contains(suite.T(), err.Error(), "pod UID is empty")
+
+	// Not found Pod UID
+	pod, err = kubeutil.GetPodFromUID("invalid")
+	require.Nil(suite.T(), pod)
+	require.NotNil(suite.T(), err)
+	require.True(suite.T(), errors.IsNotFound(err))
+
+	// Valid Pod UID
+	pod, err = kubeutil.GetPodFromUID("e42b42ec-0749-11e8-a2b8-000c29dea4f6")
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), pod)
 	require.Equal(suite.T(), "kube-proxy-rnd5q", pod.Metadata.Name)
@@ -831,7 +890,7 @@ func TestGetStatusForContainerID(t *testing.T) {
 	assert.Equal(t, containerFoo, container)
 
 	_, err := k.GetStatusForContainerID(pod, serviceBaz.GetEntityID())
-	assert.EqualError(t, err, "Container docker://bazID not found")
+	assert.EqualError(t, err, `"container docker://bazID in pod" not found`)
 }
 
 func TestGetSpecForContainerName(t *testing.T) {

--- a/pkg/util/kubernetes/kubelet/testdata/invalid.json
+++ b/pkg/util/kubernetes/kubelet/testdata/invalid.json
@@ -1,0 +1,1 @@
+invalid file


### PR DESCRIPTION
### What does this PR do?

Make `GetPodForEntityID` return `Retriable` or `NotFound` errors.

### Motivation

Make it possible for KubeUtil clients to identify transient kubelet errors.

The retry logic implemented in https://github.com/DataDog/datadog-agent/pull/6626 can now rely on the error type returned by kubelet to make smarter decisions.

### Describe your test plan

Should be tested as part of https://github.com/DataDog/datadog-agent/pull/6626
