### PR TITLE
Add support for UDP on IPv6 "unconnected" sends.

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "5b36663522dd473d0f6ebb328b1f69ef853df80b564ecaec33e78e44befbde4e")
+var Conntrack = NewRuntimeAsset("conntrack.c", "5718efcef146065430fbda9010302f96faadb0736ebcee5f0800950efd93f764")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "5fd450cb1431235cfbc0d2331dd46f4a8975ce818c0a8e2e937d1c553306a515")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "259a39bebc553b8d8d7f8a108cdaee49a2996d30f7bff7fa4e7a881c11ab526e")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "c6fddb607d723da142709d5e3a427bf2186ea45f22eec8af02ca50a96780a289")
+var Tracer = NewRuntimeAsset("tracer.c", "30422262ef778e6c9afcd925fa092d2e668f516869475ba7766c2af2e25fb3b2")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "0bc530044e1911bc276a6c0094efc9de64003336c3c52af56b71283fc19da97f")
+var Tracer = NewRuntimeAsset("tracer.c", "c6fddb607d723da142709d5e3a427bf2186ea45f22eec8af02ca50a96780a289")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "30422262ef778e6c9afcd925fa092d2e668f516869475ba7766c2af2e25fb3b2")
+var Tracer = NewRuntimeAsset("tracer.c", "95aa4813496347c0ee23401a8b7877761bd4e542d3bf04a8d44610d1f38c69f9")

--- a/pkg/ebpf/c/bpf_helpers.h
+++ b/pkg/ebpf/c/bpf_helpers.h
@@ -100,23 +100,20 @@ struct bpf_map_def {
 #define PT_REGS_PARM3(x) ((x)->dx)
 #define PT_REGS_PARM4(x) ((x)->cx)
 #define PT_REGS_PARM5(x) ((x)->r8)
+#define PT_REGS_PARM6(x) ((x)->r9)
+#define PT_REGS_PARM7(x)                                            \
+({                                                                  \
+    unsigned long p = 0;                                            \
+    unsigned long *addr = regs_get_kernel_stack_nth_addr(x, 1);     \
+    if (addr != NULL) {                                             \
+        bpf_probe_read(&p, sizeof(p), addr);                        \
+    }                                                               \
+    p;                                                              \
+})
 #define PT_REGS_RET(x) ((x)->sp)
 #define PT_REGS_FP(x) ((x)->bp)
 #define PT_REGS_RC(x) ((x)->ax)
 #define PT_REGS_SP(x) ((x)->sp)
-#define PT_REGS_IP(x) ((x)->ip)
-
-#elif defined(__s390x__)
-
-#define PT_REGS_PARM1(x) ((x)->gprs[2])
-#define PT_REGS_PARM2(x) ((x)->gprs[3])
-#define PT_REGS_PARM3(x) ((x)->gprs[4])
-#define PT_REGS_PARM4(x) ((x)->gprs[5])
-#define PT_REGS_PARM5(x) ((x)->gprs[6])
-#define PT_REGS_RET(x) ((x)->gprs[14])
-#define PT_REGS_FP(x) ((x)->gprs[11]) /* Works only with CONFIG_FRAME_POINTER */
-#define PT_REGS_RC(x) ((x)->gprs[2])
-#define PT_REGS_SP(x) ((x)->gprs[15])
 #define PT_REGS_IP(x) ((x)->ip)
 
 #elif defined(__aarch64__)
@@ -126,32 +123,20 @@ struct bpf_map_def {
 #define PT_REGS_PARM3(x) ((x)->regs[2])
 #define PT_REGS_PARM4(x) ((x)->regs[3])
 #define PT_REGS_PARM5(x) ((x)->regs[4])
+#define PT_REGS_PARM6(x) ((x)->regs[5])
+#define PT_REGS_PARM7(x) ((x)->regs[6])
 #define PT_REGS_RET(x) ((x)->regs[30])
 #define PT_REGS_FP(x) ((x)->regs[29]) /* Works only with CONFIG_FRAME_POINTER */
 #define PT_REGS_RC(x) ((x)->regs[0])
 #define PT_REGS_SP(x) ((x)->sp)
 #define PT_REGS_IP(x) ((x)->pc)
 
-#elif defined(__powerpc__)
-
-#define PT_REGS_PARM1(x) ((x)->gpr[3])
-#define PT_REGS_PARM2(x) ((x)->gpr[4])
-#define PT_REGS_PARM3(x) ((x)->gpr[5])
-#define PT_REGS_PARM4(x) ((x)->gpr[6])
-#define PT_REGS_PARM5(x) ((x)->gpr[7])
-#define PT_REGS_RC(x) ((x)->gpr[3])
-#define PT_REGS_SP(x) ((x)->sp)
-#define PT_REGS_IP(x) ((x)->nip)
-
+#else
+#error "Unsupported platform"
 #endif
 
-#ifdef __powerpc__
-#define BPF_KPROBE_READ_RET_IP(ip, ctx) ({ (ip) = (ctx)->link; })
-#define BPF_KRETPROBE_READ_RET_IP BPF_KPROBE_READ_RET_IP
-#else
 #define BPF_KPROBE_READ_RET_IP(ip, ctx) ({ bpf_probe_read(&(ip), sizeof(ip), (void*)PT_REGS_RET(ctx)); })
 #define BPF_KRETPROBE_READ_RET_IP(ip, ctx) ({ bpf_probe_read(&(ip), sizeof(ip), \
                                                   (void*)(PT_REGS_FP(ctx) + sizeof(ip))); })
