### PR TITLE
[tagger] Further improvements to remote tagger

### DIFF
--- a/cmd/agent/api/grpc.go
+++ b/cmd/agent/api/grpc.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -21,9 +22,15 @@ import (
 	pb "github.com/DataDog/datadog-agent/cmd/agent/api/pb"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
 	hostutil "github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	taggerStreamSendTimeout = 1 * time.Minute
 )
 
 type server struct {
@@ -80,10 +87,14 @@ func (s *serverSecure) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.Age
 			responseEvents = append(responseEvents, e)
 		}
 
-		err = out.Send(&pb.StreamTagsResponse{
-			Events: responseEvents,
-		})
+		err = grpc.DoWithTimeout(func() error {
+			return out.Send(&pb.StreamTagsResponse{
+				Events: responseEvents,
+			})
+		}, taggerStreamSendTimeout)
 		if err != nil {
+			log.Warnf("error sending tagger event: %s", err)
+			telemetry.ServerStreamErrors.Inc()
 			return err
 		}
 	}

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -25,12 +25,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
-	defaultTimeout = 5 * time.Minute
-	noTimeout      = 0 * time.Minute
+	defaultTimeout    = 5 * time.Minute
+	noTimeout         = 0 * time.Minute
+	streamRecvTimeout = 10 * time.Minute
 )
 
 // Tagger holds a connection to a remote tagger, processes incoming events from
@@ -43,10 +45,14 @@ type Tagger struct {
 	client pb.AgentSecureClient
 	stream pb.AgentSecure_TaggerStreamEntitiesClient
 
+	streamCtx    context.Context
+	streamCancel context.CancelFunc
+
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	health *health.Handle
+	health          *health.Handle
+	telemetryTicker *time.Ticker
 }
 
 // NewTagger returns an allocated tagger. You still have to run Init()
