### PR TITLE
pkg/trace/api: add "Datadog-Agent-Version" response HTTP header

### DIFF
--- a/releasenotes/notes/apm-version-response-header-859bde3ddda591d7.yaml
+++ b/releasenotes/notes/apm-version-response-header-859bde3ddda591d7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: All API endpoints now respond with the "Datadog-Agent-Version" HTTP response header.


### PR DESCRIPTION
This change adds the `Datadog-Agent-Version` response header on all
endpoints, regardless of status code.