### PR TITLE
Adding 'dogstatsd_context_expiry_seconds' to configure when we expire dogstatsd contexts in the aggregator

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const defaultExpiry = 300.0 // number of seconds after which contexts are expired
 const checksSourceTypeName = "System"
 
 // CheckSampler aggregates metrics from one Check instance

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -12,8 +12,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const defaultExpiry = 300.0 // number of seconds after which contexts are expired
-
 // SerieSignature holds the elements that allow to know whether two similar `Serie`s
 // from the same bucket can be merged into one
 type SerieSignature struct {
@@ -185,7 +183,7 @@ func (s *TimeSampler) flush(timestamp float64) (metrics.Series, metrics.SketchSe
 	sketches := s.flushSketches(cutoffTime)
 
 	// expiring contexts
-	s.contextResolver.expireContexts(timestamp - defaultExpiry)
+	s.contextResolver.expireContexts(timestamp - config.Datadog.GetFloat64("dogstatsd_context_expiry_seconds"))
 	s.lastCutOffTime = cutoffTime
 
 	aggregatorDogstatsdContexts.Set(int64(s.contextResolver.length()))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,7 +366,13 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_stats_port", 5000)
 	config.BindEnvAndSetDefault("dogstatsd_stats_enable", false)
 	config.BindEnvAndSetDefault("dogstatsd_stats_buffer", 10)
+	// Control for how long counter would be sampled to 0 if not received
 	config.BindEnvAndSetDefault("dogstatsd_expiry_seconds", 300)
+	// Control how long we keep dogstatsd contexts in memory. This should
+	// not be set bellow 2 dogstatsd bucket size (ie 20s, since each bucket
+	// is 10s), otherwise we won't be able to sample unseen counter as
+	// contexts will be deleted (see 'dogstatsd_expiry_seconds').
+	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 300)
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)


### PR DESCRIPTION
### What does this PR do?

Use `dogstatsd_context_expiry_seconds` configuration to expire dogstatsd contexts in the aggregator

### Motivation

Lowering this setting will help memory spike created by app sending a lot metrics once in a while (every hour for example).

### Describe your test plan

- Create a bunch of context by sending dogstatsd metric
- set `dogstatsd_context_expiry_seconds` to any value
- wait for that amount of time and check goexpvar to see if the `DogstatsdContexts` decreased.
