### PR TITLE
[collector] Fix flaky test on check Cancel timeout

### DIFF
--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -133,9 +133,11 @@ func (suite *CollectorTestSuite) TestCancelCheck_TimeoutIsApplied() {
 	ch := NewCheckSlowCancel(10 * time.Second)
 
 	start := time.Now()
-	err := suite.c.cancelCheck(ch, time.Millisecond)
+	err := suite.c.cancelCheck(ch, 100*time.Millisecond)
 	assert.NotNil(suite.T(), err)
 	assert.WithinDuration(suite.T(), start, time.Now(), 5*time.Second)
+	// assert that `Cancel` was actually called on the check, which may be flaky if the goroutine
+	// that calls `Cancel` didn't have a chance to be scheduled before the timeout is hit.
 	ch.AssertNumberOfCalls(suite.T(), "Cancel", 1)
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes flaky test on check Cancel timeout, by increasing the timeout to give more time for the goroutine actually
calling `Cancel` to be scheduled.

Example of flake this should fix: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/49842140
