### PR TITLE
[KSMcore] Generate resource-specific metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -26,13 +26,19 @@
 | `kubernetes_state.endpoint.address_not_ready` | Number of addresses not ready in endpoint.   | `endpoint` `kube_namespace`   |
 | `kubernetes_state.namespace.count` | Number of namespaces | `phase` |
 | `kubernetes_state.node.count` | Information about a cluster node.   | `node` `kernel_version` `os_image` `container_runtime_version` `kubelet_version` `kubeproxy_version` `provider_id` `pod_cidr`   |
-| `kubernetes_state.node.allocatable` | The allocatable for different resources of a node that are available for scheduling.   | `node` `resource` `unit`   |
-| `kubernetes_state.node.capacity` | The capacity for different resources of a node.   | `node` `resource` `unit`   |
+| `kubernetes_state.node.cpu_allocatable` | The allocatable cpu of a node that is available for scheduling.   | `node` `resource` `unit`   |
+| `kubernetes_state.node.memory_allocatable` | The allocatable memory of a node that is available for scheduling.   | `node` `resource` `unit`   |
+| `kubernetes_state.node.pods_allocatable` | The allocatable memory of a node that is available for scheduling.   | `node` `resource` `unit`   |
+| `kubernetes_state.node.cpu_capacity` | The cpu capacity of a node.   | `node` `resource` `unit`   |
+| `kubernetes_state.node.memory_capacity` | The memory capacity of a node.   | `node` `resource` `unit`   |
+| `kubernetes_state.node.pods_capacity` | The pods capacity of a node.   | `node` `resource` `unit`   |
 | `kubernetes_state.node.by_condition` | The condition of a cluster node.   | `condition` `node` `status`   |
 | `kubernetes_state.node.status` | Whether the node can schedule new pods.   | `node` `status`   |
 | `kubernetes_state.container.terminated` | Describes whether the container is currently in terminated state.   | `kube_namespace` `pod_name` `kube_container_name` (`env` `service` `version` from standard labels)   |
