### PR TITLE
serverless: remove some precision after float computation to have the same results on different arch

### DIFF
--- a/pkg/serverless/enhanced_metrics.go
+++ b/pkg/serverless/enhanced_metrics.go
@@ -1,6 +1,7 @@
 package serverless
 
 import (
+	"math"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -97,5 +98,7 @@ func calculateEstimatedCost(billedDurationMs float64, memorySizeMb float64) floa
 	billedDurationSeconds := billedDurationMs / 1000.0
 	memorySizeGb := memorySizeMb / 1024.0
 	gbSeconds := billedDurationSeconds * memorySizeGb
-	return baseLambdaInvocationPrice + (gbSeconds * lambdaPricePerGbSecond)
+	// round the final float result because float math could have float point imprecision
+	// on some arch. (i.e. 1.00000000000002 values)
+	return math.Round((baseLambdaInvocationPrice+(gbSeconds*lambdaPricePerGbSecond))*10e12) / 10e12
 }


### PR DESCRIPTION
### What does this PR do?

Remove some precision after float computation to have the same results on different arch. Because the lowest amount would be `0.0000166667`, I've been with `10e12`.


### Motivation

In unit tests, while running on the ARM nodes, we were having this error in the unit test:

```
            	Diff:
            	--- Expected
             	+++ Actual
             	@@ -78,3 +78,3 @@
             	   Name: (string) (len=34) "aws.lambda.enhanced.estimated_cost",
              	-  Value: (float64) 1.3533360000000002e-05,
            	+  Value: (float64) 1.353336e-05,
              	   RawValue: (string) "",
   Test:       	TestGenerateEnhancedMetricsFromReportLog
```

because of float math.

### Additional note

Another solution would be to introduce the https://github.com/shopspring/decimal dependency.

### Describe your test plan

ARM unit tests should go through.