### PR TITLE
[networks] Reduce allocations on connection close codepath

### DIFF
--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -166,7 +166,7 @@ func (c ConnectionStats) String() string {
 //     4B      2B      2B     .5B     .5B      4/16B        4/16B   = 17/41B
 //    32b     16b     16b      4b      4b     32/128b      32/128b
 // |  PID  | SPORT | DPORT | Family | Type |  SrcAddr  |  DestAddr
-func (c ConnectionStats) ByteKey(buf [ConnectionByteKeyMaxLen]byte) ([]byte, error) {
+func (c ConnectionStats) ByteKey(buf []byte) ([]byte, error) {
 	n := 0
 	// Byte-packing to improve creation speed
 	// PID (32 bits) + SPort (16 bits) + DPort (16 bits) = 64 bits
@@ -178,8 +178,8 @@ func (c ConnectionStats) ByteKey(buf [ConnectionByteKeyMaxLen]byte) ([]byte, err
 	buf[n] = uint8(c.Family)<<4 | uint8(c.Type)
 	n++
 
-	n += copy(buf[n:], c.Source.Bytes()) // 4 or 16 bytes
-	n += copy(buf[n:], c.Dest.Bytes())   // 4 or 16 bytes
+	n += c.Source.WriteTo(buf[n:]) // 4 or 16 bytes
+	n += c.Dest.WriteTo(buf[n:])   // 4 or 16 bytes
 	return buf[:n], nil
 }
 

--- a/pkg/network/event_test.go
+++ b/pkg/network/event_test.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 	"net"
+	"runtime"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -26,7 +27,7 @@ var (
 )
 
 func TestBeautifyKey(t *testing.T) {
-	var buf [ConnectionByteKeyMaxLen]byte
+	buf := make([]byte, ConnectionByteKeyMaxLen)
 	for _, c := range []ConnectionStats{
 		testConn,
 		{
@@ -57,7 +58,7 @@ func TestBeautifyKey(t *testing.T) {
 }
 
 func TestConnStatsByteKey(t *testing.T) {
-	var buf [ConnectionByteKeyMaxLen]byte
+	buf := make([]byte, ConnectionByteKeyMaxLen)
 	addrA := util.AddressFromString("127.0.0.1")
 	addrB := util.AddressFromString("127.0.0.2")
 
@@ -115,4 +116,18 @@ func TestConnStatsByteKey(t *testing.T) {
 		}
 		assert.NotEqual(t, keyA, keyB)
 	}
+}
+
+func BenchmarkByteKey(b *testing.B) {
+	buf := make([]byte, ConnectionByteKeyMaxLen)
+	addrA := util.AddressFromString("127.0.0.1")
+	addrB := util.AddressFromString("127.0.0.2")
+	c := ConnectionStats{Pid: 1, Dest: addrB, Family: 0, Type: 1, Source: addrA}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = c.ByteKey(buf)
+	}
+	runtime.KeepAlive(buf)
 }

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -89,7 +89,7 @@ type networkState struct {
 	clients   map[string]*client
 	telemetry telemetry
 
-	buf             [ConnectionByteKeyMaxLen]byte // Shared buffer
+	buf             []byte // Shared buffer
 	latestTimeEpoch uint64
 
 	// Network state configuration
@@ -110,6 +110,7 @@ func NewState(clientExpiry time.Duration, maxClosedConns, maxClientStats int, ma
 		maxClientStats:    maxClientStats,
 		maxDNSStats:       maxDNSStats,
 		collectDNSDomains: collectDNSDomains,
+		buf:               make([]byte, ConnectionByteKeyMaxLen),
 	}
 }
 
@@ -252,7 +253,7 @@ func (ns *networkState) addDNSStats(id string, conns []ConnectionStats) {
 }
 
 // getConnsByKey returns a mapping of byte-key -> connection for easier access + manipulation
-func getConnsByKey(conns []ConnectionStats, buf [ConnectionByteKeyMaxLen]byte) map[string]*ConnectionStats {
+func getConnsByKey(conns []ConnectionStats, buf []byte) map[string]*ConnectionStats {
 	connsByKey := make(map[string]*ConnectionStats, len(conns))
 	for i, c := range conns {
 		key, err := c.ByteKey(buf)

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -144,7 +144,7 @@ func TestRemoveConnections(t *testing.T) {
 		IntraHost:            true,
 	}
 
-	var buf [ConnectionByteKeyMaxLen]byte
+	buf := make([]byte, ConnectionByteKeyMaxLen)
 	key, err := conn.ByteKey(buf)
 	require.NoError(t, err)
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -83,7 +83,7 @@ type Tracer struct {
 	bufferLock sync.Mutex
 
 	// Internal buffer used to compute bytekeys
-	buf [network.ConnectionByteKeyMaxLen]byte
+	buf []byte
 
 	// Connections for the tracer to blacklist
 	sourceExcludes []*network.ConnectionFilter
@@ -241,6 +241,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 		perfHandler:    perfHandlerTCP,
 		flushIdle:      make(chan chan struct{}),
 		stop:           make(chan struct{}),
+		buf:            make([]byte, network.ConnectionByteKeyMaxLen),
 	}
 
 	tr.perfMap, tr.batchManager, err = tr.initPerfPolling(perfHandlerTCP)
@@ -390,7 +391,7 @@ func (t *Tracer) initPerfPolling(perf *ddebpf.PerfHandler) (*manager.PerfMap, *P
 				batch := toBatch(batchData)
 				conns := t.batchManager.Extract(batch, time.Now())
 				for _, c := range conns {
-					t.storeClosedConn(c)
+					t.storeClosedConn(&c)
 				}
 			case lostCount, ok := <-perf.LostChannel:
 				if !ok {
@@ -403,7 +404,7 @@ func (t *Tracer) initPerfPolling(perf *ddebpf.PerfHandler) (*manager.PerfMap, *P
 				}
 				idleConns := t.batchManager.GetIdleConns(time.Now())
 				for _, c := range idleConns {
-					t.storeClosedConn(c)
+					t.storeClosedConn(&c)
 				}
 				close(done)
 			case <-ticker.C:
@@ -433,18 +434,18 @@ func (t *Tracer) shouldSkipConnection(conn *network.ConnectionStats) bool {
 	return false
 }
 
-func (t *Tracer) storeClosedConn(cs network.ConnectionStats) {
-	cs.Direction = t.determineConnectionDirection(&cs)
-	if t.shouldSkipConnection(&cs) {
+func (t *Tracer) storeClosedConn(cs *network.ConnectionStats) {
+	cs.Direction = t.determineConnectionDirection(cs)
+	if t.shouldSkipConnection(cs) {
 		atomic.AddInt64(&t.skippedConns, 1)
 		return
 	}
 
 	atomic.AddInt64(&t.closedConns, 1)
-	cs.IPTranslation = t.conntracker.GetTranslationForConn(cs)
-	t.state.StoreClosedConnection(&cs)
+	cs.IPTranslation = t.conntracker.GetTranslationForConn(*cs)
+	t.state.StoreClosedConnection(cs)
 	if cs.IPTranslation != nil {
-		t.conntracker.DeleteTranslation(cs)
+		t.conntracker.DeleteTranslation(*cs)
 	}
 }
 

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -8,6 +8,7 @@ import (
 // Address is an IP abstraction that is family (v4/v6) agnostic
 type Address interface {
 	Bytes() []byte
+	WriteTo([]byte) int
 	String() string
 	IsLoopback() bool
 }
@@ -59,6 +60,11 @@ func (a v4Address) Bytes() []byte {
 	return a[:]
 }
 
+// WriteTo writes the address byte representation into the supplied buffer
+func (a v4Address) WriteTo(b []byte) int {
+	return copy(b, a[:])
+}
+
 // String returns the human readable string representation of an IP
 func (a v4Address) String() string {
 	return net.IPv4(a[0], a[1], a[2], a[3]).String()
@@ -89,6 +95,11 @@ func V6AddressFromBytes(buf []byte) Address {
 // Bytes returns a byte array of the underlying array
 func (a v6Address) Bytes() []byte {
 	return a[:]
+}
+
+// WriteTo writes the address byte representation into the supplied buffer
+func (a v6Address) WriteTo(b []byte) int {
+	return copy(b, a[:])
 }
 
 // String returns the human readable string representation of an IP


### PR DESCRIPTION
### What does this PR do?

Reduce memory allocations on the codepath responsible for handling TCP closed connection events.

**Before**

<img width="1359" alt="Screen Shot 2021-01-19 at 11 04 09 AM" src="https://user-images.githubusercontent.com/692520/105060962-f3d58780-5a46-11eb-806d-41fe937abfaf.png">

**After**

<img width="1429" alt="Screen Shot 2021-01-19 at 11 04 49 AM" src="https://user-images.githubusercontent.com/692520/105061009-fdf78600-5a46-11eb-8c03-bef88dc8632c.png">

```
name       old time/op    new time/op    delta
ByteKey-4    64.3ns ± 0%    15.6ns ± 0%   ~     (p=1.000 n=1+1)

name       old alloc/op   new alloc/op   delta
ByteKey-4     56.0B ± 0%      0.0B        ~     (p=1.000 n=1+1)

name       old allocs/op  new allocs/op  delta
ByteKey-4      3.00 ± 0%      0.00        ~     (p=1.000 n=1+1)
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
