### PR TITLE
Improve memory allocation made by EnrichTags

### DIFF
--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -22,7 +22,9 @@ import (
 
 func generateContextKey(sample metrics.MetricSampleContext) ckey.ContextKey {
 	k := ckey.NewKeyGenerator()
-	return k.Generate(sample.GetName(), sample.GetHost(), sample.GetTags())
+	tagsBuffer := []string{}
+	tagsBuffer = sample.GetTags(tagsBuffer)
+	return k.Generate(sample.GetName(), sample.GetHost(), tagsBuffer)
 }
 
 func TestCheckGaugeSampling(t *testing.T) {

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -7,6 +7,7 @@ package aggregator
 
 import (
 	// stdlib
+	"sort"
 	"testing"
 
 	// 3p
@@ -75,12 +76,15 @@ func TestTrackContext(t *testing.T) {
 
 	// When we look up the 2 keys, they return the correct contexts
 	context1 := contextResolver.contextsByKey[contextKey1]
+	sort.Strings(expectedContext1.Tags) // context tags are sorted
 	assert.Equal(t, expectedContext1, *context1)
 
 	context2 := contextResolver.contextsByKey[contextKey2]
+	sort.Strings(expectedContext2.Tags) // context tags are sorted
 	assert.Equal(t, expectedContext2, *context2)
 
 	context3 := contextResolver.contextsByKey[contextKey3]
+	sort.Strings(expectedContext3.Tags) // context tags are sorted
 	assert.Equal(t, expectedContext3, *context3)
 
 	unknownContextKey := ckey.ContextKey(0xffffffffffffffff)

--- a/pkg/dogstatsd/convert_bench_test.go
+++ b/pkg/dogstatsd/convert_bench_test.go
@@ -41,7 +41,7 @@ func runParseMetricBenchmark(b *testing.B, multipleValues bool) {
 					continue
 				}
 
-				benchSamples = enrichMetricSample(samples, parsed, "", namespaceBlacklist, "default-hostname", returnEmptyTags, true, false)
+				benchSamples = enrichMetricSample(samples, parsed, "", namespaceBlacklist, "default-hostname", "", true, false)
 			}
 		})
 	}

