### PR TITLE
Fix CircleCI MacOS tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
       - run:
           name: Install python deps & clang-format
           command: |
-            brew install clang-format
+            brew install clang-format || brew link --overwrite clang-format
             python3 -m pip install -r requirements.txt
       - save_cache:
           key: v2-macosdeps-{{ .Branch }}-{{ .Revision }}
@@ -260,6 +260,7 @@ jobs:
             - /usr/local/Cellar
             - /usr/local/lib
             - /usr/local/Frameworks
+            - /usr/local/opt/openssl@1.1
       - run:
           name: Compile rtloader
           command: |


### PR DESCRIPTION
### What does this PR do?

- Homebrew/homebrew-core@3f2a0d5052bef808d570f8f3ed2f087fece20fc7 updated `clang-format`. Since #7436 introduced a cache we need to fallback to overwriting the links when there is an update.
- I also found a path missing from cache: Python couldn't load the ssl module since OpenSSL is stored in `/usr/local/opt`

### Motivation

Fix CI