### PR TITLE
Adds `--flare` to `jmx [list,collect]` commands so output can be reported in an agent flare

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -9,10 +9,10 @@ package app
 
 import (
 	"fmt"
+	"path/filepath"
 	"runtime"
-    "strings"
-    "time"
-    "path/filepath"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -92,7 +92,7 @@ var (
 
 	cliSelectedChecks = []string{}
 	jmxLogLevel       string
-    saveFlare         bool
+	saveFlare         bool
 )
 
 func init() {
@@ -106,9 +106,9 @@ func init() {
 	jmxListCmd.AddCommand(jmxListEverythingCmd, jmxListMatchingCmd, jmxListLimitedCmd, jmxListCollectedCmd, jmxListNotMatchingCmd, jmxListWithMetricsCmd, jmxListWithRateMetricsCmd)
 
 	jmxListCmd.PersistentFlags().StringSliceVar(&cliSelectedChecks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
-    jmxListCmd.PersistentFlags().BoolVarP(&saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
+	jmxListCmd.PersistentFlags().BoolVarP(&saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
 	jmxCollectCmd.PersistentFlags().StringSliceVar(&cliSelectedChecks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
-    jmxCollectCmd.PersistentFlags().BoolVarP(&saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
+	jmxCollectCmd.PersistentFlags().BoolVarP(&saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
 
 	// attach the command to the root
 	AgentCmd.AddCommand(jmxCmd)
@@ -155,12 +155,12 @@ func runJmxCommandConsole(command string) error {
 		return err
 	}
 
-    logFile := ""
-    if saveFlare {
-        // Windows cannot accept ":" in file names
-        filenameSafeTimeStamp := strings.ReplaceAll(time.Now().UTC().Format(time.RFC3339), ":", "-")
-        logFile = filepath.Join(common.DefaultJMXFlareDirectory, "jmx_"+command+"_"+filenameSafeTimeStamp+".log")
-    }
+	logFile := ""
+	if saveFlare {
+		// Windows cannot accept ":" in file names
+		filenameSafeTimeStamp := strings.ReplaceAll(time.Now().UTC().Format(time.RFC3339), ":", "-")
+		logFile = filepath.Join(common.DefaultJMXFlareDirectory, "jmx_"+command+"_"+filenameSafeTimeStamp+".log")
+	}
 
 	err = config.SetupJMXLogger(jmxLoggerName, logLevel, logFile, "", false, true, false)
 	if err != nil {

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -10,6 +10,9 @@ package app
 import (
 	"fmt"
 	"runtime"
+    "strings"
+    "time"
+    "path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -89,6 +92,7 @@ var (
 
 	cliSelectedChecks = []string{}
 	jmxLogLevel       string
+    saveFlare         bool
 )
 
 func init() {
@@ -102,7 +106,9 @@ func init() {
 	jmxListCmd.AddCommand(jmxListEverythingCmd, jmxListMatchingCmd, jmxListLimitedCmd, jmxListCollectedCmd, jmxListNotMatchingCmd, jmxListWithMetricsCmd, jmxListWithRateMetricsCmd)
 
 	jmxListCmd.PersistentFlags().StringSliceVar(&cliSelectedChecks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
+    jmxListCmd.PersistentFlags().BoolVarP(&saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
 	jmxCollectCmd.PersistentFlags().StringSliceVar(&cliSelectedChecks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
+    jmxCollectCmd.PersistentFlags().BoolVarP(&saveFlare, "flare", "", false, "save jmx list results to the log dir so it may be reported in a flare")
 
 	// attach the command to the root
 	AgentCmd.AddCommand(jmxCmd)
@@ -148,7 +154,15 @@ func runJmxCommandConsole(command string) error {
 		fmt.Printf("Cannot initialize command: %v\n", err)
 		return err
 	}
-	err = config.SetupJMXLogger(jmxLoggerName, logLevel, "", "", false, true, false)
+
+    logFile := ""
+    if saveFlare {
+        // Windows cannot accept ":" in file names
+        filenameSafeTimeStamp := strings.ReplaceAll(time.Now().UTC().Format(time.RFC3339), ":", "-")
+        logFile = filepath.Join(common.DefaultJMXFlareDirectory, "jmx_"+command+"_"+filenameSafeTimeStamp+".log")
+    }
+
+	err = config.SetupJMXLogger(jmxLoggerName, logLevel, logFile, "", false, true, false)
 	if err != nil {
 		return fmt.Errorf("Unable to set up JMX logger: %v", err)
 	}

--- a/cmd/agent/common/common_android.go
+++ b/cmd/agent/common/common_android.go
@@ -20,6 +20,8 @@ const (
 	DefaultJmxLogFile = "/var/log/datadog/jmxfetch.log"
 	// DefaultCheckFlareDirectory a flare friendly location for checks to be written
 	DefaultCheckFlareDirectory = "/var/log/datadog/checks/"
+	// DefaultJMXFlareDirectory a flare friendly location for jmx command logs to be written
+	DefaultJMXFlareDirectory = "/var/log/datadog/jmxinfo/"
 )
 
 var (

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -20,6 +20,8 @@ const (
 	DefaultJmxLogFile = "/var/log/datadog/jmxfetch.log"
 	// DefaultCheckFlareDirectory a flare friendly location for checks to be written
 	DefaultCheckFlareDirectory = "/var/log/datadog/checks/"
+	// DefaultJMXFlareDirectory a flare friendly location for jmx command logs to be written
+	DefaultJMXFlareDirectory = "/var/log/datadog/jmxinfo/"
 )
 
 var (

--- a/cmd/agent/common/common_freebsd.go
+++ b/cmd/agent/common/common_freebsd.go
@@ -18,6 +18,8 @@ const (
 	DefaultDCALogFile = "/var/log/datadog/cluster-agent.log"
 	//DefaultJmxLogFile points to the jmx fetch log file that will be used if not configured
 	DefaultJmxLogFile = "/var/log/datadog/jmxfetch.log"
+	// DefaultJMXFlareDirectory a flare friendly location for jmx command logs to be written
+	DefaultJMXFlareDirectory = "/var/log/datadog/jmxinfo/"
 )
 
 var (

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -26,6 +26,8 @@ const (
 	DefaultJmxLogFile = "/var/log/datadog/jmxfetch.log"
 	// DefaultCheckFlareDirectory a flare friendly location for checks to be written
 	DefaultCheckFlareDirectory = "/var/log/datadog/checks/"
+	// DefaultJMXFlareDirectory a flare friendly location for jmx command logs to be written
+	DefaultJMXFlareDirectory = "/var/log/datadog/jmxinfo/"
 )
 
 var (

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -50,6 +50,8 @@ var (
 	DefaultJmxLogFile = "c:\\programdata\\datadog\\logs\\jmxfetch.log"
 	// DefaultCheckFlareDirectory a flare friendly location for checks to be written
 	DefaultCheckFlareDirectory = "c:\\programdata\\datadog\\logs\\checks\\"
+	// DefaultJMXFlareDirectory a flare friendly location for jmx command logs to be written
+	DefaultJMXFlareDirectory = "c:\\programdata\\datadog\\logs\\jmxinfo\\"
 )
 
 func init() {

--- a/releasenotes/notes/jmxinfo-in-flare-6003cfac9322ac6a.yaml
+++ b/releasenotes/notes/jmxinfo-in-flare-6003cfac9322ac6a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added `--flare` flag to `jmx (list|collect)` commands to save check results to the agent logs directory.
+    This enables flare to pick up jmx command results.


### PR DESCRIPTION
### What does this PR do?

Adds `--flare` flag to `jmx list` and `jmx collect` commands; output is stored where flare can pick them up.
![image](https://user-images.githubusercontent.com/20986892/105279402-8e76c780-5bfb-11eb-903e-763fc6ba0594.png)


### Motivation

- AC-697

### Additional Notes

- Follows the same workflow as https://github.com/DataDog/datadog-agent/pull/6751

### Describe your test plan

- Run any of the agent jmx commands appended by `--flare` (`agent jmx collect --flare`, `agent jmx list [subcommand] --flare`), then generate a flare 
