### PR TITLE
Remote Tagger Fixes

### DIFF
--- a/pkg/tagger/remote/grpclog.go
+++ b/pkg/tagger/remote/grpclog.go
@@ -1,0 +1,49 @@
+package remote
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"google.golang.org/grpc/grpclog"
+)
+
+type logLevel int
+
+const (
+	logLevelInfo logLevel = iota
+	logLevelWarn
+	logLevelErr
+)
+
+type redirectLogger struct {
+	level logLevel
+}
+
+func newRedirectLogger(level logLevel) redirectLogger {
+	return redirectLogger{level: level}
+}
+
+func (l redirectLogger) Write(b []byte) (int, error) {
+	msg := string(b)
+
+	switch l.level {
+	case logLevelInfo:
+		log.InfoStackDepth(stackDepth, msg)
+	case logLevelWarn:
+		log.WarnStackDepth(stackDepth, msg)
+	case logLevelErr:
+		log.ErrorStackDepth(stackDepth, msg)
+	default:
+		log.InfoStackDepth(stackDepth, msg)
+	}
+
+	return 0, nil
+}
+
+const stackDepth = 7
+
+func init() {
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(
+		newRedirectLogger(logLevelInfo),
+		newRedirectLogger(logLevelWarn),
+		newRedirectLogger(logLevelErr),
+	))
+}

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -122,7 +122,11 @@ func (t *Tagger) Tag(entityID string, cardinality collectors.TagCardinality) ([]
 		return nil, err
 	}
 
-	return entity.GetTags(cardinality), nil
+	if entity != nil {
+		return entity.GetTags(cardinality), nil
+	}
+
+	return []string{}, nil
 }
 
 // Standard returns the standard tags for a given entity.


### PR DESCRIPTION
### What does this PR do?

Applies several fixes to the remote tagger after more thorough testing in a real cluster.

* Re-fetch auth token on every new stream
* Don't `GetTags` on a nil entity
* Redirect grpc logs to the Datadog logger

### Describe your test plan

These apply only to process and trace agent, with the [remote tagger enabled](https://github.com/DataDog/datadog-agent/pull/7208).

1. The tagger starts properly, and no longer crashes when entities are not found. This is probably more easily testable by enabling the remote tagger in a real cluster and observing it for a while.
2. No more log lines like the below, without the correct datadog formatting.

```
INFO: 2021/01/27 14:47:31 parsed scheme: ""
INFO: 2021/01/27 14:47:31 scheme "" not registered, fallback to default scheme
...
```