### PR TITLE
Remove extraneous log formatting from remote tagger gRPC logs

### DIFF
--- a/pkg/tagger/remote/grpclog.go
+++ b/pkg/tagger/remote/grpclog.go
@@ -1,9 +1,13 @@
 package remote
 
 import (
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"google.golang.org/grpc/grpclog"
 )
+
+const timestampOffset = 22
 
 type logLevel int
 
@@ -22,7 +26,17 @@ func newRedirectLogger(level logLevel) redirectLogger {
 }
 
 func (l redirectLogger) Write(b []byte) (int, error) {
+	// Write receives an already formatted log line, so we need to parse it
+	// to remove bits that would be duplicated in the datadog logger.
+	// For example: `INFO: 2021/02/04 14:06:11 parsed scheme: ""`
+
 	msg := string(b)
+
+	// the log level is the only variable length substring we need to take
+	// into account. timestampOffset is the length of the timestamp itself
+	// plus extra spacing characters
+	levelSepIndex := strings.Index(msg, ":")
+	msg = msg[levelSepIndex+timestampOffset:]
 
 	switch l.level {
 	case logLevelInfo:

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -262,7 +262,9 @@ func (t *Tagger) startTaggerStream(maxElapsed time.Duration) error {
 
 		token, err := security.FetchAuthToken()
 		if err != nil {
-			return fmt.Errorf("unable to fetch authentication token: %w", err)
+			err = fmt.Errorf("unable to fetch authentication token: %w", err)
+			log.Infof("unable to establish stream, will possibly retry: %s", err)
+			return err
 		}
 
 		ctx := metadata.NewOutgoingContext(t.ctx, metadata.MD{


### PR DESCRIPTION
### What does this PR do?

The gRPC logger calls our log redirector with an already formatted log
line, so we need to parse it to remove bits that would be duplicated in
the datadog logger. For example: `INFO: 2021/02/04 14:06:11 parsed
scheme: ""`

### Describe your test plan

These apply only to process and trace agent, with the [remote tagger enabled](https://github.com/DataDog/datadog-agent/pull/7208).

Check that there are mo more log lines like the below, with the log and timestamp duplicated:

```
2021-02-04 14:06:11 CET | LOGGER | INFO | (pkg/tagger/remote/tagger.go:76 in Init) | INFO: 2021/02/04 14:06:11 parsed scheme: ""
2021-02-04 14:06:11 CET | LOGGER | INFO | (pkg/tagger/remote/tagger.go:76 in Init) | INFO: 2021/02/04 14:06:11 scheme "" not registered, fallback to default scheme
```

Instead, they should look like this:

```
2021-02-04 14:06:11 CET | LOGGER | INFO | (pkg/tagger/remote/tagger.go:76 in Init) | parsed scheme: ""
2021-02-04 14:06:11 CET | LOGGER | INFO | (pkg/tagger/remote/tagger.go:76 in Init) | scheme "" not registered, fallback to default scheme
```