### PR TITLE
snmp_listener: add loader config

### DIFF
--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -413,6 +413,8 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 		return []byte(s.config.ContextName), nil
 	case "autodiscovery_subnet":
 		return []byte(s.config.Network), nil
+	case "loader":
+		return []byte(s.config.Loader), nil
 	}
 	return []byte{}, ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -196,6 +196,7 @@ func TestExtraConfigv3(t *testing.T) {
 		AuthProtocol: "SHA",
 		PrivKey:      "private",
 		PrivProtocol: "DES",
+		Loader:       "core",
 	}
 
 	svc := SNMPService{
@@ -225,4 +226,8 @@ func TestExtraConfigv3(t *testing.T) {
 	info, err = svc.GetExtraConfig([]byte("priv_protocol"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "DES", string(info))
+
+	info, err = svc.GetExtraConfig([]byte("loader"))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "core", string(info))
 }

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -47,6 +47,7 @@ func TestSNMPListener(t *testing.T) {
 
 	job := <-testChan
 
+	assert.Equal(t, "core", job.subnet.config.Loader) // default to loader:core
 	assert.Equal(t, "snmp", job.subnet.adIdentifier)
 	assert.Equal(t, "192.168.0.0", job.currentIP.String())
 	assert.Equal(t, "192.168.0.0", job.subnet.startingIP.String())

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -25,6 +25,7 @@ func TestSNMPListener(t *testing.T) {
 	snmpConfig := snmp.Config{
 		Network:   "192.168.0.0/24",
 		Community: "public",
+		Loader: "core",
 	}
 	listenerConfig := snmp.ListenerConfig{
 		Configs: []snmp.Config{snmpConfig},
@@ -47,7 +48,7 @@ func TestSNMPListener(t *testing.T) {
 
 	job := <-testChan
 
-	assert.Equal(t, "core", job.subnet.config.Loader) // default to loader:core
+	assert.Equal(t, "core", job.subnet.config.Loader)
 	assert.Equal(t, "snmp", job.subnet.adIdentifier)
 	assert.Equal(t, "192.168.0.0", job.currentIP.String())
 	assert.Equal(t, "192.168.0.0", job.subnet.startingIP.String())

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -25,7 +25,7 @@ func TestSNMPListener(t *testing.T) {
 	snmpConfig := snmp.Config{
 		Network:   "192.168.0.0/24",
 		Community: "public",
-		Loader: "core",
+		Loader:    "core",
 	}
 	listenerConfig := snmp.ListenerConfig{
 		Configs: []snmp.Config{snmpConfig},

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -611,7 +611,7 @@ api_key:
     #
     # ad_identifier: snmp
 
-    ## @param loader - string - optional - default: core
+    ## @param loader - string - optional
     ## Check loader to use. Available loaders:
     ## - core: will use corecheck SNMP integration
     ## - python: will use python SNMP integration

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -611,7 +611,7 @@ api_key:
     #
     # ad_identifier: snmp
 
-    ## @param loader - string - optional
+    ## @param loader - string - optional - default: python
     ## Check loader to use. Available loaders:
     ## - core: will use corecheck SNMP integration
     ## - python: will use python SNMP integration

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -188,7 +188,7 @@ api_key:
 # forwarder_stop_timeout: 2
 
 ## @param forwarder_storage_max_size_in_bytes - int - optional - default: 0
-## When the retry queue of the forwarder is full, `forwarder_storage_max_size_in_bytes` 
+## When the retry queue of the forwarder is full, `forwarder_storage_max_size_in_bytes`
 ## defines the amount of disk space the Agent can use to store transactions on the disk.
 ## When `forwarder_storage_max_size_in_bytes` is `0`, the transactions are never stored on the disk.
 #
@@ -196,10 +196,10 @@ api_key:
 
 ## @param forwarder_storage_max_disk_ratio - float - optional - default: 0.95
 ## `forwarder_storage_max_disk_ratio` defines the disk capacity limit for storing transactions.
-## `0.95` means the Agent can store transactions on disk until `forwarder_storage_max_size_in_bytes` 
+## `0.95` means the Agent can store transactions on disk until `forwarder_storage_max_size_in_bytes`
 ## is reached or when the disk mount for `forwarder_storage_path` exceeds 95% of the disk capacity,
 ## whichever is lower.
-# 
+#
 # forwarder_storage_max_size_in_bytes: 0.95
 
 ## @param forwarder_storage_path - string - optional - default: /opt/datadog-agent/run/transactions_to_retry (c:\ProgramData\Datadog\run\transactions_to_retry on Windows)
@@ -610,6 +610,13 @@ api_key:
     ## specify the corresponding ad_identifier at the top of the file.
     #
     # ad_identifier: snmp
+
+    ## @param loader - string - optional - default: core
+    ## Check loader to use. Available loaders:
+    ## - core: will use corecheck SNMP integration
+    ## - python: will use python SNMP integration
+    #
+    # loader: core
 
 {{- if .Profiling -}}
 ## @param profiling - custom object - optional

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -53,6 +53,7 @@ type Config struct {
 	ContextName        string          `mapstructure:"context_name"`
 	IgnoredIPAddresses map[string]bool `mapstructure:"ignored_ip_addresses"`
 	ADIdentifier       string          `mapstructure:"ad_identifier"`
+	Loader             string          `mapstructure:"loader"`
 }
 
 // NewListenerConfig parses configuration and returns a built ListenerConfig
@@ -111,6 +112,7 @@ func (c *Config) Digest(address string) string {
 	h.Write([]byte(c.PrivProtocol))            //nolint:errcheck
 	h.Write([]byte(c.ContextEngineID))         //nolint:errcheck
 	h.Write([]byte(c.ContextName))             //nolint:errcheck
+	h.Write([]byte(c.Loader))                  //nolint:errcheck
 
 	// Sort the addresses to get a stable digest
 	addresses := make([]string, 0, len(c.IgnoredIPAddresses))

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -93,9 +93,6 @@ func NewListenerConfig() (ListenerConfig, error) {
 		if config.Retries == 0 {
 			config.Retries = defaultRetries
 		}
-		if config.Loader == "" {
-			config.Loader = "core"
-		}
 	}
 	return snmpConfig, nil
 }

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -93,6 +93,9 @@ func NewListenerConfig() (ListenerConfig, error) {
 		if config.Retries == 0 {
 			config.Retries = defaultRetries
 		}
+		if config.Loader == "" {
+			config.Loader = "core"
+		}
 	}
 	return snmpConfig, nil
 }

--- a/releasenotes/notes/add_loader_config_to_snmp_listener-18cc470abc368ec8.yaml
+++ b/releasenotes/notes/add_loader_config_to_snmp_listener-18cc470abc368ec8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``loader`` config to snmp_listener


### PR DESCRIPTION
Related PR: https://github.com/DataDog/integrations-core/pull/8686

### What does this PR do?

snmp_listener: add loader config

### Motivation

Needed to be able to select check loader without the need to change the AD template

### Additional Notes


### Describe your test plan
