### PR TITLE
pkg/config: fix apm config parameter comment for bind_host

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1078,7 +1078,7 @@ api_key:
 
 ## @param bind_host - string - optional - default: localhost
 ## The host to listen on for Dogstatsd and traces. This is ignored by APM when
-## `apm_config.non_local_traffic` is enabled and ignored by DogStatsD when `dogstatsd_non_local_traffic`
+## `apm_config.apm_non_local_traffic` is enabled and ignored by DogStatsD when `dogstatsd_non_local_traffic`
 ## is enabled. The trace-agent uses this host to send metrics to.
 ## The `localhost` default value is invalid in IPv6 environments where dogstatsd listens on "::1".
 ## To solve this problem, ensure Dogstatsd is listening on IPv4 by setting this value to "127.0.0.1".


### PR DESCRIPTION
Adds fix for `bind_host` to correctly reference `apm_config.apm_non_local_traffic`.

Fixes #7348.