### PR TITLE
avoid gather FD names when fetching FD count

### DIFF
--- a/pkg/process/procutil/dirent_linux.go
+++ b/pkg/process/procutil/dirent_linux.go
@@ -1,0 +1,97 @@
+package procutil
+
+import (
+	"bytes"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	dotBytes       = []byte(".")
+	doubleDotBytes = []byte("..")
+)
+
+func countDirent(buf []byte) (consumed int, count int) {
+	origlen := len(buf)
+	count = 0
+	for len(buf) > 0 {
+		reclen, ok := direntReclen(buf)
+		if !ok || reclen > uint64(len(buf)) {
+			return origlen, count
+		}
+
+		rec := buf[:reclen]
+		buf = buf[reclen:]
+
+		ino, ok := direntIno(rec)
+		if !ok {
+			break
+		}
+		if ino == 0 { // File absent in directory.
+			continue
+		}
+		const namoff = uint64(unsafe.Offsetof(syscall.Dirent{}.Name))
+		namlen, ok := direntNamlen(rec)
+		if !ok || namoff+namlen > uint64(len(rec)) {
+			break
+		}
+		name := rec[namoff : namoff+namlen]
+		for i, c := range name {
+			if c == 0 {
+				name = name[:i]
+				break
+			}
+		}
+
+		if bytes.Equal(name, dotBytes) || bytes.Equal(name, doubleDotBytes) {
+			// Check for useless names before allocating a string.
+			continue
+		}
+		count++
+	}
+
+	return origlen - len(buf), count
+}
+
+func direntReclen(buf []byte) (uint64, bool) {
+	return readInt(buf, unsafe.Offsetof(syscall.Dirent{}.Reclen), unsafe.Sizeof(syscall.Dirent{}.Reclen))
+}
+
+func direntIno(buf []byte) (uint64, bool) {
+	return readInt(buf, unsafe.Offsetof(syscall.Dirent{}.Ino), unsafe.Sizeof(syscall.Dirent{}.Ino))
+}
+
+func direntNamlen(buf []byte) (uint64, bool) {
+	reclen, ok := direntReclen(buf)
+	if !ok {
+		return 0, false
+	}
+	return reclen - uint64(unsafe.Offsetof(syscall.Dirent{}.Name)), true
+}
+
+// readInt returns the size-bytes unsigned integer in native byte order at offset off.
+func readInt(b []byte, off, size uintptr) (u uint64, ok bool) {
+	if len(b) < int(off+size) {
+		return 0, false
+	}
+	return readIntLE(b[off:], size), true
+}
+
+func readIntLE(b []byte, size uintptr) uint64 {
+	switch size {
+	case 1:
+		return uint64(b[0])
+	case 2:
+		_ = b[1] // bounds check hint to compiler; see golang.org/issue/14808
+		return uint64(b[0]) | uint64(b[1])<<8
+	case 4:
+		_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
+		return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24
+	case 8:
+		_ = b[7] // bounds check hint to compiler; see golang.org/issue/14808
+		return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+			uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+	default:
+		panic("syscall: readInt with unsupported size")
+	}
+}

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -863,6 +863,28 @@ func TestGetFDCountLocalFS(t *testing.T) {
 	}
 }
 
+func TestGetFDCountLocalFSV2(t *testing.T) {
+	// maySkipLocalTest(t)
+	probe := NewProcessProbe()
+	defer probe.Close()
+
+	pids, err := probe.getActivePIDs()
+	assert.NoError(t, err)
+
+	for _, pid := range pids {
+		pathForPID := filepath.Join(probe.procRootLoc, strconv.Itoa(int(pid)))
+		fdCount := probe.getFDCountV2(pathForPID)
+		expProc, err := process.NewProcess(pid)
+		assert.NoError(t, err)
+		// skip the ones that have permission issues
+		if expFdCount, err := expProc.NumFDs(); err == nil {
+			assert.Equal(t, expFdCount, fdCount)
+		} else {
+			assert.Equal(t, int32(-1), fdCount)
+		}
+	}
+}
+
 func BenchmarkGetCmdGopsutilTestFS(b *testing.B) {
 	os.Setenv("HOST_PROC", "resources/test_procfs/proc")
 	defer os.Unsetenv("HOST_PROC")


### PR DESCRIPTION
### What does this PR do?

From profiling it shows that one of the places that creates a lot of allocation is when we count FDs in `/proc/[pid]/fd`. The function `file.Readdirnames()` returns all the file names which are not needed in our case. By tracking down the Go source code, we could extract the logic for counting and avoid gathering the filenames within the dir. The code is copied from https://golang.org/src/syscall/dirent.go minus the name slice creation. 

Doing benchmarking with a local dir of 23k files yield following result:
```
BenchmarkNativeReaddirnames-4                156           7533767 ns/op         1884028 B/op      23133 allocs/op
BenchmarkNewReaddirnames-4                   194           6179359 ns/op             454 B/op          7 allocs/op
PASS
ok      github.com/DataDog/datadog-agent/pkg/process/procutil   3.788s
```

@DataDog/processes 

### Motivation

Reduce process-agent memory.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
