### PR TITLE
[logs] submit expected tags for configurable amount of time

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -565,11 +565,8 @@ func InitConfig(config Config) {
 	config.BindEnv("logs_config.api_key") //nolint:errcheck
 	config.BindEnvAndSetDefault("logs_config.logs_no_ssl", false)
 
-	// Tags that will be submitted with logs for a specified duration of time.
-	// These tags are expected to eventually be available, so after a grace period they will no longer be submitted.
-	config.BindEnvAndSetDefault("logs_config.expected_tags", []string{})
-	// Duration in minutes during which the expected_tags will be submitted.
-	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", 15) // in minutes
+	// Duration in minutes during which the host tags will be submitted with log events.
+	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", 0) // in minutes
 	// send the logs to the port 443 of the logs-backend via TCP:
 	config.BindEnvAndSetDefault("logs_config.use_port_443", false)
 	// increase the read buffer size of the UDP sockets:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -564,6 +564,12 @@ func InitConfig(config Config) {
 	// specific logs-agent api-key
 	config.BindEnv("logs_config.api_key") //nolint:errcheck
 	config.BindEnvAndSetDefault("logs_config.logs_no_ssl", false)
+
+	// Tags that will be submitted with logs for a specified duration of time.
+	// These tags are expected to eventually be available, so after a grace period they will no longer be submitted.
+	config.BindEnvAndSetDefault("logs_config.expected_tags", []string{})
+	// Duration in minutes during which the expected_tags will be submitted.
+	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", 15) // in minutes
 	// send the logs to the port 443 of the logs-backend via TCP:
 	config.BindEnvAndSetDefault("logs_config.use_port_443", false)
 	// increase the read buffer size of the UDP sockets:

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -647,7 +647,7 @@ api_key:
   # logs_no_ssl: false
 
   ## @param expected_tags_duration - int - optional - default: 15
-  ## Defines the time in minutes we expect for the host tags to be available on backend services,
+  ## Define the time in minutes of the expected availability for the host tags on backend services.
   ## after this duration, host tags will no longer be submitted with log events.
   ## A value of 0 disables the feature.
   #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -646,18 +646,10 @@ api_key:
   #
   # logs_no_ssl: false
 
-  ## @param expected_tags - list of strings - optional
-  ## Defines a list of tags that are eventually expected to be available in the backend.
-  ## These tags will be submitted with log events for  a configurable `expected_tags_duration` minutes
-  ## after which the tags are expected to be available in our backend services.
-  #
-  # expected_tags:
-  #   - foo:bar
-  #   - baz:qux
-
   ## @param expected_tags_duration - int - optional - default: 15
-  ## Defines the time in minutes we expect for the expected tags to be available on the backend,
-  ## after this duration the tags defined above in `expected_tags` will no longer be submitted.
+  ## Defines the time in minutes we expect for the host tags to be available on backend services,
+  ## after this duration, host tags will no longer be submitted with log events.
+  ## A value of 0 disables the feature.
   #
   # expected_tags_duration: 15
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -288,7 +288,7 @@ api_key:
 #   - "sensitive_key_2"
 
 ## @param no_proxy_nonexact_match - boolean - optional - default: false
-## Enable more flexible no_proxy matching. See https://godoc.org/golang.org/x/net/http/httpproxy#Config 
+## Enable more flexible no_proxy matching. See https://godoc.org/golang.org/x/net/http/httpproxy#Config
 ## for more information on accepted matching criteria.
 #
 # no_proxy_nonexact_match: false
@@ -645,6 +645,21 @@ api_key:
   ## on the proxy side.
   #
   # logs_no_ssl: false
+
+  ## @param expected_tags - list of strings - optional
+  ## Defines a list of tags that are eventually expected to be available in the backend.
+  ## These tags will be submitted with log events for  a configurable `expected_tags_duration` minutes
+  ## after which the tags are expected to be available in our backend services.
+  #
+  # expected_tags:
+  #   - foo:bar
+  #   - baz:qux
+
+  ## @param expected_tags_duration - int - optional - default: 15
+  ## Defines the time in minutes we expect for the expected tags to be available on the backend,
+  ## after this duration the tags defined above in `expected_tags` will no longer be submitted.
+  #
+  # expected_tags_duration: 15
 
   ## @param processing_rules - list of custom objects - optional
   ## Global processing rules that are applied to all logs. The available rules are

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -648,7 +648,7 @@ api_key:
 
   ## @param expected_tags_duration - int - optional - default: 15
   ## Define the time in minutes of the expected availability for the host tags on backend services.
-  ## after this duration, host tags will no longer be submitted with log events.
+  ## After this duration, host tags are no longer submitted with log events.
   ## A value of 0 disables the feature.
   #
   # expected_tags_duration: 15

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -115,9 +115,9 @@ func BuildEndpoints(httpConnectivity HTTPConnectivity) (*Endpoints, error) {
 	return buildTCPEndpoints()
 }
 
-// IsExpectedTagsSet returns boolean showing if expected tags have been set.
+// IsExpectedTagsSet returns boolean showing if expected tags feature is enabled.
 func IsExpectedTagsSet() bool {
-	return len(coreConfig.Datadog.GetStringSlice("logs_config.expected_tags")) > 0
+	return coreConfig.Datadog.GetInt("logs_config.expected_tags_duration") > 0
 }
 
 func isSocks5ProxySet() bool {
@@ -134,25 +134,6 @@ func isForceHTTPUse() bool {
 
 func hasAdditionalEndpoints() bool {
 	return len(getAdditionalEndpoints()) > 0
-}
-
-// GetExpectedTags returns slice of string with deduplicated expected tags.
-func GetExpectedTags() []string {
-	if !IsExpectedTagsSet() {
-		return nil
-	}
-
-	dedupMap := map[string]struct{}{}
-	for _, tag := range coreConfig.Datadog.GetStringSlice("logs_config.expected_tags") {
-		dedupMap[tag] = struct{}{}
-	}
-
-	tags := make([]string, 0, len(dedupMap))
-	for k := range dedupMap {
-		tags = append(tags, k)
-	}
-
-	return tags
 }
 
 func buildTCPEndpoints() (*Endpoints, error) {

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -115,6 +115,11 @@ func BuildEndpoints(httpConnectivity HTTPConnectivity) (*Endpoints, error) {
 	return buildTCPEndpoints()
 }
 
+// IsExpectedTagsSet returns boolean showing if expected tags have been set.
+func IsExpectedTagsSet() bool {
+	return len(coreConfig.Datadog.GetStringSlice("logs_config.expected_tags")) > 0
+}
+
 func isSocks5ProxySet() bool {
 	return len(coreConfig.Datadog.GetString("logs_config.socks5_proxy_address")) > 0
 }
@@ -129,6 +134,25 @@ func isForceHTTPUse() bool {
 
 func hasAdditionalEndpoints() bool {
 	return len(getAdditionalEndpoints()) > 0
+}
+
+// GetExpectedTags returns slice of string with deduplicated expected tags.
+func GetExpectedTags() []string {
+	if !IsExpectedTagsSet() {
+		return nil
+	}
+
+	dedupMap := map[string]struct{}{}
+	for _, tag := range coreConfig.Datadog.GetStringSlice("logs_config.expected_tags") {
+		dedupMap[tag] = struct{}{}
+	}
+
+	tags := make([]string, 0, len(dedupMap))
+	for k := range dedupMap {
+		tags = append(tags, k)
+	}
+
+	return tags
 }
 
 func buildTCPEndpoints() (*Endpoints, error) {

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -63,8 +63,7 @@ func (p *provider) GetTags() []string {
 
 		// start timer if necessary
 		go func() {
-			t := time.NewTimer(p.expectedTagsDuration)
-			<-t.C
+			<-time.After(p.expectedTagsDuration)
 
 			p.Lock()
 			defer p.Unlock()

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -34,7 +34,7 @@ type provider struct {
 	submitExpectedTags   bool
 	expectedTags         []string
 	sync.Once
-	sync.Mutex
+	sync.RWMutex
 }
 
 // NewProvider returns a new Provider.
@@ -78,6 +78,8 @@ func (p *provider) GetTags() []string {
 		return []string{}
 	}
 
+	p.RLock()
+	defer p.RUnlock()
 	if p.submitExpectedTags {
 		tags = append(tags, p.expectedTags...)
 	}

--- a/pkg/logs/tag/provider_test.go
+++ b/pkg/logs/tag/provider_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package tag
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProviderExpectedTags(t *testing.T) {
+	mockConfig := config.Mock()
+
+	tags := []string{"tag1:value1", "tag2", "tag3"}
+
+	mockConfig.Set("tags", tags)
+	mockConfig.Set("logs_config.expected_tags_duration", 15)
+	defer mockConfig.Set("tags", nil)
+	defer mockConfig.Set("expected_tags_duration", 0)
+
+	p := NewProvider("foo")
+	pp := p.(*provider)
+
+	// Is provider expected?
+	assert.Equal(t, time.Duration(mockConfig.GetInt("logs_config.expected_tags_duration"))*time.Minute, pp.expectedTagsDuration)
+	assert.True(t, pp.submitExpectedTags)
+
+	// A more test-friendly value for tagging
+	pp.expectedTagsDuration = time.Second
+
+	tt := pp.GetTags()
+	sort.Strings(tags)
+	sort.Strings(tt)
+	assert.Equal(t, tags, tt)
+
+	time.Sleep(time.Duration(2) * (time.Second + pp.taggerWarmupDuration))
+	assert.Equal(t, []string{}, pp.GetTags())
+
+}

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -56,7 +56,7 @@ func GetPayload(hostnameData util.HostnameData) *Payload {
 		PythonVersion: GetPythonVersion(),
 		SystemStats:   getSystemStats(),
 		Meta:          meta,
-		HostTags:      getHostTags(),
+		HostTags:      GetHostTags(false),
 		ContainerMeta: getContainerMeta(1 * time.Second),
 		NetworkMeta:   getNetworkMeta(),
 		LogsMeta:      getLogsMeta(),

--- a/pkg/metadata/host/host_tags_test.go
+++ b/pkg/metadata/host/host_tags_test.go
@@ -16,14 +16,14 @@ func TestGetHostTags(t *testing.T) {
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3"})
 	defer mockConfig.Set("tags", nil)
 
-	hostTags := getHostTags()
+	hostTags := GetHostTags(false)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3"}, hostTags.System)
 }
 
 func TestGetEmptyHostTags(t *testing.T) {
 	// getHostTags should never return a nil value under System even when there are no host tags
-	hostTags := getHostTags()
+	hostTags := GetHostTags(false)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{}, hostTags.System)
 }
@@ -34,7 +34,7 @@ func TestGetHostTagsWithSplits(t *testing.T) {
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
 	defer mockConfig.Set("tags", nil)
 
-	hostTags := getHostTags()
+	hostTags := GetHostTags(false)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0", "kafka_partition:1", "kafka_partition:2"}, hostTags.System)
 }
@@ -45,7 +45,7 @@ func TestGetHostTagsWithoutSplits(t *testing.T) {
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
 	defer mockConfig.Set("tags", nil)
 
-	hostTags := getHostTags()
+	hostTags := GetHostTags(false)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"}, hostTags.System)
 }
@@ -57,7 +57,7 @@ func TestGetHostTagsWithEnv(t *testing.T) {
 	defer mockConfig.Set("tags", nil)
 	defer mockConfig.Set("env", "")
 
-	hostTags := getHostTags()
+	hostTags := GetHostTags(false)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "env:prod", "env:preprod"}, hostTags.System)
 }

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -39,7 +39,8 @@ type LogsMeta struct {
 	Transport string `json:"transport"`
 }
 
-type tags struct {
+// Tags contains the detected host tags
+type Tags struct {
 	System              []string `json:"system,omitempty"`
 	GoogleCloudPlatform []string `json:"google cloud platform,omitempty"`
 }
@@ -64,7 +65,7 @@ type Payload struct {
 	PythonVersion string            `json:"python"`
 	SystemStats   *systemStats      `json:"systemStats"`
 	Meta          *Meta             `json:"meta"`
-	HostTags      *tags             `json:"host-tags"`
+	HostTags      *Tags             `json:"host-tags"`
 	ContainerMeta map[string]string `json:"container-meta,omitempty"`
 	NetworkMeta   *NetworkMeta      `json:"network"`
 	LogsMeta      *LogsMeta         `json:"logs"`

--- a/releasenotes/notes/logs-submit-expected-host-tags-7698438c382d2d68.yaml
+++ b/releasenotes/notes/logs-submit-expected-host-tags-7698438c382d2d68.yaml
@@ -1,7 +1,7 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# Each section from every release note is combined when the
+# CHANGELOG.rst is rendered. Therefore, the text should be worded so
 # it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
+# section. You may need to repeat some details, but each section
 # must be readable independently of the other.
 #
 # Each section note must be formatted as reStructuredText.

--- a/releasenotes/notes/logs-submit-expected-host-tags-7698438c382d2d68.yaml
+++ b/releasenotes/notes/logs-submit-expected-host-tags-7698438c382d2d68.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Submit host tags with log events for a configurable time duration
+    to avoid potential race conditions where some tags might not be
+    available to all backend services on freshly provisioned instances.


### PR DESCRIPTION
### What does this PR do?

This PR does two things:
- Submits tags with log events for a configurable amount of time. After that time `expected_tags_duration` expires, tags will no longer be sent as they will be available in our backend services and it makes little sense to continue using up bandwidth for them.
- `GetHostTags()` should allow grabbing cached results to avoid the heavy call that generates all these tags. This is not needed by the main feature described above but was part of a previous effort and still feels like a useful internal feature. We can split this into a separate PR if desired. 

### Motivation

Some customers are seeing missing tags in the initial log events from fresh instances as the tags that may be discovered by crawlers are not yet available to our backend services. 

### Additional Notes

(none)

### Describe your test plan

Two different QA tests:
- AWS EC2 tags:
1. Provision an EC2 instance and set AWS tags on it.
2. Set the `expected_tags` with the AWS tags and start a fresh agent that collects logs.
3. Tags should be available for these initial log events.
4. After a `expected_tags_duration` expires, the log events should _still_ be available with all log events but they shoult *NOT* be getting sent with logs payloads.

- NOOP:
1. If nothing gets set in `expected_tags` there should be no additional tags submitted with log events.
