### PR TITLE
Test APIKEY in Windows kitchen tests

### DIFF
--- a/test/kitchen/kitchen-azure-winstall.yml
+++ b/test/kitchen/kitchen-azure-winstall.yml
@@ -20,6 +20,7 @@ suites:
         windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
         <% end %>
         agent_install_options: >
+          APIKEY=<%= api_key %>
           TAGS=k1:v1,k2:v2
           HOSTNAME=dd-agent-installopts
           CMD_PORT=4999
@@ -34,7 +35,6 @@ suites:
           TRACE_DD_URL=https://trace.someurl.datadoghq.com
       dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
-
 
   - name: dd-agent-all-subservices
     run_list:

--- a/test/kitchen/test/integration/dd-agent-installopts/rspec/dd-agent-installopts_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-installopts/rspec/dd-agent-installopts_spec.rb
@@ -31,7 +31,7 @@ shared_examples_for 'a configured Agent' do
     confYaml = read_conf_file()
     it 'has an API key' do
       expect(confYaml).to have_key("api_key")
-      expect(confYaml["api_key"]).to be_truthy  # for now just accept that something's there
+      expect(confYaml["api_key"]).to equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     end
     it 'has tags set' do
       expect(confYaml).to have_key("tags")

--- a/test/kitchen/test/integration/dd-agent-installopts/rspec/dd-agent-installopts_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-installopts/rspec/dd-agent-installopts_spec.rb
@@ -31,7 +31,7 @@ shared_examples_for 'a configured Agent' do
     confYaml = read_conf_file()
     it 'has an API key' do
       expect(confYaml).to have_key("api_key")
-      expect(confYaml["api_key"]).to equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      expect(confYaml["api_key"]).to eql("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     end
     it 'has tags set' do
       expect(confYaml).to have_key("tags")


### PR DESCRIPTION
### What does this PR do?

This test adds a missing API key in kitchen tests and ensures that the key is actually written out.

### Motivation

Make the kitchen pass for https://github.com/DataDog/datadog-agent/pull/7204

### Additional notes

`be_truthy` is true when value is not nil or empty, which works if the content of `confYaml["api_key"]` is not nil or false.
However, even if the `confYaml["api_key"]` is defined, it can still have the nil value, which can be the case if no API key was specified.

#### Tests

The kitchen tests should pass.

