### PR TITLE
[docker/darwin] Disable docker check on macos

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build docker
+// +build docker,!darwin
 
 package containers
 
@@ -30,41 +30,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	dockerCheckName = "docker"
-	DockerServiceUp = "docker.service_up"
-	DockerExit      = "docker.exit"
-)
-
-type DockerConfig struct {
-	CollectContainerSize     bool               `yaml:"collect_container_size"`
-	CollectContainerSizeFreq uint64             `yaml:"collect_container_size_frequency"`
-	CollectExitCodes         bool               `yaml:"collect_exit_codes"`
-	CollectImagesStats       bool               `yaml:"collect_images_stats"`
-	CollectImageSize         bool               `yaml:"collect_image_size"`
-	CollectDiskStats         bool               `yaml:"collect_disk_stats"`
-	CollectVolumeCount       bool               `yaml:"collect_volume_count"`
-	Tags                     []string           `yaml:"tags"` // Used only by the configuration converter v5 → v6
-	CollectEvent             bool               `yaml:"collect_events"`
-	FilteredEventType        []string           `yaml:"filtered_event_types"`
-	CappedMetrics            map[string]float64 `yaml:"capped_metrics"`
-}
-
 type containerPerImage struct {
 	tags    []string
 	running int64
 	stopped int64
-}
-
-func (c *DockerConfig) Parse(data []byte) error {
-	// default values
-	c.CollectEvent = true
-	c.CollectContainerSizeFreq = 5
-
-	if err := yaml.Unmarshal(data, c); err != nil {
-		return err
-	}
-	return nil
 }
 
 // DockerCheck grabs docker metrics

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -28,6 +28,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const dockerCheckName = "docker"
+
 type containerPerImage struct {
 	tags    []string
 	running int64

--- a/pkg/collector/corechecks/containers/docker_config.go
+++ b/pkg/collector/corechecks/containers/docker_config.go
@@ -10,7 +10,6 @@ package containers
 import "gopkg.in/yaml.v2"
 
 const (
-	dockerCheckName = "docker"
 	DockerServiceUp = "docker.service_up"
 	DockerExit      = "docker.exit"
 )

--- a/pkg/collector/corechecks/containers/docker_config.go
+++ b/pkg/collector/corechecks/containers/docker_config.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build docker
+
+package containers
+
+import "gopkg.in/yaml.v2"
+
+const (
+	dockerCheckName = "docker"
+	DockerServiceUp = "docker.service_up"
+	DockerExit      = "docker.exit"
+)
+
+type DockerConfig struct {
+	CollectContainerSize     bool               `yaml:"collect_container_size"`
+	CollectContainerSizeFreq uint64             `yaml:"collect_container_size_frequency"`
+	CollectExitCodes         bool               `yaml:"collect_exit_codes"`
+	CollectImagesStats       bool               `yaml:"collect_images_stats"`
+	CollectImageSize         bool               `yaml:"collect_image_size"`
+	CollectDiskStats         bool               `yaml:"collect_disk_stats"`
+	CollectVolumeCount       bool               `yaml:"collect_volume_count"`
+	Tags                     []string           `yaml:"tags"` // Used only by the configuration converter v5 → v6
+	CollectEvent             bool               `yaml:"collect_events"`
+	FilteredEventType        []string           `yaml:"filtered_event_types"`
+	CappedMetrics            map[string]float64 `yaml:"capped_metrics"`
+}
+
+func (c *DockerConfig) Parse(data []byte) error {
+	// default values
+	c.CollectEvent = true
+	c.CollectContainerSizeFreq = 5
+
+	if err := yaml.Unmarshal(data, c); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/collector/corechecks/containers/docker_eventbundle.go
+++ b/pkg/collector/corechecks/containers/docker_eventbundle.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build docker
+// +build docker,!darwin
 
 package containers
 

--- a/pkg/collector/corechecks/containers/docker_events.go
+++ b/pkg/collector/corechecks/containers/docker_events.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build docker
+// +build docker,!darwin
 
 package containers
 

--- a/pkg/collector/corechecks/containers/docker_events_test.go
+++ b/pkg/collector/corechecks/containers/docker_events_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build docker
+// +build docker,!darwin
 
 package containers
 

--- a/pkg/collector/corechecks/containers/docker_rate_capping.go
+++ b/pkg/collector/corechecks/containers/docker_rate_capping.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build docker
+// +build docker,!darwin
 
 package containers
 

--- a/pkg/collector/corechecks/containers/docker_rate_capping_test.go
+++ b/pkg/collector/corechecks/containers/docker_rate_capping_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build docker
+// +build docker,!darwin
 
 package containers
 

--- a/pkg/collector/corechecks/containers/docker_test.go
+++ b/pkg/collector/corechecks/containers/docker_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2020 Datadog, Inc.
 
-// +build docker
+// +build docker,!darwin
 
 package containers
 


### PR DESCRIPTION
### What does this PR do?
The docker check was causing the agent to crash on macos when the docker check was attempting with docker env var set.
It happens because the docker build flag is set on macos but some of the functions of `docker.DockerUtil`, used in  the docker check, are relying on things not available on macos (crash was triggered [here](https://github.com/DataDog/datadog-agent/blob/7.25.0/pkg/util/containers/providers/provider.go#L18-L21)).

### Motivation
Prevent a check that could crash the agent to be included on macos build:
```
2021-01-21 10:45:47 CET | CORE | INFO | (pkg/collector/runner/runner.go:261 in work) | check:docker | Running check
panic: Trying to get nil ContainerInterface

goroutine 319 [running]:
github.com/DataDog/datadog-agent/pkg/util/containers/providers.ContainerImpl(...)
	/Users/pierre.rognant/go/src/github.com/DataDog/datadog-agent/pkg/util/containers/providers/provider.go:20
github.com/DataDog/datadog-agent/pkg/util/docker.(*DockerUtil).ListContainers(0xc000d22000, 0xc0009c291e, 0x0, 0x0, 0x0, 0x4055a35, 0x7c249a2)
	/Users/pierre.rognant/go/src/github.com/DataDog/datadog-agent/pkg/util/docker/containers.go:41 +0x121b
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers.(*DockerCheck).Run(0xc000f38000, 0x452282223, 0x81bec20)
	/Users/pierre.rognant/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/docker.go:161 +0x2f1
github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).work(0xc000c6d530)
	/Users/pierre.rognant/go/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:270 +0x4bc
created by github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).AddWorker
	/Users/pierre.rognant/go/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:100 +0x8a
```

### Describe your test plan
It should be no-op for all other platforms.
AD from Docker should remain functionnal on macos as it does not use cgroups stuff.