### PR TITLE
[logs/ad] Support file tailing config from k8s pod annotation

### DIFF
--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/input"
@@ -161,10 +160,7 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 		}
 		// We may have more than one log configuration in the annotation, ignore those
 		// unrelated to containers
-		containerType := ""
-		if tokens := strings.Split(container.ID, containers.EntitySeparator); len(tokens) == 2 {
-			containerType = tokens[0]
-		}
+		containerType, _ := containers.SplitEntityName(container.ID)
 		for _, c := range configs {
 			if c.Type == "" || c.Type == containerType {
 				cfg = c

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/input"
@@ -158,8 +159,24 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 		if err != nil || len(configs) == 0 {
 			return nil, fmt.Errorf("could not parse kubernetes annotation %v", annotation)
 		}
-		cfg = configs[0]
-	} else {
+		// We may have more than one log configuration in the annotation, ignore those
+		// unrelated to containers
+		containerType := ""
+		if tokens := strings.Split(container.ID, containers.EntitySeparator); len(tokens) == 2 {
+			containerType = tokens[0]
+		}
+		for _, c := range configs {
+			if c.Type == "" || c.Type == containerType {
+				cfg = c
+				break
+			}
+		}
+		if cfg == nil {
+			log.Debugf("annotation found: %v, for pod %v, container %v, but no config was usable for container log collection", annotation, pod.Metadata.Name, container.Name)
+		}
+	}
+
+	if cfg == nil {
 		if !l.collectAll {
 			return nil, errCollectAllDisabled
 		}

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -238,14 +238,6 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 	return sources, nil
 }
 
-func containerType(t string) bool {
-	switch t {
-	case containers.RuntimeNameDocker, containers.RuntimeNameContainerd, containers.RuntimeNameCRIO:
-		return true
-	}
-	return false
-}
-
 // toService creates a new service for an integrationConfig.
 func (s *Scheduler) toService(config integration.Config) (*service.Service, error) {
 	provider, identifier, err := s.parseEntity(config.Entity)

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	providerNames "github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -216,8 +217,8 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 		if service != nil {
 			// a config defined in a docker label or a pod annotation does not always contain a type,
 			// override it here to ensure that the config won't be dropped at validation.
-			if cfg.Type == logsConfig.FileType && service.Type == "docker" {
-				// cfg.Type is not overwritten as tailing a file from a docker AD configuration
+			if cfg.Type == logsConfig.FileType && (config.Provider == providerNames.Kubernetes || config.Provider == providerNames.Docker) {
+				// cfg.Type is not overwritten as tailing a file from a Docker or Kubernetes AD configuration
 				// is explicitly supported
 				cfg.Identifier = service.Identifier
 			} else {

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -218,12 +218,8 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 			// override it here to ensure that the config won't be dropped at validation.
 			if cfg.Type == logsConfig.FileType && (config.Provider == names.Kubernetes || config.Provider == names.Docker) {
 				// cfg.Type is not overwritten as tailing a file from a Docker or Kubernetes AD configuration
-				// is explicitly supported (other combination may be supported later)
+				// is explicitly supported (other combinations may be supported later)
 				cfg.Identifier = service.Identifier
-			} else if config.Provider == names.Kubernetes && (cfg.Type == "" || containerType(cfg.Type)) {
-				// Containers coming from the k8s provider are tailed based on a service and not a source,
-				// hence the configuration for tailing a container is ignored here
-				continue
 			} else {
 				cfg.Type = service.Type
 				cfg.Identifier = service.Identifier // used for matching a source with a service

--- a/releasenotes/notes/tail-file-from-k8s-annotation-2d5f25ee166ef692.yaml
+++ b/releasenotes/notes/tail-file-from-k8s-annotation-2d5f25ee166ef692.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    File tailing from a kubernetes pod annotation is
+    now supported. Note that the file path is relative
+    to the Agent and not the pod/container bearing
+    the annotation.
+


### PR DESCRIPTION
### What does this PR do?
Make #6883 slightly more generic by supporting annotation from both kubernetes (All runtime) & docker.

### Motivation
Feature consistency.

### Additional Notes
File path shall be relative to where the agent is running.
Add a slight modification to properly handle multiple logs config in kubernetes launcher, In that extend the following annotation will work : 
- `ad.datadoghq.com/logapp.logs: '[{"type":"file","path":"/tmp/share/test.log"}]'`, will collect log from `/tmp/share/test.log` and the container log if `container_collect_all` is set to true
- `ad.datadoghq.com/logapp.logs: '[{"type":"file","path":"/tmp/share/test.log"},{"source":"my_source", "service":"my_service"}]'`, will collect log from `/tmp/share/test.log` and the container log with a custom source/service value
- `ad.datadoghq.com/logapp.logs: '[{"type":"file","path":"/tmp/share/test.log"},{"source":"my_source", "service":"my_service", "type": "<CONTAINER_TYPE>"}]'` (where `<CONTAINER_TYPE>` is the container runtime : `cri-o`, `docker` or `containerd`) will collect log from `/tmp/share/test.log` and the container log with a custom source/service value if type is set to the correct container runtime.

Note: source/service are set independently for each config.

### Describe your test plan
Use the following pod annotation for testing.
```
apiVersion: v1
kind: Pod
metadata:
  name: logapp
  annotations:
    ad.datadoghq.com/logapp.logs: '[{"type":"file","path":"/tmp/share/test.log"}]'
spec:
  containers:
  - name: logapp
    image: mingrammer/flog:latest
    imagePullPolicy: Always
    command: ["/bin/flog"]
    args: ["-l", "-d", "2"]
```

Tests:
* Different container runtime with k8s
* Plain docker
* Assess that there are no side effects, especially regarding AD combination like    `ad.datadoghq.com/<container>.logs: '[{"type":"file","path":"/tmp/share/test.log"},{"source":"my_source", "service":"my_service"}]'` leads to properly tagged log from the container and that the file tailer actually starts. 
