### PR TITLE
[runtime-security] fix inodes when using overlayfs

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -745,6 +745,11 @@ core,"gopkg.in/natefinch/lumberjack.v2",MIT
 core,"gopkg.in/yaml.v2",Apache-2.0
 core,"gopkg.in/yaml.v3",MIT
 core,"gopkg.in/zorkian/go-datadog-api.v2",NewBSD
+core,"gotest.tools/assert",Apache-2.0
+core,"gotest.tools/assert/cmp",Apache-2.0
+core,"gotest.tools/internal/difflib",FreeBSD
+core,"gotest.tools/internal/format",Apache-2.0
+core,"gotest.tools/internal/source",Apache-2.0
 core,"k8s.io/api/admission/v1",Apache-2.0
 core,"k8s.io/api/admission/v1beta1",Apache-2.0
 core,"k8s.io/api/admissionregistration/v1",Apache-2.0

--- a/go.mod
+++ b/go.mod
@@ -174,6 +174,7 @@ require (
 	gopkg.in/ini.v1 v1.55.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	gopkg.in/zorkian/go-datadog-api.v2 v2.29.0
+	gotest.tools v2.2.0+incompatible
 	gotest.tools/gotestsum v0.5.3
 	honnef.co/go/tools v0.0.1-2020.1.5
 	k8s.io/api v0.17.4

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "5ac39a4d437faa3d983b245fea60200f229cf3a750e68c314bf265c07ceac6fb")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "95171f812af317b41db254b87349d59a2e63cc5a3bdd66cc84378de030903609")

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -193,10 +193,17 @@ void __attribute__((always_inline)) get_dentry_name(struct dentry *dentry, void 
 #define get_dentry_key_path(dentry, path) (struct path_key_t) { .ino = get_dentry_ino(dentry), .mount_id = get_path_mount_id(path) }
 #define get_inode_key_path(inode, path) (struct path_key_t) { .ino = get_inode_ino(inode), .mount_id = get_path_mount_id(path) }
 
+static int is_overlayfs(struct dentry *dentry);
+static int get_overlayfs_ino(struct dentry *dentry, struct path_key_t *path);
+
 static __attribute__((always_inline)) void set_path_key_inode(struct dentry *dentry, struct path_key_t *path_key, int invalidate) {
     path_key->path_id = get_path_id(invalidate);
     if (!path_key->ino) {
         path_key->ino = get_dentry_ino(dentry);
+    }
+
+    if (is_overlayfs(dentry)) {
+        path_key->ino = get_overlayfs_ino(dentry, path_key);
     }
 }
 

--- a/pkg/security/ebpf/c/overlayfs.h
+++ b/pkg/security/ebpf/c/overlayfs.h
@@ -1,0 +1,73 @@
+#ifndef _OVERLAYFS_H_
+#define _OVERLAYFS_H_
+
+#include "syscalls.h"
+
+#define OVERLAYFS_SUPER_MAGIC 0x794c7630
+
+int __attribute__((always_inline)) get_sizeof_inode() {
+    u64 sizeof_inode;
+    LOAD_CONSTANT("sizeof_inode", sizeof_inode);
+
+    return sizeof_inode;
+}
+
+int __attribute__((always_inline)) get_sb_magic_offset() {
+    u64 offset;
+    LOAD_CONSTANT("sb_magic_offset", offset);
+
+    return offset;
+}
+
+static __attribute__((always_inline)) int is_overlayfs(struct dentry *dentry) {
+    struct inode *d_inode;
+    bpf_probe_read(&d_inode, sizeof(d_inode), &dentry->d_inode);
+
+    struct super_block *sb;
+    bpf_probe_read(&sb, sizeof(sb), &d_inode->i_sb);
+
+    u64 magic;
+    bpf_probe_read(&magic, sizeof(magic), (char *)sb + get_sb_magic_offset());
+
+    return magic == OVERLAYFS_SUPER_MAGIC;
+}
+
+int __attribute__((always_inline)) get_ovl_lower_ino(struct dentry *dentry) {
+    struct inode *d_inode;
+    bpf_probe_read(&d_inode, sizeof(d_inode), &dentry->d_inode);
+
+    // escape from the embedded vfs_inode to reach ovl_inode
+    struct inode *lower;
+    bpf_probe_read(&lower, sizeof(lower), (char *)d_inode + get_sizeof_inode() + 8);
+
+    return get_inode_ino(lower);
+}
+
+int __attribute__((always_inline)) get_ovl_upper_ino(struct dentry *dentry) {
+    struct inode *d_inode;
+    bpf_probe_read(&d_inode, sizeof(d_inode), &dentry->d_inode);
+
+    // escape from the embedded vfs_inode to reach ovl_inode
+    struct dentry *upper;
+    bpf_probe_read(&upper, sizeof(upper), (char *)d_inode + get_sizeof_inode());
+
+    return get_dentry_ino(upper);
+}
+
+int __always_inline get_overlayfs_ino(struct dentry *dentry, struct path_key_t *path_key) {
+    u64 lower_inode = get_ovl_lower_ino(dentry);
+    u64 upper_inode = get_ovl_upper_ino(dentry);
+
+#ifdef DEBUG
+    bpf_printk("get_overlayfs_ino lower: %d upper: %d\n", lower_inode, upper_inode);
+#endif
+
+    if (lower_inode) {
+        return lower_inode;
+    } else if (upper_inode) {
+        return upper_inode;
+    }
+    return path_key->ino;
+}
+
+#endif

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -10,6 +10,7 @@
 #include "process.h"
 #include "container.h"
 #include "dentry.h"
+#include "overlayfs.h"
 #include "exec.h"
 #include "setattr.h"
 #include "mnt.h"

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -163,15 +163,15 @@ func (p *Probe) Init(client *statsd.Client) error {
 
 	p.manager = ebpf.NewRuntimeSecurityManager()
 
+	var ok bool
+	if p.perfMap, ok = p.manager.GetPerfMap("events"); !ok {
+		return errors.New("couldn't find events perf map")
+	}
+
 	// Set data and lost handlers
-	for _, perfMap := range p.manager.PerfMaps {
-		switch perfMap.Name {
-		case "events":
-			perfMap.PerfMapOptions = manager.PerfMapOptions{
-				DataHandler: p.reOrderer.HandleEvent,
-				LostHandler: p.handleLostEvents,
-			}
-		}
+	p.perfMap.PerfMapOptions = manager.PerfMapOptions{
+		DataHandler: p.reOrderer.HandleEvent,
+		LostHandler: p.handleLostEvents,
 	}
 
 	if os.Getenv("RUNTIME_SECURITY_TESTSUITE") != "true" {
@@ -199,11 +199,6 @@ func (p *Probe) Init(client *statsd.Client) error {
 
 	if p.discarderRevisions, err = p.Map("discarder_revisions"); err != nil {
 		return err
-	}
-
-	var ok bool
-	if p.perfMap, ok = p.manager.GetPerfMap("events"); !ok {
-		return errors.New("couldn't find events perf map")
 	}
 
 	if err := p.resolvers.Start(p.ctx); err != nil {
@@ -812,6 +807,14 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 		manager.ConstantEditor{
 			Name:  "mount_id_offset",
 			Value: getMountIDOffset(p),
+		},
+		manager.ConstantEditor{
+			Name:  "sizeof_inode",
+			Value: getSizeOfStructInode(p),
+		},
+		manager.ConstantEditor{
+			Name:  "sb_magic_offset",
+			Value: getSuperBlockMagicOffset(p),
 		},
 	)
 

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
+	"github.com/cobaugh/osrelease"
 	"gotest.tools/assert"
 )
 
@@ -337,7 +339,13 @@ func createOverlayLayers(t *testing.T, test *testModule) (string, string, string
 }
 
 func TestDentryOverlay(t *testing.T) {
-	if testEnvironment == DockerEnvironment {
+	sles12 := false
+	osrelease, err := osrelease.Read()
+	if err == nil {
+		sles12 = osrelease["NAME"] == "SLES" && strings.HasPrefix(osrelease["VERSION_ID"], "12")
+	}
+
+	if testEnvironment == DockerEnvironment || sles12 {
 		t.Skip()
 	}
 

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
+	"gotest.tools/assert"
 )
 
 func TestDentryRename(t *testing.T) {
@@ -456,9 +457,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode = getInode(t, testFile); inode != event.Open.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Open.Inode)
-			}
+			inode = getInode(t, testFile)
+			assert.Equal(t, event.Open.Inode, inode, "wrong open inode")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -469,9 +469,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 
@@ -495,11 +493,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode = getInode(t, testFile); inode != event.Open.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Open.Inode)
-			}
-
-			inode = event.Open.Inode
+			inode = getInode(t, testFile)
+			assert.Equal(t, inode, event.Open.Inode, "wrong open inode")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -510,9 +505,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 
@@ -536,11 +529,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode = getInode(t, testFile); inode != event.Open.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Open.Inode)
-			}
-
-			inode = event.Open.Inode
+			inode = getInode(t, testFile)
+			assert.Equal(t, event.Open.Inode, inode, "wrong open inode")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -551,9 +541,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 
@@ -582,11 +570,8 @@ func TestDentryOverlay(t *testing.T) {
 				t.Errorf("expected filename not found %s != %s", value.(string), oldFile)
 			}
 
