### PR TITLE
Fix startup for bottlerocket nodes (#7026)

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-kubernetes.sh
+++ b/Dockerfiles/agent/entrypoint/50-kubernetes.sh
@@ -18,13 +18,13 @@ fi
 
 # Enable kubernetes integrations (don't fail if integration absent)
 if [[ ! -e /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default ]]; then
-    mv /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.example \
+    cp /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.example \
     /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
 fi
 
 # The apiserver check requires leader election to be enabled
 if [[ "$DD_LEADER_ELECTION" == "true" ]] && [[ ! -e /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default ]]; then
-    mv /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.example \
+    cp /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.example \
     /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
 else
     echo "Disabling the apiserver check as leader election is disabled"


### PR DESCRIPTION
### What does this PR do?

Fixes #7026 

### Motivation

Need `datadog-agent` to work on nodes using Bottlerocket AMIs. Expected it to work based on docs like [this](https://www.datadoghq.com/blog/monitor-amazon-bottlerocket-datadog/), but failed startup with `permission denied`.

### Describe your test plan

Built and deployed a custom datadog-agent with this change; the modified agent started and ran successfully. The Dockerfile for that contained:
```
FROM datadog/agent:latest

COPY ./50-kubernetes.sh ./etc/cont-init.d/50-kubernetes.sh
```
