### PR TITLE
[flare] Do not error out if a user/group id can't be resolved

### DIFF
--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -64,25 +64,30 @@ func (p permissionsInfos) statFiles() error {
 			return fmt.Errorf("can't retrieve file %s uid/gid infos: %s", filePath, err)
 		}
 
-		u, err := user.LookupId(strconv.Itoa(int(sys.Uid)))
+		var uname string
+		var uid = strconv.Itoa(int(sys.Uid))
+		u, err := user.LookupId(uid)
 		if err != nil {
-			return fmt.Errorf("can't lookup for uid info: %v", err)
-		}
-		g, err := user.LookupGroupId(strconv.Itoa(int(sys.Gid)))
-		if err != nil {
-			return fmt.Errorf("can't lookup for gid info: %v", err)
+			uname = uid
+		} else if len(u.Name) > 0 {
+			uname = u.Name
+		} else {
+			uname = u.Username
 		}
 
-		uname := u.Name
-		if len(uname) == 0 {
-			// full name could be empty, use the login name instead
-			uname = u.Username
+		var gname string
+		var gid = strconv.Itoa(int(sys.Gid))
+		g, err := user.LookupGroupId(gid)
+		if err != nil {
+			gname = gid
+		} else {
+			gname = g.Name
 		}
 
 		p[filePath] = filePermsInfo{
 			mode:  fi.Mode(),
 			owner: uname,
-			group: g.Name,
+			group: gname,
 		}
 	}
 	return nil

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -68,6 +68,7 @@ func (p permissionsInfos) statFiles() error {
 		var uid = strconv.Itoa(int(sys.Uid))
 		u, err := user.LookupId(uid)
 		if err != nil {
+			// User not found, eg: it was deleted from the system
 			uname = uid
 		} else if len(u.Name) > 0 {
 			uname = u.Name
@@ -79,6 +80,7 @@ func (p permissionsInfos) statFiles() error {
 		var gid = strconv.Itoa(int(sys.Gid))
 		g, err := user.LookupGroupId(gid)
 		if err != nil {
+			// Group not found, eg: it was deleted from the system
 			gname = gid
 		} else {
 			gname = g.Name

--- a/releasenotes/notes/flare-keep-unresolved-uid-a79e9a242a994c56.yaml
+++ b/releasenotes/notes/flare-keep-unresolved-uid-a79e9a242a994c56.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    When generating the permissions.log file for a flare, if the owner of a file
+    no longer exists in the system, return its id instead instead of failing.


### PR DESCRIPTION
### What does this PR do?

When generating the `permissions.log` file for a flare, if the owner of a file no longer exists in the system, return its id instead instead of failing.
