### PR TITLE
[logs] Inherit source/service name in some cases

### DIFF
--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -206,9 +206,9 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 	}
 
 	configName := s.configName(config)
-	// Used to fill empty source/service in some cases
-	serviceName, sourceName := s.extractMainSourceAndService(configs)
 	var sources []*logsConfig.LogSource
+	// Used to fill empty source/service in some cases when iterating over the configs slice
+	serviceName, sourceName := s.extractMainSourceAndService(configs)
 	for _, cfg := range configs {
 		// if no service is set fall back to the global one
 		if cfg.Service == "" && globalServiceDefined {
@@ -222,7 +222,8 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 				// cfg.Type is not overwritten as tailing a file from a Docker or Kubernetes AD configuration
 				// is explicitly supported (other combinations may be supported later)
 				cfg.Identifier = service.Identifier
-				// We copy service and source name from the parent container if they are not set
+				// We copy service and source name from the parent container if they were not set for this config
+				// in the docker label or pod annotation
 				if cfg.Service == "" {
 					cfg.Service = serviceName
 				}


### PR DESCRIPTION
### What does this PR do?
When tailing a file from a pod annotation (feature introduced by #7176) and the file config has no source/service it inherits the ones set for the container for consistency purpose.

### Motivation
Source&service mapping consistency

### Additional Notes
N/A

### Describe your test plan
Same as #7176 