### PR TITLE
Add some test helper files behind the test build flag

### DIFF
--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package aggregator
 
 import (

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package aggregator
 
 import (

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package aggregator
 
 import (

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package aggregator
 
 import (

--- a/pkg/aggregator/sketch_map_test.go
+++ b/pkg/aggregator/sketch_map_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package aggregator
 
 import (

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package aggregator
 
 import (

--- a/pkg/forwarder/domain_forwarder_test.go
+++ b/pkg/forwarder/domain_forwarder_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package forwarder
 
 import (

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package forwarder
 
 import (

--- a/pkg/forwarder/worker_test.go
+++ b/pkg/forwarder/worker_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package forwarder
 
 import (

--- a/pkg/metrics/context_metrics_test.go
+++ b/pkg/metrics/context_metrics_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package metrics
 
 import (

--- a/pkg/metrics/sketch_series_test.go
+++ b/pkg/metrics/sketch_series_test.go
@@ -1,3 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build test
+
 package metrics
 
 import (

--- a/pkg/metrics/test_helper.go
+++ b/pkg/metrics/test_helper.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package metrics
 
 import (

--- a/pkg/metrics/test_helper_test.go
+++ b/pkg/metrics/test_helper_test.go
@@ -1,3 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build test
+
 package metrics
 
 import (

--- a/pkg/process/heartbeat/metric_flusher_test.go
+++ b/pkg/process/heartbeat/metric_flusher_test.go
@@ -1,3 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build test
+
 package heartbeat
 
 import (

--- a/pkg/quantile/test_helper.go
+++ b/pkg/quantile/test_helper.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package quantile
 
 import (

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package serializer
 
 import (

--- a/pkg/serializer/split/split_test.go
+++ b/pkg/serializer/split/split_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package split
 
 import (

--- a/pkg/serializer/test_common.go
+++ b/pkg/serializer/test_common.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build test
+
 package serializer
 
 import (

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -31,6 +31,7 @@ ALL_TAGS = set(
         "python",
         "secrets",
         "systemd",
+        "test",
         "zk",
         "zlib",
     ]
@@ -92,7 +93,7 @@ SYSTEM_PROBE_TAGS = AGENT_TAGS.union(set(["clusterchecks", "linux_bpf",]))
 TRACE_AGENT_TAGS = set(["docker", "kubeapiserver", "kubelet", "netcgo", "secrets",])
 
 # TEST_TAGS lists the tags that have to be added to run tests
-TEST_TAGS = AGENT_TAGS.union(set(["clusterchecks",]))
+TEST_TAGS = AGENT_TAGS.union(set(["clusterchecks", "test",]))
 
 ### Tag exclusion lists
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -186,7 +186,6 @@ def test(
 
     nocache = '-count=1' if not cache else ''
 
-    build_tags.append("test")
     cmd = 'go run gotest.tools/gotestsum --format pkgname -- {verbose} -mod={go_mod} -vet=off -timeout {timeout}s -tags "{go_build_tags}" -gcflags="{gcflags}" '
     cmd += '-ldflags="{ldflags}" {build_cpus} {race_opt} -short {covermode_opt} {coverprofile} {nocache} {pkg_folder}'
     args = {


### PR DESCRIPTION
### What does this PR do?

Add some test helper files behind the test build flag (and files using them otherwise `inefassign` complains)

### Motivation

Saves 224kb on dogstatsd x64 binary size (~1%)
Saves 220kb on dogstatsd arm binary size

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
