### PR TITLE
[KSMcore] Add node age metric

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -34,6 +34,7 @@
 | `kubernetes_state.node.pods_capacity` | The pods capacity of a node.   | `node` `resource` `unit`   |
 | `kubernetes_state.node.by_condition` | The condition of a cluster node.   | `condition` `node` `status`   |
 | `kubernetes_state.node.status` | Whether the node can schedule new pods.   | `node` `status`   |
+| `kubernetes_state.node.age` | The time in seconds since the creation of the node.   | `node`   |
 | `kubernetes_state.container.terminated` | Describes whether the container is currently in terminated state.   | `kube_namespace` `pod_name` `kube_container_name` (`env` `service` `version` from standard labels)   |
 | `kubernetes_state.container.cpu_limit` | The value of cpu limit by a container.   | `kube_namespace` `pod_name` `kube_container_name` `node` `resource` `unit` (`env` `service` `version` from standard labels)   |
 | `kubernetes_state.container.memory_limit` | The value of memory limit by a container.   | `kube_namespace` `pod_name` `kube_container_name` `node` `resource` `unit` (`env` `service` `version` from standard labels)   |

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -118,7 +118,8 @@ var (
 
 	// deniedMetrics used to configure the KSM store to ignore these metrics by KSM engine
 	deniedMetrics = options.MetricSet{
-		".*_created":                                       {},
+		// deny all *_created metrics except for kube_node_created
+		"^_created|^(?:[^k]|k[^u]|ku[^b]|kub[^e]|kube[^_]|kube_[^n]|kube_n[^o]|kube_no[^d]|kube_nod[^e]|kube_node.).*_created": {},
 		".*_generation":                                    {},
 		".*_metadata_resource_version":                     {},
 		"kube_pod_owner":                                   {},

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -900,6 +900,37 @@ func TestAllowDeny(t *testing.T) {
 	}
 }
 
+func TestCreationMetricsFiltering(t *testing.T) {
+	allowDenyList, err := allowdenylist.New(options.MetricSet{}, deniedMetrics)
+	assert.NoError(t, err)
+
+	err = allowDenyList.Parse()
+	assert.NoError(t, err)
+
+	included := []string{"kube_node_created"}
+	for _, metric := range included {
+		assert.True(t, allowDenyList.IsIncluded(metric))
+		assert.False(t, allowDenyList.IsExcluded(metric))
+	}
+
+	excluded := []string{
+		"kube_pod_created",
+		"kube_cronjob_created",
+		"kube_daemonset_created",
+		"kube_deployment_created",
+		"kube_endpoint_created",
+		"kube_job_created",
+		"kube_namespace_created",
+		"kube_replicaset_created",
+		"kube_service_created",
+		"kube_replicationcontroller_created",
+	}
+	for _, metric := range excluded {
+		assert.True(t, allowDenyList.IsExcluded(metric))
+		assert.False(t, allowDenyList.IsIncluded(metric))
+	}
+}
+
 func lenMetrics(metricsToProcess map[string][]ksmstore.DDMetricsFam) int {
 	count := 0
 	for _, metricFamily := range metricsToProcess {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -1810,3 +1810,45 @@ func Test_nodeCapacityTransformer(t *testing.T) {
 		})
 	}
 }
+
+func Test_nodeCreationTransformer(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "nominal case",
+			args: args{
+				name: "kube_node_created",
+				metric: ksmstore.DDMetric{
+					Val: 1595501615,
+					Labels: map[string]string{
+						"node": "foo",
+					},
+				},
+				tags: []string{"node:foo"},
+				now:  func() time.Time { return time.Unix(int64(1595501615+86400), 0) },
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.node.age",
+				val:  86400,
+				tags: []string{"node:foo"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			now = tt.args.now
+			nodeCreationTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Add a new metric `kubernetes_state.node.age`

### Motivation

FR

### Describe your test plan

Enable the KSM core check with the nodes collector enabled, the new metric must show up.
