### PR TITLE
Add Debian snapshot date to datadog/agent Dockerfile to use in gdb image

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -162,6 +162,9 @@ COPY init-stage3-host-pid /etc/s6/init/init-stage3-host-pid
 
 RUN find /etc -type d,f -perm -o+w -print0 | xargs -0 chmod g-w,o-w
 
+# Add Debian snapshot date for debugging
+RUN date +%Y%m%dT000000Z > .debian_repo_snapshot_date
+
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp
 

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -160,6 +160,9 @@ RUN  mv /etc/s6/init/init-stage3 /etc/s6/init/init-stage3-original
 COPY init-stage3          /etc/s6/init/init-stage3
 COPY init-stage3-host-pid /etc/s6/init/init-stage3-host-pid
 
+# Add Debian snapshot date for debugging
+RUN date +%Y%m%dT000000Z > .debian_repo_snapshot_date
+
 RUN find /etc -type d,f -perm -o+w -print0 | xargs -0 chmod g-w,o-w
 
 # Expose DogStatsD and trace-agent ports

--- a/tools/gdb/Dockerfile
+++ b/tools/gdb/Dockerfile
@@ -6,8 +6,14 @@ FROM datadog/agent:${AGENT_VERSION}
 # the same versions of the debug packages (that are deps of gdb) as what's originally installed in the image
 ARG DEBIAN_REPO_SNAPSHOT_DATE
 RUN grep '^\#' /etc/apt/sources.list | sed 's/# //' > /etc/apt/sources.list.tmp \
- && [ ! -z "$DEBIAN_REPO_SNAPSHOT_DATE" ] && sed -i -r "s/[0-9]+T[0-9]+Z/${DEBIAN_REPO_SNAPSHOT_DATE}/" /etc/apt/sources.list.tmp; \
- mv /etc/apt/sources.list.tmp /etc/apt/sources.list \
+ && if [ -f ".debian_repo_snapshot_date" ]; then \
+    sed -i -r "s/[0-9]+T[0-9]+Z/$(cat .debian_repo_snapshot_date)/" /etc/apt/sources.list.tmp; \
+    mv /etc/apt/sources.list.tmp /etc/apt/sources.list; \
+elif [ ! -z "$DEBIAN_REPO_SNAPSHOT_DATE"]; then \
+    sed -i -r "s/[0-9]+T[0-9]+Z/${DEBIAN_REPO_SNAPSHOT_DATE}/" /etc/apt/sources.list.tmp; \
+    mv /etc/apt/sources.list.tmp /etc/apt/sources.list; \
+ fi \
+ && cat /etc/apt/sources.list \ 
  && apt-get -o Acquire::Check-Valid-Until=false update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" gdb
 

--- a/tools/gdb/README.md
+++ b/tools/gdb/README.md
@@ -18,7 +18,7 @@ The image is based on the `datadog/agent` image for the version of the Agent you
   docker build -t gdb-agent:7.18.0 --build-arg AGENT_VERSION=7.18.0 .
   ```
 
-  If the Debian snapshot repos definitions in the Agent image do not actually reflect the debian repo snapshots
+  For Agent 7.26.0 or earlier, if the Debian snapshot repos definitions in the Agent image do not actually reflect the debian repo snapshots
   that were used at the time of the original Agent image build, the optional build arg `DEBIAN_REPO_SNAPSHOT_DATE`
   must be set to the snapshot's date.
 
@@ -49,6 +49,4 @@ See https://devguide.python.org/gdb/#gdb-7-and-later for more info on the Python
 
 ## TODO
 
-* make the Agent image define its debian repo snapshot date at build time so we can use it here directly, without requiring
-the use of a separate build arg (`DEBIAN_REPO_SNAPSHOT_DATE`)
 * add cpython sources


### PR DESCRIPTION
### What does this PR do?

- Add `.debian_repo_snapshot_date` file with the build date of the `datadog/agent` image.
- Use its contents for fixing the sources list on the `gdb` image for debugging.
- Keep `DEBIAN_REPO_SNAPSHOT_DATE` for Agent versions that don't have this file.


### Motivation

- Fix `gdb` image build

### Additional Notes

- A follow up PR will add `delve` to the image.

### Describe your test plan

- Image builds correctly
