### PR TITLE
[gitlab] Allow pupernetes-master job to fail

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -55,7 +55,12 @@ pupernetes-dev:
 pupernetes-master:
   extends: .pupernetes_template
   rules:
+    # The job is currently failing with timeouts. In order to not have all pipelines
+    # automatically fail, this job is therefore temporarily allowed to fail.
+    # TODO: Remove "allow_failure: true" once the job is fixed.
     - <<: *if_master_branch
+      when: on_success
+      allow_failure: true
   needs: ["dev_master_docker_hub-a6", "dev_master_docker_hub-a7"]
   script:
     - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py2 --dca-image=datadog/cluster-agent-dev:master


### PR DESCRIPTION
### What does this PR do?

Allows the `pupernetes-master` job to fail without making the whole Gitlab pipeline fail.

### Motivation

We know that the `pupernetes-master` job is failing, and is being investigated. In order to increase the visibility on the health of the pipeline, this job alone should not make the whole pipeline fail.

### Additional Notes

This should be reverted once the job is fixed.
