### PR TITLE
docs: update readme to render sections clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,28 @@ To start working on the Agent, you can build the `master` branch:
    Make sure that `$GOPATH/bin` is in your `$PATH` otherwise this step might fail.
 4. Create a development `datadog.yaml` configuration file in `dev/dist/datadog.yaml`, containing a valid API key: `api_key: <API_KEY>`
 5. Build the agent with `invoke agent.build --build-exclude=systemd`.
-   By default, the Agent will be built to use Python 3 but you can select which Python version you want to use:
-   - `invoke agent.build --python-runtimes 2` for Python2 only
-   - `invoke agent.build --python-runtimes 3` for Python3 only
-   - `invoke agent.build --python-runtimes 2,3` for both Python2 and Python3
-  You can specify a custom Python location for the agent (useful when using
-   virtualenvs): `invoke agent.build
-   --python-runtimes 2,3
-   --python-home-2=$GOPATH/src/github.com/DataDog/datadog-agent/venv2
-   --python-home-3=$GOPATH/src/github.com/DataDog/datadog-agent/venv3`.
-  Running `invoke agent.build`:
-    * Discards any changes done in `bin/agent/dist`.
-    * Builds the Agent and writes the binary to `bin/agent/agent`.
-    * Copies files from `dev/dist` to `bin/agent/dist`. See `https://github.com/DataDog/datadog-agent/blob/master/dev/dist/README.md` for more information.
-  If you built an older version of the agent, you may have the error `make: *** No targets specified and no makefile found.  Stop.`.
-  To solve the issue, you should remove `CMakeCache.txt` from `rtloader` folder with `rm rtloader/CMakeCache.txt`.
+
+    By default, the Agent will be built to use Python 3 but you can select which Python version you want to use:
+
+      - `invoke agent.build --python-runtimes 2` for Python2 only
+      - `invoke agent.build --python-runtimes 3` for Python3 only
+      - `invoke agent.build --python-runtimes 2,3` for both Python2 and Python3
+
+     You can specify a custom Python location for the agent (useful when using
+     virtualenvs):
+
+       invoke agent.build \
+         --python-runtimes 2,3 \
+         --python-home-2=$GOPATH/src/github.com/DataDog/datadog-agent/venv2 \
+         --python-home-3=$GOPATH/src/github.com/DataDog/datadog-agent/venv3 .
+
+    Running `invoke agent.build`:
+
+     * Discards any changes done in `bin/agent/dist`.
+     * Builds the Agent and writes the binary to `bin/agent/agent`.
+     * Copies files from `dev/dist` to `bin/agent/dist`. See `https://github.com/DataDog/datadog-agent/blob/master/dev/dist/README.md` for more information.
+
+     If you built an older version of the agent, you may have the error `make: *** No targets specified and no makefile found.  Stop.`. To solve the issue, you should remove `CMakeCache.txt` from `rtloader` folder with `rm rtloader/CMakeCache.txt`.
 
 
 


### PR DESCRIPTION
### What does this PR do?

When reading the rendered README.md in a browser, the structure and
flow of the paragraphs and sub-bullets is not preserved, leading to
confusion on what options the reader can choose, when and why.

Using spacing and indentation to correct the structure leads to a
more legible rendered output.

### Motivation

I was reading the readme in the browser, and the flow of the items looked incorrect and broken compared to the intended source.

### Additional Notes

I like chocolate chip cookies.

### Describe your test plan

I used Markdown preview both locally and in GitHub to compare before and after.

Wasn't certain if this deserved a `reno`, added one just in case.