### PR TITLE
Revert "Revert "pkg/trace/{agent,stats}: add tag for synthetic data""

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -294,7 +294,7 @@ func (a *Agent) ProcessStats(in pb.ClientStatsPayload, lang string) {
 				Distributions:    make(map[string]stats.Distribution),
 				ErrDistributions: make(map[string]stats.Distribution),
 			}
-			aggr := stats.NewAggregation(out.Env, b.Resource, b.Service, "", statusCode, in.Version)
+			aggr := stats.NewAggregation(out.Env, b.Resource, b.Service, "", statusCode, in.Version, false)
 			tagset := aggr.ToTagSet()
 			key := stats.GrainKey(b.Name, stats.HITS, aggr)
 			newb.Counts[key] = stats.Count{

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -10,6 +10,8 @@ const (
 	tagHostname   = "_dd.hostname"
 	tagStatusCode = "http.status_code"
 	tagVersion    = "version"
+	tagOrigin     = "_dd.origin"
+	tagSynthetics = "synthetics"
 )
 
 // Aggregation contains all the dimension on which we aggregate statistics
@@ -22,10 +24,13 @@ type Aggregation struct {
 	Hostname   string
 	StatusCode string
 	Version    string
+	Synthetics bool
 }
 
 // NewAggregationFromSpan creates a new aggregation from the provided span and env
 func NewAggregationFromSpan(s *pb.Span, env string) Aggregation {
+	synthetics := strings.HasPrefix(s.Meta[tagOrigin], "synthetics")
+
 	return Aggregation{
 		Env:        env,
 		Resource:   s.Resource,
@@ -33,11 +38,12 @@ func NewAggregationFromSpan(s *pb.Span, env string) Aggregation {
 		Hostname:   s.Meta[tagHostname],
 		StatusCode: s.Meta[tagStatusCode],
 		Version:    s.Meta[tagVersion],
+		Synthetics: synthetics,
 	}
 }
 
 // NewAggregation creates a new aggregation from the provided fields
-func NewAggregation(env string, resource string, service string, hostname string, statusCode string, version string) Aggregation {
+func NewAggregation(env string, resource string, service string, hostname string, statusCode string, version string, synthetics bool) Aggregation {
 	return Aggregation{
 		Env:        env,
 		Resource:   resource,
@@ -45,6 +51,7 @@ func NewAggregation(env string, resource string, service string, hostname string
 		Hostname:   hostname,
 		StatusCode: statusCode,
 		Version:    version,
+		Synthetics: synthetics,
 	}
 }
 
@@ -63,6 +70,9 @@ func (aggr *Aggregation) ToTagSet() TagSet {
 	if len(aggr.Version) > 0 {
 		tagSet = append(tagSet, Tag{tagVersion, aggr.Version})
 	}
+	if aggr.Synthetics {
+		tagSet = append(tagSet, Tag{tagSynthetics, "true"})
+	}
 	return tagSet
 }
 
@@ -80,6 +90,10 @@ func (aggr *Aggregation) KeyLen() int {
 	if len(aggr.Version) > 0 {
 		// +2 for "," and ":" separator
 		length += 1 + len(tagVersion) + 1 + len(aggr.Version)
+	}
+	if aggr.Synthetics {
+		// +2 for "," and ":" separator
+		length += 1 + len(tagSynthetics) + 1 + len("true")
 	}
 	return length
 }
@@ -105,5 +119,9 @@ func (aggr *Aggregation) WriteKey(b *strings.Builder) {
 	if len(aggr.Version) > 0 {
 		b.WriteString("," + tagVersion + ":")
 		b.WriteString(aggr.Version)
+	}
+	if aggr.Synthetics {
+		b.WriteString("," + tagSynthetics + ":")
+		b.WriteString("true")
 	}
 }

--- a/pkg/trace/stats/statsraw_test.go
+++ b/pkg/trace/stats/statsraw_test.go
@@ -30,13 +30,13 @@ func TestGrain(t *testing.T) {
 func TestGrainWithExtraTags(t *testing.T) {
 	assert := assert.New(t)
 
-	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{tagHostname: "host-id", tagVersion: "v0", tagStatusCode: "418"}}
+	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{tagHostname: "host-id", tagVersion: "v0", tagStatusCode: "418", tagOrigin: "synthetics-browser"}}
 	aggr := NewAggregationFromSpan(&s, "default")
 
 	b := strings.Builder{}
 	aggr.WriteKey(&b)
-	assert.Equal("env:default,resource:yo,service:thing,_dd.hostname:host-id,http.status_code:418,version:v0", b.String())
-	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}, Tag{"_dd.hostname", "host-id"}, Tag{"http.status_code", "418"}, Tag{"version", "v0"}}, aggr.ToTagSet())
+	assert.Equal("env:default,resource:yo,service:thing,_dd.hostname:host-id,http.status_code:418,version:v0,synthetics:true", b.String())
+	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}, Tag{"_dd.hostname", "host-id"}, Tag{"http.status_code", "418"}, Tag{"version", "v0"}, Tag{"synthetics", "true"}}, aggr.ToTagSet())
 }
 
 func TestHandleSpanSkipStats(t *testing.T) {

--- a/releasenotes/notes/apm-tag-synthetic-data-b9ecc0d78a1b594c.yaml
+++ b/releasenotes/notes/apm-tag-synthetic-data-b9ecc0d78a1b594c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Add a tag allowing trace metrics from synthetic data to 
+    be aggregated independently.


### PR DESCRIPTION
Reverts DataDog/datadog-agent#6997

Original PR: https://github.com/DataDog/datadog-agent/pull/6955

The original PR was accidentally merged during a code freeze. It was then reverted. Undoing the revert to merge the original PR content.