### PR TITLE
[runtime-security] Enable the profiler

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -802,6 +802,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.load_controller.control_period", 2)
 	config.BindEnvAndSetDefault("runtime_security_config.pid_cache_size", 10000)
 	config.BindEnvAndSetDefault("runtime_security_config.agent_monitoring_events", true)
+	config.BindEnvAndSetDefault("runtime_security_config.enable_profiling", false)
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -64,6 +64,8 @@ type Config struct {
 	StatsdAddr string
 	// AgentMonitoringEvents determines if the monitoring events of the agent should be sent to Datadog
 	AgentMonitoringEvents bool
+	// EnableProfiling enables Datadog Profiling on system-probe
+	EnableProfiling bool
 }
 
 // NewConfig returns a new Config object
@@ -88,6 +90,7 @@ func NewConfig(cfg *config.AgentConfig) (*Config, error) {
 		StatsPollingInterval:               time.Duration(aconfig.Datadog.GetInt("runtime_security_config.events_stats.polling_interval")) * time.Second,
 		StatsdAddr:                         fmt.Sprintf("%s:%d", cfg.StatsdHost, cfg.StatsdPort),
 		AgentMonitoringEvents:              aconfig.Datadog.GetBool("runtime_security_config.agent_monitoring_events"),
+		EnableProfiling:                    aconfig.Datadog.GetBool("runtime_security_config.enable_profiling"),
 	}
 
 	if !c.Enabled {


### PR DESCRIPTION
### What does this PR do?

We use Datadog Profiling to debug the runtime security module and hunt for memory leaks. Activating it with a configuration parameter makes using it easier.

### Motivation

Improve our debugging & memory leak hunting process.
