### PR TITLE
[tasks] Go modules RFC release tooling

### DIFF
--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -1,0 +1,58 @@
+import os
+from typing import List
+
+
+class GoModule:
+    """A Go module abstraction."""
+
+    def __init__(self, path, targets=None, condition=lambda: True, dependencies=None):
+        self.path = path
+        self.targets = targets if targets else ["."]
+        self.dependencies = dependencies if dependencies else []
+        self.condition = condition
+
+    def version(self, agent_version: str) -> str:
+        """Return the module version for a given Agent version.
+        >>> mods = [GoModule("."), GoModule("./pkg/util/log")]
+        >>> [mod.version("7.27.0") for mod in mods]
+        ["v7.27.0", "v0.27.0"]
+        """
+        if self.path == ".":
+            return "v" + agent_version
+
+        return "v0" + agent_version[1:]
+
+    def tag(self, agent_version: str) -> List[str]:
+        """Return the module tag name for a given Agent version.
+        >>> mods = [GoModule("."), GoModule("pkg/util/log")]
+        >>> [mod.tag("7.27.0") for mod in mods]
+        [["v.6.27.0", "v7.27.0"], ["pkg/util/log/v0.27.0"]]
+        """
+        if self.path == ".":
+            return ["v7" + agent_version[1:], "v6" + agent_version[1:]]
+
+        return ["{}/{}".format(self.path, self.version(agent_version))]
+
+    def full_path(self) -> str:
+        """Return the absolute path of the Go module."""
+        return os.path.abspath(self.path)
+
+    def go_mod_path(self) -> str:
+        """Return the absolute path of the Go module go.mod file."""
+        return self.full_path() + "/go.mod"
+
+    def dependency_path(self, agent_version: str) -> str:
+        """Return the versioned dependency path of the Go module
+        >>> mods = [GoModule("."), GoModule("pkg/util/log")]
+        >>> [mod.dependency_path("7.27.0") for mod in mods]
+        ["github.com/DataDog/datadog-agent@v7.27.0", "github.com/DataDog/datadog-agent/pkg/util/log@v0.27.0"]        
+        """
+        go_path = "github.com/DataDog/datadog-agent"
+        if self.path != ".":
+            go_path += "/" + self.path
+        return "{go_path}@{version}".format(go_path=go_path, version=self.version(agent_version))
+
+
+DEFAULT_MODULES = {
+    ".": GoModule(".", targets=["./pkg", "./cmd"]),
+}

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -1,5 +1,4 @@
 import os
-from typing import List
 
 
 class GoModule:
@@ -11,7 +10,7 @@ class GoModule:
         self.dependencies = dependencies if dependencies else []
         self.condition = condition
 
-    def __version(self, agent_version: str) -> str:
+    def __version(self, agent_version):
         """Return the module version for a given Agent version.
         >>> mods = [GoModule("."), GoModule("./pkg/util/log")]
         >>> [mod.__version("7.27.0") for mod in mods]
@@ -22,7 +21,7 @@ class GoModule:
 
         return "v0" + agent_version[1:]
 
-    def tag(self, agent_version: str) -> List[str]:
+    def tag(self, agent_version):
         """Return the module tag name for a given Agent version.
         >>> mods = [GoModule("."), GoModule("pkg/util/log")]
         >>> [mod.tag("7.27.0") for mod in mods]
@@ -33,15 +32,15 @@ class GoModule:
 
         return ["{}/{}".format(self.path, self.__version(agent_version))]
 
-    def full_path(self) -> str:
+    def full_path(self):
         """Return the absolute path of the Go module."""
         return os.path.abspath(self.path)
 
-    def go_mod_path(self) -> str:
+    def go_mod_path(self):
         """Return the absolute path of the Go module go.mod file."""
         return self.full_path() + "/go.mod"
 
-    def dependency_path(self, agent_version: str) -> str:
+    def dependency_path(self, agent_version):
         """Return the versioned dependency path of the Go module
         >>> mods = [GoModule("."), GoModule("pkg/util/log")]
         >>> [mod.dependency_path("7.27.0") for mod in mods]

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -12,7 +12,7 @@ class GoModule:
 
     def __version(self, agent_version):
         """Return the module version for a given Agent version.
-        >>> mods = [GoModule("."), GoModule("./pkg/util/log")]
+        >>> mods = [GoModule("."), GoModule("pkg/util/log")]
         >>> [mod.__version("7.27.0") for mod in mods]
         ["v7.27.0", "v0.27.0"]
         """
@@ -21,6 +21,7 @@ class GoModule:
 
         return "v0" + agent_version[1:]
 
+    # FIXME: Change when Agent 6 and Agent 7 releases are decoupled
     def tag(self, agent_version):
         """Return the module tag name for a given Agent version.
         >>> mods = [GoModule("."), GoModule("pkg/util/log")]

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -11,10 +11,10 @@ class GoModule:
         self.dependencies = dependencies if dependencies else []
         self.condition = condition
 
