### PR TITLE
Limit the maximum disk usage based on the free disk space.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -342,6 +342,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("forwarder_outdated_file_in_days", 10)
 	config.BindEnvAndSetDefault("forwarder_flush_to_disk_mem_ratio", 0.5)
 	config.BindEnvAndSetDefault("forwarder_storage_max_size_in_bytes", 0) // 0 means disabled. This is a BETA feature.
+	config.BindEnvAndSetDefault("forwarder_storage_max_disk_ratio", 0.95) // Do not store transactions on disk when the disk usage exceeds 95% of the disk capacity.
 
 	// Dogstatsd
 	config.BindEnvAndSetDefault("use_dogstatsd", true)

--- a/pkg/forwarder/forwarder_max_storage.go
+++ b/pkg/forwarder/forwarder_max_storage.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package forwarder
+
+import (
+	math "math"
+
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
+)
+
+type forwarderMaxStorage struct {
+	diskPath       string
+	maxSizeInBytes int64
+	disk           diskUsageRetriever
+	maxDiskRatio   float64
+}
+
+type diskUsageRetriever interface {
+	GetUsage(path string) (*filesystem.DiskUsage, error)
+}
+
+func newForwarderMaxStorage(
+	diskPath string,
+	disk diskUsageRetriever,
+	maxSizeInBytes int64,
+	maxDiskRatio float64) (*forwarderMaxStorage, error) {
+	maxStorage := &forwarderMaxStorage{
+		diskPath:       diskPath,
+		maxSizeInBytes: maxSizeInBytes,
+		disk:           disk,
+		maxDiskRatio:   maxDiskRatio,
+	}
+
+	// Check if there is an error when computing the available space
+	// in this function to warn the user sonner (and not when there is an outage)
+	_, err := maxStorage.computeMaxStorage(0)
+	return maxStorage, err
+}
+
+func (s *forwarderMaxStorage) computeMaxStorage(currentSize int64) (int64, error) {
+	usage, err := s.disk.GetUsage(s.diskPath)
+	if err != nil {
+		return 0, err
+	}
+	diskReserved := float64(usage.Total) * (1 - s.maxDiskRatio)
+	availableDiskUsage := int64(usage.Available) - int64(math.Ceil(diskReserved))
+
+	return minInt64(s.maxSizeInBytes, currentSize+availableDiskUsage), nil
+}
+
+func (s *forwarderMaxStorage) getMaxSizeInBytes() int64 {
+	return s.maxSizeInBytes
+}
+
+func minInt64(v1, v2 int64) int64 {
+	if v1 < v2 {
+		return v1
+	}
+	return v2
+}

--- a/pkg/forwarder/forwarder_max_storage_test.go
+++ b/pkg/forwarder/forwarder_max_storage_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package forwarder
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
+	"github.com/stretchr/testify/require"
+)
+
+type diskUsageRetrieverMock struct {
+	diskUsage *filesystem.DiskUsage
+}
+
+func (m diskUsageRetrieverMock) GetUsage(path string) (*filesystem.DiskUsage, error) {
+	return m.diskUsage, nil
+}
+
+func TestComputeMaxStorage(t *testing.T) {
+	r := require.New(t)
+	disk := diskUsageRetrieverMock{
+		diskUsage: &filesystem.DiskUsage{
+			Available: 30,
+			Total:     100,
+		}}
+	maxSizeInBytes := int64(30)
+	storage, err := newForwarderMaxStorage("", disk, maxSizeInBytes, 0.9)
+	r.NoError(err)
+
+	max, err := storage.computeMaxStorage(10)
+	r.NoError(err)
+	r.Equal(maxSizeInBytes, max)
+
+	max, err = storage.computeMaxStorage(5)
+	r.NoError(err)
+	r.Equal(30-int64(100*(1-0.9))+5, max)
+}

