### PR TITLE
snmp: Rename tag from `autodiscovery_subnet` to `network`

### DIFF
--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -411,7 +411,7 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 		return []byte(s.config.ContextEngineID), nil
 	case "context_name":
 		return []byte(s.config.ContextName), nil
-	case "autodiscovery_subnet":
+	case "network":
 		return []byte(s.config.Network), nil
 	}
 	return []byte{}, ErrNotSupported

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -171,7 +171,7 @@ func TestExtraConfig(t *testing.T) {
 		config:       snmpConfig,
 	}
 
-	info, err := svc.GetExtraConfig([]byte("autodiscovery_subnet"))
+	info, err := svc.GetExtraConfig([]byte("network"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "192.168.0.0/24", string(info))
 


### PR DESCRIPTION
### What does this PR do?

snmp: Rename tag from `autodiscovery_subnet` to `network`

Related PRs:

- https://github.com/DataDog/integrations-core/pull/8684
- https://github.com/DataDog/integrations-core/pull/8685

### Motivation

Friendlier name and better consistency with `network` as tag key for snmp.discovered_devices_count

### Additional Notes

- `autodiscovery_subnet` is not used in prod monitors ✅ 
- `autodiscovery_subnet` is not used in prod dashboard TBC

### Describe your test plan

