### PR TITLE
[runtime-security] generate security-agent.yaml and install security-agent.yaml.example

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -130,6 +130,7 @@ build do
             move "#{install_dir}/etc/datadog-agent/system-probe.yaml.example", "/etc/datadog-agent"
             move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent", :force=>true
             move "#{install_dir}/etc/datadog-agent/runtime-security.d", "/etc/datadog-agent", :force=>true
+            move "#{install_dir}/etc/datadog-agent/security-agent.yaml.example", "/etc/datadog-agent", :force=>true
             move "#{install_dir}/etc/datadog-agent/compliance.d", "/etc/datadog-agent"
 
             # Move SELinux policy

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -150,6 +150,7 @@ build do
   else
     command "invoke -e security-agent.build --major-version #{major_version_arg}", :env => env
     copy 'bin/security-agent/security-agent', "#{install_dir}/embedded/bin"
+    move 'bin/agent/dist/security-agent.yaml', "#{conf_dir}/security-agent.yaml.example"
   end
 
   if linux?

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -68,6 +68,12 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
       chmod 0440 ${CONFIG_DIR}/system-probe.yaml || true
     fi
 
+    # Make security-agent config read-only
+    chmod 0440 ${CONFIG_DIR}/security-agent.yaml.example || true
+    if [ -f "$CONFIG_DIR/security-agent.yaml" ]; then
+      chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
+    fi
+
     # Make the system-probe and security-agent binaries and eBPF programs owned by root
     chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
     chown root:root ${INSTALL_DIR}/embedded/bin/security-agent

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -949,6 +949,7 @@ api_key:
 #############################################
 ## Security Agent Compliance Configuration ##
 #############################################
+
 ## @param compliance_config - custom object - optional
 ## Enter specific configuration for continuous compliance checks.
 # compliance_config:
@@ -1042,6 +1043,10 @@ api_key:
   #
   # enabled: false
 
+  ## @param fim_enabled - boolean - optional - default: false
+  ## Set to true to enable the File Integrity Monitoring feature.
+  # fim_enabled: false
+
   ## @param socket - string - optional - default: /opt/datadog-agent/run/runtime-security.sock
   ## The full path to the location of the unix socket where security runtime module is accessed.
   #
@@ -1056,11 +1061,6 @@ api_key:
     #
     # dir: /etc/datadog-agent/runtime-security.d
 
-  ## @param enable_kernel_filters - boolean - optional - default: true
-  ## Enable filtering events from the kernel
-  #
-  # enable_kernel_filters: true
-
   ## @param syscall_monitor - custom object - optional
   ## Syscall monitoring
   #
@@ -1070,7 +1070,39 @@ api_key:
     ## Set to true to enable the Syscall monitoring.
     #
     #  enabled: false
+
+  ## @param custom_sensitive_words - list of strings - optional
+  ## Define your own list of sensitive data to be merged with the default one.
+  ## Read more on Datadog documentation:
+  ## https://docs.datadoghq.com/graphing/infrastructure/process/#process-arguments-scrubbing
+  #
+  # custom_sensitive_words:
+  #   - 'personal_key'
+  #   - '*token'
+  #   - 'sql*'
+  #   - '*pass*d*'
+
 {{ end -}}
