### PR TITLE
[logs] Docker container tailing from file on Windows

### DIFF
--- a/pkg/logs/input/docker/launcher_test_windows.go
+++ b/pkg/logs/input/docker/launcher_test_windows.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build docker,windows
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker/api/types"
+)
+
+func TestGetFileSource(t *testing.T) {
+	tests := []struct {
+		name            string
+		sFunc           func(string, string) string
+		container       *Container
+		source          *config.LogSource
+		wantServiceName string
+		wantPath        string
+	}{
+		{
+			name:  "service name from log config",
+			sFunc: func(n, e string) string { return "stdServiceName" },
+			container: &Container{
+				container: types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						Name:  "fooName",
+						Image: "fooImage",
+					},
+				},
+				service: &service.Service{Identifier: "123456"},
+			},
+			source:          config.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName"}),
+			wantServiceName: "configServiceName",
+			wantPath:        "c:\\programdata\\docker\\containers\\123456\\123456-json.log",
+		},
+		{
+			name:  "service name from standard tags",
+			sFunc: func(n, e string) string { return "stdServiceName" },
+			container: &Container{
+				container: types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						Name:  "fooName",
+						Image: "fooImage",
+					},
+				},
+				service: &service.Service{Identifier: "123456"},
+			},
+			source:          config.NewLogSource("from container", &config.LogsConfig{}),
+			wantServiceName: "stdServiceName",
+			wantPath:        "c:\\programdata\\docker\\containers\\123456\\123456-json.log",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Launcher{
+				serviceNameFunc: tt.sFunc,
+			}
+			fileSource := l.getFileSource(tt.container, tt.source)
+			assert.Equal(t, config.FileType, fileSource.Config.Type)
+			assert.Equal(t, tt.container.service.Identifier, fileSource.Config.Identifier)
+			assert.Equal(t, tt.wantServiceName, fileSource.Config.Service)
+		})
+	}
+}

--- a/pkg/logs/input/docker/launcher_test_windows.go
+++ b/pkg/logs/input/docker/launcher_test_windows.go
@@ -17,7 +17,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-func TestGetFileSource(t *testing.T) {
+func TestGetFileSourceOnWindows(t *testing.T) {
 	tests := []struct {
 		name            string
 		sFunc           func(string, string) string

--- a/pkg/logs/input/docker/launcher_windows.go
+++ b/pkg/logs/input/docker/launcher_windows.go
@@ -7,12 +7,16 @@
 
 package docker
 
-import "fmt"
+import (
+	"io/ioutil"
+)
 
 const (
 	basePath = "c:\\programdata\\docker\\containers"
 )
 
 func checkReadAccess() error {
-	return fmt.Errorf("Docker tailing from file is not supported on Windows")
+	// We need read access to the docker folder
+	_, err := ioutil.ReadDir(basePath)
+	return err
 }


### PR DESCRIPTION
### What does this PR do?
Tiny change to enable tailing from file for windows container.

### Motivation
Feature parity vs. linux and better perfomance.

### Additional Notes

So far it seems to work ootb:

```
  container_collect_all
  ---------------------
    - Type: docker
      Status: OK
      BytesRead: 0
      Container Info:
        Container ID: 3eacab988408, Image: nanoserver, Created: 2021-01-20T12:41:04.5253514Z, Tailing from file: c:\programdata\docker\containers\3eacab9884084b1aa0a05abdc674848ed
ba244be74f4a1b25b6b0bbefa7ce397\3eacab9884084b1aa0a05abdc674848edba244be74f4a1b25b6b0bbefa7ce397-json.log
    - Type: file
      Identifier: 3eacab9884084b1aa0a05abdc674848edba244be74f4a1b25b6b0bbefa7ce397
      Path: c:\programdata\docker\containers\3eacab9884084b1aa0a05abdc674848edba244be74f4a1b25b6b0bbefa7ce397\3eacab9884084b1aa0a05abdc674848edba244be74f4a1b25b6b0bbefa7ce397-json
.log
      Status: OK
      Inputs: c:\programdata\docker\containers\3eacab9884084b1aa0a05abdc674848edba244be74f4a1b25b6b0bbefa7ce397\3eacab9884084b1aa0a05abdc674848edba244be74f4a1b25b6b0bbefa7ce397-js
on.log
      BytesRead: 0
```

And it produces this kind of event in the log explorer (it's just cmd.exe prompt):
```
{
	"id": "AQAAAXcf11RpB5J1bwAAAABBWGNmMTF3Z0FBQTNqOU0tLWNuM09nQUI",
	"content": {
		"timestamp": "2021-01-20T12:49:01.545Z",
		"tags": [
			"container_id:3eacab9884084b1aa0a05abdc674848edba244be74f4a1b25b6b0bbefa7ce397",
			"container_name:dazzling_murdock",
			"docker_image:mcr.microsoft.com/windows/nanoserver:1903",
			"filename:3eacab9884084b1aa0a05abdc674848edba244be74f4a1b25b6b0bbefa7ce397-json.log",
			"image_name:mcr.microsoft.com/windows/nanoserver",
			"image_tag:1903",
			"service:nanoserver",
			"short_image:nanoserver",
			"source:nanoserver"
		],
		"host": "win10",
		"service": "nanoserver",
		"message": "[H\u001b]0;C:\\Windows\\system32\\cmd.exe\u0007\u001b[?25h\u001b[?25lMicrosoft Windows [Version 10.0.18362.1256]\u001b[?25h\u001b[?25l",
		"attributes": {}
	}
}
```
### Describe your test plan
Tested on win10 (on fusion to have hyper-v happy) + docker ce  
