### PR TITLE
Fix bug in #7229

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -32,7 +32,7 @@ import (
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
 
-var timeFormat = "2006-01-02 15:04:05.000000 MST"
+var timeFormat = "2006-01-02 15:04:05.999 MST"
 
 // GetStatus grabs the status from expvar and puts it into a map
 func GetStatus() (map[string]interface{}, error) {
@@ -286,10 +286,10 @@ func getCommonStatus() (map[string]interface{}, error) {
 	stats["conf_file"] = config.Datadog.ConfigFileUsed()
 	stats["pid"] = os.Getpid()
 	stats["go_version"] = runtime.Version()
-	stats["agent_start"] = config.StartTime.Format(timeFormat)
+	stats["agent_start_nano"] = config.StartTime.UnixNano()
 	stats["build_arch"] = runtime.GOARCH
 	now := time.Now()
-	stats["time"] = now.Format(timeFormat)
+	stats["time_nano"] = now.UnixNano()
 
 	return stats, nil
 }

--- a/releasenotes/notes/Fix-bug-in-#7229-49997c1090e705e5.yaml
+++ b/releasenotes/notes/Fix-bug-in-#7229-49997c1090e705e5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes bug introduced in #7229


### PR DESCRIPTION
### What does this PR do?

Fix bug in #7229 caused by missing commit during rebase.

agent status returns

```
template: /header.tmpl:8:33: executing "/header.tmpl" at <.time_nano>: invalid value; expected float64
===================================
Agent (v7.27.0-devel+git.8.6d18694)
===================================

  Status date: =========
```

### Motivation

found after testing 7229 after merge

### Additional Notes

### Describe your test plan

- `datadog-agent status` should return date/timestamp
```
===================================
Agent (v7.27.0-devel+git.8.6d18694)
===================================

  Status date: 2021-02-05 12:23:31.654 AEDT / 2021-02-05 01:23:31.654 UTC (1612488211654)
```
