### PR TITLE
[clcrunner] Allow runners to use different identifiers

### DIFF
--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -25,8 +25,8 @@ import (
 
 // Install registers v1 API endpoints
 func installClusterCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
-	r.HandleFunc("/clusterchecks/status/{nodeName}", postCheckStatus(sc)).Methods("POST")
-	r.HandleFunc("/clusterchecks/configs/{nodeName}", getCheckConfigs(sc)).Methods("GET")
+	r.HandleFunc("/clusterchecks/status/{identifier}", postCheckStatus(sc)).Methods("POST")
+	r.HandleFunc("/clusterchecks/configs/{identifier}", getCheckConfigs(sc)).Methods("GET")
 	r.HandleFunc("/clusterchecks/rebalance", postRebalanceChecks(sc)).Methods("POST")
 	r.HandleFunc("/clusterchecks", getState(sc)).Methods("GET")
 }
@@ -43,7 +43,7 @@ func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 		}
 
 		vars := mux.Vars(r)
-		nodeName := vars["nodeName"]
+		identifier := vars["identifier"]
 
 		decoder := json.NewDecoder(r.Body)
 		var status cctypes.NodeStatus
@@ -61,7 +61,7 @@ func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 			return
 		}
 
-		response, err := sc.ClusterCheckHandler.PostStatus(nodeName, clientIP, status)
+		response, err := sc.ClusterCheckHandler.PostStatus(identifier, clientIP, status)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			incrementRequestMetric("postCheckStatus", http.StatusInternalServerError)
@@ -84,8 +84,8 @@ func getCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 		}
 
 		vars := mux.Vars(r)
-		nodeName := vars["nodeName"]
-		response, err := sc.ClusterCheckHandler.GetConfigs(nodeName)
+		identifier := vars["identifier"]
+		response, err := sc.ClusterCheckHandler.GetConfigs(identifier)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			incrementRequestMetric("getCheckConfigs", http.StatusInternalServerError)

--- a/pkg/autodiscovery/providers/clusterchecks.go
+++ b/pkg/autodiscovery/providers/clusterchecks.go
@@ -26,7 +26,7 @@ type ClusterChecksConfigProvider struct {
 	graceDuration  time.Duration
 	heartbeat      time.Time
 	lastChange     int64
-	nodeName       string
+	identifier     string
 	flushedConfigs bool
 }
 
@@ -38,13 +38,16 @@ func NewClusterChecksConfigProvider(cfg config.ConfigurationProviders) (ConfigPr
 		graceDuration: defaultGraceDuration,
 	}
 
