### PR TITLE
[DSD][Origin Detection] Allow DSD clients to change tags cardinality

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -384,7 +384,7 @@ func (agg *BufferedAggregator) addServiceCheck(sc metrics.ServiceCheck) {
 		sc.Ts = time.Now().Unix()
 	}
 	tb := util.NewTagsBuilderFromSlice(sc.Tags)
-	metrics.EnrichTags(tb, sc.OriginID, sc.K8sOriginID)
+	metrics.EnrichTags(tb, sc.OriginID, sc.K8sOriginID, sc.Cardinality)
 	sc.Tags = tb.Get()
 
 	agg.serviceChecks = append(agg.serviceChecks, &sc)
@@ -396,7 +396,7 @@ func (agg *BufferedAggregator) addEvent(e metrics.Event) {
 		e.Ts = time.Now().Unix()
 	}
 	tb := util.NewTagsBuilderFromSlice(e.Tags)
-	metrics.EnrichTags(tb, e.OriginID, e.K8sOriginID)
+	metrics.EnrichTags(tb, e.OriginID, e.K8sOriginID, e.Cardinality)
 	e.Tags = tb.Get()
 
 	agg.events = append(agg.events, &e)

--- a/pkg/dogstatsd/enrich_bench_test.go
+++ b/pkg/dogstatsd/enrich_bench_test.go
@@ -24,7 +24,7 @@ func BenchmarkExtractTagsMetadata(b *testing.B) {
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				tags, _, _, _ = extractTagsMetadata(baseTags, "hostname", "", false)
+				tags, _, _, _, _ = extractTagsMetadata(baseTags, "hostname", "", false)
 			}
 		})
 	}

--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -94,6 +94,7 @@ type Event struct {
 	EventType      string         `json:"event_type,omitempty"`
 	OriginID       string         `json:"-"`
 	K8sOriginID    string         `json:"-"`
+	Cardinality    string         `json:"-"`
 }
 
 // Return a JSON string or "" in case of error during the Marshaling

--- a/pkg/metrics/metric_sample_test.go
+++ b/pkg/metrics/metric_sample_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,4 +28,48 @@ func TestMetricSampleCopy(t *testing.T) {
 
 	assert.False(t, src == dst)
 	assert.True(t, reflect.DeepEqual(&src, &dst))
+}
+
+func Test_taggerCardinality(t *testing.T) {
+	tests := []struct {
+		name        string
+		cardinality string
+		want        collectors.TagCardinality
+	}{
+		{
+			name:        "high",
+			cardinality: "high",
+			want:        collectors.HighCardinality,
+		},
+		{
+			name:        "orchestrator",
+			cardinality: "orchestrator",
+			want:        collectors.OrchestratorCardinality,
+		},
+		{
+			name:        "orch",
+			cardinality: "orch",
+			want:        collectors.OrchestratorCardinality,
+		},
+		{
+			name:        "low",
+			cardinality: "low",
+			want:        collectors.LowCardinality,
+		},
+		{
+			name:        "empty",
+			cardinality: "",
+			want:        tagger.DogstatsdCardinality,
+		},
+		{
+			name:        "unknown",
+			cardinality: "foo",
+			want:        tagger.DogstatsdCardinality,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, taggerCardinality(tt.cardinality))
+		})
+	}
 }

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -84,6 +84,7 @@ type ServiceCheck struct {
 	Tags        []string           `json:"tags"`
 	OriginID    string             `json:"-"`
 	K8sOriginID string             `json:"-"`
+	Cardinality string             `json:"-"`
 }
 
 // ServiceChecks represents a list of service checks ready to be serialize

--- a/pkg/tagger/collectors/utils.go
+++ b/pkg/tagger/collectors/utils.go
@@ -6,10 +6,11 @@ import (
 )
 
 const (
-	lowCardinalityString          = "low"
-	orchestratorCardinalityString = "orchestrator"
-	highCardinalityString         = "high"
-	unknownCardinalityString      = "unknown"
+	lowCardinalityString               = "low"
+	orchestratorCardinalityString      = "orchestrator"
+	shortOrchestratorCardinalityString = "orch"
+	highCardinalityString              = "high"
+	unknownCardinalityString           = "unknown"
 )
 
 // StringToTagCardinality extracts a TagCardinality from a string.
@@ -18,7 +19,7 @@ func StringToTagCardinality(c string) (TagCardinality, error) {
 	switch strings.ToLower(c) {
 	case highCardinalityString:
 		return HighCardinality, nil
-	case orchestratorCardinalityString:
+	case shortOrchestratorCardinalityString, orchestratorCardinalityString:
 		return OrchestratorCardinality, nil
 	case lowCardinalityString:
 		return LowCardinality, nil

--- a/releasenotes/notes/control-dsd-cardinality-via-tags-c0f8b08f424deeda.yaml
+++ b/releasenotes/notes/control-dsd-cardinality-via-tags-c0f8b08f424deeda.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Dogstatsd clients can now choose the cardinality of tags added by origin detection per metrics
+    via the tag 'dd.internal.card' ("low", "orch", "high").


### PR DESCRIPTION
### What does this PR do?

Dogstatsd clients can now choose the cardinality of tags added by origin detection via the tag `dd.internal.card` (low, orch, high).

### Motivation

Support a dynamic cardinality config

### Describe your test plan

`echo -n "dsd.testing.<CARD>:1|g|#foo:bar,dd.internal.entity_id:<Pod UID>,dd.internal.card:<CARD>" | nc -u -w1 <Agent IP> 8125`

`<CARD>` can be `low`, `orch` or `high`