-			if inode = getInode(t, newFile); inode != event.Rename.New.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Rename.New.Inode)
-			}
-
-			inode = event.Rename.New.Inode
+			inode = getInode(t, newFile)
+			assert.Equal(t, event.Rename.New.Inode, inode, "wrong rename inode")
 		}
 
 		if err := os.Remove(newFile); err != nil {
@@ -597,9 +582,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 
@@ -619,9 +602,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Rmdir.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Rename.New.Inode)
-			}
+			assert.Equal(t, event.Rmdir.Inode, inode, "wrong rmdir inode")
 		}
 	})
 
@@ -641,11 +622,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode = getInode(t, testFile); inode != event.Chmod.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Chmod.Inode)
-			}
-
-			inode = event.Chmod.Inode
+			inode = getInode(t, testFile)
+			assert.Equal(t, event.Chmod.Inode, inode, "wrong chmod inode")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -656,9 +634,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 
@@ -676,9 +652,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode := getInode(t, testFile); inode != event.Mkdir.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Mkdir.Inode)
-			}
+			inode := getInode(t, testFile)
+			assert.Equal(t, event.Mkdir.Inode, inode, "wrong mkdir inode")
 		}
 	})
 
@@ -698,11 +673,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode = getInode(t, testFile); inode != event.Utimes.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Utimes.Inode)
-			}
-
-			inode = event.Utimes.Inode
+			inode = getInode(t, testFile)
+			assert.Equal(t, event.Utimes.Inode, inode, "wrong utimes inode")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -713,9 +685,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 
@@ -735,11 +705,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode = getInode(t, testFile); inode != event.Chown.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Chown.Inode)
-			}
-
-			inode = event.Chown.Inode
+			inode = getInode(t, testFile)
+			assert.Equal(t, event.Chown.Inode, inode, "wrong chown inode")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -750,9 +717,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 
@@ -780,11 +745,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode = getInode(t, testFile); inode != event.SetXAttr.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.SetXAttr.Inode)
-			}
-
-			inode = event.SetXAttr.Inode
+			inode = getInode(t, testFile)
+			assert.Equal(t, event.SetXAttr.Inode, inode, "wrong setxattr inode")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -795,9 +757,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 
@@ -817,11 +777,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode = getInode(t, testFile); inode != event.Open.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Open.Inode)
-			}
-
-			inode = event.Open.Inode
+			inode = getInode(t, testFile)
+			assert.Equal(t, event.Open.Inode, inode, "wrong open inode")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -832,9 +789,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 
@@ -859,11 +814,8 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode = getInode(t, testSrc); inode != event.Link.Source.Inode {
-				t.Logf("expected inode not found %d(real) != %d\n", inode, event.Link.Source.Inode)
-			}
-
-			inode = event.Link.Source.Inode
+			inode = getInode(t, testSrc)
+			assert.Equal(t, event.Link.Source.Inode, inode, "wrong link inode")
 		}
 
 		if err := os.Remove(testSrc); err != nil {
@@ -874,9 +826,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 
 		if err := os.Remove(testTarget); err != nil {
@@ -887,9 +837,7 @@ func TestDentryOverlay(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode not found %d != %d\n", inode, event.Unlink.Inode)
-			}
+			assert.Equal(t, event.Unlink.Inode, inode, "wrong unlink inode")
 		}
 	})
 

