### PR TITLE
Allow more flexible journal log filters

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -38,9 +38,11 @@ type LogsConfig struct {
 	ExcludePaths []string `mapstructure:"exclude_paths" json:"exclude_paths"`   // File
 	TailingMode  string   `mapstructure:"start_position" json:"start_position"` // File
 
-	IncludeUnits  []string `mapstructure:"include_units" json:"include_units"`   // Journald
-	ExcludeUnits  []string `mapstructure:"exclude_units" json:"exclude_units"`   // Journald
-	ContainerMode bool     `mapstructure:"container_mode" json:"container_mode"` // Journald
+	IncludeUnits   []string `mapstructure:"include_units" json:"include_units"`     // Journald - DEPRECATED
+	ExcludeUnits   []string `mapstructure:"exclude_units" json:"exclude_units"`     // Journald - DEPRECATED
+	IncludeMatches []string `mapstructure:"include_matches" json:"include_matches"` // Journald
+	ExcludeMatches []string `mapstructure:"exclude_matches" json:"exclude_matches"` // Journald
+	ContainerMode  bool     `mapstructure:"container_mode" json:"container_mode"`   // Journald
 
 	Image string // Docker
 	Label string // Docker

--- a/pkg/logs/input/journald/tailer_test.go
+++ b/pkg/logs/input/journald/tailer_test.go
@@ -35,7 +35,7 @@ func TestIdentifier(t *testing.T) {
 }
 
 func TestShouldDropEntry(t *testing.T) {
-	source := config.NewLogSource("", &config.LogsConfig{ExcludeUnits: []string{"foo", "bar"}})
+	source := config.NewLogSource("", &config.LogsConfig{ExcludeUnits: []string{"foo", "bar"}, ExcludeMatches: []string{"baz=one"}})
 	tailer := NewTailer(source, nil)
 	err := tailer.setup()
 	assert.Nil(t, err)
@@ -58,6 +58,27 @@ func TestShouldDropEntry(t *testing.T) {
 		&sdjournal.JournalEntry{
 			Fields: map[string]string{
 				sdjournal.SD_JOURNAL_FIELD_SYSTEMD_UNIT: "boo",
+			},
+		}))
+
+	assert.True(t, tailer.shouldDrop(
+		&sdjournal.JournalEntry{
+			Fields: map[string]string{
+				"baz": "one",
+			},
+		}))
+
+	assert.False(t, tailer.shouldDrop(
+		&sdjournal.JournalEntry{
+			Fields: map[string]string{
+				"baz": "two",
+			},
+		}))
+
+	assert.False(t, tailer.shouldDrop(
+		&sdjournal.JournalEntry{
+			Fields: map[string]string{
+				"other": "one",
 			},
 		}))
 }

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -183,6 +183,8 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 	case config.JournaldType:
 		dictionary["IncludeUnits"] = strings.Join(c.IncludeUnits, ", ")
 		dictionary["ExcludeUnits"] = strings.Join(c.ExcludeUnits, ", ")
+		dictionary["IncludeMatches"] = strings.Join(c.ExcludeUnits, ", ")
+		dictionary["ExcludeMatches"] = strings.Join(c.ExcludeUnits, ", ")
 	case config.WindowsEventType:
 		dictionary["ChannelPath"] = c.ChannelPath
 		dictionary["Query"] = c.Query

--- a/releasenotes/notes/expanded-journal-filtering-38d6b737e7990c90.yaml
+++ b/releasenotes/notes/expanded-journal-filtering-38d6b737e7990c90.yaml
@@ -1,0 +1,6 @@
+enhancements:
+  - |
+    Logs: Support filtering on arbitrary journal log fields
+deprecations:
+  - |
+    Logs: `include_units`/`exclude_units` deprecated in favour of `include_matches`/`exclude_matches`


### PR DESCRIPTION
### What does this PR do?

Previously it was only possible to filter on the _SYSTEMD_UNIT property of journal log entries.
Users may want to filter their logs on other fields, so this change allows users to use any journal KEY=VALUE filter to include/exclude journal logs from collection.

### Motivation

We have logs in our journals that are not associated with specific systemd units, but that we don't want to send to datadog.
Also addresses #5579 

### Describe your test plan

Unit tests have been provided.
End-to-end testing can be done by modifying the journald logging file of a datadog process to use different filters.