### PR TITLE
logging instance id for easier cross-referencing of build problems

### DIFF
--- a/.gitlab/binary_build/windows.yml
+++ b/.gitlab/binary_build/windows.yml
@@ -13,6 +13,7 @@ build_windows_container_entrypoint:
   variables:
     ARCH: "x64"
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e TARGET_ARCH="$ARCH" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDIMAGES} c:\mnt\Dockerfiles\agent\windows\entrypoint\build.bat
     - get-childitem build-out\${CI_JOB_ID}

--- a/.gitlab/choco_build.yml
+++ b/.gitlab/choco_build.yml
@@ -43,6 +43,7 @@ windows_choco_online_7_x64:
   variables:
     ARCH: "x64"
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
     - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -19,6 +19,7 @@ publish_choco_7_x64:
   before_script:
     - $chocolateyApiKey = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.chocolatey_api_key --with-decryption --query "Parameter.Value" --out text)
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
     - Get-ChildItem .omnibus\pkg
     - if (Test-Path nupkg) { remove-item -recurse -force nupkg }

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -53,6 +53,7 @@ tag_release_7_windows_docker_hub:
   variables:
     VARIANT: 2004
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
     - |
       @"
@@ -200,6 +201,7 @@ tag_release_7_windows_google_container_registry:
   variables:
     VARIANT: 2004
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
     - |
       @"

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -53,7 +53,6 @@ tag_release_7_windows_docker_hub:
   variables:
     VARIANT: 2004
   script:
-    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
     - |
       @"

--- a/.gitlab/docker_common/tag_job_templates.yml
+++ b/.gitlab/docker_common/tag_job_templates.yml
@@ -39,6 +39,7 @@
   variables:
     <<: *docker_hub_variables
   before_script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
     - $SRC_TAG = "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - mkdir ci-scripts

--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -50,6 +50,7 @@
     BUILD_CONTEXT: Dockerfiles/agent
     BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
     - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip

--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -37,7 +37,6 @@ dev_branch_docker_hub-a7-windows:
   variables:
     VARIANT: 2004
   script:
-    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
     - |
       @"

--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -37,6 +37,7 @@ dev_branch_docker_hub-a7-windows:
   variables:
     VARIANT: 2004
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
     - |
       @"

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -19,6 +19,7 @@
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["go_mod_tidy_check"]
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir .omnibus\pkg
@@ -28,6 +29,8 @@
     - remove-item -recurse -force build-out\${CI_JOB_ID}
     - get-childitem build-out
     - get-childitem .omnibus\pkg
+  after_script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -118,6 +121,7 @@ windows_zip_agent_binaries_x64-a7:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_7
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir .omnibus\pkg

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -7,6 +7,7 @@
   needs: []
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - docker run --rm -m 8192M -v "$(Get-Location):c:\mnt" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e PY_RUNTIMES="$PYTHON_RUNTIMES" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\unittests.bat
 
 tests_windows-x64:


### PR DESCRIPTION
on windows, adds to the build script retrieving the instance id `i-XXX....`;
gitlab reports ec2 hostname `EC2AMAZ-......`, everything else we do is by instance id
