### PR TITLE
Add UpCloud cloud provider support

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -232,6 +232,7 @@ api_key:
 ## "azure"   Azure
 ## "alibaba" Alibaba
 ## "tencent" Tencent
+## "upcloud" UpCloud
 #
 # cloud_provider_metadata:
 #   - "aws"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -478,12 +478,13 @@ func TestIsCloudProviderEnabled(t *testing.T) {
 	holdValue := Datadog.Get("cloud_provider_metadata")
 	defer Datadog.Set("cloud_provider_metadata", holdValue)
 
-	Datadog.Set("cloud_provider_metadata", []string{"aws", "gcp", "azure", "alibaba", "tencent"})
+	Datadog.Set("cloud_provider_metadata", []string{"aws", "gcp", "azure", "alibaba", "tencent", "upcloud"})
 	assert.True(t, IsCloudProviderEnabled("AWS"))
 	assert.True(t, IsCloudProviderEnabled("GCP"))
 	assert.True(t, IsCloudProviderEnabled("Alibaba"))
 	assert.True(t, IsCloudProviderEnabled("Azure"))
 	assert.True(t, IsCloudProviderEnabled("Tencent"))
+	assert.True(t, IsCloudProviderEnabled("UpCloud"))
 
 	Datadog.Set("cloud_provider_metadata", []string{"aws"})
 	assert.True(t, IsCloudProviderEnabled("AWS"))