-#endif
 
 #endif

--- a/pkg/ebpf/c/bpf_helpers.h
+++ b/pkg/ebpf/c/bpf_helpers.h
@@ -93,6 +93,13 @@ struct bpf_map_def {
     char namespace[BUF_SIZE_MAP_NS];
 };
 
+#define PT_REGS_STACK_PARM(x,n)                                     \
+({                                                                  \
+    unsigned long p = 0;                                            \
+    bpf_probe_read(&p, sizeof(p), ((unsigned long *)x->sp) + n);    \
+    p;                                                              \
+})
+
 #if defined(__x86_64__)
 
 #define PT_REGS_PARM1(x) ((x)->di)
@@ -101,12 +108,9 @@ struct bpf_map_def {
 #define PT_REGS_PARM4(x) ((x)->cx)
 #define PT_REGS_PARM5(x) ((x)->r8)
 #define PT_REGS_PARM6(x) ((x)->r9)
-#define PT_REGS_PARM7(x)                                            \
-({                                                                  \
-    unsigned long p = 0;                                            \
-    bpf_probe_read(&p, sizeof(p), ((unsigned long *)x->sp) + 1);    \
-    p;                                                              \
-})
+#define PT_REGS_PARM7(x) PT_REGS_STACK_PARM(x,1)
+#define PT_REGS_PARM8(x) PT_REGS_STACK_PARM(x,2)
+#define PT_REGS_PARM9(x) PT_REGS_STACK_PARM(x,3)
 #define PT_REGS_RET(x) ((x)->sp)
 #define PT_REGS_FP(x) ((x)->bp)
 #define PT_REGS_RC(x) ((x)->ax)
@@ -122,6 +126,8 @@ struct bpf_map_def {
 #define PT_REGS_PARM5(x) ((x)->regs[4])
 #define PT_REGS_PARM6(x) ((x)->regs[5])
 #define PT_REGS_PARM7(x) ((x)->regs[6])
+#define PT_REGS_PARM8(x) ((x)->regs[7])
+#define PT_REGS_PARM9(x) PT_REGS_STACK_PARM(x,1)
 #define PT_REGS_RET(x) ((x)->regs[30])
 #define PT_REGS_FP(x) ((x)->regs[29]) /* Works only with CONFIG_FRAME_POINTER */
 #define PT_REGS_RC(x) ((x)->regs[0])

--- a/pkg/ebpf/c/bpf_helpers.h
+++ b/pkg/ebpf/c/bpf_helpers.h
@@ -104,10 +104,7 @@ struct bpf_map_def {
 #define PT_REGS_PARM7(x)                                            \
 ({                                                                  \
     unsigned long p = 0;                                            \
-    unsigned long *addr = regs_get_kernel_stack_nth_addr(x, 1);     \
-    if (addr != NULL) {                                             \
-        bpf_probe_read(&p, sizeof(p), addr);                        \
-    }                                                               \
+    bpf_probe_read(&p, sizeof(p), ((unsigned long *)x->sp) + 1);    \
     p;                                                              \
 })
 #define PT_REGS_RET(x) ((x)->sp)

--- a/pkg/network/config/config_linux.go
+++ b/pkg/network/config/config_linux.go
@@ -51,7 +51,12 @@ func (c *Config) EnabledProbes(runtimeTracer bool) (map[probes.ProbeName]struct{
 		enabled[probes.InetBindRet] = struct{}{}
 
 		if c.CollectIPv6Conns {
-			enabled[probes.IP6MakeSkb] = struct{}{}
+			if !runtimeTracer && kv < kernel.VersionCode(4, 7, 0) {
+				enabled[probes.IP6MakeSkbPre470] = struct{}{}
+			} else {
+				enabled[probes.IP6MakeSkb] = struct{}{}
+			}
+
 			enabled[probes.Inet6Bind] = struct{}{}
 			enabled[probes.Inet6BindRet] = struct{}{}
 		}

--- a/pkg/network/config/tracer_config.go
+++ b/pkg/network/config/tracer_config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -15,7 +16,7 @@ func TracerConfigFromConfig(cfg *config.AgentConfig) *Config {
 	tracerConfig := NewDefaultConfig()
 	tracerConfig.Config = *ebpf.SysProbeConfigFromConfig(cfg)
 
-	if !isIPv6EnabledOnHost() {
+	if !kernel.IsIPv6Enabled() {
 		tracerConfig.CollectIPv6Conns = false
 		log.Info("system probe IPv6 tracing disabled by system")
 	} else if cfg.DisableIPv6Tracing {
@@ -91,7 +92,3 @@ func TracerConfigFromConfig(cfg *config.AgentConfig) *Config {
 	return tracerConfig
 }
 
-func isIPv6EnabledOnHost() bool {
-	_, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
-	return err == nil
-}

--- a/pkg/network/config/tracer_config.go
+++ b/pkg/network/config/tracer_config.go
@@ -1,12 +1,8 @@
 package config
 
 import (
-	"io/ioutil"
-	"path/filepath"
-
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
-	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -91,4 +87,3 @@ func TracerConfigFromConfig(cfg *config.AgentConfig) *Config {
 
 	return tracerConfig
 }
-

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -179,6 +179,23 @@ int kprobe__ip6_make_skb(struct pt_regs* ctx) {
     return 0;
 }
 
+SEC("kprobe/ip6_make_skb/pre_4_7_0")
+int kprobe__ip6_make_skb__pre_4_7_0(struct pt_regs* ctx) {
+    u64 zero = 0;
+    tracer_status_t* status = bpf_map_lookup_elem(&tracer_status, &zero);
+
+    if (status == NULL) {
+        return 0;
+    }
+    struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM9(ctx);
+    if (fl6 == NULL) {
+        return 0;
+    }
+
+    guess_offsets(status, NULL, NULL, fl6);
+    return 0;
+}
+
 /* Used exclusively for offset guessing */
 SEC("kprobe/tcp_getsockopt")
 int kprobe__tcp_getsockopt(struct pt_regs* ctx) {

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -166,15 +166,10 @@ SEC("kprobe/ip6_make_skb")
 int kprobe__ip6_make_skb(struct pt_regs* ctx) {
     u64 zero = 0;
     tracer_status_t* status = bpf_map_lookup_elem(&tracer_status, &zero);
-
     if (status == NULL) {
         return 0;
     }
     struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM7(ctx);
-    if (fl6 == NULL) {
-        return 0;
-    }
-
     guess_offsets(status, NULL, NULL, fl6);
     return 0;
 }
@@ -183,15 +178,10 @@ SEC("kprobe/ip6_make_skb/pre_4_7_0")
 int kprobe__ip6_make_skb__pre_4_7_0(struct pt_regs* ctx) {
     u64 zero = 0;
     tracer_status_t* status = bpf_map_lookup_elem(&tracer_status, &zero);
-
     if (status == NULL) {
         return 0;
     }
     struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM9(ctx);
-    if (fl6 == NULL) {
-        return 0;
-    }
-
     guess_offsets(status, NULL, NULL, fl6);
     return 0;
 }

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -23,6 +23,10 @@ static const __u8 GUESS_SADDR_FL4 = 8;
 static const __u8 GUESS_DADDR_FL4 = 9;
 static const __u8 GUESS_SPORT_FL4 = 10;
 static const __u8 GUESS_DPORT_FL4 = 11;
+static const __u8 GUESS_SADDR_FL6 = 12;
+static const __u8 GUESS_DADDR_FL6 = 13;
+static const __u8 GUESS_SPORT_FL6 = 14;
+static const __u8 GUESS_DPORT_FL6 = 15;
 
 static const __u8 TRACER_STATE_UNINITIALIZED = 0;
 static const __u8 TRACER_STATE_CHECKING = 1;
@@ -52,6 +56,10 @@ typedef struct {
     __u64 offset_daddr_fl4;
     __u64 offset_sport_fl4;
     __u64 offset_dport_fl4;
+    __u64 offset_saddr_fl6;
+    __u64 offset_daddr_fl6;
+    __u64 offset_sport_fl6;
+    __u64 offset_dport_fl6;
 
     __u64 err;
 
@@ -68,9 +76,14 @@ typedef struct {
     __u32 daddr_fl4;
     __u16 sport_fl4;
     __u16 dport_fl4;
+    __u32 saddr_fl6[4];
+    __u32 daddr_fl6[4];
+    __u16 sport_fl6;
+    __u16 dport_fl6;
 
     __u8 ipv6_enabled;
     __u8 fl4_offsets;
+    __u8 fl6_offsets;
 } tracer_status_t;
 
 #endif //__OFFSET_GUESS_H

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -384,8 +384,13 @@ int kprobe__ip6_make_skb(struct pt_regs* ctx) {
             increment_telemetry_count(udp_send_missed);
             return 0;
         }
-
+// commit: https://github.com/torvalds/linux/commit/26879da58711aa604a1b866cbeedd7e0f78f90ad
+// changed the arguments to ip6_make_skb and introduced the struct ipcm6_cookie
+#if __is_identifier(ipcm6_cookie)
         struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM7(ctx);
+#else
+        struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM9(ctx);
+#endif
         bpf_probe_read(&t.saddr_h, sizeof(u64), ((char*)fl6) + offset_saddr_fl6());
         bpf_probe_read(&t.saddr_l, sizeof(u64), ((char*)fl6) + offset_saddr_fl6() + sizeof(u64));
         bpf_probe_read(&t.daddr_h, sizeof(u64), ((char*)fl6) + offset_daddr_fl6());

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -233,7 +233,7 @@ int kprobe__ip6_make_skb(struct pt_regs* ctx) {
     if (!read_conn_tuple(&t, sk, pid_tgid, CONN_TYPE_UDP)) {
 // commit: https://github.com/torvalds/linux/commit/26879da58711aa604a1b866cbeedd7e0f78f90ad
 // changed the arguments to ip6_make_skb and introduced the struct ipcm6_cookie
-#if __is_identifier(ipcm6_cookie)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
         struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM7(ctx);
 #else
         struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM9(ctx);

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -221,9 +221,9 @@ int kretprobe__tcp_close(struct pt_regs* ctx) {
     return 0;
 }
 
+#ifdef FEATURE_IPV6_ENABLED
 SEC("kprobe/ip6_make_skb")
 int kprobe__ip6_make_skb(struct pt_regs* ctx) {
-#ifdef FEATURE_IPV6_ENABLED
     struct sock* sk = (struct sock*)PT_REGS_PARM1(ctx);
     size_t size = (size_t)PT_REGS_PARM4(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -279,10 +279,10 @@ int kprobe__ip6_make_skb(struct pt_regs* ctx) {
     log_debug("kprobe/ip6_make_skb: pid_tgid: %d, size: %d\n", pid_tgid, size);
     handle_message(&t, size, 0, CONN_DIRECTION_UNKNOWN);
     increment_telemetry_count(udp_send_processed);
-#endif
 
     return 0;
 }
+#endif
 
 // Note: This is used only in the UDP send path.
 SEC("kprobe/ip_make_skb")

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -40,13 +40,6 @@ static __always_inline __u16 read_sport(struct sock* skp) {
     return sport;
 }
 
-#ifdef FEATURE_IPV6_ENABLED
-static __always_inline void read_in6_addr(__u64* addr_h, __u64* addr_l, struct in6_addr* in6) {
-    bpf_probe_read(addr_h, sizeof(__u64), &(in6->in6_u.u6_addr32[0]));
-    bpf_probe_read(addr_l, sizeof(__u64), &(in6->in6_u.u6_addr32[2]));
-}
-#endif
-
 /**
  * Reads values into a `conn_tuple_t` from a `sock`. Any values that are already set in conn_tuple_t
  * are not overwritten. Returns 1 success, 0 otherwise.

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -238,7 +238,13 @@ int kprobe__ip6_make_skb(struct pt_regs* ctx) {
 
     conn_tuple_t t = {};
     if (!read_conn_tuple(&t, sk, pid_tgid, CONN_TYPE_UDP)) {
+// commit: https://github.com/torvalds/linux/commit/26879da58711aa604a1b866cbeedd7e0f78f90ad
+// changed the arguments to ip6_make_skb and introduced the struct ipcm6_cookie
+#if __is_identifier(ipcm6_cookie)
         struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM7(ctx);
+#else
+        struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM9(ctx);
+#endif
         read_in6_addr(&t.saddr_h, &t.saddr_l, &fl6->saddr);
         read_in6_addr(&t.daddr_h, &t.daddr_l, &fl6->daddr);
 

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -28,6 +28,7 @@ func NewOffsetManager() *manager.Manager {
 			{Section: string(probes.TCPv6Connect)},
 			{Section: string(probes.IPMakeSkb)},
 			{Section: string(probes.IP6MakeSkb)},
+			{Section: string(probes.IP6MakeSkbPre470)},
 			{Section: string(probes.TCPv6ConnectReturn), KProbeMaxActive: maxActive},
 		},
 	}

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -27,6 +27,7 @@ func NewOffsetManager() *manager.Manager {
 			{Section: string(probes.TCPGetSockOpt)},
 			{Section: string(probes.TCPv6Connect)},
 			{Section: string(probes.IPMakeSkb)},
+			{Section: string(probes.IP6MakeSkb)},
 			{Section: string(probes.TCPv6ConnectReturn), KProbeMaxActive: maxActive},
 		},
 	}

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -78,7 +78,6 @@ func NewManager(closedHandler, httpHandler *ebpf.PerfHandler, runtimeTracer bool
 			{Section: string(probes.TCPSetState)},
 			{Section: string(probes.IPMakeSkb)},
 			{Section: string(probes.IP6MakeSkb)},
-			{Section: string(probes.IP6MakeSkbPre470)},
 			{Section: string(probes.UDPRecvMsg)},
 			{Section: string(probes.UDPRecvMsgPre410), MatchFuncName: "^udp_recvmsg$"},
 			{Section: string(probes.UDPRecvMsgReturn), KProbeMaxActive: maxActive},
@@ -101,6 +100,7 @@ func NewManager(closedHandler, httpHandler *ebpf.PerfHandler, runtimeTracer bool
 	// tracer.
 	if !runtimeTracer {
 		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.TCPRetransmitPre470), MatchFuncName: "^tcp_retransmit_skb$"})
+		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.IP6MakeSkbPre470)})
 	}
 
 	return mgr

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -100,8 +100,10 @@ func NewManager(closedHandler, httpHandler *ebpf.PerfHandler, runtimeTracer bool
 	// do that with #ifdefs inline. Thus the following probes should only be declared as existing in the prebuilt
 	// tracer.
 	if !runtimeTracer {
-		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.TCPRetransmitPre470), MatchFuncName: "^tcp_retransmit_skb$"})
-		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.IP6MakeSkbPre470)}, MatchFuncName: "^ip6_make_skb$"})
+		mgr.Probes = append(mgr.Probes,
+			&manager.Probe{Section: string(probes.TCPRetransmitPre470), MatchFuncName: "^tcp_retransmit_skb$"},
+			&manager.Probe{Section: string(probes.IP6MakeSkbPre470), MatchFuncName: "^ip6_make_skb$"},
+		)
 	}
 
 	return mgr

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -78,6 +78,7 @@ func NewManager(closedHandler, httpHandler *ebpf.PerfHandler, runtimeTracer bool
 			{Section: string(probes.TCPSetState)},
 			{Section: string(probes.IPMakeSkb)},
 			{Section: string(probes.IP6MakeSkb)},
+			{Section: string(probes.IP6MakeSkbPre470)},
 			{Section: string(probes.UDPRecvMsg)},
 			{Section: string(probes.UDPRecvMsgPre410), MatchFuncName: "^udp_recvmsg$"},
 			{Section: string(probes.UDPRecvMsgReturn), KProbeMaxActive: maxActive},

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -28,7 +28,7 @@ func NewOffsetManager() *manager.Manager {
 			{Section: string(probes.TCPv6Connect)},
 			{Section: string(probes.IPMakeSkb)},
 			{Section: string(probes.IP6MakeSkb)},
-			{Section: string(probes.IP6MakeSkbPre470)},
+			{Section: string(probes.IP6MakeSkbPre470), MatchFuncName: "^ip6_make_skb$"},
 			{Section: string(probes.TCPv6ConnectReturn), KProbeMaxActive: maxActive},
 		},
 	}
@@ -101,7 +101,7 @@ func NewManager(closedHandler, httpHandler *ebpf.PerfHandler, runtimeTracer bool
 	// tracer.
 	if !runtimeTracer {
 		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.TCPRetransmitPre470), MatchFuncName: "^tcp_retransmit_skb$"})
-		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.IP6MakeSkbPre470)})
+		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.IP6MakeSkbPre470)}, MatchFuncName: "^ip6_make_skb$"})
 	}
 
 	return mgr

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -43,8 +43,9 @@ const (
 	TCPCloseReturn ProbeName = "kretprobe/tcp_close"
 
 	// We use the following two probes for UDP sends
-	IPMakeSkb  ProbeName = "kprobe/ip_make_skb"
-	IP6MakeSkb ProbeName = "kprobe/ip6_make_skb"
+	IPMakeSkb        ProbeName = "kprobe/ip_make_skb"
+	IP6MakeSkb       ProbeName = "kprobe/ip6_make_skb"
+	IP6MakeSkbPre470 ProbeName = "kprobe/ip6_make_skb/pre_4_7_0"
 
 	// UDPRecvMsg traces the udp_recvmsg() system call
 	UDPRecvMsg ProbeName = "kprobe/udp_recvmsg"

--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -435,14 +435,19 @@ func checkAndUpdateCurrentOffset(mp *ebpf.Map, status *tracerStatus, expected *f
 			break
 		}
 	case guessDportFl4:
+		nextStep := guessSaddrFl6
+		if status.ipv6_enabled == disabled {
+			nextStep = guessNetns
+		}
+
 		if status.dport_fl4 == C.__u16(htons(expected.dportFl4)) {
-			logAndAdvance(status, status.offset_dport_fl4, guessSaddrFl6)
+			logAndAdvance(status, status.offset_dport_fl4, C.__u64(nextStep))
 			status.fl4_offsets = enabled
 			break
 		}
 		status.offset_dport_fl4++
 		if uint64(status.offset_dport_fl4) == threshold {
-			logAndAdvance(status, notApplicable, guessSaddrFl6)
+			logAndAdvance(status, notApplicable, C.__u64(nextStep))
 			status.fl4_offsets = disabled
 			break
 		}
@@ -453,7 +458,7 @@ func checkAndUpdateCurrentOffset(mp *ebpf.Map, status *tracerStatus, expected *f
 		}
 		status.offset_saddr_fl6++
 		if uint64(status.offset_saddr_fl6) == threshold {
-			// Let's skip all other flowi4 fields
+			// Let's skip all other flowi6 fields
 			logAndAdvance(status, notApplicable, guessNetns)
 			status.fl6_offsets = disabled
 			break

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -402,7 +402,11 @@ func runOffsetGuessing(config *config.Config, buf bytecode.AssetReader) ([]manag
 			Max: math.MaxUint64,
 		},
 	}
-	enabledProbes := offsetGuessProbes(config)
+	enabledProbes, err := offsetGuessProbes(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure offset guessing probes: %w", err)
+	}
+
 	for _, p := range offsetMgr.Probes {
 		if _, enabled := enabledProbes[probes.ProbeName(p.Section)]; !enabled {
 			offsetOptions.ExcludedSections = append(offsetOptions.ExcludedSections, p.Section)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -143,6 +143,8 @@ func TestTracerExpvar(t *testing.T) {
 			"PInetBindMisses",
 			"PInet6BindHits",
 			"PInet6BindMisses",
+			"PIp6MakeSkbHits",
+			"PIp6MakeSkbMisses",
 			"RInetCskAcceptHits",
 			"RInetCskAcceptMisses",
 			"RTcpCloseHits",
@@ -1747,7 +1749,7 @@ func TestUnconnectedUDPSendIPv4(t *testing.T) {
 	defer tr.Stop()
 
 	remotePort := rand.Int()%5000 + 15000
-	remoteAddr := &net.UDPAddr{IP: net.ParseIP("8.8.8.8"), Port: remotePort}
+	remoteAddr := &net.UDPAddr{IP: net.ParseIP(googlePublicDNSIPv4), Port: remotePort}
 	// Use ListenUDP instead of DialUDP to create a "connectionless" UDP connection
 	conn, err := net.ListenUDP("udp", nil)
 	require.NoError(t, err)
@@ -1779,6 +1781,35 @@ func TestConnectedUDPSendIPv6(t *testing.T) {
 	defer conn.Close()
 	message := []byte("payload")
 	bytesSent, err := conn.Write(message)
+	require.NoError(t, err)
+
+	connections := getConnections(t, tr)
+	outgoing := searchConnections(connections, func(cs network.ConnectionStats) bool {
+		return cs.DPort == uint16(remotePort)
+	})
+
+	require.Len(t, outgoing, 1)
+	assert.Equal(t, remoteAddr.IP.String(), outgoing[0].Dest.String())
+	assert.Equal(t, bytesSent, int(outgoing[0].MonotonicSentBytes))
+}
+
+func TestUnconnectedUDPSendIPv6(t *testing.T) {
+	cfg := config.NewDefaultConfig()
+	cfg.CollectIPv6Conns = true
+	tr, err := NewTracer(cfg)
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	linkLocal, err := getIPv6LinkLocalAddress()
+	require.NoError(t, err)
+
+	remotePort := rand.Int()%5000 + 15000
+	remoteAddr := &net.UDPAddr{IP: net.ParseIP(interfaceLocalMulticastIPv6), Port: remotePort}
+	conn, err := net.ListenUDP("udp6", linkLocal)
+	require.NoError(t, err)
+	defer conn.Close()
+	message := []byte("payload")
+	bytesSent, err := conn.WriteTo(message, remoteAddr)
 	require.NoError(t, err)
 
 	connections := getConnections(t, tr)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -677,6 +677,10 @@ func TestTCPShortlived(t *testing.T) {
 
 func TestTCPOverIPv6(t *testing.T) {
 	t.SkipNow()
+	if !kernel.IsIPv6Enabled() {
+		t.Skip("IPv6 not enabled on host")
+	}
+
 	config := testConfig()
 	config.CollectIPv6Conns = true
 
@@ -1768,6 +1772,10 @@ func TestUnconnectedUDPSendIPv4(t *testing.T) {
 }
 
 func TestConnectedUDPSendIPv6(t *testing.T) {
+	if !kernel.IsIPv6Enabled() {
+		t.Skip("IPv6 not enabled on host")
+	}
+
 	cfg := testConfig()
 	cfg.CollectIPv6Conns = true
 	tr, err := NewTracer(cfg)
@@ -1794,6 +1802,10 @@ func TestConnectedUDPSendIPv6(t *testing.T) {
 }
 
 func TestUnconnectedUDPSendIPv6(t *testing.T) {
+	if !kernel.IsIPv6Enabled() {
+		t.Skip("IPv6 not enabled on host")
+	}
+
 	cfg := config.NewDefaultConfig()
 	cfg.CollectIPv6Conns = true
 	tr, err := NewTracer(cfg)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1806,7 +1806,7 @@ func TestUnconnectedUDPSendIPv6(t *testing.T) {
 		t.Skip("IPv6 not enabled on host")
 	}
 
-	cfg := config.NewDefaultConfig()
+	cfg := testConfig()
 	cfg.CollectIPv6Conns = true
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)

--- a/pkg/util/kernel/ip.go
+++ b/pkg/util/kernel/ip.go
@@ -1,0 +1,14 @@
+package kernel
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+// IsIPv6Enabled returns whether or not IPv6 has been enabled on the host
+func IsIPv6Enabled() bool {
+	_, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
+	return err == nil
+}

--- a/pkg/util/kernel/ip.go
+++ b/pkg/util/kernel/ip.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package kernel
 
 import (

--- a/pkg/util/kernel/ip_unsupported.go
+++ b/pkg/util/kernel/ip_unsupported.go
@@ -1,0 +1,8 @@
+// +build !linux
+
+package kernel
+
+// IsIPv6Enabled returns whether or not IPv6 has been enabled on the host
+func IsIPv6Enabled() bool {
+	return true
+}


### PR DESCRIPTION
### What does this PR do?

Similar to #6307 but for IPv6 UDP sends, this adds the ability to extract addresses and ports for UDP sends that are "unconnected" (meaning they haven't received a reply yet).

### Motivation

Improving IPv6 and UDP coverage of network tracer.

### Additional Notes

The 7th and later arguments to a function on `x86_64` are stored on the stack, which is why the macro for `PT_REGS_PARM7` is so complicated. See https://eli.thegreenplace.net/2011/09/06/stack-frame-layout-on-x86-64 for more information.

I was unable to use a public IPv6 destination address for offset guessing because the agent dev VM does not have a default IPv6 route. This is likely a common setup, so I worked around it by using link-local and multicast addresses.

### Describe your test plan

Added test comparable to IPv4 version. It passes in the agent VM.
