### PR TITLE
[logs] Tail docker containers from file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -571,6 +571,8 @@ func InitConfig(config Config) {
 	config.BindEnv("logs_config.processing_rules") //nolint:errcheck
 	// enforce the agent to use files to collect container logs on kubernetes environment
 	config.BindEnvAndSetDefault("logs_config.k8s_container_use_file", false)
+	// enforce the agent to use files to collect container logs on standalone docker environment
+	config.BindEnvAndSetDefault("logs_config.docker_container_use_file", false)
 	// additional config to ensure initial logs are tagged with kubelet tags
 	// wait (seconds) for tagger before start fetching tags of new AD services
 	config.BindEnvAndSetDefault("logs_config.tagger_warmup_duration", 0) // Disabled by default (0 seconds)

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -62,6 +62,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 		container.NewLauncher(
 			coreConfig.Datadog.GetBool("logs_config.container_collect_all"),
 			coreConfig.Datadog.GetBool("logs_config.k8s_container_use_file"),
+			coreConfig.Datadog.GetBool("logs_config.docker_container_use_file"),
 			time.Duration(coreConfig.Datadog.GetInt("logs_config.docker_client_read_timeout"))*time.Second,
 			sources, services, pipelineProvider, auditor),
 		listener.NewLauncher(sources, coreConfig.Datadog.GetInt("logs_config.frame_size"), pipelineProvider),

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -22,7 +22,10 @@ import (
 // NewLauncher returns a new container launcher depending on the environment.
 // By default returns a docker launcher if the docker socket is mounted and fallback to
 // a kubernetes launcher if '/var/log/pods' is mounted ; this behaviour is reversed when
-// collectFromFiles is enabled.
+// kubernetesCollectFromFiles is enabled.
+// If dockerCollectFromFiles is enabled the docker launcher will first attempt to tail
+// containers from file instead of the docker socket if '/var/lib/docker/containers'
+// is mounted.
 // If none of those volumes are mounted, returns a lazy docker launcher with a retrier to handle the cases
 // where docker is started after the agent.
 // dockerReadTimeout is a configurable read timeout for the docker client.

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -205,7 +205,7 @@ func (l *Launcher) overrideSource(container *Container, source *config.LogSource
 		return source
 	}
 
-	source.UpdateInfo(containerID, fmt.Sprintf("Container ID: %s, Image: %s, Created: %s", ShortContainerID(containerID), shortName, container.container.Created))
+	source.UpdateInfo(containerID, fmt.Sprintf("Container ID: %s, Image: %s, Created: %s, Tailing from the Docker socket", ShortContainerID(containerID), shortName, container.container.Created))
 
 	newSource := newOverridenSource(standardService, shortName, source.Status)
 	newSource.ParentSource = source
@@ -228,8 +228,8 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 		log.Warnf("Could not get short image name for container %v: %v", ShortContainerID(containerID), err)
 	}
 
-	// If collect all may be update info for consistency with docker socket tailing
-	// source.UpdateInfo(containerID, fmt.Sprintf("Container ID: %s, Image: %s, Created: %s", ShortContainerID(containerID), shortName, container.container.Created))
+	// Update parent source with additional information
+	source.UpdateInfo(containerID, fmt.Sprintf("Container ID: %s, Image: %s, Created: %s, Tailing from file: %s", ShortContainerID(containerID), shortName, container.container.Created, l.getPath(containerID)))
 
 	var serviceName string
 	if standardService != "" {
@@ -247,6 +247,7 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 		Type:       config.FileType,
 	})
 	fileSource.SetSourceType(config.DockerSourceType)
+	fileSource.Status = source.Status
 	fileSource.ParentSource = source
 	return fileSource
 }

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -232,7 +232,9 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 	source.UpdateInfo(containerID, fmt.Sprintf("Container ID: %s, Image: %s, Created: %s, Tailing from file: %s", ShortContainerID(containerID), shortName, container.container.Created, l.getPath(containerID)))
 
 	var serviceName string
