### PR TITLE
[Fix][DCA] Avoid recreating the telemetry metrics server when running CLI commands

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -10,6 +10,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -38,6 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
@@ -146,6 +148,16 @@ func start(cmd *cobra.Command, args []string) error {
 		log.Critical("no API key configured, exiting")
 		return nil
 	}
+
+	// Expose the registered metrics via HTTP.
+	http.Handle("/metrics", telemetry.Handler())
+	go func() {
+		port := config.Datadog.GetInt("metrics_port")
+		err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil)
+		if err != nil && err != http.ErrServerClosed {
+			log.Errorf("Error creating telemetry server on port %v: %v", port, err)
+		}
+	}()
 
 	// Setup healthcheck port
 	var healthPort = config.Datadog.GetInt("health_port")

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -11,8 +11,6 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
 	"os"
 
 	_ "expvar"         // Blank import used because this isn't directly used in this file
@@ -21,8 +19,6 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/net"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system"
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -32,17 +28,6 @@ import (
 func main() {
 	// set the Agent flavor
 	flavor.SetFlavor(flavor.ClusterAgent)
-
-	// Expose the registered metrics via HTTP.
-	http.Handle("/metrics", telemetry.Handler())
-	go func() {
-		port := config.Datadog.GetInt("metrics_port")
-		err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil)
-		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server on port %v: %v", port, err)
-		}
-	}()
-
 	if err := app.ClusterAgentCmd.Execute(); err != nil {
 		log.Error(err)
 		os.Exit(-1)

--- a/releasenotes-dca/notes/fix-dca-log-error-0c29ee6e529e7e71.yaml
+++ b/releasenotes-dca/notes/fix-dca-log-error-0c29ee6e529e7e71.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix "Error creating expvar server" error log when running the Datadog Cluster Agent CLI commands.


### PR DESCRIPTION
### What does this PR do?

Move the telemetry metrics server creation to the `Start` command instead of `main`

### Motivation

Fix this

```
# agent status
Getting the status from the agent.
error: Error creating expvar server on port 5000: listen tcp 0.0.0.0:5000: bind: address already in use
===================================
Datadog Cluster Agent (v1.11.0-rc2)
===================================
```

### Describe your test plan

- CLI commands (e.g `agent status`) shouldn't print an error anymore
- The telemetry metrics server should be created successfully (`curl localhost:5000/metrics` or `agent telemetry`)
