### PR TITLE
[ECS Fargate] Fix and improve collecting containers resource limits

### DIFF
--- a/pkg/util/ecs/common_test.go
+++ b/pkg/util/ecs/common_test.go
@@ -14,36 +14,107 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertMetaV2Container(t *testing.T) {
-	container := v2.Container{
-		CreatedAt:  "2018-02-01T20:55:10.554941919Z",
-		DockerID:   "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
-		DockerName: "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
-		Image:      "nrdlngr/nginx-curl",
-		ImageID:    "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
-		StartedAt:  "2018-02-01T20:55:11.064236631Z",
-		Limits: map[string]uint64{
-			"cpu":    0,
-			"memory": 0,
+	tests := []struct {
+		name       string
+		c          v2.Container
+		taskLimits map[string]float64
+		want       *containers.Container
+	}{
+		{
+			name: "nominal case",
+			c: v2.Container{
+				CreatedAt:  "2018-02-01T20:55:10.554941919Z",
+				DockerID:   "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				DockerName: "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				Image:      "nrdlngr/nginx-curl",
+				ImageID:    "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				StartedAt:  "2018-02-01T20:55:11.064236631Z",
+				Limits: map[string]uint64{
+					"CPU":    0,
+					"Memory": 0,
+				},
+			},
+			taskLimits: map[string]float64{},
+			want: &containers.Container{
+				Created:     1517518510,
+				EntityID:    "container_id://43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				ID:          "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				Image:       "nrdlngr/nginx-curl",
+				ImageID:     "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				Name:        "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				StartedAt:   1517518511,
+				Type:        "ECS",
+				AddressList: []containers.NetworkAddress{},
+				Limits:      metrics.ContainerLimits{CPULimit: 100},
+			},
+		},
+		{
+			name: "container limits",
+			c: v2.Container{
+				CreatedAt:  "2018-02-01T20:55:10.554941919Z",
+				DockerID:   "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				DockerName: "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				Image:      "nrdlngr/nginx-curl",
+				ImageID:    "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				StartedAt:  "2018-02-01T20:55:11.064236631Z",
+				Limits: map[string]uint64{
+					"CPU":    512,
+					"Memory": 1024,
+				},
+			},
+			taskLimits: map[string]float64{"CPU": 1, "Memory": 2048},
+			want: &containers.Container{
+				Created:     1517518510,
+				EntityID:    "container_id://43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				ID:          "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				Image:       "nrdlngr/nginx-curl",
+				ImageID:     "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				Name:        "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				StartedAt:   1517518511,
+				Type:        "ECS",
+				AddressList: []containers.NetworkAddress{},
+				Limits:      metrics.ContainerLimits{CPULimit: 50, MemLimit: 1024000000},
+			},
+		},
+		{
+			name: "task limits",
+			c: v2.Container{
+				CreatedAt:  "2018-02-01T20:55:10.554941919Z",
+				DockerID:   "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				DockerName: "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				Image:      "nrdlngr/nginx-curl",
+				ImageID:    "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				StartedAt:  "2018-02-01T20:55:11.064236631Z",
+				Limits: map[string]uint64{
+					"CPU":    0,
+					"Memory": 0,
+				},
+			},
+			taskLimits: map[string]float64{"CPU": 0.5, "Memory": 1024},
+			want: &containers.Container{
+				Created:     1517518510,
+				EntityID:    "container_id://43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				ID:          "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				Image:       "nrdlngr/nginx-curl",
+				ImageID:     "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				Name:        "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				StartedAt:   1517518511,
+				Type:        "ECS",
+				AddressList: []containers.NetworkAddress{},
+				Limits:      metrics.ContainerLimits{CPULimit: 50, MemLimit: 1024000000},
+			},
 		},
 	}
-	expected := &containers.Container{
-		Created:     1517518510,
-		EntityID:    "container_id://43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
-		ID:          "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
-		Image:       "nrdlngr/nginx-curl",
-		ImageID:     "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
-		Name:        "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
-		StartedAt:   1517518511,
-		Type:        "ECS",
-		AddressList: []containers.NetworkAddress{},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, convertMetaV2Container(tt.c, tt.taskLimits))
+		})
 	}
-	expected.Limits.CPULimit = 100
-
-	assert.Equal(t, expected, convertMetaV2Container(container))
 }
 
 func TestConvertMetaV2ContainerStats(t *testing.T) {

--- a/releasenotes/notes/ecs-fargate-resource-limits-a5202ebdbef7ff32.yaml
+++ b/releasenotes/notes/ecs-fargate-resource-limits-a5202ebdbef7ff32.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Consider the task level resource limits if the container level resource limits aren't defined on ECS Fargate.
+fixes:
+  - |
+    Fix a bug that prevents from reading the correct container resource limits on ECS Fargate.


### PR DESCRIPTION
### What does this PR do?

- Consider the task level resource limits if the container level resource limits aren't defined on ECS Fargate.
- Fix a bug that prevents from reading the correct container resource limits on ECS Fargate.

### Motivation

More meaningful/correct values to show on the live containers view

### Describe your test plan

- Should be tested on Fargate 1.3 and 1.4
- The validation can be done by checking the live containers view UI
- If a container has a hard memory limit in the task definition, that value should be picked, otherwise, the task memory limit must be shown instead
- If a container has a defined CPU units value in the task definition, that value should be picked, otherwise the task cpu limit must be shown