### PR TITLE
[runtime-security] replace overlay_numlower by an in_upper_layer boolean

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -77,7 +77,7 @@ kitchen_debian_security_agent:
   extends: .kitchen_test_security_agent
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
-    - KITCHEN_PLATFORM="debian"
-    - KITCHEN_OSVERS="debian-10"
+    - export KITCHEN_PLATFORM="debian"
+    - export KITCHEN_OSVERS="debian-10"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -69,7 +69,7 @@ kitchen_suse_security_agent:
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="suse"
-    - export KITCHEN_OSVERS="sles-12,sles15"
+    - export KITCHEN_OSVERS="sles-12,sles-15"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e29c40cfe6f760c3c64a084a879bf3d07c29eb226d6544f467c8229dcaf2a1bf")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ac1ea7371a39bd4c93ac7eb9226ea083db65a803f945bf8100d9520ad85fdea6")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "259a39bebc553b8d8d7f8a108cdaee49a2996d30f7bff7fa4e7a881c11ab526e")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e29c40cfe6f760c3c64a084a879bf3d07c29eb226d6544f467c8229dcaf2a1bf")

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -59,13 +59,7 @@ int __attribute__((always_inline)) trace__sys_chmod_ret(struct pt_regs *ctx) {
 
     struct chmod_event_t event = {
         .syscall.retval = retval,
-        .file = {
-            .mount_id = syscall->setattr.path_key.mount_id,
-            .inode = syscall->setattr.path_key.ino,
-            .overlay_numlower = get_overlay_numlower(syscall->setattr.dentry),
-            .path_id = syscall->setattr.path_key.path_id,
-            .metadata = syscall->setattr.metadata,
-        },
+        .file = syscall->setattr.file,
         .padding = 0,
         .mode = syscall->setattr.mode,
     };

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -76,13 +76,7 @@ int __attribute__((always_inline)) trace__sys_chown_ret(struct pt_regs *ctx) {
 
     struct chown_event_t event = {
         .syscall.retval = retval,
-        .file = {
-            .inode = syscall->setattr.path_key.ino,
-            .mount_id = syscall->setattr.path_key.mount_id,
-            .overlay_numlower = get_overlay_numlower(syscall->setattr.dentry),
-            .path_id = syscall->setattr.path_key.path_id,
-            .metadata = syscall->setattr.metadata,
-        },
+        .file = syscall->setattr.file,
         .user = syscall->setattr.user,
         .group = syscall->setattr.group,
     };

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -239,6 +239,30 @@ struct kevent_t {
     u64 type;
 };
 
+struct syscall_t {
+    s64 retval;
+};
+
+struct process_context_t {
+    u32 pid;
+    u32 tid;
+};
+
+struct container_context_t {
+    char container_id[CONTAINER_ID_LEN];
+};
+
+enum file_flags {
+    LOWER_LAYER = 1 << 0,
+    UPPER_LAYER = 1 << 1,
+};
+
+struct path_key_t {
+    u64 ino;
+    u32 mount_id;
+    u32 path_id;
+};
+
 struct ktimeval {
     long tv_sec;
     long tv_nsec;
@@ -255,32 +279,10 @@ struct file_metadata_t {
 };
 
 struct file_t {
-    u64 inode;
-    u32 mount_id;
-    u32 overlay_numlower;
-    u32 path_id;
+    struct path_key_t path_key;
+    u32 flags;
     u32 padding;
-
     struct file_metadata_t metadata;
-};
-
-struct syscall_t {
-    s64 retval;
-};
-
-struct process_context_t {
-    u32 pid;
-    u32 tid;
-};
-
-struct container_context_t {
-    char container_id[CONTAINER_ID_LEN];
-};
-
-struct path_key_t {
-    u64 ino;
-    u32 mount_id;
-    u32 path_id;
 };
 
 struct bpf_map_def SEC("maps/path_id") path_id = {
@@ -412,7 +414,6 @@ static __attribute__((always_inline)) u32 atoi(char *buff) {
 
 // implemented in the probe.c file
 void __attribute__((always_inline)) invalidate_inode(struct pt_regs *ctx, u32 mount_id, u64 inode, int send_invalidate_event);
-void __attribute__((always_inline)) invalidate_path_key(struct pt_regs *ctx, struct path_key_t *key, int send_invalidate_event);
 
 struct bpf_map_def SEC("maps/enabled_events") enabled_events = {
     .type = BPF_MAP_TYPE_ARRAY,

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -141,10 +141,14 @@ dev_t __attribute__((always_inline)) get_mount_dev(void *mnt) {
     return get_vfsmount_dev(get_mount_vfsmount(mnt));
 }
 
-unsigned long __attribute__((always_inline)) get_dentry_ino(struct dentry *dentry) {
+struct inode* __attribute__((always_inline)) get_dentry_inode(struct dentry *dentry) {
     struct inode *d_inode;
     bpf_probe_read(&d_inode, sizeof(d_inode), &dentry->d_inode);
-    return get_inode_ino(d_inode);
+    return d_inode;
+}
+
+unsigned long __attribute__((always_inline)) get_dentry_ino(struct dentry *dentry) {
+    return get_inode_ino(get_dentry_inode(dentry));
 }
 
 void __attribute__((always_inline)) fill_file_metadata(struct dentry* dentry, struct file_metadata_t* file) {

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -141,17 +141,6 @@ dev_t __attribute__((always_inline)) get_mount_dev(void *mnt) {
     return get_vfsmount_dev(get_mount_vfsmount(mnt));
 }
 
-int __attribute__((always_inline)) get_overlay_numlower(struct dentry *dentry) {
-    int numlower;
-    void *fsdata;
-    bpf_probe_read(&fsdata, sizeof(void *), &dentry->d_fsdata);
-
-    // bpf_probe_read(&numlower, sizeof(int), fsdata + offsetof(struct ovl_entry, numlower));
-    // TODO: make it a constant and change its value based on the current kernel version. 16 is only good for kernels 4.13+
-    bpf_probe_read(&numlower, sizeof(int), fsdata + 16);
-    return numlower;
-}
-
 unsigned long __attribute__((always_inline)) get_dentry_ino(struct dentry *dentry) {
     struct inode *d_inode;
     bpf_probe_read(&d_inode, sizeof(d_inode), &dentry->d_inode);
@@ -206,16 +195,16 @@ void __attribute__((always_inline)) get_dentry_name(struct dentry *dentry, void 
 #define get_inode_key_path(inode, path) (struct path_key_t) { .ino = get_inode_ino(inode), .mount_id = get_path_mount_id(path) }
 
 static int is_overlayfs(struct dentry *dentry);
-static int get_overlayfs_ino(struct dentry *dentry, struct path_key_t *path);
+static void set_overlayfs_ino(struct dentry *dentry, u64 *ino, u32 *flags);
 
-static __attribute__((always_inline)) void set_path_key_inode(struct dentry *dentry, struct path_key_t *path_key, int invalidate) {
-    path_key->path_id = get_path_id(invalidate);
-    if (!path_key->ino) {
-        path_key->ino = get_dentry_ino(dentry);
+static __attribute__((always_inline)) void set_file_inode(struct dentry *dentry, struct file_t *file, int invalidate) {
+    file->path_key.path_id = get_path_id(invalidate);
+    if (!file->path_key.ino) {
+        file->path_key.ino = get_dentry_ino(dentry);
     }
 
     if (is_overlayfs(dentry)) {
-        path_key->ino = get_overlayfs_ino(dentry, path_key);
+        set_overlayfs_ino(dentry, &file->path_key.ino, &file->flags);
     }
 }
 

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -262,7 +262,7 @@ int __attribute__((always_inline)) is_discarded_by_process(const char mode, u64 
             return 1;
 
         struct proc_cache_t *entry = get_proc_cache(tgid);
-        if (entry && is_discarded_by_inode(event_type, entry->executable.mount_id, entry->executable.inode, 0)) {
+        if (entry && is_discarded_by_inode(event_type, entry->executable.path_key.mount_id, entry->executable.path_key.ino, 0)) {
             return 1;
         }
     }

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -152,18 +152,14 @@ SYSCALL_KPROBE4(execveat, int, fd, const char *, filename, const char **, argv, 
     return trace__sys_execveat(ctx, argv, env);
 }
 
-int __attribute__((always_inline)) handle_exec_event(struct pt_regs *ctx, struct syscall_cache_t *syscall) {
+int __attribute__((always_inline)) handle_exec_event(struct syscall_cache_t *syscall, struct file *file, struct path *path, struct inode *inode) {
     if (syscall->exec.is_parsed) {
         return 0;
     }
     syscall->exec.is_parsed = 1;
 
-    struct file *file = (struct file *)PT_REGS_PARM1(ctx);
-    struct inode *inode = (struct inode *)PT_REGS_PARM2(ctx);
-    struct path *path = &file->f_path;
-
     syscall->exec.dentry = get_file_dentry(file);
-    syscall->exec.file.path_key = get_inode_key_path(inode, &file->f_path);
+    syscall->exec.file.path_key = get_inode_key_path(inode, path);
     syscall->exec.file.path_key.path_id = get_path_id(0);
 
     u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -70,6 +70,8 @@ int kprobe__vfs_link(struct pt_regs *ctx) {
     // we generate a fake target key as the inode is the same
     syscall->link.target_file.path_key.ino = FAKE_INODE_MSW<<32 | bpf_get_prandom_u32();
     syscall->link.target_file.path_key.mount_id = syscall->link.src_file.path_key.mount_id;
+    if (is_overlayfs(src_dentry))
+        syscall->link.target_file.flags |= UPPER_LAYER;
 
     int ret = resolve_dentry(src_dentry, syscall->link.src_file.path_key, syscall->policy.mode != NO_FILTER ? EVENT_LINK : 0);
     if (ret == DENTRY_DISCARDED) {

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -59,19 +59,19 @@ int kprobe__vfs_link(struct pt_regs *ctx) {
         return discard_syscall(syscall);
     }
 
-    syscall->link.src_overlay_numlower = get_overlay_numlower(src_dentry);
-    fill_file_metadata(src_dentry, &syscall->link.src_metadata);
+    fill_file_metadata(src_dentry, &syscall->link.src_file.metadata);
+    syscall->link.target_file.metadata = syscall->link.src_file.metadata;
 
     // this is a hard link, source and target dentries are on the same filesystem & mount point
     // target_path was set by kprobe/filename_create before we reach this point.
-    syscall->link.src_key.mount_id = get_path_mount_id(syscall->link.target_path);
-    set_path_key_inode(src_dentry, &syscall->link.src_key, 1);
+    syscall->link.src_file.path_key.mount_id = get_path_mount_id(syscall->link.target_path);
+    set_file_inode(src_dentry, &syscall->link.src_file, 1);
 
     // we generate a fake target key as the inode is the same
-    syscall->link.target_key.ino = FAKE_INODE_MSW<<32 | bpf_get_prandom_u32();
-    syscall->link.target_key.mount_id = syscall->link.src_key.mount_id;
+    syscall->link.target_file.path_key.ino = FAKE_INODE_MSW<<32 | bpf_get_prandom_u32();
+    syscall->link.target_file.path_key.mount_id = syscall->link.src_file.path_key.mount_id;
 
-    int ret = resolve_dentry(src_dentry, syscall->link.src_key, syscall->policy.mode != NO_FILTER ? EVENT_LINK : 0);
+    int ret = resolve_dentry(src_dentry, syscall->link.src_file.path_key, syscall->policy.mode != NO_FILTER ? EVENT_LINK : 0);
     if (ret == DENTRY_DISCARDED) {
         return discard_syscall(syscall);
     }
@@ -92,26 +92,14 @@ int __attribute__((always_inline)) trace__sys_link_ret(struct pt_regs *ctx) {
         .event.type = EVENT_LINK,
         .event.timestamp = bpf_ktime_get_ns(),
         .syscall.retval = retval,
-        .source = {
-            .inode = syscall->link.src_key.ino,
-            .mount_id = syscall->link.src_key.mount_id,
-            .overlay_numlower = syscall->link.src_overlay_numlower,
-            .path_id = syscall->link.src_key.path_id,
-            .metadata = syscall->link.src_metadata,
-        },
-        .target = {
-            .inode = syscall->link.target_key.ino,
-            .mount_id = syscall->link.target_key.mount_id,
-            .overlay_numlower = get_overlay_numlower(syscall->link.target_dentry),
-            // this is a hard link, source and destination have necessarily the same inode metadata
-            .metadata = syscall->link.src_metadata,
-        }
+        .source = syscall->link.src_file,
+        .target = syscall->link.target_file,
     };
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
 
-    resolve_dentry(syscall->link.target_dentry, syscall->link.target_key, 0);
+    resolve_dentry(syscall->link.target_dentry, syscall->link.target_file.path_key, 0);
 
     send_event(ctx, EVENT_LINK, event);
 

--- a/pkg/security/ebpf/c/mnt.h
+++ b/pkg/security/ebpf/c/mnt.h
@@ -13,45 +13,45 @@ int kprobe__mnt_want_write(struct pt_regs *ctx) {
 
     switch (syscall->type) {
     case SYSCALL_UTIME:
-        if (syscall->setattr.path_key.mount_id > 0)
+        if (syscall->setattr.file.path_key.mount_id > 0)
             return 0;
-        syscall->setattr.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->setattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case SYSCALL_CHMOD:
-        if (syscall->setattr.path_key.mount_id > 0)
+        if (syscall->setattr.file.path_key.mount_id > 0)
             return 0;
-        syscall->setattr.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->setattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case SYSCALL_CHOWN:
-        if (syscall->setattr.path_key.mount_id > 0)
+        if (syscall->setattr.file.path_key.mount_id > 0)
             return 0;
-        syscall->setattr.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->setattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case SYSCALL_RENAME:
-        if (syscall->rename.src_key.mount_id > 0)
+        if (syscall->rename.src_file.path_key.mount_id > 0)
             return 0;
-        syscall->rename.src_key.mount_id = get_vfsmount_mount_id(mnt);
-        syscall->rename.target_key.mount_id = syscall->rename.src_key.mount_id;
+        syscall->rename.src_file.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->rename.target_file.path_key.mount_id = syscall->rename.src_file.path_key.mount_id;
         break;
     case SYSCALL_RMDIR:
-        if (syscall->rmdir.path_key.mount_id > 0)
+        if (syscall->rmdir.file.path_key.mount_id > 0)
             return 0;
-        syscall->rmdir.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->rmdir.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case SYSCALL_UNLINK:
-        if (syscall->unlink.path_key.mount_id > 0)
+        if (syscall->unlink.file.path_key.mount_id > 0)
             return 0;
-        syscall->unlink.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->unlink.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case SYSCALL_SETXATTR:
-        if (syscall->setxattr.path_key.mount_id > 0)
+        if (syscall->xattr.file.path_key.mount_id > 0)
             return 0;
-        syscall->setxattr.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->xattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case SYSCALL_REMOVEXATTR:
-        if (syscall->setxattr.path_key.mount_id > 0)
+        if (syscall->xattr.file.path_key.mount_id > 0)
             return 0;
-        syscall->setxattr.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->xattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     }
     return 0;
@@ -68,19 +68,19 @@ int __attribute__((always_inline)) trace__mnt_want_write_file(struct pt_regs *ct
 
     switch (syscall->type) {
     case SYSCALL_CHOWN:
-        if (syscall->setattr.path_key.mount_id > 0)
+        if (syscall->setattr.file.path_key.mount_id > 0)
             return 0;
-        syscall->setattr.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->setattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case SYSCALL_SETXATTR:
-        if (syscall->setxattr.path_key.mount_id > 0)
+        if (syscall->xattr.file.path_key.mount_id > 0)
             return 0;
-        syscall->setxattr.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->xattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case SYSCALL_REMOVEXATTR:
-        if (syscall->setxattr.path_key.mount_id > 0)
+        if (syscall->xattr.file.path_key.mount_id > 0)
             return 0;
-        syscall->setxattr.path_key.mount_id = get_vfsmount_mount_id(mnt);
+        syscall->xattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     }
     return 0;

--- a/pkg/security/ebpf/c/overlayfs.h
+++ b/pkg/security/ebpf/c/overlayfs.h
@@ -54,7 +54,7 @@ int __attribute__((always_inline)) get_ovl_upper_ino(struct dentry *dentry) {
     return get_dentry_ino(upper);
 }
 
-int __always_inline get_overlayfs_ino(struct dentry *dentry, struct path_key_t *path_key) {
+void __always_inline set_overlayfs_ino(struct dentry *dentry, u64 *ino, u32 *flags) {
     u64 lower_inode = get_ovl_lower_ino(dentry);
     u64 upper_inode = get_ovl_upper_ino(dentry);
 
@@ -62,12 +62,16 @@ int __always_inline get_overlayfs_ino(struct dentry *dentry, struct path_key_t *
     bpf_printk("get_overlayfs_ino lower: %d upper: %d\n", lower_inode, upper_inode);
 #endif
 
+    if (upper_inode)
+        *flags |= UPPER_LAYER;
+    else if (lower_inode)
+        *flags |= LOWER_LAYER;
+
     if (lower_inode) {
-        return lower_inode;
+        *ino = lower_inode;
     } else if (upper_inode) {
-        return upper_inode;
+        *ino = upper_inode;
     }
-    return path_key->ino;
 }
 
 #endif

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -67,10 +67,6 @@ void __attribute__((always_inline)) invalidate_inode(struct pt_regs *ctx, u32 mo
     }
 }
 
-void __attribute__((always_inline)) invalidate_path_key(struct pt_regs *ctx, struct path_key_t *key, int send_invalidate_event) {
-    invalidate_inode(ctx, key->mount_id, key->ino, send_invalidate_event);
-}
-
 __u32 _version SEC("version") = 0xFFFFFFFE;
 
 char LICENSE[] SEC("license") = "GPL";

--- a/pkg/security/ebpf/c/procfs.h
+++ b/pkg/security/ebpf/c/procfs.h
@@ -16,14 +16,19 @@ int kretprobe__get_task_exe_file(struct pt_regs *ctx) {
 
     struct dentry *dentry = get_file_dentry(file);
 
-    u64 inode = get_dentry_ino(dentry);
-    u32 overlay_numlower = get_overlay_numlower(dentry);
+    u32 flags = 0;
     u32 mount_id = get_file_mount_id(file);
+    u64 inode = get_dentry_ino(dentry);
+    if (is_overlayfs(dentry)) {
+        set_overlayfs_ino(dentry, &inode, &flags);
+    }
 
     struct file_t entry = {
-        .inode = inode,
-        .mount_id = mount_id,
-        .overlay_numlower = overlay_numlower,
+        .path_key = {
+            .ino = inode,
+            .mount_id = mount_id,
+        },
+        .flags = flags,
     };
     fill_file_metadata(dentry, &entry.metadata);
 

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -49,7 +49,7 @@ int kprobe__vfs_rename(struct pt_regs *ctx) {
         return 0;
 
     // if second pass, ex: overlayfs, just cache the inode that will be used in ret
-    if (syscall->rename.target_key.ino) {
+    if (syscall->rename.target_file.path_key.ino) {
         return 0;
     }
 
@@ -57,8 +57,10 @@ int kprobe__vfs_rename(struct pt_regs *ctx) {
     struct dentry *target_dentry = (struct dentry *)PT_REGS_PARM4(ctx);
 
     syscall->rename.src_dentry = src_dentry;
-    fill_file_metadata(src_dentry, &syscall->rename.src_metadata);
     syscall->rename.target_dentry = target_dentry;
+
+    fill_file_metadata(src_dentry, &syscall->rename.src_file.metadata);
+    syscall->rename.target_file.metadata = syscall->rename.src_file.metadata;
 
     if (filter_syscall(syscall, rename_approvers)) {
         return mark_as_discarded(syscall);
@@ -66,20 +68,18 @@ int kprobe__vfs_rename(struct pt_regs *ctx) {
 
     // use src_dentry as target inode is currently empty and the target file will
     // have the src inode anyway
-    set_path_key_inode(src_dentry, &syscall->rename.target_key, 1);
-
-    syscall->rename.src_overlay_numlower = get_overlay_numlower(syscall->rename.src_dentry);
+    set_file_inode(src_dentry, &syscall->rename.target_file, 1);
 
     // we generate a fake source key as the inode is (can be ?) reused
-    syscall->rename.src_key.ino = FAKE_INODE_MSW<<32 | bpf_get_prandom_u32();
+    syscall->rename.src_file.path_key.ino = FAKE_INODE_MSW<<32 | bpf_get_prandom_u32();
 
     // the mount id of path_key is resolved by kprobe/mnt_want_write. It is already set by the time we reach this probe.
-    resolve_dentry(syscall->rename.src_dentry, syscall->rename.src_key, 0);
+    resolve_dentry(syscall->rename.src_dentry, syscall->rename.src_file.path_key, 0);
 
     // if destination already exists invalidate
     u64 inode = get_dentry_ino(target_dentry);
     if (inode) {
-        invalidate_inode(ctx, syscall->rename.target_key.mount_id, inode, 1);
+        invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, inode, 1);
     }
 
     // If we are discarded, we still want to invalidate the inode
@@ -103,37 +103,26 @@ int __attribute__((always_inline)) trace__sys_rename_ret(struct pt_regs *ctx) {
     u64 inode = get_dentry_ino(syscall->rename.src_dentry);
 
     // invalidate inode from src dentry to handle ovl folder
-    if (syscall->rename.target_key.ino != inode) {
-        invalidate_inode(ctx, syscall->rename.target_key.mount_id, inode, 1);
+    if (syscall->rename.target_file.path_key.ino != inode) {
+        invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, inode, 1);
     }
 
     // invalidate user face inode, so no need to bump the discarder revision in the event
-    invalidate_path_key(ctx, &syscall->rename.target_key, 1);
+    invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, syscall->rename.target_file.path_key.ino, 1);
 
     if (!syscall->discarded && is_event_enabled(EVENT_RENAME)) {
         struct rename_event_t event = {
             .syscall.retval = retval,
-            .old = {
-                .inode = syscall->rename.src_key.ino,
-                .mount_id = syscall->rename.src_key.mount_id,
-                .overlay_numlower = syscall->rename.src_overlay_numlower,
-                .metadata = syscall->rename.src_metadata,
-            },
-            .new = {
-                .inode = syscall->rename.target_key.ino,
-                .mount_id = syscall->rename.target_key.mount_id,
-                .overlay_numlower = get_overlay_numlower(syscall->rename.src_dentry),
-                .path_id = syscall->rename.target_key.path_id,
-                .metadata = syscall->rename.src_metadata,
-            },
-            .discarder_revision = bump_discarder_revision(syscall->rename.target_key.mount_id),
+            .old = syscall->rename.src_file,
+            .new = syscall->rename.target_file,
+            .discarder_revision = bump_discarder_revision(syscall->rename.target_file.path_key.mount_id),
         };
 
         struct proc_cache_t *entry = fill_process_context(&event.process);
         fill_container_context(entry, &event.container);
 
         // for centos7, use src dentry for target resolution as the pointers have been swapped
-        resolve_dentry(syscall->rename.src_dentry, syscall->rename.target_key, 0);
+        resolve_dentry(syscall->rename.src_dentry, syscall->rename.target_file.path_key, 0);
 
         send_event(ctx, EVENT_RENAME, event);
     }

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -61,6 +61,9 @@ int kprobe__vfs_rename(struct pt_regs *ctx) {
 
     fill_file_metadata(src_dentry, &syscall->rename.src_file.metadata);
     syscall->rename.target_file.metadata = syscall->rename.src_file.metadata;
+    if (is_overlayfs(src_dentry)) {
+        syscall->rename.target_file.flags |= UPPER_LAYER;
+    }
 
     if (filter_syscall(syscall, rename_approvers)) {
         return mark_as_discarded(syscall);

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -44,19 +44,17 @@ int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
         case SYSCALL_RMDIR:
             event_type = EVENT_RMDIR;
 
-            if (syscall->rmdir.path_key.ino) {
+            if (syscall->rmdir.file.path_key.ino) {
                 return 0;
             }
 
             // we resolve all the information before the file is actually removed
             dentry = (struct dentry *)PT_REGS_PARM2(ctx);
-            set_path_key_inode(dentry, &syscall->rmdir.path_key, 1);
-            fill_file_metadata(dentry, &syscall->rmdir.metadata);
-
-            syscall->rmdir.overlay_numlower = get_overlay_numlower(dentry);
+            set_file_inode(dentry, &syscall->rmdir.file, 1);
+            fill_file_metadata(dentry, &syscall->rmdir.file.metadata);
 
             // the mount id of path_key is resolved by kprobe/mnt_want_write. It is already set by the time we reach this probe.
-            key = syscall->rmdir.path_key;
+            key = syscall->rmdir.file.path_key;
 
             syscall->rmdir.dentry = dentry;
             if (filter_syscall(syscall, rmdir_approvers)) {
@@ -67,19 +65,17 @@ int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
         case SYSCALL_UNLINK:
             event_type = EVENT_UNLINK;
 
-            if (syscall->unlink.path_key.ino) {
+            if (syscall->unlink.file.path_key.ino) {
                 return 0;
             }
 
             // we resolve all the information before the file is actually removed
             dentry = (struct dentry *) PT_REGS_PARM2(ctx);
-            set_path_key_inode(dentry, &syscall->unlink.path_key, 1);
-            fill_file_metadata(dentry, &syscall->unlink.metadata);
-
-            syscall->unlink.overlay_numlower = get_overlay_numlower(dentry);
+            set_file_inode(dentry, &syscall->unlink.file, 1);
+            fill_file_metadata(dentry, &syscall->unlink.file.metadata);
 
             // the mount id of path_key is resolved by kprobe/mnt_want_write. It is already set by the time we reach this probe.
-            key = syscall->unlink.path_key;
+            key = syscall->unlink.file.path_key;
 
             syscall->unlink.dentry = dentry;
             syscall->policy = fetch_policy(EVENT_RMDIR);
@@ -118,14 +114,8 @@ SYSCALL_KRETPROBE(rmdir) {
     if (pass_to_userspace) {
         struct rmdir_event_t event = {
             .syscall.retval = retval,
-            .file = {
-                .inode = syscall->rmdir.path_key.ino,
-                .mount_id = syscall->rmdir.path_key.mount_id,
-                .overlay_numlower = syscall->rmdir.overlay_numlower,
-                .path_id = syscall->rmdir.path_key.path_id,
-                .metadata = syscall->rmdir.metadata,
-            },
-            .discarder_revision = bump_discarder_revision(syscall->rmdir.path_key.mount_id),
+            .file = syscall->rmdir.file,
+            .discarder_revision = bump_discarder_revision(syscall->rmdir.file.path_key.mount_id),
         };
 
         struct proc_cache_t *entry = fill_process_context(&event.process);
@@ -134,7 +124,7 @@ SYSCALL_KRETPROBE(rmdir) {
         send_event(ctx, EVENT_RMDIR, event);
     }
 
-    invalidate_inode(ctx, syscall->rmdir.path_key.mount_id, syscall->rmdir.path_key.ino, !pass_to_userspace);
+    invalidate_inode(ctx, syscall->rmdir.file.path_key.mount_id, syscall->rmdir.file.path_key.ino, !pass_to_userspace);
 
     return 0;
 }

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -21,46 +21,39 @@ struct syscall_cache_t {
             int flags;
             umode_t mode;
             struct dentry *dentry;
-            struct path_key_t path_key;
+            struct file_t file;
         } open;
 
         struct {
             umode_t mode;
             struct dentry *dentry;
             struct path *path;
-            struct path_key_t path_key;
+            struct file_t file;
         } mkdir;
 
         struct {
             struct dentry *dentry;
-            struct path_key_t path_key;
-            struct file_metadata_t metadata;
-            int overlay_numlower;
+            struct file_t file;
             int flags;
         } unlink;
 
         struct {
             struct dentry *dentry;
-            struct path_key_t path_key;
-            struct file_metadata_t metadata;
-            int overlay_numlower;
+            struct file_t file;
         } rmdir;
 
         struct {
-            struct path_key_t src_key;
-            struct file_metadata_t src_metadata;
+            struct file_t src_file;
             unsigned long src_inode;
             struct dentry *src_dentry;
             struct dentry *target_dentry;
-            struct path_key_t target_key;
-            int src_overlay_numlower;
+            struct file_t target_file;
         } rename;
 
         struct {
             struct dentry *dentry;
             struct path *path;
-            struct path_key_t path_key;
-            struct file_metadata_t metadata;
+            struct file_t file;
             union {
                 umode_t mode;
                 struct {
@@ -87,20 +80,18 @@ struct syscall_cache_t {
         } umount;
 
         struct {
-            struct path_key_t src_key;
-            struct file_metadata_t src_metadata;
+            struct file_t src_file;
             struct path *target_path;
             struct dentry *src_dentry;
             struct dentry *target_dentry;
-            struct path_key_t target_key;
-            int src_overlay_numlower;
+            struct file_t target_file;
         } link;
 
         struct {
             struct dentry *dentry;
-            struct path_key_t path_key;
+            struct file_t file;
             const char *name;
-        } setxattr;
+        } xattr;
 
         struct {
             u8 is_thread;
@@ -108,7 +99,7 @@ struct syscall_cache_t {
 
         struct {
             struct dentry *dentry;
-            struct path_key_t path_key;
+            struct file_t file;
             struct str_array_ref_t args;
             struct str_array_ref_t envs;
             u8 is_parsed;

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -82,13 +82,7 @@ int __attribute__((always_inline)) trace__sys_utimes_ret(struct pt_regs *ctx) {
             .tv_sec = syscall->setattr.mtime.tv_sec,
             .tv_usec = syscall->setattr.mtime.tv_nsec,
         },
-        .file = {
-            .inode = syscall->setattr.path_key.ino,
-            .mount_id = syscall->setattr.path_key.mount_id,
-            .overlay_numlower = get_overlay_numlower(syscall->setattr.dentry),
-            .path_id = syscall->setattr.path_key.path_id,
-            .metadata = syscall->setattr.metadata,
-        },
+        .file = syscall->setattr.file,
     };
 
     struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -32,6 +32,7 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_bprm_committed_creds"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/exit_itimers"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kretprobe/get_task_exe_file"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_open"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_dentry_open"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/commit_creds"}},
 		}},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -19,6 +19,10 @@ var openProbes = []*manager.Probe{
 	},
 	{
 		UID:     SecurityAgentUID,
+		Section: "kprobe/vfs_open",
+	},
+	{
+		UID:     SecurityAgentUID,
 		Section: "kprobe/do_dentry_open",
 	},
 }

--- a/pkg/security/model/accessors.go
+++ b/pkg/security/model/accessors.go
@@ -119,6 +119,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "chmod.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chmod.File.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "chmod.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -136,6 +148,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Chmod.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Chmod.File.InUpperLayer
 
 			},
 			Field: field,
@@ -189,18 +213,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chmod.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Chmod.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chmod.file.path":
@@ -311,6 +323,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "chown.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chown.File.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "chown.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -328,6 +352,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Chown.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Chown.File.InUpperLayer
 
 			},
 			Field: field,
@@ -381,18 +417,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chown.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Chown.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chown.file.path":
@@ -635,6 +659,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "exec.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Exec.Process.Filesystem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "exec.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -705,18 +741,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "exec.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "exec.file.path":
@@ -899,6 +923,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.destination.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Target.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.file.destination.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -916,6 +952,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Link.Target.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Link.Target.InUpperLayer
 
 			},
 			Field: field,
@@ -971,18 +1019,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "link.file.destination.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Target.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
 	case "link.file.destination.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -1019,6 +1055,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Source.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1036,6 +1084,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Link.Source.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Link.Source.InUpperLayer
 
 			},
 			Field: field,
@@ -1089,18 +1149,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Source.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "link.file.path":
@@ -1175,6 +1223,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "mkdir.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Mkdir.File.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "mkdir.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1192,6 +1252,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Mkdir.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Mkdir.File.InUpperLayer
 
 			},
 			Field: field,
@@ -1245,18 +1317,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "mkdir.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Mkdir.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "mkdir.file.path":
@@ -1331,6 +1391,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "open.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Open.File.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "open.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1348,6 +1420,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Open.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "open.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Open.File.InUpperLayer
 
 			},
 			Field: field,
@@ -1401,18 +1485,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "open.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Open.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "open.file.path":
@@ -1682,6 +1754,29 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
+	case "process.ancestors.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = element.ProcessContext.Process.Filesystem
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
 	case "process.ancestors.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1809,29 +1904,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ProcessContext.Process.BasenameStr
-
-				}
-
-				return result
-
-			},
-			Field: field,
-
-			Weight: eval.IteratorWeight,
-		}, nil
-
-	case "process.ancestors.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				var result int
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-
-					element := (*ProcessCacheEntry)(reg.Value)
-
-					result = int(element.ProcessContext.Process.FileFields.OverlayNumLower)
 
 				}
 
@@ -2319,6 +2391,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "process.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ProcessContext.Process.Filesystem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "process.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2389,18 +2473,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "process.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.file.path":
@@ -2619,6 +2691,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "removexattr.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).RemoveXAttr.File.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "removexattr.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2636,6 +2720,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).RemoveXAttr.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "removexattr.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).RemoveXAttr.File.InUpperLayer
 
 			},
 			Field: field,
@@ -2689,18 +2785,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "removexattr.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "removexattr.file.path":
@@ -2775,6 +2859,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "rename.file.destination.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.New.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "rename.file.destination.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2792,6 +2888,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Rename.New.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.destination.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Rename.New.InUpperLayer
 
 			},
 			Field: field,
@@ -2847,18 +2955,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "rename.file.destination.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rename.New.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
 	case "rename.file.destination.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2895,6 +2991,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "rename.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.Old.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "rename.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2912,6 +3020,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Rename.Old.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Rename.Old.InUpperLayer
 
 			},
 			Field: field,
@@ -2965,18 +3085,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rename.Old.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rename.file.path":
@@ -3039,6 +3147,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "rmdir.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rmdir.File.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "rmdir.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3056,6 +3176,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Rmdir.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Rmdir.File.InUpperLayer
 
 			},
 			Field: field,
@@ -3109,18 +3241,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rmdir.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rmdir.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rmdir.file.path":
@@ -3351,6 +3471,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "setxattr.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).SetXAttr.File.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "setxattr.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3368,6 +3500,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).SetXAttr.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "setxattr.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).SetXAttr.File.InUpperLayer
 
 			},
 			Field: field,
@@ -3421,18 +3565,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "setxattr.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "setxattr.file.path":
@@ -3495,6 +3627,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "unlink.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Unlink.File.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "unlink.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3512,6 +3656,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Unlink.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "unlink.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Unlink.File.InUpperLayer
 
 			},
 			Field: field,
@@ -3565,18 +3721,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "unlink.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Unlink.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "unlink.file.path":
@@ -3639,6 +3783,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "utimes.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Utimes.File.Filesytem
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "utimes.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3656,6 +3812,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Utimes.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "utimes.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Utimes.File.InUpperLayer
 
 			},
 			Field: field,
@@ -3709,18 +3877,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "utimes.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Utimes.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "utimes.file.path":
@@ -3787,9 +3943,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"chmod.file.destination.mode",
 
+		"chmod.file.filesystem",
+
 		"chmod.file.gid",
 
 		"chmod.file.group",
+
+		"chmod.file.in_upper_layer",
 
 		"chmod.file.inode",
 
@@ -3798,8 +3958,6 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.mount_id",
 
 		"chmod.file.name",
-
-		"chmod.file.overlay_numlower",
 
 		"chmod.file.path",
 
@@ -3819,9 +3977,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"chown.file.destination.user",
 
+		"chown.file.filesystem",
+
 		"chown.file.gid",
 
 		"chown.file.group",
+
+		"chown.file.in_upper_layer",
 
 		"chown.file.inode",
 
@@ -3830,8 +3992,6 @@ func (e *Event) GetFields() []eval.Field {
 		"chown.file.mount_id",
 
 		"chown.file.name",
-
-		"chown.file.overlay_numlower",
 
 		"chown.file.path",
 
@@ -3869,6 +4029,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.file.container_path",
 
+		"exec.file.filesystem",
+
 		"exec.file.gid",
 
 		"exec.file.group",
@@ -3880,8 +4042,6 @@ func (e *Event) GetFields() []eval.Field {
 		"exec.file.mount_id",
 
 		"exec.file.name",
-
-		"exec.file.overlay_numlower",
 
 		"exec.file.path",
 
@@ -3913,9 +4073,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.destination.container_path",
 
+		"link.file.destination.filesystem",
+
 		"link.file.destination.gid",
 
 		"link.file.destination.group",
+
+		"link.file.destination.in_upper_layer",
 
 		"link.file.destination.inode",
 
@@ -3925,17 +4089,19 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.destination.name",
 
-		"link.file.destination.overlay_numlower",
-
 		"link.file.destination.path",
 
 		"link.file.destination.uid",
 
 		"link.file.destination.user",
 
+		"link.file.filesystem",
+
 		"link.file.gid",
 
 		"link.file.group",
+
+		"link.file.in_upper_layer",
 
 		"link.file.inode",
 
@@ -3944,8 +4110,6 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.mount_id",
 
 		"link.file.name",
-
-		"link.file.overlay_numlower",
 
 		"link.file.path",
 
@@ -3959,9 +4123,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"mkdir.file.destination.mode",
 
+		"mkdir.file.filesystem",
+
 		"mkdir.file.gid",
 
 		"mkdir.file.group",
+
+		"mkdir.file.in_upper_layer",
 
 		"mkdir.file.inode",
 
@@ -3970,8 +4138,6 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.mount_id",
 
 		"mkdir.file.name",
-
-		"mkdir.file.overlay_numlower",
 
 		"mkdir.file.path",
 
@@ -3985,9 +4151,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"open.file.destination.mode",
 
+		"open.file.filesystem",
+
 		"open.file.gid",
 
 		"open.file.group",
+
+		"open.file.in_upper_layer",
 
 		"open.file.inode",
 
@@ -3996,8 +4166,6 @@ func (e *Event) GetFields() []eval.Field {
 		"open.file.mount_id",
 
 		"open.file.name",
-
-		"open.file.overlay_numlower",
 
 		"open.file.path",
 
@@ -4027,6 +4195,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.file.container_path",
 
+		"process.ancestors.file.filesystem",
+
 		"process.ancestors.file.gid",
 
 		"process.ancestors.file.group",
@@ -4038,8 +4208,6 @@ func (e *Event) GetFields() []eval.Field {
 		"process.ancestors.file.mount_id",
 
 		"process.ancestors.file.name",
-
-		"process.ancestors.file.overlay_numlower",
 
 		"process.ancestors.file.path",
 
@@ -4091,6 +4259,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.file.container_path",
 
+		"process.file.filesystem",
+
 		"process.file.gid",
 
 		"process.file.group",
@@ -4102,8 +4272,6 @@ func (e *Event) GetFields() []eval.Field {
 		"process.file.mount_id",
 
 		"process.file.name",
-
-		"process.file.overlay_numlower",
 
 		"process.file.path",
 
@@ -4141,9 +4309,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"removexattr.file.destination.namespace",
 
+		"removexattr.file.filesystem",
+
 		"removexattr.file.gid",
 
 		"removexattr.file.group",
+
+		"removexattr.file.in_upper_layer",
 
 		"removexattr.file.inode",
 
@@ -4152,8 +4324,6 @@ func (e *Event) GetFields() []eval.Field {
 		"removexattr.file.mount_id",
 
 		"removexattr.file.name",
-
-		"removexattr.file.overlay_numlower",
 
 		"removexattr.file.path",
 
@@ -4167,9 +4337,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.file.destination.container_path",
 
+		"rename.file.destination.filesystem",
+
 		"rename.file.destination.gid",
 
 		"rename.file.destination.group",
+
+		"rename.file.destination.in_upper_layer",
 
 		"rename.file.destination.inode",
 
@@ -4179,17 +4353,19 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.file.destination.name",
 
-		"rename.file.destination.overlay_numlower",
-
 		"rename.file.destination.path",
 
 		"rename.file.destination.uid",
 
 		"rename.file.destination.user",
 
+		"rename.file.filesystem",
+
 		"rename.file.gid",
 
 		"rename.file.group",
+
+		"rename.file.in_upper_layer",
 
 		"rename.file.inode",
 
@@ -4198,8 +4374,6 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.mount_id",
 
 		"rename.file.name",
-
-		"rename.file.overlay_numlower",
 
 		"rename.file.path",
 
@@ -4211,9 +4385,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rmdir.file.container_path",
 
+		"rmdir.file.filesystem",
+
 		"rmdir.file.gid",
 
 		"rmdir.file.group",
+
+		"rmdir.file.in_upper_layer",
 
 		"rmdir.file.inode",
 
@@ -4222,8 +4400,6 @@ func (e *Event) GetFields() []eval.Field {
 		"rmdir.file.mount_id",
 
 		"rmdir.file.name",
-
-		"rmdir.file.overlay_numlower",
 
 		"rmdir.file.path",
 
@@ -4263,9 +4439,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setxattr.file.destination.namespace",
 
+		"setxattr.file.filesystem",
+
 		"setxattr.file.gid",
 
 		"setxattr.file.group",
+
+		"setxattr.file.in_upper_layer",
 
 		"setxattr.file.inode",
 
@@ -4274,8 +4454,6 @@ func (e *Event) GetFields() []eval.Field {
 		"setxattr.file.mount_id",
 
 		"setxattr.file.name",
-
-		"setxattr.file.overlay_numlower",
 
 		"setxattr.file.path",
 
@@ -4287,9 +4465,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"unlink.file.container_path",
 
+		"unlink.file.filesystem",
+
 		"unlink.file.gid",
 
 		"unlink.file.group",
+
+		"unlink.file.in_upper_layer",
 
 		"unlink.file.inode",
 
@@ -4298,8 +4480,6 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.mount_id",
 
 		"unlink.file.name",
-
-		"unlink.file.overlay_numlower",
 
 		"unlink.file.path",
 
@@ -4311,9 +4491,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"utimes.file.container_path",
 
+		"utimes.file.filesystem",
+
 		"utimes.file.gid",
 
 		"utimes.file.group",
+
+		"utimes.file.in_upper_layer",
 
 		"utimes.file.inode",
 
@@ -4322,8 +4506,6 @@ func (e *Event) GetFields() []eval.Field {
 		"utimes.file.mount_id",
 
 		"utimes.file.name",
-
-		"utimes.file.overlay_numlower",
 
 		"utimes.file.path",
 
@@ -4354,6 +4536,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Chmod.Mode), nil
 
+	case "chmod.file.filesystem":
+
+		return e.Chmod.File.Filesytem, nil
+
 	case "chmod.file.gid":
 
 		return int(e.Chmod.File.FileFields.GID), nil
@@ -4361,6 +4547,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.file.group":
 
 		return e.Chmod.File.FileFields.Group, nil
+
+	case "chmod.file.in_upper_layer":
+
+		return e.Chmod.File.InUpperLayer, nil
 
 	case "chmod.file.inode":
 
@@ -4377,10 +4567,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.file.name":
 
 		return e.Chmod.File.BasenameStr, nil
-
-	case "chmod.file.overlay_numlower":
-
-		return int(e.Chmod.File.FileFields.OverlayNumLower), nil
 
 	case "chmod.file.path":
 
@@ -4418,6 +4604,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Chown.User, nil
 
+	case "chown.file.filesystem":
+
+		return e.Chown.File.Filesytem, nil
+
 	case "chown.file.gid":
 
 		return int(e.Chown.File.FileFields.GID), nil
@@ -4425,6 +4615,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chown.file.group":
 
 		return e.Chown.File.FileFields.Group, nil
+
+	case "chown.file.in_upper_layer":
+
+		return e.Chown.File.InUpperLayer, nil
 
 	case "chown.file.inode":
 
@@ -4441,10 +4635,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chown.file.name":
 
 		return e.Chown.File.BasenameStr, nil
-
-	case "chown.file.overlay_numlower":
-
-		return int(e.Chown.File.FileFields.OverlayNumLower), nil
 
 	case "chown.file.path":
 
@@ -4558,6 +4748,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Exec.Process.ContainerPath, nil
 
+	case "exec.file.filesystem":
+
+		return e.Exec.Process.Filesystem, nil
+
 	case "exec.file.gid":
 
 		return int(e.Exec.Process.FileFields.GID), nil
@@ -4581,10 +4775,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "exec.file.name":
 
 		return e.Exec.Process.BasenameStr, nil
-
-	case "exec.file.overlay_numlower":
-
-		return int(e.Exec.Process.FileFields.OverlayNumLower), nil
 
 	case "exec.file.path":
 
@@ -4646,6 +4836,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Link.Target.ContainerPath, nil
 
+	case "link.file.destination.filesystem":
+
+		return e.Link.Target.Filesytem, nil
+
 	case "link.file.destination.gid":
 
 		return int(e.Link.Target.FileFields.GID), nil
@@ -4653,6 +4847,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.file.destination.group":
 
 		return e.Link.Target.FileFields.Group, nil
+
+	case "link.file.destination.in_upper_layer":
+
+		return e.Link.Target.InUpperLayer, nil
 
 	case "link.file.destination.inode":
 
@@ -4670,10 +4868,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Link.Target.BasenameStr, nil
 
-	case "link.file.destination.overlay_numlower":
-
-		return int(e.Link.Target.FileFields.OverlayNumLower), nil
-
 	case "link.file.destination.path":
 
 		return e.Link.Target.PathnameStr, nil
@@ -4686,6 +4880,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Link.Target.FileFields.User, nil
 
+	case "link.file.filesystem":
+
+		return e.Link.Source.Filesytem, nil
+
 	case "link.file.gid":
 
 		return int(e.Link.Source.FileFields.GID), nil
@@ -4693,6 +4891,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.file.group":
 
 		return e.Link.Source.FileFields.Group, nil
+
+	case "link.file.in_upper_layer":
+
+		return e.Link.Source.InUpperLayer, nil
 
 	case "link.file.inode":
 
@@ -4709,10 +4911,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.file.name":
 
 		return e.Link.Source.BasenameStr, nil
-
-	case "link.file.overlay_numlower":
-
-		return int(e.Link.Source.FileFields.OverlayNumLower), nil
 
 	case "link.file.path":
 
@@ -4738,6 +4936,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Mkdir.Mode), nil
 
+	case "mkdir.file.filesystem":
+
+		return e.Mkdir.File.Filesytem, nil
+
 	case "mkdir.file.gid":
 
 		return int(e.Mkdir.File.FileFields.GID), nil
@@ -4745,6 +4947,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mkdir.file.group":
 
 		return e.Mkdir.File.FileFields.Group, nil
+
+	case "mkdir.file.in_upper_layer":
+
+		return e.Mkdir.File.InUpperLayer, nil
 
 	case "mkdir.file.inode":
 
@@ -4761,10 +4967,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mkdir.file.name":
 
 		return e.Mkdir.File.BasenameStr, nil
-
-	case "mkdir.file.overlay_numlower":
-
-		return int(e.Mkdir.File.FileFields.OverlayNumLower), nil
 
 	case "mkdir.file.path":
 
@@ -4790,6 +4992,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Open.Mode), nil
 
+	case "open.file.filesystem":
+
+		return e.Open.File.Filesytem, nil
+
 	case "open.file.gid":
 
 		return int(e.Open.File.FileFields.GID), nil
@@ -4797,6 +5003,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "open.file.group":
 
 		return e.Open.File.FileFields.Group, nil
+
+	case "open.file.in_upper_layer":
+
+		return e.Open.File.InUpperLayer, nil
 
 	case "open.file.inode":
 
@@ -4813,10 +5023,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "open.file.name":
 
 		return e.Open.File.BasenameStr, nil
-
-	case "open.file.overlay_numlower":
-
-		return int(e.Open.File.FileFields.OverlayNumLower), nil
 
 	case "open.file.path":
 
@@ -5045,6 +5251,29 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
+	case "process.ancestors.file.filesystem":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.Process.Filesystem
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
 	case "process.ancestors.file.gid":
 
 		var values []int
@@ -5175,29 +5404,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*ProcessCacheEntry)(ptr)
 
 			result := element.ProcessContext.Process.BasenameStr
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
-
-	case "process.ancestors.file.overlay_numlower":
-
-		var values []int
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &ProcessAncestorsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-
-			element := (*ProcessCacheEntry)(ptr)
-
-			result := int(element.ProcessContext.Process.FileFields.OverlayNumLower)
 
 			values = append(values, result)
 
@@ -5610,6 +5816,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ProcessContext.Process.ContainerPath, nil
 
+	case "process.file.filesystem":
+
+		return e.ProcessContext.Process.Filesystem, nil
+
 	case "process.file.gid":
 
 		return int(e.ProcessContext.Process.FileFields.GID), nil
@@ -5633,10 +5843,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.file.name":
 
 		return e.ProcessContext.Process.BasenameStr, nil
-
-	case "process.file.overlay_numlower":
-
-		return int(e.ProcessContext.Process.FileFields.OverlayNumLower), nil
 
 	case "process.file.path":
 
@@ -5710,6 +5916,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.RemoveXAttr.Namespace, nil
 
+	case "removexattr.file.filesystem":
+
+		return e.RemoveXAttr.File.Filesytem, nil
+
 	case "removexattr.file.gid":
 
 		return int(e.RemoveXAttr.File.FileFields.GID), nil
@@ -5717,6 +5927,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "removexattr.file.group":
 
 		return e.RemoveXAttr.File.FileFields.Group, nil
+
+	case "removexattr.file.in_upper_layer":
+
+		return e.RemoveXAttr.File.InUpperLayer, nil
 
 	case "removexattr.file.inode":
 
@@ -5733,10 +5947,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "removexattr.file.name":
 
 		return e.RemoveXAttr.File.BasenameStr, nil
-
-	case "removexattr.file.overlay_numlower":
-
-		return int(e.RemoveXAttr.File.FileFields.OverlayNumLower), nil
 
 	case "removexattr.file.path":
 
@@ -5762,6 +5972,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Rename.New.ContainerPath, nil
 
+	case "rename.file.destination.filesystem":
+
+		return e.Rename.New.Filesytem, nil
+
 	case "rename.file.destination.gid":
 
 		return int(e.Rename.New.FileFields.GID), nil
@@ -5769,6 +5983,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.destination.group":
 
 		return e.Rename.New.FileFields.Group, nil
+
+	case "rename.file.destination.in_upper_layer":
+
+		return e.Rename.New.InUpperLayer, nil
 
 	case "rename.file.destination.inode":
 
@@ -5786,10 +6004,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Rename.New.BasenameStr, nil
 
-	case "rename.file.destination.overlay_numlower":
-
-		return int(e.Rename.New.FileFields.OverlayNumLower), nil
-
 	case "rename.file.destination.path":
 
 		return e.Rename.New.PathnameStr, nil
@@ -5802,6 +6016,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Rename.New.FileFields.User, nil
 
+	case "rename.file.filesystem":
+
+		return e.Rename.Old.Filesytem, nil
+
 	case "rename.file.gid":
 
 		return int(e.Rename.Old.FileFields.GID), nil
@@ -5809,6 +6027,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.group":
 
 		return e.Rename.Old.FileFields.Group, nil
+
+	case "rename.file.in_upper_layer":
+
+		return e.Rename.Old.InUpperLayer, nil
 
 	case "rename.file.inode":
 
@@ -5825,10 +6047,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.name":
 
 		return e.Rename.Old.BasenameStr, nil
-
-	case "rename.file.overlay_numlower":
-
-		return int(e.Rename.Old.FileFields.OverlayNumLower), nil
 
 	case "rename.file.path":
 
@@ -5850,6 +6068,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Rmdir.File.ContainerPath, nil
 
+	case "rmdir.file.filesystem":
+
+		return e.Rmdir.File.Filesytem, nil
+
 	case "rmdir.file.gid":
 
 		return int(e.Rmdir.File.FileFields.GID), nil
@@ -5857,6 +6079,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rmdir.file.group":
 
 		return e.Rmdir.File.FileFields.Group, nil
+
+	case "rmdir.file.in_upper_layer":
+
+		return e.Rmdir.File.InUpperLayer, nil
 
 	case "rmdir.file.inode":
 
@@ -5873,10 +6099,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rmdir.file.name":
 
 		return e.Rmdir.File.BasenameStr, nil
-
-	case "rmdir.file.overlay_numlower":
-
-		return int(e.Rmdir.File.FileFields.OverlayNumLower), nil
 
 	case "rmdir.file.path":
 
@@ -5954,6 +6176,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.SetXAttr.Namespace, nil
 
+	case "setxattr.file.filesystem":
+
+		return e.SetXAttr.File.Filesytem, nil
+
 	case "setxattr.file.gid":
 
 		return int(e.SetXAttr.File.FileFields.GID), nil
@@ -5961,6 +6187,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "setxattr.file.group":
 
 		return e.SetXAttr.File.FileFields.Group, nil
+
+	case "setxattr.file.in_upper_layer":
+
+		return e.SetXAttr.File.InUpperLayer, nil
 
 	case "setxattr.file.inode":
 
@@ -5977,10 +6207,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "setxattr.file.name":
 
 		return e.SetXAttr.File.BasenameStr, nil
-
-	case "setxattr.file.overlay_numlower":
-
-		return int(e.SetXAttr.File.FileFields.OverlayNumLower), nil
 
 	case "setxattr.file.path":
 
@@ -6002,6 +6228,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Unlink.File.ContainerPath, nil
 
+	case "unlink.file.filesystem":
+
+		return e.Unlink.File.Filesytem, nil
+
 	case "unlink.file.gid":
 
 		return int(e.Unlink.File.FileFields.GID), nil
@@ -6009,6 +6239,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.file.group":
 
 		return e.Unlink.File.FileFields.Group, nil
+
+	case "unlink.file.in_upper_layer":
+
+		return e.Unlink.File.InUpperLayer, nil
 
 	case "unlink.file.inode":
 
@@ -6025,10 +6259,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.file.name":
 
 		return e.Unlink.File.BasenameStr, nil
-
-	case "unlink.file.overlay_numlower":
-
-		return int(e.Unlink.File.FileFields.OverlayNumLower), nil
 
 	case "unlink.file.path":
 
@@ -6050,6 +6280,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Utimes.File.ContainerPath, nil
 
+	case "utimes.file.filesystem":
+
+		return e.Utimes.File.Filesytem, nil
+
 	case "utimes.file.gid":
 
 		return int(e.Utimes.File.FileFields.GID), nil
@@ -6057,6 +6291,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "utimes.file.group":
 
 		return e.Utimes.File.FileFields.Group, nil
+
+	case "utimes.file.in_upper_layer":
+
+		return e.Utimes.File.InUpperLayer, nil
 
 	case "utimes.file.inode":
 
@@ -6073,10 +6311,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "utimes.file.name":
 
 		return e.Utimes.File.BasenameStr, nil
-
-	case "utimes.file.overlay_numlower":
-
-		return int(e.Utimes.File.FileFields.OverlayNumLower), nil
 
 	case "utimes.file.path":
 
@@ -6114,10 +6348,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "chmod.file.destination.mode":
 		return "chmod", nil
 
+	case "chmod.file.filesystem":
+		return "chmod", nil
+
 	case "chmod.file.gid":
 		return "chmod", nil
 
 	case "chmod.file.group":
+		return "chmod", nil
+
+	case "chmod.file.in_upper_layer":
 		return "chmod", nil
 
 	case "chmod.file.inode":
@@ -6130,9 +6370,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chmod", nil
 
 	case "chmod.file.name":
-		return "chmod", nil
-
-	case "chmod.file.overlay_numlower":
 		return "chmod", nil
 
 	case "chmod.file.path":
@@ -6162,10 +6399,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "chown.file.destination.user":
 		return "chown", nil
 
+	case "chown.file.filesystem":
+		return "chown", nil
+
 	case "chown.file.gid":
 		return "chown", nil
 
 	case "chown.file.group":
+		return "chown", nil
+
+	case "chown.file.in_upper_layer":
 		return "chown", nil
 
 	case "chown.file.inode":
@@ -6178,9 +6421,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chown", nil
 
 	case "chown.file.name":
-		return "chown", nil
-
-	case "chown.file.overlay_numlower":
 		return "chown", nil
 
 	case "chown.file.path":
@@ -6237,6 +6477,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.file.container_path":
 		return "exec", nil
 
+	case "exec.file.filesystem":
+		return "exec", nil
+
 	case "exec.file.gid":
 		return "exec", nil
 
@@ -6253,9 +6496,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 
 	case "exec.file.name":
-		return "exec", nil
-
-	case "exec.file.overlay_numlower":
 		return "exec", nil
 
 	case "exec.file.path":
@@ -6303,10 +6543,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.destination.container_path":
 		return "link", nil
 
+	case "link.file.destination.filesystem":
+		return "link", nil
+
 	case "link.file.destination.gid":
 		return "link", nil
 
 	case "link.file.destination.group":
+		return "link", nil
+
+	case "link.file.destination.in_upper_layer":
 		return "link", nil
 
 	case "link.file.destination.inode":
@@ -6321,9 +6567,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.destination.name":
 		return "link", nil
 
-	case "link.file.destination.overlay_numlower":
-		return "link", nil
-
 	case "link.file.destination.path":
 		return "link", nil
 
@@ -6333,10 +6576,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.destination.user":
 		return "link", nil
 
+	case "link.file.filesystem":
+		return "link", nil
+
 	case "link.file.gid":
 		return "link", nil
 
 	case "link.file.group":
+		return "link", nil
+
+	case "link.file.in_upper_layer":
 		return "link", nil
 
 	case "link.file.inode":
@@ -6349,9 +6598,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "link", nil
 
 	case "link.file.name":
-		return "link", nil
-
-	case "link.file.overlay_numlower":
 		return "link", nil
 
 	case "link.file.path":
@@ -6372,10 +6618,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mkdir.file.destination.mode":
 		return "mkdir", nil
 
+	case "mkdir.file.filesystem":
+		return "mkdir", nil
+
 	case "mkdir.file.gid":
 		return "mkdir", nil
 
 	case "mkdir.file.group":
+		return "mkdir", nil
+
+	case "mkdir.file.in_upper_layer":
 		return "mkdir", nil
 
 	case "mkdir.file.inode":
@@ -6388,9 +6640,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 
 	case "mkdir.file.name":
-		return "mkdir", nil
-
-	case "mkdir.file.overlay_numlower":
 		return "mkdir", nil
 
 	case "mkdir.file.path":
@@ -6411,10 +6660,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "open.file.destination.mode":
 		return "open", nil
 
+	case "open.file.filesystem":
+		return "open", nil
+
 	case "open.file.gid":
 		return "open", nil
 
 	case "open.file.group":
+		return "open", nil
+
+	case "open.file.in_upper_layer":
 		return "open", nil
 
 	case "open.file.inode":
@@ -6427,9 +6682,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "open", nil
 
 	case "open.file.name":
-		return "open", nil
-
-	case "open.file.overlay_numlower":
 		return "open", nil
 
 	case "open.file.path":
@@ -6474,6 +6726,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.file.container_path":
 		return "*", nil
 
+	case "process.ancestors.file.filesystem":
+		return "*", nil
+
 	case "process.ancestors.file.gid":
 		return "*", nil
 
@@ -6490,9 +6745,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.file.name":
-		return "*", nil
-
-	case "process.ancestors.file.overlay_numlower":
 		return "*", nil
 
 	case "process.ancestors.file.path":
@@ -6570,6 +6822,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.file.container_path":
 		return "*", nil
 
+	case "process.file.filesystem":
+		return "*", nil
+
 	case "process.file.gid":
 		return "*", nil
 
@@ -6586,9 +6841,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.file.name":
-		return "*", nil
-
-	case "process.file.overlay_numlower":
 		return "*", nil
 
 	case "process.file.path":
@@ -6645,10 +6897,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "removexattr.file.destination.namespace":
 		return "removexattr", nil
 
+	case "removexattr.file.filesystem":
+		return "removexattr", nil
+
 	case "removexattr.file.gid":
 		return "removexattr", nil
 
 	case "removexattr.file.group":
+		return "removexattr", nil
+
+	case "removexattr.file.in_upper_layer":
 		return "removexattr", nil
 
 	case "removexattr.file.inode":
@@ -6661,9 +6919,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "removexattr", nil
 
 	case "removexattr.file.name":
-		return "removexattr", nil
-
-	case "removexattr.file.overlay_numlower":
 		return "removexattr", nil
 
 	case "removexattr.file.path":
@@ -6684,10 +6939,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.destination.container_path":
 		return "rename", nil
 
+	case "rename.file.destination.filesystem":
+		return "rename", nil
+
 	case "rename.file.destination.gid":
 		return "rename", nil
 
 	case "rename.file.destination.group":
+		return "rename", nil
+
+	case "rename.file.destination.in_upper_layer":
 		return "rename", nil
 
 	case "rename.file.destination.inode":
@@ -6702,9 +6963,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.destination.name":
 		return "rename", nil
 
-	case "rename.file.destination.overlay_numlower":
-		return "rename", nil
-
 	case "rename.file.destination.path":
 		return "rename", nil
 
@@ -6714,10 +6972,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.destination.user":
 		return "rename", nil
 
+	case "rename.file.filesystem":
+		return "rename", nil
+
 	case "rename.file.gid":
 		return "rename", nil
 
 	case "rename.file.group":
+		return "rename", nil
+
+	case "rename.file.in_upper_layer":
 		return "rename", nil
 
 	case "rename.file.inode":
@@ -6730,9 +6994,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 
 	case "rename.file.name":
-		return "rename", nil
-
-	case "rename.file.overlay_numlower":
 		return "rename", nil
 
 	case "rename.file.path":
@@ -6750,10 +7011,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rmdir.file.container_path":
 		return "rmdir", nil
 
+	case "rmdir.file.filesystem":
+		return "rmdir", nil
+
 	case "rmdir.file.gid":
 		return "rmdir", nil
 
 	case "rmdir.file.group":
+		return "rmdir", nil
+
+	case "rmdir.file.in_upper_layer":
 		return "rmdir", nil
 
 	case "rmdir.file.inode":
@@ -6766,9 +7033,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rmdir", nil
 
 	case "rmdir.file.name":
-		return "rmdir", nil
-
-	case "rmdir.file.overlay_numlower":
 		return "rmdir", nil
 
 	case "rmdir.file.path":
@@ -6828,10 +7092,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setxattr.file.destination.namespace":
 		return "setxattr", nil
 
+	case "setxattr.file.filesystem":
+		return "setxattr", nil
+
 	case "setxattr.file.gid":
 		return "setxattr", nil
 
 	case "setxattr.file.group":
+		return "setxattr", nil
+
+	case "setxattr.file.in_upper_layer":
 		return "setxattr", nil
 
 	case "setxattr.file.inode":
@@ -6844,9 +7114,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setxattr", nil
 
 	case "setxattr.file.name":
-		return "setxattr", nil
-
-	case "setxattr.file.overlay_numlower":
 		return "setxattr", nil
 
 	case "setxattr.file.path":
@@ -6864,10 +7131,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "unlink.file.container_path":
 		return "unlink", nil
 
+	case "unlink.file.filesystem":
+		return "unlink", nil
+
 	case "unlink.file.gid":
 		return "unlink", nil
 
 	case "unlink.file.group":
+		return "unlink", nil
+
+	case "unlink.file.in_upper_layer":
 		return "unlink", nil
 
 	case "unlink.file.inode":
@@ -6880,9 +7153,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "unlink", nil
 
 	case "unlink.file.name":
-		return "unlink", nil
-
-	case "unlink.file.overlay_numlower":
 		return "unlink", nil
 
 	case "unlink.file.path":
@@ -6900,10 +7170,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "utimes.file.container_path":
 		return "utimes", nil
 
+	case "utimes.file.filesystem":
+		return "utimes", nil
+
 	case "utimes.file.gid":
 		return "utimes", nil
 
 	case "utimes.file.group":
+		return "utimes", nil
+
+	case "utimes.file.in_upper_layer":
 		return "utimes", nil
 
 	case "utimes.file.inode":
@@ -6916,9 +7192,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "utimes", nil
 
 	case "utimes.file.name":
-		return "utimes", nil
-
-	case "utimes.file.overlay_numlower":
 		return "utimes", nil
 
 	case "utimes.file.path":
@@ -6957,6 +7230,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "chmod.file.filesystem":
+
+		return reflect.String, nil
+
 	case "chmod.file.gid":
 
 		return reflect.Int, nil
@@ -6964,6 +7241,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.file.group":
 
 		return reflect.String, nil
+
+	case "chmod.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "chmod.file.inode":
 
@@ -6980,10 +7261,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.file.name":
 
 		return reflect.String, nil
-
-	case "chmod.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "chmod.file.path":
 
@@ -7021,6 +7298,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "chown.file.filesystem":
+
+		return reflect.String, nil
+
 	case "chown.file.gid":
 
 		return reflect.Int, nil
@@ -7028,6 +7309,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chown.file.group":
 
 		return reflect.String, nil
+
+	case "chown.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "chown.file.inode":
 
@@ -7044,10 +7329,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chown.file.name":
 
 		return reflect.String, nil
-
-	case "chown.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "chown.file.path":
 
@@ -7121,6 +7402,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.file.filesystem":
+
+		return reflect.String, nil
+
 	case "exec.file.gid":
 
 		return reflect.Int, nil
@@ -7144,10 +7429,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "exec.file.name":
 
 		return reflect.String, nil
-
-	case "exec.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "exec.file.path":
 
@@ -7209,6 +7490,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.destination.filesystem":
+
+		return reflect.String, nil
+
 	case "link.file.destination.gid":
 
 		return reflect.Int, nil
@@ -7216,6 +7501,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "link.file.destination.group":
 
 		return reflect.String, nil
+
+	case "link.file.destination.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "link.file.destination.inode":
 
@@ -7233,10 +7522,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "link.file.destination.overlay_numlower":
-
-		return reflect.Int, nil
-
 	case "link.file.destination.path":
 
 		return reflect.String, nil
@@ -7249,6 +7534,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.filesystem":
+
+		return reflect.String, nil
+
 	case "link.file.gid":
 
 		return reflect.Int, nil
@@ -7256,6 +7545,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "link.file.group":
 
 		return reflect.String, nil
+
+	case "link.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "link.file.inode":
 
@@ -7272,10 +7565,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "link.file.name":
 
 		return reflect.String, nil
-
-	case "link.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "link.file.path":
 
@@ -7301,6 +7590,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "mkdir.file.filesystem":
+
+		return reflect.String, nil
+
 	case "mkdir.file.gid":
 
 		return reflect.Int, nil
@@ -7308,6 +7601,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mkdir.file.group":
 
 		return reflect.String, nil
+
+	case "mkdir.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "mkdir.file.inode":
 
@@ -7324,10 +7621,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mkdir.file.name":
 
 		return reflect.String, nil
-
-	case "mkdir.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "mkdir.file.path":
 
@@ -7353,6 +7646,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "open.file.filesystem":
+
+		return reflect.String, nil
+
 	case "open.file.gid":
 
 		return reflect.Int, nil
@@ -7360,6 +7657,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "open.file.group":
 
 		return reflect.String, nil
+
+	case "open.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "open.file.inode":
 
@@ -7376,10 +7677,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "open.file.name":
 
 		return reflect.String, nil
-
-	case "open.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "open.file.path":
 
@@ -7437,6 +7734,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.ancestors.file.filesystem":
+
+		return reflect.String, nil
+
 	case "process.ancestors.file.gid":
 
 		return reflect.Int, nil
@@ -7460,10 +7761,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.ancestors.file.name":
 
 		return reflect.String, nil
-
-	case "process.ancestors.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "process.ancestors.file.path":
 
@@ -7565,6 +7862,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.file.filesystem":
+
+		return reflect.String, nil
+
 	case "process.file.gid":
 
 		return reflect.Int, nil
@@ -7588,10 +7889,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.file.name":
 
 		return reflect.String, nil
-
-	case "process.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "process.file.path":
 
@@ -7665,6 +7962,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "removexattr.file.filesystem":
+
+		return reflect.String, nil
+
 	case "removexattr.file.gid":
 
 		return reflect.Int, nil
@@ -7672,6 +7973,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "removexattr.file.group":
 
 		return reflect.String, nil
+
+	case "removexattr.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "removexattr.file.inode":
 
@@ -7688,10 +7993,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "removexattr.file.name":
 
 		return reflect.String, nil
-
-	case "removexattr.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "removexattr.file.path":
 
@@ -7717,6 +8018,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "rename.file.destination.filesystem":
+
+		return reflect.String, nil
+
 	case "rename.file.destination.gid":
 
 		return reflect.Int, nil
@@ -7724,6 +8029,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.destination.group":
 
 		return reflect.String, nil
+
+	case "rename.file.destination.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "rename.file.destination.inode":
 
@@ -7741,10 +8050,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "rename.file.destination.overlay_numlower":
-
-		return reflect.Int, nil
-
 	case "rename.file.destination.path":
 
 		return reflect.String, nil
@@ -7757,6 +8062,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "rename.file.filesystem":
+
+		return reflect.String, nil
+
 	case "rename.file.gid":
 
 		return reflect.Int, nil
@@ -7764,6 +8073,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.group":
 
 		return reflect.String, nil
+
+	case "rename.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "rename.file.inode":
 
@@ -7780,10 +8093,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.name":
 
 		return reflect.String, nil
-
-	case "rename.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "rename.file.path":
 
@@ -7805,6 +8114,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "rmdir.file.filesystem":
+
+		return reflect.String, nil
+
 	case "rmdir.file.gid":
 
 		return reflect.Int, nil
@@ -7812,6 +8125,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rmdir.file.group":
 
 		return reflect.String, nil
+
+	case "rmdir.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "rmdir.file.inode":
 
@@ -7828,10 +8145,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rmdir.file.name":
 
 		return reflect.String, nil
-
-	case "rmdir.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "rmdir.file.path":
 
@@ -7909,6 +8222,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "setxattr.file.filesystem":
+
+		return reflect.String, nil
+
 	case "setxattr.file.gid":
 
 		return reflect.Int, nil
@@ -7916,6 +8233,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setxattr.file.group":
 
 		return reflect.String, nil
+
+	case "setxattr.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "setxattr.file.inode":
 
@@ -7932,10 +8253,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setxattr.file.name":
 
 		return reflect.String, nil
-
-	case "setxattr.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "setxattr.file.path":
 
@@ -7957,6 +8274,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "unlink.file.filesystem":
+
+		return reflect.String, nil
+
 	case "unlink.file.gid":
 
 		return reflect.Int, nil
@@ -7964,6 +8285,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "unlink.file.group":
 
 		return reflect.String, nil
+
+	case "unlink.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "unlink.file.inode":
 
@@ -7980,10 +8305,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "unlink.file.name":
 
 		return reflect.String, nil
-
-	case "unlink.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "unlink.file.path":
 
@@ -8005,6 +8326,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "utimes.file.filesystem":
+
+		return reflect.String, nil
+
 	case "utimes.file.gid":
 
 		return reflect.Int, nil
@@ -8012,6 +8337,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "utimes.file.group":
 
 		return reflect.String, nil
+
+	case "utimes.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "utimes.file.inode":
 
@@ -8028,10 +8357,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "utimes.file.name":
 
 		return reflect.String, nil
-
-	case "utimes.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "utimes.file.path":
 
@@ -8098,6 +8423,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.Mode = uint32(v)
 		return nil
 
+	case "chmod.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.Filesytem"}
+		}
+		e.Chmod.File.Filesytem = str
+
+		return nil
+
 	case "chmod.file.gid":
 
 		var ok bool
@@ -8117,6 +8453,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chmod.File.FileFields.Group = str
 
+		return nil
+
+	case "chmod.file.in_upper_layer":
+
+		var ok bool
+		if e.Chmod.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.InUpperLayer"}
+		}
 		return nil
 
 	case "chmod.file.inode":
@@ -8158,16 +8502,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chmod.File.BasenameStr = str
 
-		return nil
-
-	case "chmod.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.OverlayNumLower"}
-		}
-		e.Chmod.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "chmod.file.path":
@@ -8265,6 +8599,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "chown.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.Filesytem"}
+		}
+		e.Chown.File.Filesytem = str
+
+		return nil
+
 	case "chown.file.gid":
 
 		var ok bool
@@ -8284,6 +8629,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chown.File.FileFields.Group = str
 
+		return nil
+
+	case "chown.file.in_upper_layer":
+
+		var ok bool
+		if e.Chown.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.InUpperLayer"}
+		}
 		return nil
 
 	case "chown.file.inode":
@@ -8325,16 +8678,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chown.File.BasenameStr = str
 
-		return nil
-
-	case "chown.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.OverlayNumLower"}
-		}
-		e.Chown.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "chown.file.path":
@@ -8522,6 +8865,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Filesystem"}
+		}
+		e.Exec.Process.Filesystem = str
+
+		return nil
+
 	case "exec.file.gid":
 
 		var ok bool
@@ -8582,16 +8936,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Exec.Process.BasenameStr = str
 
-		return nil
-
-	case "exec.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.OverlayNumLower"}
-		}
-		e.Exec.Process.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "exec.file.path":
@@ -8753,6 +9097,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.destination.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.Filesytem"}
+		}
+		e.Link.Target.Filesytem = str
+
+		return nil
+
 	case "link.file.destination.gid":
 
 		var ok bool
@@ -8772,6 +9127,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.Target.FileFields.Group = str
 
+		return nil
+
+	case "link.file.destination.in_upper_layer":
+
+		var ok bool
+		if e.Link.Target.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.InUpperLayer"}
+		}
 		return nil
 
 	case "link.file.destination.inode":
@@ -8815,16 +9178,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
-	case "link.file.destination.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.OverlayNumLower"}
-		}
-		e.Link.Target.FileFields.OverlayNumLower = int32(v)
-		return nil
-
 	case "link.file.destination.path":
 
 		var ok bool
