### PR TITLE
Remove logs-intake from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -159,7 +159,7 @@
 /pkg/util/ecs/                          @DataDog/container-integrations
 /pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/container-app
 /pkg/util/retry/                        @DataDog/container-integrations
-/pkg/logs/                              @DataDog/logs-intake @DataDog/agent-core
+/pkg/logs/                              @DataDog/agent-core
 /pkg/logs/input/traps/                  @DataDog/agent-integrations @DataDog/agent-core
 /pkg/metadata/ecs/                      @DataDog/networks
 /pkg/metadata/kubernetes/               @DataDog/networks


### PR DESCRIPTION
agent-core has been the main owner of this package for a bit, let's remove the duplicate github pings
