### PR TITLE
pkg/trace: reduce allocs made by the obfuscator

### DIFF
--- a/pkg/trace/obfuscate/obfuscate.go
+++ b/pkg/trace/obfuscate/obfuscate.go
@@ -148,19 +148,20 @@ func compactWhitespaces(t string) string {
 // replaceDigits replaces consecutive sequences of digits with '?',
 // example: "jobs_2020_1597876964" --> "jobs_?_?"
 func replaceDigits(buffer []byte) []byte {
-	buf := make([]byte, 0, len(buffer))
 	scanningDigit := false
-	for _, c := range string(buffer) {
-		if isDigit(c) {
+	filtered := buffer[:0]
+	for _, b := range buffer {
+		// digits are encoded as 1 byte in utf8
+		if isDigit(rune(b)) {
 			if scanningDigit {
 				continue
 			}
 			scanningDigit = true
-			buf = append(buf, byte('?'))
+			filtered = append(filtered, byte('?'))
 			continue
 		}
 		scanningDigit = false
-		buf = append(buf, byte(c))
+		filtered = append(filtered, b)
 	}
-	return buf
+	return filtered
 }

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -1235,6 +1235,7 @@ func BenchmarkObfuscateSQLString(b *testing.B) {
 	}
 
 	b.Run("random", func(b *testing.B) {
+		b.ReportAllocs()
 		var j uint64
 		for i := 0; i < b.N; i++ {
 			_, err := obf.ObfuscateSQLString(fmt.Sprintf("SELECT * FROM users WHERE id=%d", atomic.AddUint64(&j, 1)))

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -490,7 +490,7 @@ exit:
 }
 
 func (tkn *SQLTokenizer) scanString(delim rune, kind TokenKind) (TokenKind, []byte) {
-	filtered := bytes.NewBuffer(tkn.buf[:0])
+	buf := bytes.NewBuffer(tkn.buf[:0])
 	for {
 		ch := tkn.lastChar
 		tkn.advance()
@@ -513,18 +513,18 @@ func (tkn *SQLTokenizer) scanString(delim rune, kind TokenKind) (TokenKind, []by
 		}
 		if ch == EndChar {
 			tkn.setErr("unexpected EOF in string")
-			return LexError, filtered.Bytes()
+			return LexError, buf.Bytes()
 		}
-		filtered.WriteRune(ch)
+		buf.WriteRune(ch)
 	}
-	if kind == ID && filtered.Len() == 0 || bytes.IndexFunc(filtered.Bytes(), func(r rune) bool { return !unicode.IsSpace(r) }) == -1 {
+	if kind == ID && buf.Len() == 0 || bytes.IndexFunc(buf.Bytes(), func(r rune) bool { return !unicode.IsSpace(r) }) == -1 {
 		// This string is an empty or white-space only identifier.
 		// We should keep the start and end delimiters in order to
 		// avoid creating invalid queries.
 		// See: https://github.com/DataDog/datadog-trace-agent/issues/316
 		return kind, append(runeBytes(delim), runeBytes(delim)...)
 	}
-	return kind, filtered.Bytes()
+	return kind, buf.Bytes()
 }
 
 func (tkn *SQLTokenizer) scanCommentType1(prefix string) (TokenKind, []byte) {


### PR DESCRIPTION
Reduce number of allocs by using the tokenizer internal buffer for filtering operations.

Benchmarks:
```
name                               old time/op    new time/op    delta
ObfuscateSQLString/Escaping/512-8    8.32µs ± 2%    7.80µs ± 5%   -6.35%  (p=0.000 n=18+5)
ObfuscateSQLString/Grouping/199-8    4.24µs ± 1%    3.85µs ± 1%   -9.18%  (p=0.000 n=18+5)
ObfuscateSQLString/Large/3694-8      71.8µs ± 2%    67.5µs ± 2%   -5.93%  (p=0.000 n=16+5)
ObfuscateSQLString/Complex/969-8     19.4µs ± 4%    18.1µs ± 1%   -6.50%  (p=0.000 n=20+5)
ObfuscateSQLString/random-8          1.27µs ± 3%    1.21µs ± 1%   -4.70%  (p=0.000 n=20+5)

name                               old alloc/op   new alloc/op   delta
ObfuscateSQLString/Escaping/512-8    1.95kB ± 0%    1.25kB ± 0%  -35.90%  (p=0.000 n=20+5)
ObfuscateSQLString/Grouping/199-8      828B ± 0%      560B ± 0%  -32.37%  (p=0.000 n=20+5)
ObfuscateSQLString/Large/3694-8      16.3kB ± 0%    11.3kB ± 0%  -30.60%  (p=0.000 n=20+5)
ObfuscateSQLString/Complex/969-8     3.01kB ± 0%    3.01kB ± 0%   -0.17%  (p=0.000 n=20+5)
ObfuscateSQLString/random-8            256B ± 0%      248B ± 0%   -3.12%  (p=0.000 n=20+5)

name                               old allocs/op  new allocs/op  delta
ObfuscateSQLString/Escaping/512-8      23.0 ± 0%       6.0 ± 0%  -73.91%  (p=0.000 n=20+5)
ObfuscateSQLString/Grouping/199-8      22.0 ± 0%       6.0 ± 0%  -72.73%  (p=0.000 n=20+5)
ObfuscateSQLString/Large/3694-8         150 ± 0%         6 ± 0%  -96.00%  (p=0.000 n=20+5)
ObfuscateSQLString/Complex/969-8       11.0 ± 0%       6.0 ± 0%  -45.45%  (p=0.000 n=20+5)
ObfuscateSQLString/random-8            9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.000 n=20+5)
```