### PR TITLE
Fix scheduling of cri/containerd when we can determine Agent is running in Docker

### DIFF
--- a/pkg/config/environment.go
+++ b/pkg/config/environment.go
@@ -24,6 +24,17 @@ func IsContainerized() bool {
 	return os.Getenv("DOCKER_DD_AGENT") != ""
 }
 
+// IsDockerRuntime returns true if we are to find the /.dockerenv file
+// which is typically only set by Docker
+func IsDockerRuntime() bool {
+	_, err := os.Stat("/.dockerenv")
+	if err == nil {
+		return true
+	}
+
+	return false
+}
+
 // IsKubernetes returns whether the Agent is running on a kubernetes cluster
 func IsKubernetes() bool {
 	// Injected by Kubernetes itself

--- a/pkg/config/environment_detection.go
+++ b/pkg/config/environment_detection.go
@@ -38,6 +38,8 @@ const (
 	defaultLinuxContainerdSocket   = "/var/run/containerd/containerd.sock"
 	defaultLinuxCrioSocket         = "/var/run/crio/crio.sock"
 	defaultHostMountPrefix         = "/host"
+	unixSocketPrefix               = "unix://"
+	winNamedPipePrefix             = "npipe://"
 )
 
 // FeatureMap represents all detected features
@@ -61,7 +63,7 @@ func IsFeaturePresent(feature Feature) bool {
 func detectFeatures() {
 	if Datadog.GetBool("autoconf_from_environment") {
 		detectContainerFeatures()
-		log.Debugf("Features detected from environment: %v", detectedFeatures)
+		log.Infof("Features detected from environment: %v", detectedFeatures)
 	}
 }
 
@@ -71,22 +73,24 @@ func detectContainerFeatures() {
 		detectedFeatures[Docker] = struct{}{}
 	} else {
 		for _, defaultDockerSocketPath := range getDefaultDockerPaths() {
-			if _, err := os.Stat(defaultDockerSocketPath); err == nil {
+			if checkSocketExists(defaultDockerSocketPath) {
 				detectedFeatures[Docker] = struct{}{}
+
 				// Even though it does not modify configuration, using the OverrideFunc mechanism for uniformity
 				AddOverrideFunc(func(Config) {
-					os.Setenv("DOCKER_HOST", "unix://"+defaultDockerSocketPath)
+					os.Setenv("DOCKER_HOST", getDefaultDockerSocketType()+defaultDockerSocketPath)
 				})
 				break
 			}
 		}
 	}
 
-	// CRI Socket - Do not automatically default socket path if Docker is running as Docker is now wrapping containerd
+	// CRI Socket - Do not automatically default socket path if the Agent runs in Docker
+	// as we'll very likely discover the containerd instance wrapped by Docker.
 	criSocket := Datadog.GetString("cri_socket_path")
-	if len(criSocket) == 0 {
+	if criSocket == "" && !IsDockerRuntime() {
 		for _, defaultCriPath := range getDefaultCriPaths() {
-			if _, err := os.Stat(defaultCriPath); err == nil {
+			if checkSocketExists(defaultCriPath) {
 				criSocket = defaultCriPath
 				AddOverride("cri_socket_path", defaultCriPath)
 				// Currently we do not support multiple CRI paths
@@ -116,11 +120,37 @@ func detectContainerFeatures() {
 	}
 }
 
+func checkSocketExists(path string) bool {
+	f, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	// On Windows, we cannot easily verify that a path is a named pipe
+	if runtime.GOOS == "windows" {
+		return true
+	}
+
+	if f.Mode()&os.ModeSocket != 0 {
+		return true
+	}
+
+	return false
+}
+
 func getHostMountPrefixes() []string {
 	if IsContainerized() {
 		return []string{"", defaultHostMountPrefix}
 	}
 	return []string{""}
+}
+
+func getDefaultDockerSocketType() string {
+	if runtime.GOOS == "windows" {
+		return winNamedPipePrefix
+	}
+
+	return unixSocketPrefix
 }
 
 func getDefaultDockerPaths() []string {


### PR DESCRIPTION
### What does this PR do?

Currently, on most Docker setups (when Docker wraps containerd), we'll schedule 3 checks:
- Docker
- Cri
- Containerd

Which is likely to be useless, but harmless. However, in some setups/distros (e.g. `minikube` for instance), `containerd` is packaged without `cri` support, leading to scheduling a check that'll always be in error.

This PR adds an heuristics to minimize these cases by checking if the Agent is currently running with Docker runtime, in which case, it's very likely that we don't need `containerd`, except if explicitly set, of course.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Run the Agent in Docker on a machine with Docker wrapping containerd (for instance minikube, GKE). The `cri` and `containerd` checks should not be scheduled automatically.
