### PR TITLE
Add telemetry around the new remote tagger machinery

### DIFF
--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -183,6 +183,8 @@ func (t *Tagger) run() {
 
 		response, err := t.stream.Recv()
 		if err != nil {
+			telemetry.StreamErrors.Inc()
+
 			// when Recv() returns an error, the stream is aborted
 			// and the contents of our store are considered out of
 			// sync and therefore no longer valid, so the tagger

--- a/pkg/tagger/subscriber/subscriber.go
+++ b/pkg/tagger/subscriber/subscriber.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
 )
 
@@ -38,6 +39,7 @@ func (s *Subscriber) Subscribe(cardinality collectors.TagCardinality, events []t
 
 	s.Lock()
 	s.subscribers[ch] = cardinality
+	telemetry.Subscribers.Inc()
 	s.Unlock()
 
 	if events != nil && len(events) > 0 {
@@ -51,6 +53,7 @@ func (s *Subscriber) Subscribe(cardinality collectors.TagCardinality, events []t
 func (s *Subscriber) Unsubscribe(ch chan []types.EntityEvent) {
 	s.Lock()
 	defer s.Unlock()
+	defer telemetry.Subscribers.Dec()
 
 	delete(s.subscribers, ch)
 	close(ch)
@@ -67,9 +70,6 @@ func (s *Subscriber) Notify(events []types.EntityEvent) {
 	defer s.RUnlock()
 
 	for ch, cardinality := range s.subscribers {
-		// NOTE: we need to add some telemetry on the amount of
-		// subscribers and notifications being sent, and at which
-		// cardinality
 		notify(ch, events, cardinality)
 	}
 }
@@ -92,6 +92,9 @@ func notify(ch chan []types.EntityEvent, events []types.EntityEvent, cardinality
 			Entity:    entity,
 		})
 	}
+
+	telemetry.Notifications.Inc()
+	telemetry.Events.Add(float64(len(events)), collectors.TagCardinalityToString(cardinality))
 
 	ch <- subscriberEvents
 }

--- a/pkg/tagger/telemetry/telemetry.go
+++ b/pkg/tagger/telemetry/telemetry.go
@@ -17,4 +17,26 @@ var (
 	Queries = telemetry.NewCounterWithOpts("tagger", "queries",
 		[]string{"cardinality"}, "Queries made against the tagger.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	// StreamErrors tracks how many errors were received when streaming
+	// tagger events.
+	StreamErrors = telemetry.NewCounterWithOpts("tagger", "stream_errors",
+		[]string{}, "Errors received when streaming tagger events",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	// Subscribers tracks how many subscribers the tagger has.
+	Subscribers = telemetry.NewGaugeWithOpts("tagger", "subscribers",
+		[]string{}, "Number of channels subscribing to tagger events",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	// Events tracks the number of tagger events being sent out.
+	Events = telemetry.NewCounterWithOpts("tagger", "events",
+		[]string{"cardinality"}, "Number of tagger events being sent out",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	// Notifications tracks the number of times the tagger has sent a
+	// notification with a group of events.
+	Notifications = telemetry.NewCounterWithOpts("tagger", "sends",
+		[]string{}, "Number of of times the tagger has sent a notification with a group of events",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 )


### PR DESCRIPTION
### What does this PR do?

We need to keep an eye on how the remote tagger is behaving, so we need
some extra telemetry:

* tagger.stream_errors tracks how often streams return an error and are
aborted. This is the main metric we should look at to make sure the
remote tagger actually works at all.

* tagger.events tracks how many events the tagger is sending out. This
is a good proxy metric for the network traffic we're generating.

* tagger.notifications tracks how many times the tagger has send a
message to a subscriber. More events but less notifications is good, too
many notifications with a small amount of events is bad.

* tagger.subscribers tracks how many subscribers there are. This should
be mostly static in the lifetime of an agent, and is here for
sanity-keeping.

### Describe your test plan

[Enable the remote tagger](https://github.com/DataDog/datadog-agent/pull/7208) and check that the telemetry is being sent properly to Datadog, and that it looks sane. Keep in mind that any insanity could also just be the remote tagger itself.