### PR TITLE
dogstatsd: Fix error handling in ListenUDP()

### DIFF
--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -63,15 +63,14 @@ func NewUDPListener(packetOut chan Packets, sharedPacketPool *PacketPool) (*UDPL
 		return nil, fmt.Errorf("could not resolve udp addr: %s", err)
 	}
 	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("can't listen: %s", err)
+	}
 
 	if rcvbuf := config.Datadog.GetInt("dogstatsd_so_rcvbuf"); rcvbuf != 0 {
 		if err := conn.SetReadBuffer(rcvbuf); err != nil {
 			return nil, fmt.Errorf("could not set socket rcvbuf: %s", err)
 		}
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("can't listen: %s", err)
 	}
 
 	bufferSize := config.Datadog.GetInt("dogstatsd_buffer_size")

--- a/releasenotes/notes/dogstatsd-Fix-error-handling-in-ListenUDP-288a788984dd1750.yaml
+++ b/releasenotes/notes/dogstatsd-Fix-error-handling-in-ListenUDP-288a788984dd1750.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix agent panic when UDP port is busy and dogstatsd_so_rcvbuf is configured.


### PR DESCRIPTION
### What does this PR do?

Fix error handling in ListenUDP that was broken by commit 0afb48b, which
added socket read buffer updating before the error check:

```
  2020-11-19 02:33:54 UTC | CORE | INFO | (cmd/agent/app/run.go:360 in StopAgent) | See ya!
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2c8925c]

  goroutine 1 [running]:
  github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners.NewUDPListener(0xc00098f380, 0xc0007d3e60, 0xe, 0x1fbd, 0x0)
  	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners/udp.go:68 +0x5fc
  github.com/DataDog/datadog-agent/pkg/dogstatsd.NewServer(0xc0008485a0, 0x3a1af38, 0xd, 0x1)
  	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/dogstatsd/server.go:158 +0x1100
  github.com/DataDog/datadog-agent/cmd/agent/app.StartAgent(0xc000000008, 0x3b17538)
  	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/agent/app/run.go:275 +0x126e
  github.com/DataDog/datadog-agent/cmd/agent/app.run(0x5627f00, 0x580e2f0, 0x0, 0x0, 0x0, 0x0)
  	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/agent/app/run.go:122 +0x1de
  github.com/spf13/cobra.(*Command).execute(0x5627f00, 0x580e2f0, 0x0, 0x0, 0x5627f00, 0x580e2f0)
  	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/vendor/github.com/spf13/cobra/command.go:842 +0x460
  github.com/spf13/cobra.(*Command).ExecuteC(0x56232e0, 0x0, 0x4f180, 0xc0000e2058)
  	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/vendor/github.com/spf13/cobra/command.go:950 +0x349
  github.com/spf13/cobra.(*Command).Execute(...)
  	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/vendor/github.com/spf13/cobra/command.go:887
  main.main()
  	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/agent/main.go:18 +0x2d
```

Fixes #6803

### Describe your test plan

I added a new `TestNewUDPListenerWhenBusyWithSoRcvBufSet` unit test to `pkg/dogstatsd/listeners/udp.go`, which reproduces issues #6803. With the fix in place, the `ListenUDP` function no longer panics.