### PR TITLE
[runtime-security] rename usr.user to usr.id

### DIFF
--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -46,19 +46,20 @@ type FileSerializer struct {
 // UserContextSerializer serializes a user context to JSON
 // easyjson:json
 type UserContextSerializer struct {
-	User  string `json:"user,omitempty"`
+	User  string `json:"id,omitempty"`
 	Group string `json:"group,omitempty"`
 }
 
 // ProcessCacheEntrySerializer serializes a process cache entry to JSON
 // easyjson:json
 type ProcessCacheEntrySerializer struct {
-	UserContextSerializer
 	Pid                 uint32     `json:"pid,omitempty"`
 	PPid                uint32     `json:"ppid,omitempty"`
 	Tid                 uint32     `json:"tid,omitempty"`
 	UID                 uint32     `json:"uid,omitempty"`
 	GID                 uint32     `json:"gid,omitempty"`
+	User                string     `json:"user,omitempty"`
+	Group               string     `json:"group,omitempty"`
 	Name                string     `json:"name,omitempty"`
 	ContainerPath       string     `json:"executable_container_path,omitempty"`
 	Path                string     `json:"executable_path,omitempty"`
@@ -191,15 +192,13 @@ func newProcessCacheEntrySerializer(pce *model.ProcessCacheEntry, e *Event, r *R
 	}
 
 	return &ProcessCacheEntrySerializer{
-		UserContextSerializer: UserContextSerializer{
-			User:  user,
-			Group: group,
-		},
 		Pid:                 pid,
 		PPid:                ppid,
 		Tid:                 tid,
 		UID:                 uid,
 		GID:                 gid,
+		User:                user,
+		Group:               group,
 		Name:                e.ResolveExecBasename(&pce.ExecEvent),
 		Path:                e.ResolveExecInode(&pce.ExecEvent),
 		PathResolutionError: pce.GetPathResolutionError(),
@@ -281,7 +280,8 @@ func newEventSerializer(event *Event) *EventSerializer {
 		s.ContainerContextSerializer = newContainerContextSerializer(&event.Container, event)
 	}
 
-	s.UserContextSerializer = s.ProcessContextSerializer.UserContextSerializer
+	s.UserContextSerializer.User = s.ProcessContextSerializer.User
+	s.UserContextSerializer.Group = s.ProcessContextSerializer.Group
 
 	switch model.EventType(event.Type) {
 	case model.FileChmodEventType:

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -39,7 +39,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 			continue
 		}
 		switch key {
-		case "user":
+		case "id":
 			out.User = string(in.String())
 		case "group":
 			out.Group = string(in.String())
@@ -58,7 +58,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 	first := true
 	_ = first
 	if in.User != "" {
-		const prefix string = ",\"user\":"
+		const prefix string = ",\"id\":"
 		first = false
 		out.RawString(prefix[1:])
 		out.String(string(in.User))
@@ -170,6 +170,10 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 			out.UID = uint32(in.Uint32())
 		case "gid":
 			out.GID = uint32(in.Uint32())
+		case "user":
+			out.User = string(in.String())
+		case "group":
+			out.Group = string(in.String())
 		case "name":
 			out.Name = string(in.String())
 		case "executable_container_path":
@@ -222,10 +226,6 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 					in.AddError((*out.ExitTime).UnmarshalJSON(data))
 				}
 			}
-		case "user":
-			out.User = string(in.String())
-		case "group":
-			out.Group = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -319,6 +319,26 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 		}
 		out.Uint32(uint32(in.GID))
 	}
+	if in.User != "" {
+		const prefix string = ",\"user\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.User))
+	}
+	if in.Group != "" {
+		const prefix string = ",\"group\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Group))
+	}
 	if in.Name != "" {
 		const prefix string = ",\"name\":"
 		if first {
@@ -429,26 +449,6 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 		}
 		out.Raw((*in.ExitTime).MarshalJSON())
 	}
-	if in.User != "" {
-		const prefix string = ",\"user\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.User))
-	}
-	if in.Group != "" {
-		const prefix string = ",\"group\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Group))
-	}
 	out.RawByte('}')
 }
 
@@ -504,6 +504,10 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 			out.UID = uint32(in.Uint32())
 		case "gid":
 			out.GID = uint32(in.Uint32())
+		case "user":
+			out.User = string(in.String())
+		case "group":
+			out.Group = string(in.String())
 		case "name":
 			out.Name = string(in.String())
 		case "executable_container_path":
@@ -556,10 +560,6 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 					in.AddError((*out.ExitTime).UnmarshalJSON(data))
 				}
 			}
-		case "user":
-			out.User = string(in.String())
-		case "group":
-			out.Group = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -620,6 +620,26 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 		}
 		out.Uint32(uint32(in.GID))
 	}
+	if in.User != "" {
+		const prefix string = ",\"user\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.User))
+	}
+	if in.Group != "" {
+		const prefix string = ",\"group\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Group))
+	}
 	if in.Name != "" {
 		const prefix string = ",\"name\":"
 		if first {
@@ -729,26 +749,6 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 			out.RawString(prefix)
 		}
 		out.Raw((*in.ExitTime).MarshalJSON())
-	}
-	if in.User != "" {
-		const prefix string = ",\"user\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.User))
-	}
-	if in.Group != "" {
-		const prefix string = ",\"group\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Group))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
### What does this PR do?

Rename usr.user to usr.id

### Motivation

This is to match the standard security monitoring attribute of the same name