### PR TITLE
Avoid check errors in malloc

### DIFF
--- a/pkg/network/dns_snooper_test.go
+++ b/pkg/network/dns_snooper_test.go
@@ -412,7 +412,7 @@ func TestDNSFailedResponseCount(t *testing.T) {
 	}, 3*time.Second, 10*time.Millisecond, "missing DNS data for TCP requests")
 	for _, d := range domains {
 		require.Equal(t, 1, len(allStats[key1][d].DNSCountByRcode))
-		assert.Equal(t, uint32(1), allStats[key1][d].DNSCountByRcode[uint32(layers.DNSResponseCodeNXDomain)])
+		assert.Equal(t, uint32(1), allStats[key1][d].DNSCountByRcode[uint32(layers.DNSResponseCodeNXDomain)], "expected one NXDOMAIN for %s, got %v", d, allStats[key1][d])
 	}
 
 	// Next check the one sent over UDP. Expected error type: ServFail

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -587,6 +587,9 @@ func prepareCompletionBuffers(h windows.Handle, count int) (iocp windows.Handle,
 	buffers = make([]*readbuffer, count)
 	for i := 0; i < count; i++ {
 		buf := (*readbuffer)(C.malloc(C.size_t(unsafe.Sizeof(readbuffer{}))))
+		if buf == nil {
+			return windows.Handle(0), nil, errors.New("error preparing completion buffers: malloc returned nil")
+		}
 		buffers[i] = buf
 
 		err = windows.ReadFile(h, buf.data[:], nil, &(buf.ol))

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -587,9 +587,6 @@ func prepareCompletionBuffers(h windows.Handle, count int) (iocp windows.Handle,
 	buffers = make([]*readbuffer, count)
 	for i := 0; i < count; i++ {
 		buf := (*readbuffer)(C.malloc(C.size_t(unsafe.Sizeof(readbuffer{}))))
-		if err != nil {
-			return windows.Handle(0), nil, err
-		}
 		buffers[i] = buf
 
 		err = windows.ReadFile(h, buf.data[:], nil, &(buf.ol))

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -587,9 +587,6 @@ func prepareCompletionBuffers(h windows.Handle, count int) (iocp windows.Handle,
 	buffers = make([]*readbuffer, count)
 	for i := 0; i < count; i++ {
 		buf := (*readbuffer)(C.malloc(C.size_t(unsafe.Sizeof(readbuffer{}))))
-		if buf == nil {
-			return windows.Handle(0), nil, errors.New("error preparing completion buffers: malloc returned nil")
-		}
 		buffers[i] = buf
 
 		err = windows.ReadFile(h, buf.data[:], nil, &(buf.ol))


### PR DESCRIPTION

### What does this PR do?

This caused driver_interface.go to fail when creating DNS buffers,
because on the second run of the loop that kicked off an IO completion
read. This is a holdover from when there was a malloc wrapper that would
return an error.

### Motivation

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
