### PR TITLE
[circleci] Do not filter out master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,21 +285,12 @@ workflows:
           requires:
             - dependencies
       - release_note:
-          filters:
-            branches:
-              ignore: master
           requires:
             - dependencies
       - team_label:
-          filters:
-            branches:
-              ignore: master
           requires:
             - dependencies
       - milestone:
-          filters:
-            branches:
-              ignore: master
           requires:
             - dependencies
       - filename_linting:


### PR DESCRIPTION
### What does this PR do?

Partially revert https://github.com/DataDog/datadog-agent/pull/7394

### Motivation

This is needed if someone opens a PR from their repo's master branch.
