### PR TITLE
[install script] Improve behavior on non-interactive shells

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -72,6 +72,11 @@ Troubleshooting and basic usage information for the Agent are available at:
 
     https://docs.datadoghq.com/agent/basic_agent_usage/\n\033[0m\n"
 
+    if ! tty -s; then
+      fallback_msg
+      exit 1;
+    fi
+    
     while true; do
         read -t 60 -p  "Do you want to send a failure report to Datadog (including $logfile)? (y/[n]) " -r yn || on_read_error
         case $yn in

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -59,6 +59,11 @@ function report(){
   fi
 }
 
+function on_read_error() {
+  printf "Timed out or input EOF reached, assuming 'No'\n"
+  yn="n"
+}
+
 function on_error() {
     printf "\033[31m$ERROR_MESSAGE
 It looks like you hit an issue when trying to install the Agent.
@@ -68,13 +73,13 @@ Troubleshooting and basic usage information for the Agent are available at:
     https://docs.datadoghq.com/agent/basic_agent_usage/\n\033[0m\n"
 
     while true; do
-        read -p  "Do you want to send a failure report to Datadog (including $logfile)? (y/n) " -r yn
+        read -t 60 -p  "Do you want to send a failure report to Datadog (including $logfile)? (y/[n]) " -r yn || on_read_error
         case $yn in
           [Yy]* )
             read -p "Enter an email address so we can follow up: " -r email
             report
             break;;
-          [Nn]* )
+          [Nn]*|"" )
             fallback_msg
             break;;
           * )

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -6,7 +6,7 @@
 # using the package manager and Datadog repositories.
 
 set -e
-install_script_version=1.3.0
+install_script_version=1.3.1
 logfile="ddagent-install.log"
 support_email=support@datadoghq.com
 

--- a/releasenotes-installscript/notes/read-timeout-19a431cf014b1fa5.yaml
+++ b/releasenotes-installscript/notes/read-timeout-19a431cf014b1fa5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    On error, the user prompt will now have a default negative answer and it will
+    time out after 60 seconds if there is no answer to prevent hanging on some
+    noninteractive environments.

--- a/releasenotes-installscript/notes/read-timeout-19a431cf014b1fa5.yaml
+++ b/releasenotes-installscript/notes/read-timeout-19a431cf014b1fa5.yaml
@@ -1,6 +1,5 @@
 ---
 fixes:
   - |
-    On error, the user prompt will now have a default negative answer and it will
-    time out after 60 seconds if there is no answer to prevent hanging on some
-    noninteractive environments.
+    On error, the user prompt will now only run when a terminal is attached.
+    It will have a default negative answer and it will time out after 60 seconds.


### PR DESCRIPTION
### What does this PR do?

- Adds some safeguards to the `read` command to account for some non-interactive shells. The command now times out if it gets no answer after 60 seconds and has a default "No" answer if the user just presses Enter.

### Motivation

- Support case

### Describe your test plan

- Tested the failure case manually on bash 4.4.20. Ran kitchen tests.