### PR TITLE
[runtime-security] use executable basename for process.name attribute

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -666,7 +666,8 @@ type ExecEvent struct {
 	FileEvent
 	ExecTimestamp time.Time `field:"-"`
 	TTYName       string    `field:"tty_name" handler:"ResolveTTY,string"`
-	Comm          string    `field:"name" handler:"ResolveComm,string"`
+	Name          string    `field:"name" handler:"ResolveName,string"`
+	Comm          string    `field:"-" handler:"ResolveComm,string"`
 
 	// pid_cache_t
 	ForkTimestamp time.Time `field:"-"`
@@ -815,6 +816,11 @@ func (e *ExecEvent) ResolveComm(event *Event) string {
 		}
 	}
 	return e.Comm
+}
+
+// ResolveName resolves the basename of the process executable
+func (e *ExecEvent) ResolveName(event *Event) string {
+	return e.ResolveBasename(event)
 }
 
 // ResolveUID resolves the user id of the process

--- a/pkg/security/probe/model_accessors.go
+++ b/pkg/security/probe/model_accessors.go
@@ -305,7 +305,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.ResolveComm((*Event)(ctx.Object))
+				return (*Event)(ctx.Object).Exec.ResolveName((*Event)(ctx.Object))
 
 			},
 			Field: field,
@@ -871,7 +871,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				if reg.Value != nil {
 					element := (*ProcessCacheEntry)(reg.Value)
 
-					result = element.ResolveComm((*Event)(ctx.Object))
+					result = element.ResolveName((*Event)(ctx.Object))
 
 				}
 
@@ -1125,7 +1125,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Process.ResolveComm((*Event)(ctx.Object))
+				return (*Event)(ctx.Object).Process.ResolveName((*Event)(ctx.Object))
 
 			},
 			Field: field,
@@ -1871,7 +1871,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "exec.name":
 
-		return e.Exec.ResolveComm(e), nil
+		return e.Exec.ResolveName(e), nil
 
 	case "exec.overlay_numlower":
 
@@ -2186,7 +2186,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		for ptr != nil {
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ResolveComm((*Event)(ctx.Object))
+			result := element.ResolveName((*Event)(ctx.Object))
 
 			values = append(values, result)
 
@@ -2379,7 +2379,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "process.name":
 
-		return e.Process.ResolveComm(e), nil
+		return e.Process.ResolveName(e), nil
 
 	case "process.overlay_numlower":
 
@@ -3729,8 +3729,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 	case "exec.name":
 
-		if e.Exec.Comm, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Comm"}
+		if e.Exec.Name, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Name"}
 		}
 		return nil
 
@@ -4042,8 +4042,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 	case "process.name":
 
-		if e.Process.Comm, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.Comm"}
+		if e.Process.Name, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Name"}
 		}
 		return nil
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -263,6 +263,8 @@ func (p *ProcessResolver) deleteEntry(pid uint32, exitTime time.Time) {
 	}
 	entry.Exit(exitTime)
 	delete(p.entryCache, entry.Pid)
+
+	p.cookieCache.Remove(entry.Cookie)
 }
 
 // DeleteEntry tries to delete an entry in the process cache

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -62,6 +62,7 @@ type ProcessCacheEntrySerializer struct {
 	ContainerPath       string     `json:"executable_container_path,omitempty"`
 	Path                string     `json:"executable_path,omitempty"`
 	PathResolutionError string     `json:"path_resolution_error,omitempty"`
+	Comm                string     `json:"comm,omitempty"`
 	Inode               uint64     `json:"executable_inode,omitempty"`
 	MountID             uint32     `json:"executable_mount_id,omitempty"`
 	TTY                 string     `json:"tty,omitempty"`
@@ -187,9 +188,11 @@ func newProcessCacheEntrySerializer(pce *ProcessCacheEntry, e *Event, r *Resolve
 		Tid:                 tid,
 		UID:                 uid,
 		GID:                 gid,
-		Name:                pce.Comm,
+		Name:                pce.ResolveName(e),
 		Path:                pce.ResolveInodeWithResolvers(r),
 		PathResolutionError: pce.GetPathResolutionError(),
+		ContainerPath:       pce.ResolveContainerPath(e),
+		Comm:                pce.ResolveComm(e),
 		Inode:               pce.Inode,
 		MountID:             pce.MountID,
 		TTY:                 pce.ResolveTTY(e),


### PR DESCRIPTION
### What does this PR do?

Change the process.name attribute from the process comm to the process executable base name.
### Motivation

Currently, the process.name maps to the process comm which can be changed by the process owner and is therefore not reliable from a security standpoint.