### PR TITLE
Rework usage of GetAPIClient/WaitForAPIClient to try our best to connect to K8S Apiserver

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -20,10 +20,8 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
-	v1 "github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -34,7 +32,7 @@ import (
 )
 
 // SetupHandlers adds the specific handlers for cluster agent endpoints
-func SetupHandlers(r *mux.Router, sc clusteragent.ServerContext) {
+func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/version", getVersion).Methods("GET")
 	r.HandleFunc("/hostname", getHostname).Methods("GET")
 	r.HandleFunc("/flare", makeFlare).Methods("POST")
@@ -43,9 +41,6 @@ func SetupHandlers(r *mux.Router, sc clusteragent.ServerContext) {
 	r.HandleFunc("/status/health", getHealth).Methods("GET")
 	r.HandleFunc("/config-check", getConfigCheck).Methods("GET")
 	r.HandleFunc("/config", getRuntimeConfig).Methods("GET")
-
-	// Install versioned apis
-	v1.Install(r.PathPrefix("/api/v1").Subrouter(), sc)
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request) {

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -25,24 +25,24 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/agent"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 var (
 	listener net.Listener
+	router   *mux.Router
 )
 
 // StartServer creates the router and starts the HTTP server
-func StartServer(sc clusteragent.ServerContext) error {
+func StartServer() error {
 	// create the root HTTP router
-	r := mux.NewRouter()
+	router = mux.NewRouter()
 
 	// IPC REST API server
-	agent.SetupHandlers(r, sc)
+	agent.SetupHandlers(router)
 
 	// Validate token for every request
-	r.Use(validateToken)
+	router.Use(validateToken)
 
 	// get the transport we're going to use under HTTP
 	var err error
@@ -85,7 +85,7 @@ func StartServer(sc clusteragent.ServerContext) error {
 	}
 
 	srv := &http.Server{
-		Handler: r,
+		Handler: router,
 		ErrorLog: stdLog.New(&config.ErrorLogWriter{
 			AdditionalDepth: 4, // Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
 		}, "Error from the agent http API server: ", 0), // log errors to seelog,
@@ -96,6 +96,11 @@ func StartServer(sc clusteragent.ServerContext) error {
 
 	go srv.Serve(tlsListener) //nolint:errcheck
 	return nil
+}
+
+// ModifyRouter allows to pass in a function to modify router used in server
+func ModifyRouter(f func(*mux.Router)) {
+	f(router)
 }
 
 // StopServer closes the connection and the server

--- a/cmd/security-agent/common/check_command.go
+++ b/cmd/security-agent/common/check_command.go
@@ -79,6 +79,7 @@ func runCheck(cmd *cobra.Command, confPathArray []string, args []string) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
+		log.Info("Waiting for APIClient")
 		apiCl, err := apiserver.WaitForAPIClient(ctx)
 		if err != nil {
 			return err

--- a/pkg/autodiscovery/listeners/kube_endpoints.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints.go
@@ -62,6 +62,7 @@ func init() {
 }
 
 func NewKubeEndpointsListener() (ServiceListener, error) {
+	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)

--- a/pkg/autodiscovery/listeners/kube_services.go
+++ b/pkg/autodiscovery/listeners/kube_services.go
@@ -57,6 +57,7 @@ func init() {
 }
 
 func NewKubeServiceListener() (ServiceListener, error) {
+	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)

--- a/pkg/autodiscovery/providers/kube_endpoints.go
+++ b/pkg/autodiscovery/providers/kube_endpoints.go
@@ -56,6 +56,7 @@ type configInfo struct {
 // NewKubeEndpointsConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
 func NewKubeEndpointsConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -38,6 +38,7 @@ type KubeServiceConfigProvider struct {
 // NewKubeServiceConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
 func NewKubeServiceConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+	// Using GetAPIClient() (no retry)
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)

--- a/pkg/autodiscovery/providers/prometheus_services.go
+++ b/pkg/autodiscovery/providers/prometheus_services.go
@@ -64,6 +64,7 @@ type PrometheusServicesConfigProvider struct {
 
 // NewPrometheusServicesConfigProvider returns a new Prometheus ConfigProvider connected to kube apiserver
 func NewPrometheusServicesConfigProvider(configProviders config.ConfigurationProviders) (ConfigProvider, error) {
+	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -161,7 +161,7 @@ func (k *KubeASCheck) Run() error {
 	}
 	// API Server client initialisation on first run
 	if k.ac == nil {
-		// We start the API Server Client.
+		// Using GetAPIClient (no wait) as check we'll naturally retry with each check run
 		k.ac, err = apiserver.GetAPIClient()
 		if err != nil {
 			k.Warnf("Could not connect to apiserver: %s", err) //nolint:errcheck

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -81,6 +81,8 @@ func (c *KubeMetadataCollector) Detect(out chan<- []*TagInfo) (CollectionMode, e
 	}
 	// Fallback to local metamapper if DCA not enabled, or in permafail state with fallback enabled.
 	if !config.Datadog.GetBool("cluster_agent.enabled") || errDCA != nil {
+		// Using GetAPIClient as error returned follows the IsErrWillRetry/IsErrPermaFail
+		// Tagger will retry calling this method until permafail
 		c.apiClient, err = apiserver.GetAPIClient()
 		if err != nil {
 			return NoCollection, err

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 
 	"strings"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -37,11 +38,12 @@ import (
 )
 
 var (
-	globalAPIClient  *APIClient
-	ErrNotFound      = errors.New("entity not found")
-	ErrIsEmpty       = errors.New("entity is empty")
-	ErrNotLeader     = errors.New("not Leader")
-	isConnectVerbose = false
+	globalAPIClient     *APIClient
+	globalAPIClientOnce sync.Once
+	ErrNotFound         = errors.New("entity not found")
+	ErrIsEmpty          = errors.New("entity is empty")
+	ErrNotLeader        = errors.New("not Leader")
+	isConnectVerbose    = false
 )
 
 const (
@@ -88,20 +90,25 @@ type APIClient struct {
 	timeoutSeconds int64
 }
 
-// GetAPIClient returns the shared ApiClient instance.
-func GetAPIClient() (*APIClient, error) {
-	if globalAPIClient == nil {
-		globalAPIClient = &APIClient{
-			timeoutSeconds: config.Datadog.GetInt64("kubernetes_apiserver_client_timeout"),
-		}
-		globalAPIClient.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck
-			Name:              "apiserver",
-			AttemptMethod:     globalAPIClient.connect,
-			Strategy:          retry.Backoff,
-			InitialRetryDelay: 1 * time.Second,
-			MaxRetryDelay:     5 * time.Minute,
-		})
+func initAPIClient() {
+	globalAPIClient = &APIClient{
+		timeoutSeconds: config.Datadog.GetInt64("kubernetes_apiserver_client_timeout"),
 	}
+	globalAPIClient.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck
+		Name:              "apiserver",
+		AttemptMethod:     globalAPIClient.connect,
+		Strategy:          retry.Backoff,
+		InitialRetryDelay: 1 * time.Second,
+		MaxRetryDelay:     5 * time.Minute,
+	})
+}
+
+// GetAPIClient returns the shared APIClient if already set
+// it will trigger a retry if not, but won't wait until retries are exhausted
+// See `WaitForAPIClient()` for a method that waits until APIClient is ready
+func GetAPIClient() (*APIClient, error) {
+	globalAPIClientOnce.Do(initAPIClient)
+
 	err := globalAPIClient.initRetry.TriggerRetry()
 	if err != nil {
 		log.Debugf("API Server init error: %s", err)
@@ -110,10 +117,9 @@ func GetAPIClient() (*APIClient, error) {
 	return globalAPIClient, nil
 }
 
+// WaitForAPIClient waits for availability of APIServer Client before returning
 func WaitForAPIClient(ctx context.Context) (*APIClient, error) {
-	if globalAPIClient == nil {
-		_, _ = GetAPIClient()
-	}
+	globalAPIClientOnce.Do(initAPIClient)
 
 	for {
 		_ = globalAPIClient.initRetry.TriggerRetry()

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -8,6 +8,7 @@
 package apiserver
 
 import (
+	"context"
 	"errors"
 
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
@@ -31,6 +32,12 @@ func GetAPIClient() (*APIClient, error) {
 	return &APIClient{}, nil
 }
 
+// WaitForAPIClient returns the shared ApiClient instance.
+func WaitForAPIClient(ctx context.Context) (*APIClient, error) {
+	log.Errorf("WaitForAPIClient not implemented %s", ErrNotCompiled.Error())
+	return &APIClient{}, nil
+}
+
 // GetPodMetadataNames is used when the API endpoint of the DCA to get the services of a pod is hit.
 func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
 	log.Errorf("GetPodMetadataNames not implemented %s", ErrNotCompiled.Error())
@@ -50,7 +57,7 @@ func GetMetadataMapBundleOnAllNodes(_ *APIClient) (*apiv1.MetadataResponse, erro
 }
 
 // GetNodeLabels retrieves the labels of the queried node from the cache of the shared informer.
-func GetNodeLabels(nodeName string) (map[string]string, error) {
+func GetNodeLabels(_ *APIClient, nodeName string) (map[string]string, error) {
 	log.Errorf("GetNodeLabels not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -129,6 +129,7 @@ func (le *LeaderEngine) init() error {
 	}
 	log.Debugf("LeaderLeaseDuration: %s", le.LeaseDuration.String())
 
+	// Using GetAPIClient (no retry) as LeaderElection is already wrapped in a retrier
 	apiClient, err := apiserver.GetAPIClient()
 	if err != nil {
 		log.Errorf("Not Able to set up a client for the Leader Election: %s", err)

--- a/pkg/util/kubernetes/apiserver/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller.go
@@ -314,16 +314,10 @@ func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
 }
 
 // GetNodeLabels retrieves the labels of the queried node from the cache of the shared informer.
-func GetNodeLabels(nodeName string) (map[string]string, error) {
+func GetNodeLabels(as *APIClient, nodeName string) (map[string]string, error) {
 	if !config.Datadog.GetBool("kubernetes_collect_metadata_tags") {
 		return nil, log.Errorf("Metadata collection is disabled on the Cluster Agent")
 	}
-
-	as, err := GetAPIClient()
-	if err != nil {
-		return nil, err
-	}
-
 	node, err := as.InformerFactory.Core().V1().Nodes().Lister().Get(nodeName)
 	if err != nil {
 		return nil, err

--- a/pkg/util/kubernetes/hostinfo/apiserver.go
+++ b/pkg/util/kubernetes/hostinfo/apiserver.go
@@ -8,11 +8,21 @@
 package hostinfo
 
 import (
+	"context"
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
 
+const (
+	apiserverTimeout = 10 * time.Second
+)
+
 func apiserverNodeLabels(nodeName string) (map[string]string, error) {
-	client, err := apiserver.GetAPIClient()
+	ctx, cancel := context.WithTimeout(context.Background(), apiserverTimeout)
+	defer cancel()
+
+	client, err := apiserver.WaitForAPIClient(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Clarify usage of `GetAPIClient` and `WaitForAPIClient`:
- GetAPIClient will always return quickly, attempting at most once to get APIClient
- WaitForAPIClient will retry until given context has expired or permafail

Changed Cluster Agent start sequence to ensure we have access to API Client before starting components that may depend on it and where we cannot use `WaitForAPIClient`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

No specific test as this should be transparent change. Run the Cluster Agent and verifies everything works as expected when it comes to APIServer connection.