### PR TITLE
[system-probe] Fix: conntrack initial dump blocks due to output channel not being read

### DIFF
--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -72,7 +72,9 @@ func NewConntracker(procRoot string, maxStateSize, targetRateLimit int, listenAl
 	done := make(chan struct{})
 
 	go func() {
+		start := time.Now()
 		conntracker, err = newConntrackerOnce(procRoot, maxStateSize, targetRateLimit, listenAllNamespaces)
+		log.Infof("conntrack initialization took %s", time.Now().Sub(start))
 		done <- struct{}{}
 	}()
 
@@ -184,7 +186,6 @@ func (ctr *realConntracker) DeleteTranslation(c network.ConnectionStats) {
 
 	delete(ctr.state, k)
 	delete(ctr.state, ipTranslationToConnKey(k.transport, t))
-	log.Tracef("deleted %+v from conntrack", k)
 	atomic.AddInt64(&ctr.stats.unregisters, 1)
 }
 

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -72,9 +72,7 @@ func NewConntracker(procRoot string, maxStateSize, targetRateLimit int, listenAl
 	done := make(chan struct{})
 
 	go func() {
-		start := time.Now()
 		conntracker, err = newConntrackerOnce(procRoot, maxStateSize, targetRateLimit, listenAllNamespaces)
-		log.Infof("conntrack initialization took %s", time.Now().Sub(start))
 		done <- struct{}{}
 	}()
 


### PR DESCRIPTION
### What does this PR do?

Fix a bug in the conntrack initialization code that blocks initialization when there are a large number of conntrack entries (> 100). The conntrack entries are sent down a buffered channel, but the reader of that channel was not reading. This change spins off the writer in a new go routine so that the reader reads at the same time the writer is writing to the channel.

### Motivation

conntrack not getting initialized in system-probe

### Additional Notes

### Describe your test plan
1. Make sure you have at least 100 or more active connections on the machine you are testing. You can ensure this by running a tcp server with `socat - TCP4-LISTEN:12345,fork,reuseaddr` in one console and ``for i in `seq 1 101`; do (nc localhost 12345 &) done;`` in another console (ctrl+C out of the server once done).
2. Start system-probe
3. There should be no errors or warnings related to conntrack in the logs
