### PR TITLE
[windows] hack the results of the pip install

### DIFF
--- a/omnibus/config/patches/pip2/remove-python27-deprecation-warning.patch
+++ b/omnibus/config/patches/pip2/remove-python27-deprecation-warning.patch
@@ -3,7 +3,7 @@
 @@ -139,23 +139,6 @@ class Command(CommandContextMixIn):
              user_log_file=options.log,
          )
- 
+
 -        if (
 -            sys.version_info[:2] == (2, 7) and
 -            not options.no_python_version_warning

--- a/omnibus/config/patches/pip2/remove-python27-deprecation-warning.patch
+++ b/omnibus/config/patches/pip2/remove-python27-deprecation-warning.patch
@@ -1,16 +1,16 @@
 --- a/src/pip/_internal/cli/base_command.py
 +++ b/src/pip/_internal/cli/base_command.py
-@@ -136,22 +136,6 @@ class Command(CommandContextMixIn):
+@@ -139,23 +139,6 @@ class Command(CommandContextMixIn):
              user_log_file=options.log,
          )
-
+ 
 -        if (
 -            sys.version_info[:2] == (2, 7) and
 -            not options.no_python_version_warning
 -        ):
 -            message = (
 -                "pip 21.0 will drop support for Python 2.7 in January 2021. "
--                "More details about Python 2 support in pip, can be found at "
+-                "More details about Python 2 support in pip can be found at "
 -                "https://pip.pypa.io/en/latest/development/release-process/#python-2-support"  # noqa
 -            )
 -            if platform.python_implementation() == "CPython":
@@ -19,9 +19,8 @@
 -                    "1st, 2020. Please upgrade your Python as Python 2.7 "
 -                    "is no longer maintained. "
 -                ) + message
