### PR TITLE
[datadog-agent] Fix issue on Windows with absolute target in symlink in testdata

### DIFF
--- a/cmd/secrets/secret_helper_test.go
+++ b/cmd/secrets/secret_helper_test.go
@@ -96,7 +96,7 @@ func TestReadSecrets(t *testing.T) {
 					"value": "secret1-value"
 				},
 				"secret5": {
-					"error": "not following symlink \"/etc/passwd\" outside of \"testdata/read-secrets\""
+					"error": "not following symlink \"$TESTDATA/secret5-target\" outside of \"testdata/read-secrets\""
 				},
 				"secret6": {
 					"error": "secret exceeds max allowed size"
@@ -107,6 +107,7 @@ func TestReadSecrets(t *testing.T) {
 	}
 
 	path := filepath.Join("testdata", "read-secrets")
+	testdata, _ := filepath.Abs("testdata")
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.skipWindows && runtime.GOOS == "windows" {
@@ -117,7 +118,7 @@ func TestReadSecrets(t *testing.T) {
 			out := string(w.Bytes())
 
 			if test.out != "" {
-				assert.JSONEq(t, test.out, out)
+				assert.JSONEq(t, strings.ReplaceAll(test.out, "$TESTDATA", testdata), out)
 			} else {
 				assert.Empty(t, out)
 			}

--- a/cmd/secrets/testdata/read-secrets/secret5
+++ b/cmd/secrets/testdata/read-secrets/secret5
@@ -1,1 +1,1 @@
-/etc/passwd
+../secret5-target


### PR DESCRIPTION
### What does this PR do?

On certain Windows systems having a symlink targeting an absolute path results in git introducing changes to the symlink. 

cc @derekwbrown 
