### PR TITLE
pkg/trace/agent: simplify rates

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -202,7 +202,6 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 			if ratelimiter := a.Receiver.RateLimiter; ratelimiter.Active() {
 				rate := ratelimiter.RealRate()
 				sampler.SetPreSampleRate(root, rate)
-				sampler.AddGlobalRate(root, rate)
 			}
 			if p.ContainerTags != "" {
 				traceutil.SetMeta(root, tagContainersTags, p.ContainerTags)
@@ -369,10 +368,7 @@ func (a *Agent) sample(ts *info.TagStats, pt ProcessedTrace) (events []*pb.Span,
 		return nil, false
 	}
 
-	sampled, rate := a.runSamplers(pt, hasPriority)
-	if sampled {
-		sampler.AddGlobalRate(pt.Root, rate)
-	}
+	sampled := a.runSamplers(pt, hasPriority)
 
 	events, numExtracted := a.EventProcessor.Process(pt.Root, pt.Trace)
 
@@ -384,7 +380,7 @@ func (a *Agent) sample(ts *info.TagStats, pt ProcessedTrace) (events []*pb.Span,
 
 // runSamplers runs all the agent's samplers on pt and returns the sampling decision
 // along with the sampling rate.
-func (a *Agent) runSamplers(pt ProcessedTrace, hasPriority bool) (bool, float64) {
+func (a *Agent) runSamplers(pt ProcessedTrace, hasPriority bool) bool {
 	if hasPriority {
 		return a.samplePriorityTrace(pt)
 	}
@@ -394,21 +390,19 @@ func (a *Agent) runSamplers(pt ProcessedTrace, hasPriority bool) (bool, float64)
 // samplePriorityTrace samples traces with priority set on them. PrioritySampler and
 // ErrorSampler are run in parallel. The ExceptionSampler catches traces with rare top-level
 // or measured spans that are not caught by PrioritySampler and ErrorSampler.
-func (a *Agent) samplePriorityTrace(pt ProcessedTrace) (sampled bool, rate float64) {
-	sampledPriority, ratePriority := a.PrioritySampler.Add(pt)
+func (a *Agent) samplePriorityTrace(pt ProcessedTrace) bool {
+	if a.PrioritySampler.Add(pt) {
+		return true
+	}
 	if traceContainsError(pt.Trace) {
-		sampledError, rateError := a.ErrorsScoreSampler.Add(pt)
-		return sampledError || sampledPriority, sampler.CombineRates(ratePriority, rateError)
+		return a.ErrorsScoreSampler.Add(pt)
 	}
-	if sampled := a.ExceptionSampler.Add(pt.Env, pt.Root, pt.Trace); sampled {
-		return sampled, 1
-	}
-	return sampledPriority, ratePriority
+	return a.ExceptionSampler.Add(pt.Env, pt.Root, pt.Trace)
 }
 
 // sampleNoPriorityTrace samples traces with no priority set on them. The traces
 // get sampled by either the score sampler or the error sampler if they have an error.
-func (a *Agent) sampleNoPriorityTrace(pt ProcessedTrace) (sampled bool, rate float64) {
+func (a *Agent) sampleNoPriorityTrace(pt ProcessedTrace) bool {
 	if traceContainsError(pt.Trace) {
 		return a.ErrorsScoreSampler.Add(pt)
 	}

--- a/pkg/trace/agent/sampler.go
+++ b/pkg/trace/agent/sampler.go
@@ -72,13 +72,13 @@ func (s *Sampler) Start() {
 }
 
 // Add samples a trace and returns true if trace was sampled (should be kept), false otherwise
-func (s *Sampler) Add(t ProcessedTrace) (sampled bool, rate float64) {
+func (s *Sampler) Add(t ProcessedTrace) bool {
 	atomic.AddUint64(&s.totalTraceCount, 1)
-	sampled, rate = s.engine.Sample(t.Trace, t.Root, t.Env)
+	sampled := s.engine.Sample(t.Trace, t.Root, t.Env)
 	if sampled {
 		atomic.AddUint64(&s.keptTraceCount, 1)
 	}
-	return sampled, rate
+	return sampled
 }
 
 // Stop stops the sampler

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -48,7 +48,7 @@ type Engine interface {
 	// Stop the sampler.
 	Stop()
 	// Sample a trace.
-	Sample(trace pb.Trace, root *pb.Span, env string) (sampled bool, samplingRate float64)
+	Sample(trace pb.Trace, root *pb.Span, env string) bool
 	// GetState returns information about the sampler.
 	GetState() interface{}
 	// GetType returns the type of the sampler.
@@ -165,13 +165,4 @@ func (s *Sampler) GetMaxTPSSampleRate() float64 {
 
 func (s *Sampler) setRateThresholdTo1(r float64) {
 	s.rateThresholdTo1 = r
-}
-
-// CombineRates merges two rates from Sampler1, Sampler2. Both samplers law are independent,
-// and {sampled} = {sampled by Sampler1} or {sampled by Sampler2}
-func CombineRates(rate1 float64, rate2 float64) float64 {
-	if rate1 >= 1 || rate2 >= 1 {
-		return 1
-	}
-	return rate1 + rate2 - rate1*rate2
 }

--- a/pkg/trace/sampler/coresampler_test.go
+++ b/pkg/trace/sampler/coresampler_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,32 +57,4 @@ func TestSamplerLoop(t *testing.T) {
 	case <-time.After(time.Second * 1):
 		assert.Fail(t, "Sampler took more than 1 second to close")
 	}
-}
-
-func TestCombineRates(t *testing.T) {
-	var combineRatesTests = []struct {
-		rate1, rate2 float64
-		expected     float64
-	}{
-		{0.1, 1.0, 1.0},
-		{0.3, 0.2, 0.44},
-		{0.0, 0.5, 0.5},
-	}
-	for _, tt := range combineRatesTests {
-		assert.Equal(t, tt.expected, CombineRates(tt.rate1, tt.rate2))
-		assert.Equal(t, tt.expected, CombineRates(tt.rate2, tt.rate1))
-	}
-}
-
-func TestAddSampleRate(t *testing.T) {
-	assert := assert.New(t)
-	tID := randomTraceID()
-
-	root := &pb.Span{TraceID: tID, SpanID: 1, ParentID: 0, Start: 123, Duration: 100000, Service: "mcnulty", Type: "web"}
-
-	AddGlobalRate(root, 0.4)
-	assert.Equal(0.4, root.Metrics["_sample_rate"], "sample rate should be 40%%")
-
-	AddGlobalRate(root, 0.5)
-	assert.Equal(0.2, root.Metrics["_sample_rate"], "sample rate should be 20%% (50%% of 40%%)")
 }

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -26,10 +26,10 @@ import (
 )
 
 const (
-	// SamplingPriorityRateKey is the metrics key holding the sampling rate at which this trace
-	// was sampled.
-	SamplingPriorityRateKey = "_sampling_priority_rate_v1"
-	syncPeriod              = 3 * time.Second
+	deprecatedRateKey = "_sampling_priority_rate_v1"
+	agentRateKey      = "_dd.agent_psr"
+	ruleRateKey       = "_dd.rule_psr"
+	syncPeriod        = 3 * time.Second
 	// prioritySamplingRateThresholdTo1 defines the maximum allowed sampling rate below 1.
 	// If this is surpassed, the rate is set to 1.
 	prioritySamplingRateThresholdTo1 = 0.3
@@ -93,10 +93,10 @@ func (s *PriorityEngine) Stop() {
 }
 
 // Sample counts an incoming trace and returns the trace sampling decision and the applied sampling rate
-func (s *PriorityEngine) Sample(trace pb.Trace, root *pb.Span, env string) (sampled bool, rate float64) {
+func (s *PriorityEngine) Sample(trace pb.Trace, root *pb.Span, env string) bool {
 	// Extra safety, just in case one trace is empty
 	if len(trace) == 0 {
-		return false, 0
+		return false
 	}
 
 	samplingPriority, _ := GetSamplingPriority(root)
@@ -104,16 +104,16 @@ func (s *PriorityEngine) Sample(trace pb.Trace, root *pb.Span, env string) (samp
 	// Regardless of rates, sampling here is based on the metadata set
 	// by the client library. Which, is turn, is based on agent hints,
 	// but the rule of thumb is: respect client choice.
-	sampled = samplingPriority > 0
+	sampled := samplingPriority > 0
 
 	// Short-circuit and return without counting the trace in the sampling rate logic
 	// if its value has not been set automaticallt by the client lib.
 	// The feedback loop should be scoped to the values it can act upon.
 	if samplingPriority < 0 {
-		return sampled, 0
+		return sampled
 	}
 	if samplingPriority > 1 {
-		return sampled, 1
+		return sampled
 	}
 
 	signature := s.catalog.register(ServiceSignature{root.Service, env})
@@ -121,20 +121,37 @@ func (s *PriorityEngine) Sample(trace pb.Trace, root *pb.Span, env string) (samp
 	// Update sampler state by counting this trace
 	s.Sampler.Backend.CountSignature(signature)
 
-	// fetching applied sample rate
-	var ok bool
-	rate, ok = root.Metrics[SamplingPriorityRateKey]
-	if !ok || rate > prioritySamplingRateThresholdTo1 {
-		rate = s.Sampler.GetSignatureSampleRate(signature)
-		root.Metrics[SamplingPriorityRateKey] = rate
-	}
-
 	if sampled {
-		// Count the trace to allow us to check for the maxTPS limit.
-		// It has to happen before the maxTPS sampling.
+		s.applyRate(sampled, root, signature)
 		s.Sampler.Backend.CountSample()
 	}
-	return sampled, rate
+	return sampled
+}
+
+func (s *PriorityEngine) applyRate(sampled bool, root *pb.Span, signature Signature) {
+	if root.ParentID != 0 {
+		return
+	}
+	// recent tracers annotate roots with applied priority rate
+	// agentRateKey is set when the agent computed rate is applied
+	if _, ok := getMetric(root, agentRateKey); ok {
+		return
+	}
+	// ruleRateKey is set when a tracer rule rate is applied
+	if _, ok := getMetric(root, ruleRateKey); ok {
+		return
+	}
+
+	// slow path used by older tracer versions
+	// dd-trace-go used to set the rate in deprecatedRateKey
+	if _, ok := getMetric(root, deprecatedRateKey); !ok {
+		// if it's not set add next rate
+		rate := s.Sampler.GetSignatureSampleRate(signature)
+		if rate > prioritySamplingRateThresholdTo1 {
+			rate = 1
+		}
+		setMetric(root, deprecatedRateKey, rate)
+	}
 }
 
 // GetState collects and return internal statistics and coefficients for indication purposes

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -87,17 +87,6 @@ func GetGlobalRate(s *pb.Span) float64 {
 	return getMetricDefault(s, KeySamplingRateGlobal, 1.0)
 }
 
-// SetGlobalRate sets the cumulative sample rate of the trace to which this span belongs to.
-func SetGlobalRate(s *pb.Span, rate float64) {
-	setMetric(s, KeySamplingRateGlobal, rate)
-}
-
-// AddGlobalRate updates the cumulative sample rate of the trace to which this span belongs to with the provided
-// rate which is assumed to belong to an independent sampler. The combination is done by simple multiplications.
-func AddGlobalRate(s *pb.Span, rate float64) {
-	setMetric(s, KeySamplingRateGlobal, GetGlobalRate(s)*rate)
-}
-
 // GetClientRate gets the rate at which the trace this span belongs to was sampled by the tracer.
 // NOTE: This defaults to 1 if no rate is stored.
 func GetClientRate(s *pb.Span) float64 {

--- a/pkg/trace/sampler/scoresampler.go
+++ b/pkg/trace/sampler/scoresampler.go
@@ -11,6 +11,8 @@ const (
 	// errorSamplingRateThresholdTo1 defines the maximum allowed sampling rate below 1.
 	// If this is surpassed, the rate is set to 1.
 	errorSamplingRateThresholdTo1 = 0.1
+	errorsRateKey                 = "_dd.errors_sr"
+	scoreRateKey                  = "_dd.score_sr"
 )
 
 // ScoreEngine is the main component of the sampling logic
@@ -53,18 +55,26 @@ func (s *ScoreEngine) Stop() {
 	s.Sampler.Stop()
 }
 
-func applySampleRate(root *pb.Span, rate float64) bool {
+func (s *ScoreEngine) applySampleRate(root *pb.Span, rate float64) bool {
 	initialRate := GetGlobalRate(root)
 	newRate := initialRate * rate
 	traceID := root.TraceID
-	return SampleByRate(traceID, newRate)
+	sampled := SampleByRate(traceID, newRate)
+	if sampled {
+		if s.engineType == ErrorsScoreEngineType {
+			setMetric(root, errorsRateKey, rate)
+		} else {
+			setMetric(root, scoreRateKey, rate)
+		}
+	}
+	return sampled
 }
 
 // Sample counts an incoming trace and tells if it is a sample which has to be kept
-func (s *ScoreEngine) Sample(trace pb.Trace, root *pb.Span, env string) (sampled bool, rate float64) {
+func (s *ScoreEngine) Sample(trace pb.Trace, root *pb.Span, env string) bool {
 	// Extra safety, just in case one trace is empty
 	if len(trace) == 0 {
-		return false, 0
+		return false
 	}
 
 	signature := computeSignatureWithRootAndEnv(trace, root, env)
@@ -72,9 +82,9 @@ func (s *ScoreEngine) Sample(trace pb.Trace, root *pb.Span, env string) (sampled
 	// Update sampler state by counting this trace
 	s.Sampler.Backend.CountSignature(signature)
 
-	rate = s.Sampler.GetSampleRate(trace, root, signature)
+	rate := s.Sampler.GetSampleRate(trace, root, signature)
 
-	sampled = applySampleRate(root, rate)
+	sampled := s.applySampleRate(root, rate)
 
 	if sampled {
 		// Count the trace to allow us to check for the maxTPS limit.
@@ -85,11 +95,11 @@ func (s *ScoreEngine) Sample(trace pb.Trace, root *pb.Span, env string) (sampled
 		// No need to check if we already decided not to keep the trace.
 		maxTPSrate := s.Sampler.GetMaxTPSSampleRate()
 		if maxTPSrate < 1 {
-			sampled = applySampleRate(root, maxTPSrate)
+			sampled = s.applySampleRate(root, maxTPSrate)
 		}
 	}
 
-	return sampled, rate
+	return sampled
 }
 
 // GetState collects and return internal statistics and coefficients for indication purposes

--- a/pkg/trace/sampler/scoresampler_test.go
+++ b/pkg/trace/sampler/scoresampler_test.go
@@ -65,12 +65,14 @@ func TestErrorSampleThresholdTo1(t *testing.T) {
 	s := getTestScoreEngine()
 	for i := 0; i < 1e2; i++ {
 		trace, root := getTestTrace()
-		_, rate := s.Sample(trace, root, env)
+		s.Sample(trace, root, env)
+		rate, _ := root.Metrics["_dd.errors_sr"]
 		assert.Equal(1.0, rate)
 	}
 	for i := 0; i < 1e3; i++ {
 		trace, root := getTestTrace()
-		_, rate := s.Sample(trace, root, env)
+		s.Sample(trace, root, env)
+		rate, _ := root.Metrics["_dd.errors_sr"]
 		if rate < 1 {
 			assert.True(rate < errorSamplingRateThresholdTo1)
 		}
@@ -101,7 +103,7 @@ func TestMaxTPS(t *testing.T) {
 		s.Sampler.Backend.(*MemoryBackend).decayScore()
 		for i := 0; i < int(tracesPerPeriod); i++ {
 			trace, root := getTestTrace()
-			sampled, _ := s.Sample(trace, root, defaultEnv)
+			sampled := s.Sample(trace, root, defaultEnv)
 			// Once we got into the "supposed-to-be" stable "regime", count the samples
 			if period > initPeriods && sampled {
 				sampledCount++

--- a/pkg/trace/test/testutil/sampler.go
+++ b/pkg/trace/test/testutil/sampler.go
@@ -13,17 +13,16 @@ import (
 // MockEngine mocks a sampler engine
 type MockEngine struct {
 	wantSampled bool
-	wantRate    float64
 }
 
 // NewMockEngine returns a MockEngine for tests
-func NewMockEngine(wantSampled bool, wantRate float64) *MockEngine {
-	return &MockEngine{wantSampled: wantSampled, wantRate: wantRate}
+func NewMockEngine(wantSampled bool) *MockEngine {
+	return &MockEngine{wantSampled: wantSampled}
 }
 
 // Sample returns a constant rate
-func (e *MockEngine) Sample(_ pb.Trace, _ *pb.Span, _ string) (bool, float64) {
-	return e.wantSampled, e.wantRate
+func (e *MockEngine) Sample(_ pb.Trace, _ *pb.Span, _ string) bool {
+	return e.wantSampled
 }
 
 // Run mocks Engine.Run()


### PR DESCRIPTION
Couple improvements on rate
- removes unused `_sample_rate`
- apply priority rate only on root spans, and if it's not already set by tracers
- add specific error / score rates when applied