--            deprecated(message, replacement=None, gone_in=None)
-
-         # TODO: Try to get these passing down from the command?
-         #       without resorting to os.environ to hold these.
-         #       This also affects isolated builds and it should.
-
+-            deprecated(message, replacement=None, gone_in="21.0")
+-
+         if (
+             sys.version_info[:2] == (3, 5) and
+             not options.no_python_version_warning

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -52,6 +52,7 @@ build do
             delete "#{install_dir}/bin/agent/dist/*.conf*"
             delete "#{install_dir}/bin/agent/dist/*.yaml"
             command "del /q /s #{windows_safe_path(install_dir)}\\*.pyc"
+            command "del /q /s #{windows_safe_path(install_dir)}\\direct_url.json"
         end
 
         if linux? || osx?

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -193,8 +193,8 @@ build do
     # Use pip-compile to create the final requirements file. Notice when we invoke `pip` through `python -m pip <...>`,
     # there's no need to refer to `pip`, the interpreter will pick the right script.
     if windows?
-      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_base"
-      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_downloader"
+      command "#{python} -m pip install --no-deps .", :cwd => "#{windows_safe_path(project_dir)}\\datadog_checks_base"
+      command "#{python} -m pip install --no-deps .", :cwd => "#{windows_safe_path(project_dir)}\\datadog_checks_downloader"
       command "#{python} -m piptools compile --generate-hashes --output-file #{windows_safe_path(install_dir)}\\#{agent_requirements_file} #{static_reqs_out_file}"
     else
       command "#{pip} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/datadog_checks_base"

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -193,8 +193,8 @@ build do
     # Use pip-compile to create the final requirements file. Notice when we invoke `pip` through `python -m pip <...>`,
     # there's no need to refer to `pip`, the interpreter will pick the right script.
     if windows?
-      command "#{python} -m pip install --no-deps .", :cwd => "#{windows_safe_path(project_dir)}\\datadog_checks_base"
-      command "#{python} -m pip install --no-deps .", :cwd => "#{windows_safe_path(project_dir)}\\datadog_checks_downloader"
+      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_base"
+      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_downloader"
       command "#{python} -m piptools compile --generate-hashes --output-file #{windows_safe_path(install_dir)}\\#{agent_requirements_file} #{static_reqs_out_file}"
     else
       command "#{pip} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/datadog_checks_base"

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -141,7 +141,7 @@ build do
     # install the core integrations.
     #
     command "#{pip} install wheel==0.34.1"
-    command "#{pip} install pip-tools==5.3.1"
+    command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {
       "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -194,7 +194,7 @@ build do
     # there's no need to refer to `pip`, the interpreter will pick the right script.
     if windows?
       command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_base"
-      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_downloader --install-option=\"--install-scripts=#{windows_safe_path(install_dir)}/bin\""
+      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_downloader"
       command "#{python} -m piptools compile --generate-hashes --output-file #{windows_safe_path(install_dir)}\\#{agent_requirements_file} #{static_reqs_out_file}"
     else
       command "#{pip} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/datadog_checks_base"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -188,7 +188,7 @@ build do
     # there's no need to refer to `pip`, the interpreter will pick the right script.
     if windows?
       command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_base"
-      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_downloader --install-option=\"--install-scripts=#{windows_safe_path(install_dir)}/bin\""
+      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_downloader"
       command "#{python} -m piptools compile --generate-hashes --output-file #{windows_safe_path(install_dir)}\\#{agent_requirements_file} #{static_reqs_out_file}"
     else
       command "#{pip} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/datadog_checks_base"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -187,8 +187,8 @@ build do
     # Use pip-compile to create the final requirements file. Notice when we invoke `pip` through `python -m pip <...>`,
     # there's no need to refer to `pip`, the interpreter will pick the right script.
     if windows?
-      command "#{python} -m pip install --no-deps .", :cwd => "#{windows_safe_path(project_dir)}\\datadog_checks_base"
-      command "#{python} -m pip install --no-deps .", :cwd => "#{windows_safe_path(project_dir)}\\datadog_checks_downloader"
+      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_base"
+      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_downloader"
       command "#{python} -m piptools compile --generate-hashes --output-file #{windows_safe_path(install_dir)}\\#{agent_requirements_file} #{static_reqs_out_file}"
     else
       command "#{pip} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/datadog_checks_base"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -187,8 +187,8 @@ build do
     # Use pip-compile to create the final requirements file. Notice when we invoke `pip` through `python -m pip <...>`,
     # there's no need to refer to `pip`, the interpreter will pick the right script.
     if windows?
-      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_base"
-      command "#{python} -m pip install --no-deps  #{windows_safe_path(project_dir)}\\datadog_checks_downloader"
+      command "#{python} -m pip install --no-deps .", :cwd => "#{windows_safe_path(project_dir)}\\datadog_checks_base"
+      command "#{python} -m pip install --no-deps .", :cwd => "#{windows_safe_path(project_dir)}\\datadog_checks_downloader"
       command "#{python} -m piptools compile --generate-hashes --output-file #{windows_safe_path(install_dir)}\\#{agent_requirements_file} #{static_reqs_out_file}"
     else
       command "#{pip} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/datadog_checks_base"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -218,6 +218,12 @@ build do
     # Install Core integrations
     #
 
+    ##
+    ## on windows, delete the `direct_url.json` file(s) created by the pip installs above, before creating the constraints
+    ## file
+    if windows?
+      command "del /q /s #{windows_safe_path(install_dir)}\\direct_url.json"
+    end
     # Create a constraint file after installing all the core dependencies and before any integration
     # This is then used as a constraint file by the integration command to avoid messing with the agent's python environment
     command "#{pip} freeze > #{install_dir}/#{final_constraints_file}"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -135,7 +135,7 @@ build do
     # install the core integrations.
     #
     command "#{pip} install wheel==0.34.1"
-    command "#{pip} install pip-tools==5.3.1"
+    command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {
       "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",

--- a/omnibus/config/software/pip2.rb
+++ b/omnibus/config/software/pip2.rb
@@ -1,11 +1,11 @@
 name "pip2"
 
-default_version "20.1.1"
+default_version "20.3.3"
 
 dependency "setuptools2"
 
 source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",
-       :sha256 => "fa20f7632bab63162d281e555e1d40dced21f22b2578709454f9015f279a0144",
+       :sha256 => "016f8d509871b72fb05da911db513c11059d8a99f4591dda3050a3cf83a29a79",
        :extract => :seven_zip
 
 relative_path "pip-#{version}"

--- a/omnibus/config/software/pip3.rb
+++ b/omnibus/config/software/pip3.rb
@@ -1,11 +1,11 @@
 name "pip3"
 
-default_version "20.1.1"
+default_version "20.3.3"
 
 dependency "setuptools3"
 
 source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",
-       :sha256 => "fa20f7632bab63162d281e555e1d40dced21f22b2578709454f9015f279a0144",
+       :sha256 => "016f8d509871b72fb05da911db513c11059d8a99f4591dda3050a3cf83a29a79",
        :extract => :seven_zip
 
 relative_path "pip-#{version}"

--- a/releasenotes/notes/update-pip-version-234234jes213awg2.yaml
+++ b/releasenotes/notes/update-pip-version-234234jes213awg2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Upgrade pip to 20.3.3 to get a newer vendored version of urllib3. 
+ 

--- a/releasenotes/notes/update-pip-version-234234jes213awg2.yaml
+++ b/releasenotes/notes/update-pip-version-234234jes213awg2.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Upgrade pip to 20.3.3 to get a newer vendored version of urllib3. 
+    Upgrade the embedded pip version to 20.3.3 to get a newer vendored version of urllib3. 
  


### PR DESCRIPTION
### What does this PR do?

Hacks the results of the various `pip install` so that the `direct_url.json` files for each wheel are removed.
Those files have hard-coded paths, and they're the hard-coded path of the install tree, so they result
in the `agent integration install` command failing.

### Additional Notes

Should either take this PR or alternate solution (PR to be added here) but not both.

