### PR TITLE
pkg/trace/api: improve discovery endpoint

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -105,19 +105,22 @@ func NewHTTPReceiver(conf *config.AgentConfig, dynConf *sampler.DynamicConfig, o
 func (r *HTTPReceiver) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 
+	hash, infoHandler := r.makeInfoHandler()
 	r.attachDebugHandlers(mux)
 	for _, e := range endpoints {
-		mux.Handle(e.Pattern, replyWithVersion(e.Handler(r)))
+		mux.Handle(e.Pattern, replyWithVersion(hash, e.Handler(r)))
 	}
-	mux.HandleFunc("/info", r.makeInfoHandler())
+	mux.HandleFunc("/info", infoHandler)
 
 	return mux
 }
 
-// replyWithVersion returns an http.Handler which calls h but adds the Datadog Agent version.
-func replyWithVersion(h http.Handler) http.Handler {
+// replyWithVersion returns an http.Handler which calls h with an addition of some
+// HTTP headers containing version and state information.
+func replyWithVersion(hash string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Datadog-Agent-Version", info.Version)
+		w.Header().Set("Datadog-Agent-State", hash)
 		h.ServeHTTP(w, r)
 	})
 }

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -117,7 +117,7 @@ func TestReceiverRequestBodyLength(t *testing.T) {
 	testBody(http.StatusRequestEntityTooLarge, " []")
 }
 