--- a/pkg/dogstatsd/enrich_bench_test.go
+++ b/pkg/dogstatsd/enrich_bench_test.go
@@ -3,8 +3,6 @@ package dogstatsd
 import (
 	"fmt"
 	"testing"
-
-	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
 
 func buildTags(tagCount int) []string {
@@ -19,28 +17,15 @@ func buildTags(tagCount int) []string {
 // used to store the result and avoid optimizations
 var tags []string
 
-func BenchmarkEnrichTags(b *testing.B) {
-	originalGetTags := getTags
-
+func BenchmarkExtractTagsMetadata(b *testing.B) {
 	for i := 20; i <= 200; i += 20 {
 		b.Run(fmt.Sprintf("%d-tags", i), func(sb *testing.B) {
 			baseTags := append([]string{hostTagPrefix + "foo", entityIDTagPrefix + "bar"}, buildTags(i/10)...)
-			extraTags := buildTags(i / 2)
-			taggerTags := buildTags(i)
-			originTagsFunc := func() []string {
-				return extraTags
-			}
-			getTags = func(entity string, cardinality collectors.TagCardinality) ([]string, error) {
-				return taggerTags, nil
-			}
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				tags, _ = enrichTags(baseTags, "hostname", originTagsFunc, false)
+				tags, _, _, _ = extractTagsMetadata(baseTags, "hostname", "", false)
 			}
 		})
 	}
-
-	// Revert to original value
-	getTags = originalGetTags
 }

--- a/pkg/dogstatsd/listeners/packet_assembler_test.go
+++ b/pkg/dogstatsd/listeners/packet_assembler_test.go
@@ -5,14 +5,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/stretchr/testify/assert"
 )
+
+// copy of aggregator.MetricSamplePoolBatchSize to avoid cycling import
+const sampleBatchSize = 32
 
 func buildPacketAssembler() (*packetAssembler, chan Packets) {
 	out := make(chan Packets, 16)
 	psb := newPacketsBuffer(1, 1*time.Hour, out)
-	pb := newPacketAssembler(100*time.Millisecond, psb, NewPacketPool(aggregator.MetricSamplePoolBatchSize))
+	pb := newPacketAssembler(100*time.Millisecond, psb, NewPacketPool(sampleBatchSize))
 	return pb, out
 }
 
@@ -70,7 +72,7 @@ func TestPacketBufferOverflow(t *testing.T) {
 	pb, out := buildPacketAssembler()
 	// generate a message exactly of the size of the buffer of the packet assembler
 	// to fill it completely
-	message1 := generateRandomPacket(aggregator.MetricSamplePoolBatchSize)
+	message1 := generateRandomPacket(sampleBatchSize)
 	message2 := []byte("12345678")
 
 	pb.addMessage(message1)
@@ -86,8 +88,8 @@ func TestPacketBufferOverflow(t *testing.T) {
 
 func TestPacketBufferMergePlusOverflow(t *testing.T) {
 	pb, out := buildPacketAssembler()
-	message1 := generateRandomPacket(aggregator.MetricSamplePoolBatchSize / 2)
-	message2 := generateRandomPacket((aggregator.MetricSamplePoolBatchSize / 2) - 1)
+	message1 := generateRandomPacket(sampleBatchSize / 2)
+	message2 := generateRandomPacket((sampleBatchSize / 2) - 1)
 	message3 := []byte("Z")
 
 	pb.addMessage(message1)

--- a/pkg/dogstatsd/server_bench_test.go
+++ b/pkg/dogstatsd/server_bench_test.go
@@ -114,13 +114,12 @@ func BenchmarkParseMetricMessage(b *testing.B) {
 	defer close(done)
 
 	parser := newParser(newFloat64ListPool())
-	originTagger := originTags{}
 	message := []byte("daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2")
 
 	b.RunParallel(func(pb *testing.PB) {
 		samplesBench = make([]metrics.MetricSample, 0, 512)
 		for pb.Next() {
-			s.parseMetricMessage(samplesBench, parser, message, originTagger.getTags)
+			s.parseMetricMessage(samplesBench, parser, message, "")
 			samplesBench = samplesBench[0:0]
 		}
 	})

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -558,7 +558,6 @@ func TestDebugStats(t *testing.T) {
 func TestNoMappingsConfig(t *testing.T) {
 	datadogYaml := ``
 	samples := []metrics.MetricSample{}
-	getOriginTags := func() []string { return []string{} }
 
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
@@ -574,7 +573,7 @@ func TestNoMappingsConfig(t *testing.T) {
 	assert.Nil(t, s.mapper)
 
 	parser := newParser(newFloat64ListPool())
-	samples, err = s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), getOriginTags)
+	samples, err = s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "")
 	assert.NoError(t, err)
 	assert.Len(t, samples, 1)
 }
@@ -587,7 +586,6 @@ type MetricSample struct {
 }
 
 func TestMappingCases(t *testing.T) {
-	getOriginTags := func() []string { return []string{} }
 	scenarios := []struct {
 		name              string
 		config            string
@@ -689,7 +687,7 @@ dogstatsd_mapper_profiles:
 			var actualSamples []MetricSample
 			for _, p := range scenario.packets {
 				parser := newParser(newFloat64ListPool())
-				samples, err := s.parseMetricMessage(samples, parser, []byte(p), getOriginTags)
+				samples, err := s.parseMetricMessage(samples, parser, []byte(p), "")
 				assert.NoError(t, err, "Case `%s` failed. parseMetricMessage should not return error %v", err)
 				for _, sample := range samples {
 					actualSamples = append(actualSamples, MetricSample{Name: sample.Name, Tags: sample.Tags, Mtype: sample.Mtype, Value: sample.Value})

--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -92,6 +92,8 @@ type Event struct {
 	AggregationKey string         `json:"aggregation_key,omitempty"`
 	SourceTypeName string         `json:"source_type_name,omitempty"`
 	EventType      string         `json:"event_type,omitempty"`
+	OriginID       string         `json:"-"`
+	K8sOriginID    string         `json:"-"`
 }
 
 // Return a JSON string or "" in case of error during the Marshaling

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -29,7 +29,10 @@ func (m *HistogramBucket) GetHost() string {
 	return m.Host
 }
 
-// GetTags returns the bucket tags
-func (m *HistogramBucket) GetTags() []string {
+// GetTags returns the bucket tags.
+func (m *HistogramBucket) GetTags([]string) []string {
+	// Other 'GetTags' methods for metrics support origin detections. Since
+	// HistogramBucket only come, for now, from checks we can simply return
+	// tags.
 	return m.Tags
 }

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -5,6 +5,15 @@
 
 package metrics
 
+import (
+	"github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
 // MetricType is the representation of an aggregator metric type
 type MetricType int
 
@@ -23,9 +32,18 @@ const (
 )
 
 // DistributionMetricTypes contains the MetricTypes that are used for percentiles
-var DistributionMetricTypes = map[MetricType]struct{}{
-	DistributionType: {},
-}
+var (
+	DistributionMetricTypes = map[MetricType]struct{}{
+		DistributionType: {},
+	}
+
+	// we use to pull tagger metrics in dogstatsd. Pulling it later in the
+	// pipeline improve memory allocation. We kept the old name to be
+	// backward compatible and because origin detection only affect
+	// dogstatsd metrics.
+	tlmUDPOriginDetectionError = telemetry.NewCounter("dogstatsd", "udp_origin_detection_error",
+		nil, "Dogstatsd UDP origin detection error count")
+)
 
 // String returns a string representation of MetricType
 func (m MetricType) String() string {
@@ -57,7 +75,7 @@ func (m MetricType) String() string {
 type MetricSampleContext interface {
 	GetName() string
 	GetHost() string
-	GetTags() []string
+	GetTags(tagsBuffer []string) []string
 }
 
 // MetricSample represents a raw metric sample
@@ -71,6 +89,8 @@ type MetricSample struct {
 	SampleRate      float64
 	Timestamp       float64
 	FlushFirstValue bool
+	OriginID        string
+	K8sOriginID     string
 }
 
 // Implement the MetricSampleContext interface
@@ -85,9 +105,50 @@ func (m *MetricSample) GetHost() string {
 	return m.Host
 }
 
+func findOriginTags(origin string, tags []string) []string {
+	if origin != listeners.NoOrigin {
+		originTags, err := tagger.Tag(origin, tagger.DogstatsdCardinality)
+		if err != nil {
+			log.Errorf(err.Error())
+		} else {
+			tags = append(tags, originTags...)
+		}
+	}
+
+	// Include orchestrator scope tags if the cardinality is set to orchestrator
+	if tagger.DogstatsdCardinality == collectors.OrchestratorCardinality {
+		orchestratorScopeTags, err := tagger.OrchestratorScopeTag()
+		if err != nil {
+			log.Error(err.Error())
+		} else {
+			tags = append(tags, orchestratorScopeTags...)
+		}
+	}
+	return tags
+}
+
+// EnrichTags expend a tag list with origin detection tags
+func EnrichTags(tagsBuffer []string, originID string, k8sOriginID string) []string {
+	if originID != "" {
+		tagsBuffer = findOriginTags(originID, tagsBuffer)
+	}
+
+	if k8sOriginID != "" {
+		if entityTags, err := tagger.Tag(k8sOriginID, tagger.DogstatsdCardinality); err == nil {
+			tagsBuffer = append(tagsBuffer, entityTags...)
+		} else {
+			tlmUDPOriginDetectionError.Inc()
+			log.Tracef("Cannot get tags for entity %s: %s", k8sOriginID, err)
+		}
+	}
+
+	return util.SortUniqInPlace(tagsBuffer)
+}
+
 // GetTags returns the metric sample tags
-func (m *MetricSample) GetTags() []string {
-	return m.Tags
+func (m *MetricSample) GetTags(tagsBuffer []string) []string {
+	tagsBuffer = append(tagsBuffer, m.Tags...)
+	return EnrichTags(tagsBuffer, m.OriginID, m.K8sOriginID)
 }
 
 // Copy returns a deep copy of the m MetricSample

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -76,12 +76,14 @@ func (s ServiceCheckStatus) String() string {
 
 // ServiceCheck holds a service check (w/ serialization to DD api format)
 type ServiceCheck struct {
-	CheckName string             `json:"check"`
-	Host      string             `json:"host_name"`
-	Ts        int64              `json:"timestamp"`
-	Status    ServiceCheckStatus `json:"status"`
-	Message   string             `json:"message"`
-	Tags      []string           `json:"tags"`
+	CheckName   string             `json:"check"`
+	Host        string             `json:"host_name"`
+	Ts          int64              `json:"timestamp"`
+	Status      ServiceCheckStatus `json:"status"`
+	Message     string             `json:"message"`
+	Tags        []string           `json:"tags"`
+	OriginID    string             `json:"-"`
+	K8sOriginID string             `json:"-"`
 }
 
 // ServiceChecks represents a list of service checks ready to be serialize


### PR DESCRIPTION
### What does this PR do?

EnrichTags use to allocate a slice per dogstatsd sample when origin
detection was enabled. This add a huge impact on k8s setup.

Moving the logic to enrich tag later in the pipeline (in the aggregator)
allow us to create a slice of tags per context (which a renewed every
10s).

Now dogstatsd only set the originID from UDS and from the k8s tag and
let the aggregator pull the tags from the tagger when needed.

### Additional Notes

Benchmark to come soon

Before profile:
![Screen Shot 2021-01-08 at 3 21 01 AM](https://user-images.githubusercontent.com/448216/103966649-4b622200-512e-11eb-8dc8-20ee500f33f4.png)

