### PR TITLE
[runtime-security] Load all macros before rules

### DIFF
--- a/pkg/security/rules/policy.go
+++ b/pkg/security/rules/policy.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -86,6 +87,7 @@ func LoadPolicies(config *config.Config, ruleSet *RuleSet) error {
 	if err != nil {
 		return err
 	}
+	sort.Slice(policyFiles, func(i, j int) bool { return policyFiles[i].Name() < policyFiles[j].Name() })
 
 	// Load and parse policies
 	for _, policyPath := range policyFiles {

--- a/pkg/security/rules/policy.go
+++ b/pkg/security/rules/policy.go
@@ -77,7 +77,10 @@ func LoadPolicy(r io.Reader, name string) (*Policy, error) {
 
 // LoadPolicies loads the policies listed in the configuration and apply them to the given ruleset
 func LoadPolicies(config *config.Config, ruleSet *RuleSet) error {
-	var result *multierror.Error
+	var (
+		result *multierror.Error
+		rules  []*RuleDefinition
+	)
 
 	policyFiles, err := ioutil.ReadDir(config.PoliciesDir)
 	if err != nil {
@@ -114,10 +117,12 @@ func LoadPolicies(config *config.Config, ruleSet *RuleSet) error {
 			result = multierror.Append(result, err)
 		}
 
-		// Add rules to the ruleset and generate rules evaluators
-		if err := ruleSet.AddRules(policy.Rules); err != nil {
-			result = multierror.Append(result, err)
-		}
+		rules = append(rules, policy.Rules...)
+	}
+
+	// Add rules to the ruleset and generate rules evaluators
+	if err := ruleSet.AddRules(rules); err != nil {
+		result = multierror.Append(result, err)
 	}
 
 	return result.ErrorOrNil()


### PR DESCRIPTION
### What does this PR do?

Load policy files in alphabetical order and load macros before rules

### Motivation

If macros and rules are defined in seperate files, macros should be loaded first.