### PR TITLE
[gitlab] Update notify message

### DIFF
--- a/.gitlab/notify.yml
+++ b/.gitlab/notify.yml
@@ -45,8 +45,7 @@ notify-on-tagged-success:
     - <<: *if_deploy_on_tag_7
   script: |
     MESSAGE_TEXT=":host-green: Tagged build <$CI_PIPELINE_URL|$CI_PIPELINE_ID> succeeded.
-    *$CI_COMMIT_REF_NAME* is available in the staging repositories.
-    Don't forget to run the \`tag_release_*\` jobs to publish the docker images."
+    *$CI_COMMIT_REF_NAME* is available in the staging repositories."
     postmessage "#agent-release-sync" "$MESSAGE_TEXT"
 
 notify-on-failure:


### PR DESCRIPTION
### What does this PR do?

Removes part of the notification message about docker jobs.

### Motivation

The job names have changed, and this part of the message was more confusing than anything else (especially when building the final artifact). Release managers can refer to the release documentation for details on which jobs they need to run.

