### PR TITLE
Add object kind tags to k8s events

### DIFF
--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -108,14 +108,14 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 			switch owner.Kind {
 			case "":
 				continue
-			case "Deployment":
-				tags.AddLow("kube_deployment", owner.Name)
-			case "DaemonSet":
-				tags.AddLow("kube_daemon_set", owner.Name)
-			case "ReplicationController":
-				tags.AddLow("kube_replication_controller", owner.Name)
-			case "StatefulSet":
-				tags.AddLow("kube_stateful_set", owner.Name)
+			case kubernetes.DeploymentKind:
+				tags.AddLow(kubernetes.DeploymentTagName, owner.Name)
+			case kubernetes.DaemonSetKind:
+				tags.AddLow(kubernetes.DaemonSetTagName, owner.Name)
+			case kubernetes.ReplicationControllerKind:
+				tags.AddLow(kubernetes.ReplicationControllerTagName, owner.Name)
+			case kubernetes.StatefulSetKind:
+				tags.AddLow(kubernetes.StatefulSetTagName, owner.Name)
 				pvcs := pod.GetPersistentVolumeClaimNames()
 				for _, pvc := range pvcs {
 					if pvc != "" {
@@ -123,21 +123,21 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 					}
 				}
 
-			case "Job":
+			case kubernetes.JobKind:
 				cronjob := parseCronJobForJob(owner.Name)
 				if cronjob != "" {
-					tags.AddOrchestrator("kube_job", owner.Name)
-					tags.AddLow("kube_cronjob", cronjob)
+					tags.AddOrchestrator(kubernetes.JobTagName, owner.Name)
+					tags.AddLow(kubernetes.CronJobTagName, cronjob)
 				} else {
-					tags.AddLow("kube_job", owner.Name)
+					tags.AddLow(kubernetes.JobTagName, owner.Name)
 				}
-			case "ReplicaSet":
+			case kubernetes.ReplicaSetKind:
 				deployment := parseDeploymentForReplicaSet(owner.Name)
 				if len(deployment) > 0 {
-					tags.AddOrchestrator("kube_replica_set", owner.Name)
-					tags.AddLow("kube_deployment", deployment)
+					tags.AddOrchestrator(kubernetes.ReplicaSetTagName, owner.Name)
+					tags.AddLow(kubernetes.DeploymentTagName, deployment)
 				} else {
-					tags.AddLow("kube_replica_set", owner.Name)
+					tags.AddLow(kubernetes.ReplicaSetTagName, owner.Name)
 				}
 			default:
 				log.Debugf("unknown owner kind %s for pod %s", owner.Kind, pod.Metadata.Name)

--- a/pkg/util/kubernetes/const.go
+++ b/pkg/util/kubernetes/const.go
@@ -35,4 +35,55 @@ const (
 
 	// KubeNodeRoleTagName is the role label tag name
 	KubeNodeRoleTagName = "kube_node_role"
+
+	// PodKind represents the Pod object kind
+	PodKind = "Pod"
+	// DeploymentKind represents the Deployment object kind
+	DeploymentKind = "Deployment"
+	// ReplicaSetKind represents the ReplicaSet object kind
+	ReplicaSetKind = "ReplicaSet"
+	// ReplicationControllerKind represents the ReplicaSetController object kind
+	ReplicationControllerKind = "ReplicationController"
+	// StatefulSetKind represents the StatefulSet object kind
+	StatefulSetKind = "StatefulSet"
+	// DaemonSetKind represents the DaemonSet object kind
+	DaemonSetKind = "DaemonSet"
+	// JobKind represents the Job object kind
+	JobKind = "Job"
+	// CronJobKind represents the CronJob object kind
+	CronJobKind = "CronJob"
+	// ServiceKind represents the ServiceKind object kind
+	ServiceKind = "Service"
+
+	// PodTagName represents the pods tag name
+	PodTagName = "pod_name"
+	// DeploymentTagName represents the Deployment tag name
+	DeploymentTagName = "kube_deployment"
+	// ReplicaSetTagName represents the ReplicaSet tag name
+	ReplicaSetTagName = "kube_replica_set"
+	// ReplicationControllerTagName represents the ReplicationController tag name
+	ReplicationControllerTagName = "kube_replication_controller"
+	// StatefulSetTagName represents the StatefulSet tag name
+	StatefulSetTagName = "kube_stateful_set"
+	// DaemonSetTagName represents the DaemonSet tag name
+	DaemonSetTagName = "kube_daemon_set"
+	// JobTagName represents the Job tag name
+	JobTagName = "kube_job"
+	// CronJobTagName represents the CronJob tag name
+	CronJobTagName = "kube_cronjob"
+	// ServiceTagName represents the CronJob tag name
+	ServiceTagName = "kube_service"
 )
+
+// KindToTagName returns the tag name for a given kubernetes object name
+var KindToTagName = map[string]string{
+	PodKind:                   PodTagName,
+	DeploymentKind:            DeploymentTagName,
+	ReplicaSetKind:            ReplicaSetTagName,
+	ReplicationControllerKind: ReplicationControllerTagName,
+	StatefulSetKind:           StatefulSetTagName,
+	DaemonSetKind:             DaemonSetTagName,
+	JobKind:                   JobTagName,
+	CronJobKind:               CronJobTagName,
+	ServiceKind:               ServiceTagName,
+}

--- a/releasenotes/notes/k8s-events-tagging-b6eaff06cd73fd9f.yaml
+++ b/releasenotes/notes/k8s-events-tagging-b6eaff06cd73fd9f.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Kubernetes events are now tagged with kube_service, kube_daemon_set, kube_job and kube_cronjob.
+    Note: Other object kinds are already supported (pod_name, kube_deployment, kube_replica_set).


### PR DESCRIPTION
### What does this PR do?

- Add `kube_service`, `kube_daemon_set`, `kube_job` and `kube_cronjob` tags to k8s events.
- Small refactoring with the tagger pkg to centralise the definition of the tag keys and kinds

### Motivation

FR

### Describe your test plan

The new tags must be attached to the events depending on the object kind.
