### PR TITLE
Remove time limit on perf batch flush

### DIFF
--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "736426d51437e2e72efd6dc6df1a4d916bd3e4379bd281897c66851d1a75f12f")
+var Tracer = NewRuntimeAsset("tracer.c", "d50a9164d5aacf5dca4103f7a6e9ce8f77aeeecfb1fca0d6099c52d60ff2a36b")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "d50a9164d5aacf5dca4103f7a6e9ce8f77aeeecfb1fca0d6099c52d60ff2a36b")
+var Tracer = NewRuntimeAsset("tracer.c", "d7d6d169a62750989f9bf9f09b11ede28b641d1e9857476853d44beed0da271a")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "5d56adab080c6269c56b0d93cf5fbb5127e1188e3bdac9b0d66c4b00297a4f33")
+var Tracer = NewRuntimeAsset("tracer.c", "736426d51437e2e72efd6dc6df1a4d916bd3e4379bd281897c66851d1a75f12f")

--- a/pkg/ebpf/perf.go
+++ b/pkg/ebpf/perf.go
@@ -9,15 +9,20 @@ import (
 )
 
 type PerfHandler struct {
-	DataChannel chan []byte
+	DataChannel chan *DataEvent
 	LostChannel chan uint64
 	once        sync.Once
 	closed      bool
 }
 
+type DataEvent struct {
+	CPU  int
+	Data []byte
+}
+
 func NewPerfHandler(dataChannelSize int) *PerfHandler {
 	return &PerfHandler{
-		DataChannel: make(chan []byte, dataChannelSize),
+		DataChannel: make(chan *DataEvent, dataChannelSize),
 		LostChannel: make(chan uint64, 10),
 	}
 }