-    def version(self, agent_version: str) -> str:
+    def __version(self, agent_version: str) -> str:
         """Return the module version for a given Agent version.
         >>> mods = [GoModule("."), GoModule("./pkg/util/log")]
-        >>> [mod.version("7.27.0") for mod in mods]
+        >>> [mod.__version("7.27.0") for mod in mods]
         ["v7.27.0", "v0.27.0"]
         """
         if self.path == ".":
@@ -26,12 +26,12 @@ class GoModule:
         """Return the module tag name for a given Agent version.
         >>> mods = [GoModule("."), GoModule("pkg/util/log")]
         >>> [mod.tag("7.27.0") for mod in mods]
-        [["v.6.27.0", "v7.27.0"], ["pkg/util/log/v0.27.0"]]
+        [["6.27.0", "7.27.0"], ["pkg/util/log/v0.27.0"]]
         """
         if self.path == ".":
-            return ["v7" + agent_version[1:], "v6" + agent_version[1:]]
+            return ["6" + agent_version[1:], "7" + agent_version[1:]]
 
-        return ["{}/{}".format(self.path, self.version(agent_version))]
+        return ["{}/{}".format(self.path, self.__version(agent_version))]
 
     def full_path(self) -> str:
         """Return the absolute path of the Go module."""
@@ -50,7 +50,7 @@ class GoModule:
         go_path = "github.com/DataDog/datadog-agent"
         if self.path != ".":
             go_path += "/" + self.path
