### PR TITLE
other: ignore local development control files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ venv3[78]/
 *.syso
 *.log
 
+# local development environment control files
+.env
+.envrc
+.python-version
+
 #file generated at build time by message compiler
 agentmsg.h
 


### PR DESCRIPTION
### What does this PR do?

When developing the project, control files are common to declare a
python version, or provide environment variables.

These are not to be included in the project's source.

### Motivation

I was getting started with local development, and found that my virtualenv control file was not ignored already.
