### PR TITLE
[cluster-agent] Validate external metrics

### DIFF
--- a/pkg/util/kubernetes/autoscalers/autoscalers_test.go
+++ b/pkg/util/kubernetes/autoscalers/autoscalers_test.go
@@ -329,6 +329,72 @@ func TestInspect(t *testing.T) {
 			},
 			[]custommetrics.ExternalMetricValue{},
 		},
+		"skip invalid metric names": {
+			&autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								MetricName: "valid_name",
+							},
+						},
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								MetricName: "valid_name.with_dots.and_underscores.AndUppercaseLetters",
+							},
+						},
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								MetricName: "0_invalid_name_must_start_with_letter",
+							},
+						},
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								MetricName: "spaces are invalid",
+							},
+						},
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								MetricName: "utf8_invalid_🤷",
+							},
+						},
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								MetricName: "over_200_characters_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding_padding",
+							},
+						},
+					},
+				},
+			},
+			[]custommetrics.ExternalMetricValue{
+				{
+					MetricName: "valid_name",
+					Ref: custommetrics.ObjectReference{
+						Type: "horizontal",
+					},
+					Labels:    nil,
+					Timestamp: 0,
+					Value:     0,
+					Valid:     false,
+				},
+				{
+					MetricName: "valid_name.with_dots.and_underscores.AndUppercaseLetters",
+					Ref: custommetrics.ObjectReference{
+						Type: "horizontal",
+					},
+					Labels:    nil,
+					Timestamp: 0,
+					Value:     0,
+					Valid:     false,
+				},
+			},
+		},
 		"upper cases handled": {
 			&autoscalingv2.HorizontalPodAutoscaler{
 				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{

--- a/releasenotes/notes/validate-externalmetrics-93c34bc37932c74e.yaml
+++ b/releasenotes/notes/validate-externalmetrics-93c34bc37932c74e.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add a validation step before accepting metrics set in HPAs.
+    This ensures that no obviously-broken metric is accepted and goes on to
+    break the whole metrics gathering process.


### PR DESCRIPTION
### What does this PR do?

Add a validation step before accepting metrics set in HPAs.

### Motivation

This ensures that no obviously-broken metric is accepted and goes on to
break the whole metrics gathering process.

### Additional Notes

Fixes #5282
Replaces #5305

### Describe your test plan

Automated tests should be enough here 👍 

I've added two positive test cases (with valid names), and three invalid test cases (with invalid names).