### PR TITLE
Refactor agent.omnibus-build and add agent.omnibus-manifest

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -375,6 +375,7 @@ def omnibus_build(
     system_probe_bin=None,
     libbcc_tarball=None,
     with_bcc=True,
+    manifest_only=False,
 ):
     """
     Build the Agent packages with Omnibus Installer.
@@ -432,9 +433,15 @@ def omnibus_build(
             # The full explanation is available on this PR: https://github.com/DataDog/datadog-agent/pull/5010.
             omnibus = "unset __PYVENV_LAUNCHER__ && bundle exec omnibus"
 
-        cmd = "{omnibus} build {project_name} --log-level={log_level} {populate_s3_cache} {overrides}"
+        if manifest_only:
+            task = "manifest"
+        else:
+            task = "build"
+
+        cmd = "{omnibus} {task} {project_name} --log-level={log_level} {populate_s3_cache} {overrides}"
         args = {
             "omnibus": omnibus,
+            "task": task,
             "project_name": target_project,
             "log_level": log_level,
             "overrides": overrides_cmd,

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -368,8 +368,8 @@ def get_omnibus_env(
         # get certificate and password from ssm
         pfxfile = get_signing_cert(ctx)
         pfxpass = get_pfx_pass(ctx)
-        env['SIGN_PFX'] = "{}".format(pfxfile)
-        env['SIGN_PFX_PW'] = "{}".format(pfxpass)
+        env['SIGN_PFX'] = str(pfxfile)
+        env['SIGN_PFX_PW'] = str(pfxpass)
 
     if sys.platform == 'darwin':
         # Target MacOS 10.12
@@ -385,9 +385,9 @@ def get_omnibus_env(
     env['PY_RUNTIMES'] = python_runtimes
     if with_bcc:
         env['WITH_BCC'] = 'true'
-    if system_probe_bin is not None:
+    if system_probe_bin:
         env['SYSTEM_PROBE_BIN'] = system_probe_bin
-    if libbcc_tarball is not None:
+    if libbcc_tarball:
         env['LIBBCC_TARBALL'] = libbcc_tarball
 
     return env

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -351,6 +351,94 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False, 
         ctx.run("{} {}".format(go_cmd, prefix))
 
 
+def get_omnibus_env(
+    ctx,
+    skip_sign=False,
+    release_version="nightly",
+    major_version='7',
+    python_runtimes='3',
+    hardened_runtime=False,
+    system_probe_bin=None,
+    libbcc_tarball=None,
+    with_bcc=True,
+):
+    env = load_release_versions(ctx, release_version)
+
+    if sys.platform == 'win32' and os.environ.get('SIGN_WINDOWS'):
+        # get certificate and password from ssm
+        pfxfile = get_signing_cert(ctx)
+        pfxpass = get_pfx_pass(ctx)
+        env['SIGN_PFX'] = "{}".format(pfxfile)
+        env['SIGN_PFX_PW'] = "{}".format(pfxpass)
+
+    if sys.platform == 'darwin':
+        # Target MacOS 10.12
+        env['MACOSX_DEPLOYMENT_TARGET'] = '10.12'
+
+    if skip_sign:
+        env['SKIP_SIGN_MAC'] = 'true'
+    if hardened_runtime:
+        env['HARDENED_RUNTIME_MAC'] = 'true'
+
+    env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, major_version=major_version, env=env)
+    env['MAJOR_VERSION'] = major_version
+    env['PY_RUNTIMES'] = python_runtimes
+    if with_bcc:
+        env['WITH_BCC'] = 'true'
+    if system_probe_bin is not None:
+        env['SYSTEM_PROBE_BIN'] = system_probe_bin
+    if libbcc_tarball is not None:
+        env['LIBBCC_TARBALL'] = libbcc_tarball
+
+    return env
+
+
+def omnibus_run_task(ctx, task, target_project, base_dir, env, omnibus_s3_cache=False, log_level="info"):
+    with ctx.cd("omnibus"):
+        overrides_cmd = ""
+        if base_dir:
+            overrides_cmd = "--override=base_dir:{}".format(base_dir)
+
+        omnibus = "bundle exec omnibus"
+        if sys.platform == 'win32':
+            omnibus = "bundle exec omnibus.bat"
+        elif sys.platform == 'darwin':
+            # HACK: This is an ugly hack to fix another hack made by python3 on MacOS
+            # The full explanation is available on this PR: https://github.com/DataDog/datadog-agent/pull/5010.
+            omnibus = "unset __PYVENV_LAUNCHER__ && bundle exec omnibus"
+
+        if omnibus_s3_cache:
+            populate_s3_cache = "--populate-s3-cache"
+        else:
+            populate_s3_cache = ""
+
+        cmd = "{omnibus} {task} {project_name} --log-level={log_level} {populate_s3_cache} {overrides}"
+        args = {
+            "omnibus": omnibus,
+            "task": task,
+            "project_name": target_project,
+            "log_level": log_level,
+            "overrides": overrides_cmd,
+            "populate_s3_cache": populate_s3_cache,
+        }
+
+        ctx.run(cmd.format(**args), env=env)
+
+
+def bundle_install_omnibus(ctx, gem_path=None, env=None):
+    with ctx.cd("omnibus"):
+        # make sure bundle install starts from a clean state
+        try:
+            os.remove("Gemfile.lock")
+        except Exception:
+            pass
+
+        cmd = "bundle install"
+        if gem_path:
+            cmd += " --path {}".format(gem_path)
+        ctx.run(cmd, env=env)
+
+
 # hardened-runtime needs to be set to False to build on MacOS < 10.13.6, as the -o runtime option is not supported.
 @task(
     help={
@@ -375,7 +463,6 @@ def omnibus_build(
     system_probe_bin=None,
     libbcc_tarball=None,
     with_bcc=True,
-    manifest_only=False,
 ):
     """
     Build the Agent packages with Omnibus Installer.
