### PR TITLE
pkg/trace/writer: added limiting retries on failed payloads

### DIFF
--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -62,6 +62,9 @@ type eventRecorder interface {
 	recordEvent(t eventType, data *eventData)
 }
 
+//maximum retries for a payload
+const maxRetries = 5
+
 // eventType specifies an event which occurred in the sender.
 type eventType int
 
@@ -247,6 +250,14 @@ func (s *sender) sendPayload(p *payload) {
 			return
 		}
 		atomic.AddInt32(&s.attempt, 1)
+		atomic.AddInt32(&p.retries, 1)
+
+		if atomic.LoadInt32(&p.retries) > maxRetries {
+			//exceeded max retries per payload, dropping payload
+			log.Error("Exceeded max retries per payload, dropping payload ")
+			s.releasePayload(p, eventTypeDropped, stats)
+			return
+		}
 		select {
 		case s.queue <- p:
 			s.recordEvent(eventTypeRetry, stats)
@@ -339,6 +350,7 @@ func (s *sender) do(req *http.Request) error {
 type payload struct {
 	body    *bytes.Buffer     // request body
 	headers map[string]string // request headers
+	retries int32
 }
 
 // ppool is a pool of payloads.
@@ -347,6 +359,7 @@ var ppool = &sync.Pool{
 		return &payload{
 			body:    &bytes.Buffer{},
 			headers: make(map[string]string),
+			retries: 0,
 		}
 	},
 }

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -371,6 +371,7 @@ func newPayload(headers map[string]string) *payload {
 	p := ppool.Get().(*payload)
 	p.body.Reset()
 	p.headers = headers
+	p.retries = 0
 	return p
 }
 

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -346,8 +346,7 @@ func TestShouldWarnRetry(t *testing.T) {
 	} {
 		actual := shouldWarnRetry(test.retries)
 		if actual != test.shouldWarn {
-			t.Fail()
-			t.Logf("expected: %t, actual: %t", test.shouldWarn, actual)
+			t.Fatalf("expected: %t, actual: %t", test.shouldWarn, actual)
 		}
 	}
 }

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -330,3 +330,24 @@ func (r *mockRecorder) recordEvent(t eventType, data *eventData) {
 		r.rejected = append(r.rejected, data)
 	}
 }
+
+func TestShouldWarnRetry(t *testing.T) {
+	for _, test := range []struct {
+		retries    int32
+		shouldWarn bool
+	}{{0, false},
+		{1, true},
+		{2, false},
+		{3, false},
+		{4, true},
+		{5, false},
+		{6, false},
+		{8, true},
+	} {
+		actual := shouldWarnRetry(test.retries)
+		if actual != test.shouldWarn {
+			t.Fail()
+			t.Logf("expected: %t, actual: %t", test.shouldWarn, actual)
+		}
+	}
+}

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -242,7 +242,7 @@ func (w *TraceWriter) recordEvent(t eventType, data *eventData) {
 	}
 	switch t {
 	case eventTypeRetry:
-		log.Warnf("Retrying to flush trace payload; error: %s", data.err)
+		log.Debugf("Retrying to flush trace payload; error: %s", data.err)
 		atomic.AddInt64(&w.stats.Retries, 1)
 
 	case eventTypeSent:

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -242,7 +242,7 @@ func (w *TraceWriter) recordEvent(t eventType, data *eventData) {
 	}
 	switch t {
 	case eventTypeRetry:
-		log.Debugf("Retrying to flush trace payload; error: %s", data.err)
+		log.Warnf("Retrying to flush trace payload; error: %s", data.err)
 		atomic.AddInt64(&w.stats.Retries, 1)
 
 	case eventTypeSent:


### PR DESCRIPTION
Closes #6960.  There were no useful logs upon retries to send payloads, so the payloads were sent multiple times with no warning until they were pushed out of queue. Now each retry happens with a warning and can be retried up to 5 times, then dropped

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
