### PR TITLE
[runtime-security] Add file metadata on all events with new SECL and JSON format

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -99,7 +99,7 @@ func checkPolicies(cmd *cobra.Command, args []string) error {
 	// enabled all the rules
 	enabled := map[eval.EventType]bool{"*": true}
 
-	opts := rules.NewOptsWithParams(model.SECLConstants, sprobe.SupportedDiscarders, enabled, sprobe.AllCustomRuleIDs(), securityLogger.DatadogAgentLogger{})
+	opts := rules.NewOptsWithParams(model.SECLConstants, sprobe.SupportedDiscarders, enabled, sprobe.AllCustomRuleIDs(), model.SECLLegacyAttributes, securityLogger.DatadogAgentLogger{})
 	model := &sprobe.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, opts)
 

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6eca29c0448c2f8e5d1998bfcc68760281af42119fac8eccc99a4c76829b92fe")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "0363c28fd23fcc91e642f02d5819c88bab18be3f5ec1e5df8645a1ae980e865b")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "a1c7526057e320374cb632519c43d6d70b934e2820cbca8a680ff6ea0512d550")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6eca29c0448c2f8e5d1998bfcc68760281af42119fac8eccc99a4c76829b92fe")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "109672f0b445868ea4d81a4876b5b5bd27436c2b18ed99c8bb6188fd74b77a3b")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "af7b9df8a5090f96748826baf95f5513f2f39207c3ca816b1fa7687b4b8b6728")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "af7b9df8a5090f96748826baf95f5513f2f39207c3ca816b1fa7687b4b8b6728")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "a1c7526057e320374cb632519c43d6d70b934e2820cbca8a680ff6ea0512d550")

--- a/pkg/security/config/default.go
+++ b/pkg/security/config/default.go
@@ -12,104 +12,104 @@ rules:
   - id: credential_accessed
     description: Sensitive credential files were accessed using a non-standard tool
     expression: >-
-      (open.filename == "/etc/shadow" || open.filename == "/etc/gshadow") &&
-      process.name not in ["vipw", "vigr", "accounts-daemon"]
+      (open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") &&
+      process.file.name not in ["vipw", "vigr", "accounts-daemon"]
     tags:
       technique: T1003
   - id: memory_dump
     description: Potential memory dump
     expression: >-
-      open.filename =~ "/proc/*" && open.basename in ["maps", "mem"]
+      open.file.path =~ "/proc/*" && open.file.name in ["maps", "mem"]
     tags:
       technique: T1003
   - id: logs_altered
     description: Log data was deleted
     expression: >-
-      (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0) &&
-      process.name not in ["agent", "security-agent", "process-agent", "system-probe", "kubelet", "containerd"]
+      (open.file.path =~ "/var/log/*" && open.flags & O_TRUNC > 0) &&
+      process.file.name not in ["agent", "security-agent", "process-agent", "system-probe", "kubelet", "containerd"]
     tags:
       technique: T1070
   - id: logs_removed
     description: Log files were removed
     expression: >-
-      unlink.filename =~ "/var/log/*" &&
-      process.name not in ["agent", "security-agent", "process-agent", "system-probe", "kubelet", "containerd"]
+      unlink.file.path =~ "/var/log/*" &&
+      process.file.name not in ["agent", "security-agent", "process-agent", "system-probe", "kubelet", "containerd"]
     tags:
       technique: T1070
   - id: permissions_changed
     description: Permissions were changed on sensitive files
     expression: >-
-      (chmod.filename =~ "/etc/*" ||
-      chmod.filename =~ "/sbin/*" || chmod.filename =~ "/usr/sbin/*" ||
-      chmod.filename =~ "/usr/local/sbin/*" || chmod.filename =~ "/usr/local/bin/*" ||
-      chmod.filename =~ "/var/log/*" || chmod.filename =~ "/usr/lib/*") &&
-      process.name not in ["containerd", "kubelet"]
+      (chmod.file.path =~ "/etc/*" ||
+      chmod.file.path =~ "/sbin/*" || chmod.file.path =~ "/usr/sbin/*" ||
+      chmod.file.path =~ "/usr/local/sbin/*" || chmod.file.path =~ "/usr/local/bin/*" ||
+      chmod.file.path =~ "/var/log/*" || chmod.file.path =~ "/usr/lib/*") &&
+      process.file.name not in ["containerd", "kubelet"]
     tags:
       technique: T1222
   - id: kernel_module
     description: A new kernel module was added
     expression: >-
-      (open.filename =~ "/lib/modules/*" || open.filename =~ "/usr/lib/modules/*") && open.flags & O_CREAT > 0
+      (open.file.path =~ "/lib/modules/*" || open.file.path =~ "/usr/lib/modules/*") && open.flags & O_CREAT > 0
     tags:
       technique: T1215
   - id: nsswitch_conf_mod
     description: Exploits that modify nsswitch.conf to interfere with authentication
     expression: >-
-      open.filename == "/etc/nsswitch.conf" && open.flags & (O_RDWR | O_WRONLY) > 0
+      open.file.path == "/etc/nsswitch.conf" && open.flags & (O_RDWR | O_WRONLY) > 0
     tags:
       technique: T1556
   - id: pam_modification
     description: PAM modification
     expression: >-
-      open.filename =~ "/etc/pam.d/*" && open.flags & (O_RDWR | O_WRONLY) > 0
+      open.file.path =~ "/etc/pam.d/*" && open.flags & (O_RDWR | O_WRONLY) > 0
     tags:
       technique: T1556
   - id: cron_at_job_injection
     description: Unauthorized scheduling client
     expression: >-
-      open.filename =~ "/var/spool/cron/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
-      process.name not in ["at", "crontab"]
+      open.file.path =~ "/var/spool/cron/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
+      process.file.name not in ["at", "crontab"]
     tags:
       technique: T1053
   - id: kernel_modification
     description: Unauthorized kernel modification
     expression: >-
-      open.filename =~ "/boot/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      open.file.path =~ "/boot/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
     tags:
       technique: T1014
   - id: systemd_modification
     description: Unauthorized modification of a service
     expression: >-
-      open.filename =~ "/usr/lib/systemd/system/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      open.file.path =~ "/usr/lib/systemd/system/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
     tags:
       technique: T1014
   - id: authentication_logs_accessed
     description: unauthorized file accessing access logs
     expression: >-
-      open.filename in ["/run/utmp", "/var/run/utmp", "/var/log/wtmp"] &&
-      process.name not in ["login", "sshd", "last", "who", "w", "vminfo"]
+      open.file.path in ["/run/utmp", "/var/run/utmp", "/var/log/wtmp"] &&
+      process.file.name not in ["login", "sshd", "last", "who", "w", "vminfo"]
     tags:
       technique: T1070
   - id: root_ssh_key
     description: attempts to create or modify root's SSH key
     expression: >-
-      open.filename == "/root/.ssh/authorized_keys" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      open.file.path == "/root/.ssh/authorized_keys" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
     tags:
       technique: T1556
   - id: ssl_certificate_tampering
     description: Tampering with SSL certificates for machine-in-the-middle attacks against OpenSSL
     expression: >-
-      open.filename =~ "/etc/ssl/certs/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      open.file.path =~ "/etc/ssl/certs/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
     tags:
       technique: T1338
   - id: pci_11_5
     description: Modification of critical system files
     expression: >-
-      (open.filename =~ "/bin/*" ||
-      open.filename =~ "/sbin/*" ||
-      open.filename =~ "/usr/bin/*" ||
-      open.filename =~ "/usr/sbin/*" ||
-      open.filename =~ "/opt/*") && 
+      (open.file.path =~ "/bin/*" ||
+      open.file.path =~ "/sbin/*" ||
+      open.file.path =~ "/usr/bin/*" ||
+      open.file.path =~ "/usr/sbin/*" ||
+      open.file.path =~ "/opt/*") &&
       open.flags & (O_RDWR | O_WRONLY) > 0 &&
-      process.name not in ["agent", "security-agent", "system-probe", "process-agent"]
+      process.file.name not in ["agent", "security-agent", "system-probe", "process-agent"]
 `

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -64,11 +64,11 @@ int __attribute__((always_inline)) trace__sys_chmod_ret(struct pt_regs *ctx) {
             .inode = syscall->setattr.path_key.ino,
             .overlay_numlower = get_overlay_numlower(syscall->setattr.dentry),
             .path_id = syscall->setattr.path_key.path_id,
+            .metadata = syscall->setattr.metadata,
         },
         .padding = 0,
         .mode = syscall->setattr.mode,
     };
-    copy_file_metadata(&syscall->setattr.metadata, &event.file.metadata);
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -68,6 +68,7 @@ int __attribute__((always_inline)) trace__sys_chmod_ret(struct pt_regs *ctx) {
         .padding = 0,
         .mode = syscall->setattr.mode,
     };
+    copy_file_metadata(&syscall->setattr.metadata, &event.file.metadata);
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -81,11 +81,11 @@ int __attribute__((always_inline)) trace__sys_chown_ret(struct pt_regs *ctx) {
             .mount_id = syscall->setattr.path_key.mount_id,
             .overlay_numlower = get_overlay_numlower(syscall->setattr.dentry),
             .path_id = syscall->setattr.path_key.path_id,
+            .metadata = syscall->setattr.metadata,
         },
         .user = syscall->setattr.user,
         .group = syscall->setattr.group,
     };
-    copy_file_metadata(&syscall->setattr.metadata, &event.file.metadata);
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -85,6 +85,7 @@ int __attribute__((always_inline)) trace__sys_chown_ret(struct pt_regs *ctx) {
         .user = syscall->setattr.user,
         .group = syscall->setattr.group,
     };
+    copy_file_metadata(&syscall->setattr.metadata, &event.file.metadata);
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -244,16 +244,6 @@ struct file_metadata_t {
     struct ktimeval mtime;
 };
 
-void __attribute__((always_inline)) copy_file_metadata(struct file_metadata_t* src, struct file_metadata_t* dst) {
-    dst->uid = src->uid;
-    dst->gid = src->gid;
-    dst->mode = src->mode;
-    dst->ctime.tv_sec = src->ctime.tv_sec;
-    dst->ctime.tv_nsec = src->ctime.tv_nsec;
-    dst->mtime.tv_sec = src->mtime.tv_sec;
-    dst->mtime.tv_nsec = src->mtime.tv_nsec;
-}
-
 struct file_t {
     u64 inode;
     u32 mount_id;

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -229,12 +229,39 @@ struct kevent_t {
     u64 type;
 };
 
+struct ktimeval {
+    long tv_sec;
+    long tv_nsec;
+};
+
+struct file_metadata_t {
+    u32 uid;
+    u32 gid;
+    u16 mode;
+    char padding[6];
+
+    struct ktimeval ctime;
+    struct ktimeval mtime;
+};
+
+void __attribute__((always_inline)) copy_file_metadata(struct file_metadata_t* src, struct file_metadata_t* dst) {
+    dst->uid = src->uid;
+    dst->gid = src->gid;
+    dst->mode = src->mode;
+    dst->ctime.tv_sec = src->ctime.tv_sec;
+    dst->ctime.tv_nsec = src->ctime.tv_nsec;
+    dst->mtime.tv_sec = src->mtime.tv_sec;
+    dst->mtime.tv_nsec = src->mtime.tv_nsec;
+}
+
 struct file_t {
     u64 inode;
     u32 mount_id;
     u32 overlay_numlower;
     u32 path_id;
     u32 padding;
+
+    struct file_metadata_t metadata;
 };
 
 struct syscall_t {

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -158,6 +158,18 @@ unsigned long __attribute__((always_inline)) get_dentry_ino(struct dentry *dentr
     return get_inode_ino(d_inode);
 }
 
+void __attribute__((always_inline)) fill_file_metadata(struct dentry* dentry, struct file_metadata_t* file) {
+    struct inode *d_inode;
+    bpf_probe_read(&d_inode, sizeof(d_inode), &dentry->d_inode);
+
+    bpf_probe_read(&file->mode, sizeof(file->mode), &d_inode->i_mode);
+    bpf_probe_read(&file->uid, sizeof(file->uid), &d_inode->i_uid);
+    bpf_probe_read(&file->gid, sizeof(file->gid), &d_inode->i_gid);
+
+    bpf_probe_read(&file->ctime, sizeof(file->ctime), &d_inode->i_ctime);
+    bpf_probe_read(&file->mtime, sizeof(file->mtime), &d_inode->i_mtime);
+}
+
 void __attribute__((always_inline)) write_dentry_inode(struct dentry *dentry, struct inode **d_inode) {
     bpf_probe_read(d_inode, sizeof(d_inode), &dentry->d_inode);
 }

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -223,9 +223,9 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
             event.proc_entry.executable.overlay_numlower = parent_proc_entry->executable.overlay_numlower;
             event.proc_entry.executable.mount_id = parent_proc_entry->executable.mount_id;
             event.proc_entry.executable.path_id = parent_proc_entry->executable.path_id;
+            event.proc_entry.executable.metadata = parent_proc_entry->executable.metadata;
             event.proc_entry.exec_timestamp = parent_proc_entry->exec_timestamp;
 
-            copy_file_metadata(&parent_proc_entry->executable.metadata, &event.proc_entry.executable.metadata);
             copy_tty_name(event.proc_entry.tty_name, parent_proc_entry->tty_name);
 
             // fetch container context
@@ -303,6 +303,7 @@ int kprobe_security_bprm_committed_creds(struct pt_regs *ctx) {
                     .overlay_numlower = proc_entry->executable.overlay_numlower,
                     .mount_id = proc_entry->executable.mount_id,
                     .path_id = proc_entry->executable.path_id,
+                    .metadata = proc_entry->executable.metadata,
                 },
                 .proc_entry.container = {},
                 .proc_entry.exec_timestamp = proc_entry->exec_timestamp,
@@ -312,7 +313,6 @@ int kprobe_security_bprm_committed_creds(struct pt_regs *ctx) {
             };
             bpf_get_current_comm(&event.proc_entry.comm, sizeof(event.proc_entry.comm));
             copy_tty_name(event.proc_entry.tty_name, proc_entry->tty_name);
-            copy_file_metadata(&proc_entry->executable.metadata, &event.proc_entry.executable.metadata);
 
             fill_process_context(&event.process);
             fill_container_context(proc_entry, &event.proc_entry.container);

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -98,10 +98,6 @@ int __attribute__((always_inline)) handle_exec_event(struct pt_regs *ctx, struct
     // cache dentry
     resolve_dentry(syscall->open.dentry, syscall->open.path_key, 0);
 
-    u32 cookie = bpf_get_prandom_u32();
-    // insert new proc cache entry
-    bpf_map_update_elem(&proc_cache, &cookie, &entry, BPF_ANY);
-
     // select the previous cookie entry in cache of the current process
     // (this entry was created by the fork of the current process)
     struct pid_cache_t *fork_entry = (struct pid_cache_t *) bpf_map_lookup_elem(&pid_cache, &tgid);
@@ -113,7 +109,15 @@ int __attribute__((always_inline)) handle_exec_event(struct pt_regs *ctx, struct
             // inherit the parent container context
             fill_container_context(parent_entry, &entry.container);
         }
-        // update pid <-> cookie mapping
+    }
+
+    // Insert new proc cache entry (Note: do not move the order of this block with the previous one, we need to inherit
+    // the container ID before saving the entry in proc_cache. Modifying entry after insertion won't work.)
+    u32 cookie = bpf_get_prandom_u32();
+    bpf_map_update_elem(&proc_cache, &cookie, &entry, BPF_ANY);
+
+    // update pid <-> cookie mapping
+    if (fork_entry) {
         fork_entry->cookie = cookie;
     } else {
         struct pid_cache_t new_pid_entry = {

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -108,7 +108,8 @@ int __attribute__((always_inline)) trace__sys_link_ret(struct pt_regs *ctx) {
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
     copy_file_metadata(&syscall->link.src_metadata, &event.source.metadata);
-    fill_file_metadata(syscall->link.target_dentry, &event.target.metadata);
+    // this is a hard link, source and destination have necessarily the same inode metadata
+    copy_file_metadata(&syscall->link.src_metadata, &event.target.metadata);
 
     resolve_dentry(syscall->link.target_dentry, syscall->link.target_key, 0);
 

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -60,6 +60,7 @@ int kprobe__vfs_link(struct pt_regs *ctx) {
     }
 
     syscall->link.src_overlay_numlower = get_overlay_numlower(src_dentry);
+    fill_file_metadata(src_dentry, &syscall->link.src_metadata);
 
     // this is a hard link, source and target dentries are on the same filesystem & mount point
     // target_path was set by kprobe/filename_create before we reach this point.
@@ -106,6 +107,8 @@ int __attribute__((always_inline)) trace__sys_link_ret(struct pt_regs *ctx) {
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
+    copy_file_metadata(&syscall->link.src_metadata, &event.source.metadata);
+    fill_file_metadata(syscall->link.target_dentry, &event.target.metadata);
 
     resolve_dentry(syscall->link.target_dentry, syscall->link.target_key, 0);
 

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -97,19 +97,19 @@ int __attribute__((always_inline)) trace__sys_link_ret(struct pt_regs *ctx) {
             .mount_id = syscall->link.src_key.mount_id,
             .overlay_numlower = syscall->link.src_overlay_numlower,
             .path_id = syscall->link.src_key.path_id,
+            .metadata = syscall->link.src_metadata,
         },
         .target = {
             .inode = syscall->link.target_key.ino,
             .mount_id = syscall->link.target_key.mount_id,
             .overlay_numlower = get_overlay_numlower(syscall->link.target_dentry),
+            // this is a hard link, source and destination have necessarily the same inode metadata
+            .metadata = syscall->link.src_metadata,
         }
     };
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
-    copy_file_metadata(&syscall->link.src_metadata, &event.source.metadata);
-    // this is a hard link, source and destination have necessarily the same inode metadata
-    copy_file_metadata(&syscall->link.src_metadata, &event.target.metadata);
 
     resolve_dentry(syscall->link.target_dentry, syscall->link.target_key, 0);
 

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -94,6 +94,7 @@ int __attribute__((always_inline)) trace__sys_mkdir_ret(struct pt_regs *ctx) {
         .mode = syscall->mkdir.mode,
     };
 
+    fill_file_metadata(syscall->mkdir.dentry, &event.file.metadata);
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
 

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -192,6 +192,7 @@ int __attribute__((always_inline)) trace__sys_open_ret(struct pt_regs *ctx) {
         .mode = syscall->open.mode,
     };
 
+    fill_file_metadata(syscall->open.dentry, &event.file.metadata);
     int ret = resolve_dentry(syscall->open.dentry, syscall->open.path_key, syscall->policy.mode != NO_FILTER ? EVENT_OPEN : 0);
     if (ret == DENTRY_DISCARDED || (ret == DENTRY_INVALID && !(IS_UNHANDLED_ERROR(retval)))) {
        return 0;

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -117,20 +117,20 @@ int __attribute__((always_inline)) trace__sys_rename_ret(struct pt_regs *ctx) {
                 .inode = syscall->rename.src_key.ino,
                 .mount_id = syscall->rename.src_key.mount_id,
                 .overlay_numlower = syscall->rename.src_overlay_numlower,
+                .metadata = syscall->rename.src_metadata,
             },
             .new = {
                 .inode = syscall->rename.target_key.ino,
                 .mount_id = syscall->rename.target_key.mount_id,
                 .overlay_numlower = get_overlay_numlower(syscall->rename.src_dentry),
                 .path_id = syscall->rename.target_key.path_id,
+                .metadata = syscall->rename.src_metadata,
             },
             .discarder_revision = bump_discarder_revision(syscall->rename.target_key.mount_id),
         };
 
         struct proc_cache_t *entry = fill_process_context(&event.process);
         fill_container_context(entry, &event.container);
-        copy_file_metadata(&syscall->rename.src_metadata, &event.old.metadata);
-        copy_file_metadata(&syscall->rename.src_metadata, &event.new.metadata);
 
         // for centos7, use src dentry for target resolution as the pointers have been swapped
         resolve_dentry(syscall->rename.src_dentry, syscall->rename.target_key, 0);

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -57,6 +57,7 @@ int kprobe__vfs_rename(struct pt_regs *ctx) {
     struct dentry *target_dentry = (struct dentry *)PT_REGS_PARM4(ctx);
 
     syscall->rename.src_dentry = src_dentry;
+    fill_file_metadata(src_dentry, &syscall->rename.src_metadata);
     syscall->rename.target_dentry = target_dentry;
 
     if (filter_syscall(syscall, rename_approvers)) {
@@ -128,6 +129,8 @@ int __attribute__((always_inline)) trace__sys_rename_ret(struct pt_regs *ctx) {
 
         struct proc_cache_t *entry = fill_process_context(&event.process);
         fill_container_context(entry, &event.container);
+        copy_file_metadata(&syscall->rename.src_metadata, &event.old.metadata);
+        copy_file_metadata(&syscall->rename.src_metadata, &event.new.metadata);
 
         // for centos7, use src dentry for target resolution as the pointers have been swapped
         resolve_dentry(syscall->rename.src_dentry, syscall->rename.target_key, 0);

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -123,13 +123,13 @@ SYSCALL_KRETPROBE(rmdir) {
                 .mount_id = syscall->rmdir.path_key.mount_id,
                 .overlay_numlower = syscall->rmdir.overlay_numlower,
                 .path_id = syscall->rmdir.path_key.path_id,
+                .metadata = syscall->rmdir.metadata,
             },
             .discarder_revision = bump_discarder_revision(syscall->rmdir.path_key.mount_id),
         };
 
         struct proc_cache_t *entry = fill_process_context(&event.process);
         fill_container_context(entry, &event.container);
-        copy_file_metadata(&syscall->rmdir.metadata, &event.file.metadata);
 
         send_event(ctx, EVENT_RMDIR, event);
     }

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -51,6 +51,7 @@ int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
             // we resolve all the information before the file is actually removed
             dentry = (struct dentry *)PT_REGS_PARM2(ctx);
             set_path_key_inode(dentry, &syscall->rmdir.path_key, 1);
+            fill_file_metadata(dentry, &syscall->rmdir.metadata);
 
             syscall->rmdir.overlay_numlower = get_overlay_numlower(dentry);
 
@@ -73,6 +74,7 @@ int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
             // we resolve all the information before the file is actually removed
             dentry = (struct dentry *) PT_REGS_PARM2(ctx);
             set_path_key_inode(dentry, &syscall->unlink.path_key, 1);
+            fill_file_metadata(dentry, &syscall->unlink.metadata);
 
             syscall->unlink.overlay_numlower = get_overlay_numlower(dentry);
 
@@ -127,6 +129,7 @@ SYSCALL_KRETPROBE(rmdir) {
 
         struct proc_cache_t *entry = fill_process_context(&event.process);
         fill_container_context(entry, &event.container);
+        copy_file_metadata(&syscall->rmdir.metadata, &event.file.metadata);
 
         send_event(ctx, EVENT_RMDIR, event);
     }

--- a/pkg/security/ebpf/c/setattr.h
+++ b/pkg/security/ebpf/c/setattr.h
@@ -14,6 +14,7 @@ int kprobe__security_inode_setattr(struct pt_regs *ctx) {
         return 0;
 
     struct dentry *dentry = (struct dentry *)PT_REGS_PARM1(ctx);
+    fill_file_metadata(dentry, &syscall->setattr.metadata);
 
     struct iattr *iattr = (struct iattr *)PT_REGS_PARM2(ctx);
     if (iattr != NULL) {

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -131,6 +131,7 @@ int __attribute__((always_inline)) trace__sys_setxattr_ret(struct pt_regs *ctx, 
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
+    fill_file_metadata(syscall->setxattr.dentry, &event.file.metadata);
 
     send_event(ctx, event_type, event);
 

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -6,11 +6,6 @@
 
 #define FSTYPE_LEN 16
 
-struct ktimeval {
-    long tv_sec;
-    long tv_nsec;
-};
-
 struct syscall_cache_t {
     struct policy_t policy;
     u64 type;
@@ -34,6 +29,7 @@ struct syscall_cache_t {
         struct {
             struct dentry *dentry;
             struct path_key_t path_key;
+            struct file_metadata_t metadata;
             int overlay_numlower;
             int flags;
         } unlink;
@@ -41,11 +37,13 @@ struct syscall_cache_t {
         struct {
             struct dentry *dentry;
             struct path_key_t path_key;
+            struct file_metadata_t metadata;
             int overlay_numlower;
         } rmdir;
 
         struct {
             struct path_key_t src_key;
+            struct file_metadata_t src_metadata;
             unsigned long src_inode;
             struct dentry *src_dentry;
             struct dentry *target_dentry;
@@ -57,6 +55,7 @@ struct syscall_cache_t {
             struct dentry *dentry;
             struct path *path;
             struct path_key_t path_key;
+            struct file_metadata_t metadata;
             union {
                 umode_t mode;
                 struct {
@@ -84,6 +83,7 @@ struct syscall_cache_t {
 
         struct {
             struct path_key_t src_key;
+            struct file_metadata_t src_metadata;
             struct path *target_path;
             struct dentry *src_dentry;
             struct dentry *target_dentry;

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -53,6 +53,7 @@ int kprobe__vfs_unlink(struct pt_regs *ctx) {
     // we resolve all the information before the file is actually removed
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     set_path_key_inode(dentry, &syscall->unlink.path_key, 1);
+    fill_file_metadata(dentry, &syscall->unlink.metadata);
 
     syscall->unlink.dentry = dentry;
     syscall->unlink.overlay_numlower = get_overlay_numlower(dentry);
@@ -107,6 +108,7 @@ int __attribute__((always_inline)) trace__sys_unlink_ret(struct pt_regs *ctx) {
 
         struct proc_cache_t *entry = fill_process_context(&event.process);
         fill_container_context(entry, &event.container);
+        copy_file_metadata(&syscall->unlink.metadata, &event.file.metadata);
 
         send_event(ctx, syscall->unlink.flags&AT_REMOVEDIR ? EVENT_RMDIR : EVENT_UNLINK, event);
     }

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -101,6 +101,7 @@ int __attribute__((always_inline)) trace__sys_unlink_ret(struct pt_regs *ctx) {
                 .inode = syscall->unlink.path_key.ino,
                 .overlay_numlower = syscall->unlink.overlay_numlower,
                 .path_id = syscall->unlink.path_key.path_id,
+                .metadata = syscall->unlink.metadata,
             },
             .flags = syscall->unlink.flags,
             .discarder_revision = bump_discarder_revision(syscall->unlink.path_key.mount_id),
@@ -108,7 +109,6 @@ int __attribute__((always_inline)) trace__sys_unlink_ret(struct pt_regs *ctx) {
 
         struct proc_cache_t *entry = fill_process_context(&event.process);
         fill_container_context(entry, &event.container);
-        copy_file_metadata(&syscall->unlink.metadata, &event.file.metadata);
 
         send_event(ctx, syscall->unlink.flags&AT_REMOVEDIR ? EVENT_RMDIR : EVENT_UNLINK, event);
     }

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -87,9 +87,9 @@ int __attribute__((always_inline)) trace__sys_utimes_ret(struct pt_regs *ctx) {
             .mount_id = syscall->setattr.path_key.mount_id,
             .overlay_numlower = get_overlay_numlower(syscall->setattr.dentry),
             .path_id = syscall->setattr.path_key.path_id,
+            .metadata = syscall->setattr.metadata,
         },
     };
-    copy_file_metadata(&syscall->setattr.metadata, &event.file.metadata);
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -89,6 +89,7 @@ int __attribute__((always_inline)) trace__sys_utimes_ret(struct pt_regs *ctx) {
             .path_id = syscall->setattr.path_key.path_id,
         },
     };
+    copy_file_metadata(&syscall->setattr.metadata, &event.file.metadata);
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/log/logger.go
+++ b/pkg/security/log/logger.go
@@ -13,15 +13,15 @@ type DatadogAgentLogger struct{}
 
 // Tracef is used to print a trace level log
 func (l DatadogAgentLogger) Tracef(format string, params ...interface{}) {
-	log.Tracef(format, params)
+	log.Tracef(format, params...)
 }
 
 // Debugf is used to print a trace level log
 func (l DatadogAgentLogger) Debugf(format string, params ...interface{}) {
-	log.Debugf(format, params)
+	log.Debugf(format, params...)
 }
 
 // Errorf is used to print an error
 func (l DatadogAgentLogger) Errorf(format string, params ...interface{}) error {
-	return log.Errorf(format, params)
+	return log.Errorf(format, params...)
 }

--- a/pkg/security/model/accessors.go
+++ b/pkg/security/model/accessors.go
@@ -59,11 +59,11 @@ func (m *Model) GetEventTypes() []eval.EventType {
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Chmod.FileEvent.BasenameStr
+				return (*Event)(ctx.Object).Chmod.File.ContainerPath
 
 			},
 			Field: field,
@@ -71,43 +71,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "chmod.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Chmod.FileEvent.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chmod.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Chmod.FileEvent.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chmod.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Chmod.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "chmod.mode":
+	case "chmod.file.destination.mode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -119,16 +83,124 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Chmod.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chmod.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chmod.File.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chmod.File.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chmod.File.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chmod.retval":
@@ -143,11 +215,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Chown.FileEvent.BasenameStr
+				return (*Event)(ctx.Object).Chown.File.ContainerPath
 
 			},
 			Field: field,
@@ -155,31 +227,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "chown.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Chown.FileEvent.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chown.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Chown.FileEvent.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chown.gid":
+	case "chown.file.destination.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -191,11 +239,23 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "chown.inode":
+	case "chown.file.destination.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chown.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.destination.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Chown.FileEvent.FileFields.Inode)
+				return int((*Event)(ctx.Object).Chown.UID)
 
 			},
 			Field: field,
@@ -203,16 +263,136 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.destination.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chown.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Chown.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Chown.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chown.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chown.File.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chown.File.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Chown.File.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chown.retval":
@@ -220,18 +400,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Chown.SyscallEvent.Retval)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "chown.uid":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Chown.UID)
 
 			},
 			Field: field,
@@ -251,11 +419,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "exec.container_path":
+	case "exec.comm":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.ContainerPath
+				return (*Event)(ctx.Object).Exec.Comm
 
 			},
 			Field: field,
@@ -275,11 +443,131 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Exec.ContainerPath
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Exec.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Exec.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Exec.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Exec.FileFields.User
 
 			},
 			Field: field,
@@ -309,42 +597,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "exec.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Exec.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "exec.name":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Exec.BasenameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "exec.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Exec.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "exec.ppid":
@@ -395,6 +647,270 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Source.ContainerPath
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Target.ContainerPath
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Target.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Target.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Target.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Target.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Source.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Source.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Source.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Link.Source.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.retval":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -407,11 +923,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "link.source.basename":
+	case "mkdir.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Link.Source.BasenameStr
+				return (*Event)(ctx.Object).Mkdir.File.ContainerPath
 
 			},
 			Field: field,
@@ -419,163 +935,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "link.source.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Link.Source.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.source.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Link.Source.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.source.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Source.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "link.source.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Source.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "link.target.basename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Link.Target.BasenameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.target.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Link.Target.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.target.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Link.Target.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.target.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Target.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "link.target.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Target.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "mkdir.basename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Mkdir.FileEvent.BasenameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "mkdir.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Mkdir.FileEvent.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "mkdir.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Mkdir.FileEvent.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "mkdir.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Mkdir.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "mkdir.mode":
+	case "mkdir.file.destination.mode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -587,16 +947,124 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "mkdir.overlay_numlower":
+	case "mkdir.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Mkdir.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Mkdir.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Mkdir.File.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Mkdir.File.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Mkdir.File.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "mkdir.retval":
@@ -611,11 +1079,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "open.basename":
+	case "open.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Open.FileEvent.BasenameStr
+				return (*Event)(ctx.Object).Open.File.ContainerPath
 
 			},
 			Field: field,
@@ -623,11 +1091,35 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.group":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Open.FileEvent.ContainerPath
+				return (*Event)(ctx.Object).Open.File.FileFields.Group
 
 			},
 			Field: field,
@@ -635,11 +1127,95 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "open.filename":
+	case "open.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Open.FileEvent.PathnameStr
+				return (*Event)(ctx.Object).Open.File.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "open.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Open.File.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "open.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Open.File.FileFields.User
 
 			},
 			Field: field,
@@ -659,42 +1235,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "open.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Open.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "open.mode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Open.Mode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "open.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Open.FileEvent.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
 	case "open.retval":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -707,7 +1247,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -717,7 +1257,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				if reg.Value != nil {
 					element := (*ProcessCacheEntry)(reg.Value)
 
-					result = element.ProcessContext.ExecEvent.ContainerPath
+					result = element.ProcessContext.ExecEvent.Comm
 
 				}
 
@@ -751,7 +1291,183 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = element.ProcessContext.ExecEvent.ContainerPath
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.GID)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = element.ProcessContext.ExecEvent.FileFields.Group
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.Inode)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.Mode)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.MountID)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = element.ProcessContext.ExecEvent.BasenameStr
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.OverlayNumLower)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -762,6 +1478,50 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ProcessContext.ExecEvent.PathnameStr
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.UID)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*ProcessCacheEntry)(reg.Value)
+
+					result = element.ProcessContext.ExecEvent.FileFields.User
 
 				}
 
@@ -828,72 +1588,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*ProcessCacheEntry)(reg.Value)
 
 					result = element.ContainerContext.ID
-
-				}
-
-				return result
-
-			},
-			Field: field,
-
-			Weight: eval.IteratorWeight,
-		}, nil
-
-	case "process.ancestors.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				var result int
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-					element := (*ProcessCacheEntry)(reg.Value)
-
-					result = int(element.ProcessContext.ExecEvent.FileFields.Inode)
-
-				}
-
-				return result
-
-			},
-			Field: field,
-
-			Weight: eval.IteratorWeight,
-		}, nil
-
-	case "process.ancestors.name":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				var result string
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-					element := (*ProcessCacheEntry)(reg.Value)
-
-					result = element.ProcessContext.ExecEvent.BasenameStr
-
-				}
-
-				return result
-
-			},
-			Field: field,
-
-			Weight: eval.IteratorWeight,
-		}, nil
-
-	case "process.ancestors.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				var result int
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-					element := (*ProcessCacheEntry)(reg.Value)
-
-					result = int(element.ProcessContext.ExecEvent.FileFields.OverlayNumLower)
 
 				}
 
@@ -1037,11 +1731,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
-	case "process.container_path":
+	case "process.comm":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Process.ExecEvent.ContainerPath
+				return (*Event)(ctx.Object).Process.ExecEvent.Comm
 
 			},
 			Field: field,
@@ -1061,11 +1755,131 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "process.filename":
+	case "process.file.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Process.ExecEvent.ContainerPath
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Process.ExecEvent.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Process.ExecEvent.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Process.ExecEvent.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Process.ExecEvent.FileFields.User
 
 			},
 			Field: field,
@@ -1095,42 +1909,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "process.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "process.name":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Process.ExecEvent.BasenameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "process.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.pid":
@@ -1205,11 +1983,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).RemoveXAttr.FileEvent.BasenameStr
+				return (*Event)(ctx.Object).RemoveXAttr.File.ContainerPath
 
 			},
 			Field: field,
@@ -1217,43 +1995,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "removexattr.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).RemoveXAttr.FileEvent.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "removexattr.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).RemoveXAttr.FileEvent.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "removexattr.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).RemoveXAttr.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "removexattr.name":
+	case "removexattr.file.destination.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1265,7 +2007,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "removexattr.namespace":
+	case "removexattr.file.destination.namespace":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1277,16 +2019,124 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).RemoveXAttr.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).RemoveXAttr.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "removexattr.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).RemoveXAttr.File.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "removexattr.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).RemoveXAttr.File.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "removexattr.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).RemoveXAttr.File.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "removexattr.retval":
@@ -1301,79 +2151,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "rename.new.basename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Rename.New.BasenameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.new.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Rename.New.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.new.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Rename.New.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.new.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rename.New.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "rename.new.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rename.New.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "rename.old.basename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Rename.Old.BasenameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.old.container_path":
+	case "rename.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1385,11 +2163,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "rename.old.filename":
+	case "rename.file.destination.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Rename.Old.PathnameStr
+				return (*Event)(ctx.Object).Rename.New.ContainerPath
 
 			},
 			Field: field,
@@ -1397,7 +2175,151 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "rename.old.inode":
+	case "rename.file.destination.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.New.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.destination.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.New.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.destination.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.New.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.destination.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.New.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.Old.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -1409,7 +2331,43 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.Old.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.overlay_numlower":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -1419,6 +2377,42 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.Old.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rename.Old.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rename.retval":
@@ -1433,11 +2427,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Rmdir.FileEvent.BasenameStr
+				return (*Event)(ctx.Object).Rmdir.File.ContainerPath
 
 			},
 			Field: field,
@@ -1445,35 +2439,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "rmdir.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Rmdir.FileEvent.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rmdir.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Rmdir.FileEvent.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rmdir.inode":
+	case "rmdir.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Rmdir.FileEvent.FileFields.Inode)
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.GID)
 
 			},
 			Field: field,
@@ -1481,16 +2451,112 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rmdir.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Rmdir.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.Inode)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rmdir.File.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rmdir.File.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Rmdir.File.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rmdir.retval":
@@ -1505,11 +2571,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).SetXAttr.FileEvent.BasenameStr
+				return (*Event)(ctx.Object).SetXAttr.File.ContainerPath
 
 			},
 			Field: field,
@@ -1517,43 +2583,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "setxattr.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).SetXAttr.FileEvent.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "setxattr.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).SetXAttr.FileEvent.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "setxattr.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).SetXAttr.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "setxattr.name":
+	case "setxattr.file.destination.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1565,7 +2595,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "setxattr.namespace":
+	case "setxattr.file.destination.namespace":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1577,16 +2607,124 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).SetXAttr.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).SetXAttr.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "setxattr.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).SetXAttr.File.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "setxattr.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).SetXAttr.File.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "setxattr.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).SetXAttr.File.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "setxattr.retval":
@@ -1601,11 +2739,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Unlink.FileEvent.BasenameStr
+				return (*Event)(ctx.Object).Unlink.File.ContainerPath
 
 			},
 			Field: field,
@@ -1613,11 +2751,23 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "unlink.container_path":
+	case "unlink.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.group":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Unlink.FileEvent.ContainerPath
+				return (*Event)(ctx.Object).Unlink.File.FileFields.Group
 
 			},
 			Field: field,
@@ -1625,11 +2775,47 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "unlink.filename":
+	case "unlink.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Unlink.FileEvent.PathnameStr
+				return (*Event)(ctx.Object).Unlink.File.BasenameStr
 
 			},
 			Field: field,
@@ -1637,11 +2823,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "unlink.flags":
+	case "unlink.file.overlay_numlower":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Unlink.Flags)
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.OverlayNumLower)
 
 			},
 			Field: field,
@@ -1649,11 +2835,23 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "unlink.inode":
+	case "unlink.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Unlink.File.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "unlink.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Unlink.FileEvent.FileFields.Inode)
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.UID)
 
 			},
 			Field: field,
@@ -1661,16 +2859,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "unlink.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
+	case "unlink.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
 
-				return int((*Event)(ctx.Object).Unlink.FileEvent.FileFields.OverlayNumLower)
+				return (*Event)(ctx.Object).Unlink.File.FileFields.User
 
 			},
 			Field: field,
 
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "unlink.retval":
@@ -1685,11 +2883,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Utimes.FileEvent.BasenameStr
+				return (*Event)(ctx.Object).Utimes.File.ContainerPath
 
 			},
 			Field: field,
@@ -1697,35 +2895,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "utimes.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Utimes.FileEvent.ContainerPath
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "utimes.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).Utimes.FileEvent.PathnameStr
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "utimes.inode":
+	case "utimes.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Utimes.FileEvent.FileFields.Inode)
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.GID)
 
 			},
 			Field: field,
@@ -1733,16 +2907,112 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Utimes.File.FileFields.Group
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "utimes.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Utimes.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.Inode)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Utimes.File.BasenameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "utimes.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Utimes.File.PathnameStr
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "utimes.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).Utimes.File.FileFields.User
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "utimes.retval":
@@ -1765,53 +3035,95 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 func (e *Event) GetFields() []eval.Field {
 	return []eval.Field{
 
-		"chmod.basename",
+		"chmod.file.container_path",
 
-		"chmod.container_path",
+		"chmod.file.destination.mode",
 
-		"chmod.filename",
+		"chmod.file.gid",
 
-		"chmod.inode",
+		"chmod.file.group",
 
-		"chmod.mode",
+		"chmod.file.inode",
 
-		"chmod.overlay_numlower",
+		"chmod.file.mode",
+
+		"chmod.file.mount_id",
+
+		"chmod.file.name",
+
+		"chmod.file.overlay_numlower",
+
+		"chmod.file.path",
+
+		"chmod.file.uid",
+
+		"chmod.file.user",
 
 		"chmod.retval",
 
-		"chown.basename",
+		"chown.file.container_path",
 
-		"chown.container_path",
+		"chown.file.destination.gid",
 
-		"chown.filename",
+		"chown.file.destination.group",
 
-		"chown.gid",
+		"chown.file.destination.uid",
 
-		"chown.inode",
+		"chown.file.destination.user",
 
-		"chown.overlay_numlower",
+		"chown.file.gid",
+
+		"chown.file.group",
+
+		"chown.file.inode",
+
+		"chown.file.mode",
+
+		"chown.file.mount_id",
+
+		"chown.file.name",
+
+		"chown.file.overlay_numlower",
+
+		"chown.file.path",
+
+		"chown.file.uid",
+
+		"chown.file.user",
 
 		"chown.retval",
 
-		"chown.uid",
-
 		"container.id",
 
-		"exec.container_path",
+		"exec.comm",
 
 		"exec.cookie",
 
-		"exec.filename",
+		"exec.file.container_path",
+
+		"exec.file.gid",
+
+		"exec.file.group",
+
+		"exec.file.inode",
+
+		"exec.file.mode",
+
+		"exec.file.mount_id",
+
+		"exec.file.name",
+
+		"exec.file.overlay_numlower",
+
+		"exec.file.path",
+
+		"exec.file.uid",
+
+		"exec.file.user",
 
 		"exec.gid",
 
 		"exec.group",
-
-		"exec.inode",
-
-		"exec.name",
-
-		"exec.overlay_numlower",
 
 		"exec.ppid",
 
@@ -1821,75 +3133,137 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.user",
 
+		"link.file.container_path",
+
+		"link.file.destination.container_path",
+
+		"link.file.destination.gid",
+
+		"link.file.destination.group",
+
+		"link.file.destination.inode",
+
+		"link.file.destination.mode",
+
+		"link.file.destination.mount_id",
+
+		"link.file.destination.name",
+
+		"link.file.destination.overlay_numlower",
+
+		"link.file.destination.path",
+
+		"link.file.destination.uid",
+
+		"link.file.destination.user",
+
+		"link.file.gid",
+
+		"link.file.group",
+
+		"link.file.inode",
+
+		"link.file.mode",
+
+		"link.file.mount_id",
+
+		"link.file.name",
+
+		"link.file.overlay_numlower",
+
+		"link.file.path",
+
+		"link.file.uid",
+
+		"link.file.user",
+
 		"link.retval",
 
-		"link.source.basename",
+		"mkdir.file.container_path",
 
-		"link.source.container_path",
+		"mkdir.file.destination.mode",
 
-		"link.source.filename",
+		"mkdir.file.gid",
 
-		"link.source.inode",
+		"mkdir.file.group",
 
-		"link.source.overlay_numlower",
+		"mkdir.file.inode",
 
-		"link.target.basename",
+		"mkdir.file.mode",
 
-		"link.target.container_path",
+		"mkdir.file.mount_id",
 
-		"link.target.filename",
+		"mkdir.file.name",
 
-		"link.target.inode",
+		"mkdir.file.overlay_numlower",
 
-		"link.target.overlay_numlower",
+		"mkdir.file.path",
 
-		"mkdir.basename",
+		"mkdir.file.uid",
 
-		"mkdir.container_path",
-
-		"mkdir.filename",
-
-		"mkdir.inode",
-
-		"mkdir.mode",
-
-		"mkdir.overlay_numlower",
+		"mkdir.file.user",
 
 		"mkdir.retval",
 
-		"open.basename",
+		"open.file.container_path",
 
-		"open.container_path",
+		"open.file.destination.mode",
 
-		"open.filename",
+		"open.file.gid",
+
+		"open.file.group",
+
+		"open.file.inode",
+
+		"open.file.mode",
+
+		"open.file.mount_id",
+
+		"open.file.name",
+
+		"open.file.overlay_numlower",
+
+		"open.file.path",
+
+		"open.file.uid",
+
+		"open.file.user",
 
 		"open.flags",
 
-		"open.inode",
-
-		"open.mode",
-
-		"open.overlay_numlower",
-
 		"open.retval",
 
-		"process.ancestors.container_path",
+		"process.ancestors.comm",
 
 		"process.ancestors.cookie",
 
-		"process.ancestors.filename",
+		"process.ancestors.file.container_path",
+
+		"process.ancestors.file.gid",
+
+		"process.ancestors.file.group",
+
+		"process.ancestors.file.inode",
+
+		"process.ancestors.file.mode",
+
+		"process.ancestors.file.mount_id",
+
+		"process.ancestors.file.name",
+
+		"process.ancestors.file.overlay_numlower",
+
+		"process.ancestors.file.path",
+
+		"process.ancestors.file.uid",
+
+		"process.ancestors.file.user",
 
 		"process.ancestors.gid",
 
 		"process.ancestors.group",
 
 		"process.ancestors.id",
-
-		"process.ancestors.inode",
-
-		"process.ancestors.name",
-
-		"process.ancestors.overlay_numlower",
 
 		"process.ancestors.pid",
 
@@ -1903,21 +3277,35 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.user",
 
-		"process.container_path",
+		"process.comm",
 
 		"process.cookie",
 
-		"process.filename",
+		"process.file.container_path",
+
+		"process.file.gid",
+
+		"process.file.group",
+
+		"process.file.inode",
+
+		"process.file.mode",
+
+		"process.file.mount_id",
+
+		"process.file.name",
+
+		"process.file.overlay_numlower",
+
+		"process.file.path",
+
+		"process.file.uid",
+
+		"process.file.user",
 
 		"process.gid",
 
 		"process.group",
-
-		"process.inode",
-
-		"process.name",
-
-		"process.overlay_numlower",
 
 		"process.pid",
 
@@ -1931,95 +3319,177 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.user",
 
-		"removexattr.basename",
+		"removexattr.file.container_path",
 
-		"removexattr.container_path",
+		"removexattr.file.destination.name",
 
-		"removexattr.filename",
+		"removexattr.file.destination.namespace",
 
-		"removexattr.inode",
+		"removexattr.file.gid",
 
-		"removexattr.name",
+		"removexattr.file.group",
 
-		"removexattr.namespace",
+		"removexattr.file.inode",
 
-		"removexattr.overlay_numlower",
+		"removexattr.file.mode",
+
+		"removexattr.file.mount_id",
+
+		"removexattr.file.name",
+
+		"removexattr.file.overlay_numlower",
+
+		"removexattr.file.path",
+
+		"removexattr.file.uid",
+
+		"removexattr.file.user",
 
 		"removexattr.retval",
 
-		"rename.new.basename",
+		"rename.file.container_path",
 
-		"rename.new.container_path",
+		"rename.file.destination.container_path",
 
-		"rename.new.filename",
+		"rename.file.destination.gid",
 
-		"rename.new.inode",
+		"rename.file.destination.group",
 
-		"rename.new.overlay_numlower",
+		"rename.file.destination.inode",
 
-		"rename.old.basename",
+		"rename.file.destination.mode",
 
-		"rename.old.container_path",
+		"rename.file.destination.mount_id",
 
-		"rename.old.filename",
+		"rename.file.destination.name",
 
-		"rename.old.inode",
+		"rename.file.destination.overlay_numlower",
 
-		"rename.old.overlay_numlower",
+		"rename.file.destination.path",
+
+		"rename.file.destination.uid",
+
+		"rename.file.destination.user",
+
+		"rename.file.gid",
+
+		"rename.file.group",
+
+		"rename.file.inode",
+
+		"rename.file.mode",
+
+		"rename.file.mount_id",
+
+		"rename.file.name",
+
+		"rename.file.overlay_numlower",
+
+		"rename.file.path",
+
+		"rename.file.uid",
+
+		"rename.file.user",
 
 		"rename.retval",
 
-		"rmdir.basename",
+		"rmdir.file.container_path",
 
-		"rmdir.container_path",
+		"rmdir.file.gid",
 
-		"rmdir.filename",
+		"rmdir.file.group",
 
-		"rmdir.inode",
+		"rmdir.file.inode",
 
-		"rmdir.overlay_numlower",
+		"rmdir.file.mode",
+
+		"rmdir.file.mount_id",
+
+		"rmdir.file.name",
+
+		"rmdir.file.overlay_numlower",
+
+		"rmdir.file.path",
+
+		"rmdir.file.uid",
+
+		"rmdir.file.user",
 
 		"rmdir.retval",
 
-		"setxattr.basename",
+		"setxattr.file.container_path",
 
-		"setxattr.container_path",
+		"setxattr.file.destination.name",
 
-		"setxattr.filename",
+		"setxattr.file.destination.namespace",
 
-		"setxattr.inode",
+		"setxattr.file.gid",
 
-		"setxattr.name",
+		"setxattr.file.group",
 
-		"setxattr.namespace",
+		"setxattr.file.inode",
 
-		"setxattr.overlay_numlower",
+		"setxattr.file.mode",
+
+		"setxattr.file.mount_id",
+
+		"setxattr.file.name",
+
+		"setxattr.file.overlay_numlower",
+
+		"setxattr.file.path",
+
+		"setxattr.file.uid",
+
+		"setxattr.file.user",
 
 		"setxattr.retval",
 
-		"unlink.basename",
+		"unlink.file.container_path",
 
-		"unlink.container_path",
+		"unlink.file.gid",
 
-		"unlink.filename",
+		"unlink.file.group",
 
-		"unlink.flags",
+		"unlink.file.inode",
 
-		"unlink.inode",
+		"unlink.file.mode",
 
-		"unlink.overlay_numlower",
+		"unlink.file.mount_id",
+
+		"unlink.file.name",
+
+		"unlink.file.overlay_numlower",
+
+		"unlink.file.path",
+
+		"unlink.file.uid",
+
+		"unlink.file.user",
 
 		"unlink.retval",
 
-		"utimes.basename",
+		"utimes.file.container_path",
 
-		"utimes.container_path",
+		"utimes.file.gid",
 
-		"utimes.filename",
+		"utimes.file.group",
 
-		"utimes.inode",
+		"utimes.file.inode",
 
-		"utimes.overlay_numlower",
+		"utimes.file.mode",
+
+		"utimes.file.mount_id",
+
+		"utimes.file.name",
+
+		"utimes.file.overlay_numlower",
+
+		"utimes.file.path",
+
+		"utimes.file.uid",
+
+		"utimes.file.user",
 
 		"utimes.retval",
 	}
@@ -2028,81 +3498,177 @@ func (e *Event) GetFields() []eval.Field {
 func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 
-		return e.Chmod.FileEvent.BasenameStr, nil
+		return e.Chmod.File.ContainerPath, nil
 
-	case "chmod.container_path":
-
-		return e.Chmod.FileEvent.ContainerPath, nil
-
-	case "chmod.filename":
-
-		return e.Chmod.FileEvent.PathnameStr, nil
-
-	case "chmod.inode":
-
-		return int(e.Chmod.FileEvent.FileFields.Inode), nil
-
-	case "chmod.mode":
+	case "chmod.file.destination.mode":
 
 		return int(e.Chmod.Mode), nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.gid":
 
-		return int(e.Chmod.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Chmod.File.FileFields.GID), nil
+
+	case "chmod.file.group":
+
+		return e.Chmod.File.FileFields.Group, nil
+
+	case "chmod.file.inode":
+
+		return int(e.Chmod.File.FileFields.Inode), nil
+
+	case "chmod.file.mode":
+
+		return int(e.Chmod.File.FileFields.Mode), nil
+
+	case "chmod.file.mount_id":
+
+		return int(e.Chmod.File.FileFields.MountID), nil
+
+	case "chmod.file.name":
+
+		return e.Chmod.File.BasenameStr, nil
+
+	case "chmod.file.overlay_numlower":
+
+		return int(e.Chmod.File.FileFields.OverlayNumLower), nil
+
+	case "chmod.file.path":
+
+		return e.Chmod.File.PathnameStr, nil
+
+	case "chmod.file.uid":
+
+		return int(e.Chmod.File.FileFields.UID), nil
+
+	case "chmod.file.user":
+
+		return e.Chmod.File.FileFields.User, nil
 
 	case "chmod.retval":
 
 		return int(e.Chmod.SyscallEvent.Retval), nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 
-		return e.Chown.FileEvent.BasenameStr, nil
+		return e.Chown.File.ContainerPath, nil
 
-	case "chown.container_path":
-
-		return e.Chown.FileEvent.ContainerPath, nil
-
-	case "chown.filename":
-
-		return e.Chown.FileEvent.PathnameStr, nil
-
-	case "chown.gid":
+	case "chown.file.destination.gid":
 
 		return int(e.Chown.GID), nil
 
-	case "chown.inode":
+	case "chown.file.destination.group":
 
-		return int(e.Chown.FileEvent.FileFields.Inode), nil
+		return e.Chown.Group, nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.destination.uid":
 
-		return int(e.Chown.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Chown.UID), nil
+
+	case "chown.file.destination.user":
+
+		return e.Chown.User, nil
+
+	case "chown.file.gid":
+
+		return int(e.Chown.File.FileFields.GID), nil
+
+	case "chown.file.group":
+
+		return e.Chown.File.FileFields.Group, nil
+
+	case "chown.file.inode":
+
+		return int(e.Chown.File.FileFields.Inode), nil
+
+	case "chown.file.mode":
+
+		return int(e.Chown.File.FileFields.Mode), nil
+
+	case "chown.file.mount_id":
+
+		return int(e.Chown.File.FileFields.MountID), nil
+
+	case "chown.file.name":
+
+		return e.Chown.File.BasenameStr, nil
+
+	case "chown.file.overlay_numlower":
+
+		return int(e.Chown.File.FileFields.OverlayNumLower), nil
+
+	case "chown.file.path":
+
+		return e.Chown.File.PathnameStr, nil
+
+	case "chown.file.uid":
+
+		return int(e.Chown.File.FileFields.UID), nil
+
+	case "chown.file.user":
+
+		return e.Chown.File.FileFields.User, nil
 
 	case "chown.retval":
 
 		return int(e.Chown.SyscallEvent.Retval), nil
 
-	case "chown.uid":
-
-		return int(e.Chown.UID), nil
-
 	case "container.id":
 
 		return e.Container.ID, nil
 
-	case "exec.container_path":
+	case "exec.comm":
 
-		return e.Exec.ContainerPath, nil
+		return e.Exec.Comm, nil
 
 	case "exec.cookie":
 
 		return int(e.Exec.Cookie), nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+
+		return e.Exec.ContainerPath, nil
+
+	case "exec.file.gid":
+
+		return int(e.Exec.FileFields.GID), nil
+
+	case "exec.file.group":
+
+		return e.Exec.FileFields.Group, nil
+
+	case "exec.file.inode":
+
+		return int(e.Exec.FileFields.Inode), nil
+
+	case "exec.file.mode":
+
+		return int(e.Exec.FileFields.Mode), nil
+
+	case "exec.file.mount_id":
+
+		return int(e.Exec.FileFields.MountID), nil
+
+	case "exec.file.name":
+
+		return e.Exec.BasenameStr, nil
+
+	case "exec.file.overlay_numlower":
+
+		return int(e.Exec.FileFields.OverlayNumLower), nil
+
+	case "exec.file.path":
 
 		return e.Exec.PathnameStr, nil
+
+	case "exec.file.uid":
+
+		return int(e.Exec.FileFields.UID), nil
+
+	case "exec.file.user":
+
+		return e.Exec.FileFields.User, nil
 
 	case "exec.gid":
 
@@ -2111,18 +3677,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "exec.group":
 
 		return e.Exec.Group, nil
-
-	case "exec.inode":
-
-		return int(e.Exec.FileFields.Inode), nil
-
-	case "exec.name":
-
-		return e.Exec.BasenameStr, nil
-
-	case "exec.overlay_numlower":
-
-		return int(e.Exec.FileFields.OverlayNumLower), nil
 
 	case "exec.ppid":
 
@@ -2140,111 +3694,207 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Exec.User, nil
 
+	case "link.file.container_path":
+
+		return e.Link.Source.ContainerPath, nil
+
+	case "link.file.destination.container_path":
+
+		return e.Link.Target.ContainerPath, nil
+
+	case "link.file.destination.gid":
+
+		return int(e.Link.Target.FileFields.GID), nil
+
+	case "link.file.destination.group":
+
+		return e.Link.Target.FileFields.Group, nil
+
+	case "link.file.destination.inode":
+
+		return int(e.Link.Target.FileFields.Inode), nil
+
+	case "link.file.destination.mode":
+
+		return int(e.Link.Target.FileFields.Mode), nil
+
+	case "link.file.destination.mount_id":
+
+		return int(e.Link.Target.FileFields.MountID), nil
+
+	case "link.file.destination.name":
+
+		return e.Link.Target.BasenameStr, nil
+
+	case "link.file.destination.overlay_numlower":
+
+		return int(e.Link.Target.FileFields.OverlayNumLower), nil
+
+	case "link.file.destination.path":
+
+		return e.Link.Target.PathnameStr, nil
+
+	case "link.file.destination.uid":
+
+		return int(e.Link.Target.FileFields.UID), nil
+
+	case "link.file.destination.user":
+
+		return e.Link.Target.FileFields.User, nil
+
+	case "link.file.gid":
+
+		return int(e.Link.Source.FileFields.GID), nil
+
+	case "link.file.group":
+
+		return e.Link.Source.FileFields.Group, nil
+
+	case "link.file.inode":
+
+		return int(e.Link.Source.FileFields.Inode), nil
+
+	case "link.file.mode":
+
+		return int(e.Link.Source.FileFields.Mode), nil
+
+	case "link.file.mount_id":
+
+		return int(e.Link.Source.FileFields.MountID), nil
+
+	case "link.file.name":
+
+		return e.Link.Source.BasenameStr, nil
+
+	case "link.file.overlay_numlower":
+
+		return int(e.Link.Source.FileFields.OverlayNumLower), nil
+
+	case "link.file.path":
+
+		return e.Link.Source.PathnameStr, nil
+
+	case "link.file.uid":
+
+		return int(e.Link.Source.FileFields.UID), nil
+
+	case "link.file.user":
+
+		return e.Link.Source.FileFields.User, nil
+
 	case "link.retval":
 
 		return int(e.Link.SyscallEvent.Retval), nil
 
-	case "link.source.basename":
+	case "mkdir.file.container_path":
 
-		return e.Link.Source.BasenameStr, nil
+		return e.Mkdir.File.ContainerPath, nil
 
-	case "link.source.container_path":
-
-		return e.Link.Source.ContainerPath, nil
-
-	case "link.source.filename":
-
-		return e.Link.Source.PathnameStr, nil
-
-	case "link.source.inode":
-
-		return int(e.Link.Source.FileFields.Inode), nil
-
-	case "link.source.overlay_numlower":
-
-		return int(e.Link.Source.FileFields.OverlayNumLower), nil
-
-	case "link.target.basename":
-
-		return e.Link.Target.BasenameStr, nil
-
-	case "link.target.container_path":
-
-		return e.Link.Target.ContainerPath, nil
-
-	case "link.target.filename":
-
-		return e.Link.Target.PathnameStr, nil
-
-	case "link.target.inode":
-
-		return int(e.Link.Target.FileFields.Inode), nil
-
-	case "link.target.overlay_numlower":
-
-		return int(e.Link.Target.FileFields.OverlayNumLower), nil
-
-	case "mkdir.basename":
-
-		return e.Mkdir.FileEvent.BasenameStr, nil
-
-	case "mkdir.container_path":
-
-		return e.Mkdir.FileEvent.ContainerPath, nil
-
-	case "mkdir.filename":
-
-		return e.Mkdir.FileEvent.PathnameStr, nil
-
-	case "mkdir.inode":
-
-		return int(e.Mkdir.FileEvent.FileFields.Inode), nil
-
-	case "mkdir.mode":
+	case "mkdir.file.destination.mode":
 
 		return int(e.Mkdir.Mode), nil
 
-	case "mkdir.overlay_numlower":
+	case "mkdir.file.gid":
 
-		return int(e.Mkdir.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Mkdir.File.FileFields.GID), nil
+
+	case "mkdir.file.group":
+
+		return e.Mkdir.File.FileFields.Group, nil
+
+	case "mkdir.file.inode":
+
+		return int(e.Mkdir.File.FileFields.Inode), nil
+
+	case "mkdir.file.mode":
+
+		return int(e.Mkdir.File.FileFields.Mode), nil
+
+	case "mkdir.file.mount_id":
+
+		return int(e.Mkdir.File.FileFields.MountID), nil
+
+	case "mkdir.file.name":
+
+		return e.Mkdir.File.BasenameStr, nil
+
+	case "mkdir.file.overlay_numlower":
+
+		return int(e.Mkdir.File.FileFields.OverlayNumLower), nil
+
+	case "mkdir.file.path":
+
+		return e.Mkdir.File.PathnameStr, nil
+
+	case "mkdir.file.uid":
+
+		return int(e.Mkdir.File.FileFields.UID), nil
+
+	case "mkdir.file.user":
+
+		return e.Mkdir.File.FileFields.User, nil
 
 	case "mkdir.retval":
 
 		return int(e.Mkdir.SyscallEvent.Retval), nil
 
-	case "open.basename":
+	case "open.file.container_path":
 
-		return e.Open.FileEvent.BasenameStr, nil
+		return e.Open.File.ContainerPath, nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
 
-		return e.Open.FileEvent.ContainerPath, nil
+		return int(e.Open.Mode), nil
 
-	case "open.filename":
+	case "open.file.gid":
 
-		return e.Open.FileEvent.PathnameStr, nil
+		return int(e.Open.File.FileFields.GID), nil
+
+	case "open.file.group":
+
+		return e.Open.File.FileFields.Group, nil
+
+	case "open.file.inode":
+
+		return int(e.Open.File.FileFields.Inode), nil
+
+	case "open.file.mode":
+
+		return int(e.Open.File.FileFields.Mode), nil
+
+	case "open.file.mount_id":
+
+		return int(e.Open.File.FileFields.MountID), nil
+
+	case "open.file.name":
+
+		return e.Open.File.BasenameStr, nil
+
+	case "open.file.overlay_numlower":
+
+		return int(e.Open.File.FileFields.OverlayNumLower), nil
+
+	case "open.file.path":
+
+		return e.Open.File.PathnameStr, nil
+
+	case "open.file.uid":
+
+		return int(e.Open.File.FileFields.UID), nil
+
+	case "open.file.user":
+
+		return e.Open.File.FileFields.User, nil
 
 	case "open.flags":
 
 		return int(e.Open.Flags), nil
 
-	case "open.inode":
-
-		return int(e.Open.FileEvent.FileFields.Inode), nil
-
-	case "open.mode":
-
-		return int(e.Open.Mode), nil
-
-	case "open.overlay_numlower":
-
-		return int(e.Open.FileEvent.FileFields.OverlayNumLower), nil
-
 	case "open.retval":
 
 		return int(e.Open.SyscallEvent.Retval), nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 
 		var values []string
 
@@ -2257,7 +3907,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		for ptr != nil {
 			element := (*ProcessCacheEntry)(ptr)
 
-			result := element.ProcessContext.ExecEvent.ContainerPath
+			result := element.ProcessContext.ExecEvent.Comm
 
 			values = append(values, result)
 
@@ -2288,7 +3938,183 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.ExecEvent.ContainerPath
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.gid":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.GID)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.group":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.ExecEvent.FileFields.Group
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.inode":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.Inode)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.mode":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.Mode)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.mount_id":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.MountID)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.name":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.ExecEvent.BasenameStr
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.overlay_numlower":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.OverlayNumLower)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.path":
 
 		var values []string
 
@@ -2302,6 +4128,50 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*ProcessCacheEntry)(ptr)
 
 			result := element.ProcessContext.ExecEvent.PathnameStr
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.uid":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.UID)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.user":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.ExecEvent.FileFields.User
 
 			values = append(values, result)
 
@@ -2368,72 +4238,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*ProcessCacheEntry)(ptr)
 
 			result := element.ContainerContext.ID
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
-
-	case "process.ancestors.inode":
-
-		var values []int
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &ProcessAncestorsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-			element := (*ProcessCacheEntry)(ptr)
-
-			result := int(element.ProcessContext.ExecEvent.FileFields.Inode)
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
-
-	case "process.ancestors.name":
-
-		var values []string
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &ProcessAncestorsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-			element := (*ProcessCacheEntry)(ptr)
-
-			result := element.ProcessContext.ExecEvent.BasenameStr
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
-
-	case "process.ancestors.overlay_numlower":
-
-		var values []int
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &ProcessAncestorsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-			element := (*ProcessCacheEntry)(ptr)
-
-			result := int(element.ProcessContext.ExecEvent.FileFields.OverlayNumLower)
 
 			values = append(values, result)
 
@@ -2574,17 +4378,57 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
-	case "process.container_path":
+	case "process.comm":
 
-		return e.Process.ExecEvent.ContainerPath, nil
+		return e.Process.ExecEvent.Comm, nil
 
 	case "process.cookie":
 
 		return int(e.Process.ExecEvent.Cookie), nil
 
-	case "process.filename":
+	case "process.file.container_path":
+
+		return e.Process.ExecEvent.ContainerPath, nil
+
+	case "process.file.gid":
+
+		return int(e.Process.ExecEvent.FileFields.GID), nil
+
+	case "process.file.group":
+
+		return e.Process.ExecEvent.FileFields.Group, nil
+
+	case "process.file.inode":
+
+		return int(e.Process.ExecEvent.FileFields.Inode), nil
+
+	case "process.file.mode":
+
+		return int(e.Process.ExecEvent.FileFields.Mode), nil
+
+	case "process.file.mount_id":
+
+		return int(e.Process.ExecEvent.FileFields.MountID), nil
+
+	case "process.file.name":
+
+		return e.Process.ExecEvent.BasenameStr, nil
+
+	case "process.file.overlay_numlower":
+
+		return int(e.Process.ExecEvent.FileFields.OverlayNumLower), nil
+
+	case "process.file.path":
 
 		return e.Process.ExecEvent.PathnameStr, nil
+
+	case "process.file.uid":
+
+		return int(e.Process.ExecEvent.FileFields.UID), nil
+
+	case "process.file.user":
+
+		return e.Process.ExecEvent.FileFields.User, nil
 
 	case "process.gid":
 
@@ -2593,18 +4437,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.group":
 
 		return e.Process.ExecEvent.Group, nil
-
-	case "process.inode":
-
-		return int(e.Process.ExecEvent.FileFields.Inode), nil
-
-	case "process.name":
-
-		return e.Process.ExecEvent.BasenameStr, nil
-
-	case "process.overlay_numlower":
-
-		return int(e.Process.ExecEvent.FileFields.OverlayNumLower), nil
 
 	case "process.pid":
 
@@ -2630,185 +4462,349 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Process.ExecEvent.User, nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 
-		return e.RemoveXAttr.FileEvent.BasenameStr, nil
+		return e.RemoveXAttr.File.ContainerPath, nil
 
-	case "removexattr.container_path":
-
-		return e.RemoveXAttr.FileEvent.ContainerPath, nil
-
-	case "removexattr.filename":
-
-		return e.RemoveXAttr.FileEvent.PathnameStr, nil
-
-	case "removexattr.inode":
-
-		return int(e.RemoveXAttr.FileEvent.FileFields.Inode), nil
-
-	case "removexattr.name":
+	case "removexattr.file.destination.name":
 
 		return e.RemoveXAttr.Name, nil
 
-	case "removexattr.namespace":
+	case "removexattr.file.destination.namespace":
 
 		return e.RemoveXAttr.Namespace, nil
 
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.gid":
 
-		return int(e.RemoveXAttr.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.RemoveXAttr.File.FileFields.GID), nil
+
+	case "removexattr.file.group":
+
+		return e.RemoveXAttr.File.FileFields.Group, nil
+
+	case "removexattr.file.inode":
+
+		return int(e.RemoveXAttr.File.FileFields.Inode), nil
+
+	case "removexattr.file.mode":
+
+		return int(e.RemoveXAttr.File.FileFields.Mode), nil
+
+	case "removexattr.file.mount_id":
+
+		return int(e.RemoveXAttr.File.FileFields.MountID), nil
+
+	case "removexattr.file.name":
+
+		return e.RemoveXAttr.File.BasenameStr, nil
+
+	case "removexattr.file.overlay_numlower":
+
+		return int(e.RemoveXAttr.File.FileFields.OverlayNumLower), nil
+
+	case "removexattr.file.path":
+
+		return e.RemoveXAttr.File.PathnameStr, nil
+
+	case "removexattr.file.uid":
+
+		return int(e.RemoveXAttr.File.FileFields.UID), nil
+
+	case "removexattr.file.user":
+
+		return e.RemoveXAttr.File.FileFields.User, nil
 
 	case "removexattr.retval":
 
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
 
-	case "rename.new.basename":
-
-		return e.Rename.New.BasenameStr, nil
-
-	case "rename.new.container_path":
-
-		return e.Rename.New.ContainerPath, nil
-
-	case "rename.new.filename":
-
-		return e.Rename.New.PathnameStr, nil
-
-	case "rename.new.inode":
-
-		return int(e.Rename.New.FileFields.Inode), nil
-
-	case "rename.new.overlay_numlower":
-
-		return int(e.Rename.New.FileFields.OverlayNumLower), nil
-
-	case "rename.old.basename":
-
-		return e.Rename.Old.BasenameStr, nil
-
-	case "rename.old.container_path":
+	case "rename.file.container_path":
 
 		return e.Rename.Old.ContainerPath, nil
 
-	case "rename.old.filename":
+	case "rename.file.destination.container_path":
 
-		return e.Rename.Old.PathnameStr, nil
+		return e.Rename.New.ContainerPath, nil
 
-	case "rename.old.inode":
+	case "rename.file.destination.gid":
+
+		return int(e.Rename.New.FileFields.GID), nil
+
+	case "rename.file.destination.group":
+
+		return e.Rename.New.FileFields.Group, nil
+
+	case "rename.file.destination.inode":
+
+		return int(e.Rename.New.FileFields.Inode), nil
+
+	case "rename.file.destination.mode":
+
+		return int(e.Rename.New.FileFields.Mode), nil
+
+	case "rename.file.destination.mount_id":
+
+		return int(e.Rename.New.FileFields.MountID), nil
+
+	case "rename.file.destination.name":
+
+		return e.Rename.New.BasenameStr, nil
+
+	case "rename.file.destination.overlay_numlower":
+
+		return int(e.Rename.New.FileFields.OverlayNumLower), nil
+
+	case "rename.file.destination.path":
+
+		return e.Rename.New.PathnameStr, nil
+
+	case "rename.file.destination.uid":
+
+		return int(e.Rename.New.FileFields.UID), nil
+
+	case "rename.file.destination.user":
+
+		return e.Rename.New.FileFields.User, nil
+
+	case "rename.file.gid":
+
+		return int(e.Rename.Old.FileFields.GID), nil
+
+	case "rename.file.group":
+
+		return e.Rename.Old.FileFields.Group, nil
+
+	case "rename.file.inode":
 
 		return int(e.Rename.Old.FileFields.Inode), nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.mode":
+
+		return int(e.Rename.Old.FileFields.Mode), nil
+
+	case "rename.file.mount_id":
+
+		return int(e.Rename.Old.FileFields.MountID), nil
+
+	case "rename.file.name":
+
+		return e.Rename.Old.BasenameStr, nil
+
+	case "rename.file.overlay_numlower":
 
 		return int(e.Rename.Old.FileFields.OverlayNumLower), nil
+
+	case "rename.file.path":
+
+		return e.Rename.Old.PathnameStr, nil
+
+	case "rename.file.uid":
+
+		return int(e.Rename.Old.FileFields.UID), nil
+
+	case "rename.file.user":
+
+		return e.Rename.Old.FileFields.User, nil
 
 	case "rename.retval":
 
 		return int(e.Rename.SyscallEvent.Retval), nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 
-		return e.Rmdir.FileEvent.BasenameStr, nil
+		return e.Rmdir.File.ContainerPath, nil
 
-	case "rmdir.container_path":
+	case "rmdir.file.gid":
 
-		return e.Rmdir.FileEvent.ContainerPath, nil
+		return int(e.Rmdir.File.FileFields.GID), nil
 
-	case "rmdir.filename":
+	case "rmdir.file.group":
 
-		return e.Rmdir.FileEvent.PathnameStr, nil
+		return e.Rmdir.File.FileFields.Group, nil
 
-	case "rmdir.inode":
+	case "rmdir.file.inode":
 
-		return int(e.Rmdir.FileEvent.FileFields.Inode), nil
+		return int(e.Rmdir.File.FileFields.Inode), nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.mode":
 
-		return int(e.Rmdir.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Rmdir.File.FileFields.Mode), nil
+
+	case "rmdir.file.mount_id":
+
+		return int(e.Rmdir.File.FileFields.MountID), nil
+
+	case "rmdir.file.name":
+
+		return e.Rmdir.File.BasenameStr, nil
+
+	case "rmdir.file.overlay_numlower":
+
+		return int(e.Rmdir.File.FileFields.OverlayNumLower), nil
+
+	case "rmdir.file.path":
+
+		return e.Rmdir.File.PathnameStr, nil
+
+	case "rmdir.file.uid":
+
+		return int(e.Rmdir.File.FileFields.UID), nil
+
+	case "rmdir.file.user":
+
+		return e.Rmdir.File.FileFields.User, nil
 
 	case "rmdir.retval":
 
 		return int(e.Rmdir.SyscallEvent.Retval), nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 
-		return e.SetXAttr.FileEvent.BasenameStr, nil
+		return e.SetXAttr.File.ContainerPath, nil
 
-	case "setxattr.container_path":
-
-		return e.SetXAttr.FileEvent.ContainerPath, nil
-
-	case "setxattr.filename":
-
-		return e.SetXAttr.FileEvent.PathnameStr, nil
-
-	case "setxattr.inode":
-
-		return int(e.SetXAttr.FileEvent.FileFields.Inode), nil
-
-	case "setxattr.name":
+	case "setxattr.file.destination.name":
 
 		return e.SetXAttr.Name, nil
 
-	case "setxattr.namespace":
+	case "setxattr.file.destination.namespace":
 
 		return e.SetXAttr.Namespace, nil
 
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.gid":
 
-		return int(e.SetXAttr.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.SetXAttr.File.FileFields.GID), nil
+
+	case "setxattr.file.group":
+
+		return e.SetXAttr.File.FileFields.Group, nil
+
+	case "setxattr.file.inode":
+
+		return int(e.SetXAttr.File.FileFields.Inode), nil
+
+	case "setxattr.file.mode":
+
+		return int(e.SetXAttr.File.FileFields.Mode), nil
+
+	case "setxattr.file.mount_id":
+
+		return int(e.SetXAttr.File.FileFields.MountID), nil
+
+	case "setxattr.file.name":
+
+		return e.SetXAttr.File.BasenameStr, nil
+
+	case "setxattr.file.overlay_numlower":
+
+		return int(e.SetXAttr.File.FileFields.OverlayNumLower), nil
+
+	case "setxattr.file.path":
+
+		return e.SetXAttr.File.PathnameStr, nil
+
+	case "setxattr.file.uid":
+
+		return int(e.SetXAttr.File.FileFields.UID), nil
+
+	case "setxattr.file.user":
+
+		return e.SetXAttr.File.FileFields.User, nil
 
 	case "setxattr.retval":
 
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 
-		return e.Unlink.FileEvent.BasenameStr, nil
+		return e.Unlink.File.ContainerPath, nil
 
-	case "unlink.container_path":
+	case "unlink.file.gid":
 
-		return e.Unlink.FileEvent.ContainerPath, nil
+		return int(e.Unlink.File.FileFields.GID), nil
 
-	case "unlink.filename":
+	case "unlink.file.group":
 
-		return e.Unlink.FileEvent.PathnameStr, nil
+		return e.Unlink.File.FileFields.Group, nil
 
-	case "unlink.flags":
+	case "unlink.file.inode":
 
-		return int(e.Unlink.Flags), nil
+		return int(e.Unlink.File.FileFields.Inode), nil
 
-	case "unlink.inode":
+	case "unlink.file.mode":
 
-		return int(e.Unlink.FileEvent.FileFields.Inode), nil
+		return int(e.Unlink.File.FileFields.Mode), nil
 
-	case "unlink.overlay_numlower":
+	case "unlink.file.mount_id":
 
-		return int(e.Unlink.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Unlink.File.FileFields.MountID), nil
+
+	case "unlink.file.name":
+
+		return e.Unlink.File.BasenameStr, nil
+
+	case "unlink.file.overlay_numlower":
+
+		return int(e.Unlink.File.FileFields.OverlayNumLower), nil
+
+	case "unlink.file.path":
+
+		return e.Unlink.File.PathnameStr, nil
+
+	case "unlink.file.uid":
+
+		return int(e.Unlink.File.FileFields.UID), nil
+
+	case "unlink.file.user":
+
+		return e.Unlink.File.FileFields.User, nil
 
 	case "unlink.retval":
 
 		return int(e.Unlink.SyscallEvent.Retval), nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 
-		return e.Utimes.FileEvent.BasenameStr, nil
+		return e.Utimes.File.ContainerPath, nil
 
-	case "utimes.container_path":
+	case "utimes.file.gid":
 
-		return e.Utimes.FileEvent.ContainerPath, nil
+		return int(e.Utimes.File.FileFields.GID), nil
 
-	case "utimes.filename":
+	case "utimes.file.group":
 
-		return e.Utimes.FileEvent.PathnameStr, nil
+		return e.Utimes.File.FileFields.Group, nil
 
-	case "utimes.inode":
+	case "utimes.file.inode":
 
-		return int(e.Utimes.FileEvent.FileFields.Inode), nil
+		return int(e.Utimes.File.FileFields.Inode), nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.mode":
 
-		return int(e.Utimes.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Utimes.File.FileFields.Mode), nil
+
+	case "utimes.file.mount_id":
+
+		return int(e.Utimes.File.FileFields.MountID), nil
+
+	case "utimes.file.name":
+
+		return e.Utimes.File.BasenameStr, nil
+
+	case "utimes.file.overlay_numlower":
+
+		return int(e.Utimes.File.FileFields.OverlayNumLower), nil
+
+	case "utimes.file.path":
+
+		return e.Utimes.File.PathnameStr, nil
+
+	case "utimes.file.uid":
+
+		return int(e.Utimes.File.FileFields.UID), nil
+
+	case "utimes.file.user":
+
+		return e.Utimes.File.FileFields.User, nil
 
 	case "utimes.retval":
 
@@ -2822,76 +4818,139 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 		return "chmod", nil
 
-	case "chmod.container_path":
+	case "chmod.file.destination.mode":
 		return "chmod", nil
 
-	case "chmod.filename":
+	case "chmod.file.gid":
 		return "chmod", nil
 
-	case "chmod.inode":
+	case "chmod.file.group":
 		return "chmod", nil
 
-	case "chmod.mode":
+	case "chmod.file.inode":
 		return "chmod", nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.mode":
+		return "chmod", nil
+
+	case "chmod.file.mount_id":
+		return "chmod", nil
+
+	case "chmod.file.name":
+		return "chmod", nil
+
+	case "chmod.file.overlay_numlower":
+		return "chmod", nil
+
+	case "chmod.file.path":
+		return "chmod", nil
+
+	case "chmod.file.uid":
+		return "chmod", nil
+
+	case "chmod.file.user":
 		return "chmod", nil
 
 	case "chmod.retval":
 		return "chmod", nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 		return "chown", nil
 
-	case "chown.container_path":
+	case "chown.file.destination.gid":
 		return "chown", nil
 
-	case "chown.filename":
+	case "chown.file.destination.group":
 		return "chown", nil
 
-	case "chown.gid":
+	case "chown.file.destination.uid":
 		return "chown", nil
 
-	case "chown.inode":
+	case "chown.file.destination.user":
 		return "chown", nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.gid":
+		return "chown", nil
+
+	case "chown.file.group":
+		return "chown", nil
+
+	case "chown.file.inode":
+		return "chown", nil
+
+	case "chown.file.mode":
+		return "chown", nil
+
+	case "chown.file.mount_id":
+		return "chown", nil
+
+	case "chown.file.name":
+		return "chown", nil
+
+	case "chown.file.overlay_numlower":
+		return "chown", nil
+
+	case "chown.file.path":
+		return "chown", nil
+
+	case "chown.file.uid":
+		return "chown", nil
+
+	case "chown.file.user":
 		return "chown", nil
 
 	case "chown.retval":
 		return "chown", nil
 
-	case "chown.uid":
-		return "chown", nil
-
 	case "container.id":
 		return "*", nil
 
-	case "exec.container_path":
+	case "exec.comm":
 		return "exec", nil
 
 	case "exec.cookie":
 		return "exec", nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+		return "exec", nil
+
+	case "exec.file.gid":
+		return "exec", nil
+
+	case "exec.file.group":
+		return "exec", nil
+
+	case "exec.file.inode":
+		return "exec", nil
+
+	case "exec.file.mode":
+		return "exec", nil
+
+	case "exec.file.mount_id":
+		return "exec", nil
+
+	case "exec.file.name":
+		return "exec", nil
+
+	case "exec.file.overlay_numlower":
+		return "exec", nil
+
+	case "exec.file.path":
+		return "exec", nil
+
+	case "exec.file.uid":
+		return "exec", nil
+
+	case "exec.file.user":
 		return "exec", nil
 
 	case "exec.gid":
 		return "exec", nil
 
 	case "exec.group":
-		return "exec", nil
-
-	case "exec.inode":
-		return "exec", nil
-
-	case "exec.name":
-		return "exec", nil
-
-	case "exec.overlay_numlower":
 		return "exec", nil
 
 	case "exec.ppid":
@@ -2906,91 +4965,193 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.user":
 		return "exec", nil
 
+	case "link.file.container_path":
+		return "link", nil
+
+	case "link.file.destination.container_path":
+		return "link", nil
+
+	case "link.file.destination.gid":
+		return "link", nil
+
+	case "link.file.destination.group":
+		return "link", nil
+
+	case "link.file.destination.inode":
+		return "link", nil
+
+	case "link.file.destination.mode":
+		return "link", nil
+
+	case "link.file.destination.mount_id":
+		return "link", nil
+
+	case "link.file.destination.name":
+		return "link", nil
+
+	case "link.file.destination.overlay_numlower":
+		return "link", nil
+
+	case "link.file.destination.path":
+		return "link", nil
+
+	case "link.file.destination.uid":
+		return "link", nil
+
+	case "link.file.destination.user":
+		return "link", nil
+
+	case "link.file.gid":
+		return "link", nil
+
+	case "link.file.group":
+		return "link", nil
+
+	case "link.file.inode":
+		return "link", nil
+
+	case "link.file.mode":
+		return "link", nil
+
+	case "link.file.mount_id":
+		return "link", nil
+
+	case "link.file.name":
+		return "link", nil
+
+	case "link.file.overlay_numlower":
+		return "link", nil
+
+	case "link.file.path":
+		return "link", nil
+
+	case "link.file.uid":
+		return "link", nil
+
+	case "link.file.user":
+		return "link", nil
+
 	case "link.retval":
 		return "link", nil
 
-	case "link.source.basename":
-		return "link", nil
-
-	case "link.source.container_path":
-		return "link", nil
-
-	case "link.source.filename":
-		return "link", nil
-
-	case "link.source.inode":
-		return "link", nil
-
-	case "link.source.overlay_numlower":
-		return "link", nil
-
-	case "link.target.basename":
-		return "link", nil
-
-	case "link.target.container_path":
-		return "link", nil
-
-	case "link.target.filename":
-		return "link", nil
-
-	case "link.target.inode":
-		return "link", nil
-
-	case "link.target.overlay_numlower":
-		return "link", nil
-
-	case "mkdir.basename":
+	case "mkdir.file.container_path":
 		return "mkdir", nil
 
-	case "mkdir.container_path":
+	case "mkdir.file.destination.mode":
 		return "mkdir", nil
 
-	case "mkdir.filename":
+	case "mkdir.file.gid":
 		return "mkdir", nil
 
-	case "mkdir.inode":
+	case "mkdir.file.group":
 		return "mkdir", nil
 
-	case "mkdir.mode":
+	case "mkdir.file.inode":
 		return "mkdir", nil
 
-	case "mkdir.overlay_numlower":
+	case "mkdir.file.mode":
+		return "mkdir", nil
+
+	case "mkdir.file.mount_id":
+		return "mkdir", nil
+
+	case "mkdir.file.name":
+		return "mkdir", nil
+
+	case "mkdir.file.overlay_numlower":
+		return "mkdir", nil
+
+	case "mkdir.file.path":
+		return "mkdir", nil
+
+	case "mkdir.file.uid":
+		return "mkdir", nil
+
+	case "mkdir.file.user":
 		return "mkdir", nil
 
 	case "mkdir.retval":
 		return "mkdir", nil
 
-	case "open.basename":
+	case "open.file.container_path":
 		return "open", nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
 		return "open", nil
 
-	case "open.filename":
+	case "open.file.gid":
+		return "open", nil
+
+	case "open.file.group":
+		return "open", nil
+
+	case "open.file.inode":
+		return "open", nil
+
+	case "open.file.mode":
+		return "open", nil
+
+	case "open.file.mount_id":
+		return "open", nil
+
+	case "open.file.name":
+		return "open", nil
+
+	case "open.file.overlay_numlower":
+		return "open", nil
+
+	case "open.file.path":
+		return "open", nil
+
+	case "open.file.uid":
+		return "open", nil
+
+	case "open.file.user":
 		return "open", nil
 
 	case "open.flags":
 		return "open", nil
 
-	case "open.inode":
-		return "open", nil
-
-	case "open.mode":
-		return "open", nil
-
-	case "open.overlay_numlower":
-		return "open", nil
-
 	case "open.retval":
 		return "open", nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 		return "*", nil
 
 	case "process.ancestors.cookie":
 		return "*", nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+		return "*", nil
+
+	case "process.ancestors.file.gid":
+		return "*", nil
+
+	case "process.ancestors.file.group":
+		return "*", nil
+
+	case "process.ancestors.file.inode":
+		return "*", nil
+
+	case "process.ancestors.file.mode":
+		return "*", nil
+
+	case "process.ancestors.file.mount_id":
+		return "*", nil
+
+	case "process.ancestors.file.name":
+		return "*", nil
+
+	case "process.ancestors.file.overlay_numlower":
+		return "*", nil
+
+	case "process.ancestors.file.path":
+		return "*", nil
+
+	case "process.ancestors.file.uid":
+		return "*", nil
+
+	case "process.ancestors.file.user":
 		return "*", nil
 
 	case "process.ancestors.gid":
@@ -3000,15 +5161,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.id":
-		return "*", nil
-
-	case "process.ancestors.inode":
-		return "*", nil
-
-	case "process.ancestors.name":
-		return "*", nil
-
-	case "process.ancestors.overlay_numlower":
 		return "*", nil
 
 	case "process.ancestors.pid":
@@ -3029,28 +5181,49 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.user":
 		return "*", nil
 
-	case "process.container_path":
+	case "process.comm":
 		return "*", nil
 
 	case "process.cookie":
 		return "*", nil
 
-	case "process.filename":
+	case "process.file.container_path":
+		return "*", nil
+
+	case "process.file.gid":
+		return "*", nil
+
+	case "process.file.group":
+		return "*", nil
+
+	case "process.file.inode":
+		return "*", nil
+
+	case "process.file.mode":
+		return "*", nil
+
+	case "process.file.mount_id":
+		return "*", nil
+
+	case "process.file.name":
+		return "*", nil
+
+	case "process.file.overlay_numlower":
+		return "*", nil
+
+	case "process.file.path":
+		return "*", nil
+
+	case "process.file.uid":
+		return "*", nil
+
+	case "process.file.user":
 		return "*", nil
 
 	case "process.gid":
 		return "*", nil
 
 	case "process.group":
-		return "*", nil
-
-	case "process.inode":
-		return "*", nil
-
-	case "process.name":
-		return "*", nil
-
-	case "process.overlay_numlower":
 		return "*", nil
 
 	case "process.pid":
@@ -3071,139 +5244,262 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.user":
 		return "*", nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 		return "removexattr", nil
 
-	case "removexattr.container_path":
+	case "removexattr.file.destination.name":
 		return "removexattr", nil
 
-	case "removexattr.filename":
+	case "removexattr.file.destination.namespace":
 		return "removexattr", nil
 
-	case "removexattr.inode":
+	case "removexattr.file.gid":
 		return "removexattr", nil
 
-	case "removexattr.name":
+	case "removexattr.file.group":
 		return "removexattr", nil
 
-	case "removexattr.namespace":
+	case "removexattr.file.inode":
 		return "removexattr", nil
 
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.mode":
+		return "removexattr", nil
+
+	case "removexattr.file.mount_id":
+		return "removexattr", nil
+
+	case "removexattr.file.name":
+		return "removexattr", nil
+
+	case "removexattr.file.overlay_numlower":
+		return "removexattr", nil
+
+	case "removexattr.file.path":
+		return "removexattr", nil
+
+	case "removexattr.file.uid":
+		return "removexattr", nil
+
+	case "removexattr.file.user":
 		return "removexattr", nil
 
 	case "removexattr.retval":
 		return "removexattr", nil
 
-	case "rename.new.basename":
+	case "rename.file.container_path":
 		return "rename", nil
 
-	case "rename.new.container_path":
+	case "rename.file.destination.container_path":
 		return "rename", nil
 
-	case "rename.new.filename":
+	case "rename.file.destination.gid":
 		return "rename", nil
 
-	case "rename.new.inode":
+	case "rename.file.destination.group":
 		return "rename", nil
 
-	case "rename.new.overlay_numlower":
+	case "rename.file.destination.inode":
 		return "rename", nil
 
-	case "rename.old.basename":
+	case "rename.file.destination.mode":
 		return "rename", nil
 
-	case "rename.old.container_path":
+	case "rename.file.destination.mount_id":
 		return "rename", nil
 
-	case "rename.old.filename":
+	case "rename.file.destination.name":
 		return "rename", nil
 
-	case "rename.old.inode":
+	case "rename.file.destination.overlay_numlower":
 		return "rename", nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.destination.path":
+		return "rename", nil
+
+	case "rename.file.destination.uid":
+		return "rename", nil
+
+	case "rename.file.destination.user":
+		return "rename", nil
+
+	case "rename.file.gid":
+		return "rename", nil
+
+	case "rename.file.group":
+		return "rename", nil
+
+	case "rename.file.inode":
+		return "rename", nil
+
+	case "rename.file.mode":
+		return "rename", nil
+
+	case "rename.file.mount_id":
+		return "rename", nil
+
+	case "rename.file.name":
+		return "rename", nil
+
+	case "rename.file.overlay_numlower":
+		return "rename", nil
+
+	case "rename.file.path":
+		return "rename", nil
+
+	case "rename.file.uid":
+		return "rename", nil
+
+	case "rename.file.user":
 		return "rename", nil
 
 	case "rename.retval":
 		return "rename", nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 		return "rmdir", nil
 
-	case "rmdir.container_path":
+	case "rmdir.file.gid":
 		return "rmdir", nil
 
-	case "rmdir.filename":
+	case "rmdir.file.group":
 		return "rmdir", nil
 
-	case "rmdir.inode":
+	case "rmdir.file.inode":
 		return "rmdir", nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.mode":
+		return "rmdir", nil
+
+	case "rmdir.file.mount_id":
+		return "rmdir", nil
+
+	case "rmdir.file.name":
+		return "rmdir", nil
+
+	case "rmdir.file.overlay_numlower":
+		return "rmdir", nil
+
+	case "rmdir.file.path":
+		return "rmdir", nil
+
+	case "rmdir.file.uid":
+		return "rmdir", nil
+
+	case "rmdir.file.user":
 		return "rmdir", nil
 
 	case "rmdir.retval":
 		return "rmdir", nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 		return "setxattr", nil
 
-	case "setxattr.container_path":
+	case "setxattr.file.destination.name":
 		return "setxattr", nil
 
-	case "setxattr.filename":
+	case "setxattr.file.destination.namespace":
 		return "setxattr", nil
 
-	case "setxattr.inode":
+	case "setxattr.file.gid":
 		return "setxattr", nil
 
-	case "setxattr.name":
+	case "setxattr.file.group":
 		return "setxattr", nil
 
-	case "setxattr.namespace":
+	case "setxattr.file.inode":
 		return "setxattr", nil
 
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.mode":
+		return "setxattr", nil
+
+	case "setxattr.file.mount_id":
+		return "setxattr", nil
+
+	case "setxattr.file.name":
+		return "setxattr", nil
+
+	case "setxattr.file.overlay_numlower":
+		return "setxattr", nil
+
+	case "setxattr.file.path":
+		return "setxattr", nil
+
+	case "setxattr.file.uid":
+		return "setxattr", nil
+
+	case "setxattr.file.user":
 		return "setxattr", nil
 
 	case "setxattr.retval":
 		return "setxattr", nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 		return "unlink", nil
 
-	case "unlink.container_path":
+	case "unlink.file.gid":
 		return "unlink", nil
 
-	case "unlink.filename":
+	case "unlink.file.group":
 		return "unlink", nil
 
-	case "unlink.flags":
+	case "unlink.file.inode":
 		return "unlink", nil
 
-	case "unlink.inode":
+	case "unlink.file.mode":
 		return "unlink", nil
 
-	case "unlink.overlay_numlower":
+	case "unlink.file.mount_id":
+		return "unlink", nil
+
+	case "unlink.file.name":
+		return "unlink", nil
+
+	case "unlink.file.overlay_numlower":
+		return "unlink", nil
+
+	case "unlink.file.path":
+		return "unlink", nil
+
+	case "unlink.file.uid":
+		return "unlink", nil
+
+	case "unlink.file.user":
 		return "unlink", nil
 
 	case "unlink.retval":
 		return "unlink", nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 		return "utimes", nil
 
-	case "utimes.container_path":
+	case "utimes.file.gid":
 		return "utimes", nil
 
-	case "utimes.filename":
+	case "utimes.file.group":
 		return "utimes", nil
 
-	case "utimes.inode":
+	case "utimes.file.inode":
 		return "utimes", nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.mode":
+		return "utimes", nil
+
+	case "utimes.file.mount_id":
+		return "utimes", nil
+
+	case "utimes.file.name":
+		return "utimes", nil
+
+	case "utimes.file.overlay_numlower":
+		return "utimes", nil
+
+	case "utimes.file.path":
+		return "utimes", nil
+
+	case "utimes.file.uid":
+		return "utimes", nil
+
+	case "utimes.file.user":
 		return "utimes", nil
 
 	case "utimes.retval":
@@ -3217,63 +5513,119 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 
 		return reflect.String, nil
 
-	case "chmod.container_path":
+	case "chmod.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "chmod.file.gid":
+
+		return reflect.Int, nil
+
+	case "chmod.file.group":
 
 		return reflect.String, nil
 
-	case "chmod.filename":
+	case "chmod.file.inode":
+
+		return reflect.Int, nil
+
+	case "chmod.file.mode":
+
+		return reflect.Int, nil
+
+	case "chmod.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "chmod.file.name":
 
 		return reflect.String, nil
 
-	case "chmod.inode":
+	case "chmod.file.overlay_numlower":
 
 		return reflect.Int, nil
 
-	case "chmod.mode":
+	case "chmod.file.path":
+
+		return reflect.String, nil
+
+	case "chmod.file.uid":
 
 		return reflect.Int, nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.user":
 
-		return reflect.Int, nil
+		return reflect.String, nil
 
 	case "chmod.retval":
 
 		return reflect.Int, nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 
 		return reflect.String, nil
 
-	case "chown.container_path":
+	case "chown.file.destination.gid":
+
+		return reflect.Int, nil
+
+	case "chown.file.destination.group":
 
 		return reflect.String, nil
 
-	case "chown.filename":
+	case "chown.file.destination.uid":
+
+		return reflect.Int, nil
+
+	case "chown.file.destination.user":
 
 		return reflect.String, nil
 
-	case "chown.gid":
+	case "chown.file.gid":
 
 		return reflect.Int, nil
 
-	case "chown.inode":
+	case "chown.file.group":
+
+		return reflect.String, nil
+
+	case "chown.file.inode":
 
 		return reflect.Int, nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.mode":
 
 		return reflect.Int, nil
+
+	case "chown.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "chown.file.name":
+
+		return reflect.String, nil
+
+	case "chown.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "chown.file.path":
+
+		return reflect.String, nil
+
+	case "chown.file.uid":
+
+		return reflect.Int, nil
+
+	case "chown.file.user":
+
+		return reflect.String, nil
 
 	case "chown.retval":
-
-		return reflect.Int, nil
-
-	case "chown.uid":
 
 		return reflect.Int, nil
 
@@ -3281,7 +5633,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "exec.container_path":
+	case "exec.comm":
 
 		return reflect.String, nil
 
@@ -3289,7 +5641,47 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+
+		return reflect.String, nil
+
+	case "exec.file.gid":
+
+		return reflect.Int, nil
+
+	case "exec.file.group":
+
+		return reflect.String, nil
+
+	case "exec.file.inode":
+
+		return reflect.Int, nil
+
+	case "exec.file.mode":
+
+		return reflect.Int, nil
+
+	case "exec.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "exec.file.name":
+
+		return reflect.String, nil
+
+	case "exec.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "exec.file.path":
+
+		return reflect.String, nil
+
+	case "exec.file.uid":
+
+		return reflect.Int, nil
+
+	case "exec.file.user":
 
 		return reflect.String, nil
 
@@ -3300,18 +5692,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "exec.group":
 
 		return reflect.String, nil
-
-	case "exec.inode":
-
-		return reflect.Int, nil
-
-	case "exec.name":
-
-		return reflect.String, nil
-
-	case "exec.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "exec.ppid":
 
@@ -3329,87 +5709,195 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.container_path":
+
+		return reflect.String, nil
+
+	case "link.file.destination.container_path":
+
+		return reflect.String, nil
+
+	case "link.file.destination.gid":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.group":
+
+		return reflect.String, nil
+
+	case "link.file.destination.inode":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.mount_id":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.name":
+
+		return reflect.String, nil
+
+	case "link.file.destination.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.path":
+
+		return reflect.String, nil
+
+	case "link.file.destination.uid":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.user":
+
+		return reflect.String, nil
+
+	case "link.file.gid":
+
+		return reflect.Int, nil
+
+	case "link.file.group":
+
+		return reflect.String, nil
+
+	case "link.file.inode":
+
+		return reflect.Int, nil
+
+	case "link.file.mode":
+
+		return reflect.Int, nil
+
+	case "link.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "link.file.name":
+
+		return reflect.String, nil
+
+	case "link.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "link.file.path":
+
+		return reflect.String, nil
+
+	case "link.file.uid":
+
+		return reflect.Int, nil
+
+	case "link.file.user":
+
+		return reflect.String, nil
+
 	case "link.retval":
 
 		return reflect.Int, nil
 
-	case "link.source.basename":
+	case "mkdir.file.container_path":
 
 		return reflect.String, nil
 
-	case "link.source.container_path":
-
-		return reflect.String, nil
-
-	case "link.source.filename":
-
-		return reflect.String, nil
-
-	case "link.source.inode":
+	case "mkdir.file.destination.mode":
 
 		return reflect.Int, nil
 
-	case "link.source.overlay_numlower":
+	case "mkdir.file.gid":
 
 		return reflect.Int, nil
 
-	case "link.target.basename":
+	case "mkdir.file.group":
 
 		return reflect.String, nil
 
-	case "link.target.container_path":
-
-		return reflect.String, nil
-
-	case "link.target.filename":
-
-		return reflect.String, nil
-
-	case "link.target.inode":
+	case "mkdir.file.inode":
 
 		return reflect.Int, nil
 
-	case "link.target.overlay_numlower":
+	case "mkdir.file.mode":
 
 		return reflect.Int, nil
 
-	case "mkdir.basename":
+	case "mkdir.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.name":
 
 		return reflect.String, nil
 
-	case "mkdir.container_path":
+	case "mkdir.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.path":
 
 		return reflect.String, nil
 
-	case "mkdir.filename":
+	case "mkdir.file.uid":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.user":
 
 		return reflect.String, nil
-
-	case "mkdir.inode":
-
-		return reflect.Int, nil
-
-	case "mkdir.mode":
-
-		return reflect.Int, nil
-
-	case "mkdir.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "mkdir.retval":
 
 		return reflect.Int, nil
 
-	case "open.basename":
+	case "open.file.container_path":
 
 		return reflect.String, nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "open.file.gid":
+
+		return reflect.Int, nil
+
+	case "open.file.group":
 
 		return reflect.String, nil
 
-	case "open.filename":
+	case "open.file.inode":
+
+		return reflect.Int, nil
+
+	case "open.file.mode":
+
+		return reflect.Int, nil
+
+	case "open.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "open.file.name":
+
+		return reflect.String, nil
+
+	case "open.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "open.file.path":
+
+		return reflect.String, nil
+
+	case "open.file.uid":
+
+		return reflect.Int, nil
+
+	case "open.file.user":
 
 		return reflect.String, nil
 
@@ -3417,23 +5905,11 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
-	case "open.inode":
-
-		return reflect.Int, nil
-
-	case "open.mode":
-
-		return reflect.Int, nil
-
-	case "open.overlay_numlower":
-
-		return reflect.Int, nil
-
 	case "open.retval":
 
 		return reflect.Int, nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 
 		return reflect.String, nil
 
@@ -3441,7 +5917,47 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+
+		return reflect.String, nil
+
+	case "process.ancestors.file.gid":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.group":
+
+		return reflect.String, nil
+
+	case "process.ancestors.file.inode":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.mode":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.name":
+
+		return reflect.String, nil
+
+	case "process.ancestors.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.path":
+
+		return reflect.String, nil
+
+	case "process.ancestors.file.uid":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.user":
 
 		return reflect.String, nil
 
@@ -3456,18 +5972,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.ancestors.id":
 
 		return reflect.String, nil
-
-	case "process.ancestors.inode":
-
-		return reflect.Int, nil
-
-	case "process.ancestors.name":
-
-		return reflect.String, nil
-
-	case "process.ancestors.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "process.ancestors.pid":
 
@@ -3493,7 +5997,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "process.container_path":
+	case "process.comm":
 
 		return reflect.String, nil
 
@@ -3501,7 +6005,47 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
-	case "process.filename":
+	case "process.file.container_path":
+
+		return reflect.String, nil
+
+	case "process.file.gid":
+
+		return reflect.Int, nil
+
+	case "process.file.group":
+
+		return reflect.String, nil
+
+	case "process.file.inode":
+
+		return reflect.Int, nil
+
+	case "process.file.mode":
+
+		return reflect.Int, nil
+
+	case "process.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "process.file.name":
+
+		return reflect.String, nil
+
+	case "process.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "process.file.path":
+
+		return reflect.String, nil
+
+	case "process.file.uid":
+
+		return reflect.Int, nil
+
+	case "process.file.user":
 
 		return reflect.String, nil
 
@@ -3512,18 +6056,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.group":
 
 		return reflect.String, nil
-
-	case "process.inode":
-
-		return reflect.Int, nil
-
-	case "process.name":
-
-		return reflect.String, nil
-
-	case "process.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "process.pid":
 
@@ -3549,185 +6081,349 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 
 		return reflect.String, nil
 
-	case "removexattr.container_path":
+	case "removexattr.file.destination.name":
 
 		return reflect.String, nil
 
-	case "removexattr.filename":
+	case "removexattr.file.destination.namespace":
 
 		return reflect.String, nil
 
-	case "removexattr.inode":
+	case "removexattr.file.gid":
 
 		return reflect.Int, nil
 
-	case "removexattr.name":
+	case "removexattr.file.group":
 
 		return reflect.String, nil
 
-	case "removexattr.namespace":
-
-		return reflect.String, nil
-
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.inode":
 
 		return reflect.Int, nil
+
+	case "removexattr.file.mode":
+
+		return reflect.Int, nil
+
+	case "removexattr.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "removexattr.file.name":
+
+		return reflect.String, nil
+
+	case "removexattr.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "removexattr.file.path":
+
+		return reflect.String, nil
+
+	case "removexattr.file.uid":
+
+		return reflect.Int, nil
+
+	case "removexattr.file.user":
+
+		return reflect.String, nil
 
 	case "removexattr.retval":
 
 		return reflect.Int, nil
 
-	case "rename.new.basename":
+	case "rename.file.container_path":
 
 		return reflect.String, nil
 
-	case "rename.new.container_path":
+	case "rename.file.destination.container_path":
 
 		return reflect.String, nil
 
-	case "rename.new.filename":
-
-		return reflect.String, nil
-
-	case "rename.new.inode":
+	case "rename.file.destination.gid":
 
 		return reflect.Int, nil
 
-	case "rename.new.overlay_numlower":
-
-		return reflect.Int, nil
-
-	case "rename.old.basename":
+	case "rename.file.destination.group":
 
 		return reflect.String, nil
 
-	case "rename.old.container_path":
-
-		return reflect.String, nil
-
-	case "rename.old.filename":
-
-		return reflect.String, nil
-
-	case "rename.old.inode":
+	case "rename.file.destination.inode":
 
 		return reflect.Int, nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.destination.mode":
 
 		return reflect.Int, nil
+
+	case "rename.file.destination.mount_id":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.name":
+
+		return reflect.String, nil
+
+	case "rename.file.destination.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.path":
+
+		return reflect.String, nil
+
+	case "rename.file.destination.uid":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.user":
+
+		return reflect.String, nil
+
+	case "rename.file.gid":
+
+		return reflect.Int, nil
+
+	case "rename.file.group":
+
+		return reflect.String, nil
+
+	case "rename.file.inode":
+
+		return reflect.Int, nil
+
+	case "rename.file.mode":
+
+		return reflect.Int, nil
+
+	case "rename.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "rename.file.name":
+
+		return reflect.String, nil
+
+	case "rename.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "rename.file.path":
+
+		return reflect.String, nil
+
+	case "rename.file.uid":
+
+		return reflect.Int, nil
+
+	case "rename.file.user":
+
+		return reflect.String, nil
 
 	case "rename.retval":
 
 		return reflect.Int, nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 
 		return reflect.String, nil
 
-	case "rmdir.container_path":
-
-		return reflect.String, nil
-
-	case "rmdir.filename":
-
-		return reflect.String, nil
-
-	case "rmdir.inode":
+	case "rmdir.file.gid":
 
 		return reflect.Int, nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.group":
+
+		return reflect.String, nil
+
+	case "rmdir.file.inode":
 
 		return reflect.Int, nil
+
+	case "rmdir.file.mode":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.name":
+
+		return reflect.String, nil
+
+	case "rmdir.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.path":
+
+		return reflect.String, nil
+
+	case "rmdir.file.uid":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.user":
+
+		return reflect.String, nil
 
 	case "rmdir.retval":
 
 		return reflect.Int, nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 
 		return reflect.String, nil
 
-	case "setxattr.container_path":
+	case "setxattr.file.destination.name":
 
 		return reflect.String, nil
 
-	case "setxattr.filename":
+	case "setxattr.file.destination.namespace":
 
 		return reflect.String, nil
 
-	case "setxattr.inode":
+	case "setxattr.file.gid":
 
 		return reflect.Int, nil
 
-	case "setxattr.name":
+	case "setxattr.file.group":
 
 		return reflect.String, nil
 
-	case "setxattr.namespace":
-
-		return reflect.String, nil
-
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.inode":
 
 		return reflect.Int, nil
+
+	case "setxattr.file.mode":
+
+		return reflect.Int, nil
+
+	case "setxattr.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "setxattr.file.name":
+
+		return reflect.String, nil
+
+	case "setxattr.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "setxattr.file.path":
+
+		return reflect.String, nil
+
+	case "setxattr.file.uid":
+
+		return reflect.Int, nil
+
+	case "setxattr.file.user":
+
+		return reflect.String, nil
 
 	case "setxattr.retval":
 
 		return reflect.Int, nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 
 		return reflect.String, nil
 
-	case "unlink.container_path":
+	case "unlink.file.gid":
+
+		return reflect.Int, nil
+
+	case "unlink.file.group":
 
 		return reflect.String, nil
 
-	case "unlink.filename":
+	case "unlink.file.inode":
+
+		return reflect.Int, nil
+
+	case "unlink.file.mode":
+
+		return reflect.Int, nil
+
+	case "unlink.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "unlink.file.name":
 
 		return reflect.String, nil
 
-	case "unlink.flags":
+	case "unlink.file.overlay_numlower":
 
 		return reflect.Int, nil
 
-	case "unlink.inode":
+	case "unlink.file.path":
+
+		return reflect.String, nil
+
+	case "unlink.file.uid":
 
 		return reflect.Int, nil
 
-	case "unlink.overlay_numlower":
+	case "unlink.file.user":
 
-		return reflect.Int, nil
+		return reflect.String, nil
 
 	case "unlink.retval":
 
 		return reflect.Int, nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 
 		return reflect.String, nil
 
-	case "utimes.container_path":
-
-		return reflect.String, nil
-
-	case "utimes.filename":
-
-		return reflect.String, nil
-
-	case "utimes.inode":
+	case "utimes.file.gid":
 
 		return reflect.Int, nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.group":
+
+		return reflect.String, nil
+
+	case "utimes.file.inode":
 
 		return reflect.Int, nil
+
+	case "utimes.file.mode":
+
+		return reflect.Int, nil
+
+	case "utimes.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "utimes.file.name":
+
+		return reflect.String, nil
+
+	case "utimes.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "utimes.file.path":
+
+		return reflect.String, nil
+
+	case "utimes.file.uid":
+
+		return reflect.Int, nil
+
+	case "utimes.file.user":
+
+		return reflect.String, nil
 
 	case "utimes.retval":
 
@@ -3741,41 +6437,15 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 
 		var ok bool
-		if e.Chmod.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.BasenameStr"}
+		if e.Chmod.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.ContainerPath"}
 		}
 		return nil
 
-	case "chmod.container_path":
-
-		var ok bool
-		if e.Chmod.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "chmod.filename":
-
-		var ok bool
-		if e.Chmod.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "chmod.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.FileFields.Inode"}
-		}
-		e.Chmod.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "chmod.mode":
+	case "chmod.file.destination.mode":
 
 		var ok bool
 		v, ok := value.(int)
@@ -3785,14 +6455,96 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.Mode = uint32(v)
 		return nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.GID"}
 		}
-		e.Chmod.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Chmod.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "chmod.file.group":
+
+		var ok bool
+		if e.Chmod.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.Group"}
+		}
+		return nil
+
+	case "chmod.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.Inode"}
+		}
+		e.Chmod.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "chmod.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.Mode"}
+		}
+		e.Chmod.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "chmod.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.MountID"}
+		}
+		e.Chmod.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "chmod.file.name":
+
+		var ok bool
+		if e.Chmod.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.BasenameStr"}
+		}
+		return nil
+
+	case "chmod.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.OverlayNumLower"}
+		}
+		e.Chmod.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "chmod.file.path":
+
+		var ok bool
+		if e.Chmod.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.PathnameStr"}
+		}
+		return nil
+
+	case "chmod.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.UID"}
+		}
+		e.Chmod.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "chmod.file.user":
+
+		var ok bool
+		if e.Chmod.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.User"}
+		}
 		return nil
 
 	case "chmod.retval":
@@ -3805,58 +6557,140 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 
 		var ok bool
-		if e.Chown.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.BasenameStr"}
+		if e.Chown.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.ContainerPath"}
 		}
 		return nil
 
-	case "chown.container_path":
-
-		var ok bool
-		if e.Chown.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "chown.filename":
-
-		var ok bool
-		if e.Chown.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "chown.gid":
+	case "chown.file.destination.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Chown.GID"}
 		}
-		e.Chown.GID = int32(v)
+		e.Chown.GID = uint32(v)
 		return nil
 
-	case "chown.inode":
+	case "chown.file.destination.group":
+
+		var ok bool
+		if e.Chown.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.Group"}
+		}
+		return nil
+
+	case "chown.file.destination.uid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Chown.UID"}
 		}
-		e.Chown.FileEvent.FileFields.Inode = uint64(v)
+		e.Chown.UID = uint32(v)
 		return nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.destination.user":
+
+		var ok bool
+		if e.Chown.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.User"}
+		}
+		return nil
+
+	case "chown.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.GID"}
 		}
-		e.Chown.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Chown.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "chown.file.group":
+
+		var ok bool
+		if e.Chown.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Group"}
+		}
+		return nil
+
+	case "chown.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Inode"}
+		}
+		e.Chown.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "chown.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Mode"}
+		}
+		e.Chown.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "chown.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.MountID"}
+		}
+		e.Chown.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "chown.file.name":
+
+		var ok bool
+		if e.Chown.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.BasenameStr"}
+		}
+		return nil
+
+	case "chown.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.OverlayNumLower"}
+		}
+		e.Chown.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "chown.file.path":
+
+		var ok bool
+		if e.Chown.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.PathnameStr"}
+		}
+		return nil
+
+	case "chown.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.UID"}
+		}
+		e.Chown.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "chown.file.user":
+
+		var ok bool
+		if e.Chown.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.User"}
+		}
 		return nil
 
 	case "chown.retval":
@@ -3869,16 +6703,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chown.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "chown.uid":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.UID"}
-		}
-		e.Chown.UID = int32(v)
-		return nil
-
 	case "container.id":
 
 		var ok bool
@@ -3887,11 +6711,11 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "exec.container_path":
+	case "exec.comm":
 
 		var ok bool
-		if e.Exec.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.ContainerPath"}
+		if e.Exec.Comm, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Comm"}
 		}
 		return nil
 
@@ -3905,11 +6729,103 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Exec.Cookie = uint32(v)
 		return nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+
+		var ok bool
+		if e.Exec.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.ContainerPath"}
+		}
+		return nil
+
+	case "exec.file.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.GID"}
+		}
+		e.Exec.FileFields.GID = uint32(v)
+		return nil
+
+	case "exec.file.group":
+
+		var ok bool
+		if e.Exec.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.Group"}
+		}
+		return nil
+
+	case "exec.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.Inode"}
+		}
+		e.Exec.FileFields.Inode = uint64(v)
+		return nil
+
+	case "exec.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.Mode"}
+		}
+		e.Exec.FileFields.Mode = uint16(v)
+		return nil
+
+	case "exec.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.MountID"}
+		}
+		e.Exec.FileFields.MountID = uint32(v)
+		return nil
+
+	case "exec.file.name":
+
+		var ok bool
+		if e.Exec.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.BasenameStr"}
+		}
+		return nil
+
+	case "exec.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.OverlayNumLower"}
+		}
+		e.Exec.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "exec.file.path":
 
 		var ok bool
 		if e.Exec.PathnameStr, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.PathnameStr"}
+		}
+		return nil
+
+	case "exec.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.UID"}
+		}
+		e.Exec.FileFields.UID = uint32(v)
+		return nil
+
+	case "exec.file.user":
+
+		var ok bool
+		if e.Exec.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.User"}
 		}
 		return nil
 
@@ -3929,34 +6845,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if e.Exec.Group, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.Group"}
 		}
-		return nil
-
-	case "exec.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.Inode"}
-		}
-		e.Exec.FileFields.Inode = uint64(v)
-		return nil
-
-	case "exec.name":
-
-		var ok bool
-		if e.Exec.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.BasenameStr"}
-		}
-		return nil
-
-	case "exec.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.OverlayNumLower"}
-		}
-		e.Exec.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "exec.ppid":
@@ -3995,6 +6883,206 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
+	case "link.file.container_path":
+
+		var ok bool
+		if e.Link.Source.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.ContainerPath"}
+		}
+		return nil
+
+	case "link.file.destination.container_path":
+
+		var ok bool
+		if e.Link.Target.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.ContainerPath"}
+		}
+		return nil
+
+	case "link.file.destination.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.GID"}
+		}
+		e.Link.Target.FileFields.GID = uint32(v)
+		return nil
+
+	case "link.file.destination.group":
+
+		var ok bool
+		if e.Link.Target.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Group"}
+		}
+		return nil
+
+	case "link.file.destination.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Inode"}
+		}
+		e.Link.Target.FileFields.Inode = uint64(v)
+		return nil
+
+	case "link.file.destination.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Mode"}
+		}
+		e.Link.Target.FileFields.Mode = uint16(v)
+		return nil
+
+	case "link.file.destination.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.MountID"}
+		}
+		e.Link.Target.FileFields.MountID = uint32(v)
+		return nil
+
+	case "link.file.destination.name":
+
+		var ok bool
+		if e.Link.Target.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.BasenameStr"}
+		}
+		return nil
+
+	case "link.file.destination.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.OverlayNumLower"}
+		}
+		e.Link.Target.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "link.file.destination.path":
+
+		var ok bool
+		if e.Link.Target.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.PathnameStr"}
+		}
+		return nil
+
+	case "link.file.destination.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.UID"}
+		}
+		e.Link.Target.FileFields.UID = uint32(v)
+		return nil
+
+	case "link.file.destination.user":
+
+		var ok bool
+		if e.Link.Target.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.User"}
+		}
+		return nil
+
+	case "link.file.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.GID"}
+		}
+		e.Link.Source.FileFields.GID = uint32(v)
+		return nil
+
+	case "link.file.group":
+
+		var ok bool
+		if e.Link.Source.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Group"}
+		}
+		return nil
+
+	case "link.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Inode"}
+		}
+		e.Link.Source.FileFields.Inode = uint64(v)
+		return nil
+
+	case "link.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Mode"}
+		}
+		e.Link.Source.FileFields.Mode = uint16(v)
+		return nil
+
+	case "link.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.MountID"}
+		}
+		e.Link.Source.FileFields.MountID = uint32(v)
+		return nil
+
+	case "link.file.name":
+
+		var ok bool
+		if e.Link.Source.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.BasenameStr"}
+		}
+		return nil
+
+	case "link.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.OverlayNumLower"}
+		}
+		e.Link.Source.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "link.file.path":
+
+		var ok bool
+		if e.Link.Source.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.PathnameStr"}
+		}
+		return nil
+
+	case "link.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.UID"}
+		}
+		e.Link.Source.FileFields.UID = uint32(v)
+		return nil
+
+	case "link.file.user":
+
+		var ok bool
+		if e.Link.Source.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.User"}
+		}
+		return nil
+
 	case "link.retval":
 
 		var ok bool
@@ -4005,129 +7093,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Link.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "link.source.basename":
+	case "mkdir.file.container_path":
 
 		var ok bool
-		if e.Link.Source.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.BasenameStr"}
+		if e.Mkdir.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.ContainerPath"}
 		}
 		return nil
 
-	case "link.source.container_path":
-
-		var ok bool
-		if e.Link.Source.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.ContainerPath"}
-		}
-		return nil
-
-	case "link.source.filename":
-
-		var ok bool
-		if e.Link.Source.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.PathnameStr"}
-		}
-		return nil
-
-	case "link.source.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Inode"}
-		}
-		e.Link.Source.FileFields.Inode = uint64(v)
-		return nil
-
-	case "link.source.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.OverlayNumLower"}
-		}
-		e.Link.Source.FileFields.OverlayNumLower = int32(v)
-		return nil
-
-	case "link.target.basename":
-
-		var ok bool
-		if e.Link.Target.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.BasenameStr"}
-		}
-		return nil
-
-	case "link.target.container_path":
-
-		var ok bool
-		if e.Link.Target.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.ContainerPath"}
-		}
-		return nil
-
-	case "link.target.filename":
-
-		var ok bool
-		if e.Link.Target.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.PathnameStr"}
-		}
-		return nil
-
-	case "link.target.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Inode"}
-		}
-		e.Link.Target.FileFields.Inode = uint64(v)
-		return nil
-
-	case "link.target.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.OverlayNumLower"}
-		}
-		e.Link.Target.FileFields.OverlayNumLower = int32(v)
-		return nil
-
-	case "mkdir.basename":
-
-		var ok bool
-		if e.Mkdir.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.BasenameStr"}
-		}
-		return nil
-
-	case "mkdir.container_path":
-
-		var ok bool
-		if e.Mkdir.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "mkdir.filename":
-
-		var ok bool
-		if e.Mkdir.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "mkdir.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.FileFields.Inode"}
-		}
-		e.Mkdir.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "mkdir.mode":
+	case "mkdir.file.destination.mode":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4137,14 +7111,96 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.Mode = uint32(v)
 		return nil
 
-	case "mkdir.overlay_numlower":
+	case "mkdir.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.GID"}
 		}
-		e.Mkdir.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Mkdir.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "mkdir.file.group":
+
+		var ok bool
+		if e.Mkdir.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.Group"}
+		}
+		return nil
+
+	case "mkdir.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.Inode"}
+		}
+		e.Mkdir.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "mkdir.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.Mode"}
+		}
+		e.Mkdir.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "mkdir.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.MountID"}
+		}
+		e.Mkdir.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "mkdir.file.name":
+
+		var ok bool
+		if e.Mkdir.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.BasenameStr"}
+		}
+		return nil
+
+	case "mkdir.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.OverlayNumLower"}
+		}
+		e.Mkdir.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "mkdir.file.path":
+
+		var ok bool
+		if e.Mkdir.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.PathnameStr"}
+		}
+		return nil
+
+	case "mkdir.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.UID"}
+		}
+		e.Mkdir.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "mkdir.file.user":
+
+		var ok bool
+		if e.Mkdir.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.User"}
+		}
 		return nil
 
 	case "mkdir.retval":
@@ -4157,27 +7213,113 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "open.basename":
+	case "open.file.container_path":
 
 		var ok bool
-		if e.Open.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.BasenameStr"}
+		if e.Open.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.ContainerPath"}
 		}
 		return nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
 
 		var ok bool
-		if e.Open.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.ContainerPath"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.Mode"}
+		}
+		e.Open.Mode = uint32(v)
+		return nil
+
+	case "open.file.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.GID"}
+		}
+		e.Open.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "open.file.group":
+
+		var ok bool
+		if e.Open.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Group"}
 		}
 		return nil
 
-	case "open.filename":
+	case "open.file.inode":
 
 		var ok bool
-		if e.Open.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.PathnameStr"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Inode"}
+		}
+		e.Open.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "open.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Mode"}
+		}
+		e.Open.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "open.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.MountID"}
+		}
+		e.Open.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "open.file.name":
+
+		var ok bool
+		if e.Open.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.BasenameStr"}
+		}
+		return nil
+
+	case "open.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.OverlayNumLower"}
+		}
+		e.Open.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "open.file.path":
+
+		var ok bool
+		if e.Open.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.PathnameStr"}
+		}
+		return nil
+
+	case "open.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.UID"}
+		}
+		e.Open.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "open.file.user":
+
+		var ok bool
+		if e.Open.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.User"}
 		}
 		return nil
 
@@ -4191,36 +7333,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Open.Flags = uint32(v)
 		return nil
 
-	case "open.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.FileFields.Inode"}
-		}
-		e.Open.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "open.mode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.Mode"}
-		}
-		e.Open.Mode = uint32(v)
-		return nil
-
-	case "open.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.FileFields.OverlayNumLower"}
-		}
-		e.Open.FileEvent.FileFields.OverlayNumLower = int32(v)
-		return nil
-
 	case "open.retval":
 
 		var ok bool
@@ -4231,15 +7343,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Open.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 
 		if e.Process.Ancestor == nil {
 			e.Process.Ancestor = &ProcessCacheEntry{}
 		}
 
 		var ok bool
-		if e.Process.Ancestor.ProcessContext.ExecEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.ContainerPath"}
+		if e.Process.Ancestor.ProcessContext.ExecEvent.Comm, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.Comm"}
 		}
 		return nil
 
@@ -4257,7 +7369,113 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Process.Ancestor.ProcessContext.ExecEvent.Cookie = uint32(v)
 		return nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.Process.Ancestor.ProcessContext.ExecEvent.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.ContainerPath"}
+		}
+		return nil
+
+	case "process.ancestors.file.gid":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.GID"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.GID = uint32(v)
+		return nil
+
+	case "process.ancestors.file.group":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.Group"}
+		}
+		return nil
+
+	case "process.ancestors.file.inode":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.Inode"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.Inode = uint64(v)
+		return nil
+
+	case "process.ancestors.file.mode":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.Mode"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.Mode = uint16(v)
+		return nil
+
+	case "process.ancestors.file.mount_id":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.MountID"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.MountID = uint32(v)
+		return nil
+
+	case "process.ancestors.file.name":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.Process.Ancestor.ProcessContext.ExecEvent.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.BasenameStr"}
+		}
+		return nil
+
+	case "process.ancestors.file.overlay_numlower":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.OverlayNumLower"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "process.ancestors.file.path":
 
 		if e.Process.Ancestor == nil {
 			e.Process.Ancestor = &ProcessCacheEntry{}
@@ -4266,6 +7484,32 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		if e.Process.Ancestor.ProcessContext.ExecEvent.PathnameStr, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.PathnameStr"}
+		}
+		return nil
+
+	case "process.ancestors.file.uid":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.UID"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.UID = uint32(v)
+		return nil
+
+	case "process.ancestors.file.user":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.User"}
 		}
 		return nil
 
@@ -4305,46 +7549,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if e.Process.Ancestor.ContainerContext.ID, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ContainerContext.ID"}
 		}
-		return nil
-
-	case "process.ancestors.inode":
-
-		if e.Process.Ancestor == nil {
-			e.Process.Ancestor = &ProcessCacheEntry{}
-		}
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.Inode"}
-		}
-		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "process.ancestors.name":
-
-		if e.Process.Ancestor == nil {
-			e.Process.Ancestor = &ProcessCacheEntry{}
-		}
-
-		var ok bool
-		if e.Process.Ancestor.ProcessContext.ExecEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.BasenameStr"}
-		}
-		return nil
-
-	case "process.ancestors.overlay_numlower":
-
-		if e.Process.Ancestor == nil {
-			e.Process.Ancestor = &ProcessCacheEntry{}
-		}
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.OverlayNumLower"}
-		}
-		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "process.ancestors.pid":
@@ -4427,11 +7631,11 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "process.container_path":
+	case "process.comm":
 
 		var ok bool
-		if e.Process.ExecEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.ContainerPath"}
+		if e.Process.ExecEvent.Comm, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.Comm"}
 		}
 		return nil
 
@@ -4445,11 +7649,103 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Process.ExecEvent.Cookie = uint32(v)
 		return nil
 
-	case "process.filename":
+	case "process.file.container_path":
+
+		var ok bool
+		if e.Process.ExecEvent.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.ContainerPath"}
+		}
+		return nil
+
+	case "process.file.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.GID"}
+		}
+		e.Process.ExecEvent.FileFields.GID = uint32(v)
+		return nil
+
+	case "process.file.group":
+
+		var ok bool
+		if e.Process.ExecEvent.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.Group"}
+		}
+		return nil
+
+	case "process.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.Inode"}
+		}
+		e.Process.ExecEvent.FileFields.Inode = uint64(v)
+		return nil
+
+	case "process.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.Mode"}
+		}
+		e.Process.ExecEvent.FileFields.Mode = uint16(v)
+		return nil
+
+	case "process.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.MountID"}
+		}
+		e.Process.ExecEvent.FileFields.MountID = uint32(v)
+		return nil
+
+	case "process.file.name":
+
+		var ok bool
+		if e.Process.ExecEvent.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.BasenameStr"}
+		}
+		return nil
+
+	case "process.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.OverlayNumLower"}
+		}
+		e.Process.ExecEvent.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "process.file.path":
 
 		var ok bool
 		if e.Process.ExecEvent.PathnameStr, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.PathnameStr"}
+		}
+		return nil
+
+	case "process.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.UID"}
+		}
+		e.Process.ExecEvent.FileFields.UID = uint32(v)
+		return nil
+
+	case "process.file.user":
+
+		var ok bool
+		if e.Process.ExecEvent.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.User"}
 		}
 		return nil
 
@@ -4469,34 +7765,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if e.Process.ExecEvent.Group, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.Group"}
 		}
-		return nil
-
-	case "process.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.Inode"}
-		}
-		e.Process.ExecEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "process.name":
-
-		var ok bool
-		if e.Process.ExecEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.BasenameStr"}
-		}
-		return nil
-
-	case "process.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.OverlayNumLower"}
-		}
-		e.Process.ExecEvent.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "process.pid":
@@ -4555,41 +7823,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 
 		var ok bool
-		if e.RemoveXAttr.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.BasenameStr"}
+		if e.RemoveXAttr.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.ContainerPath"}
 		}
 		return nil
 
-	case "removexattr.container_path":
-
-		var ok bool
-		if e.RemoveXAttr.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "removexattr.filename":
-
-		var ok bool
-		if e.RemoveXAttr.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "removexattr.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.FileFields.Inode"}
-		}
-		e.RemoveXAttr.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "removexattr.name":
+	case "removexattr.file.destination.name":
 
 		var ok bool
 		if e.RemoveXAttr.Name, ok = value.(string); !ok {
@@ -4597,7 +7839,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "removexattr.namespace":
+	case "removexattr.file.destination.namespace":
 
 		var ok bool
 		if e.RemoveXAttr.Namespace, ok = value.(string); !ok {
@@ -4605,14 +7847,96 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.GID"}
 		}
-		e.RemoveXAttr.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.RemoveXAttr.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "removexattr.file.group":
+
+		var ok bool
+		if e.RemoveXAttr.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.Group"}
+		}
+		return nil
+
+	case "removexattr.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.Inode"}
+		}
+		e.RemoveXAttr.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "removexattr.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.Mode"}
+		}
+		e.RemoveXAttr.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "removexattr.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.MountID"}
+		}
+		e.RemoveXAttr.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "removexattr.file.name":
+
+		var ok bool
+		if e.RemoveXAttr.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.BasenameStr"}
+		}
+		return nil
+
+	case "removexattr.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.OverlayNumLower"}
+		}
+		e.RemoveXAttr.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "removexattr.file.path":
+
+		var ok bool
+		if e.RemoveXAttr.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.PathnameStr"}
+		}
+		return nil
+
+	case "removexattr.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.UID"}
+		}
+		e.RemoveXAttr.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "removexattr.file.user":
+
+		var ok bool
+		if e.RemoveXAttr.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.User"}
+		}
 		return nil
 
 	case "removexattr.retval":
@@ -4625,15 +7949,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "rename.new.basename":
+	case "rename.file.container_path":
 
 		var ok bool
-		if e.Rename.New.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.BasenameStr"}
+		if e.Rename.Old.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.ContainerPath"}
 		}
 		return nil
 
-	case "rename.new.container_path":
+	case "rename.file.destination.container_path":
 
 		var ok bool
 		if e.Rename.New.ContainerPath, ok = value.(string); !ok {
@@ -4641,15 +7965,25 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "rename.new.filename":
+	case "rename.file.destination.gid":
 
 		var ok bool
-		if e.Rename.New.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.PathnameStr"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.GID"}
+		}
+		e.Rename.New.FileFields.GID = uint32(v)
+		return nil
+
+	case "rename.file.destination.group":
+
+		var ok bool
+		if e.Rename.New.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.Group"}
 		}
 		return nil
 
-	case "rename.new.inode":
+	case "rename.file.destination.inode":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4659,7 +7993,35 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.New.FileFields.Inode = uint64(v)
 		return nil
 
-	case "rename.new.overlay_numlower":
+	case "rename.file.destination.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.Mode"}
+		}
+		e.Rename.New.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rename.file.destination.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.MountID"}
+		}
+		e.Rename.New.FileFields.MountID = uint32(v)
+		return nil
+
+	case "rename.file.destination.name":
+
+		var ok bool
+		if e.Rename.New.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.BasenameStr"}
+		}
+		return nil
+
+	case "rename.file.destination.overlay_numlower":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4669,31 +8031,51 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.New.FileFields.OverlayNumLower = int32(v)
 		return nil
 
-	case "rename.old.basename":
+	case "rename.file.destination.path":
 
 		var ok bool
-		if e.Rename.Old.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.BasenameStr"}
+		if e.Rename.New.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.PathnameStr"}
 		}
 		return nil
 
-	case "rename.old.container_path":
+	case "rename.file.destination.uid":
 
 		var ok bool
-		if e.Rename.Old.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.ContainerPath"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.UID"}
+		}
+		e.Rename.New.FileFields.UID = uint32(v)
+		return nil
+
+	case "rename.file.destination.user":
+
+		var ok bool
+		if e.Rename.New.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.User"}
 		}
 		return nil
 
-	case "rename.old.filename":
+	case "rename.file.gid":
 
 		var ok bool
-		if e.Rename.Old.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.PathnameStr"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.GID"}
+		}
+		e.Rename.Old.FileFields.GID = uint32(v)
+		return nil
+
+	case "rename.file.group":
+
+		var ok bool
+		if e.Rename.Old.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.Group"}
 		}
 		return nil
 
-	case "rename.old.inode":
+	case "rename.file.inode":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4703,7 +8085,35 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.Old.FileFields.Inode = uint64(v)
 		return nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.Mode"}
+		}
+		e.Rename.Old.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rename.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.MountID"}
+		}
+		e.Rename.Old.FileFields.MountID = uint32(v)
+		return nil
+
+	case "rename.file.name":
+
+		var ok bool
+		if e.Rename.Old.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.BasenameStr"}
+		}
+		return nil
+
+	case "rename.file.overlay_numlower":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4711,6 +8121,32 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.OverlayNumLower"}
 		}
 		e.Rename.Old.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "rename.file.path":
+
+		var ok bool
+		if e.Rename.Old.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.PathnameStr"}
+		}
+		return nil
+
+	case "rename.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.UID"}
+		}
+		e.Rename.Old.FileFields.UID = uint32(v)
+		return nil
+
+	case "rename.file.user":
+
+		var ok bool
+		if e.Rename.Old.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.User"}
+		}
 		return nil
 
 	case "rename.retval":
@@ -4723,48 +8159,104 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 
 		var ok bool
-		if e.Rmdir.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.BasenameStr"}
+		if e.Rmdir.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.ContainerPath"}
 		}
 		return nil
 
-	case "rmdir.container_path":
-
-		var ok bool
-		if e.Rmdir.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "rmdir.filename":
-
-		var ok bool
-		if e.Rmdir.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "rmdir.inode":
+	case "rmdir.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.GID"}
 		}
-		e.Rmdir.FileEvent.FileFields.Inode = uint64(v)
+		e.Rmdir.File.FileFields.GID = uint32(v)
 		return nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.group":
+
+		var ok bool
+		if e.Rmdir.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Group"}
+		}
+		return nil
+
+	case "rmdir.file.inode":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Inode"}
 		}
-		e.Rmdir.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Rmdir.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "rmdir.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Mode"}
+		}
+		e.Rmdir.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rmdir.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.MountID"}
+		}
+		e.Rmdir.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "rmdir.file.name":
+
+		var ok bool
+		if e.Rmdir.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.BasenameStr"}
+		}
+		return nil
+
+	case "rmdir.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.OverlayNumLower"}
+		}
+		e.Rmdir.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "rmdir.file.path":
+
+		var ok bool
+		if e.Rmdir.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.PathnameStr"}
+		}
+		return nil
+
+	case "rmdir.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.UID"}
+		}
+		e.Rmdir.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "rmdir.file.user":
+
+		var ok bool
+		if e.Rmdir.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.User"}
+		}
 		return nil
 
 	case "rmdir.retval":
@@ -4777,41 +8269,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rmdir.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 
 		var ok bool
-		if e.SetXAttr.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.BasenameStr"}
+		if e.SetXAttr.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.ContainerPath"}
 		}
 		return nil
 
-	case "setxattr.container_path":
-
-		var ok bool
-		if e.SetXAttr.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "setxattr.filename":
-
-		var ok bool
-		if e.SetXAttr.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "setxattr.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.FileFields.Inode"}
-		}
-		e.SetXAttr.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "setxattr.name":
+	case "setxattr.file.destination.name":
 
 		var ok bool
 		if e.SetXAttr.Name, ok = value.(string); !ok {
@@ -4819,7 +8285,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "setxattr.namespace":
+	case "setxattr.file.destination.namespace":
 
 		var ok bool
 		if e.SetXAttr.Namespace, ok = value.(string); !ok {
@@ -4827,14 +8293,96 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.GID"}
 		}
-		e.SetXAttr.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.SetXAttr.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "setxattr.file.group":
+
+		var ok bool
+		if e.SetXAttr.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.Group"}
+		}
+		return nil
+
+	case "setxattr.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.Inode"}
+		}
+		e.SetXAttr.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "setxattr.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.Mode"}
+		}
+		e.SetXAttr.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "setxattr.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.MountID"}
+		}
+		e.SetXAttr.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "setxattr.file.name":
+
+		var ok bool
+		if e.SetXAttr.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.BasenameStr"}
+		}
+		return nil
+
+	case "setxattr.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.OverlayNumLower"}
+		}
+		e.SetXAttr.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "setxattr.file.path":
+
+		var ok bool
+		if e.SetXAttr.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.PathnameStr"}
+		}
+		return nil
+
+	case "setxattr.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.UID"}
+		}
+		e.SetXAttr.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "setxattr.file.user":
+
+		var ok bool
+		if e.SetXAttr.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.User"}
+		}
 		return nil
 
 	case "setxattr.retval":
@@ -4847,58 +8395,104 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 
 		var ok bool
-		if e.Unlink.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.BasenameStr"}
+		if e.Unlink.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.ContainerPath"}
 		}
 		return nil
 
-	case "unlink.container_path":
-
-		var ok bool
-		if e.Unlink.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "unlink.filename":
-
-		var ok bool
-		if e.Unlink.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "unlink.flags":
+	case "unlink.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.Flags"}
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.GID"}
 		}
-		e.Unlink.Flags = uint32(v)
+		e.Unlink.File.FileFields.GID = uint32(v)
 		return nil
 
-	case "unlink.inode":
+	case "unlink.file.group":
+
+		var ok bool
+		if e.Unlink.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Group"}
+		}
+		return nil
+
+	case "unlink.file.inode":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Inode"}
 		}
-		e.Unlink.FileEvent.FileFields.Inode = uint64(v)
+		e.Unlink.File.FileFields.Inode = uint64(v)
 		return nil
 
-	case "unlink.overlay_numlower":
+	case "unlink.file.mode":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Mode"}
 		}
-		e.Unlink.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Unlink.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "unlink.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.MountID"}
+		}
+		e.Unlink.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "unlink.file.name":
+
+		var ok bool
+		if e.Unlink.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.BasenameStr"}
+		}
+		return nil
+
+	case "unlink.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.OverlayNumLower"}
+		}
+		e.Unlink.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "unlink.file.path":
+
+		var ok bool
+		if e.Unlink.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.PathnameStr"}
+		}
+		return nil
+
+	case "unlink.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.UID"}
+		}
+		e.Unlink.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "unlink.file.user":
+
+		var ok bool
+		if e.Unlink.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.User"}
+		}
 		return nil
 
 	case "unlink.retval":
@@ -4911,48 +8505,104 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 
 		var ok bool
-		if e.Utimes.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.BasenameStr"}
+		if e.Utimes.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.ContainerPath"}
 		}
 		return nil
 
-	case "utimes.container_path":
-
-		var ok bool
-		if e.Utimes.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "utimes.filename":
-
-		var ok bool
-		if e.Utimes.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "utimes.inode":
+	case "utimes.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.GID"}
 		}
-		e.Utimes.FileEvent.FileFields.Inode = uint64(v)
+		e.Utimes.File.FileFields.GID = uint32(v)
 		return nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.group":
+
+		var ok bool
+		if e.Utimes.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Group"}
+		}
+		return nil
+
+	case "utimes.file.inode":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Inode"}
 		}
-		e.Utimes.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Utimes.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "utimes.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Mode"}
+		}
+		e.Utimes.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "utimes.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.MountID"}
+		}
+		e.Utimes.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "utimes.file.name":
+
+		var ok bool
+		if e.Utimes.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.BasenameStr"}
+		}
+		return nil
+
+	case "utimes.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.OverlayNumLower"}
+		}
+		e.Utimes.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "utimes.file.path":
+
+		var ok bool
+		if e.Utimes.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.PathnameStr"}
+		}
+		return nil
+
+	case "utimes.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.UID"}
+		}
+		e.Utimes.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "utimes.file.user":
+
+		var ok bool
+		if e.Utimes.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.User"}
+		}
 		return nil
 
 	case "utimes.retval":

--- a/pkg/security/model/legacy_secl.go
+++ b/pkg/security/model/legacy_secl.go
@@ -9,178 +9,102 @@ package model
 
 import "github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 
-// TranslateLegacyField transforms a legacy attribute into its updated version. Should be idempotent for non legacy
-// fields.
-func (m *Model) TranslateLegacyField(field eval.Field) eval.Field {
-	switch field {
+// SECLLegacyAttributes contains the list of the legacy attributes we need to support
+var SECLLegacyAttributes = map[eval.Field]eval.Field{
 	// chmod
-	case "chmod.filename":
-		return "chmod.file.path"
-	case "chmod.container_path":
-		return "chmod.file.container_path"
-	case "chmod.overlay_numlower":
-		return "chmod.file.overlay_numlower"
-	case "chmod.basename":
-		return "chmod.file.name"
-	case "chmod.mode":
-		return "chmod.file.destination.mode"
+	"chmod.filename":         "chmod.file.path",
+	"chmod.container_path":   "chmod.file.container_path",
+	"chmod.overlay_numlower": "chmod.file.overlay_numlower",
+	"chmod.basename":         "chmod.file.name",
+	"chmod.mode":             "chmod.file.destination.mode",
 
 	// chown
-	case "chown.filename":
-		return "chown.file.path"
-	case "chown.container_path":
-		return "chown.file.container_path"
-	case "chown.overlay_numlower":
-		return "chown.file.overlay_numlower"
-	case "chown.basename":
-		return "chown.file.name"
-	case "chmod.uid":
-		return "chown.file.destination.uid"
-	case "chmod.user":
-		return "chown.file.destination.user"
-	case "chmod.gid":
-		return "chown.file.destination.gid"
-	case "chmod.group":
-		return "chown.file.destination.group"
+	"chown.filename":         "chown.file.path",
+	"chown.container_path":   "chown.file.container_path",
+	"chown.overlay_numlower": "chown.file.overlay_numlower",
+	"chown.basename":         "chown.file.name",
+	"chown.uid":              "chown.file.destination.uid",
+	"chown.user":             "chown.file.destination.user",
+	"chown.gid":              "chown.file.destination.gid",
+	"chown.group":            "chown.file.destination.group",
 
-	//	open
-	case "open.filename":
-		return "open.file.path"
-	case "open.container_path":
-		return "open.file.container_path"
-	case "open.overlay_numlower":
-		return "open.file.overlay_numlower"
-	case "open.basename":
-		return "open.file.name"
-	case "open.mode":
-		return "open.file.destination.mode"
+	// open
+	"open.filename":         "open.file.path",
+	"open.container_path":   "open.file.container_path",
+	"open.overlay_numlower": "open.file.overlay_numlower",
+	"open.basename":         "open.file.name",
+	"open.mode":             "open.file.destination.mode",
 
 	// mkdir
-	case "mkdir.filename":
-		return "mkdir.file.path"
-	case "mkdir.container_path":
-		return "mkdir.file.container_path"
-	case "mkdir.overlay_numlower":
-		return "mkdir.file.overlay_numlower"
-	case "mkdir.basename":
-		return "mkdir.file.name"
-	case "mkdir.mode":
-		return "mkdir.file.destination.mode"
+	"mkdir.filename":         "mkdir.file.path",
+	"mkdir.container_path":   "mkdir.file.container_path",
+	"mkdir.overlay_numlower": "mkdir.file.overlay_numlower",
+	"mkdir.basename":         "mkdir.file.name",
+	"mkdir.mode":             "mkdir.file.destination.mode",
 
 	// rmdir
-	case "rmdir.filename":
-		return "rmdir.file.path"
-	case "rmdir.container_path":
-		return "rmdir.file.container_path"
-	case "rmdir.overlay_numlower":
-		return "rmdir.file.overlay_numlower"
-	case "rmdir.basename":
-		return "rmdir.file.name"
+	"rmdir.filename":         "rmdir.file.path",
+	"rmdir.container_path":   "rmdir.file.container_path",
+	"rmdir.overlay_numlower": "rmdir.file.overlay_numlower",
+	"rmdir.basename":         "rmdir.file.name",
 
 	// rename
-	case "rename.old.filename":
-		return "rename.file.path"
-	case "rename.old.container_path":
-		return "rename.file.container_path"
-	case "rename.old.overlay_numlower":
-		return "rename.file.overlay_numlower"
-	case "rename.old.basename":
-		return "rename.file.name"
-	case "rename.new.filename":
-		return "rename.file.destination.path"
-	case "rename.new.container_path":
-		return "rename.file.destination.container_path"
-	case "rename.new.overlay_numlower":
-		return "rename.file.destination.overlay_numlower"
-	case "rename.new.basename":
-		return "rename.file.destination.name"
+	"rename.old.filename":         "rename.file.path",
+	"rename.old.container_path":   "rename.file.container_path",
+	"rename.old.overlay_numlower": "rename.file.overlay_numlower",
+	"rename.old.basename":         "rename.file.name",
+	"rename.new.filename":         "rename.file.destination.path",
+	"rename.new.container_path":   "rename.file.destination.container_path",
+	"rename.new.overlay_numlower": "rename.file.destination.overlay_numlower",
+	"rename.new.basename":         "rename.file.destination.name",
 
 	// unlink
-	case "unlink.filename":
-		return "unlink.file.path"
-	case "unlink.container_path":
-		return "unlink.file.container_path"
-	case "unlink.overlay_numlower":
-		return "unlink.file.overlay_numlower"
-	case "unlink.basename":
-		return "unlink.file.name"
+	"unlink.filename":         "unlink.file.path",
+	"unlink.container_path":   "unlink.file.container_path",
+	"unlink.overlay_numlower": "unlink.file.overlay_numlower",
+	"unlink.basename":         "unlink.file.name",
 
 	// utimes
-	case "utimes.filename":
-		return "utimes.file.path"
-	case "utimes.container_path":
-		return "utimes.file.container_path"
-	case "utimes.overlay_numlower":
-		return "utimes.file.overlay_numlower"
-	case "utimes.basename":
-		return "utimes.file.name"
+	"utimes.filename":         "utimes.file.path",
+	"utimes.container_path":   "utimes.file.container_path",
+	"utimes.overlay_numlower": "utimes.file.overlay_numlower",
+	"utimes.basename":         "utimes.file.name",
 
 	// link
-	case "link.source.filename":
-		return "link.file.path"
-	case "link.source.container_path":
-		return "link.file.container_path"
-	case "link.source.overlay_numlower":
-		return "link.file.overlay_numlower"
-	case "link.source.basename":
-		return "link.file.name"
-	case "link.target.filename":
-		return "link.file.destination.path"
-	case "link.target.container_path":
-		return "link.file.destination.container_path"
-	case "link.target.overlay_numlower":
-		return "link.file.destination.overlay_numlower"
-	case "link.target.basename":
-		return "link.file.destination.name"
+	"link.source.filename":         "link.file.path",
+	"link.source.container_path":   "link.file.container_path",
+	"link.source.overlay_numlower": "link.file.overlay_numlower",
+	"link.source.basename":         "link.file.name",
+	"link.target.filename":         "link.file.destination.path",
+	"link.target.container_path":   "link.file.destination.container_path",
+	"link.target.overlay_numlower": "link.file.destination.overlay_numlower",
+	"link.target.basename":         "link.file.destination.name",
 
 	// setxattr
-	case "setxattr.filename":
-		return "setxattr.file.path"
-	case "setxattr.container_path":
-		return "setxattr.file.container_path"
-	case "setxattr.overlay_numlower":
-		return "setxattr.file.overlay_numlower"
-	case "setxattr.basename":
-		return "setxattr.file.name"
-	case "setxattr.namespace":
-		return "setxattr.file.destination.namespace"
-	case "setxattr.name":
-		return "setxattr.file.destination.name"
+	"setxattr.filename":         "setxattr.file.path",
+	"setxattr.container_path":   "setxattr.file.container_path",
+	"setxattr.overlay_numlower": "setxattr.file.overlay_numlower",
+	"setxattr.basename":         "setxattr.file.name",
+	"setxattr.namespace":        "setxattr.file.destination.namespace",
+	"setxattr.name":             "setxattr.file.destination.name",
 
 	// removexattr
-	case "removexattr.filename":
-		return "removexattr.file.path"
-	case "removexattr.container_path":
-		return "removexattr.file.container_path"
-	case "removexattr.overlay_numlower":
-		return "removexattr.file.overlay_numlower"
-	case "removexattr.basename":
-		return "removexattr.file.name"
-	case "removexattr.namespace":
-		return "removexattr.file.destination.namespace"
-	case "removexattr.name":
-		return "removexattr.file.destination.name"
+	"removexattr.filename":         "removexattr.file.path",
+	"removexattr.container_path":   "removexattr.file.container_path",
+	"removexattr.overlay_numlower": "removexattr.file.overlay_numlower",
+	"removexattr.basename":         "removexattr.file.name",
+	"removexattr.namespace":        "removexattr.file.destination.namespace",
+	"removexattr.name":             "removexattr.file.destination.name",
 
 	// exec
-	case "exec.filename":
-		return "exec.file.path"
-	case "exec.container_path":
-		return "exec.file.container_path"
-	case "exec.overlay_numlower":
-		return "exec.file.overlay_numlower"
-	case "exec.basename":
-		return "exec.file.name"
+	"exec.filename":         "exec.file.path",
+	"exec.container_path":   "exec.file.container_path",
+	"exec.overlay_numlower": "exec.file.overlay_numlower",
+	"exec.basename":         "exec.file.name",
 
 	// process
-	case "process.filename":
-		return "process.file.path"
-	case "process.container_path":
-		return "process.file.container_path"
-	case "process.overlay_numlower":
-		return "process.file.overlay_numlower"
-	case "process.basename":
-		return "process.file.name"
-	default:
-		return field
-	}
+	"process.filename":         "process.file.path",
+	"process.container_path":   "process.file.container_path",
+	"process.overlay_numlower": "process.file.overlay_numlower",
+	"process.basename":         "process.file.name",
 }

--- a/pkg/security/model/legacy_secl.go
+++ b/pkg/security/model/legacy_secl.go
@@ -1,0 +1,186 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+// +build linux
+
+package model
+
+import "github.com/DataDog/datadog-agent/pkg/security/secl/eval"
+
+// TranslateLegacyField transforms a legacy attribute into its updated version. Should be idempotent for non legacy
+// fields.
+func (m *Model) TranslateLegacyField(field eval.Field) eval.Field {
+	switch field {
+	// chmod
+	case "chmod.filename":
+		return "chmod.file.path"
+	case "chmod.container_path":
+		return "chmod.file.container_path"
+	case "chmod.overlay_numlower":
+		return "chmod.file.overlay_numlower"
+	case "chmod.basename":
+		return "chmod.file.name"
+	case "chmod.mode":
+		return "chmod.file.destination.mode"
+
+	// chown
+	case "chown.filename":
+		return "chown.file.path"
+	case "chown.container_path":
+		return "chown.file.container_path"
+	case "chown.overlay_numlower":
+		return "chown.file.overlay_numlower"
+	case "chown.basename":
+		return "chown.file.name"
+	case "chmod.uid":
+		return "chown.file.destination.uid"
+	case "chmod.user":
+		return "chown.file.destination.user"
+	case "chmod.gid":
+		return "chown.file.destination.gid"
+	case "chmod.group":
+		return "chown.file.destination.group"
+
+	//	open
+	case "open.filename":
+		return "open.file.path"
+	case "open.container_path":
+		return "open.file.container_path"
+	case "open.overlay_numlower":
+		return "open.file.overlay_numlower"
+	case "open.basename":
+		return "open.file.name"
+	case "open.mode":
+		return "open.file.destination.mode"
+
+	// mkdir
+	case "mkdir.filename":
+		return "mkdir.file.path"
+	case "mkdir.container_path":
+		return "mkdir.file.container_path"
+	case "mkdir.overlay_numlower":
+		return "mkdir.file.overlay_numlower"
+	case "mkdir.basename":
+		return "mkdir.file.name"
+	case "mkdir.mode":
+		return "mkdir.file.destination.mode"
+
+	// rmdir
+	case "rmdir.filename":
+		return "rmdir.file.path"
+	case "rmdir.container_path":
+		return "rmdir.file.container_path"
+	case "rmdir.overlay_numlower":
+		return "rmdir.file.overlay_numlower"
+	case "rmdir.basename":
+		return "rmdir.file.name"
+
+	// rename
+	case "rename.old.filename":
+		return "rename.file.path"
+	case "rename.old.container_path":
+		return "rename.file.container_path"
+	case "rename.old.overlay_numlower":
+		return "rename.file.overlay_numlower"
+	case "rename.old.basename":
+		return "rename.file.name"
+	case "rename.new.filename":
+		return "rename.file.destination.path"
+	case "rename.new.container_path":
+		return "rename.file.destination.container_path"
+	case "rename.new.overlay_numlower":
+		return "rename.file.destination.overlay_numlower"
+	case "rename.new.basename":
+		return "rename.file.destination.name"
+
+	// unlink
+	case "unlink.filename":
+		return "unlink.file.path"
+	case "unlink.container_path":
+		return "unlink.file.container_path"
+	case "unlink.overlay_numlower":
+		return "unlink.file.overlay_numlower"
+	case "unlink.basename":
+		return "unlink.file.name"
+
+	// utimes
+	case "utimes.filename":
+		return "utimes.file.path"
+	case "utimes.container_path":
+		return "utimes.file.container_path"
+	case "utimes.overlay_numlower":
+		return "utimes.file.overlay_numlower"
+	case "utimes.basename":
+		return "utimes.file.name"
+
+	// link
+	case "link.source.filename":
+		return "link.file.path"
+	case "link.source.container_path":
+		return "link.file.container_path"
+	case "link.source.overlay_numlower":
+		return "link.file.overlay_numlower"
+	case "link.source.basename":
+		return "link.file.name"
+	case "link.target.filename":
+		return "link.file.destination.path"
+	case "link.target.container_path":
+		return "link.file.destination.container_path"
+	case "link.target.overlay_numlower":
+		return "link.file.destination.overlay_numlower"
+	case "link.target.basename":
+		return "link.file.destination.name"
+
+	// setxattr
+	case "setxattr.filename":
+		return "setxattr.file.path"
+	case "setxattr.container_path":
+		return "setxattr.file.container_path"
+	case "setxattr.overlay_numlower":
+		return "setxattr.file.overlay_numlower"
+	case "setxattr.basename":
+		return "setxattr.file.name"
+	case "setxattr.namespace":
+		return "setxattr.file.destination.namespace"
+	case "setxattr.name":
+		return "setxattr.file.destination.name"
+
+	// removexattr
+	case "removexattr.filename":
+		return "removexattr.file.path"
+	case "removexattr.container_path":
+		return "removexattr.file.container_path"
+	case "removexattr.overlay_numlower":
+		return "removexattr.file.overlay_numlower"
+	case "removexattr.basename":
+		return "removexattr.file.name"
+	case "removexattr.namespace":
+		return "removexattr.file.destination.namespace"
+	case "removexattr.name":
+		return "removexattr.file.destination.name"
+
+	// exec
+	case "exec.filename":
+		return "exec.file.path"
+	case "exec.container_path":
+		return "exec.file.container_path"
+	case "exec.overlay_numlower":
+		return "exec.file.overlay_numlower"
+	case "exec.basename":
+		return "exec.file.name"
+
+	// process
+	case "process.filename":
+		return "process.file.path"
+	case "process.container_path":
+		return "process.file.container_path"
+	case "process.overlay_numlower":
+		return "process.file.overlay_numlower"
+	case "process.basename":
+		return "process.file.name"
+	default:
+		return field
+	}
+}

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -208,21 +208,6 @@ type FileFields struct {
 	OverlayNumLower int32  `field:"overlay_numlower"`
 }
 
-// CopyFileFields copies src into dst
-func CopyFileFields(src *FileFields, dst *FileFields) {
-	dst.UID = src.UID
-	dst.User = src.User
-	dst.GID = src.GID
-	dst.Group = src.Group
-	dst.Mode = src.Mode
-	dst.CTime = src.CTime
-	dst.MTime = src.MTime
-	dst.MountID = src.MountID
-	dst.Inode = src.Inode
-	dst.PathID = src.PathID
-	dst.OverlayNumLower = src.OverlayNumLower
-}
-
 // FileEvent is the common file event type
 type FileEvent struct {
 	FileFields

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -89,9 +89,9 @@ type ChmodEvent struct {
 type ChownEvent struct {
 	SyscallEvent
 	File  FileEvent `field:"file"`
-	UID   int32     `field:"file.destination.uid"`
+	UID   uint32    `field:"file.destination.uid"`
 	User  string    `field:"file.destination.user" handler:"ResolveChownUID,string"`
-	GID   int32     `field:"file.destination.gid"`
+	GID   uint32    `field:"file.destination.gid"`
 	Group string    `field:"file.destination.group" handler:"ResolveChownGID,string"`
 }
 

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -25,7 +25,7 @@ type BinaryUnmarshaler interface {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *ChmodEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.FileEvent)
+	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.File)
 	if err != nil {
 		return n, err
 	}
@@ -41,7 +41,7 @@ func (e *ChmodEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *ChownEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.FileEvent)
+	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.File)
 	if err != nil {
 		return n, err
 	}
@@ -137,7 +137,7 @@ func (e *InvalidateDentryEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *FileFields) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 24 {
+	if len(data) < 72 {
 		return 0, ErrNotEnoughData
 	}
 	e.Inode = ByteOrder.Uint64(data[0:8])
@@ -145,7 +145,22 @@ func (e *FileFields) UnmarshalBinary(data []byte) (int, error) {
 	e.OverlayNumLower = int32(ByteOrder.Uint32(data[12:16]))
 	e.PathID = ByteOrder.Uint32(data[16:20])
 
-	return 24, nil
+	// +4 for padding
+
+	e.UID = ByteOrder.Uint32(data[24:28])
+	e.GID = ByteOrder.Uint32(data[28:32])
+	e.Mode = ByteOrder.Uint16(data[32:34])
+
+	// +6 for padding
+
+	timeSec := ByteOrder.Uint64(data[40:48])
+	timeNsec := ByteOrder.Uint64(data[48:56])
+	e.CTime = time.Unix(int64(timeSec), int64(timeNsec))
+
+	timeSec = ByteOrder.Uint64(data[56:64])
+	timeNsec = ByteOrder.Uint64(data[64:72])
+	e.MTime = time.Unix(int64(timeSec), int64(timeNsec))
+	return 72, nil
 }
 
 // UnmarshalBinary unmarshals a binary representation of itself
@@ -160,7 +175,7 @@ func (e *LinkEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *MkdirEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.FileEvent)
+	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.File)
 	if err != nil {
 		return n, err
 	}
@@ -203,7 +218,7 @@ func (e *MountEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *OpenEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.FileEvent)
+	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.File)
 	if err != nil {
 		return n, err
 	}
@@ -252,7 +267,7 @@ func (e *RenameEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *RmdirEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.FileEvent)
+	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.File)
 	if err != nil {
 		return n, err
 	}
@@ -270,7 +285,7 @@ func (e *RmdirEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *SetXAttrEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.FileEvent)
+	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.File)
 	if err != nil {
 		return n, err
 	}
@@ -313,7 +328,7 @@ func (e *UmountEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *UnlinkEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.FileEvent)
+	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.File)
 	if err != nil {
 		return n, err
 	}
@@ -331,7 +346,7 @@ func (e *UnlinkEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *UtimesEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.FileEvent)
+	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.File)
 	if err != nil {
 		return n, err
 	}

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -51,8 +51,8 @@ func (e *ChownEvent) UnmarshalBinary(data []byte) (int, error) {
 		return n, ErrNotEnoughData
 	}
 
-	e.UID = int32(ByteOrder.Uint32(data[0:4]))
-	e.GID = int32(ByteOrder.Uint32(data[4:8]))
+	e.UID = ByteOrder.Uint32(data[0:4])
+	e.GID = ByteOrder.Uint32(data[4:8])
 	return n + 8, nil
 }
 

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -156,7 +156,7 @@ func (m *Module) Reload() error {
 
 	rsa := sprobe.NewRuleSetApplier(m.config, m.probe)
 
-	ruleSet := m.probe.NewRuleSet(rules.NewOptsWithParams(model.SECLConstants, sprobe.SupportedDiscarders, m.getEventTypeEnabled(), sprobe.AllCustomRuleIDs(), agentLogger.DatadogAgentLogger{}))
+	ruleSet := m.probe.NewRuleSet(rules.NewOptsWithParams(model.SECLConstants, sprobe.SupportedDiscarders, m.getEventTypeEnabled(), sprobe.AllCustomRuleIDs(), model.SECLLegacyAttributes, agentLogger.DatadogAgentLogger{}))
 
 	loadErr := rules.LoadPolicies(m.config.PoliciesDir, ruleSet)
 	if loadErr.ErrorOrNil() != nil {

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -60,11 +60,11 @@ func (m *Model) GetEventTypes() []eval.EventType {
 func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Evaluator, error) {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Chmod.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Chmod.File)
 
 			},
 			Field: field,
@@ -72,43 +72,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "chmod.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Chmod.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chmod.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Chmod.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chmod.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Chmod.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "chmod.mode":
+	case "chmod.file.destination.mode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -120,16 +84,124 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Chmod.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Chmod.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Chmod.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Chmod.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chmod.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Chmod.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chmod.retval":
@@ -144,11 +216,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Chown.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Chown.File)
 
 			},
 			Field: field,
@@ -156,31 +228,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "chown.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Chown.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chown.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Chown.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "chown.gid":
+	case "chown.file.destination.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -192,11 +240,23 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "chown.inode":
+	case "chown.file.destination.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveChownGID(&(*Event)(ctx.Object).Chown)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.destination.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Chown.FileEvent.FileFields.Inode)
+				return int((*Event)(ctx.Object).Chown.UID)
 
 			},
 			Field: field,
@@ -204,16 +264,136 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.destination.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveChownUID(&(*Event)(ctx.Object).Chown)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Chown.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Chown.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Chown.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Chown.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Chown.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Chown.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "chown.retval":
@@ -221,18 +401,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Chown.SyscallEvent.Retval)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "chown.uid":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Chown.UID)
 
 			},
 			Field: field,
@@ -252,11 +420,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "exec.container_path":
+	case "exec.comm":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveExecContainerPath(&(*Event)(ctx.Object).Exec)
+				return (*Event)(ctx.Object).ResolveExecComm(&(*Event)(ctx.Object).Exec)
 
 			},
 			Field: field,
@@ -276,11 +444,131 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveExecContainerPath(&(*Event)(ctx.Object).Exec)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Exec.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveExecBasename(&(*Event)(ctx.Object).Exec)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveExecInode(&(*Event)(ctx.Object).Exec)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Exec.FileFields)
 
 			},
 			Field: field,
@@ -310,42 +598,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "exec.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Exec.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "exec.name":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveExecBasename(&(*Event)(ctx.Object).Exec)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "exec.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Exec.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "exec.ppid":
@@ -396,6 +648,270 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Link.Source)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Link.Target)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Link.Target.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Link.Target)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Link.Target)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.destination.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Link.Target.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Link.Source.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Link.Source)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Link.Source)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "link.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Link.Source.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.retval":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -408,11 +924,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "link.source.basename":
+	case "mkdir.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Link.Source)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Mkdir.File)
 
 			},
 			Field: field,
@@ -420,163 +936,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "link.source.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Link.Source)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.source.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Link.Source)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.source.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Source.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "link.source.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Source.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "link.target.basename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Link.Target)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.target.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Link.Target)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.target.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Link.Target)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "link.target.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Target.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "link.target.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Link.Target.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "mkdir.basename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Mkdir.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "mkdir.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Mkdir.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "mkdir.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Mkdir.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "mkdir.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Mkdir.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "mkdir.mode":
+	case "mkdir.file.destination.mode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -588,16 +948,124 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "mkdir.overlay_numlower":
+	case "mkdir.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Mkdir.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Mkdir.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Mkdir.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Mkdir.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Mkdir.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "mkdir.retval":
@@ -612,11 +1080,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "open.basename":
+	case "open.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Open.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Open.File)
 
 			},
 			Field: field,
@@ -624,11 +1092,35 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.group":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Open.FileEvent)
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Open.File.FileFields)
 
 			},
 			Field: field,
@@ -636,11 +1128,95 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "open.filename":
+	case "open.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Open.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Open.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "open.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Open.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "open.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Open.File.FileFields)
 
 			},
 			Field: field,
@@ -660,42 +1236,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "open.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Open.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "open.mode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Open.Mode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "open.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Open.FileEvent.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
 	case "open.retval":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -708,7 +1248,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -718,7 +1258,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				if reg.Value != nil {
 					element := (*model.ProcessCacheEntry)(reg.Value)
 
-					result = (*Event)(ctx.Object).ResolveExecContainerPath(&element.ExecEvent)
+					result = (*Event)(ctx.Object).ResolveExecComm(&element.ExecEvent)
 
 				}
 
@@ -752,7 +1292,183 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = (*Event)(ctx.Object).ResolveExecContainerPath(&element.ExecEvent)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.GID)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = (*Event)(ctx.Object).ResolveGID(&element.FileFields)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.Inode)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.Mode)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.MountID)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = (*Event)(ctx.Object).ResolveExecBasename(&element.ExecEvent)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.OverlayNumLower)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -763,6 +1479,50 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*model.ProcessCacheEntry)(reg.Value)
 
 					result = (*Event)(ctx.Object).ResolveExecInode(&element.ExecEvent)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				var result int
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = int(element.ProcessContext.ExecEvent.FileFields.UID)
+
+				}
+
+				return result
+
+			},
+			Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				var result string
+
+				reg := ctx.Registers[regID]
+				if reg.Value != nil {
+					element := (*model.ProcessCacheEntry)(reg.Value)
+
+					result = (*Event)(ctx.Object).ResolveUID(&element.FileFields)
 
 				}
 
@@ -829,72 +1589,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*model.ProcessCacheEntry)(reg.Value)
 
 					result = (*Event)(ctx.Object).ResolveContainerID(&element.ContainerContext)
-
-				}
-
-				return result
-
-			},
-			Field: field,
-
-			Weight: eval.IteratorWeight,
-		}, nil
-
-	case "process.ancestors.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				var result int
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-					element := (*model.ProcessCacheEntry)(reg.Value)
-
-					result = int(element.ProcessContext.ExecEvent.FileFields.Inode)
-
-				}
-
-				return result
-
-			},
-			Field: field,
-
-			Weight: eval.IteratorWeight,
-		}, nil
-
-	case "process.ancestors.name":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				var result string
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-					element := (*model.ProcessCacheEntry)(reg.Value)
-
-					result = (*Event)(ctx.Object).ResolveExecBasename(&element.ExecEvent)
-
-				}
-
-				return result
-
-			},
-			Field: field,
-
-			Weight: eval.IteratorWeight,
-		}, nil
-
-	case "process.ancestors.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				var result int
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-					element := (*model.ProcessCacheEntry)(reg.Value)
-
-					result = int(element.ProcessContext.ExecEvent.FileFields.OverlayNumLower)
 
 				}
 
@@ -1038,11 +1732,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
-	case "process.container_path":
+	case "process.comm":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveExecContainerPath(&(*Event)(ctx.Object).Process.ExecEvent)
+				return (*Event)(ctx.Object).ResolveExecComm(&(*Event)(ctx.Object).Process.ExecEvent)
 
 			},
 			Field: field,
@@ -1062,11 +1756,131 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "process.filename":
+	case "process.file.container_path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveExecContainerPath(&(*Event)(ctx.Object).Process.ExecEvent)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Process.ExecEvent.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveExecBasename(&(*Event)(ctx.Object).Process.ExecEvent)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveExecInode(&(*Event)(ctx.Object).Process.ExecEvent)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Process.ExecEvent.FileFields)
 
 			},
 			Field: field,
@@ -1096,42 +1910,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "process.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "process.name":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveExecBasename(&(*Event)(ctx.Object).Process.ExecEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "process.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Process.ExecEvent.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
 		}, nil
 
 	case "process.pid":
@@ -1206,11 +1984,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).RemoveXAttr.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).RemoveXAttr.File)
 
 			},
 			Field: field,
@@ -1218,43 +1996,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "removexattr.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).RemoveXAttr.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "removexattr.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).RemoveXAttr.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "removexattr.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).RemoveXAttr.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "removexattr.name":
+	case "removexattr.file.destination.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1266,7 +2008,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "removexattr.namespace":
+	case "removexattr.file.destination.namespace":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1278,16 +2020,124 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).RemoveXAttr.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).RemoveXAttr.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "removexattr.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).RemoveXAttr.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "removexattr.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).RemoveXAttr.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "removexattr.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "removexattr.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).RemoveXAttr.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "removexattr.retval":
@@ -1302,79 +2152,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "rename.new.basename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Rename.New)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.new.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Rename.New)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.new.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Rename.New)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.new.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rename.New.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "rename.new.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).Rename.New.FileFields.OverlayNumLower)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "rename.old.basename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Rename.Old)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rename.old.container_path":
+	case "rename.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1386,11 +2164,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "rename.old.filename":
+	case "rename.file.destination.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Rename.Old)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Rename.New)
 
 			},
 			Field: field,
@@ -1398,7 +2176,151 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "rename.old.inode":
+	case "rename.file.destination.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Rename.New.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.destination.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Rename.New)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.destination.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Rename.New)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.destination.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Rename.New.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Rename.Old.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -1410,7 +2332,43 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Rename.Old)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.overlay_numlower":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -1420,6 +2378,42 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Rename.Old)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Rename.Old.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rename.retval":
@@ -1434,11 +2428,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Rmdir.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Rmdir.File)
 
 			},
 			Field: field,
@@ -1446,35 +2440,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "rmdir.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Rmdir.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rmdir.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Rmdir.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "rmdir.inode":
+	case "rmdir.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Rmdir.FileEvent.FileFields.Inode)
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.GID)
 
 			},
 			Field: field,
@@ -1482,16 +2452,112 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Rmdir.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Rmdir.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.Inode)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Rmdir.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Rmdir.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Rmdir.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "rmdir.retval":
@@ -1506,11 +2572,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).SetXAttr.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).SetXAttr.File)
 
 			},
 			Field: field,
@@ -1518,43 +2584,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "setxattr.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).SetXAttr.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "setxattr.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).SetXAttr.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "setxattr.inode":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-
-				return int((*Event)(ctx.Object).SetXAttr.FileEvent.FileFields.Inode)
-
-			},
-			Field: field,
-
-			Weight: eval.FunctionWeight,
-		}, nil
-
-	case "setxattr.name":
+	case "setxattr.file.destination.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1566,7 +2596,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "setxattr.namespace":
+	case "setxattr.file.destination.namespace":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
@@ -1578,16 +2608,124 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).SetXAttr.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.GID)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).SetXAttr.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "setxattr.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).SetXAttr.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "setxattr.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).SetXAttr.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "setxattr.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "setxattr.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).SetXAttr.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "setxattr.retval":
@@ -1602,11 +2740,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Unlink.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Unlink.File)
 
 			},
 			Field: field,
@@ -1614,11 +2752,23 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "unlink.container_path":
+	case "unlink.file.gid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.GID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.group":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Unlink.FileEvent)
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Unlink.File.FileFields)
 
 			},
 			Field: field,
@@ -1626,11 +2776,47 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "unlink.filename":
+	case "unlink.file.inode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.Inode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Unlink.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Unlink.File)
 
 			},
 			Field: field,
@@ -1638,11 +2824,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "unlink.flags":
+	case "unlink.file.overlay_numlower":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Unlink.Flags)
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.OverlayNumLower)
 
 			},
 			Field: field,
@@ -1650,11 +2836,23 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "unlink.inode":
+	case "unlink.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Unlink.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "unlink.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Unlink.FileEvent.FileFields.Inode)
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.UID)
 
 			},
 			Field: field,
@@ -1662,16 +2860,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "unlink.overlay_numlower":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
+	case "unlink.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
 
-				return int((*Event)(ctx.Object).Unlink.FileEvent.FileFields.OverlayNumLower)
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Unlink.File.FileFields)
 
 			},
 			Field: field,
 
-			Weight: eval.FunctionWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "unlink.retval":
@@ -1686,11 +2884,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Utimes.FileEvent)
+				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Utimes.File)
 
 			},
 			Field: field,
@@ -1698,35 +2896,11 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
-	case "utimes.container_path":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileContainerPath(&(*Event)(ctx.Object).Utimes.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "utimes.filename":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
-
-				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Utimes.FileEvent)
-
-			},
-			Field: field,
-
-			Weight: eval.HandlerWeight,
-		}, nil
-
-	case "utimes.inode":
+	case "utimes.file.gid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Utimes.FileEvent.FileFields.Inode)
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.GID)
 
 			},
 			Field: field,
@@ -1734,16 +2908,112 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.group":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveGID(&(*Event)(ctx.Object).Utimes.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "utimes.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
-				return int((*Event)(ctx.Object).Utimes.FileEvent.FileFields.OverlayNumLower)
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.Inode)
 
 			},
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.Mode)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.mount_id":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.MountID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileBasename(&(*Event)(ctx.Object).Utimes.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "utimes.file.overlay_numlower":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.OverlayNumLower)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.path":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Utimes.File)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "utimes.file.uid":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.UID)
+
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.user":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveUID(&(*Event)(ctx.Object).Utimes.File.FileFields)
+
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "utimes.retval":
@@ -1766,53 +3036,95 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 func (e *Event) GetFields() []eval.Field {
 	return []eval.Field{
 
-		"chmod.basename",
+		"chmod.file.container_path",
 
-		"chmod.container_path",
+		"chmod.file.destination.mode",
 
-		"chmod.filename",
+		"chmod.file.gid",
 
-		"chmod.inode",
+		"chmod.file.group",
 
-		"chmod.mode",
+		"chmod.file.inode",
 
-		"chmod.overlay_numlower",
+		"chmod.file.mode",
+
+		"chmod.file.mount_id",
+
+		"chmod.file.name",
+
+		"chmod.file.overlay_numlower",
+
+		"chmod.file.path",
+
+		"chmod.file.uid",
+
+		"chmod.file.user",
 
 		"chmod.retval",
 
-		"chown.basename",
+		"chown.file.container_path",
 
-		"chown.container_path",
+		"chown.file.destination.gid",
 
-		"chown.filename",
+		"chown.file.destination.group",
 
-		"chown.gid",
+		"chown.file.destination.uid",
 
-		"chown.inode",
+		"chown.file.destination.user",
 
-		"chown.overlay_numlower",
+		"chown.file.gid",
+
+		"chown.file.group",
+
+		"chown.file.inode",
+
+		"chown.file.mode",
+
+		"chown.file.mount_id",
+
+		"chown.file.name",
+
+		"chown.file.overlay_numlower",
+
+		"chown.file.path",
+
+		"chown.file.uid",
+
+		"chown.file.user",
 
 		"chown.retval",
 
-		"chown.uid",
-
 		"container.id",
 
-		"exec.container_path",
+		"exec.comm",
 
 		"exec.cookie",
 
-		"exec.filename",
+		"exec.file.container_path",
+
+		"exec.file.gid",
+
+		"exec.file.group",
+
+		"exec.file.inode",
+
+		"exec.file.mode",
+
+		"exec.file.mount_id",
+
+		"exec.file.name",
+
+		"exec.file.overlay_numlower",
+
+		"exec.file.path",
+
+		"exec.file.uid",
+
+		"exec.file.user",
 
 		"exec.gid",
 
 		"exec.group",
-
-		"exec.inode",
-
-		"exec.name",
-
-		"exec.overlay_numlower",
 
 		"exec.ppid",
 
@@ -1822,75 +3134,137 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.user",
 
+		"link.file.container_path",
+
+		"link.file.destination.container_path",
+
+		"link.file.destination.gid",
+
+		"link.file.destination.group",
+
+		"link.file.destination.inode",
+
+		"link.file.destination.mode",
+
+		"link.file.destination.mount_id",
+
+		"link.file.destination.name",
+
+		"link.file.destination.overlay_numlower",
+
+		"link.file.destination.path",
+
+		"link.file.destination.uid",
+
+		"link.file.destination.user",
+
+		"link.file.gid",
+
+		"link.file.group",
+
+		"link.file.inode",
+
+		"link.file.mode",
+
+		"link.file.mount_id",
+
+		"link.file.name",
+
+		"link.file.overlay_numlower",
+
+		"link.file.path",
+
+		"link.file.uid",
+
+		"link.file.user",
+
 		"link.retval",
 
-		"link.source.basename",
+		"mkdir.file.container_path",
 
-		"link.source.container_path",
+		"mkdir.file.destination.mode",
 
-		"link.source.filename",
+		"mkdir.file.gid",
 
-		"link.source.inode",
+		"mkdir.file.group",
 
-		"link.source.overlay_numlower",
+		"mkdir.file.inode",
 
-		"link.target.basename",
+		"mkdir.file.mode",
 
-		"link.target.container_path",
+		"mkdir.file.mount_id",
 
-		"link.target.filename",
+		"mkdir.file.name",
 
-		"link.target.inode",
+		"mkdir.file.overlay_numlower",
 
-		"link.target.overlay_numlower",
+		"mkdir.file.path",
 
-		"mkdir.basename",
+		"mkdir.file.uid",
 
-		"mkdir.container_path",
-
-		"mkdir.filename",
-
-		"mkdir.inode",
-
-		"mkdir.mode",
-
-		"mkdir.overlay_numlower",
+		"mkdir.file.user",
 
 		"mkdir.retval",
 
-		"open.basename",
+		"open.file.container_path",
 
-		"open.container_path",
+		"open.file.destination.mode",
 
-		"open.filename",
+		"open.file.gid",
+
+		"open.file.group",
+
+		"open.file.inode",
+
+		"open.file.mode",
+
+		"open.file.mount_id",
+
+		"open.file.name",
+
+		"open.file.overlay_numlower",
+
+		"open.file.path",
+
+		"open.file.uid",
+
+		"open.file.user",
 
 		"open.flags",
 
-		"open.inode",
-
-		"open.mode",
-
-		"open.overlay_numlower",
-
 		"open.retval",
 
-		"process.ancestors.container_path",
+		"process.ancestors.comm",
 
 		"process.ancestors.cookie",
 
-		"process.ancestors.filename",
+		"process.ancestors.file.container_path",
+
+		"process.ancestors.file.gid",
+
+		"process.ancestors.file.group",
+
+		"process.ancestors.file.inode",
+
+		"process.ancestors.file.mode",
+
+		"process.ancestors.file.mount_id",
+
+		"process.ancestors.file.name",
+
+		"process.ancestors.file.overlay_numlower",
+
+		"process.ancestors.file.path",
+
+		"process.ancestors.file.uid",
+
+		"process.ancestors.file.user",
 
 		"process.ancestors.gid",
 
 		"process.ancestors.group",
 
 		"process.ancestors.id",
-
-		"process.ancestors.inode",
-
-		"process.ancestors.name",
-
-		"process.ancestors.overlay_numlower",
 
 		"process.ancestors.pid",
 
@@ -1904,21 +3278,35 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.user",
 
-		"process.container_path",
+		"process.comm",
 
 		"process.cookie",
 
-		"process.filename",
+		"process.file.container_path",
+
+		"process.file.gid",
+
+		"process.file.group",
+
+		"process.file.inode",
+
+		"process.file.mode",
+
+		"process.file.mount_id",
+
+		"process.file.name",
+
+		"process.file.overlay_numlower",
+
+		"process.file.path",
+
+		"process.file.uid",
+
+		"process.file.user",
 
 		"process.gid",
 
 		"process.group",
-
-		"process.inode",
-
-		"process.name",
-
-		"process.overlay_numlower",
 
 		"process.pid",
 
@@ -1932,95 +3320,177 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.user",
 
-		"removexattr.basename",
+		"removexattr.file.container_path",
 
-		"removexattr.container_path",
+		"removexattr.file.destination.name",
 
-		"removexattr.filename",
+		"removexattr.file.destination.namespace",
 
-		"removexattr.inode",
+		"removexattr.file.gid",
 
-		"removexattr.name",
+		"removexattr.file.group",
 
-		"removexattr.namespace",
+		"removexattr.file.inode",
 
-		"removexattr.overlay_numlower",
+		"removexattr.file.mode",
+
+		"removexattr.file.mount_id",
+
+		"removexattr.file.name",
+
+		"removexattr.file.overlay_numlower",
+
+		"removexattr.file.path",
+
+		"removexattr.file.uid",
+
+		"removexattr.file.user",
 
 		"removexattr.retval",
 
-		"rename.new.basename",
+		"rename.file.container_path",
 
-		"rename.new.container_path",
+		"rename.file.destination.container_path",
 
-		"rename.new.filename",
+		"rename.file.destination.gid",
 
-		"rename.new.inode",
+		"rename.file.destination.group",
 
-		"rename.new.overlay_numlower",
+		"rename.file.destination.inode",
 
-		"rename.old.basename",
+		"rename.file.destination.mode",
 
-		"rename.old.container_path",
+		"rename.file.destination.mount_id",
 
-		"rename.old.filename",
+		"rename.file.destination.name",
 
-		"rename.old.inode",
+		"rename.file.destination.overlay_numlower",
 
-		"rename.old.overlay_numlower",
+		"rename.file.destination.path",
+
+		"rename.file.destination.uid",
+
+		"rename.file.destination.user",
+
+		"rename.file.gid",
+
+		"rename.file.group",
+
+		"rename.file.inode",
+
+		"rename.file.mode",
+
+		"rename.file.mount_id",
+
+		"rename.file.name",
+
+		"rename.file.overlay_numlower",
+
+		"rename.file.path",
+
+		"rename.file.uid",
+
+		"rename.file.user",
 
 		"rename.retval",
 
-		"rmdir.basename",
+		"rmdir.file.container_path",
 
-		"rmdir.container_path",
+		"rmdir.file.gid",
 
-		"rmdir.filename",
+		"rmdir.file.group",
 
-		"rmdir.inode",
+		"rmdir.file.inode",
 
-		"rmdir.overlay_numlower",
+		"rmdir.file.mode",
+
+		"rmdir.file.mount_id",
+
+		"rmdir.file.name",
+
+		"rmdir.file.overlay_numlower",
+
+		"rmdir.file.path",
+
+		"rmdir.file.uid",
+
+		"rmdir.file.user",
 
 		"rmdir.retval",
 
-		"setxattr.basename",
+		"setxattr.file.container_path",
 
-		"setxattr.container_path",
+		"setxattr.file.destination.name",
 
-		"setxattr.filename",
+		"setxattr.file.destination.namespace",
 
-		"setxattr.inode",
+		"setxattr.file.gid",
 
-		"setxattr.name",
+		"setxattr.file.group",
 
-		"setxattr.namespace",
+		"setxattr.file.inode",
 
-		"setxattr.overlay_numlower",
+		"setxattr.file.mode",
+
+		"setxattr.file.mount_id",
+
+		"setxattr.file.name",
+
+		"setxattr.file.overlay_numlower",
+
+		"setxattr.file.path",
+
+		"setxattr.file.uid",
+
+		"setxattr.file.user",
 
 		"setxattr.retval",
 
-		"unlink.basename",
+		"unlink.file.container_path",
 
-		"unlink.container_path",
+		"unlink.file.gid",
 
-		"unlink.filename",
+		"unlink.file.group",
 
-		"unlink.flags",
+		"unlink.file.inode",
 
-		"unlink.inode",
+		"unlink.file.mode",
 
-		"unlink.overlay_numlower",
+		"unlink.file.mount_id",
+
+		"unlink.file.name",
+
+		"unlink.file.overlay_numlower",
+
+		"unlink.file.path",
+
+		"unlink.file.uid",
+
+		"unlink.file.user",
 
 		"unlink.retval",
 
-		"utimes.basename",
+		"utimes.file.container_path",
 
-		"utimes.container_path",
+		"utimes.file.gid",
 
-		"utimes.filename",
+		"utimes.file.group",
 
-		"utimes.inode",
+		"utimes.file.inode",
 
-		"utimes.overlay_numlower",
+		"utimes.file.mode",
+
+		"utimes.file.mount_id",
+
+		"utimes.file.name",
+
+		"utimes.file.overlay_numlower",
+
+		"utimes.file.path",
+
+		"utimes.file.uid",
+
+		"utimes.file.user",
 
 		"utimes.retval",
 	}
@@ -2029,81 +3499,177 @@ func (e *Event) GetFields() []eval.Field {
 func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 
-		return e.ResolveFileBasename(&e.Chmod.FileEvent), nil
+		return e.ResolveFileContainerPath(&e.Chmod.File), nil
 
-	case "chmod.container_path":
-
-		return e.ResolveFileContainerPath(&e.Chmod.FileEvent), nil
-
-	case "chmod.filename":
-
-		return e.ResolveFileInode(&e.Chmod.FileEvent), nil
-
-	case "chmod.inode":
-
-		return int(e.Chmod.FileEvent.FileFields.Inode), nil
-
-	case "chmod.mode":
+	case "chmod.file.destination.mode":
 
 		return int(e.Chmod.Mode), nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.gid":
 
-		return int(e.Chmod.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Chmod.File.FileFields.GID), nil
+
+	case "chmod.file.group":
+
+		return e.ResolveGID(&e.Chmod.File.FileFields), nil
+
+	case "chmod.file.inode":
+
+		return int(e.Chmod.File.FileFields.Inode), nil
+
+	case "chmod.file.mode":
+
+		return int(e.Chmod.File.FileFields.Mode), nil
+
+	case "chmod.file.mount_id":
+
+		return int(e.Chmod.File.FileFields.MountID), nil
+
+	case "chmod.file.name":
+
+		return e.ResolveFileBasename(&e.Chmod.File), nil
+
+	case "chmod.file.overlay_numlower":
+
+		return int(e.Chmod.File.FileFields.OverlayNumLower), nil
+
+	case "chmod.file.path":
+
+		return e.ResolveFileInode(&e.Chmod.File), nil
+
+	case "chmod.file.uid":
+
+		return int(e.Chmod.File.FileFields.UID), nil
+
+	case "chmod.file.user":
+
+		return e.ResolveUID(&e.Chmod.File.FileFields), nil
 
 	case "chmod.retval":
 
 		return int(e.Chmod.SyscallEvent.Retval), nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 
-		return e.ResolveFileBasename(&e.Chown.FileEvent), nil
+		return e.ResolveFileContainerPath(&e.Chown.File), nil
 
-	case "chown.container_path":
-
-		return e.ResolveFileContainerPath(&e.Chown.FileEvent), nil
-
-	case "chown.filename":
-
-		return e.ResolveFileInode(&e.Chown.FileEvent), nil
-
-	case "chown.gid":
+	case "chown.file.destination.gid":
 
 		return int(e.Chown.GID), nil
 
-	case "chown.inode":
+	case "chown.file.destination.group":
 
-		return int(e.Chown.FileEvent.FileFields.Inode), nil
+		return e.ResolveChownGID(&e.Chown), nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.destination.uid":
 
-		return int(e.Chown.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Chown.UID), nil
+
+	case "chown.file.destination.user":
+
+		return e.ResolveChownUID(&e.Chown), nil
+
+	case "chown.file.gid":
+
+		return int(e.Chown.File.FileFields.GID), nil
+
+	case "chown.file.group":
+
+		return e.ResolveGID(&e.Chown.File.FileFields), nil
+
+	case "chown.file.inode":
+
+		return int(e.Chown.File.FileFields.Inode), nil
+
+	case "chown.file.mode":
+
+		return int(e.Chown.File.FileFields.Mode), nil
+
+	case "chown.file.mount_id":
+
+		return int(e.Chown.File.FileFields.MountID), nil
+
+	case "chown.file.name":
+
+		return e.ResolveFileBasename(&e.Chown.File), nil
+
+	case "chown.file.overlay_numlower":
+
+		return int(e.Chown.File.FileFields.OverlayNumLower), nil
+
+	case "chown.file.path":
+
+		return e.ResolveFileInode(&e.Chown.File), nil
+
+	case "chown.file.uid":
+
+		return int(e.Chown.File.FileFields.UID), nil
+
+	case "chown.file.user":
+
+		return e.ResolveUID(&e.Chown.File.FileFields), nil
 
 	case "chown.retval":
 
 		return int(e.Chown.SyscallEvent.Retval), nil
 
-	case "chown.uid":
-
-		return int(e.Chown.UID), nil
-
 	case "container.id":
 
 		return e.ResolveContainerID(&e.Container), nil
 
-	case "exec.container_path":
+	case "exec.comm":
 
-		return e.ResolveExecContainerPath(&e.Exec), nil
+		return e.ResolveExecComm(&e.Exec), nil
 
 	case "exec.cookie":
 
 		return int(e.ResolveExecCookie(&e.Exec)), nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+
+		return e.ResolveExecContainerPath(&e.Exec), nil
+
+	case "exec.file.gid":
+
+		return int(e.Exec.FileFields.GID), nil
+
+	case "exec.file.group":
+
+		return e.ResolveGID(&e.Exec.FileFields), nil
+
+	case "exec.file.inode":
+
+		return int(e.Exec.FileFields.Inode), nil
+
+	case "exec.file.mode":
+
+		return int(e.Exec.FileFields.Mode), nil
+
+	case "exec.file.mount_id":
+
+		return int(e.Exec.FileFields.MountID), nil
+
+	case "exec.file.name":
+
+		return e.ResolveExecBasename(&e.Exec), nil
+
+	case "exec.file.overlay_numlower":
+
+		return int(e.Exec.FileFields.OverlayNumLower), nil
+
+	case "exec.file.path":
 
 		return e.ResolveExecInode(&e.Exec), nil
+
+	case "exec.file.uid":
+
+		return int(e.Exec.FileFields.UID), nil
+
+	case "exec.file.user":
+
+		return e.ResolveUID(&e.Exec.FileFields), nil
 
 	case "exec.gid":
 
@@ -2112,18 +3678,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "exec.group":
 
 		return e.ResolveExecGroup(&e.Exec), nil
-
-	case "exec.inode":
-
-		return int(e.Exec.FileFields.Inode), nil
-
-	case "exec.name":
-
-		return e.ResolveExecBasename(&e.Exec), nil
-
-	case "exec.overlay_numlower":
-
-		return int(e.Exec.FileFields.OverlayNumLower), nil
 
 	case "exec.ppid":
 
@@ -2141,111 +3695,207 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveExecUser(&e.Exec), nil
 
+	case "link.file.container_path":
+
+		return e.ResolveFileContainerPath(&e.Link.Source), nil
+
+	case "link.file.destination.container_path":
+
+		return e.ResolveFileContainerPath(&e.Link.Target), nil
+
+	case "link.file.destination.gid":
+
+		return int(e.Link.Target.FileFields.GID), nil
+
+	case "link.file.destination.group":
+
+		return e.ResolveGID(&e.Link.Target.FileFields), nil
+
+	case "link.file.destination.inode":
+
+		return int(e.Link.Target.FileFields.Inode), nil
+
+	case "link.file.destination.mode":
+
+		return int(e.Link.Target.FileFields.Mode), nil
+
+	case "link.file.destination.mount_id":
+
+		return int(e.Link.Target.FileFields.MountID), nil
+
+	case "link.file.destination.name":
+
+		return e.ResolveFileBasename(&e.Link.Target), nil
+
+	case "link.file.destination.overlay_numlower":
+
+		return int(e.Link.Target.FileFields.OverlayNumLower), nil
+
+	case "link.file.destination.path":
+
+		return e.ResolveFileInode(&e.Link.Target), nil
+
+	case "link.file.destination.uid":
+
+		return int(e.Link.Target.FileFields.UID), nil
+
+	case "link.file.destination.user":
+
+		return e.ResolveUID(&e.Link.Target.FileFields), nil
+
+	case "link.file.gid":
+
+		return int(e.Link.Source.FileFields.GID), nil
+
+	case "link.file.group":
+
+		return e.ResolveGID(&e.Link.Source.FileFields), nil
+
+	case "link.file.inode":
+
+		return int(e.Link.Source.FileFields.Inode), nil
+
+	case "link.file.mode":
+
+		return int(e.Link.Source.FileFields.Mode), nil
+
+	case "link.file.mount_id":
+
+		return int(e.Link.Source.FileFields.MountID), nil
+
+	case "link.file.name":
+
+		return e.ResolveFileBasename(&e.Link.Source), nil
+
+	case "link.file.overlay_numlower":
+
+		return int(e.Link.Source.FileFields.OverlayNumLower), nil
+
+	case "link.file.path":
+
+		return e.ResolveFileInode(&e.Link.Source), nil
+
+	case "link.file.uid":
+
+		return int(e.Link.Source.FileFields.UID), nil
+
+	case "link.file.user":
+
+		return e.ResolveUID(&e.Link.Source.FileFields), nil
+
 	case "link.retval":
 
 		return int(e.Link.SyscallEvent.Retval), nil
 
-	case "link.source.basename":
+	case "mkdir.file.container_path":
 
-		return e.ResolveFileBasename(&e.Link.Source), nil
+		return e.ResolveFileContainerPath(&e.Mkdir.File), nil
 
-	case "link.source.container_path":
-
-		return e.ResolveFileContainerPath(&e.Link.Source), nil
-
-	case "link.source.filename":
-
-		return e.ResolveFileInode(&e.Link.Source), nil
-
-	case "link.source.inode":
-
-		return int(e.Link.Source.FileFields.Inode), nil
-
-	case "link.source.overlay_numlower":
-
-		return int(e.Link.Source.FileFields.OverlayNumLower), nil
-
-	case "link.target.basename":
-
-		return e.ResolveFileBasename(&e.Link.Target), nil
-
-	case "link.target.container_path":
-
-		return e.ResolveFileContainerPath(&e.Link.Target), nil
-
-	case "link.target.filename":
-
-		return e.ResolveFileInode(&e.Link.Target), nil
-
-	case "link.target.inode":
-
-		return int(e.Link.Target.FileFields.Inode), nil
-
-	case "link.target.overlay_numlower":
-
-		return int(e.Link.Target.FileFields.OverlayNumLower), nil
-
-	case "mkdir.basename":
-
-		return e.ResolveFileBasename(&e.Mkdir.FileEvent), nil
-
-	case "mkdir.container_path":
-
-		return e.ResolveFileContainerPath(&e.Mkdir.FileEvent), nil
-
-	case "mkdir.filename":
-
-		return e.ResolveFileInode(&e.Mkdir.FileEvent), nil
-
-	case "mkdir.inode":
-
-		return int(e.Mkdir.FileEvent.FileFields.Inode), nil
-
-	case "mkdir.mode":
+	case "mkdir.file.destination.mode":
 
 		return int(e.Mkdir.Mode), nil
 
-	case "mkdir.overlay_numlower":
+	case "mkdir.file.gid":
 
-		return int(e.Mkdir.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Mkdir.File.FileFields.GID), nil
+
+	case "mkdir.file.group":
+
+		return e.ResolveGID(&e.Mkdir.File.FileFields), nil
+
+	case "mkdir.file.inode":
+
+		return int(e.Mkdir.File.FileFields.Inode), nil
+
+	case "mkdir.file.mode":
+
+		return int(e.Mkdir.File.FileFields.Mode), nil
+
+	case "mkdir.file.mount_id":
+
+		return int(e.Mkdir.File.FileFields.MountID), nil
+
+	case "mkdir.file.name":
+
+		return e.ResolveFileBasename(&e.Mkdir.File), nil
+
+	case "mkdir.file.overlay_numlower":
+
+		return int(e.Mkdir.File.FileFields.OverlayNumLower), nil
+
+	case "mkdir.file.path":
+
+		return e.ResolveFileInode(&e.Mkdir.File), nil
+
+	case "mkdir.file.uid":
+
+		return int(e.Mkdir.File.FileFields.UID), nil
+
+	case "mkdir.file.user":
+
+		return e.ResolveUID(&e.Mkdir.File.FileFields), nil
 
 	case "mkdir.retval":
 
 		return int(e.Mkdir.SyscallEvent.Retval), nil
 
-	case "open.basename":
+	case "open.file.container_path":
 
-		return e.ResolveFileBasename(&e.Open.FileEvent), nil
+		return e.ResolveFileContainerPath(&e.Open.File), nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
 
-		return e.ResolveFileContainerPath(&e.Open.FileEvent), nil
+		return int(e.Open.Mode), nil
 
-	case "open.filename":
+	case "open.file.gid":
 
-		return e.ResolveFileInode(&e.Open.FileEvent), nil
+		return int(e.Open.File.FileFields.GID), nil
+
+	case "open.file.group":
+
+		return e.ResolveGID(&e.Open.File.FileFields), nil
+
+	case "open.file.inode":
+
+		return int(e.Open.File.FileFields.Inode), nil
+
+	case "open.file.mode":
+
+		return int(e.Open.File.FileFields.Mode), nil
+
+	case "open.file.mount_id":
+
+		return int(e.Open.File.FileFields.MountID), nil
+
+	case "open.file.name":
+
+		return e.ResolveFileBasename(&e.Open.File), nil
+
+	case "open.file.overlay_numlower":
+
+		return int(e.Open.File.FileFields.OverlayNumLower), nil
+
+	case "open.file.path":
+
+		return e.ResolveFileInode(&e.Open.File), nil
+
+	case "open.file.uid":
+
+		return int(e.Open.File.FileFields.UID), nil
+
+	case "open.file.user":
+
+		return e.ResolveUID(&e.Open.File.FileFields), nil
 
 	case "open.flags":
 
 		return int(e.Open.Flags), nil
 
-	case "open.inode":
-
-		return int(e.Open.FileEvent.FileFields.Inode), nil
-
-	case "open.mode":
-
-		return int(e.Open.Mode), nil
-
-	case "open.overlay_numlower":
-
-		return int(e.Open.FileEvent.FileFields.OverlayNumLower), nil
-
 	case "open.retval":
 
 		return int(e.Open.SyscallEvent.Retval), nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 
 		var values []string
 
@@ -2258,7 +3908,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		for ptr != nil {
 			element := (*model.ProcessCacheEntry)(ptr)
 
-			result := (*Event)(ctx.Object).ResolveExecContainerPath(&element.ExecEvent)
+			result := (*Event)(ctx.Object).ResolveExecComm(&element.ExecEvent)
 
 			values = append(values, result)
 
@@ -2289,7 +3939,183 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveExecContainerPath(&element.ExecEvent)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.gid":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.GID)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.group":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveGID(&element.FileFields)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.inode":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.Inode)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.mode":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.Mode)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.mount_id":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.MountID)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.name":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveExecBasename(&element.ExecEvent)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.overlay_numlower":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.OverlayNumLower)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.path":
 
 		var values []string
 
@@ -2303,6 +4129,50 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*model.ProcessCacheEntry)(ptr)
 
 			result := (*Event)(ctx.Object).ResolveExecInode(&element.ExecEvent)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.uid":
+
+		var values []int
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.ExecEvent.FileFields.UID)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.user":
+
+		var values []string
+
+		ctx := &eval.Context{}
+		ctx.SetObject(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveUID(&element.FileFields)
 
 			values = append(values, result)
 
@@ -2369,72 +4239,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*model.ProcessCacheEntry)(ptr)
 
 			result := (*Event)(ctx.Object).ResolveContainerID(&element.ContainerContext)
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
-
-	case "process.ancestors.inode":
-
-		var values []int
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &model.ProcessAncestorsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-			element := (*model.ProcessCacheEntry)(ptr)
-
-			result := int(element.ProcessContext.ExecEvent.FileFields.Inode)
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
-
-	case "process.ancestors.name":
-
-		var values []string
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &model.ProcessAncestorsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-			element := (*model.ProcessCacheEntry)(ptr)
-
-			result := (*Event)(ctx.Object).ResolveExecBasename(&element.ExecEvent)
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
-
-	case "process.ancestors.overlay_numlower":
-
-		var values []int
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &model.ProcessAncestorsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-			element := (*model.ProcessCacheEntry)(ptr)
-
-			result := int(element.ProcessContext.ExecEvent.FileFields.OverlayNumLower)
 
 			values = append(values, result)
 
@@ -2575,17 +4379,57 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
-	case "process.container_path":
+	case "process.comm":
 
-		return e.ResolveExecContainerPath(&e.Process.ExecEvent), nil
+		return e.ResolveExecComm(&e.Process.ExecEvent), nil
 
 	case "process.cookie":
 
 		return int(e.ResolveExecCookie(&e.Process.ExecEvent)), nil
 
-	case "process.filename":
+	case "process.file.container_path":
+
+		return e.ResolveExecContainerPath(&e.Process.ExecEvent), nil
+
+	case "process.file.gid":
+
+		return int(e.Process.ExecEvent.FileFields.GID), nil
+
+	case "process.file.group":
+
+		return e.ResolveGID(&e.Process.ExecEvent.FileFields), nil
+
+	case "process.file.inode":
+
+		return int(e.Process.ExecEvent.FileFields.Inode), nil
+
+	case "process.file.mode":
+
+		return int(e.Process.ExecEvent.FileFields.Mode), nil
+
+	case "process.file.mount_id":
+
+		return int(e.Process.ExecEvent.FileFields.MountID), nil
+
+	case "process.file.name":
+
+		return e.ResolveExecBasename(&e.Process.ExecEvent), nil
+
+	case "process.file.overlay_numlower":
+
+		return int(e.Process.ExecEvent.FileFields.OverlayNumLower), nil
+
+	case "process.file.path":
 
 		return e.ResolveExecInode(&e.Process.ExecEvent), nil
+
+	case "process.file.uid":
+
+		return int(e.Process.ExecEvent.FileFields.UID), nil
+
+	case "process.file.user":
+
+		return e.ResolveUID(&e.Process.ExecEvent.FileFields), nil
 
 	case "process.gid":
 
@@ -2594,18 +4438,6 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.group":
 
 		return e.ResolveExecGroup(&e.Process.ExecEvent), nil
-
-	case "process.inode":
-
-		return int(e.Process.ExecEvent.FileFields.Inode), nil
-
-	case "process.name":
-
-		return e.ResolveExecBasename(&e.Process.ExecEvent), nil
-
-	case "process.overlay_numlower":
-
-		return int(e.Process.ExecEvent.FileFields.OverlayNumLower), nil
 
 	case "process.pid":
 
@@ -2631,185 +4463,349 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveExecUser(&e.Process.ExecEvent), nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 
-		return e.ResolveFileBasename(&e.RemoveXAttr.FileEvent), nil
+		return e.ResolveFileContainerPath(&e.RemoveXAttr.File), nil
 
-	case "removexattr.container_path":
-
-		return e.ResolveFileContainerPath(&e.RemoveXAttr.FileEvent), nil
-
-	case "removexattr.filename":
-
-		return e.ResolveFileInode(&e.RemoveXAttr.FileEvent), nil
-
-	case "removexattr.inode":
-
-		return int(e.RemoveXAttr.FileEvent.FileFields.Inode), nil
-
-	case "removexattr.name":
+	case "removexattr.file.destination.name":
 
 		return e.GetXAttrName(&e.RemoveXAttr), nil
 
-	case "removexattr.namespace":
+	case "removexattr.file.destination.namespace":
 
 		return e.GetXAttrNamespace(&e.RemoveXAttr), nil
 
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.gid":
 
-		return int(e.RemoveXAttr.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.RemoveXAttr.File.FileFields.GID), nil
+
+	case "removexattr.file.group":
+
+		return e.ResolveGID(&e.RemoveXAttr.File.FileFields), nil
+
+	case "removexattr.file.inode":
+
+		return int(e.RemoveXAttr.File.FileFields.Inode), nil
+
+	case "removexattr.file.mode":
+
+		return int(e.RemoveXAttr.File.FileFields.Mode), nil
+
+	case "removexattr.file.mount_id":
+
+		return int(e.RemoveXAttr.File.FileFields.MountID), nil
+
+	case "removexattr.file.name":
+
+		return e.ResolveFileBasename(&e.RemoveXAttr.File), nil
+
+	case "removexattr.file.overlay_numlower":
+
+		return int(e.RemoveXAttr.File.FileFields.OverlayNumLower), nil
+
+	case "removexattr.file.path":
+
+		return e.ResolveFileInode(&e.RemoveXAttr.File), nil
+
+	case "removexattr.file.uid":
+
+		return int(e.RemoveXAttr.File.FileFields.UID), nil
+
+	case "removexattr.file.user":
+
+		return e.ResolveUID(&e.RemoveXAttr.File.FileFields), nil
 
 	case "removexattr.retval":
 
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
 
-	case "rename.new.basename":
-
-		return e.ResolveFileBasename(&e.Rename.New), nil
-
-	case "rename.new.container_path":
-
-		return e.ResolveFileContainerPath(&e.Rename.New), nil
-
-	case "rename.new.filename":
-
-		return e.ResolveFileInode(&e.Rename.New), nil
-
-	case "rename.new.inode":
-
-		return int(e.Rename.New.FileFields.Inode), nil
-
-	case "rename.new.overlay_numlower":
-
-		return int(e.Rename.New.FileFields.OverlayNumLower), nil
-
-	case "rename.old.basename":
-
-		return e.ResolveFileBasename(&e.Rename.Old), nil
-
-	case "rename.old.container_path":
+	case "rename.file.container_path":
 
 		return e.ResolveFileContainerPath(&e.Rename.Old), nil
 
-	case "rename.old.filename":
+	case "rename.file.destination.container_path":
 
-		return e.ResolveFileInode(&e.Rename.Old), nil
+		return e.ResolveFileContainerPath(&e.Rename.New), nil
 
-	case "rename.old.inode":
+	case "rename.file.destination.gid":
+
+		return int(e.Rename.New.FileFields.GID), nil
+
+	case "rename.file.destination.group":
+
+		return e.ResolveGID(&e.Rename.New.FileFields), nil
+
+	case "rename.file.destination.inode":
+
+		return int(e.Rename.New.FileFields.Inode), nil
+
+	case "rename.file.destination.mode":
+
+		return int(e.Rename.New.FileFields.Mode), nil
+
+	case "rename.file.destination.mount_id":
+
+		return int(e.Rename.New.FileFields.MountID), nil
+
+	case "rename.file.destination.name":
+
+		return e.ResolveFileBasename(&e.Rename.New), nil
+
+	case "rename.file.destination.overlay_numlower":
+
+		return int(e.Rename.New.FileFields.OverlayNumLower), nil
+
+	case "rename.file.destination.path":
+
+		return e.ResolveFileInode(&e.Rename.New), nil
+
+	case "rename.file.destination.uid":
+
+		return int(e.Rename.New.FileFields.UID), nil
+
+	case "rename.file.destination.user":
+
+		return e.ResolveUID(&e.Rename.New.FileFields), nil
+
+	case "rename.file.gid":
+
+		return int(e.Rename.Old.FileFields.GID), nil
+
+	case "rename.file.group":
+
+		return e.ResolveGID(&e.Rename.Old.FileFields), nil
+
+	case "rename.file.inode":
 
 		return int(e.Rename.Old.FileFields.Inode), nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.mode":
+
+		return int(e.Rename.Old.FileFields.Mode), nil
+
+	case "rename.file.mount_id":
+
+		return int(e.Rename.Old.FileFields.MountID), nil
+
+	case "rename.file.name":
+
+		return e.ResolveFileBasename(&e.Rename.Old), nil
+
+	case "rename.file.overlay_numlower":
 
 		return int(e.Rename.Old.FileFields.OverlayNumLower), nil
+
+	case "rename.file.path":
+
+		return e.ResolveFileInode(&e.Rename.Old), nil
+
+	case "rename.file.uid":
+
+		return int(e.Rename.Old.FileFields.UID), nil
+
+	case "rename.file.user":
+
+		return e.ResolveUID(&e.Rename.Old.FileFields), nil
 
 	case "rename.retval":
 
 		return int(e.Rename.SyscallEvent.Retval), nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 
-		return e.ResolveFileBasename(&e.Rmdir.FileEvent), nil
+		return e.ResolveFileContainerPath(&e.Rmdir.File), nil
 
-	case "rmdir.container_path":
+	case "rmdir.file.gid":
 
-		return e.ResolveFileContainerPath(&e.Rmdir.FileEvent), nil
+		return int(e.Rmdir.File.FileFields.GID), nil
 
-	case "rmdir.filename":
+	case "rmdir.file.group":
 
-		return e.ResolveFileInode(&e.Rmdir.FileEvent), nil
+		return e.ResolveGID(&e.Rmdir.File.FileFields), nil
 
-	case "rmdir.inode":
+	case "rmdir.file.inode":
 
-		return int(e.Rmdir.FileEvent.FileFields.Inode), nil
+		return int(e.Rmdir.File.FileFields.Inode), nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.mode":
 
-		return int(e.Rmdir.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Rmdir.File.FileFields.Mode), nil
+
+	case "rmdir.file.mount_id":
+
+		return int(e.Rmdir.File.FileFields.MountID), nil
+
+	case "rmdir.file.name":
+
+		return e.ResolveFileBasename(&e.Rmdir.File), nil
+
+	case "rmdir.file.overlay_numlower":
+
+		return int(e.Rmdir.File.FileFields.OverlayNumLower), nil
+
+	case "rmdir.file.path":
+
+		return e.ResolveFileInode(&e.Rmdir.File), nil
+
+	case "rmdir.file.uid":
+
+		return int(e.Rmdir.File.FileFields.UID), nil
+
+	case "rmdir.file.user":
+
+		return e.ResolveUID(&e.Rmdir.File.FileFields), nil
 
 	case "rmdir.retval":
 
 		return int(e.Rmdir.SyscallEvent.Retval), nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 
-		return e.ResolveFileBasename(&e.SetXAttr.FileEvent), nil
+		return e.ResolveFileContainerPath(&e.SetXAttr.File), nil
 
-	case "setxattr.container_path":
-
-		return e.ResolveFileContainerPath(&e.SetXAttr.FileEvent), nil
-
-	case "setxattr.filename":
-
-		return e.ResolveFileInode(&e.SetXAttr.FileEvent), nil
-
-	case "setxattr.inode":
-
-		return int(e.SetXAttr.FileEvent.FileFields.Inode), nil
-
-	case "setxattr.name":
+	case "setxattr.file.destination.name":
 
 		return e.GetXAttrName(&e.SetXAttr), nil
 
-	case "setxattr.namespace":
+	case "setxattr.file.destination.namespace":
 
 		return e.GetXAttrNamespace(&e.SetXAttr), nil
 
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.gid":
 
-		return int(e.SetXAttr.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.SetXAttr.File.FileFields.GID), nil
+
+	case "setxattr.file.group":
+
+		return e.ResolveGID(&e.SetXAttr.File.FileFields), nil
+
+	case "setxattr.file.inode":
+
+		return int(e.SetXAttr.File.FileFields.Inode), nil
+
+	case "setxattr.file.mode":
+
+		return int(e.SetXAttr.File.FileFields.Mode), nil
+
+	case "setxattr.file.mount_id":
+
+		return int(e.SetXAttr.File.FileFields.MountID), nil
+
+	case "setxattr.file.name":
+
+		return e.ResolveFileBasename(&e.SetXAttr.File), nil
+
+	case "setxattr.file.overlay_numlower":
+
+		return int(e.SetXAttr.File.FileFields.OverlayNumLower), nil
+
+	case "setxattr.file.path":
+
+		return e.ResolveFileInode(&e.SetXAttr.File), nil
+
+	case "setxattr.file.uid":
+
+		return int(e.SetXAttr.File.FileFields.UID), nil
+
+	case "setxattr.file.user":
+
+		return e.ResolveUID(&e.SetXAttr.File.FileFields), nil
 
 	case "setxattr.retval":
 
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 
-		return e.ResolveFileBasename(&e.Unlink.FileEvent), nil
+		return e.ResolveFileContainerPath(&e.Unlink.File), nil
 
-	case "unlink.container_path":
+	case "unlink.file.gid":
 
-		return e.ResolveFileContainerPath(&e.Unlink.FileEvent), nil
+		return int(e.Unlink.File.FileFields.GID), nil
 
-	case "unlink.filename":
+	case "unlink.file.group":
 
-		return e.ResolveFileInode(&e.Unlink.FileEvent), nil
+		return e.ResolveGID(&e.Unlink.File.FileFields), nil
 
-	case "unlink.flags":
+	case "unlink.file.inode":
 
-		return int(e.Unlink.Flags), nil
+		return int(e.Unlink.File.FileFields.Inode), nil
 
-	case "unlink.inode":
+	case "unlink.file.mode":
 
-		return int(e.Unlink.FileEvent.FileFields.Inode), nil
+		return int(e.Unlink.File.FileFields.Mode), nil
 
-	case "unlink.overlay_numlower":
+	case "unlink.file.mount_id":
 
-		return int(e.Unlink.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Unlink.File.FileFields.MountID), nil
+
+	case "unlink.file.name":
+
+		return e.ResolveFileBasename(&e.Unlink.File), nil
+
+	case "unlink.file.overlay_numlower":
+
+		return int(e.Unlink.File.FileFields.OverlayNumLower), nil
+
+	case "unlink.file.path":
+
+		return e.ResolveFileInode(&e.Unlink.File), nil
+
+	case "unlink.file.uid":
+
+		return int(e.Unlink.File.FileFields.UID), nil
+
+	case "unlink.file.user":
+
+		return e.ResolveUID(&e.Unlink.File.FileFields), nil
 
 	case "unlink.retval":
 
 		return int(e.Unlink.SyscallEvent.Retval), nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 
-		return e.ResolveFileBasename(&e.Utimes.FileEvent), nil
+		return e.ResolveFileContainerPath(&e.Utimes.File), nil
 
-	case "utimes.container_path":
+	case "utimes.file.gid":
 
-		return e.ResolveFileContainerPath(&e.Utimes.FileEvent), nil
+		return int(e.Utimes.File.FileFields.GID), nil
 
-	case "utimes.filename":
+	case "utimes.file.group":
 
-		return e.ResolveFileInode(&e.Utimes.FileEvent), nil
+		return e.ResolveGID(&e.Utimes.File.FileFields), nil
 
-	case "utimes.inode":
+	case "utimes.file.inode":
 
-		return int(e.Utimes.FileEvent.FileFields.Inode), nil
+		return int(e.Utimes.File.FileFields.Inode), nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.mode":
 
-		return int(e.Utimes.FileEvent.FileFields.OverlayNumLower), nil
+		return int(e.Utimes.File.FileFields.Mode), nil
+
+	case "utimes.file.mount_id":
+
+		return int(e.Utimes.File.FileFields.MountID), nil
+
+	case "utimes.file.name":
+
+		return e.ResolveFileBasename(&e.Utimes.File), nil
+
+	case "utimes.file.overlay_numlower":
+
+		return int(e.Utimes.File.FileFields.OverlayNumLower), nil
+
+	case "utimes.file.path":
+
+		return e.ResolveFileInode(&e.Utimes.File), nil
+
+	case "utimes.file.uid":
+
+		return int(e.Utimes.File.FileFields.UID), nil
+
+	case "utimes.file.user":
+
+		return e.ResolveUID(&e.Utimes.File.FileFields), nil
 
 	case "utimes.retval":
 
@@ -2823,76 +4819,139 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 		return "chmod", nil
 
-	case "chmod.container_path":
+	case "chmod.file.destination.mode":
 		return "chmod", nil
 
-	case "chmod.filename":
+	case "chmod.file.gid":
 		return "chmod", nil
 
-	case "chmod.inode":
+	case "chmod.file.group":
 		return "chmod", nil
 
-	case "chmod.mode":
+	case "chmod.file.inode":
 		return "chmod", nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.mode":
+		return "chmod", nil
+
+	case "chmod.file.mount_id":
+		return "chmod", nil
+
+	case "chmod.file.name":
+		return "chmod", nil
+
+	case "chmod.file.overlay_numlower":
+		return "chmod", nil
+
+	case "chmod.file.path":
+		return "chmod", nil
+
+	case "chmod.file.uid":
+		return "chmod", nil
+
+	case "chmod.file.user":
 		return "chmod", nil
 
 	case "chmod.retval":
 		return "chmod", nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 		return "chown", nil
 
-	case "chown.container_path":
+	case "chown.file.destination.gid":
 		return "chown", nil
 
-	case "chown.filename":
+	case "chown.file.destination.group":
 		return "chown", nil
 
-	case "chown.gid":
+	case "chown.file.destination.uid":
 		return "chown", nil
 
-	case "chown.inode":
+	case "chown.file.destination.user":
 		return "chown", nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.gid":
+		return "chown", nil
+
+	case "chown.file.group":
+		return "chown", nil
+
+	case "chown.file.inode":
+		return "chown", nil
+
+	case "chown.file.mode":
+		return "chown", nil
+
+	case "chown.file.mount_id":
+		return "chown", nil
+
+	case "chown.file.name":
+		return "chown", nil
+
+	case "chown.file.overlay_numlower":
+		return "chown", nil
+
+	case "chown.file.path":
+		return "chown", nil
+
+	case "chown.file.uid":
+		return "chown", nil
+
+	case "chown.file.user":
 		return "chown", nil
 
 	case "chown.retval":
 		return "chown", nil
 
-	case "chown.uid":
-		return "chown", nil
-
 	case "container.id":
 		return "*", nil
 
-	case "exec.container_path":
+	case "exec.comm":
 		return "exec", nil
 
 	case "exec.cookie":
 		return "exec", nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+		return "exec", nil
+
+	case "exec.file.gid":
+		return "exec", nil
+
+	case "exec.file.group":
+		return "exec", nil
+
+	case "exec.file.inode":
+		return "exec", nil
+
+	case "exec.file.mode":
+		return "exec", nil
+
+	case "exec.file.mount_id":
+		return "exec", nil
+
+	case "exec.file.name":
+		return "exec", nil
+
+	case "exec.file.overlay_numlower":
+		return "exec", nil
+
+	case "exec.file.path":
+		return "exec", nil
+
+	case "exec.file.uid":
+		return "exec", nil
+
+	case "exec.file.user":
 		return "exec", nil
 
 	case "exec.gid":
 		return "exec", nil
 
 	case "exec.group":
-		return "exec", nil
-
-	case "exec.inode":
-		return "exec", nil
-
-	case "exec.name":
-		return "exec", nil
-
-	case "exec.overlay_numlower":
 		return "exec", nil
 
 	case "exec.ppid":
@@ -2907,91 +4966,193 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.user":
 		return "exec", nil
 
+	case "link.file.container_path":
+		return "link", nil
+
+	case "link.file.destination.container_path":
+		return "link", nil
+
+	case "link.file.destination.gid":
+		return "link", nil
+
+	case "link.file.destination.group":
+		return "link", nil
+
+	case "link.file.destination.inode":
+		return "link", nil
+
+	case "link.file.destination.mode":
+		return "link", nil
+
+	case "link.file.destination.mount_id":
+		return "link", nil
+
+	case "link.file.destination.name":
+		return "link", nil
+
+	case "link.file.destination.overlay_numlower":
+		return "link", nil
+
+	case "link.file.destination.path":
+		return "link", nil
+
+	case "link.file.destination.uid":
+		return "link", nil
+
+	case "link.file.destination.user":
+		return "link", nil
+
+	case "link.file.gid":
+		return "link", nil
+
+	case "link.file.group":
+		return "link", nil
+
+	case "link.file.inode":
+		return "link", nil
+
+	case "link.file.mode":
+		return "link", nil
+
+	case "link.file.mount_id":
+		return "link", nil
+
+	case "link.file.name":
+		return "link", nil
+
+	case "link.file.overlay_numlower":
+		return "link", nil
+
+	case "link.file.path":
+		return "link", nil
+
+	case "link.file.uid":
+		return "link", nil
+
+	case "link.file.user":
+		return "link", nil
+
 	case "link.retval":
 		return "link", nil
 
-	case "link.source.basename":
-		return "link", nil
-
-	case "link.source.container_path":
-		return "link", nil
-
-	case "link.source.filename":
-		return "link", nil
-
-	case "link.source.inode":
-		return "link", nil
-
-	case "link.source.overlay_numlower":
-		return "link", nil
-
-	case "link.target.basename":
-		return "link", nil
-
-	case "link.target.container_path":
-		return "link", nil
-
-	case "link.target.filename":
-		return "link", nil
-
-	case "link.target.inode":
-		return "link", nil
-
-	case "link.target.overlay_numlower":
-		return "link", nil
-
-	case "mkdir.basename":
+	case "mkdir.file.container_path":
 		return "mkdir", nil
 
-	case "mkdir.container_path":
+	case "mkdir.file.destination.mode":
 		return "mkdir", nil
 
-	case "mkdir.filename":
+	case "mkdir.file.gid":
 		return "mkdir", nil
 
-	case "mkdir.inode":
+	case "mkdir.file.group":
 		return "mkdir", nil
 
-	case "mkdir.mode":
+	case "mkdir.file.inode":
 		return "mkdir", nil
 
-	case "mkdir.overlay_numlower":
+	case "mkdir.file.mode":
+		return "mkdir", nil
+
+	case "mkdir.file.mount_id":
+		return "mkdir", nil
+
+	case "mkdir.file.name":
+		return "mkdir", nil
+
+	case "mkdir.file.overlay_numlower":
+		return "mkdir", nil
+
+	case "mkdir.file.path":
+		return "mkdir", nil
+
+	case "mkdir.file.uid":
+		return "mkdir", nil
+
+	case "mkdir.file.user":
 		return "mkdir", nil
 
 	case "mkdir.retval":
 		return "mkdir", nil
 
-	case "open.basename":
+	case "open.file.container_path":
 		return "open", nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
 		return "open", nil
 
-	case "open.filename":
+	case "open.file.gid":
+		return "open", nil
+
+	case "open.file.group":
+		return "open", nil
+
+	case "open.file.inode":
+		return "open", nil
+
+	case "open.file.mode":
+		return "open", nil
+
+	case "open.file.mount_id":
+		return "open", nil
+
+	case "open.file.name":
+		return "open", nil
+
+	case "open.file.overlay_numlower":
+		return "open", nil
+
+	case "open.file.path":
+		return "open", nil
+
+	case "open.file.uid":
+		return "open", nil
+
+	case "open.file.user":
 		return "open", nil
 
 	case "open.flags":
 		return "open", nil
 
-	case "open.inode":
-		return "open", nil
-
-	case "open.mode":
-		return "open", nil
-
-	case "open.overlay_numlower":
-		return "open", nil
-
 	case "open.retval":
 		return "open", nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 		return "*", nil
 
 	case "process.ancestors.cookie":
 		return "*", nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+		return "*", nil
+
+	case "process.ancestors.file.gid":
+		return "*", nil
+
+	case "process.ancestors.file.group":
+		return "*", nil
+
+	case "process.ancestors.file.inode":
+		return "*", nil
+
+	case "process.ancestors.file.mode":
+		return "*", nil
+
+	case "process.ancestors.file.mount_id":
+		return "*", nil
+
+	case "process.ancestors.file.name":
+		return "*", nil
+
+	case "process.ancestors.file.overlay_numlower":
+		return "*", nil
+
+	case "process.ancestors.file.path":
+		return "*", nil
+
+	case "process.ancestors.file.uid":
+		return "*", nil
+
+	case "process.ancestors.file.user":
 		return "*", nil
 
 	case "process.ancestors.gid":
@@ -3001,15 +5162,6 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.id":
-		return "*", nil
-
-	case "process.ancestors.inode":
-		return "*", nil
-
-	case "process.ancestors.name":
-		return "*", nil
-
-	case "process.ancestors.overlay_numlower":
 		return "*", nil
 
 	case "process.ancestors.pid":
@@ -3030,28 +5182,49 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.user":
 		return "*", nil
 
-	case "process.container_path":
+	case "process.comm":
 		return "*", nil
 
 	case "process.cookie":
 		return "*", nil
 
-	case "process.filename":
+	case "process.file.container_path":
+		return "*", nil
+
+	case "process.file.gid":
+		return "*", nil
+
+	case "process.file.group":
+		return "*", nil
+
+	case "process.file.inode":
+		return "*", nil
+
+	case "process.file.mode":
+		return "*", nil
+
+	case "process.file.mount_id":
+		return "*", nil
+
+	case "process.file.name":
+		return "*", nil
+
+	case "process.file.overlay_numlower":
+		return "*", nil
+
+	case "process.file.path":
+		return "*", nil
+
+	case "process.file.uid":
+		return "*", nil
+
+	case "process.file.user":
 		return "*", nil
 
 	case "process.gid":
 		return "*", nil
 
 	case "process.group":
-		return "*", nil
-
-	case "process.inode":
-		return "*", nil
-
-	case "process.name":
-		return "*", nil
-
-	case "process.overlay_numlower":
 		return "*", nil
 
 	case "process.pid":
@@ -3072,139 +5245,262 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.user":
 		return "*", nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 		return "removexattr", nil
 
-	case "removexattr.container_path":
+	case "removexattr.file.destination.name":
 		return "removexattr", nil
 
-	case "removexattr.filename":
+	case "removexattr.file.destination.namespace":
 		return "removexattr", nil
 
-	case "removexattr.inode":
+	case "removexattr.file.gid":
 		return "removexattr", nil
 
-	case "removexattr.name":
+	case "removexattr.file.group":
 		return "removexattr", nil
 
-	case "removexattr.namespace":
+	case "removexattr.file.inode":
 		return "removexattr", nil
 
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.mode":
+		return "removexattr", nil
+
+	case "removexattr.file.mount_id":
+		return "removexattr", nil
+
+	case "removexattr.file.name":
+		return "removexattr", nil
+
+	case "removexattr.file.overlay_numlower":
+		return "removexattr", nil
+
+	case "removexattr.file.path":
+		return "removexattr", nil
+
+	case "removexattr.file.uid":
+		return "removexattr", nil
+
+	case "removexattr.file.user":
 		return "removexattr", nil
 
 	case "removexattr.retval":
 		return "removexattr", nil
 
-	case "rename.new.basename":
+	case "rename.file.container_path":
 		return "rename", nil
 
-	case "rename.new.container_path":
+	case "rename.file.destination.container_path":
 		return "rename", nil
 
-	case "rename.new.filename":
+	case "rename.file.destination.gid":
 		return "rename", nil
 
-	case "rename.new.inode":
+	case "rename.file.destination.group":
 		return "rename", nil
 
-	case "rename.new.overlay_numlower":
+	case "rename.file.destination.inode":
 		return "rename", nil
 
-	case "rename.old.basename":
+	case "rename.file.destination.mode":
 		return "rename", nil
 
-	case "rename.old.container_path":
+	case "rename.file.destination.mount_id":
 		return "rename", nil
 
-	case "rename.old.filename":
+	case "rename.file.destination.name":
 		return "rename", nil
 
-	case "rename.old.inode":
+	case "rename.file.destination.overlay_numlower":
 		return "rename", nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.destination.path":
+		return "rename", nil
+
+	case "rename.file.destination.uid":
+		return "rename", nil
+
+	case "rename.file.destination.user":
+		return "rename", nil
+
+	case "rename.file.gid":
+		return "rename", nil
+
+	case "rename.file.group":
+		return "rename", nil
+
+	case "rename.file.inode":
+		return "rename", nil
+
+	case "rename.file.mode":
+		return "rename", nil
+
+	case "rename.file.mount_id":
+		return "rename", nil
+
+	case "rename.file.name":
+		return "rename", nil
+
+	case "rename.file.overlay_numlower":
+		return "rename", nil
+
+	case "rename.file.path":
+		return "rename", nil
+
+	case "rename.file.uid":
+		return "rename", nil
+
+	case "rename.file.user":
 		return "rename", nil
 
 	case "rename.retval":
 		return "rename", nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 		return "rmdir", nil
 
-	case "rmdir.container_path":
+	case "rmdir.file.gid":
 		return "rmdir", nil
 
-	case "rmdir.filename":
+	case "rmdir.file.group":
 		return "rmdir", nil
 
-	case "rmdir.inode":
+	case "rmdir.file.inode":
 		return "rmdir", nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.mode":
+		return "rmdir", nil
+
+	case "rmdir.file.mount_id":
+		return "rmdir", nil
+
+	case "rmdir.file.name":
+		return "rmdir", nil
+
+	case "rmdir.file.overlay_numlower":
+		return "rmdir", nil
+
+	case "rmdir.file.path":
+		return "rmdir", nil
+
+	case "rmdir.file.uid":
+		return "rmdir", nil
+
+	case "rmdir.file.user":
 		return "rmdir", nil
 
 	case "rmdir.retval":
 		return "rmdir", nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 		return "setxattr", nil
 
-	case "setxattr.container_path":
+	case "setxattr.file.destination.name":
 		return "setxattr", nil
 
-	case "setxattr.filename":
+	case "setxattr.file.destination.namespace":
 		return "setxattr", nil
 
-	case "setxattr.inode":
+	case "setxattr.file.gid":
 		return "setxattr", nil
 
-	case "setxattr.name":
+	case "setxattr.file.group":
 		return "setxattr", nil
 
-	case "setxattr.namespace":
+	case "setxattr.file.inode":
 		return "setxattr", nil
 
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.mode":
+		return "setxattr", nil
+
+	case "setxattr.file.mount_id":
+		return "setxattr", nil
+
+	case "setxattr.file.name":
+		return "setxattr", nil
+
+	case "setxattr.file.overlay_numlower":
+		return "setxattr", nil
+
+	case "setxattr.file.path":
+		return "setxattr", nil
+
+	case "setxattr.file.uid":
+		return "setxattr", nil
+
+	case "setxattr.file.user":
 		return "setxattr", nil
 
 	case "setxattr.retval":
 		return "setxattr", nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 		return "unlink", nil
 
-	case "unlink.container_path":
+	case "unlink.file.gid":
 		return "unlink", nil
 
-	case "unlink.filename":
+	case "unlink.file.group":
 		return "unlink", nil
 
-	case "unlink.flags":
+	case "unlink.file.inode":
 		return "unlink", nil
 
-	case "unlink.inode":
+	case "unlink.file.mode":
 		return "unlink", nil
 
-	case "unlink.overlay_numlower":
+	case "unlink.file.mount_id":
+		return "unlink", nil
+
+	case "unlink.file.name":
+		return "unlink", nil
+
+	case "unlink.file.overlay_numlower":
+		return "unlink", nil
+
+	case "unlink.file.path":
+		return "unlink", nil
+
+	case "unlink.file.uid":
+		return "unlink", nil
+
+	case "unlink.file.user":
 		return "unlink", nil
 
 	case "unlink.retval":
 		return "unlink", nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 		return "utimes", nil
 
-	case "utimes.container_path":
+	case "utimes.file.gid":
 		return "utimes", nil
 
-	case "utimes.filename":
+	case "utimes.file.group":
 		return "utimes", nil
 
-	case "utimes.inode":
+	case "utimes.file.inode":
 		return "utimes", nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.mode":
+		return "utimes", nil
+
+	case "utimes.file.mount_id":
+		return "utimes", nil
+
+	case "utimes.file.name":
+		return "utimes", nil
+
+	case "utimes.file.overlay_numlower":
+		return "utimes", nil
+
+	case "utimes.file.path":
+		return "utimes", nil
+
+	case "utimes.file.uid":
+		return "utimes", nil
+
+	case "utimes.file.user":
 		return "utimes", nil
 
 	case "utimes.retval":
@@ -3218,63 +5514,119 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 
 		return reflect.String, nil
 
-	case "chmod.container_path":
+	case "chmod.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "chmod.file.gid":
+
+		return reflect.Int, nil
+
+	case "chmod.file.group":
 
 		return reflect.String, nil
 
-	case "chmod.filename":
+	case "chmod.file.inode":
+
+		return reflect.Int, nil
+
+	case "chmod.file.mode":
+
+		return reflect.Int, nil
+
+	case "chmod.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "chmod.file.name":
 
 		return reflect.String, nil
 
-	case "chmod.inode":
+	case "chmod.file.overlay_numlower":
 
 		return reflect.Int, nil
 
-	case "chmod.mode":
+	case "chmod.file.path":
+
+		return reflect.String, nil
+
+	case "chmod.file.uid":
 
 		return reflect.Int, nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.user":
 
-		return reflect.Int, nil
+		return reflect.String, nil
 
 	case "chmod.retval":
 
 		return reflect.Int, nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 
 		return reflect.String, nil
 
-	case "chown.container_path":
+	case "chown.file.destination.gid":
+
+		return reflect.Int, nil
+
+	case "chown.file.destination.group":
 
 		return reflect.String, nil
 
-	case "chown.filename":
+	case "chown.file.destination.uid":
+
+		return reflect.Int, nil
+
+	case "chown.file.destination.user":
 
 		return reflect.String, nil
 
-	case "chown.gid":
+	case "chown.file.gid":
 
 		return reflect.Int, nil
 
-	case "chown.inode":
+	case "chown.file.group":
+
+		return reflect.String, nil
+
+	case "chown.file.inode":
 
 		return reflect.Int, nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.mode":
 
 		return reflect.Int, nil
+
+	case "chown.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "chown.file.name":
+
+		return reflect.String, nil
+
+	case "chown.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "chown.file.path":
+
+		return reflect.String, nil
+
+	case "chown.file.uid":
+
+		return reflect.Int, nil
+
+	case "chown.file.user":
+
+		return reflect.String, nil
 
 	case "chown.retval":
-
-		return reflect.Int, nil
-
-	case "chown.uid":
 
 		return reflect.Int, nil
 
@@ -3282,7 +5634,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "exec.container_path":
+	case "exec.comm":
 
 		return reflect.String, nil
 
@@ -3290,7 +5642,47 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+
+		return reflect.String, nil
+
+	case "exec.file.gid":
+
+		return reflect.Int, nil
+
+	case "exec.file.group":
+
+		return reflect.String, nil
+
+	case "exec.file.inode":
+
+		return reflect.Int, nil
+
+	case "exec.file.mode":
+
+		return reflect.Int, nil
+
+	case "exec.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "exec.file.name":
+
+		return reflect.String, nil
+
+	case "exec.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "exec.file.path":
+
+		return reflect.String, nil
+
+	case "exec.file.uid":
+
+		return reflect.Int, nil
+
+	case "exec.file.user":
 
 		return reflect.String, nil
 
@@ -3301,18 +5693,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "exec.group":
 
 		return reflect.String, nil
-
-	case "exec.inode":
-
-		return reflect.Int, nil
-
-	case "exec.name":
-
-		return reflect.String, nil
-
-	case "exec.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "exec.ppid":
 
@@ -3330,87 +5710,195 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.container_path":
+
+		return reflect.String, nil
+
+	case "link.file.destination.container_path":
+
+		return reflect.String, nil
+
+	case "link.file.destination.gid":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.group":
+
+		return reflect.String, nil
+
+	case "link.file.destination.inode":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.mount_id":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.name":
+
+		return reflect.String, nil
+
+	case "link.file.destination.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.path":
+
+		return reflect.String, nil
+
+	case "link.file.destination.uid":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.user":
+
+		return reflect.String, nil
+
+	case "link.file.gid":
+
+		return reflect.Int, nil
+
+	case "link.file.group":
+
+		return reflect.String, nil
+
+	case "link.file.inode":
+
+		return reflect.Int, nil
+
+	case "link.file.mode":
+
+		return reflect.Int, nil
+
+	case "link.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "link.file.name":
+
+		return reflect.String, nil
+
+	case "link.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "link.file.path":
+
+		return reflect.String, nil
+
+	case "link.file.uid":
+
+		return reflect.Int, nil
+
+	case "link.file.user":
+
+		return reflect.String, nil
+
 	case "link.retval":
 
 		return reflect.Int, nil
 
-	case "link.source.basename":
+	case "mkdir.file.container_path":
 
 		return reflect.String, nil
 
-	case "link.source.container_path":
-
-		return reflect.String, nil
-
-	case "link.source.filename":
-
-		return reflect.String, nil
-
-	case "link.source.inode":
+	case "mkdir.file.destination.mode":
 
 		return reflect.Int, nil
 
-	case "link.source.overlay_numlower":
+	case "mkdir.file.gid":
 
 		return reflect.Int, nil
 
-	case "link.target.basename":
+	case "mkdir.file.group":
 
 		return reflect.String, nil
 
-	case "link.target.container_path":
-
-		return reflect.String, nil
-
-	case "link.target.filename":
-
-		return reflect.String, nil
-
-	case "link.target.inode":
+	case "mkdir.file.inode":
 
 		return reflect.Int, nil
 
-	case "link.target.overlay_numlower":
+	case "mkdir.file.mode":
 
 		return reflect.Int, nil
 
-	case "mkdir.basename":
+	case "mkdir.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.name":
 
 		return reflect.String, nil
 
-	case "mkdir.container_path":
+	case "mkdir.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.path":
 
 		return reflect.String, nil
 
-	case "mkdir.filename":
+	case "mkdir.file.uid":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.user":
 
 		return reflect.String, nil
-
-	case "mkdir.inode":
-
-		return reflect.Int, nil
-
-	case "mkdir.mode":
-
-		return reflect.Int, nil
-
-	case "mkdir.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "mkdir.retval":
 
 		return reflect.Int, nil
 
-	case "open.basename":
+	case "open.file.container_path":
 
 		return reflect.String, nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "open.file.gid":
+
+		return reflect.Int, nil
+
+	case "open.file.group":
 
 		return reflect.String, nil
 
-	case "open.filename":
+	case "open.file.inode":
+
+		return reflect.Int, nil
+
+	case "open.file.mode":
+
+		return reflect.Int, nil
+
+	case "open.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "open.file.name":
+
+		return reflect.String, nil
+
+	case "open.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "open.file.path":
+
+		return reflect.String, nil
+
+	case "open.file.uid":
+
+		return reflect.Int, nil
+
+	case "open.file.user":
 
 		return reflect.String, nil
 
@@ -3418,23 +5906,11 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
-	case "open.inode":
-
-		return reflect.Int, nil
-
-	case "open.mode":
-
-		return reflect.Int, nil
-
-	case "open.overlay_numlower":
-
-		return reflect.Int, nil
-
 	case "open.retval":
 
 		return reflect.Int, nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 
 		return reflect.String, nil
 
@@ -3442,7 +5918,47 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+
+		return reflect.String, nil
+
+	case "process.ancestors.file.gid":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.group":
+
+		return reflect.String, nil
+
+	case "process.ancestors.file.inode":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.mode":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.name":
+
+		return reflect.String, nil
+
+	case "process.ancestors.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.path":
+
+		return reflect.String, nil
+
+	case "process.ancestors.file.uid":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.user":
 
 		return reflect.String, nil
 
@@ -3457,18 +5973,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.ancestors.id":
 
 		return reflect.String, nil
-
-	case "process.ancestors.inode":
-
-		return reflect.Int, nil
-
-	case "process.ancestors.name":
-
-		return reflect.String, nil
-
-	case "process.ancestors.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "process.ancestors.pid":
 
@@ -3494,7 +5998,7 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "process.container_path":
+	case "process.comm":
 
 		return reflect.String, nil
 
@@ -3502,7 +6006,47 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
-	case "process.filename":
+	case "process.file.container_path":
+
+		return reflect.String, nil
+
+	case "process.file.gid":
+
+		return reflect.Int, nil
+
+	case "process.file.group":
+
+		return reflect.String, nil
+
+	case "process.file.inode":
+
+		return reflect.Int, nil
+
+	case "process.file.mode":
+
+		return reflect.Int, nil
+
+	case "process.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "process.file.name":
+
+		return reflect.String, nil
+
+	case "process.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "process.file.path":
+
+		return reflect.String, nil
+
+	case "process.file.uid":
+
+		return reflect.Int, nil
+
+	case "process.file.user":
 
 		return reflect.String, nil
 
@@ -3513,18 +6057,6 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.group":
 
 		return reflect.String, nil
-
-	case "process.inode":
-
-		return reflect.Int, nil
-
-	case "process.name":
-
-		return reflect.String, nil
-
-	case "process.overlay_numlower":
-
-		return reflect.Int, nil
 
 	case "process.pid":
 
@@ -3550,185 +6082,349 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 
 		return reflect.String, nil
 
-	case "removexattr.container_path":
+	case "removexattr.file.destination.name":
 
 		return reflect.String, nil
 
-	case "removexattr.filename":
+	case "removexattr.file.destination.namespace":
 
 		return reflect.String, nil
 
-	case "removexattr.inode":
+	case "removexattr.file.gid":
 
 		return reflect.Int, nil
 
-	case "removexattr.name":
+	case "removexattr.file.group":
 
 		return reflect.String, nil
 
-	case "removexattr.namespace":
-
-		return reflect.String, nil
-
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.inode":
 
 		return reflect.Int, nil
+
+	case "removexattr.file.mode":
+
+		return reflect.Int, nil
+
+	case "removexattr.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "removexattr.file.name":
+
+		return reflect.String, nil
+
+	case "removexattr.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "removexattr.file.path":
+
+		return reflect.String, nil
+
+	case "removexattr.file.uid":
+
+		return reflect.Int, nil
+
+	case "removexattr.file.user":
+
+		return reflect.String, nil
 
 	case "removexattr.retval":
 
 		return reflect.Int, nil
 
-	case "rename.new.basename":
+	case "rename.file.container_path":
 
 		return reflect.String, nil
 
-	case "rename.new.container_path":
+	case "rename.file.destination.container_path":
 
 		return reflect.String, nil
 
-	case "rename.new.filename":
-
-		return reflect.String, nil
-
-	case "rename.new.inode":
+	case "rename.file.destination.gid":
 
 		return reflect.Int, nil
 
-	case "rename.new.overlay_numlower":
-
-		return reflect.Int, nil
-
-	case "rename.old.basename":
+	case "rename.file.destination.group":
 
 		return reflect.String, nil
 
-	case "rename.old.container_path":
-
-		return reflect.String, nil
-
-	case "rename.old.filename":
-
-		return reflect.String, nil
-
-	case "rename.old.inode":
+	case "rename.file.destination.inode":
 
 		return reflect.Int, nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.destination.mode":
 
 		return reflect.Int, nil
+
+	case "rename.file.destination.mount_id":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.name":
+
+		return reflect.String, nil
+
+	case "rename.file.destination.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.path":
+
+		return reflect.String, nil
+
+	case "rename.file.destination.uid":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.user":
+
+		return reflect.String, nil
+
+	case "rename.file.gid":
+
+		return reflect.Int, nil
+
+	case "rename.file.group":
+
+		return reflect.String, nil
+
+	case "rename.file.inode":
+
+		return reflect.Int, nil
+
+	case "rename.file.mode":
+
+		return reflect.Int, nil
+
+	case "rename.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "rename.file.name":
+
+		return reflect.String, nil
+
+	case "rename.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "rename.file.path":
+
+		return reflect.String, nil
+
+	case "rename.file.uid":
+
+		return reflect.Int, nil
+
+	case "rename.file.user":
+
+		return reflect.String, nil
 
 	case "rename.retval":
 
 		return reflect.Int, nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 
 		return reflect.String, nil
 
-	case "rmdir.container_path":
-
-		return reflect.String, nil
-
-	case "rmdir.filename":
-
-		return reflect.String, nil
-
-	case "rmdir.inode":
+	case "rmdir.file.gid":
 
 		return reflect.Int, nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.group":
+
+		return reflect.String, nil
+
+	case "rmdir.file.inode":
 
 		return reflect.Int, nil
+
+	case "rmdir.file.mode":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.name":
+
+		return reflect.String, nil
+
+	case "rmdir.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.path":
+
+		return reflect.String, nil
+
+	case "rmdir.file.uid":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.user":
+
+		return reflect.String, nil
 
 	case "rmdir.retval":
 
 		return reflect.Int, nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 
 		return reflect.String, nil
 
-	case "setxattr.container_path":
+	case "setxattr.file.destination.name":
 
 		return reflect.String, nil
 
-	case "setxattr.filename":
+	case "setxattr.file.destination.namespace":
 
 		return reflect.String, nil
 
-	case "setxattr.inode":
+	case "setxattr.file.gid":
 
 		return reflect.Int, nil
 
-	case "setxattr.name":
+	case "setxattr.file.group":
 
 		return reflect.String, nil
 
-	case "setxattr.namespace":
-
-		return reflect.String, nil
-
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.inode":
 
 		return reflect.Int, nil
+
+	case "setxattr.file.mode":
+
+		return reflect.Int, nil
+
+	case "setxattr.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "setxattr.file.name":
+
+		return reflect.String, nil
+
+	case "setxattr.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "setxattr.file.path":
+
+		return reflect.String, nil
+
+	case "setxattr.file.uid":
+
+		return reflect.Int, nil
+
+	case "setxattr.file.user":
+
+		return reflect.String, nil
 
 	case "setxattr.retval":
 
 		return reflect.Int, nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 
 		return reflect.String, nil
 
-	case "unlink.container_path":
+	case "unlink.file.gid":
+
+		return reflect.Int, nil
+
+	case "unlink.file.group":
 
 		return reflect.String, nil
 
-	case "unlink.filename":
+	case "unlink.file.inode":
+
+		return reflect.Int, nil
+
+	case "unlink.file.mode":
+
+		return reflect.Int, nil
+
+	case "unlink.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "unlink.file.name":
 
 		return reflect.String, nil
 
-	case "unlink.flags":
+	case "unlink.file.overlay_numlower":
 
 		return reflect.Int, nil
 
-	case "unlink.inode":
+	case "unlink.file.path":
+
+		return reflect.String, nil
+
+	case "unlink.file.uid":
 
 		return reflect.Int, nil
 
-	case "unlink.overlay_numlower":
+	case "unlink.file.user":
 
-		return reflect.Int, nil
+		return reflect.String, nil
 
 	case "unlink.retval":
 
 		return reflect.Int, nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 
 		return reflect.String, nil
 
-	case "utimes.container_path":
-
-		return reflect.String, nil
-
-	case "utimes.filename":
-
-		return reflect.String, nil
-
-	case "utimes.inode":
+	case "utimes.file.gid":
 
 		return reflect.Int, nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.group":
+
+		return reflect.String, nil
+
+	case "utimes.file.inode":
 
 		return reflect.Int, nil
+
+	case "utimes.file.mode":
+
+		return reflect.Int, nil
+
+	case "utimes.file.mount_id":
+
+		return reflect.Int, nil
+
+	case "utimes.file.name":
+
+		return reflect.String, nil
+
+	case "utimes.file.overlay_numlower":
+
+		return reflect.Int, nil
+
+	case "utimes.file.path":
+
+		return reflect.String, nil
+
+	case "utimes.file.uid":
+
+		return reflect.Int, nil
+
+	case "utimes.file.user":
+
+		return reflect.String, nil
 
 	case "utimes.retval":
 
@@ -3742,41 +6438,15 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	switch field {
 
-	case "chmod.basename":
+	case "chmod.file.container_path":
 
 		var ok bool
-		if e.Chmod.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.BasenameStr"}
+		if e.Chmod.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.ContainerPath"}
 		}
 		return nil
 
-	case "chmod.container_path":
-
-		var ok bool
-		if e.Chmod.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "chmod.filename":
-
-		var ok bool
-		if e.Chmod.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "chmod.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.FileFields.Inode"}
-		}
-		e.Chmod.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "chmod.mode":
+	case "chmod.file.destination.mode":
 
 		var ok bool
 		v, ok := value.(int)
@@ -3786,14 +6456,96 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.Mode = uint32(v)
 		return nil
 
-	case "chmod.overlay_numlower":
+	case "chmod.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.GID"}
 		}
-		e.Chmod.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Chmod.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "chmod.file.group":
+
+		var ok bool
+		if e.Chmod.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.Group"}
+		}
+		return nil
+
+	case "chmod.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.Inode"}
+		}
+		e.Chmod.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "chmod.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.Mode"}
+		}
+		e.Chmod.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "chmod.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.MountID"}
+		}
+		e.Chmod.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "chmod.file.name":
+
+		var ok bool
+		if e.Chmod.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.BasenameStr"}
+		}
+		return nil
+
+	case "chmod.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.OverlayNumLower"}
+		}
+		e.Chmod.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "chmod.file.path":
+
+		var ok bool
+		if e.Chmod.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.PathnameStr"}
+		}
+		return nil
+
+	case "chmod.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.UID"}
+		}
+		e.Chmod.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "chmod.file.user":
+
+		var ok bool
+		if e.Chmod.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.User"}
+		}
 		return nil
 
 	case "chmod.retval":
@@ -3806,58 +6558,140 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "chown.basename":
+	case "chown.file.container_path":
 
 		var ok bool
-		if e.Chown.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.BasenameStr"}
+		if e.Chown.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.ContainerPath"}
 		}
 		return nil
 
-	case "chown.container_path":
-
-		var ok bool
-		if e.Chown.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "chown.filename":
-
-		var ok bool
-		if e.Chown.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "chown.gid":
+	case "chown.file.destination.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Chown.GID"}
 		}
-		e.Chown.GID = int32(v)
+		e.Chown.GID = uint32(v)
 		return nil
 
-	case "chown.inode":
+	case "chown.file.destination.group":
+
+		var ok bool
+		if e.Chown.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.Group"}
+		}
+		return nil
+
+	case "chown.file.destination.uid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Chown.UID"}
 		}
-		e.Chown.FileEvent.FileFields.Inode = uint64(v)
+		e.Chown.UID = uint32(v)
 		return nil
 
-	case "chown.overlay_numlower":
+	case "chown.file.destination.user":
+
+		var ok bool
+		if e.Chown.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.User"}
+		}
+		return nil
+
+	case "chown.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.GID"}
 		}
-		e.Chown.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Chown.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "chown.file.group":
+
+		var ok bool
+		if e.Chown.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Group"}
+		}
+		return nil
+
+	case "chown.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Inode"}
+		}
+		e.Chown.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "chown.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Mode"}
+		}
+		e.Chown.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "chown.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.MountID"}
+		}
+		e.Chown.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "chown.file.name":
+
+		var ok bool
+		if e.Chown.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.BasenameStr"}
+		}
+		return nil
+
+	case "chown.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.OverlayNumLower"}
+		}
+		e.Chown.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "chown.file.path":
+
+		var ok bool
+		if e.Chown.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.PathnameStr"}
+		}
+		return nil
+
+	case "chown.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.UID"}
+		}
+		e.Chown.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "chown.file.user":
+
+		var ok bool
+		if e.Chown.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.User"}
+		}
 		return nil
 
 	case "chown.retval":
@@ -3870,16 +6704,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chown.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "chown.uid":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.UID"}
-		}
-		e.Chown.UID = int32(v)
-		return nil
-
 	case "container.id":
 
 		var ok bool
@@ -3888,11 +6712,11 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "exec.container_path":
+	case "exec.comm":
 
 		var ok bool
-		if e.Exec.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.ContainerPath"}
+		if e.Exec.Comm, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Comm"}
 		}
 		return nil
 
@@ -3906,11 +6730,103 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Exec.Cookie = uint32(v)
 		return nil
 
-	case "exec.filename":
+	case "exec.file.container_path":
+
+		var ok bool
+		if e.Exec.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.ContainerPath"}
+		}
+		return nil
+
+	case "exec.file.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.GID"}
+		}
+		e.Exec.FileFields.GID = uint32(v)
+		return nil
+
+	case "exec.file.group":
+
+		var ok bool
+		if e.Exec.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.Group"}
+		}
+		return nil
+
+	case "exec.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.Inode"}
+		}
+		e.Exec.FileFields.Inode = uint64(v)
+		return nil
+
+	case "exec.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.Mode"}
+		}
+		e.Exec.FileFields.Mode = uint16(v)
+		return nil
+
+	case "exec.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.MountID"}
+		}
+		e.Exec.FileFields.MountID = uint32(v)
+		return nil
+
+	case "exec.file.name":
+
+		var ok bool
+		if e.Exec.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.BasenameStr"}
+		}
+		return nil
+
+	case "exec.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.OverlayNumLower"}
+		}
+		e.Exec.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "exec.file.path":
 
 		var ok bool
 		if e.Exec.PathnameStr, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.PathnameStr"}
+		}
+		return nil
+
+	case "exec.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.UID"}
+		}
+		e.Exec.FileFields.UID = uint32(v)
+		return nil
+
+	case "exec.file.user":
+
+		var ok bool
+		if e.Exec.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.User"}
 		}
 		return nil
 
@@ -3930,34 +6846,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if e.Exec.Group, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.Group"}
 		}
-		return nil
-
-	case "exec.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.Inode"}
-		}
-		e.Exec.FileFields.Inode = uint64(v)
-		return nil
-
-	case "exec.name":
-
-		var ok bool
-		if e.Exec.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.BasenameStr"}
-		}
-		return nil
-
-	case "exec.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.FileFields.OverlayNumLower"}
-		}
-		e.Exec.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "exec.ppid":
@@ -3996,6 +6884,206 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
+	case "link.file.container_path":
+
+		var ok bool
+		if e.Link.Source.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.ContainerPath"}
+		}
+		return nil
+
+	case "link.file.destination.container_path":
+
+		var ok bool
+		if e.Link.Target.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.ContainerPath"}
+		}
+		return nil
+
+	case "link.file.destination.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.GID"}
+		}
+		e.Link.Target.FileFields.GID = uint32(v)
+		return nil
+
+	case "link.file.destination.group":
+
+		var ok bool
+		if e.Link.Target.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Group"}
+		}
+		return nil
+
+	case "link.file.destination.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Inode"}
+		}
+		e.Link.Target.FileFields.Inode = uint64(v)
+		return nil
+
+	case "link.file.destination.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Mode"}
+		}
+		e.Link.Target.FileFields.Mode = uint16(v)
+		return nil
+
+	case "link.file.destination.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.MountID"}
+		}
+		e.Link.Target.FileFields.MountID = uint32(v)
+		return nil
+
+	case "link.file.destination.name":
+
+		var ok bool
+		if e.Link.Target.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.BasenameStr"}
+		}
+		return nil
+
+	case "link.file.destination.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.OverlayNumLower"}
+		}
+		e.Link.Target.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "link.file.destination.path":
+
+		var ok bool
+		if e.Link.Target.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.PathnameStr"}
+		}
+		return nil
+
+	case "link.file.destination.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.UID"}
+		}
+		e.Link.Target.FileFields.UID = uint32(v)
+		return nil
+
+	case "link.file.destination.user":
+
+		var ok bool
+		if e.Link.Target.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.User"}
+		}
+		return nil
+
+	case "link.file.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.GID"}
+		}
+		e.Link.Source.FileFields.GID = uint32(v)
+		return nil
+
+	case "link.file.group":
+
+		var ok bool
+		if e.Link.Source.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Group"}
+		}
+		return nil
+
+	case "link.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Inode"}
+		}
+		e.Link.Source.FileFields.Inode = uint64(v)
+		return nil
+
+	case "link.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Mode"}
+		}
+		e.Link.Source.FileFields.Mode = uint16(v)
+		return nil
+
+	case "link.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.MountID"}
+		}
+		e.Link.Source.FileFields.MountID = uint32(v)
+		return nil
+
+	case "link.file.name":
+
+		var ok bool
+		if e.Link.Source.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.BasenameStr"}
+		}
+		return nil
+
+	case "link.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.OverlayNumLower"}
+		}
+		e.Link.Source.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "link.file.path":
+
+		var ok bool
+		if e.Link.Source.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.PathnameStr"}
+		}
+		return nil
+
+	case "link.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.UID"}
+		}
+		e.Link.Source.FileFields.UID = uint32(v)
+		return nil
+
+	case "link.file.user":
+
+		var ok bool
+		if e.Link.Source.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.User"}
+		}
+		return nil
+
 	case "link.retval":
 
 		var ok bool
@@ -4006,129 +7094,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Link.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "link.source.basename":
+	case "mkdir.file.container_path":
 
 		var ok bool
-		if e.Link.Source.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.BasenameStr"}
+		if e.Mkdir.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.ContainerPath"}
 		}
 		return nil
 
-	case "link.source.container_path":
-
-		var ok bool
-		if e.Link.Source.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.ContainerPath"}
-		}
-		return nil
-
-	case "link.source.filename":
-
-		var ok bool
-		if e.Link.Source.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.PathnameStr"}
-		}
-		return nil
-
-	case "link.source.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Inode"}
-		}
-		e.Link.Source.FileFields.Inode = uint64(v)
-		return nil
-
-	case "link.source.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.OverlayNumLower"}
-		}
-		e.Link.Source.FileFields.OverlayNumLower = int32(v)
-		return nil
-
-	case "link.target.basename":
-
-		var ok bool
-		if e.Link.Target.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.BasenameStr"}
-		}
-		return nil
-
-	case "link.target.container_path":
-
-		var ok bool
-		if e.Link.Target.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.ContainerPath"}
-		}
-		return nil
-
-	case "link.target.filename":
-
-		var ok bool
-		if e.Link.Target.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.PathnameStr"}
-		}
-		return nil
-
-	case "link.target.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Inode"}
-		}
-		e.Link.Target.FileFields.Inode = uint64(v)
-		return nil
-
-	case "link.target.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.OverlayNumLower"}
-		}
-		e.Link.Target.FileFields.OverlayNumLower = int32(v)
-		return nil
-
-	case "mkdir.basename":
-
-		var ok bool
-		if e.Mkdir.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.BasenameStr"}
-		}
-		return nil
-
-	case "mkdir.container_path":
-
-		var ok bool
-		if e.Mkdir.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "mkdir.filename":
-
-		var ok bool
-		if e.Mkdir.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "mkdir.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.FileFields.Inode"}
-		}
-		e.Mkdir.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "mkdir.mode":
+	case "mkdir.file.destination.mode":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4138,14 +7112,96 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.Mode = uint32(v)
 		return nil
 
-	case "mkdir.overlay_numlower":
+	case "mkdir.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.GID"}
 		}
-		e.Mkdir.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Mkdir.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "mkdir.file.group":
+
+		var ok bool
+		if e.Mkdir.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.Group"}
+		}
+		return nil
+
+	case "mkdir.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.Inode"}
+		}
+		e.Mkdir.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "mkdir.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.Mode"}
+		}
+		e.Mkdir.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "mkdir.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.MountID"}
+		}
+		e.Mkdir.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "mkdir.file.name":
+
+		var ok bool
+		if e.Mkdir.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.BasenameStr"}
+		}
+		return nil
+
+	case "mkdir.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.OverlayNumLower"}
+		}
+		e.Mkdir.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "mkdir.file.path":
+
+		var ok bool
+		if e.Mkdir.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.PathnameStr"}
+		}
+		return nil
+
+	case "mkdir.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.UID"}
+		}
+		e.Mkdir.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "mkdir.file.user":
+
+		var ok bool
+		if e.Mkdir.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.User"}
+		}
 		return nil
 
 	case "mkdir.retval":
@@ -4158,27 +7214,113 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "open.basename":
+	case "open.file.container_path":
 
 		var ok bool
-		if e.Open.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.BasenameStr"}
+		if e.Open.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.ContainerPath"}
 		}
 		return nil
 
-	case "open.container_path":
+	case "open.file.destination.mode":
 
 		var ok bool
-		if e.Open.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.ContainerPath"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.Mode"}
+		}
+		e.Open.Mode = uint32(v)
+		return nil
+
+	case "open.file.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.GID"}
+		}
+		e.Open.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "open.file.group":
+
+		var ok bool
+		if e.Open.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Group"}
 		}
 		return nil
 
-	case "open.filename":
+	case "open.file.inode":
 
 		var ok bool
-		if e.Open.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.PathnameStr"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Inode"}
+		}
+		e.Open.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "open.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Mode"}
+		}
+		e.Open.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "open.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.MountID"}
+		}
+		e.Open.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "open.file.name":
+
+		var ok bool
+		if e.Open.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.BasenameStr"}
+		}
+		return nil
+
+	case "open.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.OverlayNumLower"}
+		}
+		e.Open.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "open.file.path":
+
+		var ok bool
+		if e.Open.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.PathnameStr"}
+		}
+		return nil
+
+	case "open.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.UID"}
+		}
+		e.Open.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "open.file.user":
+
+		var ok bool
+		if e.Open.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.User"}
 		}
 		return nil
 
@@ -4192,36 +7334,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Open.Flags = uint32(v)
 		return nil
 
-	case "open.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.FileFields.Inode"}
-		}
-		e.Open.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "open.mode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.Mode"}
-		}
-		e.Open.Mode = uint32(v)
-		return nil
-
-	case "open.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.FileEvent.FileFields.OverlayNumLower"}
-		}
-		e.Open.FileEvent.FileFields.OverlayNumLower = int32(v)
-		return nil
-
 	case "open.retval":
 
 		var ok bool
@@ -4232,15 +7344,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Open.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "process.ancestors.container_path":
+	case "process.ancestors.comm":
 
 		if e.Process.Ancestor == nil {
 			e.Process.Ancestor = &model.ProcessCacheEntry{}
 		}
 
 		var ok bool
-		if e.Process.Ancestor.ProcessContext.ExecEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.ContainerPath"}
+		if e.Process.Ancestor.ProcessContext.ExecEvent.Comm, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.Comm"}
 		}
 		return nil
 
@@ -4258,7 +7370,113 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Process.Ancestor.ProcessContext.ExecEvent.Cookie = uint32(v)
 		return nil
 
-	case "process.ancestors.filename":
+	case "process.ancestors.file.container_path":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.Process.Ancestor.ProcessContext.ExecEvent.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.ContainerPath"}
+		}
+		return nil
+
+	case "process.ancestors.file.gid":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.GID"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.GID = uint32(v)
+		return nil
+
+	case "process.ancestors.file.group":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.Group"}
+		}
+		return nil
+
+	case "process.ancestors.file.inode":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.Inode"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.Inode = uint64(v)
+		return nil
+
+	case "process.ancestors.file.mode":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.Mode"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.Mode = uint16(v)
+		return nil
+
+	case "process.ancestors.file.mount_id":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.MountID"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.MountID = uint32(v)
+		return nil
+
+	case "process.ancestors.file.name":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.Process.Ancestor.ProcessContext.ExecEvent.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.BasenameStr"}
+		}
+		return nil
+
+	case "process.ancestors.file.overlay_numlower":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.OverlayNumLower"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "process.ancestors.file.path":
 
 		if e.Process.Ancestor == nil {
 			e.Process.Ancestor = &model.ProcessCacheEntry{}
@@ -4267,6 +7485,32 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		if e.Process.Ancestor.ProcessContext.ExecEvent.PathnameStr, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.PathnameStr"}
+		}
+		return nil
+
+	case "process.ancestors.file.uid":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.UID"}
+		}
+		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.UID = uint32(v)
+		return nil
+
+	case "process.ancestors.file.user":
+
+		if e.Process.Ancestor == nil {
+			e.Process.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.User"}
 		}
 		return nil
 
@@ -4306,46 +7550,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if e.Process.Ancestor.ContainerContext.ID, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ContainerContext.ID"}
 		}
-		return nil
-
-	case "process.ancestors.inode":
-
-		if e.Process.Ancestor == nil {
-			e.Process.Ancestor = &model.ProcessCacheEntry{}
-		}
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.Inode"}
-		}
-		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "process.ancestors.name":
-
-		if e.Process.Ancestor == nil {
-			e.Process.Ancestor = &model.ProcessCacheEntry{}
-		}
-
-		var ok bool
-		if e.Process.Ancestor.ProcessContext.ExecEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.BasenameStr"}
-		}
-		return nil
-
-	case "process.ancestors.overlay_numlower":
-
-		if e.Process.Ancestor == nil {
-			e.Process.Ancestor = &model.ProcessCacheEntry{}
-		}
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.Ancestor.ProcessContext.ExecEvent.FileFields.OverlayNumLower"}
-		}
-		e.Process.Ancestor.ProcessContext.ExecEvent.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "process.ancestors.pid":
@@ -4428,11 +7632,11 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "process.container_path":
+	case "process.comm":
 
 		var ok bool
-		if e.Process.ExecEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.ContainerPath"}
+		if e.Process.ExecEvent.Comm, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.Comm"}
 		}
 		return nil
 
@@ -4446,11 +7650,103 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Process.ExecEvent.Cookie = uint32(v)
 		return nil
 
-	case "process.filename":
+	case "process.file.container_path":
+
+		var ok bool
+		if e.Process.ExecEvent.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.ContainerPath"}
+		}
+		return nil
+
+	case "process.file.gid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.GID"}
+		}
+		e.Process.ExecEvent.FileFields.GID = uint32(v)
+		return nil
+
+	case "process.file.group":
+
+		var ok bool
+		if e.Process.ExecEvent.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.Group"}
+		}
+		return nil
+
+	case "process.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.Inode"}
+		}
+		e.Process.ExecEvent.FileFields.Inode = uint64(v)
+		return nil
+
+	case "process.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.Mode"}
+		}
+		e.Process.ExecEvent.FileFields.Mode = uint16(v)
+		return nil
+
+	case "process.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.MountID"}
+		}
+		e.Process.ExecEvent.FileFields.MountID = uint32(v)
+		return nil
+
+	case "process.file.name":
+
+		var ok bool
+		if e.Process.ExecEvent.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.BasenameStr"}
+		}
+		return nil
+
+	case "process.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.OverlayNumLower"}
+		}
+		e.Process.ExecEvent.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "process.file.path":
 
 		var ok bool
 		if e.Process.ExecEvent.PathnameStr, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.PathnameStr"}
+		}
+		return nil
+
+	case "process.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.UID"}
+		}
+		e.Process.ExecEvent.FileFields.UID = uint32(v)
+		return nil
+
+	case "process.file.user":
+
+		var ok bool
+		if e.Process.ExecEvent.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.User"}
 		}
 		return nil
 
@@ -4470,34 +7766,6 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if e.Process.ExecEvent.Group, ok = value.(string); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.Group"}
 		}
-		return nil
-
-	case "process.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.Inode"}
-		}
-		e.Process.ExecEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "process.name":
-
-		var ok bool
-		if e.Process.ExecEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.BasenameStr"}
-		}
-		return nil
-
-	case "process.overlay_numlower":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Process.ExecEvent.FileFields.OverlayNumLower"}
-		}
-		e.Process.ExecEvent.FileFields.OverlayNumLower = int32(v)
 		return nil
 
 	case "process.pid":
@@ -4556,41 +7824,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "removexattr.basename":
+	case "removexattr.file.container_path":
 
 		var ok bool
-		if e.RemoveXAttr.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.BasenameStr"}
+		if e.RemoveXAttr.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.ContainerPath"}
 		}
 		return nil
 
-	case "removexattr.container_path":
-
-		var ok bool
-		if e.RemoveXAttr.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "removexattr.filename":
-
-		var ok bool
-		if e.RemoveXAttr.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "removexattr.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.FileFields.Inode"}
-		}
-		e.RemoveXAttr.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "removexattr.name":
+	case "removexattr.file.destination.name":
 
 		var ok bool
 		if e.RemoveXAttr.Name, ok = value.(string); !ok {
@@ -4598,7 +7840,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "removexattr.namespace":
+	case "removexattr.file.destination.namespace":
 
 		var ok bool
 		if e.RemoveXAttr.Namespace, ok = value.(string); !ok {
@@ -4606,14 +7848,96 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "removexattr.overlay_numlower":
+	case "removexattr.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.GID"}
 		}
-		e.RemoveXAttr.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.RemoveXAttr.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "removexattr.file.group":
+
+		var ok bool
+		if e.RemoveXAttr.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.Group"}
+		}
+		return nil
+
+	case "removexattr.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.Inode"}
+		}
+		e.RemoveXAttr.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "removexattr.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.Mode"}
+		}
+		e.RemoveXAttr.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "removexattr.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.MountID"}
+		}
+		e.RemoveXAttr.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "removexattr.file.name":
+
+		var ok bool
+		if e.RemoveXAttr.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.BasenameStr"}
+		}
+		return nil
+
+	case "removexattr.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.OverlayNumLower"}
+		}
+		e.RemoveXAttr.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "removexattr.file.path":
+
+		var ok bool
+		if e.RemoveXAttr.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.PathnameStr"}
+		}
+		return nil
+
+	case "removexattr.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.UID"}
+		}
+		e.RemoveXAttr.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "removexattr.file.user":
+
+		var ok bool
+		if e.RemoveXAttr.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.User"}
+		}
 		return nil
 
 	case "removexattr.retval":
@@ -4626,15 +7950,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "rename.new.basename":
+	case "rename.file.container_path":
 
 		var ok bool
-		if e.Rename.New.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.BasenameStr"}
+		if e.Rename.Old.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.ContainerPath"}
 		}
 		return nil
 
-	case "rename.new.container_path":
+	case "rename.file.destination.container_path":
 
 		var ok bool
 		if e.Rename.New.ContainerPath, ok = value.(string); !ok {
@@ -4642,15 +7966,25 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "rename.new.filename":
+	case "rename.file.destination.gid":
 
 		var ok bool
-		if e.Rename.New.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.PathnameStr"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.GID"}
+		}
+		e.Rename.New.FileFields.GID = uint32(v)
+		return nil
+
+	case "rename.file.destination.group":
+
+		var ok bool
+		if e.Rename.New.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.Group"}
 		}
 		return nil
 
-	case "rename.new.inode":
+	case "rename.file.destination.inode":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4660,7 +7994,35 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.New.FileFields.Inode = uint64(v)
 		return nil
 
-	case "rename.new.overlay_numlower":
+	case "rename.file.destination.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.Mode"}
+		}
+		e.Rename.New.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rename.file.destination.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.MountID"}
+		}
+		e.Rename.New.FileFields.MountID = uint32(v)
+		return nil
+
+	case "rename.file.destination.name":
+
+		var ok bool
+		if e.Rename.New.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.BasenameStr"}
+		}
+		return nil
+
+	case "rename.file.destination.overlay_numlower":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4670,31 +8032,51 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.New.FileFields.OverlayNumLower = int32(v)
 		return nil
 
-	case "rename.old.basename":
+	case "rename.file.destination.path":
 
 		var ok bool
-		if e.Rename.Old.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.BasenameStr"}
+		if e.Rename.New.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.PathnameStr"}
 		}
 		return nil
 
-	case "rename.old.container_path":
+	case "rename.file.destination.uid":
 
 		var ok bool
-		if e.Rename.Old.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.ContainerPath"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.UID"}
+		}
+		e.Rename.New.FileFields.UID = uint32(v)
+		return nil
+
+	case "rename.file.destination.user":
+
+		var ok bool
+		if e.Rename.New.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.User"}
 		}
 		return nil
 
-	case "rename.old.filename":
+	case "rename.file.gid":
 
 		var ok bool
-		if e.Rename.Old.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.PathnameStr"}
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.GID"}
+		}
+		e.Rename.Old.FileFields.GID = uint32(v)
+		return nil
+
+	case "rename.file.group":
+
+		var ok bool
+		if e.Rename.Old.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.Group"}
 		}
 		return nil
 
-	case "rename.old.inode":
+	case "rename.file.inode":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4704,7 +8086,35 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.Old.FileFields.Inode = uint64(v)
 		return nil
 
-	case "rename.old.overlay_numlower":
+	case "rename.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.Mode"}
+		}
+		e.Rename.Old.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rename.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.MountID"}
+		}
+		e.Rename.Old.FileFields.MountID = uint32(v)
+		return nil
+
+	case "rename.file.name":
+
+		var ok bool
+		if e.Rename.Old.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.BasenameStr"}
+		}
+		return nil
+
+	case "rename.file.overlay_numlower":
 
 		var ok bool
 		v, ok := value.(int)
@@ -4712,6 +8122,32 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.OverlayNumLower"}
 		}
 		e.Rename.Old.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "rename.file.path":
+
+		var ok bool
+		if e.Rename.Old.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.PathnameStr"}
+		}
+		return nil
+
+	case "rename.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.UID"}
+		}
+		e.Rename.Old.FileFields.UID = uint32(v)
+		return nil
+
+	case "rename.file.user":
+
+		var ok bool
+		if e.Rename.Old.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.User"}
+		}
 		return nil
 
 	case "rename.retval":
@@ -4724,48 +8160,104 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "rmdir.basename":
+	case "rmdir.file.container_path":
 
 		var ok bool
-		if e.Rmdir.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.BasenameStr"}
+		if e.Rmdir.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.ContainerPath"}
 		}
 		return nil
 
-	case "rmdir.container_path":
-
-		var ok bool
-		if e.Rmdir.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "rmdir.filename":
-
-		var ok bool
-		if e.Rmdir.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "rmdir.inode":
+	case "rmdir.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.GID"}
 		}
-		e.Rmdir.FileEvent.FileFields.Inode = uint64(v)
+		e.Rmdir.File.FileFields.GID = uint32(v)
 		return nil
 
-	case "rmdir.overlay_numlower":
+	case "rmdir.file.group":
+
+		var ok bool
+		if e.Rmdir.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Group"}
+		}
+		return nil
+
+	case "rmdir.file.inode":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Inode"}
 		}
-		e.Rmdir.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Rmdir.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "rmdir.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Mode"}
+		}
+		e.Rmdir.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rmdir.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.MountID"}
+		}
+		e.Rmdir.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "rmdir.file.name":
+
+		var ok bool
+		if e.Rmdir.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.BasenameStr"}
+		}
+		return nil
+
+	case "rmdir.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.OverlayNumLower"}
+		}
+		e.Rmdir.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "rmdir.file.path":
+
+		var ok bool
+		if e.Rmdir.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.PathnameStr"}
+		}
+		return nil
+
+	case "rmdir.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.UID"}
+		}
+		e.Rmdir.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "rmdir.file.user":
+
+		var ok bool
+		if e.Rmdir.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.User"}
+		}
 		return nil
 
 	case "rmdir.retval":
@@ -4778,41 +8270,15 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rmdir.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "setxattr.basename":
+	case "setxattr.file.container_path":
 
 		var ok bool
-		if e.SetXAttr.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.BasenameStr"}
+		if e.SetXAttr.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.ContainerPath"}
 		}
 		return nil
 
-	case "setxattr.container_path":
-
-		var ok bool
-		if e.SetXAttr.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "setxattr.filename":
-
-		var ok bool
-		if e.SetXAttr.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "setxattr.inode":
-
-		var ok bool
-		v, ok := value.(int)
-		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.FileFields.Inode"}
-		}
-		e.SetXAttr.FileEvent.FileFields.Inode = uint64(v)
-		return nil
-
-	case "setxattr.name":
+	case "setxattr.file.destination.name":
 
 		var ok bool
 		if e.SetXAttr.Name, ok = value.(string); !ok {
@@ -4820,7 +8286,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "setxattr.namespace":
+	case "setxattr.file.destination.namespace":
 
 		var ok bool
 		if e.SetXAttr.Namespace, ok = value.(string); !ok {
@@ -4828,14 +8294,96 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		return nil
 
-	case "setxattr.overlay_numlower":
+	case "setxattr.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.GID"}
 		}
-		e.SetXAttr.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.SetXAttr.File.FileFields.GID = uint32(v)
+		return nil
+
+	case "setxattr.file.group":
+
+		var ok bool
+		if e.SetXAttr.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.Group"}
+		}
+		return nil
+
+	case "setxattr.file.inode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.Inode"}
+		}
+		e.SetXAttr.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "setxattr.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.Mode"}
+		}
+		e.SetXAttr.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "setxattr.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.MountID"}
+		}
+		e.SetXAttr.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "setxattr.file.name":
+
+		var ok bool
+		if e.SetXAttr.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.BasenameStr"}
+		}
+		return nil
+
+	case "setxattr.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.OverlayNumLower"}
+		}
+		e.SetXAttr.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "setxattr.file.path":
+
+		var ok bool
+		if e.SetXAttr.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.PathnameStr"}
+		}
+		return nil
+
+	case "setxattr.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.UID"}
+		}
+		e.SetXAttr.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "setxattr.file.user":
+
+		var ok bool
+		if e.SetXAttr.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.User"}
+		}
 		return nil
 
 	case "setxattr.retval":
@@ -4848,58 +8396,104 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "unlink.basename":
+	case "unlink.file.container_path":
 
 		var ok bool
-		if e.Unlink.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.BasenameStr"}
+		if e.Unlink.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.ContainerPath"}
 		}
 		return nil
 
-	case "unlink.container_path":
-
-		var ok bool
-		if e.Unlink.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "unlink.filename":
-
-		var ok bool
-		if e.Unlink.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "unlink.flags":
+	case "unlink.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.Flags"}
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.GID"}
 		}
-		e.Unlink.Flags = uint32(v)
+		e.Unlink.File.FileFields.GID = uint32(v)
 		return nil
 
-	case "unlink.inode":
+	case "unlink.file.group":
+
+		var ok bool
+		if e.Unlink.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Group"}
+		}
+		return nil
+
+	case "unlink.file.inode":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Inode"}
 		}
-		e.Unlink.FileEvent.FileFields.Inode = uint64(v)
+		e.Unlink.File.FileFields.Inode = uint64(v)
 		return nil
 
-	case "unlink.overlay_numlower":
+	case "unlink.file.mode":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Mode"}
 		}
-		e.Unlink.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Unlink.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "unlink.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.MountID"}
+		}
+		e.Unlink.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "unlink.file.name":
+
+		var ok bool
+		if e.Unlink.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.BasenameStr"}
+		}
+		return nil
+
+	case "unlink.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.OverlayNumLower"}
+		}
+		e.Unlink.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "unlink.file.path":
+
+		var ok bool
+		if e.Unlink.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.PathnameStr"}
+		}
+		return nil
+
+	case "unlink.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.UID"}
+		}
+		e.Unlink.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "unlink.file.user":
+
+		var ok bool
+		if e.Unlink.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.User"}
+		}
 		return nil
 
 	case "unlink.retval":
@@ -4912,48 +8506,104 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
 
-	case "utimes.basename":
+	case "utimes.file.container_path":
 
 		var ok bool
-		if e.Utimes.FileEvent.BasenameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.BasenameStr"}
+		if e.Utimes.File.ContainerPath, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.ContainerPath"}
 		}
 		return nil
 
-	case "utimes.container_path":
-
-		var ok bool
-		if e.Utimes.FileEvent.ContainerPath, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.ContainerPath"}
-		}
-		return nil
-
-	case "utimes.filename":
-
-		var ok bool
-		if e.Utimes.FileEvent.PathnameStr, ok = value.(string); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.PathnameStr"}
-		}
-		return nil
-
-	case "utimes.inode":
+	case "utimes.file.gid":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.FileFields.Inode"}
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.GID"}
 		}
-		e.Utimes.FileEvent.FileFields.Inode = uint64(v)
+		e.Utimes.File.FileFields.GID = uint32(v)
 		return nil
 
-	case "utimes.overlay_numlower":
+	case "utimes.file.group":
+
+		var ok bool
+		if e.Utimes.File.FileFields.Group, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Group"}
+		}
+		return nil
+
+	case "utimes.file.inode":
 
 		var ok bool
 		v, ok := value.(int)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.FileEvent.FileFields.OverlayNumLower"}
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Inode"}
 		}
-		e.Utimes.FileEvent.FileFields.OverlayNumLower = int32(v)
+		e.Utimes.File.FileFields.Inode = uint64(v)
+		return nil
+
+	case "utimes.file.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Mode"}
+		}
+		e.Utimes.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "utimes.file.mount_id":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.MountID"}
+		}
+		e.Utimes.File.FileFields.MountID = uint32(v)
+		return nil
+
+	case "utimes.file.name":
+
+		var ok bool
+		if e.Utimes.File.BasenameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.BasenameStr"}
+		}
+		return nil
+
+	case "utimes.file.overlay_numlower":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.OverlayNumLower"}
+		}
+		e.Utimes.File.FileFields.OverlayNumLower = int32(v)
+		return nil
+
+	case "utimes.file.path":
+
+		var ok bool
+		if e.Utimes.File.PathnameStr, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.PathnameStr"}
+		}
+		return nil
+
+	case "utimes.file.uid":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.UID"}
+		}
+		e.Utimes.File.FileFields.UID = uint32(v)
+		return nil
+
+	case "utimes.file.user":
+
+		var ok bool
+		if e.Utimes.File.FileFields.User, ok = value.(string); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.User"}
+		}
 		return nil
 
 	case "utimes.retval":

--- a/pkg/security/probe/approvers.go
+++ b/pkg/security/probe/approvers.go
@@ -82,14 +82,14 @@ func onNewBasenameApprovers(probe *Probe, eventType model.EventType, field strin
 	var basenameApprovers []activeApprover
 	for field, values := range approvers {
 		switch field {
-		case prefix + ".basename":
+		case prefix + ".name":
 			activeApprovers, err := approveBasenames("basename_approvers", eventType, stringValues(values)...)
 			if err != nil {
 				return nil, err
 			}
 			basenameApprovers = append(basenameApprovers, activeApprovers...)
 
-		case prefix + ".filename":
+		case prefix + ".path":
 			for _, value := range stringValues(values) {
 				basename := path.Base(value)
 				activeApprover, err := approveBasename("basename_approvers", eventType, basename)
@@ -106,7 +106,7 @@ func onNewBasenameApprovers(probe *Probe, eventType model.EventType, field strin
 
 func onNewBasenameApproversWrapper(event model.EventType) onApproverHandler {
 	return func(probe *Probe, approvers rules.Approvers) (activeApprovers, error) {
-		basenameApprovers, err := onNewBasenameApprovers(probe, event, "", approvers)
+		basenameApprovers, err := onNewBasenameApprovers(probe, event, "file", approvers)
 		if err != nil {
 			return nil, err
 		}
@@ -132,10 +132,10 @@ func onNewTwoBasenamesApproversWrapper(event model.EventType, field1, field2 str
 func init() {
 	allApproversHandlers["chmod"] = onNewBasenameApproversWrapper(model.FileChmodEventType)
 	allApproversHandlers["chown"] = onNewBasenameApproversWrapper(model.FileChownEventType)
-	allApproversHandlers["link"] = onNewTwoBasenamesApproversWrapper(model.FileLinkEventType, "source", "target")
+	allApproversHandlers["link"] = onNewTwoBasenamesApproversWrapper(model.FileLinkEventType, "file", "file.destination")
 	allApproversHandlers["mkdir"] = onNewBasenameApproversWrapper(model.FileMkdirEventType)
 	allApproversHandlers["open"] = openOnNewApprovers
-	allApproversHandlers["rename"] = onNewTwoBasenamesApproversWrapper(model.FileRenameEventType, "old", "new")
+	allApproversHandlers["rename"] = onNewTwoBasenamesApproversWrapper(model.FileRenameEventType, "file", "file.destination")
 	allApproversHandlers["rmdir"] = onNewBasenameApproversWrapper(model.FileRmdirEventType)
 	allApproversHandlers["unlink"] = onNewBasenameApproversWrapper(model.FileUnlinkEventType)
 	allApproversHandlers["utimes"] = onNewBasenameApproversWrapper(model.FileUtimeEventType)

--- a/pkg/security/probe/capabilities.go
+++ b/pkg/security/probe/capabilities.go
@@ -59,11 +59,11 @@ func (caps Capabilities) GetFieldCapabilities() rules.FieldCapabilities {
 
 func oneBasenameCapabilities(event string) Capabilities {
 	return Capabilities{
-		event + ".filename": {
+		event + ".file.path": {
 			PolicyFlags:     PolicyFlagBasename,
 			FieldValueTypes: eval.ScalarValueType,
 		},
-		event + ".basename": {
+		event + ".file.name": {
 			PolicyFlags:     PolicyFlagBasename,
 			FieldValueTypes: eval.ScalarValueType,
 		},
@@ -72,19 +72,19 @@ func oneBasenameCapabilities(event string) Capabilities {
 
 func twoBasenameCapabilities(event string, field1, field2 string) Capabilities {
 	return Capabilities{
-		event + "." + field1 + ".filename": {
+		event + "." + field1 + ".path": {
 			PolicyFlags:     PolicyFlagBasename,
 			FieldValueTypes: eval.ScalarValueType,
 		},
-		event + "." + field1 + ".basename": {
+		event + "." + field1 + ".name": {
 			PolicyFlags:     PolicyFlagBasename,
 			FieldValueTypes: eval.ScalarValueType,
 		},
-		event + "." + field2 + ".filename": {
+		event + "." + field2 + ".path": {
 			PolicyFlags:     PolicyFlagBasename,
 			FieldValueTypes: eval.ScalarValueType,
 		},
-		event + "." + field2 + ".basename": {
+		event + "." + field2 + ".name": {
 			PolicyFlags:     PolicyFlagBasename,
 			FieldValueTypes: eval.ScalarValueType,
 		},
@@ -94,10 +94,10 @@ func twoBasenameCapabilities(event string, field1, field2 string) Capabilities {
 func init() {
 	allCapabilities["chmod"] = oneBasenameCapabilities("chmod")
 	allCapabilities["chown"] = oneBasenameCapabilities("chown")
-	allCapabilities["link"] = twoBasenameCapabilities("link", "source", "target")
+	allCapabilities["link"] = twoBasenameCapabilities("link", "file", "file.destination")
 	allCapabilities["mkdir"] = oneBasenameCapabilities("mkdir")
 	allCapabilities["open"] = openCapabilities
-	allCapabilities["rename"] = twoBasenameCapabilities("rename", "old", "new")
+	allCapabilities["rename"] = twoBasenameCapabilities("rename", "file", "file.destination")
 	allCapabilities["rmdir"] = oneBasenameCapabilities("rmdir")
 	allCapabilities["unlink"] = oneBasenameCapabilities("unlink")
 	allCapabilities["utimes"] = oneBasenameCapabilities("utimes")

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -84,20 +84,20 @@ var (
 
 // InvalidDiscarders exposes list of values that are not discarders
 var InvalidDiscarders = map[eval.Field][]interface{}{
-	"open.filename":        dentryInvalidDiscarder,
-	"unlink.filename":      dentryInvalidDiscarder,
-	"chmod.filename":       dentryInvalidDiscarder,
-	"chown.filename":       dentryInvalidDiscarder,
-	"mkdir.filename":       dentryInvalidDiscarder,
-	"rmdir.filename":       dentryInvalidDiscarder,
-	"rename.old.filename":  dentryInvalidDiscarder,
-	"rename.new.filename":  dentryInvalidDiscarder,
-	"utimes.filename":      dentryInvalidDiscarder,
-	"link.source.filename": dentryInvalidDiscarder,
-	"link.target.filename": dentryInvalidDiscarder,
-	"process.filename":     dentryInvalidDiscarder,
-	"setxattr.filename":    dentryInvalidDiscarder,
-	"removexattr.filename": dentryInvalidDiscarder,
+	"open.file.path":               dentryInvalidDiscarder,
+	"unlink.file.path":             dentryInvalidDiscarder,
+	"chmod.file.path":              dentryInvalidDiscarder,
+	"chown.file.path":              dentryInvalidDiscarder,
+	"mkdir.file.path":              dentryInvalidDiscarder,
+	"rmdir.file.path":              dentryInvalidDiscarder,
+	"rename.file.path":             dentryInvalidDiscarder,
+	"rename.file.destination.path": dentryInvalidDiscarder,
+	"utimes.file.path":             dentryInvalidDiscarder,
+	"link.file.path":               dentryInvalidDiscarder,
+	"link.file.destination.path":   dentryInvalidDiscarder,
+	"process.file.path":            dentryInvalidDiscarder,
+	"setxattr.file.path":           dentryInvalidDiscarder,
+	"removexattr.file.path":        dentryInvalidDiscarder,
 }
 
 func marshalDiscardHeader(req *ERPCRequest, eventType model.EventType, timeout uint64) int {
@@ -216,7 +216,7 @@ func isParentPathDiscarder(rs *rules.RuleSet, regexCache *simplelru.LRU, eventTy
 		return false, nil
 	}
 
-	basenameField := strings.Replace(filenameField, ".filename", ".basename", 1)
+	basenameField := strings.Replace(filenameField, ".path", ".name", 1)
 
 	event := NewEvent(nil)
 	if _, err := event.GetFieldType(filenameField); err != nil {
@@ -231,12 +231,12 @@ func isParentPathDiscarder(rs *rules.RuleSet, regexCache *simplelru.LRU, eventTy
 		// ensure we don't push parent discarder if there is another rule relying on the parent path
 
 		// first case: rule contains a filename field
-		// ex: rule		open.filename == "/etc/passwd"
+		// ex: rule		open.file.path == "/etc/passwd"
 		//     discarder /etc/fstab
 		// /etc/fstab is a discarder but not the parent
 
 		// second case: rule doesn't contain a filename field but a basename field
-		// ex: rule	 	open.basename == "conf.d"
+		// ex: rule	 	open.file.name == "conf.d"
 		//     discarder /etc/conf.d/httpd.conf
 		// /etc/conf.d/httpd.conf is a discarder but not the parent
 
@@ -315,7 +315,7 @@ func (id *inodeDiscarders) discardParentInode(rs *rules.RuleSet, eventType model
 	return true, parentMountID, parentInode, nil
 }
 
-// function used to retrieve discarder information, *.filename, mountID, inode, file deleted
+// function used to retrieve discarder information, *.file.path, mountID, inode, file deleted
 type inodeEventGetter = func(event *Event) (eval.Field, uint32, uint64, uint32, bool)
 
 func filenameDiscarderWrapper(eventType model.EventType, handler onDiscarderHandler, getter inodeEventGetter) onDiscarderHandler {
@@ -340,13 +340,13 @@ func filenameDiscarderWrapper(eventType model.EventType, handler onDiscarderHand
 			isDiscarded, _, parentInode, err := probe.inodeDiscarders.discardParentInode(rs, eventType, field, filename, mountID, inode, pathID)
 			if !isDiscarded && !isDeleted {
 				if _, ok := err.(*ErrInvalidKeyPath); !ok {
-					log.Tracef("Apply `%s.filename` inode discarder for event `%s`, inode: %d", eventType, eventType, inode)
+					log.Tracef("Apply `%s.file.path` inode discarder for event `%s`, inode: %d", eventType, eventType, inode)
 
 					// not able to discard the parent then only discard the filename
 					err = probe.inodeDiscarders.discardInode(eventType, mountID, inode, true)
 				}
 			} else {
-				log.Tracef("Apply `%s.filename` parent inode discarder for event `%s` with value `%s`", eventType, eventType, filename)
+				log.Tracef("Apply `%s.file.path` parent inode discarder for event `%s` with value `%s`", eventType, eventType, filename)
 			}
 
 			if err != nil {
@@ -396,15 +396,15 @@ func createInvalidDiscardersCache() map[eval.Field]map[interface{}]bool {
 
 func processDiscarderWrapper(eventType model.EventType, fnc onDiscarderHandler) onDiscarderHandler {
 	return func(rs *rules.RuleSet, event *Event, probe *Probe, discarder Discarder) error {
-		if discarder.Field == "process.filename" {
-			log.Tracef("Apply process.filename discarder for event `%s`, inode: %d, pid: %d", eventType, event.Process.Inode, event.Process.Pid)
+		if discarder.Field == "process.file.path" {
+			log.Tracef("Apply process.file.path discarder for event `%s`, inode: %d, pid: %d", eventType, event.Process.FileFields.Inode, event.Process.Pid)
 
 			// discard by PID for long running process
 			if err := probe.pidDiscarders.discard(eventType, event.Process.Pid); err != nil {
 				return err
 			}
 
-			return probe.inodeDiscarders.discardInode(eventType, event.Process.MountID, event.Process.Inode, true)
+			return probe.inodeDiscarders.discardInode(eventType, event.Process.FileFields.MountID, event.Process.FileFields.Inode, true)
 		}
 
 		if fnc != nil {
@@ -420,21 +420,21 @@ var invalidDiscarders map[eval.Field]map[interface{}]bool
 func init() {
 	invalidDiscarders = createInvalidDiscardersCache()
 
-	SupportedDiscarders["process.filename"] = true
+	SupportedDiscarders["process.file.path"] = true
 
 	allDiscarderHandlers["open"] = processDiscarderWrapper(model.FileOpenEventType,
 		filenameDiscarderWrapper(model.FileOpenEventType, nil,
 			func(event *Event) (eval.Field, uint32, uint64, uint32, bool) {
-				return "open.filename", event.Open.MountID, event.Open.Inode, event.Open.PathID, false
+				return "open.file.path", event.Open.File.MountID, event.Open.File.Inode, event.Open.File.PathID, false
 			}))
-	SupportedDiscarders["open.filename"] = true
+	SupportedDiscarders["open.file.path"] = true
 
 	allDiscarderHandlers["mkdir"] = processDiscarderWrapper(model.FileMkdirEventType,
 		filenameDiscarderWrapper(model.FileMkdirEventType, nil,
 			func(event *Event) (eval.Field, uint32, uint64, uint32, bool) {
-				return "mkdir.filename", event.Mkdir.MountID, event.Mkdir.Inode, event.Mkdir.PathID, false
+				return "mkdir.file.path", event.Mkdir.File.MountID, event.Mkdir.File.Inode, event.Mkdir.File.PathID, false
 			}))
-	SupportedDiscarders["mkdir.filename"] = true
+	SupportedDiscarders["mkdir.file.path"] = true
 
 	allDiscarderHandlers["link"] = processDiscarderWrapper(model.FileLinkEventType, nil)
 
@@ -443,49 +443,49 @@ func init() {
 	allDiscarderHandlers["unlink"] = processDiscarderWrapper(model.FileUnlinkEventType,
 		filenameDiscarderWrapper(model.FileUnlinkEventType, nil,
 			func(event *Event) (eval.Field, uint32, uint64, uint32, bool) {
-				return "unlink.filename", event.Unlink.MountID, event.Unlink.Inode, event.Unlink.PathID, true
+				return "unlink.file.path", event.Unlink.File.MountID, event.Unlink.File.Inode, event.Unlink.File.PathID, true
 			}))
-	SupportedDiscarders["unlink.filename"] = true
+	SupportedDiscarders["unlink.file.path"] = true
 
 	allDiscarderHandlers["rmdir"] = processDiscarderWrapper(model.FileRmdirEventType,
 		filenameDiscarderWrapper(model.FileRmdirEventType, nil,
 			func(event *Event) (eval.Field, uint32, uint64, uint32, bool) {
-				return "rmdir.filename", event.Rmdir.MountID, event.Rmdir.Inode, event.Rmdir.PathID, false
+				return "rmdir.file.path", event.Rmdir.File.MountID, event.Rmdir.File.Inode, event.Rmdir.File.PathID, false
 			}))
-	SupportedDiscarders["rmdir.filename"] = true
+	SupportedDiscarders["rmdir.file.path"] = true
 
 	allDiscarderHandlers["chmod"] = processDiscarderWrapper(model.FileChmodEventType,
 		filenameDiscarderWrapper(model.FileChmodEventType, nil,
 			func(event *Event) (eval.Field, uint32, uint64, uint32, bool) {
-				return "chmod.filename", event.Chmod.MountID, event.Chmod.Inode, event.Chmod.PathID, false
+				return "chmod.file.path", event.Chmod.File.MountID, event.Chmod.File.Inode, event.Chmod.File.PathID, false
 			}))
-	SupportedDiscarders["chmod.filename"] = true
+	SupportedDiscarders["chmod.file.path"] = true
 
 	allDiscarderHandlers["chown"] = processDiscarderWrapper(model.FileChownEventType,
 		filenameDiscarderWrapper(model.FileChownEventType, nil,
 			func(event *Event) (eval.Field, uint32, uint64, uint32, bool) {
-				return "chown.filename", event.Chown.MountID, event.Chown.Inode, event.Chown.PathID, false
+				return "chown.file.path", event.Chown.File.MountID, event.Chown.File.Inode, event.Chown.File.PathID, false
 			}))
-	SupportedDiscarders["chown.filename"] = true
+	SupportedDiscarders["chown.file.path"] = true
 
 	allDiscarderHandlers["utimes"] = processDiscarderWrapper(model.FileUtimeEventType,
 		filenameDiscarderWrapper(model.FileUtimeEventType, nil,
 			func(event *Event) (eval.Field, uint32, uint64, uint32, bool) {
-				return "utimes.filename", event.Utimes.MountID, event.Utimes.Inode, event.Utimes.PathID, false
+				return "utimes.file.path", event.Utimes.File.MountID, event.Utimes.File.Inode, event.Utimes.File.PathID, false
 			}))
-	SupportedDiscarders["utimes.filename"] = true
+	SupportedDiscarders["utimes.file.path"] = true
 
 	allDiscarderHandlers["setxattr"] = processDiscarderWrapper(model.FileSetXAttrEventType,
 		filenameDiscarderWrapper(model.FileSetXAttrEventType, nil,
 			func(event *Event) (eval.Field, uint32, uint64, uint32, bool) {
-				return "setxattr.filename", event.SetXAttr.MountID, event.SetXAttr.Inode, event.SetXAttr.PathID, false
+				return "setxattr.file.path", event.SetXAttr.File.MountID, event.SetXAttr.File.Inode, event.SetXAttr.File.PathID, false
 			}))
-	SupportedDiscarders["setxattr.filename"] = true
+	SupportedDiscarders["setxattr.file.path"] = true
 
 	allDiscarderHandlers["removexattr"] = processDiscarderWrapper(model.FileRemoveXAttrEventType,
 		filenameDiscarderWrapper(model.FileRemoveXAttrEventType, nil,
 			func(event *Event) (eval.Field, uint32, uint64, uint32, bool) {
-				return "removexattr.filename", event.RemoveXAttr.MountID, event.RemoveXAttr.Inode, event.RemoveXAttr.PathID, false
+				return "removexattr.file.path", event.RemoveXAttr.File.MountID, event.RemoveXAttr.File.Inode, event.RemoveXAttr.File.PathID, false
 			}))
-	SupportedDiscarders["removexattr.filename"] = true
+	SupportedDiscarders["removexattr.file.path"] = true
 }

--- a/pkg/security/probe/kfilters_test.go
+++ b/pkg/security/probe/kfilters_test.go
@@ -44,49 +44,49 @@ func TestIsParentDiscarder(t *testing.T) {
 
 	enabled := map[eval.EventType]bool{"*": true}
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
@@ -94,56 +94,56 @@ func TestIsParentDiscarder(t *testing.T) {
 	}
 
 	// field that doesn't exists shouldn't return any discarders
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log"); is {
@@ -153,7 +153,7 @@ func TestIsParentDiscarder(t *testing.T) {
 
 func TestApproverAncestors(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
 	addRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]

--- a/pkg/security/probe/kfilters_test.go
+++ b/pkg/security/probe/kfilters_test.go
@@ -45,108 +45,108 @@ func TestIsParentDiscarder(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
 
 	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.filename != "/var/log/datadog/system-probe.log"`)
+	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/var/log/datadog/system-probe.log"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.filename != "/var/log/datadog/system-probe.log"`)
+	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/var/lib/datadog/system-probe.sock"); !is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock"); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename == "/var/log/datadog/system-probe.log"`, `unlink.basename == "datadog"`)
+	addRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/var/log/datadog/datadog-agent.log"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename =~ "/var/log/*" && unlink.basename =~ ".*"`)
+	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/var/lib/.runc/1234"); !is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234"); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename == "/etc/conf.d/httpd.conf" || unlink.basename == "conf.d"`)
+	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/etc/conf.d/nginx.conf"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename == "/etc/conf.d/httpd.conf" || unlink.basename == "sys.d"`)
+	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/etc/sys.d/nginx.conf"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.basename == "conf.d"`)
+	addRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/etc/conf.d/nginx.conf"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	// field that doesn't exists shouldn't return any discarders
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `rename.old.filename == "/etc/conf.d/abc"`)
+	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.filename", "/etc/conf.d/nginx.conf"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `rename.old.filename == "/etc/conf.d/abc"`)
+	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.old.filename", "/etc/nginx/nginx.conf"); !is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename =~ "/etc/conf.d/*"`)
+	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/etc/sys.d/nginx.conf"); !is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename =~ "*/conf.*"`)
+	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename =~ "/etc/conf.d/ab*"`)
+	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename =~ "*/conf.d/ab*"`)
+	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename =~ "*/conf.d"`)
+	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/etc/conf.d/abc"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `unlink.filename =~ "/etc/*"`)
+	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.filename", "/etc/cron.d/log"); is {
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 }
@@ -154,7 +154,7 @@ func TestIsParentDiscarder(t *testing.T) {
 func TestApproverAncestors(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
 	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, log.DatadogAgentLogger{}))
-	addRuleExpr(t, rs, `open.filename == "/etc/passwd" && process.ancestors.name == "vipw"`, `open.filename == "/etc/shadow" && process.ancestors.name == "vipw"`)
+	addRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]
 	if !exists {
@@ -166,7 +166,7 @@ func TestApproverAncestors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if values, exists := approvers["open.filename"]; !exists || len(values) != 2 {
+	if values, exists := approvers["open.file.path"]; !exists || len(values) != 2 {
 		t.Fatalf("expected approver not found: %v", values)
 	}
 }

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -147,7 +147,7 @@ func (ev *Event) UnmarshalExecEvent(data []byte) (int, error) {
 
 	// Some fields need to be copied manually in the ExecEvent structure because they do not have "Exec" specific
 	// resolvers, and the data was parsed in the ProcessCacheEntry structure
-	model.CopyFileFields(&ev.processCacheEntry.ProcessContext.ExecEvent.FileFields, &ev.Exec.FileFields)
+	ev.Exec.FileFields = ev.processCacheEntry.ProcessContext.ExecEvent.FileFields
 	return n, nil
 }
 

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -16,25 +16,25 @@ import (
 
 func TestAbsolutePath(t *testing.T) {
 	model := &Model{}
-	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "/var/log/*"}); err != nil {
+	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "/var/log/*"}); err != nil {
 		t.Fatalf("shouldn't return an error: %s", err)
 	}
-	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "~/apache/httpd.conf"}); err == nil {
+	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "~/apache/httpd.conf"}); err == nil {
 		t.Fatal("should return an error")
 	}
-	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "../../../etc/apache/httpd.conf"}); err == nil {
+	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "../../../etc/apache/httpd.conf"}); err == nil {
 		t.Fatal("should return an error")
 	}
-	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "/etc/apache/./httpd.conf"}); err == nil {
+	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "/etc/apache/./httpd.conf"}); err == nil {
 		t.Fatal("should return an error")
 	}
-	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "*/"}); err == nil {
+	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "*/"}); err == nil {
 		t.Fatal("should return an error")
 	}
-	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16"}); err == nil {
+	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16"}); err == nil {
 		t.Fatal("should return an error")
 	}
-	if err := model.ValidateField("open.filename", eval.FieldValue{Value: "f59226f52267c120c1accfe3d158aa2f201ff02f45692a1c574da29c07fb985ef59226f52267c120c1accfe3d158aa2f201ff02f45692a1c574da29c07fb985e"}); err == nil {
+	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "f59226f52267c120c1accfe3d158aa2f201ff02f45692a1c574da29c07fb985ef59226f52267c120c1accfe3d158aa2f201ff02f45692a1c574da29c07fb985e"}); err == nil {
 		t.Fatal("should return an error")
 	}
 }

--- a/pkg/security/probe/open.go
+++ b/pkg/security/probe/open.go
@@ -16,11 +16,11 @@ import (
 )
 
 var openCapabilities = Capabilities{
-	"open.filename": {
+	"open.file.path": {
 		PolicyFlags:     PolicyFlagBasename,
 		FieldValueTypes: eval.ScalarValueType,
 	},
-	"open.basename": {
+	"open.file.name": {
 		PolicyFlags:     PolicyFlagBasename,
 		FieldValueTypes: eval.ScalarValueType,
 	},
@@ -39,14 +39,14 @@ func openOnNewApprovers(probe *Probe, approvers rules.Approvers) (activeApprover
 		return values
 	}
 
-	openApprovers, err := onNewBasenameApprovers(probe, model.FileOpenEventType, "", approvers)
+	openApprovers, err := onNewBasenameApprovers(probe, model.FileOpenEventType, "file", approvers)
 	if err != nil {
 		return nil, err
 	}
 
 	for field, values := range approvers {
 		switch field {
-		case "open.basename", "open.filename": // already handled by onNewBasenameApprovers
+		case "open.file.name", "open.file.path": // already handled by onNewBasenameApprovers
 		case "open.flags":
 			activeApprover, err := approveFlags("open_flags_approvers", intValues(values)...)
 			if err != nil {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -361,7 +361,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		}
 
 		// defer it do ensure that it will be done after the dispatch that could re-add it
-		defer p.invalidateDentry(event.Rmdir.MountID, event.Rmdir.Inode, event.Rmdir.DiscarderRevision)
+		defer p.invalidateDentry(event.Rmdir.File.MountID, event.Rmdir.File.Inode, event.Rmdir.DiscarderRevision)
 	case model.FileUnlinkEventType:
 		if _, err := event.Unlink.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode unlink event: %s (offset %d, len %d)", err, offset, dataLen)
@@ -369,7 +369,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		}
 
 		// defer it do ensure that it will be done after the dispatch that could re-add it
-		defer p.invalidateDentry(event.Unlink.MountID, event.Unlink.Inode, event.Unlink.DiscarderRevision)
+		defer p.invalidateDentry(event.Unlink.File.MountID, event.Unlink.File.Inode, event.Unlink.DiscarderRevision)
 	case model.FileRenameEventType:
 		if _, err := event.Rename.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode rename event: %s (offset %d, len %d)", err, offset, dataLen)

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -150,17 +151,13 @@ func (p *ProcessResolver) enrichEventFromProc(entry *model.ProcessCacheEntry, pr
 			return errors.Wrapf(err, "snapshot failed for %d: couldn't parse container ID", proc.Pid)
 		}
 
-		entry.FileFields = model.FileFields{
-			Inode:           inode,
-			OverlayNumLower: info.OverlayNumLower,
-			MountID:         info.MountID,
-		}
+		entry.FileFields = *info
 		entry.ExecEvent.PathnameStr = pathnameStr
+		entry.ExecEvent.BasenameStr = path.Base(pathnameStr)
 		entry.ContainerContext.ID = string(containerID)
+		// resolve container path with the MountResolver
+		entry.ContainerPath = p.resolvers.resolveContainerPath(&entry.ExecEvent.FileFields)
 	}
-
-	// resolve container path with the MountResolver
-	entry.ContainerPath = p.resolvers.resolveContainerPath(&entry.ExecEvent.FileFields)
 
 	entry.ExecTime = time.Unix(0, filledProc.CreateTime*int64(time.Millisecond))
 	entry.ForkTime = entry.ExecTime
@@ -181,7 +178,8 @@ func (p *ProcessResolver) enrichEventFromProc(entry *model.ProcessCacheEntry, pr
 }
 
 // retrieveInodeInfo fetches inode metadata from kernel space
-func (p *ProcessResolver) retrieveInodeInfo(inode uint64) (*InodeInfo, error) {
+func (p *ProcessResolver) retrieveInodeInfo(inode uint64) (*model.FileFields, error) {
+	var info model.FileFields
 	inodeb := make([]byte, 8)
 
 	model.ByteOrder.PutUint64(inodeb, inode)
@@ -190,13 +188,12 @@ func (p *ProcessResolver) retrieveInodeInfo(inode uint64) (*InodeInfo, error) {
 		return nil, err
 	}
 
-	if data == nil {
-		return nil, errors.New("not found")
+	if _, err = info.UnmarshalBinary(data); err != nil {
+		return nil, err
 	}
 
-	var info InodeInfo
-	if _, err := info.UnmarshalBinary(data); err != nil {
-		return nil, err
+	if info.Inode == 0 {
+		return nil, errors.New("not found")
 	}
 
 	return &info, nil
@@ -304,7 +301,7 @@ func (p *ProcessResolver) unmarshalProcessCacheEntry(entry *model.ProcessCacheEn
 	// resolve FileEvent now so that the dentry cache is up to date. Fork events might send a null inode if the parent
 	// wasn't in the kernel cache, so only resolve if necessary
 
-	if entry.Inode != 0 && entry.MountID != 0 {
+	if entry.FileFields.Inode != 0 && entry.FileFields.MountID != 0 {
 		entry.PathnameStr, _ = p.resolvers.resolveInode(&entry.FileFields)
 		entry.ContainerPath = p.resolvers.resolveContainerPath(&entry.FileFields)
 	}
@@ -465,7 +462,7 @@ func (p *ProcessResolver) syncCache(proc *process.Process) (*model.ProcessCacheE
 		return nil, false
 	}
 
-	log.Tracef("New process cache entry added: %s %s %d/%d", entry.Comm, entry.PathnameStr, pid, entry.Inode)
+	log.Tracef("New process cache entry added: %s %s %d/%d", entry.Comm, entry.PathnameStr, pid, entry.FileFields.Inode)
 
 	return entry, true
 }

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -108,6 +108,22 @@ func (r *Resolvers) ResolveInode(e *model.FileEvent) string {
 	return path
 }
 
+// ResolveUser resolves the user id of the file to a username
+func (r *Resolvers) ResolveUser(e *model.FileEvent) string {
+	if len(e.User) == 0 {
+		e.User, _ = r.UserGroupResolver.ResolveUser(int(e.UID))
+	}
+	return e.User
+}
+
+// ResolveGroup resolves the group id of the file to a group name
+func (r *Resolvers) ResolveGroup(e *model.FileEvent) string {
+	if len(e.Group) == 0 {
+		e.Group, _ = r.UserGroupResolver.ResolveGroup(int(e.GID))
+	}
+	return e.Group
+}
+
 // ResolveProcessUser resolves the user id of the process to a username
 func (r *Resolvers) ResolveProcessUser(p *model.ProcessContext) string {
 	if len(p.User) == 0 {

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -108,16 +108,16 @@ func (r *Resolvers) ResolveInode(e *model.FileEvent) string {
 	return path
 }
 
-// ResolveUser resolves the user id of the file to a username
-func (r *Resolvers) ResolveUser(e *model.FileEvent) string {
+// ResolveUID resolves the user id of the file to a username
+func (r *Resolvers) ResolveUID(e *model.FileFields) string {
 	if len(e.User) == 0 {
 		e.User, _ = r.UserGroupResolver.ResolveUser(int(e.UID))
 	}
 	return e.User
 }
 
-// ResolveGroup resolves the group id of the file to a group name
-func (r *Resolvers) ResolveGroup(e *model.FileEvent) string {
+// ResolveGID resolves the group id of the file to a group name
+func (r *Resolvers) ResolveGID(e *model.FileFields) string {
 	if len(e.Group) == 0 {
 		e.Group, _ = r.UserGroupResolver.ResolveGroup(int(e.GID))
 	}

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -314,7 +314,7 @@ func newEventSerializer(event *Event) *EventSerializer {
 		Date:                     event.ResolveEventTimestamp(),
 	}
 
-	if event.Container.ID != "" {
+	if event.ResolveContainerID(&event.Container) != "" {
 		s.ContainerContextSerializer = newContainerContextSerializer(&event.Container, event)
 	}
 

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -135,9 +135,9 @@ func newExecSerializer(exec *model.ExecEvent, e *Event) *FileSerializer {
 		Path:                e.ResolveExecInode(exec),
 		PathResolutionError: exec.GetPathResolutionError(),
 		ContainerPath:       e.ResolveExecContainerPath(exec),
-		Inode:               getUint64Pointer(&exec.Inode),
-		MountID:             getUint32Pointer(&exec.MountID),
-		OverlayNumLower:     getInt32Pointer(&exec.OverlayNumLower),
+		Inode:               getUint64Pointer(&exec.FileFields.Inode),
+		MountID:             getUint32Pointer(&exec.FileFields.MountID),
+		OverlayNumLower:     getInt32Pointer(&exec.FileFields.OverlayNumLower),
 	}
 }
 
@@ -170,47 +170,44 @@ func getTimeIfNotZero(t time.Time) *time.Time {
 }
 
 func newProcessCacheEntrySerializer(pce *model.ProcessCacheEntry, e *Event, r *Resolvers, useEvent bool) *ProcessCacheEntrySerializer {
-	var pid, ppid, tid, uid, gid uint32
-	var user, group string
-
-	if useEvent && e != nil {
-		pid = e.Process.Pid
-		ppid = e.Process.PPid
-		tid = e.Process.Tid
-		uid = e.Process.UID
-		gid = e.Process.GID
-		user = e.ResolveProcessUser(&e.Process)
-		group = e.ResolveProcessGroup(&e.Process)
-	} else {
-		pid = pce.Pid
-		ppid = pce.PPid
-		tid = pce.Tid
-		uid = pce.UID
-		gid = pce.GID
-		user = e.ResolveExecUser(&pce.ProcessContext.ExecEvent)
-		group = e.ResolveExecGroup(&pce.ProcessContext.ExecEvent)
-	}
-
-	return &ProcessCacheEntrySerializer{
-		Pid:                 pid,
-		PPid:                ppid,
-		Tid:                 tid,
-		UID:                 uid,
-		GID:                 gid,
-		User:                user,
-		Group:               group,
-		Name:                e.ResolveExecBasename(&pce.ExecEvent),
-		Path:                e.ResolveExecInode(&pce.ExecEvent),
+	pceSerializer := &ProcessCacheEntrySerializer{
+		Inode:               pce.FileFields.Inode,
+		MountID:             pce.FileFields.MountID,
 		PathResolutionError: pce.GetPathResolutionError(),
-		ContainerPath:       e.ResolveExecContainerPath(&pce.ExecEvent),
-		Comm:                e.ResolveExecComm(&pce.ExecEvent),
-		Inode:               pce.Inode,
-		MountID:             pce.MountID,
-		TTY:                 e.ResolveExecTTY(&pce.ExecEvent),
 		ForkTime:            getTimeIfNotZero(pce.ForkTime),
 		ExecTime:            getTimeIfNotZero(pce.ExecTime),
 		ExitTime:            getTimeIfNotZero(pce.ExitTime),
 	}
+
+	if useEvent && e != nil {
+		pceSerializer.Pid = e.Process.Pid
+		pceSerializer.PPid = e.Process.PPid
+		pceSerializer.Tid = e.Process.Tid
+		pceSerializer.UID = e.Process.UID
+		pceSerializer.GID = e.Process.GID
+		pceSerializer.User = e.ResolveProcessUser(&e.Process)
+		pceSerializer.Group = e.ResolveProcessGroup(&e.Process)
+		pceSerializer.Name = e.ResolveExecBasename(&pce.ExecEvent)
+		pceSerializer.Path = e.ResolveExecInode(&pce.ExecEvent)
+		pceSerializer.ContainerPath = e.ResolveExecContainerPath(&pce.ExecEvent)
+		pceSerializer.Comm = e.ResolveExecComm(&pce.ExecEvent)
+		pceSerializer.TTY = e.ResolveExecTTY(&pce.ExecEvent)
+	} else {
+		pceSerializer.Pid = pce.Pid
+		pceSerializer.PPid = pce.PPid
+		pceSerializer.Tid = pce.Tid
+		pceSerializer.UID = pce.UID
+		pceSerializer.GID = pce.GID
+		pceSerializer.User = r.ResolveProcessUser(&pce.ProcessContext)
+		pceSerializer.Group = r.ResolveProcessGroup(&pce.ProcessContext)
+		pceSerializer.Name = pce.ExecEvent.BasenameStr
+		pceSerializer.Path = pce.ExecEvent.PathnameStr
+		pceSerializer.ContainerPath = pce.ExecEvent.ContainerPath
+		pceSerializer.Comm = pce.Comm
+		pceSerializer.TTY = pce.TTYName
+	}
+
+	return pceSerializer
 }
 
 func newContainerContextSerializer(cc *model.ContainerContext, e *Event) *ContainerContextSerializer {
@@ -286,13 +283,13 @@ func newEventSerializer(event *Event) *EventSerializer {
 	switch model.EventType(event.Type) {
 	case model.FileChmodEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.Chmod.FileEvent, event),
+			FileSerializer: *newFileSerializer(&event.Chmod.File, event),
 		}
 		s.FileSerializer.Mode = &event.Chmod.Mode
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Chmod.Retval)
 	case model.FileChownEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.Chown.FileEvent, event),
+			FileSerializer: *newFileSerializer(&event.Chown.File, event),
 		}
 		s.FileSerializer.UID = &event.Chown.UID
 		s.FileSerializer.GID = &event.Chown.GID
@@ -305,25 +302,25 @@ func newEventSerializer(event *Event) *EventSerializer {
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Link.Retval)
 	case model.FileOpenEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.Open.FileEvent, event),
+			FileSerializer: *newFileSerializer(&event.Open.File, event),
 		}
 		s.FileSerializer.Mode = &event.Open.Mode
 		s.FileSerializer.Flags = model.OpenFlags(event.Open.Flags).StringArray()
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Open.Retval)
 	case model.FileMkdirEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.Mkdir.FileEvent, event),
+			FileSerializer: *newFileSerializer(&event.Mkdir.File, event),
 		}
 		s.FileSerializer.Mode = &event.Mkdir.Mode
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Mkdir.Retval)
 	case model.FileRmdirEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.Rmdir.FileEvent, event),
+			FileSerializer: *newFileSerializer(&event.Rmdir.File, event),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Rmdir.Retval)
 	case model.FileUnlinkEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.Unlink.FileEvent, event),
+			FileSerializer: *newFileSerializer(&event.Unlink.File, event),
 		}
 		s.FileSerializer.Flags = model.UnlinkFlags(event.Unlink.Flags).StringArray()
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Unlink.Retval)
@@ -335,21 +332,21 @@ func newEventSerializer(event *Event) *EventSerializer {
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Rename.Retval)
 	case model.FileRemoveXAttrEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.RemoveXAttr.FileEvent, event),
+			FileSerializer: *newFileSerializer(&event.RemoveXAttr.File, event),
 		}
 		s.FileSerializer.XAttrName = event.GetXAttrName(&event.RemoveXAttr)
 		s.FileSerializer.XAttrNamespace = event.GetXAttrNamespace(&event.RemoveXAttr)
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.RemoveXAttr.Retval)
 	case model.FileSetXAttrEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.SetXAttr.FileEvent, event),
+			FileSerializer: *newFileSerializer(&event.SetXAttr.File, event),
 		}
 		s.FileSerializer.XAttrName = event.GetXAttrName(&event.SetXAttr)
 		s.FileSerializer.XAttrNamespace = event.GetXAttrNamespace(&event.SetXAttr)
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.SetXAttr.Retval)
 	case model.FileUtimeEventType:
 		s.FileEventSerializer = &FileEventSerializer{
-			FileSerializer: *newFileSerializer(&event.Utimes.FileEvent, event),
+			FileSerializer: *newFileSerializer(&event.Utimes.File, event),
 		}
 		s.FileSerializer.Atime = getTimeIfNotZero(event.Utimes.Atime)
 		s.FileSerializer.Mtime = getTimeIfNotZero(event.Utimes.Mtime)

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -234,6 +234,16 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 				}
 				(*out.Executable).UnmarshalEasyJSON(in)
 			}
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.Container = nil
+			} else {
+				if out.Container == nil {
+					out.Container = new(ContainerContextSerializer)
+				}
+				(*out.Container).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -387,6 +397,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 		out.RawString(prefix)
 		(*in.Executable).MarshalEasyJSON(out)
 	}
+	if in.Container != nil {
+		const prefix string = ",\"container\":"
+		out.RawString(prefix)
+		(*in.Container).MarshalEasyJSON(out)
+	}
 	out.RawByte('}')
 }
 
@@ -505,6 +520,16 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 					out.Executable = new(FileSerializer)
 				}
 				(*out.Executable).UnmarshalEasyJSON(in)
+			}
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.Container = nil
+			} else {
+				if out.Container == nil {
+					out.Container = new(ContainerContextSerializer)
+				}
+				(*out.Container).UnmarshalEasyJSON(in)
 			}
 		default:
 			in.SkipRecursive()
@@ -625,6 +650,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 		const prefix string = ",\"executable\":"
 		out.RawString(prefix)
 		(*in.Executable).MarshalEasyJSON(out)
+	}
+	if in.Container != nil {
+		const prefix string = ",\"container\":"
+		out.RawString(prefix)
+		(*in.Container).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -174,8 +174,6 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 			out.User = string(in.String())
 		case "group":
 			out.Group = string(in.String())
-		case "name":
-			out.Name = string(in.String())
 		case "executable_container_path":
 			out.ContainerPath = string(in.String())
 		case "executable_path":
@@ -225,6 +223,16 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 				if data := in.Raw(); in.Ok() {
 					in.AddError((*out.ExitTime).UnmarshalJSON(data))
 				}
+			}
+		case "executable":
+			if in.IsNull() {
+				in.Skip()
+				out.Executable = nil
+			} else {
+				if out.Executable == nil {
+					out.Executable = new(FileSerializer)
+				}
+				(*out.Executable).UnmarshalEasyJSON(in)
 			}
 		default:
 			in.SkipRecursive()
@@ -299,7 +307,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 		}
 		out.Uint32(uint32(in.Tid))
 	}
-	if in.UID != 0 {
+	{
 		const prefix string = ",\"uid\":"
 		if first {
 			first = false
@@ -309,145 +317,75 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 		}
 		out.Uint32(uint32(in.UID))
 	}
-	if in.GID != 0 {
+	{
 		const prefix string = ",\"gid\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Uint32(uint32(in.GID))
 	}
 	if in.User != "" {
 		const prefix string = ",\"user\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.User))
 	}
 	if in.Group != "" {
 		const prefix string = ",\"group\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.Group))
-	}
-	if in.Name != "" {
-		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Name))
 	}
 	if in.ContainerPath != "" {
 		const prefix string = ",\"executable_container_path\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.ContainerPath))
 	}
 	if in.Path != "" {
 		const prefix string = ",\"executable_path\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.Path))
 	}
 	if in.PathResolutionError != "" {
 		const prefix string = ",\"path_resolution_error\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.PathResolutionError))
 	}
 	if in.Comm != "" {
 		const prefix string = ",\"comm\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.Comm))
 	}
 	if in.Inode != 0 {
 		const prefix string = ",\"executable_inode\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Uint64(uint64(in.Inode))
 	}
 	if in.MountID != 0 {
 		const prefix string = ",\"executable_mount_id\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Uint32(uint32(in.MountID))
 	}
 	if in.TTY != "" {
 		const prefix string = ",\"tty\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.TTY))
 	}
 	if in.ForkTime != nil {
 		const prefix string = ",\"fork_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.ForkTime).MarshalJSON())
 	}
 	if in.ExecTime != nil {
 		const prefix string = ",\"exec_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.ExecTime).MarshalJSON())
 	}
 	if in.ExitTime != nil {
 		const prefix string = ",\"exit_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.ExitTime).MarshalJSON())
+	}
+	if in.Executable != nil {
+		const prefix string = ",\"executable\":"
+		out.RawString(prefix)
+		(*in.Executable).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -508,8 +446,6 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 			out.User = string(in.String())
 		case "group":
 			out.Group = string(in.String())
-		case "name":
-			out.Name = string(in.String())
 		case "executable_container_path":
 			out.ContainerPath = string(in.String())
 		case "executable_path":
@@ -560,6 +496,16 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 					in.AddError((*out.ExitTime).UnmarshalJSON(data))
 				}
 			}
+		case "executable":
+			if in.IsNull() {
+				in.Skip()
+				out.Executable = nil
+			} else {
+				if out.Executable == nil {
+					out.Executable = new(FileSerializer)
+				}
+				(*out.Executable).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -600,7 +546,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 		}
 		out.Uint32(uint32(in.Tid))
 	}
-	if in.UID != 0 {
+	{
 		const prefix string = ",\"uid\":"
 		if first {
 			first = false
@@ -610,145 +556,75 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 		}
 		out.Uint32(uint32(in.UID))
 	}
-	if in.GID != 0 {
+	{
 		const prefix string = ",\"gid\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Uint32(uint32(in.GID))
 	}
 	if in.User != "" {
 		const prefix string = ",\"user\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.User))
 	}
 	if in.Group != "" {
 		const prefix string = ",\"group\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.Group))
-	}
-	if in.Name != "" {
-		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Name))
 	}
 	if in.ContainerPath != "" {
 		const prefix string = ",\"executable_container_path\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.ContainerPath))
 	}
 	if in.Path != "" {
 		const prefix string = ",\"executable_path\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.Path))
 	}
 	if in.PathResolutionError != "" {
 		const prefix string = ",\"path_resolution_error\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.PathResolutionError))
 	}
 	if in.Comm != "" {
 		const prefix string = ",\"comm\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.Comm))
 	}
 	if in.Inode != 0 {
 		const prefix string = ",\"executable_inode\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Uint64(uint64(in.Inode))
 	}
 	if in.MountID != 0 {
 		const prefix string = ",\"executable_mount_id\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Uint32(uint32(in.MountID))
 	}
 	if in.TTY != "" {
 		const prefix string = ",\"tty\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.TTY))
 	}
 	if in.ForkTime != nil {
 		const prefix string = ",\"fork_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.ForkTime).MarshalJSON())
 	}
 	if in.ExecTime != nil {
 		const prefix string = ",\"exec_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.ExecTime).MarshalJSON())
 	}
 	if in.ExitTime != nil {
 		const prefix string = ",\"exit_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.ExitTime).MarshalJSON())
+	}
+	if in.Executable != nil {
+		const prefix string = ",\"executable\":"
+		out.RawString(prefix)
+		(*in.Executable).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -844,25 +720,13 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 				*out.MountID = uint32(in.Uint32())
 			}
 		case "uid":
-			if in.IsNull() {
-				in.Skip()
-				out.UID = nil
-			} else {
-				if out.UID == nil {
-					out.UID = new(int32)
-				}
-				*out.UID = int32(in.Int32())
-			}
+			out.UID = uint32(in.Uint32())
 		case "gid":
-			if in.IsNull() {
-				in.Skip()
-				out.GID = nil
-			} else {
-				if out.GID == nil {
-					out.GID = new(int32)
-				}
-				*out.GID = int32(in.Int32())
-			}
+			out.GID = uint32(in.Uint32())
+		case "user":
+			out.User = string(in.String())
+		case "group":
+			out.Group = string(in.String())
 		case "attribute_name":
 			out.XAttrName = string(in.String())
 		case "attribute_namespace":
@@ -912,6 +776,18 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 				}
 				if data := in.Raw(); in.Ok() {
 					in.AddError((*out.Mtime).UnmarshalJSON(data))
+				}
+			}
+		case "change_time":
+			if in.IsNull() {
+				in.Skip()
+				out.Ctime = nil
+			} else {
+				if out.Ctime == nil {
+					out.Ctime = new(time.Time)
+				}
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.Ctime).UnmarshalJSON(data))
 				}
 			}
 		default:
@@ -1004,7 +880,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 		}
 		out.Uint32(uint32(*in.MountID))
 	}
-	if in.UID != nil {
+	{
 		const prefix string = ",\"uid\":"
 		if first {
 			first = false
@@ -1012,46 +888,36 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 		} else {
 			out.RawString(prefix)
 		}
-		out.Int32(int32(*in.UID))
+		out.Uint32(uint32(in.UID))
 	}
-	if in.GID != nil {
+	{
 		const prefix string = ",\"gid\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int32(int32(*in.GID))
+		out.RawString(prefix)
+		out.Uint32(uint32(in.GID))
+	}
+	if in.User != "" {
+		const prefix string = ",\"user\":"
+		out.RawString(prefix)
+		out.String(string(in.User))
+	}
+	if in.Group != "" {
+		const prefix string = ",\"group\":"
+		out.RawString(prefix)
+		out.String(string(in.Group))
 	}
 	if in.XAttrName != "" {
 		const prefix string = ",\"attribute_name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.XAttrName))
 	}
 	if in.XAttrNamespace != "" {
 		const prefix string = ",\"attribute_namespace\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.XAttrNamespace))
 	}
 	if len(in.Flags) != 0 {
 		const prefix string = ",\"flags\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		{
 			out.RawByte('[')
 			for v5, v6 := range in.Flags {
@@ -1065,23 +931,18 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 	}
 	if in.Atime != nil {
 		const prefix string = ",\"access_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.Atime).MarshalJSON())
 	}
 	if in.Mtime != nil {
 		const prefix string = ",\"modification_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.Mtime).MarshalJSON())
+	}
+	if in.Ctime != nil {
+		const prefix string = ",\"change_time\":"
+		out.RawString(prefix)
+		out.Raw((*in.Ctime).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -1195,25 +1056,13 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jle
 				*out.MountID = uint32(in.Uint32())
 			}
 		case "uid":
-			if in.IsNull() {
-				in.Skip()
-				out.UID = nil
-			} else {
-				if out.UID == nil {
-					out.UID = new(int32)
-				}
-				*out.UID = int32(in.Int32())
-			}
+			out.UID = uint32(in.Uint32())
 		case "gid":
-			if in.IsNull() {
-				in.Skip()
-				out.GID = nil
-			} else {
-				if out.GID == nil {
-					out.GID = new(int32)
-				}
-				*out.GID = int32(in.Int32())
-			}
+			out.GID = uint32(in.Uint32())
+		case "user":
+			out.User = string(in.String())
+		case "group":
+			out.Group = string(in.String())
 		case "attribute_name":
 			out.XAttrName = string(in.String())
 		case "attribute_namespace":
@@ -1263,6 +1112,18 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jle
 				}
 				if data := in.Raw(); in.Ok() {
 					in.AddError((*out.Mtime).UnmarshalJSON(data))
+				}
+			}
+		case "change_time":
+			if in.IsNull() {
+				in.Skip()
+				out.Ctime = nil
+			} else {
+				if out.Ctime == nil {
+					out.Ctime = new(time.Time)
+				}
+				if data := in.Raw(); in.Ok() {
+					in.AddError((*out.Ctime).UnmarshalJSON(data))
 				}
 			}
 		default:
@@ -1405,7 +1266,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 		}
 		out.Uint32(uint32(*in.MountID))
 	}
-	if in.UID != nil {
+	{
 		const prefix string = ",\"uid\":"
 		if first {
 			first = false
@@ -1413,46 +1274,36 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 		} else {
 			out.RawString(prefix)
 		}
-		out.Int32(int32(*in.UID))
+		out.Uint32(uint32(in.UID))
 	}
-	if in.GID != nil {
+	{
 		const prefix string = ",\"gid\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int32(int32(*in.GID))
+		out.RawString(prefix)
+		out.Uint32(uint32(in.GID))
+	}
+	if in.User != "" {
+		const prefix string = ",\"user\":"
+		out.RawString(prefix)
+		out.String(string(in.User))
+	}
+	if in.Group != "" {
+		const prefix string = ",\"group\":"
+		out.RawString(prefix)
+		out.String(string(in.Group))
 	}
 	if in.XAttrName != "" {
 		const prefix string = ",\"attribute_name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.XAttrName))
 	}
 	if in.XAttrNamespace != "" {
 		const prefix string = ",\"attribute_namespace\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.String(string(in.XAttrNamespace))
 	}
 	if len(in.Flags) != 0 {
 		const prefix string = ",\"flags\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		{
 			out.RawByte('[')
 			for v8, v9 := range in.Flags {
@@ -1466,23 +1317,18 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 	}
 	if in.Atime != nil {
 		const prefix string = ",\"access_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.Atime).MarshalJSON())
 	}
 	if in.Mtime != nil {
 		const prefix string = ",\"modification_time\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+		out.RawString(prefix)
 		out.Raw((*in.Mtime).MarshalJSON())
+	}
+	if in.Ctime != nil {
+		const prefix string = ",\"change_time\":"
+		out.RawString(prefix)
+		out.Raw((*in.Ctime).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/rules/logger.go
+++ b/pkg/security/rules/logger.go
@@ -23,15 +23,15 @@ type DefaultLogger struct{}
 
 // Tracef is used to print a trace level log
 func (l DefaultLogger) Tracef(format string, params ...interface{}) {
-	log.Tracef(format, params)
+	log.Tracef(format, params...)
 }
 
 // Debugf is used to print a trace level log
 func (l DefaultLogger) Debugf(format string, params ...interface{}) {
-	log.Debugf(format, params)
+	log.Debugf(format, params...)
 }
 
 // Errorf is used to print an error
 func (l DefaultLogger) Errorf(format string, params ...interface{}) error {
-	return log.Errorf(format, params)
+	return log.Errorf(format, params...)
 }

--- a/pkg/security/rules/model_test.go
+++ b/pkg/security/rules/model_test.go
@@ -80,15 +80,6 @@ func (m *testModel) ValidateField(key string, value eval.FieldValue) error {
 	return nil
 }
 
-func (m *testModel) TranslateLegacyField(field eval.Field) eval.Field {
-	switch field {
-	case "process.legacy_name":
-		return "process.name"
-	default:
-		return field
-	}
-}
-
 func (m *testModel) GetIterator(field eval.Field) (eval.Iterator, error) {
 	return nil, &eval.ErrIteratorNotSupported{Field: field}
 }

--- a/pkg/security/rules/model_test.go
+++ b/pkg/security/rules/model_test.go
@@ -80,6 +80,15 @@ func (m *testModel) ValidateField(key string, value eval.FieldValue) error {
 	return nil
 }
 
+func (m *testModel) TranslateLegacyField(field eval.Field) eval.Field {
+	switch field {
+	case "process.legacy_name":
+		return "process.name"
+	default:
+		return field
+	}
+}
+
 func (m *testModel) GetIterator(field eval.Field) (eval.Iterator, error) {
 	return nil, &eval.ErrIteratorNotSupported{Field: field}
 }

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -70,14 +70,15 @@ type Opts struct {
 }
 
 // NewOptsWithParams initializes a new Opts instance with Debug and Constants parameters
-func NewOptsWithParams(constants map[string]interface{}, supportedDiscarders map[eval.Field]bool, eventTypeEnabled map[eval.EventType]bool, reservedRuleIDs []RuleID, logger ...Logger) *Opts {
+func NewOptsWithParams(constants map[string]interface{}, supportedDiscarders map[eval.Field]bool, eventTypeEnabled map[eval.EventType]bool, reservedRuleIDs []RuleID, legacyAttributes map[eval.Field]eval.Field, logger ...Logger) *Opts {
 	if len(logger) == 0 {
 		logger = []Logger{DefaultLogger{}}
 	}
 	return &Opts{
 		Opts: eval.Opts{
-			Constants: constants,
-			Macros:    make(map[eval.MacroID]*eval.Macro),
+			Constants:        constants,
+			Macros:           make(map[eval.MacroID]*eval.Macro),
+			LegacyAttributes: legacyAttributes,
 		},
 		SupportedDiscarders: supportedDiscarders,
 		ReservedRuleIDs:     reservedRuleIDs,

--- a/pkg/security/rules/ruleset_test.go
+++ b/pkg/security/rules/ruleset_test.go
@@ -74,7 +74,7 @@ func addRuleExpr(t *testing.T, rs *RuleSet, exprs ...string) {
 
 func TestRuleBuckets(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil, nil))
 
 	exprs := []string{
 		`(open.filename =~ "/sbin/*" || open.filename =~ "/usr/sbin/*") && process.uid != 0 && open.flags & O_CREAT > 0`,
@@ -99,15 +99,15 @@ func TestRuleBuckets(t *testing.T) {
 }
 
 func TestRuleSetDiscarders(t *testing.T) {
-	model := &testModel{}
+	m := &testModel{}
 
 	handler := &testHandler{
-		model:   model,
+		model:   m,
 		filters: make(map[string]testFieldValues),
 	}
 
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(model, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil))
+	rs := NewRuleSet(m, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil, nil))
 	rs.AddListener(handler)
 
 	exprs := []string{
@@ -168,7 +168,7 @@ func TestRuleSetDiscarders(t *testing.T) {
 
 func TestRuleSetFilters1(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil, nil))
 
 	addRuleExpr(t, rs, `open.filename in ["/etc/passwd", "/etc/shadow"] && (process.uid == 0 || process.gid == 0)`)
 
@@ -227,7 +227,7 @@ func TestRuleSetFilters1(t *testing.T) {
 
 func TestRuleSetFilters2(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil, nil))
 
 	exprs := []string{
 		`open.filename in ["/etc/passwd", "/etc/shadow"] && process.uid == 0`,
@@ -284,7 +284,7 @@ func TestRuleSetFilters2(t *testing.T) {
 
 func TestRuleSetFilters3(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil, nil))
 
 	addRuleExpr(t, rs, `open.filename in ["/etc/passwd", "/etc/shadow"] && (process.uid == process.gid)`)
 
@@ -311,7 +311,7 @@ func TestRuleSetFilters3(t *testing.T) {
 
 func TestRuleSetFilters4(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil, nil))
 
 	addRuleExpr(t, rs, `open.filename =~ "/etc/passwd" && process.uid == 0`)
 
@@ -340,7 +340,7 @@ func TestRuleSetFilters4(t *testing.T) {
 
 func TestRuleSetFilters5(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil, nil))
 
 	addRuleExpr(t, rs, `(open.flags & O_CREAT > 0 || open.flags & O_EXCL > 0) && open.flags & O_RDWR > 0`)
 
@@ -365,7 +365,7 @@ func TestRuleSetFilters6(t *testing.T) {
 	t.Skip()
 
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, testSupportedDiscarders, enabled, nil, nil))
 
 	addRuleExpr(t, rs, `(open.flags & O_CREAT > 0 || open.flags & O_EXCL > 0) || process.name == "httpd"`)
 

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -16,6 +16,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/ast"
 )
 
+// NewOptsWithParams initializes a new Opts instance with Constants parameters
+func NewOptsWithParams(constants map[string]interface{}, legacyAttributes map[Field]Field) *Opts {
+	return &Opts{
+		Constants:        constants,
+		Macros:           make(map[MacroID]*Macro),
+		LegacyAttributes: legacyAttributes,
+	}
+}
+
 func parseRule(expr string, model Model, opts *Opts) (*Rule, error) {
 	rule := &Rule{
 		ID:         "id1",
@@ -39,7 +48,7 @@ func eval(t *testing.T, event *testEvent, expr string) (bool, *ast.Rule, error) 
 	ctx := &Context{}
 	ctx.SetObject(unsafe.Pointer(event))
 
-	opts := NewOptsWithParams(testConstants)
+	opts := NewOptsWithParams(testConstants, nil)
 	rule, err := parseRule(expr, model, opts)
 	if err != nil {
 		return false, nil, err
@@ -470,7 +479,7 @@ func TestMacroList(t *testing.T) {
 		t.Fatalf("%s\n%s", err, macro.Expression)
 	}
 
-	opts := NewOptsWithParams(make(map[string]interface{}))
+	opts := NewOptsWithParams(make(map[string]interface{}), nil)
 	opts.Macros = map[string]*Macro{
 		"list": macro,
 	}
@@ -515,7 +524,7 @@ func TestMacroExpression(t *testing.T) {
 		t.Fatalf("%s\n%s", err, macro.Expression)
 	}
 
-	opts := NewOptsWithParams(make(map[string]interface{}))
+	opts := NewOptsWithParams(make(map[string]interface{}), nil)
 	opts.Macros = map[string]*Macro{
 		"is_passwd": macro,
 	}
@@ -560,7 +569,7 @@ func TestMacroPartial(t *testing.T) {
 		t.Fatalf("%s\n%s", err, macro.Expression)
 	}
 
-	opts := NewOptsWithParams(make(map[string]interface{}))
+	opts := NewOptsWithParams(make(map[string]interface{}), nil)
 	opts.Macros = map[string]*Macro{
 		"is_passwd": macro,
 	}
@@ -626,7 +635,7 @@ func TestNestedMacros(t *testing.T) {
 
 	model := &testModel{}
 
-	opts := NewOptsWithParams(make(map[string]interface{}))
+	opts := NewOptsWithParams(make(map[string]interface{}), nil)
 	opts.Macros = map[string]*Macro{
 		"sensitive_files":     macro1,
 		"is_sensitive_opened": macro2,
@@ -664,7 +673,7 @@ func TestFieldValidator(t *testing.T) {
 
 func TestLegacyField(t *testing.T) {
 	model := &testModel{}
-	opts := NewOptsWithParams(testConstants)
+	opts := NewOptsWithParams(testConstants, legacyAttributes)
 
 	tests := []struct {
 		Expr     string
@@ -685,7 +694,7 @@ func TestLegacyField(t *testing.T) {
 
 func TestRegisterSyntaxError(t *testing.T) {
 	model := &testModel{}
-	opts := NewOptsWithParams(testConstants)
+	opts := NewOptsWithParams(testConstants, nil)
 
 	tests := []struct {
 		Expr     string

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -662,6 +662,27 @@ func TestFieldValidator(t *testing.T) {
 	}
 }
 
+func TestLegacyField(t *testing.T) {
+	model := &testModel{}
+	opts := NewOptsWithParams(testConstants)
+
+	tests := []struct {
+		Expr     string
+		Expected bool
+	}{
+		{Expr: `process.legacy_name == "/tmp/secrets"`, Expected: true},
+		{Expr: `process.random_name == "/tmp/secrets"`, Expected: false},
+		{Expr: `process.name == "/tmp/secrets"`, Expected: true},
+	}
+
+	for _, test := range tests {
+		_, err := parseRule(test.Expr, model, opts)
+		if err == nil != test.Expected {
+			t.Errorf("expected result `%t` not found, got `%t`\n%s", test.Expected, err == nil, test.Expr)
+		}
+	}
+}
+
 func TestRegisterSyntaxError(t *testing.T) {
 	model := &testModel{}
 	opts := NewOptsWithParams(testConstants)

--- a/pkg/security/secl/eval/macro.go
+++ b/pkg/security/secl/eval/macro.go
@@ -63,11 +63,11 @@ func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*
 
 	switch {
 	case macro.Expression != nil:
-		eval, _, _, err = nodeToEvaluator(macro.Expression, opts, state, model)
+		eval, _, _, err = nodeToEvaluator(macro.Expression, opts, state)
 	case macro.Array != nil:
-		eval, _, _, err = nodeToEvaluator(macro.Array, opts, state, model)
+		eval, _, _, err = nodeToEvaluator(macro.Array, opts, state)
 	case macro.Primary != nil:
-		eval, _, _, err = nodeToEvaluator(macro.Primary, opts, state, model)
+		eval, _, _, err = nodeToEvaluator(macro.Primary, opts, state)
 	}
 
 	if err != nil {

--- a/pkg/security/secl/eval/macro.go
+++ b/pkg/security/secl/eval/macro.go
@@ -63,11 +63,11 @@ func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*
 
 	switch {
 	case macro.Expression != nil:
-		eval, _, _, err = nodeToEvaluator(macro.Expression, opts, state)
+		eval, _, _, err = nodeToEvaluator(macro.Expression, opts, state, model)
 	case macro.Array != nil:
-		eval, _, _, err = nodeToEvaluator(macro.Array, opts, state)
+		eval, _, _, err = nodeToEvaluator(macro.Array, opts, state, model)
 	case macro.Primary != nil:
-		eval, _, _, err = nodeToEvaluator(macro.Primary, opts, state)
+		eval, _, _, err = nodeToEvaluator(macro.Primary, opts, state, model)
 	}
 
 	if err != nil {

--- a/pkg/security/secl/eval/model.go
+++ b/pkg/security/secl/eval/model.go
@@ -15,7 +15,4 @@ type Model interface {
 	GetIterator(field Field) (Iterator, error)
 	// NewEvent returns a new event instance
 	NewEvent() Event
-	// TranslateLegacyField transforms a legacy attribute into its updated version. Should be idempotent for non legacy
-	// fields.
-	TranslateLegacyField(field Field) Field
 }

--- a/pkg/security/secl/eval/model.go
+++ b/pkg/security/secl/eval/model.go
@@ -15,4 +15,7 @@ type Model interface {
 	GetIterator(field Field) (Iterator, error)
 	// NewEvent returns a new event instance
 	NewEvent() Event
+	// TranslateLegacyField transforms a legacy attribute into its updated version. Should be idempotent for non legacy
+	// fields.
+	TranslateLegacyField(field Field) Field
 }

--- a/pkg/security/secl/eval/model_test.go
+++ b/pkg/security/secl/eval/model_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+var legacyAttributes = map[Field]Field{
+	"process.legacy_name": "process.name",
+}
+
 type testItem struct {
 	key   int
 	value int

--- a/pkg/security/secl/eval/model_test.go
+++ b/pkg/security/secl/eval/model_test.go
@@ -139,6 +139,15 @@ func (m *testModel) ValidateField(key string, value FieldValue) error {
 	return nil
 }
 
+func (m *testModel) TranslateLegacyField(field Field) Field {
+	switch field {
+	case "process.legacy_name":
+		return "process.name"
+	default:
+		return field
+	}
+}
+
 func (m *testModel) GetIterator(field Field) (Iterator, error) {
 	switch field {
 	case "process.list":

--- a/pkg/security/secl/eval/rule.go
+++ b/pkg/security/secl/eval/rule.go
@@ -218,7 +218,7 @@ func ruleToEvaluator(rule *ast.Rule, model Model, opts *Opts) (*RuleEvaluator, e
 	}
 	state := newState(model, "", macros)
 
-	eval, _, _, err := nodeToEvaluator(rule.BooleanExpression, opts, state, model)
+	eval, _, _, err := nodeToEvaluator(rule.BooleanExpression, opts, state)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +304,7 @@ func (r *Rule) GenPartials() error {
 
 	for _, field := range r.GetFields() {
 		state := newState(r.Model, field, macroPartials[field])
-		pEval, _, _, err := nodeToEvaluator(r.ast.BooleanExpression, r.Opts, state, r.Model)
+		pEval, _, _, err := nodeToEvaluator(r.ast.BooleanExpression, r.Opts, state)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't generate partial for field %s and rule %s", field, r.ID)
 		}

--- a/pkg/security/secl/eval/rule.go
+++ b/pkg/security/secl/eval/rule.go
@@ -218,7 +218,7 @@ func ruleToEvaluator(rule *ast.Rule, model Model, opts *Opts) (*RuleEvaluator, e
 	}
 	state := newState(model, "", macros)
 
-	eval, _, _, err := nodeToEvaluator(rule.BooleanExpression, opts, state)
+	eval, _, _, err := nodeToEvaluator(rule.BooleanExpression, opts, state, model)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +304,7 @@ func (r *Rule) GenPartials() error {
 
 	for _, field := range r.GetFields() {
 		state := newState(r.Model, field, macroPartials[field])
-		pEval, _, _, err := nodeToEvaluator(r.ast.BooleanExpression, r.Opts, state)
+		pEval, _, _, err := nodeToEvaluator(r.ast.BooleanExpression, r.Opts, state, r.Model)
 		if err != nil {
 			return errors.Wrapf(err, "couldn't generate partial for field %s and rule %s", field, r.ID)
 		}

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
@@ -18,7 +19,7 @@ import (
 func TestChmod(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `chmod.filename == "{{.Root}}/test-chmod" && (chmod.mode == 0707 || chmod.mode == 0757)`,
+		Expression: `chmod.file.path == "{{.Root}}/test-chmod" && chmod.file.destination.mode in [0707, 0447, 0757] && chmod.file.uid == 98 && chmod.file.gid == 99`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
@@ -27,20 +28,16 @@ func TestChmod(t *testing.T) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("test-chmod")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := os.Create(testFile)
+	fileMode := 0o447
+	expectedMode := applyUmask(fileMode)
+	testFile, testFilePtr, err := test.CreateWithOptions("test-chmod", 98, 99, fileMode)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(testFile)
-	defer f.Close()
 
 	t.Run("chmod", func(t *testing.T) {
-		if _, _, errno := syscall.Syscall(syscall.SYS_CHMOD, uintptr(testFilePtr), uintptr(0707), 0); errno != 0 {
+		if _, _, errno := syscall.Syscall(syscall.SYS_CHMOD, uintptr(testFilePtr), uintptr(0o707), 0); errno != 0 {
 			t.Fatal(err)
 		}
 
@@ -52,22 +49,40 @@ func TestChmod(t *testing.T) {
 				t.Errorf("expected chmod event, got %s", event.GetType())
 			}
 
-			if mode := event.Chmod.Mode; mode != 0707 {
-				t.Errorf("expected chmod mode 0707, got %#o", mode)
+			if mode := event.Chmod.Mode; mode != 0o707 {
+				t.Errorf("expected chmod mode 0o707, got %#o", mode)
 			}
 
-			if inode := getInode(t, testFile); inode != event.Chmod.Inode {
-				t.Logf("expected inode %d, got %d", event.Chmod.Inode, inode)
+			if inode := getInode(t, testFile); inode != event.Chmod.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Chmod.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "chmod.container_path")
+			if int(event.Chmod.File.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chmod.File.Mode) & expectedMode)
+			}
+
+			now := time.Now()
+			if event.Chmod.File.MTime.After(now) || event.Chmod.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Chmod.File.MTime)
+			}
+
+			if event.Chmod.File.CTime.After(now) || event.Chmod.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Chmod.File.CTime)
+			}
+
+			testContainerPath(t, event, "chmod.file.container_path")
 		}
 	})
 
 	t.Run("fchmod", func(t *testing.T) {
-		if _, _, errno := syscall.Syscall(syscall.SYS_FCHMOD, f.Fd(), uintptr(0707), 0); errno != 0 {
+		f, err := os.Open(testFile)
+		if err != nil {
 			t.Fatal(err)
 		}
+		if _, _, errno := syscall.Syscall(syscall.SYS_FCHMOD, f.Fd(), uintptr(0o447), 0); errno != 0 {
+			t.Fatal(err)
+		}
+		defer f.Close()
 
 		event, _, err := test.GetEvent()
 		if err != nil {
@@ -77,20 +92,33 @@ func TestChmod(t *testing.T) {
 				t.Errorf("expected chmod event, got %s", event.GetType())
 			}
 
-			if mode := event.Chmod.Mode; mode != 0707 {
-				t.Errorf("expected chmod mode 0707, got %#o", mode)
+			if mode := event.Chmod.Mode; mode != 0o447 {
+				t.Errorf("expected chmod mode 0o447, got %#o", mode)
 			}
 
-			if inode := getInode(t, testFile); inode != event.Chmod.Inode {
-				t.Logf("expected inode %d, got %d", event.Chmod.Inode, inode)
+			if inode := getInode(t, testFile); inode != event.Chmod.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Chmod.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "chmod.container_path")
+			if int(event.Chmod.File.Mode) & 0o707 != 0o707 {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chmod.File.Mode) & expectedMode)
+			}
+
+			now := time.Now()
+			if event.Chmod.File.MTime.After(now) || event.Chmod.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Chmod.File.MTime)
+			}
+
+			if event.Chmod.File.CTime.After(now) || event.Chmod.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Chmod.File.CTime)
+			}
+
+			testContainerPath(t, event, "chmod.file.container_path")
 		}
 	})
 
 	t.Run("fchmodat", func(t *testing.T) {
-		if _, _, errno := syscall.Syscall6(syscall.SYS_FCHMODAT, 0, uintptr(testFilePtr), uintptr(0757), 0, 0, 0); errno != 0 {
+		if _, _, errno := syscall.Syscall6(syscall.SYS_FCHMODAT, 0, uintptr(testFilePtr), uintptr(0o757), 0, 0, 0); errno != 0 {
 			t.Fatal(err)
 		}
 
@@ -102,15 +130,28 @@ func TestChmod(t *testing.T) {
 				t.Errorf("expected chmod event, got %s", event.GetType())
 			}
 
-			if mode := event.Chmod.Mode; mode != 0757 {
-				t.Errorf("expected chmod mode 0757, got %#o", mode)
+			if mode := event.Chmod.Mode; mode != 0o757 {
+				t.Errorf("expected chmod mode 0o757, got %#o", mode)
 			}
 
-			if inode := getInode(t, testFile); inode != event.Chmod.Inode {
-				t.Logf("expected inode %d, got %d", event.Chmod.Inode, inode)
+			if inode := getInode(t, testFile); inode != event.Chmod.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Chmod.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "chmod.container_path")
+			if int(event.Chmod.File.Mode) & 0o447 != 0o447 {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chmod.File.Mode) & expectedMode)
+			}
+
+			now := time.Now()
+			if event.Chmod.File.MTime.After(now) || event.Chmod.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Chmod.File.MTime)
+			}
+
+			if event.Chmod.File.CTime.After(now) || event.Chmod.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Chmod.File.CTime)
+			}
+
+			testContainerPath(t, event, "chmod.file.container_path")
 		}
 	})
 }

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -57,16 +57,16 @@ func TestChmod(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chmod.File.Inode, inode)
 			}
 
-			if int(event.Chmod.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chmod.File.Mode) & expectedMode)
+			if int(event.Chmod.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chmod.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Chmod.File.MTime.After(now) || event.Chmod.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chmod.File.MTime.After(now) || event.Chmod.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chmod.File.MTime)
 			}
 
-			if event.Chmod.File.CTime.After(now) || event.Chmod.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chmod.File.CTime.After(now) || event.Chmod.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chmod.File.CTime)
 			}
 
@@ -100,16 +100,16 @@ func TestChmod(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chmod.File.Inode, inode)
 			}
 
-			if int(event.Chmod.File.Mode) & 0o707 != 0o707 {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chmod.File.Mode) & expectedMode)
+			if int(event.Chmod.File.Mode)&0o707 != 0o707 {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chmod.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Chmod.File.MTime.After(now) || event.Chmod.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chmod.File.MTime.After(now) || event.Chmod.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chmod.File.MTime)
 			}
 
-			if event.Chmod.File.CTime.After(now) || event.Chmod.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chmod.File.CTime.After(now) || event.Chmod.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chmod.File.CTime)
 			}
 
@@ -138,16 +138,16 @@ func TestChmod(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chmod.File.Inode, inode)
 			}
 
-			if int(event.Chmod.File.Mode) & 0o447 != 0o447 {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chmod.File.Mode) & expectedMode)
+			if int(event.Chmod.File.Mode)&0o447 != 0o447 {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chmod.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Chmod.File.MTime.After(now) || event.Chmod.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chmod.File.MTime.After(now) || event.Chmod.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chmod.File.MTime)
 			}
 
-			if event.Chmod.File.CTime.After(now) || event.Chmod.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chmod.File.CTime.After(now) || event.Chmod.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chmod.File.CTime)
 			}
 

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -64,8 +64,8 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			if int(event.Chown.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode)&expectedMode)
 			}
 
 			if event.Chown.File.UID != 98 {
@@ -77,11 +77,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 		}
@@ -117,8 +117,8 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			if int(event.Chown.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode)&expectedMode)
 			}
 
 			if event.Chown.File.UID != 100 {
@@ -130,11 +130,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 		}
@@ -165,8 +165,8 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			if int(event.Chown.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode)&expectedMode)
 			}
 
 			if event.Chown.File.UID != 101 {
@@ -178,11 +178,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 		}
@@ -227,7 +227,7 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & 0o777 != 0o777 {
+			if int(event.Chown.File.Mode)&0o777 != 0o777 {
 				t.Errorf("expected initial mode %d, got %d", 0o777, int(event.Chown.File.Mode))
 			}
 
@@ -240,11 +240,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 		}
@@ -289,7 +289,7 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & 0o777 != 0o777 {
+			if int(event.Chown.File.Mode)&0o777 != 0o777 {
 				t.Errorf("expected initial mode %d, got %d", 0o777, int(event.Chown.File.Mode))
 			}
 
@@ -302,11 +302,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 		}
@@ -338,8 +338,8 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			if int(event.Chown.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode)&expectedMode)
 			}
 
 			if event.Chown.File.UID != 102 {
@@ -351,11 +351,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 		}
@@ -386,8 +386,8 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			if int(event.Chown.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode)&expectedMode)
 			}
 
 			if event.Chown.File.UID != 101 {
@@ -399,11 +399,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 		}

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -65,8 +65,8 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			if int(event.Chown.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode)&expectedMode)
 			}
 
 			if event.Chown.File.UID != 98 {
@@ -78,11 +78,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 
@@ -121,8 +121,8 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			if int(event.Chown.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode)&expectedMode)
 			}
 
 			if event.Chown.File.UID != 100 {
@@ -134,11 +134,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 
@@ -171,8 +171,8 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			if int(event.Chown.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode)&expectedMode)
 			}
 
 			if event.Chown.File.UID != 101 {
@@ -184,11 +184,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 
@@ -235,7 +235,7 @@ func TestChown(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			if int(event.Chown.File.Mode) & 0o777 != 0o777 {
+			if int(event.Chown.File.Mode)&0o777 != 0o777 {
 				t.Errorf("expected initial mode %d, got %d", 0o777, int(event.Chown.File.Mode))
 			}
 
@@ -248,11 +248,11 @@ func TestChown(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
 			}
 
-			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
 			}
 

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
@@ -18,12 +19,12 @@ import (
 func TestChown(t *testing.T) {
 	ruleDef := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `chown.filename == "{{.Root}}/test-chown"`,
+		Expression: `chown.file.path == "{{.Root}}/test-chown" && chown.file.destination.uid in [100, 101, 102, 103] && chown.file.destination.gid in [200, 201, 202, 203]`,
 	}
 
 	ruleDef2 := &rules.RuleDefinition{
 		ID:         "test_rule2",
-		Expression: `chown.filename == "{{.Root}}/test-symlink"`,
+		Expression: `chown.file.path == "{{.Root}}/test-symlink" && chown.file.destination.uid in [100, 101, 102, 103] && chown.file.destination.gid in [200, 201, 202, 203]`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{ruleDef, ruleDef2}, testOpts{})
@@ -32,17 +33,12 @@ func TestChown(t *testing.T) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("test-chown")
+	fileMode := 0o447
+	expectedMode := applyUmask(fileMode)
+	testFile, testFilePtr, err := test.CreateWithOptions("test-chown", 98, 99, fileMode)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	f, err := os.Create(testFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(testFile)
-	defer f.Close()
 
 	t.Run("chown", func(t *testing.T) {
 		if _, _, errno := syscall.Syscall(syscall.SYS_CHOWN, uintptr(testFilePtr), 100, 200); errno != 0 {
@@ -65,19 +61,45 @@ func TestChown(t *testing.T) {
 				t.Errorf("expected chown group 200, got %d", group)
 			}
 
-			if inode := getInode(t, testFile); inode != event.Chown.Inode {
-				t.Logf("expected inode %d, got %d", event.Chown.Inode, inode)
+			if inode := getInode(t, testFile); inode != event.Chown.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "chown.container_path")
+			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			}
+
+			if event.Chown.File.UID != 98 {
+				t.Errorf("expected initial UID %d, got %d", 98, event.Chown.File.UID)
+			}
+
+			if event.Chown.File.GID != 99 {
+				t.Errorf("expected initial GID %d, got %d", 99, event.Chown.File.GID)
+			}
+
+			now := time.Now()
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
+			}
+
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
+			}
+
+			testContainerPath(t, event, "chown.file.container_path")
 		}
 	})
 
 	t.Run("fchown", func(t *testing.T) {
+		f, err := os.Open(testFile)
+		if err != nil {
+			t.Fatal(err)
+		}
 		// fchown syscall
 		if _, _, errno := syscall.Syscall(syscall.SYS_FCHOWN, f.Fd(), 101, 201); errno != 0 {
 			t.Fatal(err)
 		}
+		defer f.Close()
 
 		event, _, err := test.GetEvent()
 		if err != nil {
@@ -95,11 +117,32 @@ func TestChown(t *testing.T) {
 				t.Errorf("expected chown group 201, got %d", group)
 			}
 
-			if inode := getInode(t, testFile); inode != event.Chown.Inode {
-				t.Logf("expected inode %d, got %d", event.Chown.Inode, inode)
+			if inode := getInode(t, testFile); inode != event.Chown.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "chown.container_path")
+			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			}
+
+			if event.Chown.File.UID != 100 {
+				t.Errorf("expected initial UID %d, got %d", 100, event.Chown.File.UID)
+			}
+
+			if event.Chown.File.GID != 200 {
+				t.Errorf("expected initial GID %d, got %d", 200, event.Chown.File.GID)
+			}
+
+			now := time.Now()
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
+			}
+
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
+			}
+
+			testContainerPath(t, event, "chown.file.container_path")
 		}
 	})
 
@@ -124,11 +167,32 @@ func TestChown(t *testing.T) {
 				t.Errorf("expected chown group 202, got %d", group)
 			}
 
-			if inode := getInode(t, testFile); inode != event.Chown.Inode {
-				t.Logf("expected inode %d, got %d", event.Chown.Inode, inode)
+			if inode := getInode(t, testFile); inode != event.Chown.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "chown.container_path")
+			if int(event.Chown.File.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Chown.File.Mode) & expectedMode)
+			}
+
+			if event.Chown.File.UID != 101 {
+				t.Errorf("expected initial UID %d, got %d", 101, event.Chown.File.UID)
+			}
+
+			if event.Chown.File.GID != 201 {
+				t.Errorf("expected initial GID %d, got %d", 201, event.Chown.File.GID)
+			}
+
+			now := time.Now()
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
+			}
+
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
+			}
+
+			testContainerPath(t, event, "chown.file.container_path")
 		}
 	})
 
@@ -167,11 +231,32 @@ func TestChown(t *testing.T) {
 				t.Errorf("expected chown group 203, got %d", group)
 			}
 
-			if inode := getInode(t, testSymlink); inode != event.Chown.Inode {
-				t.Logf("expected inode %d, got %d", event.Chown.Inode, inode)
+			if inode := getInode(t, testSymlink); inode != event.Chown.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Chown.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "chown.container_path")
+			if int(event.Chown.File.Mode) & 0o777 != 0o777 {
+				t.Errorf("expected initial mode %d, got %d", 0o777, int(event.Chown.File.Mode))
+			}
+
+			if event.Chown.File.UID != 0 {
+				t.Errorf("expected initial UID %d, got %d", 0, event.Chown.File.UID)
+			}
+
+			if event.Chown.File.GID != 0 {
+				t.Errorf("expected initial GID %d, got %d", 0, event.Chown.File.GID)
+			}
+
+			now := time.Now()
+			if event.Chown.File.MTime.After(now) || event.Chown.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Chown.File.MTime)
+			}
+
+			if event.Chown.File.CTime.After(now) || event.Chown.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Chown.File.CTime)
+			}
+
+			testContainerPath(t, event, "chown.file.container_path")
 		}
 	})
 }

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -44,7 +44,7 @@ func openTestFile(test *testModule, filename string, flags int) (int, string, er
 func TestOpenBasenameApproverFilter(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename == "{{.Root}}/test-oba-1"`,
+		Expression: `open.file.path == "{{.Root}}/test-oba-1"`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
@@ -117,7 +117,7 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 func TestOpenParentDiscarderFilter(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename =~ "/usr/test-obd-2" && open.flags & (O_CREAT | O_SYNC) > 0`,
+		Expression: `open.file.path =~ "/usr/test-obd-2" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
@@ -199,7 +199,7 @@ func TestOpenFlagsApproverFilter(t *testing.T) {
 func TestOpenProcessPidDiscarder(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename =="{{.Root}}/test-oba-1" && process.filename == "/bin/cat"`,
+		Expression: `open.file.path =="{{.Root}}/test-oba-1" && process.file.path == "/bin/cat"`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
@@ -234,7 +234,7 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 func TestDiscarderRetentionFilter(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename =~ "{{.Root}}/test-obc-1" && open.flags & (O_CREAT | O_SYNC) > 0`,
+		Expression: `open.file.path =~ "{{.Root}}/test-obc-1" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
 	testDrive, err := newTestDrive("xfs", nil)

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -11,15 +11,15 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
 
 func TestLink(t *testing.T) {
-
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `link.source.filename == "{{.Root}}/test-link" && link.target.filename == "{{.Root}}/test2-link"`,
+		Expression: `link.file.path == "{{.Root}}/test-link" && link.file.destination.path == "{{.Root}}/test2-link" && link.file.uid == 98 && link.file.gid == 99 && link.file.destination.uid == 98 && link.file.destination.gid == 99`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
@@ -28,17 +28,10 @@ func TestLink(t *testing.T) {
 	}
 	defer test.Close()
 
-	testOldFile, testOldFilePtr, err := test.Path("test-link")
+	fileMode := 0o447
+	expectedMode := applyUmask(fileMode)
+	_, testOldFilePtr, err := test.CreateWithOptions("test-link", 98, 99, fileMode)
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := os.Create(testOldFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -47,42 +40,99 @@ func TestLink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, errno := syscall.Syscall(syscall.SYS_LINK, uintptr(testOldFilePtr), uintptr(testNewFilePtr), 0)
-	if errno != 0 {
-		t.Fatal(err)
-	}
-
-	event, _, err := test.GetEvent()
-	if err != nil {
-		t.Error(err)
-	} else {
-		if event.GetType() != "link" {
-			t.Errorf("expected link event, got %s", event.GetType())
+	t.Run("link", func(t *testing.T) {
+		_, _, errno := syscall.Syscall(syscall.SYS_LINK, uintptr(testOldFilePtr), uintptr(testNewFilePtr), 0)
+		if errno != 0 {
+			t.Fatal(err)
 		}
-	}
+
+		event, _, err := test.GetEvent()
+		if err != nil {
+			t.Error(err)
+		} else {
+			if event.GetType() != "link" {
+				t.Errorf("expected link event, got %s", event.GetType())
+			}
+
+			testContainerPath(t, event, "link.file.container_path")
+			testContainerPath(t, event, "link.file.destination.container_path")
+
+			if int(event.Link.Source.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected source mode %d, got %d", expectedMode, event.Link.Source.Mode)
+			}
+
+			if int(event.Link.Target.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected target mode %d, got %d", expectedMode, event.Link.Target.Mode)
+			}
+
+			now := time.Now()
+			if event.Link.Source.MTime.After(now) || event.Link.Source.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected source mtime close to %s, got %s", now, event.Link.Source.MTime)
+			}
+
+			if event.Link.Source.CTime.After(now) || event.Link.Source.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected source ctime close to %s, got %s", now, event.Link.Source.CTime)
+			}
+
+			if event.Link.Target.MTime.After(now) || event.Link.Target.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected target mtime close to %s, got %s", now, event.Link.Target.MTime)
+			}
+
+			if event.Link.Target.CTime.After(now) || event.Link.Target.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected target ctime close to %s, got %s", now, event.Link.Target.CTime)
+			}
+		}
+	})
 
 	if err := os.Remove(testNewFile); err != nil {
 		t.Fatal(err)
 	}
 
-	_, _, errno = syscall.Syscall6(syscall.SYS_LINKAT, 0, uintptr(testOldFilePtr), 0, uintptr(testNewFilePtr), 0, 0)
-	if errno != 0 {
-		t.Fatal(err)
-	}
-
-	event, _, err = test.GetEvent()
-	if err != nil {
-		t.Error(err)
-	} else {
-		if event.GetType() != "link" {
-			t.Errorf("expected rename event, got %s", event.GetType())
+	t.Run("linkat", func(t *testing.T) {
+		_, _, errno := syscall.Syscall6(syscall.SYS_LINKAT, 0, uintptr(testOldFilePtr), 0, uintptr(testNewFilePtr), 0, 0)
+		if errno != 0 {
+			t.Fatal(err)
 		}
 
-		if inode := getInode(t, testNewFile); inode != event.Link.Source.Inode {
-			t.Logf("expected inode %d, got %d", event.Link.Source.Inode, inode)
-		}
+		event, _, err := test.GetEvent()
+		if err != nil {
+			t.Error(err)
+		} else {
+			if event.GetType() != "link" {
+				t.Errorf("expected rename event, got %s", event.GetType())
+			}
 
-		testContainerPath(t, event, "link.source.container_path")
-		testContainerPath(t, event, "link.target.container_path")
-	}
+			if inode := getInode(t, testNewFile); inode != event.Link.Source.Inode {
+				t.Logf("expected inode %d, got %d", event.Link.Source.Inode, inode)
+			}
+
+			testContainerPath(t, event, "link.file.container_path")
+			testContainerPath(t, event, "link.file.destination.container_path")
+
+			if int(event.Link.Source.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, event.Link.Source.Mode)
+			}
+
+			if int(event.Link.Target.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected target mode %d, got %d", expectedMode, event.Link.Target.Mode)
+			}
+
+			now := time.Now()
+			if event.Link.Source.MTime.After(now) || event.Link.Source.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected source mtime close to %s, got %s", now, event.Link.Source.MTime)
+			}
+
+			if event.Link.Source.CTime.After(now) || event.Link.Source.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected source ctime close to %s, got %s", now, event.Link.Source.CTime)
+			}
+
+			if event.Link.Target.MTime.After(now) || event.Link.Target.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected target mtime close to %s, got %s", now, event.Link.Target.MTime)
+			}
+
+			if event.Link.Target.CTime.After(now) || event.Link.Target.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected target ctime close to %s, got %s", now, event.Link.Target.CTime)
+			}
+		}
+	})
 }

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -57,28 +57,28 @@ func TestLink(t *testing.T) {
 			testContainerPath(t, event, "link.file.container_path")
 			testContainerPath(t, event, "link.file.destination.container_path")
 
-			if int(event.Link.Source.Mode) & expectedMode != expectedMode {
+			if int(event.Link.Source.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected source mode %d, got %d", expectedMode, event.Link.Source.Mode)
 			}
 
-			if int(event.Link.Target.Mode) & expectedMode != expectedMode {
+			if int(event.Link.Target.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected target mode %d, got %d", expectedMode, event.Link.Target.Mode)
 			}
 
 			now := time.Now()
-			if event.Link.Source.MTime.After(now) || event.Link.Source.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Link.Source.MTime.After(now) || event.Link.Source.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected source mtime close to %s, got %s", now, event.Link.Source.MTime)
 			}
 
-			if event.Link.Source.CTime.After(now) || event.Link.Source.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Link.Source.CTime.After(now) || event.Link.Source.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected source ctime close to %s, got %s", now, event.Link.Source.CTime)
 			}
 
-			if event.Link.Target.MTime.After(now) || event.Link.Target.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Link.Target.MTime.After(now) || event.Link.Target.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected target mtime close to %s, got %s", now, event.Link.Target.MTime)
 			}
 
-			if event.Link.Target.CTime.After(now) || event.Link.Target.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Link.Target.CTime.After(now) || event.Link.Target.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected target ctime close to %s, got %s", now, event.Link.Target.CTime)
 			}
 		}
@@ -109,28 +109,28 @@ func TestLink(t *testing.T) {
 			testContainerPath(t, event, "link.file.container_path")
 			testContainerPath(t, event, "link.file.destination.container_path")
 
-			if int(event.Link.Source.Mode) & expectedMode != expectedMode {
+			if int(event.Link.Source.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected initial mode %d, got %d", expectedMode, event.Link.Source.Mode)
 			}
 
-			if int(event.Link.Target.Mode) & expectedMode != expectedMode {
+			if int(event.Link.Target.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected target mode %d, got %d", expectedMode, event.Link.Target.Mode)
 			}
 
 			now := time.Now()
-			if event.Link.Source.MTime.After(now) || event.Link.Source.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Link.Source.MTime.After(now) || event.Link.Source.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected source mtime close to %s, got %s", now, event.Link.Source.MTime)
 			}
 
-			if event.Link.Source.CTime.After(now) || event.Link.Source.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Link.Source.CTime.After(now) || event.Link.Source.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected source ctime close to %s, got %s", now, event.Link.Source.CTime)
 			}
 
-			if event.Link.Target.MTime.After(now) || event.Link.Target.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Link.Target.MTime.After(now) || event.Link.Target.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected target mtime close to %s, got %s", now, event.Link.Target.MTime)
 			}
 
-			if event.Link.Target.CTime.After(now) || event.Link.Target.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Link.Target.CTime.After(now) || event.Link.Target.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected target ctime close to %s, got %s", now, event.Link.Target.CTime)
 			}
 		}

--- a/pkg/security/tests/macros_test.go
+++ b/pkg/security/tests/macros_test.go
@@ -29,7 +29,7 @@ func TestMacros(t *testing.T) {
 	rules := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule",
-			Expression: `testmacro in testmacro2 && mkdir.filename in testmacro2`,
+			Expression: `testmacro in testmacro2 && mkdir.file.path in testmacro2`,
 		},
 	}
 

--- a/pkg/security/tests/mitre_test.go
+++ b/pkg/security/tests/mitre_test.go
@@ -139,4 +139,10 @@ func TestMitre(t *testing.T) {
 			}
 		})
 	}
+
+	// The default policy can be somewhat noisy and some events may leak to the next tests (there is a short delay
+	// between the reset of the maps and the reload of the rules, we can't move the reset after the reload either,
+	// otherwise the ruleset_reload test won't work => we would have reset the channel that contains the reload event).
+	// Load a fake new test module to empty the rules and properly cleanup the channels.
+	_, _ = newTestModule(nil, nil, testOpts{})
 }

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -64,16 +64,16 @@ func TestMkdir(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Mkdir.File.Inode, inode)
 			}
 
-			if int(event.Mkdir.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Mkdir.File.Mode) & expectedMode)
+			if int(event.Mkdir.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Mkdir.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Mkdir.File.MTime.After(now) || event.Mkdir.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Mkdir.File.MTime.After(now) || event.Mkdir.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Mkdir.File.MTime)
 			}
 
-			if event.Mkdir.File.CTime.After(now) || event.Mkdir.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Mkdir.File.CTime.After(now) || event.Mkdir.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Mkdir.File.CTime)
 			}
 
@@ -108,16 +108,16 @@ func TestMkdir(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Mkdir.File.Inode, inode)
 			}
 
-			if int(event.Mkdir.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Mkdir.File.Mode) & expectedMode)
+			if int(event.Mkdir.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Mkdir.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Mkdir.File.MTime.After(now) || event.Mkdir.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Mkdir.File.MTime.After(now) || event.Mkdir.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Mkdir.File.MTime)
 			}
 
-			if event.Mkdir.File.CTime.After(now) || event.Mkdir.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Mkdir.File.CTime.After(now) || event.Mkdir.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Mkdir.File.CTime)
 			}
 

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -23,7 +23,7 @@ func TestMount(t *testing.T) {
 	dstMntBasename := "test-dest-mount"
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: fmt.Sprintf(`utimes.filename == "{{.Root}}/%s/test-mount"`, dstMntBasename),
+		Expression: fmt.Sprintf(`utimes.file.path == "{{.Root}}/%s/test-mount"`, dstMntBasename),
 	}
 
 	testDrive, err := newTestDrive("ext4", []string{})
@@ -112,8 +112,8 @@ func TestMount(t *testing.T) {
 				t.Errorf("expected utimes event, got %s", event.GetType())
 			}
 
-			if event.Utimes.PathnameStr != utimFile {
-				t.Errorf("expected %v for PathnameStr, got %v", utimFile, event.Utimes.PathnameStr)
+			if event.Utimes.File.PathnameStr != utimFile {
+				t.Errorf("expected %v for PathnameStr, got %v", utimFile, event.Utimes.File.PathnameStr)
 			}
 		}
 	})

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -298,16 +298,16 @@ func TestOpenMetadata(t *testing.T) {
 				t.Errorf("expected open event, got %s", event.GetType())
 			}
 
-			if int(event.Open.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected mode %d, got %d", expectedMode, int(event.Open.File.Mode) & expectedMode)
+			if int(event.Open.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected mode %d, got %d", expectedMode, int(event.Open.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Open.File.MTime.After(now) || event.Open.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Open.File.MTime.After(now) || event.Open.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Open.File.MTime)
 			}
 
-			if event.Open.File.CTime.After(now) || event.Open.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Open.File.CTime.After(now) || event.Open.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Open.File.CTime)
 			}
 		}

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -33,7 +33,7 @@ func TestProbeMonitor(t *testing.T) {
 
 	rule := &rules.RuleDefinition{
 		ID:         "path_test",
-		Expression: `open.filename =~ "*a/test-open" && open.flags & O_CREAT != 0`,
+		Expression: `open.file.path =~ "*a/test-open" && open.flags & O_CREAT != 0`,
 	}
 
 	probeMonitorOpts := testOpts{}
@@ -116,7 +116,7 @@ func TestProbeMonitor(t *testing.T) {
 func TestNoisyProcess(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "path_test",
-		Expression: `open.filename =~ "*do-not-match/test-open" && open.flags & O_CREAT != 0`,
+		Expression: `open.file.path =~ "*do-not-match/test-open" && open.flags & O_CREAT != 0`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{disableDiscarders: true, eventsCountThreshold: 1000})

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -294,16 +294,16 @@ func TestProcessMetadata(t *testing.T) {
 			t.Errorf("expected exec event, got %s", event.GetType())
 		}
 
-		if int(event.Exec.FileFields.Mode) & expectedMode != expectedMode {
-			t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Exec.FileFields.Mode) & expectedMode)
+		if int(event.Exec.FileFields.Mode)&expectedMode != expectedMode {
+			t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Exec.FileFields.Mode)&expectedMode)
 		}
 
 		now := time.Now()
-		if event.Exec.FileFields.MTime.After(now) || event.Exec.FileFields.MTime.Before(now.Add(-1 * time.Hour)) {
+		if event.Exec.FileFields.MTime.After(now) || event.Exec.FileFields.MTime.Before(now.Add(-1*time.Hour)) {
 			t.Errorf("expected mtime close to %s, got %s", now, event.Exec.FileFields.MTime)
 		}
 
-		if event.Exec.FileFields.CTime.After(now) || event.Exec.FileFields.CTime.Before(now.Add(-1 * time.Hour)) {
+		if event.Exec.FileFields.CTime.After(now) || event.Exec.FileFields.CTime.Before(now.Add(-1*time.Hour)) {
 			t.Errorf("expected ctime close to %s, got %s", now, event.Exec.FileFields.CTime)
 		}
 	}

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -65,28 +65,28 @@ func TestRename(t *testing.T) {
 			testContainerPath(t, event, "rename.file.container_path")
 			testContainerPath(t, event, "rename.file.destination.container_path")
 
-			if int(event.Rename.Old.Mode) & expectedMode != expectedMode {
+			if int(event.Rename.Old.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected old mode %d, got %d", expectedMode, event.Rename.Old.Mode)
 			}
 
 			now := time.Now()
-			if event.Rename.Old.MTime.After(now) || event.Rename.Old.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.Old.MTime.After(now) || event.Rename.Old.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected old mtime close to %s, got %s", now, event.Rename.Old.MTime)
 			}
 
-			if event.Rename.Old.CTime.After(now) || event.Rename.Old.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.Old.CTime.After(now) || event.Rename.Old.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected old ctime close to %s, got %s", now, event.Rename.Old.CTime)
 			}
 
-			if int(event.Rename.New.Mode) & expectedMode != expectedMode {
+			if int(event.Rename.New.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected new mode %d, got %d", expectedMode, event.Rename.New.Mode)
 			}
 
-			if event.Rename.New.MTime.After(now) || event.Rename.New.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.New.MTime.After(now) || event.Rename.New.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected new mtime close to %s, got %s", now, event.Rename.New.MTime)
 			}
 
-			if event.Rename.New.CTime.After(now) || event.Rename.New.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.New.CTime.After(now) || event.Rename.New.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected new ctime close to %s, got %s", now, event.Rename.New.CTime)
 			}
 		}
@@ -117,28 +117,28 @@ func TestRename(t *testing.T) {
 			testContainerPath(t, event, "rename.file.container_path")
 			testContainerPath(t, event, "rename.file.destination.container_path")
 
-			if int(event.Rename.Old.Mode) & expectedMode != expectedMode {
+			if int(event.Rename.Old.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected old mode %d, got %d", expectedMode, event.Rename.Old.Mode)
 			}
 
 			now := time.Now()
-			if event.Rename.Old.MTime.After(now) || event.Rename.Old.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.Old.MTime.After(now) || event.Rename.Old.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected old mtime close to %s, got %s", now, event.Rename.Old.MTime)
 			}
 
-			if event.Rename.Old.CTime.After(now) || event.Rename.Old.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.Old.CTime.After(now) || event.Rename.Old.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected old ctime close to %s, got %s", now, event.Rename.Old.CTime)
 			}
 
-			if int(event.Rename.New.Mode) & expectedMode != expectedMode {
+			if int(event.Rename.New.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected new mode %d, got %d", expectedMode, event.Rename.New.Mode)
 			}
 
-			if event.Rename.New.MTime.After(now) || event.Rename.New.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.New.MTime.After(now) || event.Rename.New.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected new mtime close to %s, got %s", now, event.Rename.New.MTime)
 			}
 
-			if event.Rename.New.CTime.After(now) || event.Rename.New.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.New.CTime.After(now) || event.Rename.New.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected new ctime close to %s, got %s", now, event.Rename.New.CTime)
 			}
 		}
@@ -179,28 +179,28 @@ func TestRename(t *testing.T) {
 			testContainerPath(t, event, "rename.file.container_path")
 			testContainerPath(t, event, "rename.file.destination.container_path")
 
-			if int(event.Rename.Old.Mode) & expectedMode != expectedMode {
+			if int(event.Rename.Old.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected old mode %d, got %d", expectedMode, event.Rename.Old.Mode)
 			}
 
 			now := time.Now()
-			if event.Rename.Old.MTime.After(now) || event.Rename.Old.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.Old.MTime.After(now) || event.Rename.Old.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected old mtime close to %s, got %s", now, event.Rename.Old.MTime)
 			}
 
-			if event.Rename.Old.CTime.After(now) || event.Rename.Old.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.Old.CTime.After(now) || event.Rename.Old.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected old ctime close to %s, got %s", now, event.Rename.Old.CTime)
 			}
 
-			if int(event.Rename.New.Mode) & expectedMode != expectedMode {
+			if int(event.Rename.New.Mode)&expectedMode != expectedMode {
 				t.Errorf("expected new mode %d, got %d", expectedMode, event.Rename.New.Mode)
 			}
 
-			if event.Rename.New.MTime.After(now) || event.Rename.New.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.New.MTime.After(now) || event.Rename.New.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected new mtime close to %s, got %s", now, event.Rename.New.MTime)
 			}
 
-			if event.Rename.New.CTime.After(now) || event.Rename.New.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rename.New.CTime.After(now) || event.Rename.New.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected new ctime close to %s, got %s", now, event.Rename.New.CTime)
 			}
 		}

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
@@ -18,7 +19,7 @@ import (
 func TestRmdir(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `rmdir.filename == "{{.Root}}/test-rmdir" || rmdir.filename == "{{.Root}}/test-unlink-rmdir"`,
+		Expression: `rmdir.file.path in ["{{.Root}}/test-rmdir", "{{.Root}}/test-unlink-rmdir"] && rmdir.file.uid == 0 && rmdir.file.gid == 0`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
@@ -27,13 +28,16 @@ func TestRmdir(t *testing.T) {
 	}
 	defer test.Close()
 
+	mkdirMode := 0o707
+	expectedMode := applyUmask(mkdirMode)
+
 	t.Run("rmdir", func(t *testing.T) {
 		testFile, testFilePtr, err := test.Path("test-rmdir")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if err := syscall.Mkdir(testFile, 0777); err != nil {
+		if err := syscall.Mkdir(testFile, uint32(mkdirMode)); err != nil {
 			t.Fatal(err)
 		}
 		defer os.Remove(testFile)
@@ -52,11 +56,24 @@ func TestRmdir(t *testing.T) {
 				t.Errorf("expected rmdir event, got %s", event.GetType())
 			}
 
-			if inode != event.Rmdir.Inode {
-				t.Logf("expected inode %d, got %d", event.Mkdir.Inode, inode)
+			if inode != event.Rmdir.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Mkdir.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "rmdir.container_path")
+			if int(event.Rmdir.File.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Rmdir.File.Mode) & expectedMode)
+			}
+
+			now := time.Now()
+			if event.Rmdir.File.MTime.After(now) || event.Rmdir.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Rmdir.File.MTime)
+			}
+
+			if event.Rmdir.File.CTime.After(now) || event.Rmdir.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Rmdir.File.CTime)
+			}
+
+			testContainerPath(t, event, "rmdir.file.container_path")
 		}
 	})
 
@@ -66,7 +83,7 @@ func TestRmdir(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := syscall.Mkdir(testDir, 0777); err != nil {
+		if err := syscall.Mkdir(testDir, uint32(mkdirMode)); err != nil {
 			t.Fatal(err)
 		}
 		defer os.Remove(testDir)
@@ -85,11 +102,24 @@ func TestRmdir(t *testing.T) {
 				t.Errorf("expected rmdir event, got %s", event.GetType())
 			}
 
-			if inode != event.Rmdir.Inode {
-				t.Logf("expected inode %d, got %d", event.Mkdir.Inode, inode)
+			if inode != event.Rmdir.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Mkdir.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "rmdir.container_path")
+			if int(event.Rmdir.File.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Rmdir.File.Mode) & expectedMode)
+			}
+
+			now := time.Now()
+			if event.Rmdir.File.MTime.After(now) || event.Rmdir.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Rmdir.File.MTime)
+			}
+
+			if event.Rmdir.File.CTime.After(now) || event.Rmdir.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Rmdir.File.CTime)
+			}
+
+			testContainerPath(t, event, "rmdir.file.container_path")
 		}
 	})
 }

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -60,16 +60,16 @@ func TestRmdir(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Mkdir.File.Inode, inode)
 			}
 
-			if int(event.Rmdir.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Rmdir.File.Mode) & expectedMode)
+			if int(event.Rmdir.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Rmdir.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Rmdir.File.MTime.After(now) || event.Rmdir.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rmdir.File.MTime.After(now) || event.Rmdir.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Rmdir.File.MTime)
 			}
 
-			if event.Rmdir.File.CTime.After(now) || event.Rmdir.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rmdir.File.CTime.After(now) || event.Rmdir.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Rmdir.File.CTime)
 			}
 
@@ -106,16 +106,16 @@ func TestRmdir(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Mkdir.File.Inode, inode)
 			}
 
-			if int(event.Rmdir.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Rmdir.File.Mode) & expectedMode)
+			if int(event.Rmdir.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Rmdir.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Rmdir.File.MTime.After(now) || event.Rmdir.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rmdir.File.MTime.After(now) || event.Rmdir.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Rmdir.File.MTime)
 			}
 
-			if event.Rmdir.File.CTime.After(now) || event.Rmdir.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Rmdir.File.CTime.After(now) || event.Rmdir.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Rmdir.File.CTime)
 			}
 

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -139,7 +139,7 @@ func TestStress_E2EOpenNoKprobe(t *testing.T) {
 func TestStress_E2EOpenEvent(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename == "{{.Root}}/folder1/folder2/test" && open.flags & O_CREAT != 0`,
+		Expression: `open.file.path == "{{.Root}}/folder1/folder2/test" && open.flags & O_CREAT != 0`,
 	}
 
 	stressOpen(t, rule, "folder1/folder2/test", 0)
@@ -150,7 +150,7 @@ func TestStress_E2EOpenEvent(t *testing.T) {
 func TestStress_E2EOpenNoEvent(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename == "{{.Root}}/folder1/folder2/test-no-event" && open.flags & O_APPEND != 0`,
+		Expression: `open.file.path == "{{.Root}}/folder1/folder2/test-no-event" && open.flags & O_APPEND != 0`,
 	}
 
 	stressOpen(t, rule, "folder1/folder2/test", 0)
@@ -161,7 +161,7 @@ func TestStress_E2EOpenNoEvent(t *testing.T) {
 func TestStress_E2EOpenWrite1KEvent(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename == "{{.Root}}/folder1/folder2/test" && open.flags & O_CREAT != 0`,
+		Expression: `open.file.path == "{{.Root}}/folder1/folder2/test" && open.flags & O_CREAT != 0`,
 	}
 
 	stressOpen(t, rule, "folder1/folder2/test", 1024)
@@ -179,7 +179,7 @@ func TestStress_E2EOpenWrite1KNoKprobe(t *testing.T) {
 func TestStress_E2EOpenWrite1KNoEvent(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename == "{{.Root}}/folder1/folder2/test-no-event" && open.flags & O_APPEND != 0`,
+		Expression: `open.file.path == "{{.Root}}/folder1/folder2/test-no-event" && open.flags & O_APPEND != 0`,
 	}
 
 	stressOpen(t, rule, "folder1/folder2/test", 1024)
@@ -305,7 +305,7 @@ func TestStress_E2EExecEvent(t *testing.T) {
 
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: fmt.Sprintf(`open.filename == "{{.Root}}/folder1/folder2/test-ancestors" && process.name == "%s"`, "touch"),
+		Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/folder1/folder2/test-ancestors" && process.file.name == "%s"`, "touch"),
 	}
 
 	stressExec(t, rule, "folder1/folder2/test-ancestors", executable)

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -55,16 +55,16 @@ func TestUnlink(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Unlink.File.Inode, inode)
 			}
 
-			if int(event.Unlink.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Unlink.File.Mode) & expectedMode)
+			if int(event.Unlink.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Unlink.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Unlink.File.MTime.After(now) || event.Unlink.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Unlink.File.MTime.After(now) || event.Unlink.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Unlink.File.MTime)
 			}
 
-			if event.Unlink.File.CTime.After(now) || event.Unlink.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Unlink.File.CTime.After(now) || event.Unlink.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Unlink.File.CTime)
 			}
 
@@ -97,16 +97,16 @@ func TestUnlink(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Unlink.File.Inode, inode)
 			}
 
-			if int(event.Unlink.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Unlink.File.Mode) & expectedMode)
+			if int(event.Unlink.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Unlink.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Unlink.File.MTime.After(now) || event.Unlink.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Unlink.File.MTime.After(now) || event.Unlink.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Unlink.File.MTime)
 			}
 
-			if event.Unlink.File.CTime.After(now) || event.Unlink.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Unlink.File.CTime.After(now) || event.Unlink.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Unlink.File.CTime)
 			}
 

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
@@ -18,7 +19,7 @@ import (
 func TestUnlink(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `unlink.filename == "{{.Root}}/test-unlink" || unlink.filename == "{{.Root}}/test-unlinkat"`,
+		Expression: `unlink.file.path in ["{{.Root}}/test-unlink", "{{.Root}}/test-unlinkat"] && unlink.file.uid == 98 && unlink.file.gid == 99`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})
@@ -27,16 +28,12 @@ func TestUnlink(t *testing.T) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("test-unlink")
+	fileMode := 0o447
+	expectedMode := applyUmask(fileMode)
+	testFile, testFilePtr, err := test.CreateWithOptions("test-unlink", 98, 99, fileMode)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	f, err := os.Create(testFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.Close()
 	defer os.Remove(testFile)
 
 	inode := getInode(t, testFile)
@@ -54,30 +51,37 @@ func TestUnlink(t *testing.T) {
 				t.Errorf("expected unlink event, got %s", event.GetType())
 			}
 
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode %d, got %d", event.Unlink.Inode, inode)
+			if inode != event.Unlink.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Unlink.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "unlink.container_path")
+			if int(event.Unlink.File.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Unlink.File.Mode) & expectedMode)
+			}
+
+			now := time.Now()
+			if event.Unlink.File.MTime.After(now) || event.Unlink.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Unlink.File.MTime)
+			}
+
+			if event.Unlink.File.CTime.After(now) || event.Unlink.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Unlink.File.CTime)
+			}
+
+			testContainerPath(t, event, "unlink.file.container_path")
 		}
 	})
 
-	testatFile, testatFilePtr, err := test.Path("test-unlinkat")
+	testAtFile, testAtFilePtr, err := test.CreateWithOptions("test-unlinkat", 98, 99, fileMode)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.Remove(testAtFile)
 
-	f, err = os.Create(testatFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.Close()
-	defer os.Remove(testatFile)
-
-	inode = getInode(t, testatFile)
+	inode = getInode(t, testAtFile)
 
 	t.Run("unlinkat", func(t *testing.T) {
-		if _, _, err := syscall.Syscall(syscall.SYS_UNLINKAT, 0, uintptr(testatFilePtr), 0); err != 0 {
+		if _, _, err := syscall.Syscall(syscall.SYS_UNLINKAT, 0, uintptr(testAtFilePtr), 0); err != 0 {
 			t.Fatal(err)
 		}
 
@@ -89,11 +93,24 @@ func TestUnlink(t *testing.T) {
 				t.Errorf("expected unlink event, got %s", event.GetType())
 			}
 
-			if inode != event.Unlink.Inode {
-				t.Logf("expected inode %d, got %d", event.Unlink.Inode, inode)
+			if inode != event.Unlink.File.Inode {
+				t.Logf("expected inode %d, got %d", event.Unlink.File.Inode, inode)
 			}
 
-			testContainerPath(t, event, "unlink.container_path")
+			if int(event.Unlink.File.Mode) & expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Unlink.File.Mode) & expectedMode)
+			}
+
+			now := time.Now()
+			if event.Unlink.File.MTime.After(now) || event.Unlink.File.MTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, event.Unlink.File.MTime)
+			}
+
+			if event.Unlink.File.CTime.After(now) || event.Unlink.File.CTime.Before(now.Add(-1 * time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, event.Unlink.File.CTime)
+			}
+
+			testContainerPath(t, event, "unlink.file.container_path")
 		}
 	})
 }

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -67,16 +67,16 @@ func TestUtime(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Utimes.File.Inode, inode)
 			}
 
-			if int(event.Utimes.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Utimes.File.Mode) & expectedMode)
+			if int(event.Utimes.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Utimes.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Utimes.File.MTime.After(now) || event.Utimes.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Utimes.File.MTime.After(now) || event.Utimes.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Utimes.File.MTime)
 			}
 
-			if event.Utimes.File.CTime.After(now) || event.Utimes.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Utimes.File.CTime.After(now) || event.Utimes.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Utimes.File.CTime)
 			}
 
@@ -128,16 +128,16 @@ func TestUtime(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Utimes.File.Inode, inode)
 			}
 
-			if int(event.Utimes.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Utimes.File.Mode) & expectedMode)
+			if int(event.Utimes.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Utimes.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Utimes.File.MTime.After(now) || event.Utimes.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Utimes.File.MTime.After(now) || event.Utimes.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Utimes.File.MTime)
 			}
 
-			if event.Utimes.File.CTime.After(now) || event.Utimes.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Utimes.File.CTime.After(now) || event.Utimes.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Utimes.File.CTime)
 			}
 
@@ -192,16 +192,16 @@ func TestUtime(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.Utimes.File.Inode, inode)
 			}
 
-			if int(event.Utimes.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Utimes.File.Mode) & expectedMode)
+			if int(event.Utimes.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.Utimes.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.Utimes.File.MTime.After(now) || event.Utimes.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Utimes.File.MTime.After(now) || event.Utimes.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.Utimes.File.MTime)
 			}
 
-			if event.Utimes.File.CTime.After(now) || event.Utimes.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.Utimes.File.CTime.After(now) || event.Utimes.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.Utimes.File.CTime)
 			}
 

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -74,16 +74,16 @@ func TestSetXAttr(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.SetXAttr.File.Inode, inode)
 			}
 
-			if int(event.SetXAttr.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.SetXAttr.File.Mode) & expectedMode)
+			if int(event.SetXAttr.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.SetXAttr.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.SetXAttr.File.MTime.After(now) || event.SetXAttr.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.SetXAttr.File.MTime.After(now) || event.SetXAttr.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.SetXAttr.File.MTime)
 			}
 
-			if event.SetXAttr.File.CTime.After(now) || event.SetXAttr.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.SetXAttr.File.CTime.After(now) || event.SetXAttr.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.SetXAttr.File.CTime)
 			}
 
@@ -165,16 +165,16 @@ func TestSetXAttr(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.SetXAttr.File.Inode, inode)
 			}
 
-			if int(event.SetXAttr.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.SetXAttr.File.Mode) & expectedMode)
+			if int(event.SetXAttr.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.SetXAttr.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.SetXAttr.File.MTime.After(now) || event.SetXAttr.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.SetXAttr.File.MTime.After(now) || event.SetXAttr.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.SetXAttr.File.MTime)
 			}
 
-			if event.SetXAttr.File.CTime.After(now) || event.SetXAttr.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.SetXAttr.File.CTime.After(now) || event.SetXAttr.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.SetXAttr.File.CTime)
 			}
 
@@ -252,16 +252,16 @@ func TestRemoveXAttr(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.RemoveXAttr.File.Inode, inode)
 			}
 
-			if int(event.RemoveXAttr.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.RemoveXAttr.File.Mode) & expectedMode)
+			if int(event.RemoveXAttr.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.RemoveXAttr.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.RemoveXAttr.File.MTime.After(now) || event.RemoveXAttr.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.RemoveXAttr.File.MTime.After(now) || event.RemoveXAttr.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.RemoveXAttr.File.MTime)
 			}
 
-			if event.RemoveXAttr.File.CTime.After(now) || event.RemoveXAttr.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.RemoveXAttr.File.CTime.After(now) || event.RemoveXAttr.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.RemoveXAttr.File.CTime)
 			}
 
@@ -356,16 +356,16 @@ func TestRemoveXAttr(t *testing.T) {
 				t.Logf("expected inode %d, got %d", event.RemoveXAttr.File.Inode, inode)
 			}
 
-			if int(event.RemoveXAttr.File.Mode) & expectedMode != expectedMode {
-				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.RemoveXAttr.File.Mode) & expectedMode)
+			if int(event.RemoveXAttr.File.Mode)&expectedMode != expectedMode {
+				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.RemoveXAttr.File.Mode)&expectedMode)
 			}
 
 			now := time.Now()
-			if event.RemoveXAttr.File.MTime.After(now) || event.RemoveXAttr.File.MTime.Before(now.Add(-1 * time.Hour)) {
+			if event.RemoveXAttr.File.MTime.After(now) || event.RemoveXAttr.File.MTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected mtime close to %s, got %s", now, event.RemoveXAttr.File.MTime)
 			}
 
-			if event.RemoveXAttr.File.CTime.After(now) || event.RemoveXAttr.File.CTime.Before(now.Add(-1 * time.Hour)) {
+			if event.RemoveXAttr.File.CTime.After(now) || event.RemoveXAttr.File.CTime.Before(now.Add(-1*time.Hour)) {
 				t.Errorf("expected ctime close to %s, got %s", now, event.RemoveXAttr.File.CTime)
 			}
 

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -90,7 +90,7 @@ func GetProcControlGroups(tgid, pid uint32) ([]ControlGroup, error) {
 func GetProcContainerID(tgid, pid uint32) (ContainerID, error) {
 	cgroups, err := GetProcControlGroups(tgid, pid)
 	if err != nil {
-		return ContainerID(""), err
+		return "", err
 	}
 
 	for _, cgroup := range cgroups {
@@ -98,5 +98,5 @@ func GetProcContainerID(tgid, pid uint32) (ContainerID, error) {
 			return containerID, nil
 		}
 	}
-	return ContainerID(""), nil
+	return "", nil
 }

--- a/releasenotes/notes/runtime-security-file-metadata-2dc6d21ab8f63544.yaml
+++ b/releasenotes/notes/runtime-security-file-metadata-2dc6d21ab8f63544.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    SECL and JSON format were updated to introduce the new attributes. Legacy support was added to avoid breaking
+    existing rules.
+features:
+  - |
+    File metadata attributes are now available for all events. Those new attributes include uid, user, gid, group, mode,
+    modification time and change time.


### PR DESCRIPTION
### What does this PR do?

This PR introduces file metadata attributes on all events with the new SECL and JSON format. The following fields are now collected:
- `uid` and `user` the uid and resolved user of the file
- `gid` and `group` the gid and resolved group of the file
- `mode` the access mode of the file
- `mtime` the modification time of the file
- `ctime` the change time of the file

Those fields are introduced along with the new SECL and JSON format. The new formats are described in the official documentation of the agent (coming soon). To avoid breaking legacy existing rules, this PR introduces a legacy support mechanism (for the SECL syntax as of 7.26).

### Motivation

Providing file metadata attributes extends the filtering capabilities of the agent. New rules based on the user and group owner of a file can now be written. For example, it is now possible to detect the execution of setuid and setgid binaries.

### Describe your test plan

Functional tests were written for each event to ensure that the new fields are properly collected for each events. Unit tests were also implemented to make sure that the legacy support feature works properly.