### PR TITLE
pkg/{trace, config}: add support for statsd over windows pipes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,6 +181,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("check_runners", int64(4))
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	config.BindEnvAndSetDefault("bind_host", "localhost")
+	config.BindEnvAndSetDefault("dogstatsd_windows_pipe_name", "")
 	config.BindEnvAndSetDefault("ipc_address", "localhost")
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -238,6 +238,9 @@ func (c *AgentConfig) applyDatadogConfig() error {
 		}
 	}
 
+	if config.Datadog.IsSet("dogstatsd_windows_pipe_name") {
+		c.StatsdWindowsPipe = config.Datadog.GetString("dogstatsd_windows_pipe_name")
+	}
 	if config.Datadog.IsSet("bind_host") {
 		host := config.Datadog.GetString("bind_host")
 		c.StatsdHost = host

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -83,8 +83,9 @@ type AgentConfig struct {
 	ConnectionResetInterval time.Duration // frequency at which outgoing connections are reset. 0 means no reset is performed
 
 	// internal telemetry
-	StatsdHost string
-	StatsdPort int
+	StatsdWindowsPipe string
+	StatsdHost        string
+	StatsdPort        int
 
 	// logging
 	LogLevel      string

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -15,14 +15,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/Microsoft/go-winio"
 )
 
 // Configure creates a statsd client for the given agent's configuration, using the specified global tags.
 func Configure(conf *config.AgentConfig, tags []string) error {
 	var client *statsd.Client
 	if conf.StatsdWindowsPipe != "" {
-		pipe, err := winio.DialPipe(conf.StatsdWindowsPipe, nil)
+		pipe, err := DialPipe(conf.StatsdWindowsPipe, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -19,7 +19,10 @@ import (
 
 // Configure creates a statsd client for the given agent's configuration, using the specified global tags.
 func Configure(conf *config.AgentConfig, tags []string) error {
-	var client *statsd.Client
+	var (
+		client *statsd.Client
+		err    error
+	)
 	if conf.StatsdWindowsPipe != "" {
 		pipe, err := DialPipe(conf.StatsdWindowsPipe, nil)
 		if err != nil {

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -24,7 +24,7 @@ func Configure(conf *config.AgentConfig, tags []string) error {
 		err    error
 	)
 	if conf.StatsdWindowsPipe != "" {
-		pipe, err := DialPipe(conf.StatsdWindowsPipe, nil)
+		pipe, err := dialPipe(conf.StatsdWindowsPipe, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -30,7 +30,7 @@ func Configure(conf *config.AgentConfig, tags []string) error {
 			return err
 		}
 	} else {
-		client, err := statsd.New(fmt.Sprintf("%s:%d", conf.StatsdHost, conf.StatsdPort), statsd.WithTags(tags))
+		client, err = statsd.New(fmt.Sprintf("%s:%d", conf.StatsdHost, conf.StatsdPort), statsd.WithTags(tags))
 		if err != nil {
 			return err
 		}

--- a/pkg/trace/metrics/pipe.go
+++ b/pkg/trace/metrics/pipe.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+	"time"
+)
+
+func DialPipe(path string, timeout *time.Duration) (net.Conn, error) {
+	return nil, fmt.Errorf("Windows Pipe not available on %s", runtime.GOOS)
+}

--- a/pkg/trace/metrics/pipe.go
+++ b/pkg/trace/metrics/pipe.go
@@ -1,14 +1,16 @@
-// +build !windows
-
 package metrics
 
 import (
-	"fmt"
+	"errors"
 	"net"
-	"runtime"
 	"time"
 )
 
-func DialPipe(path string, timeout *time.Duration) (net.Conn, error) {
-	return nil, fmt.Errorf("Windows Pipe not available on %s", runtime.GOOS)
+type statsWriter struct {
+	net.Conn
+}
+
+// SetWriteTimeout is not available for Windows Pipes. returns error
+func (w *statsWriter) SetWriteTimeout(d time.Duration) error {
+	return errors.New("SetWriteTimeout: not supported for Windows Pipe connections")
 }

--- a/pkg/trace/metrics/pipe_nonwindows.go
+++ b/pkg/trace/metrics/pipe_nonwindows.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package metrics
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+func DialPipe(path string, timeout *time.Duration) (*statsWriter, error) {
+	return nil, fmt.Errorf("Windows Pipe not available on %s", runtime.GOOS)
+}

--- a/pkg/trace/metrics/pipe_nonwindows.go
+++ b/pkg/trace/metrics/pipe_nonwindows.go
@@ -8,6 +8,6 @@ import (
 	"time"
 )
 
-func DialPipe(path string, timeout *time.Duration) (*statsWriter, error) {
+func dialPipe(path string, timeout *time.Duration) (*statsWriter, error) {
 	return nil, fmt.Errorf("Windows Pipe not available on %s", runtime.GOOS)
 }

--- a/pkg/trace/metrics/pipe_windows.go
+++ b/pkg/trace/metrics/pipe_windows.go
@@ -7,6 +7,10 @@ import (
 	"github.com/Microsoft/go-winio"
 )
 
-func DialPipe(path string, timeout *time.Duration) (net.Conn, error) {
-	return winio.DialPipe(path, timeout)
+func DialPipe(path string, timeout *time.Duration) (*statsWriter, error) {
+	c, err := winio.DialPipe(path, timeout)
+	if err != nil {
+		return nil, err 
+}
+	return &statsWriter{c}
 }

--- a/pkg/trace/metrics/pipe_windows.go
+++ b/pkg/trace/metrics/pipe_windows.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Microsoft/go-winio"
 )
 
-func DialPipe(path string, timeout *time.Duration) (*statsWriter, error) {
+func dialPipe(path string, timeout *time.Duration) (*statsWriter, error) {
 	c, err := winio.DialPipe(path, timeout)
 	if err != nil {
 		return nil, err 

--- a/pkg/trace/metrics/pipe_windows.go
+++ b/pkg/trace/metrics/pipe_windows.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"net"
 	"time"
 
 	"github.com/Microsoft/go-winio"
@@ -10,7 +9,7 @@ import (
 func dialPipe(path string, timeout *time.Duration) (*statsWriter, error) {
 	c, err := winio.DialPipe(path, timeout)
 	if err != nil {
-		return nil, err 
-}
-	return &statsWriter{c}
+		return nil, err
+	}
+	return &statsWriter{c}, nil
 }

--- a/pkg/trace/metrics/pipe_windows.go
+++ b/pkg/trace/metrics/pipe_windows.go
@@ -1,0 +1,12 @@
+package metrics
+
+import (
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func DialPipe(path string, timeout *time.Duration) (net.Conn, error) {
+	return winio.DialPipe(path, timeout)
+}


### PR DESCRIPTION
This commit adds the dogstatsd_windows_pipe_name and the corresponding env
variable DD_DOGSTATSD_WINDOWS_PIPE_NAME to pkg/config. It also adds support
for these in pkg/trace/config and pkg/trace/metrics.

When dogstatsd_windows_pipe_name is defined, the trace agent will use the
specified pipe for dogstatsd communication with the agent core.

### Motivation

This is a follow-on from #6615. When the agent is running on windows pipes, currently no internal metrics are communicated to the agent core.

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
This should be manually tested on a Windows machine, ensuring that trace agent metrics are appearing in the UI when DD_DOGSTATSD_WINDOWS_PIPE_NAME and/or dogstatsd_windows_pipe_name are set.
