### PR TITLE
pkg/trace/{agent,config}: add support for apm_config.filter_tags

### DIFF
--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -29,6 +29,8 @@ func setupAPM(config Config) {
 	config.SetKnown("apm_config.obfuscation.remove_stack_traces")
 	config.SetKnown("apm_config.obfuscation.redis.enabled")
 	config.SetKnown("apm_config.obfuscation.memcached.enabled")
+	config.SetKnown("apm_config.filter_tags.require")
+	config.SetKnown("apm_config.filter_tags.reject")
 	config.SetKnown("apm_config.extra_sample_rate")
 	config.SetKnown("apm_config.dd_agent_bin")
 	config.SetKnown("apm_config.trace_writer.connection_limit")
@@ -75,6 +77,8 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.ignore_resources", "DD_APM_IGNORE_RESOURCES", "DD_IGNORE_RESOURCE")       //nolint:errcheck
 	config.BindEnv("apm_config.receiver_socket", "DD_APM_RECEIVER_SOCKET")                               //nolint:errcheck
 	config.BindEnv("apm_config.windows_pipe_name", "DD_APM_WINDOWS_PIPE_NAME")                           //nolint:errcheck
+	config.BindEnv("apm_config.filter_tags.require", "DD_APM_FILTER_TAGS_REQUIRE")                       //nolint:errcheck
+	config.BindEnv("apm_config.filter_tags.reject", "DD_APM_FILTER_TAGS_REJECT")                         //nolint:errcheck
 
 	config.SetEnvKeyTransformer("apm_config.ignore_resources", func(in string) interface{} {
 		r, err := splitCSVString(in, ',')
@@ -83,6 +87,14 @@ func setupAPM(config Config) {
 			return []string{}
 		}
 		return r
+	})
+
+	config.SetEnvKeyTransformer("apm_config.filter_tags.require", func(in string) interface{} {
+		return strings.Split(in, " ")
+	})
+
+	config.SetEnvKeyTransformer("apm_config.filter_tags.reject", func(in string) interface{} {
+		return strings.Split(in, " ")
 	})
 
 	config.SetEnvKeyTransformer("apm_config.replace_tags", func(in string) interface{} {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -764,11 +764,13 @@ api_key:
 
   ## @param filter_tags - object - optional
   ## Defines rules by which to filter traces based on tags.
+  ##  * require - list of key or key/value strings - traces must have those tags in order to be sent to Datadog
+  ##  * reject - list of key or key/value strings - traces with these tags are dropped by the Agent
+  ## Note: Rules take into account the intersection of tags defined.
   #
   # filter_tags:
-  #     <FILTER_TAGS_CONFIGURATION>
-  #
-  # TODO(x): Find out how to do this and if we need a page on the official docs
+  #     require: "<LIST_OF_KEY_VALUE_TAGS>"
+  #     reject: "<LIST_OF_KEY_VALUE_TAGS>"
 
   ## @param replace_tags - list of objects - optional
   ## Defines a set of rules to replace or remove certain resources, tags containing

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -769,8 +769,8 @@ api_key:
   ## Note: Rules take into account the intersection of tags defined.
   #
   # filter_tags:
-  #     require: "<LIST_OF_KEY_VALUE_TAGS>"
-  #     reject: "<LIST_OF_KEY_VALUE_TAGS>"
+  #     require: [<LIST_OF_KEY_VALUE_TAGS>]
+  #     reject: [<LIST_OF_KEY_VALUE_TAGS>]
 
   ## @param replace_tags - list of objects - optional
   ## Defines a set of rules to replace or remove certain resources, tags containing

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -762,6 +762,14 @@ api_key:
   # obfuscation:
   #     <OBFUSCATION_CONFIGURATION>
 
+  ## @param filter_tags - object - optional
+  ## Defines rules by which to filter traces based on tags.
+  #
+  # filter_tags:
+  #     <FILTER_TAGS_CONFIGURATION>
+  #
+  # TODO(x): Find out how to do this and if we need a page on the official docs
+
   ## @param replace_tags - list of objects - optional
   ## Defines a set of rules to replace or remove certain resources, tags containing
   ## potentially sensitive information.

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -426,18 +426,15 @@ func traceContainsError(trace pb.Trace) bool {
 	return false
 }
 
-func filteredByTags(root *pb.Span, require, reject []config.Tag) bool {
+func filteredByTags(root *pb.Span, require, reject []*config.Tag) bool {
 	for _, tag := range reject {
-		if v, ok := root.Meta[tag.K]; ok && v == tag.V {
+		if v, ok := root.Meta[tag.K]; ok && (tag.V == "" || (v != "" && v == tag.V)) {
 			return true
 		}
 	}
 	for _, tag := range require {
 		v, ok := root.Meta[tag.K]
-		if !ok {
-			return true
-		}
-		if v != tag.V {
+		if !ok || (tag.V != "" && v != "" && v != tag.V) {
 			return true
 		}
 	}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -184,6 +184,10 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 			continue
 		}
 
+		if filteredByTags(root, a.conf.RequireTags, a.conf.RejectTags) {
+			continue
+		}
+
 		// Extra sanitization steps of the trace.
 		for _, span := range t {
 			a.obfuscator.Obfuscate(span)
@@ -416,6 +420,24 @@ func (a *Agent) sampleNoPriorityTrace(pt ProcessedTrace) bool {
 func traceContainsError(trace pb.Trace) bool {
 	for _, span := range trace {
 		if span.Error != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func filteredByTags(root *pb.Span, require, reject []config.Tag) bool {
+	for _, tag := range reject {
+		if v, ok := root.Meta[tag.K]; ok && v == tag.V {
+			return true
+		}
+	}
+	for _, tag := range require {
+		v, ok := root.Meta[tag.K]
+		if !ok {
+			return true
+		}
+		if v != tag.V {
 			return true
 		}
 	}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -185,6 +185,9 @@ func (a *Agent) Process(p *api.Payload, sublayerCalculator *stats.SublayerCalcul
 		}
 
 		if filteredByTags(root, a.conf.RequireTags, a.conf.RejectTags) {
+			log.Debugf("Trace rejected as it fails to meet tag requirements. root: %v", root)
+			atomic.AddInt64(&ts.TracesFiltered, 1)
+			atomic.AddInt64(&ts.SpansFiltered, tracen)
 			continue
 		}
 

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -428,13 +428,13 @@ func traceContainsError(trace pb.Trace) bool {
 
 func filteredByTags(root *pb.Span, require, reject []*config.Tag) bool {
 	for _, tag := range reject {
-		if v, ok := root.Meta[tag.K]; ok && (tag.V == "" || (v != "" && v == tag.V)) {
+		if v, ok := root.Meta[tag.K]; ok && (tag.V == "" || v == tag.V) {
 			return true
 		}
 	}
 	for _, tag := range require {
 		v, ok := root.Meta[tag.K]
-		if !ok || (tag.V != "" && v != "" && v != tag.V) {
+		if !ok || (tag.V != "" && v != tag.V) {
 			return true
 		}
 	}

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -58,7 +58,6 @@ func Run(ctx context.Context) {
 		}
 		osutil.Exitf("%v", err)
 	}
-	fmt.Printf("%#v\n%#v", cfg.RequireTags, cfg.RejectTags)
 	err = info.InitInfo(cfg) // for expvar & -info option
 	if err != nil {
 		osutil.Exitf("%v", err)

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -58,6 +58,7 @@ func Run(ctx context.Context) {
 		}
 		osutil.Exitf("%v", err)
 	}
+	fmt.Printf("%#v\n%#v", cfg.RequireTags, cfg.RejectTags)
 	err = info.InitInfo(cfg) // for expvar & -info option
 	if err != nil {
 		osutil.Exitf("%v", err)

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/osutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/davecgh/go-spew/spew"
 )
 
 // apiEndpointPrefix is the URL prefix prepended to the default site value from YamlAgentConfig.
@@ -276,6 +277,7 @@ func (c *AgentConfig) applyDatadogConfig() error {
 		tags := config.Datadog.GetStringSlice("apm_config.filter_tags.reject")
 		for _, tag := range tags {
 			c.RejectTags = append(c.RejectTags, splitTag(tag))
+			spew.Dump(c.RejectTags)
 		}
 	}
 
@@ -461,9 +463,9 @@ func toFloat64(val interface{}) (float64, error) {
 	}
 }
 
-func splitTag(tag string) Tag {
+func splitTag(tag string) *Tag {
 	parts := strings.SplitN(tag, ":", 2)
-	kv := Tag{
+	kv := &Tag{
 		K: strings.TrimSpace(parts[0]),
 	}
 	if len(parts) > 1 {

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/osutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/davecgh/go-spew/spew"
 )
 
 // apiEndpointPrefix is the URL prefix prepended to the default site value from YamlAgentConfig.
@@ -277,7 +276,6 @@ func (c *AgentConfig) applyDatadogConfig() error {
 		tags := config.Datadog.GetStringSlice("apm_config.filter_tags.reject")
 		for _, tag := range tags {
 			c.RejectTags = append(c.RejectTags, splitTag(tag))
-			spew.Dump(c.RejectTags)
 		}
 	}
 

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -271,7 +271,6 @@ func (c *AgentConfig) applyDatadogConfig() error {
 			c.RequireTags = append(c.RequireTags, splitTag(tag))
 		}
 	}
-
 	if config.Datadog.IsSet("apm_config.filter_tags.reject") {
 		tags := config.Datadog.GetStringSlice("apm_config.filter_tags.reject")
 		for _, tag := range tags {
@@ -461,6 +460,7 @@ func toFloat64(val interface{}) (float64, error) {
 	}
 }
 
+// splitTag splits a "k:v" formatted string and returns a Tag.
 func splitTag(tag string) *Tag {
 	parts := strings.SplitN(tag, ":", 2)
 	kv := &Tag{

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -265,6 +265,20 @@ func (c *AgentConfig) applyDatadogConfig() error {
 		}
 	}
 
+	if config.Datadog.IsSet("apm_config.filter_tags.require") {
+		tags := config.Datadog.GetStringSlice("apm_config.filter_tags.require")
+		for _, tag := range tags {
+			c.RequireTags = append(c.RequireTags, splitTag(tag))
+		}
+	}
+
+	if config.Datadog.IsSet("apm_config.filter_tags.reject") {
+		tags := config.Datadog.GetStringSlice("apm_config.filter_tags.reject")
+		for _, tag := range tags {
+			c.RejectTags = append(c.RejectTags, splitTag(tag))
+		}
+	}
+
 	// undocumented
 	if config.Datadog.IsSet("apm_config.max_cpu_percent") {
 		c.MaxCPU = config.Datadog.GetFloat64("apm_config.max_cpu_percent") / 100
@@ -445,4 +459,17 @@ func toFloat64(val interface{}) (float64, error) {
 	default:
 		return 0, fmt.Errorf("%v can not be converted to float64", val)
 	}
+}
+
+func splitTag(tag string) Tag {
+	parts := strings.SplitN(tag, ":", 2)
+	kv := Tag{
+		K: strings.TrimSpace(parts[0]),
+	}
+	if len(parts) > 1 {
+		if v := strings.TrimSpace(parts[1]); v != "" {
+			kv.V = v
+		}
+	}
+	return kv
 }

--- a/pkg/trace/config/apply_test.go
+++ b/pkg/trace/config/apply_test.go
@@ -27,3 +27,36 @@ func TestParseRepaceRules(t *testing.T) {
 		assert.Equal(r.Pattern, r.Re.String())
 	}
 }
+
+// TestSplitTag tests the splitTag helper function.
+func TestSplitTag(t *testing.T) {
+	for _, tt := range []struct {
+		tag string
+		kv  *Tag
+	}{
+		{
+			tag: "",
+			kv:  &Tag{K: ""},
+		},
+		{
+			tag: "key:value",
+			kv:  &Tag{K: "key", V: "value"},
+		},
+		{
+			tag: "env:prod",
+			kv:  &Tag{K: "env", V: "prod"},
+		},
+		{
+			tag: "env:staging:east",
+			kv:  &Tag{K: "env", V: "staging:east"},
+		},
+		{
+			tag: "key",
+			kv:  &Tag{K: "key"},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, splitTag(tt.tag), tt.kv)
+		})
+	}
+}

--- a/pkg/trace/config/apply_test.go
+++ b/pkg/trace/config/apply_test.go
@@ -28,7 +28,6 @@ func TestParseRepaceRules(t *testing.T) {
 	}
 }
 
-// TestSplitTag tests the splitTag helper function.
 func TestSplitTag(t *testing.T) {
 	for _, tt := range []struct {
 		tag string

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -117,11 +117,18 @@ type AgentConfig struct {
 	// Obfuscation holds sensitive data obufscator's configuration.
 	Obfuscation *ObfuscationConfig
 
-	RequireTags []Tag
-	RejectTags  []Tag
+	// RequireTags represents a list of tags required for a root span.
+	RequireTags []*Tag
+
+	// RejectTags represents a list of tags that a root span must not have.
+	RejectTags []*Tag
 }
 
-type Tag struct{ K, V string }
+// Tag represents a key/value pair for filterable tags.
+type Tag struct {
+	K string
+	V string
+}
 
 // New returns a configuration with the default values.
 func New() *AgentConfig {

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -116,7 +116,12 @@ type AgentConfig struct {
 
 	// Obfuscation holds sensitive data obufscator's configuration.
 	Obfuscation *ObfuscationConfig
+
+	RequireTags []Tag
+	RejectTags  []Tag
 }
+
+type Tag struct{ K, V string }
 
 // New returns a configuration with the default values.
 func New() *AgentConfig {

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -117,17 +117,16 @@ type AgentConfig struct {
 	// Obfuscation holds sensitive data obufscator's configuration.
 	Obfuscation *ObfuscationConfig
 
-	// RequireTags represents a list of tags required for a root span.
+	// RequireTags specifies a list of tags which must be present on the root span in order for a trace to be accepted.
 	RequireTags []*Tag
 
-	// RejectTags represents a list of tags that a root span must not have.
+	// RejectTags specifies a list of tags which must be absent on the root span in order for a trace to be accepted.
 	RejectTags []*Tag
 }
 
-// Tag represents a key/value pair for filterable tags.
+// Tag represents a key/value pair.
 type Tag struct {
-	K string
-	V string
+	K, V string
 }
 
 // New returns a configuration with the default values.

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -181,6 +181,8 @@ func TestFullYamlConfig(t *testing.T) {
 		{Host: "https://my2.endpoint.eu", APIKey: "apikey5", NoProxy: noProxy},
 	}, c.Endpoints)
 
+	assert.ElementsMatch([]*Tag{{K: "env", V: "prod"}, {K: "db", V: "mongodb"}}, c.RequireTags)
+	assert.ElementsMatch([]*Tag{{K: "outcome", V: "success"}}, c.RejectTags)
 	assert.ElementsMatch([]*ReplaceRule{
 		{
 			Name:    "http.method",

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -183,6 +183,7 @@ func TestFullYamlConfig(t *testing.T) {
 
 	assert.ElementsMatch([]*Tag{{K: "env", V: "prod"}, {K: "db", V: "mongodb"}}, c.RequireTags)
 	assert.ElementsMatch([]*Tag{{K: "outcome", V: "success"}}, c.RejectTags)
+
 	assert.ElementsMatch([]*ReplaceRule{
 		{
 			Name:    "http.method",

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -253,6 +253,24 @@ func TestLoadEnv(t *testing.T) {
 		assert.Contains(cfg.ReplaceTags, rule2)
 	})
 
+	env = "DD_APM_FILTER_TAGS"
+	t.Run(env, func(t *testing.T) {
+		defer cleanConfig()()
+		assert := assert.New(t)
+		err := os.Setenv(env, `[{"require": ["important1", "important2:value1"], "reject": ["bad1:value1"]}]`)
+		assert.NoError(err)
+		defer os.Unsetenv(env)
+		cfg, err := Load("./testdata/full.yaml")
+		assert.NoError(err)
+		reqTags := make([]*Tag, 0)
+		reqTags = append(reqTags, splitTag("important1"))
+		reqTags = append(reqTags, splitTag("important2:value1"))
+		rejTags := make([]*Tag, 0)
+		rejTags = append(rejTags, splitTag("outcome:success"))
+		assert.Contains(cfg.RequireTags, reqTags)
+		assert.Contains(cfg.RejectTags, rejTags)
+	})
+
 	for _, envKey := range []string{
 		"DD_CONNECTION_LIMIT", // deprecated
 		"DD_APM_CONNECTION_LIMIT",

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -253,22 +253,28 @@ func TestLoadEnv(t *testing.T) {
 		assert.Contains(cfg.ReplaceTags, rule2)
 	})
 
-	env = "DD_APM_FILTER_TAGS"
+	env = "DD_APM_FILTER_TAGS_REQUIRE"
 	t.Run(env, func(t *testing.T) {
 		defer cleanConfig()()
 		assert := assert.New(t)
-		err := os.Setenv(env, `[{"require": ["important1", "important2:value1"], "reject": ["bad1:value1"]}]`)
+		err := os.Setenv(env, `important1 important2:value1`)
 		assert.NoError(err)
 		defer os.Unsetenv(env)
 		cfg, err := Load("./testdata/full.yaml")
 		assert.NoError(err)
-		reqTags := make([]*Tag, 0)
-		reqTags = append(reqTags, splitTag("important1"))
-		reqTags = append(reqTags, splitTag("important2:value1"))
-		rejTags := make([]*Tag, 0)
-		rejTags = append(rejTags, splitTag("outcome:success"))
-		assert.Contains(cfg.RequireTags, reqTags)
-		assert.Contains(cfg.RejectTags, rejTags)
+		assert.Equal(cfg.RequireTags, []*Tag{{K: "important1", V: ""}, {K: "important2", V: "value1"}})
+	})
+
+	env = "DD_APM_FILTER_TAGS_REJECT"
+	t.Run(env, func(t *testing.T) {
+		defer cleanConfig()()
+		assert := assert.New(t)
+		err := os.Setenv(env, `bad1:value1`)
+		assert.NoError(err)
+		defer os.Unsetenv(env)
+		cfg, err := Load("./testdata/full.yaml")
+		assert.NoError(err)
+		assert.Equal(cfg.RejectTags, []*Tag{{K: "bad1", V: "value1"}})
 	})
 
 	for _, envKey := range []string{

--- a/pkg/trace/config/testdata/full.yaml
+++ b/pkg/trace/config/testdata/full.yaml
@@ -36,6 +36,10 @@ apm_config:
     - /health
     - /500
 
+  filter_tags:    
+    require: ["env:prod", "db:mongodb"]
+    reject: ["outcome:success"]
+
   replace_tags:
     - name: "http.method"
       pattern: "\\?.*$"

--- a/pkg/trace/test/testsuite/traces_test.go
+++ b/pkg/trace/test/testsuite/traces_test.go
@@ -89,7 +89,7 @@ func TestTraces(t *testing.T) {
 	})
 
 	t.Run("filter_tags", func(t *testing.T) {
-		if err := r.RunAgent([]byte("apm_config:\r\n  filter_tags:\r\n require: "["env:prod", db:mysql"]" \r\n"reject": ["outcome:"success"]}]")); err != nil {
+		if err := r.RunAgent([]byte("apm_config:\r\n  filter_tags.require: [env:prod, db:mysql]\r\n  filter_tags.reject: [outcome:success]")); err != nil {
 			t.Fatal(err)
 		}
 		defer r.KillAgent()

--- a/releasenotes/notes/apm-filter-tags-d07ca95829159d2e.yaml
+++ b/releasenotes/notes/apm-filter-tags-d07ca95829159d2e.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Add support for filtering tags by means of apm_config.filter_tags or environment
+    variables DD_APM_FILTER_TAGS_REQUIRE and DD_APM_FILTER_TAGS_REJECT.


### PR DESCRIPTION
This change adds support for filtering tags based on a set of required
or rejected tags. If any root spans are found that do not contain the
required set of tags, the trace will be dropped. If any root spans are
found that contain the rejected set of tags, that trace is also dropped.

Example configuration:

	apm_config:
		filter_tags:
			require: ["db:sql", "db.instance:mysql"]
			reject: ["outcome:success"]

These settings can also be configured by means of environment variables
DD_APM_FILTER_TAGS_REQUIRE and DD_APM_FILTER_TAGS_REJECT as a set k:v
pairs separated by space.

Fixes #7050 