### PR TITLE
[process-agent] return -1 for IO metrics that have permission problem

### DIFF
--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -8,15 +8,13 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/shirou/w32"
+	"golang.org/x/sys/windows"
 
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	process "github.com/DataDog/gopsutil/process"
-
-	"github.com/shirou/w32"
-
-	"golang.org/x/sys/windows"
 )
 
 var (
@@ -178,10 +176,10 @@ func getAllProcesses(probe *procutil.Probe) (map[int32]*procutil.Process, error)
 					Swap: 0,
 				},
 				IOStat: &procutil.IOCountersStat{
-					ReadCount:  ioCounters.ReadOperationCount,
-					WriteCount: ioCounters.WriteOperationCount,
-					ReadBytes:  ioCounters.ReadTransferCount,
-					WriteBytes: ioCounters.WriteTransferCount,
+					ReadCount:  int64(ioCounters.ReadOperationCount),
+					WriteCount: int64(ioCounters.WriteOperationCount),
+					ReadBytes:  int64(ioCounters.ReadTransferCount),
+					WriteBytes: int64(ioCounters.WriteTransferCount),
 				},
 				CtxSwitches: &procutil.NumCtxSwitchesStat{},
 			},

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -291,26 +291,23 @@ func formatIO(fp *procutil.Stats, lastIO *procutil.IOCountersStat, before time.T
 	if before.IsZero() || diff <= 0 {
 		return &model.IOStat{}
 	}
-	// Reading 0 as a counter means the file could not be opened due to permissions. We distinguish this from a real 0 in rates.
-	var readRate float32
-	readRate = -1
-	if fp.IOStat.ReadCount != 0 {
-		readRate = calculateRate(fp.IOStat.ReadCount, lastIO.ReadCount, before)
+	// Reading -1 as counter means the file could not be opened due to permissions.
+	// In that case we set the rate as -1 to distinguish from a real 0 in rates.
+	readRate := float32(-1)
+	if fp.IOStat.ReadCount >= 0 {
+		readRate = calculateRate(uint64(fp.IOStat.ReadCount), uint64(lastIO.ReadCount), before)
 	}
-	var writeRate float32
-	writeRate = -1
-	if fp.IOStat.WriteCount != 0 {
-		writeRate = calculateRate(fp.IOStat.WriteCount, lastIO.WriteCount, before)
+	writeRate := float32(-1)
+	if fp.IOStat.WriteCount >= 0 {
+		writeRate = calculateRate(uint64(fp.IOStat.WriteCount), uint64(lastIO.WriteCount), before)
 	}
-	var readBytesRate float32
-	readBytesRate = -1
-	if fp.IOStat.ReadBytes != 0 {
-		readBytesRate = calculateRate(fp.IOStat.ReadBytes, lastIO.ReadBytes, before)
+	readBytesRate := float32(-1)
+	if fp.IOStat.ReadBytes >= 0 {
+		readBytesRate = calculateRate(uint64(fp.IOStat.ReadBytes), uint64(lastIO.ReadBytes), before)
 	}
-	var writeBytesRate float32
-	writeBytesRate = -1
-	if fp.IOStat.WriteBytes != 0 {
-		writeBytesRate = calculateRate(fp.IOStat.WriteBytes, lastIO.WriteBytes, before)
+	writeBytesRate := float32(-1)
+	if fp.IOStat.WriteBytes >= 0 {
+		writeBytesRate = calculateRate(uint64(fp.IOStat.WriteBytes), uint64(lastIO.WriteBytes), before)
 	}
 	return &model.IOStat{
 		ReadRate:       readRate,

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -282,14 +282,21 @@ func TestFormatIO(t *testing.T) {
 		WriteBytes: 4,
 	}
 
-	// fp.IoStat is nil
+	// fp.IOStat is nil
 	assert.NotNil(t, formatIO(&procutil.Stats{}, last, time.Now().Add(-2*time.Second)))
+
+	// IOStats have 0 values
+	result := formatIO(&procutil.Stats{IOStat: &procutil.IOCountersStat{}}, last, time.Now().Add(-2*time.Second))
+	assert.Equal(t, float32(0), result.ReadRate)
+	assert.Equal(t, float32(0), result.WriteRate)
+	assert.Equal(t, float32(0), result.ReadBytesRate)
+	assert.Equal(t, float32(0), result.WriteBytesRate)
 
 	// Elapsed time < 1s
 	assert.NotNil(t, formatIO(fp, last, time.Now()))
 
-	// IOStats that have permission problem
-	result := formatIO(&procutil.Stats{IOStat: &procutil.IOCountersStat{
+	// IOStats have permission problem
+	result = formatIO(&procutil.Stats{IOStat: &procutil.IOCountersStat{
 		ReadCount:  -1,
 		WriteCount: -1,
 		ReadBytes:  -1,
@@ -302,7 +309,6 @@ func TestFormatIO(t *testing.T) {
 
 	result = formatIO(fp, last, time.Now().Add(-1*time.Second))
 	require.NotNil(t, result)
-
 	assert.Equal(t, float32(5), result.ReadRate)
 	assert.Equal(t, float32(6), result.WriteRate)
 	assert.Equal(t, float32(7), result.ReadBytesRate)

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -288,7 +288,19 @@ func TestFormatIO(t *testing.T) {
 	// Elapsed time < 1s
 	assert.NotNil(t, formatIO(fp, last, time.Now()))
 
-	result := formatIO(fp, last, time.Now().Add(-1*time.Second))
+	// IOStats that have permission problem
+	result := formatIO(&procutil.Stats{IOStat: &procutil.IOCountersStat{
+		ReadCount:  -1,
+		WriteCount: -1,
+		ReadBytes:  -1,
+		WriteBytes: -1,
+	}}, last, time.Now().Add(-1*time.Second))
+	assert.Equal(t, float32(-1), result.ReadRate)
+	assert.Equal(t, float32(-1), result.WriteRate)
+	assert.Equal(t, float32(-1), result.ReadBytesRate)
+	assert.Equal(t, float32(-1), result.WriteBytesRate)
+
+	result = formatIO(fp, last, time.Now().Add(-1*time.Second))
 	require.NotNil(t, result)
 
 	assert.Equal(t, float32(5), result.ReadRate)

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -281,7 +281,12 @@ func (p *Probe) parseIO(pidPath string) *IOCountersStat {
 	path := filepath.Join(pidPath, "io")
 	var err error
 
-	io := &IOCountersStat{}
+	io := &IOCountersStat{
+		ReadBytes:  -1,
+		ReadCount:  -1,
+		WriteBytes: -1,
+		WriteCount: -1,
+	}
 
 	if err = p.ensurePathReadable(path); err != nil {
 		return io
@@ -321,22 +326,22 @@ func (p *Probe) parseIOLine(line []byte, io *IOCountersStat) {
 func (p *Probe) parseIOKV(key, value string, io *IOCountersStat) {
 	switch key {
 	case "syscr":
-		v, err := strconv.ParseUint(value, 10, 64)
+		v, err := strconv.ParseInt(value, 10, 64)
 		if err == nil {
 			io.ReadCount = v
 		}
 	case "syscw":
-		v, err := strconv.ParseUint(value, 10, 64)
+		v, err := strconv.ParseInt(value, 10, 64)
 		if err == nil {
 			io.WriteCount = v
 		}
 	case "read_bytes":
-		v, err := strconv.ParseUint(value, 10, 64)
+		v, err := strconv.ParseInt(value, 10, 64)
 		if err == nil {
 			io.ReadBytes = v
 		}
 	case "write_bytes":
-		v, err := strconv.ParseUint(value, 10, 64)
+		v, err := strconv.ParseInt(value, 10, 64)
 		if err == nil {
 			io.WriteBytes = v
 		}

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -571,6 +571,23 @@ func testParseIO(t *testing.T) {
 	}
 }
 
+func TestFetchFieldsWithoutPermission(t *testing.T) {
+	t.Skip("This test is not working in CI, but could be tested locally")
+	probe := NewProcessProbe()
+	defer probe.Close()
+
+	// PID 1 should be owned by root so we would always get permission error
+	pid := int32(1)
+	actual := probe.parseIO(filepath.Join(probe.procRootLoc, strconv.Itoa(int(pid))))
+	assert.Equal(t, int64(-1), actual.ReadCount)
+	assert.Equal(t, int64(-1), actual.ReadBytes)
+	assert.Equal(t, int64(-1), actual.WriteCount)
+	assert.Equal(t, int64(-1), actual.WriteBytes)
+
+	fd := probe.getFDCount(strconv.Itoa(int(pid)))
+	assert.Equal(t, int32(-1), fd)
+}
+
 func TestParseStatContent(t *testing.T) {
 	probe := NewProcessProbe()
 	defer probe.Close()

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -607,10 +607,7 @@ func testParseIO(t *testing.T) {
 		require.NoError(t, err)
 		expIO, err := expProc.IOCounters()
 		require.NoError(t, err)
-		assert.Equal(t, int64(expIO.ReadCount), actual.ReadCount)
-		assert.Equal(t, int64(expIO.ReadBytes), actual.ReadBytes)
-		assert.Equal(t, int64(expIO.WriteCount), actual.WriteCount)
-		assert.Equal(t, int64(expIO.WriteBytes), actual.WriteBytes)
+		assert.EqualValues(t, ConvertFromIOStats(expIO), actual)
 	}
 }
 

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -198,29 +198,6 @@ func testStatsForPIDs(t *testing.T) {
 	assert.Len(t, stats, len(pids))
 }
 
-func compareStats(t *testing.T, procV1, procV2 *process.FilledProcess) {
-	assert.Equal(t, procV1.Pid, procV2.Pid)
-	// CPU Timestamp might be different between gopsutil and procutil fetches data,
-	// so we compare with tolerance of 1s, then compare CpuTime without `Timestamp` field
-	assert.InDelta(t, procV1.CpuTime.Timestamp, procV2.CpuTime.Timestamp, 1.0)
-	procV1.CpuTime.Timestamp = 0
-	procV2.CpuTime.Timestamp = 0
-	assert.EqualValues(t, procV1.CpuTime, procV2.CpuTime)
-
-	assert.Equal(t, procV1.CreateTime, procV2.CreateTime)
-	assert.Equal(t, procV1.OpenFdCount, procV2.OpenFdCount)
-	assert.Equal(t, procV1.Status, procV2.Status)
-	assert.Equal(t, procV1.NumThreads, procV2.NumThreads)
-	assert.EqualValues(t, procV1.CtxSwitches, procV2.CtxSwitches)
-	assert.EqualValues(t, procV1.MemInfo, procV2.MemInfo)
-	// gopsutil has a bug in statm parsing https://github.com/shirou/gopsutil/issues/277
-	// so we compare after swapping the value of field `Data` and `Dirty` from gopsutil
-	// TODO: fix the problem in gopsutil forked by `Datadog`
-	procV1.MemInfoEx.Dirty, procV1.MemInfoEx.Data = procV1.MemInfoEx.Data, procV1.MemInfoEx.Dirty
-	assert.EqualValues(t, procV1.MemInfoEx, procV2.MemInfoEx)
-	assert.EqualValues(t, procV1.IOStat, procV2.IOStat)
-}
-
 func TestMultipleProbes(t *testing.T) {
 	os.Setenv("HOST_PROC", "resources/test_procfs/proc/")
 	defer os.Unsetenv("HOST_PROC")

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -571,22 +571,6 @@ func testParseIO(t *testing.T) {
 	}
 }
 
-func TestFetchFieldsWithoutPermission(t *testing.T) {
-	probe := NewProcessProbe()
-	defer probe.Close()
-
-	// PID 1 is always owned by root so we would always get permission error
-	pid := int32(1)
-	actual := probe.parseIO(filepath.Join(probe.procRootLoc, strconv.Itoa(int(pid))))
-	assert.Equal(t, int64(-1), actual.ReadCount)
-	assert.Equal(t, int64(-1), actual.ReadBytes)
-	assert.Equal(t, int64(-1), actual.WriteCount)
-	assert.Equal(t, int64(-1), actual.WriteBytes)
-
-	fd := probe.getFDCount(strconv.Itoa(int(pid)))
-	assert.Equal(t, int32(-1), fd)
-}
-
 func TestParseStatContent(t *testing.T) {
 	probe := NewProcessProbe()
 	defer probe.Close()

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -88,10 +88,10 @@ type MemoryInfoExStat struct {
 
 // IOCountersStat holds IO metrics for a process
 type IOCountersStat struct {
-	ReadCount  uint64
-	WriteCount uint64
-	ReadBytes  uint64
-	WriteBytes uint64
+	ReadCount  int64
+	WriteCount int64
+	ReadBytes  int64
+	WriteBytes int64
 }
 
 // IsZeroValue checks whether all fields are 0 in value for IOCountersStat
@@ -103,100 +103,6 @@ func (i *IOCountersStat) IsZeroValue() bool {
 type NumCtxSwitchesStat struct {
 	Voluntary   int64
 	Involuntary int64
-}
-
-// ConvertAllProcesses takes a group of Process objects and convert them into FilledProcess
-func ConvertAllProcesses(processes map[int32]*Process) map[int32]*process.FilledProcess {
-	result := make(map[int32]*process.FilledProcess, len(processes))
-	for pid, p := range processes {
-		result[pid] = ConvertToFilledProcess(p)
-	}
-	return result
-}
-
-// ConvertToFilledProcess takes a Process object and convert it into FilledProcess
-func ConvertToFilledProcess(p *Process) *process.FilledProcess {
-	return &process.FilledProcess{
-		Pid:         p.Pid,
-		Ppid:        p.Ppid,
-		NsPid:       p.NsPid,
-		Cmdline:     p.Cmdline,
-		CpuTime:     *ConvertCPUStat(p.Stats.CPUTime),
-		Nice:        p.Stats.Nice,
-		CreateTime:  p.Stats.CreateTime,
-		OpenFdCount: p.Stats.OpenFdCount,
-		Name:        p.Name,
-		Status:      p.Stats.Status,
-		Uids:        p.Uids,
-		Gids:        p.Gids,
-		NumThreads:  p.Stats.NumThreads,
-		CtxSwitches: ConvertCtxSwitches(p.Stats.CtxSwitches),
-		MemInfo:     ConvertMemInfo(p.Stats.MemInfo),
-		MemInfoEx:   ConvertMemInfoEx(p.Stats.MemInfoEx),
-		Cwd:         p.Cwd,
-		Exe:         p.Exe,
-		IOStat:      ConvertIOStats(p.Stats.IOStat),
-		Username:    p.Username,
-	}
-}
-
-// ConvertCPUStat converts procutil CPUTimeStat object to TimesStat in gopsutil
-func ConvertCPUStat(s *CPUTimesStat) *cpu.TimesStat {
-	return &cpu.TimesStat{
-		CPU:       "cpu",
-		User:      s.User,
-		System:    s.System,
-		Idle:      s.Idle,
-		Nice:      s.Nice,
-		Iowait:    s.Iowait,
-		Irq:       s.Irq,
-		Softirq:   s.Softirq,
-		Steal:     s.Steal,
-		Guest:     s.Guest,
-		GuestNice: s.GuestNice,
-		Stolen:    s.Stolen,
-		Timestamp: s.Timestamp,
-	}
-}
-
-// ConvertMemInfo converts procutil MemoryInfoStat object to MemoryInfoStat in gopsutil
-func ConvertMemInfo(s *MemoryInfoStat) *process.MemoryInfoStat {
-	return &process.MemoryInfoStat{
-		RSS:  s.RSS,
-		VMS:  s.VMS,
-		Swap: s.Swap,
-	}
-}
-
-// ConvertMemInfoEx converts procutil MemoryInfoExStat object to MemoryInfoExStat in gopsutil
-func ConvertMemInfoEx(s *MemoryInfoExStat) *process.MemoryInfoExStat {
-	return &process.MemoryInfoExStat{
-		RSS:    s.RSS,
-		VMS:    s.VMS,
-		Shared: s.Shared,
-		Text:   s.Text,
-		Lib:    s.Lib,
-		Data:   s.Data,
-		Dirty:  s.Dirty,
-	}
-}
-
-// ConvertIOStats converts procutil IOCountersStat object to IOCounterStat in gopsutil
-func ConvertIOStats(s *IOCountersStat) *process.IOCountersStat {
-	return &process.IOCountersStat{
-		ReadCount:  s.ReadCount,
-		WriteCount: s.WriteCount,
-		ReadBytes:  s.ReadBytes,
-		WriteBytes: s.WriteBytes,
-	}
-}
-
-// ConvertCtxSwitches converts procutil NumCtxSwitchesStat object to NumCtxSwitchesStat in gopsutil
-func ConvertCtxSwitches(s *NumCtxSwitchesStat) *process.NumCtxSwitchesStat {
-	return &process.NumCtxSwitchesStat{
-		Voluntary:   s.Voluntary,
-		Involuntary: s.Involuntary,
-	}
 }
 
 // ConvertAllFilledProcesses takes a group of FilledProcess objects and convert them into Process
@@ -293,10 +199,10 @@ func ConvertFromMemInfoEx(s *process.MemoryInfoExStat) *MemoryInfoExStat {
 // ConvertFromIOStats converts gopsutil IOCountersStat object to IOCounterStat in procutil
 func ConvertFromIOStats(s *process.IOCountersStat) *IOCountersStat {
 	return &IOCountersStat{
-		ReadCount:  s.ReadCount,
-		WriteCount: s.WriteCount,
-		ReadBytes:  s.ReadBytes,
-		WriteBytes: s.WriteBytes,
+		ReadCount:  int64(s.ReadCount),
+		WriteCount: int64(s.WriteCount),
+		ReadBytes:  int64(s.ReadBytes),
+		WriteBytes: int64(s.WriteBytes),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

The current IO rate calculation is inaccurate. It assumes that if gopsutil(now procutil) has permission problem collecting the IO metrics, the library will return 0s. In reality, having 0 read/write count is an actual case, so process-agent output actually failed to distinguish 0 values and permission problem.

This PR updates procutil library to return -1 for `fd` and `io` metrics upon permission error when doing collection. The value propagates to process-agent level and we handle 0 value and permission problem separately.

This PR also removes some original methods that convert from procutil's `Process` model to `FilledProcess` model in gopsutil for backward compatibility, we now uses `Process` model everywhere because of this PR: https://github.com/DataDog/datadog-agent/pull/7430.

@DataDog/processes 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
