### PR TITLE
[pkg/dogstatsd] Fix `parseEvent` header parsing with negative values

### DIFF
--- a/pkg/dogstatsd/parse_events_test.go
+++ b/pkg/dogstatsd/parse_events_test.go
@@ -63,8 +63,11 @@ func TestEventError(t *testing.T) {
 	_, err = parseEvent([]byte("_e{10,10}:title|text"))
 	assert.Error(t, err)
 
-	// zero length
+	// zero length title
 	_, err = parseEvent([]byte("_e{0,0}:a|a"))
+	assert.Error(t, err)
+
+	_, err = parseEvent([]byte("_e{0,4}:text"))
 	assert.Error(t, err)
 
 	// missing title or text length
@@ -96,6 +99,18 @@ func TestEventError(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = parseEvent([]byte("_e:|text"))
+	assert.Error(t, err)
+
+	// invalid title length
+	_, err = parseEvent([]byte("_e{-123,-987}:"))
+	assert.Error(t, err)
+
+	// invalid text length
+	_, err = parseEvent([]byte("_e{5,-987}:title"))
+	assert.Error(t, err)
+
+	// malformed message
+	_, err = parseEvent([]byte("_e{0001,-9876"))
 	assert.Error(t, err)
 
 	// invalid timestamp

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -309,8 +309,14 @@ func TestUDPReceive(t *testing.T) {
 		assert.FailNow(t, "Timeout on receive channel")
 	}
 
-	// Test erroneous Event
-	conn.Write([]byte("_e{0,9}:|test text\n_e{11,10}:test title2|test\\ntext|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
+	// Test erroneous Events
+	conn.Write(
+		[]byte("_e{0,9}:|test text\n" +
+			"_e{-5,2}:abc\n" +
+			"_e{11,10}:test title2|test\\ntext|" +
+			"t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test",
+		),
+	)
 	select {
 	case res := <-eventOut:
 		assert.Equal(t, 1, len(res))

--- a/releasenotes/notes/fix-dogstatd-event-header-offset-parsing-f879851ece9974aa.yaml
+++ b/releasenotes/notes/fix-dogstatd-event-header-offset-parsing-f879851ece9974aa.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix parsing of dogstatsd event strings that contained negative lengths for
+    event title and/or event text length.


### PR DESCRIPTION
### What does this PR do?

When `parseEvent` was invoked with a header that contained a negative
value either in the `titleLength` or the `textLength` fields, we were
not correctly discarding that event as erroneous, causing a panic. This
change ensures that a header containing those values will now correctly
return a parsing error instead.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

[Upstream Issue](https://datadoghq.atlassian.net/jira/software/projects/AC/boards/625?selectedIssue=AC-598)

### Describe your test plan

dogstatsd:
- Regular event processing should be tested 
- Sending an event with negative offsets to ensure no panics occur
