### PR TITLE
Fix: only push internal images on release with a manual validation

### DIFF
--- a/.gitlab/image_deploy/internal_trigger.yml
+++ b/.gitlab/image_deploy/internal_trigger.yml
@@ -1,17 +1,13 @@
 ---
-.if_version_7: &if_version_7
-  if: $RELEASE_VERSION_7 != ""
-
-.if_deploy_7: &if_deploy_7
-  if: $DEPLOY_AGENT == "true" && $RELEASE_VERSION_7 != ""
+.if_deploy_on_tag_7: &if_deploy_on_tag_7
+  # no RELEASE_VERSION means a nightly build for omnibus
+  if: $DEPLOY_AGENT == "true" && $RELEASE_VERSION_7 != "nightly-a7" && $RELEASE_VERSION_7 != ""
 
 docker_trigger_internal_amd64:
   stage: image_deploy
   rules:
-    - <<: *if_version_7
-      when: on_success
-    - <<: *if_deploy_7
-      when: on_success
+    - <<: *if_deploy_on_tag_7
+      when: manual
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false
@@ -20,7 +16,7 @@ docker_trigger_internal_amd64:
     branch: master
     strategy: depend
   variables:
-    IMAGE_VERSION: tmpl-v1
+    IMAGE_VERSION: tmpl-v2
     IMAGE_NAME: datadog-agent
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-jmx
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-jmx


### PR DESCRIPTION
### What does this PR do?

* limit to release build the possibility to push the `datadog-agent` image to our internal registries.
* this action is now also triggered by a manual confirmation.

### Motivation

to many branch build where pushed to the internal registry

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
