### PR TITLE
[gdb image] Allow specifying the deb repo snapshot date

### DIFF
--- a/tools/gdb/Dockerfile
+++ b/tools/gdb/Dockerfile
@@ -4,10 +4,12 @@ FROM datadog/agent:${AGENT_VERSION}
 # Install gdb
 # Use the debian snapshot repo commented out in the sources.list file, so that we install
 # the same versions of the debug packages (that are deps of gdb) as what's originally installed in the image
+ARG DEBIAN_REPO_SNAPSHOT_DATE
 RUN grep '^\#' /etc/apt/sources.list | sed 's/# //' > /etc/apt/sources.list.tmp \
- && mv /etc/apt/sources.list.tmp /etc/apt/sources.list \
+ && [ ! -z "$DEBIAN_REPO_SNAPSHOT_DATE" ] && sed -i -r "s/[0-9]+T[0-9]+Z/${DEBIAN_REPO_SNAPSHOT_DATE}/" /etc/apt/sources.list.tmp; \
+ mv /etc/apt/sources.list.tmp /etc/apt/sources.list \
  && apt-get -o Acquire::Check-Valid-Until=false update \
- && apt-get install -y gdb
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" gdb
 
 # Install Go version used to build the Agent, to get appropriate GDB debug script
 RUN export GIMME_GO_VERSION=$(agent version | grep --only-matching -E 'go[0-9\.]*' | sed 's/go//') \

--- a/tools/gdb/README.md
+++ b/tools/gdb/README.md
@@ -18,12 +18,18 @@ The image is based on the `datadog/agent` image for the version of the Agent you
   docker build -t gdb-agent:7.18.0 --build-arg AGENT_VERSION=7.18.0 .
   ```
 
-  Optional build args, which configure how to source the `datadog-agent-dbg` package:
+  If the Debian snapshot repos definitions in the Agent image do not actually reflect the debian repo snapshots
+  that were used at the time of the original Agent image build, the optional build arg `DEBIAN_REPO_SNAPSHOT_DATE`
+  must be set to the snapshot's date.
+
+  Example: for `7.25.1`, which was built on `2021-01-26`, you have to specify `--build-arg DEBIAN_REPO_SNAPSHOT_DATE=20210126T000000Z`.
+
+  Optional build args which configure how to source the `datadog-agent-dbg` package:
   * `APT_REPO`: APT repo (default: `apt.datadoghq.com`)
   * `APT_DISTRIBUTION`: APT distro (default: `stable`)
 
   Example: for `7.18.0-rc.2` use `--build-arg APT_REPO=apt.datad0g.com --build-arg APT_DISTRIBUTION=beta`.
-  
+
 2. Navigate the core dump file in a gdb prompt:
 
   ```sh
@@ -43,4 +49,6 @@ See https://devguide.python.org/gdb/#gdb-7-and-later for more info on the Python
 
 ## TODO
 
+* make the Agent image define its debian repo snapshot date at build time so we can use it here directly, without requiring
+the use of a separate build arg (`DEBIAN_REPO_SNAPSHOT_DATE`)
 * add cpython sources


### PR DESCRIPTION
### What does this PR do?

Allow specifying the deb repo snapshot date as an arg of the custom `gdb` troubleshooting image.

### Motivation

Since the debian snapshot repos defined in comments in
`/etc/apt/sources.list` do not necessarily accurately reflect the deb
repos' state when the Agent image was built, add an option to allow
changing the debian snapshot dates so that the gdb image build can be successful. Otherwise, there may be
dep mismatches between the system packages already installed (that were installedd when the Agent image
was built) and the packages we try to install in this gdb image (e.g. the `gdb` pkg).

Also, make sure the install of gdb succeeds in fully non-interactive
mode.

### Additional Notes

This is a temp fix: ideally the Agent image should keep track of when it
was built, so that we can re-use that date in this gdb image build to
use the snapshot of the deb repos for that date.

Tracking this as a TODO in the readme.

### Describe your test plan

This change doesn't affect Agent images, so no test plan needed for Agent QA. I've checked that the docker image build of this gdb image works with 7.25.1.
