### PR TITLE
Bump gstatus version

### DIFF
--- a/omnibus/config/software/gstatus.rb
+++ b/omnibus/config/software/gstatus.rb
@@ -19,7 +19,7 @@ name "gstatus"
 default_version "1.0.5"
 
 source :url => "https://github.com/gluster/gstatus/releases/download/v#{version}/gstatus",
-       :sha256 => "60f4b08c0bdbe0e710e4c025ccf7cf5496cb2ec6a6ca2c1569cd060ae0463bc8",
+       :sha256 => "485b79c42d5623e2593374be3b8d8cde8a00f080ab2fe417c84a2dc3d2a49719",
        :target_filename => "gstatus"
 
 build do

--- a/omnibus/config/software/gstatus.rb
+++ b/omnibus/config/software/gstatus.rb
@@ -16,7 +16,7 @@
 #
 
 name "gstatus"
-default_version "1.0.4"
+default_version "1.0.5"
 
 source :url => "https://github.com/gluster/gstatus/releases/download/v#{version}/gstatus",
        :sha256 => "60f4b08c0bdbe0e710e4c025ccf7cf5496cb2ec6a6ca2c1569cd060ae0463bc8",

--- a/releasenotes/notes/bump-gstatus-version-1da2fe7b301e51ba.yaml
+++ b/releasenotes/notes/bump-gstatus-version-1da2fe7b301e51ba.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Bump gstatus version from 1.0.4 to 1.0.5.


### PR DESCRIPTION
### What does this PR do?

This PR bumps the gstatus version from 1.0.4 to 1.0.5. gstatus 1.0.5 introduces a bugfix where distribute-type volumes encounter an error.

### Motivation

What inspired you to submit this pull request?
The GlusterFS integration relies on gstatus to collect metrics. 
### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan
This version is tested in the integration e2e test environment.