@@ -8857,6 +9210,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.Filesytem"}
+		}
+		e.Link.Source.Filesytem = str
+
+		return nil
+
 	case "link.file.gid":
 
 		var ok bool
@@ -8876,6 +9240,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.Source.FileFields.Group = str
 
+		return nil
+
+	case "link.file.in_upper_layer":
+
+		var ok bool
+		if e.Link.Source.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.InUpperLayer"}
+		}
 		return nil
 
 	case "link.file.inode":
@@ -8917,16 +9289,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.Source.BasenameStr = str
 
-		return nil
-
-	case "link.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.OverlayNumLower"}
-		}
-		e.Link.Source.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "link.file.path":
@@ -8992,6 +9354,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.Mode = uint32(v)
 		return nil
 
+	case "mkdir.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.Filesytem"}
+		}
+		e.Mkdir.File.Filesytem = str
+
+		return nil
+
 	case "mkdir.file.gid":
 
 		var ok bool
@@ -9011,6 +9384,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.File.FileFields.Group = str
 
+		return nil
+
+	case "mkdir.file.in_upper_layer":
+
+		var ok bool
+		if e.Mkdir.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.InUpperLayer"}
+		}
 		return nil
 
 	case "mkdir.file.inode":
@@ -9052,16 +9433,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.File.BasenameStr = str
 
