### PR TITLE
[procutil] update test to reset nice value for processes

### DIFF
--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -274,17 +274,17 @@ func TestMultipleProbes(t *testing.T) {
 
 	procByPID1, err := probe1.ProcessesByPID(now)
 	assert.NoError(t, err)
-	procByPID1 = resetNiceValues(procByPID1)
+	resetNiceValues(procByPID1)
 	procByPID2, err := probe2.ProcessesByPID(now)
 	assert.NoError(t, err)
-	procByPID2 = resetNiceValues(procByPID2)
+	resetNiceValues(procByPID2)
 	for i := 0; i < 10; i++ {
 		currProcByPID1, err := probe1.ProcessesByPID(now)
 		assert.NoError(t, err)
-		currProcByPID1 = resetNiceValues(currProcByPID1)
+		resetNiceValues(currProcByPID1)
 		currProcByPID2, err := probe2.ProcessesByPID(now)
 		assert.NoError(t, err)
-		currProcByPID2 = resetNiceValues(currProcByPID2)
+		resetNiceValues(currProcByPID2)
 		assert.EqualValues(t, currProcByPID1, currProcByPID2)
 		assert.EqualValues(t, currProcByPID1, procByPID1)
 		assert.EqualValues(t, currProcByPID2, procByPID2)
@@ -1098,9 +1098,8 @@ func maySkipLocalTest(t *testing.T) {
 // resetNiceValues takes a group of processes and reset the "nice" values on them.
 // this is needed because the "nice" values are not extract from procfs but using system call,
 // so it might cause test flakiness if we don't reset the value
-func resetNiceValues(procs map[int32]*Process) map[int32]*Process {
+func resetNiceValues(procs map[int32]*Process) {
 	for _, p := range procs {
 		p.Stats.Nice = 0
 	}
-	return procs
 }

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -274,13 +274,17 @@ func TestMultipleProbes(t *testing.T) {
 
 	procByPID1, err := probe1.ProcessesByPID(now)
 	assert.NoError(t, err)
+	procByPID1 = resetNiceValues(procByPID1)
 	procByPID2, err := probe2.ProcessesByPID(now)
 	assert.NoError(t, err)
+	procByPID2 = resetNiceValues(procByPID2)
 	for i := 0; i < 10; i++ {
 		currProcByPID1, err := probe1.ProcessesByPID(now)
 		assert.NoError(t, err)
+		currProcByPID1 = resetNiceValues(currProcByPID1)
 		currProcByPID2, err := probe2.ProcessesByPID(now)
 		assert.NoError(t, err)
+		currProcByPID2 = resetNiceValues(currProcByPID2)
 		assert.EqualValues(t, currProcByPID1, currProcByPID2)
 		assert.EqualValues(t, currProcByPID1, procByPID1)
 		assert.EqualValues(t, currProcByPID2, procByPID2)
@@ -1089,4 +1093,14 @@ func maySkipLocalTest(t *testing.T) {
 	if skipLocalTest {
 		t.Skip("flaky test in CI")
 	}
+}
+
+// resetNiceValues takes a group of processes and reset the "nice" values on them.
+// this is needed because the "nice" values are not extract from procfs but using system call,
+// so it might cause test flakiness if we don't reset the value
+func resetNiceValues(procs map[int32]*Process) map[int32]*Process {
+	for _, p := range procs {
+		p.Stats.Nice = 0
+	}
+	return procs
 }


### PR DESCRIPTION
### What does this PR do?

The "nice" value for a process is fetched by system call not by parsing procfs, so the test would actually be flaky since it's not 100% relied on the underlying files. This PR adds a function to reset the values so we could still compare processes on object basis.

@DataDog/processes 

### Motivation

Fix flaky test.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
