### PR TITLE
[runtime-security] fix parent discarder applied on leaf

### DIFF
--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -403,8 +403,8 @@ static __attribute__((always_inline)) u64 get_enabled_events(void) {
     return 0;
 }
 
-static __attribute__((always_inline)) int mask_has_event(u64 event_mask, enum event_type event) {
-    return event_mask & (1 << (event-1));
+static __attribute__((always_inline)) int mask_has_event(u64 mask, enum event_type event) {
+    return mask & (1 << (event-1));
 }
 
 static __attribute__((always_inline)) int is_event_enabled(enum event_type event) {

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -225,7 +225,7 @@ static __attribute__((always_inline)) int resolve_dentry(struct dentry *dentry, 
 
         // discard filename and its parent only in order to limit the number of lookup
         if (event_type && i < 2) {
-            if (discarded_by_inode(event_type, key.mount_id, key.ino)) {
+            if (discarded_by_inode(event_type, key.mount_id, key.ino, i)) {
                 return DENTRY_DISCARDED;
             }
         }

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -851,7 +851,7 @@ func processDiscarderWrapper(eventType EventType, fnc onDiscarderHandler) onDisc
 				return err
 			}
 
-			return probe.discardInode(eventType, event.Process.MountID, event.Process.Inode)
+			return probe.discardInode(eventType, event.Process.MountID, event.Process.Inode, true)
 		}
 
 		if fnc != nil {
@@ -890,7 +890,7 @@ func filenameDiscarderWrapper(eventType EventType, handler onDiscarderHandler, g
 					log.Tracef("Apply `%s.filename` inode discarder for event `%s`, inode: %d", eventType, eventType, inode)
 
 					// not able to discard the parent then only discard the filename
-					err = probe.discardInode(eventType, mountID, inode)
+					err = probe.discardInode(eventType, mountID, inode, true)
 				}
 			} else {
 				log.Tracef("Apply `%s.filename` parent inode discarder for event `%s` with value `%s`", eventType, eventType, filename)

--- a/pkg/security/probe/process_cache_entry.go
+++ b/pkg/security/probe/process_cache_entry.go
@@ -44,14 +44,18 @@ func (pc *ProcessCacheEntry) Exec(entry *ProcessCacheEntry) {
 // Fork returns a copy of the current ProcessCacheEntry
 func (pc *ProcessCacheEntry) Fork(childEntry *ProcessCacheEntry) {
 	childEntry.PPid = pc.Pid
-	childEntry.UID = pc.UID
-	childEntry.User = pc.User
-	childEntry.GID = pc.GID
-	childEntry.Group = pc.Group
 	childEntry.Ancestor = pc
 
-	// keep some context
-	copyProcessContext(pc, childEntry)
+	// keep some context if not present in the ebpf event
+	if childEntry.ExecTimestamp.IsZero() {
+		childEntry.TTYName = pc.TTYName
+		childEntry.Comm = pc.Comm
+		childEntry.FileEvent = pc.FileEvent
+		childEntry.ExecTimestamp = pc.ExecTimestamp
+		childEntry.Cookie = pc.Cookie
+
+		copyProcessContext(pc, childEntry)
+	}
 }
 
 func (pc *ProcessCacheEntry) String() string {

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -407,7 +407,7 @@ func (p *ProcessResolver) cacheFlush(ctx context.Context) {
 			p.RUnlock()
 
 			delEntry := func(pid uint32, exitTime time.Time) {
-				p.deleteEntry(pid, now)
+				p.deleteEntry(pid, exitTime)
 				_ = p.client.Count(MetricProcessResolverFlushed, 1, []string{}, 1.0)
 			}
 
@@ -420,6 +420,8 @@ func (p *ProcessResolver) cacheFlush(ctx context.Context) {
 						if tm := entry.ExecTimestamp; !tm.IsZero() && tm.Add(time.Minute).Before(now) {
 							delEntry(pid, now)
 						} else if tm := entry.ForkTimestamp; !tm.IsZero() && tm.Add(time.Minute).Before(now) {
+							delEntry(pid, now)
+						} else if entry.ForkTimestamp.IsZero() && entry.ExecTimestamp.IsZero() {
 							delEntry(pid, now)
 						}
 					}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -200,17 +200,15 @@ func TestProcessContext(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			if filename, _ := event.GetFieldValue("process.filename"); filename.(string) != executable {
+			if filename := event.Process.ResolveInode(event); filename != executable {
 				t.Errorf("expected process filename `%s`, got `%s`: %v", executable, filename, event)
 			}
 
 			if rule.ID != "test_rule_ancestors" {
 				t.Error("Wrong rule triggered")
 			}
-
-			values, _ := event.GetFieldValue("process.ancestors.name")
-			if names := values.([]string); names[0] != "sh" {
-				t.Errorf("ancestor `sh` expected, got %s, event:%v", names[0], event)
+			if comm := event.Process.Ancestor.Comm; comm != "sh" {
+				t.Errorf("ancestor `sh` expected, got %s, event:%v", comm, event)
 			}
 		}
 	})


### PR DESCRIPTION
### What does this PR do?

This PR add a bit mask to inode discarder to ensure they are applied at the right level of path. It also ensure that the process file context is copied during a fork

### Motivation

Some event were discarder because of inode discarder not applied at the right level. A process ancestor functional test was failing because of this bug.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Kitchen test shouldn't fail anymore.
