### PR TITLE
Send timeout metric, handle restarts after timeouts, and send metrics when logs are disabled (attempt 2)

### DIFF
--- a/cmd/serverless/README.md
+++ b/cmd/serverless/README.md
@@ -8,10 +8,10 @@ GOOS=linux go build -tags serverless -o datadog-agent
 
 ## Serverless environment configuration
 
-- `DD_API_KEY` should be set to provide the API key to use, or `DD_KMS_API_KEY` to use a KMS encrypted API key or `DD_API_KEY_SECRET_ARN` to use a secret set in Secrets Manager for the API key.
-- `DD_SITE` (optional)
-- `DD_LOG_LEVEL` (optional)
-- `DD_LOGS_ENABLED` (optional) to enable the logs collection if supported in the serverless environment
+  - `DD_API_KEY` - should be set to provide the API key to use, or `DD_KMS_API_KEY` to use a KMS encrypted API key or `DD_API_KEY_SECRET_ARN` to use a secret set in Secrets Manager for the API key.
+  - `DD_SITE` (optional)
+  - `DD_LOG_LEVEL` (optional)
+  - `DD_LOGS_ENABLED` (optional) - send function logs to Datadog. If false, logs will still be collected to generate metrics, but will not be sent.
 
 ## Limitations
 

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/serverless"
+	"github.com/DataDog/datadog-agent/pkg/serverless/aws"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
 	traceAgent "github.com/DataDog/datadog-agent/pkg/trace/agent"
 	traceConfig "github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -265,49 +266,49 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 		log.Error("No API key configured, exiting")
 	}
 
-	// starts logs collection if enabled
-	// ---------------------------------
+	// restore the current function ARN and request ID from the cache in case the extension was restarted
+	// ---------------------------
 
