### PR TITLE
[gitlab] Use Debian key from a single SSM entry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,8 +137,7 @@ variables:
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded
   # the deb signing key is split in halves, as it exceeds the maximum size of 4096 chars for a single entry
   DEB_GPG_KEY_NAME: "Datadog, Inc <package@datadoghq.com>"
-  DEB_GPG_KEY_SSM_NAME_PART1: ci.datadog-agent.deb_signing_private_key_8387EEAF_part1
-  DEB_GPG_KEY_SSM_NAME_PART2: ci.datadog-agent.deb_signing_private_key_8387EEAF_part2
+  DEB_GPG_KEY_SSM_NAME: ci.datadog-agent.deb_signing_private_key_8387EEAF
   DEB_SIGNING_PASSPHRASE_SSM_NAME: ci.datadog-agent.deb_signing_key_passphrase_8387EEAF
   RPM_GPG_KEY_ID: e09422b3
   RPM_GPG_KEY_SSM_NAME: ci.datadog-agent.rpm_signing_private_key_e09422b3

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -1,9 +1,8 @@
 ---
 .setup_deb_signing_key: &setup_deb_signing_key
   - set +x
-  - DEB_GPG_KEY_P1=$(aws ssm get-parameter --region us-east-1 --name $DEB_GPG_KEY_SSM_NAME_PART1 --with-decryption --query "Parameter.Value" --out text)
-  - DEB_GPG_KEY_P2=$(aws ssm get-parameter --region us-east-1 --name $DEB_GPG_KEY_SSM_NAME_PART2 --with-decryption --query "Parameter.Value" --out text)
-  - printf -- "${DEB_GPG_KEY_P1}\n${DEB_GPG_KEY_P2}" | gpg --import --batch
+  - DEB_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name $DEB_GPG_KEY_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
+  - printf -- "${DEB_GPG_KEY}" | gpg --import --batch
   - export DEB_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $DEB_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
   - set -x
 


### PR DESCRIPTION
### What does this PR do?

Uses a Debian signing key from a single SSM entry, instead of the previously split key.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
