### PR TITLE
[runtime] add package to handle gomaxprocs and runtime settings

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -46,6 +46,9 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
 
+	// runtime init routines
+	_ "github.com/DataDog/datadog-agent/pkg/runtime"
+
 	// register core checks
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers"

--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -12,7 +12,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	_ "go.uber.org/automaxprocs"
+	// runtime init routines
+	_ "github.com/DataDog/datadog-agent/pkg/runtime"
 )
 
 // handleSignal closes a channel to exit cleanly from routines

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,0 +1,72 @@
+package runtime
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	// Imported for side-effects only. This import will cause GOMAXPROCS to be set to the number of vCPUs
+	// allocated to the process if the process is running in a Linux environment (including when its running
+	// in a docker / K8s setup).
+	_ "go.uber.org/automaxprocs"
+)
+
+const (
+	gomaxprocsKey = "GOMAXPROCS"
+)
+
+func init() {
+	defer func() {
+		log.Infof("runtime: final GOMAXPROCS value is: %d", runtime.GOMAXPROCS(0))
+	}()
+
+	if max, exists := os.LookupEnv(gomaxprocsKey); exists {
+		if max == "" {
+			log.Errorf("runtime: GOMAXPROCS value was empty string")
+			return
+		}
+
+		_, err := strconv.Atoi(max)
+		if err == nil {
+			// Go runtime will already have parsed the integer and set it properly.
+			return
+		}
+
+		if strings.HasSuffix(max, "m") {
+			// Value represented as millicpus.
+			trimmed := strings.TrimSuffix(max, "m")
+			milliCPUs, err := strconv.Atoi(trimmed)
+			if err != nil {
+				log.Errorf("runtime: error parsing GOMAXPROCS milliCPUs value: %v", max)
+				return
+			}
+
+			cpus := milliCPUs / 1000
+			if cpus > 0 {
+				log.Infof("runtime: honoring GOMAXPROCS millicpu configuration: %v, setting GOMAXPROCS to: %d", max, cpus)
+				runtime.GOMAXPROCS(cpus)
+			} else {
+				log.Infof(
+					"runtime: GOMAXPROCS millicpu configuration: %s was less than 1, setting GOMAXPROCS to 1",
+					max)
+				runtime.GOMAXPROCS(1)
+			}
+			return
+		}
+
+		log.Errorf(
+			"runtime: unhandled GOMAXPROCS value: %s", max)
+	}
+}
+
+// NumVCPU returns the number of virtualizes CPUs available to the process. It should be used instead of
+// runtime.NumCPU() in virtualized environments like K8s to ensure that processes don't attempt to
+// over-subscribe CPUs. For example, on a 16 vCPU machine in a docker container allocated 8 vCPUs,
+// runtime.NumCPU() will return 16 but NumVCPU() will return 8.
+func NumVCPU() int {
+	// Value < 1 returns the current value without altering it.
+	return runtime.GOMAXPROCS(0)
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -23,6 +23,13 @@ func init() {
 		log.Infof("runtime: final GOMAXPROCS value is: %d", runtime.GOMAXPROCS(0))
 	}()
 
+	SetMaxProcs()
+
+}
+
+// SetMaxProcs sets the GOMAXPROCS for the go runtime to a sane value
+func SetMaxProcs() {
+
 	if max, exists := os.LookupEnv(gomaxprocsKey); exists {
 		if max == "" {
 			log.Errorf("runtime: GOMAXPROCS value was empty string")

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1,0 +1,30 @@
+package runtime
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	// "github.com/stretchr/testify/require"
+)
+
+func TestAutoMaxProcs(t *testing.T) {
+
+	assert.Equal(t, runtime.NumCPU(), runtime.GOMAXPROCS(0))
+
+	os.Setenv("GOMAXPROCS", "1000m")
+	// set new limit
+	SetMaxProcs()
+	assert.Equal(t, 1, runtime.GOMAXPROCS(0))
+
+	os.Setenv("GOMAXPROCS", "1500m")
+	// set new limit
+	SetMaxProcs()
+	assert.Equal(t, 1, runtime.GOMAXPROCS(0))
+
+	os.Setenv("GOMAXPROCS", "2000m")
+	// set new limit
+	SetMaxProcs()
+	assert.Equal(t, 2, runtime.GOMAXPROCS(0))
+}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -12,6 +12,7 @@ import (
 func TestAutoMaxProcs(t *testing.T) {
 
 	assert.Equal(t, runtime.NumCPU(), runtime.GOMAXPROCS(0))
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(0))
 
 	os.Setenv("GOMAXPROCS", "1000m")
 	// set new limit

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	// "github.com/stretchr/testify/require"
 )
 
 func TestAutoMaxProcs(t *testing.T) {
 
-	assert.Equal(t, runtime.NumCPU(), runtime.GOMAXPROCS(0))
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(0))
+
+	// let's change at runtime to 2 threads
+	runtime.GOMAXPROCS(2)
+	assert.Equal(t, 2, runtime.GOMAXPROCS(0))
 
 	os.Setenv("GOMAXPROCS", "1000m")
 	// set new limit

--- a/releasenotes/notes/gomaxprocs-sane-settings-87c98222af7086d3.yaml
+++ b/releasenotes/notes/gomaxprocs-sane-settings-87c98222af7086d3.yaml
@@ -10,4 +10,4 @@ enhancements:
   - |
     GOMAXPROCS is now set automatically to match the allocated CPU cgroup quota.
     GOMAXPROCS can now also be manually specified and overridden in millicore units.
-    If no quota or GOMAXPROC value is set it will default to the original behavior.
+    If no quota or GOMAXPROCS value is set it will default to the original behavior.

--- a/releasenotes/notes/gomaxprocs-sane-settings-87c98222af7086d3.yaml
+++ b/releasenotes/notes/gomaxprocs-sane-settings-87c98222af7086d3.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    GOMAXPROCS is now set automatically to match the allocated CPU cgroup quota.
+    GOMAXPROCS can now also be manually specified and overridden in millicore units.
+    If no quota or GOMAXPROC value is set it will default to the original behavior.


### PR DESCRIPTION
### What does this PR do?

This PR adds a `runtime` package. This package is geared towards allowing us to tweak the go runtime settings. 

For now it handles automatically setting `GOMAXPROCS` to the desired setting. If `GOMAXPROCS` is set as an environment variable, that value will take precedence. It relies on work done here: https://pkg.go.dev/go.uber.org/automaxprocs to set the value if no override is in place.

The heavy-lifting takes place in an `init()` routine so make a nameless import in your binary as follows to have the correct settings set:

```
import( 
        ...
        
	// runtime init routines
	_ "github.com/DataDog/datadog-agent/pkg/runtime"
)
```

### Motivation

Set the right number of system threads for the go runtime in heterogenous environments where cgroups could be in place (ie. kubernetes).

### Additional Notes

-

### Describe your test plan

TO-DO