### PR TITLE
Update Android NDK and gomobile

### DIFF
--- a/.gitlab/package_build/apk.yml
+++ b/.gitlab/package_build/apk.yml
@@ -5,6 +5,12 @@
 .if_deploy: &if_deploy
   if: $DEPLOY_AGENT == "true"
 
+.retrieve_linux_go_deps: &retrieve_linux_go_deps |
+  mkdir -p $GOPATH/bin && tar xzf go-bin.tar.gz -C $GOPATH/bin
+  mkdir -p $GOPATH/pkg && tar xzf go-pkg.tar.gz -C $GOPATH/pkg
+  mkdir vendor && tar xzf vendor.tar.gz -C vendor
+  rm -f go-bin.tar.gz go-pkg.tar.gz vendor.tar.gz
+
 agent_android_apk:
   rules:
     - <<: *if_not_version_7
@@ -13,11 +19,13 @@ agent_android_apk:
       when: never
     - when: on_success
   stage: package_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/android_builder:$DATADOG_AGENT_BUILDERS
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/android_builder:v3715617-76ed3eb
   tags: ["runner:main", "size:large"]
+  needs: ["linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
+    - *retrieve_linux_go_deps
     - echo running android before_script
     - cd $SRC_PATH
     - python3 -m pip install -r requirements.txt
@@ -27,12 +35,6 @@ agent_android_apk:
     - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -depth  # -delete implies -depth
     - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -delete || true  # Allow failure, we can't remove parent folders of datadog-agent
     - inv -e deps --android
-    # Some Android license has changed, we have to accept the new version.
-    # But on top of that, there is a bug in sdkmanager not updating correctly
-    # the existing license, so, we have to manually accept the new license.
-    # https://issuetracker.google.com/issues/123054726
-    # The real fix will be to change the builders
-    - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license"
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -51,7 +51,7 @@
             "type": "go"
         },
         "golang.org/x/mobile/cmd/gomobile": {
-            "version": "8b05ea26b5669e5f52084ab001b8e49ec8877955",
+            "version": "e6ae53a27f4f",
             "type": "go"
         },
         "github.com/golangci/golangci-lint": {

--- a/cmd/agent/android/build.gradle
+++ b/cmd/agent/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 

--- a/cmd/agent/android/gradle/wrapper/gradle-wrapper.properties
+++ b/cmd/agent/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -307,9 +307,7 @@ def deps(
             print("set ANDROID_NDK_HOME to build android")
             raise Exit(code=1)
 
-        cmd = "gomobile init -ndk {}".format(ndkhome)
-        print("gomobile command {}".format(cmd))
-        ctx.run(cmd)
+        ctx.run("gomobile init")
 
     if not no_dep_ensure:
         # source level deps


### PR DESCRIPTION
### What does this PR do?

Bumps the Android NDK and changes the init command (it's no longer needed to pass the NDK path).

It also bumps Gradle and the Gradle plugin versions, so they are compatible with the new NDK.

I also added `retrieve_linux_go_deps`: even if we still call `inv deps`, a lot of dependencies are reused this way.

### Describe your test plan

It builds.