@@ -61,6 +67,7 @@ func NewTagger() *Tagger {
 // events.
 func (t *Tagger) Init() error {
 	t.health = health.RegisterLiveness("tagger")
+	t.telemetryTicker = time.NewTicker(1 * time.Minute)
 
 	t.ctx, t.cancel = context.WithCancel(context.Background())
 
@@ -106,10 +113,13 @@ func (t *Tagger) Stop() error {
 		return err
 	}
 
+	t.telemetryTicker.Stop()
 	err = t.health.Deregister()
 	if err != nil {
 		return err
 	}
+
+	log.Info("remote tagger stopped successfully")
 
 	return nil
 }
@@ -181,14 +191,24 @@ func (t *Tagger) run() {
 	for {
 		select {
 		case <-t.health.C:
+		case <-t.telemetryTicker.C:
+			t.store.collectTelemetry()
 		case <-t.ctx.Done():
 			return
 		default:
 		}
 
-		response, err := t.stream.Recv()
+		var response *pb.StreamTagsResponse
+		err := grpcutil.DoWithTimeout(func() error {
+			var err error
+			response, err = t.stream.Recv()
+			return err
+		}, streamRecvTimeout)
+
 		if err != nil {
-			telemetry.StreamErrors.Inc()
+			t.streamCancel()
+
+			telemetry.ClientStreamErrors.Inc()
 
 			// when Recv() returns an error, the stream is aborted
 			// and the contents of our store are considered out of
@@ -207,6 +227,8 @@ func (t *Tagger) run() {
 			}
 			continue
 		}
+
+		telemetry.Receives.Inc()
 
 		err = t.processResponse(response)
 		if err != nil {
@@ -277,11 +299,13 @@ func (t *Tagger) startTaggerStream(maxElapsed time.Duration) error {
 			return err
 		}
 
-		ctx := metadata.NewOutgoingContext(t.ctx, metadata.MD{
-			"authorization": []string{fmt.Sprintf("Bearer %s", token)},
-		})
+		t.streamCtx, t.streamCancel = context.WithCancel(
+			metadata.NewOutgoingContext(t.ctx, metadata.MD{
+				"authorization": []string{fmt.Sprintf("Bearer %s", token)},
+			}),
+		)
 
-		t.stream, err = t.client.TaggerStreamEntities(ctx, &pb.StreamTagsRequest{
+		t.stream, err = t.client.TaggerStreamEntities(t.streamCtx, &pb.StreamTagsRequest{
 			Cardinality: pb.TagCardinality_HIGH,
 		})
 
@@ -289,6 +313,8 @@ func (t *Tagger) startTaggerStream(maxElapsed time.Duration) error {
 			log.Infof("unable to establish stream, will possibly retry: %s", err)
 			return err
 		}
+
+		log.Info("tagger stream established successfully")
 
 		return nil
 	}, expBackoff)

--- a/pkg/tagger/subscriber/subscriber.go
+++ b/pkg/tagger/subscriber/subscriber.go
@@ -93,7 +93,7 @@ func notify(ch chan []types.EntityEvent, events []types.EntityEvent, cardinality
 		})
 	}
 
-	telemetry.Notifications.Inc()
+	telemetry.Sends.Inc()
 	telemetry.Events.Add(float64(len(events)), collectors.TagCardinalityToString(cardinality))
 
 	ch <- subscriberEvents

--- a/pkg/tagger/telemetry/telemetry.go
+++ b/pkg/tagger/telemetry/telemetry.go
@@ -18,10 +18,16 @@ var (
 		[]string{"cardinality"}, "Queries made against the tagger.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
-	// StreamErrors tracks how many errors were received when streaming
+	// ClientStreamErrors tracks how many errors were received when streaming
 	// tagger events.
-	StreamErrors = telemetry.NewCounterWithOpts("tagger", "stream_errors",
+	ClientStreamErrors = telemetry.NewCounterWithOpts("tagger", "client_stream_errors",
 		[]string{}, "Errors received when streaming tagger events",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	// ServerStreamErrors tracks how many errors happened when streaming
+	// out tagger events.
+	ServerStreamErrors = telemetry.NewCounterWithOpts("tagger", "server_stream_errors",
+		[]string{}, "Errors when streaming out tagger events",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// Subscribers tracks how many subscribers the tagger has.
@@ -34,9 +40,15 @@ var (
 		[]string{"cardinality"}, "Number of tagger events being sent out",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
-	// Notifications tracks the number of times the tagger has sent a
+	// Sends tracks the number of times the tagger has sent a
 	// notification with a group of events.
-	Notifications = telemetry.NewCounterWithOpts("tagger", "sends",
+	Sends = telemetry.NewCounterWithOpts("tagger", "sends",
 		[]string{}, "Number of of times the tagger has sent a notification with a group of events",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	// Receives tracks the number of times the tagger has received a
+	// notification with a group of events.
+	Receives = telemetry.NewCounterWithOpts("tagger", "receives",
+		[]string{}, "Number of of times the tagger has received a notification with a group of events",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 )

--- a/pkg/util/grpc/timeout.go
+++ b/pkg/util/grpc/timeout.go
@@ -1,0 +1,29 @@
+package grpc
+
+import (
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// DoWithTimeout runs f and returns its error.  If the deadline d elapses first,
+// it returns a grpc DeadlineExceeded error instead.
+func DoWithTimeout(f func() error, d time.Duration) error {
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- f()
+		close(errChan)
+	}()
+
+	t := time.NewTimer(d)
+	select {
+	case <-t.C:
+		return status.Errorf(codes.DeadlineExceeded, "timed out waiting for operation")
+	case err := <-errChan:
+		if !t.Stop() {
+			<-t.C
+		}
+		return err
+	}
+}


### PR DESCRIPTION
### What does this PR do?

We found the remote tagger starts but immediately hangs in some nodes
without anything useful appearing in the logs. We suspect that either
the server is hanging while trying to send a message that the client
never receives, or that the client is receiving it but also getting
stuck.

If that's the case, a newly introduced 1 minute timeout on the server and 10 minutes on the client 
should cause the stream to be restared, and hopefully things will get
unstuck on their own. Naturally, we also added some telemetry to track
when that happens.

Additionally, instead of tracking the tagger store state as entities are
added or removed, now we have a separate goroutine running every minute
to take care of that. This avoids not having data for stored entities
when the tagger hangs. It's not all that different in theory, but in
practice we can now detect that in Datadog by querying for agents with
zero stored entities.

### Describe your test plan

Trying to induce a timeout will probably be very hard work, so it's probably best to QA this by deploying to a large enough cluster, and trying to find a node where `datadog.process_agent.tagger_stored_entities` is zero (which should be few if any, a large number would imply this PR broke the telemetry instead of fix it). It's expected that such a node would be re-starting the stream every minute. In the absence of any node without stored entities, you *may* find `datadog.process_agent.tagger_client_stream_errors` or `datadog.agent.tagger_server_stream_errors`. If none of this works, try a bigger cluster ;)