### PR TITLE
[forwarder] disk persistence: add facilities for per agent features

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -296,7 +296,12 @@ func StartAgent() error {
 	if err != nil {
 		log.Error("Misconfiguration of agent endpoints: ", err)
 	}
-	common.Forwarder = forwarder.NewDefaultForwarder(forwarder.NewOptions(keysPerDomain))
+
+	// Enable core agent specific features like persistence-to-disk
+	options := forwarder.NewOptions(keysPerDomain)
+	options.EnabledFeatures = forwarder.SetFeature(options.EnabledFeatures, forwarder.CoreFeatures)
+
+	common.Forwarder = forwarder.NewDefaultForwarder(options)
 	log.Debugf("Starting forwarder")
 	common.Forwarder.Start() //nolint:errcheck
 	log.Debugf("Forwarder started")

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -54,6 +54,23 @@ func TestNewDefaultForwarder(t *testing.T) {
 	assert.Equal(t, forwarder.State(), forwarder.internalState)
 }
 
+func TestFeature(t *testing.T) {
+	var featureSet Features
+
+	featureSet = SetFeature(featureSet, CoreFeatures)
+	featureSet = SetFeature(featureSet, ProcessFeatures)
+	assert.True(t, HasFeature(featureSet, CoreFeatures))
+	assert.True(t, HasFeature(featureSet, ProcessFeatures))
+
+	featureSet = ClearFeature(featureSet, CoreFeatures)
+	assert.False(t, HasFeature(featureSet, CoreFeatures))
+	assert.True(t, HasFeature(featureSet, ProcessFeatures))
+
+	featureSet = ToggleFeature(featureSet, ProcessFeatures)
+	assert.False(t, HasFeature(featureSet, CoreFeatures))
+	assert.False(t, HasFeature(featureSet, ProcessFeatures))
+}
+
 func TestStart(t *testing.T) {
 	forwarder := NewDefaultForwarder(NewOptions(monoKeysDomains))
 	err := forwarder.Start()


### PR DESCRIPTION
### What does this PR do?

Some forwarder features should only be available to certain agents (in this case the core agent specifically). This PR tries to make it easy for us to set features which may be selectively made available to different agents.

### Motivation

A bug found in the disk persistence feature as the process agent was interfering with the core agent. The process agent has different forwarding strategy so the current disk persistence logic will not work for it. Let's require enabling of the disk persistence feature explicitly in the forwarder during instantiation at startup.  

### Additional Notes

We probably need to make the feature itself be able to silo transactions so that it serves the specific agent (core, trace, process, system-probe if they were able to use the same forwarder) where the feature is enabled. But for now this is probably good enough. 

### Describe your test plan

1. stop the datadog-agent and configure the options:
```
forwarder_retry_queue_payloads_max_size: 65536
forwarder_storage_max_size_in_bytes: 8388608
```
2. remove `/opt/datadog-agent/run/transactions_to_retry`
3. set iptables rule to drop outbound 443 traffic: `sudo iptables -A OUTPUT -p tcp --dport 443 -j DROP`
4. restart the agent
5. verify the persistence files are correctly written to disk.