### PR TITLE
Remove copy between tagger and dogstatsd metrics

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -376,7 +376,9 @@ func (agg *BufferedAggregator) addServiceCheck(sc metrics.ServiceCheck) {
 	if sc.Ts == 0 {
 		sc.Ts = time.Now().Unix()
 	}
-	sc.Tags = metrics.EnrichTags(sc.Tags, sc.OriginID, sc.K8sOriginID)
+	tb := util.NewTagsBuilderFromSlice(sc.Tags)
+	metrics.EnrichTags(tb, sc.OriginID, sc.K8sOriginID)
+	sc.Tags = tb.Get()
 
 	agg.serviceChecks = append(agg.serviceChecks, &sc)
 }
@@ -386,7 +388,9 @@ func (agg *BufferedAggregator) addEvent(e metrics.Event) {
 	if e.Ts == 0 {
 		e.Ts = time.Now().Unix()
 	}
-	e.Tags = metrics.EnrichTags(e.Tags, e.OriginID, e.K8sOriginID)
+	tb := util.NewTagsBuilderFromSlice(e.Tags)
+	metrics.EnrichTags(tb, e.OriginID, e.K8sOriginID)
+	e.Tags = tb.Get()
 
 	agg.events = append(agg.events, &e)
 }

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -9,6 +9,8 @@ package aggregator
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/util"
+
 	// stdlib
 	"math"
 	"testing"
@@ -24,9 +26,9 @@ import (
 
 func generateContextKey(sample metrics.MetricSampleContext) ckey.ContextKey {
 	k := ckey.NewKeyGenerator()
-	tagsBuffer := []string{}
-	tagsBuffer = sample.GetTags(tagsBuffer)
-	return k.Generate(sample.GetName(), sample.GetHost(), tagsBuffer)
+	tb := util.NewTagsBuilder()
+	sample.GetTags(tb)
+	return k.Generate(sample.GetName(), sample.GetHost(), tb.Get())
 }
 
 func TestCheckGaugeSampling(t *testing.T) {

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -5,6 +5,8 @@
 
 package metrics
 
+import "github.com/DataDog/datadog-agent/pkg/util"
+
 // HistogramBucket represents a prometheus/openmetrics histogram bucket
 type HistogramBucket struct {
 	Name       string
@@ -30,9 +32,9 @@ func (m *HistogramBucket) GetHost() string {
 }
 
 // GetTags returns the bucket tags.
-func (m *HistogramBucket) GetTags([]string) []string {
+func (m *HistogramBucket) GetTags(tb *util.TagsBuilder) {
 	// Other 'GetTags' methods for metrics support origin detections. Since
 	// HistogramBucket only come, for now, from checks we can simply return
 	// tags.
-	return m.Tags
+	tb.Append(m.Tags...)
 }

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/local"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -62,9 +63,17 @@ func Init() {
 
 // Tag queries the defaultTagger to get entity tags from cache or sources.
 // It can return tags at high cardinality (with tags about individual containers),
-// or at orchestrator cardinality (pod/task level)
+// or at orchestrator cardinality (pod/task level).
 func Tag(entity string, cardinality collectors.TagCardinality) ([]string, error) {
 	return defaultTagger.Tag(entity, cardinality)
+}
+
+// TagBuilder queries the defaultTagger to get entity tags from cache or
+// sources and appends them to the TagsBuilder.  It can return tags at high
+// cardinality (with tags about individual containers), or at orchestrator
+// cardinality (pod/task level).
+func TagBuilder(entity string, cardinality collectors.TagCardinality, tb *util.TagsBuilder) error {
+	return defaultTagger.TagBuilder(entity, cardinality, tb)
 }
 
 // TagWithHash is similar to Tag but it also computes and returns the hash of the tags found
@@ -104,6 +113,12 @@ func AgentTags(cardinality collectors.TagCardinality) ([]string, error) {
 // OrchestratorScopeTag queries tags for orchestrator scope (e.g. task_arn in ECS Fargate)
 func OrchestratorScopeTag() ([]string, error) {
 	return defaultTagger.Tag(collectors.OrchestratorScopeEntityID, collectors.OrchestratorCardinality)
+}
+
+// OrchestratorScopeTagBuilder queries tags for orchestrator scope (e.g.
+// task_arn in ECS Fargate) and appends them to the TagsBuilder
+func OrchestratorScopeTagBuilder(tb *util.TagsBuilder) error {
+	return defaultTagger.TagBuilder(collectors.OrchestratorScopeEntityID, collectors.OrchestratorCardinality, tb)
 }
 
 // Stop queues a stop signal to the defaultTagger

--- a/pkg/tagger/interface.go
+++ b/pkg/tagger/interface.go
@@ -4,6 +4,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 // Tagger is an interface for transparent access to both localTagger and
@@ -13,6 +14,7 @@ type Tagger interface {
 	Stop() error
 
 	Tag(entity string, cardinality collectors.TagCardinality) ([]string, error)
+	TagBuilder(entity string, cardinality collectors.TagCardinality, tb *util.TagsBuilder) error
 	Standard(entity string) ([]string, error)
 	List(cardinality collectors.TagCardinality) response.TaggerListResponse
 

--- a/pkg/tagger/local/tagger_bench_test.go
+++ b/pkg/tagger/local/tagger_bench_test.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package local
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util"
+)
+
+func initTagger() *Tagger {
+	catalog := collectors.Catalog{}
+	tagger := NewTagger(catalog)
+	tagger.Init()
+	tagger.store.processTagInfo([]*collectors.TagInfo{
+		{
+			Source:               "source1",
+			Entity:               "test",
+			LowCardTags:          []string{"low_tag1", "low_tag2", "low_tag3"},
+			OrchestratorCardTags: []string{"orch_tag1", "orch_tag2", "orch_tag3"},
+			HighCardTags:         []string{"his_tag1", "his_tag2", "his_tag3"},
+		},
+		{
+			Source:               "source2",
+			Entity:               "test",
+			LowCardTags:          []string{"2low_tag1", "2low_tag2", "2low_tag3"},
+			OrchestratorCardTags: []string{"2orch_tag1", "2orch_tag2", "2orch_tag3"},
+			HighCardTags:         []string{"2his_tag1", "2his_tag2", "2his_tag3"},
+		},
+	})
+
+	return tagger
+}
+
+func BenchmarkTagLowCardinality(b *testing.B) {
+	tagger := initTagger()
+	defer tagger.Stop()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			tagger.Tag("test", collectors.LowCardinality)
+		}
+	})
+	b.ReportAllocs()
+}
+
+func BenchmarkTagBuilderLowCardinality(b *testing.B) {
+	tagger := initTagger()
+	defer tagger.Stop()
+
+	b.RunParallel(func(pb *testing.PB) {
+		tb := util.NewTagsBuilder()
+		for pb.Next() {
+			tagger.TagBuilder("test", collectors.LowCardinality, tb)
+			tb.Reset()
+		}
+	})
+	b.ReportAllocs()
+}
+
+func BenchmarkTagHighCardinality(b *testing.B) {
+	tagger := initTagger()
+	defer tagger.Stop()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			tagger.Tag("test", collectors.HighCardinality)
+		}
+	})
+	b.ReportAllocs()
+}
+
+func BenchmarkTagBuilderHighCardinality(b *testing.B) {
+	tagger := initTagger()
+	defer tagger.Stop()
+
+	b.RunParallel(func(pb *testing.PB) {
+		tb := util.NewTagsBuilder()
+		for pb.Next() {
+			tagger.TagBuilder("test", collectors.HighCardinality, tb)
+			tb.Reset()
+		}
+	})
+	b.ReportAllocs()
+}

