### PR TITLE
pkg/trace/stats: Add new status code tag

### DIFF
--- a/pkg/trace/stats/statsraw_test.go
+++ b/pkg/trace/stats/statsraw_test.go
@@ -30,13 +30,25 @@ func TestGrain(t *testing.T) {
 func TestGrainWithExtraTags(t *testing.T) {
 	assert := assert.New(t)
 
-	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{tagHostname: "host-id", tagVersion: "v0", tagStatusCode: "418", tagOrigin: "synthetics-browser"}}
+	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{tagHostname: "host-id", tagVersion: "v0", tagHTTPStatusCode: "418", tagOrigin: "synthetics-browser"}}
 	aggr := NewAggregationFromSpan(&s, "default")
 
 	b := strings.Builder{}
 	aggr.WriteKey(&b)
-	assert.Equal("env:default,resource:yo,service:thing,_dd.hostname:host-id,http.status_code:418,version:v0,synthetics:true", b.String())
-	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}, Tag{"_dd.hostname", "host-id"}, Tag{"http.status_code", "418"}, Tag{"version", "v0"}, Tag{"synthetics", "true"}}, aggr.ToTagSet())
+	assert.Equal("env:default,resource:yo,service:thing,_dd.hostname:host-id,http.status_code:418,status_code:418,version:v0,synthetics:true", b.String())
+	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}, Tag{"_dd.hostname", "host-id"}, Tag{"http.status_code", "418"}, Tag{"status_code", "418"}, Tag{"version", "v0"}, Tag{"synthetics", "true"}}, aggr.ToTagSet())
+}
+
+func TestGrainWithGRPCStatusCode(t *testing.T) {
+	assert := assert.New(t)
+
+	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{tagGRPCStatusCode: "StatusCode.UNKNOWN"}}
+	aggr := NewAggregationFromSpan(&s, "default")
+
+	b := strings.Builder{}
+	aggr.WriteKey(&b)
+	assert.Equal("env:default,resource:yo,service:thing,status_code:StatusCode.UNKNOWN", b.String())
+	assert.Equal(TagSet{Tag{"env", "default"}, Tag{"resource", "yo"}, Tag{"service", "thing"}, Tag{"status_code", "StatusCode.UNKNOWN"}}, aggr.ToTagSet())
 }
 
 func TestHandleSpanSkipStats(t *testing.T) {


### PR DESCRIPTION
Problem:

grpc stats are not tagged with the status code.

Proposed solution:
Add a tag `status_code` common to http, grpc, more if add later.

Concerns:
This is going to increase the amount of data we send to the backend, since we will add both http.status_code and status_code on all stats.