### PR TITLE
Preserve numbers in probe expvar names but strip UID/PID

### DIFF
--- a/pkg/ebpf/probes.go
+++ b/pkg/ebpf/probes.go
@@ -33,14 +33,14 @@ func (c *Config) ChooseSyscallProbe(tracepoint string, x64probe string, fallback
 	if len(fparts) != 2 {
 		return "", fmt.Errorf("invalid fallback probe name")
 	}
-	syscall := fparts[1]
+	syscall := strings.TrimPrefix(fparts[1], "sys_")
 
 	if x64probe != "" {
 		xparts := strings.Split(x64probe, "/")
 		if len(xparts) < 2 {
 			return "", fmt.Errorf("invalid x64 probe name")
 		}
-		if xparts[1] != syscall {
+		if strings.TrimPrefix(xparts[1], "sys_") != syscall {
 			return "", fmt.Errorf("x64 and fallback probe syscalls do not match")
 		}
 	}

--- a/pkg/network/tracer/string.go
+++ b/pkg/network/tracer/string.go
@@ -7,7 +7,7 @@ func snakeToCapInitialCamel(s string) string {
 	n := ""
 	capNext := true
 	for _, v := range s {
-		if v >= 'A' && v <= 'Z' {
+		if (v >= 'A' && v <= 'Z') || (v >= '0' && v <= '9') {
 			n += string(v)
 		}
 		if v >= 'a' && v <= 'z' {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -115,8 +115,8 @@ func TestTracerExpvar(t *testing.T) {
 			"PTcpSendmsgMisses",
 			"PTcpSetStateHits",
 			"PTcpSetStateMisses",
-			"PTcpVDestroySockHits",
-			"PTcpVDestroySockMisses",
+			"PTcpV4DestroySockHits",
+			"PTcpV4DestroySockMisses",
 			"PUdpDestroySockHits",
 			"PUdpDestroySockMisses",
 			"PUdpRecvmsgHits",
@@ -135,14 +135,14 @@ func TestTracerExpvar(t *testing.T) {
 	}
 
 	archSpecificKprobes := [][]string{
-		{"PSySBindHits", "PXSysBindHits"},
-		{"PSySBindMisses", "PXSysBindMisses"},
-		{"PSySSocketHits", "PXSysSocketHits"},
-		{"PSySSocketMisses", "PXSysSocketMisses"},
-		{"RSySBindHits", "RXSysBindHits"},
-		{"RSySBindMisses", "RXSysBindMisses"},
-		{"RSySSocketHits", "RXSysSocketHits"},
-		{"RSySSocketMisses", "RXSysSocketMisses"},
+		{"PSysBindHits", "PX64SysBindHits"},
+		{"PSysBindMisses", "PX64SysBindMisses"},
+		{"PSysSocketHits", "PX64SysSocketHits"},
+		{"PSysSocketMisses", "PX64SysSocketMisses"},
+		{"RSysBindHits", "RX64SysBindHits"},
+		{"RSysBindMisses", "RX64SysBindMisses"},
+		{"RSysSocketHits", "RX64SysSocketHits"},
+		{"RSysSocketMisses", "RX64SysSocketMisses"},
 	}
 
 	for _, et := range expvarTypes {


### PR DESCRIPTION
### What does this PR do?

Preserve numbers in probe expvar names but strip UID/PID.

### Motivation

Important numbers such as `4`, `6`, and `64` (for IPv4, IPv6, and 64bit) were being removed from the expvar names. This could cause confusion and name collision. This allows numbers in expvar names, while also stripping UID/PID from the event name. It also enforces consistent casing.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

`TestTracerExpvar` should continue to pass.