### PR TITLE
Upstart: change respawn limit to 5 times every 10 seconds

### DIFF
--- a/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
@@ -4,7 +4,7 @@ start on started networking
 stop on runlevel [!2345]
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_debian.process.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.process.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_debian.security.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.security.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -4,7 +4,7 @@ start on starting datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_debian.trace.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.trace.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
@@ -4,7 +4,7 @@ start on started network
 stop on runlevel [!2345]
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.process.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.process.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.security.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.security.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -4,7 +4,7 @@ start on starting datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.trace.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.trace.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-dogstatsd/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-dogstatsd/upstart_debian.conf.erb
@@ -4,7 +4,7 @@ start on started networking or started network
 stop on runlevel [!2345]
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 console log # redirect daemon's outputs to `/var/log/upstart/dogstatsd.log`

--- a/omnibus/config/templates/datadog-dogstatsd/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-dogstatsd/upstart_redhat.conf.erb
@@ -4,7 +4,7 @@ start on started networking or started network
 stop on runlevel [!2345]
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 # console log is not available before upstart 1.4. CentOS/RHEL6 use an earlier version of upstart.

--- a/omnibus/config/templates/datadog-iot-agent/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-iot-agent/upstart_debian.conf.erb
@@ -4,7 +4,7 @@ start on started networking
 stop on runlevel [!2345]
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-iot-agent/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-iot-agent/upstart_redhat.conf.erb
@@ -4,7 +4,7 @@ start on started network
 stop on runlevel [!2345]
 
 respawn
-respawn limit 10 5
+respawn limit 5 10
 normal exit 0
 
 console output


### PR DESCRIPTION
### Motivation

The previous limit was set to 10 times in 5 seconds, which we could potentially not reach (specially on a loaded or slow machine) if the Agent takes long enough to start, causing an infinite restart loop and high CPU usage.

### Additional Notes

The new values match the defaults in systemd.

### Test plan

Run the Agent manually (`datadog-agent run`) then try to start it through upstart. 

Number of retries with the old values:
```
[2021-01-27 19:01:01] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:01] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:01] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:02] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:02] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:03] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:04] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:04] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:05] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:05] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:06] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:06] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:07] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:07] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:08] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:08] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:09] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:09] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:10] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:01:10] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
```

Number of retries with the old values in a machine under load (generated with the `stress` tool):
```
<never stops retrying>
```

Number of retries with the new values, also under stress:
```
[2021-01-27 19:00:43] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:00:44] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:00:44] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:00:45] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:00:45] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
[2021-01-27 19:00:46] Error: Error while starting api server, exiting: Unable to create the api server: listen tcp 127.0.0.1:5001: bind: address already in use
```
