### PR TITLE
Fix agent crashes from rtloader being destroyed early

### DIFF
--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -49,10 +49,15 @@ type PythonCheck struct {
 }
 
 // NewPythonCheck conveniently creates a PythonCheck instance
-func NewPythonCheck(name string, class *C.rtloader_pyobject_t) *PythonCheck {
-	glock := newStickyLock()
+func NewPythonCheck(name string, class *C.rtloader_pyobject_t) (*PythonCheck, error) {
+	glock, err := newStickyLock()
+	if err != nil {
+		return nil, err
+	}
+
 	C.rtloader_incref(rtloader, class) // own the ref
 	glock.unlock()
+
 	pyCheck := &PythonCheck{
 		ModuleName:   name,
 		class:        class,
@@ -61,12 +66,16 @@ func NewPythonCheck(name string, class *C.rtloader_pyobject_t) *PythonCheck {
 		telemetry:    telemetry_utils.IsCheckEnabled(name),
 	}
 	runtime.SetFinalizer(pyCheck, pythonCheckFinalizer)
-	return pyCheck
+
+	return pyCheck, nil
 }
 
 func (c *PythonCheck) runCheck(commitMetrics bool) error {
 	// Lock the GIL and release it at the end of the run
-	gstate := newStickyLock()
+	gstate, err := newStickyLock()
+	if err != nil {
+		return err
+	}
 	defer gstate.unlock()
 
 	log.Debugf("Running python check %s %s", c.ModuleName, c.id)
@@ -91,11 +100,11 @@ func (c *PythonCheck) runCheck(commitMetrics bool) error {
 	// grab the warnings and add them to the struct
 	c.lastWarnings = c.getPythonWarnings(gstate)
 
-	err := C.GoString(cResult)
-	if err == "" {
+	checkErrStr := C.GoString(cResult)
+	if checkErrStr == "" {
 		return nil
 	}
-	return errors.New(err)
+	return errors.New(checkErrStr)
 }
 
 // Run a Python check
@@ -114,7 +123,11 @@ func (c *PythonCheck) Stop() {}
 // Cancel signals to a python check that he can free all internal resources and
 // deregisters the sender
 func (c *PythonCheck) Cancel() {
-	gstate := newStickyLock()
+	gstate, err := newStickyLock()
+	if err != nil {
+		log.Warnf("failed to cancel check %s: %s", c.id, err)
+		return
+	}
 	defer gstate.unlock()
 
 	C.cancel_check(rtloader, c.instance)
@@ -308,8 +321,15 @@ func pythonCheckFinalizer(c *PythonCheck) {
 	// Run in a separate goroutine because acquiring the python lock might take some time,
 	// and we're in a finalizer
 	go func(c *PythonCheck) {
-		glock := newStickyLock() // acquire lock to call DecRef
+		log.Debugf("Running finalizer for check %s", c.id)
+
+		glock, err := newStickyLock() // acquire lock to call DecRef
+		if err != nil {
+			log.Warnf("Could not finalize check %s: %s", c.id, err.Error())
+			return
+		}
 		defer glock.unlock()
+
 		C.rtloader_decref(rtloader, c.class)
 		if c.instance != nil {
 			C.rtloader_decref(rtloader, c.instance)

--- a/pkg/collector/python/check_test.go
+++ b/pkg/collector/python/check_test.go
@@ -15,8 +15,32 @@ func TestRunCheck(t *testing.T) {
 	testRunCheck(t)
 }
 
+func TestInitCheckWithRuntimeNotInitialized(t *testing.T) {
+	testInitiCheckWithRuntimeNotInitialized(t)
+}
+
+func TestRunCheckWithRuntimeNotInitialized(t *testing.T) {
+	testRunCheckWithRuntimeNotInitializedError(t)
+}
+
 func TestRunErrorNil(t *testing.T) {
 	testRunErrorNil(t)
+}
+
+func TestCheckCancel(t *testing.T) {
+	testCheckCancel(t)
+}
+
+func TestCheckCancelWhenRuntimeUnloaded(t *testing.T) {
+	testCheckCancelWhenRuntimeUnloaded(t)
+}
+
+func TestFinalizer(t *testing.T) {
+	testFinalizer(t)
+}
+
+func TestFinalizerWhenRuntimeUnloaded(t *testing.T) {
+	testFinalizerWhenRuntimeUnloaded(t)
 }
 
 func TestRunErrorReturn(t *testing.T) {

--- a/pkg/collector/python/helpers.go
+++ b/pkg/collector/python/helpers.go
@@ -83,13 +83,23 @@ var (
 // newStickyLock registers the current thread with the interpreter and locks
 // the GIL. It also sticks the goroutine to the current thread so that a
 // subsequent call to `Unlock` will unregister the very same thread.
-func newStickyLock() *stickyLock {
+func newStickyLock() (*stickyLock, error) {
 	runtime.LockOSThread()
+
+	pyDestroyLock.RLock()
+	defer pyDestroyLock.RUnlock()
+
+	// Ensure that rtloader isn't destroyed while we are trying to acquire GIL
+	if rtloader == nil {
+		return nil, fmt.Errorf("error acquiring the GIL: rtloader is not initialized")
+	}
+
 	state := C.ensure_gil(rtloader)
+
 	return &stickyLock{
 		gstate: state,
 		locked: 1,
-	}
+	}, nil
 }
 
 // unlock deregisters the current thread from the interpreter, unlocks the GIL
@@ -120,11 +130,11 @@ func cStringArrayToSlice(array **C.char) []string {
 
 // GetPythonIntegrationList collects python datadog installed integrations list
 func GetPythonIntegrationList() ([]string, error) {
-	if rtloader == nil {
-		return nil, fmt.Errorf("rtloader is not initialized")
+	glock, err := newStickyLock()
+	if err != nil {
+		return nil, err
 	}
 
-	glock := newStickyLock()
 	defer glock.unlock()
 
 	integrationsList := C.get_integration_list(rtloader)
@@ -151,11 +161,11 @@ func GetPythonIntegrationList() ([]string, error) {
 
 // GetIntepreterMemoryUsage collects a python interpreter memory usage snapshot
 func GetPythonInterpreterMemoryUsage() ([]*PythonStats, error) {
-	if rtloader == nil {
-		return nil, fmt.Errorf("rtloader is not initialized")
+	glock, err := newStickyLock()
+	if err != nil {
+		return nil, err
 	}
 
-	glock := newStickyLock()
 	defer glock.unlock()
 
 	usage := C.get_interpreter_memory_usage(rtloader)
@@ -210,11 +220,10 @@ func GetPythonInterpreterMemoryUsage() ([]*PythonStats, error) {
 
 // SetPythonPsutilProcPath sets python psutil.PROCFS_PATH
 func SetPythonPsutilProcPath(procPath string) error {
-	if rtloader == nil {
-		return fmt.Errorf("rtloader is not initialized")
+	glock, err := newStickyLock()
+	if err != nil {
+		return err
 	}
-
-	glock := newStickyLock()
 	defer glock.unlock()
 
 	module := TrackedCString(psutilModule)

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -183,9 +183,10 @@ var (
 
 	rtloader *C.rtloader_t = nil
 
-	expvarPyInit *expvar.Map
-	pyInitLock   sync.RWMutex
-	pyInitErrors []string
+	expvarPyInit  *expvar.Map
+	pyInitLock    sync.RWMutex
+	pyDestroyLock sync.RWMutex
+	pyInitErrors  []string
 )
 
 func init() {
@@ -348,7 +349,11 @@ func Initialize(paths ...string) error {
 	}
 
 	// Lock the GIL
-	glock := newStickyLock()
+	glock, err := newStickyLock()
+	if err != nil {
+		return err
+	}
+
 	pyInfo := C.get_py_info(rtloader)
 	glock.unlock()
 
@@ -372,9 +377,21 @@ func Initialize(paths ...string) error {
 
 // Destroy destroys the loaded Python interpreter initialized by 'Initialize'
 func Destroy() {
-	if rtloader != nil {
-		C.destroy(rtloader)
+	pyDestroyLock.Lock()
+	defer pyDestroyLock.Unlock()
+
+	// Sanity check - this should ideally never happen
+	if rtloader == nil {
+		log.Warn("Python runtime already destroyed. Ignoring action.")
+		return
 	}
+
+	// Clear the C-side and Go-side rtloader pointers
+	log.Info("Destroying Python runtime")
+	C.destroy(rtloader)
+	rtloader = nil
+
+	log.Info("Python runtime destroyed")
 }
 
 // GetRtLoader returns the underlying rtloader_t struct. This is meant for testing and

--- a/pkg/collector/python/test_check.go
+++ b/pkg/collector/python/test_check.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -81,6 +82,14 @@ char *run_check(rtloader_t *s, rtloader_pyobject_t *check) {
 	run_check_instance = check;
 	run_check_calls++;
 	return run_check_return;
+}
+
+int cancel_check_calls = 0;
+rtloader_pyobject_t *cancel_check_instance = NULL;
+void cancel_check(rtloader_t *s, rtloader_pyobject_t *check) {
+	cancel_check_instance = check;
+	cancel_check_calls++;
+	return;
 }
 
 //
@@ -161,6 +170,8 @@ void reset_check_mock() {
 	get_check_check_id = NULL;
 	get_check_check_name = NULL;
 	get_check_check = NULL;
+	cancel_check_calls = 0;
+	cancel_check_instance = NULL;
 
 	get_check_deprecated_calls = 0;
 	get_check_deprecated_return = 0;
@@ -177,7 +188,15 @@ void reset_check_mock() {
 import "C"
 
 func testRunCheck(t *testing.T) {
-	check := NewPythonFakeCheck()
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	check, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
 	check.instance = &C.rtloader_pyobject_t{}
 
 	C.reset_check_mock()
@@ -185,7 +204,7 @@ func testRunCheck(t *testing.T) {
 	warn := []*C.char{C.CString("warn1"), C.CString("warn2"), nil}
 	C.get_checks_warnings_return = &warn[0]
 
-	err := check.runCheck(false)
+	err = check.runCheck(false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, C.int(1), C.gil_locked_calls)
@@ -197,8 +216,221 @@ func testRunCheck(t *testing.T) {
 	assert.Equal(t, check.lastWarnings, []error{fmt.Errorf("warn1"), fmt.Errorf("warn2")})
 }
 
+func testRunCheckWithRuntimeNotInitializedError(t *testing.T) {
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	check, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	check.instance = &C.rtloader_pyobject_t{}
+
+	C.reset_check_mock()
+	C.run_check_return = C.CString("")
+
+	rtloader = nil
+
+	err = check.runCheck(false)
+	assert.EqualError(
+		t,
+		err,
+		"error acquiring the GIL: rtloader is not initialized",
+	)
+}
+
+func testInitiCheckWithRuntimeNotInitialized(t *testing.T) {
+	// Ensure RT pointer is zeroized
+	rtloader = nil
+
+	C.reset_check_mock()
+
+	_, err := NewPythonFakeCheck()
+	if !assert.NotNil(t, err) {
+		return
+	}
+
+	assert.EqualError(
+		t,
+		err,
+		"error acquiring the GIL: rtloader is not initialized",
+	)
+
+	assert.Equal(t, C.int(0), C.gil_locked_calls)
+	assert.Equal(t, C.int(0), C.gil_unlocked_calls)
+	assert.Equal(t, C.int(0), C.run_check_calls)
+	assert.Equal(t, C.int(0), C.rtloader_free_calls)
+	assert.Equal(t, C.int(0), C.rtloader_incref_calls)
+	assert.Equal(t, C.int(0), C.rtloader_decref_calls)
+}
+
+func testCheckCancel(t *testing.T) {
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	check, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	C.reset_check_mock()
+	check.instance = &C.rtloader_pyobject_t{}
+	C.run_check_return = C.CString("")
+
+	err = check.runCheck(false)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	// Sanity checks to ensure known start state
+	assert.Equal(t, C.int(1), C.gil_locked_calls)
+	assert.Equal(t, C.int(1), C.gil_unlocked_calls)
+	assert.Equal(t, C.int(0), C.rtloader_incref_calls)
+	assert.Equal(t, C.int(0), C.rtloader_decref_calls)
+	assert.Equal(t, C.int(0), C.cancel_check_calls)
+	assert.Equal(t, check.instance, C.run_check_instance)
+
+	check.Cancel()
+
+	// Check that the lock was acquired
+	assert.Equal(t, C.int(2), C.gil_locked_calls)
+	assert.Equal(t, C.int(2), C.gil_unlocked_calls)
+
+	// Check that the call was passed to C
+	assert.Equal(t, C.int(1), C.cancel_check_calls)
+	assert.Equal(t, check.instance, C.cancel_check_instance)
+}
+
+func testCheckCancelWhenRuntimeUnloaded(t *testing.T) {
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	check, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	C.reset_check_mock()
+	check.instance = &C.rtloader_pyobject_t{}
+	C.run_check_return = C.CString("")
+
+	err = check.runCheck(false)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	// Sanity checks to ensure known start state
+	assert.Equal(t, C.int(1), C.gil_locked_calls)
+	assert.Equal(t, C.int(1), C.gil_unlocked_calls)
+	assert.Equal(t, C.int(0), C.rtloader_incref_calls)
+	assert.Equal(t, C.int(0), C.rtloader_decref_calls)
+	assert.Equal(t, C.int(0), C.cancel_check_calls)
+	assert.Equal(t, check.instance, C.run_check_instance)
+
+	// Simulate rtloader being unloaded
+	rtloader = nil
+
+	check.Cancel()
+
+	// There should be no invocations of cancel
+	assert.Equal(t, C.int(0), C.cancel_check_calls)
+}
+
+func testFinalizer(t *testing.T) {
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	check, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	C.reset_check_mock()
+	check.instance = &C.rtloader_pyobject_t{}
+	C.run_check_return = C.CString("")
+
+	err = check.runCheck(false)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	// Sanity checks to ensure known start state
+	assert.Equal(t, C.int(1), C.gil_locked_calls)
+	assert.Equal(t, C.int(1), C.gil_unlocked_calls)
+	assert.Equal(t, C.int(0), C.rtloader_incref_calls)
+	assert.Equal(t, C.int(0), C.rtloader_decref_calls)
+	assert.Equal(t, check.instance, C.run_check_instance)
+
+	pythonCheckFinalizer(check)
+
+	// Finalizer runs in a goroutine so we have to wait a bit
+	time.Sleep(100 * time.Millisecond)
+
+	// Check that the lock was acquired
+	assert.Equal(t, C.int(2), C.gil_locked_calls)
+	assert.Equal(t, C.int(2), C.gil_unlocked_calls)
+
+	// Check that the class and instance have been decref-d
+	assert.Equal(t, C.int(0), C.rtloader_incref_calls)
+	assert.Equal(t, C.int(2), C.rtloader_decref_calls)
+}
+
+func testFinalizerWhenRuntimeUnloaded(t *testing.T) {
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	check, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	C.reset_check_mock()
+	check.instance = &C.rtloader_pyobject_t{}
+	C.run_check_return = C.CString("")
+
+	err = check.runCheck(false)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	// Sanity checks to ensure known start state
+	assert.Equal(t, C.int(1), C.gil_locked_calls)
+	assert.Equal(t, C.int(1), C.gil_unlocked_calls)
+	assert.Equal(t, C.int(0), C.rtloader_incref_calls)
+	assert.Equal(t, C.int(0), C.rtloader_decref_calls)
+	assert.Equal(t, check.instance, C.run_check_instance)
+
+	// Simulate rtloader being unloaded
+	rtloader = nil
+
+	pythonCheckFinalizer(check)
+
+	// Finalizer runs in a goroutine so we have to wait a bit
+	time.Sleep(100 * time.Millisecond)
+
+	// There should be no changes in the lock/unlock and inc/decref calls
+	assert.Equal(t, C.int(1), C.gil_locked_calls)
+	assert.Equal(t, C.int(1), C.gil_unlocked_calls)
+	assert.Equal(t, C.int(0), C.rtloader_incref_calls)
+	assert.Equal(t, C.int(0), C.rtloader_decref_calls)
+}
+
 func testRunErrorNil(t *testing.T) {
-	check := NewPythonFakeCheck()
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	check, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
 	check.instance = &C.rtloader_pyobject_t{}
 
 	C.reset_check_mock()
@@ -206,9 +438,9 @@ func testRunErrorNil(t *testing.T) {
 	C.has_error_return = 1
 	C.get_error_return = C.CString("some error")
 
-	err := check.runCheck(false)
-	assert.NotNil(t, err)
-	assert.NotNil(t, fmt.Errorf("some error"), err)
+	errStr := check.runCheck(false)
+	assert.NotNil(t, errStr)
+	assert.NotNil(t, fmt.Errorf("some error"), errStr)
 
 	assert.Equal(t, C.int(1), C.gil_locked_calls)
 	assert.Equal(t, C.int(1), C.gil_unlocked_calls)
@@ -219,15 +451,23 @@ func testRunErrorNil(t *testing.T) {
 }
 
 func testRunErrorReturn(t *testing.T) {
-	check := NewPythonFakeCheck()
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	check, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
 	check.instance = &C.rtloader_pyobject_t{}
 
 	C.reset_check_mock()
 	C.run_check_return = C.CString("not OK")
 
-	err := check.runCheck(false)
-	assert.NotNil(t, err)
-	assert.NotNil(t, fmt.Errorf("not OK"), err)
+	errStr := check.runCheck(false)
+	assert.NotNil(t, errStr)
+	assert.NotNil(t, fmt.Errorf("not OK"), errStr)
 
 	assert.Equal(t, C.int(1), C.gil_locked_calls)
 	assert.Equal(t, C.int(1), C.gil_unlocked_calls)
@@ -241,7 +481,14 @@ func testRun(t *testing.T) {
 	sender := mocksender.NewMockSender(check.ID("testID"))
 	sender.SetupAcceptAll()
 
-	c := NewPythonFakeCheck()
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	c, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
 
 	c.instance = &C.rtloader_pyobject_t{}
 	c.id = check.ID("testID")
@@ -249,7 +496,7 @@ func testRun(t *testing.T) {
 	C.reset_check_mock()
 	C.run_check_return = C.CString("")
 
-	err := c.Run()
+	err = c.Run()
 	assert.Nil(t, err)
 
 	assert.Equal(t, C.int(1), C.gil_locked_calls)
@@ -268,7 +515,14 @@ func testRunSimple(t *testing.T) {
 	sender := mocksender.NewMockSender(check.ID("testID"))
 	sender.SetupAcceptAll()
 
-	c := NewPythonFakeCheck()
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	c, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
 
 	c.instance = &C.rtloader_pyobject_t{}
 	c.id = check.ID("testID")
@@ -276,7 +530,7 @@ func testRunSimple(t *testing.T) {
 	C.reset_check_mock()
 	C.run_check_return = C.CString("")
 
-	err := c.RunSimple()
+	err = c.RunSimple()
 	assert.Nil(t, err)
 
 	assert.Equal(t, C.int(1), C.gil_locked_calls)
@@ -292,14 +546,22 @@ func testRunSimple(t *testing.T) {
 }
 
 func testConfigure(t *testing.T) {
-	c := NewPythonFakeCheck()
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	c, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
 	c.class = &C.rtloader_pyobject_t{}
 
 	C.reset_check_mock()
 
 	C.get_check_return = 1
 	C.get_check_check = &C.rtloader_pyobject_t{}
-	err := c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
+	err = c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
 	assert.Nil(t, err)
 
 	assert.Equal(t, c.class, C.get_check_py_class)
@@ -319,7 +581,15 @@ func testConfigure(t *testing.T) {
 }
 
 func testConfigureDeprecated(t *testing.T) {
-	c := NewPythonFakeCheck()
+	// Initialize rtloader pointer
+	rtloader = &C.rtloader_t{}
+	defer func() { rtloader = nil }()
+
+	c, err := NewPythonFakeCheck()
+	if !assert.Nil(t, err) {
+		return
+	}
+
 	c.class = &C.rtloader_pyobject_t{}
 
 	C.reset_check_mock()
@@ -327,7 +597,7 @@ func testConfigureDeprecated(t *testing.T) {
 	C.get_check_return = 0
 	C.get_check_deprecated_check = &C.rtloader_pyobject_t{}
 	C.get_check_deprecated_return = 1
-	err := c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
+	err = c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
 	assert.Nil(t, err)
 
 	assert.Equal(t, c.class, C.get_check_py_class)
@@ -347,9 +617,13 @@ func testConfigureDeprecated(t *testing.T) {
 	assert.Equal(t, c.instance, C.get_check_deprecated_check)
 }
 
-func NewPythonFakeCheck() *PythonCheck {
-	c := NewPythonCheck("fake_check", nil)
+func NewPythonFakeCheck() (*PythonCheck, error) {
+	c, err := NewPythonCheck("fake_check", nil)
+
 	// Remove check finalizer that may trigger race condition while testing
-	runtime.SetFinalizer(c, nil)
-	return c
+	if err == nil {
+		runtime.SetFinalizer(c, nil)
+	}
+
+	return c, err
 }

--- a/releasenotes/notes/fix-rtloader-cleanup-gil-race-conditions-f8fae7b8d0e137a1.yaml
+++ b/releasenotes/notes/fix-rtloader-cleanup-gil-race-conditions-f8fae7b8d0e137a1.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix agent crashes from Python interpreter being freed too early. This was
+    most likely to occur as an edge case during a shutdown of the agent where
+    the interpreter was destroyed before the finalizers for a check were
+    invoked by finalizers.


### PR DESCRIPTION
### What does this PR do?

Our old code was unable to handle situations where the rtloader pointer
was deleted but then subsequent operations (like check finalizers)
needed to run which would end up in the agent crashing. This change
ensures that any GIL-locking operations print a user-friendly error
or warn when that situation occurs.



### Motivation

AC-795 / Crashes during program exit

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

1. Start a container with AD (so it can be unscheduled): 
```
$ docker run --net=host -ti -l 'com.datadoghq.ad.check_names=["redisdb"]' -l 'com.datadoghq.ad.init_configs=[{}]'  -l 'com.datadoghq.ad.instances=[{"host": "%%host%%","port":"6379"}]' redis
```
2. Start the agent
3. Stop the redis instance and wait (~5s) for the check to be canceled
4. Before you see `Running finalizer for check ...` in the log, stop the agent process (with a `ctrl-c`/`SIGINT`), triggering a clearing of the Python runtime
5. The agent should not produce any panics (test may need repeating some number of times since the finalizers may run quickly after unscheduling)
6. Client should just produce an innocuous warning similar to this: `... GIL lock attempted when rtloader is not initialized ...`
