### PR TITLE
[process-agent][system-probe][PROC-815] Place all strings used for checks into a config file as constants

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -30,7 +30,7 @@ var inactivityLogDuration = 10 * time.Minute
 var NetworkTracer = api.Factory{
 	Name: "network_tracer",
 	Fn: func(cfg *config.AgentConfig) (api.Module, error) {
-		if !cfg.CheckIsEnabled(config.NetworkCheckName) { // this folder tbh
+		if !cfg.CheckIsEnabled(config.NetworkCheckName) {
 			log.Infof("Network tracer disabled")
 			return nil, api.ErrNotEnabled
 		}

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -30,7 +30,7 @@ var inactivityLogDuration = 10 * time.Minute
 var NetworkTracer = api.Factory{
 	Name: "network_tracer",
 	Fn: func(cfg *config.AgentConfig) (api.Module, error) {
-		if !cfg.CheckIsEnabled("Network") {
+		if !cfg.CheckIsEnabled(config.NetworkCheckName) { // this folder tbh
 			log.Infof("Network tracer disabled")
 			return nil, api.ErrNotEnabled
 		}

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -16,7 +16,7 @@ import (
 var OOMKillProbe = api.Factory{
 	Name: "oom_kill_probe",
 	Fn: func(cfg *config.AgentConfig) (api.Module, error) {
-		if !cfg.CheckIsEnabled("OOM Kill") {
+		if !cfg.CheckIsEnabled(config.OOMKillCheckName) {
 			log.Info("OOM kill probe disabled")
 			return nil, api.ErrNotEnabled
 		}

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -17,7 +17,7 @@ import (
 var TCPQueueLength = api.Factory{
 	Name: "tcp_queue_length_tracer",
 	Fn: func(cfg *config.AgentConfig) (api.Module, error) {
-		if !cfg.CheckIsEnabled("TCP queue length") {
+		if !cfg.CheckIsEnabled(config.TCPQueueLengthCheckName) {
 			log.Infof("TCP queue length tracer disabled")
 			return nil, api.ErrNotEnabled
 		}

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -48,7 +48,7 @@ func (c *ContainerCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
 }
 
 // Name returns the name of the ProcessCheck.
-func (c *ContainerCheck) Name() string { return "container" }
+func (c *ContainerCheck) Name() string { return config.ContainerCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (c *ContainerCheck) RealTime() bool { return false }

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -28,7 +28,7 @@ func (r *RTContainerCheck) Init(_ *config.AgentConfig, sysInfo *model.SystemInfo
 }
 
 // Name returns the name of the RTContainerCheck.
-func (r *RTContainerCheck) Name() string { return "rtcontainer" }
+func (r *RTContainerCheck) Name() string { return config.RTContainerCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (r *RTContainerCheck) RealTime() bool { return true }

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -60,7 +60,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, _ *model.SystemInfo) {
 }
 
 // Name returns the name of the ConnectionsCheck.
-func (c *ConnectionsCheck) Name() string { return "connections" }
+func (c *ConnectionsCheck) Name() string { return config.ConnectionsCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (c *ConnectionsCheck) RealTime() bool { return false }

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -37,7 +37,7 @@ func (c *PodCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
 }
 
 // Name returns the name of the ProcessCheck.
-func (c *PodCheck) Name() string { return "pod" }
+func (c *PodCheck) Name() string { return config.PodCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (c *PodCheck) RealTime() bool { return false }

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -57,7 +57,7 @@ func (p *ProcessCheck) Init(_ *config.AgentConfig, info *model.SystemInfo) {
 }
 
 // Name returns the name of the ProcessCheck.
-func (p *ProcessCheck) Name() string { return "process" }
+func (p *ProcessCheck) Name() string { return config.ProcessCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (p *ProcessCheck) RealTime() bool { return false }

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -32,7 +32,7 @@ func (r *RTProcessCheck) Init(_ *config.AgentConfig, info *model.SystemInfo) {
 }
 
 // Name returns the name of the RTProcessCheck.
-func (r *RTProcessCheck) Name() string { return "rtprocess" }
+func (r *RTProcessCheck) Name() string { return config.RTProcessCheckName }
 
 // RealTime indicates if this check only runs in real-time mode.
 func (r *RTProcessCheck) RealTime() bool { return true }

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -35,9 +35,23 @@ const (
 	defaultRuntimeCompilerOutputDir = "/var/tmp/datadog-agent/system-probe/build"
 )
 
+// Name for check performed by process-agent or system-probe
+const (
+	ProcessCheckName     = "process"
+	RTProcessCheckName   = "rtprocess"
+	ContainerCheckName   = "container"
+	RTContainerCheckName = "rtcontainer"
+	ConnectionsCheckName = "connections"
+	PodCheckName         = "pod"
+
+	NetworkCheckName        = "Network"
+	OOMKillCheckName        = "OOM Kill"
+	TCPQueueLengthCheckName = "TCP queue length"
+)
+
 var (
-	processChecks   = []string{"process", "rtprocess"}
-	containerChecks = []string{"container", "rtcontainer"}
+	processChecks   = []string{ProcessCheckName, RTProcessCheckName}
+	containerChecks = []string{ContainerCheckName, RTContainerCheckName}
 )
 
 type proxyFunc func(*http.Request) (*url.URL, error)
@@ -243,12 +257,12 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		// Check config
 		EnabledChecks: enabledChecks,
 		CheckIntervals: map[string]time.Duration{
-			"process":     10 * time.Second,
-			"rtprocess":   2 * time.Second,
-			"container":   10 * time.Second,
-			"rtcontainer": 2 * time.Second,
-			"connections": 30 * time.Second,
-			"pod":         10 * time.Second,
+			ProcessCheckName:     10 * time.Second,
+			RTProcessCheckName:   2 * time.Second,
+			ContainerCheckName:   10 * time.Second,
+			RTContainerCheckName: 2 * time.Second,
+			ConnectionsCheckName: 30 * time.Second,
+			PodCheckName:         10 * time.Second,
 		},
 
 		// DataScrubber to hide command line sensitive words
@@ -389,7 +403,7 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 	// activate the pod collection if enabled and we have the cluster name set
 	if cfg.Orchestrator.OrchestrationCollectionEnabled {
 		if cfg.Orchestrator.KubeClusterName != "" {
-			cfg.EnabledChecks = append(cfg.EnabledChecks, "pod")
+			cfg.EnabledChecks = append(cfg.EnabledChecks, PodCheckName)
 		} else {
 			log.Warnf("Failed to auto-detect a Kubernetes cluster name. Pod collection will not start. To fix this, set it manually via the cluster_name config option")
 		}

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -290,8 +290,8 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(true, agentConfig.AllowRealTime)
 	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(append(processChecks), agentConfig.EnabledChecks)
-	assert.Equal(8*time.Second, agentConfig.CheckIntervals["container"])
-	assert.Equal(30*time.Second, agentConfig.CheckIntervals["process"])
+	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
+	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(false, agentConfig.Windows.AddNewArgs)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
@@ -311,13 +311,13 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(10, agentConfig.QueueSize)
 	assert.Equal(true, agentConfig.AllowRealTime)
 	assert.Equal(true, agentConfig.Enabled)
-	assert.Equal(8*time.Second, agentConfig.CheckIntervals["container"])
-	assert.Equal(30*time.Second, agentConfig.CheckIntervals["process"])
+	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
+	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(false, agentConfig.Windows.AddNewArgs)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
 	assert.Equal("/var/my-location/system-probe.log", agentConfig.SystemProbeAddress)
-	assert.Equal(append(processChecks, "connections", "Network"), agentConfig.EnabledChecks)
+	assert.Equal(append(processChecks, ConnectionsCheckName, NetworkCheckName), agentConfig.EnabledChecks)
 	assert.Equal(500, agentConfig.ClosedChannelSize)
 	assert.True(agentConfig.SysProbeBPFDebug)
 	assert.Empty(agentConfig.ExcludedBPFLinuxVersions)
@@ -338,8 +338,8 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(10, agentConfig.QueueSize)
 	assert.Equal(true, agentConfig.AllowRealTime)
 	assert.Equal(true, agentConfig.Enabled)
-	assert.Equal(8*time.Second, agentConfig.CheckIntervals["container"])
-	assert.Equal(30*time.Second, agentConfig.CheckIntervals["process"])
+	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
+	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(false, agentConfig.Windows.AddNewArgs)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
@@ -527,7 +527,7 @@ func TestNetworkConfig(t *testing.T) {
 
 		assert.True(t, agentConfig.EnableSystemProbe)
 		assert.True(t, agentConfig.Enabled)
-		assert.ElementsMatch(t, []string{"connections", "Network", "process", "rtprocess"}, agentConfig.EnabledChecks)
+		assert.ElementsMatch(t, []string{ConnectionsCheckName, NetworkCheckName, ProcessCheckName, RTProcessCheckName}, agentConfig.EnabledChecks)
 	})
 
 	t.Run("env", func(t *testing.T) {
@@ -539,7 +539,7 @@ func TestNetworkConfig(t *testing.T) {
 
 		assert.True(t, agentConfig.EnableSystemProbe)
 		assert.True(t, agentConfig.Enabled)
-		assert.ElementsMatch(t, []string{"connections", "Network", "process", "rtprocess"}, agentConfig.EnabledChecks)
+		assert.ElementsMatch(t, []string{ConnectionsCheckName, NetworkCheckName, ProcessCheckName, RTProcessCheckName}, agentConfig.EnabledChecks)
 	})
 }
 
@@ -553,7 +553,7 @@ func TestSystemProbeNoNetwork(t *testing.T) {
 
 	assert.True(t, agentConfig.EnableSystemProbe)
 	assert.True(t, agentConfig.Enabled)
-	assert.ElementsMatch(t, []string{"OOM Kill", "process", "rtprocess"}, agentConfig.EnabledChecks)
+	assert.ElementsMatch(t, []string{OOMKillCheckName, ProcessCheckName, RTProcessCheckName}, agentConfig.EnabledChecks)
 
 }
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -171,7 +171,7 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	if config.Datadog.GetBool(key(spNS, "enable_oom_kill")) {
 		log.Info("system_probe_config.enable_oom_kill detected, will enable system-probe with OOM Kill check")
 		a.EnableSystemProbe = true
-		a.EnabledChecks = append(a.EnabledChecks, "OOM Kill")
+		a.EnabledChecks = append(a.EnabledChecks, OOMKillCheckName)
 	}
 
 	if config.Datadog.GetBool("runtime_security_config.enabled") {
@@ -192,17 +192,17 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 	// Enable network and connections check
 	if config.Datadog.GetBool("network_config.enabled") {
 		log.Info(fmt.Sprintf("network_config.enabled detected: enabling system-probe with network module running."))
-		a.EnabledChecks = append(a.EnabledChecks, "connections", "Network")
+		a.EnabledChecks = append(a.EnabledChecks, ConnectionsCheckName, NetworkCheckName)
 		a.EnableSystemProbe = true // system-probe is implicitly enabled if networks is enabled
 	} else if config.Datadog.IsSet(key(spNS, "enabled")) && config.Datadog.GetBool(key(spNS, "enabled")) && !config.Datadog.IsSet(key("network_config", "enabled")) {
 		// This case exists to preserve backwards compatibility. If system_probe.enabled is explicitlty set to true, and there is no network_config block,
 		// enable the connections/network check.
 		log.Info("network_config not found, but system-probe was enabled, enabling network module by default")
-		a.EnabledChecks = append(a.EnabledChecks, "Network", "connections")
+		a.EnabledChecks = append(a.EnabledChecks, NetworkCheckName, ConnectionsCheckName)
 		a.EnableSystemProbe = true
 	}
 
-	if !a.Enabled && util.StringInSlice(a.EnabledChecks, "connections") {
+	if !a.Enabled && util.StringInSlice(a.EnabledChecks, ConnectionsCheckName) {
 		log.Info("enabling process-agent for connections check as the system-probe is enabled")
 		a.Enabled = true
 	}
@@ -288,11 +288,11 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	// The interval, in seconds, at which we will run each check. If you want consistent
 	// behavior between real-time you may set the Container/ProcessRT intervals to 10.
 	// Defaults to 10s for normal checks and 2s for others.
-	a.setCheckInterval(ns, "container", "container")
-	a.setCheckInterval(ns, "container_realtime", "rtcontainer")
-	a.setCheckInterval(ns, "process", "process")
-	a.setCheckInterval(ns, "process_realtime", "rtprocess")
-	a.setCheckInterval(ns, "connections", "connections")
+	a.setCheckInterval(ns, "container", ContainerCheckName)
+	a.setCheckInterval(ns, "container_realtime", RTContainerCheckName)
+	a.setCheckInterval(ns, "process", ProcessCheckName)
+	a.setCheckInterval(ns, "process_realtime", RTProcessCheckName)
+	a.setCheckInterval(ns, "connections", ConnectionsCheckName)
 
 	// A list of regex patterns that will exclude a process if matched.
 	if k := key(ns, "blacklist_patterns"); config.Datadog.IsSet(k) {


### PR DESCRIPTION
### What does this PR do?

* Place all strings used for checks into a config file as constants
* Replaces all instances inside and outside of the `config` package with the constants

### Motivation

* https://datadoghq.atlassian.net/browse/PROC-815 We were using hard coded strings everywhere for checks. Restricting it to one place is safer. 

### Additional Notes

* Constants changes affect @DataDog/processes @DataDog/networks @DataDog/container-integrations 

### Describe your test plan

* Making sure all unit tests pass ✅ 

Write there any instructions and details that should be tested during the QA.
