### PR TITLE
Make installation of the npm driver optional

### DIFF
--- a/omnibus/resources/agent/msi/localbuild/parameters.wxi
+++ b/omnibus/resources/agent/msi/localbuild/parameters.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
-  <?define VersionNumber="7.24.1.1" ?>
-  <?define DisplayVersionNumber="7.24.1" ?>
+  <?define VersionNumber="7.27.1.1" ?>
+  <?define DisplayVersionNumber="7.27.1" ?>
   <?define UpgradeCode="0c50421b-aefb-4f15-a809-7af256d608a5" ?>
   <?define InstallDir="C:/opt/datadog-agent" ?>
   <?define InstallFiles="C:/omnibus-ruby/src/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files" ?>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -177,6 +177,13 @@
                       Name="ConfigRoot" />
     </Property>
 
+    <Property Id="DD_FILTER_INSTALLED">
+      <RegistrySearch Key="SYSTEM\CurrentControlSet\Services\ddnpm"
+                      Root="HKLM"
+                      Type="raw"
+                      Id="DDFILTERINSTALLED_REGSEARCH"
+                      Name="Start" />
+    </Property>
     <DirectoryRef Id="PROJECTLOCATION">
       <Component Id="CleanupMainApplicationFolder" Guid="096249cf-3fe7-4342-a80f-77101ceed5fe">
         <!-- We need to use APPLICATIONROOTDIRECTORY variable here or RemoveFolderEx
@@ -560,7 +567,7 @@
                >
         <MergeRef Id="ddnpminstall"/>
         
-        <Condition Level="1"><![CDATA[NPM OR NPMPVS="true"]]></Condition>
+        <Condition Level="1"><![CDATA[NPM OR (DD_FILTER_INSTALLED and (not WixUI_InstallMode = "Change"))]]></Condition>
         
       </Feature>
     <?endif ?>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -506,8 +506,8 @@
            installer is called twice; the existing (previously installed)
            installer is called with _UPGRADE, and then the new installer
            is called with _INSTALL -->
-      <Custom Action='SetFinalizeProperty' Before='FinalizeInstall'> <![CDATA[Installed="" ]]> </Custom>
-      <Custom Action='FinalizeInstall' After='InstallServices'>      <![CDATA[Installed="" ]]> </Custom>
+      <Custom Action='SetFinalizeProperty' Before='FinalizeInstall'> <![CDATA[Installed="" OR REMOVE="" ]]> </Custom>
+      <Custom Action='FinalizeInstall' After='InstallServices'>      <![CDATA[Installed="" OR REMOVE="" ]]> </Custom>
 
       <!-- Same deal here -->
       <Custom Action='StartDDServices' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL"]]></Custom>
@@ -545,10 +545,25 @@
       <?endif ?>
     <?if $(var.IncludeSysprobe) = true ?>
         <ComponentRef Id="DATADOGSYSPROBESERVICE" />
-        <MergeRef Id="ddnpminstall"/>
         <ComponentRef Id="system_probe.yaml.example" />
     <?endif ?>
     </Feature>
+     <?if $(var.IncludeSysprobe) = true ?>
+      <!-- don't install by default (indicated by level 100)  Only things with level
+           <= INSTALLLEVEL (1 by default) will be installed.  Can be changed via gui or command line params to optionally install -->
+      <Feature Id="WindowsNP" 
+               Level="100"  
+               Title="Network Performance Monitoring" 
+               ConfigurableDirectory="APPLICATIONROOTDIRECTORY"
+               Absent="allow"
+               AllowAdvertise="no"
+               >
+        <MergeRef Id="ddnpminstall"/>
+        
+        <Condition Level="1"><![CDATA[NPM OR NPMPVS="true"]]></Condition>
+        
+      </Feature>
+    <?endif ?>
     <!-- UI Stuff: 100% Omnibus Generated -->
     <Icon Id="project.ico" SourceFile="Resources\assets\project_16x16.ico"/>
     <Property Id="ARPPRODUCTICON" Value="project.ico" />
@@ -613,15 +628,34 @@
            VerifyReady
 
            -->
-
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT PREVIOUSFOUND</Publish>
       
 
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">PREVIOUSFOUND</Publish>
+      <?if $(var.IncludeSysprobe) = true ?>
+        <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">PREVIOUSFOUND</Publish>
 
-      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
+        <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">NOT PREVIOUSFOUND</Publish>
 
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">PREVIOUSFOUND</Publish>
+        <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="ApiKeyDlg">(NOT WixUI_InstallMode) AND (NOT PREVIOUSFOUND)</Publish>
+        <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">WixUI_InstallMode OR PREVIOUSFOUND</Publish>
+
+        <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">(NOT WixUI_InstallMode) AND (NOT PREVIOUSFOUND)</Publish>
+        <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">(NOT WixUI_InstallMode) AND PREVIOUSFOUND</Publish>
+        <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg"> WixUI_InstallMode </Publish>
+
+        <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">(NOT WixUI_InstallMode) AND PREVIOUSFOUND</Publish>
+        <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg">WixUI_InstallMode = "Change"</Publish>
+
+        <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>
+
+
+      <?else ?>
+        <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">PREVIOUSFOUND</Publish>
+
+        <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
+
+        <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">(NOT WixUI_InstallMode) AND PREVIOUSFOUND</Publish>
+      <?endif ?>
 
       <!-- if the dialog is displayed, there's only one back from here, which is the welcome -->
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg"></Publish>
@@ -635,11 +669,17 @@
 
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
 
