### PR TITLE
Fix windows logs bytecount on the status page

### DIFF
--- a/pkg/logs/input/file/tailer_windows.go
+++ b/pkg/logs/input/file/tailer_windows.go
@@ -44,14 +44,14 @@ func (t *Tailer) setup(offset int64, whence int) error {
 func (t *Tailer) readAvailable() (int, error) {
 	f, err := openFile(t.fullpath)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer f.Close()
 
 	st, err := f.Stat()
 	if err != nil {
 		log.Debugf("Error stat()ing file %v", err)
-		return err
+		return 0, err
 	}
 
 	sz := st.Size()

--- a/pkg/logs/input/file/tailer_windows.go
+++ b/pkg/logs/input/file/tailer_windows.go
@@ -89,10 +89,10 @@ func (t *Tailer) readAvailable() (int, error) {
 func (t *Tailer) read() (int, error) {
 	n, err := t.readAvailable()
 	if err == io.EOF || os.IsNotExist(err) {
-		return 0, nil
+		return n, nil
 	} else if err != nil {
 		t.file.Source.Status.Error(err)
-		return 0, log.Error("Err: ", err)
+		return n, log.Error("Err: ", err)
 	}
 	return n, nil
 }

--- a/pkg/logs/input/file/tailer_windows.go
+++ b/pkg/logs/input/file/tailer_windows.go
@@ -81,7 +81,6 @@ func (t *Tailer) readAvailable() (int, error) {
 		t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
 		t.incrementReadOffset(n)
 	}
-	return bytes, nil
 }
 
 // read lets the tailer tail the content of a file until it is closed. The

--- a/releasenotes/notes/fix-windows-byte-count-5c62ed2b1d4464ad.yaml
+++ b/releasenotes/notes/fix-windows-byte-count-5c62ed2b1d4464ad.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Log file byte count now works correctly on windows. 


### PR DESCRIPTION
### What does this PR do?

The byte count for windows log collection was not working because the underlying read bytes were not exposed to the tailer. This PR exposes the underlying byte count so it shows on the status page.

### Describe your test plan

Test a log file on a windows agent - confirm the byte count on the status page
