### PR TITLE
[runtime-security] Fix cookie cache usage and size

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -801,6 +801,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.load_controller.discarder_timeout", 10)
 	config.BindEnvAndSetDefault("runtime_security_config.load_controller.control_period", 2)
 	config.BindEnvAndSetDefault("runtime_security_config.pid_cache_size", 10000)
+	config.BindEnvAndSetDefault("runtime_security_config.cookie_cache_size", 100)
 	config.BindEnvAndSetDefault("runtime_security_config.agent_monitoring_events", true)
 
 	// command line options

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -48,6 +48,8 @@ type Config struct {
 	EventServerRate int
 	// PIDCacheSize is the size of the user space PID caches
 	PIDCacheSize int
+	// CookieCacheSize is the size of the cookie cache used to cache process context
+	CookieCacheSize int
 	// LoadControllerEventsCountThreshold defines the amount of events past which we will trigger the in-kernel circuit breaker
 	LoadControllerEventsCountThreshold int64
 	// LoadControllerForkBombThreshold defines the amount fork events triggered by the same process binary past which
@@ -81,6 +83,7 @@ func NewConfig(cfg *config.AgentConfig) (*Config, error) {
 		EventServerBurst:                   aconfig.Datadog.GetInt("runtime_security_config.event_server.burst"),
 		EventServerRate:                    aconfig.Datadog.GetInt("runtime_security_config.event_server.rate"),
 		PIDCacheSize:                       aconfig.Datadog.GetInt("runtime_security_config.pid_cache_size"),
+		CookieCacheSize:                    aconfig.Datadog.GetInt("runtime_security_config.cookie_cache_size"),
 		LoadControllerEventsCountThreshold: int64(aconfig.Datadog.GetInt("runtime_security_config.load_controller.events_count_threshold")),
 		LoadControllerForkBombThreshold:    int64(aconfig.Datadog.GetInt("runtime_security_config.load_controller.fork_bomb_threshold")),
 		LoadControllerDiscarderTimeout:     time.Duration(aconfig.Datadog.GetInt("runtime_security_config.load_controller.discarder_timeout")) * time.Second,

--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -119,7 +119,7 @@ func (lc *LoadController) CountFork(event *Event) {
 		lc.probe.DispatchCustomEvent(NewForkBombEvent(event))
 
 		// drop fork events with the given cookie in kernel space
-		lc.probe.resolvers.ProcessResolver.MarkCookieAsBestEffort(uint32(event.Process.ResolveCookie(event)))
+		lc.probe.resolvers.ProcessResolver.MarkCookieAsBestEffort(uint32(event.Process.ResolveCookie(event)), event.ResolveProcessCacheEntry())
 	}
 }
 

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -57,7 +57,7 @@ func NewResolvers(probe *Probe, client *statsd.Client) (*Resolvers, error) {
 		UserGroupResolver: userGroupResolver,
 	}
 
-	processResolver, err := NewProcessResolver(probe, resolvers, client, NewProcessResolverOpts(true, probe.config.PIDCacheSize))
+	processResolver, err := NewProcessResolver(probe, resolvers, client, NewProcessResolverOpts(true, probe.config.CookieCacheSize))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

This PR reduces the size of `ProcessResolver.cookieCache`. This cache should only be used when a fork bomb is detected, thus its usage can be reduced considerably to improve the memory footprint of system-probe.

### Motivation

This map is only used when a fork bomb is detected and should not track every process.
