### PR TITLE
Remove SetDefault for `bind_host` to allow checking if it was explicitly set

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -244,7 +244,7 @@ func start(cmd *cobra.Command, args []string) error {
 	defer stopper.Stop()
 
 	// Retrieve statsd host and port from the datadog agent configuration file
-	statsdHost := coreconfig.Datadog.GetString("bind_host")
+	statsdHost := coreconfig.GetBindHost()
 	statsdPort := coreconfig.Datadog.GetInt("dogstatsd_port")
 
 	// Create a statsd Client

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -188,7 +188,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("enable_gohai", true)
 	config.BindEnvAndSetDefault("check_runners", int64(4))
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
-	config.BindEnvAndSetDefault("bind_host", "localhost")
+	_ = config.BindEnv("bind_host")
 	config.BindEnvAndSetDefault("ipc_address", "localhost")
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
@@ -1288,4 +1288,15 @@ func IsCLCRunner() bool {
 		}
 	}
 	return false
+}
+
+// GetBindHost returns `bind_host` variable or default value
+// Not using `config.BindEnvAndSetDefault` as some processes need to know
+// if value was default one or not (e.g. trace-agent)
+func GetBindHost() string {
+	if Datadog.IsSet("bind_host") {
+		return Datadog.GetString("bind_host")
+	}
+
+	return "localhost"
 }

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -55,7 +55,7 @@ func NewUDPListener(packetOut chan Packets, sharedPacketPool *PacketPool) (*UDPL
 		// Listen to all network interfaces
 		url = fmt.Sprintf(":%d", config.Datadog.GetInt("dogstatsd_port"))
 	} else {
-		url = net.JoinHostPort(config.Datadog.GetString("bind_host"), config.Datadog.GetString("dogstatsd_port"))
+		url = net.JoinHostPort(config.GetBindHost(), config.Datadog.GetString("dogstatsd_port"))
 	}
 
 	addr, err := net.ResolveUDPAddr("udp", url)

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -205,7 +205,7 @@ func (j *JMXFetch) Start(manage bool) error {
 		if common.DSD != nil && common.DSD.UdsListenerRunning {
 			reporter = fmt.Sprintf("statsd:unix://%s", config.Datadog.GetString("dogstatsd_socket"))
 		} else {
-			bindHost := config.Datadog.GetString("bind_host")
+			bindHost := config.GetBindHost()
 			if bindHost == "" || bindHost == "0.0.0.0" {
 				bindHost = "localhost"
 			}

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -414,7 +414,7 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.StatsdPort = config.Datadog.GetInt(k)
 	}
 
-	if bindHost := config.Datadog.GetString("bind_host"); bindHost != "" {
+	if bindHost := config.GetBindHost(); bindHost != "" {
 		a.StatsdHost = bindHost
 	}
 

--- a/pkg/snmp/traps/config.go
+++ b/pkg/snmp/traps/config.go
@@ -8,6 +8,7 @@ package traps
 import (
 	"errors"
 	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/soniah/gosnmp"
 )
@@ -45,7 +46,7 @@ func ReadConfig() (*Config, error) {
 	}
 	if c.BindHost == "" {
 		// Default to global bind_host option.
-		c.BindHost = config.Datadog.GetString("bind_host")
+		c.BindHost = config.GetBindHost()
 	}
 	if c.StopTimeout == 0 {
 		c.StopTimeout = defaultStopTimeout


### PR DESCRIPTION
### What does this PR do?

Remove `localhost` default from `BindEnvAndSetDefault` as in trace-agent we need to be able to distinguish between `bind_host` set by user and default value, see #7044.
Fixes #7044

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy Agent in a container with APM activated but without `bind_host` or `apm_non_local_traffic`. Make sure trace-agent listens on `0.0.0.0`, make sure `dogstatsd` listens on `localhost`.
