### PR TITLE
tasks/dogstatsd: slightly increase the maximum valid size for the DogStatsD binary size.

### DIFF
--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -26,7 +26,7 @@ from .utils import (
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
 STATIC_BIN_PATH = os.path.join(".", "bin", "static")
-MAX_BINARY_SIZE = 20 * 1024
+MAX_BINARY_SIZE = 20600
 DOGSTATSD_TAG = "datadog/dogstatsd:master"
 
 


### PR DESCRIPTION
### What does this PR do?

We test the size of the DogStatsD binary in the pipeline to avoid it growing too much without notice.
Due to some recent changes, this commit is slightly increasing the maximum limit considered before the job is failing.
