### PR TITLE
[system-probe] Fix, document, and validate system_probe_config.sysprobe_socket config on windows

### DIFF
--- a/cmd/agent/app/dependent_services_windows.go
+++ b/cmd/agent/app/dependent_services_windows.go
@@ -35,7 +35,7 @@ var subservices = []Servicedef{
 	},
 	{
 		name:        "process",
-		configKeys:  []string{"process_config.enabled", "network_config.enabled", "system_probe.enabled"},
+		configKeys:  []string{"process_config.enabled", "network_config.enabled", "system_probe_config.enabled"},
 		serviceName: "datadog-process-agent",
 		serviceInit: processInit,
 	},

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -981,8 +981,7 @@ api_key:
   ## The full path to the location of the unix socket where system probes are accessed.
   #
   # sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
-{{ end -}}
-
+{{ end }}
   ## @param log_file - string - optional - default: /var/log/datadog/system-probe.log
   ## The full path to the file where system-probe logs are written.
   #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -971,10 +971,17 @@ api_key:
 ## Uncomment this parameter and the one below to enable them.
 #
 # system_probe_config:
+{{- if (eq .OS "windows")}}
+  ## @param sysprobe_socket - string - optional - default: localhost:3333
+  ## The TCP address where system probes are accessed.
+  #
+  # sysprobe_socket: localhost:3333
+{{else}}
   ## @param sysprobe_socket - string - optional - default: /opt/datadog-agent/run/sysprobe.sock
   ## The full path to the location of the unix socket where system probes are accessed.
   #
   # sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
