### PR TITLE
[Windows][Entrypoint] Increase timeout in service start

### DIFF
--- a/Dockerfiles/agent/windows/entrypoint/Service.h
+++ b/Dockerfiles/agent/windows/entrypoint/Service.h
@@ -23,7 +23,7 @@ public:
     ~Service();
 
     DWORD PID();
-    void Start(std::chrono::milliseconds timeout = std::chrono::seconds(30));
+    void Start(std::chrono::milliseconds timeout = std::chrono::seconds(60));
     void Stop(std::chrono::milliseconds timeout = std::chrono::seconds(30));
 };
 

--- a/releasenotes/notes/windows_container_increase_timeout-ce687e52809080f3.yaml
+++ b/releasenotes/notes/windows_container_increase_timeout-ce687e52809080f3.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Increase the timeout for starting the Agent in a Windows Container


### PR DESCRIPTION
### What does this PR do?

Increase timeout for the service start in the entrypoint.

### Motivation

The Agent takes longer to start and it times out unless we increase the CPU units or the timeout.
