### PR TITLE
[tasks] Use docker/compose image

### DIFF
--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -77,7 +77,7 @@ def dockerize_test(ctx, binary, skip_cleanup=False):
 
     with open("%s/Dockerfile" % temp_folder, 'w') as stream:
         stream.write(
-            """FROM docker/compose:1.16.1
+            """FROM docker/compose:debian-1.28.3
 ENV DOCKER_DD_AGENT=yes
 WORKDIR /
 CMD /test.bin

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -77,13 +77,9 @@ def dockerize_test(ctx, binary, skip_cleanup=False):
 
     with open("%s/Dockerfile" % temp_folder, 'w') as stream:
         stream.write(
-            """FROM debian:stretch-slim
+            """FROM docker/compose:1.16.1
 ENV DOCKER_DD_AGENT=yes
 WORKDIR /
-ADD https://github.com/docker/compose/releases/download/1.16.1/docker-compose-Linux-x86_64 /bin/docker-compose
-RUN echo "1804b0ce6596efe707b9cab05d74b161833ed503f0535a937dd5d17bea8fc50a  /bin/docker-compose" > sum && \
-    sha256sum -c sum && \
-    chmod +x /bin/docker-compose
 CMD /test.bin
 COPY test.bin /test.bin
 """


### PR DESCRIPTION
### What does this PR do?

- Use `docker/compose` base image to prevent network errors
- Bump docker compose version to 1.28.1

### Motivation

- The integration tests are consistently failing because of network errors when downloading the docker-compose scripts.

### Additional Notes

- I am not sure what these tests do so please review carefully