### PR TITLE
[runtime-security] remove userspace discarder invalidation

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "82c30572aef4e3548583d8501d11dfd849720501a04871f4c8ce3e5e2df527af")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d34782afbc3fec4efa9bbc94466b2130ab41b66fc9bd10579b322de5d93dafae")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "eea575909a803f79986707f52f6b9d1f3bd333a4cc7fdc16abb2fe0bea3c4f60")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "959e32af8fbfd67edd47858a2010493b7ffdd2a3678477e22209ff3ccfa59c50")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d34782afbc3fec4efa9bbc94466b2130ab41b66fc9bd10579b322de5d93dafae")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "eea575909a803f79986707f52f6b9d1f3bd333a4cc7fdc16abb2fe0bea3c4f60")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "959e32af8fbfd67edd47858a2010493b7ffdd2a3678477e22209ff3ccfa59c50")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "68085049c924158580bccf734a258cc13230ba84042e00c6892ea3b9c46cca6c")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "17d93805017aa6a558f28d343695a19da26b8db2161d4c8b2b7e2d8a287e88f0")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "109672f0b445868ea4d81a4876b5b5bd27436c2b18ed99c8bb6188fd74b77a3b")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "68085049c924158580bccf734a258cc13230ba84042e00c6892ea3b9c46cca6c")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "17d93805017aa6a558f28d343695a19da26b8db2161d4c8b2b7e2d8a287e88f0")

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -19,7 +19,7 @@ int __attribute__((always_inline)) chmod_approvers(struct syscall_cache_t *sysca
 
 int __attribute__((always_inline)) trace__sys_chmod(umode_t mode) {
     struct policy_t policy = fetch_policy(EVENT_CHMOD);
-    if (discarded_by_process(policy.mode, EVENT_CHMOD)) {
+    if (is_discarded_by_process(policy.mode, EVENT_CHMOD)) {
         return 0;
     }
 

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -19,7 +19,7 @@ int __attribute__((always_inline)) chown_approvers(struct syscall_cache_t *sysca
 
 int __attribute__((always_inline)) trace__sys_chown(uid_t user, gid_t group) {
     struct policy_t policy = fetch_policy(EVENT_CHOWN);
-    if (discarded_by_process(policy.mode, EVENT_CHOWN)) {
+    if (is_discarded_by_process(policy.mode, EVENT_CHOWN)) {
         return 0;
     }
 

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -181,7 +181,8 @@
 
 enum event_type
 {
-    EVENT_OPEN = 1,
+    EVENT_FIRST_DISCARDER = 1,
+    EVENT_OPEN = EVENT_FIRST_DISCARDER,
     EVENT_MKDIR,
     EVENT_LINK,
     EVENT_RENAME,
@@ -190,16 +191,17 @@ enum event_type
     EVENT_CHMOD,
     EVENT_CHOWN,
     EVENT_UTIME,
-    EVENT_MOUNT,
-    EVENT_UMOUNT,
     EVENT_SETXATTR,
     EVENT_REMOVEXATTR,
+    EVENT_LAST_DISCARDER = EVENT_REMOVEXATTR,
+
+    EVENT_MOUNT,
+    EVENT_UMOUNT,
     EVENT_FORK,
     EVENT_EXEC,
     EVENT_EXIT,
     EVENT_INVALIDATE_DENTRY,
     EVENT_MAX, // has to be the last one
-    EVENT_MAX_ROUNDED_UP = 32, // closest power of 2 that is bigger than EVENT_MAX
 };
 
 enum syscall_type

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -232,7 +232,7 @@ static __attribute__((always_inline)) int resolve_dentry(struct dentry *dentry, 
 
         // discard filename and its parent only in order to limit the number of lookup
         if (event_type && i < 2) {
-            if (discarded_by_inode(event_type, key.mount_id, key.ino, i)) {
+            if (is_discarded_by_inode(event_type, key.mount_id, key.ino, i)) {
                 return DENTRY_DISCARDED;
             }
         }

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -232,7 +232,7 @@ static __attribute__((always_inline)) int resolve_dentry(struct dentry *dentry, 
 
         // discard filename and its parent only in order to limit the number of lookup
         if (event_type && i < 2) {
-            if (is_discarded_by_inode(event_type, key.mount_id, key.ino, i)) {
+            if (is_discarded_by_inode(event_type, key.mount_id, key.ino, i == 0)) {
                 return DENTRY_DISCARDED;
             }
         }

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -39,6 +39,75 @@ int __attribute__((always_inline)) bump_discarder_revision(u32 mount_id) {
     return *revision;
 }
 
+struct discarder_state_t {
+    u64 expire_at;
+    u32 is_invalid;
+};
+
+struct discarder_parameters_t {
+    u64 event_mask;
+    u64 timestamps[EVENT_MAX_ROUNDED_UP];
+    struct discarder_state_t state;
+    u32 padding;
+};
+
+void __attribute__((always_inline)) discard(struct bpf_map_def *discarder_map, void *key, u64 event_type, u64 timeout) {
+    u64 timestamp = timeout ? bpf_ktime_get_ns() + timeout : 0;
+
+    struct discarder_parameters_t *params = bpf_map_lookup_elem(discarder_map, key);
+    if (params) {
+        params->event_mask |= event_type;
+        params->timestamps[(event_type-1)&(EVENT_MAX_ROUNDED_UP-1)] = timestamp;
+    } else {
+        struct discarder_parameters_t new_params = {
+            .event_mask = event_type,
+        };
+
+        void *dst = new_params.timestamps + ((event_type-1)&(EVENT_MAX_ROUNDED_UP-1));
+        bpf_probe_read(dst, sizeof(u64), &timestamp);
+
+        bpf_map_update_elem(discarder_map, key, &new_params, BPF_NOEXIST);
+    }
+}
+
+int __attribute__((always_inline)) is_discarded(struct bpf_map_def *discarder_map, void *key, u64 event_type) {
+    struct discarder_parameters_t *params = bpf_map_lookup_elem(discarder_map, key);
+    if (!params) {
+        return 0;
+    }
+
+    u64 tm = bpf_ktime_get_ns();
+
+    // this discarder has been marked as invalid by event such as unlink, rename, etc.
+    // keep them for a while in the map to avoid userspace to reinsert it
+    if (params->state.is_invalid) {
+        if (params->state.expire_at < tm) {
+            bpf_map_delete_elem(discarder_map, key);
+        }
+        return 0;
+    }
+
+    u64 pid_tm = params->timestamps[(event_type-1)&(EVENT_MAX_ROUNDED_UP-1)];
+    if (event_type > 0 && pid_tm != 0 && pid_tm <= tm) {
+        return 0;
+    }
+
+    if (mask_has_event(params->event_mask, event_type)) {
+        return 1;
+    }
+
+    return 0;
+}
+
+// do not remove it direclty, first mark it as invalid for a period of time, after that it will be removed
+void __attribute__((always_inline)) remove_discarder(struct bpf_map_def *discarder_map, void *key) {
+    struct discarder_parameters_t *params = bpf_map_lookup_elem(discarder_map, key);
+    if (params) {
+        params->state.is_invalid = 1;
+        params->state.expire_at = bpf_ktime_get_ns() + DISCARDER_RETENTION;
+    }
+}
+
 struct inode_discarder_t {
     struct path_key_t path_key;
     u32 revision;
@@ -46,6 +115,7 @@ struct inode_discarder_t {
 };
 
 struct inode_filter_t {
+    struct discarder_parameters_t params;
     u64 parent_mask;
     u64 leaf_mask;
     u64 timestamp;
@@ -56,13 +126,13 @@ struct inode_filter_t {
 struct bpf_map_def SEC("maps/inode_discarders") inode_discarders = {
     .type = BPF_MAP_TYPE_LRU_HASH,
     .key_size = sizeof(struct inode_discarder_t),
-    .value_size = sizeof(struct inode_filter_t),
+    .value_size = sizeof(struct discarder_parameters_t),
     .max_entries = 512,
     .pinning = 0,
     .namespace = "",
 };
 
-int __attribute__((always_inline)) discarded_by_inode(u64 event_type, u32 mount_id, u64 inode, u64 depth) {
+int __attribute__((always_inline)) discard_inode(u64 event_type, u32 mount_id, u64 inode, u64 timeout) {
     struct inode_discarder_t key = {
         .path_key = {
             .ino = inode,
@@ -71,27 +141,21 @@ int __attribute__((always_inline)) discarded_by_inode(u64 event_type, u32 mount_
         .revision = get_discarder_revision(mount_id),
     };
 
-    struct inode_filter_t *filter = bpf_map_lookup_elem(&inode_discarders, &key);
-    if (!filter) {
-        return 0;
-    }
-
-    if ((depth == 0 && mask_has_event(filter->leaf_mask, event_type)) ||
-        (depth > 0 && mask_has_event(filter->parent_mask, event_type))) {
-
-         // this discarder has been marked as invalid by event such as unlink, rename, etc.
-        // keep them for a while in the map to avoid userspace to reinsert it
-        if (filter->is_invalid) {
-            if (filter->timestamp < bpf_ktime_get_ns()) {
-                bpf_map_delete_elem(&inode_discarders, &key);
-            }
-            return 0;
-        }
-
-        return 1;
-    }
+    discard(&inode_discarders, &key, event_type, timeout);
 
     return 0;
+}
+
+int __attribute__((always_inline)) is_discarded_by_inode(u64 event_type, u32 mount_id, u64 inode, int depth) {
+    struct inode_discarder_t key = {
+        .path_key = {
+            .ino = inode,
+            .mount_id = mount_id,
+        },
+        .revision = get_discarder_revision(mount_id),
+    };
+
+    return is_discarded(&inode_discarders, &key, event_type);
 }
 
 void __attribute__((always_inline)) remove_inode_discarder(u32 mount_id, u64 inode) {
@@ -103,17 +167,7 @@ void __attribute__((always_inline)) remove_inode_discarder(u32 mount_id, u64 ino
         .revision = get_discarder_revision(mount_id),
     };
 
-    u64 mask = ~0; // all the events
-    
-    // do not remove it direclty, first mark it as invalid for a period of time, after that it will be removed
-    struct inode_filter_t filter = {
-        .leaf_mask = mask,
-        .parent_mask = mask,
-        .is_invalid = 1,
-        .timestamp = bpf_ktime_get_ns() + 5000000000, // 5 seconds
-    };
-
-    bpf_map_update_elem(&inode_discarders, &key, &filter, BPF_EXIST);
+    remove_discarder(&inode_discarders, &key);
 }
 
 static __always_inline u32 get_system_probe_pid() {
@@ -126,21 +180,26 @@ struct pid_discarder_t {
     u32 tgid;
 };
 
-struct pid_discarder_parameters_t {
-    u64 event_mask;
-    u64 timestamps[EVENT_MAX_ROUNDED_UP];
-};
-
 struct bpf_map_def SEC("maps/pid_discarders") pid_discarders = { \
     .type = BPF_MAP_TYPE_LRU_HASH,
     .key_size = sizeof(u32),
-    .value_size = sizeof(struct pid_discarder_parameters_t),
+    .value_size = sizeof(struct discarder_parameters_t),
     .max_entries = 512,
     .pinning = 0,
     .namespace = "",
 };
 
-int __attribute__((always_inline)) discarded_by_pid(u64 event_type, u32 tgid) {
+int __attribute__((always_inline)) discard_pid(u64 event_type, u32 tgid, u64 timeout) {
+    struct pid_discarder_t key = {
+        .tgid = tgid,
+    };
+
+    discard(&pid_discarders, &key, event_type, timeout);
+
+    return 0;
+}
+
+int __attribute__((always_inline)) is_discarded_by_pid(u64 event_type, u32 tgid) {
     u32 system_probe_pid = get_system_probe_pid();
     if (system_probe_pid && system_probe_pid == tgid) {
         return 1;
@@ -150,35 +209,33 @@ int __attribute__((always_inline)) discarded_by_pid(u64 event_type, u32 tgid) {
         .tgid = tgid,
     };
 
-    struct pid_discarder_parameters_t *params = bpf_map_lookup_elem(&pid_discarders, &key);
-
-    if (params == NULL || (event_type > 0 && params->timestamps[(event_type-1)&(EVENT_MAX_ROUNDED_UP-1)] != 0 && params->timestamps[(event_type-1)&(EVENT_MAX_ROUNDED_UP-1)] <= bpf_ktime_get_ns())) {
-        return 0;
-    }
-
-#ifdef DEBUG
-        bpf_printk("process with pid %d discarded\n", tgid);
-#endif
-    return mask_has_event(params->event_mask, event_type);
+    return is_discarded(&pid_discarders, &key, event_type);
 }
 
-// cache_syscall checks the event policy in order to see if the syscall struct can be cached
-int __attribute__((always_inline)) discarded_by_process(const char mode, u64 event_type) {
+int __attribute__((always_inline)) is_discarded_by_process(const char mode, u64 event_type) {
     if (mode != NO_FILTER) {
         u64 pid_tgid = bpf_get_current_pid_tgid();
         u32 tgid = pid_tgid >> 32;
 
         // try with pid first
-        if (discarded_by_pid(event_type, tgid))
+        if (is_discarded_by_pid(event_type, tgid))
             return 1;
 
         struct proc_cache_t *entry = get_proc_cache(tgid);
-        if (entry && discarded_by_inode(event_type, entry->executable.mount_id, entry->executable.inode, 0)) {
+        if (entry && is_discarded_by_inode(event_type, entry->executable.mount_id, entry->executable.inode, 0)) {
             return 1;
         }
     }
 
     return 0;
+}
+
+void __attribute__((always_inline)) remove_pid_discarder(u32 tgid) {
+    struct pid_discarder_t key = {
+        .tgid = tgid,
+    };
+
+    remove_discarder(&pid_discarders, &key);
 }
 
 #endif

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -44,7 +44,7 @@ int __attribute__((always_inline)) handle_discard_inode(void *data) {
     struct discard_inode_t discarder;
     bpf_probe_read(&discarder, sizeof(discarder), data);
 
-    return discard_inode(discarder.req.event_type, discarder.mount_id, discarder.inode, discarder.req.timeout);
+    return discard_inode(discarder.req.event_type, discarder.mount_id, discarder.inode, discarder.req.timeout, discarder.is_leaf);
 }
 
 int __attribute__((always_inline)) handle_discard_pid(void *data) {

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -1,0 +1,101 @@
+#ifndef _ERPC_H
+#define _ERPC_H
+
+#include "filters.h"
+
+#define RPC_CMD 0xdeadc001
+
+enum erpc_op {
+    UNKNOW_OP,
+    DISCARD_INODE_OP,
+    DISCARD_PID_OP
+};
+
+int __attribute__((always_inline)) handle_discard(void *data, u64 *event_type, u64 *timeout) {
+    u64 value;
+
+    bpf_probe_read(&value, sizeof(value), data);
+    *event_type = value;
+
+    bpf_probe_read(&value, sizeof(value), data + sizeof(value));
+    *timeout = value;
+
+    return 2*sizeof(value);
+}
+
+struct discard_request_t {
+    u64 event_type;
+    u64 timeout;
+};
+
+struct discard_inode_t {
+    struct discard_request_t req;
+    u64 inode;
+    u32 mount_id;
+    u32 is_leaf;
+};
+
+struct discard_pid_t {
+    struct discard_request_t req;
+    u32 pid;
+};
+
+int __attribute__((always_inline)) handle_discard_inode(void *data) {
+    struct discard_inode_t discarder;
+    bpf_probe_read(&discarder, sizeof(discarder), data);
+
+    return discard_inode(discarder.req.event_type, discarder.mount_id, discarder.inode, discarder.req.timeout);
+}
+
+int __attribute__((always_inline)) handle_discard_pid(void *data) {
+    struct discard_pid_t discarder;
+    bpf_probe_read(&discarder, sizeof(discarder), data);
+
+    return discard_pid(discarder.req.event_type, discarder.pid, discarder.req.timeout);
+}
+
+int __attribute__((always_inline)) is_eprc_request(struct pt_regs *ctx) {
+    u64 fd, pid;
+
+    LOAD_CONSTANT("erpc_fd", fd);
+    LOAD_CONSTANT("erpc_pid", pid);
+
+    u32 vfs_fd = PT_REGS_PARM2(ctx);
+    if (!vfs_fd || (u64)vfs_fd != fd) {
+        return 0;
+    }
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 tgid = pid_tgid >> 32;
+
+    if ((u64)tgid != pid) {
+        return 0;
+    }
+
+    u32 cmd = PT_REGS_PARM3(ctx);
+    if (cmd != RPC_CMD) {
+        return 0;
+    }
+
+    return 1;
+}
+
+int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
+    void *req = (void *)PT_REGS_PARM4(ctx);
+
+    u8 op;
+    bpf_probe_read(&op, sizeof(op), req);
+
+    void *data = req + sizeof(op);
+
+    switch (op) {
+        case DISCARD_INODE_OP:
+            return handle_discard_inode(data);
+        case DISCARD_PID_OP:
+            return handle_discard_pid(data);
+    }
+
+    return 0;
+}
+
+#endif

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -6,7 +6,7 @@
 #define RPC_CMD 0xdeadc001
 
 enum erpc_op {
-    UNKNOW_OP,
+    UNKNOWN_OP,
     DISCARD_INODE_OP,
     DISCARD_PID_OP
 };

--- a/pkg/security/ebpf/c/filters.h
+++ b/pkg/security/ebpf/c/filters.h
@@ -3,6 +3,8 @@
 
 #include "process.h"
 
+#define DISCARDER_RETENTION 5000000000 // 5 seconds
+
 enum policy_mode
 {
     NO_FILTER = 0,

--- a/pkg/security/ebpf/c/filters.h
+++ b/pkg/security/ebpf/c/filters.h
@@ -3,8 +3,6 @@
 
 #include "process.h"
 
-#define DISCARDER_RETENTION 5000000000 // 5 seconds
-
 enum policy_mode
 {
     NO_FILTER = 0,

--- a/pkg/security/ebpf/c/ioctl.h
+++ b/pkg/security/ebpf/c/ioctl.h
@@ -1,9 +1,15 @@
 #ifndef _IOCTL_H
 #define _IOCTL_H
 
+#include "erpc.h"
+
 SEC("kprobe/do_vfs_ioctl")
 int kprobe__do_vfs_ioctl(struct pt_regs *ctx) {
+    if (is_eprc_request(ctx)) {
+        return handle_erpc_request(ctx);
+    }
 
+    return 0;
 }
 
 #endif

--- a/pkg/security/ebpf/c/ioctl.h
+++ b/pkg/security/ebpf/c/ioctl.h
@@ -1,0 +1,9 @@
+#ifndef _IOCTL_H
+#define _IOCTL_H
+
+SEC("kprobe/do_vfs_ioctl")
+int kprobe__do_vfs_ioctl(struct pt_regs *ctx) {
+
+}
+
+#endif

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -19,7 +19,7 @@ int __attribute__((always_inline)) link_approvers(struct syscall_cache_t *syscal
 
 int __attribute__((always_inline)) trace__sys_link() {
     struct policy_t policy = fetch_policy(EVENT_LINK);
-    if (discarded_by_process(policy.mode, EVENT_LINK)) {
+    if (is_discarded_by_process(policy.mode, EVENT_LINK)) {
         return 0;
     }
 

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -19,7 +19,7 @@ int __attribute__((always_inline)) mkdir_approvers(struct syscall_cache_t *sysca
 
 long __attribute__((always_inline)) trace__sys_mkdir(umode_t mode) {
     struct policy_t policy = fetch_policy(EVENT_MKDIR);
-    if (discarded_by_process(policy.mode, EVENT_MKDIR)) {
+    if (is_discarded_by_process(policy.mode, EVENT_MKDIR)) {
         return 0;
     }
 

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -27,7 +27,7 @@ struct open_event_t {
 
 int __attribute__((always_inline)) trace__sys_openat(int flags, umode_t mode) {
     struct policy_t policy = fetch_policy(EVENT_OPEN);
-    if (discarded_by_process(policy.mode, EVENT_OPEN)) {
+    if (is_discarded_by_process(policy.mode, EVENT_OPEN)) {
         return 0;
     }
 

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -34,6 +34,8 @@
 #include "raw_syscalls.h"
 #include "procfs.h"
 #include "setxattr.h"
+#include "erpc.h"
+#include "ioctl.h"
 
 struct invalidate_dentry_event_t {
     struct kevent_t event;

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -49,7 +49,9 @@ void __attribute__((always_inline)) invalidate_inode(struct pt_regs *ctx, u32 mo
         return;
 
     if (!is_flushing_discarders()) {
-        remove_inode_discarder(mount_id, inode);
+        // remove both regular and parent discarders
+        remove_inode_discarder(mount_id, inode, 1);
+        remove_inode_discarder(mount_id, inode, 0);
     }
 
     if (send_invalidate_event) {

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -82,7 +82,7 @@ int kprobe__vfs_rename(struct pt_regs *ctx) {
     }
 
     // If we are discarded, we still want to invalidate the inode
-    if (discarded_by_process(syscall->policy.mode, EVENT_RENAME)) {
+    if (is_discarded_by_process(syscall->policy.mode, EVENT_RENAME)) {
         return mark_as_discarded(syscall);
     }
 

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -88,7 +88,7 @@ int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
             break;
     }
 
-    if (discarded_by_process(syscall->policy.mode, event_type)) {
+    if (is_discarded_by_process(syscall->policy.mode, event_type)) {
         return mark_as_discarded(syscall);
     }
 

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -14,7 +14,7 @@ struct setxattr_event_t {
 
 int __attribute__((always_inline)) trace__sys_setxattr(const char *xattr_name) {
     struct policy_t policy = fetch_policy(EVENT_SETXATTR);
-    if (discarded_by_process(policy.mode, EVENT_SETXATTR)) {
+    if (is_discarded_by_process(policy.mode, EVENT_SETXATTR)) {
         return 0;
     }
 
@@ -45,7 +45,7 @@ SYSCALL_KPROBE2(fsetxattr, int, fd, const char *, name) {
 
 int __attribute__((always_inline)) trace__sys_removexattr(const char *xattr_name) {
     struct policy_t policy = fetch_policy(EVENT_REMOVEXATTR);
-    if (discarded_by_process(policy.mode, EVENT_REMOVEXATTR)) {
+    if (is_discarded_by_process(policy.mode, EVENT_REMOVEXATTR)) {
         return 0;
     }
 

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -61,7 +61,7 @@ int kprobe__vfs_unlink(struct pt_regs *ctx) {
         return mark_as_discarded(syscall);
     }
 
-    if (discarded_by_process(syscall->policy.mode, EVENT_UNLINK)) {
+    if (is_discarded_by_process(syscall->policy.mode, EVENT_UNLINK)) {
         return mark_as_discarded(syscall);
     }
 

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -23,7 +23,7 @@ struct utime_event_t {
 
 int __attribute__((always_inline)) trace__sys_utimes() {
     struct policy_t policy = fetch_policy(EVENT_UTIME);
-    if (discarded_by_process(policy.mode, EVENT_UTIME)) {
+    if (is_discarded_by_process(policy.mode, EVENT_UTIME)) {
         return 0;
     }
 

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -29,6 +29,7 @@ func AllProbes() []*manager.Probe {
 	allProbes = append(allProbes, sharedProbes...)
 	allProbes = append(allProbes, getUnlinkProbes()...)
 	allProbes = append(allProbes, getXattrProbes()...)
+	allProbes = append(allProbes, getIoctlProbes()...)
 
 	allProbes = append(allProbes,
 		// Syscall monitor

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -189,6 +189,13 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		},
 	},
 
+	// List of probes to activate to capture mkdir events
+	"ioctl": {
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_vfs_ioctl"}},
+		}},
+	},
+
 	// List of probes to activate to capture open events
 	"open": {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -109,6 +109,11 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		&manager.OneOf{Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_dentry_open"}},
 		}},
+
+		// ioctl probes
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_vfs_ioctl"}},
+		}},
 	},
 
 	// List of probes to activate to capture chmod events
@@ -187,13 +192,6 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
 			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "mkdirat"}, EntryAndExit),
 		},
-	},
-
-	// List of probes to activate to capture mkdir events
-	"ioctl": {
-		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_vfs_ioctl"}},
-		}},
 	},
 
 	// List of probes to activate to capture open events

--- a/pkg/security/ebpf/probes/ioctl.go
+++ b/pkg/security/ebpf/probes/ioctl.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux
+
+package probes
+
+import "github.com/DataDog/ebpf/manager"
+
+// ioctlProbes holds the list of probes used to track ioctl events
+var ioctlProbes = []*manager.Probe{
+	{
+		UID:     SecurityAgentUID,
+		Section: "kprobe/do_vfs_ioctl",
+	},
+}
+
+func getIoctlProbes() []*manager.Probe {
+	return ioctlProbes
+}

--- a/pkg/security/ebpf/probes/mkdir.go
+++ b/pkg/security/ebpf/probes/mkdir.go
@@ -9,7 +9,7 @@ package probes
 
 import "github.com/DataDog/ebpf/manager"
 
-// mkdirProbes holds the list of probes used to track unlink events
+// mkdirProbes holds the list of probes used to track mkdir events
 var mkdirProbes = []*manager.Probe{
 	{
 		UID:     SecurityAgentUID,

--- a/pkg/security/model/events.go
+++ b/pkg/security/model/events.go
@@ -31,14 +31,14 @@ const (
 	FileChownEventType
 	// FileUtimeEventType Utime event
 	FileUtimeEventType
-	// FileMountEventType Mount event
-	FileMountEventType
-	// FileUmountEventType Umount event
-	FileUmountEventType
 	// FileSetXAttrEventType Setxattr event
 	FileSetXAttrEventType
 	// FileRemoveXAttrEventType Removexattr event
 	FileRemoveXAttrEventType
+	// FileMountEventType Mount event
+	FileMountEventType
+	// FileUmountEventType Umount event
+	FileUmountEventType
 	// ForkEventType Fork event
 	ForkEventType
 	// ExecEventType Exec event
@@ -50,8 +50,14 @@ const (
 	// MaxEventType is used internally to get the maximum number of kernel events.
 	MaxEventType
 
+	// FirstDiscarderEventType first event that accepts discarders
+	FirstDiscarderEventType = FileOpenEventType
+
+	// LastDiscarderEventType last event that accepts discarders
+	LastDiscarderEventType = FileRemoveXAttrEventType
+
 	// CustomLostReadEventType is the custom event used to report lost events detected in user space
-	CustomLostReadEventType
+	CustomLostReadEventType EventType = iota
 	// CustomLostWriteEventType is the custom event used to report lost events detected in kernel space
 	CustomLostWriteEventType
 	// CustomRulesetLoadedEventType is the custom event used to report that a new ruleset was loaded
@@ -64,9 +70,6 @@ const (
 	CustomTruncatedParentsEventType
 	// CustomTruncatedSegmentEventType is the custom event used to report that a segment of a path was truncated
 	CustomTruncatedSegmentEventType
-
-	// MaxEventRoundedUp is the closest power of 2 that is bigger than MaxEventType
-	MaxEventRoundedUp = 32
 )
 
 func (t EventType) String() string {

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -159,16 +159,6 @@ func newInodeDiscarders(inodesMap, revisionsMap *lib.Map, erpc *ERPC, dentryReso
 	}, nil
 }
 
-func (id *inodeDiscarders) removeInode(mountID uint32, inode uint64) {
-	key := inodeDiscarder{
-		PathKey: PathKey{
-			MountID: mountID,
-			Inode:   inode,
-		},
-	}
-	_ = id.Delete(&key)
-}
-
 func (id *inodeDiscarders) discardInode(eventType model.EventType, mountID uint32, inode uint64, isLeaf bool) error {
 	req := ERPCRequest{
 		OP: DiscardInodeOp,

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -80,7 +80,7 @@ var InvalidDiscarders = map[eval.Field][]interface{}{
 	"removexattr.filename": dentryInvalidDiscarder,
 }
 
-func discardMarshalHeader(req *ERPCRequest, eventType model.EventType, timeout uint64) int {
+func marshalDiscardHeader(req *ERPCRequest, eventType model.EventType, timeout uint64) int {
 	ebpf.ByteOrder.PutUint64(req.Data[0:8], uint64(eventType))
 	ebpf.ByteOrder.PutUint64(req.Data[8:16], uint64(timeout))
 
@@ -103,7 +103,7 @@ func (p *pidDiscarders) discard(eventType model.EventType, pid uint32) error {
 		OP: DiscardPidOp,
 	}
 
-	offset := discardMarshalHeader(&req, eventType, 0)
+	offset := marshalDiscardHeader(&req, eventType, 0)
 	ebpf.ByteOrder.PutUint32(req.Data[offset:offset+4], pid)
 
 	return p.erpc.Request(&req)
@@ -114,7 +114,7 @@ func (p *pidDiscarders) discardWithTimeout(eventType model.EventType, pid uint32
 		OP: DiscardPidOp,
 	}
 
-	offset := discardMarshalHeader(&req, eventType, uint64(timeout))
+	offset := marshalDiscardHeader(&req, eventType, uint64(timeout))
 	ebpf.ByteOrder.PutUint32(req.Data[offset:offset+4], pid)
 
 	return p.erpc.Request(&req)
@@ -169,7 +169,7 @@ func (id *inodeDiscarders) discardInode(eventType model.EventType, mountID uint3
 		isLeafInt = 1
 	}
 
-	offset := discardMarshalHeader(&req, eventType, 0)
+	offset := marshalDiscardHeader(&req, eventType, 0)
 	ebpf.ByteOrder.PutUint64(req.Data[offset:offset+8], inode)
 	ebpf.ByteOrder.PutUint32(req.Data[offset+8:offset+12], mountID)
 	ebpf.ByteOrder.PutUint32(req.Data[offset+12:offset+16], isLeafInt)

--- a/pkg/security/probe/erpc.go
+++ b/pkg/security/probe/erpc.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux
+
+package probe
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/DataDog/ebpf/manager"
+)
+
+const (
+	rpcCmd = 0xdeadc001
+
+	// ERPCMaxDataSize maximum size of data of a request
+	ERPCMaxDataSize = 256
+)
+
+// ERPC defines a krpc object
+type ERPC struct {
+	fd int
+}
+
+// ERPCRequest defines a EPRC request
+type ERPCRequest struct {
+	OP   uint8
+	Data [ERPCMaxDataSize]byte
+}
+
+// GetConstants returns the ebpf constants
+func (k *ERPC) GetConstants() []manager.ConstantEditor {
+	return []manager.ConstantEditor{
+		{
+			Name:  "erpc_fd",
+			Value: uint64(k.fd),
+		},
+		{
+			Name:  "erpc_pid",
+			Value: uint64(os.Getpid()),
+		},
+	}
+}
+
+// Request generates an ioctl syscall with the required request
+func (k *ERPC) Request(req *ERPCRequest) error {
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(k.fd), rpcCmd, uintptr(unsafe.Pointer(req))); errno != 0 {
+		if errno != syscall.ENOTTY {
+			return errno
+		}
+	}
+
+	return nil
+}
+
+// NewERPC returns a new ERPC object
+func NewERPC() (*ERPC, error) {
+	fd, err := syscall.Dup(syscall.Stdout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ERPC{
+		fd: fd,
+	}, nil
+}

--- a/pkg/security/probe/erpc.go
+++ b/pkg/security/probe/erpc.go
@@ -8,10 +8,10 @@
 package probe
 
 import (
-	"os"
 	"syscall"
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/ebpf/manager"
 )
 
@@ -42,7 +42,7 @@ func (k *ERPC) GetConstants() []manager.ConstantEditor {
 		},
 		{
 			Name:  "erpc_pid",
-			Value: uint64(os.Getpid()),
+			Value: uint64(utils.Getpid()),
 		},
 	}
 }

--- a/pkg/security/probe/kfilters_test.go
+++ b/pkg/security/probe/kfilters_test.go
@@ -9,8 +9,9 @@ package probe
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/security/log"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/log"
 
 	"github.com/DataDog/datadog-agent/pkg/security/model"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -51,7 +51,6 @@ type Probe struct {
 	_              uint32 // padding for goarch=386
 	ctx            context.Context
 	cancelFnc      context.CancelFunc
-
 	// Events section
 	handler   EventHandler
 	monitor   *Monitor
@@ -61,6 +60,7 @@ type Probe struct {
 	reOrderer *ReOrderer
 
 	// Approvers / discarders section
+	erpc               *ERPC
 	pidDiscarders      *pidDiscarders
 	inodeDiscarders    *inodeDiscarders
 	flushingDiscarders int64
@@ -164,7 +164,7 @@ func (p *Probe) Init(client *statsd.Client) error {
 	if err != nil {
 		return err
 	}
-	p.pidDiscarders = newPidDiscarders(pidDiscardersMap)
+	p.pidDiscarders = newPidDiscarders(pidDiscardersMap, p.erpc)
 
 	inodeDiscardersMap, err := p.Map("inode_discarders")
 	if err != nil {
@@ -176,7 +176,7 @@ func (p *Probe) Init(client *statsd.Client) error {
 		return err
 	}
 
-	if p.inodeDiscarders, err = newInodeDiscarders(inodeDiscardersMap, discarderRevisionsMap, p.resolvers.DentryResolver); err != nil {
+	if p.inodeDiscarders, err = newInodeDiscarders(inodeDiscardersMap, discarderRevisionsMap, p.erpc, p.resolvers.DentryResolver); err != nil {
 		return err
 	}
 
@@ -278,12 +278,6 @@ func (p *Probe) invalidateDentry(mountID uint32, inode uint64, revision uint32) 
 	} else {
 		log.Tracef("remove dentry cache entry for inode %d", inode)
 		p.resolvers.DentryResolver.DelCacheEntry(mountID, inode)
-
-		// If a temporary file is created and deleted in a row a discarder can be added
-		// after the in-kernel discarder cleanup and thus a discarder will be pushed for a deleted file.
-		// If the inode is reused this can be a problem.
-		// Call a user space remove function to ensure the discarder will be removed.
-		p.inodeDiscarders.removeInode(mountID, inode)
 	}
 }
 
@@ -704,6 +698,11 @@ func (p *Probe) NewRuleSet(opts *rules.Opts) *rules.RuleSet {
 func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
+	erpc, err := NewERPC()
+	if err != nil {
+		return nil, err
+	}
+
 	p := &Probe{
 		config:         config,
 		approvers:      make(map[eval.EventType]activeApprovers),
@@ -711,6 +710,7 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 		ctx:            ctx,
 		cancelFnc:      cancel,
 		statsdClient:   client,
+		erpc:           erpc,
 	}
 	p.detectKernelVersion()
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -606,15 +606,14 @@ func (p *Probe) FlushDiscarders() error {
 	time.Sleep(100 * time.Millisecond)
 
 	var discardedInodes []inodeDiscarder
-	var inodeParams inodeDiscarderParameters
+	var mapValue [256]byte
 	var inode inodeDiscarder
-	for entries := p.inodeDiscarders.Iterate(); entries.Next(&inode, &inodeParams); {
+	for entries := p.inodeDiscarders.Iterate(); entries.Next(&inode, &mapValue); {
 		discardedInodes = append(discardedInodes, inode)
 	}
 
 	var discardedPids []uint32
-	var pidParams pidDiscarderParameters
-	for pid, entries := uint32(0), p.pidDiscarders.Iterate(); entries.Next(&pid, &pidParams); {
+	for pid, entries := uint32(0), p.pidDiscarders.Iterate(); entries.Next(&pid, &mapValue); {
 		discardedPids = append(discardedPids, pid)
 	}
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -696,12 +696,12 @@ func (p *Probe) NewRuleSet(opts *rules.Opts) *rules.RuleSet {
 
 // NewProbe instantiates a new runtime security agent probe
 func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-
 	erpc, err := NewERPC()
 	if err != nil {
 		return nil, err
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
 
 	p := &Probe{
 		config:         config,
@@ -742,6 +742,8 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 			Value: getSuperBlockMagicOffset(p),
 		},
 	)
+	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, erpc.GetConstants()...)
+	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)
 
 	resolvers, err := NewResolvers(p, client)
 	if err != nil {

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -381,8 +381,10 @@ func newEventSerializer(event *Event) *EventSerializer {
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Umount.Retval)
 	case model.ForkEventType:
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(0)
+		s.Category = ProcessActivity
 	case model.ExitEventType:
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(0)
+		s.Category = ProcessActivity
 	case model.ExecEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newExecSerializer(&event.processCacheEntry.ExecEvent, event),

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -13,9 +13,12 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/pkg/errors"
+
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
 
 func openTestFile(test *testModule, filename string, flags int) (int, string, error) {
@@ -76,7 +79,7 @@ func TestOpenBasenameApproverFilter(t *testing.T) {
 func TestOpenLeafDiscarderFilter(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename =="{{.Root}}/test-obc-1" && open.flags & (O_CREAT | O_SYNC) > 0`,
+		Expression: `open.filename =~ "{{.Root}}/test-obc-1" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
@@ -225,5 +228,85 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 
 	if event, err := waitForOpenProbeEvent(test, testFile2); err == nil {
 		t.Fatalf("shouldn't get an event: %+v", event)
+	}
+}
+
+func TestDiscarderRetentionFilter(t *testing.T) {
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `open.filename =~ "{{.Root}}/test-obc-1" && open.flags & (O_CREAT | O_SYNC) > 0`,
+	}
+
+	testDrive, err := newTestDrive("xfs", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testDrive.Close()
+
+	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{testDir: testDrive.Root(), wantProbeEvents: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	fd1, testFile1, err := openTestFile(test, "test-obc-2", syscall.O_CREAT|syscall.O_SYNC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Close(fd1)
+	defer os.Remove(testFile1)
+
+	if _, err := waitForOpenDiscarder(test, testFile1); err != nil {
+		inode := getInode(t, testFile1)
+		parentInode := getInode(t, path.Dir(testFile1))
+
+		t.Fatalf("not able to get the expected event inode: %d, parent inode: %d", inode, parentInode)
+	}
+
+	fd2, testFile2, err := openTestFile(test, "test-obc-2", syscall.O_CREAT|syscall.O_SYNC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	syscall.Close(fd2)
+
+	if event, err := waitForOpenProbeEvent(test, testFile2); err == nil {
+		t.Fatalf("shouldn't get an event: %+v", event)
+	}
+
+	// check the retention, we should have event during the retention period
+	var discarded bool
+
+	start := time.Now()
+	end := start.Add(20 * time.Second)
+
+	newFile, _, err := test.Path("test-obc-renamed")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// rename to generate an invalidation of the discarder in kernel marking it as retained
+	if err := os.Rename(testFile2, newFile); err != nil {
+		t.Fatal(err)
+	}
+
+	for time.Now().Before(end) {
+		fd2, testFile2, err = openTestFile(test, "test-obc-renamed", syscall.O_CREAT|syscall.O_SYNC)
+		if err != nil {
+			t.Fatal(err)
+		}
+		syscall.Close(fd2)
+
+		if _, err := waitForOpenProbeEvent(test, testFile2); err != nil {
+			discarded = true
+			break
+		}
+	}
+
+	if !discarded {
+		t.Fatalf("should be discarded")
+	}
+
+	if diff := time.Now().Sub(start); uint64(diff) < uint64(probe.DiscardRetention)-uint64(time.Second) {
+		t.Errorf("discarder retention (%s) not reached: %s", time.Duration(uint64(probe.DiscardRetention)-uint64(time.Second)), diff)
 	}
 }

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/gopsutil/process"
@@ -19,6 +20,17 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
+
+// Getpid returns the current process ID in the host namespace
+func Getpid() int32 {
+	p, err := os.Readlink(filepath.Join(util.HostProc(), "/self"))
+	if err == nil {
+		if pid, err := strconv.Atoi(p); err == nil {
+			return int32(pid)
+		}
+	}
+	return int32(os.Getpid())
+}
 
 // MountInfoPath returns the path to the mountinfo file of the current pid in /proc
 func MountInfoPath() string {

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -401,6 +401,7 @@ def build_object_files(ctx, bundle_ebpf=False):
         '-fno-color-diagnostics',
         '-fno-unwind-tables',
         '-fno-asynchronous-unwind-tables',
+        '-fno-jump-tables',
         "-I{}".format(c_dir),
     ]
 


### PR DESCRIPTION
### What does this PR do?

This PR removes the userspace discarder map operation that were done to invalidate discarder. The discarder were invalidated by the userspace to prevent a race condition when an inode discarder can be pushed after the file deletion. The PR let the kernel ebpf code handling the discarder invalidation by introduction a retention period avoiding to discard an inode. In order to remove the race between the kernel and the userspace this PR introduce a mechanism to trigger multiple map operation from the userspace using the ioctl syscall.

### Motivation

This reduce the number of syscall to invalidate discarders

### Additional Notes

This also unify the timeout mechanism for the discarders

### Describe your test plan

The kitchen test are already there to ensure there is no regression introduce by this patch.
