### PR TITLE
fix orchestrator config loading

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -340,7 +340,7 @@ func StartAgent() error {
 	log.Debugf("Forwarder started")
 
 	// setup the orchestrator forwarder (only on cluster check runners)
-	orchestratorForwarder = orchcfg.NewOrchestratorForwarder(confFilePath)
+	orchestratorForwarder = orchcfg.NewOrchestratorForwarder()
 	if orchestratorForwarder != nil {
 		orchestratorForwarder.Start() //nolint:errcheck
 	}

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -195,7 +195,7 @@ func start(cmd *cobra.Command, args []string) error {
 	f := forwarder.NewDefaultForwarder(forwarderOpts)
 	f.Start() //nolint:errcheck
 	// setup the orchestrator forwarder
-	orchestratorForwarder = orchcfg.NewOrchestratorForwarder(confPath)
+	orchestratorForwarder = orchcfg.NewOrchestratorForwarder()
 	if orchestratorForwarder != nil {
 		orchestratorForwarder.Start() //nolint:errcheck
 	}

--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -53,7 +53,7 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 	// get orchestrator endpoints
 	endpoints := map[string]string{}
 	orchestratorCfg := orchcfg.NewDefaultOrchestratorConfig()
-	err = orchestratorCfg.LoadYamlConfig()
+	err = orchestratorCfg.Load()
 	if err == nil {
 		// obfuscate the api keys
 		for _, endpoint := range orchestratorCfg.OrchestratorEndpoints {

--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -53,7 +53,7 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 	// get orchestrator endpoints
 	endpoints := map[string]string{}
 	orchestratorCfg := orchcfg.NewDefaultOrchestratorConfig()
-	err = orchestratorCfg.LoadYamlConfig(config.Datadog.ConfigFileUsed())
+	err = orchestratorCfg.LoadYamlConfig()
 	if err == nil {
 		// obfuscate the api keys
 		for _, endpoint := range orchestratorCfg.OrchestratorEndpoints {

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -8,7 +8,6 @@ package config
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -63,12 +62,8 @@ func key(pieces ...string) string {
 }
 
 // LoadYamlConfig load orchestrator-specific configuration
-func (oc *OrchestratorConfig) LoadYamlConfig(path string) error {
-	// Resolve any secrets
-	if err := config.ResolveSecrets(config.Datadog, filepath.Base(path)); err != nil {
-		return err
-	}
-
+// at this point secrets should already be resolved by the core/process/cluster agent
+func (oc *OrchestratorConfig) LoadYamlConfig() error {
 	URL, err := extractOrchestratorDDUrl()
 	if err != nil {
 		return err
@@ -162,7 +157,7 @@ func extractOrchestratorDDUrl() (*url.URL, error) {
 
 // NewOrchestratorForwarder returns an orchestratorForwarder
 // if the feature is activated on the cluster-agent/cluster-check runner, nil otherwise
-func NewOrchestratorForwarder(confPath string) *forwarder.DefaultForwarder {
+func NewOrchestratorForwarder() *forwarder.DefaultForwarder {
 	if !config.Datadog.GetBool("orchestrator_explorer.enabled") {
 		return nil
 	}
@@ -170,7 +165,7 @@ func NewOrchestratorForwarder(confPath string) *forwarder.DefaultForwarder {
 		return nil
 	}
 	orchestratorCfg := NewDefaultOrchestratorConfig()
-	if err := orchestratorCfg.LoadYamlConfig(confPath); err != nil {
+	if err := orchestratorCfg.LoadYamlConfig(); err != nil {
 		log.Errorf("Error loading the orchestrator config: %s", err)
 	}
 	keysPerDomain := apicfg.KeysPerDomains(orchestratorCfg.OrchestratorEndpoints)

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -61,9 +61,9 @@ func key(pieces ...string) string {
 	return strings.Join(pieces, ".")
 }
 
-// LoadYamlConfig load orchestrator-specific configuration
+// Load load orchestrator-specific configuration
 // at this point secrets should already be resolved by the core/process/cluster agent
-func (oc *OrchestratorConfig) LoadYamlConfig() error {
+func (oc *OrchestratorConfig) Load() error {
 	URL, err := extractOrchestratorDDUrl()
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func NewOrchestratorForwarder() *forwarder.DefaultForwarder {
 		return nil
 	}
 	orchestratorCfg := NewDefaultOrchestratorConfig()
-	if err := orchestratorCfg.LoadYamlConfig(); err != nil {
+	if err := orchestratorCfg.Load(); err != nil {
 		log.Errorf("Error loading the orchestrator config: %s", err)
 	}
 	keysPerDomain := apicfg.KeysPerDomains(orchestratorCfg.OrchestratorEndpoints)

--- a/pkg/orchestrator/config/config_test.go
+++ b/pkg/orchestrator/config/config_test.go
@@ -121,7 +121,7 @@ func (suite *YamlConfigTestSuite) TestExtractOrchestratorEndpointsPrecedence() {
 func (suite *YamlConfigTestSuite) TestNoEnvConfigArgsScrubbing() {
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
-	err := orchestratorCfg.LoadYamlConfig("")
+	err := orchestratorCfg.LoadYamlConfig()
 	suite.NoError(err)
 
 	cases := []struct {
@@ -145,7 +145,7 @@ func (suite *YamlConfigTestSuite) TestOnlyEnvConfigArgsScrubbing() {
 	suite.config.Set("orchestrator_explorer.custom_sensitive_words", `["token","consul"]`)
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
-	err := orchestratorCfg.LoadYamlConfig("")
+	err := orchestratorCfg.LoadYamlConfig()
 	suite.NoError(err)
 
 	cases := []struct {
@@ -169,7 +169,7 @@ func (suite *YamlConfigTestSuite) TestOnlyEnvContainsConfigArgsScrubbing() {
 	suite.config.Set("orchestrator_explorer.custom_sensitive_words", `["token","consul"]`)
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
-	err := orchestratorCfg.LoadYamlConfig("")
+	err := orchestratorCfg.LoadYamlConfig()
 	suite.NoError(err)
 
 	cases := []struct {

--- a/pkg/orchestrator/config/config_test.go
+++ b/pkg/orchestrator/config/config_test.go
@@ -121,7 +121,7 @@ func (suite *YamlConfigTestSuite) TestExtractOrchestratorEndpointsPrecedence() {
 func (suite *YamlConfigTestSuite) TestNoEnvConfigArgsScrubbing() {
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
-	err := orchestratorCfg.LoadYamlConfig()
+	err := orchestratorCfg.Load()
 	suite.NoError(err)
 
 	cases := []struct {
@@ -145,7 +145,7 @@ func (suite *YamlConfigTestSuite) TestOnlyEnvConfigArgsScrubbing() {
 	suite.config.Set("orchestrator_explorer.custom_sensitive_words", `["token","consul"]`)
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
-	err := orchestratorCfg.LoadYamlConfig()
+	err := orchestratorCfg.Load()
 	suite.NoError(err)
 
 	cases := []struct {
@@ -169,7 +169,7 @@ func (suite *YamlConfigTestSuite) TestOnlyEnvContainsConfigArgsScrubbing() {
 	suite.config.Set("orchestrator_explorer.custom_sensitive_words", `["token","consul"]`)
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
-	err := orchestratorCfg.LoadYamlConfig()
+	err := orchestratorCfg.Load()
 	suite.NoError(err)
 
 	cases := []struct {

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -346,7 +346,7 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 		return nil, err
 	}
 
-	if err := cfg.Orchestrator.LoadYamlConfig(yamlPath); err != nil {
+	if err := cfg.Orchestrator.LoadYamlConfig(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -346,7 +346,7 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 		return nil, err
 	}
 
-	if err := cfg.Orchestrator.LoadYamlConfig(); err != nil {
+	if err := cfg.Orchestrator.Load(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
### What does this PR do?

Avoid an extra pass at resolving secrets as it should already be done on by the agent running the orchestrator check:
* process https://github.com/DataDog/datadog-agent/blob/a421e18ebb41b928533ea4471ba12d6575893c45/pkg/process/config/yaml_config.go#L238
* core/cluster-agent  https://github.com/DataDog/datadog-agent/blob/94b7f2d09e9c1b50c958d9882a3aa11f2c3ce216/cmd/agent/common/helpers.go#L64

Removing the secret resolution also removes the need of passing down the path as everything should already be loaded in the `config.Datadog` object

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
