### PR TITLE
Try to align fields in struct

### DIFF
--- a/pkg/util/cloudfoundry/cccache.go
+++ b/pkg/util/cloudfoundry/cccache.go
@@ -31,12 +31,12 @@ type CCCacheI interface {
 // CCCache is a simple structure that caches and automatically refreshes data from Cloud Foundry API
 type CCCache struct {
 	sync.RWMutex
+	pollAttempts  int64
+	pollSuccesses int64
 	cancelContext context.Context
 	configured    bool
 	ccAPIClient   CCClientI
 	pollInterval  time.Duration
-	pollAttempts  int64
-	pollSuccesses int64
 	lastUpdated   time.Time
 	appsByGUID    map[string]*CFApp
 }


### PR DESCRIPTION
### What does this PR do?

Fix CI: atomic variable need to be 64 bits aligned