### PR TITLE
pkg/trace: enable client tracers to drop auto_drop/p0 spans

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -158,6 +158,7 @@ func (a *Agent) Process(p *api.Payload) {
 	ts := p.Source
 	ss := new(writer.SampledSpans)
 	var sinputs []stats.Input
+	a.PrioritySampler.CountClientDroppedP0s(p.ClientDroppedP0s)
 	for _, t := range p.Traces {
 		if len(t) == 0 {
 			log.Debugf("Skipping received empty trace")
@@ -231,7 +232,7 @@ func (a *Agent) Process(p *api.Payload) {
 			Env:           env,
 		}
 
-		events, keep := a.sample(ts, pt)
+		events, keep := a.sample(ts, pt, p.ClientDroppedP0s > 0)
 
 		if !p.ClientComputedStats {
 			if sinputs == nil {
@@ -347,7 +348,7 @@ func (a *Agent) ProcessStats(in pb.ClientStatsPayload, lang string) {
 
 // sample decides whether the trace will be kept and extracts any APM events
 // from it.
-func (a *Agent) sample(ts *info.TagStats, pt ProcessedTrace) (events []*pb.Span, keep bool) {
+func (a *Agent) sample(ts *info.TagStats, pt ProcessedTrace, clientDroppedP0s bool) (events []*pb.Span, keep bool) {
 	priority, hasPriority := sampler.GetSamplingPriority(pt.Root)
 
 	// Depending on the sampling priority, count that trace differently.
@@ -369,7 +370,7 @@ func (a *Agent) sample(ts *info.TagStats, pt ProcessedTrace) (events []*pb.Span,
 		return nil, false
 	}
 
-	sampled := a.runSamplers(pt, hasPriority)
+	sampled := a.runSamplers(pt, hasPriority, clientDroppedP0s)
 
 	events, numExtracted := a.EventProcessor.Process(pt.Root, pt.Trace)
 
@@ -381,9 +382,9 @@ func (a *Agent) sample(ts *info.TagStats, pt ProcessedTrace) (events []*pb.Span,
 
 // runSamplers runs all the agent's samplers on pt and returns the sampling decision
 // along with the sampling rate.
-func (a *Agent) runSamplers(pt ProcessedTrace, hasPriority bool) bool {
+func (a *Agent) runSamplers(pt ProcessedTrace, hasPriority, clientDroppedP0s bool) bool {
 	if hasPriority {
-		return a.samplePriorityTrace(pt)
+		return a.samplePriorityTrace(pt, clientDroppedP0s)
 	}
 	return a.sampleNoPriorityTrace(pt)
 }
@@ -391,8 +392,8 @@ func (a *Agent) runSamplers(pt ProcessedTrace, hasPriority bool) bool {
 // samplePriorityTrace samples traces with priority set on them. PrioritySampler and
 // ErrorSampler are run in parallel. The ExceptionSampler catches traces with rare top-level
 // or measured spans that are not caught by PrioritySampler and ErrorSampler.
-func (a *Agent) samplePriorityTrace(pt ProcessedTrace) bool {
-	if a.PrioritySampler.Sample(pt.Trace, pt.Root, pt.Env) {
+func (a *Agent) samplePriorityTrace(pt ProcessedTrace, clientDroppedP0s bool) bool {
+	if a.PrioritySampler.Sample(pt.Trace, pt.Root, pt.Env, clientDroppedP0s) {
 		return true
 	}
 	if traceContainsError(pt.Trace) {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -628,7 +628,7 @@ func TestSampling(t *testing.T) {
 				}
 			}
 
-			sampled := a.runSamplers(pt, tt.hasPriority)
+			sampled := a.runSamplers(pt, tt.hasPriority, false)
 			assert.EqualValues(t, tt.wantSampled, sampled)
 		})
 	}

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -628,7 +628,7 @@ func TestSampling(t *testing.T) {
 				}
 			}
 
-			sampled := a.runSamplers(pt, tt.hasPriority, false)
+			sampled := a.runSamplers(pt, tt.hasPriority)
 			assert.EqualValues(t, tt.wantSampled, sampled)
 		})
 	}

--- a/pkg/trace/agent/processed_trace.go
+++ b/pkg/trace/agent/processed_trace.go
@@ -13,10 +13,11 @@ import (
 
 // ProcessedTrace represents a trace being processed in the agent.
 type ProcessedTrace struct {
-	Trace         pb.Trace
-	WeightedTrace stats.WeightedTrace
-	Root          *pb.Span
-	Env           string
+	Trace            pb.Trace
+	WeightedTrace    stats.WeightedTrace
+	Root             *pb.Span
+	Env              string
+	ClientDroppedP0s bool
 }
 
 // Weight returns the weight at the root span.

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -507,6 +507,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		}()
 	}
 }
+
 func droppedP0Traces(req *http.Request, ts *info.TagStats) int64 {
 	var dropped int64
 	if v := req.Header.Get(headerDroppedP0Traces); v != "" {

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -488,7 +488,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		ContainerTags:          getContainerTags(req.Header.Get(headerContainerID)),
 		ClientComputedTopLevel: req.Header.Get(headerComputedTopLevel) != "",
 		ClientComputedStats:    req.Header.Get(headerComputedStats) != "",
-		ClientDroppedP0s:       droppedP0Traces(req, ts),
+		ClientDroppedP0s:       droppedTracesFromHeader(req.Header, ts),
 	}
 
 	select {
@@ -508,16 +508,16 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	}
 }
 
-func droppedP0Traces(req *http.Request, ts *info.TagStats) int64 {
+func droppedTracesFromHeader(h http.Header, ts *info.TagStats) int64 {
 	var dropped int64
-	if v := req.Header.Get(headerDroppedP0Traces); v != "" {
+	if v := h.Get(headerDroppedP0Traces); v != "" {
 		count, err := strconv.ParseInt(v, 10, 64)
 		if err == nil {
 			dropped = count
 			atomic.AddInt64(&ts.ClientDroppedP0Traces, count)
 		}
 	}
-	if v := req.Header.Get(headerDroppedP0Spans); v != "" {
+	if v := h.Get(headerDroppedP0Spans); v != "" {
 		count, err := strconv.ParseInt(v, 10, 64)
 		if err == nil {
 			atomic.AddInt64(&ts.ClientDroppedP0Spans, count)

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -55,18 +55,20 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		oconf.Memcached = o.Memcached.Enabled
 	}
 	txt, err := json.MarshalIndent(struct {
-		Version      string        `json:"version"`
-		GitCommit    string        `json:"git_commit"`
-		BuildDate    string        `json:"build_date"`
-		Endpoints    []string      `json:"endpoints"`
-		FeatureFlags []string      `json:"feature_flags,omitempty"`
-		Config       reducedConfig `json:"config"`
+		Version       string        `json:"version"`
+		GitCommit     string        `json:"git_commit"`
+		BuildDate     string        `json:"build_date"`
+		Endpoints     []string      `json:"endpoints"`
+		FeatureFlags  []string      `json:"feature_flags,omitempty"`
+		ClientDropP0s bool          `json:"client_drop_p0s"`
+		Config        reducedConfig `json:"config"`
 	}{
-		Version:      info.Version,
-		GitCommit:    info.GitCommit,
-		BuildDate:    info.BuildDate,
-		Endpoints:    all,
-		FeatureFlags: config.Features(),
+		Version:       info.Version,
+		GitCommit:     info.GitCommit,
+		BuildDate:     info.BuildDate,
+		Endpoints:     all,
+		FeatureFlags:  config.Features(),
+		ClientDropP0s: true,
 		Config: reducedConfig{
 			DefaultEnv:             r.conf.DefaultEnv,
 			TargetTPS:              r.conf.TargetTPS,

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -123,6 +123,7 @@ func TestInfoHandler(t *testing.T) {
 	"feature_flags": [
 		"feature_flag"
 	],
+	"client_drop_p0s": true,
 	"config": {
 		"default_env": "prod",
 		"target_tps": 11,

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -138,6 +138,8 @@ func (ts *TagStats) publish() {
 	tracesPriority0 := atomic.LoadInt64(&ts.TracesPriority0)
 	tracesPriority1 := atomic.LoadInt64(&ts.TracesPriority1)
 	tracesPriority2 := atomic.LoadInt64(&ts.TracesPriority2)
+	clientDroppedP0Spans := atomic.LoadInt64(&ts.ClientDroppedP0Spans)
+	clientDroppedP0Traces := atomic.LoadInt64(&ts.ClientDroppedP0Traces)
 	tracesBytes := atomic.LoadInt64(&ts.TracesBytes)
 	spansReceived := atomic.LoadInt64(&ts.SpansReceived)
 	spansDropped := atomic.LoadInt64(&ts.SpansDropped)
@@ -166,6 +168,8 @@ func (ts *TagStats) publish() {
 	metrics.Count("datadog.trace_agent.receiver.events_sampled", eventsSampled, tags, 1)
 	metrics.Count("datadog.trace_agent.receiver.payload_accepted", requestsMade, tags, 1)
 	metrics.Count("datadog.trace_agent.receiver.payload_refused", requestsRejected, tags, 1)
+	metrics.Count("datadog.trace_agent.receiver.client_dropped_p0_spans", clientDroppedP0Spans, tags, 1)
+	metrics.Count("datadog.trace_agent.receiver.client_dropped_p0_traces", clientDroppedP0Traces, tags, 1)
 
 	for reason, count := range ts.TracesDropped.tagValues() {
 		metrics.Count("datadog.trace_agent.normalizer.traces_dropped", count, append(tags, "reason:"+reason), 1)
@@ -305,6 +309,10 @@ type Stats struct {
 	TracesPriority1 int64
 	// TracesPriority2 is the number of traces with sampling priority manually set to 2 or more.
 	TracesPriority2 int64
+	// ClientDroppedP0Traces number of P0 traces dropped by client.
+	ClientDroppedP0Traces int64
+	// ClientDroppedP0Spans number of P0 spans dropped by client.
+	ClientDroppedP0Spans int64
 	// TracesBytes is the amount of data received on the traces endpoint (raw data, encoded, compressed).
 	TracesBytes int64
 	// SpansReceived is the total number of spans received, including the dropped ones.
@@ -349,7 +357,8 @@ func (s *Stats) update(recent *Stats) {
 	atomic.AddInt64(&s.TracesPriorityNeg, atomic.LoadInt64(&recent.TracesPriorityNeg))
 	atomic.AddInt64(&s.TracesPriority0, atomic.LoadInt64(&recent.TracesPriority0))
 	atomic.AddInt64(&s.TracesPriority1, atomic.LoadInt64(&recent.TracesPriority1))
-	atomic.AddInt64(&s.TracesPriority2, atomic.LoadInt64(&recent.TracesPriority2))
+	atomic.AddInt64(&s.ClientDroppedP0Traces, atomic.LoadInt64(&recent.ClientDroppedP0Traces))
+	atomic.AddInt64(&s.ClientDroppedP0Spans, atomic.LoadInt64(&recent.ClientDroppedP0Spans))
 	atomic.AddInt64(&s.TracesBytes, atomic.LoadInt64(&recent.TracesBytes))
 	atomic.AddInt64(&s.SpansReceived, atomic.LoadInt64(&recent.SpansReceived))
 	atomic.AddInt64(&s.SpansDropped, atomic.LoadInt64(&recent.SpansDropped))
@@ -388,6 +397,8 @@ func (s *Stats) reset() {
 	atomic.StoreInt64(&s.TracesPriority0, 0)
 	atomic.StoreInt64(&s.TracesPriority1, 0)
 	atomic.StoreInt64(&s.TracesPriority2, 0)
+	atomic.StoreInt64(&s.ClientDroppedP0Traces, 0)
+	atomic.StoreInt64(&s.ClientDroppedP0Spans, 0)
 	atomic.StoreInt64(&s.TracesBytes, 0)
 	atomic.StoreInt64(&s.SpansReceived, 0)
 	atomic.StoreInt64(&s.SpansDropped, 0)

--- a/pkg/trace/sampler/memory_backend.go
+++ b/pkg/trace/sampler/memory_backend.go
@@ -69,11 +69,27 @@ func (b *MemoryBackend) CountSignature(signature Signature) {
 	b.mu.Unlock()
 }
 
+// CountClientDropped counts client dropped traces. They are added
+// to the totalScore, allowing them to weight on sampling rates during
+// adjust calls
+func (b *MemoryBackend) CountClientDropped(dropped int64) {
+	b.mu.Lock()
+	b.totalScore += float64(dropped)
+	b.mu.Unlock()
+}
+
 // CountSample counts a trace sampled by the sampler.
 func (b *MemoryBackend) CountSample() {
 	b.mu.Lock()
 	b.sampledScore++
 	atomic.AddInt64(&b.kept, 1)
+	b.mu.Unlock()
+}
+
+// CountWeightedSig counts a trace sampled by the sampler.
+func (b *MemoryBackend) CountWeightedSig(signature Signature, n float64) {
+	b.mu.Lock()
+	b.scores[signature] += n
 	b.mu.Unlock()
 }
 

--- a/pkg/trace/sampler/memory_backend.go
+++ b/pkg/trace/sampler/memory_backend.go
@@ -69,12 +69,10 @@ func (b *MemoryBackend) CountSignature(signature Signature) {
 	b.mu.Unlock()
 }
 
-// CountClientDropped counts client dropped traces. They are added
-// to the totalScore, allowing them to weight on sampling rates during
-// adjust calls
-func (b *MemoryBackend) CountClientDropped(dropped int64) {
+// AddTotalScore adds to the total score.
+func (b *MemoryBackend) AddTotalScore(n float64) {
 	b.mu.Lock()
-	b.totalScore += float64(dropped)
+	b.totalScore += n
 	b.mu.Unlock()
 }
 

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -129,9 +129,11 @@ func (s *PrioritySampler) Sample(trace pb.Trace, root *pb.Span, env string, clie
 	return sampled
 }
 
-// CountClientDroppedP0s counts client dropped traces.
+// CountClientDroppedP0s counts client dropped traces. They are added
+// to the totalScore, allowing them to weight on sampling rates during
+// adjust calls
 func (s *PrioritySampler) CountClientDroppedP0s(dropped int64) {
-	s.Sampler.Backend.CountClientDropped(dropped)
+	s.Sampler.Backend.AddTotalScore(float64(dropped))
 }
 
 func (s *PrioritySampler) applyRate(sampled bool, root *pb.Span, signature Signature) float64 {

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -120,7 +120,7 @@ func (s *PrioritySampler) Sample(trace pb.Trace, root *pb.Span, env string, clie
 		s.Sampler.Backend.CountSample()
 		// adjust sig score with the expected P0 count for that sig
 		// adjusting this score only matters for root spans
-		if clientDroppedP0s && rate != 0 {
+		if clientDroppedP0s && rate > 0 && rate < 1 {
 			// removing 1 to not count twice the P1 chunk
 			weight := 1/rate - 1
 			s.Sampler.Backend.CountWeightedSig(signature, weight)

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -73,7 +73,7 @@ func TestPrioritySample(t *testing.T) {
 	trace, root := getTestTraceWithService(t, "my-service", s)
 
 	SetSamplingPriority(root, -1)
-	sampled := s.Sample(trace, root, env)
+	sampled := s.Sample(trace, root, env, false)
 	assert.False(sampled, "trace with negative priority is dropped")
 	assert.Equal(0.0, s.Sampler.Backend.GetTotalScore(), "sampling a priority -1 trace should *NOT* impact sampler backend")
 	assert.Equal(0.0, s.Sampler.Backend.GetSampledScore(), "sampling a priority -1 trace should *NOT* impact sampler backend")
@@ -82,7 +82,7 @@ func TestPrioritySample(t *testing.T) {
 	trace, root = getTestTraceWithService(t, "my-service", s)
 
 	SetSamplingPriority(root, 0)
-	sampled = s.Sample(trace, root, env)
+	sampled = s.Sample(trace, root, env, false)
 	assert.False(sampled, "trace with priority 0 is dropped")
 	assert.True(0.0 < s.Sampler.Backend.GetTotalScore(), "sampling a priority 0 trace should increase total score")
 	assert.Equal(0.0, s.Sampler.Backend.GetSampledScore(), "sampling a priority 0 trace should *NOT* increase sampled score")
@@ -91,7 +91,7 @@ func TestPrioritySample(t *testing.T) {
 	trace, root = getTestTraceWithService(t, "my-service", s)
 
 	SetSamplingPriority(root, 1)
-	sampled = s.Sample(trace, root, env)
+	sampled = s.Sample(trace, root, env, false)
 	assert.True(sampled, "trace with priority 1 is kept")
 	assert.True(0.0 < s.Sampler.Backend.GetTotalScore(), "sampling a priority 0 trace should increase total score")
 	assert.True(0.0 < s.Sampler.Backend.GetSampledScore(), "sampling a priority 0 trace should increase sampled score")
@@ -100,7 +100,7 @@ func TestPrioritySample(t *testing.T) {
 	trace, root = getTestTraceWithService(t, "my-service", s)
 
 	SetSamplingPriority(root, 2)
-	sampled = s.Sample(trace, root, env)
+	sampled = s.Sample(trace, root, env, false)
 	assert.True(sampled, "trace with priority 2 is kept")
 	assert.Equal(0.0, s.Sampler.Backend.GetTotalScore(), "sampling a priority 2 trace should *NOT* increase total score")
 	assert.Equal(0.0, s.Sampler.Backend.GetSampledScore(), "sampling a priority 2 trace should *NOT* increase sampled score")
@@ -109,13 +109,13 @@ func TestPrioritySample(t *testing.T) {
 	trace, root = getTestTraceWithService(t, "my-service", s)
 
 	SetSamplingPriority(root, PriorityUserKeep)
-	sampled = s.Sample(trace, root, env)
+	sampled = s.Sample(trace, root, env, false)
 	assert.True(sampled, "trace with high priority is kept")
 	assert.Equal(0.0, s.Sampler.Backend.GetTotalScore(), "sampling a high priority trace should *NOT* increase total score")
 	assert.Equal(0.0, s.Sampler.Backend.GetSampledScore(), "sampling a high priority trace should *NOT* increase sampled score")
 
 	delete(root.Metrics, KeySamplingPriority)
-	sampled = s.Sample(trace, root, env)
+	sampled = s.Sample(trace, root, env, false)
 	assert.False(sampled, "this should not happen but a trace without priority sampling set should be dropped")
 }
 
@@ -127,7 +127,7 @@ func TestPrioritySampleThresholdTo1(t *testing.T) {
 	for i := 0; i < 1e2; i++ {
 		trace, root := getTestTraceWithService(t, "my-service", s)
 		SetSamplingPriority(root, SamplingPriority(i%2))
-		sampled := s.Sample(trace, root, env)
+		sampled := s.Sample(trace, root, env, false)
 		if sampled {
 			rate, _ := root.Metrics[deprecatedRateKey]
 			assert.Equal(1.0, rate)
@@ -136,7 +136,7 @@ func TestPrioritySampleThresholdTo1(t *testing.T) {
 	for i := 0; i < 1e3; i++ {
 		trace, root := getTestTraceWithService(t, "my-service", s)
 		SetSamplingPriority(root, SamplingPriority(i%2))
-		sampled := s.Sample(trace, root, env)
+		sampled := s.Sample(trace, root, env, false)
 		if sampled {
 			rate, _ := root.Metrics[deprecatedRateKey]
 			if rate < 1 {
@@ -193,7 +193,7 @@ func TestTargetTPSByService(t *testing.T) {
 			s.Sampler.AdjustScoring()
 			for i := 0; i < int(tracesPerPeriod); i++ {
 				trace, root := getTestTraceWithService(t, "service-a", s)
-				sampled := s.Sample(trace, root, defaultEnv)
+				sampled := s.Sample(trace, root, defaultEnv, false)
 				// Once we got into the "supposed-to-be" stable "regime", count the samples
 				if period > initPeriods {
 					handledCount++

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -48,7 +48,7 @@ func getTestTraceWithService(t *testing.T, service string, s *PrioritySampler) (
 	var rate float64
 	if serviceRate, ok := rates[key]; ok {
 		rate = serviceRate
-		trace[0].Metrics["_dd.agent_psr"] = serviceRate
+		trace[0].Metrics[agentRateKey] = serviceRate
 	} else {
 		rate = 1
 	}
@@ -130,7 +130,7 @@ func TestPrioritySampleThresholdTo1(t *testing.T) {
 		SetSamplingPriority(root, SamplingPriority(i%2))
 		sampled := s.Sample(trace, root, env, false)
 		if sampled {
-			rate, _ := root.Metrics[deprecatedRateKey]
+			rate, _ := root.Metrics[agentRateKey]
 			assert.Equal(1.0, rate)
 		}
 	}
@@ -139,7 +139,7 @@ func TestPrioritySampleThresholdTo1(t *testing.T) {
 		SetSamplingPriority(root, SamplingPriority(i%2))
 		sampled := s.Sample(trace, root, env, false)
 		if sampled {
-			rate, _ := root.Metrics[deprecatedRateKey]
+			rate, _ := root.Metrics[agentRateKey]
 			if rate < 1 {
 				assert.True(rate < prioritySamplingRateThresholdTo1)
 			}

--- a/releasenotes/notes/apm-clients-drop-p0-traces-61bb0c8744ba5aa8.yaml
+++ b/releasenotes/notes/apm-clients-drop-p0-traces-61bb0c8744ba5aa8.yaml
@@ -8,4 +8,5 @@
 ---
 features:
   - |
-    APM: allow tracer clients to drop AUTO_DROP traces
+    APM: Tracing clients no longer need to be sending traces marked
+    with sampling priority 0 (AUTO_DROP) in order for stats to be correct.

--- a/releasenotes/notes/apm-clients-drop-p0-traces-61bb0c8744ba5aa8.yaml
+++ b/releasenotes/notes/apm-clients-drop-p0-traces-61bb0c8744ba5aa8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: allow tracer clients to drop AUTO_DROP traces


### PR DESCRIPTION
Priority rates by service are computed in 2 steps:
1. scoreService(matchingChunkKept, matchingChunkSeen)
2. adjust(allChunksSeen): the global volume of chunks received by the Trace Agent

Dropping P0 chunks in the tracer will change the values of `matchingChunkSeen` and `allChunksSeen`.
- `allChunksSeen` is  filled with `CountClientDroppedP0s`, a new value sent by the tracer 
- `matchingChunkSeen` is approximated by `CountWeightedSig` by using the weights on root spans.

P0 chunks with no root will stop being taken in account in `matchingChunkSeen`, they will still impact the sampling rates by weighting in the adjust phase