### PR TITLE
Refactor invoke test task to work with modules

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -229,6 +229,7 @@ def test(
         print("----- Module '{}'".format(module.full_path()))
         if not module.condition():
             print("----- Skipped")
+            continue
 
         with ctx.cd(module.full_path()):
             matches = ["{}/...".format(t) for t in module.targets]

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -78,11 +78,18 @@ def test(
     go_mod="vendor",
 ):
     """
-    Run all the tools and tests on the given targets. If targets are not specified,
-    the value from `invoke.yaml` will be used.
+    Run all the tools and tests on the given module and targets.
+
+    A module should be provided as the path to one of the go modules in the repository.
+
+    Targets should be provided as a comma-separated list of relative paths within the given module.
+    If targets are provided but no module is set, the main module (".") is used.
+
+    If no module or target is set the tests are run against all modules and targets.
 
     Example invokation:
         inv test --targets=./pkg/collector/check,./pkg/aggregator --race
+        inv test --module=. --race
     """
     if isinstance(module, str):
         # when this function is called from the command line, targets are passed
@@ -232,8 +239,11 @@ def test(
             continue
 
         with ctx.cd(module.full_path()):
-            matches = ["{}/...".format(t) for t in module.targets]
-            ctx.run(cmd.format(pkg_folder=' '.join(matches), **args), env=env, out_stream=test_profiler)
+            ctx.run(
+                cmd.format(pkg_folder=' '.join("{}/...".format(t) for t in module.targets), **args),
+                env=env,
+                out_stream=test_profiler,
+            )
 
     if coverage:
         print("\n--- Test coverage:")

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -21,16 +21,26 @@ from .go import fmt, generate, golangci_lint, ineffassign, lint, lint_licenses, 
 from .trace_agent import integration_tests as trace_integration_tests
 from .utils import get_build_flags
 
+
+class GoModule:
+    """A Go module abstraction."""
+
+    def __init__(self, path, targets=None, condition=lambda: True):
+        if targets is None:
+            targets = ["."]
+
+        self.path = path
+        self.targets = targets
+        self.condition = condition
+
+    def full_path(self):
+        return os.path.abspath(self.path)
+
+
 PROFILE_COV = "profile.cov"
 
-DEFAULT_TOOL_TARGETS = [
-    "./pkg",
-    "./cmd",
-]
-
-DEFAULT_TEST_TARGETS = [
-    "./pkg",
-    "./cmd",
+DEFAULT_MODULES = [
+    GoModule(".", targets=["./pkg", "./cmd"]),
 ]
 
 DEFAULT_GIT_BRANCH = 'master'
@@ -46,6 +56,7 @@ def ensure_bytes(s):
 @task()
 def test(
     ctx,
+    module=None,
     targets=None,
     coverage=False,
     build_include=None,
@@ -73,15 +84,18 @@ def test(
     Example invokation:
         inv test --targets=./pkg/collector/check,./pkg/aggregator --race
     """
-    if isinstance(targets, str):
+    if isinstance(module, str):
         # when this function is called from the command line, targets are passed
         # as comma separated tokens in a string
-        tool_targets = test_targets = targets.split(',')
-    elif targets is None:
-        tool_targets = DEFAULT_TOOL_TARGETS
-        test_targets = DEFAULT_TEST_TARGETS
+        if isinstance(targets, str):
+            modules = [GoModule(module, targets=targets.split(','))]
+        else:
+            modules = [m for m in DEFAULT_MODULES if m.path == module]
+    elif isinstance(targets, str):
+        modules = GoModule(".", targets=targets.split(','))
     else:
-        tool_targets = test_targets = targets
+        print("Using default modules and targets")
+        modules = DEFAULT_MODULES
 
     build_include = (
         get_default_build_tags(build="test-with-process-tags", arch=arch)
@@ -111,17 +125,33 @@ def test(
         # from the 'skip-dirs' list we need to keep using the old functions that
         # lint without build flags (linting some file is better than no linting).
         print("--- Vetting and linting (legacy):")
-        vet(ctx, targets=tool_targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch)
-        fmt(ctx, targets=tool_targets, fail_on_fmt=fail_on_fmt)
-        lint(ctx, targets=tool_targets)
-        misspell(ctx, targets=tool_targets)
-        ineffassign(ctx, targets=tool_targets)
-        staticcheck(ctx, targets=tool_targets, build_tags=build_tags, arch=arch)
+        for module in modules:
+            print("----- Module '{}'".format(module.full_path()))
+            if not module.condition():
+                print("----- Skipped")
+                continue
+
+            with ctx.cd(module.full_path()):
+                vet(ctx, targets=module.targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch)
+                fmt(ctx, targets=module.targets, fail_on_fmt=fail_on_fmt)
+                lint(ctx, targets=module.targets)
+                misspell(ctx, targets=module.targets)
+                ineffassign(ctx, targets=module.targets)
+                staticcheck(ctx, targets=module.targets, build_tags=build_tags, arch=arch)
 
         # for now we only run golangci_lint on Unix as the Windows env need more work
         if sys.platform != 'win32':
             print("--- golangci_lint:")
-            golangci_lint(ctx, targets=tool_targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch)
+            for module in modules:
+                print("----- Module '{}'".format(module.full_path()))
+                if not module.condition():
+                    print("----- Skipped")
+                    continue
+
+                with ctx.cd(module.full_path()):
+                    golangci_lint(
+                        ctx, targets=module.targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch
+                    )
 
     with open(PROFILE_COV, "w") as f_cov:
         f_cov.write("mode: count")
@@ -170,7 +200,6 @@ def test(
         else:
             covermode_opt = "-covermode=count"
 
-    matches = ["{}/...".format(t) for t in test_targets]
     print("\n--- Running unit tests:")
 
     coverprofile = ""
@@ -191,12 +220,19 @@ def test(
         "build_cpus": build_cpus_opt,
         "covermode_opt": covermode_opt,
         "coverprofile": coverprofile,
-        "pkg_folder": ' '.join(matches),
         "timeout": timeout,
         "verbose": '-v' if verbose else '',
         "nocache": nocache,
     }
-    ctx.run(cmd.format(**args), env=env, out_stream=test_profiler)
+
+    for module in modules:
+        print("----- Module '{}'".format(module.full_path()))
+        if not module.condition():
+            print("----- Skipped")
+
+        with ctx.cd(module.full_path()):
+            matches = ["{}/...".format(t) for t in module.targets]
+            ctx.run(cmd.format(pkg_folder=' '.join(matches), **args), env=env, out_stream=test_profiler)
 
     if coverage:
         print("\n--- Test coverage:")


### PR DESCRIPTION
### What does this PR do?

- Refactor invoke test task to work with Go modules

### Motivation

- Allow the testing of Go modules since otherwise we would only test the main module. Part of the PRs to incorporate #6581 changes on master, which is the PoC for RFC 779. the motivation, as defined in the RFC is that
  >  By default, go tools such as `go test`, `go fmt`, `go vet`, etc., when run on at the root of the repository, are not applied to go submodules: each tool must be invoked once per go module instead.
  > Therefore, the test tools of the `datadog-agent` project need to be amended to run on each go submodule. A master list of the go submodules should be kept somewhere in the repository for that purpose.

### Additional Notes

- I don't like the repetition but doing multiline functions on Python is ugly and I think the code would be harder to read

### Describe your test plan

- Should be a no-op; check test CI job logs