### PR TITLE
serverless: import HostnameProviderConfiguration and HostnameData

### DIFF
--- a/pkg/util/hostname_serverless.go
+++ b/pkg/util/hostname_serverless.go
@@ -2,6 +2,17 @@
 
 package util
 
+// HostnameData contains hostname and the hostname provider
+// Copy of the original struct in hostname.go
+type HostnameData struct {
+	Hostname string
+	Provider string
+}
+
+// HostnameProviderConfiguration is the key for the hostname provider associated to datadog.yaml
+// Copy of the original struct in hostname.go
+const HostnameProviderConfiguration = "configuration"
+
 // Fqdn returns the FQDN for the host if any
 func Fqdn(hostname string) string {
 	return ""


### PR DESCRIPTION

### What does this PR do?

These two structs are used by some helpers which are imported while building the
Serverless Agent. Even if these helpers are not actively used by the Serverless
Agent, we need these structs symbols to be available during the build.

### Describe your test plan

The Serverless Agent / Datadog Lambda Extension is building (`go build` in `cmd/serverless`).