### PR TITLE
Notify python checks when they're unscheduled

### DIFF
--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -185,6 +185,16 @@ DATADOG_AGENT_RTLOADER_API int get_check_deprecated(rtloader_t *rtloader, rtload
 */
 DATADOG_AGENT_RTLOADER_API char *run_check(rtloader_t *, rtloader_pyobject_t *check);
 
+/*! \fn char *cancel_check(rtloader_t *, rtloader_pyobject_t *check)
+    \brief Cancels a check instance. This allow check to be notified when
+    they're unscheduled and can free any remaining resources.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param check A rtloader_pyobject_t * pointer to the check instance we wish to cancel.
+    \return A C-string with the check summary.
+    \sa rtloader_pyobject_t, rtloader_t
+*/
+DATADOG_AGENT_RTLOADER_API void cancel_check(rtloader_t *, rtloader_pyobject_t *check);
+
 /*! \fn char **get_checks_warnings(rtloader_t *, rtloader_pyobject_t *check)
     \brief Get all warnings, if any, for a check instance.
     \param rtloader_t A rtloader_t * pointer to the RtLoader instance.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -115,6 +115,12 @@ public:
     */
     virtual char *runCheck(RtLoaderPyObject *check) = 0;
 
+    //! Pure virtual cancelCheck member.
+    /*!
+      \param check The python object pointer to the check we wish to cancel.
+    */
+    virtual void cancelCheck(RtLoaderPyObject *check) = 0;
+
     //! Pure virtual getCheckWarnings member.
     /*!
       \param check The python object pointer to the check we wish to collect existing warnings for.

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -315,6 +315,11 @@ char *run_check(rtloader_t *rtloader, rtloader_pyobject_t *check)
     return AS_TYPE(RtLoader, rtloader)->runCheck(AS_TYPE(RtLoaderPyObject, check));
 }
 
+void cancel_check(rtloader_t *rtloader, rtloader_pyobject_t *check)
+{
+    AS_TYPE(RtLoader, rtloader)->cancelCheck(AS_TYPE(RtLoaderPyObject, check));
+}
+
 char **get_checks_warnings(rtloader_t *rtloader, rtloader_pyobject_t *check)
 {
     return AS_TYPE(RtLoader, rtloader)->getCheckWarnings(AS_TYPE(RtLoaderPyObject, check));

--- a/rtloader/test/python/datadog_checks/base/checks/__init__.py
+++ b/rtloader/test/python/datadog_checks/base/checks/__init__.py
@@ -3,6 +3,9 @@ class AgentCheck(object):
     def __init__(self, *args, **kwargs):
         pass
 
+    def cancel(self):
+        pass
+
     def run(self):
         return ""  # empty string means success
 

--- a/rtloader/test/python/fake_check/__init__.py
+++ b/rtloader/test/python/fake_check/__init__.py
@@ -1,8 +1,14 @@
 from datadog_checks.base.checks import AgentCheck
 
+was_canceled = False
 
 # Fake check for testing purposes
 class FakeCheck(AgentCheck):
+    def cancel(self):
+        global was_canceled
+        assert not was_canceled
+        was_canceled = True
+
     def get_warnings(self):
         return ["warning 1", "warning 2", "warning 3"]
 

--- a/rtloader/test/rtloader/rtloader_test.go
+++ b/rtloader/test/rtloader/rtloader_test.go
@@ -196,3 +196,38 @@ with open(r'%s', 'w') as f:
 	// Check for leaks
 	helpers.AssertMemoryUsage(t)
 }
+
+func TestCancelCheck(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	code := `import fake_check
+fake_check.was_canceled = False`
+
+	if _, err := runString(code); err != nil {
+		t.Fatalf("`TestCancelCheck` error resetting was_canceled: %v", err)
+	}
+
+	if err := cancelFakeCheck(); err != nil {
+		t.Fatal(err)
+	}
+
+	code = fmt.Sprintf(`
+import sys
+import fake_check
+with open(r'%s', 'w') as f:
+	f.write(str(fake_check.was_canceled))`, tmpfile.Name())
+
+	output, err := runString(code)
+
+	if err != nil {
+		t.Fatalf("`cancel_check` error: %v", err)
+	}
+
+	if output != "True" {
+		t.Errorf("Unexpected printed value: '%s'", output)
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -435,6 +435,25 @@ done:
     return ret;
 }
 
+void Three::cancelCheck(RtLoaderPyObject *check)
+{
+    if (check == NULL) {
+        return;
+    }
+
+    PyObject *py_check = reinterpret_cast<PyObject *>(check);
+
+    char cancel[] = "cancel";
+    PyObject *result = NULL;
+
+    result = PyObject_CallMethod(py_check, cancel, NULL);
+    // at least None should be returned
+    if (result == NULL) {
+        setError("error invoking 'cancel' method: " + _fetchPythonError());
+    }
+    Py_XDECREF(result);
+}
+
 char **Three::getCheckWarnings(RtLoaderPyObject *check)
 {
     if (check == NULL) {

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -67,6 +67,7 @@ public:
                   RtLoaderPyObject *&check);
 
     char *runCheck(RtLoaderPyObject *check);
+    void cancelCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);
     void decref(RtLoaderPyObject *obj);
     void incref(RtLoaderPyObject *obj);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -432,6 +432,25 @@ done:
     return ret_copy;
 }
 
+void Two::cancelCheck(RtLoaderPyObject *check)
+{
+    if (check == NULL) {
+        return;
+    }
+
+    PyObject *py_check = reinterpret_cast<PyObject *>(check);
+
+    char cancel[] = "cancel";
+    PyObject *result = NULL;
+
+    result = PyObject_CallMethod(py_check, cancel, NULL);
+    // at least None should be returned
+    if (result == NULL) {
+        setError("error invoking 'cancel' method: " + _fetchPythonError());
+    }
+    Py_XDECREF(result);
+}
+
 char **Two::getCheckWarnings(RtLoaderPyObject *check)
 {
     if (check == NULL) {

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -66,6 +66,7 @@ public:
                   RtLoaderPyObject *&check);
 
     char *runCheck(RtLoaderPyObject *check);
+    void cancelCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);
     void decref(RtLoaderPyObject *obj);
     void incref(RtLoaderPyObject *obj);


### PR DESCRIPTION
### What does this PR do?

The 'cancel' method signal to a python check that it's being
unscheduled. This is a signal and the 'cancel' function can be called
while the check is currently running, it's up to the Python check to
correctly handle it and free resources in a safe way.

This is linked to https://github.com/DataDog/integrations-core/pull/8463

### Motivation

Some Python checks have internal object to free/stop such as thread pools.

### Additional Notes

### Describe your test plan

1. Create a check that implement the `cancel` method in python  (a simple `self.log.error("I was canceled")` is enough)
2. run a container linked to that check using autodicsovery (ex: `docker run --rm -ti -l 'com.datadoghq.ad.check_names=["my_check"]' -l 'com.datadoghq.ad.init_configs=[{}]'  -l 'com.datadoghq.ad.instances=[{}]' debian`)
3. start the agent and let it run until the container is picked up (few seconds)
4. stop the container and wait 5s (internal delay between the docker event and unscheduling of a check)
5. check that your `cancel` method was called on your python check

