### PR TITLE
pkg/trace/obfuscate: allow nested-queries in SQL values

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -78,7 +78,7 @@ func (f *discardFilter) Filter(token, lastToken TokenKind, buffer []byte) (Token
 	case As:
 		return As, nil, nil
 	case Comment, ';':
-		return FilteredGroupable, nil, nil
+		return markFilteredGroupable(token), nil, nil
 	default:
 		return token, buffer, nil
 	}
@@ -97,20 +97,20 @@ type replaceFilter struct {
 func (f *replaceFilter) Filter(token, lastToken TokenKind, buffer []byte) (tokenType TokenKind, tokenBytes []byte, err error) {
 	switch lastToken {
 	case Savepoint:
-		return FilteredGroupable, questionMark, nil
+		return markFilteredGroupable(token), questionMark, nil
 	case '=':
 		switch token {
 		case DoubleQuotedString:
 			// double-quoted strings after assignments are eligible for obfuscation
-			return FilteredGroupable, questionMark, nil
+			return markFilteredGroupable(token), questionMark, nil
 		}
 	}
 	switch token {
 	case String, Number, Null, Variable, PreparedStatement, BooleanLiteral, EscapeSequence:
-		return FilteredGroupable, questionMark, nil
+		return markFilteredGroupable(token), questionMark, nil
 	case '?':
 		// Cases like 'ARRAY [ ?, ? ]' should be collapsed into 'ARRAY [ ? ]'
-		return FilteredGroupable, questionMark, nil
+		return markFilteredGroupable(token), questionMark, nil
 	case TableName:
 		if f.quantizeTableNames {
 			return token, replaceDigits(buffer), nil
@@ -127,8 +127,8 @@ func (f *replaceFilter) Reset() {}
 // groupingFilter is a token filter which groups together items replaced by the replaceFilter. It is meant
 // to run immediately after it.
 type groupingFilter struct {
-	groupFilter int
-	groupMulti  int
+	groupFilter int // counts the number of values, e.g. 3 = ?, ?, ?
+	groupMulti  int // counts the number of groups, e.g. 2 = (?, ?), (?, ?, ?)
 }
 
 // Filter the given token so that it will be discarded if a grouping pattern
@@ -138,33 +138,59 @@ type groupingFilter struct {
 func (f *groupingFilter) Filter(token, lastToken TokenKind, buffer []byte) (tokenType TokenKind, tokenBytes []byte, err error) {
 	// increasing the number of groups means that we're filtering an entire group
 	// because it can be represented with a single '( ? )'
-	if (lastToken == '(' && token == FilteredGroupable) || (token == '(' && f.groupMulti > 0) {
+	if (lastToken == '(' && isFilteredGroupable(token)) || (token == '(' && f.groupMulti > 0) {
 		f.groupMulti++
 	}
 
 	switch {
-	case token == FilteredGroupable:
+	case f.groupMulti > 0 && lastToken == FilteredGroupableParenthesis && token == ID:
+		// this is the start of a new group that seems to be a nested query;
+		// cancel grouping.
+		f.Reset()
+		return token, append([]byte("( "), buffer...), nil
+	case isFilteredGroupable(token):
 		// the previous filter has dropped this token so we should start
 		// counting the group filter so that we accept only one '?' for
 		// the same group
 		f.groupFilter++
 
 		if f.groupFilter > 1 {
-			return FilteredGroupable, nil, nil
+			return markFilteredGroupable(token), nil, nil
 		}
 	case f.groupFilter > 0 && (token == ',' || token == '?'):
 		// if we are in a group drop all commas
-		return FilteredGroupable, nil, nil
+		return markFilteredGroupable(token), nil, nil
 	case f.groupMulti > 1:
 		// drop all tokens since we're in a counting group
 		// and they're duplicated
-		return FilteredGroupable, nil, nil
-	case token != ',' && token != '(' && token != ')' && token != FilteredGroupable:
+		return markFilteredGroupable(token), nil, nil
+	case token != ',' && token != '(' && token != ')' && !isFilteredGroupable(token):
 		// when we're out of a group reset the filter state
 		f.Reset()
 	}
 
 	return token, buffer, nil
+}
+
+// isFilteredGroupable reports whether token is to be considered filtered groupable.
+func isFilteredGroupable(token TokenKind) bool {
+	switch token {
+	case FilteredGroupable, FilteredGroupableParenthesis:
+		return true
+	default:
+		return false
+	}
+}
+
+// markFilteredGroupable returns the appropriate TokenKind to mark this token as
+// filtered groupable.
+func markFilteredGroupable(token TokenKind) TokenKind {
+	switch token {
+	case '(':
+		return FilteredGroupableParenthesis
+	default:
+		return FilteredGroupable
+	}
 }
 
 // Reset resets the groupingFilter so that it may be used again.

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -669,6 +669,43 @@ ORDER BY [b].[Name]`,
 			`SELECT id, name FROM emp WHERE name LIKE {fn UCASE('Smith')}`,
 			`SELECT id, name FROM emp WHERE name LIKE ?`,
 		},
+		{
+			`DROP TABLE IF EXISTS django_site;
+DROP TABLE IF EXISTS knowledgebase_article;
+
+CREATE TABLE django_site (
+    id integer PRIMARY KEY,
+    domain character varying(100) NOT NULL,
+    name character varying(50) NOT NULL,
+    uuid uuid NOT NULL,
+    disabled boolean DEFAULT false NOT NULL
+);
+
+CREATE TABLE knowledgebase_article (
+    id integer PRIMARY KEY,
+    title character varying(255) NOT NULL,
+    site_id integer NOT NULL,
+    CONSTRAINT knowledgebase_article_site_id_fkey FOREIGN KEY (site_id) REFERENCES django_site(id)
+);
+
+INSERT INTO django_site(id, domain, name, uuid, disabled) VALUES (1, 'foo.domain', 'Foo', 'cb4776c1-edf3-4041-96a8-e152f5ae0f91', false);
+INSERT INTO knowledgebase_article(id, title, site_id) VALUES(1, 'title', 1);`,
+			`DROP TABLE IF EXISTS django_site DROP TABLE IF EXISTS knowledgebase_article CREATE TABLE django_site ( id integer PRIMARY KEY, domain character varying ( ? ) NOT ? name character varying ( ? ) NOT ? uuid uuid NOT ? disabled boolean DEFAULT ? NOT ? ) CREATE TABLE knowledgebase_article ( id integer PRIMARY KEY, title character varying ( ? ) NOT ? site_id integer NOT ? CONSTRAINT knowledgebase_article_site_id_fkey FOREIGN KEY ( site_id ) REFERENCES django_site ( id ) ) INSERT INTO django_site ( id, domain, name, uuid, disabled ) VALUES ( ? ) INSERT INTO knowledgebase_article ( id, title, site_id ) VALUES ( ? )`,
+		},
+		{
+			`
+SELECT set_config('foo.bar', (SELECT foo.bar FROM sometable WHERE sometable.uuid = %(some_id)s)::text, FALSE);
+SELECT
+    othertable.id,
+    othertable.title
+FROM othertable
+INNER JOIN sometable ON sometable.id = othertable.site_id
+WHERE
+    sometable.uuid = %(some_id)s
+LIMIT 1
+;`,
+			`SELECT set_config ( ? ( SELECT foo.bar FROM sometable WHERE sometable.uuid = ? ) :: text, ? ) SELECT othertable.id, othertable.title FROM othertable INNER JOIN sometable ON sometable.id = othertable.site_id WHERE sometable.uuid = ? LIMIT ?`,
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -66,6 +66,12 @@ const (
 	// tokens.
 	FilteredGroupable
 
+	// FilteredGroupableParenthesis is a parenthesis marked as filtered groupable. It is the
+	// beginning of either a group of values ('(') or a nested query. We track is as
+	// a special case for when it may start a nested query as opposed to just another
+	// value group to be obfuscated.
+	FilteredGroupableParenthesis
+
 	// Filtered specifies that the token is a comma and was discarded by one
 	// of the filters.
 	Filtered
@@ -75,6 +81,48 @@ const (
 	// See issue https://github.com/DataDog/datadog-trace-agent/issues/475.
 	FilteredBracketedIdentifier
 )
+
+var tokenKindStrings = map[TokenKind]string{
+	LexError:                     "LexError",
+	ID:                           "ID",
+	Limit:                        "Limit",
+	Null:                         "Null",
+	String:                       "String",
+	DoubleQuotedString:           "DoubleQuotedString",
+	Number:                       "Number",
+	BooleanLiteral:               "BooleanLiteral",
+	ValueArg:                     "ValueArg",
+	ListArg:                      "ListArg",
+	Comment:                      "Comment",
+	Variable:                     "Variable",
+	Savepoint:                    "Savepoint",
+	PreparedStatement:            "PreparedStatement",
+	EscapeSequence:               "EscapeSequence",
+	NullSafeEqual:                "NullSafeEqual",
+	LE:                           "LE",
+	GE:                           "GE",
+	NE:                           "NE",
+	As:                           "As",
+	From:                         "From",
+	Update:                       "Update",
+	Insert:                       "Insert",
+	Into:                         "Into",
+	Join:                         "Join",
+	TableName:                    "TableName",
+	ColonCast:                    "ColonCast",
+	FilteredGroupable:            "FilteredGroupable",
+	FilteredGroupableParenthesis: "FilteredGroupableParenthesis",
+	Filtered:                     "Filtered",
+	FilteredBracketedIdentifier:  "FilteredBracketedIdentifier",
+}
+
+func (k TokenKind) String() string {
+	str, ok := tokenKindStrings[k]
+	if !ok {
+		return "<unknown>"
+	}
+	return str
+}
 
 const escapeCharacter = '\\'
 

--- a/releasenotes/notes/apm-nested-query-obfuscation-229e1db1dc6b0eea.yaml
+++ b/releasenotes/notes/apm-nested-query-obfuscation-229e1db1dc6b0eea.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fixes a bug where nested SQL queries may occasionally result in bad obfuscator output.


### PR DESCRIPTION
This change ensures that nested queries as part of a list of values in
the obfuscator correctly get obfuscated. Previously this used to cause a
bug where the obfuscator would abruptly end a query.