### PR TITLE
[logs/latency stats] Fix small discrepancies and omissions

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -320,7 +320,6 @@
             {{- if .inputs }}
             Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}</br>
             BytesRead: {{ .bytes_read }}</br>
-            BytesRead: {{ .bytes_read }}</br>
             Average Latency (ms): {{ .all_time_avg_latency }}</br>
             24h Average Latency (ms): {{ .recent_avg_latency }}</br>
             Peak Latency (ms): {{ .all_time_peak_latency }}</br>

--- a/pkg/logs/config/source.go
+++ b/pkg/logs/config/source.go
@@ -45,6 +45,8 @@ type LogSource struct {
 	info       map[string]string
 	// In the case that the source is overridden, keep a reference to the parent for bubbling up information about the child
 	ParentSource *LogSource
+	// LatencyStats tracks internal stats on the time spent by messages from this source in a processing pipeline, i.e.
+	// the duration between when a message is decoded by the tailer/listener/decoder and when the message is handled by a sender
 	LatencyStats *util.StatsTracker
 }
 

--- a/pkg/logs/input/channel/tailer.go
+++ b/pkg/logs/input/channel/tailer.go
@@ -7,6 +7,7 @@ package channel
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -65,6 +66,6 @@ func (t *Tailer) run() {
 			tags = append(tags, t.source.Config.Tags...)
 		}
 		origin.SetTags(tags)
-		t.outputChan <- message.NewMessageFromLambda([]byte(logline.StringRecord), origin, message.StatusInfo, logline.Time, aws.GetARN(), aws.GetRequestID())
+		t.outputChan <- message.NewMessageFromLambda([]byte(logline.StringRecord), origin, message.StatusInfo, logline.Time, aws.GetARN(), aws.GetRequestID(), time.Now().UnixNano())
 	}
 }

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -47,12 +47,13 @@ func NewMessage(content []byte, origin *Origin, status string, ingestionTimestam
 }
 
 // NewMessageFromLambda construts a message with content, status, origin and with the given timestamp and Lambda metadata
-func NewMessageFromLambda(content []byte, origin *Origin, status string, utcTime time.Time, ARN, reqID string) *Message {
+func NewMessageFromLambda(content []byte, origin *Origin, status string, utcTime time.Time, ARN, reqID string, ingestionTimestamp int64) *Message {
 	return &Message{
-		Content:   content,
-		Origin:    origin,
-		status:    status,
-		Timestamp: utcTime,
+		Content:            content,
+		Origin:             origin,
+		status:             status,
+		IngestionTimestamp: ingestionTimestamp,
+		Timestamp:          utcTime,
 		Lambda: &Lambda{
 			ARN:       ARN,
 			RequestID: reqID,


### PR DESCRIPTION
### What does this PR do?

3 small fixes to https://github.com/DataDog/datadog-agent/pull/6801:

* Add comment on LatencyStats field to clarify what it measures
* Add ingestion timestamp to logs from channel input to avoid having completely wrong latency stats on these logs. Currently
only affects the serverless agent.
* Remove duplicate of `BytesRead` on GUI status page.

### Motivation

Fix small issues found during 7.26 QA.

### Describe your test plan

The fixes are trivial, but we should check that:

* `BytesRead` only appears once per log source on the GUI status page
* that on the serverless agent the displayed latency stats make sense
