### PR TITLE
[windows] Add ability to set `ec2_use_windows_prefix_detection` via Win CLI installer

### DIFF
--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -46,6 +46,7 @@ var (
 	subServices = map[string]string{"logs_enabled": "logs_enabled",
 		"apm_enabled":     "apm_config.enabled",
 		"process_enabled": "process_config.enabled"}
+	ec2UseWinPrefixDetectionKey = "ec2_use_windows_prefix_detection"
 )
 
 func init() {
@@ -324,6 +325,15 @@ func importRegistryConfig() error {
 		overrides["hostname_fqdn"] = val
 		log.Debugf("Setting hostname_fqdn to %s", val)
 	}
+	if val, _, err = k.GetStringValue(ec2UseWinPrefixDetectionKey); err == nil && val != "" {
+		val = strings.ToLower(val)
+		if enabled, ok := enabledVals[val]; ok {
+			overrides[ec2UseWinPrefixDetectionKey] = enabled
+			log.Debugf("Setting %s to %s", ec2UseWinPrefixDetectionKey, val)
+		} else {
+			log.Warnf("Unparsable boolean value for %s: %s", ec2UseWinPrefixDetectionKey, val)
+		}
+	}
 
 	// apply overrides to the config
 	config.AddOverrides(overrides)
@@ -347,8 +357,17 @@ func importRegistryConfig() error {
 		return fmt.Errorf("unable to unmarshal config to %s: %v", datadogYamlPath, err)
 	}
 
-	valuenames := []string{"api_key", "tags", "hostname",
-		"proxy_host", "proxy_port", "proxy_user", "proxy_password", "cmd_port"}
+	valuenames := []string{
+		"api_key",
+		"tags",
+		"hostname",
+		"proxy_host",
+		"proxy_port",
+		"proxy_user",
+		"proxy_password",
+		"cmd_port",
+		ec2UseWinPrefixDetectionKey,
+	}
 	for _, valuename := range valuenames {
 		k.DeleteValue(valuename)
 	}

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -53,13 +53,10 @@ var (
 	// Maps which settings from the registry should be taken and placed into
 	// datadog.yaml keys
 	regSettings = map[string]string{
-		"dd_url":         "dd_url",
-		"hostname_fqdn":  "hostname_fqdn",
-		"logs_dd_url":    "logs_config.logs_dd_url",
-		"process_dd_url": "process_config.process_dd_url",
-		"py_version":     "python_version",
-		"site":           "site",
-		"trace_dd_url":   "apm_config.apm_dd_url",
+		"dd_url":        "dd_url",
+		"hostname_fqdn": "hostname_fqdn",
+		"py_version":    "python_version",
+		"site":          "site",
 	}
 
 	subServices = map[string]string{

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -264,6 +264,9 @@
           <RegistryValue Name="hostname_fqdn"
                          Type="string"
                          Value="[HOSTNAME_FQDN_ENABLED]" />
+          <RegistryValue Name="ec2_use_windows_prefix_detection"
+                         Type="string"
+                         Value="[EC2_USE_WINDOWS_PREFIX_DETECTION]" />
         </RegistryKey>
 
       </Component>

--- a/omnibus/resources/dogstatsd/msi/source.wxs.erb
+++ b/omnibus/resources/dogstatsd/msi/source.wxs.erb
@@ -143,7 +143,7 @@
                          Type="string"
                          Value="[PROXY_PASSWORD]" >
                        </RegistryValue>
-          
+
           <RegistryValue Name="site"
                          Type="string"
                          Value="[SITE]" />
@@ -154,6 +154,9 @@
           <RegistryValue Name="hostname_fqdn"
                          Type="string"
                          Value="[HOSTNAME_FQDN_ENABLED]" />
+          <RegistryValue Name="ec2_use_windows_prefix_detection"
+                         Type="string"
+                         Value="[EC2_USE_WINDOWS_PREFIX_DETECTION]" />
          </RegistryKey>
 
       </Component>

--- a/omnibus/resources/iot/msi/source.wxs.erb
+++ b/omnibus/resources/iot/msi/source.wxs.erb
@@ -212,6 +212,9 @@
           <RegistryValue Name="hostname_fqdn"
                          Type="string"
                          Value="[HOSTNAME_FQDN_ENABLED]" />
+          <RegistryValue Name="ec2_use_windows_prefix_detection"
+                         Type="string"
+                         Value="[EC2_USE_WINDOWS_PREFIX_DETECTION]" />
         </RegistryKey>
 
       </Component>

--- a/releasenotes/notes/allow-windows-installer-ec2-prefix-detection-flag-c1510d7eeffefb22.yaml
+++ b/releasenotes/notes/allow-windows-installer-ec2-prefix-detection-flag-c1510d7eeffefb22.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Windows installer can now use the command line key ``EC2_USE_WINDOWS_PREFIX_DETECTION`` to set the config
+    value of ``ec2_use_windows_prefix_detection``


### PR DESCRIPTION
### What does this PR do?

This flag is rather useful in EC2 Windows machines so a way to set this
flag via the CLI was needed. This change allows the installer now to
accept this value through the `EC2_USE_WINDOWS_PREFIX_DETECTION`
variable.

Some cleanups to registry values handling was done as part of this PR thus the extended QA procedure 

### Motivation

AC-165

### Describe your test plan

#### Agent

- [ ] Install Agent via MSI installer using something like this:
  ```powershell
  Start-Process -Wait msiexec -ArgumentList '/qn /i C:\Users\dev1\datadog-dogstatsd-...x86_64.msi APIKEY="blah" SITE="mysite" EC2_USE_WINDOWS_PREFIX_DETECTION="true" HOSTNAME_FQDN_ENABLED="true" TRACE_DD_URL="https://test.org/trace"  PROCESS_DD_URL="https://test.org/process"  LOGS_DD_URL="https://test.org/logs" DD_URL="https://test.org/main"'
  ```
- Verify that the following values are set properly in `\ProgramData\Datadog\datadog.yaml`:
  - [ ] "apm_config.apm_dd_url"
  - [ ] "dd_url"
  - [ ] "hostname_fqdn"
  - [ ] "logs_config.logs_dd_url"
  - [ ] "process_config.process_dd_url"
  - [ ] "site"
  
- [ ] Try different permutations of the field values in clean VM snapshot installs and see them reflected correctly in the config file

#### Dogstatsd

- [ ] Install standalone dogstatsd via MSI installer using something like this:
  ```powershell
  Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-dogstatsd-...-x86_64.msi APIKEY="blah" SITE="mysite" EC2_USE_WINDOWS_PREFIX_DETECTION="true" HOSTNAME_FQDN_ENABLED="true" DD_URL="https://test.org/main"'
  ```
- Verify that the following values are set properly in `\ProgramData\Datadog\dogstatsd.yaml`:
  - [ ] "dd_url"
  - [ ] "hostname_fqdn"
  - [ ] "site"
  
- [ ] Try different permutations of the field values in clean VM snapshot installs and see them reflected correctly in the config file
