### PR TITLE
[datadog-agent] Add support for kubernetes_namespace_labels_as_tags

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -128,6 +128,7 @@ func isExternalPath(path string) bool {
 		path == "/version" ||
 		strings.HasPrefix(path, "/api/v1/tags/pod/") && (len(strings.Split(path, "/")) == 6 || len(strings.Split(path, "/")) == 8) ||
 		strings.HasPrefix(path, "/api/v1/tags/node/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/tags/namespace/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/clusterchecks/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/endpointschecks/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/tags/cf/apps/") && len(strings.Split(path, "/")) == 7 ||

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -12,7 +12,7 @@ import (
 
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gorilla/mux"
 )
 

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -21,6 +21,7 @@ func installKubernetesMetadataEndpoints(r *mux.Router) {
 	r.HandleFunc("/tags/pod/{nodeName}", getPodMetadataForNode).Methods("GET")
 	r.HandleFunc("/tags/pod", getAllMetadata).Methods("GET")
 	r.HandleFunc("/tags/node/{nodeName}", getNodeMetadata).Methods("GET")
+	r.HandleFunc("/tags/namespace/{ns}", getNamespaceMetadata).Methods("GET")
 	r.HandleFunc("/cluster/id", getClusterID).Methods("GET")
 }
 
@@ -83,6 +84,65 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
 		strconv.Itoa(http.StatusNotFound),
 	)
 	w.Write([]byte(fmt.Sprintf("Could not find labels on the node: %s", nodeName)))
+}
+
+// getNamespaceMetadata is only used when the node agent hits the DCA for the list of labels
+func getNamespaceMetadata(w http.ResponseWriter, r *http.Request) {
+	/*
+		Input
+			localhost:5001/api/v1/tags/namespace/default
+		Outputs
+			Status: 200
+			Returns: []string
+			Example: ["label1:value1", "label2:value2"]
+
+			Status: 404
+			Returns: string
+			Example: 404 page not found
+
+			Status: 500
+			Returns: string
+			Example: "no cached metadata found for the namespace default"
+	*/
+
+	vars := mux.Vars(r)
+	var labelBytes []byte
+	nsName := vars["ns"]
+	nsLabels, err := as.GetNamespaceLabels(nsName)
+	if err != nil {
+		log.Errorf("Could not retrieve the namespace labels of %s: %v", nsName, err.Error()) //nolint:errcheck
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		apiRequests.Inc(
+			"getNamespaceMetadata",
+			strconv.Itoa(http.StatusInternalServerError),
+		)
+		return
+	}
+	labelBytes, err = json.Marshal(nsLabels)
+	if err != nil {
+		log.Errorf("Could not process the labels of the namespace %s from the informer's cache: %v", nsName, err.Error()) //nolint:errcheck
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		apiRequests.Inc(
+			"getNamespaceMetadata",
+			strconv.Itoa(http.StatusInternalServerError),
+		)
+		return
+	}
+	if len(labelBytes) > 0 {
+		w.WriteHeader(http.StatusOK)
+		w.Write(labelBytes)
+		apiRequests.Inc(
+			"getNamespaceMetadata",
+			strconv.Itoa(http.StatusOK),
+		)
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
+	apiRequests.Inc(
+		"getNamespaceMetadata",
+		strconv.Itoa(http.StatusNotFound),
+	)
+	w.Write([]byte(fmt.Sprintf("Could not find labels on the namespace: %s", nsName)))
 }
 
 // getPodMetadata is only used when the node agent hits the DCA for the tags list.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -415,6 +415,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("kubernetes_pod_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_pod_annotations_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_node_labels_as_tags", map[string]string{})
+	config.BindEnvAndSetDefault("kubernetes_namespace_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")
 
 	// CRI

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1613,6 +1613,14 @@ api_key:
 #   <ANNOTATION>: <TAG_KEY>
 #   <HIGH_CARDINALITY_ANNOTATION>: +<TAG_KEY>
 
+## @param kubernetes_namespace_labels_as_tags - map - optional
+## The Agent can extract namespace label values and set them as metric tags values associated to a <TAG_KEY>.
+## If you prefix your tag name with +, it will only be added to high cardinality metrics.
+#
+# kubernetes_namespace_labels_as_tags:
+#   <NAMESPACE_LABEL>: <TAG_KEY>
+#   <HIGH_CARDINALITY_NAMESPACE_LABEL_NAME>: +<TAG_KEY>
+
 {{ end -}}
 {{- if .ECS }}
 

--- a/pkg/tagger/collectors/garden_extract_test.go
+++ b/pkg/tagger/collectors/garden_extract_test.go
@@ -88,6 +88,10 @@ func (fakeDCAClient) GetNodeLabels(nodeName string) (map[string]string, error) {
 	panic("implement me")
 }
 
+func (fakeDCAClient) GetNamespaceLabels(nsName string) (map[string]string, error) {
+	panic("implement me")
+}
+
 func (fakeDCAClient) GetPodsMetadataForNode(nodeName string) (apiv1.NamespacesPodsStringsSet, error) {
 	panic("implement me")
 }

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -12,7 +12,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/gobwas/glob"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
@@ -41,6 +43,9 @@ type KubeMetadataCollector struct {
 	lastUpdate time.Time
 	lastExpire time.Time
 	lastSeen   map[string]time.Time
+
+	namespaceLabelsAsTags map[string]string
+	globNamespaceLabels   map[string]glob.Glob
 }
 
 // Detect tries to connect to the kubelet and the API Server if the DCA is not used or the DCA.
@@ -87,6 +92,10 @@ func (c *KubeMetadataCollector) Detect(out chan<- []*TagInfo) (CollectionMode, e
 	c.expireFreq = kubeMetadataExpireFreq
 	c.lastExpire = time.Now()
 	c.lastSeen = make(map[string]time.Time)
+
+	c.namespaceLabelsAsTags, c.globNamespaceLabels = utils.InitMetadataAsTags(
+		config.Datadog.GetStringMapString("kubernetes_namespace_labels_as_tags"),
+	)
 
 	return PullCollection, nil
 }
@@ -197,6 +206,10 @@ func (c *KubeMetadataCollector) isClusterAgentEnabled() bool {
 		}
 	}
 	return false
