### PR TITLE
[DCA][Fix] Avoid potential nil pointer

### DIFF
--- a/pkg/autodiscovery/listeners/kube_endpoints.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints.go
@@ -252,6 +252,7 @@ func (l *KubeEndpointsListener) isEndpointsAnnotated(kep *v1.Endpoints) bool {
 	ksvc, err := l.serviceLister.Services(kep.Namespace).Get(kep.Name)
 	if err != nil {
 		log.Tracef("Cannot get Kubernetes service: %s", err)
+		return false
 	}
 	return isServiceAnnotated(ksvc, kubeEndpointsAnnotationFormat) || l.promInclAnnot.IsMatchingAnnotations(ksvc.GetAnnotations())
 }


### PR DESCRIPTION
### What does this PR do?

Make `isEndpointsAnnotated` return `false` directly if we couldn't get the corresponding Service

### Motivation

`ksvc.GetAnnotations()` at line 256 would panic if we don't return

### Additional Notes

Master is broken for the DCA, this should fix it.

### Describe your test plan

The Cluster Agent shouldn't panic when cluster checks and endpoint checks are enabled.
