### PR TITLE
[python] warn message instead of error message if the linter has an issue

### DIFF
--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -293,7 +293,7 @@ func reportPy3Warnings(checkName string, checkFilePath string) {
 
 			if err != nil {
 				status = a7TagUnknown
-				log.Errorf("Failed to validate Python 3 linting for check '%s': '%s'", checkName, err)
+				log.Warnf("Failed to validate Python 3 linting for check '%s': '%s'", checkName, err)
 			} else if len(warnings) == 0 {
 				status = a7TagReady
 				metricValue = 1.0


### PR DESCRIPTION
This is not a critical issue for the Agent to run, it's better to lower
the log level of this message.

### Describe your test plan

Removing the linter binary on the system would probably help to reproduce.