### PR TITLE
Fix MappingProfile Json Parsing of match_type

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,17 +114,17 @@ type Proxy struct {
 
 // MappingProfile represent a group of mappings
 type MappingProfile struct {
-	Name     string          `mapstructure:"name"`
-	Prefix   string          `mapstructure:"prefix"`
-	Mappings []MetricMapping `mapstructure:"mappings"`
+	Name     string          `mapstructure:"name" json:"name"`
+	Prefix   string          `mapstructure:"prefix" json:"prefix"`
+	Mappings []MetricMapping `mapstructure:"mappings" json:"mappings"`
 }
 
 // MetricMapping represent one mapping rule
 type MetricMapping struct {
-	Match     string            `mapstructure:"match"`
-	MatchType string            `mapstructure:"match_type"`
-	Name      string            `mapstructure:"name"`
-	Tags      map[string]string `mapstructure:"tags"`
+	Match     string            `mapstructure:"match" json:"match"`
+	MatchType string            `mapstructure:"match_type" json:"match_type"`
+	Name      string            `mapstructure:"name" json:"name"`
+	Tags      map[string]string `mapstructure:"tags" json:"tags"`
 }
 
 // Warnings represent the warnings in the config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -804,8 +804,9 @@ dogstatsd_mapper_profiles:
   - name: "airflow"
     prefix: "airflow."
     mappings:
-      - match: "airflow.job.duration_sec.*.*"
+      - match: 'airflow\.job\.duration_sec\.(.*)'
         name: "airflow.job.duration"
+        match_type: "regex"
         tags:
           job_type: "$1"
           job_name: "$2"
@@ -832,9 +833,10 @@ dogstatsd_mapper_profiles:
 			Prefix: "airflow.",
 			Mappings: []MetricMapping{
 				{
-					Match: "airflow.job.duration_sec.*.*",
-					Name:  "airflow.job.duration",
-					Tags:  map[string]string{"job_type": "$1", "job_name": "$2"},
+					Match:     "airflow\\.job\\.duration_sec\\.(.*)",
+					MatchType: "regex",
+					Name:      "airflow.job.duration",
+					Tags:      map[string]string{"job_type": "$1", "job_name": "$2"},
 				},
 				{
 					Match: "airflow.job.size.*.*",
@@ -890,12 +892,12 @@ dogstatsd_mapper_profiles:
 
 func TestDogstatsdMappingProfilesEnv(t *testing.T) {
 	env := "DD_DOGSTATSD_MAPPER_PROFILES"
-	err := os.Setenv(env, `[{"name":"another_profile","prefix":"abcd","mappings":[{"match":"foo.bar.*.*","name":"foo","tags":{"a":"$1","b":"$2"}}]},{"name":"some_other_profile","prefix":"some_other_profile.","mappings":[{"match":"some_other_profile.*","name":"some_other_profile.abc","tags":{"a":"$1"}}]}]`)
+	err := os.Setenv(env, `[{"name":"another_profile","prefix":"abcd","mappings":[{"match":"airflow\\.dag_processing\\.last_runtime\\.(.*)","match_type":"regex","name":"foo","tags":{"a":"$1","b":"$2"}}]},{"name":"some_other_profile","prefix":"some_other_profile.","mappings":[{"match":"some_other_profile.*","name":"some_other_profile.abc","tags":{"a":"$1"}}]}]`)
 	assert.Nil(t, err)
 	defer os.Unsetenv(env)
 	expected := []MappingProfile{
 		{Name: "another_profile", Prefix: "abcd", Mappings: []MetricMapping{
-			{Match: "foo.bar.*.*", Name: "foo", Tags: map[string]string{"a": "$1", "b": "$2"}},
+			{Match: "airflow\\.dag_processing\\.last_runtime\\.(.*)", MatchType: "regex", Name: "foo", Tags: map[string]string{"a": "$1", "b": "$2"}},
 		}},
 		{Name: "some_other_profile", Prefix: "some_other_profile.", Mappings: []MetricMapping{
 			{Match: "some_other_profile.*", Name: "some_other_profile.abc", Tags: map[string]string{"a": "$1"}},


### PR DESCRIPTION
### What does this PR do?

When `DD_DOGSTATSD_MAPPER_PROFILES` is set as an environment variable, the json key for `match_type` was being incorrectly parsed as `matchType`. This caused some mapping profiles to not work when the match type `regex` was used because it defaulted to `wildcard` when `match_type` was not set.

### Motivation

Found bug

### Describe your test plan

Tested manually and updated unit tests to capture this case