### PR TITLE
[system-probe] Retry failed offset guessing

### DIFF
--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -182,7 +182,13 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 		}
 		defer offsetBuf.Close()
 
-		mgrOptions.ConstantEditors, err = runOffsetGuessing(config, offsetBuf)
+		// Offset guessing has been flaky for some customers, so if it fails we'll retry it up to 5 times
+		for i := 0; i < 5; i++ {
+			mgrOptions.ConstantEditors, err = runOffsetGuessing(config, offsetBuf)
+			if err == nil {
+				break
+			}
+		}
 		if err != nil {
 			return nil, fmt.Errorf("error guessing offsets: %s", err)
 		}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -188,6 +188,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 			if err == nil {
 				break
 			}
+			time.Sleep(1 * time.Second)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("error guessing offsets: %s", err)


### PR DESCRIPTION
### What does this PR do?

Adds logic to retry offset guessing if it fails (up to 5 times max).

### Motivation

Customers have reported that offset guessing is intermittently failing on their system-probe containers, causing them to have trouble setting up NPM.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
