### PR TITLE
[logs] Aggregation timeout config option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -616,7 +616,7 @@ func InitConfig(config Config) {
 	// It may be useful to increase it when logs writing is slowed down, that
 	// could happen while serializing large objects on log lines.
 	config.BindEnvAndSetDefault("logs_config.aggregation_timeout", 1000)
-	config.BindEnv("logs_config.additional_endpoints")                        //nolint:errcheck
+	config.BindEnv("logs_config.additional_endpoints") //nolint:errcheck
 
 	// The cardinality of tags to send for checks and dogstatsd respectively.
 	// Choices are: low, orchestrator, high.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -611,6 +611,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
 	config.BindEnvAndSetDefault("logs_config.close_timeout", 60)
 	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL) // in hours
+	// Timeout in milliseonds used when performing agreggation operations,
+	// including multi-line log processing rules and chunked line reaggregation.
+	// It may be useful to increase it when logs writing is slowed down, that
+	// could happen while serializing large objects on log lines.
+	config.BindEnvAndSetDefault("logs_config.aggregation_timeout", 1000)
 	config.BindEnv("logs_config.additional_endpoints")                        //nolint:errcheck
 
 	// The cardinality of tags to send for checks and dogstatsd respectively.

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -322,3 +322,8 @@ func batchWaitFromKey(config coreConfig.Config, batchWaitKey string) time.Durati
 func TaggerWarmupDuration() time.Duration {
 	return coreConfig.Datadog.GetDuration("logs_config.tagger_warmup_duration") * time.Second
 }
+
+// AggregationTimeout is used when performing aggregation operations
+func AggregationTimeout() time.Duration {
+	return coreConfig.Datadog.GetDuration("logs_config.aggregation_timeout") * time.Millisecond
+}

--- a/pkg/logs/decoder/decoder.go
+++ b/pkg/logs/decoder/decoder.go
@@ -91,7 +91,7 @@ func NewDecoderWithEndLineMatcher(source *config.LogSource, parser parser.Parser
 
 	for _, rule := range source.Config.ProcessingRules {
 		if rule.Type == config.MultiLine {
-			lineHandler = NewMultiLineHandler(outputChan, rule.Regex, defaultFlushTimeout, lineLimit)
+			lineHandler = NewMultiLineHandler(outputChan, rule.Regex, config.AggregationTimeout(), lineLimit)
 		}
 	}
 	if lineHandler == nil {
@@ -99,7 +99,7 @@ func NewDecoderWithEndLineMatcher(source *config.LogSource, parser parser.Parser
 	}
 
 	if parser.SupportsPartialLine() {
-		lineParser = NewMultiLineParser(defaultFlushTimeout, parser, lineHandler, lineLimit)
+		lineParser = NewMultiLineParser(config.AggregationTimeout(), parser, lineHandler, lineLimit)
 	} else {
 		lineParser = NewSingleLineParser(parser, lineHandler)
 	}

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -100,7 +100,7 @@ func (h *SingleLineHandler) process(message *Message) {
 
 // defaultFlushTimeout represents the time after which a multiline
 // will be be considered as complete.
-const defaultFlushTimeout = 1000 * time.Millisecond
+// const defaultFlushTimeout = 1000 * time.Millisecond
 
 // MultiLineHandler makes sure that multiple lines from a same content
 // are properly put together.

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -98,10 +98,6 @@ func (h *SingleLineHandler) process(message *Message) {
 	}
 }
 
-// defaultFlushTimeout represents the time after which a multiline
-// will be be considered as complete.
-// const defaultFlushTimeout = 1000 * time.Millisecond
-
 // MultiLineHandler makes sure that multiple lines from a same content
 // are properly put together.
 type MultiLineHandler struct {


### PR DESCRIPTION
### What does this PR do?
Made the aggregation timeout configurable through the
new setting `logs_config.aggregation_timeout`. The default
value is the same as the previsous hardcoded one.

### Motivation
Allow use that have log lines that are slow to
write no to exceed the aggregation timeout.

### Additional Notes
I was planning to update `./pkg/config/config_template.yaml` but it contains only few heavily used option, almost all logs_agent config knob are not mentioned in that file. So it seems unconsistent to add it there (the question might be reopened later, but for many config option that are left out of `./pkg/config/config_template.yaml`)


### Describe your test plan
To test:
* Aggregation shall not be broken (both multiline/rule based and chunked line re-aggregation)
* The timeout shall be enforced