### PR TITLE
[procutil] move Status field to Stats structure

### DIFF
--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -106,6 +106,7 @@ func (p *Probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, err
 
 		statsByPID[pid] = &Stats{
 			CreateTime:  statInfo.createTime,      // /proc/[pid]/stat
+			Status:      statusInfo.status,        // /proc/[pid]/status
 			Nice:        statInfo.nice,            // /proc/[pid]/stat
 			OpenFdCount: p.getFDCount(pathForPID), // /proc/[pid]/fd, requires permission checks
 			CPUTime:     statInfo.cpuStat,         // /proc/[pid]/stat
@@ -151,7 +152,6 @@ func (p *Probe) ProcessesByPID(now time.Time) (map[int32]*Process, error) {
 			Ppid:    statInfo.ppid,                             // /proc/[pid]/stat
 			Cmdline: cmdline,                                   // /proc/[pid]/cmdline
 			Name:    statusInfo.name,                           // /proc/[pid]/status
-			Status:  statusInfo.status,                         // /proc/[pid]/status
 			Uids:    statusInfo.uids,                           // /proc/[pid]/status
 			Gids:    statusInfo.gids,                           // /proc/[pid]/status
 			Cwd:     p.getLinkWithAuthCheck(pathForPID, "cwd"), // /proc/[pid]/cwd, requires permission checks
@@ -159,6 +159,7 @@ func (p *Probe) ProcessesByPID(now time.Time) (map[int32]*Process, error) {
 			NsPid:   statusInfo.nspid,                          // /proc/[pid]/status
 			Stats: &Stats{
 				CreateTime:  statInfo.createTime,      // /proc/[pid]/stat
+				Status:      statusInfo.status,        // /proc/[pid]/status
 				Nice:        statInfo.nice,            // /proc/[pid]/stat
 				OpenFdCount: p.getFDCount(pathForPID), // /proc/[pid]/fd, requires permission checks
 				CPUTime:     statInfo.cpuStat,         // /proc/[pid]/stat

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -2,22 +2,13 @@ package procutil
 
 // Process holds all relevant metadata and metrics for a process
 type Process struct {
-	Pid   int32
-	Ppid  int32
-	NsPid int32 // process namespaced PID
-
-	// Status returns the process status.
-	// Return value could be one of these.
-	// R: Running S: Sleep T: Stop I: Idle
-	// Z: Zombie W: Wait L: Lock
-	// The character is same within all supported platforms.
-	Status string
-
-	Name    string
-	Cwd     string
-	Exe     string
-	Cmdline []string
-
+	Pid      int32
+	Ppid     int32
+	NsPid    int32 // process namespaced PID
+	Name     string
+	Cwd      string
+	Exe      string
+	Cmdline  []string
 	Username string // (Windows only)
 	Uids     []int32
 	Gids     []int32
@@ -28,11 +19,15 @@ type Process struct {
 // Stats holds all relevant stats metrics of a process
 type Stats struct {
 	CreateTime int64
-
+	// Status returns the process status.
+	// Return value could be one of these.
+	// R: Running S: Sleep T: Stop I: Idle
+	// Z: Zombie W: Wait L: Lock
+	// The character is the same within all supported platforms.
+	Status      string
 	Nice        int32
 	OpenFdCount int32
 	NumThreads  int32
-
 	CPUTime     *CPUTimesStat
 	MemInfo     *MemoryInfoStat
 	MemInfoEx   *MemoryInfoExStat


### PR DESCRIPTION
### What does this PR do?

During the testing I realized that the `Status` was collected in rt checks in the old library but not in procutil. This PR merely moves the field into `Stats` structure so the rt collection includes this data.
 
@DataDog/processes 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
