### PR TITLE
Force debug level with JMX --flare command

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -149,17 +149,18 @@ func doJmxListNotCollected(cmd *cobra.Command, args []string) error {
 // runJmxCommandConsole sets up the common utils necessary for JMX, and executes the command
 // with the Console reporter
 func runJmxCommandConsole(command string) error {
-	logLevel, _, err := standalone.SetupCLI(loggerName, confFilePath, "", jmxLogLevel, "debug")
-	if err != nil {
-		fmt.Printf("Cannot initialize command: %v\n", err)
-		return err
-	}
-
 	logFile := ""
 	if saveFlare {
 		// Windows cannot accept ":" in file names
 		filenameSafeTimeStamp := strings.ReplaceAll(time.Now().UTC().Format(time.RFC3339), ":", "-")
 		logFile = filepath.Join(common.DefaultJMXFlareDirectory, "jmx_"+command+"_"+filenameSafeTimeStamp+".log")
+		jmxLogLevel = "debug"
+	}
+
+	logLevel, _, err := standalone.SetupCLI(loggerName, confFilePath, "", logFile, jmxLogLevel, "debug")
+	if err != nil {
+		fmt.Printf("Cannot initialize command: %v\n", err)
+		return err
 	}
 
 	err = config.SetupJMXLogger(jmxLoggerName, logLevel, logFile, "", false, true, false)

--- a/cmd/agent/app/standalone/setup.go
+++ b/cmd/agent/app/standalone/setup.go
@@ -16,7 +16,7 @@ import (
 // - config, with defaults to avoid conflicting with an agent process running in parallel
 // - logger
 // and returns the log level resolved from cliLogLevel and defaultLogLevel
-func SetupCLI(loggerName config.LoggerName, confFilePath, configName string, cliLogLevel string, defaultLogLevel string) (string, *config.Warnings, error) {
+func SetupCLI(loggerName config.LoggerName, confFilePath, configName string, cliLogFile string, cliLogLevel string, defaultLogLevel string) (string, *config.Warnings, error) {
 	var resolvedLogLevel string
 
 	if cliLogLevel != "" {
@@ -38,7 +38,7 @@ func SetupCLI(loggerName config.LoggerName, confFilePath, configName string, cli
 		return resolvedLogLevel, warnings, fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
 
-	err = config.SetupLogger(loggerName, resolvedLogLevel, "", "", false, true, false)
+	err = config.SetupLogger(loggerName, resolvedLogLevel, cliLogFile, "", false, true, false)
 	if err != nil {
 		return resolvedLogLevel, warnings, fmt.Errorf("unable to set up logger: %v", err)
 	}

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -105,7 +105,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				// we'll search for a config file named `datadog-cluster.yaml`
 				configName = "datadog-cluster"
 			}
-			resolvedLogLevel, warnings, err := standalone.SetupCLI(loggerName, *confFilePath, configName, logLevel, "off")
+			resolvedLogLevel, warnings, err := standalone.SetupCLI(loggerName, *confFilePath, configName, "", logLevel, "off")
 			if err != nil {
 				fmt.Printf("Cannot initialize command: %v\n", err)
 				return err

--- a/releasenotes/notes/Use-debug-with-JMX-flare-command-079f03184778587e.yaml
+++ b/releasenotes/notes/Use-debug-with-JMX-flare-command-079f03184778587e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Automatically set debug log_level with JMX --flare command

--- a/releasenotes/notes/Use-debug-with-JMX-flare-command-079f03184778587e.yaml
+++ b/releasenotes/notes/Use-debug-with-JMX-flare-command-079f03184778587e.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Automatically set debug log_level with JMX --flare command
+    Automatically set debug log_level when the '--flare' option is used with the  JMX command


### PR DESCRIPTION
### What does this PR do?

Force log_level:debug with the JMX `--flare` flag

### Motivation

- follow-up to #7230 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Run any of the agent jmx commands appended by`--flare` (`agent jmx collect --flare`, `agent jmx list [subcommand] --flare`), then generate a flare.
Resulting file should be generated in debug mode in `/var/log/datadog/jmxinfo/` regardless of `--level` flag or `DD_LOG_LEVEL`