--- a/pkg/forwarder/transactions_file_storage.go
+++ b/pkg/forwarder/transactions_file_storage.go
@@ -24,7 +24,7 @@ const retryFileFormat = "2006_01_02__15_04_05_"
 type transactionsFileStorage struct {
 	serializer         *TransactionsSerializer
 	storagePath        string
-	maxSizeInBytes     int64
+	maxStorage         *forwarderMaxStorage
 	filenames          []string
 	currentSizeInBytes int64
 	telemetry          transactionsFileStorageTelemetry
@@ -33,7 +33,7 @@ type transactionsFileStorage struct {
 func newTransactionsFileStorage(
 	serializer *TransactionsSerializer,
 	storagePath string,
-	maxSizeInBytes int64,
+	maxStorage *forwarderMaxStorage,
 	telemetry transactionsFileStorageTelemetry) (*transactionsFileStorage, error) {
 
 	if err := os.MkdirAll(storagePath, 0755); err != nil {
@@ -41,10 +41,10 @@ func newTransactionsFileStorage(
 	}
 
 	storage := &transactionsFileStorage{
-		serializer:     serializer,
-		storagePath:    storagePath,
-		maxSizeInBytes: maxSizeInBytes,
-		telemetry:      telemetry,
+		serializer:  serializer,
+		storagePath: storagePath,
+		maxStorage:  maxStorage,
+		telemetry:   telemetry,
 	}
 
 	if err := storage.reloadExistingRetryFiles(); err != nil {
@@ -138,11 +138,16 @@ func (s *transactionsFileStorage) getCurrentSizeInBytes() int64 {
 }
 
 func (s *transactionsFileStorage) makeRoomFor(bufferSize int64) error {
-	if bufferSize > s.maxSizeInBytes {
-		return fmt.Errorf("The payload is too big. Current:%v Maximum:%v", bufferSize, s.maxSizeInBytes)
+	maxSizeInBytes := s.maxStorage.getMaxSizeInBytes()
+	if bufferSize > maxSizeInBytes {
+		return fmt.Errorf("The payload is too big. Current:%v Maximum:%v", bufferSize, maxSizeInBytes)
 	}
 
-	for len(s.filenames) > 0 && s.currentSizeInBytes+bufferSize > s.maxSizeInBytes {
+	maxStorageInBytes, err := s.maxStorage.computeMaxStorage(s.currentSizeInBytes)
+	if err != nil {
+		return err
+	}
+	for len(s.filenames) > 0 && s.currentSizeInBytes+bufferSize > maxStorageInBytes {
 		index := 0
 		filename := s.filenames[index]
 		log.Infof("Maximum disk space for retry transactions is reached. Removing %s", filename)

--- a/pkg/forwarder/transactions_file_storage_test.go
+++ b/pkg/forwarder/transactions_file_storage_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -112,7 +113,14 @@ func getEndpointsFromTransactions(transactions []Transaction) []string {
 
 func newTestTransactionsFileStorage(a *assert.Assertions, path string, maxSizeInBytes int64) *transactionsFileStorage {
 	telemetry := transactionsFileStorageTelemetry{}
-	storage, err := newTransactionsFileStorage(NewTransactionsSerializer(domainName, nil), path, maxSizeInBytes, telemetry)
+	disk := diskUsageRetrieverMock{
+		diskUsage: &filesystem.DiskUsage{
+			Available: 10000,
+			Total:     10000,
+		}}
+	maxStorage, err := newForwarderMaxStorage("", disk, maxSizeInBytes, 1)
+	a.NoError(err)
+	storage, err := newTransactionsFileStorage(NewTransactionsSerializer(domainName, nil), path, maxStorage, telemetry)
 	a.NoError(err)
 	return storage
 }

--- a/pkg/util/filesystem/disk.go
+++ b/pkg/util/filesystem/disk.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+// +build !windows
+
+package filesystem
+
+import "github.com/shirou/gopsutil/disk"
+
+type Disk struct{}
+
+func NewDisk() Disk {
+	return Disk{}
+}
+
+func (Disk) GetUsage(path string) (*DiskUsage, error) {
+	usage, err := disk.Usage(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DiskUsage{
+		Total:     usage.Total,
+		Available: usage.Free,
+	}, nil
+}

--- a/pkg/util/filesystem/disk.go
+++ b/pkg/util/filesystem/disk.go
@@ -8,12 +8,15 @@ package filesystem
 
 import "github.com/shirou/gopsutil/disk"
 
+// Disk gets information about the disk
 type Disk struct{}
 
+// NewDisk creates a new instance of Disk
 func NewDisk() Disk {
 	return Disk{}
 }
 
+// GetUsage gets the disk usage
 func (Disk) GetUsage(path string) (*DiskUsage, error) {
 	usage, err := disk.Usage(path)
 	if err != nil {

--- a/pkg/util/filesystem/disk_usage.go
+++ b/pkg/util/filesystem/disk_usage.go
@@ -5,6 +5,7 @@
 
 package filesystem
 
+// DiskUsage is the disk usage
 type DiskUsage struct {
 	Total     uint64
 	Available uint64

--- a/pkg/util/filesystem/disk_usage.go
+++ b/pkg/util/filesystem/disk_usage.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package filesystem
+
+type DiskUsage struct {
+	Total     uint64
+	Available uint64
+}

--- a/pkg/util/filesystem/disk_windows.go
+++ b/pkg/util/filesystem/disk_windows.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+// +build windows
+
+package filesystem
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type Disk struct {
+	procGetDiskFreeSpaceExW *windows.LazyProc
+}
+
+func NewDisk() Disk {
+	modkernel32 := windows.NewLazyDLL("kernel32.dll")
+	return Disk{
+		procGetDiskFreeSpaceExW: modkernel32.NewProc("GetDiskFreeSpaceExW"),
+	}
+}
+
+func (d Disk) GetUsage(path string) (*DiskUsage, error) {
+	free := uint64(0)
+	total := uint64(0)
+
+	winPath, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, _, err := d.procGetDiskFreeSpaceExW.Call(
+		uintptr(unsafe.Pointer(winPath)),
+		uintptr(unsafe.Pointer(&free)),
+		uintptr(unsafe.Pointer(&total)),
+		uintptr(unsafe.Pointer(nil)),
+	)
+
+	if ret == 0 {
+		return nil, err
+	}
+
+	return &DiskUsage{
+		Total:     total,
+		Available: free,
+	}, nil
+}

--- a/pkg/util/filesystem/disk_windows.go
+++ b/pkg/util/filesystem/disk_windows.go
@@ -12,10 +12,12 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// Disk gets information about the disk
 type Disk struct {
 	procGetDiskFreeSpaceExW *windows.LazyProc
 }
 
+// NewDisk creates a new instance of Disk
 func NewDisk() Disk {
 	modkernel32 := windows.NewLazyDLL("kernel32.dll")
 	return Disk{
@@ -23,6 +25,7 @@ func NewDisk() Disk {
 	}
 }
 
+// GetUsage gets the disk usage
 func (d Disk) GetUsage(path string) (*DiskUsage, error) {
 	free := uint64(0)
 	total := uint64(0)


### PR DESCRIPTION
### What does this PR do?

Limit the maximum disk usage to store failed transactions.
The limit is defined as a ratio of the disk capacity, for example 90%

### Motivation

Do not fill the disk in case of misconfiguration


### Describe your test plan
Check on Windows and Unix system that when the threshold is reached (`forwarder_storage_max_disk_ratio`), the Agent stops writing `.retry` file on disk.