### PR TITLE
Fix the image push to internal registry in gitlabci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3021,7 +3021,7 @@ docker_trigger_internal_amd64:
   stage: image_deploy
   rules:
     - <<: *if_deploy_on_tag_7
-      when: on_success
+      when: manual
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3020,9 +3020,7 @@ docker_build_dogstatsd_amd64:
 docker_trigger_internal_amd64:
   stage: image_deploy
   rules:
-    - <<: *if_version_7
-      when: on_success
-    - <<: *if_deploy_7
+    - <<: *if_deploy_on_tag_7
       when: on_success
   needs:
     - job: docker_build_agent7_jmx
@@ -3032,7 +3030,7 @@ docker_trigger_internal_amd64:
     branch: master
     strategy: depend
   variables:
-    IMAGE_VERSION: tmpl-v1
+    IMAGE_VERSION: tmpl-v2
     IMAGE_NAME: datadog-agent
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-jmx
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-jmx


### PR DESCRIPTION
### What does this PR do?

This PR is the equivalent on `7.25.x` branch of the PR #/7113 on master.

* limit to release build the possibility to push the `datadog-agent` image to our internal registries.
* this action is now also triggered by a manual confirmation.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