@@ -26,7 +31,7 @@ func (c *PerfHandler) DataHandler(CPU int, data []byte, perfMap *manager.PerfMap
 	if c.closed {
 		return
 	}
-	c.DataChannel <- data
+	c.DataChannel <- &DataEvent{CPU, data}
 }
 
 func (c *PerfHandler) LostHandler(CPU int, lostCount uint64, perfMap *manager.PerfMap, manager *manager.Manager) {

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -385,11 +385,11 @@ int kprobe__tcp_close(struct pt_regs* ctx) {
     sk = (struct sock*)PT_REGS_PARM1(ctx);
 
     // Get network namespace id
-    log_debug("kprobe/tcp_close: pid_tgid: %d, ns: %d\n", pid_tgid, get_netns_from_sock(sk));
-
+    log_debug("kprobe/tcp_close: tgid: %u, pid: %u\n", pid_tgid >> 32, pid_tgid & 0xFFFFFFFF);
     if (!read_conn_tuple(&t, sk, pid_tgid, CONN_TYPE_TCP)) {
         return 0;
     }
+    log_debug("kprobe/tcp_close: netns: %u, sport: %u, dport: %u\n", t.netns, t.sport, t.dport);
 
     cleanup_conn(&t);
     return 0;

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -311,11 +311,11 @@ int kprobe__tcp_close(struct pt_regs* ctx) {
     sk = (struct sock*)PT_REGS_PARM1(ctx);
 
     // Get network namespace id
-    log_debug("kprobe/tcp_close: pid_tgid: %d, ns: %d\n", pid_tgid, get_netns_from_sock(sk));
-
+    log_debug("kprobe/tcp_close: tgid: %u, pid: %u\n", pid_tgid >> 32, pid_tgid & 0xFFFFFFFF);
     if (!read_conn_tuple(&t, sk, pid_tgid, CONN_TYPE_TCP)) {
         return 0;
     }
+    log_debug("kprobe/tcp_close: netns: %u, sport: %u, dport: %u\n", t.netns, t.sport, t.dport);
 
     cleanup_conn(&t);
     return 0;

--- a/pkg/network/ebpf/c/tracer.h
+++ b/pkg/network/ebpf/c/tracer.h
@@ -160,7 +160,6 @@ typedef struct {
     conn_t c3;
     conn_t c4;
     __u16 len;
-    __u16 cpu;
     __u64 id;
 } batch_t;
 

--- a/pkg/network/ebpf/c/tracer.h
+++ b/pkg/network/ebpf/c/tracer.h
@@ -159,8 +159,9 @@ typedef struct {
     conn_t c2;
     conn_t c3;
     conn_t c4;
-    __u16 pos;
+    __u16 len;
     __u16 cpu;
+    __u64 id;
 } batch_t;
 
 // Telemetry names

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -105,13 +105,13 @@ func (m *Monitor) Start() error {
 		defer report.Stop()
 		for {
 			select {
-			case data, ok := <-m.perfHandler.DataChannel:
+			case dataEvent, ok := <-m.perfHandler.DataChannel:
 				if !ok {
 					return
 				}
 
 				// The notification we read from the perf ring tells us which HTTP batch of transactions is ready to be consumed
-				notification := toHTTPNotification(data)
+				notification := toHTTPNotification(dataEvent.Data)
 				transactions, err := m.batchManager.GetTransactionsFrom(notification)
 				m.process(transactions, err)
 			case _, ok := <-m.perfHandler.LostChannel:

--- a/pkg/network/tracer/perf_batching.go
+++ b/pkg/network/tracer/perf_batching.go
@@ -2,6 +2,10 @@
 
 package tracer
 
+/*
+#include "../ebpf/c/tracer.h"
+*/
+import "C"
 import (
 	"fmt"
 	"time"
@@ -11,6 +15,8 @@ import (
 
 	"github.com/DataDog/ebpf"
 )
+
+const ConnCloseBatchSize = uint16(C.CONN_CLOSED_BATCH_SIZE)
 
 // PerfBatchManager is reponsbile for two things:
 //
@@ -25,73 +31,136 @@ type PerfBatchManager struct {
 
 	// stateByCPU contains the state of each batch.
 	// The slice is indexed by the CPU core number.
-	stateByCPU []batchState
+	stateByCPU []percpuState
 }
 
 // NewPerfBatchManager returns a new `PerfBatchManager` and initializes the
 // eBPF map that holds the tcp_close batch objects.
-func NewPerfBatchManager(batchMap *ebpf.Map, numBatches int) (*PerfBatchManager, error) {
+func NewPerfBatchManager(batchMap *ebpf.Map, numCPUs int) (*PerfBatchManager, error) {
 	if batchMap == nil {
 		return nil, fmt.Errorf("batchMap is nil")
 	}
 
-	for i := 0; i < numBatches; i++ {
+	state := make([]percpuState, numCPUs)
+	for cpu := 0; cpu < numCPUs; cpu++ {
 		b := new(batch)
-		b.cpu = _Ctype_ushort(i)
-		batchMap.Put(unsafe.Pointer(&i), unsafe.Pointer(b))
+		b.cpu = C.__u16(cpu)
+		batchMap.Put(unsafe.Pointer(&cpu), unsafe.Pointer(b))
+		state[cpu] = percpuState{
+			processed: make(map[uint64]batchState),
+		}
 	}
 
 	return &PerfBatchManager{
 		batchMap:   batchMap,
-		stateByCPU: make([]batchState, numBatches),
+		stateByCPU: state,
 	}, nil
 }
 
 // Extract from the given batch all connections that haven't been processed yet.
 // This method is also responsible for keeping track of each CPU core batch state.
-func (p *PerfBatchManager) Extract(b *batch, now time.Time) []network.ConnectionStats {
+func (p *PerfBatchManager) Extract(b *batch) []network.ConnectionStats {
 	if int(b.cpu) >= len(p.stateByCPU) {
 		return nil
 	}
 
-	state := &p.stateByCPU[b.cpu]
-	lastOffset := state.offset
-	state.offset = 0
+	batchId := uint64(b.id)
+	cpuState := &p.stateByCPU[b.cpu]
+	start := uint16(0)
+	if bState, ok := cpuState.processed[batchId]; ok {
+		start = bState.offset
+	}
 
-	buffer := make([]network.ConnectionStats, 0, ConnCloseBatchSize)
-	return ExtractBatchInto(buffer, b, lastOffset, ConnCloseBatchSize)
+	buffer := make([]network.ConnectionStats, 0, ConnCloseBatchSize-start)
+	conns := p.extractBatchInto(buffer, b, start, ConnCloseBatchSize)
+	if len(conns) > 0 {
+		cpuState.processed[batchId] = batchState{offset: ConnCloseBatchSize, updated: time.Now()}
+	}
+
+	p.cleanupExpiredState()
+	return conns
 }
 
 // GetIdleConns return all connections that have been "stuck" in idle batches
 // for more than `idleInterval`
 func (p *PerfBatchManager) GetIdleConns() []network.ConnectionStats {
 	var idle []network.ConnectionStats
-	batch := new(batch)
-	for i := 0; i < len(p.stateByCPU); i++ {
-		state := &p.stateByCPU[i]
+	b := new(batch)
+	for cpu := 0; cpu < len(p.stateByCPU); cpu++ {
+		cpuState := &p.stateByCPU[cpu]
 
 		// we have an idle batch, so let's retrieve its data from eBPF
-		err := p.batchMap.Lookup(unsafe.Pointer(&i), unsafe.Pointer(batch))
+		err := p.batchMap.Lookup(unsafe.Pointer(&cpu), unsafe.Pointer(b))
 		if err != nil {
 			continue
 		}
 
-		pos := int(batch.pos)
-		if pos == 0 {
+		batchLen := uint16(b.len)
+		if batchLen == 0 {
 			continue
 		}
-
-		if pos == state.offset {
-			continue
+		// have we already processed these messages?
+		start := uint16(0)
+		batchId := uint64(b.id)
+		if bState, ok := cpuState.processed[batchId]; ok {
+			if batchLen <= bState.offset {
+				continue
+			}
+			start = bState.offset
 		}
 
-		idle = ExtractBatchInto(idle, batch, state.offset, pos)
-		state.offset = pos
+		idle = p.extractBatchInto(idle, b, start, batchLen)
+		if len(idle) > 0 {
+			cpuState.processed[batchId] = batchState{offset: batchLen, updated: time.Now()}
+		}
 	}
 
+	p.cleanupExpiredState()
 	return idle
 }
 
+type percpuState struct {
+	// map of batch id -> offset of conns already processed by GetIdleConns
+	processed map[uint64]batchState
+}
+
 type batchState struct {
-	offset int
+	offset  uint16
+	updated time.Time
+}
+
+// ExtractBatchInto extract network.ConnectionStats objects from the given `batch` into the supplied `buffer`.
+// The `start` (inclusive) and `end` (exclusive) arguments represent the offsets of the connections we're interested in.
+func (p *PerfBatchManager) extractBatchInto(buffer []network.ConnectionStats, b *batch, start, end uint16) []network.ConnectionStats {
+	if start >= end || end > ConnCloseBatchSize {
+		return nil
+	}
+
+	current := uintptr(unsafe.Pointer(b)) + uintptr(start)*C.sizeof_conn_t
+	for i := start; i < end; i++ {
+		ct := Conn(*(*C.conn_t)(unsafe.Pointer(current)))
+
+		tup := ConnTuple(ct.tup)
+		cst := ConnStatsWithTimestamp(ct.conn_stats)
+		tst := TCPStats(ct.tcp_stats)
+
+		buffer = append(buffer, connStats(&tup, &cst, &tst))
+		current += C.sizeof_conn_t
+	}
+
+	return buffer
+}
+
+const expiredStateInterval = 60 * time.Second
+
+func (p *PerfBatchManager) cleanupExpiredState() {
+	now := time.Now()
+	for cpu := 0; cpu < len(p.stateByCPU); cpu++ {
+		cpuState := &p.stateByCPU[cpu]
+		for id, s := range cpuState.processed {
+			if now.Sub(s.updated) > expiredStateInterval {
+				delete(cpuState.processed, id)
+			}
+		}
+	}
 }

--- a/pkg/network/tracer/perf_batching.go
+++ b/pkg/network/tracer/perf_batching.go
@@ -26,15 +26,11 @@ type PerfBatchManager struct {
 	// stateByCPU contains the state of each batch.
 	// The slice is indexed by the CPU core number.
 	stateByCPU []batchState
-
-	// maxIdleInterval represents the maximum time (in nanoseconds)
-	// a batch can remain idle (that is, without being flushed) on eBPF
-	maxIdleInterval int64
 }
 
 // NewPerfBatchManager returns a new `PerfBatchManager` and initializes the
 // eBPF map that holds the tcp_close batch objects.
-func NewPerfBatchManager(batchMap *ebpf.Map, maxIdleInterval time.Duration, numBatches int) (*PerfBatchManager, error) {
+func NewPerfBatchManager(batchMap *ebpf.Map, numBatches int) (*PerfBatchManager, error) {
 	if batchMap == nil {
 		return nil, fmt.Errorf("batchMap is nil")
 	}
@@ -46,9 +42,8 @@ func NewPerfBatchManager(batchMap *ebpf.Map, maxIdleInterval time.Duration, numB
 	}
 
 	return &PerfBatchManager{
-		batchMap:        batchMap,
-		stateByCPU:      make([]batchState, numBatches),
-		maxIdleInterval: maxIdleInterval.Nanoseconds(),
+		batchMap:   batchMap,
+		stateByCPU: make([]batchState, numBatches),
 	}, nil
 }
 
@@ -61,7 +56,6 @@ func (p *PerfBatchManager) Extract(b *batch, now time.Time) []network.Connection
 
 	state := &p.stateByCPU[b.cpu]
 	lastOffset := state.offset
-	state.updated = now.UnixNano()
 	state.offset = 0
 
 	buffer := make([]network.ConnectionStats, 0, ConnCloseBatchSize)
@@ -70,16 +64,11 @@ func (p *PerfBatchManager) Extract(b *batch, now time.Time) []network.Connection
 
 // GetIdleConns return all connections that have been "stuck" in idle batches
 // for more than `idleInterval`
-func (p *PerfBatchManager) GetIdleConns(now time.Time) []network.ConnectionStats {
+func (p *PerfBatchManager) GetIdleConns() []network.ConnectionStats {
 	var idle []network.ConnectionStats
-	nowTS := now.UnixNano()
 	batch := new(batch)
 	for i := 0; i < len(p.stateByCPU); i++ {
 		state := &p.stateByCPU[i]
-
-		if (nowTS - state.updated) < p.maxIdleInterval {
-			continue
-		}
 
 		// we have an idle batch, so let's retrieve its data from eBPF
 		err := p.batchMap.Lookup(unsafe.Pointer(&i), unsafe.Pointer(batch))
@@ -92,7 +81,6 @@ func (p *PerfBatchManager) GetIdleConns(now time.Time) []network.ConnectionStats
 			continue
 		}
 
-		state.updated = nowTS
 		if pos == state.offset {
 			continue
 		}
@@ -105,6 +93,5 @@ func (p *PerfBatchManager) GetIdleConns(now time.Time) []network.ConnectionStats
 }
 
 type batchState struct {
-	offset  int
-	updated int64
+	offset int
 }

--- a/pkg/network/tracer/perf_batching_test.go
+++ b/pkg/network/tracer/perf_batching_test.go
@@ -27,9 +27,8 @@ func TestPerfBatchManagerExtract(t *testing.T) {
 		batch.c2.tup.pid = 3
 		batch.c3.tup.pid = 4
 		batch.c4.tup.pid = 5
-		batch.cpu = 0
 
-		conns := manager.Extract(batch)
+		conns := manager.Extract(batch, 0)
 		assert.Len(t, conns, 5)
 		assert.Equal(t, uint32(1), conns[0].Pid)
 		assert.Equal(t, uint32(2), conns[1].Pid)
@@ -48,14 +47,13 @@ func TestPerfBatchManagerExtract(t *testing.T) {
 		batch.c2.tup.pid = 3
 		batch.c3.tup.pid = 4
 		batch.c4.tup.pid = 5
-		batch.cpu = 0
 
 		// Simulate a partial flush
 		manager.stateByCPU[0].processed = map[uint64]batchState{
 			0: {offset: 3},
 		}
 
-		conns := manager.Extract(batch)
+		conns := manager.Extract(batch, 0)
 		assert.Len(t, conns, 2)
 		assert.Equal(t, uint32(4), conns[0].Pid)
 		assert.Equal(t, uint32(5), conns[1].Pid)
@@ -71,10 +69,10 @@ func TestGetIdleConns(t *testing.T) {
 	batch.c0.tup.pid = 1
 	batch.c1.tup.pid = 2
 	batch.len = 2
-	batch.cpu = 0
 
+	cpu := 0
 	updateBatch := func() {
-		manager.batchMap.Put(unsafe.Pointer(&batch.cpu), unsafe.Pointer(batch))
+		manager.batchMap.Put(unsafe.Pointer(&cpu), unsafe.Pointer(batch))
 	}
 	updateBatch()
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -410,7 +410,7 @@ func (t *Tracer) initPerfPolling(perf *ddebpf.PerfHandler) (*manager.PerfMap, *P
 	connCloseEventMap, _ := t.getMap(probes.ConnCloseEventMap)
 	connCloseMap, _ := t.getMap(probes.ConnCloseBatchMap)
 	numCPUs := int(connCloseEventMap.ABI().MaxEntries)
-	batchManager, err := NewPerfBatchManager(connCloseMap, 30*time.Second, numCPUs)
+	batchManager, err := NewPerfBatchManager(connCloseMap, numCPUs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -444,7 +444,7 @@ func (t *Tracer) initPerfPolling(perf *ddebpf.PerfHandler) (*manager.PerfMap, *P
 				if !ok {
 					return
 				}
-				idleConns := t.batchManager.GetIdleConns(time.Now())
+				idleConns := t.batchManager.GetIdleConns()
 				for _, c := range idleConns {
 					t.storeClosedConn(&c)
 				}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -430,8 +430,8 @@ func (t *Tracer) initPerfPolling(perf *ddebpf.PerfHandler) (*manager.PerfMap, *P
 				}
 				atomic.AddInt64(&t.perfReceived, 1)
 
-				batch := toBatch(batchData)
-				conns := t.batchManager.Extract(batch)
+				batch := toBatch(batchData.Data)
+				conns := t.batchManager.Extract(batch, batchData.CPU)
 				for _, c := range conns {
 					t.storeClosedConn(&c)
 				}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -431,7 +431,7 @@ func (t *Tracer) initPerfPolling(perf *ddebpf.PerfHandler) (*manager.PerfMap, *P
 				atomic.AddInt64(&t.perfReceived, 1)
 
 				batch := toBatch(batchData)
-				conns := t.batchManager.Extract(batch, time.Now())
+				conns := t.batchManager.Extract(batch)
 				for _, c := range conns {
 					t.storeClosedConn(&c)
 				}


### PR DESCRIPTION
### What does this PR do?

Having a minimum "idle" time for flushing connections from a connection batch was causing connections to be missed during tests. This would also manifest in production by connections not being returned in the interval they occurred, but the next one.

### Motivation

Lots of flaky tests that were often caused by expected connections not appearing.

### Describe your test plan

Automated tests updated.