### PR TITLE
List tags per entity and per source

### DIFF
--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -24,6 +24,5 @@ type TaggerListResponse struct {
 
 // TaggerListEntity holds the tagging info about an entity
 type TaggerListEntity struct {
-	Sources []string `json:"sources"`
-	Tags    []string `json:"tags"`
+	Tags map[string][]string `json:"tags"`
 }

--- a/cmd/agent/app/tagger_list.go
+++ b/cmd/agent/app/tagger_list.go
@@ -75,30 +75,38 @@ var taggerListCommand = &cobra.Command{
 		for entity, tagItem := range tr.Entities {
 			fmt.Fprintln(color.Output, fmt.Sprintf("\n=== Entity %s ===", color.GreenString(entity)))
 
-			fmt.Fprint(color.Output, "Tags: [")
-			// sort tags for easy comparison
-			sort.Slice(tagItem.Tags, func(i, j int) bool {
-				return tagItem.Tags[i] < tagItem.Tags[j]
-			})
-			for i, tag := range tagItem.Tags {
-				tagInfo := strings.Split(tag, ":")
-				fmt.Fprintf(color.Output, fmt.Sprintf("%s:%s", color.BlueString(tagInfo[0]), color.CyanString(strings.Join(tagInfo[1:], ":"))))
-				if i != len(tagItem.Tags)-1 {
-					fmt.Fprintf(color.Output, " ")
-				}
+			sources := make([]string, 0, len(tagItem.Tags))
+			for source := range tagItem.Tags {
+				sources = append(sources, source)
 			}
-			fmt.Fprintln(color.Output, "]")
-			fmt.Fprint(color.Output, "Sources: [")
-			sort.Slice(tagItem.Sources, func(i, j int) bool {
-				return tagItem.Sources[i] < tagItem.Sources[j]
+
+			// sort sources for deterministic output
+			sort.Slice(sources, func(i, j int) bool {
+				return sources[i] < sources[j]
 			})
-			for i, source := range tagItem.Sources {
-				fmt.Fprintf(color.Output, fmt.Sprintf("%s", color.BlueString(source)))
-				if i != len(tagItem.Sources)-1 {
-					fmt.Fprintf(color.Output, " ")
+
+			for _, source := range sources {
+				fmt.Fprintln(color.Output, fmt.Sprintf("== Source %s ==", source))
+
+				fmt.Fprint(color.Output, "Tags: [")
+
+				// sort tags for easy comparison
+				tags := tagItem.Tags[source]
+				sort.Slice(tags, func(i, j int) bool {
+					return tags[i] < tags[j]
+				})
+
+				for i, tag := range tags {
+					tagInfo := strings.Split(tag, ":")
+					fmt.Fprintf(color.Output, fmt.Sprintf("%s:%s", color.BlueString(tagInfo[0]), color.CyanString(strings.Join(tagInfo[1:], ":"))))
+					if i != len(tags)-1 {
+						fmt.Fprintf(color.Output, " ")
+					}
 				}
+
+				fmt.Fprintln(color.Output, "]")
 			}
-			fmt.Fprintln(color.Output, "]")
+
 			fmt.Fprintln(color.Output, "===")
 		}
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -250,8 +250,9 @@ func TestCleanDirectoryName(t *testing.T) {
 func TestZipTaggerList(t *testing.T) {
 	tagMap := make(map[string]response.TaggerListEntity)
 	tagMap["random_entity_name"] = response.TaggerListEntity{
-		Sources: []string{"docker_source_name"},
-		Tags:    []string{"docker_image:custom-agent:latest", "image_name:custom-agent"},
+		Tags: map[string][]string{
+			"docker_source_name": {"docker_image:custom-agent:latest", "image_name:custom-agent"},
+		},
 	}
 	resp := response.TaggerListResponse{
 		Entities: tagMap,

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -332,11 +332,19 @@ func (t *Tagger) List(cardinality collectors.TagCardinality) response.TaggerList
 
 	t.store.RLock()
 	defer t.store.RUnlock()
+
 	for entityID, et := range t.store.store {
-		entity := response.TaggerListEntity{}
-		tags, sources := et.get(cardinality)
-		entity.Tags = copyArray(tags)
-		entity.Sources = copyArray(sources)
+		entity := response.TaggerListEntity{
+			Tags: make(map[string][]string),
+		}
+
+		for source, sourceTags := range et.sourceTags {
+			tags := append([]string(nil), sourceTags.lowCardTags...)
+			tags = append(tags, sourceTags.orchestratorCardTags...)
+			tags = append(tags, sourceTags.highCardTags...)
+			entity.Tags[source] = tags
+		}
+
 		r.Entities[entityID] = entity
 	}
 

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -169,7 +169,9 @@ func (t *Tagger) List(cardinality collectors.TagCardinality) response.TaggerList
 
 	for _, e := range entities {
 		resp.Entities[e.ID] = response.TaggerListEntity{
-			Tags: e.GetTags(collectors.HighCardinality),
+			Tags: map[string][]string{
+				remoteSource: e.GetTags(collectors.HighCardinality),
+			},
 		}
 	}
 

--- a/releasenotes/notes/agent-tagger-list-09b1515cbe13ecfb.yaml
+++ b/releasenotes/notes/agent-tagger-list-09b1515cbe13ecfb.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Group the output of `agent tagger-list` by entity and by source.


### PR DESCRIPTION
### What does this PR do?

Changes the output of `agent tagger-list` to also group tags per source,

### Describe your test plan

Check the output from `agent tagger-list`. It should've changed from...

```
=== Entity container_id://4e5b44871f0f84a37dd07e48f2a544b26fa8d9becf32c6bec7110aebb80e5176 ===
Tags: [...]
Sources: [kube-metadata-collector kubelet]
===
```

... to ...

```
=== Entity container_id://4e5b44871f0f84a37dd07e48f2a544b26fa8d9becf32c6bec7110aebb80e5176 ===
== kube-metadata-collector ==
Tags: [...]
== kubelet ==
Tags: [...]
```

This PR also changes the `tagger-list.json` file in the flare generated by `agent flare`. To verify it works properly, create a flare with `agent flare` and check that the `tagger-list.json` file looks like the following, and contains tags as expected:

```
{
        "entities": {
                "container_id://00dde0d5156fb1d6a59008f77c4b1fc29148c91e6576abadd47f3fd5d0708e50": {
                        "tags": {
                                "kube-metadata-collector": [ /* ... */ ],
                                "kubelet": [ /* ... */ ]
                        }
                },
            ...
    }
}
```