### PR TITLE
[Backport] Make sure environment autodiscovery is as close as current behavior as possible - fix read config before init

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -407,7 +407,6 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("extra_listeners", []string{})
 	config.BindEnvAndSetDefault("extra_config_providers", []string{})
 	config.BindEnvAndSetDefault("ignore_autoconf", []string{})
-	config.BindEnvAndSetDefault("autoconf_from_environment", true)
 
 	// Docker
 	config.BindEnvAndSetDefault("docker_query_timeout", int64(5))

--- a/releasenotes/notes/autodiscovery-container-runtimes-1c0bab73f1052663.yaml
+++ b/releasenotes/notes/autodiscovery-container-runtimes-1c0bab73f1052663.yaml
@@ -9,4 +9,4 @@ features:
     and/or Docker - activating relevant configuration depending on node
     configuration).
     This feature is activated by default and can be de-activated by setting
-    `autoconf_from_environment: false`.
+    environment variable `AUTCONFIG_FROM_ENVIRONMENT=false`.


### PR DESCRIPTION
### What does this PR do?

Backport #7359 to 7.26

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

See #7359