-		return nil
-
-	case "mkdir.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.OverlayNumLower"}
-		}
-		e.Mkdir.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "mkdir.file.path":
@@ -9127,6 +9498,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Open.Mode = uint32(v)
 		return nil
 
+	case "open.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.Filesytem"}
+		}
+		e.Open.File.Filesytem = str
+
+		return nil
+
 	case "open.file.gid":
 
 		var ok bool
@@ -9146,6 +9528,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Open.File.FileFields.Group = str
 
+		return nil
+
+	case "open.file.in_upper_layer":
+
+		var ok bool
+		if e.Open.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.InUpperLayer"}
+		}
 		return nil
 
 	case "open.file.inode":
@@ -9187,16 +9577,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Open.File.BasenameStr = str
 
-		return nil
-
-	case "open.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.OverlayNumLower"}
-		}
-		e.Open.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "open.file.path":
@@ -9381,6 +9761,21 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.ancestors.file.filesystem":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Filesystem"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Filesystem = str
+
+		return nil
+
 	case "process.ancestors.file.gid":
 
 		if e.ProcessContext.Ancestor == nil {
@@ -9465,20 +9860,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.BasenameStr = str
 
-		return nil
-
-	case "process.ancestors.file.overlay_numlower":
-
-		if e.ProcessContext.Ancestor == nil {
-			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
-		}
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.OverlayNumLower"}
-		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "process.ancestors.file.path":
@@ -9807,6 +10188,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Filesystem"}
+		}
+		e.ProcessContext.Process.Filesystem = str
+
+		return nil
+
 	case "process.file.gid":
 
 		var ok bool
