### PR TITLE
[CircleCI] Reset cache after switch to go mod mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,11 @@ templates:
           # If incremental dep fails, increase the cache gen number
           # in restore_deps AND save_deps
           # See https://github.com/DataDog/datadog-agent/pull/2384
-          - gen16-godeps-{{ .Branch }}-{{ .Revision }}
-          - gen16-godeps-{{ .Branch }}-
-          - gen16-godeps-master-
+          - gen17-godeps-{{ .Branch }}-{{ .Revision }}
+          - gen17-godeps-{{ .Branch }}-
+          - gen17-godeps-master-
     - save_cache: &save_deps
-        key: gen16-godeps-{{ .Branch }}-{{ .Revision }}
+        key: gen17-godeps-{{ .Branch }}-{{ .Revision }}
     - restore_cache: &restore_source
         keys:
           # Cache retrieval is faster than full git checkout


### PR DESCRIPTION
### What does this PR do?

Following #7435, resets all CircleCI deps caches.

### Motivation

Some weird behavior can happen on branches that were created before #7435 and then rebased / merged master, due to the caching process we have (the `vendor/` directory from an old run can be reused, leading to errors if there are commands that don't explicitly set `-mod=mod` + discrepancies between `go.mod` and the `vendor/` directory state.

To avoid these issues, we can reset the CircleCI cache on master. Then all branches that rebase / merge master will start using a fresh cache.