-func TestVersionHeader(t *testing.T) {
+func TestStateHeaders(t *testing.T) {
 	assert := assert.New(t)
 	r := newTestReceiverFromConfig(config.New())
 	r.Start()
@@ -143,6 +143,11 @@ func TestVersionHeader(t *testing.T) {
 		assert.True(ok)
 		v := resp.Header.Get("Datadog-Agent-Version")
 		assert.Equal(v, info.Version)
+
+		_, ok = resp.Header["Datadog-Agent-State"]
+		assert.True(ok)
+		v = resp.Header.Get("Datadog-Agent-State")
+		assert.NotEmpty(v)
 	}
 }
 

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
@@ -30,23 +29,19 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		Memcached            bool                         `json:"memcached"`
 	}
 	type reducedConfig struct {
-		DefaultEnv                  string                        `json:"default_env"`
-		BucketInterval              time.Duration                 `json:"bucket_interval"`
-		ExtraAggregators            []string                      `json:"extra_aggregators"`
-		ExtraSampleRate             float64                       `json:"extra_sample_rate"`
-		TargetTPS                   float64                       `json:"target_tps"`
-		MaxEPS                      float64                       `json:"max_eps"`
-		ReceiverPort                int                           `json:"receiver_port"`
-		ReceiverSocket              string                        `json:"receiver_socket"`
-		ConnectionLimit             int                           `json:"connection_limit"`
-		ReceiverTimeout             int                           `json:"receiver_timeout"`
-		MaxRequestBytes             int64                         `json:"max_request_bytes"`
-		StatsdPort                  int                           `json:"statsd_port"`
-		MaxMemory                   float64                       `json:"max_memory"`
-		MaxCPU                      float64                       `json:"max_cpu"`
-		AnalyzedRateByServiceLegacy map[string]float64            `json:"analyzed_rate_by_service_legacy,omitempty"`
-		AnalyzedSpansByService      map[string]map[string]float64 `json:"analyzed_spans_by_service"`
-		Obfuscation                 reducedObfuscationConfig      `json:"obfuscation"`
+		DefaultEnv             string                        `json:"default_env"`
+		TargetTPS              float64                       `json:"target_tps"`
+		MaxEPS                 float64                       `json:"max_eps"`
+		ReceiverPort           int                           `json:"receiver_port"`
+		ReceiverSocket         string                        `json:"receiver_socket"`
+		ConnectionLimit        int                           `json:"connection_limit"`
+		ReceiverTimeout        int                           `json:"receiver_timeout"`
+		MaxRequestBytes        int64                         `json:"max_request_bytes"`
+		StatsdPort             int                           `json:"statsd_port"`
+		MaxMemory              float64                       `json:"max_memory"`
+		MaxCPU                 float64                       `json:"max_cpu"`
+		AnalyzedSpansByService map[string]map[string]float64 `json:"analyzed_spans_by_service"`
+		Obfuscation            reducedObfuscationConfig      `json:"obfuscation"`
 	}
 	var oconf reducedObfuscationConfig
 	if o := r.conf.Obfuscation; o != nil {
@@ -60,12 +55,12 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		oconf.Memcached = o.Memcached.Enabled
 	}
 	txt, err := json.MarshalIndent(struct {
-		Version      string          `json:"version"`
-		GitCommit    string          `json:"git_commit"`
-		BuildDate    string          `json:"build_date"`
-		Endpoints    []string        `json:"endpoints"`
-		FeatureFlags map[string]bool `json:"feature_flags,omitempty"`
-		Config       reducedConfig   `json:"config"`
+		Version      string        `json:"version"`
+		GitCommit    string        `json:"git_commit"`
+		BuildDate    string        `json:"build_date"`
+		Endpoints    []string      `json:"endpoints"`
+		FeatureFlags []string      `json:"feature_flags,omitempty"`
+		Config       reducedConfig `json:"config"`
 	}{
 		Version:      info.Version,
 		GitCommit:    info.GitCommit,
@@ -73,23 +68,19 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		Endpoints:    all,
 		FeatureFlags: config.Features(),
 		Config: reducedConfig{
-			DefaultEnv:                  r.conf.DefaultEnv,
-			BucketInterval:              r.conf.BucketInterval,
-			ExtraAggregators:            r.conf.ExtraAggregators,
-			ExtraSampleRate:             r.conf.ExtraSampleRate,
-			TargetTPS:                   r.conf.TargetTPS,
-			MaxEPS:                      r.conf.MaxEPS,
-			ReceiverPort:                r.conf.ReceiverPort,
-			ReceiverSocket:              r.conf.ReceiverSocket,
-			ConnectionLimit:             r.conf.ConnectionLimit,
-			ReceiverTimeout:             r.conf.ReceiverTimeout,
-			MaxRequestBytes:             r.conf.MaxRequestBytes,
-			StatsdPort:                  r.conf.StatsdPort,
-			MaxMemory:                   r.conf.MaxMemory,
-			MaxCPU:                      r.conf.MaxCPU,
-			AnalyzedRateByServiceLegacy: r.conf.AnalyzedRateByServiceLegacy,
-			AnalyzedSpansByService:      r.conf.AnalyzedSpansByService,
-			Obfuscation:                 oconf,
+			DefaultEnv:             r.conf.DefaultEnv,
+			TargetTPS:              r.conf.TargetTPS,
+			MaxEPS:                 r.conf.MaxEPS,
+			ReceiverPort:           r.conf.ReceiverPort,
+			ReceiverSocket:         r.conf.ReceiverSocket,
+			ConnectionLimit:        r.conf.ConnectionLimit,
+			ReceiverTimeout:        r.conf.ReceiverTimeout,
+			MaxRequestBytes:        r.conf.MaxRequestBytes,
+			StatsdPort:             r.conf.StatsdPort,
+			MaxMemory:              r.conf.MaxMemory,
+			MaxCPU:                 r.conf.MaxCPU,
+			AnalyzedSpansByService: r.conf.AnalyzedSpansByService,
+			Obfuscation:            oconf,
 		},
 	}, "", "\t")
 	if err != nil {

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -103,7 +103,7 @@ func TestInfoHandler(t *testing.T) {
 	info.Version = "0.99.0"
 	info.GitCommit = "fab047e10"
 	info.BuildDate = "2020-12-04 15:57:06.74187 +0200 EET m=+0.029001792"
-	h := rcv.makeInfoHandler()
+	_, h := rcv.makeInfoHandler()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/info", nil)
 	h.ServeHTTP(rec, req)
@@ -120,9 +120,15 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.5/stats",
 		"/profiling/v1/input"
 	],
-	"feature_flags": [
-		"feature_flag"
-	],
+	"feature_flags": {
+		"429": false,
+		"big_resource": false,
+		"disable_sublayer_spans": false,
+		"disable_sublayer_stats": false,
+		"quantize_sql_tables": false,
+		"sql_cache": false,
+		"table_names": false
+	},
 	"config": {
 		"default_env": "prod",
 		"bucket_interval": 1000000000,
@@ -163,8 +169,8 @@ func TestInfoHandler(t *testing.T) {
 		}
 	}
 }` {
-		t.Fatal("Output of /info has changed. Changing the keys " +
-			"is not allowed because the client rely on them and " +
-			"is considered a breaking change")
+		t.Fatal("Output of /info has changed. Changing the keys "+
+			"is not allowed because the client rely on them and "+
+			"is considered a breaking change:\n\n%f", rec.Body.String())
 	}
 }

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -120,22 +120,11 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.5/stats",
 		"/profiling/v1/input"
 	],
-	"feature_flags": {
-		"429": false,
-		"big_resource": false,
-		"disable_sublayer_spans": false,
-		"disable_sublayer_stats": false,
-		"quantize_sql_tables": false,
-		"sql_cache": false,
-		"table_names": false
-	},
+	"feature_flags": [
+		"feature_flag"
+	],
 	"config": {
 		"default_env": "prod",
-		"bucket_interval": 1000000000,
-		"extra_aggregators": [
-			"agg:val"
-		],
-		"extra_sample_rate": 2.4,
 		"target_tps": 11,
 		"max_eps": 12,
 		"receiver_port": 8111,
@@ -146,9 +135,6 @@ func TestInfoHandler(t *testing.T) {
 		"statsd_port": 123,
 		"max_memory": 1000000,
 		"max_cpu": 12345,
-		"analyzed_rate_by_service_legacy": {
-			"X": 1.2
-		},
 		"analyzed_spans_by_service": {
 			"X": {
 				"Y": 2.4

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -274,19 +275,39 @@ func prepareConfig(path string) (*AgentConfig, error) {
 	return cfg, nil
 }
 
+// allFeatures keeps track of all features that ever existed in the trace-agent.
+var allFeatures = map[string]struct{}{
+	// Do not remove any features from here, regardless of whether they exist
+	// in the code or not, and do not omit any features (code will panic).
+	// They are used by the discovery endpoint to report the state of the agent
+	// to clients.
+	//
+	// A removed feature flag may mean its permanent enabling when it comes to code,
+	// but its absence from discovery may erroneously lead clients to believe that
+	// the feature is off, and this would be false!
+	"sql_cache":              struct{}{},
+	"table_names":            struct{}{},
+	"quantize_sql_tables":    struct{}{},
+	"429":                    struct{}{},
+	"big_resource":           struct{}{},
+	"disable_sublayer_spans": struct{}{},
+	"disable_sublayer_stats": struct{}{},
+}
+
 // HasFeature returns true if the feature f is present. Features are values
 // of the DD_APM_FEATURES environment variable.
 func HasFeature(f string) bool {
+	if _, ok := allFeatures[f]; !ok {
+		panic(fmt.Errorf("feature %q must be added to the (pkg/trace/config).allFeatures map", f))
+	}
 	return strings.Contains(os.Getenv("DD_APM_FEATURES"), f)
 }
 
-// Features returns a list of all the features configured by means of DD_APM_FEATURES.
-func Features() []string {
-	var all []string
-	if fenv := os.Getenv("DD_APM_FEATURES"); fenv != "" {
-		for _, f := range strings.Split(fenv, ",") {
-			all = append(all, strings.TrimSpace(f))
-		}
+// Features returns the state of all feature flags.
+func Features() map[string]bool {
+	all := make(map[string]bool, len(allFeatures))
+	for f := range allFeatures {
+		all[f] = HasFeature(f)
 	}
 	return all
 }


### PR DESCRIPTION
This adds the new Datadog-Agent-State HTTP response header to all
endpoint responses and makes sure that feature flags are hard-coded as a
list to ensure that their removal does not affect future discovery.