### PR TITLE
Adding expvar metrics to capture the current number of context in the aggregator

### DIFF
--- a/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
+++ b/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
@@ -96,6 +96,7 @@ instances:
       - path: aggregator/FlushCount/Series/LastFlush
       - path: aggregator/FlushCount/Events/LastFlush
       - path: aggregator/FlushCount/Sketches/LastFlush
+      - path: aggregator/DogstatsdContexts
       - path: aggregator/SeriesFlushed
         type: rate
       - path: aggregator/ServiceCheckFlushed

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -107,6 +107,7 @@ var (
 	aggregatorHostnameUpdate                   = expvar.Int{}
 	aggregatorOrchestratorMetadata             = expvar.Int{}
 	aggregatorOrchestratorMetadataErrors       = expvar.Int{}
+	aggregatorDogstatsdContexts                = expvar.Int{}
 
 	tlmFlush = telemetry.NewCounter("aggregator", "flush",
 		[]string{"data_type", "state"}, "Number of metrics/service checks/events flushed")
@@ -114,6 +115,8 @@ var (
 		[]string{"data_type"}, "Amount of metrics/services_checks/events processed by the aggregator")
 	tlmHostnameUpdate = telemetry.NewCounter("aggregator", "hostname_update",
 		nil, "Count of hostname update")
+	tlmDogstatsdContexts = telemetry.NewGauge("aggregator", "dogstatsd_contexts",
+		nil, "Count the number of dogstatsd contexts in the aggregator")
 
 	// Hold series to be added to aggregated series on each flush
 	recurrentSeries     metrics.Series
@@ -151,6 +154,7 @@ func init() {
 	aggregatorExpvars.Set("HostnameUpdate", &aggregatorHostnameUpdate)
 	aggregatorExpvars.Set("OrchestratorMetadata", &aggregatorOrchestratorMetadata)
 	aggregatorExpvars.Set("OrchestratorMetadataErrors", &aggregatorOrchestratorMetadataErrors)
+	aggregatorExpvars.Set("DogstatsdContexts", &aggregatorDogstatsdContexts)
 }
 
 // InitAggregator returns the Singleton instance

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -65,6 +65,15 @@ func (cr *ContextResolver) trackContext(metricSampleContext metrics.MetricSample
 	return contextKey
 }
 
+func (cr *ContextResolver) get(key ckey.ContextKey) (*Context, bool) {
+	ctx, found := cr.contextsByKey[key]
+	return ctx, found
+}
+
+func (cr *ContextResolver) length() int {
+	return len(cr.contextsByKey)
+}
+
 // updateTrackedContext updates the last seen timestamp on a given context key
 func (cr *ContextResolver) updateTrackedContext(contextKey ckey.ContextKey, timestamp float64) error {
 	if _, ok := cr.lastSeenByKey[contextKey]; ok && cr.lastSeenByKey[contextKey] < timestamp {

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -83,7 +83,7 @@ func (s *TimeSampler) addSample(metricSample *metrics.MetricSample, timestamp fl
 }
 
 func (s *TimeSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.SketchPoint) metrics.SketchSeries {
-	ctx := s.contextResolver.contextsByKey[ck]
+	ctx, _ := s.contextResolver.get(ck)
 	ss := metrics.SketchSeries{
 		Name:       ctx.Name,
 		Tags:       ctx.Tags,
@@ -142,7 +142,7 @@ func (s *TimeSampler) flushSeries(cutoffTime int64) metrics.Series {
 			existingSerie.Points = append(existingSerie.Points, serie.Points[0])
 		} else {
 			// Resolve context and populate new Serie
-			context, ok := s.contextResolver.contextsByKey[serie.ContextKey]
+			context, ok := s.contextResolver.get(serie.ContextKey)
 			if !ok {
 				log.Errorf("Ignoring all metrics on context key '%v': inconsistent context resolver state: the context is not tracked", serie.ContextKey)
 				continue
@@ -188,6 +188,8 @@ func (s *TimeSampler) flush(timestamp float64) (metrics.Series, metrics.SketchSe
 	s.contextResolver.expireContexts(timestamp - defaultExpiry)
 	s.lastCutOffTime = cutoffTime
 
+	aggregatorDogstatsdContexts.Set(int64(s.contextResolver.length()))
+	tlmDogstatsdContexts.Set(float64(s.contextResolver.length()))
 	return series, sketches
 }
 
@@ -195,7 +197,7 @@ func (s *TimeSampler) flush(timestamp float64) (metrics.Series, metrics.SketchSe
 func (s *TimeSampler) flushContextMetrics(timestamp int64, contextMetrics metrics.ContextMetrics) []*metrics.Serie {
 	series, errors := contextMetrics.Flush(float64(timestamp))
 	for ckey, err := range errors {
-		context, ok := s.contextResolver.contextsByKey[ckey]
+		context, ok := s.contextResolver.get(ckey)
 		if !ok {
 			log.Errorf("Can't resolve context of error '%s': inconsistent context resolver state: context with key '%v' is not tracked", err, ckey)
 			continue


### PR DESCRIPTION
### What does this PR do?

Adding expvar metrics to capture the current number of context in the aggregator

### Motivation

We want to be able to track the number of context in the aggregator (especially for DogStatsD) to troubleshoot tagging issues that might increase the number of context for a metrics.