### PR TITLE
[runtime-security] add flush mechanism to process resolver

### DIFF
--- a/pkg/security/probe/metrics.go
+++ b/pkg/security/probe/metrics.go
@@ -92,9 +92,9 @@ var (
 	// MetricProcessResolverAdded is the name of the metric used to report the number of entries added in the cache
 	// Tags: -
 	MetricProcessResolverAdded = newRuntimeSecurityMetric(".process_resolver.added")
-	// MetricProcessResolverDeleted is the name of the metric used to report the number of entries deleted from the cache
+	// MetricProcessResolverFlushed is the name of the metric used to report the number cache flush
 	// Tags: -
-	MetricProcessResolverDeleted = newRuntimeSecurityMetric(".process_resolver.deleted")
+	MetricProcessResolverFlushed = newRuntimeSecurityMetric(".process_resolver.flushed")
 
 	// Custom events
 

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -10,7 +10,6 @@ package probe
 import (
 	"context"
 	"fmt"
-	"github.com/cihub/seelog"
 	"math"
 	"math/rand"
 	"os"
@@ -18,6 +17,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-go/statsd"
 	lib "github.com/DataDog/ebpf"
@@ -204,7 +205,7 @@ func (p *Probe) Init(client *statsd.Client) error {
 		return errors.New("couldn't find events perf map")
 	}
 
-	if err := p.resolvers.Start(); err != nil {
+	if err := p.resolvers.Start(p.ctx); err != nil {
 		return err
 	}
 
@@ -467,7 +468,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		}
 	case ForkEventType:
 		if _, err := event.Exec.UnmarshalEvent(data[offset:], event); err != nil {
-			log.Errorf("failed to decode exec event: %s (offset %d, len %d)", err, offset, dataLen)
+			log.Errorf("failed to decode fork event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 		event.updateProcessCachePointer(p.resolvers.ProcessResolver.AddForkEntry(event.Process.Pid, event.processCacheEntry))

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -8,6 +8,7 @@
 package probe
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -254,11 +255,7 @@ func (p *ProcessResolver) insertExecEntry(pid uint32, entry *ProcessCacheEntry) 
 	return entry
 }
 
-// DeleteEntry tries to delete an entry in the process cache
-func (p *ProcessResolver) DeleteEntry(pid uint32, exitTime time.Time) {
-	p.Lock()
-	defer p.Unlock()
-
+func (p *ProcessResolver) deleteEntry(pid uint32, exitTime time.Time) {
 	// Start by updating the exit timestamp of the pid cache entry
 	entry, ok := p.entryCache[pid]
 	if !ok {
@@ -266,6 +263,14 @@ func (p *ProcessResolver) DeleteEntry(pid uint32, exitTime time.Time) {
 	}
 	entry.Exit(exitTime)
 	delete(p.entryCache, entry.Pid)
+}
+
+// DeleteEntry tries to delete an entry in the process cache
+func (p *ProcessResolver) DeleteEntry(pid uint32, exitTime time.Time) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.deleteEntry(pid, exitTime)
 }
 
 // Resolve returns the cache entry for the given pid
@@ -363,7 +368,7 @@ func (p *ProcessResolver) Get(pid uint32) *ProcessCacheEntry {
 }
 
 // Start starts the resolver
-func (p *ProcessResolver) Start() error {
+func (p *ProcessResolver) Start(ctx context.Context) error {
 	var err error
 	if p.inodeInfoMap, err = p.probe.Map("inode_info_cache"); err != nil {
 		return err
@@ -385,7 +390,46 @@ func (p *ProcessResolver) Start() error {
 		return err
 	}
 
+	go p.cacheFlusher(ctx)
+
 	return nil
+}
+
+func (p *ProcessResolver) cacheFlusher(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case now := <-ticker.C:
+			var pids []uint32
+
+			p.RLock()
+			for pid := range p.entryCache {
+				pids = append(pids, pid)
+			}
+			p.RUnlock()
+
+			// flush slowly
+			for _, pid := range pids {
+				if _, err := process.NewProcess(int32(pid)); err != nil {
+					// check start time to ensure to not delete a recent pid
+					p.Lock()
+					if entry := p.entryCache[pid]; entry != nil {
+						if tm := entry.ExecTimestamp; !tm.IsZero() && tm.Add(time.Minute).Before(now) {
+							p.deleteEntry(pid, now)
+						} else if tm := entry.ForkTimestamp; !tm.IsZero() && tm.Add(time.Minute).Before(now) {
+							p.deleteEntry(pid, now)
+						}
+					}
+					p.Unlock()
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // SyncCache snapshots /proc for the provided pid. This method returns true if it updated the process cache.

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -75,6 +75,26 @@ func ParseMountInfoFile(pid int32) ([]*mountinfo.Info, error) {
 	return mountinfo.GetMountsFromReader(f, nil)
 }
 
+// GetProcesses returns list of active processes
+func GetProcesses() ([]*process.Process, error) {
+	pids, err := process.Pids()
+	if err != nil {
+		return nil, err
+	}
+
+	var processes []*process.Process
+	for _, pid := range pids {
+		proc, err := process.NewProcess(pid)
+		if err != nil {
+			// the process does not exist anymore, continue
+			continue
+		}
+		processes = append(processes, proc)
+	}
+
+	return processes, nil
+}
+
 // GetFilledProcess returns a FilledProcess from a Process input
 // TODO: make a PR to export a similar function in Datadog/gopsutil. We only populate the fields we need for now.
 func GetFilledProcess(p *process.Process) *process.FilledProcess {


### PR DESCRIPTION
### What does this PR do?

Add a flush mechanism to evict entry from process resolver cache in case of exit event lost of reorder issue. This ensure that we don't leak entry.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

the entry_cache size metric should be stable
