### PR TITLE
Release note for host tags fix

### DIFF
--- a/releasenotes/notes/empty-host-tags-fix-bed5569e2f17b1e5.yaml
+++ b/releasenotes/notes/empty-host-tags-fix-bed5569e2f17b1e5.yaml
@@ -1,10 +1,3 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
 fixes:
   - |

--- a/releasenotes/notes/empty-host-tags-fix-bed5569e2f17b1e5.yaml
+++ b/releasenotes/notes/empty-host-tags-fix-bed5569e2f17b1e5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Agent host tags are now correctly removed from the in-app host when the configured `tags`/`DD_TAGS` list is empty or not defined.

--- a/releasenotes/notes/empty-host-tags-fix-bed5569e2f17b1e5.yaml
+++ b/releasenotes/notes/empty-host-tags-fix-bed5569e2f17b1e5.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Agent host tags are now correctly removed from the in-app host when the configured `tags`/`DD_TAGS` list is empty or not defined.
+    Agent host tags are now correctly removed from the in-app host when the configured ``tags``/``DD_TAGS`` list is empty or not defined.


### PR DESCRIPTION
### What does this PR do?

Add a release note for https://github.com/DataDog/datadog-agent/pull/7377
