### PR TITLE
[runtime-security] make _ register a random register

### DIFF
--- a/pkg/security/secl/eval/eval.go
+++ b/pkg/security/secl/eval/eval.go
@@ -524,7 +524,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, in
 
 			if iterator != nil {
 				// regID not specified generate one
-				if regID == "" {
+				if regID == "" || regID == "_" {
 					regID = RandString(8)
 				}
 

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -706,13 +706,14 @@ func TestRegisterSyntaxError(t *testing.T) {
 		{Expr: `process.list.key[] == 10 && process.list.value == 11`, Expected: false},
 		{Expr: `process[].list.key == 10 && process.list.value == 11`, Expected: false},
 		{Expr: `[]process.list.key == 10 && process.list.value == 11`, Expected: false},
-		{Expr: `process.list[_].key == 10 && process.list[_].value == 11 && process.array[_].key == 10 && process.array[_].value == 11`, Expected: false},
+		{Expr: `process.list[_].key == 10 && process.list[_].value == 11 && process.array[_].key == 10 && process.array[_].value == 11`, Expected: true},
+		{Expr: `process.list[A].key == 10 && process.list[A].value == 11 && process.array[A].key == 10 && process.array[A].value == 11`, Expected: false},
 	}
 
 	for _, test := range tests {
 		_, err := parseRule(test.Expr, model, opts)
 		if err == nil != test.Expected {
-			t.Errorf("expected result `%t` not found, got `%t`\n%s", test.Expected, err == nil, test.Expr)
+			t.Errorf("expected result `%t` not found, got `%t`\n%s, %s", test.Expected, err == nil, test.Expr, err)
 		}
 	}
 }
@@ -736,19 +737,20 @@ func TestRegister(t *testing.T) {
 		Expr     string
 		Expected bool
 	}{
-		{Expr: `process.list[_].key == 10 && process.list[_].value == 11`, Expected: true},
-		{Expr: `process.list[_].key == 9999 && process.list[_].value == 11`, Expected: false},
-		{Expr: `process.list[_].key == 100 && process.list[_].value == 101`, Expected: true},
-		{Expr: `process.list[_].key == 200 && process.list[_].value == 201`, Expected: true},
+		{Expr: `process.list[_].key == 10 && process.list[_].value == 101`, Expected: true},
+		{Expr: `process.list[A].key == 10 && process.list[A].value == 11`, Expected: true},
+		{Expr: `process.list[A].key == 9999 && process.list[A].value == 11`, Expected: false},
+		{Expr: `process.list[A].key == 100 && process.list[A].value == 101`, Expected: true},
+		{Expr: `process.list[A].key == 200 && process.list[A].value == 201`, Expected: true},
 		{Expr: `process.list[A].key == 200 && process.list[A].value == 201`, Expected: true},
 		{Expr: `process.list[A].key == 200 && process.list[B].value == 101`, Expected: true},
 		{Expr: `process.list[A].key == 200 || process.list[B].value == 11`, Expected: true},
 		{Expr: `process.list.key == 200 && process.list.value == 11`, Expected: true},
 		{Expr: `process.list[_].key == 10 && process.list.value == 11`, Expected: true},
-		{Expr: `process.array[_].key == 1000 && process.array[_].value == 1001`, Expected: true},
-		{Expr: `process.array[_].key == 1002 && process.array[_].value == 1001`, Expected: false},
+		{Expr: `process.array[A].key == 1000 && process.array[A].value == 1001`, Expected: true},
+		{Expr: `process.array[A].key == 1002 && process.array[A].value == 1001`, Expected: false},
 		{Expr: `process.array[A].key == 1002 && process.array[B].value == 1003`, Expected: true},
-		{Expr: `process.list[_].key == 10 && process.list[_].value == 11 && process.array[A].key == 1002 && process.array[A].value == 1003`, Expected: true},
+		{Expr: `process.list[A].key == 10 && process.list[A].value == 11 && process.array[B].key == 1002 && process.array[B].value == 1003`, Expected: true},
 	}
 
 	for _, test := range tests {
@@ -783,10 +785,10 @@ func TestRegisterPartial(t *testing.T) {
 		Field       Field
 		IsDiscarder bool
 	}{
-		{Expr: `process.list[_].key == 10 && process.list[_].value == 11`, Field: "process.list.key", IsDiscarder: false},
-		{Expr: `process.list[_].key == 55 && process.list[_].value == 11`, Field: "process.list.key", IsDiscarder: true},
-		{Expr: `process.list[_].key == 55 && process.list[_].value == 11`, Field: "process.list.value", IsDiscarder: false},
-		{Expr: `process.list[_].key == 10 && process.list[_].value == 55`, Field: "process.list.value", IsDiscarder: true},
+		{Expr: `process.list[A].key == 10 && process.list[A].value == 11`, Field: "process.list.key", IsDiscarder: false},
+		{Expr: `process.list[A].key == 55 && process.list[A].value == 11`, Field: "process.list.key", IsDiscarder: true},
+		{Expr: `process.list[A].key == 55 && process.list[A].value == 11`, Field: "process.list.value", IsDiscarder: false},
+		{Expr: `process.list[A].key == 10 && process.list[A].value == 55`, Field: "process.list.value", IsDiscarder: true},
 		{Expr: `process.list[A].key == 10 && process.list[B].value == 55`, Field: "process.list.key", IsDiscarder: false},
 		{Expr: `process.list[A].key == 55 && process.list[B].value == 11`, Field: "process.list.key", IsDiscarder: true},
 	}

--- a/releasenotes/notes/runtime-security-wildcard-register-82ba329b35d634a6.yaml
+++ b/releasenotes/notes/runtime-security-wildcard-register-82ba329b35d634a6.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Runtime security SECL language consider `_` register as random register.
+    It means that this register can match multiple levels of fields.


### PR DESCRIPTION
### What does this PR do?

This PR makes `_` register a random register that can match multiple fields and multiple level of fields. ex:

```
process.ancestors[_].uid = 44 && process.list[_].value = 55
````

### Motivation

`_` was supposed to be random.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Nothing special, unit test cover the new behavior
