### PR TITLE
[docker] Simplify DockerUtil.ResolveImageNameFromContainer

### DIFF
--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -161,10 +161,18 @@ func (d *DockerUtil) GetStorageStats() ([]*StorageStats, error) {
 	return parseStorageStatsFromInfo(info)
 }
 
+func isImageShaID(image string) bool {
+	return strings.HasPrefix(image, "sha256:")
+}
+
+func isImageRepoDigest(image string) bool {
+	return strings.Contains(image, "@sha256:")
+}
+
 // ResolveImageName will resolve sha image name to their user-friendly name.
-// For non-sha names we will just return the name as-is.
+// For non-sha/non-repodigest names we will just return the name as-is.
 func (d *DockerUtil) ResolveImageName(image string) (string, error) {
-	if !strings.Contains(image, "sha256:") {
+	if !isImageShaID(image) && !isImageRepoDigest(image) {
 		return image, nil
 	}
 
@@ -204,59 +212,11 @@ func (d *DockerUtil) ResolveImageName(image string) (string, error) {
 // It is similar to ResolveImageName except it tries to match the image to the container Config.Image.
 // For non-sha names we will just return the name as-is.
 func (d *DockerUtil) ResolveImageNameFromContainer(co types.ContainerJSON) (string, error) {
-	image := co.Image
-	if !strings.Contains(image, "sha256:") {
-		return image, nil
+	if co.Config.Image != "" && !isImageShaID(co.Config.Image) && !isImageRepoDigest(co.Config.Image) {
+		return co.Config.Image, nil
 	}
 
-	d.Lock()
-	defer d.Unlock()
-	if _, ok := d.imageNameBySha[image]; !ok {
-		ctx, cancel := context.WithTimeout(context.Background(), d.queryTimeout)
-		defer cancel()
-		r, _, err := d.cli.ImageInspectWithRaw(ctx, image)
-		if err != nil {
-			// Only log errors that aren't "not found" because some images may
-			// just not be available in docker inspect.
-			if !client.IsErrNotFound(err) {
-				return image, err
-			}
-			d.imageNameBySha[image] = image
-		}
-
-		imageName := getBestImageName(r, co.Config.Image)
-		if imageName != "" {
-			d.imageNameBySha[image] = imageName
-		}
-	}
-	return d.imageNameBySha[image], nil
-}
-
-func getBestImageName(r types.ImageInspect, configImage string) string {
-	var imageName string
-	// Try RepoTags first and fall back to RepoDigest otherwise.
-	if len(r.RepoTags) == 1 {
-		imageName = r.RepoTags[0]
-	} else if len(r.RepoTags) > 1 {
-		// If one of the RepoTags is the tag used to run the image, then set that
-		// as the image tag. Otherwise, use the first one (random)
-		for _, t := range r.RepoTags {
-			if t == configImage {
-				imageName = t
-				break
-			}
-		}
-		if imageName == "" {
-			sort.Strings(r.RepoTags)
-			imageName = r.RepoTags[0]
-		}
-	} else if len(r.RepoDigests) > 0 {
-		// Digests formatted like quay.io/foo/bar@sha256:hash
-		sort.Strings(r.RepoDigests)
-		sp := strings.SplitN(r.RepoDigests[0], "@", 2)
-		imageName = sp[0]
-	}
-	return imageName
+	return d.ResolveImageName(co.Image)
 }
 
 // Inspect returns a docker inspect object for a given container ID.

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -161,18 +161,14 @@ func (d *DockerUtil) GetStorageStats() ([]*StorageStats, error) {
 	return parseStorageStatsFromInfo(info)
 }
 
-func isImageShaID(image string) bool {
-	return strings.HasPrefix(image, "sha256:")
-}
-
-func isImageRepoDigest(image string) bool {
-	return strings.Contains(image, "@sha256:")
+func isImageShaOrRepoDigest(image string) bool {
+	return strings.HasPrefix(image, "sha256:") || strings.Contains(image, "@sha256:")
 }
 
 // ResolveImageName will resolve sha image name to their user-friendly name.
 // For non-sha/non-repodigest names we will just return the name as-is.
 func (d *DockerUtil) ResolveImageName(image string) (string, error) {
-	if !isImageShaID(image) && !isImageRepoDigest(image) {
+	if !isImageShaOrRepoDigest(image) {
 		return image, nil
 	}
 
@@ -212,7 +208,7 @@ func (d *DockerUtil) ResolveImageName(image string) (string, error) {
 // It is similar to ResolveImageName except it tries to match the image to the container Config.Image.
 // For non-sha names we will just return the name as-is.
 func (d *DockerUtil) ResolveImageNameFromContainer(co types.ContainerJSON) (string, error) {
-	if co.Config.Image != "" && !isImageShaID(co.Config.Image) && !isImageRepoDigest(co.Config.Image) {
+	if co.Config.Image != "" && !isImageShaOrRepoDigest(co.Config.Image) {
 		return co.Config.Image, nil
 	}
 

--- a/releasenotes/notes/docker-simplify-image-name-from-container-6c93cd7652abfbed.yaml
+++ b/releasenotes/notes/docker-simplify-image-name-from-container-6c93cd7652abfbed.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Address issue with referencing the wrong repo tag for Docker image by
+    simplifying logic in DockerUtil.ResolveImageNameFromContainer to prefer
+    Config.Image when possible.
+


### PR DESCRIPTION
### What does this PR do?

Address two issues with potentially undesired behavior of `DockerUtil.ResolveImageNameFromContainer`
- Given two containers with the same image ID but different image name (tag), `Config.Image` can be cashed for one container and then used for the other ignoring container's `Config.Image`.
- Contaners with deleted image tags - `Config.Image` will be currently ignored and the first repotag picked for the image.

New behavior - prefer `Config.Image` without consulting the cache, use `Config.Image` if it is not a `sha256` ID or repo digest in the form of `repo@sha256:digest`.

### Motivation

Make the image name cache in `DockerUtil.imageNameBySha` more predictable

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test the two scenarios outlined in the description above and various permutations of containers with more than one tag for the same image (in Docker standalone, ECS).

Example of a test:

Start some containers with various tags of the same image:
```bash
$ docker run --name redis -d redis
$ docker tag redis redis:foo
$ docker tag redis redis:bar
$ docker run --name foo -d redis:foo
$ docker run --name bar -d redis:bar

$ docker ps
CONTAINER ID   IMAGE ...
52a97bc5f76a   redis:bar ...
2c91041e3cef   redis:foo ... 
c861b4d43f7c   cc69ae189a1a ...
``` 

Delete one of the tags:
```bash
docker rmi redis:latest
```

Inspect the image:
```bash
$ docker image inspect redis:bar
[
    {
        "Id": "sha256:cc69ae189a1af885de0cd1bab530cb4633e63b0f5babc01bb96845ab3843b25e",
        "RepoTags": [
            "redis:bar",
            "redis:foo"
        ],
...
```


Tags before changes in this PR:
```bash
$ agent tagger-list
...
=== Entity container_id://52a97bc5f76a6efdf14a873e593e25e91783ee6aa6a5362411159a77c00a1485 ===
Tags: [docker_image:redis:bar image_name:redis image_tag:bar short_image:redis]
Sources: [docker]
===

=== Entity container_id://c861b4d43f7c2ab5aa52da3ac747e9adbfea75f0de946998708d7341b3804d60 ===
Tags: [docker_image:redis:bar image_name:redis image_tag:bar short_image:redis]
Sources: [docker]
===

=== Entity container_id://2c91041e3cef91551c0d0ab74fcf9ccb75833947e2c4b3d519dcd8569ee2f7c9 ===
Tags: [docker_image:redis:bar image_name:redis image_tag:bar short_image:redis]
Sources: [docker]
===
```

Tags with changes in this PR:
```bash
$ agent tagger-list

=== Entity container_id://2c91041e3cef91551c0d0ab74fcf9ccb75833947e2c4b3d519dcd8569ee2f7c9 ===
Tags: [docker_image:redis:foo image_name:redis image_tag:foo short_image:redis]
Sources: [docker]
===

=== Entity container_id://52a97bc5f76a6efdf14a873e593e25e91783ee6aa6a5362411159a77c00a1485 ===
Tags: [docker_image:redis:bar image_name:redis image_tag:bar short_image:redis]
Sources: [docker]
===

=== Entity container_id://c861b4d43f7c2ab5aa52da3ac747e9adbfea75f0de946998708d7341b3804d60 ===
Tags: [docker_image:redis image_name:redis short_image:redis]
Sources: [docker]
===
```