@@ -9867,16 +10259,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Process.BasenameStr = str
 
-		return nil
-
-	case "process.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.OverlayNumLower"}
-		}
-		e.ProcessContext.Process.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "process.file.path":
@@ -10069,6 +10451,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "removexattr.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.Filesytem"}
+		}
+		e.RemoveXAttr.File.Filesytem = str
+
+		return nil
+
 	case "removexattr.file.gid":
 
 		var ok bool
@@ -10088,6 +10481,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.RemoveXAttr.File.FileFields.Group = str
 
+		return nil
+
+	case "removexattr.file.in_upper_layer":
+
+		var ok bool
+		if e.RemoveXAttr.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.InUpperLayer"}
+		}
 		return nil
 
 	case "removexattr.file.inode":
@@ -10129,16 +10530,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.RemoveXAttr.File.BasenameStr = str
 
-		return nil
-
-	case "removexattr.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.OverlayNumLower"}
-		}
-		e.RemoveXAttr.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "removexattr.file.path":
@@ -10205,6 +10596,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "rename.file.destination.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.Filesytem"}
+		}
+		e.Rename.New.Filesytem = str
+
+		return nil
+
 	case "rename.file.destination.gid":
 
 		var ok bool
@@ -10224,6 +10626,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rename.New.FileFields.Group = str
 
+		return nil
+
+	case "rename.file.destination.in_upper_layer":
+
+		var ok bool
+		if e.Rename.New.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.InUpperLayer"}
+		}
 		return nil
 
 	case "rename.file.destination.inode":
@@ -10267,16 +10677,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
-	case "rename.file.destination.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.OverlayNumLower"}
-		}
-		e.Rename.New.FileFields.OverlayNumLower = int32(v)
-		return nil
-
 	case "rename.file.destination.path":
 
 		var ok bool
@@ -10309,6 +10709,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "rename.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.Filesytem"}
+		}
+		e.Rename.Old.Filesytem = str
+
+		return nil
+
 	case "rename.file.gid":
 
 		var ok bool
@@ -10328,6 +10739,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rename.Old.FileFields.Group = str
 
+		return nil
+
+	case "rename.file.in_upper_layer":
+
+		var ok bool
+		if e.Rename.Old.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.InUpperLayer"}
+		}
 		return nil
 
 	case "rename.file.inode":
@@ -10369,16 +10788,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rename.Old.BasenameStr = str
 
-		return nil
-
-	case "rename.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.OverlayNumLower"}
-		}
-		e.Rename.Old.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "rename.file.path":
@@ -10434,6 +10843,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "rmdir.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.Filesytem"}
+		}
+		e.Rmdir.File.Filesytem = str
+
+		return nil
+
 	case "rmdir.file.gid":
 
 		var ok bool
@@ -10453,6 +10873,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rmdir.File.FileFields.Group = str
 
+		return nil
+
+	case "rmdir.file.in_upper_layer":
+
+		var ok bool
+		if e.Rmdir.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.InUpperLayer"}
+		}
 		return nil
 
 	case "rmdir.file.inode":
@@ -10494,16 +10922,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rmdir.File.BasenameStr = str
 
-		return nil
-
-	case "rmdir.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.OverlayNumLower"}
-		}
-		e.Rmdir.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "rmdir.file.path":
@@ -10707,6 +11125,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "setxattr.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.Filesytem"}
+		}
+		e.SetXAttr.File.Filesytem = str
+
+		return nil
+
 	case "setxattr.file.gid":
 
 		var ok bool
@@ -10726,6 +11155,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.SetXAttr.File.FileFields.Group = str
 
+		return nil
+
+	case "setxattr.file.in_upper_layer":
+
+		var ok bool
+		if e.SetXAttr.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.InUpperLayer"}
+		}
 		return nil
 
 	case "setxattr.file.inode":
@@ -10767,16 +11204,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.SetXAttr.File.BasenameStr = str
 
-		return nil
-
-	case "setxattr.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.OverlayNumLower"}
-		}
-		e.SetXAttr.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "setxattr.file.path":
@@ -10832,6 +11259,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "unlink.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.Filesytem"}
+		}
+		e.Unlink.File.Filesytem = str
+
+		return nil
+
 	case "unlink.file.gid":
 
 		var ok bool
@@ -10851,6 +11289,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Unlink.File.FileFields.Group = str
 
+		return nil
+
+	case "unlink.file.in_upper_layer":
+
+		var ok bool
+		if e.Unlink.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.InUpperLayer"}
+		}
 		return nil
 
 	case "unlink.file.inode":
@@ -10892,16 +11338,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Unlink.File.BasenameStr = str
 
-		return nil
-
-	case "unlink.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.OverlayNumLower"}
-		}
-		e.Unlink.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "unlink.file.path":
@@ -10957,6 +11393,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "utimes.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.Filesytem"}
+		}
+		e.Utimes.File.Filesytem = str
+
+		return nil
+
 	case "utimes.file.gid":
 
 		var ok bool
@@ -10976,6 +11423,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Utimes.File.FileFields.Group = str
 
+		return nil
+
+	case "utimes.file.in_upper_layer":
+
+		var ok bool
+		if e.Utimes.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.InUpperLayer"}
+		}
 		return nil
 
 	case "utimes.file.inode":
@@ -11017,16 +11472,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Utimes.File.BasenameStr = str
 
-		return nil
-
-	case "utimes.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.OverlayNumLower"}
-		}
-		e.Utimes.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "utimes.file.path":

--- a/pkg/security/model/consts.go
+++ b/pkg/security/model/consts.go
@@ -280,6 +280,12 @@ var (
 	kernelCapabilitiesStrings = map[int]string{}
 )
 
