### PR TITLE
Fix shellcheck pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
   hooks:
     - id: shellcheck
       args: ["--severity=info", "-e", "SC2059", "-e", "SC2028"]
+      additional_dependencies: []
 - repo: local
   hooks:
     - id: golint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   hooks:
     - id: shellcheck
       args: ["--severity=info", "-e", "SC2059", "-e", "SC2028"]
-      additional_dependencies: []
+      additional_dependencies: [] # Can be removed after this fix gets merged: https://github.com/jumanjihouse/pre-commit-hooks/pull/80
 - repo: local
   hooks:
     - id: golint


### PR DESCRIPTION
### What does this PR do?

- Fix shellcheck pre-commit 

### Motivation

- Allow people to use pre-commit 2.10.1. pre-commit/pre-commit#1771 has a breaking change that breaks the shellcheck hook we use (see jumanjihouse/pre-commit-hooks#82).
