### PR TITLE
[logs/k8s] Retry query to kubelet, partial reimplementation of #6626

### DIFF
--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -131,7 +131,7 @@ func (l *Launcher) scheduleServiceForRetry(svc *service.Service) {
 			backoff:          b,
 			removalScheduled: false,
 		}
-		l.pendingRetries[svc.GetEntityID()] = ops
+		l.pendingRetries[containerID] = ops
 	}
 	l.delayRetry(ops)
 }

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -11,13 +11,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/input"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/cenkalti/backoff"
 )
 
 const (
@@ -28,6 +31,12 @@ const (
 
 var errCollectAllDisabled = fmt.Errorf("%s disabled", config.ContainerCollectAll)
 
+type retryOps struct {
+	service          *service.Service
+	backoff          backoff.BackOff
+	removalScheduled bool
+}
+
 // Launcher looks for new and deleted pods to create or delete one logs-source per container.
 type Launcher struct {
 	sources            *config.LogSources
@@ -36,7 +45,9 @@ type Launcher struct {
 	kubeutil           kubelet.KubeUtilInterface
 	addedServices      chan *service.Service
 	removedServices    chan *service.Service
+	retryOperations    chan *retryOps
 	collectAll         bool
+	pendingRetries     map[string]*retryOps
 	serviceNameFunc    func(string, string) string // serviceNameFunc gets the service name from the tagger, it is in a separate field for testing purpose
 }
 
@@ -55,6 +66,8 @@ func NewLauncher(sources *config.LogSources, services *service.Services, collect
 		stopped:            make(chan struct{}),
 		kubeutil:           kubeutil,
 		collectAll:         collectAll,
+		pendingRetries:     make(map[string]*retryOps),
+		retryOperations:    make(chan *retryOps),
 		serviceNameFunc:    input.ServiceNameFromTags,
 	}
 	launcher.addedServices = services.GetAllAddedServices()
@@ -91,11 +104,49 @@ func (l *Launcher) run() {
 			l.addSource(service)
 		case service := <-l.removedServices:
 			l.removeSource(service)
+		case ops := <-l.retryOperations:
+			l.addSource(ops.service)
 		case <-l.stopped:
 			log.Info("Kubernetes launcher stopped")
 			return
 		}
 	}
+}
+
+func (l *Launcher) scheduleServiceForRetry(svc *service.Service) {
+	containerID := svc.GetEntityID()
+	ops, exists := l.pendingRetries[containerID]
+	if !exists {
+		b := &backoff.ExponentialBackOff{
+			InitialInterval:     500 * time.Millisecond,
+			RandomizationFactor: 0,
+			Multiplier:          2,
+			MaxInterval:         5 * time.Second,
+			MaxElapsedTime:      30 * time.Second,
+			Clock:               backoff.SystemClock,
+		}
+		b.Reset()
+		ops = &retryOps{
+			service:          svc,
+			backoff:          b,
+			removalScheduled: false,
+		}
+		l.pendingRetries[svc.GetEntityID()] = ops
+	}
+	l.delayRetry(ops)
+}
+
+func (l *Launcher) delayRetry(ops *retryOps) {
+	delay := ops.backoff.NextBackOff()
+	if delay == backoff.Stop {
+		log.Warnf("Unable to add source for container %v", ops.service.GetEntityID())
+		delete(l.pendingRetries, ops.service.GetEntityID())
+		return
+	}
+	go func() {
+		<-time.After(delay)
+		l.retryOperations <- ops
+	}()
 }
 
 // addSource creates a new log-source from a service by resolving the
@@ -110,6 +161,12 @@ func (l *Launcher) addSource(svc *service.Service) {
 
 	pod, err := l.kubeutil.GetPodForEntityID(svc.GetEntityID())
 	if err != nil {
+		if errors.IsRetriable(err) {
+			// Attempt to reschedule the source later
+			log.Debugf("Failed to fetch pod info for container %v, will retry: %v", svc.Identifier, err)
+			l.scheduleServiceForRetry(svc)
+			return
+		}
 		log.Warnf("Could not add source for container %v: %v", svc.Identifier, err)
 		return
 	}
@@ -135,11 +192,25 @@ func (l *Launcher) addSource(svc *service.Service) {
 
 	l.sourcesByContainer[svc.GetEntityID()] = source
 	l.sources.AddSource(source)
+
+	// Clean-up retry logic
+	if ops, exists := l.pendingRetries[svc.GetEntityID()]; exists {
+		if ops.removalScheduled {
+			// A removal was emitted while addSource was being retried
+			l.removeSource(ops.service)
+		}
+		delete(l.pendingRetries, svc.GetEntityID())
+	}
 }
 
 // removeSource removes a new log-source from a service
 func (l *Launcher) removeSource(service *service.Service) {
 	containerID := service.GetEntityID()
+	if ops, exists := l.pendingRetries[containerID]; exists {
+		// Service was added unsuccessfully and is being retried
+		ops.removalScheduled = true
+		return
+	}
 	if source, exists := l.sourcesByContainer[containerID]; exists {
 		delete(l.sourcesByContainer, containerID)
 		l.sources.RemoveSource(source)

--- a/pkg/logs/input/kubernetes/launcher_test.go
+++ b/pkg/logs/input/kubernetes/launcher_test.go
@@ -8,12 +8,15 @@
 package kubernetes
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 
 	"github.com/stretchr/testify/assert"
@@ -460,6 +463,98 @@ func TestGetShortImageName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRetry(t *testing.T) {
+	containerName := "fooName"
+	containerType := "docker"
+	containerID := "123456789abcdefoo"
+	imageName := "fooImage"
+	serviceName := "fooService"
+
+	l := &Launcher{
+		collectAll:         true,
+		kubeutil:           dummyKubeUtil{shouldRetry: true},
+		pendingRetries:     make(map[string]*retryOps),
+		retryOperations:    make(chan *retryOps),
+		serviceNameFunc:    func(n, e string) string { return serviceName },
+		sources:            config.NewLogSources(),
+		sourcesByContainer: make(map[string]*config.LogSource),
+	}
+
+	sourceOutputChan := l.sources.GetAddedForType(config.FileType)
+
+	service := service.NewService(containerType, containerID, service.After)
+	l.addSource(service)
+
+	ops := <-l.retryOperations
+
+	assert.Equal(t, containerType, ops.service.Type)
+	assert.Equal(t, containerID, ops.service.Identifier)
+
+	l.kubeutil = dummyKubeUtil{
+		name:        containerName,
+		id:          containerID,
+		image:       imageName,
+		shouldRetry: false,
+	}
+
+	go func() {
+		l.addSource(ops.service)
+	}()
+
+	source := <-sourceOutputChan
+	assert.Equal(t, 1, len(l.sourcesByContainer))
+
+	assert.Equal(t, containerID, source.Config.Identifier)
+	assert.Equal(t, serviceName, source.Config.Service)
+	assert.Equal(t, imageName, source.Config.Source)
+
+	assert.Equal(t, 0, len(l.pendingRetries))
+	assert.Equal(t, 1, len(l.sourcesByContainer))
+}
+
+type dummyKubeUtil struct {
+	kubelet.KubeUtilInterface
+	name        string
+	image       string
+	id          string
+	shouldRetry bool
+}
+
+func (d dummyKubeUtil) GetStatusForContainerID(pod *kubelet.Pod, containerID string) (kubelet.ContainerStatus, error) {
+	status := kubelet.ContainerStatus{
+		Name:  d.name,
+		Image: d.image,
+		ID:    d.id,
+		Ready: true,
+		State: kubelet.ContainerState{},
+	}
+	return status, nil
+}
+
+func (d dummyKubeUtil) GetSpecForContainerName(pod *kubelet.Pod, containerName string) (kubelet.ContainerSpec, error) {
+	spec := kubelet.ContainerSpec{
+		Name:  d.name,
+		Image: d.image,
+	}
+	return spec, nil
+}
+
+func (d dummyKubeUtil) GetPodForEntityID(entityID string) (*kubelet.Pod, error) {
+	if d.shouldRetry {
+		return nil, errors.NewRetriable("dummy error", fmt.Errorf("retriable error"))
+	}
+	pod := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{},
+		Spec: kubelet.Spec{
+			Containers: []kubelet.ContainerSpec{{
+				Name:  d.name,
+				Image: d.image,
+			}},
+		},
+	}
+	return pod, nil
 }
 
 func getLauncher(collectAll bool) *Launcher {


### PR DESCRIPTION
### What does this PR do?
Retry addSource when kubelet query fails with a retriable errors (Retriable errors have been introduced by #7045). 
It's is partial re-implementation of #6626 (has been reverted, hence this PR), but it waits outside the launcher go routine.

### Motivation
Prevent container from not being tailed when the kubelet api is transiently failing.

### Additional Notes
N/A

### Describe your test plan
Block trafic between kubelet/agent while creating pods with logs agent enabled.
"Artificially" tested it by adding a `sleep` before the call to `kubeutil.GetPodForEntityID(...)` and cut the network connection between the agent and kubelet to trigger a retriable error and restore connectivity to check that the retry actually happens for real.

In QA we should assess that the issue that occurred (consumption of new container event from k8s was too slow in the k8s launcher) with #6626 is not happening, from a practical standpoint it means assessing that no problem occur on host that have a relatively high pod churn rate (the cluster that had issues with #6626 also used a significant number of init container, that made the issue even worse) 