### PR TITLE
Fix end-to-end tests

### DIFF
--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -100,6 +100,10 @@ systemd:
         [Install]
         WantedBy=multi-user.target
 storage:
+  links:
+    - path: /etc/crypto-policies/back-ends/opensshserver.config
+      target: /usr/share/crypto-policies/LEGACY/opensshserver.txt
+      overwrite: true
   files:
     - path: /usr/local/bin/setup-pupernetes
       mode: 0500


### PR DESCRIPTION
### What does this PR do?

Fixes the e2e tests which have been broken for a while.

### Motivation

E2e tests are currently systematically timing out, and failing, while the GitLab workers are attempting to log on the pupernetes VM with the following issue:
```
Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
```

### Additional Notes

The OpenSSH client installed in the GitLab workers is old and supports only deprecated weak cryptographic algorithms.
We need to enable those legacy crypto algorithms for the GitLab workers to succeed in connecting to the pupernetes VM.

### Describe your test plan

Launch the e2e pupernetes tests and check that the GitLab workers can now connect to the pupernetes VM.