--- a/pkg/security/tests/molecule/resources/playbooks/run-script/verify.yml
+++ b/pkg/security/tests/molecule/resources/playbooks/run-script/verify.yml
@@ -11,6 +11,7 @@
   - shell: "/tmp/{{ lookup('env', 'SCRIPT') | basename }} {{ lookup('env', 'ARGS') }}"
     become: true
     register: scriptoutput
+    ignore_errors: yes
 
   - name: Display script output
     debug: msg="{{ scriptoutput.stdout }}"

--- a/pkg/security/tests/molecule/resources/playbooks/testsuite/converge.yml
+++ b/pkg/security/tests/molecule/resources/playbooks/testsuite/converge.yml
@@ -2,6 +2,36 @@
 - name: Converge
   hosts: all
   tasks:
+  - name: Add microchip8 repository for xfsprogs
+    community.general.zypper_repository:
+      repo: 'https://download.opensuse.org/repositories/home:microchip8/SLE_12_SP5/home:microchip8.repo'
+      state: present
+      disable_gpg_check: true
+    become: true
+    when: ansible_distribution == "SLES" and ansible_distribution_major_version == "12"
+    ignore_errors: true
+
+  - name: Refresh all repos
+    community.general.zypper_repository:
+      repo: '*'
+      runrefresh: yes
+    become: true
+    when: ansible_distribution == "SLES" and ansible_distribution_major_version == "12"
+
+  - name: Add the xfs module
+    community.general.modprobe:
+      name: xfs
+      state: present
+      params: 'allow_unsupported=1'
+    become: true
+    when: ansible_distribution == "SLES" and ansible_distribution_major_version == "12"
+
+  - name: Install xfsprogs
+    package:
+      name: xfsprogs
+      state: present
+    become: true
+
   - name: Copy testsuite
     copy:
       src: ../../../../testsuite

