### PR TITLE
Improve TestShouldSkipExcludedConnection

### DIFF
--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -943,9 +943,19 @@ func TestShouldSkipExcludedConnection(t *testing.T) {
 
 	// Make sure we're not picking up 127.0.0.1:80
 	for _, c := range getConnections(t, tr).Conns {
-		assert.False(t, c.Source.String() == "127.0.0.1" && c.SPort == 80)
-		assert.True(t, c.Dest.String() == "127.0.0.1" && c.DPort == 80)
+		assert.False(t, c.Source.String() == "127.0.0.1" && c.SPort == 80, "connection %s should be excluded", c)
+		assert.False(t, c.Dest.String() == "127.0.0.1" && c.DPort == 80 && c.Type == network.TCP, "connection %s should be excluded", c)
 	}
+
+	// ensure one of the connections is UDP to 127.0.0.1:80
+	assert.Condition(t, func() bool {
+		for _, c := range getConnections(t, tr).Conns {
+			if c.Dest.String() == "127.0.0.1" && c.DPort == 80 && c.Type == network.UDP {
+				return true
+			}
+		}
+		return false
+	}, "Unable to find UDP connection to 127.0.0.1:80")
 }
 
 func TestTooSmallBPFMap(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds assert for excluding destination tcp/127.0.0.1:80

Instead of requiring every connection to have a destination of udp/127.0.0.1:80, only one must. This allows for spurious connections that happen during tests to not cause this test to fail.

### Motivation

Test failures in CI.

