### PR TITLE
[logs] fix delayed tags deadline to compute from agent startup

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+
 	// DefaultSite is the default site the Agent sends data to.
 	DefaultSite    = "datadoghq.com"
 	infraURLPrefix = "https://app."
@@ -74,6 +75,12 @@ var (
 	// the Python version set in the configuration and use `DefaultPython` instead.
 	// We use this to force Python 3 in the Agent 7 as it's the only one available.
 	ForceDefaultPython string
+)
+
+// Variables to initialize at start time
+var (
+	// StartTime is the agent startup time
+	StartTime = time.Now()
 )
 
 // MetadataProviders helps unmarshalling `metadata_providers` config param

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -638,13 +638,6 @@ api_key:
   #
   # logs_no_ssl: false
 
-  ## @param expected_tags_duration - int - optional - default: 15
-  ## Define the time in minutes of the expected availability for the host tags on backend services.
-  ## After this duration, host tags are no longer submitted with log events.
-  ## A value of 0 disables the feature.
-  #
-  # expected_tags_duration: 15
-
   ## @param processing_rules - list of custom objects - optional
   ## Global processing rules that are applied to all logs. The available rules are
   ## "exclude_at_match", "include_at_match" and "mask_sequences". More information in Datadog documentation:

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -117,7 +117,7 @@ func BuildEndpoints(httpConnectivity HTTPConnectivity) (*Endpoints, error) {
 
 // IsExpectedTagsSet returns boolean showing if expected tags feature is enabled.
 func IsExpectedTagsSet() bool {
-	return coreConfig.Datadog.GetInt("logs_config.expected_tags_duration") > 0
+	return coreConfig.Datadog.GetDuration("logs_config.expected_tags_duration") > 0
 }
 
 func isSocks5ProxySet() bool {

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -46,8 +46,7 @@ func NewProvider(entityID string) Provider {
 
 	if config.IsExpectedTagsSet() {
 		p.submitExpectedTags = true
-		p.expectedTagsDeadline = coreConfig.StartTime.Add(
-			time.Duration(coreConfig.Datadog.GetInt("logs_config.expected_tags_duration")) * time.Minute)
+		p.expectedTagsDeadline = coreConfig.StartTime.Add(coreConfig.Datadog.GetDuration("logs_config.expected_tags_duration"))
 
 		// reset submitExpectedTags after deadline elapsed
 		go func() {

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -31,7 +31,7 @@ var (
 type provider struct {
 	entityID             string
 	taggerWarmupDuration time.Duration
-	expectedTagsDuration time.Duration
+	expectedTagsDeadline time.Time
 	submitExpectedTags   bool
 	sync.Once
 	sync.RWMutex
@@ -46,7 +46,17 @@ func NewProvider(entityID string) Provider {
 
 	if config.IsExpectedTagsSet() {
 		p.submitExpectedTags = true
-		p.expectedTagsDuration = time.Duration(coreConfig.Datadog.GetInt("logs_config.expected_tags_duration")) * time.Minute
+		p.expectedTagsDeadline = coreConfig.StartTime.Add(
+			time.Duration(coreConfig.Datadog.GetInt("logs_config.expected_tags_duration")) * time.Minute)
+
+		// reset submitExpectedTags after deadline elapsed
+		go func() {
+			<-time.After(time.Until(p.expectedTagsDeadline))
+
+			p.Lock()
+			defer p.Unlock()
+			p.submitExpectedTags = false
+		}()
 	}
 
 	return p
@@ -60,15 +70,6 @@ func (p *provider) GetTags() []string {
 		// TODO: remove this once AD and Tagger use the same PodWatcher instance
 		<-time.After(p.taggerWarmupDuration)
 
-		// start timer if necessary
-		go func() {
-			deadline := coreConfig.StartTime.Add(p.expectedTagsDuration)
-			<-time.After(time.Until(deadline))
-
-			p.Lock()
-			defer p.Unlock()
-			p.submitExpectedTags = false
-		}()
 	})
 
 	tags, err := tagger.Tag(p.entityID, collectors.HighCardinality)

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -62,7 +62,8 @@ func (p *provider) GetTags() []string {
 
 		// start timer if necessary
 		go func() {
-			<-time.After(p.expectedTagsDuration)
+			deadline := coreConfig.StartTime.Add(p.expectedTagsDuration)
+			<-time.After(time.Until(deadline))
 
 			p.Lock()
 			defer p.Unlock()

--- a/pkg/logs/tag/provider_test.go
+++ b/pkg/logs/tag/provider_test.go
@@ -20,7 +20,8 @@ func TestProviderExpectedTags(t *testing.T) {
 	tags := []string{"tag1:value1", "tag2", "tag3"}
 
 	mockConfig.Set("tags", tags)
-	mockConfig.Set("logs_config.expected_tags_duration", 15)
+	// Setting a test-friendly value for the deadline
+	mockConfig.Set("logs_config.expected_tags_duration", "5s")
 	defer mockConfig.Set("tags", nil)
 	defer mockConfig.Set("expected_tags_duration", 0)
 
@@ -28,12 +29,9 @@ func TestProviderExpectedTags(t *testing.T) {
 	pp := p.(*provider)
 
 	// Is provider expected?
-	d := time.Duration(mockConfig.GetInt("logs_config.expected_tags_duration"))
-	assert.InDelta(t, time.Now().Add(d*time.Minute).Unix(), pp.expectedTagsDeadline.Unix(), 1)
+	d := mockConfig.GetDuration("logs_config.expected_tags_duration")
+	assert.InDelta(t, time.Now().Add(d).Unix(), pp.expectedTagsDeadline.Unix(), 1)
 	assert.True(t, pp.submitExpectedTags)
-
-	// A more test-friendly value for the deadline
-	pp.expectedTagsDeadline = time.Now().Add(time.Second)
 
 	tt := pp.GetTags()
 	sort.Strings(tags)
@@ -43,7 +41,9 @@ func TestProviderExpectedTags(t *testing.T) {
 	// let the deadline expire + a little grace period
 	<-time.After(time.Until(pp.expectedTagsDeadline.Add(2 * time.Second)))
 
+	pp.Lock()
 	assert.False(t, pp.submitExpectedTags)
+	pp.Unlock()
 	assert.Equal(t, []string{}, pp.GetTags())
 
 }

--- a/pkg/logs/tag/provider_test.go
+++ b/pkg/logs/tag/provider_test.go
@@ -29,7 +29,7 @@ func TestProviderExpectedTags(t *testing.T) {
 
 	// Is provider expected?
 	d := time.Duration(mockConfig.GetInt("logs_config.expected_tags_duration"))
-	assert.Equal(t, time.Now().Add(d*time.Minute).Unix(), pp.expectedTagsDeadline.Unix())
+	assert.InDelta(t, time.Now().Add(d*time.Minute).Unix(), pp.expectedTagsDeadline.Unix(), 1)
 	assert.True(t, pp.submitExpectedTags)
 
 	// A more test-friendly value for the deadline
@@ -40,8 +40,8 @@ func TestProviderExpectedTags(t *testing.T) {
 	sort.Strings(tt)
 	assert.Equal(t, tags, tt)
 
-	// let the deadline expire
-	<-time.After(time.Until(pp.expectedTagsDeadline))
+	// let the deadline expire + a little grace period
+	<-time.After(time.Until(pp.expectedTagsDeadline.Add(2 * time.Second)))
 
 	assert.False(t, pp.submitExpectedTags)
 	assert.Equal(t, []string{}, pp.GetTags())

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -32,7 +32,6 @@ import (
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
 
-var startTime = time.Now()
 var timeFormat = "2006-01-02 15:04:05.000000 MST"
 
 // GetStatus grabs the status from expvar and puts it into a map
@@ -287,7 +286,7 @@ func getCommonStatus() (map[string]interface{}, error) {
 	stats["conf_file"] = config.Datadog.ConfigFileUsed()
 	stats["pid"] = os.Getpid()
 	stats["go_version"] = runtime.Version()
-	stats["agent_start"] = startTime.Format(timeFormat)
+	stats["agent_start"] = config.StartTime.Format(timeFormat)
 	stats["build_arch"] = runtime.GOARCH
 	now := time.Now()
 	stats["time"] = now.Format(timeFormat)


### PR DESCRIPTION
### What does this PR do?

Fixes #7169; the tags should be submitted for X minutes after agent *startup* not after tag provider instantiation.

The config option should now be specified as a duration (ie. "15m", etc)

It also removes option from config template.

### Motivation

Fixes unwanted behavior.

### Additional Notes

(none)

### Describe your test plan

See #7169 
