### PR TITLE
[runtime-security] add metrics for the dentry resolver

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -52,6 +52,15 @@ var (
 	// Tags: -
 	MetricConcurrentSyscall = newRuntimeMetric(".concurrent_syscalls")
 
+	// Dentry Resolver metrics
+
+	// MetricDentryResolverHits is the counter of successful dentry resolution
+	// Tags: cache, kernel_maps
+	MetricDentryResolverHits = newRuntimeMetric(".dentry_resolver.hits")
+	// MetricDentryResolverMiss is the counter of unsuccessful dentry resolution
+	// Tags: cache, kernel_maps
+	MetricDentryResolverMiss = newRuntimeMetric(".dentry_resolver.miss")
+
 	// Perf buffer metrics
 
 	// MetricPerfBufferLostWrite is the name of the metric used to count the number of lost events, as reported by a
@@ -134,6 +143,24 @@ var (
 func SetTagsWithCardinality(cardinality string, tags ...string) []string {
 	return append(tags, fmt.Sprintf("%s:%s", dogstatsd.CardinalityTagPrefix, cardinality))
 }
+
+var (
+	// CacheTag is assigned to metrics related to userspace cache
+	CacheTag = "type:cache"
+	// KernelMapsTag is assigned to metrics related to eBPF kernel maps
+	KernelMapsTag = "type:kernel_maps"
+	// ProcFSTag is assigned to metrics related to /proc fallbacks
+	ProcFSTag = "type:procfs"
+	// ERPCTag is assigned to metrics related to eRPC
+	ERPCTag = "type:erpc"
+
+	// SegmentResolutionTag is assigned to metrics related to the resolution of a segment
+	SegmentResolutionTag = "resolution:segment"
+	// ParentResolutionTag is assigned to metrics related to the resolution of a parent
+	ParentResolutionTag = "resolution:parent"
+	// PathResolutionTag is assigned to metrics related to the resolution of a path
+	PathResolutionTag = "resolution:path"
+)
 
 func newRuntimeMetric(name string) string {
 	return MetricRuntimePrefix + name

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -153,6 +153,8 @@ var (
 	ProcFSTag = "type:procfs"
 	// ERPCTag is assigned to metrics related to eRPC
 	ERPCTag = "type:erpc"
+	// AllTypesTags is the list of types
+	AllTypesTags = []string{CacheTag, KernelMapsTag, ProcFSTag, ERPCTag}
 
 	// SegmentResolutionTag is assigned to metrics related to the resolution of a segment
 	SegmentResolutionTag = "resolution:segment"
@@ -160,6 +162,8 @@ var (
 	ParentResolutionTag = "resolution:parent"
 	// PathResolutionTag is assigned to metrics related to the resolution of a path
 	PathResolutionTag = "resolution:path"
+	// AllResolutionsTags is the list of resolution tags
+	AllResolutionsTags = []string{SegmentResolutionTag, ParentResolutionTag, PathResolutionTag}
 )
 
 func newRuntimeMetric(name string) string {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -139,8 +139,6 @@ func (p *Probe) Init(client *statsd.Client) error {
 		defer bytecodeReader.Close()
 	}
 
-	p.manager = ebpf.NewRuntimeSecurityManager()
-
 	var ok bool
 	if p.perfMap, ok = p.manager.GetPerfMap("events"); !ok {
 		return errors.New("couldn't find events perf map")
@@ -788,6 +786,7 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	p := &Probe{
 		config:         config,
 		approvers:      make(map[eval.EventType]activeApprovers),
+		manager:        ebpf.NewRuntimeSecurityManager(),
 		managerOptions: ebpf.NewDefaultOptions(),
 		ctx:            ctx,
 		cancelFnc:      cancel,
@@ -846,7 +845,7 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	// tail calls
 	p.managerOptions.TailCallRouter = probes.AllTailRoutes()
 
-	resolvers, err := NewResolvers(config, p, client)
+	resolvers, err := NewResolvers(config, p)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -90,6 +90,9 @@ func (m *Monitor) SendStats() error {
 		if err := resolvers.ProcessResolver.SendStats(); err != nil {
 			return errors.Wrap(err, "failed to send process_resolver stats")
 		}
+		if err := resolvers.DentryResolver.SendStats(); err != nil {
+			return errors.Wrap(err, "failed to send process_resolver stats")
+		}
 	}
 
 	// Comment this out for now, until we fix the cardinality of the perf_buffer.* metrics.

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -398,7 +398,7 @@ func (p *ProcessResolver) Resolve(pid, tid uint32) *model.ProcessCacheEntry {
 
 	entry, exists := p.entryCache[pid]
 	if exists {
-		_ = p.client.Count(metrics.MetricProcessResolverCacheHits, 1, []string{"type:cache"}, 1.0)
+		_ = p.client.Count(metrics.MetricProcessResolverCacheHits, 1, []string{metrics.CacheTag}, 1.0)
 		return entry
 	}
 
@@ -408,13 +408,13 @@ func (p *ProcessResolver) Resolve(pid, tid uint32) *model.ProcessCacheEntry {
 
 	// fallback to the kernel maps directly, the perf event may be delayed / may have been lost
 	if entry = p.resolveWithKernelMaps(pid, tid); entry != nil {
-		_ = p.client.Count(metrics.MetricProcessResolverCacheHits, 1, []string{"type:kernel_maps"}, 1.0)
+		_ = p.client.Count(metrics.MetricProcessResolverCacheHits, 1, []string{metrics.KernelMapsTag}, 1.0)
 		return entry
 	}
 
 	// fallback to /proc, the in-kernel LRU may have deleted the entry
 	if entry = p.resolveWithProcfs(pid, procResolveMaxDepth); entry != nil {
-		_ = p.client.Count(metrics.MetricProcessResolverCacheHits, 1, []string{"type:procfs"}, 1.0)
+		_ = p.client.Count(metrics.MetricProcessResolverCacheHits, 1, []string{metrics.ProcFSTag}, 1.0)
 		return entry
 	}
 

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/avast/retry-go"
 	"github.com/pkg/errors"
 
@@ -37,7 +36,7 @@ type Resolvers struct {
 }
 
 // NewResolvers creates a new instance of Resolvers
-func NewResolvers(config *config.Config, probe *Probe, client *statsd.Client) (*Resolvers, error) {
+func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 	dentryResolver, err := NewDentryResolver(probe)
 	if err != nil {
 		return nil, err
@@ -63,7 +62,7 @@ func NewResolvers(config *config.Config, probe *Probe, client *statsd.Client) (*
 		TagsResolver:      NewTagsResolver(config),
 	}
 
-	processResolver, err := NewProcessResolver(probe, resolvers, client, NewProcessResolverOpts(probe.config.CookieCacheSize))
+	processResolver, err := NewProcessResolver(probe, resolvers, probe.statsdClient, NewProcessResolverOpts(probe.config.CookieCacheSize))
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +187,7 @@ func (r *Resolvers) Start(ctx context.Context) error {
 		return err
 	}
 
-	return r.DentryResolver.Start()
+	return r.DentryResolver.Start(r.probe)
 }
 
 // Snapshot collects data on the current state of the system to populate user space and kernel space caches.

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -349,7 +349,7 @@ func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(); err != nil {
+	if err := resolver.Start(test.probe); err != nil {
 		b.Fatal(err)
 	}
 	name, err := resolver.GetNameFromERPC(event.Open.File.MountID, event.Open.File.Inode, event.Open.File.PathID)
@@ -408,7 +408,7 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(); err != nil {
+	if err := resolver.Start(test.probe); err != nil {
 		b.Fatal(err)
 	}
 	f, err := resolver.ResolveFromERPC(event.Open.File.MountID, event.Open.File.Inode, event.Open.File.PathID)
@@ -467,7 +467,7 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(); err != nil {
+	if err := resolver.Start(test.probe); err != nil {
 		b.Fatal(err)
 	}
 	name, err := resolver.GetNameFromMap(event.Open.File.MountID, event.Open.File.Inode, event.Open.File.PathID)
@@ -526,7 +526,7 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(); err != nil {
+	if err := resolver.Start(test.probe); err != nil {
 		b.Fatal(err)
 	}
 	f, err := resolver.ResolveFromMap(event.Open.File.MountID, event.Open.File.Inode, event.Open.File.PathID)


### PR DESCRIPTION
### What does this PR do?

Add metrics regarding the number of successful and failed dentry resolves.
