### PR TITLE
Bump debian version to fix kitchen tests

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -48,6 +48,6 @@ kitchen_debian_sysprobe:
   extends: .kitchen_test_system_probe
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
-    - export TEST_PLATFORMS="debian-10,urn,Debian:debian-10:10:0.20200610.293"
+    - export TEST_PLATFORMS="debian-10,urn,Debian:debian-10:10:0.20210129.530"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh


### PR DESCRIPTION
### What does this PR do?

Fix the job for debian kitchen system probe tests: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/52626592

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