+{{ end -}}
+
+{{- if .SecurityAgent -}}
+##########################################
+## Security Agent Runtime Configuration ##
+##                                      ##
+## Settings to sent logs to Datadog are ##
+## fetched from section `logs_config`   ##
+##########################################
+
+# runtime_security_config:
+  ## @param enabled - boolean - optional - default: false
+  ## Set to true to enable the Security Runtime Module.
+  #
+  # enabled: false
+
+  ## @param socket - string - optional - default: /opt/datadog-agent/run/runtime-security.sock
+  ## The full path to the location of the unix socket where security runtime module is accessed.
+  #
+  # socket: /opt/datadog-agent/run/runtime-security.sock
 {{ end -}}
 {{- if .Dogstatsd }}
 

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -77,7 +77,6 @@ func mkContext(buildType string) context {
 		KubeApiServer:     true, // TODO: remove when phasing out from node-agent
 		Compliance:        true,
 		SNMP:              true,
-		SecurityModule:    true,
 	}
 
 	switch buildType {
@@ -97,8 +96,9 @@ func mkContext(buildType string) context {
 		}
 	case "system-probe":
 		return context{
-			SystemProbe:   true,
-			NetworkModule: true,
+			SystemProbe:    true,
+			NetworkModule:  true,
+			SecurityModule: true,
 		}
 	case "dogstatsd":
 		return context{

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -47,6 +47,7 @@ type context struct {
 	Compliance        bool
 	SNMP              bool
 	SecurityModule    bool
+	SecurityAgent     bool
 	NetworkModule     bool // Sub-module of System Probe
 }
 
@@ -125,6 +126,10 @@ func mkContext(buildType string) context {
 			ClusterChecks:   true,
 			CloudFoundryBBS: true,
 			CloudFoundryCC:  true,
+		}
+	case "security-agent":
+		return context{
+			SecurityAgent: true,
 		}
 	}
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -23,6 +23,7 @@ from .ssm import get_pfx_pass, get_signing_cert
 from .utils import (
     REPO_PATH,
     bin_name,
+    generate_config,
     get_build_flags,
     get_version,
     get_version_numeric_only,
@@ -183,27 +184,17 @@ def build(
     )
 
     # Render the Agent configuration file template
-    cmd = "go run {go_file} {build_type} {template_file} {output_file}"
-
     build_type = "agent-py3"
     if iot:
         build_type = "iot-agent"
     elif has_both_python(python_runtimes):
         build_type = "agent-py2py3"
 
-    args = {
-        "go_file": "./pkg/config/render_config.go",
-        "build_type": build_type,
-        "template_file": "./pkg/config/config_template.yaml",
-        "output_file": "./cmd/agent/dist/datadog.yaml",
-    }
-
-    ctx.run(cmd.format(**args), env=env)
+    generate_config(ctx, build_type=build_type, output_file="./cmd/agent/dist/datadog.yaml", env=env)
 
     # On Linux and MacOS, render the system-probe configuration file template
     if sys.platform != 'win32' or windows_sysprobe:
-        cmd = "go run ./pkg/config/render_config.go system-probe ./pkg/config/config_template.yaml ./cmd/agent/dist/system-probe.yaml"
-        ctx.run(cmd, env=env)
+        generate_config(ctx, build_type="system-probe", output_file="./cmd/agent/dist/system-probe.yaml", env=env)
 
     if not skip_assets:
         refresh_assets(ctx, build_tags, development=development, iot=iot, windows_sysprobe=windows_sysprobe)

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -9,6 +9,7 @@ from .go import generate
 from .utils import (
     REPO_PATH,
     bin_name,
+    generate_config,
     get_build_flags,
     get_git_branch_name,
     get_git_commit,
@@ -17,8 +18,8 @@ from .utils import (
     get_version,
 )
 
-BIN_DIR = os.path.join(".", "bin", "security-agent")
-BIN_PATH = os.path.join(BIN_DIR, bin_name("security-agent", android=False))
+BIN_DIR = os.path.join(".", "bin")
+BIN_PATH = os.path.join(BIN_DIR, "security-agent", bin_name("security-agent", android=False))
 GIMME_ENV_VARS = ['GOROOT', 'PATH']
 
 
@@ -106,9 +107,9 @@ def build(
     ctx.run(cmd.format(**args), env=env)
 
     if not skip_assets:
-        dist_folder = os.path.join(BIN_DIR, "dist", "runtime-security.d")
-        if not os.path.exists(dist_folder):
-            os.makedirs(dist_folder)
+        dist_folder = os.path.join(BIN_DIR, "agent", "dist")
+        generate_config(ctx, build_type="security-agent", output_file="./cmd/agent/dist/security-agent.yaml", env=env)
+        shutil.copy("./cmd/agent/dist/security-agent.yaml", os.path.join(dist_folder, "security-agent.yaml"))
 
 
 @task()

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -294,3 +294,14 @@ def load_release_versions(_, target_version):
             # environment when running a subprocess.
             return {str(k): str(v) for k, v in versions[target_version].items()}
     raise Exception("Could not find '{}' version in release.json".format(target_version))
+
+
+def generate_config(ctx, build_type, output_file, env=None):
+    args = {
+        "go_file": "./pkg/config/render_config.go",
+        "build_type": build_type,
+        "template_file": "./pkg/config/config_template.yaml",
+        "output_file": output_file,
+    }
+    cmd = "go run {go_file} {build_type} {template_file} {output_file}"
+    return ctx.run(cmd.format(**args), env=env or {})


### PR DESCRIPTION
### What does this PR do?

Move the security module config from datadog.yaml to system-probe.yaml and install security-agent.yaml.example

### Motivation

Using datadog.yaml for the security agent is now deprecated and security-agent.yaml should be used instead