### PR TITLE
windows/npm fix system probe dependencies

### DIFF
--- a/omnibus/config/patches/snowflake-connector-python-py2/cryptography-dependency.patch
+++ b/omnibus/config/patches/snowflake-connector-python-py2/cryptography-dependency.patch
@@ -1,9 +1,13 @@
 diff --git a/setup.py b/setup.py
-index 0da6a8a..9df4fb5 100644
+index 0da6a8a..f486585 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -188,8 +188,8 @@ setup(
-         'pytz<2021.0',
+@@ -185,11 +185,11 @@ setup(
+         'certifi<2021.0.0',
+         'future<1.0.0',
+         'six<2.0.0',
+-        'pytz<2021.0',
++        'pytz<2021.2',
          'pycryptodomex>=3.2,!=3.5.0,<4.0.0',
          'pyOpenSSL>=16.2.0,<21.0.0',
 -        'cffi>=1.9,<1.14',

--- a/omnibus/config/patches/snowflake-connector-python-py3/cryptography-dependency.patch
+++ b/omnibus/config/patches/snowflake-connector-python-py3/cryptography-dependency.patch
@@ -1,9 +1,13 @@
 diff --git a/setup.py b/setup.py
-index 0da6a8a..9df4fb5 100644
+index 0da6a8a..f486585 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -188,8 +188,8 @@ setup(
-         'pytz<2021.0',
+@@ -185,11 +185,11 @@ setup(
+         'certifi<2021.0.0',
+         'future<1.0.0',
+         'six<2.0.0',
+-        'pytz<2021.0',
++        'pytz<2021.2',
          'pycryptodomex>=3.2,!=3.5.0,<4.0.0',
          'pyOpenSSL>=16.2.0,<21.0.0',
 -        'cffi>=1.9,<1.14',

--- a/tools/windows/install-help/cal/customactiondata.cpp
+++ b/tools/windows/install-help/cal/customactiondata.cpp
@@ -3,6 +3,7 @@
 CustomActionData::CustomActionData()
     : domainUser(false)
     , doInstallSysprobe(true)
+    , ddnpmPresent(false)
     , userParamMismatch(false)
 {
 }
@@ -116,6 +117,11 @@ bool CustomActionData::installSysprobe() const
     return doInstallSysprobe;
 }
 
+bool CustomActionData::npmPresent() const 
+{
+    return this->ddnpmPresent;
+}
+
 const TargetMachine &CustomActionData::GetTargetMachine() const
 {
     return machine;
@@ -130,6 +136,7 @@ bool CustomActionData::parseSysprobeData()
     std::wstring sysprobePresent;
     std::wstring addlocal;
     this->doInstallSysprobe = false;
+    this->ddnpmPresent = false;
     if (!this->value(L"SYSPROBE_PRESENT", sysprobePresent))
     {
         // key isn't even there.
@@ -144,6 +151,26 @@ bool CustomActionData::parseSysprobeData()
         return true;
     }
     this->doInstallSysprobe = true;
+
+    // now check to see if we're installing the driver
+    if(!this->value(L"ADDLOCAL", addlocal))
+    {
+        // should never happen.  But if the addlocalkey isn't there,
+        // don't bother trying
+        WcaLog(LOGMSG_STANDARD, "ADDLOCAL not present");
+
+        return true;
+    }
+    WcaLog(LOGMSG_STANDARD, "ADDLOCAL is (%S)", addlocal.c_str());
+    if(_wcsicmp(addlocal.c_str(), L"ALL")== 0){
+        // installing all components, do it
+        this->ddnpmPresent = true;
+        WcaLog(LOGMSG_STANDARD, "ADDLOCAL is ALL");
+    } else if (addlocal.find(L"WindowsNP") != std::wstring::npos) {
+        WcaLog(LOGMSG_STANDARD, "ADDLOCAL contains WindowsNP %S", addlocal.c_str());
+        this->ddnpmPresent = true;
+    }
+    
     return true;
 }
 

--- a/tools/windows/install-help/cal/customactiondata.h
+++ b/tools/windows/install-help/cal/customactiondata.h
@@ -32,6 +32,7 @@ class CustomActionData
     void Sid(sid_ptr &sid);
 
     bool installSysprobe() const;
+    bool npmPresent() const;
 
     bool UserParamMismatch() const
     {
@@ -53,6 +54,7 @@ class CustomActionData
     std::wstring pvsDomain; // previously installed domain for user, read from registry
     sid_ptr _sid;
     bool doInstallSysprobe;
+    bool ddnpmPresent;
     bool _ddUserExists;
     bool findPreviousUserInfo();
     void checkForUserMismatch(bool previousInstall, bool userSupplied, std::wstring &computed_domain,

--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -708,6 +708,18 @@ class serviceDef
             }
             WcaLog(LOGMSG_STANDARD, "Updated path for existing service");
         }
+        {
+            WcaLog(LOGMSG_STANDARD, "Resetting dependencies");
+            BOOL bRet = ChangeServiceConfigW(hService, SERVICE_NO_CHANGE, SERVICE_NO_CHANGE, SERVICE_NO_CHANGE,
+                                             NULL, NULL, NULL, this->lpDependencies, NULL, NULL, NULL);
+            if (!bRet)
+            {
+                retval = GetLastError();
+                WcaLog(LOGMSG_STANDARD, "Failed to update service dependency config %d\n", retval);
+                goto done_verify;
+            }
+            WcaLog(LOGMSG_STANDARD, "Updated dependencies for existing service, dependencies now %S", this->lpDependencies);
+        }
 
     done_verify:
         CloseServiceHandle(hService);
@@ -721,12 +733,16 @@ class serviceDef
     const wchar_t* getServiceName() const { return this->svcName;  }
 };
 
+static    wchar_t * probeDepsNoNPM = L"datadogagent\0\0";
+static    wchar_t * probeDepsWithNPM = L"datadogagent\0ddnpm\0\0";
+
 int installServices(CustomActionData &data, PSID sid, const wchar_t *password)
 {
     SC_HANDLE hScManager = NULL;
     SC_HANDLE hService = NULL;
     int retval = 0;
     // Get a handle to the SCM database.
+    
 #ifdef __REGISTER_ALL_SERVICES
 #define NUM_SERVICES 4
     serviceDef services[NUM_SERVICES] = {
@@ -737,7 +753,7 @@ int installServices(CustomActionData &data, PSID sid, const wchar_t *password)
         serviceDef(processService.c_str(), L"Datadog Process Agent", L"Send process metrics to Datadog",
                    process_exe.c_str(), L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL),
         serviceDef(systemProbeService.c_str(), L"Datadog System Probe", L"Send network metrics to Datadog",
-                   sysprobe_exe.c_str(), L"datadogagent\0ddnpm\0\0", SERVICE_DEMAND_START, NULL, NULL)
+                   sysprobe_exe.c_str(), data.npmPresent() ? probeDepsWithNPM : probeDepsNoNPM, SERVICE_DEMAND_START, NULL, NULL)
 
     };
     // by default, don't add sysprobe
@@ -834,7 +850,7 @@ int uninstallServices(CustomActionData &data)
         serviceDef(processService.c_str(), L"Datadog Process Agent", L"Send process metrics to Datadog",
                    process_exe.c_str(), L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL),
         serviceDef(systemProbeService.c_str(), L"Datadog System Probe", L"Send network metrics to Datadog",
-                   sysprobe_exe.c_str(), L"datadogagent\0ddnpm\0\0", SERVICE_DEMAND_START, NULL, NULL)
+                   sysprobe_exe.c_str(), data.npmPresent() ? probeDepsWithNPM : probeDepsNoNPM, SERVICE_DEMAND_START, NULL, NULL)
 
     };
 #else
@@ -885,7 +901,7 @@ int verifyServices(CustomActionData &data)
         serviceDef(processService.c_str(), L"Datadog Process Agent", L"Send process metrics to Datadog",
                    process_exe.c_str(), L"datadogagent\0\0", SERVICE_DEMAND_START, NULL, NULL),
         serviceDef(systemProbeService.c_str(), L"Datadog System Probe", L"Send network metrics to Datadog",
-                   sysprobe_exe.c_str(), L"datadogagent\0ddnpm\0\0", SERVICE_DEMAND_START, NULL, NULL)
+                   sysprobe_exe.c_str(), data.npmPresent() ? probeDepsWithNPM : probeDepsNoNPM, SERVICE_DEMAND_START, NULL, NULL)
 
     };
     // by default, don't add sysprobe


### PR DESCRIPTION
### What does this PR do?

Fixes dependency assignment code so that system probe depends on npm only when npm is installed.

### Motivation

user experience discovered in testing

### Additional Notes

must be layered on top of https://github.com/DataDog/datadog-agent/pull/7311