### PR TITLE
Avoid warning about EC2 tags when detecting cluster name with ec2

### DIFF
--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -190,9 +190,9 @@ func GetClusterName() (string, error) {
 	if !config.IsCloudProviderEnabled(CloudProviderName) {
 		return "", fmt.Errorf("cloud provider is disabled by configuration")
 	}
-	tags, err := GetTags()
+	tags, err := fetchTagsFromCache()
 	if err != nil {
-		return "", fmt.Errorf("unable to retrieve clustername from EC2: %s", err)
+		return "", err
 	}
 
 	return extractClusterName(tags)

--- a/pkg/util/ec2/ec2_no_tags.go
+++ b/pkg/util/ec2/ec2_no_tags.go
@@ -11,3 +11,7 @@ package ec2
 func GetTags() ([]string, error) {
 	return []string{}, nil
 }
+
+func fetchTagsFromCache() ([]string, error) {
+	return []string{}, nil
+}


### PR DESCRIPTION
### What does this PR do?

The warning was misleading for user disabling 'collect_ec2_tags'
configuration.