-	c.nodeName, _ = util.GetHostname()
-	if config.Datadog.GetBool("cloud_foundry") {
-		boshID := config.Datadog.GetString("bosh_id")
-		if boshID == "" {
-			log.Warn("configuration variable cloud_foundry is set to true, but bosh_id is empty, can't retrieve node name")
-		} else {
-			c.nodeName = boshID
+	c.identifier = config.Datadog.GetString("clc_runner_id")
+	if c.identifier == "" {
+		c.identifier, _ = util.GetHostname()
+		if config.Datadog.GetBool("cloud_foundry") {
+			boshID := config.Datadog.GetString("bosh_id")
+			if boshID == "" {
+				log.Warn("configuration variable cloud_foundry is set to true, but bosh_id is empty, can't retrieve node name")
+			} else {
+				c.identifier = boshID
+			}
 		}
 	}
 
@@ -89,7 +92,7 @@ func (c *ClusterChecksConfigProvider) IsUpToDate() (bool, error) {
 		LastChange: c.lastChange,
 	}
 
-	reply, err := c.dcaClient.PostClusterCheckStatus(c.nodeName, status)
+	reply, err := c.dcaClient.PostClusterCheckStatus(c.identifier, status)
 	if err != nil {
 		if c.withinGracePeriod() {
 			// Return true to keep the configs during the grace period
@@ -118,7 +121,7 @@ func (c *ClusterChecksConfigProvider) Collect() ([]integration.Config, error) {
 		}
 	}
 
-	reply, err := c.dcaClient.GetClusterCheckConfigs(c.nodeName)
+	reply, err := c.dcaClient.GetClusterCheckConfigs(c.identifier)
 	if err != nil {
 		if !c.flushedConfigs {
 			// On first error after grace period, mask the error once

--- a/pkg/clusteragent/clusterchecks/api.go
+++ b/pkg/clusteragent/clusterchecks/api.go
@@ -50,9 +50,9 @@ func (h *Handler) GetState() (types.StateResponse, error) {
 	}
 }
 
-// GetConfigs returns configurations dispatched to a given node
-func (h *Handler) GetConfigs(nodeName string) (types.ConfigResponse, error) {
-	configs, lastChange, err := h.dispatcher.getNodeConfigs(nodeName)
+// GetConfigs returns configurations dispatched to a given agent
+func (h *Handler) GetConfigs(identifier string) (types.ConfigResponse, error) {
+	configs, lastChange, err := h.dispatcher.getClusterCheckConfigs(identifier)
 	response := types.ConfigResponse{
 		Configs:    configs,
 		LastChange: lastChange,
@@ -61,8 +61,8 @@ func (h *Handler) GetConfigs(nodeName string) (types.ConfigResponse, error) {
 }
 
 // PostStatus handles status reports from the node agents
-func (h *Handler) PostStatus(nodeName, clientIP string, status types.NodeStatus) (types.StatusResponse, error) {
-	upToDate, err := h.dispatcher.processNodeStatus(nodeName, clientIP, status)
+func (h *Handler) PostStatus(identifier, clientIP string, status types.NodeStatus) (types.StatusResponse, error) {
+	upToDate, err := h.dispatcher.processNodeStatus(identifier, clientIP, status)
 	response := types.StatusResponse{
 		IsUpToDate: upToDate,
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -20,8 +20,8 @@ import (
 
 const defaultBusynessValue int = -1
 
-// getNodeConfigs returns configurations dispatched to a given node
-func (d *dispatcher) getNodeConfigs(nodeName string) ([]integration.Config, int64, error) {
+// getClusterCheckConfigs returns configurations dispatched to a given node
+func (d *dispatcher) getClusterCheckConfigs(nodeName string) ([]integration.Config, int64, error) {
 	d.store.RLock()
 	defer d.store.RUnlock()
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -100,20 +100,20 @@ func TestScheduleReschedule(t *testing.T) {
 
 	// Register to node1
 	dispatcher.addConfig(config, "node1")
-	configs1, _, err := dispatcher.getNodeConfigs("node1")
+	configs1, _, err := dispatcher.getClusterCheckConfigs("node1")
 	assert.NoError(t, err)
 	assert.Len(t, configs1, 1)
 	assert.Contains(t, configs1, config)
 
 	// Move to node2
 	dispatcher.addConfig(config, "node2")
-	configs2, _, err := dispatcher.getNodeConfigs("node2")
+	configs2, _, err := dispatcher.getClusterCheckConfigs("node2")
 	assert.NoError(t, err)
 	assert.Len(t, configs2, 1)
 	assert.Contains(t, configs2, config)
 
 	// De-registered from previous node
-	configs1, _, err = dispatcher.getNodeConfigs("node1")
+	configs1, _, err = dispatcher.getClusterCheckConfigs("node1")
 	assert.NoError(t, err)
 	assert.Len(t, configs1, 0)
 
@@ -163,7 +163,7 @@ func TestDescheduleRescheduleSameNode(t *testing.T) {
 
 	// Schedule to node1
 	dispatcher.addConfig(config, "node1")
-	configs1, _, err := dispatcher.getNodeConfigs("node1")
+	configs1, _, err := dispatcher.getClusterCheckConfigs("node1")
 	assert.NoError(t, err)
 	assert.Len(t, configs1, 1)
 	assert.Contains(t, configs1, config)
@@ -176,7 +176,7 @@ func TestDescheduleRescheduleSameNode(t *testing.T) {
 
 	// Re-schedule to node1
 	dispatcher.addConfig(config, "node1")
-	configs2, _, err := dispatcher.getNodeConfigs("node1")
+	configs2, _, err := dispatcher.getClusterCheckConfigs("node1")
 	assert.NoError(t, err)
 	assert.Len(t, configs2, 1)
 	assert.Contains(t, configs2, config)
@@ -308,7 +308,7 @@ func TestRescheduleDanglingFromExpiredNodes(t *testing.T) {
 	assert.Equal(t, []string{"A"}, extractCheckNames(allConfigs))
 
 	// Ensure it's running correctly
-	configsA, _, err := dispatcher.getNodeConfigs("nodeA")
+	configsA, _, err := dispatcher.getClusterCheckConfigs("nodeA")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(configsA))
 
@@ -337,7 +337,7 @@ func TestRescheduleDanglingFromExpiredNodes(t *testing.T) {
 	assert.Equal(t, []string{"A"}, extractCheckNames(danglingConfig))
 
 	// Make sure make sure the dangling check is rescheduled on the new node
-	configsB, _, err := dispatcher.getNodeConfigs("nodeB")
+	configsB, _, err := dispatcher.getClusterCheckConfigs("nodeB")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(configsB))
 }
@@ -362,11 +362,11 @@ func TestDispatchFourConfigsTwoNodes(t *testing.T) {
 	assert.Equal(t, 4, len(allConfigs))
 	assert.Equal(t, []string{"A", "B", "C", "D"}, extractCheckNames(allConfigs))
 
-	configsA, _, err := dispatcher.getNodeConfigs("nodeA")
+	configsA, _, err := dispatcher.getClusterCheckConfigs("nodeA")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(configsA))
 
-	configsB, _, err := dispatcher.getNodeConfigs("nodeB")
+	configsB, _, err := dispatcher.getClusterCheckConfigs("nodeB")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(configsB))
 
@@ -412,7 +412,7 @@ func TestReset(t *testing.T) {
 
 	// Register to node1
 	dispatcher.addConfig(config, "node1")
-	configs1, _, err := dispatcher.getNodeConfigs("node1")
+	configs1, _, err := dispatcher.getClusterCheckConfigs("node1")
 	assert.NoError(t, err)
 	assert.Len(t, configs1, 1)
 	assert.Contains(t, configs1, config)
@@ -422,7 +422,7 @@ func TestReset(t *testing.T) {
 	stored, err := dispatcher.getAllConfigs()
 	assert.NoError(t, err)
 	assert.Len(t, stored, 0)
-	_, _, err = dispatcher.getNodeConfigs("node1")
+	_, _, err = dispatcher.getClusterCheckConfigs("node1")
 	assert.EqualError(t, err, "node node1 is unknown")
 
 	requireNotLocked(t, dispatcher.store)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -675,6 +675,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	// Cluster check runner
 	config.BindEnvAndSetDefault("clc_runner_enabled", false)
+	config.BindEnvAndSetDefault("clc_runner_id", "")
 	config.BindEnvAndSetDefault("clc_runner_host", "") // must be set using the Kubernetes downward API
 	config.BindEnvAndSetDefault("clc_runner_port", 5005)
 	config.BindEnvAndSetDefault("clc_runner_server_write_timeout", 15)

--- a/pkg/tagger/collectors/garden_extract_test.go
+++ b/pkg/tagger/collectors/garden_extract_test.go
@@ -100,11 +100,11 @@ func (fakeDCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([
 	panic("implement me")
 }
 
-func (fakeDCAClient) PostClusterCheckStatus(nodeName string, status types.NodeStatus) (types.StatusResponse, error) {
+func (fakeDCAClient) PostClusterCheckStatus(identifier string, status types.NodeStatus) (types.StatusResponse, error) {
 	panic("implement me")
 }
 
-func (fakeDCAClient) GetClusterCheckConfigs(nodeName string) (types.ConfigResponse, error) {
+func (fakeDCAClient) GetClusterCheckConfigs(identifier string) (types.ConfigResponse, error) {
 	panic("implement me")
 }
 

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper_test.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper_test.go
@@ -85,11 +85,11 @@ func (f *FakeDCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string)
 	return f.KubernetesMetadataNames, f.KubernetesMetadataNamesErr
 }
 
-func (f *FakeDCAClient) PostClusterCheckStatus(nodeName string, status types.NodeStatus) (types.StatusResponse, error) {
+func (f *FakeDCAClient) PostClusterCheckStatus(identifier string, status types.NodeStatus) (types.StatusResponse, error) {
 	return f.ClusterCheckStatus, f.ClusterCheckStatusErr
 }
 
-func (f *FakeDCAClient) GetClusterCheckConfigs(nodeName string) (types.ConfigResponse, error) {
+func (f *FakeDCAClient) GetClusterCheckConfigs(identifier string) (types.ConfigResponse, error) {
 	return f.ClusterCheckConfigs, f.ClusterCheckConfigsErr
 }
 

--- a/pkg/util/clusteragent/clusterchecks.go
+++ b/pkg/util/clusteragent/clusterchecks.go
@@ -23,20 +23,20 @@ const (
 )
 
 // PostClusterCheckStatus is called by the clustercheck config provider
-func (c *DCAClient) PostClusterCheckStatus(nodeName string, status types.NodeStatus) (types.StatusResponse, error) {
+func (c *DCAClient) PostClusterCheckStatus(identifier string, status types.NodeStatus) (types.StatusResponse, error) {
 	// Retry on the main URL if the leader fails
 	willRetry := c.leaderClient.hasLeader()
 
-	result, err := c.doPostClusterCheckStatus(nodeName, status)
+	result, err := c.doPostClusterCheckStatus(identifier, status)
 	if err != nil && willRetry {
 		log.Debugf("Got error on leader, retrying via the service: %s", err)
 		c.leaderClient.resetURL()
-		return c.doPostClusterCheckStatus(nodeName, status)
+		return c.doPostClusterCheckStatus(identifier, status)
 	}
 	return result, err
 }
 
-func (c *DCAClient) doPostClusterCheckStatus(nodeName string, status types.NodeStatus) (types.StatusResponse, error) {
+func (c *DCAClient) doPostClusterCheckStatus(identifier string, status types.NodeStatus) (types.StatusResponse, error) {
 	var response types.StatusResponse
 
 	queryBody, err := json.Marshal(status)
@@ -44,8 +44,8 @@ func (c *DCAClient) doPostClusterCheckStatus(nodeName string, status types.NodeS
 		return response, err
 	}
 
-	// https://host:port/api/v1/clusterchecks/status/{nodeName}
-	rawURL := c.leaderClient.buildURL(dcaClusterChecksStatusPath, nodeName)
+	// https://host:port/api/v1/clusterchecks/status/{identifier}
+	rawURL := c.leaderClient.buildURL(dcaClusterChecksStatusPath, identifier)
 	req, err := http.NewRequest("POST", rawURL, bytes.NewBuffer(queryBody))
 	if err != nil {
 		return response, err
@@ -71,25 +71,25 @@ func (c *DCAClient) doPostClusterCheckStatus(nodeName string, status types.NodeS
 }
 
 // GetClusterCheckConfigs is called by the clustercheck config provider
-func (c *DCAClient) GetClusterCheckConfigs(nodeName string) (types.ConfigResponse, error) {
+func (c *DCAClient) GetClusterCheckConfigs(identifier string) (types.ConfigResponse, error) {
 	// Retry on the main URL if the leader fails
 	willRetry := c.leaderClient.hasLeader()
 
-	result, err := c.doGetClusterCheckConfigs(nodeName)
+	result, err := c.doGetClusterCheckConfigs(identifier)
 	if err != nil && willRetry {
 		log.Debugf("Got error on leader, retrying via the service: %s", err)
 		c.leaderClient.resetURL()
-		return c.doGetClusterCheckConfigs(nodeName)
+		return c.doGetClusterCheckConfigs(identifier)
 	}
 	return result, err
 }
 
-func (c *DCAClient) doGetClusterCheckConfigs(nodeName string) (types.ConfigResponse, error) {
+func (c *DCAClient) doGetClusterCheckConfigs(identifier string) (types.ConfigResponse, error) {
 	var configs types.ConfigResponse
 	var err error
 
-	// https://host:port/api/v1/clusterchecks/configs/{nodeName}
-	rawURL := c.leaderClient.buildURL(dcaClusterChecksConfigsPath, nodeName)
+	// https://host:port/api/v1/clusterchecks/configs/{identifier}
+	rawURL := c.leaderClient.buildURL(dcaClusterChecksConfigsPath, identifier)
 	req, err := http.NewRequest("GET", rawURL, nil)
 	if err != nil {
 		return configs, err

--- a/releasenotes/notes/clc-runner-id-76878b3dc7a16860.yaml
+++ b/releasenotes/notes/clc-runner-id-76878b3dc7a16860.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Introduce a clc_runner_id config option to allow overriding the default
+    Cluster Checks Runner identifier. Defaults to the node name to make it
+    backwards compatible. It is intended to allow binpacking more than a single
+    runner per node.


### PR DESCRIPTION
We want to allow users to binpack Cluster Checks Runners to a single
node when necessary. Previously, each CLC runner was identifier by the
node name where they resided, so it was not possible to run more than
one per node without causing collisions.

This commit introduces a `clc_runner_id` config
option to allow users to override that now. It's probably not very
useful as a static value, so the intended usage is by injecting the
`DD_CLC_RUNNER_ID` env var in the pod spec as follows:

```
env:
- name: DD_CLC_RUNNER_ID
  valueFrom:
    fieldRef:
      fieldPath: metadata.name
```

### Describe your test plan

* Enable DCA and cluster checks: https://docs.datadoghq.com/agent/cluster_agent/clusterchecks/#set-up-cluster-checks -- make sure to enable the cluster checks runner as well (`clusterChecksRunner.enabled` with the helm chart)
* Edit the cluster checks runner deployment to include the `DD_CLC_RUNNER_ID` env var as described above, and have more than one pod per node. You can do that with a `nodeSelector`: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
* Check that the DCA sees all the pods by running `agent clusterchecks`.