### PR TITLE
Improve accuracy of retransmit counting on kernels >= 4.7

### DIFF
--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "09b4823f1a0d5534d5a03a8e153cf6c20150cc33ecf5bc51b503307ed902c68e")
+var Tracer = NewRuntimeAsset("tracer.c", "22bb3fffd77195dfb4cdcc6c5eaaa5cf252b5a627ecd7957568df35799e9e200")

--- a/pkg/network/dns_snooper_test.go
+++ b/pkg/network/dns_snooper_test.go
@@ -45,7 +45,7 @@ func getSnooper(
 		return nil, nil
 	}
 
-	mgr := netebpf.NewManager(ddebpf.NewPerfHandler(1), ddebpf.NewPerfHandler(1))
+	mgr := netebpf.NewManager(ddebpf.NewPerfHandler(1), ddebpf.NewPerfHandler(1), false)
 	mgrOptions := manager.Options{
 		MapSpecEditors: map[string]manager.MapSpecEditor{
 			// These maps are unrelated to DNS but are getting set because the eBPF library loads all of them

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -213,7 +213,7 @@ static __always_inline int handle_message(conn_tuple_t* t, size_t sent_bytes, si
     return 0;
 }
 
-static __always_inline int handle_retransmit(struct sock* sk) {
+static __always_inline int handle_retransmit(struct sock* sk, int segs) {
     conn_tuple_t t = {};
     u64 zero = 0;
 
@@ -221,7 +221,7 @@ static __always_inline int handle_retransmit(struct sock* sk) {
         return 0;
     }
 
-    tcp_stats_t stats = { .retransmits = 1, .rtt = 0, .rtt_var = 0 };
+    tcp_stats_t stats = { .retransmits = segs, .rtt = 0, .rtt_var = 0 };
     update_tcp_stats(&t, stats);
 
     return 0;
@@ -483,9 +483,15 @@ int kretprobe__udp_recvmsg(struct pt_regs* ctx) {
 SEC("kprobe/tcp_retransmit_skb")
 int kprobe__tcp_retransmit_skb(struct pt_regs* ctx) {
     struct sock* sk = (struct sock*)PT_REGS_PARM1(ctx);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)
+    int segs = 1;
+#else
+    int segs = (int)PT_REGS_PARM3(ctx);
+#endif
     log_debug("kprobe/tcp_retransmit\n");
 
-    return handle_retransmit(sk);
+    return handle_retransmit(sk, segs);
 }
 
 SEC("kprobe/tcp_set_state")

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -32,8 +32,8 @@ func NewOffsetManager() *manager.Manager {
 	}
 }
 
-func NewManager(closedHandler, httpHandler *ebpf.PerfHandler) *manager.Manager {
-	return &manager.Manager{
+func NewManager(closedHandler, httpHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Manager {
+	mgr := &manager.Manager{
 		Maps: []*manager.Map{
 			{Name: string(probes.ConnMap)},
 			{Name: string(probes.TcpStatsMap)},
@@ -93,4 +93,10 @@ func NewManager(closedHandler, httpHandler *ebpf.PerfHandler) *manager.Manager {
 			{Section: string(probes.SocketHTTPFilter)},
 		},
 	}
+
+	if !runtimeTracer {
+		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.TCPRetransmitPre470)})
+	}
+
+	return mgr
 }

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -95,7 +95,7 @@ func NewManager(closedHandler, httpHandler *ebpf.PerfHandler, runtimeTracer bool
 	}
 
 	if !runtimeTracer {
-		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.TCPRetransmitPre470)})
+		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.TCPRetransmitPre470), MatchFuncName: "^tcp_retransmit_skb$"})
 	}
 
 	return mgr

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -94,6 +94,9 @@ func NewManager(closedHandler, httpHandler *ebpf.PerfHandler, runtimeTracer bool
 		},
 	}
 
