### PR TITLE
pkg/trace/agent: Ensured start-up errors are logged to the log file

### DIFF
--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -39,9 +39,14 @@ func Run(ctx context.Context) {
 	}
 
 	cfg, err := config.Load(flags.ConfigPath)
+	//initializing logger before checking the error to ensure start-up errors are logged to the log file
+	//even if cfg is loaded with an error or does not exist, valid log file will still be created
+	initLogger(cfg)
+	defer log.Flush()
+
 	if err != nil {
 		if err == config.ErrMissingAPIKey {
-			fmt.Println(config.ErrMissingAPIKey)
+			log.Error(config.ErrMissingAPIKey)
 
 			// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
 			// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
@@ -66,19 +71,6 @@ func Run(ctx context.Context) {
 		}
 		return
 	}
-
-	if err := coreconfig.SetupLogger(
-		coreconfig.LoggerName("TRACE"),
-		cfg.LogLevel,
-		cfg.LogFilePath,
-		coreconfig.GetSyslogURI(),
-		coreconfig.Datadog.GetBool("syslog_rfc"),
-		coreconfig.Datadog.GetBool("log_to_console"),
-		coreconfig.Datadog.GetBool("log_format_json"),
-	); err != nil {
-		osutil.Exitf("Cannot create logger: %v", err)
-	}
-	defer log.Flush()
 
 	if !cfg.Enabled {
 		log.Info(messageAgentDisabled)
@@ -146,5 +138,19 @@ func Run(ctx context.Context) {
 			log.Error("Could not write memory profile: ", err)
 		}
 		f.Close()
+	}
+}
+
+func initLogger(cfg *config.AgentConfig) {
+	if err := coreconfig.SetupLogger(
+		coreconfig.LoggerName("TRACE"),
+		cfg.LogLevel,
+		cfg.LogFilePath,
+		coreconfig.GetSyslogURI(),
+		coreconfig.Datadog.GetBool("syslog_rfc"),
+		coreconfig.Datadog.GetBool("log_to_console"),
+		coreconfig.Datadog.GetBool("log_format_json"),
+	); err != nil {
+		osutil.Exitf("Cannot create logger: %v", err)
 	}
 }

--- a/releasenotes/notes/apm-start-up-error-logging-3e927cdbb059db57.yaml
+++ b/releasenotes/notes/apm-start-up-error-logging-3e927cdbb059db57.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    APM : Ensured start-up errors are logged to the log file
+    APM: Ensured start-up errors are logged to the log file

--- a/releasenotes/notes/apm-start-up-error-logging-3e927cdbb059db57.yaml
+++ b/releasenotes/notes/apm-start-up-error-logging-3e927cdbb059db57.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    APM : Ensured start-up errors are logged to the log file


### PR DESCRIPTION
Moved logger init higher to persist errors to the log file

### What does this PR do?

Ensured errors encountered when loading and validating the config file are persisted to the log file as discussed in [https://datadoghq.atlassian.net/browse/APMAGENT-72](this issue)

### Motivation

Missed logs could make it hard to debug trace-agent startup errors in some cases.
### Additional Notes



### Describe your test plan

Tested with proper/or improper configs, or lack thereof