--- a/pkg/security/tests/molecule/resources/playbooks/testsuite/verify.yml
+++ b/pkg/security/tests/molecule/resources/playbooks/testsuite/verify.yml
@@ -5,10 +5,11 @@
   - debug:
       msg: "sudo /tmp/testsuite -test.v -test.run {{ lookup('env', 'TEST_PATTERN') | default('^.*$', True) }}"
 
-  - shell: "/tmp/testsuite -test.v -test.run {{ lookup('env', 'TEST_PATTERN') | default('^.*$', True) }} &> /tmp/logs"
+  - shell: "/tmp/testsuite {{ lookup('env', 'TEST_FLAGS') }} -test.v -test.run {{ lookup('env', 'TEST_PATTERN') | default('^.*$', True) }} 2>&1 > /tmp/logs"
     become: true
+    ignore_errors: yes
 
   - fetch:
-      dest: ../../../../testsuite.log
+      dest: "../../../../testsuite-{{ ansible_facts['nodename'] }}.log"
       src: /tmp/logs
       flat: true

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -213,8 +213,9 @@ func TestProcessContext(t *testing.T) {
 			if rule.ID != "test_rule_ancestors" {
 				t.Error("Wrong rule triggered")
 			}
-			if comm := event.Process.Ancestor.Comm; comm != shell {
-				t.Errorf("ancestor `%s` expected, got %s, event:%v", shell, comm, event)
+
+			if ancestor := event.Process.Ancestor; ancestor == nil || ancestor.Comm != shell {
+				t.Errorf("ancestor `%s` expected, got %v, event:%v", shell, ancestor, event)
 			}
 		}
 	})

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -611,7 +611,7 @@ func (t *simpleTest) swapLogLevel(logLevel seelog.LogLevel) (seelog.LogLevel, er
 
 		var err error
 
-		logger, err = seelog.LoggerFromWriterWithMinLevelAndFormat(os.Stdout, seelog.TraceLvl, logFormat)
+		logger, err = seelog.LoggerFromWriterWithMinLevelAndFormat(os.Stdout, logLevel, logFormat)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
### What does this PR do?

Handle overlayfs inodes and ensure inode correctness in functional tests

### Motivation

Right now, we were only using the VFS inode which caused the inode to be incorrect when using overlayfs.