+{{ end -}}
 
   ## @param log_file - string - optional - default: /var/log/datadog/system-probe.log
   ## The full path to the file where system-probe logs are written.

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -12,11 +12,13 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
 // context contains the context used to render the config file template
 type context struct {
+	OS                string
 	Common            bool
 	Agent             bool
 	Python            bool // Sub-option of Agent
@@ -51,6 +53,7 @@ func mkContext(buildType string) context {
 	buildType = strings.ToLower(buildType)
 
 	agentContext := context{
+		OS:                runtime.GOOS,
 		Common:            true,
 		Agent:             true,
 		Python:            true,

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -521,7 +521,6 @@ func loadSysProbeEnvVariables() {
 		{"DD_SYSTEM_PROBE_ENABLED", "system_probe_config.enabled"},
 		{"DD_SYSTEM_PROBE_NETWORK_ENABLED", "network_config.enabled"},
 		{"DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "network_config.enable_http_monitoring"},
-		{"DD_SYSPROBE_SOCKET", "system_probe_config.sysprobe_socket"},
 		{"DD_SYSTEM_PROBE_CONNTRACK_IGNORE_ENOBUFS", "system_probe_config.conntrack_ignore_enobufs"},
 		{"DD_SYSTEM_PROBE_ENABLE_CONNTRACK_ALL_NAMESPACES", "system_probe_config.enable_conntrack_all_namespaces"},
 		{"DD_SYSTEM_PROBE_NETWORK_IGNORE_CONNTRACK_INIT_FAILURE", "network_config.ignore_conntrack_init_failure"},
@@ -543,6 +542,14 @@ func loadSysProbeEnvVariables() {
 	} {
 		if v, ok := os.LookupEnv(variable.env); ok {
 			config.Datadog.Set(variable.cfg, v)
+		}
+	}
+
+	if v, ok := os.LookupEnv("DD_SYSPROBE_SOCKET"); ok {
+		if err := ValidateSysprobeSocket(v); err != nil {
+			log.Errorf("Could not parse DD_SYSPROBE_SOCKET: %s", err)
+		} else {
+			config.Datadog.Set(key(spNS, "sysprobe_socket"), v)
 		}
 	}
 }

--- a/pkg/process/config/config_nix.go
+++ b/pkg/process/config/config_nix.go
@@ -2,6 +2,11 @@
 
 package config
 
+import (
+	"fmt"
+	"path/filepath"
+)
+
 const (
 	defaultLogFilePath = "/var/log/datadog/process-agent.log"
 
@@ -14,3 +19,11 @@ const (
 	// defaultSystemProbeAddress is the default unix socket path to be used for connecting to the system probe
 	defaultSystemProbeAddress = "/opt/datadog-agent/run/sysprobe.sock"
 )
+
+// ValidateSysprobeSocket validates that the sysprobe socket config option is of the correct format.
+func ValidateSysprobeSocket(sockPath string) error {
+	if !filepath.IsAbs(sockPath) {
+		return fmt.Errorf("it must be an absolute file path")
+	}
+	return nil
+}

--- a/pkg/process/config/config_nix.go
+++ b/pkg/process/config/config_nix.go
@@ -23,7 +23,7 @@ const (
 // ValidateSysprobeSocket validates that the sysprobe socket config option is of the correct format.
 func ValidateSysprobeSocket(sockPath string) error {
 	if !filepath.IsAbs(sockPath) {
-		return fmt.Errorf("it must be an absolute file path")
+		return fmt.Errorf("socket path must be an absolute file path")
 	}
 	return nil
 }

--- a/pkg/process/config/config_windows.go
+++ b/pkg/process/config/config_windows.go
@@ -3,6 +3,8 @@
 package config
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -35,4 +37,12 @@ func init() {
 			defaultDDAgentBin = agentFilePath
 		}
 	}
+}
+
+// ValidateSysprobeSocket validates that the sysprobe socket config option is of the correct format.
+func ValidateSysprobeSocket(sockAddress string) error {
+	if _, _, err := net.SplitHostPort(sockAddress); err != nil {
+		return fmt.Errorf("it must be of the form 'host:port'")
+	}
+	return nil
 }

--- a/pkg/process/config/config_windows.go
+++ b/pkg/process/config/config_windows.go
@@ -42,7 +42,7 @@ func init() {
 // ValidateSysprobeSocket validates that the sysprobe socket config option is of the correct format.
 func ValidateSysprobeSocket(sockAddress string) error {
 	if _, _, err := net.SplitHostPort(sockAddress); err != nil {
-		return fmt.Errorf("it must be of the form 'host:port'")
+		return fmt.Errorf("socket address must be of the form 'host:port'")
 	}
 	return nil
 }

--- a/pkg/process/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net-Windows.yaml
+++ b/pkg/process/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-Net-Windows.yaml
@@ -1,0 +1,7 @@
+system_probe_config:
+    enabled: true
+    bpf_debug: true
+    sysprobe_socket: localhost:4444
+
+network_config:
+    enabled: true

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -81,7 +81,11 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 
 	// The full path to the location of the unix socket where connections will be accessed
 	if socketPath := config.Datadog.GetString(key(spNS, "sysprobe_socket")); socketPath != "" {
-		a.SystemProbeAddress = socketPath
+		if err := ValidateSysprobeSocket(socketPath); err != nil {
+			log.Errorf("Could not parse %s.sysprobe_socket: %s", spNS, err)
+		} else {
+			a.SystemProbeAddress = socketPath
+		}
 	}
 
 	if config.Datadog.IsSet(key(spNS, "enable_conntrack")) {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -199,7 +199,7 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		a.EnabledChecks = append(a.EnabledChecks, ConnectionsCheckName, NetworkCheckName)
 		a.EnableSystemProbe = true // system-probe is implicitly enabled if networks is enabled
 	} else if config.Datadog.IsSet(key(spNS, "enabled")) && config.Datadog.GetBool(key(spNS, "enabled")) && !config.Datadog.IsSet(key("network_config", "enabled")) {
-		// This case exists to preserve backwards compatibility. If system_probe_config.enabled is explicitlty set to true, and there is no network_config block,
+		// This case exists to preserve backwards compatibility. If system_probe_config.enabled is explicitly set to true, and there is no network_config block,
 		// enable the connections/network check.
 		log.Info("network_config not found, but system-probe was enabled, enabling network module by default")
 		a.EnabledChecks = append(a.EnabledChecks, NetworkCheckName, ConnectionsCheckName)

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -195,7 +195,7 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		a.EnabledChecks = append(a.EnabledChecks, ConnectionsCheckName, NetworkCheckName)
 		a.EnableSystemProbe = true // system-probe is implicitly enabled if networks is enabled
 	} else if config.Datadog.IsSet(key(spNS, "enabled")) && config.Datadog.GetBool(key(spNS, "enabled")) && !config.Datadog.IsSet(key("network_config", "enabled")) {
-		// This case exists to preserve backwards compatibility. If system_probe.enabled is explicitlty set to true, and there is no network_config block,
+		// This case exists to preserve backwards compatibility. If system_probe_config.enabled is explicitlty set to true, and there is no network_config block,
 		// enable the connections/network check.
 		log.Info("network_config not found, but system-probe was enabled, enabling network module by default")
 		a.EnabledChecks = append(a.EnabledChecks, NetworkCheckName, ConnectionsCheckName)

--- a/pkg/status/status_system_probe.go
+++ b/pkg/status/status_system_probe.go
@@ -15,8 +15,6 @@ import (
 
 // GetSystemProbeStats returns the expvar stats of the system probe
 func GetSystemProbeStats(socketPath string) map[string]interface{} {
-
-	// TODO: Pull system-probe path from system-probe.yaml
 	net.SetSystemProbePath(socketPath)
 	probeUtil, err := net.GetRemoteSystemProbeUtil()
 

--- a/pkg/status/status_system_probe.go
+++ b/pkg/status/status_system_probe.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// +build process,!windows
+// +build process
 
 package status
 

--- a/pkg/status/status_system_probe_unsupported.go
+++ b/pkg/status/status_system_probe_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// +build !process windows
+// +build !process
 
 package status
 


### PR DESCRIPTION
### What does this PR do?

This fixes a bug where an error would be returned if `system_probe_config.sysprobe_socket` was specified on windows. It also clarifies the config template to have the correct format on windows. In addition, validation was used on both windows/non-windows to ensure only a valid config value is used. Otherwise the default is used.

### Motivation

A support ticket where a customer on windows had incorrectly used the following on windows:
```
sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
```
which caused the error: `System Probe is not supported on this system`, which is incorrect.