+// File flags
+const (
+	LowerLayer = 1 << iota
+	UpperLayer
+)
+
 func initOpenConstants() {
 	for k, v := range openFlagsConstants {
 		SECLConstants[k] = &eval.IntEvaluator{Value: v}

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -273,6 +273,7 @@ type Process struct {
 	PathnameStr         string `field:"file.path" handler:"ResolveProcessInode,string"`
 	ContainerPath       string `field:"file.container_path" handler:"ResolveProcessContainerPath,string"`
 	BasenameStr         string `field:"file.name" handler:"ResolveProcessBasename,string"`
+	Filesystem          string `field:"file.filesystem" handler:"ResolveProcessFilesystem,string"`
 	PathResolutionError error  `field:"-"`
 
 	ExecTimestamp uint64    `field:"-"`
@@ -324,10 +325,10 @@ type FileFields struct {
 	CTime time.Time `field:"-"`
 	MTime time.Time `field:"-"`
 
-	MountID         uint32 `field:"mount_id"`
-	Inode           uint64 `field:"inode"`
-	PathID          uint32 `field:"-"`
-	OverlayNumLower int32  `field:"overlay_numlower"`
+	MountID uint32 `field:"mount_id"`
+	Inode   uint64 `field:"inode"`
+	PathID  uint32 `field:"-"`
+	Flags   int32  `field:"-"`
 }
 
 // FileEvent is the common file event type
@@ -336,6 +337,8 @@ type FileEvent struct {
 	PathnameStr   string `field:"path" handler:"ResolveFileInode,string"`
 	ContainerPath string `field:"container_path" handler:"ResolveFileContainerPath,string"`
 	BasenameStr   string `field:"name" handler:"ResolveFileBasename,string"`
+	Filesytem     string `field:"filesystem" handler:"ResolveFileFilesystem,string"`
+	InUpperLayer  bool   `field:"in_upper_layer" handler:"ResolveFileInUpperLayer,bool"`
 
 	PathResolutionError error `field:"-"`
 }

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -230,8 +230,8 @@ func (e *FileFields) UnmarshalBinary(data []byte) (int, error) {
 	}
 	e.Inode = ByteOrder.Uint64(data[0:8])
 	e.MountID = ByteOrder.Uint32(data[8:12])
-	e.OverlayNumLower = int32(ByteOrder.Uint32(data[12:16]))
-	e.PathID = ByteOrder.Uint32(data[16:20])
+	e.PathID = ByteOrder.Uint32(data[12:16])
+	e.Flags = int32(ByteOrder.Uint32(data[16:20]))
 
 	// +4 for padding
 

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -120,6 +120,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "chmod.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Chmod.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "chmod.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -137,6 +149,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Chmod.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Chmod.File)
 
 			},
 			Field: field,
@@ -190,18 +214,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chmod.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Chmod.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chmod.file.path":
@@ -312,6 +324,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "chown.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Chown.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "chown.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -329,6 +353,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Chown.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Chown.File)
 
 			},
 			Field: field,
@@ -382,18 +418,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chown.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Chown.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "chown.file.path":
@@ -636,6 +660,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "exec.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveProcessFilesystem(&(*Event)(ctx.Object).Exec.Process)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "exec.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -706,18 +742,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "exec.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Exec.Process.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "exec.file.path":
@@ -900,6 +924,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.destination.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Link.Target)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.file.destination.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -917,6 +953,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Link.Target.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Link.Target)
 
 			},
 			Field: field,
@@ -972,18 +1020,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "link.file.destination.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Target.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
 	case "link.file.destination.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -1020,6 +1056,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Link.Source)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1037,6 +1085,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Link.Source.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Link.Source)
 
 			},
 			Field: field,
@@ -1090,18 +1150,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Source.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "link.file.path":
@@ -1176,6 +1224,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "mkdir.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Mkdir.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "mkdir.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1193,6 +1253,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Mkdir.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Mkdir.File)
 
 			},
 			Field: field,
@@ -1246,18 +1318,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "mkdir.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Mkdir.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "mkdir.file.path":
@@ -1332,6 +1392,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "open.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Open.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "open.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1349,6 +1421,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Open.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "open.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Open.File)
 
 			},
 			Field: field,
@@ -1402,18 +1486,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "open.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Open.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "open.file.path":
@@ -1683,6 +1755,29 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
+	case "process.ancestors.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = (*Event)(ctx.Object).ResolveProcessFilesystem(&element.Process)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
 	case "process.ancestors.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1810,29 +1905,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*model.ProcessCacheEntry)(reg.Value)
 
 					result = (*Event)(ctx.Object).ResolveProcessBasename(&element.Process)
-
-				}
-
-				return result
-
-			},
-			Field: field,
-
-			Weight: eval.IteratorWeight,
-		}, nil
-
-	case "process.ancestors.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				var result int
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-
-					element := (*model.ProcessCacheEntry)(reg.Value)
-
-					result = int(element.ProcessContext.Process.FileFields.OverlayNumLower)
 
 				}
 
@@ -2320,6 +2392,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "process.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveProcessFilesystem(&(*Event)(ctx.Object).ProcessContext.Process)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "process.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2390,18 +2474,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "process.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.file.path":
@@ -2620,6 +2692,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "removexattr.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).RemoveXAttr.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "removexattr.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2637,6 +2721,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).RemoveXAttr.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "removexattr.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).RemoveXAttr.File)
 
 			},
 			Field: field,
@@ -2690,18 +2786,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "removexattr.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "removexattr.file.path":
@@ -2776,6 +2860,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "rename.file.destination.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Rename.New)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "rename.file.destination.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2793,6 +2889,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Rename.New.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.destination.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Rename.New)
 
 			},
 			Field: field,
@@ -2848,18 +2956,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "rename.file.destination.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rename.New.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
 	case "rename.file.destination.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2896,6 +2992,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "rename.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Rename.Old)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "rename.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2913,6 +3021,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Rename.Old.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Rename.Old)
 
 			},
 			Field: field,
@@ -2966,18 +3086,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rename.Old.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rename.file.path":
@@ -3040,6 +3148,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "rmdir.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Rmdir.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "rmdir.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3057,6 +3177,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Rmdir.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Rmdir.File)
 
 			},
 			Field: field,
@@ -3110,18 +3242,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rmdir.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rmdir.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "rmdir.file.path":
@@ -3352,6 +3472,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "setxattr.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).SetXAttr.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "setxattr.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3369,6 +3501,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).SetXAttr.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "setxattr.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).SetXAttr.File)
 
 			},
 			Field: field,
@@ -3422,18 +3566,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "setxattr.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "setxattr.file.path":
@@ -3496,6 +3628,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "unlink.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Unlink.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "unlink.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3513,6 +3657,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Unlink.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "unlink.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Unlink.File)
 
 			},
 			Field: field,
@@ -3566,18 +3722,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "unlink.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Unlink.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "unlink.file.path":
@@ -3640,6 +3784,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "utimes.file.filesystem":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileFilesystem(&(*Event)(ctx.Object).Utimes.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "utimes.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3657,6 +3813,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveGroup(&(*Event)(ctx.Object).Utimes.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "utimes.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Utimes.File)
 
 			},
 			Field: field,
@@ -3710,18 +3878,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "utimes.file.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Utimes.File.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "utimes.file.path":
@@ -3788,9 +3944,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"chmod.file.destination.mode",
 
+		"chmod.file.filesystem",
+
 		"chmod.file.gid",
 
 		"chmod.file.group",
+
+		"chmod.file.in_upper_layer",
 
 		"chmod.file.inode",
 
@@ -3799,8 +3959,6 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.mount_id",
 
 		"chmod.file.name",
-
-		"chmod.file.overlay_numlower",
 
 		"chmod.file.path",
 
@@ -3820,9 +3978,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"chown.file.destination.user",
 
+		"chown.file.filesystem",
+
 		"chown.file.gid",
 
 		"chown.file.group",
+
+		"chown.file.in_upper_layer",
 
 		"chown.file.inode",
 
