### PR TITLE
Fixes agent status additional endpoints display

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -374,12 +374,15 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 
 func getFullRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	runtimeConfig, err := yaml.Marshal(config.Datadog.AllSettings())
-	config.ResolveSecrets(config.Datadog, "datadog.yaml")
 	if err != nil {
 		log.Errorf("Unable to marshal runtime config response: %s", err)
 		body, _ := json.Marshal(map[string]string{"error": err.Error()})
 		http.Error(w, string(body), 500)
 		return
+	}
+	
+	if err := config.ResolveSecrets(config.Datadog, "datadog.yaml"); err != nil {
+		log.Warnf("Failed to resolve secrets: %s", err)
 	}
 
 	scrubbed, err := log.CredentialsCleanerBytes(runtimeConfig)

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -374,7 +374,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 
 func getFullRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	runtimeConfig, err := yaml.Marshal(config.Datadog.AllSettings())
-    config.ResolveSecrets(config.Datadog, "datadog.yaml")
+	config.ResolveSecrets(config.Datadog, "datadog.yaml")
 	if err != nil {
 		log.Errorf("Unable to marshal runtime config response: %s", err)
 		body, _ := json.Marshal(map[string]string{"error": err.Error()})

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -380,7 +380,7 @@ func getFullRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, string(body), 500)
 		return
 	}
-	
+
 	if err := config.ResolveSecrets(config.Datadog, "datadog.yaml"); err != nil {
 		log.Warnf("Failed to resolve secrets: %s", err)
 	}

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -374,6 +374,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 
 func getFullRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	runtimeConfig, err := yaml.Marshal(config.Datadog.AllSettings())
+    config.ResolveSecrets(config.Datadog, "datadog.yaml")
 	if err != nil {
 		log.Errorf("Unable to marshal runtime config response: %s", err)
 		body, _ := json.Marshal(map[string]string{"error": err.Error()})

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -253,8 +253,8 @@ func getEndpointsInfos() (map[string]interface{}, error) {
 	// obfuscate the api keys
 	for endpoint, keys := range endpoints {
 		for i, key := range keys {
-	        scrubbedKey, _ := log.CredentialsCleanerBytes([]byte(key))
-	        keys[i] = string(scrubbedKey)
+			scrubbedKey, _ := log.CredentialsCleanerBytes([]byte(key))
+			keys[i] = string(scrubbedKey)
 		}
 		endpointsInfos[endpoint] = keys
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -253,9 +253,8 @@ func getEndpointsInfos() (map[string]interface{}, error) {
 	// obfuscate the api keys
 	for endpoint, keys := range endpoints {
 		for i, key := range keys {
-			if len(key) > 5 {
-				keys[i] = key[len(key)-5:]
-			}
+	        scrubbedKey, _ := log.CredentialsCleanerBytes([]byte(key))
+	        keys[i] = string(scrubbedKey)
 		}
 		endpointsInfos[endpoint] = keys
 	}

--- a/releasenotes/notes/Fix-agent-status-extra-endpoint-display-201d12be33b83694.yaml
+++ b/releasenotes/notes/Fix-agent-status-extra-endpoint-display-201d12be33b83694.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes agent status additional endpoint keys display when decrypted by Secrets Management


### PR DESCRIPTION
### What does this PR do?

Fix agent status additional endpoints display. Additional endpoints, when decrypted via Secrets Management shows up incorrectly after running `config.AllSettings()` get called (e.g. via `datadog-agent config`. 

before fix:
```
Endpoints
==========
  https://app.datadoghq.com - API Key ending with:
      - ***************************a6917
  https://mbcd.datadoghq.com - API Keys ending with:
      - ENC[s1]
      - ENC[s2]
```
after fix:
```
Endpoints
==========
  https://app.datadoghq.com - API Key ending with:
      - ***************************a6917
  https://mbcd.datadoghq.com - API Keys ending with:
      - ***************************11111
      - ***************************22222
 ```

### Motivation

- AC-640


### Describe your test plan

- Configure additional api keys via secrets
```
additional_endpoints:
  "https://extra.datadoghq.com":
  - ENC[s1]
  - ENC[s2]
```

- start the agent
- `agent status` to check if keys are decrypted and masked
- `agent config` and wait
- `agent status` again to verify if keys are still decrypted and masked
