### PR TITLE
[gitlab][pupernetes-master] temporarily allow failures

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -54,6 +54,7 @@ pupernetes-dev:
 
 pupernetes-master:
   extends: .pupernetes_template
+  allow_failure: true # temporary while investigating
   rules:
     - <<: *if_master_branch
   needs: ["dev_master_docker_hub-a6", "dev_master_docker_hub-a7"]


### PR DESCRIPTION
### What does this PR do?

Temporarily allow failures in `pupernetes-master` job while investigating an issue

### Motivation

Prevent failed pipeline notifications

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
