### PR TITLE
[windows] fix status to SCM 

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -384,7 +384,8 @@ func StartAgent() error {
 	}
 
 	// start dependent services
-	startDependentServices()
+	go startDependentServices()
+
 	return nil
 }
 

--- a/cmd/agent/windows/service/service.go
+++ b/cmd/agent/windows/service/service.go
@@ -28,7 +28,7 @@ type agentWindowsService struct{}
 func (m *agentWindowsService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
-	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+
 	if err := common.ImportRegistryConfig(); err != nil {
 		elog.Warning(0x80000001, err.Error())
 		// continue running agent with existing config
@@ -45,7 +45,7 @@ func (m *agentWindowsService) Execute(args []string, r <-chan svc.ChangeRequest,
 		return
 	}
 	elog.Info(0x40000003, config.ServiceName)
-
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 loop:
 	for {
 		select {


### PR DESCRIPTION
Move notification of SCM that the service is running until after StartAgent() actually completes.
Move `StartDependentServices()` to a goroutine, otherwise a deadlock is created (the dependent services can't start until the agent has started).

Workaround for customer issue where multiple successive starts/stops (restarts) result in unstable system.
Previously, the stop notification was being ignored if it occurred during StartAgent(), b/c we had notified the SCM that the service was started, but the loop that actually handled notifications couldn't start until afterward.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
