### PR TITLE
[orchestrator] Add QoS to pod payload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.49.0+incompatible
+	github.com/DataDog/agent-payload v4.53.0+incompatible
 	github.com/DataDog/datadog-go v4.2.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
 	github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/DataDog/agent-payload v4.49.0+incompatible h1:CKWb5v7M6o3b5JHbX43qs1bswTri8LH7cmfIKQrEtyk=
-github.com/DataDog/agent-payload v4.49.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/agent-payload v4.53.0+incompatible h1:M//H0sBfc8AnLPtziNunUElwq3+vggAKT4AcIFIhr3s=
 github.com/DataDog/agent-payload v4.53.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
@@ -94,8 +92,6 @@ github.com/DataDog/datadog-go v4.2.0+incompatible h1:Q73jzyKHwyA04Gf4SSukRF+KR4w
 github.com/DataDog/datadog-go v4.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822 h1:E5WNl43j4mpE3V35QySkRnP/m9pjXOnEZD6eyTK7Qvk=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822/go.mod h1:a5NqgPglcSct+NwO9gPvVhoL5V6G1+gHbRaRnU8U54M=
-github.com/DataDog/ebpf v0.0.0-20210104093318-524278fe0bfe h1:xIQF3z6+bD1Q+K7TCAIAIeK0aBZMQ3thVGqzQxzQjaU=
-github.com/DataDog/ebpf v0.0.0-20210104093318-524278fe0bfe/go.mod h1:rIVS3jqxhqtYJtznvFI8qtCbYG1M7WQZS4Z15/nCmOI=
 github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d h1:FCSp3GWrMD+dTCinb/E5JrV5z9xBB/2wDHZVG9CoWq4=
 github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d/go.mod h1:VSpIdBT/hwSbP3xKa5eYtiiBN2E37YePfTuyQVzSSig=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71 h1:0TOAH3X9tEvMBVQ1HYrQfrnAUcSS1mfMrhqeN+spV1s=

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload v4.49.0+incompatible h1:CKWb5v7M6o3b5JHbX43qs1bswTri8LH7cmfIKQrEtyk=
 github.com/DataDog/agent-payload v4.49.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.53.0+incompatible h1:M//H0sBfc8AnLPtziNunUElwq3+vggAKT4AcIFIhr3s=
+github.com/DataDog/agent-payload v4.53.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/pkg/orchestrator/pod.go
+++ b/pkg/orchestrator/pod.go
@@ -140,6 +140,7 @@ func extractPodMessage(p *v1.Pod) *model.Pod {
 	podModel.NominatedNodeName = p.Status.NominatedNodeName
 	podModel.IP = p.Status.PodIP
 	podModel.RestartCount = 0
+	podModel.QOSClass = string(p.Status.QOSClass)
 	for _, cs := range p.Status.ContainerStatuses {
 		podModel.RestartCount += cs.RestartCount
 		cStatus := convertContainerStatus(cs)

--- a/pkg/orchestrator/pod_test.go
+++ b/pkg/orchestrator/pod_test.go
@@ -78,6 +78,7 @@ func TestExtractPodMessage(t *testing.T) {
 							},
 						},
 					},
+					QOSClass: v1.PodQOSGuaranteed,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					UID:               types.UID("e42e5adc-0749-11e8-a2b8-000c29dea4f6"),
@@ -123,6 +124,7 @@ func TestExtractPodMessage(t *testing.T) {
 				NodeName:          "node",
 				RestartCount:      42,
 				Status:            "chillin",
+				QOSClass:          "Guaranteed",
 				ContainerStatuses: []*model.ContainerStatus{
 					{
 						State:        "Running",
@@ -179,6 +181,7 @@ func TestExtractPodMessage(t *testing.T) {
 							Name: "bazName",
 						},
 					},
+					QOSClass: v1.PodQOSBurstable,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod",
@@ -201,6 +204,7 @@ func TestExtractPodMessage(t *testing.T) {
 				},
 				RestartCount: 10,
 				Status:       "chillin",
+				QOSClass:     "Burstable",
 				ContainerStatuses: []*model.ContainerStatus{
 					{
 						Name:        "fooName",
@@ -261,6 +265,7 @@ func TestExtractPodMessage(t *testing.T) {
 							Name: "bazName",
 						},
 					},
+					QOSClass: v1.PodQOSBestEffort,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod",
@@ -307,6 +312,7 @@ func TestExtractPodMessage(t *testing.T) {
 						Name: "bazName",
 					},
 				},
+				QOSClass: "BestEffort",
 			},
 		},
 		"partial pod with resourceRequirements": {

--- a/releasenotes/notes/orchestrator-Add-QoS-to-the-pod-payload-775e2f281339cc85.yaml
+++ b/releasenotes/notes/orchestrator-Add-QoS-to-the-pod-payload-775e2f281339cc85.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The Quality of Service of pods is now collected and sent to the orchestration endpoint.


### PR DESCRIPTION
Sends the QoS of the pod in the payload.
The QoS field was added in the protobuf definition here: https://github.com/DataDog/agent-payload/pull/77