### PR TITLE
[e2e tests] Fix following the activation of DatadogMetrics

### DIFF
--- a/test/e2e/argo-workflows/templates/nginx.yaml
+++ b/test/e2e/argo-workflows/templates/nginx.yaml
@@ -303,8 +303,8 @@ spec:
           set -euo pipefail
           set -x
 
-          # Verify the DCA has written in the configmap
-          until [[ -n $(kubectl --namespace {{inputs.parameters.namespace}} get cm datadog-custom-metrics -o jsonpath='{.data}') ]]; do
+          # Verify the DCA has written in the DatadogMetric
+          until kubectl --namespace {{inputs.parameters.namespace}} get datadogmetrics.datadoghq.com -o jsonpath='{range .items[*]}{.spec.externalMetricName}{"\n"}{end}' | grep nginx.net.request_per_s; do
            sleep 1
           done
 


### PR DESCRIPTION
### What does this PR do?

Since PR [DataDog/helm-charts#100](https://github.com/DataDog/helm-charts/pull/100/files#diff-2fcec98016e714405bc936fd949012c2e72f23c20a1a94acf695a9cd3e29d75fR419), the `DatadogMetrics` are enabled by default.
As a consequence, the `validate-hpa` e2e step which was waiting for the `datadog-custom-metrics` `ConfigMap` was systematically failing.
This step needs to be adapted to look for the `DatadogMetrics` CR instead of the old `ConfigMap`.

### Motivation

Fix the e2e tests.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Check that e2e tests are fixed.
