### PR TITLE
Do not override iot_host, just change the default

### DIFF
--- a/pkg/util/flavor/flavor.go
+++ b/pkg/util/flavor/flavor.go
@@ -31,7 +31,7 @@ func SetFlavor(flavor string) {
 	agentFlavor = flavor
 
 	if agentFlavor == IotAgent {
-		config.Datadog.Set("iot_host", true)
+		config.Datadog.SetDefault("iot_host", true)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

On the IoT Agent, just change the default of the `iot_host` setting instead of overriding it.

### Motivation

We still want the setting to be configurable on the iot-agent.
