### PR TITLE
Fix deadlock in HTTP monitor

### DIFF
--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -109,7 +109,11 @@ func (m *Monitor) Start() error {
 				}
 
 				m.process(nil, errLostBatch)
-			case reply := <-m.pollRequests:
+			case reply, ok := <-m.pollRequests:
+				if !ok {
+					return
+				}
+
 				transactions := m.batchManager.GetPendingTransactions()
 				m.process(transactions, nil)
 				reply <- struct{}{}


### PR DESCRIPTION
### What does this PR do?

Fixes a deadlock experienced during test `TestEnableHTTPMonitoring`.

### Motivation

It can deadlock between sending to a nil channel from a closed `m.pollRequests` and `m.eventLoopWG.Wait()` in `http.Monitor.Stop()`.