+}
+
+func (c *KubeMetadataCollector) hasNamespaceLabelsAsTags() bool {
+	return len(c.namespaceLabelsAsTags) != 0 || len(c.globNamespaceLabels) != 0
 }
 
 func kubernetesFactory() Collector {

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/golang-lru/simplelru"
 )
 
+// maxNamespacesInLRU limits the number of entries in the LRU cache for namespace labels on tags fetch
 const maxNamespacesInLRU = 100
 
 func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -16,7 +16,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/hashicorp/golang-lru/simplelru"
 )
+
+const maxNamespacesInLRU = 100
 
 func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	var err error
@@ -37,6 +40,13 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	var tagInfo []*TagInfo
 	var metadataNames []string
 	var tag []string
+
+	lruNamespaceTags, err := simplelru.NewLRU(maxNamespacesInLRU, nil)
+	if err != nil {
+		log.Debugf("Failed to create LRU for namespace tags: %v", err)
+		return nil
+	}
+
 	for _, po := range pods {
 		if kubelet.IsPodReady(po) == false {
 			log.Debugf("pod %q is not ready, skipping", po.Metadata.Name)
@@ -63,7 +73,15 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 			continue
 		}
 
-		tagList := utils.NewTagList()
+		var tagList *utils.TagList
+		if c.hasNamespaceLabelsAsTags() {
+			tagList = c.namespaceTagsFromLRU(lruNamespaceTags, po.Metadata.Namespace)
+		}
+
+		if tagList == nil {
+			tagList = utils.NewTagList()
+		}
+
 		metadataNames, err = c.getMetadaNames(apiserver.GetPodMetadataNames, metadataByNsPods, po)
 		if err != nil {
 			log.Errorf("Could not fetch tags, %v", err)
@@ -115,6 +133,20 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	return tagInfo
 }
 
+func (c *KubeMetadataCollector) namespaceTagsFromLRU(lru *simplelru.LRU, ns string) *utils.TagList {
+	var tagList *utils.TagList
+	if v, ok := lru.Get(ns); ok {
+		tagList = v.(*utils.TagList)
+	} else {
+		tagList = c.getNamespaceTags(apiserver.GetNamespaceLabels, ns)
+		lru.Add(ns, tagList)
+	}
+	if tagList != nil {
+		tagList = tagList.Copy()
+	}
+	return tagList
+}
+
 func (c *KubeMetadataCollector) getMetadaNames(getPodMetaDataFromAPIServerFunc func(string, string, string) ([]string, error), metadataByNsPods apiv1.NamespacesPodsStringsSet, po *kubelet.Pod) ([]string, error) {
 	if !c.isClusterAgentEnabled() {
 		metadataNames, err := getPodMetaDataFromAPIServerFunc(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
@@ -136,6 +168,27 @@ func (c *KubeMetadataCollector) getMetadaNames(getPodMetaDataFromAPIServerFunc f
 		err = fmt.Errorf("Could not pull the metadata map of pod %s on node %s, %v", po.Metadata.Name, po.Spec.NodeName, err)
 	}
 	return metadataNames, err
+}
+
+func (c *KubeMetadataCollector) getNamespaceTags(getNamespaceLabelsFromAPIServerFunc func(string) (map[string]string, error), ns string) *utils.TagList {
+	if !c.hasNamespaceLabelsAsTags() {
+		return nil
+	}
+
+	if c.isClusterAgentEnabled() {
+		getNamespaceLabelsFromAPIServerFunc = c.dcaClient.GetNamespaceLabels
+	}
+	labels, err := getNamespaceLabelsFromAPIServerFunc(ns)
+	if err != nil {
+		_ = log.Warnf("Could not fetch labels for namespace: %s, %v", ns, err)
+		return nil
+	}
+
+	tags := utils.NewTagList()
+	for name, value := range labels {
+		utils.AddMetadataAsTags(name, value, c.namespaceLabelsAsTags, c.globNamespaceLabels, tags)
+	}
+	return tags
 }
 
 // addToCacheMetadataMapping is acting like the DCA at the node level.

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -121,6 +121,7 @@ func StartControllers(ctx ControllerContext) errors.Aggregate {
 func startMetadataController(ctx ControllerContext, c chan error) {
 	metaController := NewMetadataController(
 		ctx.InformerFactory.Core().V1().Nodes(),
+		ctx.InformerFactory.Core().V1().Namespaces(),
 		ctx.InformerFactory.Core().V1().Endpoints(),
 	)
 	go metaController.Run(ctx.StopCh)

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -474,6 +474,7 @@ func newFakeMetadataController(client kubernetes.Interface) (*MetadataController
 
 	metaController := NewMetadataController(
 		informerFactory.Core().V1().Nodes(),
+		informerFactory.Core().V1().Namespaces(),
 		informerFactory.Core().V1().Endpoints(),
 	)
 

--- a/releasenotes/notes/add-kubernetes_namespace_labels_as_tags-d64b84547146b238.yaml
+++ b/releasenotes/notes/add-kubernetes_namespace_labels_as_tags-d64b84547146b238.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds support for Kubernetes namespace labels as tags extraction (kubernetes_namespace_labels_as_tags).


### PR DESCRIPTION
### What does this PR do?

- Implements a new endpoint in DCA which serves list of labels for a particular namespace.
- Implements querying the new endpoint in metadata mapping for pods.

### Motivation

Support extracting tags from namespace labels similarly to pod labels as tags.

### Describe your test plan

- Tag a namespace that contains a specific pod targeted for testing, e.g. `label=value`.
- Configure `kubernetes_namespace_labels_as_tags`:
```
  - name: DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS
    value: '{"*":"kube_ns_%%label%%"}'
```
- Enable metadata tag collector.
- Make sure that the pod has tags from the namespace:
```
=== Entity kubernetes_pod_uid://uid ===
Tags: [... kube_namespace:default kube_ns_label:value ...]
Sources: [kube-metadata-collector kubelet]
===
```

Note that these changes require that the cluster role is able to observe changes to namespaces:
```
kubectl describe clusterrole datadog-monitoring-cluster-agent
...
PolicyRule:
  Resources                                 Non-Resource URLs  Resource Names                      Verbs
  ---------                                 -----------------  --------------                      -----
...
  namespaces                                []                 []                                  [get list watch]
```