@@ -3831,8 +3993,6 @@ func (e *Event) GetFields() []eval.Field {
 		"chown.file.mount_id",
 
 		"chown.file.name",
-
-		"chown.file.overlay_numlower",
 
 		"chown.file.path",
 
@@ -3870,6 +4030,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.file.container_path",
 
+		"exec.file.filesystem",
+
 		"exec.file.gid",
 
 		"exec.file.group",
@@ -3881,8 +4043,6 @@ func (e *Event) GetFields() []eval.Field {
 		"exec.file.mount_id",
 
 		"exec.file.name",
-
-		"exec.file.overlay_numlower",
 
 		"exec.file.path",
 
@@ -3914,9 +4074,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.destination.container_path",
 
+		"link.file.destination.filesystem",
+
 		"link.file.destination.gid",
 
 		"link.file.destination.group",
+
+		"link.file.destination.in_upper_layer",
 
 		"link.file.destination.inode",
 
@@ -3926,17 +4090,19 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.destination.name",
 
-		"link.file.destination.overlay_numlower",
-
 		"link.file.destination.path",
 
 		"link.file.destination.uid",
 
 		"link.file.destination.user",
 
+		"link.file.filesystem",
+
 		"link.file.gid",
 
 		"link.file.group",
+
+		"link.file.in_upper_layer",
 
 		"link.file.inode",
 
@@ -3945,8 +4111,6 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.mount_id",
 
 		"link.file.name",
-
-		"link.file.overlay_numlower",
 
 		"link.file.path",
 
@@ -3960,9 +4124,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"mkdir.file.destination.mode",
 
+		"mkdir.file.filesystem",
+
 		"mkdir.file.gid",
 
 		"mkdir.file.group",
+
+		"mkdir.file.in_upper_layer",
 
 		"mkdir.file.inode",
 
@@ -3971,8 +4139,6 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.mount_id",
 
 		"mkdir.file.name",
-
-		"mkdir.file.overlay_numlower",
 
 		"mkdir.file.path",
 
@@ -3986,9 +4152,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"open.file.destination.mode",
 
+		"open.file.filesystem",
+
 		"open.file.gid",
 
 		"open.file.group",
+
+		"open.file.in_upper_layer",
 
 		"open.file.inode",
 
@@ -3997,8 +4167,6 @@ func (e *Event) GetFields() []eval.Field {
 		"open.file.mount_id",
 
 		"open.file.name",
-
-		"open.file.overlay_numlower",
 
 		"open.file.path",
 
@@ -4028,6 +4196,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.file.container_path",
 
+		"process.ancestors.file.filesystem",
+
 		"process.ancestors.file.gid",
 
 		"process.ancestors.file.group",
@@ -4039,8 +4209,6 @@ func (e *Event) GetFields() []eval.Field {
 		"process.ancestors.file.mount_id",
 
 		"process.ancestors.file.name",
-
-		"process.ancestors.file.overlay_numlower",
 
 		"process.ancestors.file.path",
 
@@ -4092,6 +4260,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.file.container_path",
 
+		"process.file.filesystem",
+
 		"process.file.gid",
 
 		"process.file.group",
@@ -4103,8 +4273,6 @@ func (e *Event) GetFields() []eval.Field {
 		"process.file.mount_id",
 
 		"process.file.name",
-
-		"process.file.overlay_numlower",
 
 		"process.file.path",
 
@@ -4142,9 +4310,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"removexattr.file.destination.namespace",
 
+		"removexattr.file.filesystem",
+
 		"removexattr.file.gid",
 
 		"removexattr.file.group",
+
+		"removexattr.file.in_upper_layer",
 
 		"removexattr.file.inode",
 
@@ -4153,8 +4325,6 @@ func (e *Event) GetFields() []eval.Field {
 		"removexattr.file.mount_id",
 
 		"removexattr.file.name",
-
-		"removexattr.file.overlay_numlower",
 
 		"removexattr.file.path",
 
@@ -4168,9 +4338,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.file.destination.container_path",
 
+		"rename.file.destination.filesystem",
+
 		"rename.file.destination.gid",
 
 		"rename.file.destination.group",
+
+		"rename.file.destination.in_upper_layer",
 
 		"rename.file.destination.inode",
 
@@ -4180,17 +4354,19 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.file.destination.name",
 
-		"rename.file.destination.overlay_numlower",
-
 		"rename.file.destination.path",
 
 		"rename.file.destination.uid",
 
 		"rename.file.destination.user",
 
+		"rename.file.filesystem",
+
 		"rename.file.gid",
 
 		"rename.file.group",
+
+		"rename.file.in_upper_layer",
 
 		"rename.file.inode",
 
@@ -4199,8 +4375,6 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.mount_id",
 
 		"rename.file.name",
-
-		"rename.file.overlay_numlower",
 
 		"rename.file.path",
 
@@ -4212,9 +4386,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rmdir.file.container_path",
 
+		"rmdir.file.filesystem",
+
 		"rmdir.file.gid",
 
 		"rmdir.file.group",
+
+		"rmdir.file.in_upper_layer",
 
 		"rmdir.file.inode",
 
@@ -4223,8 +4401,6 @@ func (e *Event) GetFields() []eval.Field {
 		"rmdir.file.mount_id",
 
 		"rmdir.file.name",
-
-		"rmdir.file.overlay_numlower",
 
 		"rmdir.file.path",
 
@@ -4264,9 +4440,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setxattr.file.destination.namespace",
 
+		"setxattr.file.filesystem",
+
 		"setxattr.file.gid",
 
 		"setxattr.file.group",
+
+		"setxattr.file.in_upper_layer",
 
 		"setxattr.file.inode",
 
@@ -4275,8 +4455,6 @@ func (e *Event) GetFields() []eval.Field {
 		"setxattr.file.mount_id",
 
 		"setxattr.file.name",
-
-		"setxattr.file.overlay_numlower",
 
 		"setxattr.file.path",
 
@@ -4288,9 +4466,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"unlink.file.container_path",
 
+		"unlink.file.filesystem",
+
 		"unlink.file.gid",
 
 		"unlink.file.group",
+
+		"unlink.file.in_upper_layer",
 
 		"unlink.file.inode",
 
@@ -4299,8 +4481,6 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.mount_id",
 
 		"unlink.file.name",
-
-		"unlink.file.overlay_numlower",
 
 		"unlink.file.path",
 
@@ -4312,9 +4492,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"utimes.file.container_path",
 
+		"utimes.file.filesystem",
+
 		"utimes.file.gid",
 
 		"utimes.file.group",
+
+		"utimes.file.in_upper_layer",
 
 		"utimes.file.inode",
 
@@ -4323,8 +4507,6 @@ func (e *Event) GetFields() []eval.Field {
 		"utimes.file.mount_id",
 
 		"utimes.file.name",
-
-		"utimes.file.overlay_numlower",
 
 		"utimes.file.path",
 
@@ -4355,6 +4537,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Chmod.Mode), nil
 
+	case "chmod.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Chmod.File), nil
+
 	case "chmod.file.gid":
 
 		return int(e.Chmod.File.FileFields.GID), nil
@@ -4362,6 +4548,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.file.group":
 
 		return e.ResolveGroup(&e.Chmod.File.FileFields), nil
+
+	case "chmod.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Chmod.File), nil
 
 	case "chmod.file.inode":
 
@@ -4378,10 +4568,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.file.name":
 
 		return e.ResolveFileBasename(&e.Chmod.File), nil
-
-	case "chmod.file.overlay_numlower":
-
-		return int(e.Chmod.File.FileFields.OverlayNumLower), nil
 
 	case "chmod.file.path":
 
@@ -4419,6 +4605,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveChownUID(&e.Chown), nil
 
+	case "chown.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Chown.File), nil
+
 	case "chown.file.gid":
 
 		return int(e.Chown.File.FileFields.GID), nil
@@ -4426,6 +4616,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chown.file.group":
 
 		return e.ResolveGroup(&e.Chown.File.FileFields), nil
+
+	case "chown.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Chown.File), nil
 
 	case "chown.file.inode":
 
@@ -4442,10 +4636,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chown.file.name":
 
 		return e.ResolveFileBasename(&e.Chown.File), nil
-
-	case "chown.file.overlay_numlower":
-
-		return int(e.Chown.File.FileFields.OverlayNumLower), nil
 
 	case "chown.file.path":
 
@@ -4559,6 +4749,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveProcessContainerPath(&e.Exec.Process), nil
 
+	case "exec.file.filesystem":
+
+		return e.ResolveProcessFilesystem(&e.Exec.Process), nil
+
 	case "exec.file.gid":
 
 		return int(e.Exec.Process.FileFields.GID), nil
@@ -4582,10 +4776,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "exec.file.name":
 
 		return e.ResolveProcessBasename(&e.Exec.Process), nil
-
-	case "exec.file.overlay_numlower":
-
-		return int(e.Exec.Process.FileFields.OverlayNumLower), nil
 
 	case "exec.file.path":
 
@@ -4647,6 +4837,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileContainerPath(&e.Link.Target), nil
 
+	case "link.file.destination.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Link.Target), nil
+
 	case "link.file.destination.gid":
 
 		return int(e.Link.Target.FileFields.GID), nil
@@ -4654,6 +4848,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.file.destination.group":
 
 		return e.ResolveGroup(&e.Link.Target.FileFields), nil
+
+	case "link.file.destination.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Link.Target), nil
 
 	case "link.file.destination.inode":
 
@@ -4671,10 +4869,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileBasename(&e.Link.Target), nil
 
-	case "link.file.destination.overlay_numlower":
-
-		return int(e.Link.Target.FileFields.OverlayNumLower), nil
-
 	case "link.file.destination.path":
 
 		return e.ResolveFileInode(&e.Link.Target), nil
@@ -4687,6 +4881,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveUser(&e.Link.Target.FileFields), nil
 
+	case "link.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Link.Source), nil
+
 	case "link.file.gid":
 
 		return int(e.Link.Source.FileFields.GID), nil
@@ -4694,6 +4892,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.file.group":
 
 		return e.ResolveGroup(&e.Link.Source.FileFields), nil
+
+	case "link.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Link.Source), nil
 
 	case "link.file.inode":
 
@@ -4710,10 +4912,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.file.name":
 
 		return e.ResolveFileBasename(&e.Link.Source), nil
-
-	case "link.file.overlay_numlower":
-
-		return int(e.Link.Source.FileFields.OverlayNumLower), nil
 
 	case "link.file.path":
 
@@ -4739,6 +4937,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Mkdir.Mode), nil
 
+	case "mkdir.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Mkdir.File), nil
+
 	case "mkdir.file.gid":
 
 		return int(e.Mkdir.File.FileFields.GID), nil
@@ -4746,6 +4948,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mkdir.file.group":
 
 		return e.ResolveGroup(&e.Mkdir.File.FileFields), nil
+
+	case "mkdir.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Mkdir.File), nil
 
 	case "mkdir.file.inode":
 
@@ -4762,10 +4968,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mkdir.file.name":
 
 		return e.ResolveFileBasename(&e.Mkdir.File), nil
-
-	case "mkdir.file.overlay_numlower":
-
-		return int(e.Mkdir.File.FileFields.OverlayNumLower), nil
 
 	case "mkdir.file.path":
 
@@ -4791,6 +4993,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Open.Mode), nil
 
+	case "open.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Open.File), nil
+
 	case "open.file.gid":
 
 		return int(e.Open.File.FileFields.GID), nil
@@ -4798,6 +5004,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "open.file.group":
 
 		return e.ResolveGroup(&e.Open.File.FileFields), nil
+
+	case "open.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Open.File), nil
 
 	case "open.file.inode":
 
@@ -4814,10 +5024,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "open.file.name":
 
 		return e.ResolveFileBasename(&e.Open.File), nil
-
-	case "open.file.overlay_numlower":
-
-		return int(e.Open.File.FileFields.OverlayNumLower), nil
 
 	case "open.file.path":
 
@@ -5046,6 +5252,29 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
+	case "process.ancestors.file.filesystem":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveProcessFilesystem(&element.Process)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
 	case "process.ancestors.file.gid":
 
 		var values []int
@@ -5176,29 +5405,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*model.ProcessCacheEntry)(ptr)
 
 			result := (*Event)(ctx.Object).ResolveProcessBasename(&element.Process)
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
-
-	case "process.ancestors.file.overlay_numlower":
-
-		var values []int
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &model.ProcessAncestorsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-
-			element := (*model.ProcessCacheEntry)(ptr)
-
-			result := int(element.ProcessContext.Process.FileFields.OverlayNumLower)
 
 			values = append(values, result)
 
@@ -5611,6 +5817,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveProcessContainerPath(&e.ProcessContext.Process), nil
 
+	case "process.file.filesystem":
+
+		return e.ResolveProcessFilesystem(&e.ProcessContext.Process), nil
+
 	case "process.file.gid":
 
 		return int(e.ProcessContext.Process.FileFields.GID), nil
@@ -5634,10 +5844,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.file.name":
 
 		return e.ResolveProcessBasename(&e.ProcessContext.Process), nil
-
-	case "process.file.overlay_numlower":
-
-		return int(e.ProcessContext.Process.FileFields.OverlayNumLower), nil
 
 	case "process.file.path":
 
@@ -5711,6 +5917,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.GetXAttrNamespace(&e.RemoveXAttr), nil
 
+	case "removexattr.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.RemoveXAttr.File), nil
+
 	case "removexattr.file.gid":
 
 		return int(e.RemoveXAttr.File.FileFields.GID), nil
@@ -5718,6 +5928,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "removexattr.file.group":
 
 		return e.ResolveGroup(&e.RemoveXAttr.File.FileFields), nil
+
+	case "removexattr.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.RemoveXAttr.File), nil
 
 	case "removexattr.file.inode":
 
@@ -5734,10 +5948,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "removexattr.file.name":
 
 		return e.ResolveFileBasename(&e.RemoveXAttr.File), nil
-
-	case "removexattr.file.overlay_numlower":
-
-		return int(e.RemoveXAttr.File.FileFields.OverlayNumLower), nil
 
 	case "removexattr.file.path":
 
@@ -5763,6 +5973,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileContainerPath(&e.Rename.New), nil
 
+	case "rename.file.destination.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Rename.New), nil
+
 	case "rename.file.destination.gid":
 
 		return int(e.Rename.New.FileFields.GID), nil
@@ -5770,6 +5984,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.destination.group":
 
 		return e.ResolveGroup(&e.Rename.New.FileFields), nil
+
+	case "rename.file.destination.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Rename.New), nil
 
 	case "rename.file.destination.inode":
 
@@ -5787,10 +6005,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileBasename(&e.Rename.New), nil
 
-	case "rename.file.destination.overlay_numlower":
-
-		return int(e.Rename.New.FileFields.OverlayNumLower), nil
-
 	case "rename.file.destination.path":
 
 		return e.ResolveFileInode(&e.Rename.New), nil
@@ -5803,6 +6017,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveUser(&e.Rename.New.FileFields), nil
 
+	case "rename.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Rename.Old), nil
+
 	case "rename.file.gid":
 
 		return int(e.Rename.Old.FileFields.GID), nil
@@ -5810,6 +6028,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.group":
 
 		return e.ResolveGroup(&e.Rename.Old.FileFields), nil
+
+	case "rename.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Rename.Old), nil
 
 	case "rename.file.inode":
 
@@ -5826,10 +6048,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.name":
 
 		return e.ResolveFileBasename(&e.Rename.Old), nil
-
-	case "rename.file.overlay_numlower":
-
-		return int(e.Rename.Old.FileFields.OverlayNumLower), nil
 
 	case "rename.file.path":
 
@@ -5851,6 +6069,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileContainerPath(&e.Rmdir.File), nil
 
+	case "rmdir.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Rmdir.File), nil
+
 	case "rmdir.file.gid":
 
 		return int(e.Rmdir.File.FileFields.GID), nil
@@ -5858,6 +6080,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rmdir.file.group":
 
 		return e.ResolveGroup(&e.Rmdir.File.FileFields), nil
+
+	case "rmdir.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Rmdir.File), nil
 
 	case "rmdir.file.inode":
 
@@ -5874,10 +6100,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rmdir.file.name":
 
 		return e.ResolveFileBasename(&e.Rmdir.File), nil
-
-	case "rmdir.file.overlay_numlower":
-
-		return int(e.Rmdir.File.FileFields.OverlayNumLower), nil
 
 	case "rmdir.file.path":
 
@@ -5955,6 +6177,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.GetXAttrNamespace(&e.SetXAttr), nil
 
+	case "setxattr.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.SetXAttr.File), nil
+
 	case "setxattr.file.gid":
 
 		return int(e.SetXAttr.File.FileFields.GID), nil
@@ -5962,6 +6188,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "setxattr.file.group":
 
 		return e.ResolveGroup(&e.SetXAttr.File.FileFields), nil
+
+	case "setxattr.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.SetXAttr.File), nil
 
 	case "setxattr.file.inode":
 
@@ -5978,10 +6208,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "setxattr.file.name":
 
 		return e.ResolveFileBasename(&e.SetXAttr.File), nil
-
-	case "setxattr.file.overlay_numlower":
-
-		return int(e.SetXAttr.File.FileFields.OverlayNumLower), nil
 
 	case "setxattr.file.path":
 
@@ -6003,6 +6229,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileContainerPath(&e.Unlink.File), nil
 
+	case "unlink.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Unlink.File), nil
+
 	case "unlink.file.gid":
 
 		return int(e.Unlink.File.FileFields.GID), nil
@@ -6010,6 +6240,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.file.group":
 
 		return e.ResolveGroup(&e.Unlink.File.FileFields), nil
+
+	case "unlink.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Unlink.File), nil
 
 	case "unlink.file.inode":
 
@@ -6026,10 +6260,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.file.name":
 
 		return e.ResolveFileBasename(&e.Unlink.File), nil
-
-	case "unlink.file.overlay_numlower":
-
-		return int(e.Unlink.File.FileFields.OverlayNumLower), nil
 
 	case "unlink.file.path":
 
@@ -6051,6 +6281,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileContainerPath(&e.Utimes.File), nil
 
+	case "utimes.file.filesystem":
+
+		return e.ResolveFileFilesystem(&e.Utimes.File), nil
+
 	case "utimes.file.gid":
 
 		return int(e.Utimes.File.FileFields.GID), nil
@@ -6058,6 +6292,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "utimes.file.group":
 
 		return e.ResolveGroup(&e.Utimes.File.FileFields), nil
+
+	case "utimes.file.in_upper_layer":
+
+		return e.ResolveFileInUpperLayer(&e.Utimes.File), nil
 
 	case "utimes.file.inode":
 
@@ -6074,10 +6312,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "utimes.file.name":
 
 		return e.ResolveFileBasename(&e.Utimes.File), nil
-
-	case "utimes.file.overlay_numlower":
-
-		return int(e.Utimes.File.FileFields.OverlayNumLower), nil
 
 	case "utimes.file.path":
 
@@ -6115,10 +6349,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "chmod.file.destination.mode":
 		return "chmod", nil
 
+	case "chmod.file.filesystem":
+		return "chmod", nil
+
 	case "chmod.file.gid":
 		return "chmod", nil
 
 	case "chmod.file.group":
+		return "chmod", nil
+
+	case "chmod.file.in_upper_layer":
 		return "chmod", nil
 
 	case "chmod.file.inode":
@@ -6131,9 +6371,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chmod", nil
 
 	case "chmod.file.name":
-		return "chmod", nil
-
-	case "chmod.file.overlay_numlower":
 		return "chmod", nil
 
 	case "chmod.file.path":
@@ -6163,10 +6400,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "chown.file.destination.user":
 		return "chown", nil
 
+	case "chown.file.filesystem":
+		return "chown", nil
+
 	case "chown.file.gid":
 		return "chown", nil
 
 	case "chown.file.group":
+		return "chown", nil
+
+	case "chown.file.in_upper_layer":
 		return "chown", nil
 
 	case "chown.file.inode":
@@ -6179,9 +6422,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chown", nil
 
 	case "chown.file.name":
-		return "chown", nil
-
-	case "chown.file.overlay_numlower":
 		return "chown", nil
 
 	case "chown.file.path":
@@ -6238,6 +6478,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.file.container_path":
 		return "exec", nil
 
+	case "exec.file.filesystem":
+		return "exec", nil
+
 	case "exec.file.gid":
 		return "exec", nil
 
@@ -6254,9 +6497,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 
 	case "exec.file.name":
-		return "exec", nil
-
-	case "exec.file.overlay_numlower":
 		return "exec", nil
 
 	case "exec.file.path":
@@ -6304,10 +6544,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.destination.container_path":
 		return "link", nil
 
+	case "link.file.destination.filesystem":
+		return "link", nil
+
 	case "link.file.destination.gid":
 		return "link", nil
 
 	case "link.file.destination.group":
+		return "link", nil
+
+	case "link.file.destination.in_upper_layer":
 		return "link", nil
 
 	case "link.file.destination.inode":
@@ -6322,9 +6568,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.destination.name":
 		return "link", nil
 
-	case "link.file.destination.overlay_numlower":
-		return "link", nil
-
 	case "link.file.destination.path":
 		return "link", nil
 
@@ -6334,10 +6577,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.destination.user":
 		return "link", nil
 
+	case "link.file.filesystem":
+		return "link", nil
+
 	case "link.file.gid":
 		return "link", nil
 
 	case "link.file.group":
+		return "link", nil
+
+	case "link.file.in_upper_layer":
 		return "link", nil
 
 	case "link.file.inode":
@@ -6350,9 +6599,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "link", nil
 
 	case "link.file.name":
-		return "link", nil
-
-	case "link.file.overlay_numlower":
 		return "link", nil
 
 	case "link.file.path":
@@ -6373,10 +6619,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mkdir.file.destination.mode":
 		return "mkdir", nil
 
+	case "mkdir.file.filesystem":
+		return "mkdir", nil
+
 	case "mkdir.file.gid":
 		return "mkdir", nil
 
 	case "mkdir.file.group":
+		return "mkdir", nil
+
+	case "mkdir.file.in_upper_layer":
 		return "mkdir", nil
 
 	case "mkdir.file.inode":
@@ -6389,9 +6641,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 
 	case "mkdir.file.name":
-		return "mkdir", nil
-
-	case "mkdir.file.overlay_numlower":
 		return "mkdir", nil
 
 	case "mkdir.file.path":
@@ -6412,10 +6661,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "open.file.destination.mode":
 		return "open", nil
 
+	case "open.file.filesystem":
+		return "open", nil
+
 	case "open.file.gid":
 		return "open", nil
 
 	case "open.file.group":
+		return "open", nil
+
+	case "open.file.in_upper_layer":
 		return "open", nil
 
 	case "open.file.inode":
@@ -6428,9 +6683,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "open", nil
 
 	case "open.file.name":
-		return "open", nil
-
-	case "open.file.overlay_numlower":
 		return "open", nil
 
 	case "open.file.path":
@@ -6475,6 +6727,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.file.container_path":
 		return "*", nil
 
+	case "process.ancestors.file.filesystem":
+		return "*", nil
+
 	case "process.ancestors.file.gid":
 		return "*", nil
 
@@ -6491,9 +6746,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.file.name":
-		return "*", nil
-
-	case "process.ancestors.file.overlay_numlower":
 		return "*", nil
 
 	case "process.ancestors.file.path":
@@ -6571,6 +6823,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.file.container_path":
 		return "*", nil
 
+	case "process.file.filesystem":
+		return "*", nil
+
 	case "process.file.gid":
 		return "*", nil
 
@@ -6587,9 +6842,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.file.name":
-		return "*", nil
-
-	case "process.file.overlay_numlower":
 		return "*", nil
 
 	case "process.file.path":
@@ -6646,10 +6898,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "removexattr.file.destination.namespace":
 		return "removexattr", nil
 
+	case "removexattr.file.filesystem":
+		return "removexattr", nil
+
 	case "removexattr.file.gid":
 		return "removexattr", nil
 
 	case "removexattr.file.group":
+		return "removexattr", nil
+
+	case "removexattr.file.in_upper_layer":
 		return "removexattr", nil
 
 	case "removexattr.file.inode":
@@ -6662,9 +6920,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "removexattr", nil
 
 	case "removexattr.file.name":
-		return "removexattr", nil
-
-	case "removexattr.file.overlay_numlower":
 		return "removexattr", nil
 
 	case "removexattr.file.path":
@@ -6685,10 +6940,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.destination.container_path":
 		return "rename", nil
 
+	case "rename.file.destination.filesystem":
+		return "rename", nil
+
 	case "rename.file.destination.gid":
 		return "rename", nil
 
 	case "rename.file.destination.group":
+		return "rename", nil
+
+	case "rename.file.destination.in_upper_layer":
 		return "rename", nil
 
 	case "rename.file.destination.inode":
@@ -6703,9 +6964,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.destination.name":
 		return "rename", nil
 
-	case "rename.file.destination.overlay_numlower":
-		return "rename", nil
-
 	case "rename.file.destination.path":
 		return "rename", nil
 
@@ -6715,10 +6973,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.destination.user":
 		return "rename", nil
 
+	case "rename.file.filesystem":
+		return "rename", nil
+
 	case "rename.file.gid":
 		return "rename", nil
 
 	case "rename.file.group":
+		return "rename", nil
+
+	case "rename.file.in_upper_layer":
 		return "rename", nil
 
 	case "rename.file.inode":
@@ -6731,9 +6995,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 
 	case "rename.file.name":
-		return "rename", nil
-
-	case "rename.file.overlay_numlower":
 		return "rename", nil
 
 	case "rename.file.path":
@@ -6751,10 +7012,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rmdir.file.container_path":
 		return "rmdir", nil
 
+	case "rmdir.file.filesystem":
+		return "rmdir", nil
+
 	case "rmdir.file.gid":
 		return "rmdir", nil
 
 	case "rmdir.file.group":
+		return "rmdir", nil
+
+	case "rmdir.file.in_upper_layer":
 		return "rmdir", nil
 
 	case "rmdir.file.inode":
@@ -6767,9 +7034,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rmdir", nil
 
 	case "rmdir.file.name":
-		return "rmdir", nil
-
-	case "rmdir.file.overlay_numlower":
 		return "rmdir", nil
 
 	case "rmdir.file.path":
@@ -6829,10 +7093,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setxattr.file.destination.namespace":
 		return "setxattr", nil
 
+	case "setxattr.file.filesystem":
+		return "setxattr", nil
+
 	case "setxattr.file.gid":
 		return "setxattr", nil
 
 	case "setxattr.file.group":
+		return "setxattr", nil
+
+	case "setxattr.file.in_upper_layer":
 		return "setxattr", nil
 
 	case "setxattr.file.inode":
@@ -6845,9 +7115,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "setxattr", nil
 
 	case "setxattr.file.name":
-		return "setxattr", nil
-
-	case "setxattr.file.overlay_numlower":
 		return "setxattr", nil
 
 	case "setxattr.file.path":
@@ -6865,10 +7132,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "unlink.file.container_path":
 		return "unlink", nil
 
+	case "unlink.file.filesystem":
+		return "unlink", nil
+
 	case "unlink.file.gid":
 		return "unlink", nil
 
 	case "unlink.file.group":
+		return "unlink", nil
+
+	case "unlink.file.in_upper_layer":
 		return "unlink", nil
 
 	case "unlink.file.inode":
@@ -6881,9 +7154,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "unlink", nil
 
 	case "unlink.file.name":
-		return "unlink", nil
-
-	case "unlink.file.overlay_numlower":
 		return "unlink", nil
 
 	case "unlink.file.path":
@@ -6901,10 +7171,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "utimes.file.container_path":
 		return "utimes", nil
 
+	case "utimes.file.filesystem":
+		return "utimes", nil
+
 	case "utimes.file.gid":
 		return "utimes", nil
 
 	case "utimes.file.group":
+		return "utimes", nil
+
+	case "utimes.file.in_upper_layer":
 		return "utimes", nil
 
 	case "utimes.file.inode":
@@ -6917,9 +7193,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "utimes", nil
 
 	case "utimes.file.name":
-		return "utimes", nil
-
-	case "utimes.file.overlay_numlower":
 		return "utimes", nil
 
 	case "utimes.file.path":
@@ -6958,6 +7231,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "chmod.file.filesystem":
+
+		return reflect.String, nil
+
 	case "chmod.file.gid":
 
 		return reflect.Int, nil
@@ -6965,6 +7242,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.file.group":
 
 		return reflect.String, nil
+
+	case "chmod.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "chmod.file.inode":
 
@@ -6981,10 +7262,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.file.name":
 
 		return reflect.String, nil
-
-	case "chmod.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "chmod.file.path":
 
@@ -7022,6 +7299,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "chown.file.filesystem":
+
+		return reflect.String, nil
+
 	case "chown.file.gid":
 
 		return reflect.Int, nil
@@ -7029,6 +7310,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chown.file.group":
 
 		return reflect.String, nil
+
+	case "chown.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "chown.file.inode":
 
@@ -7045,10 +7330,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chown.file.name":
 
 		return reflect.String, nil
-
-	case "chown.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "chown.file.path":
 
@@ -7122,6 +7403,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.file.filesystem":
+
+		return reflect.String, nil
+
 	case "exec.file.gid":
 
 		return reflect.Int, nil
@@ -7145,10 +7430,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "exec.file.name":
 
 		return reflect.String, nil
-
-	case "exec.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "exec.file.path":
 
@@ -7210,6 +7491,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.destination.filesystem":
+
+		return reflect.String, nil
+
 	case "link.file.destination.gid":
 
 		return reflect.Int, nil
@@ -7217,6 +7502,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "link.file.destination.group":
 
 		return reflect.String, nil
+
+	case "link.file.destination.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "link.file.destination.inode":
 
@@ -7234,10 +7523,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "link.file.destination.overlay_numlower":
-
-		return reflect.Int, nil
-
 	case "link.file.destination.path":
 
 		return reflect.String, nil
@@ -7250,6 +7535,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.filesystem":
+
+		return reflect.String, nil
+
 	case "link.file.gid":
 
 		return reflect.Int, nil
@@ -7257,6 +7546,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "link.file.group":
 
 		return reflect.String, nil
+
+	case "link.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "link.file.inode":
 
@@ -7273,10 +7566,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "link.file.name":
 
 		return reflect.String, nil
-
-	case "link.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "link.file.path":
 
@@ -7302,6 +7591,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "mkdir.file.filesystem":
+
+		return reflect.String, nil
+
 	case "mkdir.file.gid":
 
 		return reflect.Int, nil
@@ -7309,6 +7602,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mkdir.file.group":
 
 		return reflect.String, nil
+
+	case "mkdir.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "mkdir.file.inode":
 
@@ -7325,10 +7622,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mkdir.file.name":
 
 		return reflect.String, nil
-
-	case "mkdir.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "mkdir.file.path":
 
@@ -7354,6 +7647,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "open.file.filesystem":
+
+		return reflect.String, nil
+
 	case "open.file.gid":
 
 		return reflect.Int, nil
@@ -7361,6 +7658,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "open.file.group":
 
 		return reflect.String, nil
+
+	case "open.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "open.file.inode":
 
@@ -7377,10 +7678,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "open.file.name":
 
 		return reflect.String, nil
-
-	case "open.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "open.file.path":
 
@@ -7438,6 +7735,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.ancestors.file.filesystem":
+
+		return reflect.String, nil
+
 	case "process.ancestors.file.gid":
 
 		return reflect.Int, nil
@@ -7461,10 +7762,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.ancestors.file.name":
 
 		return reflect.String, nil
-
-	case "process.ancestors.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "process.ancestors.file.path":
 
@@ -7566,6 +7863,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.file.filesystem":
+
+		return reflect.String, nil
+
 	case "process.file.gid":
 
 		return reflect.Int, nil
@@ -7589,10 +7890,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.file.name":
 
 		return reflect.String, nil
-
-	case "process.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "process.file.path":
 
@@ -7666,6 +7963,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "removexattr.file.filesystem":
+
+		return reflect.String, nil
+
 	case "removexattr.file.gid":
 
 		return reflect.Int, nil
@@ -7673,6 +7974,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "removexattr.file.group":
 
 		return reflect.String, nil
+
+	case "removexattr.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "removexattr.file.inode":
 
@@ -7689,10 +7994,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "removexattr.file.name":
 
 		return reflect.String, nil
-
-	case "removexattr.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "removexattr.file.path":
 
@@ -7718,6 +8019,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "rename.file.destination.filesystem":
+
+		return reflect.String, nil
+
 	case "rename.file.destination.gid":
 
 		return reflect.Int, nil
@@ -7725,6 +8030,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.destination.group":
 
 		return reflect.String, nil
+
+	case "rename.file.destination.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "rename.file.destination.inode":
 
@@ -7742,10 +8051,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "rename.file.destination.overlay_numlower":
-
-		return reflect.Int, nil
-
 	case "rename.file.destination.path":
 
 		return reflect.String, nil
@@ -7758,6 +8063,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "rename.file.filesystem":
+
+		return reflect.String, nil
+
 	case "rename.file.gid":
 
 		return reflect.Int, nil
@@ -7765,6 +8074,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.group":
 
 		return reflect.String, nil
+
+	case "rename.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "rename.file.inode":
 
@@ -7781,10 +8094,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.name":
 
 		return reflect.String, nil
-
-	case "rename.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "rename.file.path":
 
@@ -7806,6 +8115,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "rmdir.file.filesystem":
+
+		return reflect.String, nil
+
 	case "rmdir.file.gid":
 
 		return reflect.Int, nil
@@ -7813,6 +8126,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rmdir.file.group":
 
 		return reflect.String, nil
+
+	case "rmdir.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "rmdir.file.inode":
 
@@ -7829,10 +8146,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rmdir.file.name":
 
 		return reflect.String, nil
-
-	case "rmdir.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "rmdir.file.path":
 
@@ -7910,6 +8223,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "setxattr.file.filesystem":
+
+		return reflect.String, nil
+
 	case "setxattr.file.gid":
 
 		return reflect.Int, nil
@@ -7917,6 +8234,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setxattr.file.group":
 
 		return reflect.String, nil
+
+	case "setxattr.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "setxattr.file.inode":
 
@@ -7933,10 +8254,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "setxattr.file.name":
 
 		return reflect.String, nil
-
-	case "setxattr.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "setxattr.file.path":
 
@@ -7958,6 +8275,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "unlink.file.filesystem":
+
+		return reflect.String, nil
+
 	case "unlink.file.gid":
 
 		return reflect.Int, nil
@@ -7965,6 +8286,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "unlink.file.group":
 
 		return reflect.String, nil
+
+	case "unlink.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "unlink.file.inode":
 
@@ -7981,10 +8306,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "unlink.file.name":
 
 		return reflect.String, nil
-
-	case "unlink.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "unlink.file.path":
 
@@ -8006,6 +8327,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "utimes.file.filesystem":
+
+		return reflect.String, nil
+
 	case "utimes.file.gid":
 
 		return reflect.Int, nil
@@ -8013,6 +8338,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "utimes.file.group":
 
 		return reflect.String, nil
+
+	case "utimes.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "utimes.file.inode":
 
@@ -8029,10 +8358,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "utimes.file.name":
 
 		return reflect.String, nil
-
-	case "utimes.file.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "utimes.file.path":
 
@@ -8099,6 +8424,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.Mode = uint32(v)
 		return nil
 
+	case "chmod.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.Filesytem"}
+		}
+		e.Chmod.File.Filesytem = str
+
+		return nil
+
 	case "chmod.file.gid":
 
 		var ok bool
@@ -8118,6 +8454,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chmod.File.FileFields.Group = str
 
+		return nil
+
+	case "chmod.file.in_upper_layer":
+
+		var ok bool
+		if e.Chmod.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.InUpperLayer"}
+		}
 		return nil
 
 	case "chmod.file.inode":
@@ -8159,16 +8503,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chmod.File.BasenameStr = str
 
-		return nil
-
-	case "chmod.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.OverlayNumLower"}
-		}
-		e.Chmod.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "chmod.file.path":
@@ -8266,6 +8600,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "chown.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.Filesytem"}
+		}
+		e.Chown.File.Filesytem = str
+
+		return nil
+
 	case "chown.file.gid":
 
 		var ok bool
