### PR TITLE
[networks][hotfix] Fix map size when HTTP monitoring is disabled

### DIFF
--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -126,8 +126,12 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 		enabledProbes[probes.SocketDnsFilter] = struct{}{}
 	}
 
+	// TODO: This is a hotfix to prevent the following error when HTTP monitoring is disabled
+	// couldn’t load eBPF programs: map http_in_flight: map create: cannot allocate memory
+	maxHTTPInFlightEntries := uint(1)
 	if config.EnableHTTPMonitoring && !pre410Kernel {
 		enabledProbes[probes.SocketHTTPFilter] = struct{}{}
+		maxHTTPInFlightEntries = config.MaxTrackedConnections
 	}
 
 	mgrOptions := manager.Options{
@@ -146,7 +150,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 			string(probes.TcpStatsMap):        {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 			string(probes.PortBindingsMap):    {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 			string(probes.UdpPortBindingsMap): {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
-			string(probes.HttpInFlightMap):    {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
+			string(probes.HttpInFlightMap):    {Type: ebpf.Hash, MaxEntries: uint32(maxHTTPInFlightEntries), EditorFlag: manager.EditMaxEntries},
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR ensures that we minimize the memory footprint of the `HTTPInFlightMap` when `network_config.enable_http_monitoring` is disabled (which is the default).

We've been seeing a few hosts  throwing the following error during initialization:
```
couldn’t load eBPF programs: map http_in_flight: map create: cannot allocate memory
````
This PR should fix that while we investigate the issue
(PS.: it doesn't look like this is related to `RLIMIT_MEMLOCK` which is being correctly set to `unlimited` before the BPF map is created)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