-| `kubernetes_state.container.resource_limits` | The number of requested limit resource by a container.   | `kube_namespace` `pod_name` `kube_container_name` `node` `resource` `unit` (`env` `service` `version` from standard labels)   |
-| `kubernetes_state.container.resource_requests` | The number of requested request resource by a container.   | `kube_namespace` `pod_name` `kube_container_name` `node` `resource` `unit` (`env` `service` `version` from standard labels)   |
+| `kubernetes_state.container.cpu_limit` | The value of cpu limit by a container.   | `kube_namespace` `pod_name` `kube_container_name` `node` `resource` `unit` (`env` `service` `version` from standard labels)   |
+| `kubernetes_state.container.memory_limit` | The value of memory limit by a container.   | `kube_namespace` `pod_name` `kube_container_name` `node` `resource` `unit` (`env` `service` `version` from standard labels)   |
+| `kubernetes_state.container.cpu_requested` | The value of cpu requested by a container.   | `kube_namespace` `pod_name` `kube_container_name` `node` `resource` `unit` (`env` `service` `version` from standard labels)   |
+| `kubernetes_state.container.memory_requested` | The value of memory requested by a container.   | `kube_namespace` `pod_name` `kube_container_name` `node` `resource` `unit` (`env` `service` `version` from standard labels)   |
 | `kubernetes_state.container.ready` | Describes whether the containers readiness check succeeded.   | `kube_namespace` `pod_name` `kube_container_name` (`env` `service` `version` from standard labels)   |
 | `kubernetes_state.container.restarts` | The number of container restarts per container.   | `kube_namespace` `pod_name` `kube_container_name` (`env` `service` `version` from standard labels)   |
 | `kubernetes_state.container.running` | Describes whether the container is currently in running state.   | `kube_namespace` `pod_name` `kube_container_name` (`env` `service` `version` from standard labels)   |

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -64,16 +64,12 @@ var (
 		"kube_endpoint_address_available":                                                          "endpoint.address_available",
 		"kube_endpoint_address_not_ready":                                                          "endpoint.address_not_ready",
 		"kube_node_info":                                                                           "node.count",
-		"kube_node_status_allocatable":                                                             "node.allocatable", // TODO: Investigate adding a transformer to generate one metric per resource?
-		"kube_node_status_capacity":                                                                "node.capacity",    // TODO: Investigate adding need a transformer to generate one metric per resource?
 		"kube_pod_container_status_terminated":                                                     "container.terminated",
 		"kube_pod_container_status_waiting":                                                        "container.waiting",
 		"kube_persistentvolumeclaim_status_phase":                                                  "persistentvolumeclaim.status",
 		"kube_persistentvolumeclaim_access_mode":                                                   "persistentvolumeclaim.access_mode",
 		"kube_persistentvolumeclaim_resource_requests_storage_bytes":                               "persistentvolumeclaim.request_storage",
 		"kube_persistentvolume_capacity_bytes":                                                     "persistentvolume.capacity",
-		"kube_pod_container_resource_limits":                                                       "container.resource_limits",   // TODO: Investigate adding a transformer to generate one metric per resource?
-		"kube_pod_container_resource_requests":                                                     "container.resource_requests", // TODO: Investigate adding a transformer to generate one metric per resource?
 		"kube_pod_container_status_ready":                                                          "container.ready",
 		"kube_pod_container_status_restarts_total":                                                 "container.restarts",
 		"kube_pod_container_status_running":                                                        "container.running",

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -287,7 +287,7 @@ func TestProcessMetrics(t *testing.T) {
 			metricTransformers: metricTransformers,
 			expected: []metricsExpected{
 				{
-					name:     "kubernetes_state.node.capacity",
+					name:     "kubernetes_state.node.cpu_capacity",
 					val:      4,
 					tags:     []string{"node:nodename", "resource:cpu", "unit:core", "kube_region:europe-west1", "kube_zone:europe-west1-b"},
 					hostname: "nodename",

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -31,6 +31,8 @@ var (
 		"kube_pod_status_phase":                       podPhaseTransformer,
 		"kube_pod_container_status_waiting_reason":    containerWaitingReasonTransformer,
 		"kube_pod_container_status_terminated_reason": containerTerminatedReasonTransformer,
+		"kube_pod_container_resource_requests":        containerResourceRequestsTransformer,
+		"kube_pod_container_resource_limits":          containerResourceLimitsTransformer,
 		"kube_cronjob_next_schedule_time":             cronJobNextScheduleTransformer,
 		"kube_cronjob_status_last_schedule_time":      cronJobLastScheduleTransformer,
 		"kube_job_complete":                           jobCompleteTransformer,
@@ -39,6 +41,8 @@ var (
 		"kube_job_status_succeeded":                   jobStatusSucceededTransformer,
 		"kube_node_status_condition":                  nodeConditionTransformer,
 		"kube_node_spec_unschedulable":                nodeUnschedulableTransformer,
+		"kube_node_status_allocatable":                nodeAllocatableTransformer,
+		"kube_node_status_capacity":                   nodeCapacityTransformer,
 		"kube_resourcequota":                          resourcequotaTransformer,
 		"kube_limitrange":                             limitrangeTransformer,
 		"kube_persistentvolume_status_phase":          pvPhaseTransformer,
@@ -175,6 +179,71 @@ func containerTerminatedReasonTransformer(s aggregator.Sender, name string, metr
 		if _, allowed := allowedTerminatedReasons[strings.ToLower(reason)]; allowed {
 			s.Gauge(ksmMetricPrefix+"container.status_report.count.terminated", metric.Val, hostname, tags)
 		}
+	}
+}
+
+// containerResourceRequestsTransformer transforms the generic ksm resource request metrics into resource-specific metrics
+func containerResourceRequestsTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+	submitContainerResourceMetric(s, name, metric, hostname, tags, "requested")
+}
+
+// containerResourceLimitsTransformer transforms the generic ksm resource limit metrics into resource-specific metrics
+func containerResourceLimitsTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+	submitContainerResourceMetric(s, name, metric, hostname, tags, "limit")
+}
+
+// submitContainerResourceMetric can be called by container resource metric transformers to submit resource-specific metrics
+// metricSuffix can be either requested or limit
+func submitContainerResourceMetric(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, metricSuffix string) {
+	resource, found := metric.Labels["resource"]
+	if !found {
+		log.Debugf("Couldn't find 'resource' label, ignoring resource metric '%s'", name)
+		return
+	}
+
+	switch resource {
+	case "cpu":
+		s.Gauge(ksmMetricPrefix+"container.cpu_"+metricSuffix, metric.Val, hostname, tags)
+		return
+	case "memory":
+		s.Gauge(ksmMetricPrefix+"container.memory_"+metricSuffix, metric.Val, hostname, tags)
+		return
+	default:
+		log.Tracef("Ignoring container resource metric '%s': resource '%s' is not supported", name, resource)
+	}
+}
+
+// nodeAllocatableTransformer transforms the generic ksm node allocatable metrics into resource-specific metrics
+func nodeAllocatableTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+	submitNodeResourceMetric(s, name, metric, hostname, tags, "allocatable")
+}
+
+// nodeCapacityTransformer transforms the generic ksm node capacity metrics into resource-specific metrics
+func nodeCapacityTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+	submitNodeResourceMetric(s, name, metric, hostname, tags, "capacity")
+}
+
+// submitNodeResourceMetric can be called by node resource metric transformers to submit resource-specific metrics
+// metricSuffix can be either allocatable or capacity
+func submitNodeResourceMetric(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, metricSuffix string) {
+	resource, found := metric.Labels["resource"]
+	if !found {
+		log.Debugf("Couldn't find 'resource' label, ignoring resource metric '%s'", name)
+		return
+	}
+
+	switch resource {
+	case "cpu":
+		s.Gauge(ksmMetricPrefix+"node.cpu_"+metricSuffix, metric.Val, hostname, tags)
+		return
+	case "memory":
+		s.Gauge(ksmMetricPrefix+"node.memory_"+metricSuffix, metric.Val, hostname, tags)
+		return
+	case "pods":
+		s.Gauge(ksmMetricPrefix+"node.pods_"+metricSuffix, metric.Val, hostname, tags)
+		return
+	default:
+		log.Tracef("Ignoring node resource metric '%s': resource '%s' is not supported", name, resource)
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -1452,3 +1452,361 @@ func Test_validateJob(t *testing.T) {
 		})
 	}
 }
