### PR TITLE
[runtime-security] Lock process resolver before computing cache size

### DIFF
--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -222,7 +222,7 @@ func (p *Probe) SendStats(statsdClient *statsd.Client) error {
 		}
 	}
 
-	if err := statsdClient.Gauge(MetricPrefix+".process_resolver.cache_size", float64(len(p.resolvers.ProcessResolver.entryCache)), []string{}, 1.0); err != nil {
+	if err := statsdClient.Gauge(MetricPrefix+".process_resolver.cache_size", p.resolvers.ProcessResolver.GetCacheSize(), []string{}, 1.0); err != nil {
 		return errors.Wrap(err, "failed to send process_resolver cache_size metric")
 	}
 	return nil

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -444,6 +444,13 @@ func (p *ProcessResolver) syncCache(proc *process.FilledProcess) (*ProcessCacheE
 	return entry, true
 }
 
+// GetCacheSize returns the cache size of the process resolver
+func (p *ProcessResolver) GetCacheSize() float64 {
+	p.resolvers.ProcessResolver.RLock()
+	defer p.resolvers.ProcessResolver.RUnlock()
+	return float64(len(p.resolvers.ProcessResolver.entryCache))
+}
+
 // NewProcessResolver returns a new process resolver
 func NewProcessResolver(probe *Probe, resolvers *Resolvers, client *statsd.Client) (*ProcessResolver, error) {
 	return &ProcessResolver{


### PR DESCRIPTION
### What does this PR do?

This PR requests a read lock on the process resolver before computing its cache size. This prevents a race while reading the map.

### Motivation

Better be safe than sorry, this map can be written to / read by other go routines.