-	if standardService != "" {
+	if source.Name != config.ContainerCollectAll && source.Config.Service != "" {
+		serviceName = source.Config.Service
+	} else if standardService != "" {
 		serviceName = standardService
 	} else {
 		serviceName = shortName
@@ -301,6 +303,9 @@ func (l *Launcher) scheduleFileSource(container *Container, source *config.LogSo
 
 func (l *Launcher) unscheduleFileSource(containerID string) {
 	if fileSource, exists := l.fileSourcesByContainer[containerID]; exists {
+		if fileSource.ParentSource != nil {
+			fileSource.ParentSource.RemoveInfo(containerID)
+		}
 		delete(l.fileSourcesByContainer, containerID)
 		l.sources.RemoveSource(fileSource)
 	}

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -62,17 +62,18 @@ func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services
 	}
 
 	launcher := &Launcher{
-		pipelineProvider:   pipelineProvider,
-		tailers:            make(map[string]*Tailer),
-		pendingContainers:  make(map[string]*Container),
-		registry:           registry,
-		stop:               make(chan struct{}),
-		erroredContainerID: make(chan string),
-		lock:               &sync.Mutex{},
-		readTimeout:        readTimeout,
-		serviceNameFunc:    input.ServiceNameFromTags,
-		sources:            sources,
-		tailFromFile:       tailFromFile,
+		pipelineProvider:       pipelineProvider,
+		tailers:                make(map[string]*Tailer),
+		pendingContainers:      make(map[string]*Container),
+		registry:               registry,
+		stop:                   make(chan struct{}),
+		erroredContainerID:     make(chan string),
+		lock:                   &sync.Mutex{},
+		readTimeout:            readTimeout,
+		serviceNameFunc:        input.ServiceNameFromTags,
+		sources:                sources,
+		tailFromFile:           tailFromFile,
+		fileSourcesByContainer: make(map[string]*config.LogSource),
 	}
 
 	if tailFromFile {

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -9,7 +9,6 @@ package docker
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -27,7 +26,6 @@ import (
 const (
 	backoffInitialDuration = 1 * time.Second
 	backoffMaxDuration     = 60 * time.Second
-	basePath               = "/var/lib/docker/containers"
 )
 
 // A Launcher starts and stops new tailers for every new containers discovered by autodiscovery.
@@ -77,8 +75,8 @@ func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services
 	}
 
 	if tailFromFile {
-		if _, err := os.Stat(basePath); err != nil {
-			log.Errorf("%s not found, falling back on tailing from Docker socket", basePath)
+		if err := checkReadAccess(); err != nil {
+			log.Errorf("Error accessing %s, %v, falling back on tailing from Docker socket", basePath, err)
 			launcher.tailFromFile = false
 		}
 	}

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -295,7 +295,7 @@ func (l *Launcher) scheduleFileSource(container *Container, source *config.LogSo
 	fileSource := l.getFileSource(container, source)
 	// Keep source for later unscheduling
 	l.fileSourcesByContainer[containerID] = fileSource
-	l.sources.AddSource(source)
+	l.sources.AddSource(fileSource)
 }
 
 func (l *Launcher) unscheduleFileSource(containerID string) {

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -217,7 +217,7 @@ func (l *Launcher) overrideSource(container *Container, source *config.LogSource
 func (l *Launcher) getFileSource(container *Container, source *config.LogSource) *config.LogSource {
 	containerID := container.service.Identifier
 
-	// Just in case
+	// Populate the collectAllSource if we don't have it yet
 	if source.Name == config.ContainerCollectAll && l.collectAllSource == nil {
 		l.collectAllSource = source
 	}
@@ -295,7 +295,7 @@ func (l *Launcher) scheduleFileSource(container *Container, source *config.LogSo
 		log.Warnf("Can't tail twice the same container: %v", ShortContainerID(containerID))
 		return
 	}
-	// overridenSource == source if the containerCollectAll option is not activated or the container has AD labels
+	// fileSource is a new source using the original source as its parent
 	fileSource := l.getFileSource(container, source)
 	// Keep source for later unscheduling
 	l.fileSourcesByContainer[containerID] = fileSource

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -94,13 +94,14 @@ func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services
 
 // Start starts the Launcher
 func (l *Launcher) Start() {
-	log.Info("Starting Docker socket launcher")
+	log.Info("Starting Docker launcher")
 	go l.run()
 }
 
 // Stop stops the Launcher and its tailers in parallel,
 // this call returns only when all the tailers are stopped.
 func (l *Launcher) Stop() {
+	log.Info("Stopping Docker launcher")
 	l.stop <- struct{}{}
 	stopper := restart.NewParallelStopper()
 	l.lock.Lock()

--- a/pkg/logs/input/docker/launcher_nix.go
+++ b/pkg/logs/input/docker/launcher_nix.go
@@ -14,5 +14,5 @@ const (
 )
 
 func checkReadAccess() error {
-	return unix.Access(basePath, unix.R_OK)
+	return unix.Access(basePath, unix.X_OK)
 }

--- a/pkg/logs/input/docker/launcher_nix.go
+++ b/pkg/logs/input/docker/launcher_nix.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build docker !windows
+
+package docker
+
+import "golang.org/x/sys/unix"
+
+const (
+	basePath = "/var/lib/docker/containers"
+)
+
+func checkReadAccess() error {
+	return unix.Access(basePath, unix.R_OK)
+}

--- a/pkg/logs/input/docker/launcher_nix.go
+++ b/pkg/logs/input/docker/launcher_nix.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build docker !windows
+// +build docker,!windows
 
 package docker
 

--- a/pkg/logs/input/docker/launcher_nodocker.go
+++ b/pkg/logs/input/docker/launcher_nodocker.go
@@ -20,7 +20,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new Launcher
-func NewLauncher(readTimeout time.Duration, psources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry bool) (*Launcher, error) {
+func NewLauncher(readTimeout time.Duration, psources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry, tailFromFile bool) (*Launcher, error) {
 	return &Launcher{}, nil
 }
 

--- a/pkg/logs/input/docker/launcher_test.go
+++ b/pkg/logs/input/docker/launcher_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/docker/docker/api/types"
 )
 
@@ -100,6 +103,61 @@ func TestNewOverridenSourceServiceNameOrder(t *testing.T) {
 			if got := newOverridenSource(tt.standardService, tt.shortName, tt.status); !reflect.DeepEqual(got.Config.Service, tt.wantServiceName) {
 				t.Errorf("newOverridenSource() = %v, want %v", got.Config.Service, tt.wantServiceName)
 			}
+		})
+	}
+}
+
+func TestGetFileSource(t *testing.T) {
+	tests := []struct {
+		name            string
+		sFunc           func(string, string) string
+		container       *Container
+		source          *config.LogSource
+		wantServiceName string
+		wantPath        string
+	}{
+		{
+			name:  "service name from log config",
+			sFunc: func(n, e string) string { return "stdServiceName" },
+			container: &Container{
+				container: types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						Name:  "fooName",
+						Image: "fooImage",
+					},
+				},
+				service: &service.Service{Identifier: "123456"},
+			},
+			source:          config.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName"}),
+			wantServiceName: "configServiceName",
+			wantPath:        "/var/lib/docker/containers/123456/123456-json.log",
+		},
+		{
+			name:  "service name from standard tags",
+			sFunc: func(n, e string) string { return "stdServiceName" },
+			container: &Container{
+				container: types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						Name:  "fooName",
+						Image: "fooImage",
+					},
+				},
+				service: &service.Service{Identifier: "123456"},
+			},
+			source:          config.NewLogSource("from container", &config.LogsConfig{}),
+			wantServiceName: "stdServiceName",
+			wantPath:        "/var/lib/docker/containers/123456/123456-json.log",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Launcher{
+				serviceNameFunc: tt.sFunc,
+			}
+			fileSource := l.getFileSource(tt.container, tt.source)
+			assert.Equal(t, config.FileType, fileSource.Config.Type)
+			assert.Equal(t, tt.container.service.Identifier, fileSource.Config.Identifier)
+			assert.Equal(t, tt.wantServiceName, fileSource.Config.Service)
 		})
 	}
 }

--- a/pkg/logs/input/docker/launcher_windows.go
+++ b/pkg/logs/input/docker/launcher_windows.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build docker windows
+// +build docker,windows
 
 package docker
 

--- a/pkg/logs/input/docker/launcher_windows.go
+++ b/pkg/logs/input/docker/launcher_windows.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build docker windows
+
+package docker
+
+import "fmt"
+
+const (
+	basePath = "c:\\programdata\\docker\\containers"
+)
+
+func checkReadAccess() error {
+	return fmt.Errorf("Docker tailing from file is not supported on Windows")
+}

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -148,6 +148,9 @@ func (t *Tailer) readForever() {
 			return
 		}
 		t.file.Source.BytesRead.Add(int64(n))
+		if t.file.Source.ParentSource != nil {
+			t.file.Source.ParentSource.BytesRead.Add(int64(n))
+		}
 
 		select {
 		case <-t.stop:

--- a/releasenotes/notes/tail-docker-containers-from-file-16f01b57a7adfab7.yaml
+++ b/releasenotes/notes/tail-docker-containers-from-file-16f01b57a7adfab7.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Docker container, when not running in a Kubernetes
+    environment may now be tailed from their log file.
+    The Agent must have read access to /var/lib/docker/containers
+    and Docker containers must use the JSON logging driver.
+    This new option can be activated using the new configuration
+    flag ``logs_config.docker_container_use_file``.


### PR DESCRIPTION
### What does this PR do?
Add the ability to tail docker container from file.
Introduce an option to choose between docker socket and file tailing (`logs_config.docker_container_use_file `)

### Motivation

Bypass the docker socket to increase the performance and lessen the
pressure on the docker daemon.

### Additional Notes
Doc to be updated as the agent would need to have read access to /var/lib/docker/containers/... :
* The volume should be mounted inside the containerised agent (general case, ECS included)
* The agent (DEB/RPM packaged deployment) may be running in the same env as the docker daemon and some permission adjustment may allow this feature to be used in that case
 
This feature is disabled by default as enabling it may cause registry offset upon upgrade. This may be addressed later.
This feature only works on linux, windows support will come in a subsequent PR.

See the RFC for extra details.
JIRA ref ac-614

Status output for `container_collect_all` source:
```
  container_collect_all
  ---------------------
    - Type: docker
      Status: OK
      BytesRead: 1278
      Container Info:
        Container ID: bb9550541655, Image: flog, Created: 2021-01-06T17:42:22.51003287Z, Tailing from file: /var/lib/docker/containers/bb9550541655aec0f7d11566a7d1a6f29c32d774c5906aa390fc98cea41eb520/bb9550541655aec0f7d11566a7d1a6f29c32d774c5906aa390fc98cea41eb520-json.log
        Container ID: fcbf622d31ef, Image: flog, Created: 2021-01-06T17:42:27.375435144Z, Tailing from file: /var/lib/docker/containers/fcbf622d31ef69973013e78db8b1d3a330b76132cb8c1e261930b1d61987840b/fcbf622d31ef69973013e78db8b1d3a330b76132cb8c1e261930b1d61987840b-json.log
    - Type: file
      Identifier: bb9550541655aec0f7d11566a7d1a6f29c32d774c5906aa390fc98cea41eb520
      Path: /var/lib/docker/containers/bb9550541655aec0f7d11566a7d1a6f29c32d774c5906aa390fc98cea41eb520/bb9550541655aec0f7d11566a7d1a6f29c32d774c5906aa390fc98cea41eb520-json.log
      Status: OK
      Inputs: /var/lib/docker/containers/bb9550541655aec0f7d11566a7d1a6f29c32d774c5906aa390fc98cea41eb520/bb9550541655aec0f7d11566a7d1a6f29c32d774c5906aa390fc98cea41eb520-json.log
      BytesRead: 714
    - Type: file
      Identifier: fcbf622d31ef69973013e78db8b1d3a330b76132cb8c1e261930b1d61987840b
      Path: /var/lib/docker/containers/fcbf622d31ef69973013e78db8b1d3a330b76132cb8c1e261930b1d61987840b/fcbf622d31ef69973013e78db8b1d3a330b76132cb8c1e261930b1d61987840b-json.log
      Status: OK
      Inputs: /var/lib/docker/containers/fcbf622d31ef69973013e78db8b1d3a330b76132cb8c1e261930b1d61987840b/fcbf622d31ef69973013e78db8b1d3a330b76132cb8c1e261930b1d61987840b-json.log
      BytesRead: 564
```

Status output for other sources:
```
  docker
  ------
    - Type: docker
      Status: OK
      BytesRead: 37264
      Container Info:
        Container ID: 26ff2a07e094, Image: flog, Created: 2021-01-06T16:18:10.602282008Z, Tailing from file: /var/lib/docker/containers/26ff2a07e094e6864aff043c6245a060c97339a2c01a505ef189582ba211dccb/26ff2a07e094e6864aff043c6245a060c97339a2c01a505ef189582ba211dccb-json.log
    - Type: file
      Identifier: 26ff2a07e094e6864aff043c6245a060c97339a2c01a505ef189582ba211dccb
      Path: /var/lib/docker/containers/26ff2a07e094e6864aff043c6245a060c97339a2c01a505ef189582ba211dccb/26ff2a07e094e6864aff043c6245a060c97339a2c01a505ef189582ba211dccb-json.log
      Status: OK
      Inputs: /var/lib/docker/containers/26ff2a07e094e6864aff043c6245a060c97339a2c01a505ef189582ba211dccb/26ff2a07e094e6864aff043c6245a060c97339a2c01a505ef189582ba211dccb-json.log
      BytesRead: 37264
```
### Describe your test plan
* Test plan to cover before QA cycle https://gist.github.com/prognant/5a25608c93c1470d554a6aeb6728ecdc
* Pieces of logs agent QA board 