### PR TITLE
[rtloader/aggregator] Parse optional flush_first_value boolean with |b

### DIFF
--- a/releasenotes/notes/fix-agent-arm-metrics-23b8b5893b75a7d4.yaml
+++ b/releasenotes/notes/fix-agent-arm-metrics-23b8b5893b75a7d4.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue on arm64 where non-gauge metrics from Python checks
+    were treated as gauges.

--- a/rtloader/common/builtins/aggregator.c
+++ b/rtloader/common/builtins/aggregator.c
@@ -192,7 +192,7 @@ static PyObject *submit_metric(PyObject *self, PyObject *args)
     bool flush_first_value = false;
 
     // Python call: aggregator.submit_metric(self, check_id, aggregator.metric_type.GAUGE, name, value, tags, hostname, flush_first_value)
-    if (!PyArg_ParseTuple(args, "OsisdOs|i", &check, &check_id, &mt, &name, &value, &py_tags, &hostname, &flush_first_value)) {
+    if (!PyArg_ParseTuple(args, "OsisdOs|b", &check, &check_id, &mt, &name, &value, &py_tags, &hostname, &flush_first_value)) {
         goto error;
     }
 


### PR DESCRIPTION
### What does this PR do?

Changes the `aggregator.submit_metric` method's argument parsing from `OsisdOs|i` to `OsisdOs|b`, converting into an unsigned char instead of an int (see https://docs.python.org/3/c-api/arg.html).

### Motivation

#6663 added a new optional boolean parameter, `flush_first_value`, to the `aggregator.submit_metric` method. However, either the Python argument parsing or the argument sizes are different on arm64 than on amd64. 

The core problem comes from the optional `flush_first_value` boolean being parsed as a 4-byte integer. On amd64, this isn't a problem, but it seems like the way the args are parsed on arm64 made it so that only the first 8 bits of the metric type integer (out of 32) were taken into account (the remaining 24 bits are seemingly all set to 0). This became obvious when I tried passing arbitrary values for metric types:
- 1000000000 (`00111011100110101100101000000000`) became 989855744 (`00111011000000000000000000000000`)
- 989855743 (`00111010111111111111111111111111`) became 973078528 (`00111010000000000000000000000000`)
- 16777216 (= 2^24) remained the same, while 16777215 became 0.

This resulted in all current metric types (which are mapped from 0 to 6) being sent as metric type 0 (ie. gauge) since Agent 6/7.24.0.

### Describe your test plan

Tested with Python 2 and Python 3, on an Ubuntu 20.04 arm64 host and an Ubuntu 20.04 amd64 host. Both the metric type and the `flush_first_value` seem to be passed correctly with the new parsing format.