### PR TITLE
[DCA][Fix] Support DD_FORCE_TLS_12

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -80,6 +80,10 @@ func StartServer(sc clusteragent.ServerContext) error {
 		Certificates: []tls.Certificate{rootTLSCert},
 	}
 
+	if config.Datadog.GetBool("force_tls_12") {
+		tlsConfig.MinVersion = tls.VersionTLS12
+	}
+
 	srv := &http.Server{
 		Handler: r,
 		ErrorLog: stdLog.New(&config.ErrorLogWriter{

--- a/releasenotes-dca/notes/dca-supportforce-tls1.2-dee4998518e78910.yaml
+++ b/releasenotes-dca/notes/dca-supportforce-tls1.2-dee4998518e78910.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The Cluster Agent can now be configured to use tls 1.2 via DD_FORCE_TLS_12=true


### PR DESCRIPTION
### What does this PR do?

The Cluster Agent can now be configured to use tls 1.2 via DD_FORCE_TLS_12=true

### Motivation

Same behaviour as the core agent

### Describe your test plan

` openssl s_client -connect localhost:5005 -tls1_1` shouldn't work 
