### PR TITLE
pkg/trace/{agent,config,filters}:create validator struct for filtering by required tags

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -103,6 +103,9 @@ type AgentConfig struct {
 	// filtering
 	Ignore map[string][]string
 
+	// RequiredTags for filtering tags
+	RequiredTags []string
+
 	// ReplaceTags is used to filter out sensitive information from tag values.
 	// It maps tag keys to a set of replacements. Only supported in A6.
 	ReplaceTags []*ReplaceRule

--- a/pkg/trace/filters/validator.go
+++ b/pkg/trace/filters/validator.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package filters
+
+import "github.com/DataDog/datadog-agent/pkg/trace/pb"
+
+// Validator holds a list of required tags.
+type Validator struct {
+	reqTags []string
+}
+
+// Validates returns true if root span contains all required tags from Validator.
+func (v *Validator) Validates(span *pb.Span) bool {
+	for _, tag := range v.reqTags {
+		if _, ok := span.Meta[tag]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// NewValidator creates new Validator based on given list of required tags.
+func NewValidator(reqTags []string) *Validator {
+	return &Validator{reqTags: reqTags}
+}

--- a/pkg/trace/filters/validator_test.go
+++ b/pkg/trace/filters/validator_test.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package filters
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidator(t *testing.T) {
+	tests := []struct {
+		reqTags   []string
+		traceMeta map[string]string
+		isValid   bool
+	}{
+		{
+			[]string{"important1", "important2"},
+			map[string]string{
+				"important1": "test-value",
+				"important2": "test-value-2",
+			},
+			true,
+		},
+		{
+			[]string{"important1", "important2"},
+			map[string]string{
+				"important1": "test-value",
+				"important2": "another-test-value",
+				"blah":       "blah",
+			},
+			true,
+		},
+		{
+			[]string{"important1", "important2"},
+			map[string]string{
+				"important1": "test-value",
+				"blah":       "blah",
+			},
+			false,
+		},
+		{
+			[]string{},
+			map[string]string{
+				"somekey": "12345",
+				"blah":    "blah",
+			},
+			true,
+		},
+		{
+			[]string{},
+			map[string]string{},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		span := testutil.RandomSpan()
+		span.Meta = test.traceMeta
+		filter := NewValidator(test.reqTags)
+
+		assert.Equal(t, test.isValid, filter.Validates(span))
+	}
+}


### PR DESCRIPTION
Accidentally closed the [initial PR](https://github.com/DataDog/datadog-agent/pull/7283).

Add new `validTags` method to validate root trace's spans by adding configurable `RequiredTags` and `RejectedTags`.

Fixes #7050