+
+func Test_containerResourceRequestsTransformer(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "memory",
+			args: args{
+				name: "kube_pod_container_resource_requests",
+				metric: ksmstore.DDMetric{
+					Val: 50000000,
+					Labels: map[string]string{
+						"resource": "memory",
+						"unit":     "byte",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.container.memory_requested",
+				val:      50000000,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "cpu",
+			args: args{
+				name: "kube_pod_container_resource_requests",
+				metric: ksmstore.DDMetric{
+					Val: 2,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.container.cpu_requested",
+				val:      2,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "no resource label",
+			args: args{
+				name: "kube_pod_container_resource_requests",
+				metric: ksmstore.DDMetric{
+					Val: 2,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags: []string{"foo:bar"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			containerResourceRequestsTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}
+
+func Test_containerResourceLimitsTransformer(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "memory",
+			args: args{
+				name: "kube_pod_container_resource_limits",
+				metric: ksmstore.DDMetric{
+					Val: 50000000,
+					Labels: map[string]string{
+						"resource": "memory",
+						"unit":     "byte",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.container.memory_limit",
+				val:      50000000,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "cpu",
+			args: args{
+				name: "kube_pod_container_resource_limits",
+				metric: ksmstore.DDMetric{
+					Val: 2,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.container.cpu_limit",
+				val:      2,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "no resource label",
+			args: args{
+				name: "kube_pod_container_resource_limits",
+				metric: ksmstore.DDMetric{
+					Val: 2,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags: []string{"foo:bar"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			containerResourceLimitsTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}
+
+func Test_nodeAllocatableTransformer(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "memory",
+			args: args{
+				name: "kube_node_status_allocatable",
+				metric: ksmstore.DDMetric{
+					Val: 50000000,
+					Labels: map[string]string{
+						"resource": "memory",
+						"unit":     "byte",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.node.memory_allocatable",
+				val:      50000000,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "cpu",
+			args: args{
+				name: "kube_node_status_allocatable",
+				metric: ksmstore.DDMetric{
+					Val: 4,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.node.cpu_allocatable",
+				val:      4,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "pods",
+			args: args{
+				name: "kube_node_status_allocatable",
+				metric: ksmstore.DDMetric{
+					Val: 100,
+					Labels: map[string]string{
+						"resource": "pods",
+						"unit":     "integer",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.node.pods_allocatable",
+				val:      100,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "no resource label",
+			args: args{
+				name: "kube_node_status_allocatable",
+				metric: ksmstore.DDMetric{
+					Val: 4,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags: []string{"foo:bar"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			nodeAllocatableTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}
+
+func Test_nodeCapacityTransformer(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "memory",
+			args: args{
+				name: "kube_node_status_capacity",
+				metric: ksmstore.DDMetric{
+					Val: 50000000,
+					Labels: map[string]string{
+						"resource": "memory",
+						"unit":     "byte",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.node.memory_capacity",
+				val:      50000000,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "cpu",
+			args: args{
+				name: "kube_node_status_capacity",
+				metric: ksmstore.DDMetric{
+					Val: 2,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.node.cpu_capacity",
+				val:      2,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "pods",
+			args: args{
+				name: "kube_node_status_capacity",
+				metric: ksmstore.DDMetric{
+					Val: 100,
+					Labels: map[string]string{
+						"resource": "pods",
+						"unit":     "integer",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.node.pods_capacity",
+				val:      100,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "no resource label",
+			args: args{
+				name: "kube_node_status_capacity",
+				metric: ksmstore.DDMetric{
+					Val: 4,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags: []string{"foo:bar"},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			nodeCapacityTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Generate the following metrics based on the generic container and node resource ksm metrics
- container.memory_limit
- container.cpu_limit
- container.memory_requested
- container.cpu_requested
- node.memory_allocatable
- node.cpu_allocatable
- node.pods_allocatable
- node.cpu_capacity
- node.memory_capacity
- node.pods_capacity

### Motivation

- Backward compatibility
- DD requires a known metric type for each metric

### Describe your test plan

- Run the check with `pods` and `nodes` collectors enabled, the metrics in question should appear.
- The metrics should have the same names as in the ksm check v1 https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/metadata.csv