@@ -389,114 +476,109 @@ def omnibus_build(
         deps_end = datetime.datetime.now()
         deps_elapsed = deps_end - deps_start
 
-    # omnibus config overrides
-    overrides = []
-
     # base dir (can be overridden through env vars, command line takes precedence)
     base_dir = base_dir or os.environ.get("OMNIBUS_BASE_DIR")
-    if base_dir:
-        overrides.append("base_dir:{}".format(base_dir))
 
-    overrides_cmd = ""
-    if overrides:
-        overrides_cmd = "--override=" + " ".join(overrides)
+    env = get_omnibus_env(
+        ctx,
+        skip_sign=skip_sign,
+        release_version=release_version,
+        major_version=major_version,
+        python_runtimes=python_runtimes,
+        hardened_runtime=hardened_runtime,
+        system_probe_bin=system_probe_bin,
+        libbcc_tarball=libbcc_tarball,
+        with_bcc=with_bcc,
+    )
 
-    with ctx.cd("omnibus"):
-        # make sure bundle install starts from a clean state
-        try:
-            os.remove("Gemfile.lock")
-        except Exception:
-            pass
+    target_project = "agent"
+    if iot:
+        target_project = "iot-agent"
+    elif agent_binaries:
+        target_project = "agent-binaries"
 
-        env = load_release_versions(ctx, release_version)
+    bundle_start = datetime.datetime.now()
+    bundle_install_omnibus(ctx, gem_path, env)
+    bundle_done = datetime.datetime.now()
+    bundle_elapsed = bundle_done - bundle_start
 
-        cmd = "bundle install"
-        if gem_path:
-            cmd += " --path {}".format(gem_path)
+    omnibus_start = datetime.datetime.now()
+    omnibus_run_task(
+        ctx=ctx,
+        task="build",
+        target_project=target_project,
+        base_dir=base_dir,
+        env=env,
+        omnibus_s3_cache=omnibus_s3_cache,
+        log_level=log_level,
+    )
+    omnibus_done = datetime.datetime.now()
+    omnibus_elapsed = omnibus_done - omnibus_start
 
-        bundle_start = datetime.datetime.now()
-        ctx.run(cmd, env=env)
+    print("Build component timing:")
+    if not skip_deps:
+        print("Deps:    {}".format(deps_elapsed))
+    print("Bundle:  {}".format(bundle_elapsed))
+    print("Omnibus: {}".format(omnibus_elapsed))
 
-        bundle_done = datetime.datetime.now()
-        bundle_elapsed = bundle_done - bundle_start
-        target_project = "agent"
-        if iot:
-            target_project = "iot-agent"
-        elif agent_binaries:
-            target_project = "agent-binaries"
 
-        omnibus = "bundle exec omnibus"
-        if sys.platform == 'win32':
-            omnibus = "bundle exec omnibus.bat"
-        elif sys.platform == 'darwin':
-            # HACK: This is an ugly hack to fix another hack made by python3 on MacOS
-            # The full explanation is available on this PR: https://github.com/DataDog/datadog-agent/pull/5010.
-            omnibus = "unset __PYVENV_LAUNCHER__ && bundle exec omnibus"
+@task
+def omnibus_manifest(
+    ctx,
+    platform=None,
+    arch=None,
+    iot=False,
+    agent_binaries=False,
+    log_level="info",
+    base_dir=None,
+    gem_path=None,
+    skip_sign=False,
+    release_version="nightly",
+    major_version='7',
+    python_runtimes='3',
+    hardened_runtime=False,
+    system_probe_bin=None,
+    libbcc_tarball=None,
+    with_bcc=True,
+):
+    # base dir (can be overridden through env vars, command line takes precedence)
+    base_dir = base_dir or os.environ.get("OMNIBUS_BASE_DIR")
 
-        if manifest_only:
-            task = "manifest"
-        else:
-            task = "build"
+    env = get_omnibus_env(
+        ctx,
+        skip_sign=skip_sign,
+        release_version=release_version,
+        major_version=major_version,
+        python_runtimes=python_runtimes,
+        hardened_runtime=hardened_runtime,
+        system_probe_bin=system_probe_bin,
+        libbcc_tarball=libbcc_tarball,
+        with_bcc=with_bcc,
+    )
 
-        cmd = "{omnibus} {task} {project_name} --log-level={log_level} {populate_s3_cache} {overrides}"
-        args = {
-            "omnibus": omnibus,
-            "task": task,
-            "project_name": target_project,
-            "log_level": log_level,
-            "overrides": overrides_cmd,
-            "populate_s3_cache": "",
-        }
-        pfxfile = None
-        try:
-            if sys.platform == 'win32' and os.environ.get('SIGN_WINDOWS'):
-                # get certificate and password from ssm
-                pfxfile = get_signing_cert(ctx)
-                pfxpass = get_pfx_pass(ctx)
-                # hack for now.  Remove `sign_windows, and set sign_pfx`
-                env['SIGN_PFX'] = "{}".format(pfxfile)
-                env['SIGN_PFX_PW'] = "{}".format(pfxpass)
+    target_project = "agent"
+    if iot:
+        target_project = "iot-agent"
+    elif agent_binaries:
+        target_project = "agent-binaries"
 
-            if sys.platform == 'darwin':
-                # Target MacOS 10.12
-                env['MACOSX_DEPLOYMENT_TARGET'] = '10.12'
+    bundle_install_omnibus(ctx, gem_path, env)
 
-            if omnibus_s3_cache:
-                args['populate_s3_cache'] = " --populate-s3-cache "
-            if skip_sign:
-                env['SKIP_SIGN_MAC'] = 'true'
-            if hardened_runtime:
-                env['HARDENED_RUNTIME_MAC'] = 'true'
+    task = "manifest"
+    if platform is not None:
+        task += " --platform-family={} --platform={} ".format(platform, platform)
+    if arch is not None:
+        task += " --architecture={} ".format(arch)
 
-            env['PACKAGE_VERSION'] = get_version(
-                ctx, include_git=True, url_safe=True, major_version=major_version, env=env
-            )
-            env['MAJOR_VERSION'] = major_version
-            env['PY_RUNTIMES'] = python_runtimes
-            if with_bcc:
-                env['WITH_BCC'] = 'true'
-            if system_probe_bin is not None:
-                env['SYSTEM_PROBE_BIN'] = system_probe_bin
-            if libbcc_tarball is not None:
-                env['LIBBCC_TARBALL'] = libbcc_tarball
-            omnibus_start = datetime.datetime.now()
-            ctx.run(cmd.format(**args), env=env)
-            omnibus_done = datetime.datetime.now()
-            omnibus_elapsed = omnibus_done - omnibus_start
-
-        except Exception:
-            if pfxfile:
-                os.remove(pfxfile)
-            raise
-
-        if pfxfile:
-            os.remove(pfxfile)
-
-        print("Build compoonent timing:")
-        if not skip_deps:
-            print("Deps:    {}".format(deps_elapsed))
-        print("Bundle:  {}".format(bundle_elapsed))
-        print("Omnibus: {}".format(omnibus_elapsed))
+    omnibus_run_task(
+        ctx=ctx,
+        task=task,
+        target_project=target_project,
+        base_dir=base_dir,
+        env=env,
+        omnibus_s3_cache=False,
+        log_level=log_level,
+    )
 
 
 @task

--- a/tasks/ssm.py
+++ b/tasks/ssm.py
@@ -1,3 +1,4 @@
+import atexit
 import base64
 import json
 import os
@@ -55,6 +56,12 @@ def get_signing_cert(ctx):
     f, fn = tempfile.mkstemp()  # default mode is binary, which we want
     os.write(f, pfx_b64_decoded)
     os.close(f)
+
+    def delete_pfxfile():
+        os.remove(fn)
+
+    atexit.register(delete_pfxfile)
+
     return fn
 
 


### PR DESCRIPTION
### What does this PR do?

- Split `agent.omnibus_build` in smaller functions.
- Add a new `agent.omnibus_manifest` task that reuses some of those functions, but calling `omnibus manifest` instead of `omnibus build`.

### Motivation

Add a way to call `omnibus manifest` to make it easier to audit which dependencies are being built.
