### PR TITLE
[system-probe] Fix concurrent map access

### DIFF
--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -4,7 +4,6 @@ package http
 
 import (
 	"C"
-	"strings"
 	"sync"
 )
 
@@ -30,7 +29,7 @@ func (h *httpStatKeeper) Process(transactions []httpTX) {
 			SourcePort: tx.SourcePort(),
 			DestPort:   tx.DestPort(),
 		}
-		path := cleanPath(tx.Path())
+		path := tx.Path()
 		statusClass := tx.StatusClass()
 		latency := tx.RequestLatency()
 
@@ -53,26 +52,3 @@ func (h *httpStatKeeper) GetAndResetAllStats() map[Key]map[string]RequestStats {
 }
 
 func (h *httpStatKeeper) Close() {}
-
-func cleanPath(path string) string {
-	// TODO: remove query variables / redact sensitive information from the request path
-
-	// For now, we'll simply remove queries from the path by stripping anything after a ?
-	i := strings.Index(path, "?")
-	if i > -1 {
-		path = path[:i]
-	}
-
-	return path
-}
-
-// for testing (needs to be here because cgo cannot be imported into test files)
-func makeRequestFragment(path string) [25]C.char {
-	fragment := "GET " + path + " HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"
-
-	var ret [25]C.char
-	for i := 0; i < 25; i++ {
-		ret[i] = C.char(fragment[i])
-	}
-	return ret
-}

--- a/pkg/network/http/http_statkeeper_test.go
+++ b/pkg/network/http/http_statkeeper_test.go
@@ -64,23 +64,13 @@ func TestProcessHTTPTransactions(t *testing.T) {
 	}
 }
 
-func TestCleanPath(t *testing.T) {
-	path := "/some/path?key1=val1&key2=val2"
-	expected := "/some/path"
-	assert.Equal(t, expected, cleanPath(path))
-
-	path = "/some/path/with/no/query"
-	expected = "/some/path/with/no/query"
-	assert.Equal(t, expected, cleanPath(path))
-}
-
 func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourcePort int, destPort int, path string, code int, latency float64) httpTX {
 	var tx httpTX
 
 	tx.request_started = 0
 	tx.response_last_seen = _Ctype_ulonglong(latency * 1000000.0) // ms to ns
 	tx.response_status_code = _Ctype_ushort(code)
-	tx.request_fragment = makeRequestFragment(path)
+	tx.request_fragment = requestFragment([]byte(path))
 	tx.tup.saddr_l = _Ctype_ulonglong(binary.LittleEndian.Uint32(source.Bytes()))
 	tx.tup.sport = _Ctype_ushort(sourcePort)
 	tx.tup.daddr_l = _Ctype_ulonglong(binary.LittleEndian.Uint32(dest.Bytes()))

--- a/pkg/network/http/http_statkeeper_test.go
+++ b/pkg/network/http/http_statkeeper_test.go
@@ -4,6 +4,7 @@ package http
 
 import (
 	"encoding/binary"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -67,10 +68,11 @@ func TestProcessHTTPTransactions(t *testing.T) {
 func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourcePort int, destPort int, path string, code int, latency float64) httpTX {
 	var tx httpTX
 
+	reqFragment := fmt.Sprintf("GET %s HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0", path)
 	tx.request_started = 0
 	tx.response_last_seen = _Ctype_ulonglong(latency * 1000000.0) // ms to ns
 	tx.response_status_code = _Ctype_ushort(code)
-	tx.request_fragment = requestFragment([]byte(path))
+	tx.request_fragment = requestFragment([]byte(reqFragment))
 	tx.tup.saddr_l = _Ctype_ulonglong(binary.LittleEndian.Uint32(source.Bytes()))
 	tx.tup.sport = _Ctype_ushort(sourcePort)
 	tx.tup.daddr_l = _Ctype_ulonglong(binary.LittleEndian.Uint32(dest.Bytes()))

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -39,9 +39,10 @@ func (k *httpBatchKey) Prepare(n httpNotification) {
 	k.page_num = C.uint(int(n.batch_idx) % HTTPBatchPages)
 }
 
-// Path returns the URL from the request fragment captured in eBPF
-// Usually the request fragment will look like
-// GET /foo HTTP/1.1
+// Path returns the URL from the request fragment captured in eBPF with
+// GET variables excluded.
+// Example:
+// For a request fragment "GET /foo?var=bar HTTP/1.1", this method will return "/foo"
 func (tx *httpTX) Path() string {
 	b := C.GoBytes(unsafe.Pointer(&tx.request_fragment), C.int(C.HTTP_BUFFER_SIZE))
 

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -16,6 +16,7 @@ import "C"
 const (
 	HTTPBatchSize  = int(C.HTTP_BATCH_SIZE)
 	HTTPBatchPages = int(C.HTTP_BATCH_PAGES)
+	HTTPBufferSize = int(C.HTTP_BUFFER_SIZE)
 )
 
 type httpTX C.http_transaction_t
@@ -50,7 +51,7 @@ func (tx *httpTX) Path() string {
 
 	i++
 
-	for j = i; j < len(b) && b[j] != ' '; j++ {
+	for j = i; j < len(b) && b[j] != ' ' && b[j] != '?'; j++ {
 	}
 
 	if i < j && j <= len(b) {

--- a/pkg/network/http/model_test.go
+++ b/pkg/network/http/model_test.go
@@ -1,0 +1,27 @@
+// +build linux_bpf
+
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPath(t *testing.T) {
+	tx := httpTX{
+		request_fragment: requestFragment(
+			[]byte("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
+		),
+	}
+
+	assert.Equal(t, "/foo/bar", tx.Path())
+}
+
+func requestFragment(fragment []byte) [HTTPBufferSize]_Ctype_char {
+	var b [HTTPBufferSize]_Ctype_char
+	for i := 0; i < len(b) && i < len(fragment); i++ {
+		b[i] = _Ctype_char(fragment[i])
+	}
+	return b
+}

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -168,7 +168,7 @@ func (m *Monitor) GetHTTPStats() map[Key]map[string]RequestStats {
 }
 
 func (m *Monitor) GetStats() map[string]interface{} {
-	currentTime, telemetryData := m.telemetry.getStats()
+	currentTime, telemetryData := m.telemetry.get()
 	return map[string]interface{}{
 		"current_time": currentTime,
 		"telemetry":    telemetryData,


### PR DESCRIPTION
### What does this PR do?

Fix concurrent map access issue which was causing system-probe to crash when experimental HTTP monitoring feature was enabled. Since code is in hot code path I'm using atomic operations.

(Additionally I refactored the `Path()` function` to exclude GET variables, but this should have no side effect)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

1. Deploy agent in load-test cluster
2. Make sure it doesn't crash after an hour or so
3. Verify that stats are showing up correctly in `curl -XGET --unix-socket /var/run/sysprobe/sysprobe.sock http://unix/debug/stats | jq .network_tracer.http`
