### PR TITLE
[gitlab] Update periodic cleanup script to remove all kitchen resources

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,7 @@ variables:
   RELEASE_VERSION_6: nightly
   RELEASE_VERSION_7: nightly-a7
   DATADOG_AGENT_BUILDIMAGES: v3507010-02f01e5
-  DATADOG_AGENT_BUILDERS: v3508755-028d4c9
+  DATADOG_AGENT_BUILDERS: v3648669-71b458d
   DATADOG_AGENT_WINBUILDIMAGES: v3544599-93cde73
   DATADOG_AGENT_ARMBUILDIMAGES: v3507010-02f01e5
   DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v3507010-02f01e5
@@ -4626,7 +4626,9 @@ periodic_kitchen_cleanup_azure:
     - export ARM_CLIENT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_client_id --with-decryption --query "Parameter.Value" --out text`
     - export ARM_CLIENT_SECRET=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_client_secret --with-decryption --query "Parameter.Value" --out text`
     - export ARM_TENANT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_tenant_id --with-decryption --query "Parameter.Value" --out text`
-    - python3.6 ~/deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-dd-agent python3.6 ~/deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-dd-security-agent python3.6 ~/deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-dd-system-probe python3.6 ~/deploy_scripts/cleanup_azure.py
 
 #
 # Use this step to delete a tag of a given image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4626,6 +4626,7 @@ periodic_kitchen_cleanup_azure:
     - export ARM_CLIENT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_client_id --with-decryption --query "Parameter.Value" --out text`
     - export ARM_CLIENT_SECRET=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_client_secret --with-decryption --query "Parameter.Value" --out text`
     - export ARM_TENANT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_tenant_id --with-decryption --query "Parameter.Value" --out text`
+    # Remove kitchen resources for all existing test suite prefixes
     - RESOURCE_GROUP_PREFIX=kitchen-dd-agent python3.6 ~/deploy_scripts/cleanup_azure.py
     - RESOURCE_GROUP_PREFIX=kitchen-dd-security-agent python3.6 ~/deploy_scripts/cleanup_azure.py
     - RESOURCE_GROUP_PREFIX=kitchen-dd-system-probe python3.6 ~/deploy_scripts/cleanup_azure.py

--- a/test/kitchen/docs/README.md
+++ b/test/kitchen/docs/README.md
@@ -208,3 +208,15 @@ Each test suite runs one or more chef recipes (usually to install the agent in v
 - Remember that your main test file must be in `test/integration/<suite_name>/<suite_name>_spec.rb`.
 
 4. Create the necessary Gitlab jobs to run your test suite on all platforms, Agent flavors and versions you want, following the existing naming conventions.
+
+5. Update the periodic cleanup job (`periodic_kitchen_cleanup_azure`)
+
+When kitchen tests are run, VMs are created in dedicated resource groups in Azure. These resource groups are prefixed with `kitchen-<name_of_the_test_suite>`.
+
+The periodic cleanup jobs runs the `cleanup_azure.py` script on a given list of Azure resource group prefixes. Eg.:
+```
+RESOURCE_GROUP_PREFIX=kitchen-dd-agent python3.6 ~/deploy_scripts/cleanup_azure.py
+```
+cleans up all resources created by test suites that start with `dd-agent`.
+
+If you add a new test suite that doesn't match any of the already present prefixes, then you need to add a line to the cleanup job to clean up the resources created under this new prefix.


### PR DESCRIPTION
### What does this PR do?

Updates the periodic cleanup script invocation to also clean up resources created by system-probe and security-agent kitchen tests.

### Motivation

system-probe and security-agent kitchen resources do not get periodically deleted.
