### PR TITLE
[networks] Avoid netlink for UDP timeouts

### DIFF
--- a/pkg/network/config/tracer_config.go
+++ b/pkg/network/config/tracer_config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 
@@ -81,10 +83,24 @@ func TracerConfigFromConfig(cfg *config.AgentConfig) *Config {
 	tracerConfig.EnableMonotonicCount = cfg.Windows.EnableMonotonicCount
 	tracerConfig.DriverBufferSize = cfg.Windows.DriverBufferSize
 
+	tracerConfig.UDPConnTimeout = getUDPConnTimeout()
+
 	return tracerConfig
 }
 
 func isIPv6EnabledOnHost() bool {
 	_, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
 	return err == nil
+}
+
+func getUDPConnTimeout() time.Duration {
+	content, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "sys/net/netfilter/nf_conntrack_udp_timeout_stream"))
+	if err != nil {
+		return 2 * time.Minute
+	}
+
+	if seconds, err := strconv.Atoi(string(content)); err == nil {
+		return time.Second * time.Duration(seconds)
+	}
+	return 2 * time.Minute
 }

--- a/pkg/network/tracer/event.go
+++ b/pkg/network/tracer/event.go
@@ -159,6 +159,10 @@ func (t *ConnTuple) isTCP() bool {
 	return connType(uint(t.metadata)) == network.TCP
 }
 
+func (t *ConnTuple) isUDP() bool {
+	return connType(uint(t.metadata)) == network.UDP
+}
+
 func (t *ConnTuple) isIPv4() bool {
 	return connFamily(uint(t.metadata)) == network.AFINET
 }


### PR DESCRIPTION


### What does this PR do?

Expiry is now handled differently for UDP and TCP. For TCP where
conntrack TTL is very long, we use a short expiry for userspace tracking
but use conntrack as a source of truth to keep long lived idle TCP conns
in the userspace state, while evicting closed TCP connections.   This is
important in systems like istio where a long lived (translated) TCP
connectino might time out of the eBPF, but stay alive in conntrack. When
the connection becmoes active again, the connection needs to have stayed
in the userspace conntrack. Thus we gate TCP expiry from userspace on a
connection being gone from conntrack.

However, this conntrack check incurs a netlink call which gets
expensive.

For UDP, the conntrack TTL is low enough (two minutes), that we can
use the same TTL in userspace, and safely assume if a UDP connection
times out of userspace it is also gone from conntrack.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
