### PR TITLE
[cmd/health] Do not resolve secrets + fix CLI options

### DIFF
--- a/cmd/agent/app/health.go
+++ b/cmd/agent/app/health.go
@@ -10,5 +10,5 @@ import (
 )
 
 func init() {
-	AgentCmd.AddCommand(commands.Health(loggerName, confFilePath, flagNoColor))
+	AgentCmd.AddCommand(commands.Health(loggerName, &confFilePath, &flagNoColor))
 }

--- a/cmd/agent/common/commands/health.go
+++ b/cmd/agent/common/commands/health.go
@@ -33,7 +33,9 @@ func Health(loggerName config.LoggerName, confPath string, flagNoColor bool) *co
 				config.Datadog.SetConfigName("datadog-cluster")
 			}
 
-			err := common.SetupConfig(confPath)
+			// Set up config without secrets so that running the health command (e.g. from container
+			// liveness probe script) does not trigger a secret backend command call.
+			err := common.SetupConfigWithoutSecrets(confPath, "")
 			if err != nil {
 				return fmt.Errorf("unable to set up global agent configuration: %v", err)
 			}

--- a/cmd/agent/common/commands/health.go
+++ b/cmd/agent/common/commands/health.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Health returns a cobra command to report on the agent's health
-func Health(loggerName config.LoggerName, confPath string, flagNoColor bool) *cobra.Command {
+func Health(loggerName config.LoggerName, confPath *string, flagNoColor *bool) *cobra.Command {
 	return &cobra.Command{
 		Use:          "health",
 		Short:        "Print the current agent health",
@@ -25,7 +25,7 @@ func Health(loggerName config.LoggerName, confPath string, flagNoColor bool) *co
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if flagNoColor {
+			if *flagNoColor {
 				color.NoColor = true
 			}
 
@@ -35,7 +35,7 @@ func Health(loggerName config.LoggerName, confPath string, flagNoColor bool) *co
 
 			// Set up config without secrets so that running the health command (e.g. from container
 			// liveness probe script) does not trigger a secret backend command call.
-			err := common.SetupConfigWithoutSecrets(confPath, "")
+			err := common.SetupConfigWithoutSecrets(*confPath, "")
 			if err != nil {
 				return fmt.Errorf("unable to set up global agent configuration: %v", err)
 			}

--- a/cmd/cluster-agent/app/health.go
+++ b/cmd/cluster-agent/app/health.go
@@ -12,5 +12,5 @@ import (
 )
 
 func init() {
-	ClusterAgentCmd.AddCommand(commands.Health(loggerName, confPath, flagNoColor))
+	ClusterAgentCmd.AddCommand(commands.Health(loggerName, &confPath, &flagNoColor))
 }

--- a/releasenotes/notes/health-cmd-without-secrets-c8d9abe36c225aa8.yaml
+++ b/releasenotes/notes/health-cmd-without-secrets-c8d9abe36c225aa8.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Do not invoke the secret backend command (if configured) when the agent
+    health command/agent container liveness probe is called.
+  - |
+    Fix parsing of CLI options of the ``agent health`` command


### PR DESCRIPTION
### What does this PR do?

Fixes 2 regressions introduced in https://github.com/DataDog/datadog-agent/pull/6144 (agent 7.23.0):

1. Do not resolve the secrets in the agent's configuration: resolving secrets can be relatively costly for the secret backend command, and since the health command is frequently called by the container liveness probe (see [probe.sh](https://github.com/DataDog/datadog-agent/blob/268463deeb9d9c517c8aaa9624aee012a44206a0/Dockerfiles/agent/probe.sh#L3)), this can cause an unnecessary load on the actual secret backend. For reference, see the PR that originally disabled resolving secrets across a large number of commands that don't require it: https://github.com/DataDog/datadog-agent/pull/3208. Note that our k8s helm chart now configures the liveness/readiness probe as [direct http requests to the Agent's API](https://github.com/DataDog/datadog-agent/blob/e9cb55fb06525528d0f1940848fbd9f96e8884e5/Dockerfiles/manifests/agent-only/daemonset.yaml#L79-L98) instead of running the `health` command, so isn't affected.
2. Fix the CLI options of this command (`--cfgpath` and `--no-color`), which were being ignored.

### Additional Notes

I validated the change works on the `agent` binary, and @juliogreff did for the `cluster-agent`.

### Describe your test plan

This should be QA'ed on both the `agent health` command and the `cluster-agent health` command:
1. configure a `secret_backend_command`: it should not be called when the `agent health` command is run
2. check that the CLI options of the `health` command are actually taken into account
