### PR TITLE
[CircleCI] Bump macOS setup script to use Go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,9 +241,9 @@ jobs:
           keys:
             # If incremental dep fails, increase the cache version number
             # See https://github.com/DataDog/datadog-agent/pull/2384
-            - v1-macosdeps-{{ .Branch }}-{{ .Revision }}
-            - v1-macosdeps-{{ .Branch }}-
-            - v1-macosdeps-master-
+            - v2-macosdeps-{{ .Branch }}-{{ .Revision }}
+            - v2-macosdeps-{{ .Branch }}-
+            - v2-macosdeps-master-
       - run:
           name: Setup runner
           command: |
@@ -254,10 +254,12 @@ jobs:
             brew install clang-format
             python3 -m pip install -r requirements.txt
       - save_cache:
-          key: v1-macosdeps-{{ .Branch }}-{{ .Revision }}
+          key: v2-macosdeps-{{ .Branch }}-{{ .Revision }}
           paths:
             - /usr/local/bin
-            - /usr/local/Cellar/
+            - /usr/local/Cellar
+            - /usr/local/lib
+            - /usr/local/Frameworks
       - run:
           name: Compile rtloader
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,13 @@ jobs:
           name: Remove existing packages
           command: |
             brew remove --force $(brew list --formula)
+      - restore_cache:
+          keys:
+            # If incremental dep fails, increase the cache version number
+            # See https://github.com/DataDog/datadog-agent/pull/2384
+            - v1-macosdeps-{{ .Branch }}-{{ .Revision }}
+            - v1-macosdeps-{{ .Branch }}-
+            - v1-macosdeps-master-
       - run:
           name: Setup runner
           command: |
@@ -246,6 +253,11 @@ jobs:
           command: |
             brew install clang-format
             python3 -m pip install -r requirements.txt
+      - save_cache:
+          key: v1-macosdeps-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /usr/local/bin
+            - /usr/local/Cellar/
       - run:
           name: Compile rtloader
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
     macos:
       xcode: 11.7.0
     environment:
-      BUILDIMAGES_VERSION: "a8226a8e78774afad285e7372fe8c6c179340dd9" # datadog-agent-buildimages commit to fetch to get the MacOS scripts
+      BUILDIMAGES_VERSION: "aa0a9b99830e937e32986359794361aeb95940f5" # datadog-agent-buildimages commit to fetch to get the MacOS scripts
     working_directory: ~/go/src/github.com/DataDog/datadog-agent
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Remove existing packages
+          command: |
+            brew remove --force $(brew list --formula)
+      - run:
           name: Setup runner
           command: |
             bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/$BUILDIMAGES_VERSION/macos/builder_setup.sh)"


### PR DESCRIPTION
### What does this PR do?

- Bump macOS builder setup script to commit DataDog/datadog-agent-buildimages@aa0a9b99830e937e32986359794361aeb95940f5. This was undocumented on the Go upgrade instructions and so was not done on #6942
- Remove existing formulas before starting, similar to [what we do in the macos-build repository](https://github.com/DataDog/datadog-agent-macos-build/blob/2ce836872d2a3aa870ec22b5bdb43fb8e2960a69/.github/workflows/macos.yaml#L39-L51)
- Add cache to reduce build time

### Motivation

- Keep go version consistent