-	if config.Datadog.GetBool("logs_enabled") {
+	err = aws.RestoreCurrentStateFromFile()
+	if err != nil {
+		log.Debug("Did not restore current state from file")
+	}
 
-		// type of logs we are subscribing to
-		var logsType []string
-		// TODO(remy): there is two different things that we may have to differentiate:
-		//             the user may want to send these logs to the intake, and the Agent
-		//             may want to fetch more than what he want sent. For instance, if the
-		//             user don't care about the platform logs, the Agent will still want
-		//             to receive them in order to generate the enhanced metrics.
-		if envLogsType, exists := os.LookupEnv(logsLogsTypeSubscribed); exists {
-			parts := strings.Split(strings.TrimSpace(envLogsType), " ")
-			for _, part := range parts {
-				part = strings.ToLower(strings.TrimSpace(part))
-				switch part {
-				case "function", "platform", "extension":
-					logsType = append(logsType, part)
-				default:
-					log.Warn("While subscribing to logs, unknown log type", part)
-				}
+	// starts logs collection
+	// ----------------------
+
+	// type of logs we are subscribing to
+	var logsType []string
+	if envLogsType, exists := os.LookupEnv(logsLogsTypeSubscribed); exists {
+		parts := strings.Split(strings.TrimSpace(envLogsType), " ")
+		for _, part := range parts {
+			part = strings.ToLower(strings.TrimSpace(part))
+			switch part {
+			case "function", "platform", "extension":
+				logsType = append(logsType, part)
+			default:
+				log.Warn("While subscribing to logs, unknown log type", part)
 			}
-		} else {
-			logsType = append(logsType, "platform", "function")
 		}
+	} else {
+		logsType = append(logsType, "platform", "function")
+	}
 
-		log.Debug("Enabling logs collection HTTP route")
-		if httpAddr, logsChan, err := daemon.EnableLogsCollection(); err != nil {
-			log.Error("While starting the HTTP Logs Server:", err)
+	log.Debug("Enabling logs collection HTTP route")
+	if httpAddr, logsChan, err := daemon.EnableLogsCollection(); err != nil {
+		log.Error("While starting the HTTP Logs Server:", err)
+	} else {
+		// subscribe to the logs on the platform
+		if err := serverless.SubscribeLogs(serverlessID, httpAddr, logsType); err != nil {
+			log.Error("Can't subscribe to logs:", err)
 		} else {
-			// subscribe to the logs on the platform
-			if err := serverless.SubscribeLogs(serverlessID, httpAddr, logsType); err != nil {
-				log.Error("Can't subscribe to logs:", err)
-			} else {
-				// we subscribed to the logs collection on the platform, let's instantiate
-				// a logs agent to collect/process/flush the logs.
-				if err := logs.StartServerless(
-					func() *autodiscovery.AutoConfig { return common.AC },
-					logsChan, extraTags,
-				); err != nil {
-					log.Error("Could not start an instance of the Logs Agent:", err)
-				}
+			// we subscribed to the logs collection on the platform, let's instantiate
+			// a logs agent to collect/process/flush the logs.
+			if err := logs.StartServerless(
+				func() *autodiscovery.AutoConfig { return common.AC },
+				logsChan, extraTags,
+			); err != nil {
+				log.Error("Could not start an instance of the Logs Agent:", err)
 			}
 		}
 	}
@@ -329,6 +330,7 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 	serializer := serializer.NewSerializer(f)
 
 	aggregatorInstance := aggregator.InitAggregator(serializer, "serverless")
+	metricsChan := aggregatorInstance.GetBufferedMetricsWithTsChannel()
 
 	// initializes the DogStatsD server
 	// --------------------------------
@@ -342,6 +344,7 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 		log.Errorf("Unable to start the DogStatsD server: %s", err)
 	}
 	statsdServer.ServerlessMode = true // we're running in a serverless environment (will removed host field from samples)
+
 	// initializes the trace agent
 	// --------------------------------
 	var ta *traceAgent.Agent
@@ -364,7 +367,7 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 	// the invocation route, we can't report init errors anymore.
 	go func() {
 		for {
-			if err := serverless.WaitForNextInvocation(stopCh, daemon, serverlessID); err != nil {
+			if err := serverless.WaitForNextInvocation(stopCh, daemon, metricsChan, serverlessID); err != nil {
 				log.Error(err)
 			}
 		}

--- a/pkg/serverless/aws/arn.go
+++ b/pkg/serverless/aws/arn.go
@@ -6,9 +6,18 @@
 package aws
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"strings"
 	"sync"
 )
+
+const persistedStateFilePath = "/tmp/dd-lambda-extension-cache.json"
+
+type persistedState struct {
+	CurrentARN   string
+	CurrentReqID string
+}
 
 var currentARN struct {
 	value string
@@ -46,6 +55,14 @@ func SetARN(arn string) {
 	currentARN.value = arn
 }
 
+// FunctionNameFromARN returns the function name from the currently set ARN.
+// Thread-safe.
+func FunctionNameFromARN() string {
+	arn := GetARN()
+	parts := strings.Split(arn, ":")
+	return parts[len(parts)-1]
+}
+
 // GetRequestID returns the currently running function request ID.
 func GetRequestID() string {
 	currentReqID.Lock()
@@ -62,15 +79,39 @@ func SetRequestID(reqID string) {
 	currentReqID.value = reqID
 }
 
-// FunctionNameFromARN returns the function name from the currently set ARN.
-// Thread-safe.
-func FunctionNameFromARN() string {
-	currentARN.Lock()
-	defer currentARN.Unlock()
-	if currentARN.value == "" {
-		return ""
+// PersistCurrentStateToFile persists the current state (ARN and Request ID) to a file.
+// This allows the state to be restored after the extension restarts.
+// Call this function when the extension shuts down.
+func PersistCurrentStateToFile() error {
+	dataToPersist := persistedState{
+		CurrentARN:   GetARN(),
+		CurrentReqID: GetRequestID(),
 	}
 
-	parts := strings.Split(currentARN.value, ":")
-	return parts[len(parts)-1]
+	file, err := json.MarshalIndent(dataToPersist, "", "")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(persistedStateFilePath, file, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RestoreCurrentStateFromFile restores the current state (ARN and Request ID) from a file
+// after the extension is restarted. Call this function when the extension starts.
+func RestoreCurrentStateFromFile() error {
+	file, err := ioutil.ReadFile(persistedStateFilePath)
+	if err != nil {
+		return err
+	}
+	var restoredState persistedState
+	err = json.Unmarshal(file, &restoredState)
+	if err != nil {
+		return err
+	}
+	SetARN(restoredState.CurrentARN)
+	SetRequestID(restoredState.CurrentReqID)
+	return nil
 }

--- a/pkg/serverless/aws/arn_test.go
+++ b/pkg/serverless/aws/arn_test.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	exampleArn               = "arn:aws:lambda:us-east-1:123456789012:function:my-function:7"
+	exampleArnWithoutVersion = "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+	exampleFunctionName      = "my-function"
+	exampleRequestID         = "123"
+)
+
+func TestGetAndSetARN(t *testing.T) {
+	t.Cleanup(resetState)
+	SetARN(exampleArn)
+
+	output := GetARN()
+	assert.Equal(t, exampleArnWithoutVersion, output)
+
+	functionName := FunctionNameFromARN()
+	assert.Equal(t, exampleFunctionName, functionName)
+}
+
+func TestGetAndSetRequestID(t *testing.T) {
+	t.Cleanup(resetState)
+	SetRequestID(exampleRequestID)
+
+	output := GetRequestID()
+	assert.Equal(t, exampleRequestID, output)
+}
+
+func TestPersistAndRestoreCurrentState(t *testing.T) {
+	t.Cleanup(resetState)
+	SetARN(exampleArn)
+	SetRequestID(exampleRequestID)
+	PersistCurrentStateToFile()
+
+	SetARN("")
+	SetRequestID("")
+	output := GetARN()
+	assert.Equal(t, "", output)
+	output = GetRequestID()
+	assert.Equal(t, "", output)
+
+	err := RestoreCurrentStateFromFile()
+	assert.Equal(t, err, nil)
+	output = GetARN()
+	assert.Equal(t, exampleArnWithoutVersion, output)
+	output = GetRequestID()
+	assert.Equal(t, exampleRequestID, output)
+}
+
+func resetState() {
+	SetARN("")
+	SetRequestID("")
+}

--- a/pkg/serverless/aws/arn_test.go
+++ b/pkg/serverless/aws/arn_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package aws
 
 import (

--- a/pkg/serverless/aws/logs.go
+++ b/pkg/serverless/aws/logs.go
@@ -26,6 +26,8 @@ const (
 	LogTypePlatformEnd = "platform.end"
 	// LogTypePlatformReport is used for the log messages containing a report of the last invocation.
 	LogTypePlatformReport = "platform.report"
+	// LogTypePlatformLogsDropped is used when AWS has dropped logs because we were unable to consume them fast enough.
+	LogTypePlatformLogsDropped = "platform.logsDropped"
 )
 
 // LogMessage is a log message sent by the AWS API.
@@ -42,7 +44,7 @@ type LogMessage struct {
 type PlatformObjectRecord struct {
 	RequestID string           // uuid; present in LogTypePlatform{Start,End,Report}
 	Version   string           // present in LogTypePlatformStart only
-	Metrics   ReportLogMetrics // pretesent in LogTypePlatformReport only
+	Metrics   ReportLogMetrics // present in LogTypePlatformReport only
 }
 
 // ReportLogMetrics contains metrics found in a LogTypePlatformReport log

--- a/pkg/serverless/enhanced_metrics.go
+++ b/pkg/serverless/enhanced_metrics.go
@@ -6,8 +6,10 @@
 package serverless
 
 import (
+	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/aws"
@@ -96,6 +98,28 @@ func generateEnhancedMetricsFromReportLog(message aws.LogMessage, tags []string,
 		SampleRate: 1,
 		Timestamp:  float64(message.Time.UnixNano()),
 	}}
+}
+
+// sendTimeoutEnhancedMetric sends an enhanced metric representing a timeout
+func sendTimeoutEnhancedMetric(tags []string, metricsChan chan []metrics.MetricSample) {
+	metricsChan <- []metrics.MetricSample{{
+		Name:       "aws.lambda.enhanced.timeouts",
+		Value:      1.0,
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		Timestamp:  float64(time.Now().UnixNano()),
+	}}
+}
+
+// getTagsForEnhancedMetrics returns the tags that should be included with enhanced metrics
+func getTagsForEnhancedMetrics() []string {
+	functionARN := aws.GetARN()
+	functionName := aws.FunctionNameFromARN()
+	return []string{
+		fmt.Sprintf("functionname:%s", functionName),
+		fmt.Sprintf("function_arn:%s", functionARN),
+	}
 }
 
 // calculateEstimatedCost returns the estimated cost in USD of a Lambda invocation

--- a/pkg/serverless/enhanced_metrics_test.go
+++ b/pkg/serverless/enhanced_metrics_test.go
@@ -117,6 +117,37 @@ func TestGenerateEnhancedMetricsFromReportLog(t *testing.T) {
 	}})
 }
 
+func TestSendTimeoutEnhancedMetric(t *testing.T) {
+	metricsChan := make(chan []metrics.MetricSample)
+	tags := []string{"functionname:test-function"}
+
+	go sendTimeoutEnhancedMetric(tags, metricsChan)
+
+	generatedMetrics := <-metricsChan
+
+	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
+		Name:       "aws.lambda.enhanced.timeouts",
+		Value:      1.0,
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		// compare the generated timestamp to itself because we can't know its value
+		Timestamp: generatedMetrics[0].Timestamp,
+	}})
+}
+
+func TestGetTagsForEnhancedMetrics(t *testing.T) {
+	aws.SetARN("arn:aws:lambda:us-east-1:123456789012:function:my-function:7")
+	defer aws.SetARN("")
+
+	generatedTags := getTagsForEnhancedMetrics()
+
+	assert.Equal(t, generatedTags, []string{
+		"functionname:my-function",
+		"function_arn:arn:aws:lambda:us-east-1:123456789012:function:my-function",
+	})
+}
+
 func TestCalculateEstimatedCost(t *testing.T) {
 	// Latest Lambda pricing and billing examples from https://aws.amazon.com/lambda/pricing/
 	const freeTierComputeCost = lambdaPricePerGbSecond * 400000

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -14,14 +14,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
-	traceAgent "github.com/DataDog/datadog-agent/pkg/trace/agent"
-
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/serverless/aws"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
+	traceAgent "github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -55,7 +54,7 @@ type Daemon struct {
 	stopCh     chan struct{}
 
 	// Wait on this WaitGroup in controllers to be sure that the Daemon is ready.
-	// (i.e. that the DogStatsD server is properly instanciated)
+	// (i.e. that the DogStatsD server is properly instantiated)
 	ReadyWg *sync.WaitGroup
 }
 
@@ -146,6 +145,7 @@ func (d *Daemon) TriggerFlush(ctx context.Context, shutdown bool) {
 // If the Flush route is called before the statsd server has been set, a 503
 // is returned by the HTTP route.
 func StartDaemon(stopCh chan struct{}) *Daemon {
+	log.Debug("Starting daemon to receive messages from runtime...")
 	mux := http.NewServeMux()
 
 	daemon := &Daemon{
@@ -164,7 +164,7 @@ func StartDaemon(stopCh chan struct{}) *Daemon {
 	mux.Handle("/lambda/hello", &Hello{daemon})
 	mux.Handle("/lambda/flush", &Flush{daemon})
 
-	// this wait group will be blocking until the DogStatsD server has been instanciated
+	// this wait group will be blocking until the DogStatsD server has been instantiated
 	daemon.ReadyWg.Add(1)
 
 	// start the HTTP server used to communicate with the clients
@@ -198,39 +198,45 @@ type LogsCollection struct {
 
 // ServeHTTP - see type LogsCollection comment.
 func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// If the DogStatsD daemon isn't ready, wait for it.
+	l.daemon.ReadyWg.Wait()
+
 	data, _ := ioutil.ReadAll(r.Body)
 	defer r.Body.Close()
 	var messages []aws.LogMessage
+
 	if err := json.Unmarshal(data, &messages); err != nil {
 		log.Error("Can't read log message")
 		w.WriteHeader(400)
 	} else {
 		metricsChan := l.daemon.aggregator.GetBufferedMetricsWithTsChannel()
-		functionARN := aws.GetARN()
-		functionName := aws.FunctionNameFromARN()
-		// FIXME(remy): could this be exported to properly get all tags?
-		metricTags := []string{
-			fmt.Sprintf("functionname:%s", functionName),
-			fmt.Sprintf("function_arn:%s", functionARN),
-		}
+		metricTags := getTagsForEnhancedMetrics()
+		sendLogsToIntake := config.Datadog.GetBool("logs_enabled")
 		for _, message := range messages {
-			switch message.Type {
-			case aws.LogTypePlatformStart:
+			// Do not send logs or metrics if we can't associate them with an ARN or Request ID
+			// First, if the log has a Request ID, set the global Request ID variable
+			if message.Type == aws.LogTypePlatformStart {
 				if len(message.ObjectRecord.RequestID) > 0 {
 					aws.SetRequestID(message.ObjectRecord.RequestID)
 				}
-				l.ch <- message
+			}
+			// If the global request ID or ARN variable isn't set at this point, do not process further
+			if aws.GetARN() == "" || aws.GetRequestID() == "" {
+				continue
+			}
+
+			switch message.Type {
 			case aws.LogTypeFunction:
-				if functionName != "" {
-					generateEnhancedMetricsFromFunctionLog(message, metricTags, metricsChan)
-				}
-				l.ch <- message
+				generateEnhancedMetricsFromFunctionLog(message, metricTags, metricsChan)
 			case aws.LogTypePlatformReport:
-				if functionName != "" {
-					generateEnhancedMetricsFromReportLog(message, metricTags, metricsChan)
-				}
-				l.ch <- message
-			default:
+				generateEnhancedMetricsFromReportLog(message, metricTags, metricsChan)
+			case aws.LogTypePlatformLogsDropped:
+				log.Debug("Logs were dropped by the AWS Lambda Logs API")
+			}
+
+			// We always collect and process logs for the purpose of extracting enhanced metrics.
+			// However, if logs are not enabled, we do not send them to the intake.
+			if sendLogsToIntake {
 				l.ch <- message
 			}
 		}
@@ -238,9 +244,8 @@ func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Hello implements the basic Hello route, creating a way for the runtime to
-// know that the serverless agent is running.
-// It is blocking until the DogStatsD daemon is ready.
+// Hello implements the basic Hello route, creating a way for the Datadog Lambda Library
+// to know that the serverless agent is running. It is blocking until the DogStatsD daemon is ready.
 type Hello struct {
 	daemon *Daemon
 }

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -14,9 +14,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/aws"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -35,7 +37,8 @@ const (
 	headerExtErrType  string = "Lambda-Extension-Function-Error-Type"
 	headerContentType string = "Content-Type"
 
-	requestTimeout time.Duration = 5 * time.Second
+	requestTimeout      time.Duration = 5 * time.Second
+	arbitraryShortDelay time.Duration = 10 * time.Millisecond
 
 	// FatalNoAPIKey is the error reported to the AWS Extension environment when
 	// no API key has been set. Unused until we can report error
@@ -76,6 +79,7 @@ type Payload struct {
 	EventType          string `json:"eventType"`
 	DeadlineMs         int64  `json:"deadlineMs"`
 	InvokedFunctionArn string `json:"invokedFunctionArn"`
+	ShutdownReason     string `json:"shutdownReason"`
 	//    RequestId string `json:"requestId"` // unused
 }
 
@@ -226,14 +230,11 @@ func ReportInitError(id ID, errorEnum ErrorEnum) error {
 	return nil
 }
 
-// WaitForNextInvocation starts waiting and blocking until it receives a request.
-// Note that for now, we only subscribe to INVOKE and SHUTDOWN messages.
+// WaitForNextInvocation makes a blocking HTTP call to receive the next event from AWS.
+// Note that for now, we only subscribe to INVOKE and SHUTDOWN events.
 // Write into stopCh to stop the main thread of the running program.
-func WaitForNextInvocation(stopCh chan struct{}, daemon *Daemon, id ID) error {
+func WaitForNextInvocation(stopCh chan struct{}, daemon *Daemon, metricsChan chan []metrics.MetricSample, id ID) error {
 	var err error
-
-	// do the blocking HTTP GET call
-
 	var request *http.Request
 	var response *http.Response
 
@@ -242,13 +243,14 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *Daemon, id ID) error {
 	}
 	request.Header.Set(headerExtID, id.String())
 
-	// the blocking call is here
+	// make a blocking HTTP call to wait for the next event from AWS
+	log.Debug("Waiting for next invocation...")
 	client := &http.Client{Timeout: 0} // this one should never timeout
 	if response, err = client.Do(request); err != nil {
 		return fmt.Errorf("WaitForNextInvocation: while GET next route: %v", err)
 	}
 
-	// we received a response, meaning we've been invoked
+	// we received an INVOKE or SHUTDOWN event
 	daemon.StoreInvocationTime(time.Now())
 
 	var body []byte
@@ -262,33 +264,43 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *Daemon, id ID) error {
 		return fmt.Errorf("WaitForNextInvocation: can't unmarshal the payload: %v", err)
 	}
 
-	// sets the current ARN.
-	// TODO(remy): we could probably do this once
-	if payload.InvokedFunctionArn != "" {
+	if payload.EventType == "INVOKE" {
+		log.Debug("Received invocation event")
 		aws.SetARN(payload.InvokedFunctionArn)
-	}
 
-	// immediately check if we should flush data
-	// note that since we're flushing synchronously here, there is a scenario
-	// where this could be blocking the function if the flush is slow (if the
-	// extension is not quickly going back to listen on the "wait next event"
-	// route). That's why we use a context.Context with a timeout `flushTimeout``
-	// to avoid blocking for too long.
-	// This flushTimeout is re-using the forwarder_timeout value.
-	if daemon.flushStrategy.ShouldFlush(flush.Starting, time.Now()) {
-		log.Debugf("The flush strategy %s has decided to flush the data in the moment: %s", daemon.flushStrategy, flush.Starting)
-		flushTimeout := config.Datadog.GetDuration("forwarder_timeout") * time.Second
-		ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
-		daemon.TriggerFlush(ctx, false)
-		cancel() // free the resource of the context
-	} else {
-		log.Debugf("The flush strategy %s has decided to not flush in the moment: %s", daemon.flushStrategy, flush.Starting)
+		// immediately check if we should flush data
+		// note that since we're flushing synchronously here, there is a scenario
+		// where this could be blocking the function if the flush is slow (if the
+		// extension is not quickly going back to listen on the "wait next event"
+		// route). That's why we use a context.Context with a timeout `flushTimeout``
+		// to avoid blocking for too long.
+		// This flushTimeout is re-using the forwarder_timeout value.
+		if daemon.flushStrategy.ShouldFlush(flush.Starting, time.Now()) {
+			log.Debugf("The flush strategy %s has decided to flush the data in the moment: %s", daemon.flushStrategy, flush.Starting)
+			flushTimeout := config.Datadog.GetDuration("forwarder_timeout") * time.Second
+			ctx, cancel := context.WithTimeout(context.Background(), flushTimeout)
+			daemon.TriggerFlush(ctx, false)
+			cancel() // free the resource of the context
+		} else {
+			log.Debugf("The flush strategy %s has decided to not flush in the moment: %s", daemon.flushStrategy, flush.Starting)
+		}
 	}
-
 	if payload.EventType == "SHUTDOWN" {
-		// note that there is no scenario where we would not want to flush while the env
-		// is shutting down, then, we're not relying on the current flush strategy,
-		// we are flushing in all cases.
+		log.Debug("Received shutdown event. Reason: " + payload.ShutdownReason)
+
+		err := aws.PersistCurrentStateToFile()
+		if err != nil {
+			log.Error("Unable to persist current state to file while shutting down")
+		}
+
+		if strings.ToLower(payload.ShutdownReason) == "timeout" {
+			metricTags := getTagsForEnhancedMetrics()
+			sendTimeoutEnhancedMetric(metricTags, metricsChan)
+			// Ensure that timeout metric has been received by the statsdServer before flushing
+			time.Sleep(arbitraryShortDelay)
+		}
+
+		// Always flush when shutting down, regardless of flushing strategy
 		daemon.TriggerFlush(context.Background(), true)
 
 		// shutdown the serverless agent


### PR DESCRIPTION
### What does this PR do?

This PR is mostly same as #7529, which was reverted. It fixes an issue with a test failing in Windows by adding a [build tag](https://github.com/DataDog/datadog-agent/compare/ngh/enhanced-metrics-3?expand=1#diff-5bcb373cfba3ffef9b3fa2c08951fbe9abee2c06502312d5a5c5e585fabfdae2R1) that will prevent the test from running in Windows. The code in question will only be run on the AWS Lambda Platform (i.e. not Windows).

### Motivation

See #7529

### Describe your test plan

I manually tested the expected behaviors in a Lambda, and also added unit test coverage.
