### PR TITLE
[TEST] Possible issue with tags

### DIFF
--- a/pkg/collector/corechecks/net/network.go
+++ b/pkg/collector/corechecks/net/network.go
@@ -150,7 +150,6 @@ func (c *NetworkCheck) Run() error {
 	for i := 0; i < 1000; i++ {
 		sendMetric(sender, rowTags)
 	}
-	return nil
 
 	ioByInterface, err := c.net.IOCounters(true)
 	if err != nil {

--- a/pkg/collector/corechecks/net/network.go
+++ b/pkg/collector/corechecks/net/network.go
@@ -115,12 +115,43 @@ func (n defaultNetworkStats) NetstatTCPExtCounters() (map[string]int64, error) {
 	return netstatTCPExtCounters()
 }
 
+func sendMetric(sender aggregator.Sender, tags []string) {
+	if !checkContainsTag(tags, "mytag1") {
+		log.Errorf("missing tag %s in %v", "mytag1", tags)
+	}
+	if !checkContainsTag(tags, "mytag2") {
+		log.Errorf("missing tag %s in %v", "mytag2", tags)
+	}
+	if !checkContainsTag(tags, "mytag3") {
+		log.Errorf("missing tag %s in %v", "mytag3", tags)
+	}
+
+	sender.Gauge("metric.name", 1.0, "", tags)
+}
+
+func checkContainsTag(tags []string, tagToFind string) bool {
+	for _, tag := range tags {
+		if tag == tagToFind {
+			return true
+		}
+	}
+	log.Warnf("missing tag %s in %v", tagToFind, tags)
+	return false
+}
+
 // Run executes the check
 func (c *NetworkCheck) Run() error {
 	sender, err := aggregator.GetSender(c.ID())
 	if err != nil {
 		return err
 	}
+
+	rowTags := []string{"mytag1", "mytag2", "mytag3"}
+	rowTags = append(rowTags, "abc")
+	for i := 0; i < 10; i++ {
+		sendMetric(sender, rowTags)
+	}
+	return nil
 
 	ioByInterface, err := c.net.IOCounters(true)
 	if err != nil {

--- a/pkg/collector/corechecks/net/network.go
+++ b/pkg/collector/corechecks/net/network.go
@@ -147,7 +147,7 @@ func (c *NetworkCheck) Run() error {
 
 	rowTags := []string{"mytag1", "mytag2", "mytag3"}
 	rowTags = append(rowTags, "abc")
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 1000; i++ {
 		sendMetric(sender, rowTags)
 	}
 	return nil

--- a/pkg/collector/corechecks/net/network.go
+++ b/pkg/collector/corechecks/net/network.go
@@ -135,7 +135,6 @@ func checkContainsTag(tags []string, tagToFind string) bool {
 			return true
 		}
 	}
-	log.Warnf("missing tag %s in %v", tagToFind, tags)
 	return false
 }
 


### PR DESCRIPTION
### What does this PR do?

When `tags` are passed to sender (e.g. `sender.Gauge`) they seems to be changed **occasionally** in unexpected way.

### How to reproduce

1/ Change `/etc/datadog-agent/conf.d/network.d/conf.yaml.default` content to:
```
instances:
  - collect_connection_state: false
    tags:
      - foo:bar
```
Having instance tags is necessary to reproduce the issue.

2/ Checkout this branch

3/ Then build the agent and run network check as follow:

```
$ inv agent.build --python-runtimes 3
$ for i in `seq 1 100`; do echo $i; ./bin/agent/agent check network -l info | grep 'missing tag'; done
```
We are running the `agent check network` multiple times since the issue doesn't happen consistently.

You should see some log lines like this:
```
2021-01-13 10:55:07 UTC | CORE | ERROR | (pkg/collector/corechecks/net/network.go:126 in sendMetric) | missing tag mytag3 in [abc foo:bar mytag1 mytag2]
2021-01-13 10:55:07 UTC | CORE | ERROR | (pkg/collector/corechecks/net/network.go:126 in sendMetric) | missing tag mytag3 in [abc foo:bar mytag1 mytag2]
2021-01-13 10:55:07 UTC | CORE | ERROR | (pkg/collector/corechecks/net/network.go:126 in sendMetric) | missing tag mytag3 in [abc foo:bar mytag1 mytag2]
```

The issue: `mytag3` is not present sometimes.

### Motivation

Possible bug.

### Additional Notes

- the issue seems to not happen (or less often) when we pass a copy of the tags to `sender.Gauge` (it happened that even giving a copy to Gauge the issue still happen, but not easy to reproduce)
- the issue seems to not happen (or less often) when this line is removed https://github.com/DataDog/datadog-agent/blob/master/pkg/aggregator/sender.go#L232

### Describe your test plan
