### PR TITLE
Add 'and' and 'or' aliases to && and ||

### DIFF
--- a/pkg/security/secl/ast/secl.go
+++ b/pkg/security/secl/ast/secl.go
@@ -154,7 +154,7 @@ type BitOperation struct {
 type Unary struct {
 	Pos lexer.Position
 
-	Op      *string  `parser:"( @( \"!\" | \"-\" | \"^\" )"`
+	Op      *string  `parser:"( @( \"!\" | \"not\" | \"-\" | \"^\" )"`
 	Unary   *Unary   `parser:"@@ )"`
 	Primary *Primary `parser:"| @@"`
 }

--- a/pkg/security/secl/ast/secl.go
+++ b/pkg/security/secl/ast/secl.go
@@ -112,7 +112,7 @@ type Expression struct {
 	Pos lexer.Position
 
 	Comparison *Comparison        `parser:"@@"`
-	Op         *string            `parser:"[ @( \"|\" \"|\" | \"&\" \"&\" )"`
+	Op         *string            `parser:"[ @( \"|\" \"|\" | \"or\" | \"&\" \"&\" | \"and\" )"`
 	Next       *BooleanExpression `parser:"@@ ]"`
 }
 

--- a/pkg/security/secl/ast/secl_test.go
+++ b/pkg/security/secl/ast/secl_test.go
@@ -80,8 +80,17 @@ func TestRegister(t *testing.T) {
 	print(t, rule)
 }
 
-func TestBoolAnd(t *testing.T) {
+func TestIntAnd(t *testing.T) {
 	rule, err := ParseRule(`3 & 3`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestBoolAnd(t *testing.T) {
+	rule, err := ParseRule(`true and true`)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/security/secl/eval/eval.go
+++ b/pkg/security/secl/eval/eval.go
@@ -212,13 +212,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, in
 			}
 
 			switch *obj.Op {
-			case "||":
+			case "||", "or":
 				boolEvaluator, err := Or(cmpBool, nextBool, opts, state)
 				if err != nil {
 					return nil, nil, obj.Pos, err
 				}
 				return boolEvaluator, nil, obj.Pos, nil
-			case "&&":
+			case "&&", "and":
 				boolEvaluator, err := And(cmpBool, nextBool, opts, state)
 				if err != nil {
 					return nil, nil, obj.Pos, err

--- a/pkg/security/secl/eval/eval.go
+++ b/pkg/security/secl/eval/eval.go
@@ -453,7 +453,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, in
 			}
 
 			switch *obj.Op {
-			case "!":
+			case "!", "not":
 				unaryBool, ok := unary.(*BoolEvaluator)
 				if !ok {
 					return nil, nil, pos, NewTypeError(pos, reflect.Bool)

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -199,6 +199,8 @@ func TestPrecedence(t *testing.T) {
 		{Expr: `false || true`, Expected: true},
 		{Expr: `false or true`, Expected: true},
 		{Expr: `1 == 1 & 1`, Expected: true},
+		{Expr: `not true && false`, Expected: false},
+		{Expr: `not (true && false)`, Expected: true},
 	}
 
 	for _, test := range tests {

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -164,6 +164,7 @@ func TestSimpleBool(t *testing.T) {
 		Expected bool
 	}{
 		{Expr: `(444 == 444) && ("test" == "test")`, Expected: true},
+		{Expr: `(444 == 444) and ("test" == "test")`, Expected: true},
 		{Expr: `(444 != 444) && ("test" == "test")`, Expected: false},
 		{Expr: `(444 != 555) && ("test" == "test")`, Expected: true},
 		{Expr: `(444 != 555) && ("test" != "aaaa")`, Expected: true},
@@ -196,6 +197,7 @@ func TestPrecedence(t *testing.T) {
 	}{
 		{Expr: `false || (true != true)`, Expected: false},
 		{Expr: `false || true`, Expected: true},
+		{Expr: `false or true`, Expected: true},
 		{Expr: `1 == 1 & 1`, Expected: true},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Support "and" and "or" in addition to && and ||

### Motivation

Using words in rules make them clearer and closer to what's used in the backend