+      
+
+
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">NOT APIKEY</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="SiteDlg">APIKEY AND (NOT SITE)</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">APIKEY AND SITE</Publish>
 
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">WixUI_InstallMode = "Repair"</Publish>
+
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+
 
       <AdminUISequence>
         <Show Dialog="FatalError" OnExit="error" />
@@ -708,3 +748,7 @@
 
   </Product>
 </Wix>
+<!-- check 
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ddnpm
+
+-->

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -4,6 +4,7 @@ package tracer
 
 import (
 	"expvar"
+	"syscall"
 	"fmt"
 	"sync"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -56,7 +58,11 @@ type Tracer struct {
 // NewTracer returns an initialized tracer struct
 func NewTracer(config *config.Config) (*Tracer, error) {
 	di, err := network.NewDriverInterface(config.EnableMonotonicCount, config.DriverBufferSize)
-	if err != nil {
+
+	if err != nil && errors.Cause(err) == syscall.Errno(syscall.ERROR_FILE_NOT_FOUND) {
+		log.Debugf("could not create driver interface: %v", err)
+		return nil, fmt.Errorf("The windows driver was not installed, reinstall the datadog with network performance monitoring enabled")	
+	} else if err != nil {
 		return nil, fmt.Errorf("could not create windows driver controller: %v", err)
 	}
 

--- a/release.json
+++ b/release.json
@@ -7,8 +7,8 @@
         "JMXFETCH_HASH": "3102eb76aa973e4ac08f9727130979d95eda734876424ca4d92b1c4c43081a1f",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "attestation-signed",
-        "WINDOWS_DDNPM_VERSION": "0.98.2.git.41.c46c971",
-        "WINDOWS_DDNPM_SHASUM": "79e641b2078737f6176a50779cb233af6cb2fc86ad6a783c871f1310ff751deb"
+        "WINDOWS_DDNPM_VERSION": "0.98.2.git.47.635bb9b.msm",
+        "WINDOWS_DDNPM_SHASUM": "d5641a09805fdfd0c8c445178ba46ae92275688d4c4ec30de01d4ba00fd94563"
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
@@ -18,8 +18,8 @@
         "JMXFETCH_HASH": "3102eb76aa973e4ac08f9727130979d95eda734876424ca4d92b1c4c43081a1f",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "attestation-signed",
-        "WINDOWS_DDNPM_VERSION": "0.98.2.git.41.c46c971",
-        "WINDOWS_DDNPM_SHASUM": "79e641b2078737f6176a50779cb233af6cb2fc86ad6a783c871f1310ff751deb",
+        "WINDOWS_DDNPM_VERSION": "0.98.2.git.47.635bb9b.msm",
+        "WINDOWS_DDNPM_SHASUM": "d5641a09805fdfd0c8c445178ba46ae92275688d4c4ec30de01d4ba00fd94563",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "6.26.0-rc.1": {

--- a/release.json
+++ b/release.json
@@ -7,7 +7,7 @@
         "JMXFETCH_HASH": "3102eb76aa973e4ac08f9727130979d95eda734876424ca4d92b1c4c43081a1f",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "attestation-signed",
-        "WINDOWS_DDNPM_VERSION": "0.98.2.git.47.635bb9b.msm",
+        "WINDOWS_DDNPM_VERSION": "0.98.2.git.47.635bb9b",
         "WINDOWS_DDNPM_SHASUM": "d5641a09805fdfd0c8c445178ba46ae92275688d4c4ec30de01d4ba00fd94563"
     },
     "nightly-a7": {
@@ -18,7 +18,7 @@
         "JMXFETCH_HASH": "3102eb76aa973e4ac08f9727130979d95eda734876424ca4d92b1c4c43081a1f",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "attestation-signed",
-        "WINDOWS_DDNPM_VERSION": "0.98.2.git.47.635bb9b.msm",
+        "WINDOWS_DDNPM_VERSION": "0.98.2.git.47.635bb9b",
         "WINDOWS_DDNPM_SHASUM": "d5641a09805fdfd0c8c445178ba46ae92275688d4c4ec30de01d4ba00fd94563",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },


### PR DESCRIPTION
### What does this PR do?

Makes the installation of the npm driver optional, enabled by command line flag or GUI selection.

The system probe is always installed, however, it will fail to run if the driver option isn't installed as well.

Includes change to have clearer error message if driver isn't present.

### Motivation

Change motivated by inclusion of driver, which was deemed necessary to have a separate install step.

### Additional Notes

This change also includes (requires) fixes to the "change" and "repair" functionality, because those
features were not working correctly and would be necessary to allow a user who didn't install the driver, but
wanted to, to re-run the install and add the driver.  Otherwise re-running the install would have no impact.


### Describe your test plan

Need to test the following functionality
Upgrade from beta retains driver w/o any special flags
Upgrade from previous version does not contain driver w/o flags
upgrade from previous version does contain driver with flags
change and repair work as desired

upgrade to future version (we'll need to simulate a future build version) also handles upgrade case properly.

