### PR TITLE
Pin dulwich to 0.20.18 max

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # python development requirements for the Datadog Agent
 invoke==1.4.1
 reno==3.1.0
+dulwich<=0.20.18
 docker==3.7.3
 docker-squash==1.0.8
 requests==2.23.0


### PR DESCRIPTION
### What does this PR do?

Pins `dulwich` so that versions beyond 0.20.18 cannot be installed.

### Motivation

In some systems, the 0.20.19 install ends up in failure.

### Additional notes

Short-term fix, we need to understand why 0.20.19 somehow breaks installs.