### PR TITLE
[runtime-security] remove useless dentry resolution from container pa…

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -196,10 +196,6 @@ func (e *FileEvent) ResolveContainerPathWithResolvers(resolvers *Resolvers) stri
 		if err == nil {
 			e.ContainerPath = containerPath
 		}
-		if len(containerPath) == 0 && len(e.PathnameStr) == 0 {
-			// The container path might be included in the pathname. The container path will be set there.
-			_ = e.ResolveInodeWithResolvers(resolvers)
-		}
 	}
 	return e.ContainerPath
 }

--- a/pkg/security/probe/probe_bpf.go
+++ b/pkg/security/probe/probe_bpf.go
@@ -400,7 +400,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 
 		// Delete new mount point from cache
 		if err := p.resolvers.MountResolver.Delete(event.Umount.MountID); err != nil {
-			log.Errorf("failed to delete mount point %d from cache: %s", event.Umount.MountID, err)
+			log.Warnf("failed to delete mount point %d from cache: %s", event.Umount.MountID, err)
 		}
 	case FileOpenEventType:
 		if _, err := event.Open.UnmarshalBinary(data[offset:]); err != nil {


### PR DESCRIPTION
…th model handler (#7472)

* Change log level for mount point delete error

* Remove useless dentry inode resolution from container path model handler

(cherry picked from commit 28c92492005e2635f105854493221119dd1e52d5)

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
