### PR TITLE
[runtime-security] do not try to resolve inode for forks

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -123,5 +123,5 @@ func newRuntimeMetric(name string) string {
 }
 
 func newAgentMetric(name string) string {
-	return MetricRuntimePrefix + name
+	return MetricAgentPrefix + name
 }

--- a/pkg/security/model/legacy_secl.go
+++ b/pkg/security/model/legacy_secl.go
@@ -101,10 +101,15 @@ var SECLLegacyAttributes = map[eval.Field]eval.Field{
 	"exec.container_path":   "exec.file.container_path",
 	"exec.overlay_numlower": "exec.file.overlay_numlower",
 	"exec.basename":         "exec.file.name",
+	"exec.name":             "exec.comm",
 
 	// process
-	"process.filename":         "process.file.path",
-	"process.container_path":   "process.file.container_path",
-	"process.overlay_numlower": "process.file.overlay_numlower",
-	"process.basename":         "process.file.name",
+	"process.filename":                 "process.file.path",
+	"process.container_path":           "process.file.container_path",
+	"process.basename":                 "process.file.name",
+	"process.name":                     "process.comm",
+	"process.ancestors.filename":       "process.ancestors.file.path",
+	"process.ancestors.container_path": "process.ancestors.file.container_path",
+	"process.ancestors.basename":       "process.ancestors.file.name",
+	"process.ancestors.name":           "process.ancestors.comm",
 }

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -324,13 +324,17 @@ func NewModule(cfg *config.Config) (api.Module, error) {
 
 	ctx, cancelFnc := context.WithCancel(context.Background())
 
+	// custom limiters
+	limits := make(map[rules.RuleID]Limit)
+	limits[sprobe.AbnormalPathRuleID] = Limit{Limit: 5, Burst: 10}
+
 	m := &Module{
 		config:         cfg,
 		probe:          probe,
 		statsdClient:   statsdClient,
 		apiServer:      NewAPIServer(cfg, probe, statsdClient),
 		grpcServer:     grpc.NewServer(),
-		rateLimiter:    NewRateLimiter(statsdClient),
+		rateLimiter:    NewRateLimiter(statsdClient, LimiterOpts{Limits: limits}),
 		sigupChan:      make(chan os.Signal, 1),
 		currentRuleSet: 1,
 		ctx:            ctx,

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -430,8 +430,13 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 			log.Errorf("failed to decode exec event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
-		p.resolvers.ProcessResolver.ResolveArgs(event.processCacheEntry)
-		p.resolvers.ProcessResolver.ResolveEnvs(event.processCacheEntry)
+		p.resolvers.ProcessResolver.SetProcessArgs(event.processCacheEntry)
+		p.resolvers.ProcessResolver.SetProcessEnvs(event.processCacheEntry)
+
+		if _, err := p.resolvers.ProcessResolver.SetProcessPath(event.processCacheEntry); err != nil {
+			log.Errorf("failed to resolve exec path: %s", err)
+		}
+		p.resolvers.ProcessResolver.SetProcessContainerPath(event.processCacheEntry)
 
 		event.updateProcessCachePointer(p.resolvers.ProcessResolver.AddExecEntry(event.ProcessContext.Pid, event.processCacheEntry))
 	case model.ExitEventType:

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -434,7 +434,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		p.resolvers.ProcessResolver.SetProcessEnvs(event.processCacheEntry)
 
 		if _, err := p.resolvers.ProcessResolver.SetProcessPath(event.processCacheEntry); err != nil {
-			log.Errorf("failed to resolve exec path: %s", err)
+			log.Debugf("failed to resolve exec path: %s", err)
 		}
 		p.resolvers.ProcessResolver.SetProcessContainerPath(event.processCacheEntry)
 


### PR DESCRIPTION
### What does this PR do?

Remove the inode resolution from fork event as the in-kernel entry is probably not present anymore.

### Motivation

Remove noisy error.
