### PR TITLE
Remove some hardcoded VOLUMES from Datadog Agent image

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -169,7 +169,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
 
 # Leave following directories RW to allow use of kubernetes readonlyrootfs flag
-VOLUME ["/var/run/s6", "/etc/datadog-agent", "/var/log/datadog", "/tmp"]
+VOLUME ["/var/run/s6", "/var/log/datadog"]
 
 CMD ["/init"]
 

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -169,7 +169,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
 
 # Leave following directories RW to allow use of kubernetes readonlyrootfs flag
-VOLUME ["/var/run/s6", "/etc/datadog-agent", "/var/log/datadog", "/tmp"]
+VOLUME ["/var/run/s6", "/var/log/datadog"]
 
 CMD ["/init"]
 

--- a/releasenotes/notes/remove-volumes-dockerfile-bfd439d55a7ba71e.yaml
+++ b/releasenotes/notes/remove-volumes-dockerfile-bfd439d55a7ba71e.yaml
@@ -1,0 +1,4 @@
+---
+issues:
+  - |
+    Remove Docker volumes for `/etc/datadog-agent` and `/tmp` as it prevents to inherit from Datadog Agent image. It was originally done to allow read-only rootfs on Kubernetes, so continue supporting this feature, relevant volumes are created in newer Kubernetes manifest or Helm chart >= 2.6.9


### PR DESCRIPTION
### What does this PR do?

Remove Docker volumes for `/etc/datadog-agent` and `/tmp` as it prevents to inherit from Datadog Agent image. It was originally done to allow read-only rootfs on Kubernetes, so continue supporting this feature, relevant volumes are created in newer Kubernetes manifest or Helm chart >= 2.6.9

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Build a child Docker image using:
```
FROM gcr.io/datadoghq/agent:latest
RUN touch /etc/datadog-agent/conf.d/bar
```

When you run your image, the `bar` file should be present.