### PR TITLE
 [cherry-pick] partly revert #6776 [auditor] Allow to filter registry update by source ID (#7074)

### DIFF
--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -34,17 +34,14 @@ const registryAPIVersion = 2
 type Registry interface {
 	GetOffset(identifier string) string
 	GetTailingMode(identifier string) string
-	SetConfigID(identifier, configID string)
 }
 
 // A RegistryEntry represents an entry in the registry where we keep track
 // of current offsets
 type RegistryEntry struct {
-	LastUpdated time.Time `json:"LastUpdated"`
-	Offset      string    `json:"Offset"`
-	TailingMode string    `json:"TailingMode"`
-	// CurrentConfigID is meaningfull only during runtime
-	CurrentConfigID string `json:"-"`
+	LastUpdated time.Time
+	Offset      string
+	TailingMode string
 }
 
 // JSONRegistry represents the registry that will be written on disk
@@ -53,23 +50,16 @@ type JSONRegistry struct {
 	Registry map[string]RegistryEntry
 }
 
-// Identifiers associates config id vs. origin id
-type Identifiers struct {
-	OriginID string
-	ConfigID string
-}
-
 // An Auditor handles messages successfully submitted to the intake
 type Auditor struct {
-	health          *health.Handle
-	chansMutex      sync.Mutex
-	inputChan       chan *message.Message
-	identifiersChan chan *Identifiers
-	registry        map[string]*RegistryEntry
-	registryPath    string
-	registryMutex   sync.Mutex
-	entryTTL        time.Duration
-	done            chan struct{}
+	health        *health.Handle
+	chansMutex    sync.Mutex
+	inputChan     chan *message.Message
+	registry      map[string]*RegistryEntry
+	registryPath  string
+	registryMutex sync.Mutex
+	entryTTL      time.Duration
+	done          chan struct{}
 }
 
 // New returns an initialized Auditor
@@ -102,7 +92,6 @@ func (a *Auditor) createChannels() {
 	a.chansMutex.Lock()
 	defer a.chansMutex.Unlock()
 	a.inputChan = make(chan *message.Message, config.ChanSize)
-	a.identifiersChan = make(chan *Identifiers, config.ChanSize)
 	a.done = make(chan struct{})
 }
 
@@ -112,32 +101,18 @@ func (a *Auditor) closeChannels() {
 	if a.inputChan != nil {
 		close(a.inputChan)
 	}
-	if a.identifiersChan != nil {
-		close(a.identifiersChan)
-	}
 
 	if a.done != nil {
 		<-a.done
 		a.done = nil
 	}
-
 	a.inputChan = nil
-	a.identifiersChan = nil
 }
 
 // Channel returns the channel to use to communicate with the auditor or nil
 // if the auditor is currently stopped.
 func (a *Auditor) Channel() chan *message.Message {
 	return a.inputChan
-}
-
-// SetConfigID set the valid source configuration ID (typically a container ID) for registry
-// update subsequent attempt with a different ID will be ignore for this identifier. It aims
-// to allow only one tailer for the same file to be able to update the registry.
-func (a *Auditor) SetConfigID(identifier, configID string) {
-	if a.identifiersChan != nil {
-		a.identifiersChan <- &Identifiers{identifier, configID}
-	}
 }
 
 // GetOffset returns the last committed offset for a given identifier,
