### PR TITLE
Re-enable the `kubelet` check when running on Kubernetes

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-kubernetes.sh
+++ b/Dockerfiles/agent/entrypoint/50-kubernetes.sh
@@ -11,6 +11,12 @@ if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
         /etc/datadog-agent/datadog.yaml
 fi
 
+# Enable kubernetes integrations (don't fail if integration absent)
+if [[ ! -e /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default ]]; then
+    mv /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.example \
+    /etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
+fi
+
 # The apiserver check requires leader election to be enabled
 if [[ "$DD_LEADER_ELECTION" == "true" ]] && [[ ! -e /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default ]]; then
     mv /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.example \


### PR DESCRIPTION
### What does this PR do?

Re-enable the `kubelet` check when running on Kubernetes.

### Motivation

The `kubelet` check seems to not be automatically scheduled on Kubernetes anymore

### Additional Notes



### Describe your test plan

Start the agent on a Kubernetes cluster. The `kubelet` check should be properly scheduled.