### PR TITLE
[logs] local tag provider fix + benchmark

### DIFF
--- a/pkg/logs/tag/local_provider.go
+++ b/pkg/logs/tag/local_provider.go
@@ -24,11 +24,12 @@ type localProvider struct {
 // NewLocalProvider returns a new local Provider.
 func NewLocalProvider(t []string) Provider {
 	p := &localProvider{
-		tags: t,
+		tags:         t,
+		expectedTags: t,
 	}
 
 	if config.IsExpectedTagsSet() {
-		p.expectedTags = append(p.tags, host.GetHostTags(true).System...)
+		p.expectedTags = append(p.tags, host.GetHostTags(false).System...)
 		p.expectedTagsDeadline = coreConfig.StartTime.Add(coreConfig.Datadog.GetDuration("logs_config.expected_tags_duration"))
 
 		// reset submitExpectedTags after deadline elapsed

--- a/pkg/logs/tag/provider_benchmark_test.go
+++ b/pkg/logs/tag/provider_benchmark_test.go
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package tag
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func BenchmarkProviderExpectedTags(b *testing.B) {
+	b.ReportAllocs()
+
+	m, start := setupConfig([]string{"tag1:value1", "tag2", "tag3"})
+	defer func() {
+		config.StartTime = start
+	}()
+
+	defer m.Set("tags", nil)
+
+	// Setting a test-friendly value for the deadline (test should not take 1m)
+	m.Set("logs_config.expected_tags_duration", "1m")
+	defer m.Set("logs_config.expected_tags_duration", 0)
+
+	p := NewProvider("foo")
+
+	for i := 0; i < b.N; i++ {
+		p.GetTags()
+	}
+}
+
+func BenchmarkProviderExpectedTagsEmptySlice(b *testing.B) {
+	b.ReportAllocs()
+
+	m, start := setupConfig([]string{})
+	defer func() {
+		config.StartTime = start
+	}()
+
+	if len(m.Config.GetStringSlice("tags")) > 0 {
+		b.Errorf("Expected tags: %v", m.Config.GetStringSlice("tags"))
+	}
+
+	// Setting a test-friendly value for the deadline (test should not take 1m)
+	m.Set("logs_config.expected_tags_duration", "1m")
+	defer m.Set("logs_config.expected_tags_duration", 0)
+
+	p := NewProvider("foo")
+
+	for i := 0; i < b.N; i++ {
+		p.GetTags()
+	}
+}
+
+func BenchmarkProviderExpectedTagsNil(b *testing.B) {
+	b.ReportAllocs()
+
+	m, start := setupConfig(nil)
+	defer func() {
+		config.StartTime = start
+	}()
+
+	if len(m.Config.GetStringSlice("tags")) > 0 {
+		b.Errorf("Expected tags: %v", m.Config.GetStringSlice("tags"))
+	}
+
+	// Setting a test-friendly value for the deadline (test should not take 1m)
+	m.Set("logs_config.expected_tags_duration", "1m")
+	defer m.Set("logs_config.expected_tags_duration", 0)
+
+	p := NewProvider("foo")
+
+	for i := 0; i < b.N; i++ {
+		p.GetTags()
+	}
+}
+
+func BenchmarkProviderNoExpectedTags(b *testing.B) {
+	b.ReportAllocs()
+
+	m, start := setupConfig([]string{"tag1:value1", "tag2", "tag3"})
+	defer func() {
+		config.StartTime = start
+	}()
+
+	defer m.Set("tags", nil)
+
+	// Setting a test-friendly value for the deadline (test should not take 1m)
+	m.Set("logs_config.expected_tags_duration", "0")
+
+	p := NewProvider("foo")
+
+	for i := 0; i < b.N; i++ {
+		p.GetTags()
+	}
+}
+
+func BenchmarkProviderNoExpectedTagsNil(b *testing.B) {
+	b.ReportAllocs()
+
+	m, start := setupConfig(nil)
+	defer func() {
+		config.StartTime = start
+	}()
+
+	defer m.Set("tags", nil)
+
+	// Setting a test-friendly value for the deadline (test should not take 1m)
+	m.Set("logs_config.expected_tags_duration", "0")
+
+	p := NewProvider("foo")
+
+	for i := 0; i < b.N; i++ {
+		p.GetTags()
+	}
+}

--- a/pkg/logs/tag/provider_test.go
+++ b/pkg/logs/tag/provider_test.go
@@ -14,29 +14,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestProviderExpectedTags(t *testing.T) {
+func setupConfig(tags []string) (*config.MockConfig, time.Time) {
 	mockConfig := config.Mock()
 
 	startTime := config.StartTime
 	config.StartTime = time.Now()
-	defer func() {
-		config.StartTime = startTime
-	}()
-
-	tags := []string{"tag1:value1", "tag2", "tag3"}
 
 	mockConfig.Set("tags", tags)
-	defer mockConfig.Set("tags", nil)
+
+	return mockConfig, startTime
+}
+
+func TestProviderExpectedTags(t *testing.T) {
+
+	tags := []string{"tag1:value1", "tag2", "tag3"}
+	m, start := setupConfig(tags)
+	defer func() {
+		config.StartTime = start
+	}()
+
+	defer m.Set("tags", nil)
 
 	// Setting a test-friendly value for the deadline
-	mockConfig.Set("logs_config.expected_tags_duration", "5s")
-	defer mockConfig.Set("logs_config.expected_tags_duration", 0)
+	m.Set("logs_config.expected_tags_duration", "5s")
+	defer m.Set("logs_config.expected_tags_duration", 0)
 
 	p := NewProvider("foo")
 	pp := p.(*provider)
 
 	// Is provider expected?
-	d := mockConfig.GetDuration("logs_config.expected_tags_duration")
+	d := m.GetDuration("logs_config.expected_tags_duration")
 	l := pp.localTagProvider
 	ll := l.(*localProvider)
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the local provider to avoid returning a `nil` slice if no expected tags duration is set and the user passes an empty string slice instead. This is important because `encoding/json` will marshal `nil` to `null`, while the empty slice is marshalled to `[]`. The PR also introduces a minor change such that when the tag provider is instantiated it does not rely on cached host tags; this is acceptably because providers are not instantiated often.

Finally, a benchmark is added to understand potential performance regressions in the tag provider code as it happens to sit in a fairly hot path in the logs agent.
  
### Motivation

Tiny bugfix, and benchmarking requirements.

### Additional Notes

```
➜ go test -test.bench "Provider*" -test.benchtime=5s  ./pkg/logs/tag/...
goos: darwin
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/logs/tag
BenchmarkProviderExpectedTags-4                 21244228               282 ns/op              64 B/op          2 allocs/op
BenchmarkProviderExpectedTagsEmptySlice-4       26608165               188 ns/op              16 B/op          1 allocs/op
BenchmarkProviderExpectedTagsNil-4              32146963               189 ns/op              16 B/op          1 allocs/op
BenchmarkProviderNoExpectedTags-4               30229300               192 ns/op              16 B/op          1 allocs/op
BenchmarkProviderNoExpectedTagsNil-4            32082676               201 ns/op              16 B/op          1 allocs/op
PASS
ok      github.com/DataDog/datadog-agent/pkg/logs/tag   44.768s
```

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
