### PR TITLE
[e2e tests] Attempt to remove flakiness

### DIFF
--- a/test/e2e/argo-workflows/templates/fake-datadog.yaml
+++ b/test/e2e/argo-workflows/templates/fake-datadog.yaml
@@ -137,7 +137,7 @@ spec:
           set -euo pipefail
           set -x
 
-          until curl -f http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local/_/reset -XPOST --max-time 1; do
+          until timeout 2 curl  --max-time 1 --fail http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local/_/reset -XPOST; do
             sleep 3
           done
 


### PR DESCRIPTION
### What does this PR do?

e2e tests are sometimes failing at the `fake-dd-reset` step.
The error is a time-out, but the logs of the job show that `curl` was called once and that it was successful as it outputs the json answer from the `fake-datadog` app.
It’s as if `curl` did the HTTP request, got the HTTP reply, printed it but remained stuck forever without exiting despite the `--max-time 1` parameter.
Let’s put it behind a `timeout` to (in)validate this hypothesis.

### Motivation

Fix e2e tests flakiness

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Check if the e2e tests are still failing at the `fake-dd-reset` step from time to time.