@@ -177,17 +152,13 @@ func (a *Auditor) run() {
 	for {
 		select {
 		case <-a.health.C:
-		case id, isOpen := <-a.identifiersChan:
-			if isOpen {
-				a.updateCurrentConfigID(id.OriginID, id.ConfigID)
-			}
 		case msg, isOpen := <-a.inputChan:
 			if !isOpen {
 				// inputChan has been closed, no need to update the registry anymore
 				return
 			}
 			// update the registry with new entry
-			a.updateRegistry(msg.Origin.Identifier, msg.Origin.Offset, msg.Origin.LogSource.Config.TailingMode, msg.Origin.LogSource.Config.Identifier)
+			a.updateRegistry(msg.Origin.Identifier, msg.Origin.Offset, msg.Origin.LogSource.Config.TailingMode)
 		case <-cleanUpTicker.C:
 			// remove expired offsets from registry
 			a.cleanupRegistry()
@@ -239,7 +210,7 @@ func (a *Auditor) cleanupRegistry() {
 }
 
 // updateRegistry updates the registry entry matching identifier with new the offset and timestamp
-func (a *Auditor) updateRegistry(identifier string, offset string, tailingMode string, configID string) {
+func (a *Auditor) updateRegistry(identifier string, offset string, tailingMode string) {
 	a.registryMutex.Lock()
 	defer a.registryMutex.Unlock()
 	if identifier == "" {
@@ -248,26 +219,10 @@ func (a *Auditor) updateRegistry(identifier string, offset string, tailingMode s
 		// specially want to avoid storing the offset
 		return
 	}
-	entry, exists := a.registry[identifier]
-	if !(exists && entry.CurrentConfigID != configID) {
-		a.registry[identifier] = &RegistryEntry{
-			LastUpdated:     time.Now().UTC(),
-			Offset:          offset,
-			TailingMode:     tailingMode,
-			CurrentConfigID: configID,
-		}
-	}
-}
-
-// updateCurrentConfigID updates the registry entry matching identifier with new the offset and timestamp
-func (a *Auditor) updateCurrentConfigID(identifier, configID string) {
-	a.registryMutex.Lock()
-	defer a.registryMutex.Unlock()
-	if identifier == "" {
-		return
-	}
-	if _, exists := a.registry[identifier]; exists {
-		a.registry[identifier].CurrentConfigID = configID
+	a.registry[identifier] = &RegistryEntry{
+		LastUpdated: time.Now().UTC(),
+		Offset:      offset,
+		TailingMode: tailingMode,
 	}
 }
 

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -62,31 +62,11 @@ func (suite *AuditorTestSuite) TestAuditorStartStop() {
 func (suite *AuditorTestSuite) TestAuditorUpdatesRegistry() {
 	suite.a.registry = make(map[string]*RegistryEntry)
 	suite.Equal(0, len(suite.a.registry))
-	suite.a.updateRegistry(suite.source.Config.Path, "42", "end", "")
+	suite.a.updateRegistry(suite.source.Config.Path, "42", "end")
 	suite.Equal(1, len(suite.a.registry))
 	suite.Equal("42", suite.a.registry[suite.source.Config.Path].Offset)
 	suite.Equal("end", suite.a.registry[suite.source.Config.Path].TailingMode)
-	suite.a.updateRegistry(suite.source.Config.Path, "43", "beginning", "")
-	suite.Equal(1, len(suite.a.registry))
-	suite.Equal("43", suite.a.registry[suite.source.Config.Path].Offset)
-	suite.Equal("beginning", suite.a.registry[suite.source.Config.Path].TailingMode)
-}
-
-func (suite *AuditorTestSuite) TestAuditorUpdatesRegistryWithConfigID() {
-	suite.a.registry = make(map[string]*RegistryEntry)
-	suite.Equal(0, len(suite.a.registry))
-
-	suite.a.updateRegistry(suite.source.Config.Path, "42", "end", "123456789")
-	suite.Equal(1, len(suite.a.registry))
-	suite.Equal("42", suite.a.registry[suite.source.Config.Path].Offset)
-	suite.Equal("end", suite.a.registry[suite.source.Config.Path].TailingMode)
-
-	suite.a.updateRegistry(suite.source.Config.Path, "56", "beginning", "")
-	suite.Equal(1, len(suite.a.registry))
-	suite.Equal("42", suite.a.registry[suite.source.Config.Path].Offset)
-	suite.Equal("end", suite.a.registry[suite.source.Config.Path].TailingMode)
-
-	suite.a.updateRegistry(suite.source.Config.Path, "43", "beginning", "123456789")
+	suite.a.updateRegistry(suite.source.Config.Path, "43", "beginning")
 	suite.Equal(1, len(suite.a.registry))
 	suite.Equal("43", suite.a.registry[suite.source.Config.Path].Offset)
 	suite.Equal("beginning", suite.a.registry[suite.source.Config.Path].TailingMode)

--- a/pkg/logs/auditor/mock/mock.go
+++ b/pkg/logs/auditor/mock/mock.go
@@ -9,8 +9,6 @@ package mock
 type Registry struct {
 	offset      string
 	tailingMode string
-	configID    string
-	identifier  string
 }
 
 // NewRegistry returns a new registry.
@@ -36,20 +34,4 @@ func (r *Registry) GetTailingMode(identifier string) string {
 // SetTailingMode sets the tailing mode.
 func (r *Registry) SetTailingMode(tailingMode string) {
 	r.tailingMode = tailingMode
-}
-
-// SetConfigID allow only one identifier to update an offset
-func (r *Registry) SetConfigID(identifier, configID string) {
-	r.configID = configID
-	r.identifier = identifier
-}
-
-// GetConfigID get the config identifier
-func (r *Registry) GetConfigID() string {
-	return r.configID
-}
-
-// GetIdentifier get the config identifier
-func (r *Registry) GetIdentifier() string {
-	return r.identifier
 }

--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -39,14 +39,6 @@ func NewFile(path string, source *config.LogSource, isWildcardPath bool) *File {
 	}
 }
 
-// getSourceIdentifier returns the source config identifier
-func (t *File) getSourceIdentifier() string {
-	if t.Source != nil && t.Source.Config != nil {
-		return t.Source.Config.Identifier
-	}
-	return ""
-}
-
 // GetScanKey returns a key used by the scanner to index the scanned file.
 // If it is a file scanned for a container, it will use the format: <filepath>/<container_id>
 // Otherwise, it will simply use the format: <filepath>

--- a/pkg/logs/input/file/scanner.go
+++ b/pkg/logs/input/file/scanner.go
@@ -222,10 +222,6 @@ func (s *Scanner) startNewTailer(file *File, m config.TailingMode) bool {
 		log.Warnf("Could not recover offset for file with path %v: %v", file.Path, err)
 	}
 
-	if sourceID := file.getSourceIdentifier(); sourceID != "" {
-		s.registry.SetConfigID(tailer.Identifier(), sourceID)
-	}
-
 	log.Infof("Starting a new tailer for: %s (offset: %d, whence: %d) for tailer key %s", file.Path, offset, whence, file.GetScanKey())
 
 	err = tailer.Start(offset, whence)

--- a/pkg/logs/input/file/scanner_test.go
+++ b/pkg/logs/input/file/scanner_test.go
@@ -244,9 +244,6 @@ func TestScannerScanStartNewTailer(t *testing.T) {
 		assert.Equal(t, "hello", string(msg.Content))
 		msg = <-tailer.outputChan
 		assert.Equal(t, "world", string(msg.Content))
-
-		// Ensure registry has the correct ID
-		assert.Equal(t, configID, registry.GetConfigID())
 	}
 }
 
@@ -293,17 +290,9 @@ func TestScannerWithConcurrentContainerTailer(t *testing.T) {
 	msg = <-tailer.outputChan
 	assert.Equal(t, "Time", string(msg.Content))
 
-	// Ensure registry has the correct ID
-	assert.Equal(t, firstSource.Config.Identifier, registry.GetConfigID())
-	assert.Equal(t, "file:"+path, registry.GetIdentifier())
-
 	// Add a second source, same file, different container ID, tailing twice the same file is supported in that case
 	scanner.addSource(secondSource)
 	assert.Equal(t, 2, len(scanner.tailers))
-
-	// Ensure registry has been updated
-	assert.Equal(t, secondSource.Config.Identifier, registry.GetConfigID())
-	assert.Equal(t, "file:"+path, registry.GetIdentifier())
 }
 
 func TestScannerTailFromTheBeginning(t *testing.T) {
@@ -352,9 +341,6 @@ func TestScannerTailFromTheBeginning(t *testing.T) {
 		assert.Equal(t, "A", string(msg.Content))
 		msg = <-tailer.outputChan
 		assert.Equal(t, "Time", string(msg.Content))
-
-		// Ensure registry has the correct ID
-		assert.Equal(t, source.Config.Identifier, registry.GetConfigID())
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Cherry picks #7074 into 7.25.x

### Motivation

Reverts some buggy logic from a fix that didn't fix the issue.

### Additional Notes

None

### Describe your test plan

Ongoing QA