### PR TITLE
[omnibus] Relax pyjwt dependency

### DIFF
--- a/omnibus/config/patches/snowflake-connector-python-py2/cryptography-dependency.patch
+++ b/omnibus/config/patches/snowflake-connector-python-py2/cryptography-dependency.patch
@@ -1,8 +1,8 @@
 diff --git a/setup.py b/setup.py
-index 0da6a8a..f486585 100644
+index 0da6a8a..761de39 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -185,11 +185,11 @@ setup(
+@@ -185,13 +185,13 @@ setup(
          'certifi<2021.0.0',
          'future<1.0.0',
          'six<2.0.0',
@@ -15,5 +15,8 @@ index 0da6a8a..f486585 100644
 +        'cffi>=1.9,<1.15',
 +        'cryptography>=1.8.2,<3.4',
          'ijson<3.0.0',
-         'pyjwt<2.0.0',
+-        'pyjwt<2.0.0',
++        'pyjwt<3.0.0',
          'idna<3.0.0',
+         'oscrypto<2.0.0',
+         'asn1crypto>0.24.0,<2.0.0',

--- a/omnibus/config/patches/snowflake-connector-python-py3/cryptography-dependency.patch
+++ b/omnibus/config/patches/snowflake-connector-python-py3/cryptography-dependency.patch
@@ -1,8 +1,8 @@
 diff --git a/setup.py b/setup.py
-index 0da6a8a..f486585 100644
+index 0da6a8a..761de39 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -185,11 +185,11 @@ setup(
+@@ -185,13 +185,13 @@ setup(
          'certifi<2021.0.0',
          'future<1.0.0',
          'six<2.0.0',
@@ -15,5 +15,8 @@ index 0da6a8a..f486585 100644
 +        'cffi>=1.9,<1.15',
 +        'cryptography>=1.8.2,<3.4',
          'ijson<3.0.0',
-         'pyjwt<2.0.0',
+-        'pyjwt<2.0.0',
++        'pyjwt<3.0.0',
          'idna<3.0.0',
+         'oscrypto<2.0.0',
+         'asn1crypto>0.24.0,<2.0.0',


### PR DESCRIPTION
### What does this PR do?

- Relax `pyjwt` dependency for snowflake connector 

### Motivation

- DataDog/integrations-core#8762 broke the builds

### Additional Notes

To generate the patch I did roughly the following

```
git clone git@github.com:snowflakedb/snowflake-connector-python.git
cd snowflake-connector-python
git checkout 2.1.3  # current version pinned in Omnibus
git apply path/to/current/patch
nano setup.py  # change pyjwt<2.0.0 by pjwt<3.0.0
git diff > path/to/python2/patch
git diff > path/to/python3/patch
```
