### PR TITLE
[runtime-security] Remove fork bomb detector

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -804,7 +804,6 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.rate", 10)
 	config.BindEnvAndSetDefault("runtime_security_config.load_controller.events_count_threshold", 20000)
-	config.BindEnvAndSetDefault("runtime_security_config.load_controller.fork_bomb_threshold", 500)
 	config.BindEnvAndSetDefault("runtime_security_config.load_controller.discarder_timeout", 10)
 	config.BindEnvAndSetDefault("runtime_security_config.load_controller.control_period", 2)
 	config.BindEnvAndSetDefault("runtime_security_config.pid_cache_size", 10000)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -52,9 +52,6 @@ type Config struct {
 	CookieCacheSize int
 	// LoadControllerEventsCountThreshold defines the amount of events past which we will trigger the in-kernel circuit breaker
 	LoadControllerEventsCountThreshold int64
-	// LoadControllerForkBombThreshold defines the amount fork events triggered by the same process binary past which
-	// we will report a fork bomb alert
-	LoadControllerForkBombThreshold int64
 	// LoadControllerDiscarderTimeout defines the amount of time discarders set by the load controller should last
 	LoadControllerDiscarderTimeout time.Duration
 	// LoadControllerControlPeriod defines the period at which the load controller will empty the user space counter used
@@ -85,7 +82,6 @@ func NewConfig(cfg *config.AgentConfig) (*Config, error) {
 		PIDCacheSize:                       aconfig.Datadog.GetInt("runtime_security_config.pid_cache_size"),
 		CookieCacheSize:                    aconfig.Datadog.GetInt("runtime_security_config.cookie_cache_size"),
 		LoadControllerEventsCountThreshold: int64(aconfig.Datadog.GetInt("runtime_security_config.load_controller.events_count_threshold")),
-		LoadControllerForkBombThreshold:    int64(aconfig.Datadog.GetInt("runtime_security_config.load_controller.fork_bomb_threshold")),
 		LoadControllerDiscarderTimeout:     time.Duration(aconfig.Datadog.GetInt("runtime_security_config.load_controller.discarder_timeout")) * time.Second,
 		LoadControllerControlPeriod:        time.Duration(aconfig.Datadog.GetInt("runtime_security_config.load_controller.control_period")) * time.Second,
 		StatsPollingInterval:               time.Duration(aconfig.Datadog.GetInt("runtime_security_config.events_stats.polling_interval")) * time.Second,

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -186,7 +186,6 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
     u32 ppid = 0;
     bpf_probe_read(&pid, sizeof(pid), &args->child_pid);
     u64 ts = bpf_ktime_get_ns();
-    u8 best_effort_cookie = 0;
 
     struct exec_event_t event = {
         .pid_entry.fork_timestamp = ts,
@@ -205,12 +204,6 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
     event.pid_entry.gid = event.process.gid;
 
     struct pid_cache_t *parent_pid_entry = (struct pid_cache_t *) bpf_map_lookup_elem(&pid_cache, &ppid);
-    if (!parent_pid_entry) {
-        parent_pid_entry = (struct pid_cache_t *) bpf_map_lookup_elem(&best_effort_pid_cache, &ppid);
-        if (parent_pid_entry) {
-            best_effort_cookie = 1;
-        }
-    }
     if (parent_pid_entry) {
         // ensures pid and ppid point to the same cookie
         event.pid_entry.cookie = parent_pid_entry->cookie;
@@ -230,41 +223,13 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
             // fetch container context
             fill_container_context(parent_proc_entry, &event.proc_entry.container);
         }
-
-        if (!best_effort_cookie) {
-            // check if the provided cookie was not marked as best effort
-            u8 *is_best_effort = (u8 *) bpf_map_lookup_elem(&best_effort_cookies, &event.pid_entry.cookie);
-            if (is_best_effort) {
-                best_effort_cookie = 1;
-
-                // insert the parent entry to the best effort pid cache
-                struct pid_cache_t new_parent_pid_entry = {
-                    .cookie = parent_pid_entry->cookie,
-                    .ppid = parent_pid_entry->ppid,
-                    .fork_timestamp = parent_pid_entry->fork_timestamp,
-                    .exit_timestamp = parent_pid_entry->exit_timestamp,
-                    .uid = parent_pid_entry->uid,
-                    .gid = parent_pid_entry->gid,
-                };
-                bpf_map_update_elem(&best_effort_pid_cache, &ppid, &new_parent_pid_entry, BPF_ANY);
-
-                // delete the parent entry from the normal pid cache
-                bpf_map_delete_elem(&pid_cache, &ppid);
-            }
-        }
     }
 
-    if (!best_effort_cookie) {
-        // insert the pid cache entry for the new process
-        bpf_map_update_elem(&pid_cache, &pid, &event.pid_entry, BPF_ANY);
+    // insert the pid cache entry for the new process
+    bpf_map_update_elem(&pid_cache, &pid, &event.pid_entry, BPF_ANY);
 
-        // send the entry to maintain userspace cache
-        send_event(args, EVENT_FORK, event);
-    } else {
-        // insert the pid cache entry for the new process in the best effort pid cache
-        bpf_map_update_elem(&best_effort_pid_cache, &pid, &event.pid_entry, BPF_ANY);
-        // do not send to user space
-    }
+    // send the entry to maintain userspace cache
+    send_event(args, EVENT_FORK, event);
 
     return 0;
 }

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -40,31 +40,10 @@ struct bpf_map_def SEC("maps/pid_cache") pid_cache = {
     .namespace = "",
 };
 
-struct bpf_map_def SEC("maps/best_effort_pid_cache") best_effort_pid_cache = {
-    .type = BPF_MAP_TYPE_LRU_HASH,
-    .key_size = sizeof(u32),
-    .value_size = sizeof(struct pid_cache_t),
-    .max_entries = 4096,
-    .pinning = 0,
-    .namespace = "",
-};
-
-struct bpf_map_def SEC("maps/best_effort_cookies") best_effort_cookies = {
-    .type = BPF_MAP_TYPE_LRU_HASH,
-    .key_size = sizeof(u32),
-    .value_size = sizeof(u8),
-    .max_entries = 4096,
-    .pinning = 0,
-    .namespace = "",
-};
-
 struct proc_cache_t * __attribute__((always_inline)) get_proc_cache(u32 tgid) {
     struct proc_cache_t *entry = NULL;
 
     struct pid_cache_t *pid_entry = (struct pid_cache_t *) bpf_map_lookup_elem(&pid_cache, &tgid);
-    if (!pid_entry) {
-        pid_entry = (struct pid_cache_t *) bpf_map_lookup_elem(&best_effort_pid_cache, &tgid);
-    }
     if (pid_entry) {
         // Select the cache entry
         u32 cookie = pid_entry->cookie;

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -26,8 +26,6 @@ const (
 	NoisyProcessRuleID = "noisy_process"
 	// AbnormalPathRuleID is the rule ID for the abnormal_path events
 	AbnormalPathRuleID = "abnormal_path"
-	// ForkBombRuleID is the rule ID for the fork_bomb events
-	ForkBombRuleID = "fork_bomb"
 )
 
 // AllCustomRuleIDs returns the list of custom rule IDs
@@ -37,7 +35,6 @@ func AllCustomRuleIDs() []string {
 		RulesetLoadedRuleID,
 		NoisyProcessRuleID,
 		AbnormalPathRuleID,
-		ForkBombRuleID,
 	}
 }
 
@@ -220,22 +217,5 @@ func NewAbnormalPathEvent(event *Event, pathResolutionError error) (*rules.Rule,
 			Timestamp:           event.ResolveEventTimestamp(),
 			Event:               newEventSerializer(event),
 			PathResolutionError: pathResolutionError.Error(),
-		}.MarshalJSON)
-}
-
-// ForkBombEvent is used to report the detection of a fork bomb
-// easyjson:json
-type ForkBombEvent struct {
-	Timestamp time.Time        `json:"date"`
-	Event     *EventSerializer `json:"triggering_event"`
-}
-
-// NewForkBombEvent returns the rule and a populated custom event for a fork_bomb event
-func NewForkBombEvent(event *Event) (*rules.Rule, *CustomEvent) {
-	return newRule(&rules.RuleDefinition{
-			ID: ForkBombRuleID,
-		}), newCustomEvent(CustomForkBombEventType, ForkBombEvent{
-			Timestamp: event.ResolveEventTimestamp(),
-			Event:     newEventSerializer(event),
 		}.MarshalJSON)
 }

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -331,94 +331,7 @@ func (v *NoisyProcessEvent) UnmarshalJSON(data []byte) error {
 func (v *NoisyProcessEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jlexer.Lexer, out *ForkBombEvent) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeString()
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "date":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.Timestamp).UnmarshalJSON(data))
-			}
-		case "triggering_event":
-			if in.IsNull() {
-				in.Skip()
-				out.Event = nil
-			} else {
-				if out.Event == nil {
-					out.Event = new(EventSerializer)
-				}
-				(*out.Event).UnmarshalEasyJSON(in)
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jwriter.Writer, in ForkBombEvent) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"date\":"
-		out.RawString(prefix[1:])
-		out.Raw((in.Timestamp).MarshalJSON())
-	}
-	{
-		const prefix string = ",\"triggering_event\":"
-		out.RawString(prefix)
-		if in.Event == nil {
-			out.RawString("null")
-		} else {
-			(*in.Event).MarshalEasyJSON(out)
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v ForkBombEvent) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v ForkBombEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *ForkBombEvent) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *ForkBombEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(l, v)
-}
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jlexer.Lexer, out *EventLostWrite) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jlexer.Lexer, out *EventLostWrite) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -491,7 +404,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jwriter.Writer, in EventLostWrite) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jwriter.Writer, in EventLostWrite) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -548,27 +461,27 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 // MarshalJSON supports json.Marshaler interface
 func (v EventLostWrite) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventLostWrite) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *EventLostWrite) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&r, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventLostWrite) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jlexer.Lexer, out *EventLostRead) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jlexer.Lexer, out *EventLostRead) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -623,7 +536,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jwriter.Writer, in EventLostRead) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jwriter.Writer, in EventLostRead) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -664,27 +577,27 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 // MarshalJSON supports json.Marshaler interface
 func (v EventLostRead) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventLostRead) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *EventLostRead) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&r, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventLostRead) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(in *jlexer.Lexer, out *AbnormalPathEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jlexer.Lexer, out *AbnormalPathEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -729,7 +642,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(out *jwriter.Writer, in AbnormalPathEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jwriter.Writer, in AbnormalPathEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -758,23 +671,23 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(out *jw
 // MarshalJSON supports json.Marshaler interface
 func (v AbnormalPathEvent) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(&w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AbnormalPathEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *AbnormalPathEvent) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(&r, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AbnormalPathEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(l, v)
 }

--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/hashicorp/golang-lru/simplelru"
-	"github.com/pkg/errors"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -35,10 +34,8 @@ type LoadController struct {
 
 	eventsTotal    int64
 	eventsCounters *simplelru.LRU
-	forkCounters   *simplelru.LRU
 
 	EventsCountThreshold int64
-	ForkBombThreshold    int64
 	DiscarderTimeout     time.Duration
 	ControllerPeriod     time.Duration
 }
@@ -50,20 +47,13 @@ func NewLoadController(probe *Probe, statsdClient *statsd.Client) (*LoadControll
 		return nil, err
 	}
 
-	forkLru, err := simplelru.NewLRU(probe.config.PIDCacheSize, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	lc := &LoadController{
 		probe:        probe,
 		statsdClient: statsdClient,
 
 		eventsCounters: lru,
-		forkCounters:   forkLru,
 
 		EventsCountThreshold: probe.config.LoadControllerEventsCountThreshold,
-		ForkBombThreshold:    probe.config.LoadControllerForkBombThreshold,
 		DiscarderTimeout:     probe.config.LoadControllerDiscarderTimeout,
 		ControllerPeriod:     probe.config.LoadControllerControlPeriod,
 	}
@@ -74,52 +64,8 @@ func NewLoadController(probe *Probe, statsdClient *statsd.Client) (*LoadControll
 func (lc *LoadController) Count(event *Event) {
 	switch event.GetEventType() {
 	case ExitEventType, ExecEventType, InvalidateDentryEventType:
-	case ForkEventType:
-		lc.CountFork(event)
 	default:
 		lc.GenericCount(event)
-	}
-}
-
-// ResetForkCount removes the fork counter for the provided mount_id & inode. Returns true if the entry was present.
-func (lc *LoadController) ResetForkCount(mountID uint32, inode uint64) bool {
-	return lc.forkCounters.Remove(PathKey{MountID: mountID, Inode: inode})
-}
-
-// CountFork increments the fork counter of the provided cookie
-func (lc *LoadController) CountFork(event *Event) {
-	lc.Lock()
-	defer lc.Unlock()
-	var forkBomb bool
-	var newCount uint64
-
-	key := PathKey{
-		MountID: event.Process.MountID,
-		Inode:   event.Process.Inode,
-	}
-	entry, ok := lc.forkCounters.Get(key)
-	if ok {
-		counter := entry.(*uint64)
-		*counter++
-		if *counter >= uint64(lc.ForkBombThreshold) {
-			forkBomb = true
-
-			// reset counter to avoid spamming fork bomb alerts until the best_effort move takes effect
-			*counter = 0
-		}
-	} else {
-		newCount = uint64(1)
-		lc.forkCounters.Add(key, &newCount)
-	}
-
-	if forkBomb {
-		if err := lc.statsdClient.Count(MetricForkBomb, 1, []string{}, 1); err != nil {
-			log.Warn(errors.Wrapf(err, "failed to send %s metric", MetricForkBomb))
-		}
-		lc.probe.DispatchCustomEvent(NewForkBombEvent(event))
-
-		// drop fork events with the given cookie in kernel space
-		lc.probe.resolvers.ProcessResolver.MarkCookieAsBestEffort(uint32(event.Process.ResolveCookie(event)), event.ResolveProcessCacheEntry())
 	}
 }
 
@@ -189,7 +135,7 @@ func (lc *LoadController) discardNoisiestProcess() {
 		}
 
 		// fetch noisy process metadata
-		process := lc.probe.resolvers.ProcessResolver.Resolve(maxKey.Pid, maxKey.Cookie)
+		process := lc.probe.resolvers.ProcessResolver.Resolve(maxKey.Pid)
 		if process == nil {
 			log.Warnf("Unable to resolver process with pid: %d", maxKey.Pid)
 			return
@@ -227,16 +173,6 @@ func (lc *LoadController) cleanup() {
 		atomic.SwapUint64(counter, 0)
 	}
 	atomic.SwapInt64(&lc.eventsTotal, 0)
-
-	// reset fork counters
-	for _, key := range lc.forkCounters.Keys() {
-		val, ok := lc.forkCounters.Peek(key)
-		if !ok || val == nil {
-			continue
-		}
-		counter := val.(*uint64)
-		atomic.SwapUint64(counter, 0)
-	}
 }
 
 // Start resets the internal counters periodically

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -1110,7 +1110,7 @@ func (e *Event) ResolveEventTimestamp() time.Time {
 // ResolveProcessCacheEntry queries the ProcessResolver to retrieve the ProcessCacheEntry of the event
 func (e *Event) ResolveProcessCacheEntry() *ProcessCacheEntry {
 	if e.processCacheEntry == nil {
-		e.processCacheEntry = e.resolvers.ProcessResolver.Resolve(e.Process.Pid, e.Process.Cookie)
+		e.processCacheEntry = e.resolvers.ProcessResolver.Resolve(e.Process.Pid)
 		if e.processCacheEntry == nil {
 			e.processCacheEntry = &ProcessCacheEntry{}
 		}

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -335,7 +335,6 @@ func (p *Probe) invalidateDentry(mountID uint32, inode uint64, revision uint32) 
 		// Call a user space remove function to ensure the discarder will be removed.
 		p.removeDiscarderInode(mountID, inode)
 	}
-	_ = p.monitor.loadController.ResetForkCount(mountID, inode)
 }
 
 func (p *Probe) handleEvent(CPU uint64, data []byte) {

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -112,7 +112,6 @@ type testOpts struct {
 	disableDiscarders    bool
 	wantProbeEvents      bool
 	eventsCountThreshold int
-	forkBombThreshold    int
 	reuseProbeHandler    bool
 }
 
@@ -122,7 +121,6 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.disableDiscarders == opts.disableDiscarders &&
 		to.disableFilters == opts.disableFilters &&
 		to.eventsCountThreshold == opts.eventsCountThreshold &&
-		to.forkBombThreshold == opts.forkBombThreshold &&
 		to.reuseProbeHandler == opts.reuseProbeHandler
 }
 
@@ -222,9 +220,6 @@ func setTestConfig(dir string, opts testOpts) error {
 	if opts.eventsCountThreshold == 0 {
 		opts.eventsCountThreshold = 100000000
 	}
-	if opts.forkBombThreshold == 0 {
-		opts.forkBombThreshold = 2000
-	}
 
 	buffer := new(bytes.Buffer)
 	if err := tmpl.Execute(buffer, map[string]interface{}{
@@ -232,7 +227,6 @@ func setTestConfig(dir string, opts testOpts) error {
 		"DisableApprovers":     opts.disableApprovers,
 		"DisableDiscarders":    opts.disableDiscarders,
 		"EventsCountThreshold": opts.eventsCountThreshold,
-		"ForkBombThreshold":    opts.forkBombThreshold,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

This PR removes the fork bomb detector feature.

### Motivation

The fork bomb detector is noisy and does not provide the safe guard we hopped it would.

### Describe your test plan

Kitchen tests will ensure that we removing this feature will not introduce a regression.
