### PR TITLE
serverless: space-separated lambda logs type to collect instead of comma-separated.

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -257,7 +257,7 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 		//             user don't care about the platform logs, the Agent will still want
 		//             to receive them in order to generate the enhanced metrics.
 		if envLogsType, exists := os.LookupEnv(logsLogsTypeSubscribed); exists {
-			parts := strings.Split(strings.TrimSpace(envLogsType), ",")
+			parts := strings.Split(strings.TrimSpace(envLogsType), " ")
 			for _, part := range parts {
 				part = strings.ToLower(strings.TrimSpace(part))
 				switch part {


### PR DESCRIPTION
### What does this PR do?

Use a space-separated lambda logs type to collect instead of a comma-separated in order to be more consistent with other settings of the Datadog Agent.

