### PR TITLE
[deps] Do not use cryptography 3.4.x

### DIFF
--- a/omnibus/config/patches/snowflake-connector-python-py2/cryptography-dependency.patch
+++ b/omnibus/config/patches/snowflake-connector-python-py2/cryptography-dependency.patch
@@ -13,7 +13,7 @@ index 0da6a8a..f486585 100644
 -        'cffi>=1.9,<1.14',
 -        'cryptography>=1.8.2,<3.0.0',
 +        'cffi>=1.9,<1.15',
-+        'cryptography>=1.8.2',
++        'cryptography>=1.8.2,<3.4',
          'ijson<3.0.0',
          'pyjwt<2.0.0',
          'idna<3.0.0',

--- a/omnibus/config/patches/snowflake-connector-python-py3/cryptography-dependency.patch
+++ b/omnibus/config/patches/snowflake-connector-python-py3/cryptography-dependency.patch
@@ -13,7 +13,7 @@ index 0da6a8a..f486585 100644
 -        'cffi>=1.9,<1.14',
 -        'cryptography>=1.8.2,<3.0.0',
 +        'cffi>=1.9,<1.15',
-+        'cryptography>=1.8.2',
++        'cryptography>=1.8.2,<3.4',
          'ijson<3.0.0',
          'pyjwt<2.0.0',
          'idna<3.0.0',


### PR DESCRIPTION
### What does this PR do?

- Pin snowflake-connector dependencies to use `cryptography`  version 3.3.x or older.

### Motivation

- This is breaking the builds since it needs a Rust toolchain

### Additional Notes

- We could alternatively install a Rust toolchain on our SUSE images

### Describe your test plan

- To be done by Agent Integrations team
