### PR TITLE
[backport] Remove extraneous log formatting from remote tagger gRPC logs

### DIFF
--- a/pkg/tagger/remote/grpclog.go
+++ b/pkg/tagger/remote/grpclog.go
@@ -1,9 +1,13 @@
 package remote
 
 import (
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"google.golang.org/grpc/grpclog"
 )
+
+const timestampOffset = 22
 
 type logLevel int
 
@@ -22,7 +26,17 @@ func newRedirectLogger(level logLevel) redirectLogger {
 }
 
 func (l redirectLogger) Write(b []byte) (int, error) {
+	// Write receives an already formatted log line, so we need to parse it
+	// to remove bits that would be duplicated in the datadog logger.
+	// For example: `INFO: 2021/02/04 14:06:11 parsed scheme: ""`
+
 	msg := string(b)
+
+	// the log level is the only variable length substring we need to take
+	// into account. timestampOffset is the length of the timestamp itself
+	// plus extra spacing characters
+	levelSepIndex := strings.Index(msg, ":")
+	msg = msg[levelSepIndex+timestampOffset:]
 
 	switch l.level {
 	case logLevelInfo:


### PR DESCRIPTION
Backport of #7357 to 7.26