@@ -8285,6 +8630,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chown.File.FileFields.Group = str
 
+		return nil
+
+	case "chown.file.in_upper_layer":
+
+		var ok bool
+		if e.Chown.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.InUpperLayer"}
+		}
 		return nil
 
 	case "chown.file.inode":
@@ -8326,16 +8679,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chown.File.BasenameStr = str
 
-		return nil
-
-	case "chown.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.OverlayNumLower"}
-		}
-		e.Chown.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "chown.file.path":
@@ -8523,6 +8866,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Filesystem"}
+		}
+		e.Exec.Process.Filesystem = str
+
+		return nil
+
 	case "exec.file.gid":
 
 		var ok bool
@@ -8583,16 +8937,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Exec.Process.BasenameStr = str
 
-		return nil
-
-	case "exec.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.OverlayNumLower"}
-		}
-		e.Exec.Process.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "exec.file.path":
@@ -8754,6 +9098,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.destination.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.Filesytem"}
+		}
+		e.Link.Target.Filesytem = str
+
+		return nil
+
 	case "link.file.destination.gid":
 
 		var ok bool
@@ -8773,6 +9128,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.Target.FileFields.Group = str
 
+		return nil
+
+	case "link.file.destination.in_upper_layer":
+
+		var ok bool
+		if e.Link.Target.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.InUpperLayer"}
+		}
 		return nil
 
 	case "link.file.destination.inode":
@@ -8816,16 +9179,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
-	case "link.file.destination.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.OverlayNumLower"}
-		}
-		e.Link.Target.FileFields.OverlayNumLower = int32(v)
-		return nil
-
 	case "link.file.destination.path":
 
 		var ok bool
@@ -8858,6 +9211,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.Filesytem"}
+		}
+		e.Link.Source.Filesytem = str
+
+		return nil
+
 	case "link.file.gid":
 
 		var ok bool
@@ -8877,6 +9241,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.Source.FileFields.Group = str
 
+		return nil
+
+	case "link.file.in_upper_layer":
+
+		var ok bool
+		if e.Link.Source.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.InUpperLayer"}
+		}
 		return nil
 
 	case "link.file.inode":
@@ -8918,16 +9290,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Link.Source.BasenameStr = str
 
-		return nil
-
-	case "link.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.OverlayNumLower"}
-		}
-		e.Link.Source.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "link.file.path":
@@ -8993,6 +9355,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.Mode = uint32(v)
 		return nil
 
+	case "mkdir.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.Filesytem"}
+		}
+		e.Mkdir.File.Filesytem = str
+
+		return nil
+
 	case "mkdir.file.gid":
 
 		var ok bool
@@ -9012,6 +9385,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.File.FileFields.Group = str
 
+		return nil
+
+	case "mkdir.file.in_upper_layer":
+
+		var ok bool
+		if e.Mkdir.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.InUpperLayer"}
+		}
 		return nil
 
 	case "mkdir.file.inode":
@@ -9053,16 +9434,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.File.BasenameStr = str
 
-		return nil
-
-	case "mkdir.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.OverlayNumLower"}
-		}
-		e.Mkdir.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "mkdir.file.path":
@@ -9128,6 +9499,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Open.Mode = uint32(v)
 		return nil
 
+	case "open.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.Filesytem"}
+		}
+		e.Open.File.Filesytem = str
+
+		return nil
+
 	case "open.file.gid":
 
 		var ok bool
@@ -9147,6 +9529,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Open.File.FileFields.Group = str
 
+		return nil
+
+	case "open.file.in_upper_layer":
+
+		var ok bool
+		if e.Open.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.InUpperLayer"}
+		}
 		return nil
 
 	case "open.file.inode":
@@ -9188,16 +9578,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Open.File.BasenameStr = str
 
-		return nil
-
-	case "open.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.OverlayNumLower"}
-		}
-		e.Open.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "open.file.path":
@@ -9382,6 +9762,21 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.ancestors.file.filesystem":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Filesystem"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Filesystem = str
+
+		return nil
+
 	case "process.ancestors.file.gid":
 
 		if e.ProcessContext.Ancestor == nil {
@@ -9466,20 +9861,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.BasenameStr = str
 
-		return nil
-
-	case "process.ancestors.file.overlay_numlower":
-
-		if e.ProcessContext.Ancestor == nil {
-			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
-		}
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.OverlayNumLower"}
-		}
-		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "process.ancestors.file.path":
@@ -9808,6 +10189,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Filesystem"}
+		}
+		e.ProcessContext.Process.Filesystem = str
+
+		return nil
+
 	case "process.file.gid":
 
 		var ok bool
@@ -9868,16 +10260,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Process.BasenameStr = str
 
-		return nil
-
-	case "process.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.OverlayNumLower"}
-		}
-		e.ProcessContext.Process.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "process.file.path":
@@ -10070,6 +10452,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "removexattr.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.Filesytem"}
+		}
+		e.RemoveXAttr.File.Filesytem = str
+
+		return nil
+
 	case "removexattr.file.gid":
 
 		var ok bool
@@ -10089,6 +10482,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.RemoveXAttr.File.FileFields.Group = str
 
+		return nil
+
+	case "removexattr.file.in_upper_layer":
+
+		var ok bool
+		if e.RemoveXAttr.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.InUpperLayer"}
+		}
 		return nil
 
 	case "removexattr.file.inode":
@@ -10130,16 +10531,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.RemoveXAttr.File.BasenameStr = str
 
-		return nil
-
-	case "removexattr.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.OverlayNumLower"}
-		}
-		e.RemoveXAttr.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "removexattr.file.path":
@@ -10206,6 +10597,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "rename.file.destination.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.Filesytem"}
+		}
+		e.Rename.New.Filesytem = str
+
+		return nil
+
 	case "rename.file.destination.gid":
 
 		var ok bool
@@ -10225,6 +10627,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rename.New.FileFields.Group = str
 
+		return nil
+
+	case "rename.file.destination.in_upper_layer":
+
+		var ok bool
+		if e.Rename.New.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.InUpperLayer"}
+		}
 		return nil
 
 	case "rename.file.destination.inode":
@@ -10268,16 +10678,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
-	case "rename.file.destination.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.OverlayNumLower"}
-		}
-		e.Rename.New.FileFields.OverlayNumLower = int32(v)
-		return nil
-
 	case "rename.file.destination.path":
 
 		var ok bool
@@ -10310,6 +10710,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "rename.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.Filesytem"}
+		}
+		e.Rename.Old.Filesytem = str
+
+		return nil
+
 	case "rename.file.gid":
 
 		var ok bool
@@ -10329,6 +10740,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rename.Old.FileFields.Group = str
 
+		return nil
+
+	case "rename.file.in_upper_layer":
+
+		var ok bool
+		if e.Rename.Old.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.InUpperLayer"}
+		}
 		return nil
 
 	case "rename.file.inode":
@@ -10370,16 +10789,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rename.Old.BasenameStr = str
 
-		return nil
-
-	case "rename.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.OverlayNumLower"}
-		}
-		e.Rename.Old.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "rename.file.path":
@@ -10435,6 +10844,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "rmdir.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.Filesytem"}
+		}
+		e.Rmdir.File.Filesytem = str
+
+		return nil
+
 	case "rmdir.file.gid":
 
 		var ok bool
@@ -10454,6 +10874,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rmdir.File.FileFields.Group = str
 
+		return nil
+
+	case "rmdir.file.in_upper_layer":
+
+		var ok bool
+		if e.Rmdir.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.InUpperLayer"}
+		}
 		return nil
 
 	case "rmdir.file.inode":
@@ -10495,16 +10923,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rmdir.File.BasenameStr = str
 
-		return nil
-
-	case "rmdir.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.OverlayNumLower"}
-		}
-		e.Rmdir.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "rmdir.file.path":
@@ -10708,6 +11126,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "setxattr.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.Filesytem"}
+		}
+		e.SetXAttr.File.Filesytem = str
+
+		return nil
+
 	case "setxattr.file.gid":
 
 		var ok bool
@@ -10727,6 +11156,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.SetXAttr.File.FileFields.Group = str
 
+		return nil
+
+	case "setxattr.file.in_upper_layer":
+
+		var ok bool
+		if e.SetXAttr.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.InUpperLayer"}
+		}
 		return nil
 
 	case "setxattr.file.inode":
@@ -10768,16 +11205,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.SetXAttr.File.BasenameStr = str
 
-		return nil
-
-	case "setxattr.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.OverlayNumLower"}
-		}
-		e.SetXAttr.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "setxattr.file.path":
@@ -10833,6 +11260,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "unlink.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.Filesytem"}
+		}
+		e.Unlink.File.Filesytem = str
+
+		return nil
+
 	case "unlink.file.gid":
 
 		var ok bool
@@ -10852,6 +11290,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Unlink.File.FileFields.Group = str
 
+		return nil
+
+	case "unlink.file.in_upper_layer":
+
+		var ok bool
+		if e.Unlink.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.InUpperLayer"}
+		}
 		return nil
 
 	case "unlink.file.inode":
@@ -10893,16 +11339,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Unlink.File.BasenameStr = str
 
-		return nil
-
-	case "unlink.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.OverlayNumLower"}
-		}
-		e.Unlink.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "unlink.file.path":
@@ -10958,6 +11394,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "utimes.file.filesystem":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.Filesytem"}
+		}
+		e.Utimes.File.Filesytem = str
+
+		return nil
+
 	case "utimes.file.gid":
 
 		var ok bool
@@ -10977,6 +11424,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Utimes.File.FileFields.Group = str
 
+		return nil
+
+	case "utimes.file.in_upper_layer":
+
+		var ok bool
+		if e.Utimes.File.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.InUpperLayer"}
+		}
 		return nil
 
 	case "utimes.file.inode":
@@ -11018,16 +11473,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Utimes.File.BasenameStr = str
 
-		return nil
-
-	case "utimes.file.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.OverlayNumLower"}
-		}
-		e.Utimes.File.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "utimes.file.path":

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -80,6 +80,16 @@ func (ev *Event) ResolveFileContainerPath(f *model.FileEvent) string {
 	return f.ContainerPath
 }
 
