### PR TITLE
CI promote_install_script: use needs instead of depends

### DIFF
--- a/.gitlab/deploy_7/install_script.yml
+++ b/.gitlab/deploy_7/install_script.yml
@@ -15,7 +15,7 @@ promote_install_script:
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main", "size:large"]
-  dependencies:
+  needs:
     - kitchen_centos_install_script_agent-a6
     - kitchen_centos_install_script_agent-a7
     - kitchen_centos_install_script_iot_agent-a7


### PR DESCRIPTION
### What does this PR do?

Change the `promote_install_script` job definition so the kitchen tests are listed as `needs` instead of `depends`.

### Motivation

We don't need to pass any artifacts to this job
