### PR TITLE
aggregator/CheckSampler: set interval on metrics sent from checks

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -18,27 +18,29 @@ const checksSourceTypeName = "System"
 
 // CheckSampler aggregates metrics from one Check instance
 type CheckSampler struct {
-	series          []*metrics.Serie
-	sketches        []metrics.SketchSeries
-	contextResolver *ContextResolver
-	metrics         metrics.ContextMetrics
-	sketchMap       sketchMap
-	lastBucketValue map[ckey.ContextKey]int64
-	lastSeenBucket  map[ckey.ContextKey]time.Time
-	bucketExpiry    time.Duration
+	series               []*metrics.Serie
+	sketches             []metrics.SketchSeries
+	contextResolver      *ContextResolver
+	flushIntervalSeconds int64
+	metrics              metrics.ContextMetrics
+	sketchMap            sketchMap
+	lastBucketValue      map[ckey.ContextKey]int64
+	lastSeenBucket       map[ckey.ContextKey]time.Time
+	bucketExpiry         time.Duration
 }
 
 // newCheckSampler returns a newly initialized CheckSampler
 func newCheckSampler() *CheckSampler {
 	return &CheckSampler{
-		series:          make([]*metrics.Serie, 0),
-		sketches:        make([]metrics.SketchSeries, 0),
-		contextResolver: newContextResolver(),
-		metrics:         metrics.MakeContextMetrics(),
-		sketchMap:       make(sketchMap),
-		lastBucketValue: make(map[ckey.ContextKey]int64),
-		lastSeenBucket:  make(map[ckey.ContextKey]time.Time),
-		bucketExpiry:    1 * time.Minute,
+		series:               make([]*metrics.Serie, 0),
+		sketches:             make([]metrics.SketchSeries, 0),
+		contextResolver:      newContextResolver(),
+		metrics:              metrics.MakeContextMetrics(),
+		flushIntervalSeconds: 0,
+		sketchMap:            make(sketchMap),
+		lastBucketValue:      make(map[ckey.ContextKey]int64),
+		lastSeenBucket:       make(map[ckey.ContextKey]time.Time),
+		bucketExpiry:         1 * time.Minute,
 	}
 }
 
@@ -139,6 +141,9 @@ func (cs *CheckSampler) commitSeries(timestamp float64) {
 		serie.Name = context.Name + serie.NameSuffix
 		serie.Tags = context.Tags
 		serie.Host = context.Host
+		if cs.flushIntervalSeconds > 0 {
+			serie.Interval = cs.flushIntervalSeconds
+		}
 		serie.SourceTypeName = checksSourceTypeName // this source type is required for metrics coming from the checks
 
 		cs.series = append(cs.series, serie)

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -72,6 +72,7 @@ type CommonInstanceConfig struct {
 // CommonGlobalConfig holds the reserved fields for the yaml init_config data
 type CommonGlobalConfig struct {
 	Service string `yaml:"service"`
+	MetricsMetadataSetInterval bool `yaml:"metrics_metadata_set_interval"`
 }
 
 // Equal determines whether the passed config is the same

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -206,6 +206,15 @@ func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Da
 		c.interval = time.Duration(commonOptions.MinCollectionInterval) * time.Second
 	}
 
+	if commonGlobalOptions.MetricsMetadataSetInterval {
+		s, err := aggregator.GetSender(c.id)
+		if err != nil {
+			log.Errorf("failed to retrieve a sender for check %s: %s", string(c.id), err)
+		} else {
+			s.SetCheckCollectionInterval(c.interval)
+		}
+	}
+
 	// Disable default hostname if specified
 	if commonOptions.EmptyDefaultHostname {
 		s, err := aggregator.GetSender(c.id)


### PR DESCRIPTION
### What does this PR do?

Adds a flag to enable setting of the interval on metric metadata for metrics sent from checks. 

Redo of earlier attempt https://github.com/DataDog/datadog-agent/pull/5876

### Motivation

The metric interval is currently missing from all metrics sent from checks via the aggregator.

This causes all count metrics to be *very* wrong when plotted as a rate using `.as_rate()`:
* `self.count`
* `self.histogram("foo", ...)` `foo.count` (the rest of the metrics (min, max, median, p95) are ok)

`self.increment` is still broken even with the interval being set on the metadata as it's the wrong type (`rate` when it should be `count`). It is deprecated though so perhaps we don't need to worry about it.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
