### PR TITLE
add new versioned docker_hub manual deploy job

### DIFF
--- a/.gitlab/image_deploy/docker_linux.yml
+++ b/.gitlab/image_deploy/docker_linux.yml
@@ -52,6 +52,17 @@ dev_branch_docker_hub-dogstatsd:
   script:
     - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG}-amd64                 datadog/dogstatsd-dev:${CI_COMMIT_REF_SLUG}
 
+dev_branch_docker_hub_versioned-a7:
+  extends: .docker_tag_job_definition
+  rules:
+    - <<: *if_version_7
+      when: manual
+      allow_failure: true
+  needs: ["docker_build_agent7", "docker_build_agent7_jmx"]
+  script:
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-amd64             datadog/agent-dev:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-py3
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-amd64         datadog/agent-dev:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-py3-jmx
+
 dev_branch_docker_hub-a7:
   extends: .docker_tag_job_definition
   rules:


### PR DESCRIPTION
### What does this PR do?

Adds a new `dev_branch_docker_hub_versioned-a7 ` job which include the commit hash in the tag name along with the branch/tag. 

Example:
* Original `dev_branch_docker_hub-a7`: `datadog/agent-dev:dev-dbm-beta-py3`
* New `dev_branch_docker_hub_versioned-a7`: `datadog/agent-dev:dev-dbm-beta-f1fe2e54-py3 `

### Motivation

This ensures that when building beta builds off of a branch (without explicitly setting a versioned tag), the docker tags will include the commit hash and therefore always be different. 

Prior to this the docker tag for all branch builds would be the same across subsequent builds from different versions of the code. 
