### PR TITLE
[pkg/collector/check] Initialize check fail/success telemetry counters

### DIFF
--- a/pkg/collector/check/stats_test.go
+++ b/pkg/collector/check/stats_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package check
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	agentConfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+)
+
+// Mock Check implementation used for testing
+type mockCheck struct {
+	StubCheck
+	cfgSource string
+	id        ID
+	stringVal string
+	version   string
+}
+
+// Mock Check interface implementation
+func (mc *mockCheck) ConfigSource() string { return mc.cfgSource }
+func (mc *mockCheck) ID() ID               { return mc.id }
+func (mc *mockCheck) String() string       { return mc.stringVal }
+func (mc *mockCheck) Version() string      { return mc.version }
+
+func newMockCheck() Check {
+	return &mockCheck{
+		cfgSource: "checkConfigSrc",
+		id:        "checkID",
+		stringVal: "checkString",
+		version:   "checkVersion",
+	}
+}
+
+func getTelemetryData() (string, error) {
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		return "", err
+	}
+
+	rec := httptest.NewRecorder()
+	telemetry.Handler().ServeHTTP(rec, req)
+
+	return rec.Body.String(), nil
+}
+
+func TestNewStats(t *testing.T) {
+	stats := NewStats(newMockCheck())
+
+	assert.Equal(t, stats.CheckID, ID("checkID"))
+	assert.Equal(t, stats.CheckName, "checkString")
+	assert.Equal(t, stats.CheckVersion, "checkVersion")
+	assert.Equal(t, stats.CheckVersion, "checkVersion")
+	assert.Equal(t, stats.CheckConfigSource, "checkConfigSrc")
+}
+
+func TestNewStatsStateTelemetryIgnoredWhenGloballyDisabled(t *testing.T) {
+	mockConfig := agentConfig.Mock()
+	mockConfig.Set("telemetry.enabled", false)
+	mockConfig.Set("telemetry.checks", "*")
+
+	NewStats(newMockCheck())
+
+	tlmData, err := getTelemetryData()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Assert that no telemetry is recorded
+	assert.NotContains(t, tlmData, "checkString")
+	assert.NotContains(t, tlmData, "state=\"fail\"")
+	assert.NotContains(t, tlmData, "state=\"ok\"")
+}
+
+func TestNewStatsStateTelemetryInitializedWhenGloballyEnabled(t *testing.T) {
+	mockConfig := agentConfig.Mock()
+	mockConfig.Set("telemetry.enabled", true)
+	mockConfig.Set("telemetry.checks", "*")
+
+	NewStats(newMockCheck())
+
+	tlmData, err := getTelemetryData()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Contains(
+		t,
+		tlmData,
+		"checks__runs{check_name=\"checkString\",state=\"fail\"} 0",
+	)
+	assert.Contains(
+		t,
+		tlmData,
+		"checks__runs{check_name=\"checkString\",state=\"ok\"} 0",
+	)
+}

