### PR TITLE
[install_script] Add option to send report to Datadog on error

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -8,6 +8,7 @@
 set -e
 install_script_version=1.1.0
 logfile="ddagent-install.log"
+support_email=support@datadoghq.com
 
 LEGACY_ETCDIR="/etc/dd-agent"
 LEGACY_CONF="$LEGACY_ETCDIR/datadog.conf"
@@ -36,6 +37,27 @@ exec 1>&-
 exec 1>$npipe 2>&1
 trap 'rm -f $npipe' EXIT
 
+function fallback_msg(){
+  printf "
+If you are still having problems, please send an email to $support_email
+with the contents of $logfile and any information you think would be
+useful and we will do our very best to help you solve your problem.\n"
+}
+
+function report(){
+  if curl -f -s \
+    --data-urlencode "os=${OS}" \
+    --data-urlencode "version=${agent_major_version}" \
+    --data-urlencode "log=$(cat $logfile)" \
+    --data-urlencode "email=${email}" \
+    --data-urlencode "apikey=${apikey}" \
+    "$report_failure_url"; then
+   printf "A notification has been sent to Datadog with the contents of $logfile\n"
+  else
+    printf "Unable to send the notification (curl v7.18 or newer is required)"
+    fallback_msg
+  fi
+}
 
 function on_error() {
     printf "\033[31m$ERROR_MESSAGE
@@ -43,11 +65,23 @@ It looks like you hit an issue when trying to install the Agent.
 
 Troubleshooting and basic usage information for the Agent are available at:
 
-    https://docs.datadoghq.com/agent/basic_agent_usage/
+    https://docs.datadoghq.com/agent/basic_agent_usage/\n\033[0m\n"
 
-If you're still having problems, please send an email to support@datadoghq.com
-with the contents of ddagent-install.log and we'll do our very best to help you
-solve your problem.\n\033[0m\n"
+    while true; do
+        read -p  "Do you want to send a failure report to Datadog (including $logfile)? (y/n) " -r yn
+        case $yn in
+          [Yy]* )
+            read -p "Enter an email address so we can follow up: " -r email
+            report
+            break;;
+          [Nn]* )
+            fallback_msg
+            break;;
+          * )
+            printf "Please answer yes or no.\n"
+            ;;
+        esac
+    done
 }
 trap on_error ERR
 
@@ -143,6 +177,11 @@ backup_keyserver="hkp://pool.sks-keyservers.net:80"
 # hkp://p80.pool.sks-keyservers.net:80 for example.
 if [ -n "$DD_KEYSERVER" ]; then
   keyserver="$DD_KEYSERVER"
+fi
+
+report_failure_url="http://api.datadoghq.com/agent_stats/report_failure"
+if [ -n "$TESTING_REPORT_URL" ]; then
+  report_failure_url=$TESTING_REPORT_URL
 fi
 
 if [ ! "$apikey" ]; then

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -179,7 +179,7 @@ if [ -n "$DD_KEYSERVER" ]; then
   keyserver="$DD_KEYSERVER"
 fi
 
-report_failure_url="http://api.datadoghq.com/agent_stats/report_failure"
+report_failure_url="https://api.datadoghq.com/agent_stats/report_failure"
 if [ -n "$TESTING_REPORT_URL" ]; then
   report_failure_url=$TESTING_REPORT_URL
 fi

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -6,7 +6,7 @@
 # using the package manager and Datadog repositories.
 
 set -e
-install_script_version=1.1.0
+install_script_version=1.2.0
 logfile="ddagent-install.log"
 support_email=support@datadoghq.com
 

--- a/releasenotes-installscript/notes/report-failure-to-endpoint-d6cc39235f33fbc1.yaml
+++ b/releasenotes-installscript/notes/report-failure-to-endpoint-d6cc39235f33fbc1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Prompt user to open support case when there is a failure during installation.


### PR DESCRIPTION
### What does this PR do?

- Add option to send error report to Datadog support when the install script finds an error. 
  The user is prompted for confirmation and for an email address for followup. 
  A report is then sent to Datadog including the installation logs.
- This tries to replicate the behavior of [the Agent v5 install script](https://github.com/DataDog/dd-agent/blob/2ce604ee0d7c70cdf85786deed689122b0e1957f/packaging/datadog-agent/source/setup_agent.sh#L187-L228).

### Motivation

- Make it easy for users to open a support case when they encounter an error.

### Additional Notes

- One can override the URL where failures are reported by using the `TESTING_REPORT_URL` environment variable.
- I did not add the changes to the Mac script since I believe the `on_error` function is currently not used.

### Describe your test plan

- Test normal installation on a supported platform. It should succeed as normally.
- Set `TESTING_REPORT_URL` to a local server that logs requests and cause an error in the script (e.g. by doing a parallel install in Ubuntu). Then:
    * If you answer 'No' to the prompt no request should be sent.
    * If you answer 'Yes' to the prompt then you should be asked for an email and a request should be sent to the server with the contents of the log file.
    * If you answer a different thing (not starting by y, Y, n or N) you should be prompted again
