### PR TITLE
[core] Prevent API key from appearing in `agent status`

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -106,7 +106,7 @@
     <div class="stat">
       <span class="stat_title">Transport Proxy Warnings</span>
       <span class="stat_data">
-      The following URLs used a proxy - but will ignore the proxy in future Agent versions with the no_proxy setting. 
+      The following hosts used a proxy - but will ignore the proxy in future Agent versions with the no_proxy setting.
       Enable the new behavior now with no_proxy_nonexact_match: true
         <span class="stat_data">
         {{- range $key, $value := .TransportWarnings }}

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -89,7 +89,7 @@ NOTE: Changes made to this template should be reflected on the following templat
 
   Transport Proxy Warnings
   ========================
-    The following hosts used a proxy - but will ignore the proxy in future Agent versions with the no_proxy setting.
+    The requests to the following hosts use a proxy - but will ignore the proxy in future Agent versions based on the no_proxy setting.
     Enable the new behavior now with no_proxy_nonexact_match: true
     {{- range $key, $value := .TransportWarnings }}
       {{ $key }}

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -89,7 +89,7 @@ NOTE: Changes made to this template should be reflected on the following templat
 
   Transport Proxy Warnings
   ========================
-    The following URLs used a proxy - but will ignore the proxy in future Agent versions with the no_proxy setting. 
+    The following hosts used a proxy - but will ignore the proxy in future Agent versions with the no_proxy setting.
     Enable the new behavior now with no_proxy_nonexact_match: true
     {{- range $key, $value := .TransportWarnings }}
       {{ $key }}

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -131,8 +131,8 @@ func GetProxyTransportFunc(p *config.Proxy) func(*http.Request) (*url.URL, error
 			urlString := r.URL.String()
 			NoProxyWarningMapMutex.Lock()
 			if _, ok := NoProxyWarningMap[urlString]; !ok {
-				NoProxyWarningMap[SanitizeURL(r.URL.String())] = true
 				logSafeURL := r.URL.Scheme + "://" + r.URL.Host
+				NoProxyWarningMap[logSafeURL] = true
 				log.Warnf("Deprecation warning: the HTTP request to %s uses proxy %s but will ignore the proxy when the Agent configuration option no_proxy_nonexact_match defaults to true in a future agent version. Please adapt the Agent’s proxy configuration accordingly", logSafeURL, url.String())
 			}
 			NoProxyWarningMapMutex.Unlock()


### PR DESCRIPTION
### What does this PR do?
#6897 introduce a new way of handling noproxy settings. It also displays some information on `agent status` to assist transition to the new behaviour:

```
  Transport Proxy Warnings
  ========================
    The following URLs used a proxy - but will ignore the proxy in future Agent versions with the no_proxy setting.
    Enable the new behavior now with no_proxy_nonexact_match: true
      https://7-26-0-app.agent.datadoghq.com/api/v1/check_run?api_key=*************************66ce5
      https://7-26-0-app.agent.datadoghq.com/api/v1/series?api_key=*************************66ce5
      https://7-26-0-app.agent.datadoghq.com/intake/?api_key=*************************66ce5
      https://agent-http-intake.logs.datadoghq.com/v1/input/#was_shown_in_agent_status_output#66ce5
      https://api.datadoghq.com/api/v1/validate?api_key=*************************66ce5
``` 

With this PR `agent status` will show:

```
  Transport Proxy Warnings
  ========================
    The following hosts used a proxy - but will ignore the proxy in future Agent versions with the no_proxy setting.
    Enable the new behavior now with no_proxy_nonexact_match: true
      https://7-26-0-app.agent.datadoghq.com
      https://agent-http-intake.logs.datadoghq.com
      https://api.datadoghq.com
```

### Motivation
Prevent API key from leaking.

### Additional Notes
N/A
### Describe your test plan
Test with a proxy config similar to:

```
no_proxy_nonexact_match: false
proxy:
  https: http://localhost:8888/
  http: http://localhost:8888/
  no_proxy:
    - datadoghq.com  
```