### PR TITLE
[runtime-security] add test and tool to test and debug process resolver

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -45,11 +45,42 @@ var (
 	checkPoliciesArgs = struct {
 		dir string
 	}{}
+
+	dumpCmd = &cobra.Command{
+		Use:   "dump",
+		Short: "Dump security module information",
+	}
+
+	dumpProcessCacheCmd = &cobra.Command{
+		Use:   "process-cache",
+		Short: "process cache",
+		RunE:  dumpProcessCache,
+	}
 )
 
 func init() {
+	dumpCmd.AddCommand(dumpProcessCacheCmd)
+	runtimeCmd.AddCommand(dumpCmd)
+
 	runtimeCmd.AddCommand(checkPoliciesCmd)
 	checkPoliciesCmd.Flags().StringVar(&checkPoliciesArgs.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+}
+
+func dumpProcessCache(cmd *cobra.Command, args []string) error {
+	client, err := secagent.NewRuntimeSecurityClient()
+	if err != nil {
+		return errors.Wrap(err, "unable to create a runtime security client instance")
+	}
+	defer client.Close()
+
+	filename, err := client.DumpProcessCache()
+	if err != nil {
+		return errors.Wrap(err, "unable to get a process cache dump")
+	}
+
+	fmt.Printf("Dump written: %s\n", filename)
+
+	return nil
 }
 
 func checkPolicies(cmd *cobra.Command, args []string) error {

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -75,7 +75,7 @@ func (rsa *RuntimeSecurityAgent) StartEventListener() {
 
 	rsa.running.Store(true)
 	for rsa.running.Load() == true {
-		stream, err := apiClient.GetEvents(context.Background(), &api.GetParams{})
+		stream, err := apiClient.GetEvents(context.Background(), &api.GetEventParams{})
 		if err != nil {
 			rsa.connected.Store(false)
 

--- a/pkg/security/agent/client.go
+++ b/pkg/security/agent/client.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package agent
+
+import (
+	"context"
+	"errors"
+
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/security/api"
+	"google.golang.org/grpc"
+)
+
+// RuntimeSecurityClient is used to send request to security module
+type RuntimeSecurityClient struct {
+	conn *grpc.ClientConn
+}
+
+// DumpProcessCache send a dump request
+func (c *RuntimeSecurityClient) DumpProcessCache() (string, error) {
+	apiClient := api.NewSecurityModuleClient(c.conn)
+
+	response, err := apiClient.DumpProcessCache(context.Background(), &api.DumpProcessCacheParams{})
+	if err != nil {
+		return "", err
+	}
+
+	return response.Filename, nil
+}
+
+// Close closes the connection
+func (c *RuntimeSecurityClient) Close() {
+	c.conn.Close()
+}
+
+// NewRuntimeSecurityClient instantiates a new RuntimeSecurityClient
+func NewRuntimeSecurityClient() (*RuntimeSecurityClient, error) {
+	socketPath := coreconfig.Datadog.GetString("runtime_security_config.socket")
+	if socketPath == "" {
+		return nil, errors.New("runtime_security_config.socket must be set")
+	}
+
+	path := "unix://" + socketPath
+	conn, err := grpc.Dial(path, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+
+	return &RuntimeSecurityClient{
+		conn: conn,
+	}, nil
+}

--- a/pkg/security/api/api.pb.go
+++ b/pkg/security/api/api.pb.go
@@ -24,36 +24,36 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
-type GetParams struct {
+type GetEventParams struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *GetParams) Reset()         { *m = GetParams{} }
-func (m *GetParams) String() string { return proto.CompactTextString(m) }
-func (*GetParams) ProtoMessage()    {}
-func (*GetParams) Descriptor() ([]byte, []int) {
+func (m *GetEventParams) Reset()         { *m = GetEventParams{} }
+func (m *GetEventParams) String() string { return proto.CompactTextString(m) }
+func (*GetEventParams) ProtoMessage()    {}
+func (*GetEventParams) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ce049ba84fb5261a, []int{0}
 }
 
-func (m *GetParams) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetParams.Unmarshal(m, b)
+func (m *GetEventParams) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetEventParams.Unmarshal(m, b)
 }
-func (m *GetParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetParams.Marshal(b, m, deterministic)
+func (m *GetEventParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetEventParams.Marshal(b, m, deterministic)
 }
-func (m *GetParams) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetParams.Merge(m, src)
+func (m *GetEventParams) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetEventParams.Merge(m, src)
 }
-func (m *GetParams) XXX_Size() int {
-	return xxx_messageInfo_GetParams.Size(m)
+func (m *GetEventParams) XXX_Size() int {
+	return xxx_messageInfo_GetEventParams.Size(m)
 }
-func (m *GetParams) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetParams.DiscardUnknown(m)
+func (m *GetEventParams) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetEventParams.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_GetParams proto.InternalMessageInfo
+var xxx_messageInfo_GetEventParams proto.InternalMessageInfo
 
 type SecurityEventMessage struct {
 	RuleID               string   `protobuf:"bytes,1,opt,name=RuleID,proto3" json:"RuleID,omitempty"`
@@ -110,27 +110,104 @@ func (m *SecurityEventMessage) GetTags() []string {
 	return nil
 }
 
+type DumpProcessCacheParams struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DumpProcessCacheParams) Reset()         { *m = DumpProcessCacheParams{} }
+func (m *DumpProcessCacheParams) String() string { return proto.CompactTextString(m) }
+func (*DumpProcessCacheParams) ProtoMessage()    {}
+func (*DumpProcessCacheParams) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ce049ba84fb5261a, []int{2}
+}
+
+func (m *DumpProcessCacheParams) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DumpProcessCacheParams.Unmarshal(m, b)
+}
+func (m *DumpProcessCacheParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DumpProcessCacheParams.Marshal(b, m, deterministic)
+}
+func (m *DumpProcessCacheParams) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DumpProcessCacheParams.Merge(m, src)
+}
+func (m *DumpProcessCacheParams) XXX_Size() int {
+	return xxx_messageInfo_DumpProcessCacheParams.Size(m)
+}
+func (m *DumpProcessCacheParams) XXX_DiscardUnknown() {
+	xxx_messageInfo_DumpProcessCacheParams.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DumpProcessCacheParams proto.InternalMessageInfo
+
+type SecurityDumpProcessCacheMessage struct {
+	Filename             string   `protobuf:"bytes,1,opt,name=Filename,proto3" json:"Filename,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *SecurityDumpProcessCacheMessage) Reset()         { *m = SecurityDumpProcessCacheMessage{} }
+func (m *SecurityDumpProcessCacheMessage) String() string { return proto.CompactTextString(m) }
+func (*SecurityDumpProcessCacheMessage) ProtoMessage()    {}
+func (*SecurityDumpProcessCacheMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ce049ba84fb5261a, []int{3}
+}
+
+func (m *SecurityDumpProcessCacheMessage) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SecurityDumpProcessCacheMessage.Unmarshal(m, b)
+}
+func (m *SecurityDumpProcessCacheMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SecurityDumpProcessCacheMessage.Marshal(b, m, deterministic)
+}
+func (m *SecurityDumpProcessCacheMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SecurityDumpProcessCacheMessage.Merge(m, src)
+}
+func (m *SecurityDumpProcessCacheMessage) XXX_Size() int {
+	return xxx_messageInfo_SecurityDumpProcessCacheMessage.Size(m)
+}
+func (m *SecurityDumpProcessCacheMessage) XXX_DiscardUnknown() {
+	xxx_messageInfo_SecurityDumpProcessCacheMessage.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SecurityDumpProcessCacheMessage proto.InternalMessageInfo
+
+func (m *SecurityDumpProcessCacheMessage) GetFilename() string {
+	if m != nil {
+		return m.Filename
+	}
+	return ""
+}
+
 func init() {
-	proto.RegisterType((*GetParams)(nil), "api.GetParams")
+	proto.RegisterType((*GetEventParams)(nil), "api.GetEventParams")
 	proto.RegisterType((*SecurityEventMessage)(nil), "api.SecurityEventMessage")
+	proto.RegisterType((*DumpProcessCacheParams)(nil), "api.DumpProcessCacheParams")
+	proto.RegisterType((*SecurityDumpProcessCacheMessage)(nil), "api.SecurityDumpProcessCacheMessage")
 }
 
 func init() { proto.RegisterFile("pkg/security/api/api.proto", fileDescriptor_ce049ba84fb5261a) }
 
 var fileDescriptor_ce049ba84fb5261a = []byte{
-	// 179 bytes of a gzipped FileDescriptorProto
+	// 257 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2a, 0xc8, 0x4e, 0xd7,
 	0x2f, 0x4e, 0x4d, 0x2e, 0x2d, 0xca, 0x2c, 0xa9, 0xd4, 0x4f, 0x2c, 0xc8, 0x04, 0x61, 0xbd, 0x82,
-	0xa2, 0xfc, 0x92, 0x7c, 0x21, 0xe6, 0xc4, 0x82, 0x4c, 0x25, 0x6e, 0x2e, 0x4e, 0xf7, 0xd4, 0x92,
-	0x80, 0xc4, 0xa2, 0xc4, 0xdc, 0x62, 0xa5, 0x30, 0x2e, 0x91, 0x60, 0xa8, 0x5a, 0xd7, 0xb2, 0xd4,
-	0xbc, 0x12, 0xdf, 0xd4, 0xe2, 0xe2, 0xc4, 0xf4, 0x54, 0x21, 0x31, 0x2e, 0xb6, 0xa0, 0xd2, 0x9c,
-	0x54, 0x4f, 0x17, 0x09, 0x46, 0x05, 0x46, 0x0d, 0xce, 0x20, 0x28, 0x4f, 0x48, 0x88, 0x8b, 0xc5,
-	0x25, 0xb1, 0x24, 0x51, 0x82, 0x49, 0x81, 0x51, 0x83, 0x27, 0x08, 0xcc, 0x06, 0x89, 0x85, 0x24,
-	0xa6, 0x17, 0x4b, 0x30, 0x2b, 0x30, 0x6b, 0x70, 0x06, 0x81, 0xd9, 0x46, 0x3e, 0x5c, 0x7c, 0x30,
-	0x73, 0x7d, 0xf3, 0x53, 0x4a, 0x73, 0x52, 0x85, 0xac, 0xc0, 0xd6, 0x82, 0x2d, 0x29, 0x16, 0xe2,
-	0xd3, 0x03, 0x39, 0x0a, 0xee, 0x0c, 0x29, 0x49, 0x30, 0x1f, 0x9b, 0x4b, 0x94, 0x18, 0x0c, 0x18,
-	0x93, 0xd8, 0xc0, 0xce, 0x37, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0xec, 0x75, 0xa3, 0xcf, 0xdc,
-	0x00, 0x00, 0x00,
+	0xa2, 0xfc, 0x92, 0x7c, 0x21, 0xe6, 0xc4, 0x82, 0x4c, 0x25, 0x01, 0x2e, 0x3e, 0xf7, 0xd4, 0x12,
+	0xd7, 0xb2, 0xd4, 0xbc, 0x92, 0x80, 0xc4, 0xa2, 0xc4, 0xdc, 0x62, 0xa5, 0x30, 0x2e, 0x91, 0x60,
+	0xa8, 0x06, 0xb0, 0xb0, 0x6f, 0x6a, 0x71, 0x71, 0x62, 0x7a, 0xaa, 0x90, 0x18, 0x17, 0x5b, 0x50,
+	0x69, 0x4e, 0xaa, 0xa7, 0x8b, 0x04, 0xa3, 0x02, 0xa3, 0x06, 0x67, 0x10, 0x94, 0x27, 0x24, 0xc4,
+	0xc5, 0xe2, 0x92, 0x58, 0x92, 0x28, 0xc1, 0xa4, 0xc0, 0xa8, 0xc1, 0x13, 0x04, 0x66, 0x83, 0xc4,
+	0x42, 0x12, 0xd3, 0x8b, 0x25, 0x98, 0x15, 0x98, 0x35, 0x38, 0x83, 0xc0, 0x6c, 0x25, 0x09, 0x2e,
+	0x31, 0x97, 0xd2, 0xdc, 0x82, 0x80, 0xa2, 0xfc, 0xe4, 0xd4, 0xe2, 0x62, 0xe7, 0xc4, 0xe4, 0x8c,
+	0x54, 0xa8, 0x8d, 0xb6, 0x5c, 0xf2, 0x30, 0x1b, 0xd1, 0x55, 0xc0, 0x2c, 0x97, 0xe2, 0xe2, 0x70,
+	0xcb, 0xcc, 0x49, 0xcd, 0x4b, 0xcc, 0x4d, 0x85, 0x5a, 0x0f, 0xe7, 0x1b, 0xad, 0x62, 0xe4, 0xe2,
+	0x83, 0xe9, 0xf7, 0xcd, 0x4f, 0x29, 0xcd, 0x49, 0x15, 0xb2, 0xe7, 0xe2, 0x84, 0xf9, 0xaa, 0x58,
+	0x48, 0x58, 0x0f, 0xe4, 0x67, 0x54, 0x5f, 0x4a, 0x49, 0x82, 0x05, 0xb1, 0x79, 0x54, 0x89, 0xc1,
+	0x80, 0x51, 0x28, 0x9c, 0x4b, 0x00, 0xdd, 0x29, 0x42, 0xd2, 0x60, 0x2d, 0xd8, 0xfd, 0x20, 0xa5,
+	0x82, 0x62, 0x1e, 0x0e, 0x6f, 0x28, 0x31, 0x38, 0x09, 0x45, 0x09, 0xa0, 0x47, 0x49, 0x12, 0x1b,
+	0x38, 0x3e, 0x8c, 0x01, 0x01, 0x00, 0x00, 0xff, 0xff, 0x76, 0xa5, 0xea, 0x01, 0xad, 0x01, 0x00,
+	0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -145,7 +222,8 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type SecurityModuleClient interface {
-	GetEvents(ctx context.Context, in *GetParams, opts ...grpc.CallOption) (SecurityModule_GetEventsClient, error)
+	GetEvents(ctx context.Context, in *GetEventParams, opts ...grpc.CallOption) (SecurityModule_GetEventsClient, error)
+	DumpProcessCache(ctx context.Context, in *DumpProcessCacheParams, opts ...grpc.CallOption) (*SecurityDumpProcessCacheMessage, error)
 }
 
 type securityModuleClient struct {
@@ -156,7 +234,7 @@ func NewSecurityModuleClient(cc *grpc.ClientConn) SecurityModuleClient {
 	return &securityModuleClient{cc}
 }
 
-func (c *securityModuleClient) GetEvents(ctx context.Context, in *GetParams, opts ...grpc.CallOption) (SecurityModule_GetEventsClient, error) {
+func (c *securityModuleClient) GetEvents(ctx context.Context, in *GetEventParams, opts ...grpc.CallOption) (SecurityModule_GetEventsClient, error) {
 	stream, err := c.cc.NewStream(ctx, &_SecurityModule_serviceDesc.Streams[0], "/api.SecurityModule/GetEvents", opts...)
 	if err != nil {
 		return nil, err
@@ -188,17 +266,30 @@ func (x *securityModuleGetEventsClient) Recv() (*SecurityEventMessage, error) {
 	return m, nil
 }
 
+func (c *securityModuleClient) DumpProcessCache(ctx context.Context, in *DumpProcessCacheParams, opts ...grpc.CallOption) (*SecurityDumpProcessCacheMessage, error) {
+	out := new(SecurityDumpProcessCacheMessage)
+	err := c.cc.Invoke(ctx, "/api.SecurityModule/DumpProcessCache", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SecurityModuleServer is the server API for SecurityModule service.
 type SecurityModuleServer interface {
-	GetEvents(*GetParams, SecurityModule_GetEventsServer) error
+	GetEvents(*GetEventParams, SecurityModule_GetEventsServer) error
+	DumpProcessCache(context.Context, *DumpProcessCacheParams) (*SecurityDumpProcessCacheMessage, error)
 }
 
 // UnimplementedSecurityModuleServer can be embedded to have forward compatible implementations.
 type UnimplementedSecurityModuleServer struct {
 }
 
-func (*UnimplementedSecurityModuleServer) GetEvents(req *GetParams, srv SecurityModule_GetEventsServer) error {
+func (*UnimplementedSecurityModuleServer) GetEvents(req *GetEventParams, srv SecurityModule_GetEventsServer) error {
 	return status.Errorf(codes.Unimplemented, "method GetEvents not implemented")
+}
+func (*UnimplementedSecurityModuleServer) DumpProcessCache(ctx context.Context, req *DumpProcessCacheParams) (*SecurityDumpProcessCacheMessage, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DumpProcessCache not implemented")
 }
 
 func RegisterSecurityModuleServer(s *grpc.Server, srv SecurityModuleServer) {
@@ -206,7 +297,7 @@ func RegisterSecurityModuleServer(s *grpc.Server, srv SecurityModuleServer) {
 }
 
 func _SecurityModule_GetEvents_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(GetParams)
+	m := new(GetEventParams)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
@@ -226,10 +317,33 @@ func (x *securityModuleGetEventsServer) Send(m *SecurityEventMessage) error {
 	return x.ServerStream.SendMsg(m)
 }
 
+func _SecurityModule_DumpProcessCache_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DumpProcessCacheParams)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SecurityModuleServer).DumpProcessCache(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/api.SecurityModule/DumpProcessCache",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SecurityModuleServer).DumpProcessCache(ctx, req.(*DumpProcessCacheParams))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _SecurityModule_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "api.SecurityModule",
 	HandlerType: (*SecurityModuleServer)(nil),
-	Methods:     []grpc.MethodDesc{},
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "DumpProcessCache",
+			Handler:    _SecurityModule_DumpProcessCache_Handler,
+		},
+	},
 	Streams: []grpc.StreamDesc{
 		{
 			StreamName:    "GetEvents",

--- a/pkg/security/api/api.proto
+++ b/pkg/security/api/api.proto
@@ -1,8 +1,10 @@
 syntax = "proto3";
 
+option go_package = "pkg/security/api";
+
 package api;
 
-message GetParams{}
+message GetEventParams{}
 
 message SecurityEventMessage {
     string RuleID = 1;
@@ -10,6 +12,13 @@ message SecurityEventMessage {
     repeated string Tags = 3;
 }
 
+message DumpProcessCacheParams{}
+
+message SecurityDumpProcessCacheMessage {
+    string Filename = 1;
+}
+
 service SecurityModule {
-    rpc GetEvents(GetParams) returns (stream SecurityEventMessage) {}
+    rpc GetEvents(GetEventParams) returns (stream SecurityEventMessage) {}
+    rpc DumpProcessCache(DumpProcessCacheParams) returns (SecurityDumpProcessCacheMessage) {}
 }

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -41,7 +41,7 @@ type Module struct {
 	ruleSets       [2]*rules.RuleSet
 	currentRuleSet uint64
 	reloading      uint64
-	eventServer    *EventServer
+	apiServer      *APIServer
 	grpcServer     *grpc.Server
 	listener       net.Listener
 	rateLimiter    *RateLimiter
@@ -138,7 +138,7 @@ func (m *Module) Reload() error {
 	ruleSet.AddListener(m)
 	ruleIDs := ruleSet.ListRuleIDs()
 
-	m.eventServer.Apply(ruleIDs)
+	m.apiServer.Apply(ruleIDs)
 	m.rateLimiter.Apply(ruleIDs)
 
 	atomic.StoreUint64(&m.currentRuleSet, 1-m.currentRuleSet)
@@ -168,7 +168,7 @@ func (m *Module) Close() {
 // RuleMatch is called by the ruleset when a rule matches
 func (m *Module) RuleMatch(rule *rules.Rule, event eval.Event) {
 	if m.rateLimiter.Allow(rule.ID) {
-		m.eventServer.SendEvent(rule, event)
+		m.apiServer.SendEvent(rule, event)
 	} else {
 		log.Tracef("Event on rule %s was dropped due to rate limiting", rule.ID)
 	}
@@ -208,7 +208,7 @@ func (m *Module) statsMonitor(ctx context.Context) {
 			if err := m.rateLimiter.SendStats(); err != nil {
 				log.Debug(err)
 			}
-			if err := m.eventServer.SendStats(); err != nil {
+			if err := m.apiServer.SendStats(); err != nil {
 				log.Debug(err)
 			}
 		case <-ctx.Done():
@@ -265,14 +265,14 @@ func NewModule(cfg *config.Config) (api.Module, error) {
 	m := &Module{
 		config:         cfg,
 		probe:          probe,
-		eventServer:    NewEventServer(cfg, statsdClient),
+		apiServer:      NewAPIServer(cfg, probe, statsdClient),
 		grpcServer:     grpc.NewServer(),
 		rateLimiter:    NewRateLimiter(statsdClient),
 		sigupChan:      make(chan os.Signal, 1),
 		currentRuleSet: 1,
 	}
 
-	sapi.RegisterSecurityModuleServer(m.grpcServer, m.eventServer)
+	sapi.RegisterSecurityModuleServer(m.grpcServer, m.apiServer)
 
 	return m, nil
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -8,6 +8,7 @@
 package module
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -26,30 +27,31 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// EventServer represents a gRPC server in charge of receiving events sent by
+// APIServer represents a gRPC server in charge of receiving events sent by
 // the runtime security system-probe module and forwards them to Datadog
-type EventServer struct {
+type APIServer struct {
 	sync.RWMutex
 	msgs          chan *api.SecurityEventMessage
 	expiredEvents map[rules.RuleID]*int64
 	rate          *Limiter
 	statsdClient  *statsd.Client
+	probe         *sprobe.Probe
 }
 
 // GetEvents waits for security events
-func (e *EventServer) GetEvents(params *api.GetParams, stream api.SecurityModule_GetEventsServer) error {
+func (a *APIServer) GetEvents(params *api.GetEventParams, stream api.SecurityModule_GetEventsServer) error {
 	// Read 10 security events per call
 	msgs := 10
 LOOP:
 	for {
 		// Check that the limit is not reached
-		if !e.rate.limiter.Allow() {
+		if !a.rate.limiter.Allow() {
 			return nil
 		}
 
 		// Read on message
 		select {
-		case msg := <-e.msgs:
+		case msg := <-a.msgs:
 			if err := stream.Send(msg); err != nil {
 				return err
 			}
@@ -67,8 +69,22 @@ LOOP:
 	return nil
 }
 
+// DumpProcessCache handle process dump cache requests
+func (a *APIServer) DumpProcessCache(ctx context.Context, params *api.DumpProcessCacheParams) (*api.SecurityDumpProcessCacheMessage, error) {
+	resolvers := a.probe.GetResolvers()
+
+	filename, err := resolvers.ProcessResolver.Dump()
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.SecurityDumpProcessCacheMessage{
+		Filename: filename,
+	}, nil
+}
+
 // SendEvent forwards events sent by the runtime security module to Datadog
-func (e *EventServer) SendEvent(rule *rules.Rule, event eval.Event) {
+func (a *APIServer) SendEvent(rule *rules.Rule, event eval.Event) {
 	agentContext := &AgentContext{
 		RuleID: rule.Definition.ID,
 	}
@@ -107,32 +123,32 @@ func (e *EventServer) SendEvent(rule *rules.Rule, event eval.Event) {
 	}
 
 	select {
-	case e.msgs <- msg:
+	case a.msgs <- msg:
 		break
 	default:
 		// The channel is full, consume the oldest event
-		oldestMsg := <-e.msgs
+		oldestMsg := <-a.msgs
 		// Try to send the event again
 		select {
-		case e.msgs <- msg:
+		case a.msgs <- msg:
 			break
 		default:
 			// Looks like the channel is full again, expire the current message too
-			e.expireEvent(msg)
+			a.expireEvent(msg)
 			break
 		}
-		e.expireEvent(oldestMsg)
+		a.expireEvent(oldestMsg)
 		break
 	}
 }
 
 // expireEvent updates the count of expired messages for the appropriate rule
-func (e *EventServer) expireEvent(msg *api.SecurityEventMessage) {
-	e.RLock()
-	defer e.RUnlock()
+func (a *APIServer) expireEvent(msg *api.SecurityEventMessage) {
+	a.RLock()
+	defer a.RUnlock()
 
 	// Update metric
-	count, ok := e.expiredEvents[msg.RuleID]
+	count, ok := a.expiredEvents[msg.RuleID]
 	if ok {
 		atomic.AddInt64(count, 1)
 	}
@@ -141,23 +157,23 @@ func (e *EventServer) expireEvent(msg *api.SecurityEventMessage) {
 
 // GetStats returns a map indexed by ruleIDs that describes the amount of events
 // that were expired or rate limited before reaching
-func (e *EventServer) GetStats() map[string]int64 {
-	e.RLock()
-	defer e.RUnlock()
+func (a *APIServer) GetStats() map[string]int64 {
+	a.RLock()
+	defer a.RUnlock()
 
 	stats := make(map[string]int64)
-	for ruleID, val := range e.expiredEvents {
+	for ruleID, val := range a.expiredEvents {
 		stats[ruleID] = atomic.SwapInt64(val, 0)
 	}
 	return stats
 }
 
 // SendStats sends statistics about the number of dropped events
-func (e *EventServer) SendStats() error {
-	for ruleID, val := range e.GetStats() {
+func (a *APIServer) SendStats() error {
+	for ruleID, val := range a.GetStats() {
 		tags := []string{fmt.Sprintf("rule_id:%s", ruleID)}
 		if val > 0 {
-			if err := e.statsdClient.Count(sprobe.MetricPrefix+".rules.event_server.expired", val, tags, 1.0); err != nil {
+			if err := a.statsdClient.Count(sprobe.MetricPrefix+".rules.event_server.expired", val, tags, 1.0); err != nil {
 				return err
 			}
 		}
@@ -166,23 +182,24 @@ func (e *EventServer) SendStats() error {
 }
 
 // Apply a rule set
-func (e *EventServer) Apply(ruleIDs []rules.RuleID) {
-	e.Lock()
-	defer e.Unlock()
+func (a *APIServer) Apply(ruleIDs []rules.RuleID) {
+	a.Lock()
+	defer a.Unlock()
 
-	e.expiredEvents = make(map[rules.RuleID]*int64)
+	a.expiredEvents = make(map[rules.RuleID]*int64)
 	for _, id := range ruleIDs {
-		e.expiredEvents[id] = new(int64)
+		a.expiredEvents[id] = new(int64)
 	}
 }
 
-// NewEventServer returns a new gRPC event server
-func NewEventServer(cfg *config.Config, client *statsd.Client) *EventServer {
-	es := &EventServer{
+// NewAPIServer returns a new gRPC event server
+func NewAPIServer(cfg *config.Config, probe *sprobe.Probe, client *statsd.Client) *APIServer {
+	es := &APIServer{
 		msgs:          make(chan *api.SecurityEventMessage, cfg.EventServerBurst*3),
 		expiredEvents: make(map[rules.RuleID]*int64),
 		rate:          NewLimiter(rate.Limit(cfg.EventServerRate), cfg.EventServerBurst),
 		statsdClient:  client,
+		probe:         probe,
 	}
 	return es
 }

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -239,6 +239,10 @@ func (p *Probe) SendStats() error {
 		return errors.Wrap(err, "failed to send process_resolver cache_size metric")
 	}
 
+	if err := p.statsdClient.Gauge(MetricPrefix+".process_resolver.entry_cache_size", p.resolvers.ProcessResolver.GetEntryCacheSize(), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send process_resolver cache_size metric")
+	}
+
 	return p.eventsStats.SendStats(p.statsdClient)
 }
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -8,6 +8,9 @@
 package probe
 
 import (
+	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"sync"
@@ -382,6 +385,60 @@ func (p *ProcessResolver) syncCache(proc *process.Process) (*ProcessCacheEntry, 
 	log.Tracef("New process cache entry added: %s %s %d/%d", entry.Comm, entry.PathnameStr, pid, entry.Inode)
 
 	return entry, true
+}
+
+func (p *ProcessResolver) dumpEntry(writer io.Writer, entry *ProcessCacheEntry, already map[string]bool) {
+	for entry != nil {
+		label := fmt.Sprintf("%s:%d", entry.Comm, entry.Pid)
+		if _, exists := already[label]; !exists {
+			if !entry.ExitTimestamp.IsZero() {
+				label = "[" + label + "]"
+			}
+
+			fmt.Fprintf(writer, `"%d:%s" [label="%s"];`, entry.Pid, entry.Comm, label)
+			fmt.Fprintln(writer)
+
+			already[label] = true
+		}
+
+		if entry.Ancestor != nil {
+			relation := fmt.Sprintf(`"%d:%s" -> "%d:%s";`, entry.Ancestor.Pid, entry.Ancestor.Comm, entry.Pid, entry.Comm)
+			if _, exists := already[relation]; !exists {
+				fmt.Fprintln(writer, relation)
+
+				already[relation] = true
+			}
+		}
+
+		entry = entry.Ancestor
+	}
+}
+
+// Dump create a temp file and dump the cache
+func (p *ProcessResolver) Dump() (string, error) {
+	dump, err := ioutil.TempFile("/tmp", "process-cache-dump-")
+	if err != nil {
+		return "", err
+	}
+	defer dump.Close()
+
+	if err := os.Chmod(dump.Name(), 0400); err != nil {
+		return "", err
+	}
+
+	p.RLock()
+	defer p.RUnlock()
+
+	fmt.Fprintf(dump, "digraph ProcessTree {\n")
+
+	already := make(map[string]bool)
+	for _, entry := range p.entryCache {
+		p.dumpEntry(dump, entry, already)
+	}
+
+	fmt.Fprintf(dump, `}`)
+
+	return dump.Name(), err
 }
 
 // GetCacheSize returns the cache size of the process resolver

--- a/pkg/security/probe/process_resolver_test.go
+++ b/pkg/security/probe/process_resolver_test.go
@@ -1,0 +1,481 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux
+
+package probe
+
+import (
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func testCacheSize(t *testing.T, resolver *ProcessResolver) {
+	err := retry.Do(
+		func() error {
+			runtime.GC()
+			if atomic.LoadInt64(&resolver.cacheSize) == 0 {
+				return nil
+			}
+
+			return errors.New("cache size error")
+		},
+	)
+	assert.Nil(t, err)
+}
+
+func TestFork1st(t *testing.T) {
+	parent := NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTimestamp = time.Now()
+
+	child := NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTimestamp = time.Now()
+
+	resolver, err := NewProcessResolver(nil, nil, nil, ProcessResolverOpts{DebugCacheSize: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parent
+	resolver.AddForkEntry(parent.Pid, parent)
+	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+
+	// parent
+	//     \ child
+	resolver.AddForkEntry(child.Pid, child)
+	assert.Equal(t, resolver.entryCache[child.Pid], child)
+	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, child.Ancestor, parent)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+
+	// parent
+	resolver.DeleteEntry(child.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[child.Pid])
+	assert.Equal(t, len(resolver.entryCache), 1)
+
+	// nothing
+	resolver.DeleteEntry(parent.Pid, time.Now())
+	assert.Zero(t, len(resolver.entryCache))
+
+	testCacheSize(t, resolver)
+}
+
+func TestFork2nd(t *testing.T) {
+	parent := NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTimestamp = time.Now()
+
+	child := NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTimestamp = time.Now()
+
+	resolver, err := NewProcessResolver(nil, nil, nil, ProcessResolverOpts{DebugCacheSize: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parent
+	resolver.AddForkEntry(parent.Pid, parent)
+	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+
+	// parent
+	//     \ child
+	resolver.AddForkEntry(child.Pid, child)
+	assert.Equal(t, resolver.entryCache[child.Pid], child)
+	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, child.Ancestor, parent)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+
+	// [parent]
+	//     \ child
+	resolver.DeleteEntry(parent.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[parent.Pid])
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, child.Ancestor, parent)
+
+	// nothing
+	resolver.DeleteEntry(child.Pid, time.Now())
+	assert.Zero(t, len(resolver.entryCache))
+
+	testCacheSize(t, resolver)
+}
+
+func TestForkExec(t *testing.T) {
+	parent := NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTimestamp = time.Now()
+
+	child := NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTimestamp = time.Now()
+
+	exec := NewProcessCacheEntry()
+	exec.Pid = child.Pid
+	exec.PPid = child.PPid
+	exec.ExecTimestamp = time.Now()
+
+	resolver, err := NewProcessResolver(nil, nil, nil, ProcessResolverOpts{DebugCacheSize: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parent
+	resolver.AddForkEntry(parent.Pid, parent)
+	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+
+	// parent
+	//     \ child
+	resolver.AddForkEntry(child.Pid, child)
+	assert.Equal(t, resolver.entryCache[child.Pid], child)
+	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, child.Ancestor, parent)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+
+	// parent
+	//     \ [child] -> exec
+	resolver.AddExecEntry(exec.Pid, exec)
+	assert.Equal(t, resolver.entryCache[exec.Pid], exec)
+	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, exec.Ancestor, child)
+	assert.Equal(t, exec.Ancestor.Ancestor, parent)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 3)
+
+	// [parent]
+	//     \ [child] -> exec
+	resolver.DeleteEntry(parent.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[parent.Pid])
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, exec.Ancestor, child)
+	assert.Equal(t, exec.Ancestor.Ancestor, parent)
+
+	// nothing
+	resolver.DeleteEntry(exec.Pid, time.Now())
+	assert.Zero(t, len(resolver.entryCache))
+
+	testCacheSize(t, resolver)
+}
+
+func TestOrphanExec(t *testing.T) {
+	parent := NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTimestamp = time.Now()
+
+	child := NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTimestamp = time.Now()
+
+	exec := NewProcessCacheEntry()
+	exec.Pid = child.Pid
+	exec.PPid = child.PPid
+	exec.ExecTimestamp = time.Now()
+
+	resolver, err := NewProcessResolver(nil, nil, nil, ProcessResolverOpts{DebugCacheSize: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parent
+	resolver.AddForkEntry(parent.Pid, parent)
+	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+
+	// parent
+	//     \ child
+	resolver.AddForkEntry(child.Pid, child)
+	assert.Equal(t, resolver.entryCache[child.Pid], child)
+	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, child.Ancestor, parent)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+
+	// [parent]
+	//     \ child
+	resolver.DeleteEntry(parent.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[parent.Pid])
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, child.Ancestor, parent)
+
+	// [parent]
+	//     \ [child] -> exec
+	resolver.AddExecEntry(exec.Pid, exec)
+	assert.Equal(t, resolver.entryCache[exec.Pid], exec)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, exec.Ancestor, child)
+	assert.Equal(t, exec.Ancestor.Ancestor, parent)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 3)
+
+	// nothing
+	resolver.DeleteEntry(exec.Pid, time.Now())
+	assert.Zero(t, len(resolver.entryCache))
+
+	testCacheSize(t, resolver)
+}
+
+func TestForkExecExec(t *testing.T) {
+	parent := NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTimestamp = time.Now()
+
+	child := NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTimestamp = time.Now()
+
+	exec1 := NewProcessCacheEntry()
+	exec1.Pid = child.Pid
+	exec1.PPid = child.PPid
+	exec1.ExecTimestamp = time.Now()
+
+	exec2 := NewProcessCacheEntry()
+	exec2.Pid = child.Pid
+	exec2.PPid = child.PPid
+	exec2.ExecTimestamp = time.Now()
+
+	resolver, err := NewProcessResolver(nil, nil, nil, ProcessResolverOpts{DebugCacheSize: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parent
+	resolver.AddForkEntry(parent.Pid, parent)
+	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+
+	// parent
+	//     \ child
+	resolver.AddForkEntry(child.Pid, child)
+	assert.Equal(t, resolver.entryCache[child.Pid], child)
+	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, child.Ancestor, parent)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+
+	// [parent]
+	//     \ child
+	resolver.DeleteEntry(parent.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[parent.Pid])
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, child.Ancestor, parent)
+
+	// [parent]
+	//     \ [child] -> exec1
+	resolver.AddExecEntry(exec1.Pid, exec1)
+	assert.Equal(t, resolver.entryCache[exec1.Pid], exec1)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, exec1.Ancestor, child)
+	assert.Equal(t, exec1.Ancestor.Ancestor, parent)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 3)
+
+	// [parent]
+	//     \ [child] -> [exec1] -> exec2
+	resolver.AddExecEntry(exec2.Pid, exec2)
+	assert.Equal(t, resolver.entryCache[exec2.Pid], exec2)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, exec2.Ancestor, exec1)
+	assert.Equal(t, exec2.Ancestor.Ancestor, child)
+	assert.Equal(t, exec2.Ancestor.Ancestor.Ancestor, parent)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 4)
+
+	// nothing
+	resolver.DeleteEntry(exec2.Pid, time.Now())
+	assert.Zero(t, len(resolver.entryCache))
+
+	testCacheSize(t, resolver)
+}
+
+func TestForkReuse(t *testing.T) {
+	parent1 := NewProcessCacheEntry()
+	parent1.Pid = 1
+	parent1.ForkTimestamp = time.Now()
+
+	child1 := NewProcessCacheEntry()
+	child1.Pid = 2
+	child1.PPid = parent1.Pid
+	child1.ForkTimestamp = time.Now()
+
+	exec1 := NewProcessCacheEntry()
+	exec1.Pid = child1.Pid
+	exec1.PPid = child1.PPid
+	exec1.ExecTimestamp = time.Now()
+
+	parent2 := NewProcessCacheEntry()
+	parent2.Pid = 1
+	parent2.ForkTimestamp = time.Now()
+
+	child2 := NewProcessCacheEntry()
+	child2.Pid = 3
+	child2.PPid = parent2.Pid
+	child2.ForkTimestamp = time.Now()
+
+	resolver, err := NewProcessResolver(nil, nil, nil, ProcessResolverOpts{DebugCacheSize: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parent1
+	resolver.AddForkEntry(parent1.Pid, parent1)
+	assert.Equal(t, resolver.entryCache[parent1.Pid], parent1)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+
+	// parent1
+	//     \ child1
+	resolver.AddForkEntry(child1.Pid, child1)
+	assert.Equal(t, resolver.entryCache[child1.Pid], child1)
+	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, child1.Ancestor, parent1)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+
+	// [parent1]
+	//     \ child1
+	resolver.DeleteEntry(parent1.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[parent1.Pid])
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, child1.Ancestor, parent1)
+
+	// [parent1]
+	//     \ [child1] -> exec1
+	resolver.AddExecEntry(exec1.Pid, exec1)
+	assert.Equal(t, resolver.entryCache[exec1.Pid], exec1)
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, exec1.Ancestor, child1)
+	assert.Equal(t, exec1.Ancestor.Ancestor, parent1)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 3)
+
+	// [parent1:pid1]
+	//     \ [child1] -> exec1
+	//
+	// parent2:pid1
+	resolver.AddForkEntry(parent2.Pid, parent2)
+	assert.Equal(t, resolver.entryCache[parent2.Pid], parent2)
+	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 4)
+
+	// [parent1:pid1]
+	//     \ [child1] -> exec1
+	//
+	// parent2:pid1
+	//     \ child2
+	resolver.AddForkEntry(child2.Pid, child2)
+	assert.Equal(t, resolver.entryCache[child2.Pid], child2)
+	assert.Equal(t, len(resolver.entryCache), 3)
+	assert.Equal(t, child2.Ancestor, parent2)
+	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 5)
+
+	// parent2:pid1
+	//     \ child2
+	resolver.DeleteEntry(exec1.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[exec1.Pid])
+	assert.Equal(t, len(resolver.entryCache), 2)
+
+	// [parent2:pid1]
+	//     \ child2
+	resolver.DeleteEntry(parent2.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[parent2.Pid])
+	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, child2.Ancestor, parent2)
+
+	// nothing
+	resolver.DeleteEntry(child2.Pid, time.Now())
+	assert.Zero(t, len(resolver.entryCache))
+
+	testCacheSize(t, resolver)
+}
+
+func TestForkForkExec(t *testing.T) {
+	parent := NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTimestamp = time.Now()
+
+	child := NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTimestamp = time.Now()
+
+	grandChild := NewProcessCacheEntry()
+	grandChild.Pid = 3
+	grandChild.PPid = child.Pid
+	grandChild.ForkTimestamp = time.Now()
+
+	childExec := NewProcessCacheEntry()
+	childExec.Pid = child.Pid
+	childExec.PPid = child.PPid
+	childExec.ExecTimestamp = time.Now()
+
+	resolver, err := NewProcessResolver(nil, nil, nil, ProcessResolverOpts{DebugCacheSize: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parent
+	resolver.AddForkEntry(parent.Pid, parent)
+	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
+	assert.Equal(t, len(resolver.entryCache), 1)
+
+	// parent
+	//     \ child
+	resolver.AddForkEntry(child.Pid, child)
+	assert.Equal(t, resolver.entryCache[child.Pid], child)
+	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, child.Ancestor, parent)
+
+	// parent
+	//     \ child
+	//          \ grandChild
+	resolver.AddForkEntry(grandChild.Pid, grandChild)
+	assert.Equal(t, resolver.entryCache[grandChild.Pid], grandChild)
+	assert.Equal(t, len(resolver.entryCache), 3)
+	assert.Equal(t, grandChild.Ancestor, child)
+	assert.Equal(t, grandChild.Ancestor.Ancestor, parent)
+
+	// parent
+	//     \ [child] -> childExec
+	//          \ grandChild
+	resolver.AddExecEntry(childExec.Pid, childExec)
+	assert.Equal(t, resolver.entryCache[childExec.Pid], childExec)
+	assert.Equal(t, len(resolver.entryCache), 3)
+	assert.Equal(t, childExec.Ancestor, child)
+	assert.Equal(t, childExec.Ancestor.Ancestor, parent)
+	assert.Equal(t, grandChild.Ancestor, child)
+	assert.Equal(t, grandChild.Ancestor.Ancestor, parent)
+
+	// [parent]
+	//     \ [child] -> childExec
+	//          \ grandChild
+	resolver.DeleteEntry(parent.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[parent.Pid])
+	assert.Equal(t, len(resolver.entryCache), 2)
+
+	// [parent]
+	//     \ [child]
+	//          \ grandChild
+	resolver.DeleteEntry(childExec.Pid, time.Now())
+	assert.Nil(t, resolver.entryCache[childExec.Pid])
+	assert.Equal(t, len(resolver.entryCache), 1)
+
+	// nothing
+	resolver.DeleteEntry(grandChild.Pid, time.Now())
+	assert.Zero(t, len(resolver.entryCache))
+
+	testCacheSize(t, resolver)
+}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -56,7 +56,7 @@ func NewResolvers(probe *Probe, client *statsd.Client) (*Resolvers, error) {
 		UserGroupResolver: userGroupResolver,
 	}
 
-	processResolver, err := NewProcessResolver(probe, resolvers, client, ProcessResolverOpts{})
+	processResolver, err := NewProcessResolver(probe, resolvers, client, ProcessResolverOpts{DebugCacheSize: true})
 	if err != nil {
 		return nil, err
 	}

--- a/releasenotes/notes/process-detection-cache-dump-3cc2e4e569b0e508.yaml
+++ b/releasenotes/notes/process-detection-cache-dump-3cc2e4e569b0e508.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Runtime-security new command line allowing to trigger a process cache dump..

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -271,7 +271,6 @@ def docker_functional_tests(
 ):
     build_functional_tests(
         ctx,
-        verbose=verbose,
         go_version=go_version,
         arch=arch,
         major_version=major_version,


### PR DESCRIPTION
### What does this PR do?

This PR add unit and functional tests testing process resolver. It also add a security-agent command line to trigger a process resolver cache dump that can be rendered as a dot graph.
