### PR TITLE
pkg/trace/metrics: ensure that metrics can be sent using alternatives to UDP when available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	github.com/DataDog/agent-payload v4.55.0+incompatible
-	github.com/DataDog/datadog-go v4.2.0+incompatible
+	github.com/DataDog/datadog-go v4.4.0+incompatible
 	github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822
 	github.com/DataDog/ebpf v0.0.0-20210121152636-7fc17cac5ed7
 	github.com/DataDog/gohai v0.0.0-20200605003749-e17d616e422a

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.2.0+incompatible h1:Q73jzyKHwyA04Gf4SSukRF+KR4wJEimU6tAuU0B8Y4Y=
 github.com/DataDog/datadog-go v4.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/datadog-go v4.4.0+incompatible h1:R7WqXWP4fIOAqWJtUKmSfuc7eDsBT58k9AY5WSHVosk=
+github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822 h1:E5WNl43j4mpE3V35QySkRnP/m9pjXOnEZD6eyTK7Qvk=
 github.com/DataDog/datadog-operator v0.2.1-0.20200709152311-9c71245c6822/go.mod h1:a5NqgPglcSct+NwO9gPvVhoL5V6G1+gHbRaRnU8U54M=
 github.com/DataDog/ebpf v0.0.0-20210121152636-7fc17cac5ed7 h1:Gl1fG+QK2tVnxTwtuqraUymTfjMGPMOPjfogRs7vpdA=

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -10,15 +10,40 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 
+	mainconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-go/statsd"
 )
 
+// findAddr finds the correct address to connect to the Dogstatsd server.
+func findAddr(conf *config.AgentConfig) (string, error) {
+	if conf.StatsdPort > 0 {
+		// UDP enabled
+		return fmt.Sprintf("%s:%d", conf.StatsdHost, conf.StatsdPort), nil
+	}
+	pipename := mainconfig.Datadog.GetString("dogstatsd_pipe_name")
+	if pipename != "" {
+		// Windows Pipes can be used
+		return `\\.\pipe\` + pipename, nil
+	}
+	sockname := mainconfig.Datadog.GetString("dogstatsd_socket")
+	if sockname != "" {
+		// Unix sockets can be used
+		return `unix://` + pipename, nil
+	}
+	return "", errors.New("dogstatsd_port is set to 0 and no alternative is available")
+}
+
 // Configure creates a statsd client for the given agent's configuration, using the specified global tags.
 func Configure(conf *config.AgentConfig, tags []string) error {
-	client, err := statsd.New(fmt.Sprintf("%s:%d", conf.StatsdHost, conf.StatsdPort), statsd.WithTags(tags))
+	addr, err := findAddr(conf)
+	if err != nil {
+		return err
+	}
+	client, err := statsd.New(addr, statsd.WithTags(tags))
 	if err != nil {
 		return err
 	}

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -32,7 +32,7 @@ func findAddr(conf *config.AgentConfig) (string, error) {
 	sockname := mainconfig.Datadog.GetString("dogstatsd_socket")
 	if sockname != "" {
 		// Unix sockets can be used
-		return `unix://` + pipename, nil
+		return `unix://` + sockname, nil
 	}
 	return "", errors.New("dogstatsd_port is set to 0 and no alternative is available")
 }

--- a/releasenotes/notes/apm-metrics-non-udp-394d25b741677aef.yaml
+++ b/releasenotes/notes/apm-metrics-non-udp-394d25b741677aef.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: When UDP is not available for Dogstatsd, the trace-agent can now use any other
+    available alternative, such as UDS or Windows Pipes.


### PR DESCRIPTION
This changes updates datadog-go@v4.4.0 to add support for Windows pipes and ensures that the trace-agent is able to use this functionality when UDP is not available.