### PR TITLE
[windows] Make uninstall/upgrade explicitly stop all services.

### DIFF
--- a/releasenotes/notes/installstopallservices-5391c764f737d90a.yaml
+++ b/releasenotes/notes/installstopallservices-5391c764f737d90a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, fixes uninstall/upgrade problem if core agent is not running
+    but other services are.

--- a/tools/windows/install-help/cal/CustomAction.cpp
+++ b/tools/windows/install-help/cal/CustomAction.cpp
@@ -42,7 +42,7 @@ extern "C" UINT __stdcall PreStopServices(MSIHANDLE hInstall) {
     ExitOnFailure(hr, "Failed to initialize");
     
     WcaLog(LOGMSG_STANDARD, "Initialized.");
-    DoStopSvc(agentService);
+    DoStopAllServices();
     WcaLog(LOGMSG_STANDARD, "Waiting for prestop to complete");
     Sleep(10000);
     WcaLog(LOGMSG_STANDARD, "Prestop complete");
@@ -115,7 +115,7 @@ extern "C" UINT __stdcall DoRollback(MSIHANDLE hInstall) {
     initializeStringsFromStringTable();
     // we'll need to stop the services manually if we got far enough to start
     // them before installation failed.
-    DoStopSvc(agentService);
+    DoStopAllServices();
     er = doUninstallAs(UNINSTALL_ROLLBACK);
     if (er != 0) {
         hr = -1;

--- a/tools/windows/install-help/cal/customaction.h
+++ b/tools/windows/install-help/cal/customaction.h
@@ -77,7 +77,7 @@ LSA_HANDLE GetPolicyHandle();
 
 
 //stopservices.cpp
-VOID  DoStopSvc(std::wstring &svcName);
+VOID DoStopAllServices();
 DWORD DoStartSvc(std::wstring &svcName);
 int doesServiceExist(std::wstring& svcName);
 int installServices(CustomActionData& data, PSID sid, const wchar_t *password);

--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -1,7 +1,19 @@
 #include "stdafx.h"
 
 static BOOL StopDependentServices(SC_HANDLE hScManager, SC_HANDLE hService);
+static VOID  DoStopSvc(const wchar_t*);
+VOID DoStopAllServices()
+{
+    /*
+     * temporary, clunky workaround to account for subservices running when main
+     * agent is not
+     */
+    DoStopSvc(L"datadog-system-probe");
+    DoStopSvc(L"datadog-process-agent");
+    DoStopSvc(L"datadog-trace-agent");
+    DoStopSvc(L"datadogagent");
 
+}
 int doesServiceExist(std::wstring& svcName)
 {
     SC_HANDLE hScManager = NULL;
@@ -61,7 +73,7 @@ int doesServiceExist(std::wstring& svcName)
 // Return value:
 //   None
 //
-VOID  DoStopSvc(std::wstring &svcName)
+VOID  DoStopSvc(const wchar_t* inSvcName)
 {
     SERVICE_STATUS_PROCESS ssp;
     DWORD dwStartTime = GetTickCount();
@@ -70,6 +82,7 @@ VOID  DoStopSvc(std::wstring &svcName)
     DWORD dwWaitTime;
     SC_HANDLE hScManager = NULL;
     SC_HANDLE hService = NULL;
+    std::wstring svcName = inSvcName;
 
     // Get a handle to the SCM database. 
     WcaLog(LOGMSG_STANDARD, "Stopping service %S", svcName.c_str());


### PR DESCRIPTION
### What does this PR do?

Makes the installer explicitly stop all services. Previously only explicitly stopped agent service,
which would stop others as a result of the SCM dependencies.
Fixes (rare) case where core agent is not running but another service is.

### Motivation

Support issue.

