### PR TITLE
pkg/trace/obfuscate: fix SQL query leak when obfuscation fails

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -357,7 +357,7 @@ func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
 			span.Meta = make(map[string]string, 1)
 		}
 		if _, ok := span.Meta[sqlQueryTag]; !ok {
-			span.Meta[sqlQueryTag] = span.Resource
+			span.Meta[sqlQueryTag] = nonParsableResource
 		}
 		span.Resource = nonParsableResource
 		return

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -92,12 +92,9 @@ func TestSQLResourceWithError(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		// copy test cases as Quantize mutates
-		testSpan := tc.span
-
 		NewObfuscator(nil).Obfuscate(&tc.span)
 		assert.Equal("Non-parsable SQL query", tc.span.Resource)
-		assert.Equal(testSpan.Resource, tc.span.Meta["sql.query"])
+		assert.Equal("Non-parsable SQL query", tc.span.Meta["sql.query"])
 	}
 }
 

--- a/releasenotes/notes/apm-nonparsable-resource-leak-a16ab87fb2c04c36.yaml
+++ b/releasenotes/notes/apm-nonparsable-resource-leak-a16ab87fb2c04c36.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: When SQL query obfuscation fails, the "sql.query" tag no longer contains the original query,
+    risking the exposure of sensitive data.
+


### PR DESCRIPTION
### What does this PR do?

Does not expose the full SQL query when obfuscation fails.

### Motivation

We found some traces that contained the full query in Datadog, unobfuscated. Example:

![pg](https://user-images.githubusercontent.com/92085/106169135-f3479a00-6186-11eb-870f-7c5c705b872c.png)
