### PR TITLE
[system-probe] Make ebpf compiler buildable on non-GLIBC environment

### DIFF
--- a/pkg/ebpf/compiler/wrapper.h
+++ b/pkg/ebpf/compiler/wrapper.h
@@ -13,6 +13,8 @@ $ objdump -p bin/system-probe/system-probe
 $ nm bin/system-probe/system-probe | grep GLIBC_X.XX
 */
 
+#ifdef __GLIBC__
+
 #ifdef __x86_64__
 #define GLIBC_VERS "GLIBC_2.2.5"
 #elif defined(__aarch64__)
@@ -47,6 +49,34 @@ asm(".symver __" #func "_prior_glibc, " #func "@" GLIBC_VERS);  \
 float __wrap_ ## func (float x) {                               \
   return __ ## func ## _prior_glibc(x);                         \
 }
+
+#else
+
+// Use functions directly for non-GLIBC environments.
+
+#define symver_wrap_d1(func)                                    \
+double func(double x);                                          \
+                                                                \
+double __wrap_ ## func (double x) {                             \
+  return func(x);                                               \
+}
+
+#define symver_wrap_d2(func)                                    \
+double func(double x, double y);                                \
+                                                                \
+double __wrap_ ## func (double x, double y) {                   \
+  return func(x, y);                                            \
+}
+
+#define symver_wrap_f1(func)                                    \
+float func(float x);                                            \
+                                                                \
+float __wrap_ ## func (float x) {                               \
+  return func(x);                                               \
+}
+
+#endif
+
 
 symver_wrap_d1(exp)
 symver_wrap_d1(log)

--- a/releasenotes/notes/make-ebpf-compiler-buildable-on-non-glibc-env-4ebe7f98ea1ace2c.yaml
+++ b/releasenotes/notes/make-ebpf-compiler-buildable-on-non-glibc-env-4ebe7f98ea1ace2c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Make ebpf compiler buildable on non-GLIBC environment.


### PR DESCRIPTION
### What does this PR do?

Fixes #7512

`pkg/ebpf/compiler/wrapper.h ` wrapped some versioned GLIBC functions even if it is built with non-GLIBC libc (like musl).
This PR adds check whether build is with GLIBC or not and switch to use functions directly on non-GLIBC environment.

### Motivation

I'm making and using Alpine Linux based datadog-agent.
v7.26.0 build on Alpine failed due to #7512: https://github.com/seqsense/datadog-agent-alpine/pull/25

### Additional Notes

I believe the it doesn't cause any change for GLIBC environment build.

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