+// ResolveFileFilesystem resolves the filesystem a file resides in
+func (ev *Event) ResolveFileFilesystem(f *model.FileEvent) string {
+	return ev.resolvers.ResolveFilesystem(&f.FileFields)
+}
+
+// ResolveFileInUpperLayer resolves whether the file is in an upper layer
+func (ev *Event) ResolveFileInUpperLayer(f *model.FileEvent) bool {
+	return ev.resolvers.ResolveInUpperLayer(&f.FileFields)
+}
+
 // GetXAttrName returns the string representation of the extended attribute name
 func (ev *Event) GetXAttrName(e *model.SetXAttrEvent) string {
 	if len(e.Name) == 0 {
@@ -242,6 +252,16 @@ func (ev *Event) ResolveProcessTTY(e *model.Process) string {
 	return e.TTYName
 }
 
+// ResolveProcessFilesystem resolves the filesystem an executable resides in
+func (ev *Event) ResolveProcessFilesystem(e *model.Process) string {
+	if e.Filesystem == "" && ev != nil {
+		if entry := ev.ResolveProcessCacheEntry(); entry != nil {
+			e.Filesystem = ev.resolvers.ResolveFilesystem(&entry.FileFields)
+		}
+	}
+	return e.Filesystem
+}
+
 // ResolveProcessComm resolves the comm of the process
 func (ev *Event) ResolveProcessComm(e *model.Process) string {
 	if len(e.Comm) == 0 && ev != nil {
@@ -362,7 +382,7 @@ func (ev *Event) ResolveCredentialsFSGroup(e *model.Credentials) string {
 
 // ResolveCredentialsCapEffective resolves the cap_effective kernel capability of the process
 func (ev *Event) ResolveCredentialsCapEffective(e *model.Credentials) int {
-	if e.CapEffective == 0 {
+	if e.CapEffective == 0 && ev != nil {
 		if entry := ev.ResolveProcessCacheEntry(); entry != nil {
 			e.CapEffective = entry.CapEffective
 		}
@@ -372,7 +392,7 @@ func (ev *Event) ResolveCredentialsCapEffective(e *model.Credentials) int {
 
 // ResolveCredentialsCapPermitted resolves the cap_permitted kernel capability of the process
 func (ev *Event) ResolveCredentialsCapPermitted(e *model.Credentials) int {
-	if e.CapPermitted == 0 {
+	if e.CapPermitted == 0 && ev != nil {
 		if entry := ev.ResolveProcessCacheEntry(); entry != nil {
 			e.CapPermitted = entry.CapPermitted
 		}
@@ -382,7 +402,7 @@ func (ev *Event) ResolveCredentialsCapPermitted(e *model.Credentials) int {
 
 // ResolveSetuidUser resolves the user of the Setuid event
 func (ev *Event) ResolveSetuidUser(e *model.SetuidEvent) string {
-	if len(e.User) == 0 {
+	if len(e.User) == 0 && ev != nil {
 		e.User, _ = ev.resolvers.UserGroupResolver.ResolveUser(int(e.UID))
 	}
 	return e.User
@@ -390,7 +410,7 @@ func (ev *Event) ResolveSetuidUser(e *model.SetuidEvent) string {
 
 // ResolveSetuidEUser resolves the effective user of the Setuid event
 func (ev *Event) ResolveSetuidEUser(e *model.SetuidEvent) string {
-	if len(e.EUser) == 0 {
+	if len(e.EUser) == 0 && ev != nil {
 		e.EUser, _ = ev.resolvers.UserGroupResolver.ResolveUser(int(e.EUID))
 	}
 	return e.EUser
@@ -398,7 +418,7 @@ func (ev *Event) ResolveSetuidEUser(e *model.SetuidEvent) string {
 
 // ResolveSetuidFSUser resolves the file-system user of the Setuid event
 func (ev *Event) ResolveSetuidFSUser(e *model.SetuidEvent) string {
-	if len(e.FSUser) == 0 {
+	if len(e.FSUser) == 0 && ev != nil {
 		e.FSUser, _ = ev.resolvers.UserGroupResolver.ResolveUser(int(e.FSUID))
 	}
 	return e.FSUser
@@ -406,7 +426,7 @@ func (ev *Event) ResolveSetuidFSUser(e *model.SetuidEvent) string {
 
 // ResolveSetgidGroup resolves the group of the Setgid event
 func (ev *Event) ResolveSetgidGroup(e *model.SetgidEvent) string {
-	if len(e.Group) == 0 {
+	if len(e.Group) == 0 && ev != nil {
 		e.Group, _ = ev.resolvers.UserGroupResolver.ResolveUser(int(e.GID))
 	}
 	return e.Group
@@ -414,7 +434,7 @@ func (ev *Event) ResolveSetgidGroup(e *model.SetgidEvent) string {
 
 // ResolveSetgidEGroup resolves the effective group of the Setgid event
 func (ev *Event) ResolveSetgidEGroup(e *model.SetgidEvent) string {
-	if len(e.EGroup) == 0 {
+	if len(e.EGroup) == 0 && ev != nil {
 		e.EGroup, _ = ev.resolvers.UserGroupResolver.ResolveUser(int(e.EGID))
 	}
 	return e.EGroup
@@ -422,7 +442,7 @@ func (ev *Event) ResolveSetgidEGroup(e *model.SetgidEvent) string {
 
 // ResolveSetgidFSGroup resolves the file-system group of the Setgid event
 func (ev *Event) ResolveSetgidFSGroup(e *model.SetgidEvent) string {
-	if len(e.FSGroup) == 0 {
+	if len(e.FSGroup) == 0 && ev != nil {
 		e.FSGroup, _ = ev.resolvers.UserGroupResolver.ResolveUser(int(e.FSGID))
 	}
 	return e.FSGroup

--- a/pkg/security/probe/mount.go
+++ b/pkg/security/probe/mount.go
@@ -157,6 +157,19 @@ func (mr *MountResolver) Delete(mountID uint32) error {
 	return nil
 }
 
+// GetFilesystem returns the name of the filesystem
+func (mr *MountResolver) GetFilesystem(mountID uint32) string {
+	mr.lock.RLock()
+	defer mr.lock.RUnlock()
+
+	mount, exists := mr.mounts[mountID]
+	if !exists {
+		return ""
+	}
+
+	return mount.GetFSType()
+}
+
 // IsOverlayFS returns the type of a mountID
 func (mr *MountResolver) IsOverlayFS(mountID uint32) bool {
 	mr.lock.RLock()

--- a/pkg/security/probe/mount.go
+++ b/pkg/security/probe/mount.go
@@ -309,27 +309,30 @@ func getMountIDOffset(probe *Probe) uint64 {
 }
 
 func getSizeOfStructInode(probe *Probe) uint64 {
-	var rh7Kernel bool
-	var rh8Kernel bool
-	var suse12Kernel bool
+	var rh7Kernel, rh8Kernel, suse12Kernel, suse15Kernel bool
 
 	osrelease, err := osrelease.Read()
 	if err == nil {
 		rh7Kernel = (osrelease["ID"] == "centos" || osrelease["ID"] == "rhel") && osrelease["VERSION_ID"] == "7"
 		rh8Kernel = osrelease["PLATFORM_ID"] == "platform:el8"
-		suse12Kernel = ((osrelease["ID"] == "sles") || (osrelease["ID"] == "opensuse-leap")) && strings.HasPrefix(osrelease["VERSION_ID"], "12")
+		suseKernel := ((osrelease["ID"] == "sles") || (osrelease["ID"] == "opensuse-leap"))
+		suse12Kernel = suseKernel && strings.HasPrefix(osrelease["VERSION_ID"], "12")
+		suse15Kernel = suseKernel && strings.HasPrefix(osrelease["VERSION_ID"], "15")
 	}
 
 	var sizeOf uint64
-	if rh7Kernel {
+	switch {
+	case rh7Kernel:
 		sizeOf = 584
-	} else if rh8Kernel {
+	case rh8Kernel:
 		sizeOf = 648
-	} else if suse12Kernel {
+	case suse12Kernel:
 		sizeOf = 560
-	} else if probe.kernelVersion != 0 && probe.kernelVersion < kernel4_16 {
+	case suse15Kernel:
+		sizeOf = 592
+	case probe.kernelVersion != 0 && probe.kernelVersion < kernel4_16:
 		sizeOf = 608
-	} else {
+	default:
 		sizeOf = 600
 	}
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -53,8 +53,8 @@ func getDoForkInput(probe *Probe) uint64 {
 
 // InodeInfo holds information related to inode from kernel
 type InodeInfo struct {
-	MountID         uint32
-	OverlayNumLower int32
+	MountID uint32
+	Flags   int32
 }
 
 // UnmarshalBinary unmarshals a binary representation of itself
@@ -63,7 +63,7 @@ func (i *InodeInfo) UnmarshalBinary(data []byte) (int, error) {
 		return 0, model.ErrNotEnoughData
 	}
 	i.MountID = model.ByteOrder.Uint32(data)
-	i.OverlayNumLower = int32(model.ByteOrder.Uint32(data[4:]))
+	i.Flags = int32(model.ByteOrder.Uint32(data[4:]))
 	return 8, nil
 }
 

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -188,6 +188,16 @@ func (r *Resolvers) ResolveProcessContextGroup(p *model.ProcessContext) string {
 	return p.Group
 }
 
+// ResolveFilesystem resolves the filesystem a file resides in
+func (r *Resolvers) ResolveFilesystem(f *model.FileFields) string {
+	return r.MountResolver.GetFilesystem(f.MountID)
+}
+
+// ResolveInUpperLayer resolves whether the file is in an upper layer
+func (r *Resolvers) ResolveInUpperLayer(f *model.FileFields) bool {
+	return f.Flags&model.UpperLayer != 0
+}
+
 // Start the resolvers
 func (r *Resolvers) Start(ctx context.Context) error {
 	if err := r.ProcessResolver.Start(ctx); err != nil {

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -631,6 +631,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jle
 			out.Inode = uint64(in.Uint64())
 		case "executable_mount_id":
 			out.MountID = uint32(in.Uint32())
+		case "executable_filesystem":
+			out.Filesystem = string(in.String())
 		case "tty":
 			out.TTY = string(in.String())
 		case "fork_time":
@@ -877,6 +879,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 		out.RawString(prefix)
 		out.Uint32(uint32(in.MountID))
 	}
+	if in.Filesystem != "" {
+		const prefix string = ",\"executable_filesystem\":"
+		out.RawString(prefix)
+		out.String(string(in.Filesystem))
+	}
 	if in.TTY != "" {
 		const prefix string = ",\"tty\":"
 		out.RawString(prefix)
@@ -1021,6 +1028,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(in *jle
 			out.Inode = uint64(in.Uint64())
 		case "executable_mount_id":
 			out.MountID = uint32(in.Uint32())
+		case "executable_filesystem":
+			out.Filesystem = string(in.String())
 		case "tty":
 			out.TTY = string(in.String())
 		case "fork_time":
@@ -1234,6 +1243,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(out *jw
 		out.RawString(prefix)
 		out.Uint32(uint32(in.MountID))
 	}
+	if in.Filesystem != "" {
+		const prefix string = ",\"executable_filesystem\":"
+		out.RawString(prefix)
+		out.String(string(in.Filesystem))
+	}
 	if in.TTY != "" {
 		const prefix string = ",\"tty\":"
 		out.RawString(prefix)
@@ -1380,15 +1394,15 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(in *jle
 				}
 				*out.Mode = uint32(in.Uint32())
 			}
-		case "overlay_numlower":
+		case "in_upper_layer":
 			if in.IsNull() {
 				in.Skip()
-				out.OverlayNumLower = nil
+				out.InUpperLayer = nil
 			} else {
-				if out.OverlayNumLower == nil {
-					out.OverlayNumLower = new(int32)
+				if out.InUpperLayer == nil {
+					out.InUpperLayer = new(bool)
 				}
-				*out.OverlayNumLower = int32(in.Int32())
+				*out.InUpperLayer = bool(in.Bool())
 			}
 		case "mount_id":
 			if in.IsNull() {
@@ -1400,6 +1414,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(in *jle
 				}
 				*out.MountID = uint32(in.Uint32())
 			}
+		case "filesystem":
+			out.Filesystem = string(in.String())
 		case "uid":
 			out.UID = uint32(in.Uint32())
 		case "gid":
@@ -1541,15 +1557,15 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jw
 		}
 		out.Uint32(uint32(*in.Mode))
 	}
-	if in.OverlayNumLower != nil {
-		const prefix string = ",\"overlay_numlower\":"
+	if in.InUpperLayer != nil {
+		const prefix string = ",\"in_upper_layer\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.Int32(int32(*in.OverlayNumLower))
+		out.Bool(bool(*in.InUpperLayer))
 	}
 	if in.MountID != nil {
 		const prefix string = ",\"mount_id\":"
@@ -1560,6 +1576,16 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jw
 			out.RawString(prefix)
 		}
 		out.Uint32(uint32(*in.MountID))
+	}
+	if in.Filesystem != "" {
+		const prefix string = ",\"filesystem\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Filesystem))
 	}
 	if in.UID != 0 {
 		const prefix string = ",\"uid\":"
@@ -1761,15 +1787,15 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(in *jle
 				}
 				*out.Mode = uint32(in.Uint32())
 			}
-		case "overlay_numlower":
+		case "in_upper_layer":
 			if in.IsNull() {
 				in.Skip()
-				out.OverlayNumLower = nil
+				out.InUpperLayer = nil
 			} else {
-				if out.OverlayNumLower == nil {
-					out.OverlayNumLower = new(int32)
+				if out.InUpperLayer == nil {
+					out.InUpperLayer = new(bool)
 				}
-				*out.OverlayNumLower = int32(in.Int32())
+				*out.InUpperLayer = bool(in.Bool())
 			}
 		case "mount_id":
 			if in.IsNull() {
@@ -1781,6 +1807,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(in *jle
 				}
 				*out.MountID = uint32(in.Uint32())
 			}
+		case "filesystem":
+			out.Filesystem = string(in.String())
 		case "uid":
 			out.UID = uint32(in.Uint32())
 		case "gid":
@@ -1972,15 +2000,15 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(out *jw
 		}
 		out.Uint32(uint32(*in.Mode))
 	}
-	if in.OverlayNumLower != nil {
-		const prefix string = ",\"overlay_numlower\":"
+	if in.InUpperLayer != nil {
+		const prefix string = ",\"in_upper_layer\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.Int32(int32(*in.OverlayNumLower))
+		out.Bool(bool(*in.InUpperLayer))
 	}
 	if in.MountID != nil {
 		const prefix string = ",\"mount_id\":"
@@ -1991,6 +2019,16 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(out *jw
 			out.RawString(prefix)
 		}
 		out.Uint32(uint32(*in.MountID))
+	}
+	if in.Filesystem != "" {
+		const prefix string = ",\"filesystem\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Filesystem))
 	}
 	if in.UID != 0 {
 		const prefix string = ",\"uid\":"

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -170,6 +170,8 @@ func TestOverlayFS(t *testing.T) {
 		} else {
 			inode = getInode(t, testFile)
 			assert.Equal(t, event.Open.File.Inode, inode, "wrong open inode")
+			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -181,6 +183,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
 		}
 	})
 
@@ -206,6 +210,8 @@ func TestOverlayFS(t *testing.T) {
 		} else {
 			inode = getInode(t, testFile)
 			assert.Equal(t, inode, event.Open.File.Inode, "wrong open inode")
+			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -217,6 +223,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 
@@ -242,6 +250,8 @@ func TestOverlayFS(t *testing.T) {
 		} else {
 			inode = getInode(t, testFile)
 			assert.Equal(t, event.Open.File.Inode, inode, "wrong open inode")
+			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -253,6 +263,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 
@@ -283,6 +295,11 @@ func TestOverlayFS(t *testing.T) {
 
 			inode = getInode(t, newFile)
 			assert.Equal(t, event.Rename.New.Inode, inode, "wrong rename inode")
+			inUpperLayer, _ := event.GetFieldValue("rename.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+
+			inUpperLayer, _ = event.GetFieldValue("rename.file.destination.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 
 		if err := os.Remove(newFile); err != nil {
@@ -294,6 +311,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 
@@ -314,6 +333,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Rmdir.File.Inode, inode, "wrong rmdir inode")
+			inUpperLayer, _ := event.GetFieldValue("rmdir.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
 		}
 	})
 
@@ -369,6 +390,8 @@ func TestOverlayFS(t *testing.T) {
 		} else {
 			inode := getInode(t, testFile)
 			assert.Equal(t, event.Mkdir.File.Inode, inode, "wrong mkdir inode")
+			inUpperLayer, _ := event.GetFieldValue("mkdir.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 
@@ -390,6 +413,8 @@ func TestOverlayFS(t *testing.T) {
 		} else {
 			inode = getInode(t, testFile)
 			assert.Equal(t, event.Utimes.File.Inode, inode, "wrong utimes inode")
+			inUpperLayer, _ := event.GetFieldValue("utimes.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -401,6 +426,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 
@@ -422,6 +449,8 @@ func TestOverlayFS(t *testing.T) {
 		} else {
 			inode = getInode(t, testFile)
 			assert.Equal(t, event.Chown.File.Inode, inode, "wrong chown inode")
+			inUpperLayer, _ := event.GetFieldValue("chown.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -433,6 +462,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 
@@ -462,6 +493,8 @@ func TestOverlayFS(t *testing.T) {
 		} else {
 			inode = getInode(t, testFile)
 			assert.Equal(t, event.SetXAttr.File.Inode, inode, "wrong setxattr inode")
+			inUpperLayer, _ := event.GetFieldValue("setxattr.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -473,6 +506,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 
@@ -494,6 +529,8 @@ func TestOverlayFS(t *testing.T) {
 		} else {
 			inode = getInode(t, testFile)
 			assert.Equal(t, event.Open.File.Inode, inode, "wrong open inode")
+			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -505,6 +542,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 
@@ -530,7 +569,13 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			inode = getInode(t, testSrc)
-			assert.Equal(t, event.Link.Source.Inode, inode, "wrong link inode")
+			assert.Equal(t, event.Link.Source.Inode, inode, "wrong link source inode")
+
+			inUpperLayer, _ := event.GetFieldValue("link.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+
+			inUpperLayer, _ = event.GetFieldValue("link.file.destination.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 
 		if err := os.Remove(testSrc); err != nil {
@@ -542,6 +587,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in base layer")
 		}
 
 		if err := os.Remove(testTarget); err != nil {
@@ -553,6 +600,8 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -8,10 +8,8 @@
 package tests
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 	"syscall"
 	"testing"
@@ -24,301 +22,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
-
-func TestDentryRename(t *testing.T) {
-	rule := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: `rename.file.path in ["{{.Root}}/test-rename", "{{.Root}}/test2-rename"]`,
-	}
-
-	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer test.Close()
-
-	testOldFile, _, err := test.Path("test-rename")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := os.Create(testOldFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	testNewFile, _, err := test.Path("test2-rename")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i != 5; i++ {
-		if err := os.Rename(testOldFile, testNewFile); err != nil {
-			t.Fatal(err)
-		}
-
-		event, _, err := test.GetEvent()
-		if err != nil {
-			t.Error(err)
-		} else {
-			if event.GetType() != "rename" {
-				t.Errorf("expected rename event, got %s", event.GetType())
-			}
-			if value, _ := event.GetFieldValue("rename.file.destination.path"); value.(string) != testNewFile {
-				t.Errorf("expected filename not found")
-			}
-		}
-
-		// swap
-		old := testOldFile
-		testOldFile = testNewFile
-		testNewFile = old
-	}
-}
-
-func TestDentryRenameReuseInode(t *testing.T) {
-	rules := []*rules.RuleDefinition{{
-		ID:         "test_rule",
-		Expression: `open.file.path == "{{.Root}}/test-rename-reuse-inode"`,
-	}, {
-		ID:         "test_rule2",
-		Expression: `open.file.path == "{{.Root}}/test-rename-new"`,
-	}}
-
-	testDrive, err := newTestDrive("xfs", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer testDrive.Close()
-
-	test, err := newTestModule(nil, rules, testOpts{testDir: testDrive.Root()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer test.Close()
-
-	testOldFile, _, err := test.Path("test-rename-old")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := os.Create(testOldFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(testOldFile)
-
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	testNewFile, _, err := test.Path("test-rename-new")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(testNewFile)
-
-	f, err = os.Create(testNewFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	event, _, err := test.GetEvent()
-	if err != nil {
-		t.Error(err)
-	} else {
-		if event.GetType() != "open" {
-			t.Errorf("expected open event, got %s", event.GetType())
-		}
-	}
-
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Rename(testOldFile, testNewFile); err != nil {
-		t.Fatal(err)
-	}
-
-	// At this point, the inode of test-rename-new was freed. We then
-	// create a new file - with xfs, it will recycle the inode. This test
-	// checks that we properly invalidated the cache entry of this inode.
-
-	testReuseInodeFile, _, err := test.Path("test-rename-reuse-inode")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err = os.Create(testReuseInodeFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(testReuseInodeFile)
-
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	event, _, err = test.GetEvent()
-	if err != nil {
-		t.Error(err)
-	} else {
-		if event.GetType() != "open" {
-			t.Errorf("expected open event, got %s", event.GetType())
-		}
-
-		if value, _ := event.GetFieldValue("open.file.path"); value.(string) != testReuseInodeFile {
-			t.Errorf("expected filename not found %s != %s", value.(string), testReuseInodeFile)
-		}
-	}
-}
-
-func TestDentryRenameFolder(t *testing.T) {
-	rule := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: `open.file.name == "test-rename" && (open.flags & O_CREAT) > 0`,
-	}
-
-	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer test.Close()
-
-	testOldFolder, _, err := test.Path(path.Dir("folder/folder-old/test-rename"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	os.MkdirAll(testOldFolder, os.ModePerm)
-
-	testNewFolder, _, err := test.Path(path.Dir("folder/folder-new/test-rename"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	filename := fmt.Sprintf("%s/test-rename", testOldFolder)
-	defer os.Remove(filename)
-
-	for i := 0; i != 5; i++ {
-		testFile, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0755)
-		if err != nil {
-			t.Fatal(err)
-		}
-		testFile.Close()
-
-		event, _, err := test.GetEvent()
-		if err != nil {
-			t.Error(err)
-		} else {
-			if event.GetType() != "open" {
-				t.Errorf("expected open event, got %s", event.GetType())
-			}
-
-			if value, _ := event.GetFieldValue("open.file.path"); value.(string) != filename {
-				t.Errorf("#%d expected filename not found, `%s` != `%s`", i, value.(string), filename)
-			}
-
-			// swap
-			if err := os.Rename(testOldFolder, testNewFolder); err != nil {
-				t.Fatal(err)
-			}
-
-			old := testOldFolder
-			testOldFolder = testNewFolder
-			testNewFolder = old
-
-			filename = fmt.Sprintf("%s/test-rename", testOldFolder)
-		}
-	}
-}
-
-func TestDentryUnlink(t *testing.T) {
-	rule := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: `unlink.file.path =~ "{{.Root}}/test-unlink-*"`,
-	}
-
-	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer test.Close()
-
-	for i := 0; i != 5; i++ {
-		filename := fmt.Sprintf("test-unlink-%d", i)
-
-		testFile, _, err := test.Path(filename)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		f, err := os.Create(testFile)
-		if err != nil {
-			t.Fatal(err)
-		}
-		f.Close()
-		os.Remove(testFile)
-
-		event, _, err := test.GetEvent()
-		if err != nil {
-			t.Error(err)
-		} else {
-			if event.GetType() != "unlink" {
-				t.Errorf("expected unlink event, got %s", event.GetType())
-			}
-
-			if value, _ := event.GetFieldValue("unlink.file.path"); value.(string) != testFile {
-				t.Errorf("expected filename not found")
-			}
-		}
-	}
-}
-
-func TestDentryRmdir(t *testing.T) {
-	rule := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: `rmdir.file.path =~ "{{.Root}}/test-rmdir-*"`,
-	}
-
-	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer test.Close()
-
-	for i := 0; i != 5; i++ {
-		testFile, _, err := test.Path(fmt.Sprintf("test-rmdir-%d", i))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := syscall.Mkdir(testFile, 0777); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := syscall.Rmdir(testFile); err != nil {
-			t.Fatal(err)
-		}
-
-		event, _, err := test.GetEvent()
-		if err != nil {
-			t.Error(err)
-		} else {
-			if event.GetType() != "rmdir" {
-				t.Errorf("expected rmdir event, got %s", event.GetType())
-			}
-
-			if value, _ := event.GetFieldValue("rmdir.file.path"); value.(string) != testFile {
-				t.Errorf("expected filename not found")
-			}
-		}
-	}
-}
 
 func createOverlayLayer(t *testing.T, test *testModule, name string) string {
 	p, _, err := test.Path(name)
@@ -338,7 +41,7 @@ func createOverlayLayers(t *testing.T, test *testModule) (string, string, string
 		createOverlayLayer(t, test, "merged")
 }
 
-func TestDentryOverlay(t *testing.T) {
+func TestOverlayFS(t *testing.T) {
 	sles12 := false
 	osrelease, err := osrelease.Read()
 	if err == nil {
@@ -632,6 +335,8 @@ func TestDentryOverlay(t *testing.T) {
 		} else {
 			inode = getInode(t, testFile)
 			assert.Equal(t, event.Chmod.File.Inode, inode, "wrong chmod inode")
+			inUpperLayer, _ := event.GetFieldValue("chmod.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, false, "should be in base layer")
 		}
 
 		if err := os.Remove(testFile); err != nil {
@@ -643,6 +348,8 @@ func TestDentryOverlay(t *testing.T) {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
+			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
 		}
 	})
 

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -8,7 +8,9 @@
 package tests
 
 import (
+	"fmt"
 	"os"
+	"path"
 	"runtime"
 	"syscall"
 	"testing"
@@ -205,4 +207,216 @@ func TestRename(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestRenameInvalidate(t *testing.T) {
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `rename.file.path in ["{{.Root}}/test-rename", "{{.Root}}/test2-rename"]`,
+	}
+
+	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	testOldFile, _, err := test.Path("test-rename")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Create(testOldFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	testNewFile, _, err := test.Path("test2-rename")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i != 5; i++ {
+		if err := os.Rename(testOldFile, testNewFile); err != nil {
+			t.Fatal(err)
+		}
+
+		event, _, err := test.GetEvent()
+		if err != nil {
+			t.Error(err)
+		} else {
+			if event.GetType() != "rename" {
+				t.Errorf("expected rename event, got %s", event.GetType())
+			}
+			if value, _ := event.GetFieldValue("rename.file.destination.path"); value.(string) != testNewFile {
+				t.Errorf("expected filename not found")
+			}
+		}
+
+		// swap
+		old := testOldFile
+		testOldFile = testNewFile
+		testNewFile = old
+	}
+}
+
+func TestRenameReuseInode(t *testing.T) {
+	rules := []*rules.RuleDefinition{{
+		ID:         "test_rule",
+		Expression: `open.file.path == "{{.Root}}/test-rename-reuse-inode"`,
+	}, {
+		ID:         "test_rule2",
+		Expression: `open.file.path == "{{.Root}}/test-rename-new"`,
+	}}
+
+	testDrive, err := newTestDrive("xfs", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testDrive.Close()
+
+	test, err := newTestModule(nil, rules, testOpts{testDir: testDrive.Root()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	testOldFile, _, err := test.Path("test-rename-old")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Create(testOldFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testOldFile)
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	testNewFile, _, err := test.Path("test-rename-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testNewFile)
+
+	f, err = os.Create(testNewFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event, _, err := test.GetEvent()
+	if err != nil {
+		t.Error(err)
+	} else {
+		if event.GetType() != "open" {
+			t.Errorf("expected open event, got %s", event.GetType())
+		}
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Rename(testOldFile, testNewFile); err != nil {
+		t.Fatal(err)
+	}
+
+	// At this point, the inode of test-rename-new was freed. We then
+	// create a new file - with xfs, it will recycle the inode. This test
+	// checks that we properly invalidated the cache entry of this inode.
+
+	testReuseInodeFile, _, err := test.Path("test-rename-reuse-inode")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err = os.Create(testReuseInodeFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testReuseInodeFile)
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	event, _, err = test.GetEvent()
+	if err != nil {
+		t.Error(err)
+	} else {
+		if event.GetType() != "open" {
+			t.Errorf("expected open event, got %s", event.GetType())
+		}
+
+		if value, _ := event.GetFieldValue("open.file.path"); value.(string) != testReuseInodeFile {
+			t.Errorf("expected filename not found %s != %s", value.(string), testReuseInodeFile)
+		}
+	}
+}
+
+func TestDentryRenameFolder(t *testing.T) {
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `open.file.name == "test-rename" && (open.flags & O_CREAT) > 0`,
+	}
+
+	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	testOldFolder, _, err := test.Path(path.Dir("folder/folder-old/test-rename"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.MkdirAll(testOldFolder, os.ModePerm)
+
+	testNewFolder, _, err := test.Path(path.Dir("folder/folder-new/test-rename"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filename := fmt.Sprintf("%s/test-rename", testOldFolder)
+	defer os.Remove(filename)
+
+	for i := 0; i != 5; i++ {
+		testFile, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+		testFile.Close()
+
+		event, _, err := test.GetEvent()
+		if err != nil {
+			t.Error(err)
+		} else {
+			if event.GetType() != "open" {
+				t.Errorf("expected open event, got %s", event.GetType())
+			}
+
+			if value, _ := event.GetFieldValue("open.file.path"); value.(string) != filename {
+				t.Errorf("#%d expected filename not found, `%s` != `%s`", i, value.(string), filename)
+			}
+
+			// swap
+			if err := os.Rename(testOldFolder, testNewFolder); err != nil {
+				t.Fatal(err)
+			}
+
+			old := testOldFolder
+			testOldFolder = testNewFolder
+			testNewFolder = old
+
+			filename = fmt.Sprintf("%s/test-rename", testOldFolder)
+		}
+	}
 }

--- a/releasenotes/notes/runtime-security-upper-layer-3c1e0859458ec8ad.yaml
+++ b/releasenotes/notes/runtime-security-upper-layer-3c1e0859458ec8ad.yaml
@@ -1,0 +1,9 @@
+
+---
+upgrade:
+  - |
+    The `overlay_numlower` integer attribute that was reported for files
+    and executables was unreliable. It was replaced by a simple boolean
+    attribute named `in_upper_layer` that is set to true when a file
+    is either only on the upper layer of an overlayfs filesystem, or
+    is an altered version of a file present in a base layer.


### PR DESCRIPTION
### What does this PR do?

Replace overlay_numlower by an `is_upper_layer` boolean

### Motivation

The `overlay_numlower` integer attribute that was reported for files
and executables was unreliable. It was replaced by a simple boolean
attribute named `is_upper_layer` that is set to true when a file
is either only on the upper layer of an overlayfs filesystem, or
is an altered version of a file present in a base layer.