### PR TITLE
[logs] changing process-agent log message to only log nonempty queues

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -205,10 +205,13 @@ func (l *Collector) run(exit chan struct{}) error {
 				updateQueueBytes(processResults.Weight(), podResults.Weight())
 				updateQueueSize(processResults.Len(), podResults.Len())
 			case <-queueLogTicker.C:
-				log.Infof(
-					"Delivery queues: process[size=%d, weight=%d], pod[size=%d, weight=%d]",
-					processResults.Len(), processResults.Weight(), podResults.Len(), podResults.Weight(),
-				)
+				processSize, podSize := processResults.Len(), podResults.Len()
+				if processSize > 0 || podSize > 0 {
+					log.Infof(
+						"Delivery queues: process[size=%d, weight=%d], pod[size=%d, weight=%d]",
+						processSize, processResults.Weight(), podSize, podResults.Weight(),
+					)
+				}
 			case <-exit:
 				return
 			}


### PR DESCRIPTION
### What does this PR do?

Changing process-agent log message to only log nonempty queues. 

### Motivation

We should only log helpful messages. We were logging messages like 
`2020-12-30 18:23:33 EST | PROCESS | INFO | (collector.go:208 in func1) | Delivery queues: process[size=0, weight=0], pod[size=0, weight=0]`

### Additional Notes

Since size of the queue is changing, two consecutive calls may have different results. Hence I made one call to `Len()` functions and saved the variables. 

### Describe your test plan

Make sure that no statements matching `Delivery queues: process[size=0, weight=0], pod[size=0, weight=0]` is logged.