### PR TITLE
Add missing variable DefaultCheckFlareDirectory for FreeBSD build

### DIFF
--- a/cmd/agent/common/common_freebsd.go
+++ b/cmd/agent/common/common_freebsd.go
@@ -19,7 +19,7 @@ const (
 	//DefaultJmxLogFile points to the jmx fetch log file that will be used if not configured
 	DefaultJmxLogFile = "/var/log/datadog/jmxfetch.log"
 	// DefaultCheckFlareDirectory a flare friendly location for checks to be written
-	DefaultCheckFlareDirectory = "/var/log/datadog/checks/"	
+	DefaultCheckFlareDirectory = "/var/log/datadog/checks/"
 	// DefaultJMXFlareDirectory a flare friendly location for jmx command logs to be written
 	DefaultJMXFlareDirectory = "/var/log/datadog/jmxinfo/"
 )

--- a/cmd/agent/common/common_freebsd.go
+++ b/cmd/agent/common/common_freebsd.go
@@ -18,6 +18,8 @@ const (
 	DefaultDCALogFile = "/var/log/datadog/cluster-agent.log"
 	//DefaultJmxLogFile points to the jmx fetch log file that will be used if not configured
 	DefaultJmxLogFile = "/var/log/datadog/jmxfetch.log"
+	// DefaultCheckFlareDirectory a flare friendly location for checks to be written
+	DefaultCheckFlareDirectory = "/var/log/datadog/checks/"	
 	// DefaultJMXFlareDirectory a flare friendly location for jmx command logs to be written
 	DefaultJMXFlareDirectory = "/var/log/datadog/jmxinfo/"
 )


### PR DESCRIPTION
### What does this PR do?

Fixes broken FreeBSD build on 7.25.0 by adding missing `DefaultCheckFlareDirectory` variable

### Motivation

I'm maintainer of FreeBSD port and during upgrade to 7.25.0 I've noticed failed build
Fix should be fairly harmless and if it can land to 7.25.1 then I cain wait with new port release and update to the latest
