### PR TITLE
DCA: Add app/api keys settings dedicated to external metrics

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -642,6 +642,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics_provider.enabled", false)
 	config.BindEnvAndSetDefault("external_metrics_provider.port", 443)
 	config.BindEnvAndSetDefault("external_metrics_provider.endpoint", "")                 // Override the Datadog API endpoint to query external metrics from
+	config.BindEnvAndSetDefault("external_metrics_provider.api_key", "")                  // Override the Datadog API Key for external metrics endpoint
+	config.BindEnvAndSetDefault("external_metrics_provider.app_key", "")                  // Override the Datadog APP Key for external metrics endpoint
 	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)           // value in seconds. Frequency of calls to Datadog to refresh metric values
 	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)             // value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)
 	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 120)                 // value in seconds. 4 cycles from the Autoscaler controller (up to Kubernetes 1.11) is enough to consider a metric stale

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -185,8 +185,15 @@ func (p *Processor) updateRateLimitingMetrics() error {
 
 // NewDatadogClient generates a new client to query metrics from Datadog
 func NewDatadogClient() (*datadog.Client, error) {
-	apiKey := config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
-	appKey := config.Datadog.GetString("app_key")
+	apiKey := config.SanitizeAPIKey(config.Datadog.GetString("external_metrics_provider.api_key"))
+	if apiKey == "" {
+		apiKey = config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
+	}
+
+	appKey := config.SanitizeAPIKey(config.Datadog.GetString("external_metrics_provider.app_key"))
+	if appKey == "" {
+		appKey = config.SanitizeAPIKey(config.Datadog.GetString("app_key"))
+	}
 
 	// DATADOG_HOST used to be the only way to set the external metrics
 	// endpoint, so we need to keep backwards compatibility. In order of

--- a/releasenotes-dca/notes/api-keys-external-metrics-0c5657ce87bd647f.yaml
+++ b/releasenotes-dca/notes/api-keys-external-metrics-0c5657ce87bd647f.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Add `external_metrics_provider.api_key` and `external_metrics_provider.app_key` parameters overriding default `api_key` and `app_key` if set.


### PR DESCRIPTION
### What does this PR do?

Add dedicated parameters for external metrics App/Api keys in Cluster Agent

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Set `external_metrics_provider.api_key` and `external_metrics_provider.app_key`, verify these are used to target the proper DD instance.