### PR TITLE
[runtime-security] fix eventstats race (#7191)

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -70,8 +70,6 @@ func (m *Module) Register(httpMux *http.ServeMux) error {
 		}
 	}()
 
-	go m.statsMonitor(context.Background())
-
 	// initialize the eBPF manager and load the programs and maps in the kernel. At this stage, the probes are not
 	// running yet.
 	if err := m.probe.Init(); err != nil {
@@ -94,6 +92,8 @@ func (m *Module) Register(httpMux *http.ServeMux) error {
 	}
 
 	m.probe.SetEventHandler(m)
+
+	go m.statsMonitor(context.Background())
 
 	signal.Notify(m.sigupChan, syscall.SIGHUP)
 


### PR DESCRIPTION
(cherry picked from commit 491c309e374ed5c7f1b385b347d5f9b5ac72c2b6)

### What does this PR do?

This PR fixes a race on startup that might prevent the agent from starting if the agent takes more than 20 seconds to start.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