--- a/pkg/tagger/local/tagger_test.go
+++ b/pkg/tagger/local/tagger_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
@@ -119,6 +120,32 @@ func TestFetchAllMiss(t *testing.T) {
 
 	streamer.AssertCalled(t, "Fetch", "entity_name")
 	puller.AssertCalled(t, "Fetch", "entity_name")
+}
+
+func TestTagBuilder(t *testing.T) {
+	catalog := collectors.Catalog{"stream": NewDummyStreamer, "pull": NewDummyPuller}
+	tagger := NewTagger(catalog)
+	tagger.Init()
+	defer tagger.Stop()
+
+	tagger.store.processTagInfo([]*collectors.TagInfo{
+		{
+			Entity:       "entity_name",
+			Source:       "stream",
+			LowCardTags:  []string{"low1"},
+			HighCardTags: []string{"high"},
+		},
+		{
+			Entity:      "entity_name",
+			Source:      "pull",
+			LowCardTags: []string{"low2"},
+		},
+	})
+
+	tb := util.NewTagsBuilder()
+	err := tagger.TagBuilder("entity_name", collectors.HighCardinality, tb)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"high", "low1", "low2"}, tb.Get())
 }
 
 func TestFetchAllCached(t *testing.T) {

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -127,6 +128,15 @@ func (t *Tagger) Tag(entityID string, cardinality collectors.TagCardinality) ([]
 	}
 
 	return []string{}, nil
+}
+
+// TagBuilder returns tags for a given entity at the desired cardinality.
+func (t *Tagger) TagBuilder(entityID string, cardinality collectors.TagCardinality, tb *util.TagsBuilder) error {
+	tags, err := t.Tag(entityID, cardinality)
+	if err == nil {
+		tb.Append(tags...)
+	}
+	return err
 }
 
 // Standard returns the standard tags for a given entity.

