### PR TITLE
Log datadog.yaml syntax errors

### DIFF
--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -50,7 +50,7 @@ var flareCmd = &cobra.Command{
 
 		err := common.SetupConfig(confFilePath)
 		if err != nil {
-			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+			fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
 
 		// The flare command should not log anything, all errors should be reported directly to the console without the log format

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -50,7 +50,7 @@ var flareCmd = &cobra.Command{
 
 		err := common.SetupConfig(confFilePath)
 		if err != nil {
-			fmt.Errorf("unable to set up global agent configuration: %v", err)
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
 
 		// The flare command should not log anything, all errors should be reported directly to the console without the log format

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -147,7 +147,7 @@ func StartAgent() error {
 	common.MainCtx, common.MainCtxCancel = context.WithCancel(context.Background())
 
 	// Global Agent configuration
-	err_start := common.SetupConfig(confFilePath)
+	errStart := common.SetupConfig(confFilePath)
 
 	// Setup logger
 	if runtime.GOOS != "android" {
@@ -219,7 +219,7 @@ func StartAgent() error {
 		return fmt.Errorf("Error while setting up logging, exiting: %v", err)
 	}
 
-	if err_start != nil {
+	if errStart != nil {
 		log.Errorf("Failed to setup config %v", err)
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -141,15 +141,10 @@ func run(cmd *cobra.Command, args []string) error {
 
 // StartAgent Initializes the agent process
 func StartAgent() error {
+	var err error
+
 	// Main context passed to components
 	common.MainCtx, common.MainCtxCancel = context.WithCancel(context.Background())
-
-	// Global Agent configuration
-	err := common.SetupConfig(confFilePath)
-	if err != nil {
-		log.Errorf("Failed to setup config %v", err)
-		return fmt.Errorf("unable to set up global agent configuration: %v", err)
-	}
 
 	// Setup logger
 	if runtime.GOOS != "android" {
@@ -219,6 +214,13 @@ func StartAgent() error {
 	}
 	if err != nil {
 		return fmt.Errorf("Error while setting up logging, exiting: %v", err)
+	}
+
+	// Global Agent configuration
+	err = common.SetupConfig(confFilePath)
+	if err != nil {
+		log.Errorf("Failed to setup config %v", err)
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
 
 	log.Infof("Starting Datadog Agent v%v", version.AgentVersion)

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -146,6 +146,9 @@ func StartAgent() error {
 	// Main context passed to components
 	common.MainCtx, common.MainCtxCancel = context.WithCancel(context.Background())
 
+	// Global Agent configuration
+	err_start := common.SetupConfig(confFilePath)
+
 	// Setup logger
 	if runtime.GOOS != "android" {
 		syslogURI := config.GetSyslogURI()
@@ -216,9 +219,7 @@ func StartAgent() error {
 		return fmt.Errorf("Error while setting up logging, exiting: %v", err)
 	}
 
-	// Global Agent configuration
-	err = common.SetupConfig(confFilePath)
-	if err != nil {
+	if err_start != nil {
 		log.Errorf("Failed to setup config %v", err)
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/releasenotes/notes/log-yaml-errors-before-exiting-d1e93fbea228b591.yaml
+++ b/releasenotes/notes/log-yaml-errors-before-exiting-d1e93fbea228b591.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - Log startup errors due to syntax errors in datadog.yaml before exiting


### PR DESCRIPTION
### What does this PR do?

Initialize logging prior to parsing the main Datadog YAML config. Allows errors to be logged in default location

### Motivation

- AC-749

### Additional Notes

### Describe your test plan

- Set custom log path in datadog.yaml, e.g. `log_file: /var/log/datadog/agent_alt.log`
- Attempt to start the agent with an invalid datadog.yaml. e.g.
  ```
  log_file: /var/log/datadog/agent_alt.log
    x: x
  ```
  - Expected: Agent will not run but error should be logged in default `/var/log/datadog/agent.log`

- Fix the config by removing line `  x: x` and start the agent. 
  - Expected: Agent runs and logs to custom `/var/log/datadog/agent_alt.log`
