### PR TITLE
Remove stray component ref

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -476,7 +476,6 @@
         <?endif ?>
         <ComponentGroupRef Id="ExtraEXAMPLECONFSLOCATION" />
         <ComponentRef Id="CleanupMainApplicationFolder" />
-        <ComponentRef Id="RegisterConfVariables" />
         <?if $(var.IncludePython2) = true ?>
           <ComponentRef Id="MSVCRUNTIME" />
         <?endif ?>


### PR DESCRIPTION
### What does this PR do?

This PR removes a stray component ref that was incorrectly left over when merging https://github.com/DataDog/datadog-agent/pull/7575 and https://github.com/DataDog/datadog-agent/pull/7204

### Motivation

Fix CI
