### PR TITLE
[runtime] module shouldn't be verbose

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -570,7 +570,6 @@ core,"go.opencensus.io/trace",Apache-2.0
 core,"go.opencensus.io/trace/internal",Apache-2.0
 core,"go.opencensus.io/trace/tracestate",Apache-2.0
 core,"go.uber.org/atomic",MIT
-core,"go.uber.org/automaxprocs",MIT
 core,"go.uber.org/automaxprocs/internal/cgroups",MIT
 core,"go.uber.org/automaxprocs/internal/runtime",MIT
 core,"go.uber.org/automaxprocs/maxprocs",MIT

--- a/go.sum
+++ b/go.sum
@@ -93,10 +93,6 @@ github.com/DataDog/datadog-go v4.2.0+incompatible h1:Q73jzyKHwyA04Gf4SSukRF+KR4w
 github.com/DataDog/datadog-go v4.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822 h1:E5WNl43j4mpE3V35QySkRnP/m9pjXOnEZD6eyTK7Qvk=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822/go.mod h1:a5NqgPglcSct+NwO9gPvVhoL5V6G1+gHbRaRnU8U54M=
-github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d h1:FCSp3GWrMD+dTCinb/E5JrV5z9xBB/2wDHZVG9CoWq4=
-github.com/DataDog/ebpf v0.0.0-20210105142228-437eab38189d/go.mod h1:VSpIdBT/hwSbP3xKa5eYtiiBN2E37YePfTuyQVzSSig=
-github.com/DataDog/ebpf v0.0.0-20210121090404-ba23a575ea48 h1:AFFovncrrPMses0iwkhd128nOLmG5THIohHsbTbEEho=
-github.com/DataDog/ebpf v0.0.0-20210121090404-ba23a575ea48/go.mod h1:VSpIdBT/hwSbP3xKa5eYtiiBN2E37YePfTuyQVzSSig=
 github.com/DataDog/ebpf v0.0.0-20210121152636-7fc17cac5ed7 h1:Gl1fG+QK2tVnxTwtuqraUymTfjMGPMOPjfogRs7vpdA=
 github.com/DataDog/ebpf v0.0.0-20210121152636-7fc17cac5ed7/go.mod h1:VSpIdBT/hwSbP3xKa5eYtiiBN2E37YePfTuyQVzSSig=
 github.com/DataDog/gobpf v0.0.0-20200907093925-5f8313cb4d71 h1:0TOAH3X9tEvMBVQ1HYrQfrnAUcSS1mfMrhqeN+spV1s=

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -29,7 +29,10 @@ func SetMaxProcs() {
 
 	// This call will cause GOMAXPROCS to be set to the number of vCPUs allocated to the process
 	// if the process is running in a Linux environment (including when its running in a docker / K8s setup).
-	maxprocs.Set(maxprocs.Logger(log.Debugf))
+	_, err := maxprocs.Set(maxprocs.Logger(log.Debugf))
+	if err != nil {
+		log.Errorf("runtime: error auto-setting maxprocs: %v ", err)
+	}
 
 	if max, exists := os.LookupEnv(gomaxprocsKey); exists {
 		if max == "" {
@@ -37,7 +40,7 @@ func SetMaxProcs() {
 			return
 		}
 
-		_, err := strconv.Atoi(max)
+		_, err = strconv.Atoi(max)
 		if err == nil {
 			// Go runtime will already have parsed the integer and set it properly.
 			return

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -8,9 +8,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	// Imported for side-effects only. This import will cause GOMAXPROCS to be set to the number of vCPUs
-	// allocated to the process if the process is running in a Linux environment (including when its running
-	// in a docker / K8s setup).
 	"go.uber.org/automaxprocs/maxprocs"
 )
 
@@ -30,6 +27,8 @@ func init() {
 // SetMaxProcs sets the GOMAXPROCS for the go runtime to a sane value
 func SetMaxProcs() {
 
+	// This call will cause GOMAXPROCS to be set to the number of vCPUs allocated to the process
+	// if the process is running in a Linux environment (including when its running in a docker / K8s setup).
 	maxprocs.Set(maxprocs.Logger(log.Debugf))
 
 	if max, exists := os.LookupEnv(gomaxprocsKey); exists {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -11,7 +11,7 @@ import (
 	// Imported for side-effects only. This import will cause GOMAXPROCS to be set to the number of vCPUs
 	// allocated to the process if the process is running in a Linux environment (including when its running
 	// in a docker / K8s setup).
-	_ "go.uber.org/automaxprocs"
+	"go.uber.org/automaxprocs/maxprocs"
 )
 
 const (
@@ -29,6 +29,8 @@ func init() {
 
 // SetMaxProcs sets the GOMAXPROCS for the go runtime to a sane value
 func SetMaxProcs() {
+
+	maxprocs.Set(maxprocs.Logger(log.Debugf))
 
 	if max, exists := os.LookupEnv(gomaxprocsKey); exists {
 		if max == "" {


### PR DESCRIPTION
### What does this PR do?

This PR overrides the default automaxprocs module init implementation, and uses our own which makes use of our log package and should give us the level of verbosity defined in the agent, and keep functionalities like `agent status` where we silence logging intentionally consistent. 

### Motivation

Noisy `automaxprocs` import

### Additional Notes

- (nothing)

### Describe your test plan

`agent status` should have no additional extraneous output about automaxprocs.