@@ -491,6 +492,7 @@ func TestIsCloudProviderEnabled(t *testing.T) {
 	assert.False(t, IsCloudProviderEnabled("Alibaba"))
 	assert.False(t, IsCloudProviderEnabled("Azure"))
 	assert.False(t, IsCloudProviderEnabled("Tencent"))
+	assert.False(t, IsCloudProviderEnabled("UpCloud"))
 
 	Datadog.Set("cloud_provider_metadata", []string{"tencent"})
 	assert.False(t, IsCloudProviderEnabled("AWS"))
@@ -498,6 +500,7 @@ func TestIsCloudProviderEnabled(t *testing.T) {
 	assert.False(t, IsCloudProviderEnabled("Alibaba"))
 	assert.False(t, IsCloudProviderEnabled("Azure"))
 	assert.True(t, IsCloudProviderEnabled("Tencent"))
+	assert.False(t, IsCloudProviderEnabled("UpCloud"))
 
 	Datadog.Set("cloud_provider_metadata", []string{})
 	assert.False(t, IsCloudProviderEnabled("AWS"))
@@ -505,6 +508,7 @@ func TestIsCloudProviderEnabled(t *testing.T) {
 	assert.False(t, IsCloudProviderEnabled("Alibaba"))
 	assert.False(t, IsCloudProviderEnabled("Azure"))
 	assert.False(t, IsCloudProviderEnabled("Tencent"))
+	assert.False(t, IsCloudProviderEnabled("UpCloud"))
 }
 
 func TestEnvNestedConfig(t *testing.T) {

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/tencent"
+	"github.com/DataDog/datadog-agent/pkg/util/upcloud"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 	"github.com/DataDog/datadog-agent/pkg/util/azure"
@@ -150,13 +151,21 @@ func getHostAliases() []string {
 		aliases = append(aliases, tencentAlias)
 	}
 
+	upcloudAlias, err := upcloud.GetHostAlias()
+	if err != nil {
+		log.Debugf("no UpCloud Host Alias: %s", err)
+	} else if upcloudAlias != "" {
+		aliases = append(aliases, upcloudAlias)
+	}
+
 	return aliases
 }
 
 func getPublicIPv4() (string, error) {
 	publicIPFetcher := map[string]func() (string, error){
-		"EC2": ec2.GetPublicIPv4,
-		"GCE": gce.GetPublicIPv4,
+		"EC2":     ec2.GetPublicIPv4,
+		"GCE":     gce.GetPublicIPv4,
+		"UpCloud": upcloud.GetPublicIPv4,
 	}
 	for name, fetcher := range publicIPFetcher {
 		publicIPv4, err := fetcher()

--- a/pkg/util/cloudprovider.go
+++ b/pkg/util/cloudprovider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/tencent"
+	"github.com/DataDog/datadog-agent/pkg/util/upcloud"
 )
 
 type cloudProviderDetector struct {
@@ -34,6 +35,7 @@ type cloudProviderNTPDetector struct {
 // * Azure
 // * Alibaba
 // * Tencent
+// * UpCloud
 func DetectCloudProvider() {
 	detectors := []cloudProviderDetector{
 		{name: ecscommon.CloudProviderName, callback: ecs.IsRunningOn},
@@ -42,6 +44,7 @@ func DetectCloudProvider() {
 		{name: azure.CloudProviderName, callback: azure.IsRunningOn},
 		{name: alibaba.CloudProviderName, callback: alibaba.IsRunningOn},
 		{name: tencent.CloudProviderName, callback: tencent.IsRunningOn},
+		{name: upcloud.CloudProviderName, callback: upcloud.IsRunningOn},
 	}
 
 	for _, cloudDetector := range detectors {
@@ -63,6 +66,7 @@ func GetCloudProviderNTPHosts() []string {
 		{name: azure.CloudProviderName, callback: azure.GetNTPHosts},
 		{name: alibaba.CloudProviderName, callback: alibaba.GetNTPHosts},
 		{name: tencent.CloudProviderName, callback: tencent.GetNTPHosts},
+		{name: upcloud.CloudProviderName, callback: upcloud.GetNTPHosts},
 	}
 
 	for _, cloudNTPDetector := range detectors {

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/upcloud"
 )
 
 // GetNetworkID retrieves the network_id which can be used to improve network
@@ -16,6 +17,7 @@ import (
 // * configuration
 // * GCE
 // * EC2
+// * UpCloud
 func GetNetworkID() (string, error) {
 	cacheNetworkIDKey := cache.BuildAgentKey("networkID")
 	if cacheNetworkID, found := cache.Cache.Get(cacheNetworkIDKey); found {
@@ -40,6 +42,13 @@ func GetNetworkID() (string, error) {
 	if networkID, err := ec2.GetNetworkID(); err == nil {
 		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
 		log.Debugf("GetNetworkID: using network ID from EC2 metadata: %s", networkID)
+		return networkID, nil
+	}
+
+	log.Debugf("GetNetworkID trying UpCloud")
+	if networkID, err := upcloud.GetNetworkID(); err == nil {
+		cache.Cache.Set(cacheNetworkIDKey, networkID, cache.NoExpiration)
+		log.Debugf("GetNetworkID: using network ID from UpCloud metadata: %s", networkID)
 		return networkID, nil
 	}
 

--- a/pkg/util/upcloud/diagnosis.go
+++ b/pkg/util/upcloud/diagnosis.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package upcloud
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func init() {
+	diagnosis.Register("UpCloud metadata availability", diagnose)
+}
+
+// diagnose the UpCloud metadata API availability
+func diagnose() error {
+	_, err := GetHostAlias()
+	if err != nil {
+		log.Error(err)
+	}
+	return err
+}

--- a/pkg/util/upcloud/upcloud.go
+++ b/pkg/util/upcloud/upcloud.go
@@ -1,0 +1,174 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package upcloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+)
+
+// declare these as vars not const to ease testing
+var (
+	metadataURL = "http://169.254.169.254"
+	timeout     = 300 * time.Millisecond
+
+	// CloudProviderName contains the inventory name of UpCloud
+	CloudProviderName = "UpCloud"
+)
+
+type Metadata struct {
+	CloudName  string `json:"cloud_name"`
+	InstanceId string `json:"instance_id"`
+	Network    Network
+}
+
+type Network struct {
+	Interfaces []Interface
+}
+
+type Interface struct {
+	Index       uint8
+	IpAddresses []IpAddress `json:"ip_addresses"`
+	NetworkId   string      `json:"network_id"`
+	Type        string
+}
+
+type IpAddress struct {
+	Address string
+	Family  string
+}
+
+// IsRunningOn returns true if the agent is running on UpCloud
+func IsRunningOn() bool {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return false
+	}
+	cloudName, err := getResponse(metadataURL + "/metadata/v1/cloud_name")
+	if err != nil || string(cloudName) != "upcloud" {
+		return false
+	}
+	return true
+}
+
+// GetHostAlias returns the VM UUID from the UpCloud metadata API
+func GetHostAlias() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
+	res, err := getResponseWithMaxLength(metadataURL+"/metadata/v1/instance_id",
+		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+	if err != nil {
+		return "", fmt.Errorf("UpCloud GetHostAlias: unable to query metadata endpoint: %s", err)
+	}
+	return string(res), err
+}
+
+// GetPublicIPv4 returns the public IPv4 address of the current UpCloud instance
+func GetPublicIPv4() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
+	result, err := getResponse(metadataURL + "/metadata/v1.json")
+	if err != nil {
+		return "", err
+	}
+	var metadata Metadata
+	err = json.Unmarshal(result, &metadata)
+	if err != nil {
+		return "", err
+	}
+	for _, iface := range metadata.Network.Interfaces {
+		if iface.Type != "public" {
+			continue
+		}
+		for _, ip := range iface.IpAddresses {
+			if ip.Family == "IPv4" {
+				return ip.Address, nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// GetNetworkID returns the network ID of the current UpCloud instance.
+// For UpCloud instances, the network ID is non-empty, if the instance is found to be part of exactly one network.
+func GetNetworkID() (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
+	result, err := getResponse(metadataURL + "/metadata/v1.json")
+	if err != nil {
+		return "", err
+	}
+	var metadata Metadata
+	err = json.Unmarshal(result, &metadata)
+	if err != nil {
+		return "", err
+	}
+	if len(metadata.Network.Interfaces) == 0 {
+		return "", fmt.Errorf("zero network interfaces detected")
+	}
+	var id string
+	for _, iface := range metadata.Network.Interfaces {
+		if id != "" && id != iface.NetworkId {
+			return "", fmt.Errorf("interfaces in more than one network detected, cannot get network ID")
+		}
+		id = iface.NetworkId
+	}
+	return id, nil
+}
+
+// GetNTPHosts returns nil for UpCloud.
+func GetNTPHosts() []string {
+
+	return nil
+}
+
+func getResponseWithMaxLength(endpoint string, maxLength int) ([]byte, error) {
+	result, err := getResponse(endpoint)
+	if err != nil {
+		return result, err
+	}
+	if len(result) > maxLength {
+		return nil, fmt.Errorf("%v gave a response with length > to %v", endpoint, maxLength)
+	}
+	return result, err
+}
+
+func getResponse(url string) ([]byte, error) {
+	client := http.Client{
+		Transport: httputils.CreateHTTPTransport(),
+		Timeout:   timeout,
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("status code %d trying to GET %s", res.StatusCode, url)
+	}
+
+	defer res.Body.Close()
+	all, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error while reading response from UpCloud metadata endpoint: %s", err)
+	}
+
+	return all, nil
+}

--- a/pkg/util/upcloud/upcloud_test.go
+++ b/pkg/util/upcloud/upcloud_test.go
@@ -1,0 +1,166 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package upcloud
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+const fixture = `
+{
+  "cloud_name": "upcloud",
+  "instance_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "hostname": "test-hostname",
+  "platform": "servers",
+  "subplatform": "metadata (http://169.254.169.254)",
+  "public_keys": [
+    "ssh-ed25519 AAAA foo"
+  ],
+  "region": "fi-hel2",
+  "network": {
+    "interfaces": [
+      {
+        "index": 1,
+        "ip_addresses": [
+          {
+            "address": "127.42.42.42",
+            "dhcp": true,
+            "dns": [
+              "94.237.127.9",
+              "94.237.40.9"
+            ],
+            "family": "IPv4",
+            "floating": false,
+            "gateway": "127.42.42.1",
+            "network": "127.42.42.0/24"
+          }
+        ],
+        "mac": "mm:mm:mm:mm:mm:m1",
+        "network_id": "nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn",
+        "type": "public"
+      },
+      {
+        "index": 2,
+        "ip_addresses": [
+          {
+            "address": "127.42.42.43",
+            "dhcp": true,
+            "dns": [
+              "94.237.127.9",
+              "94.237.40.9"
+            ],
+            "family": "IPv4",
+            "floating": false,
+            "gateway": "127.42.42.1",
+            "network": "127.42.42.0/24"
+          }
+        ],
+        "mac": "mm:mm:mm:mm:mm:m2",
+        "network_id": "nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn",
+        "type": "public"
+      }
+    ],
+    "dns": [
+      "94.237.127.9",
+      "94.237.40.9"
+    ]
+  },
+  "storage": {
+    "disks": [
+      {
+        "id": "ssssssss-ssss-ssss-ssss-ssssssssssss",
+        "serial": "00000000000000000000",
+        "size": 25600,
+        "type": "disk",
+        "tier": "maxiops"
+      }
+    ]
+  },
+  "tags": [],
+  "user_data": "",
+  "vendor_data": ""
+}
+`
+
+func TestGetHostname(t *testing.T) {
+	holdValue := config.Datadog.Get("cloud_provider_metadata")
+	defer config.Datadog.Set("cloud_provider_metadata", holdValue)
+	config.Datadog.Set("cloud_provider_metadata", []string{"upcloud"})
+
+	expected := "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, expected)
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetHostAlias()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, val)
+	assert.Equal(t, "/metadata/v1/instance_id", lastRequest.URL.Path)
+}
+
+func TestGetNetworkID(t *testing.T) {
+	holdValue := config.Datadog.Get("cloud_provider_metadata")
+	defer config.Datadog.Set("cloud_provider_metadata", holdValue)
+	config.Datadog.Set("cloud_provider_metadata", []string{"upcloud"})
+
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json#")
+		io.WriteString(w, fixture)
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetNetworkID()
+	assert.Nil(t, err)
+	assert.Equal(t, "nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn", val)
+	assert.Equal(t, "/metadata/v1.json", lastRequest.URL.Path)
+}
+
+func TestGetPublicIPv4(t *testing.T) {
+	holdValue := config.Datadog.Get("cloud_provider_metadata")
+	defer config.Datadog.Set("cloud_provider_metadata", holdValue)
+	config.Datadog.Set("cloud_provider_metadata", []string{"upcloud"})
+
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, fixture)
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetPublicIPv4()
+	assert.Nil(t, err)
+	assert.Equal(t, "127.42.42.42", val)
+	assert.Equal(t, "/metadata/v1.json", lastRequest.URL.Path)
+}
+
+func TestGetNTPHosts(t *testing.T) {
+	holdValue := config.Datadog.Get("cloud_provider_metadata")
+	defer config.Datadog.Set("cloud_provider_metadata", holdValue)
+	config.Datadog.Set("cloud_provider_metadata", []string{"upcloud"})
+
+	var expectedHosts []string
+
+	actualHosts := GetNTPHosts()
+
+	assert.Equal(t, expectedHosts, actualHosts)
+}


### PR DESCRIPTION
### What does this PR do?

Adds support for UpCloud cloud provider, https://upcloud.com : host alias, public IPv4, network UUID.

### Motivation

Noticing support for other cloud providers, and lack of UpCloud.

### Additional Notes

Wondering if this could be enabled by default. Currently it's not.

### Describe your test plan

N/A