### PR TITLE
[system-probe] bump ebpf lib version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/DataDog/agent-payload v4.49.0+incompatible
 	github.com/DataDog/datadog-go v4.2.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
-	github.com/DataDog/ebpf v0.0.0-20201222144656-a9dbb488c715
+	github.com/DataDog/ebpf v0.0.0-20201229144711-5db4ced1a6dd
 	github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,8 @@ github.com/DataDog/datadog-go v4.2.0+incompatible h1:Q73jzyKHwyA04Gf4SSukRF+KR4w
 github.com/DataDog/datadog-go v4.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822 h1:E5WNl43j4mpE3V35QySkRnP/m9pjXOnEZD6eyTK7Qvk=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822/go.mod h1:a5NqgPglcSct+NwO9gPvVhoL5V6G1+gHbRaRnU8U54M=
-github.com/DataDog/ebpf v0.0.0-20201120093539-d2690c373d70 h1:NdZRtbZ0ToAL5nfqCbDQXQsIgP/6D/5uymRkTYgGXQw=
-github.com/DataDog/ebpf v0.0.0-20201120093539-d2690c373d70/go.mod h1:rIVS3jqxhqtYJtznvFI8qtCbYG1M7WQZS4Z15/nCmOI=
-github.com/DataDog/ebpf v0.0.0-20201222144656-a9dbb488c715 h1:4NodY6lHucfUqCB5Z+isUq0Ot3K8kH8KdFWA3RvMazA=
-github.com/DataDog/ebpf v0.0.0-20201222144656-a9dbb488c715/go.mod h1:rIVS3jqxhqtYJtznvFI8qtCbYG1M7WQZS4Z15/nCmOI=
+github.com/DataDog/ebpf v0.0.0-20201229144711-5db4ced1a6dd h1:0bpIuKLtroTz2YlM44K1gQc88rcmMxHgptWIaop6sQA=
+github.com/DataDog/ebpf v0.0.0-20201229144711-5db4ced1a6dd/go.mod h1:rIVS3jqxhqtYJtznvFI8qtCbYG1M7WQZS4Z15/nCmOI=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71 h1:0TOAH3X9tEvMBVQ1HYrQfrnAUcSS1mfMrhqeN+spV1s=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71/go.mod h1:rNvi5cSHdpxN6495MOYAWN3yukac8lORoluL+9Osrsw=
 github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a h1:BkU6uq4Ib7Kp1zP7MT33IdHZQazC+kxbuTyEmgePyyA=
@@ -104,12 +102,6 @@ github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321 h1:OPAXA+r6yznoxW
 github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321/go.mod h1:tGQp6XG4XpOyy67WG/YWXVxzOY6LejK35e8KcQhtRIQ=
 github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 h1:UcKqIrOowv2PjTkOC27Xm9TMZlPbRi3CK1OCoawdvl0=
 github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/sketches-go v0.0.1 h1:RtG+76WKgZuz6FIaGsjoPePmadDBkuD/KC6+ZWu78b8=
-github.com/DataDog/sketches-go v0.0.1/go.mod h1:Q5DbzQ+3AkgGwymQO7aZFNP7ns2lZKGtvRBzRXfdi60=
-github.com/DataDog/sketches-go v0.0.2-0.20201116143040-410dba39eebd h1:V67hPIsPAG8eXBCKklv7/rp2J/OacTCFf6/a8QGFHk0=
-github.com/DataDog/sketches-go v0.0.2-0.20201116143040-410dba39eebd/go.mod h1:N/AKLngSAER1t13lVobz7XD1mHKSWEwd6TCaNy1j31U=
-github.com/DataDog/sketches-go v0.0.2-0.20201202141728-7e4faaa360e8 h1:1tMoUaRtNVQhb2YSTFqByvIF6r/AHMcNihZD0QFUrIo=
-github.com/DataDog/sketches-go v0.0.2-0.20201202141728-7e4faaa360e8/go.mod h1:N/AKLngSAER1t13lVobz7XD1mHKSWEwd6TCaNy1j31U=
 github.com/DataDog/sketches-go v0.0.2-0.20201202232949-822217a43020 h1:V+iCPax04YSuxiNEoulq87AX+aoOoyMo8ByeIVS4DNg=
 github.com/DataDog/sketches-go v0.0.2-0.20201202232949-822217a43020/go.mod h1:N/AKLngSAER1t13lVobz7XD1mHKSWEwd6TCaNy1j31U=
 github.com/DataDog/viper v1.8.0 h1:+0s6jzOzQEpMCW+c4bkirz+4vNoWm4jmiQNmKfO2p38=
@@ -1739,8 +1731,6 @@ google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvx
 google.golang.org/genproto v0.0.0-20191115194625-c23dd37a84c9/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200305110556-506484158171 h1:xes2Q2k+d/+YNXVw0FpZkIDJiaux4OVrRKXRAzH6A0U=
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884 h1:fiNLklpBwWK1mth30Hlwk+fcdBmIALlgF5iy77O37Ig=
-google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=


### PR DESCRIPTION
### What does this PR do?

This PR bumps the eBPF lib version to fix a bug that prevents system-probe from starting when it is OOM killed to many times.

### Motivation

Fix a bug that prevents system-probe from starting.

### Describe your test plan

Kitchen tests will ensure that this new version of the eBPF library won't break anything.