### PR TITLE
[e2e tests] Fix following the deactivation of DatadogMetrics

### DIFF
--- a/test/e2e/argo-workflows/templates/nginx.yaml
+++ b/test/e2e/argo-workflows/templates/nginx.yaml
@@ -303,8 +303,8 @@ spec:
           set -euo pipefail
           set -x
 
-          # Verify the DCA has written in the DatadogMetric
-          until kubectl --namespace {{inputs.parameters.namespace}} get datadogmetrics.datadoghq.com -o jsonpath='{range .items[*]}{.spec.externalMetricName}{"\n"}{end}' | grep nginx.net.request_per_s; do
+          # Verify the DCA has written in the configmap
+          until [[ -n $(kubectl --namespace {{inputs.parameters.namespace}} get cm datadog-custom-metrics -o jsonpath='{.data}') ]]; do
            sleep 1
           done
 


### PR DESCRIPTION
This reverts commit cbde19a11c0dc5c4b46ebe45ea402d01b5fbb4d1.

### What does this PR do?

Since PR DataDog/helm-charts#159, the `DatadogMetrics` are disabled by default.
As a consequence, the `validate-hpa` e2e step which was waiting for the `DatadogMetrics` CR was systematically failing.
This step needs to be adapted to look for the `datadog-custom-metrics` `ConfigMap` instead of the `DatadogMetrics` CR.

### Motivation

Fix the e2e tests.

### Additional Notes

We could also consider fixing the value of `clusterAgent.metricsProvider.useDatadogMetrics` in the `values.yaml` parameter file used by the e2e tests but I thought it would be better to keep as many values as possible to their default value to validate a setup which is as close as possible to what most users will use.

### Describe your test plan

Check that e2e tests are fixed.