### PR TITLE
all: Sanitize API Keys 

### DIFF
--- a/cmd/agent/android/main_android.go
+++ b/cmd/agent/android/main_android.go
@@ -21,7 +21,7 @@ import (
 func AndroidMain(apikey string, hostname string, tags string) {
 	overrides := make(map[string]interface{})
 	if len(apikey) != 0 {
-		overrides["api_key"] = apikey
+		overrides["api_key"] = config.SanitizeAPIKey(apikey)
 	}
 	if len(hostname) != 0 {
 		overrides["hostname"] = hostname

--- a/cmd/agent/app/settings/runtime_setting_profiling.go
+++ b/cmd/agent/app/settings/runtime_setting_profiling.go
@@ -57,7 +57,7 @@ func (l profilingRuntimeSetting) Set(v interface{}) error {
 
 		v, _ := version.Agent()
 		err := profiling.Start(
-			config.Datadog.GetString("api_key"),
+			config.SanitizeAPIKey(config.Datadog.GetString("api_key")),
 			site,
 			config.Datadog.GetString("env"),
 			profiling.ProfileCoreService,

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -179,7 +179,7 @@ func ImportRegistryConfig() error {
 	var val string
 
 	if val, _, err = k.GetStringValue("api_key"); err == nil && val != "" {
-		overrides["api_key"] = val
+		overrides["api_key"] = config.SanitizeAPIKey(val)
 		log.Debug("Setting API key")
 		commandLineSettingFound = true
 	} else {

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -207,7 +207,7 @@ func importRegistryConfig() error {
 	var val string
 
 	if val, _, err = k.GetStringValue("api_key"); err == nil && val != "" {
-		overrides["api_key"] = val
+		overrides["api_key"] = config.SanitizeAPIKey(val)
 		log.Debug("Setting API key")
 	} else {
 		log.Debug("API key not found, not setting")

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -81,7 +81,7 @@ func (c *APMCheck) run() error {
 	hostname, _ := util.GetHostname()
 
 	env := os.Environ()
-	env = append(env, fmt.Sprintf("DD_API_KEY=%s", config.Datadog.GetString("api_key")))
+	env = append(env, fmt.Sprintf("DD_API_KEY=%s", config.SanitizeAPIKey(config.Datadog.GetString("api_key"))))
 	env = append(env, fmt.Sprintf("DD_HOSTNAME=%s", hostname))
 	env = append(env, fmt.Sprintf("DD_DOGSTATSD_PORT=%s", config.Datadog.GetString("dogstatsd_port")))
 	env = append(env, fmt.Sprintf("DD_LOG_LEVEL=%s", config.Datadog.GetString("log_level")))

--- a/pkg/config/legacy/converter.go
+++ b/pkg/config/legacy/converter.go
@@ -244,7 +244,7 @@ func extractURLAPIKeys(agentConfig Config, converter *config.LegacyConfigConvert
 		converter.Set("dd_url", urls[0])
 	}
 
-	converter.Set("api_key", keys[0])
+	converter.Set("api_key", config.SanitizeAPIKey(keys[0]))
 	if len(urls) == 1 {
 		return nil
 	}
@@ -257,6 +257,7 @@ func extractURLAPIKeys(agentConfig Config, converter *config.LegacyConfigConvert
 		if url == "" || keys[idx] == "" {
 			return fmt.Errorf("Found empty additional 'dd_url' or 'api_key'. Please check that you don't have any misplaced commas")
 		}
+		keys[idx] = config.SanitizeAPIKey(keys[idx])
 		if _, ok := additionalEndpoints[url]; ok {
 			additionalEndpoints[url] = append(additionalEndpoints[url], keys[idx])
 		} else {

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -128,7 +128,7 @@ func analyzeResponse(r *http.Response, err error) (string, error) {
 		return response, err
 	}
 	if r.StatusCode == http.StatusForbidden {
-		apiKey := config.Datadog.GetString("api_key")
+		apiKey := config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 		var errStr string
 
 		if len(apiKey) == 0 {
@@ -177,6 +177,6 @@ func mkURL(caseID string) string {
 	if caseID != "" {
 		url += "/" + caseID
 	}
-	url += "?api_key=" + config.Datadog.GetString("api_key")
+	url += "?api_key=" + config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 	return url
 }

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -286,9 +286,9 @@ func isSetAndNotEmpty(config coreConfig.Config, key string) bool {
 // getLogsAPIKey provides the dd api key used by the main logs agent sender.
 func getLogsAPIKey(config coreConfig.Config) string {
 	if isSetAndNotEmpty(config, "logs_config.api_key") {
-		return config.GetString("logs_config.api_key")
+		return coreConfig.SanitizeAPIKey(config.GetString("logs_config.api_key"))
 	}
-	return config.GetString("api_key")
+	return coreConfig.SanitizeAPIKey(config.GetString("api_key"))
 }
 
 // parseAddress returns the host and the port of the address.

--- a/pkg/metadata/common/common.go
+++ b/pkg/metadata/common/common.go
@@ -37,5 +37,5 @@ func getAPIKey() string {
 		apiKey = strings.Split(config.Datadog.GetString("api_key"), ",")[0]
 	}
 
-	return apiKey
+	return config.SanitizeAPIKey(apiKey)
 }

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -139,7 +139,7 @@ func extractEndpoints(URL *url.URL, k string, endpoints *[]api.Endpoint) error {
 		}
 		for _, k := range apiKeys {
 			*endpoints = append(*endpoints, api.Endpoint{
-				APIKey:   k,
+				APIKey:   config.SanitizeAPIKey(k),
 				Endpoint: u,
 			})
 		}

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -74,7 +74,7 @@ func (oc *OrchestratorConfig) LoadYamlConfig(path string) error {
 	oc.OrchestratorEndpoints[0].Endpoint = URL
 
 	if key := "api_key"; config.Datadog.IsSet(key) {
-		oc.OrchestratorEndpoints[0].APIKey = config.Datadog.GetString(key)
+		oc.OrchestratorEndpoints[0].APIKey = config.SanitizeAPIKey(config.Datadog.GetString(key))
 	}
 
 	if err := extractOrchestratorAdditionalEndpoints(URL, &oc.OrchestratorEndpoints); err != nil {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -376,7 +376,7 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 			}
 			for _, k := range apiKeys {
 				a.APIEndpoints = append(a.APIEndpoints, api.Endpoint{
-					APIKey:   k,
+					APIKey:   config.SanitizeAPIKey(k),
 					Endpoint: u,
 				})
 			}

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -207,7 +207,7 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		a.ProfilingEnabled = config.Datadog.GetBool(key(spNS, "profiling.enabled"))
 		a.ProfilingSite = config.Datadog.GetString(key(spNS, "profiling.site"))
 		a.ProfilingURL = config.Datadog.GetString(key(spNS, "profiling.profile_dd_url"))
-		a.ProfilingAPIKey = config.Datadog.GetString(key(spNS, "profiling.api_key"))
+		a.ProfilingAPIKey = config.SanitizeAPIKey(config.Datadog.GetString(key(spNS, "profiling.api_key")))
 		a.ProfilingEnvironment = config.Datadog.GetString(key(spNS, "profiling.env"))
 	}
 	a.EnableRuntimeCompiler = config.Datadog.GetBool(key(spNS, "enable_runtime_compiler"))
@@ -238,7 +238,7 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	a.APIEndpoints[0].Endpoint = URL
 
 	if key := "api_key"; config.Datadog.IsSet(key) {
-		a.APIEndpoints[0].APIKey = config.Datadog.GetString(key)
+		a.APIEndpoints[0].APIKey = config.SanitizeAPIKey(config.Datadog.GetString(key))
 	}
 
 	if config.Datadog.IsSet("hostname") {
@@ -389,7 +389,7 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.ProfilingEnabled = config.Datadog.GetBool(key(ns, "profiling.enabled"))
 		a.ProfilingSite = config.Datadog.GetString("site")
 		a.ProfilingURL = config.Datadog.GetString("profiling.profile_dd_url")
-		a.ProfilingAPIKey = config.Datadog.GetString("api_key")
+		a.ProfilingAPIKey = config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 		a.ProfilingEnvironment = config.Datadog.GetString("env")
 	}
 

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -122,7 +122,7 @@ func (c *AgentConfig) applyDatadogConfig() error {
 		c.Endpoints = []*Endpoint{{}}
 	}
 	if config.Datadog.IsSet("api_key") {
-		c.Endpoints[0].APIKey = config.Datadog.GetString("api_key")
+		c.Endpoints[0].APIKey = config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 	}
 	if config.Datadog.IsSet("hostname") {
 		c.Hostname = config.Datadog.GetString("hostname")
@@ -335,7 +335,7 @@ func (c *AgentConfig) applyDatadogConfig() error {
 func (c *AgentConfig) loadDeprecatedValues() error {
 	cfg := config.Datadog
 	if cfg.IsSet("apm_config.api_key") {
-		c.Endpoints[0].APIKey = config.Datadog.GetString("apm_config.api_key")
+		c.Endpoints[0].APIKey = config.SanitizeAPIKey(config.Datadog.GetString("apm_config.api_key"))
 	}
 	if cfg.IsSet("apm_config.log_level") {
 		c.LogLevel = config.Datadog.GetString("apm_config.log_level")

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -185,7 +185,7 @@ func (p *Processor) updateRateLimitingMetrics() error {
 
 // NewDatadogClient generates a new client to query metrics from Datadog
 func NewDatadogClient() (*datadog.Client, error) {
-	apiKey := config.Datadog.GetString("api_key")
+	apiKey := config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 	appKey := config.Datadog.GetString("app_key")
 
 	// DATADOG_HOST used to be the only way to set the external metrics

--- a/releasenotes/notes/apm-sanitize-api-keys-241a002c0a33161d.yaml
+++ b/releasenotes/notes/apm-sanitize-api-keys-241a002c0a33161d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: All Datadog API key usage is sanitized to exclude newlines and other control characters.


### PR DESCRIPTION
Standardizes API key usage by sanitizing all API key reads when config is set.

Fixes #6961. 
