### PR TITLE
[logs/docker] Improve transition to docker container file tailing

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -584,8 +584,12 @@ func InitConfig(config Config) {
 	config.BindEnv("logs_config.processing_rules") //nolint:errcheck
 	// enforce the agent to use files to collect container logs on kubernetes environment
 	config.BindEnvAndSetDefault("logs_config.k8s_container_use_file", false)
-	// enforce the agent to use files to collect container logs on standalone docker environment
+	// Enable the agent to use files to collect container logs on standalone docker environment, containers
+	// with an existing registry offset will continue to be tailed from the docker socket unless
+	// logs_config.docker_container_force_use_file is set to true.
 	config.BindEnvAndSetDefault("logs_config.docker_container_use_file", false)
+	// Force tailing from file for all docker container, even the ones with an existing registry entry
+	config.BindEnvAndSetDefault("logs_config.docker_container_force_use_file", false)
 	// additional config to ensure initial logs are tagged with kubelet tags
 	// wait (seconds) for tagger before start fetching tags of new AD services
 	config.BindEnvAndSetDefault("logs_config.tagger_warmup_duration", 0) // Disabled by default (0 seconds)

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -67,6 +67,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 			coreConfig.Datadog.GetBool("logs_config.container_collect_all"),
 			coreConfig.Datadog.GetBool("logs_config.k8s_container_use_file"),
 			coreConfig.Datadog.GetBool("logs_config.docker_container_use_file"),
+			coreConfig.Datadog.GetBool("logs_config.docker_container_force_use_file"),
 			time.Duration(coreConfig.Datadog.GetInt("logs_config.docker_client_read_timeout"))*time.Second,
 			sources, services, pipelineProvider, auditor),
 		listener.NewLauncher(sources, coreConfig.Datadog.GetInt("logs_config.frame_size"), pipelineProvider),

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -29,7 +29,15 @@ import (
 // If none of those volumes are mounted, returns a lazy docker launcher with a retrier to handle the cases
 // where docker is started after the agent.
 // dockerReadTimeout is a configurable read timeout for the docker client.
-func NewLauncher(collectAll bool, kubernetesCollectFromFiles bool, dockerCollectFromFiles bool, dockerReadTimeout time.Duration, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) restart.Restartable {
+func NewLauncher(collectAll bool,
+	kubernetesCollectFromFiles bool,
+	dockerCollectFromFiles bool,
+	dockerForceCollectFromFile bool,
+	dockerReadTimeout time.Duration,
+	sources *config.LogSources,
+	services *service.Services,
+	pipelineProvider pipeline.Provider,
+	registry auditor.Registry) restart.Restartable {
 	var (
 		launcher restart.Restartable
 		err      error
@@ -43,14 +51,14 @@ func NewLauncher(collectAll bool, kubernetesCollectFromFiles bool, dockerCollect
 		}
 		log.Infof("Could not setup the kubernetes launcher: %v", err)
 
-		launcher, err = docker.NewLauncher(dockerReadTimeout, sources, services, pipelineProvider, registry, false, dockerCollectFromFiles)
+		launcher, err = docker.NewLauncher(dockerReadTimeout, sources, services, pipelineProvider, registry, false, dockerCollectFromFiles, dockerForceCollectFromFile)
 		if err == nil {
 			log.Info("Docker launcher initialized")
 			return launcher
 		}
 		log.Infof("Could not setup the docker launcher: %v", err)
 	} else {
-		launcher, err = docker.NewLauncher(dockerReadTimeout, sources, services, pipelineProvider, registry, false, dockerCollectFromFiles)
+		launcher, err = docker.NewLauncher(dockerReadTimeout, sources, services, pipelineProvider, registry, false, dockerCollectFromFiles, dockerForceCollectFromFile)
 		if err == nil {
 			log.Info("Docker launcher initialized")
 			return launcher
@@ -65,7 +73,7 @@ func NewLauncher(collectAll bool, kubernetesCollectFromFiles bool, dockerCollect
 		log.Infof("Could not setup the kubernetes launcher: %v", err)
 	}
 
-	launcher, err = docker.NewLauncher(dockerReadTimeout, sources, services, pipelineProvider, registry, true, dockerCollectFromFiles)
+	launcher, err = docker.NewLauncher(dockerReadTimeout, sources, services, pipelineProvider, registry, true, dockerCollectFromFiles, dockerForceCollectFromFile)
 	if err != nil {
 		log.Warnf("Could not setup the docker launcher: %v. Will not be able to collect container logs", err)
 		return NewNoopLauncher()

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -53,7 +53,7 @@ type Launcher struct {
 }
 
 // NewLauncher returns a new launcher
-func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry, tailFromFile bool) (*Launcher, error) {
+func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry, tailFromFile, forceTailingFromFile bool) (*Launcher, error) {
 	if !shouldRetry {
 		if _, err := dockerutil.GetDockerUtil(); err != nil {
 			return nil, err
@@ -71,6 +71,7 @@ func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services
 		readTimeout:            readTimeout,
 		serviceNameFunc:        input.ServiceNameFromTags,
 		sources:                sources,
+		forceTailingFromFile:   forceTailingFromFile,
 		tailFromFile:           tailFromFile,
 		fileSourcesByContainer: make(map[string]*config.LogSource),
 	}
@@ -292,6 +293,7 @@ func (l *Launcher) shouldTailFromFile(container *Container) bool {
 	if !l.tailFromFile {
 		return false
 	}
+	// Unsure this one is really useful, user could be instructed to clean up the registry
 	if l.forceTailingFromFile {
 		return true
 	}

--- a/pkg/logs/input/docker/launcher_nodocker.go
+++ b/pkg/logs/input/docker/launcher_nodocker.go
@@ -20,7 +20,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new Launcher
-func NewLauncher(readTimeout time.Duration, psources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry, tailFromFile bool) (*Launcher, error) {
+func NewLauncher(readTimeout time.Duration, psources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry, shouldRetry, tailFromFile, forceTailingFromFile bool) (*Launcher, error) {
 	return &Launcher{}, nil
 }
 

--- a/releasenotes/notes/docker-tailing-from-file-migration-64bcfd388da07884.yaml
+++ b/releasenotes/notes/docker-tailing-from-file-migration-64bcfd388da07884.yaml
@@ -1,0 +1,11 @@
+---
+enhancements:
+  - |
+    Improve migration path when shifting docker container tailing
+    from the socket to file. If tailing from file for Docker
+    containers is enabled, container with an existing entry
+    relative to a socket tailer will continue being tailed
+    from the Docker socket unless the following newly introduced
+    option is set to true:  ``logs_config.docker_container_force_use_file``
+    It aims to allow smooth transition to file tailing for Docker
+    containers.


### PR DESCRIPTION
### What does this PR do?
Improve transition to docker container file tailing.
If a container is being tailed from the docker socket it will continue being tailed that way unless `logs_config.docker_container_force_use_file` is set to true, and only new container will be tailed from file.
It aims to prevent tailing offset from being mixed up.

### Motivation
Better migration path from docker socket to file tailing.

### Additional Notes
N/A

### Describe your test plan
Test all combination of the following parameters:
* `logs_config.docker_container_use_file`
* `logs_config.docker_container_force_use_file`

The following migration scenario should be covered:
* An older agent (<=7.26.0) tailing a docker container (a), pushing an entry to the registry
* The agent get upgraded, the docker container (a) continues to run and emit logs
* The newer agent (that supports docker tailing from file) is configured with `logs_config.docker_container_use_file: true` (`logs_config.docker_container_force_use_file` should be left to its default value (`false` if unset is config))
* Once start the newer agent should continue tailing from the docker socket
* Start a new docker container (b), it should be tailed from file 
* Flip `logs_config.docker_container_force_use_file` to `true` and restart the agent
* Container (a) and (b) should be tailed from file