-        return "{go_path}@{version}".format(go_path=go_path, version=self.version(agent_version))
+        return "{go_path}@{version}".format(go_path=go_path, version=self.__version(agent_version))
 
 
 DEFAULT_MODULES = {

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -875,18 +875,18 @@ def update_modules(ctx, agent_version, verify=True):
 
 
 @task
-def tag_version(ctx, agent_version, commit="HEAD", verify=True, push=False):
+def tag_version(ctx, agent_version, commit="HEAD", verify=True, push=True):
     """
     Create tags for a given Datadog Agent version.
     The version should be given as an Agent 7 version.
 
     * --commit COMMIT will tag COMMIT with the tags (default HEAD)
     * --verify checks for correctness on the Agent version (on by default).
-    * --push will push the tags to the origin remote (off by default).
+    * --push will push the tags to the origin remote (on by default).
 
     Examples:
-    inv -e release.tag-version 7.27.0              # Create tags; don't push them
-    inv -e release.tag-version 7.27.0-rc.3 --push  # Create and push tags to origin
+    inv -e release.tag-version 7.27.0                 # Create tags and push them to origin
+    inv -e release.tag-version 7.27.0-rc.3 --no-push  # Create tags locally; don't push them
     """
     if verify:
         check_version(agent_version)

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -572,6 +572,8 @@ def finish(
 
     """
     Creates new entry in the release.json file for the new version. Removes all the RC entries.
+
+    Update internal module dependencies with the new version.
     """
 
     if sys.version_info[0] < 3:

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -14,6 +14,8 @@ from datetime import date
 from invoke import Failure, task
 from invoke.exceptions import Exit
 
+from tasks.modules import DEFAULT_MODULES
+
 
 @task
 def add_prelude(ctx, version):
@@ -557,7 +559,7 @@ def _save_release_json(
 
 @task
 def finish(
-    _,
+    ctx,
     major_versions="6,7",
     integration_version=None,
     omnibus_software_version=None,
@@ -721,10 +723,13 @@ def finish(
         macos_build_version,
     )
 
+    # Update internal module dependencies
+    update_modules(ctx, _stringify_version(highest_version))
+
 
 @task
 def create_rc(
-    _,
+    ctx,
     major_versions="6,7",
     integration_version=None,
     omnibus_software_version=None,
@@ -737,6 +742,8 @@ def create_rc(
     """
     Takes whatever version is the highest in release.json and adds a new RC to it.
     If there was no RC, creates one and bump minor version. If there was an RC, create RC + 1.
+
+    Update internal module dependencies with the new RC.
     """
 
     if sys.version_info[0] < 3:
@@ -831,3 +838,61 @@ def create_rc(
         security_agent_policies_version,
         macos_build_version,
     )
+
+    # Update internal module dependencies
+    update_modules(ctx, _stringify_version(highest_version))
+
+
+def check_version(agent_version):
+    """Check Agent version to see if it is valid."""
+    version_re = re.compile(r'7[.](\d+)[.](\d+)(-rc\.(\d+))?')
+    if not version_re.match(agent_version):
+        raise Exit(message="Version should be of the form 7.Y.Z or 7.Y.Z-rc.t")
+
+
+@task
+def update_modules(ctx, agent_version, verify=True):
+    """
+    Update internal dependencies between the different Agent modules.
+    * --verify checks for correctness on the Agent Version (on by default).
+
+    Examples:
+    inv -e update-modules 7.27.0 
+    """
+    if verify:
+        check_version(agent_version)
+
+    for module in DEFAULT_MODULES.values():
+        for dependency in module.dependencies:
+            dependency_mod = DEFAULT_MODULES[dependency]
+            ctx.run(
+                "go mod edit -require={dependency_path} {go_mod_path}".format(
+                    dependency_path=dependency_mod.dependency_path(agent_version), go_mod_path=module.go_mod_path()
+                )
+            )
+
+
+@task
+def tag_version(ctx, agent_version, commit="HEAD", verify=True, push=False):
+    """
+    Create tags for a given Datadog Agent version.
+    The version should be given as an Agent 7 version.
+
+    * --commit COMMIT will tag COMMIT with the tags (default HEAD)
+    * --verify checks for correctness on the Agent version (on by default).
+    * --push will push the tags to the origin remote (off by default).
+
+    Examples:
+    inv -e release.tag-version 7.27.0              # Create tags; don't push them
+    inv -e release.tag-version 7.27.0-rc.3 --push  # Create and push tags to origin
+    """
+    if verify:
+        check_version(agent_version)
+
+    for module in DEFAULT_MODULES.values():
+        for tag in module.tag(agent_version):
+            ctx.run("git tag -m {tag} {tag} {commit}".format(tag=tag, commit=commit))
+            if push:
+                ctx.run("git push origin {}".format(tag))
+
+    print("Created all tags for version {}".format(agent_version))

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -857,7 +857,7 @@ def update_modules(ctx, agent_version, verify=True):
     * --verify checks for correctness on the Agent Version (on by default).
 
     Examples:
-    inv -e update-modules 7.27.0 
+    inv -e release.update-modules 7.27.0 
     """
     if verify:
         check_version(agent_version)

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -14,7 +14,7 @@ from datetime import date
 from invoke import Failure, task
 from invoke.exceptions import Exit
 
-from tasks.modules import DEFAULT_MODULES
+from .modules import DEFAULT_MODULES
 
 
 @task

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -18,31 +18,11 @@ from .build_tags import filter_incompatible_tags, get_build_tags, get_default_bu
 from .cluster_agent import integration_tests as dca_integration_tests
 from .dogstatsd import integration_tests as dsd_integration_tests
 from .go import fmt, generate, golangci_lint, ineffassign, lint, lint_licenses, misspell, staticcheck, vet
+from .modules import DEFAULT_MODULES, GoModule
 from .trace_agent import integration_tests as trace_integration_tests
 from .utils import get_build_flags
 
-
-class GoModule:
-    """A Go module abstraction."""
-
-    def __init__(self, path, targets=None, condition=lambda: True):
-        if targets is None:
-            targets = ["."]
-
-        self.path = path
-        self.targets = targets
-        self.condition = condition
-
-    def full_path(self):
-        return os.path.abspath(self.path)
-
-
 PROFILE_COV = "profile.cov"
-
-DEFAULT_MODULES = [
-    GoModule(".", targets=["./pkg", "./cmd"]),
-]
-
 DEFAULT_GIT_BRANCH = 'master'
 
 
@@ -97,12 +77,12 @@ def test(
         if isinstance(targets, str):
             modules = [GoModule(module, targets=targets.split(','))]
         else:
-            modules = [m for m in DEFAULT_MODULES if m.path == module]
+            modules = [m for m in DEFAULT_MODULES.values() if m.path == module]
     elif isinstance(targets, str):
         modules = GoModule(".", targets=targets.split(','))
     else:
         print("Using default modules and targets")
-        modules = DEFAULT_MODULES
+        modules = DEFAULT_MODULES.values()
 
     build_include = (
         get_default_build_tags(build="test-with-process-tags", arch=arch)


### PR DESCRIPTION
### What does this PR do?

- Move `GoModule` to its own file
- Create `update_module` and `tag_version` tasks to respectively update inter-module dependencies and tag versions.

#### Open questions

- Should the task be used for an Agent 6 only release?
- Should `push` be on by default?

### Motivation

- Part of Go Modules RFC (RFC 779) 

### Additional Notes

- Right now `update_modules` is a no-op and `tag_version` only tags the main module with the 6 and 7 version tags.

### Describe your test plan

- For QA, during RCs use them to tag versions
