### PR TITLE
[android] Bump gradle to version 5.3

### DIFF
--- a/cmd/agent/android/gradle/wrapper/gradle-wrapper.properties
+++ b/cmd/agent/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-all.zip


### PR DESCRIPTION
### What does this PR do?

- Bump Gradle version used to 5.3

### Motivation

- Avoid gradle/gradle#3117

### Additional Notes

- Should be a no-op, I think?