### PR TITLE
Add hint when `datadog` is missing in package name for integration install command.

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -268,7 +268,7 @@ func validateArgs(args []string, local bool) error {
 
 	if !local {
 		if !datadogPkgNameRe.MatchString(args[0]) {
-			return fmt.Errorf("invalid package name - this manager only handles datadog packages")
+			return fmt.Errorf("invalid package name - this manager only handles datadog packages. Did you mean `datadog-%s`?", args[0])
 		}
 	} else {
 		// Validate the wheel we try to install exists


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

Adds a hint to the `agent integration install [package==version]` command.
Example:

```
$ agent integration install redis
Error: invalid package name - this manager only handles datadog packages. Did you mean `datadog-redis`?
```

### Motivation

What inspired you to submit this pull request?
This would significantly improve the usability of the integration command due to many users submitting support tickets for this issue.

### Additional Notes

Anything else we should know when reviewing?

This will hint if the package name does not match the format `datadog-*`. This means that we might hint something like this:
```
$ agent integration install dd-redis
Error: invalid package name - this manager only handles datadog packages. Did you mean `datadog-dd-redis`?
```
Although this is incorrect, most support tickets were from users forgetting to prepend `datadog-`. Nonetheless, a more sophisticated error checking can be done if needed. 

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
