### PR TITLE
[system-probe] Use local trace agent for profiling when available

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -163,7 +163,7 @@ func enableProfiling(cfg *config.AgentConfig) error {
 
 	// check if TRACE_AGENT_URL is set, in which case, forward the profiles to the trace agent
 	if traceAgentURL := os.Getenv("TRACE_AGENT_URL"); len(traceAgentURL) > 0 {
-		site = fmt.Sprintf(profiling.ProfilingLocalURL, traceAgentURL)
+		site = fmt.Sprintf(profiling.ProfilingLocalURLTemplate, traceAgentURL)
 	} else {
 		// allow full url override for development use
 		s := ddconfig.DefaultSite

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -23,6 +23,8 @@ const (
 	ProfileURLTemplate = "https://intake.profile.%s/v1/input"
 	// ProfileCoreService default service for the core agent profiler.
 	ProfileCoreService = "datadog-agent"
+	// ProfilingLocalURL is the constant used to compute the URL of the local trace agent
+	ProfilingLocalURL = "http://%v/profiling/v1/input"
 )
 
 // Active returns a boolean indicating whether profiling is active or not;

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -23,8 +23,8 @@ const (
 	ProfileURLTemplate = "https://intake.profile.%s/v1/input"
 	// ProfileCoreService default service for the core agent profiler.
 	ProfileCoreService = "datadog-agent"
-	// ProfilingLocalURL is the constant used to compute the URL of the local trace agent
-	ProfilingLocalURL = "http://%v/profiling/v1/input"
+	// ProfilingLocalURLTemplate is the constant used to compute the URL of the local trace agent
+	ProfilingLocalURLTemplate = "http://%v/profiling/v1/input"
 )
 
 // Active returns a boolean indicating whether profiling is active or not;


### PR DESCRIPTION
### What does this PR do?

This PR introduces ensures that we use the local trace agent for profiling instead of querying directly the profiling intake endpoint. Using the local trace agent ensures that the tags are properly set (namely the hostname) instead of falling back to `/etc/hostname`.

### Motivation

Right now when we activate profiling on system-probe the hostname falls back to `/etc/hostname` instead of using the hostname resolved by the agent.