--- a/pkg/telemetry/counter.go
+++ b/pkg/telemetry/counter.go
@@ -13,6 +13,10 @@ import (
 
 // Counter tracks how many times something is happening.
 type Counter interface {
+	// Initialize creates the counter with the given tags and initializes it to 0.
+	// This method is intended to be used when the counter value is important to
+	// send even before any incrementing/addition is done on it.
+	Initialize(tagsValue ...string)
 	// Inc increments the counter with the given tags value.
 	Inc(tagsValue ...string)
 	// Add adds the given value to the counter with the given tags value.

--- a/pkg/telemetry/counter_test.go
+++ b/pkg/telemetry/counter_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCounterInitializer(t *testing.T) {
+	// Reset telemetry registry data
+	Reset()
+
+	counter := NewCounter("subsystem", "test", []string{"check_name", "state"}, "help docs")
+
+	// Sanity check that we don't have any metrics
+	startMetrics, err := telemetryRegistry.Gather()
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	assert.Zero(t, len(startMetrics))
+
+	// Set some values and ensure that we have those counters
+	counter.Initialize("mycheck", "mystate")
+
+	endMetrics, err := telemetryRegistry.Gather()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if !assert.Equal(t, len(endMetrics), 1) {
+		return
+	}
+
+	metricFamily := endMetrics[0]
+	if !assert.Equal(t, len(metricFamily.GetMetric()), 1) {
+		return
+	}
+
+	assert.Equal(t, metricFamily.GetName(), "subsystem__test")
+
+	metric := metricFamily.GetMetric()[0]
+	assert.Equal(t, metric.GetLabel()[0].GetName(), "check_name")
+	assert.Equal(t, metric.GetLabel()[0].GetValue(), "mycheck")
+
+	assert.Equal(t, metric.GetLabel()[1].GetName(), "state")
+	assert.Equal(t, metric.GetLabel()[1].GetValue(), "mystate")
+
+	assert.Equal(t, metric.GetCounter().GetValue(), 0.0)
+}

--- a/pkg/telemetry/prom_counter.go
+++ b/pkg/telemetry/prom_counter.go
@@ -14,6 +14,16 @@ type promCounter struct {
 	pc *prometheus.CounterVec
 }
 
+// Initialize creates the counter with the given tags and initializes it to 0.
+// This method is intended to be used when the counter value is important to
+// send even before any incrementing/addition is done on it.
+func (c *promCounter) Initialize(tagsValue ...string) {
+	// By requesting a counter for a set of tags, we are creating and initializing
+	// the counter at 0. See the following for more info:
+	// https://github.com/prometheus/client_golang/blob/v1.9.0/prometheus/counter.go#L194-L196
+	c.pc.WithLabelValues(tagsValue...)
+}
+
 // Add adds the given value to the counter with the given tags value.
 func (c *promCounter) Add(value float64, tagsValue ...string) {
 	c.pc.WithLabelValues(tagsValue...).Add(value)

--- a/pkg/telemetry/prom_counter_test.go
+++ b/pkg/telemetry/prom_counter_test.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPromCounterInitializer(t *testing.T) {
+	promTelemetry := prometheus.NewRegistry()
+
+	counter := promCounter{
+		pc: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: "subsystem",
+				Name:      "test",
+				Help:      "help docs",
+			},
+			[]string{"check_name", "state"},
+		),
+	}
+
+	promTelemetry.MustRegister(counter.pc)
+
+	// Sanity check that we don't have any metrics
+	startMetrics, err := promTelemetry.Gather()
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	assert.Zero(t, len(startMetrics))
+
+	// Set some values and ensure that we have those counters
+	counter.Initialize("mycheck", "mystate")
+
+	endMetrics, err := promTelemetry.Gather()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if !assert.Equal(t, len(endMetrics), 1) {
+		return
+	}
+
+	metricFamily := endMetrics[0]
+	if !assert.Equal(t, len(metricFamily.GetMetric()), 1) {
+		return
+	}
+
+	assert.Equal(t, metricFamily.GetName(), "subsystem_test")
+
+	metric := metricFamily.GetMetric()[0]
+	assert.Equal(t, metric.GetLabel()[0].GetName(), "check_name")
+	assert.Equal(t, metric.GetLabel()[0].GetValue(), "mycheck")
+
+	assert.Equal(t, metric.GetLabel()[1].GetName(), "state")
+	assert.Equal(t, metric.GetLabel()[1].GetValue(), "mystate")
+
+	assert.Equal(t, metric.GetCounter().GetValue(), 0.0)
+}


### PR DESCRIPTION
### What does this PR do?

When telemetry is turned on, we previously were unable to ascertain the
number of fail/ok checks since only one of the tags (`"state":"ok"` or
`"state":"fail"`) would be set on each check. If a particular check had
no failures (or successes), the telemetry for the opposite state (of
value 0) would not be sent and aggregation of data would not be accurate.

This change ensures that when a check is scheduled we initialize both
the "ok" and "fail" counts to 0 which should fix things like the averaging
of metrics.

### Motivation

AC-657

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

When averages of hosts for a check are done via query like:
```
avg:datadog.agent.check.runs{check_name:foo,state:fail,service:bar} avg by {host}
```
If there is only one host failing, the averages should still be reported correctly.
