### PR TITLE
[backport] [rtloader/aggregator] Parse optional flush_first_value boolean with |b

### DIFF
--- a/releasenotes/notes/fix-agent-arm-metrics-23b8b5893b75a7d4.yaml
+++ b/releasenotes/notes/fix-agent-arm-metrics-23b8b5893b75a7d4.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue on arm64 where non-gauge metrics from Python checks
+    were treated as gauges.

--- a/rtloader/common/builtins/aggregator.c
+++ b/rtloader/common/builtins/aggregator.c
@@ -192,7 +192,7 @@ static PyObject *submit_metric(PyObject *self, PyObject *args)
     bool flush_first_value = false;
 
     // Python call: aggregator.submit_metric(self, check_id, aggregator.metric_type.GAUGE, name, value, tags, hostname, flush_first_value)
-    if (!PyArg_ParseTuple(args, "OsisdOs|i", &check, &check_id, &mt, &name, &value, &py_tags, &hostname, &flush_first_value)) {
+    if (!PyArg_ParseTuple(args, "OsisdOs|b", &check, &check_id, &mt, &name, &value, &py_tags, &hostname, &flush_first_value)) {
         goto error;
     }
 


### PR DESCRIPTION
### What does this PR do?

Backport of #7125.

Changes the aggregator.submit_metric method's argument parsing from `OsisdOs|i` to `OsisdOs|b`, converting into an unsigned char instead of an int (see https://docs.python.org/3/c-api/arg.html).

### Motivation

7.25.1 release.

