### PR TITLE
[runtime] require explicit call; fixes side-effect import unpredictable logging

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -47,7 +47,7 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
 
 	// runtime init routines
-	_ "github.com/DataDog/datadog-agent/pkg/runtime"
+	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
 
 	// register core checks
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
@@ -92,6 +92,9 @@ func run(cmd *cobra.Command, args []string) error {
 	defer func() {
 		StopAgent()
 	}()
+
+	// prepare go runtime
+	ddruntime.SetMaxProcs()
 
 	// Setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)

--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -11,9 +11,6 @@ import (
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	// runtime init routines
-	_ "github.com/DataDog/datadog-agent/pkg/runtime"
 )
 
 // handleSignal closes a channel to exit cleanly from routines

--- a/cmd/trace-agent/main_nix.go
+++ b/cmd/trace-agent/main_nix.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"flag"
 
+	"github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 )
@@ -18,6 +19,9 @@ import (
 // main is the main application entry point
 func main() {
 	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	// prepare go runtime
+	runtime.SetMaxProcs()
 
 	// Handle stops properly
 	go func() {

--- a/cmd/trace-agent/main_windows.go
+++ b/cmd/trace-agent/main_windows.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/flags"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
@@ -150,6 +151,9 @@ func main() {
 			return
 		}
 	}
+
+	// prepare go runtime
+	runtime.SetMaxProcs()
 
 	// if we are an interactive session, then just invoke the agent on the command line.
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -15,17 +15,12 @@ const (
 	gomaxprocsKey = "GOMAXPROCS"
 )
 
-func init() {
+// SetMaxProcs sets the GOMAXPROCS for the go runtime to a sane value
+func SetMaxProcs() {
+
 	defer func() {
 		log.Infof("runtime: final GOMAXPROCS value is: %d", runtime.GOMAXPROCS(0))
 	}()
-
-	SetMaxProcs()
-
-}
-
-// SetMaxProcs sets the GOMAXPROCS for the go runtime to a sane value
-func SetMaxProcs() {
 
 	// This call will cause GOMAXPROCS to be set to the number of vCPUs allocated to the process
 	// if the process is running in a Linux environment (including when its running in a docker / K8s setup).


### PR DESCRIPTION

### What does this PR do?

Do not auto-set GOMAXPROCS without explicitly calling, the `init()` import side-effect approach was causing some logging issues we'd like to approach. 

### Motivation

Cleaner logging.

### Additional Notes

(none)

### Describe your test plan

Kitchen tests should trigger if the logging output isn't expected + manual QA.
