### PR TITLE
Specify python tools in requirements.txt to use the same versions locally than in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ jobs:
           command: |
             python3 -m pip install wheel
             python3 -m pip install -r requirements.txt
-            python3 -m pip install flake8~=3.8.3 flake8-bugbear~=20.1.4 black~=19.10b0 isort~=5.2.2
       - run:
           name: grab go deps
           command: |

--- a/.gitlab/choco_build.yml
+++ b/.gitlab/choco_build.yml
@@ -20,6 +20,8 @@ windows_choco_offline_7_x64:
   needs: ["windows_msi_and_bosh_zip_x64-a7"]
   variables:
     ARCH: "x64"
+  before_script:
+    - $env:chocolateyUseWindowsCompression = 'true'; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
   script:
     - $ErrorActionPreference = "Stop"
     - Get-ChildItem .omnibus\pkg
@@ -42,6 +44,8 @@ windows_choco_online_7_x64:
   needs: ["deploy_staging_windows_tags-a7"]
   variables:
     ARCH: "x64"
+  before_script:
+    - $env:chocolateyUseWindowsCompression = 'true'; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -17,6 +17,7 @@ publish_choco_7_x64:
   variables:
     ARCH: "x64"
   before_script:
+    - $env:chocolateyUseWindowsCompression = 'true'; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
     - $chocolateyApiKey = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.chocolatey_api_key --with-decryption --query "Parameter.Value" --out text)
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ docker-squash==1.0.8
 requests==2.23.0
 PyYAML==5.4
 toml==0.9.4
+flake8~=3.8.3
+flake8-bugbear~=20.1.4
+black~=19.10b0
+isort~=5.2.2


### PR DESCRIPTION
Is there any reason to not do this?

### Motivation

Make sure we run the same checks locally and in the CI.

