### PR TITLE
[Fix] Fix sending duplicated k8s events

### DIFF
--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -86,6 +86,14 @@ func (c *APIClient) RunEventCollection(resVer string, lastListTime time.Time, ev
 				}
 			}
 
+			if rcv.Type == watch.Deleted {
+				// The events informer sends the state of an object immediately before deletion.
+				// We're not interested in re-processing these events because they should be processed already when they were added.
+				// This happens when an event reaches the events TTL, an apiserver config (default 1 hour).
+				// Ignoring this type of informer events will prevent from sending duplicated datadog events.
+				continue
+			}
+
 			ev, ok := rcv.Object.(*v1.Event)
 			if !ok {
 				// Could not cast the ev, might as well drop this event, and continue.

--- a/releasenotes/notes/fix-k8s-events-0438b8a02a838106.yaml
+++ b/releasenotes/notes/fix-k8s-events-0438b8a02a838106.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix sending duplicated kubernetes events.


### PR DESCRIPTION
### What does this PR do?

Ignore the `Deleted Events` events sent by the events informer. 

### Motivation

Ignoring this type of informer events will prevent from sending duplicated Datadog events.

### Describe your test plan

Enable events collection and make sure we don't send duplicated events when the TTL is reached, the default TTL is 1 hour but can be shortened to speed up the validation of the fix.
