### PR TITLE
[runtime-security] remove useless dentry resolution from container path model handler

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -74,10 +74,6 @@ func (ev *Event) ResolveFileBasename(f *model.FileEvent) string {
 func (ev *Event) ResolveFileContainerPath(f *model.FileEvent) string {
 	if len(f.ContainerPath) == 0 {
 		f.ContainerPath = ev.resolvers.resolveContainerPath(&f.FileFields)
-		if len(f.ContainerPath) == 0 && len(f.PathnameStr) == 0 {
-			// The container path might be included in the pathname. The container path will be set there.
-			_ = ev.ResolveFileInode(f)
-		}
 	}
 	return f.ContainerPath
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -348,7 +348,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 
 		// Delete new mount point from cache
 		if err := p.resolvers.MountResolver.Delete(event.Umount.MountID); err != nil {
-			log.Errorf("failed to delete mount point %d from cache: %s", event.Umount.MountID, err)
+			log.Warnf("failed to delete mount point %d from cache: %s", event.Umount.MountID, err)
 		}
 	case model.FileOpenEventType:
 		if _, err := event.Open.UnmarshalBinary(data[offset:]); err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR change the loglevel of the mount point errors and remove a useless and racy dentry resolution from the container path model handler. It fixes a map access race during the snapshot.

### Motivation

Fixes a map concurrent access during the snapshot

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
