### PR TITLE
Fix Windows build scripts error checks

### DIFF
--- a/tasks/winbuildscripts/buildlocal.bat
+++ b/tasks/winbuildscripts/buildlocal.bat
@@ -13,5 +13,4 @@ if NOT DEFINED CI_JOB_ID set CI_JOB_ID=1
 if NOT DEFINED TARGET_ARCH set TARGET_ARCH=x64
 
 call %~dp0dobuild.bat
-if not %ERRORLEVEL% == 0 exit /b %ERRORLEVEL%
-
+if not %ERRORLEVEL% == 0 @echo "Build failed %ERRORLEVEL%"

--- a/tasks/winbuildscripts/buildlocal.bat
+++ b/tasks/winbuildscripts/buildlocal.bat
@@ -12,5 +12,6 @@ if NOT DEFINED PY_RUNTIMES set PY_RUNTIMES="3"
 if NOT DEFINED CI_JOB_ID set CI_JOB_ID=1
 if NOT DEFINED TARGET_ARCH set TARGET_ARCH=x64
 
-call %~dp0dobuild.bat || @echo "Build failed %ERRORLEVEL%"
+call %~dp0dobuild.bat
+if %ERRORLEVEL% -ne 0 @echo "Build failed %ERRORLEVEL%"
 

--- a/tasks/winbuildscripts/buildlocal.bat
+++ b/tasks/winbuildscripts/buildlocal.bat
@@ -13,5 +13,5 @@ if NOT DEFINED CI_JOB_ID set CI_JOB_ID=1
 if NOT DEFINED TARGET_ARCH set TARGET_ARCH=x64
 
 call %~dp0dobuild.bat
-if %ERRORLEVEL% -ne 0 @echo "Build failed %ERRORLEVEL%"
+if not %ERRORLEVEL% == 0 exit /b %ERRORLEVEL%
 

--- a/tasks/winbuildscripts/buildwin.bat
+++ b/tasks/winbuildscripts/buildwin.bat
@@ -3,15 +3,16 @@ if not exist c:\mnt\ goto nomntdir
 @echo c:\mnt found, continuing
 
 mkdir \dev\go\src\github.com\DataDog\datadog-agent
-if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 1
-cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 2
-xcopy /e/s/h/q c:\mnt\*.* || exit /b 3
+if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 2
+cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 3
+xcopy /e/s/h/q c:\mnt\*.* || exit /b 4
 
 REM
 REM after copying files in from the host, execute the build
 REM using `dobuild.bat`
 REM
-call %~p0dobuild.bat %* || exit /b %ERRORLEVEL%
+call %~p0dobuild.bat %* 
+if %ERRORLEVEL% -ne 0 exit /b %ERRORLEVEL%
 
 REM show output directories (for debugging)
 dir \omnibus\pkg
@@ -19,9 +20,9 @@ dir \omnibus\pkg
 dir \omnibus-ruby\pkg\
 
 REM copy resulting packages to expected location for collection by gitlab.
-if not exist %PKG_OUTDIR% mkdir %PKG_OUTDIR% || exit /b 7
-if exist \omnibus-ruby\pkg\*.msi copy \omnibus-ruby\pkg\*.msi %PKG_OUTDIR% || exit /b 8
-if exist \omnibus-ruby\pkg\*.zip copy \omnibus-ruby\pkg\*.zip %PKG_OUTDIR% || exit /b 9
+if not exist %PKG_OUTDIR% mkdir %PKG_OUTDIR% || exit /b 5
+if exist \omnibus-ruby\pkg\*.msi copy \omnibus-ruby\pkg\*.msi %PKG_OUTDIR% || exit /b 6
+if exist \omnibus-ruby\pkg\*.zip copy \omnibus-ruby\pkg\*.zip %PKG_OUTDIR% || exit /b 7
 
 goto :EOF
 

--- a/tasks/winbuildscripts/buildwin.bat
+++ b/tasks/winbuildscripts/buildwin.bat
@@ -12,7 +12,7 @@ REM after copying files in from the host, execute the build
 REM using `dobuild.bat`
 REM
 call %~p0dobuild.bat %* 
-if %ERRORLEVEL% -ne 0 exit /b %ERRORLEVEL%
+if not %ERRORLEVEL% == 0 exit /b %ERRORLEVEL%
 
 REM show output directories (for debugging)
 dir \omnibus\pkg

--- a/tasks/winbuildscripts/dobuild.bat
+++ b/tasks/winbuildscripts/dobuild.bat
@@ -39,13 +39,13 @@ if "%TARGET_ARCH%" == "x86" (
     Powershell -C "ridk enable; cd omnibus; bundle install"
 )
 
-if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 1
-cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 2
+if not exist \dev\go\src\github.com\DataDog\datadog-agent exit /b 100
+cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 101
 
 
-pip3 install -r requirements.txt || exit /b 4
+pip3 install -r requirements.txt || exit /b 102
 
-inv -e deps --verbose || exit /b 5
+inv -e deps --verbose || exit /b 103
 
 @echo "inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION%"
-inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 6
+inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 104


### PR DESCRIPTION
### What does this PR do?

Amends the logic to check the return value of `dobuild.bat` to make it correct.
Gives different error numbers for all errors.

### Motivation

When `call %~p0dobuild.bat %* || exit /b %ERRORLEVEL%` is evaluated, `%ERRORLEVEL%` is expanded _before_ `call %~p0dobuild.bat %*` is run.
Thus, provided that `%ERRORLEVEL%` is 0 before the line is evaluated, if `call %~p0dobuild.bat %*` fails, then `exit /b 0` is run, making the `buildwin.bat` / `buildlocal.bat` exit with a success code (instead of exiting with the error code that `dobuild.bat` set).

This resulted in confusing Gitlab job results: jobs that should have failed were reporting success.