+	// the runtime compiled tracer has no need for separate probes targeting specific kernel versions, since it can
+	// do that with #ifdefs inline. Thus the following probes should only be declared as existing in the prebuilt
+	// tracer.
 	if !runtimeTracer {
 		mgr.Probes = append(mgr.Probes, &manager.Probe{Section: string(probes.TCPRetransmitPre470), MatchFuncName: "^tcp_retransmit_skb$"})
 	}

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -59,7 +59,8 @@ const (
 	UDPDestroySockReturn ProbeName = "kretprobe/udp_destroy_sock"
 
 	// TCPRetransmit traces the return value for the tcp_retransmit_skb() system call
-	TCPRetransmit ProbeName = "kprobe/tcp_retransmit_skb"
+	TCPRetransmit       ProbeName = "kprobe/tcp_retransmit_skb"
+	TCPRetransmitPre470 ProbeName = "kprobe/tcp_retransmit_skb/pre_4_7_0"
 
 	// InetCskAcceptReturn traces the return value for the inet_csk_accept syscall
 	InetCskAcceptReturn ProbeName = "kretprobe/inet_csk_accept"

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -134,7 +134,7 @@ func eBPFSetup(t *testing.T) (*manager.Manager, *ddebpf.PerfHandler) {
 	}
 
 	httpPerfHandler := ddebpf.NewPerfHandler(10)
-	mgr := netebpf.NewManager(ddebpf.NewPerfHandler(1), httpPerfHandler)
+	mgr := netebpf.NewManager(ddebpf.NewPerfHandler(1), httpPerfHandler, false)
 	mgrOptions := manager.Options{
 		MapSpecEditors: map[string]manager.MapSpecEditor{
 			string(probes.HttpInFlightMap): {Type: ebpf.Hash, MaxEntries: 1024, EditorFlag: manager.EditMaxEntries},

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -56,11 +56,12 @@ type Tracer struct {
 
 	httpMonitor *http.Monitor
 
-	perfMap      *manager.PerfMap
-	perfHandler  *ddebpf.PerfHandler
-	batchManager *PerfBatchManager
-	flushIdle    chan chan struct{}
-	stop         chan struct{}
+	perfMap       *manager.PerfMap
+	perfHandler   *ddebpf.PerfHandler
+	batchManager  *PerfBatchManager
+	flushIdle     chan chan struct{}
+	stop          chan struct{}
+	runtimeTracer bool
 
 	// Telemetry
 	perfReceived  int64
@@ -116,8 +117,23 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 		log.Infof("detected platform %s, switch to use kprobes from kernel version < 4.1.0", currKernelVersion)
 	}
 
+	runtimeTracer := false
+	var buf bytecode.AssetReader
+	if config.EnableRuntimeCompiler {
+		buf, err = getRuntimeCompiledTracer(config)
+		if err != nil {
+			if !config.AllowPrecompiledFallback {
+				return nil, fmt.Errorf("error compiling network tracer: %s", err)
+			}
+			log.Warnf("error compiling network tracer, falling back to pre-compiled: %s", err)
+		} else {
+			runtimeTracer = true
+			defer buf.Close()
+		}
+	}
+
 	// Use the config to determine what kernel probes should be enabled
-	enabledProbes, err := config.EnabledProbes(pre410Kernel)
+	enabledProbes, err := config.EnabledProbes(runtimeTracer)
 	if err != nil {
 		return nil, fmt.Errorf("invalid probe configuration: %v", err)
 	}
@@ -149,19 +165,6 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 			string(probes.UdpPortBindingsMap): {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 			string(probes.HttpInFlightMap):    {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 		},
-	}
-
-	var buf bytecode.AssetReader
-	if config.EnableRuntimeCompiler {
-		buf, err = getRuntimeCompiledTracer(config)
-		if err != nil {
-			if !config.AllowPrecompiledFallback {
-				return nil, fmt.Errorf("error compiling network tracer: %s", err)
-			}
-			log.Warnf("error compiling network tracer, falling back to pre-compiled: %s", err)
-		} else {
-			defer buf.Close()
-		}
 	}
 
 	if buf == nil {
@@ -196,7 +199,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 	}
 	perfHandlerTCP := ddebpf.NewPerfHandler(closedChannelSize)
 	perfHandlerHTTP := ddebpf.NewPerfHandler(closedChannelSize)
-	m := netebpf.NewManager(perfHandlerTCP, perfHandlerHTTP)
+	m := netebpf.NewManager(perfHandlerTCP, perfHandlerHTTP, runtimeTracer)
 
 	// exclude all non-enabled probes to ensure we don't run into problems with unsupported probe types
 	for _, p := range m.Probes {
@@ -266,6 +269,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 		flushIdle:      make(chan chan struct{}),
 		stop:           make(chan struct{}),
 		buf:            make([]byte, network.ConnectionByteKeyMaxLen),
+		runtimeTracer:  runtimeTracer,
 	}
 
 	tr.perfMap, tr.batchManager, err = tr.initPerfPolling(perfHandlerTCP)

--- a/releasenotes/notes/npm-accurate-retransmits-f5fb7a6dd535ab4e.yaml
+++ b/releasenotes/notes/npm-accurate-retransmits-f5fb7a6dd535ab4e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    NPM - Improve accuracy of retransmits tracking on kernels >=4.7


### PR DESCRIPTION
### What does this PR do?

In kernel 4.7 a [change](https://github.com/torvalds/linux/commit/10d3be569243def8d92ac3722395ef5a59c504e6) was made to send multiple retransmits in the same socket buffer. In order to accurately track retransmitted segments, we need to use the newly added 3rd argument, named `segs` (for segments).

### Motivation

Improved accuracy of the reported retransmits number.

### Additional Notes

This installs a different probe depending on whether the kernel version is >= 4.7 or not. This is the same pattern we use for some of the < 4.1 probes.

The runtime compilation version doesn't need this switch, so it doesn't have a "pre 4.7" probe at all. This means we have to only declare that probe when using the prebuilt tracer. This code handles that logic.

### Describe your test plan

CI Kitchen tests are passing. I'm not sure there is a way to create the situation in CI that would result in `segs > 1`.