### PR TITLE
[procutil] add procfs permission cache

### DIFF
--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -602,8 +602,8 @@ func (p *Probe) isReadableFromCache(pid int32, pidPath string, createTime int64)
 	// use /proc/[pid]/io path to get readability
 	path := filepath.Join(pidPath, "io")
 
-	result, missing := p.permCache.Get(pidStr)
-	if missing {
+	result, found := p.permCache.Get(pidStr)
+	if !found {
 		// check and cache readability for new PIDs
 		isReadable = p.checkAndCacheReadability(pidStr, path, createTime)
 	} else {

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -640,7 +640,6 @@ func (p *Probe) ensurePathReadable(path string) error {
 		return nil
 	}
 
-	// TODO (sk): Provide caching on this!
 	info, err := os.Lstat(path)
 	if err != nil {
 		return err

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -28,7 +28,9 @@ const (
 	// C.sysconf(C._SC_CLK_TCK)
 	DefaultClockTicks = float64(100)
 
-	DefaultPermCacheTTL           = 5 * time.Minute
+	// DefaultPermCacheTTL is the default TTL for permission cache
+	DefaultPermCacheTTL = 5 * time.Minute
+	// DefaultPermCacheCleanInterval is the default clean up interval for permission cache
 	DefaultPermCacheCleanInterval = 10 * time.Minute
 )
 

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -523,7 +523,7 @@ func testParseIO(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, pid := range pids {
-		actual := probe.parseIO(filepath.Join(probe.procRootLoc, strconv.Itoa(int(pid))))
+		actual := probe.parseIO(filepath.Join(probe.procRootLoc, strconv.Itoa(int(pid))), true)
 		expProc, err := process.NewProcess(pid)
 		assert.NoError(t, err)
 		expIO, err := expProc.IOCounters()
@@ -733,8 +733,8 @@ func TestGetLinkWithAuthCheck(t *testing.T) {
 
 	for _, pid := range pids {
 		pathForPID := filepath.Join(probe.procRootLoc, strconv.Itoa(int(pid)))
-		cwd := probe.getLinkWithAuthCheck(pathForPID, "cwd")
-		exe := probe.getLinkWithAuthCheck(pathForPID, "exe")
+		cwd := probe.getLinkWithAuthCheck(pathForPID, "cwd", true)
+		exe := probe.getLinkWithAuthCheck(pathForPID, "exe", true)
 
 		expProc, err := process.NewProcess(pid)
 		assert.NoError(t, err)
@@ -758,7 +758,7 @@ func TestGetFDCountLocalFS(t *testing.T) {
 
 	for _, pid := range pids {
 		pathForPID := filepath.Join(probe.procRootLoc, strconv.Itoa(int(pid)))
-		fdCount := probe.getFDCount(pathForPID)
+		fdCount := probe.getFDCount(pathForPID, true)
 		expProc, err := process.NewProcess(pid)
 		assert.NoError(t, err)
 		// skip the ones that have permission issues
@@ -945,7 +945,7 @@ func benchmarkParseIOProcutil(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for _, pid := range pids {
-			probe.parseIO(filepath.Join(probe.procRootLoc, strconv.Itoa(int(pid))))
+			probe.parseIO(filepath.Join(probe.procRootLoc, strconv.Itoa(int(pid))), true)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds permission cache to avoid calling `lstat` repeatedly to check permission for dirs/files like `fd`, `io`, `cwd` and `exe`.  Since they all share the same ptrace permission `PTRACE_MODE_READ_FSCREDS`, we only use `io` to do the initial testing before caching by `PID`.

The cache entry holds `isReadable` and `CreateTime` for the process. If current process's `CreateTime` is later than the one in cache, it indicates that the PID has assigned to a different process, we then delete the cache entry and re-check permission.

@DataDog/processes 

### Motivation

Reduce system calls.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
