### PR TITLE
[rtloader] Explicitly set -mod=mod in rtloader tests, serverless builds and security agent tests

### DIFF
--- a/.gitlab/binary_build/serverless.yml
+++ b/.gitlab/binary_build/serverless.yml
@@ -14,7 +14,7 @@ build_serverless-deb_x64:
   before_script:
     - *retrieve_linux_go_deps
   script:
-    - cd cmd/serverless && go build -a -v -tags serverless
+    - cd cmd/serverless && go build -mod=mod -a -v -tags serverless
 
 build_serverless-deb_arm64:
   stage: binary_build
@@ -24,4 +24,4 @@ build_serverless-deb_arm64:
   before_script:
     - *retrieve_linux_go_deps
   script:
-    - cd cmd/serverless && go build -a -v -tags serverless
+    - cd cmd/serverless && go build -mod=mod -a -v -tags serverless

--- a/rtloader/test/CMakeLists.txt
+++ b/rtloader/test/CMakeLists.txt
@@ -31,7 +31,7 @@ if (NOT DISABLE_PYTHON2)
     set (CGO_LDFLAGS \"-L${PROJECT_BINARY_DIR}/two/ ${CGO_LDFLAGS}\")
     add_custom_command(
         OUTPUT testPy2
-        COMMAND ${CMAKE_COMMAND} -E env CGO_CFLAGS=${CGO_CFLAGS} CGO_LDFLAGS=${CGO_LDFLAGS} DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "two" -count=1 -p=1 ${PKGS}
+        COMMAND ${CMAKE_COMMAND} -E env CGO_CFLAGS=${CGO_CFLAGS} CGO_LDFLAGS=${CGO_LDFLAGS} DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -mod=mod -tags "two" -count=1 -p=1 ${PKGS}
     )
     list(APPEND TARGETS "testPy2")
 endif()
@@ -40,7 +40,7 @@ if (NOT DISABLE_PYTHON3)
     set (CGO_LDFLAGS \"-L${PROJECT_BINARY_DIR}/three/ ${CGO_LDFLAGS}\")
     add_custom_command(
         OUTPUT testPy3
-        COMMAND ${CMAKE_COMMAND} -E env CGO_CFLAGS=${CGO_CFLAGS} CGO_LDFLAGS=${CGO_LDFLAGS} DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -tags "three" -count=1 -p=1 ${PKGS}
+        COMMAND ${CMAKE_COMMAND} -E env CGO_CFLAGS=${CGO_CFLAGS} CGO_LDFLAGS=${CGO_LDFLAGS} DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -mod=mod -tags "three" -count=1 -p=1 ${PKGS}
     )
     list(APPEND TARGETS "testPy3")
 endif()

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -172,7 +172,7 @@ def build_functional_tests(
         ldflags += '-extldflags "-static"'
         build_tags += ',osusergo'
 
-    cmd = 'go test -tags {build_tags} -ldflags="{ldflags}" -c -o {output} '
+    cmd = 'go test -mod=mod -tags {build_tags} -ldflags="{ldflags}" -c -o {output} '
     cmd += '{repo_path}/pkg/security/tests'
 
     args = {


### PR DESCRIPTION
### What does this PR do?

- Sets `-mod=mod` in `testPy2` and `testPy3` `go test` commands.
- Sets `-mod=mod` on serverless builds and security agent tests.

### Motivation

Prevent these tests and builds from misbehaving when a `vendor/` directory is present when the tests are run (this directory should be ignored now that we switched to `-mod=mod`, see #7435).

