### PR TITLE
Introduce the Remote Tagger to the Security Agent

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -31,6 +31,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/remote"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -256,6 +258,12 @@ func start(cmd *cobra.Command, args []string) error {
 	statsdClient, err := ddgostatsd.New(statsdAddr)
 	if err != nil {
 		return log.Criticalf("Error creating statsd Client: %s", err)
+	}
+
+	// Initialize the remote tagger
+	if coreconfig.Datadog.GetBool("security_agent.remote_tagger") {
+		tagger.SetDefaultTagger(remote.NewTagger())
+		tagger.Init()
 	}
 
 	if err = startCompliance(hostname, stopper, statsdClient); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -828,6 +828,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
 	config.BindEnvAndSetDefault("security_agent.log_file", defaultSecurityAgentLogFile)
+	config.BindEnvAndSetDefault("security_agent.remote_tagger", false)
 
 	// Datadog security agent (compliance)
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)


### PR DESCRIPTION
### What does this PR do?

To support possible future use cases, and to test its viability, we're
enabling the remote tagger in the security agent. This has already been
done on the other agents, see context in
[#7208](https://github.com/DataDog/datadog-agent/pull/7208)

### Describe your test plan

* Enable the remote tagger in the security agent with `DD_SECURITY_AGENT_REMOTE_TAGGER=true`
* Check that the tagger starts correctly. Look for `remote tagger initialized successfully` in the logs
Write there any instructions and details that should be tested during the QA.
