### PR TITLE
[gitlab] Increase dsd max size test to 21MiB

### DIFF
--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -26,7 +26,7 @@ from .utils import (
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
 STATIC_BIN_PATH = os.path.join(".", "bin", "static")
-MAX_BINARY_SIZE = 21000
+MAX_BINARY_SIZE = 21 * 1024
 DOGSTATSD_TAG = "datadog/dogstatsd:master"
 
 

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -26,7 +26,7 @@ from .utils import (
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
 STATIC_BIN_PATH = os.path.join(".", "bin", "static")
-MAX_BINARY_SIZE = 20600
+MAX_BINARY_SIZE = 21000
 DOGSTATSD_TAG = "datadog/dogstatsd:master"
 
 


### PR DESCRIPTION
### What does this PR do?

Increases the limit of the dogstatsd size test from 20600kB to 21MiB.

### Motivation

The current dogstatsd size is 20700kB, making tests fail.

