### PR TITLE
Fix TestPerfBatchStateCleanup to not depend on actual elapsed time

### DIFF
--- a/pkg/network/tracer/perf_batching.go
+++ b/pkg/network/tracer/perf_batching.go
@@ -111,7 +111,7 @@ func (p *PerfBatchManager) GetIdleConns() []network.ConnectionStats {
 		cpuState.processed[batchId] = batchState{offset: batchLen, updated: time.Now()}
 	}
 
-	p.cleanupExpiredState()
+	p.cleanupExpiredState(time.Now())
 	return idle
 }
 
@@ -147,12 +147,11 @@ func (p *PerfBatchManager) extractBatchInto(buffer []network.ConnectionStats, b 
 	return buffer
 }
 
-func (p *PerfBatchManager) cleanupExpiredState() {
-	now := time.Now()
+func (p *PerfBatchManager) cleanupExpiredState(now time.Time) {
 	for cpu := 0; cpu < len(p.stateByCPU); cpu++ {
 		cpuState := &p.stateByCPU[cpu]
 		for id, s := range cpuState.processed {
-			if now.Sub(s.updated) > p.expiredStateInterval {
+			if now.Sub(s.updated) >= p.expiredStateInterval {
 				delete(cpuState.processed, id)
 			}
 		}

--- a/pkg/network/tracer/perf_batching_test.go
+++ b/pkg/network/tracer/perf_batching_test.go
@@ -108,18 +108,17 @@ func TestPerfBatchStateCleanup(t *testing.T) {
 	manager.batchMap.Put(unsafe.Pointer(&cpu), unsafe.Pointer(batch))
 
 	manager.GetIdleConns()
-	_, ok := manager.stateByCPU[cpu].processed[0]
+	_, ok := manager.stateByCPU[cpu].processed[uint64(batch.id)]
 	require.True(t, ok)
-	assert.Equal(t, uint16(2), manager.stateByCPU[cpu].processed[0].offset)
+	assert.Equal(t, uint16(2), manager.stateByCPU[cpu].processed[uint64(batch.id)].offset)
 
-	// wait for expiration and read partial batches again
-	time.Sleep(manager.expiredStateInterval)
+	manager.cleanupExpiredState(time.Now().Add(manager.expiredStateInterval))
 	manager.GetIdleConns()
 
 	// state should not have been cleaned up, since no more connections have happened
-	_, ok = manager.stateByCPU[cpu].processed[0]
+	_, ok = manager.stateByCPU[cpu].processed[uint64(batch.id)]
 	require.True(t, ok)
-	assert.Equal(t, uint16(2), manager.stateByCPU[cpu].processed[0].offset)
+	assert.Equal(t, uint16(2), manager.stateByCPU[cpu].processed[uint64(batch.id)].offset)
 }
 
 func newEmptyBatchManager() *PerfBatchManager {


### PR DESCRIPTION
### What does this PR do?

Other non-test connections were influencing this test result. Hopefully by making it assert as fast as possible, will fix the flakiness.

### Motivation

Flaky CI test results.