--- a/pkg/util/tags_builder.go
+++ b/pkg/util/tags_builder.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.Datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+// TagsBuilder allows to build a slice of tags to generate the context while
+// reusing the same internal slice.
+type TagsBuilder struct {
+	data []string
+}
+
+// NewTagsBuilder returns a new empty TagsBuilder.
+func NewTagsBuilder() *TagsBuilder {
+	return &TagsBuilder{
+		// Slice will grow as more tags are added to it. 128 tags
+		// should be enough for most metrics.
+		data: make([]string, 0, 128)}
+}
+
+// NewTagsBuilderFromSlice return a new TagsBuilder with the input slice for
+// it's internal buffer.
+func NewTagsBuilderFromSlice(tags []string) *TagsBuilder {
+	return &TagsBuilder{
+		data: tags,
+	}
+}
+
+// Append appends tags to the builder
+func (tb *TagsBuilder) Append(tags ...string) {
+	tb.data = append(tb.data, tags...)
+}
+
+// SortUniq sorts and remove duplicate in place
+func (tb *TagsBuilder) SortUniq() {
+	tb.data = SortUniqInPlace(tb.data)
+}
+
+// Reset resets the size of the builder to 0 without discaring the internal
+// buffer
+func (tb *TagsBuilder) Reset() {
+	// we keep the internal buffer but reset size
+	tb.data = tb.data[0:0]
+}
+
+// Get returns the internal slice
+func (tb *TagsBuilder) Get() []string {
+	return tb.data
+}
+
+// Copy makes a copy of the internal slice
+func (tb *TagsBuilder) Copy() []string {
+	return append(make([]string, 0, len(tb.data)), tb.data...)
+}

--- a/pkg/util/tags_builder_test.go
+++ b/pkg/util/tags_builder_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBuilder(t *testing.T) {
+	tb := NewTagsBuilder()
+	assert.NotNil(t, tb)
+	assert.Equal(t, []string{}, tb.data)
+}
+
+func TestNewBuilderFromSlice(t *testing.T) {
+	test := []string{"a", "b", "c"}
+	tb := NewTagsBuilderFromSlice(test)
+	assert.NotNil(t, tb)
+	assert.Equal(t, test, tb.data)
+}
+
+func TestTagsBuilderAppend(t *testing.T) {
+	tb := NewTagsBuilder()
+
+	tb.Append("a", "b", "c")
+	assert.Equal(t, []string{"a", "b", "c"}, tb.data)
+
+	tb.Append("d")
+	assert.Equal(t, []string{"a", "b", "c", "d"}, tb.data)
+}
+
+func TestTagsBuilderSortUniq(t *testing.T) {
+	tb := NewTagsBuilder()
+
+	tb.Append("c", "b", "b", "a")
+	assert.Equal(t, []string{"c", "b", "b", "a"}, tb.data)
+
+	tb.SortUniq()
+	assert.Equal(t, []string{"a", "b", "c"}, tb.data)
+}
+
+func TestTagsBuilderReset(t *testing.T) {
+	tb := NewTagsBuilder()
+
+	tb.Append("a", "b", "c")
+	assert.Equal(t, []string{"a", "b", "c"}, tb.data)
+
+	tb.Reset()
+	assert.Equal(t, []string{}, tb.data)
+}
+
+func TestTagsBuilderGet(t *testing.T) {
+	tb := NewTagsBuilder()
+
+	tb.Append("a", "b", "c")
+	internalData := tb.Get()
+	assert.Equal(t, []string{"a", "b", "c"}, internalData)
+
+	// check that the internal buffer was indeed returned and not a copy
+	internalData[0] = "test"
+	assert.Equal(t, []string{"test", "b", "c"}, internalData)
+	assert.Equal(t, []string{"test", "b", "c"}, tb.data)
+}
+
+func TestTagsBuilderCopy(t *testing.T) {
+	tb := NewTagsBuilder()
+
+	tb.Append("a", "b", "c")
+	tagsCopy := tb.Copy()
+	assert.Equal(t, []string{"a", "b", "c"}, tagsCopy)
+	assert.NotSame(t, &tagsCopy, &tb.data)
+
+	tagsCopy[0] = "test"
+	assert.Equal(t, []string{"test", "b", "c"}, tagsCopy)
+	assert.Equal(t, []string{"a", "b", "c"}, tb.data)
+}


### PR DESCRIPTION
### What does this PR do?

When enriching tags for each dogstatsd point we do not need the copy.
The removed copy use to create a lot of allocation (1 per dogstatsd
point) and longer GC runs.

The copy was there to prevent modification of the dat in the cache from
outside the tagger. Since enrichTags only read the data it's safe.

benchmark:

```
BenchmarkTagLowCardinality
BenchmarkTagLowCardinality-6           	 6154857	       197 ns/op	     112 B/op	       2 allocs/op
BenchmarkTagBuilderLowCardinality
BenchmarkTagBuilderLowCardinality-6    	 8601315	       143 ns/op	      16 B/op	       1 allocs/op
BenchmarkTagHighCardinality
BenchmarkTagHighCardinality-6          	 3733388	       316 ns/op	     304 B/op	       2 allocs/op
BenchmarkTagBuilderHighCardinality
BenchmarkTagBuilderHighCardinality-6   	 8447785	       147 ns/op	      16 B/op	       1 allocs/op
```