### PR TITLE
[runtime-security] handle multierror in runtime security policy check

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -103,7 +103,7 @@ func checkPolicies(cmd *cobra.Command, args []string) error {
 	model := &sprobe.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, opts)
 
-	if err := rules.LoadPolicies(cfg.PoliciesDir, ruleSet); err != nil {
+	if err := rules.LoadPolicies(cfg.PoliciesDir, ruleSet); err.ErrorOrNil() != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?

Make the check-policy command return 0 when the policy was successfully checked

### Motivation

LoadPolicy returns a *multierror.Error which may contain no error.