### PR TITLE
[cherry-pick] Prevent unsafe map access in inventories (#6958)

### DIFF
--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -99,16 +99,20 @@ func SetCheckMetadata(checkID, key string, value interface{}) {
 }
 
 func createCheckInstanceMetadata(checkID, configProvider string) *CheckInstanceMetadata {
+	const transientFields = 3
 
 	var checkInstanceMetadata CheckInstanceMetadata
-	lastUpdated := agentStartupTime
+	var lastUpdated time.Time
 
-	entry, found := checkMetadataCache[checkID]
-	if found {
-		checkInstanceMetadata = entry.CheckInstanceMetadata
+	if entry, found := checkMetadataCache[checkID]; found {
+		checkInstanceMetadata = make(CheckInstanceMetadata, len(entry.CheckInstanceMetadata)+transientFields)
+		for k, v := range entry.CheckInstanceMetadata {
+			checkInstanceMetadata[k] = v
+		}
 		lastUpdated = entry.LastUpdated
 	} else {
-		checkInstanceMetadata = make(CheckInstanceMetadata)
+		checkInstanceMetadata = make(CheckInstanceMetadata, transientFields)
+		lastUpdated = agentStartupTime
 	}
 
 	checkInstanceMetadata["last_updated"] = lastUpdated.UnixNano()

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -257,3 +257,24 @@ func TestSetup(t *testing.T) {
 	assert.True(t, waitForCalledSignal(ms.sendNowCalled))
 	assert.True(t, ms.lastSendNowDelay > time.Duration(0))
 }
+
+func Test_createCheckInstanceMetadata_returnsNewMetadata(t *testing.T) {
+	defer clearMetadata()
+
+	const (
+		checkID        = "a-check-id"
+		configProvider = "a-config-provider"
+		metadataKey    = "a-metadata-key"
+	)
+
+	checkMetadataCache[checkID] = &checkMetadataCacheEntry{
+		CheckInstanceMetadata: CheckInstanceMetadata{
+			metadataKey: "a-metadata-value",
+		},
+	}
+
+	md := createCheckInstanceMetadata(checkID, configProvider)
+	(*md)[metadataKey] = "a-different-metadata-value"
+
+	assert.NotEqual(t, checkMetadataCache[checkID].CheckInstanceMetadata[metadataKey], (*md)[metadataKey])
+}

--- a/releasenotes/notes/Fix-a-crash-in-metadata/inventories-dce415da91e3fec5.yaml
+++ b/releasenotes/notes/Fix-a-crash-in-metadata/inventories-dce415da91e3fec5.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fix "fatal error: concurrent map read and map write" due to reads of
+    a concurrently mutated map in inventories.payload.MarshalJSON()
+


### PR DESCRIPTION
### What does this PR do?

This is a cherry-pick of https://github.com/DataDog/datadog-agent/pull/6959 to be ship in `7.25.1`

### Motivation

This fixes a panic in the agent.
