### PR TITLE
[orchestrator] add config tests and use viper auto register of envar

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -680,6 +680,7 @@ func InitConfig(config Config) {
 	// enabling/disabling the environment variables & command scrubbing from the container specs
 	// this option will potentially impact the CPU usage of the agent
 	config.BindEnvAndSetDefault("orchestrator_explorer.container_scrubbing.enabled", true)
+	config.SetKnown("orchestrator_explorer.custom_sensitive_words")
 
 	// Orchestrator Explorer - process agent
 	config.BindEnv("orchestrator_explorer.orchestrator_dd_url", "") //nolint:errcheck

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -680,7 +680,7 @@ func InitConfig(config Config) {
 	// enabling/disabling the environment variables & command scrubbing from the container specs
 	// this option will potentially impact the CPU usage of the agent
 	config.BindEnvAndSetDefault("orchestrator_explorer.container_scrubbing.enabled", true)
-	config.SetKnown("orchestrator_explorer.custom_sensitive_words")
+	config.BindEnvAndSetDefault("orchestrator_explorer.custom_sensitive_words", []string{})
 
 	// Orchestrator Explorer - process agent
 	config.BindEnv("orchestrator_explorer.orchestrator_dd_url", "") //nolint:errcheck

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -8,7 +8,6 @@ package config
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -63,7 +62,6 @@ func key(pieces ...string) string {
 
 // LoadYamlConfig load orchestrator-specific configuration
 func (oc *OrchestratorConfig) LoadYamlConfig(path string) error {
-	loadEnvVariables()
 	// Resolve any secrets
 	if err := config.ResolveSecrets(config.Datadog, filepath.Base(path)); err != nil {
 		return err
@@ -118,12 +116,6 @@ func (oc *OrchestratorConfig) LoadYamlConfig(path string) error {
 	oc.ExtraTags = config.Datadog.GetStringSlice("orchestrator_explorer.extra_tags")
 
 	return nil
-}
-
-func loadEnvVariables() {
-	if v := os.Getenv("DD_ORCHESTRATOR_CUSTOM_SENSITIVE_WORDS"); v != "" {
-		config.Datadog.Set(key(orchestratorNS, "custom_sensitive_words"), strings.Split(v, ","))
-	}
 }
 
 func extractOrchestratorAdditionalEndpoints(URL *url.URL, orchestratorEndpoints *[]api.Endpoint) error {

--- a/pkg/orchestrator/config/config_test.go
+++ b/pkg/orchestrator/config/config_test.go
@@ -7,7 +7,6 @@ package config
 
 import (
 	"net/url"
-	"os"
 	"testing"
 
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -136,15 +135,14 @@ func (suite *YamlConfigTestSuite) TestNoEnvConfigArgsScrubbing() {
 	}
 
 	for i := range cases {
-		a, _ := orchestratorCfg.Scrubber.ScrubSimpleCommand(cases[i].cmdline)
-		suite.Equal(a, cases[i].parsedCmdline)
+		actual, _ := orchestratorCfg.Scrubber.ScrubSimpleCommand(cases[i].cmdline)
+		suite.Equal(cases[i].parsedCmdline, actual)
 	}
 }
 
 func (suite *YamlConfigTestSuite) TestOnlyEnvConfigArgsScrubbing() {
 
-	os.Setenv("DD_ORCHESTRATOR_CUSTOM_SENSITIVE_WORDS", "token,consul")
-	defer os.Unsetenv("DD_ORCHESTRATOR_CUSTOM_SENSITIVE_WORDS")
+	suite.config.Set("orchestrator_explorer.custom_sensitive_words", `["token","consul"]`)
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
 	err := orchestratorCfg.LoadYamlConfig("")
@@ -161,15 +159,14 @@ func (suite *YamlConfigTestSuite) TestOnlyEnvConfigArgsScrubbing() {
 	}
 
 	for i := range cases {
-		a, _ := orchestratorCfg.Scrubber.ScrubSimpleCommand(cases[i].cmdline)
-		suite.Equal(a, cases[i].parsedCmdline)
+		actual, _ := orchestratorCfg.Scrubber.ScrubSimpleCommand(cases[i].cmdline)
+		suite.Equal(cases[i].parsedCmdline, actual)
 	}
 }
 
 func (suite *YamlConfigTestSuite) TestOnlyEnvContainsConfigArgsScrubbing() {
 
-	os.Setenv("DD_ORCHESTRATOR_CUSTOM_SENSITIVE_WORDS", "token,consul")
-	defer os.Unsetenv("DD_ORCHESTRATOR_CUSTOM_SENSITIVE_WORDS")
+	suite.config.Set("orchestrator_explorer.custom_sensitive_words", `["token","consul"]`)
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
 	err := orchestratorCfg.LoadYamlConfig("")
@@ -198,8 +195,8 @@ func (suite *YamlConfigTestSuite) TestOnlyEnvContainsConfigArgsScrubbing() {
 	}
 
 	for i := range cases {
-		hasWord := orchestratorCfg.Scrubber.ContainsSensitiveWord(cases[i].word)
-		suite.Equal(hasWord, cases[i].expected)
+		actual := orchestratorCfg.Scrubber.ContainsSensitiveWord(cases[i].word)
+		suite.Equal(cases[i].expected, actual)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

- adding tests for our config sensitive words usage 
- register `DD_ORCHESTRATOR_EXPLORER_CUSTOM_SENSITIVE_WORDS` by making it known by binding the envVar

### Motivation

adding tests to show use-cases

### Example Cases

Usage should be using the DD_ORCHESTRATOR_EXPLORER_CUSTOM_SENSITIVE_WORDS env.
Both should work:
```
            - name: DD_ORCHESTRATOR_CUSTOM_SENSITIVE_WORDS
              value: 'gitlab_token,consul_token'
            - name: DD_ORCHESTRATOR_CUSTOM_SENSITIVE_WORDS
            - value: ["token","consul"]
```