### PR TITLE
[runtime-security] use passed duration for stress tests

### DIFF
--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -97,7 +97,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 	}
 
 	opts := StressOpts{
-		Duration:    time.Duration(30) * time.Second,
+		Duration:    time.Duration(duration) * time.Second,
 		KeepProfile: keepProfile,
 		DiffBase:    diffBase,
 		TopFrom:     "probe",


### PR DESCRIPTION
### What does this PR do?

Use the -duration parameter passed to the stress suite
