### PR TITLE
add support for arguments in secrets_tester.ps1

### DIFF
--- a/docs/agent/secrets_scripts/secrets_tester.ps1
+++ b/docs/agent/secrets_scripts/secrets_tester.ps1
@@ -8,6 +8,9 @@ param(
     [Parameter(Mandatory=$True)]
     [string]$password,
 
+    [Parameter(Mandatory=$False)]
+    [string]$arguments,
+
     [Parameter(Mandatory=$True)]
     [string]$payload
 )
@@ -17,6 +20,7 @@ $ErrorActionPreference = "Stop"
 $cmd  = New-Object System.Diagnostics.ProcessStartInfo;
 
 $cmd.FileName = $executable
+$cmd.Arguments = $arguments
 $cmd.RedirectStandardOutput = $true
 $cmd.RedirectStandardError = $true
 $cmd.RedirectStandardInput = $true
@@ -24,7 +28,7 @@ $cmd.UseShellExecute = $false
 $cmd.UserName = $user
 $cmd.Password = ConvertTo-SecureString $password -AsPlainText -Force
 
-"Creating new Process with $($executable)"
+"Creating new Process with $($executable) $($arguments)"
 $process = [System.Diagnostics.Process]::Start($cmd);
 
 "Waiting a second for the process to be up and running"


### PR DESCRIPTION
### What does this PR do?

add support for arguments in secrets_tester powershell script

### Motivation

Needed to test passing arguments using ths script before

### Additional Notes

Since this isn't part of a release, not sure if I need release notes

### Describe your test plan

- https://docs.datadoghq.com/agent/guide/secrets-management/?tab=windows#testing-your-executable
