### PR TITLE
Remove agent MaxNumWorkers hard limit

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1260,11 +1260,6 @@ func setNumWorkers(config Config) {
 		numWorkers = 1
 	}
 
-	if numWorkers > MaxNumWorkers {
-		numWorkers = MaxNumWorkers
-		log.Warnf("Configured number of checks workers (%v) is too high: %v will be used", numWorkers, MaxNumWorkers)
-	}
-
 	// update config with the actual effective number of workers
 	config.Set("check_runners", numWorkers)
 }

--- a/releasenotes/notes/agent_remove_max_wokers_hard_limit-41fd2c1873d89549.yaml
+++ b/releasenotes/notes/agent_remove_max_wokers_hard_limit-41fd2c1873d89549.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Remove agent max workers hard limit

--- a/releasenotes/notes/agent_remove_max_wokers_hard_limit-41fd2c1873d89549.yaml
+++ b/releasenotes/notes/agent_remove_max_wokers_hard_limit-41fd2c1873d89549.yaml
@@ -1,4 +1,6 @@
 ---
 enhancements:
   - |
-    Remove agent max workers hard limit
+    Remove agent MaxNumWorkers hard limit that cap the number of check runners
+    to 25. The removal is motivated by the need for some users to run thousands
+    of integrations like snmp corecheck.


### PR DESCRIPTION
### What does this PR do?

Remove max check workers hard limit related to [`check_runners` config](https://github.com/DataDog/datadog-agent/blob/eb0b08db9191c9ee526dd42bb0c72fa573e31e46/pkg/config/config_template.yaml#L380-L390).

### Motivation

It seems the limit is here because most integrations are in python, and the agent won't be able to handle 25+ python instances being run concurrently. But 25+ go corecheck instances being run concurrently is not an issue.

Use case: Users might use integrations like corecheck SNMP integration with thousands of check instances.
Currently, the limit is 25 check runners and that's not enough to run thousands of check instances with reasonable collection interval (e.g. 15-60 sec).

For example, with 25 runners and expected 15 sec collection interval, with 1sec per check run (snmp check might take multiple seconds to complete), we can only run at most ~375 (25 * 15) instances. 

If the customer have more than ~375 instances, that will lead to lower collection interval e.g. 1000 instances with 25 check runners will lead to ~40 sec collection interval.

A possible reason it hasn't been an issue previously is that we didn't have a use case with such large # of check instances 1000+ that is "heavy" to run (`snmp` is "heavier" to run than `ping` or `http_check` integration).

### Is there any risk to remove the hard limit ?

In theory removing the hard limit might cause issue to users if they have a config with a high # of check runners `check_runners: 100` and in the past the agent was limited to 25 check runners, but with the removal of the hard limit, they have now more check runners than before. The new higher number of check runners might create bottle neck elsewhere:
- Aggregator/Forwarder level (if there are a lot more metrics being processed by the agent)
- Too many Python check instances being run in parallel

That being said, I think this theoretical case described above might be rare, an edge case.

If that's an issue, see Alternative.

### Alternative solution

An alternative solution is to add a new option like `disable_check_runners_limit`, set to `false` by default.

### Describe your test plan

- Test we can use more than 25 check runners.
- Test with a high number of SNMP instances e.g. 1000 instances
