### PR TITLE
[runtime-security] Pause perf maps while applying rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/DataDog/agent-payload v4.54.0+incompatible
 	github.com/DataDog/datadog-go v4.2.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
-	github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d
+	github.com/DataDog/ebpf v0.0.0-20210121152636-7fc17cac5ed7
 	github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a
 	github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,10 @@ github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822 h1:E5WN
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822/go.mod h1:a5NqgPglcSct+NwO9gPvVhoL5V6G1+gHbRaRnU8U54M=
 github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d h1:FCSp3GWrMD+dTCinb/E5JrV5z9xBB/2wDHZVG9CoWq4=
 github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d/go.mod h1:VSpIdBT/hwSbP3xKa5eYtiiBN2E37YePfTuyQVzSSig=
+github.com/DataDog/ebpf v0.0.0-20210121090404-ba23a575ea48 h1:AFFovncrrPMses0iwkhd128nOLmG5THIohHsbTbEEho=
+github.com/DataDog/ebpf v0.0.0-20210121090404-ba23a575ea48/go.mod h1:VSpIdBT/hwSbP3xKa5eYtiiBN2E37YePfTuyQVzSSig=
+github.com/DataDog/ebpf v0.0.0-20210121152636-7fc17cac5ed7 h1:Gl1fG+QK2tVnxTwtuqraUymTfjMGPMOPjfogRs7vpdA=
+github.com/DataDog/ebpf v0.0.0-20210121152636-7fc17cac5ed7/go.mod h1:VSpIdBT/hwSbP3xKa5eYtiiBN2E37YePfTuyQVzSSig=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71 h1:0TOAH3X9tEvMBVQ1HYrQfrnAUcSS1mfMrhqeN+spV1s=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71/go.mod h1:rNvi5cSHdpxN6495MOYAWN3yukac8lORoluL+9Osrsw=
 github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a h1:BkU6uq4Ib7Kp1zP7MT33IdHZQazC+kxbuTyEmgePyyA=

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -615,6 +615,9 @@ func (p *Probe) SelectProbes(rs *rules.RuleSet) error {
 		}
 	}
 
+	p.perfMap.Pause()
+	defer p.perfMap.Resume()
+
 	if err := enabledEventsMap.Put(ebpf.ZeroUint32MapItem, enabledEvents); err != nil {
 		return errors.Wrap(err, "failed to set enabled events")
 	}

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -615,8 +615,16 @@ func (p *Probe) SelectProbes(rs *rules.RuleSet) error {
 		}
 	}
 
-	p.perfMap.Pause()
-	defer p.perfMap.Resume()
+	// We might end up missing events during the snapshot. Ultimately we might want to stop the rules evaluation but
+	// not the perf map entirely. For now this will do though :)
+	if err := p.perfMap.Pause(); err != nil {
+		return err
+	}
+	defer func() {
+		if err := p.perfMap.Resume(); err != nil {
+			log.Errorf("failed to resume perf map: %s", err)
+		}
+	}()
 
 	if err := enabledEventsMap.Put(ebpf.ZeroUint32MapItem, enabledEvents); err != nil {
 		return errors.Wrap(err, "failed to set enabled events")


### PR DESCRIPTION
### What does this PR do?

Stop perf maps while loading/reloading rules

### Motivation

When applying rules, required kprobes are applied sequentially. Events could be sent by some kprobes while some other kprobes are not applied yet, which can cause incorrect hard to debug side effects.