### PR TITLE
[runtime-security] use a binary tree to queue event and add a reorderer monitor

### DIFF
--- a/pkg/security/probe/metrics.go
+++ b/pkg/security/probe/metrics.go
@@ -72,6 +72,10 @@ var (
 	// MetricPerfBufferSortingError is the name of the metric used to report events reordering issues.
 	// Tags: map, cpu, event_type
 	MetricPerfBufferSortingError = newRuntimeSecurityMetric(".perf_buffer.sorting_error")
+	// MetricPerfBufferSortingQueueSize is the name of the metric used to report reordering queue size.
+	MetricPerfBufferSortingQueueSize = newRuntimeSecurityMetric(".perf_buffer.sorting_queue_size")
+	// MetricPerfBufferSortingAvgOp is the name of the metric used to report average sorting operations.
+	MetricPerfBufferSortingAvgOp = newRuntimeSecurityMetric(".perf_buffer.sorting_avg_op")
 
 	// Process Resolver metrics
 

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -13,7 +13,6 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -823,18 +822,13 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	p.resolvers = resolvers
 	p.event = NewEvent(p.resolvers)
 
-	windowSize := uint64(15 * runtime.NumCPU())
-	if windowSize < 60 {
-		windowSize = 60
-	}
-
 	p.reOrderer = NewReOrderer(p.handleEvent,
 		ExtractEventInfo,
 		ReOrdererOpts{
-			QueueSize:  100000,
-			WindowSize: windowSize,
-			Delay:      100 * time.Millisecond,
-			Rate:       100 * time.Millisecond,
+			QueueSize:  10000,
+			Rate:       50 * time.Millisecond,
+			Retention:  5,
+			MetricRate: 5 * time.Second,
 		})
 
 	eventZero.resolvers = p.resolvers

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -9,11 +9,10 @@ package probe
 
 import (
 	"context"
-	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/DataDog/ebpf/manager"
 	"github.com/pkg/errors"
@@ -27,6 +26,7 @@ type Monitor struct {
 	loadController    *LoadController
 	perfBufferMonitor *PerfBufferMonitor
 	syscallMonitor    *SyscallMonitor
+	reordererMonitor  *ReordererMonitor
 }
 
 // NewMonitor returns a new instance of a ProbeMonitor
@@ -49,6 +49,11 @@ func NewMonitor(p *Probe, client *statsd.Client) (*Monitor, error) {
 		return nil, errors.Wrap(err, "couldn't create the events statistics monitor")
 	}
 
+	m.reordererMonitor, err = NewReOrderMonitor(p, client)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't create the reorder monitor")
+	}
+
 	// create a new syscall monitor if requested
 	if p.config.SyscallMonitor {
 		m.syscallMonitor, err = NewSyscallMonitor(p.manager)
@@ -67,6 +72,7 @@ func (m *Monitor) GetPerfBufferMonitor() *PerfBufferMonitor {
 // Start triggers the goroutine of all the underlying controllers and monitors of the Monitor
 func (m *Monitor) Start(ctx context.Context) error {
 	go m.loadController.Start(ctx)
+	go m.reordererMonitor.Start(ctx)
 	return nil
 }
 

--- a/pkg/security/probe/reorderer_monitor.go
+++ b/pkg/security/probe/reorderer_monitor.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux
+
+package probe
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+// ReordererMonitor represents a reorderer monitor
+type ReordererMonitor struct {
+	// probe is a pointer to the Probe
+	probe *Probe
+	// statsdClient is a pointer to the statsdClient used to report the metrics of the perf buffer monitor
+	statsdClient *statsd.Client
+}
+
+// NewReOrderMonitor instantiates a new reorder statistics counter
+func NewReOrderMonitor(p *Probe, client *statsd.Client) (*ReordererMonitor, error) {
+	return &ReordererMonitor{
+		probe:        p,
+		statsdClient: client,
+	}, nil
+}
+
+// Start the reorderer monitor
+func (r *ReordererMonitor) Start(ctx context.Context) {
+	for {
+		select {
+		case metric := <-r.probe.reOrderer.Metrics:
+			_ = r.statsdClient.Gauge(MetricPerfBufferSortingQueueSize, float64(metric.QueueSize), []string{}, 1.0)
+			var avg float64
+			if metric.TotalOp > 0 {
+				avg = float64(metric.TotalDepth) / float64(metric.TotalOp)
+			}
+			_ = r.statsdClient.Gauge(MetricPerfBufferSortingAvgOp, avg, []string{}, 1.0)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/pkg/security/probe/reorderer_test.go
+++ b/pkg/security/probe/reorderer_test.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux
+
+package probe
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func TestOrder(t *testing.T) {
+	heap := &reOrdererHeap{
+		pool: &reOrdererNodePool{},
+	}
+	metric := ReOrdererMetric{}
+
+	for i := 0; i != 200; i++ {
+		n := rand.Int()%254 + 1
+		heap.enqueue(0, []byte{byte(n)}, uint64(n), 1, &metric)
+	}
+
+	var count int
+	var last byte
+	heap.dequeue(func(cpu uint64, data []byte) {
+		count++
+		if last > 0 {
+			assert.GreaterOrEqual(t, data[0], last)
+		}
+		last = data[0]
+	}, 1, &metric)
+
+	assert.Equal(t, 200, count)
+}
+
+func TestOrderRetention(t *testing.T) {
+	heap := &reOrdererHeap{
+		pool: &reOrdererNodePool{},
+	}
+	metric := ReOrdererMetric{}
+
+	for i := 0; i != 90; i++ {
+		heap.enqueue(0, []byte{byte(i)}, uint64(i), uint64(i/30+1), &metric)
+	}
+
+	var count int
+	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 1, &metric)
+	assert.Equal(t, 30, count)
+	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 2, &metric)
+	assert.Equal(t, 60, count)
+	heap.dequeue(func(cpu uint64, data []byte) { count++ }, 3, &metric)
+	assert.Equal(t, 90, count)
+}
+
+func TestOrderGeneration(t *testing.T) {
+	heap := &reOrdererHeap{
+		pool: &reOrdererNodePool{},
+	}
+	metric := ReOrdererMetric{}
+
+	heap.enqueue(0, []byte{byte(10)}, uint64(10), uint64(1), &metric)
+	heap.enqueue(0, []byte{byte(1)}, uint64(1), uint64(2), &metric)
+
+	var data []byte
+	heap.dequeue(func(c uint64, d []byte) { data = d }, 1, &metric)
+	assert.Equal(t, 1, int(data[0]))
+
+	heap.dequeue(func(c uint64, d []byte) { data = d }, 2, &metric)
+	assert.Equal(t, 10, int(data[0]))
+}
+
+func TestOrderRate(t *testing.T) {
+	var event []byte
+	rate := 1 * time.Second
+	retention := 5
+
+	var lock sync.RWMutex
+
+	reOrderer := NewReOrderer(func(cpu uint64, data []byte) {
+		lock.Lock()
+		event = append(event, data[2])
+		lock.Unlock()
+	},
+		func(data []byte) (uint64, uint64, error) {
+			return uint64(data[0]), uint64(data[1]), nil
+		},
+		ReOrdererOpts{
+			QueueSize:  100,
+			Rate:       rate,
+			Retention:  uint64(retention),
+			MetricRate: 200 * time.Millisecond,
+		})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go reOrderer.Start(ctx)
+
+	var e uint8
+	for i := 0; i != 10; i++ {
+		reOrderer.HandleEvent(0, []byte{0, byte(i + 1), e}, nil, nil)
+		e++
+	}
+
+	lock.RLock()
+	assert.Zero(t, event)
+	lock.RUnlock()
+
+	time.Sleep(100 * time.Millisecond)
+
+	lock.RLock()
+	assert.Zero(t, event)
+	lock.RUnlock()
+
+	time.Sleep(rate * time.Duration(retention))
+
+	// should now get the elements
+	lock.RLock()
+	assert.Equal(t, event, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	lock.RUnlock()
+
+	cancel()
+}


### PR DESCRIPTION
### What does this PR do?

Use a binary tree to queue event instead of a list. Some event can be delayed a lot. Consequently we need to keep more event in the queue in order to sort them. In that case a binary tree is more efficient than our previous approach with the list. We use an event generation value to dequeue them periodically.

It also add some metrics to monitor the activity of the reorderer

### Motivation

On pretty loaded environment we have seen event ordering error.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

We should see less the reorderer errors 
