### PR TITLE
Add datadog-agent jmx help message

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -21,7 +21,7 @@ import (
 var (
 	jmxCmd = &cobra.Command{
 		Use:   "jmx",
-		Short: "Run the troubleshoot specified jmx integrations",
+		Short: "Run troubleshooting commands on JMXFetch integrations",
 		Long:  ``,
 	}
 

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -21,7 +21,7 @@ import (
 var (
 	jmxCmd = &cobra.Command{
 		Use:   "jmx",
-		Short: "",
+		Short: "Run the troubleshoot specified jmx integrations",
 		Long:  ``,
 	}
 


### PR DESCRIPTION
### What does this PR do?
Added description of jmx command.

### Motivation

Run the 「datadog-agent --help」,But there was no explanation for imx.
That's why we created the pull request.

```
# datadog-agent --help
...
  import          Import and convert configuration files from previous versions of the Agent
  integration     Datadog integration manager
  jmx             
  launch-gui      starts the Datadog Agent GUI
  run             Run the Agent
...
```

### Additional Notes

Please confirm this as the scope of impact is not well recognized.

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
