### PR TITLE
(windows) backport fix for agent startup

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -379,9 +379,7 @@ func StartAgent() error {
 	}
 
 	// start dependent services
-	go func () {
-		startDependentServices()
-	}()
+	go startDependentServices()
 	return nil
 }
 

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -379,7 +379,9 @@ func StartAgent() error {
 	}
 
 	// start dependent services
-	startDependentServices()
+	go func () {
+		startDependentServices()
+	}()
 	return nil
 }
 

--- a/cmd/agent/windows/service/service.go
+++ b/cmd/agent/windows/service/service.go
@@ -28,7 +28,7 @@ type agentWindowsService struct{}
 func (m *agentWindowsService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
-	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+	
 	if err := common.ImportRegistryConfig(); err != nil {
 		elog.Warning(0x80000001, err.Error())
 		// continue running agent with existing config
@@ -45,7 +45,7 @@ func (m *agentWindowsService) Execute(args []string, r <-chan svc.ChangeRequest,
 		return
 	}
 	elog.Info(0x40000003, config.ServiceName)
-
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 loop:
 	for {
 		select {


### PR DESCRIPTION
try to fix asynchronous start

### What does this PR do?

delays notifying the SCM that the agent is started until `StartAgent()` returns.  Calls `startDependentServices()` from a goroutine to prevent deadlock.

master PR: https://github.com/DataDog/datadog-agent/pull/7048
### Motivation

customer issue surrounding restarts of the service immediately after install.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
