### PR TITLE
[KSMCore] Add kube_region and kube_zone tags to node metrics via label joins

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_state_defaults.go
@@ -19,24 +19,28 @@ const ksmMetricPrefix = "kubernetes_state."
 var (
 	// defaultLabelsMapper contains the default label to tag names mapping
 	defaultLabelsMapper = map[string]string{
-		"namespace":                        "kube_namespace",
-		"job_name":                         "kube_job",
-		"cronjob":                          "kube_cronjob",
-		"pod":                              "pod_name",
-		"phase":                            "pod_phase",
-		"daemonset":                        "kube_daemon_set",
-		"replicationcontroller":            "kube_replication_controller",
-		"replicaset":                       "kube_replica_set",
-		"statefulset ":                     "kube_stateful_set",
-		"deployment":                       "kube_deployment",
-		"service":                          "kube_service",
-		"endpoint":                         "kube_endpoint",
-		"container":                        "kube_container_name",
-		"container_id":                     "container_id",
-		"image":                            "image_name",
-		"label_tags_datadoghq_com_env":     "env",
-		"label_tags_datadoghq_com_service": "service",
-		"label_tags_datadoghq_com_version": "version",
+		"namespace":                           "kube_namespace",
+		"job_name":                            "kube_job",
+		"cronjob":                             "kube_cronjob",
+		"pod":                                 "pod_name",
+		"phase":                               "pod_phase",
+		"daemonset":                           "kube_daemon_set",
+		"replicationcontroller":               "kube_replication_controller",
+		"replicaset":                          "kube_replica_set",
+		"statefulset ":                        "kube_stateful_set",
+		"deployment":                          "kube_deployment",
+		"service":                             "kube_service",
+		"endpoint":                            "kube_endpoint",
+		"container":                           "kube_container_name",
+		"container_id":                        "container_id",
+		"image":                               "image_name",
+		"label_tags_datadoghq_com_env":        "env",
+		"label_tags_datadoghq_com_service":    "service",
+		"label_tags_datadoghq_com_version":    "version",
+		"label_topology_kubernetes_io_region": "kube_region",
+		"label_topology_kubernetes_io_zone":   "kube_zone",
+		"label_failure_domain_beta_kubernetes_io_region": "kube_region",
+		"label_failure_domain_beta_kubernetes_io_zone":   "kube_zone",
 	}
 
 	// metricNamesMapper translates KSM metric names to Datadog metric names
@@ -194,6 +198,15 @@ var (
 		"kube_cronjob_labels": {
 			LabelsToMatch: []string{"cronjob", "namespace"},
 			LabelsToGet:   defaultStandardLabels,
+		},
+		"kube_node_labels": {
+			LabelsToMatch: []string{"node"},
+			LabelsToGet: []string{
+				"label_topology_kubernetes_io_region",            // k8s v1.17+
+				"label_topology_kubernetes_io_zone",              // k8s v1.17+
+				"label_failure_domain_beta_kubernetes_io_region", // k8s < v1.17
+				"label_failure_domain_beta_kubernetes_io_zone",   // k8s < v1.17
+			},
 		},
 	}
 )

--- a/releasenotes/notes/ksmcore-node-zone-and-region-labeljoins-be163117ca1154e1.yaml
+++ b/releasenotes/notes/ksmcore-node-zone-and-region-labeljoins-be163117ca1154e1.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add kube_region and kube_zone tags to node metrics reported by the kube-state-metrics core check


### PR DESCRIPTION
### What does this PR do?

Auto-configure label joins to attach `kube_region` and `kube_zone` tags to node metrics

### Motivation

Enrich node metrics reported by the KSM core check

### Describe your test plan

Run the check and see the tags attached to node metrics
