### PR TITLE
Collect & send resources manifests (json definition) separately

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	model "github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
@@ -224,6 +225,10 @@ func (l *Collector) run(exit chan struct{}) error {
 	podForwarderOpts.DisableAPIKeyChecking = true
 	podForwarderOpts.RetryQueueSize = l.cfg.QueueSize // Allow more in-flight requests than the default
 	podForwarder := forwarder.NewDefaultForwarder(podForwarderOpts)
+
+	// start orchestrator manifest collector
+	orchestrator.InitManifestCollector(l.cfg.Orchestrator, l.cfg.HostName)
+	go orchestrator.Collector.Start(exit)
 
 	if err := processForwarder.Start(); err != nil {
 		return fmt.Errorf("error starting forwarder: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.49.0+incompatible
+	github.com/DataDog/agent-payload v4.52.0+incompatible
 	github.com/DataDog/datadog-go v4.2.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
 	github.com/DataDog/ebpf v0.0.0-20210104093318-524278fe0bfe

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload v4.49.0+incompatible h1:CKWb5v7M6o3b5JHbX43qs1bswTri8LH7cmfIKQrEtyk=
 github.com/DataDog/agent-payload v4.49.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.52.0+incompatible h1:GEpqrGtKV/gmUjAnRMski9s3e+1vnkJHKeBzzVjpd6c=
+github.com/DataDog/agent-payload v4.52.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -33,6 +33,8 @@ const (
 	PayloadTypeService = "service"
 	// PayloadTypeNode is the name of the node payload type
 	PayloadTypeNode = "node"
+	// PayloadTypeManifest is the name of the manifest payload type
+	PayloadTypeManifest = "manifest"
 )
 
 var (
@@ -42,6 +44,7 @@ var (
 	transactionsIntakeReplicaSet = expvar.Int{}
 	transactionsIntakeService    = expvar.Int{}
 	transactionsIntakeNode       = expvar.Int{}
+	transactionsIntakeManifest   = expvar.Int{}
 
 	v1SeriesEndpoint       = endpoint{"/api/v1/series", "series_v1"}
 	v1CheckRunsEndpoint    = endpoint{"/api/v1/check_run", "check_run_v1"}
@@ -91,6 +94,7 @@ func initOrchestratorExpVars() {
 	transactionsExpvars.Set("ReplicaSets", &transactionsIntakeReplicaSet)
 	transactionsExpvars.Set("Services", &transactionsIntakeService)
 	transactionsExpvars.Set("Nodes", &transactionsIntakeNode)
+	transactionsExpvars.Set("Manifests", &transactionsIntakeNode)
 }
 
 const (
@@ -600,6 +604,8 @@ func (f *DefaultForwarder) SubmitOrchestratorChecks(payload Payloads, extra http
 		transactionsIntakeService.Add(1)
 	case PayloadTypeNode:
 		transactionsIntakeNode.Add(1)
+	case PayloadTypeManifest:
+		transactionsIntakeManifest.Add(1)
 	}
 
 	return f.submitProcessLikePayload(orchestratorEndpoint, payload, extra, true)

--- a/pkg/orchestrator/manifest.go
+++ b/pkg/orchestrator/manifest.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package orchestrator
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	model "github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Collector is the public manifest collector instance
+var Collector *ManifestCollector
+
+// ManifestCollector buffers and sends manifest
+type ManifestCollector struct {
+	buffer     []*model.Manifest
+	bufferLock sync.Mutex
+	sender     *Sender
+	groupID    int32
+	cfg        *config.OrchestratorConfig
+}
+
+// InitManifestCollector inits the public collector
+func InitManifestCollector(cfg *config.OrchestratorConfig, hostName string) {
+	Collector = &ManifestCollector{
+		sender:  NewSender(cfg, hostName),
+		groupID: rand.Int31(),
+		cfg:     cfg,
+	}
+}
+
+// BufferManifest buffers manifest before sending them
+func (m *ManifestCollector) BufferManifest(manifests []*model.Manifest) {
+	m.bufferLock.Lock()
+	m.buffer = append(m.buffer, manifests...)
+	m.bufferLock.Unlock()
+}
+
+// Start starts the manifest collector
+func (m *ManifestCollector) Start(stopCh <-chan struct{}) {
+	if err := m.sender.Start(); err != nil {
+		log.Errorf("Error starting manifest forwarder: %s", err)
+		return
+	}
+	defer m.sender.Stop()
+	go wait.Until(m.sendManifests, 10*time.Second, stopCh)
+	<-stopCh
+}
+
+func (m *ManifestCollector) sendManifests() {
+	m.bufferLock.Lock()
+	defer m.bufferLock.Unlock()
+
+	if len(m.buffer) == 0 {
+		return
+	}
+
+	clusterID, err := clustername.GetClusterID()
+	if err != nil {
+		log.Errorf("Error sending manifests, could not get cluster ID: %s", err)
+		return
+	}
+
+	groupSize := len(m.buffer) / m.cfg.MaxPerMessage
+	if len(m.buffer)%m.cfg.MaxPerMessage != 0 {
+		groupSize++
+	}
+	chunkedManifests := chunkManifests(m.buffer, groupSize, m.cfg.MaxPerMessage)
+	manifestMessages := make([]model.MessageBody, 0, groupSize)
+	for i := 0; i < groupSize; i++ {
+		manifestMessages = append(manifestMessages, &model.CollectorManifest{
+			ClusterName: m.cfg.KubeClusterName,
+			Manifests:   chunkedManifests[i],
+			GroupId:     m.groupID,
+			GroupSize:   int32(groupSize),
+			ClusterId:   clusterID,
+		})
+	}
+	m.sender.SendMessages(manifestMessages, forwarder.PayloadTypeManifest)
+	// clear the buffer
+	m.buffer = nil
+}
+
+// chunkManifests formats and chunks the pods into a slice of chunks using a specific number of chunks.
+func chunkManifests(manifests []*model.Manifest, chunkCount, chunkSize int) [][]*model.Manifest {
+	chunks := make([][]*model.Manifest, 0, chunkCount)
+
+	for c := 1; c <= chunkCount; c++ {
+		var (
+			chunkStart = chunkSize * (c - 1)
+			chunkEnd   = chunkSize * (c)
+		)
+		// last chunk may be smaller than the chunk size
+		if c == chunkCount {
+			chunkEnd = len(manifests)
+		}
+		chunks = append(chunks, manifests[chunkStart:chunkEnd])
+	}
+
+	return chunks
+}

--- a/pkg/orchestrator/manifest_test.go
+++ b/pkg/orchestrator/manifest_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package orchestrator
+
+import (
+	"testing"
+
+	model "github.com/DataDog/agent-payload/process"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunkManifests(t *testing.T) {
+	manifests := []*model.Manifest{
+		{
+			Uid: "1",
+		},
+		{
+			Uid: "2",
+		},
+		{
+			Uid: "3",
+		},
+		{
+			Uid: "4",
+		},
+		{
+			Uid: "5",
+		},
+	}
+	expected := [][]*model.Manifest{
+		{{
+			Uid: "1",
+		},
+			{
+				Uid: "2",
+			}},
+		{{
+			Uid: "3",
+		},
+			{
+				Uid: "4",
+			}},
+		{{
+			Uid: "5",
+		}},
+	}
+	actual := chunkManifests(manifests, 3, 2)
+	assert.ElementsMatch(t, expected, actual)
+}

--- a/pkg/orchestrator/transport.go
+++ b/pkg/orchestrator/transport.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package orchestrator
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	model "github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator/config"
+	"github.com/DataDog/datadog-agent/pkg/process/util/api"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Sender exposes a way to send orchestrator payload
+type Sender struct {
+	hostName  string
+	forwarder forwarder.Forwarder
+}
+
+// Start starts the sender's forwarder
+func (s *Sender) Start() error {
+	if err := s.forwarder.Start(); err != nil {
+		log.Errorf("Error starting manifest forwarder: %s", err)
+		return err
+	}
+	return nil
+}
+
+// Stop stops the sender's forwarder
+func (s *Sender) Stop() {
+	s.forwarder.Stop()
+}
+
+// NewSender returns a new sender
+func NewSender(cfg *config.OrchestratorConfig, hostname string) *Sender {
+	keysPerDomain := api.KeysPerDomains(cfg.OrchestratorEndpoints)
+	orchestratorForwarderOpts := forwarder.NewOptions(keysPerDomain)
+	orchestratorForwarderOpts.DisableAPIKeyChecking = true
+
+	return &Sender{
+		hostName:  hostname,
+		forwarder: forwarder.NewDefaultForwarder(orchestratorForwarderOpts),
+	}
+}
+
+// SendMessages sends a message to the orchestrator intake
+func (s *Sender) SendMessages(msg []model.MessageBody, payloadType string) {
+	clusterID, err := clustername.GetClusterID()
+	if err != nil {
+		log.Errorf("Could not send manifest messages: %s", err)
+		return
+	}
+
+	for _, m := range msg {
+		extraHeaders := make(http.Header)
+		extraHeaders.Set(api.HostHeader, s.hostName)
+		extraHeaders.Set(api.ClusterIDHeader, clusterID)
+		extraHeaders.Set(api.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
+
+		body, err := api.EncodePayload(m)
+		if err != nil {
+			log.Errorf("Unable to encode message: %s", err)
+			continue
+		}
+
+		payloads := forwarder.Payloads{&body}
+		responses, err := s.forwarder.SubmitOrchestratorChecks(payloads, extraHeaders, payloadType)
+		if err != nil {
+			log.Errorf("Unable to submit payload: %s", err)
+			continue
+		}
+
+		// Consume the responses so that writers to the channel do not become blocked
+		// we don't need the bodies here though
+		for range responses {
+
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

* Isolate sending message code in a dedicated `sender`
* Create a manifest collector with its own lifecycle to collect & send manifests in the background

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
