### PR TITLE
fix bug in vCPU count when more than one phys CPU

### DIFF
--- a/pkg/process/checks/system_info_windows.go
+++ b/pkg/process/checks/system_info_windows.go
@@ -32,7 +32,7 @@ func CollectSystemInfo(cfg *config.AgentConfig) (*model.SystemInfo, error) {
 	// i.e. physCount * coreCount * 1 if not HT CPU
 	//      physCount * coreCount * 2 if an HT CPU.
 	logicalCount, _ := strconv.ParseInt(cpuInfo["cpu_logical_processors"], 10, 64)
-	logicalCountPerPhys := logicalCount / physCount;
+	logicalCountPerPhys := logicalCount / physCount
 	clockSpeed, _ := strconv.ParseInt(cpuInfo["mhz"], 10, 64)
 	l2Cache, _ := strconv.ParseInt(cpuInfo["cache_size_l2"], 10, 64)
 	cpus := make([]*model.CPUInfo, 0)

--- a/pkg/process/checks/system_info_windows.go
+++ b/pkg/process/checks/system_info_windows.go
@@ -1,6 +1,7 @@
 package checks
 
 import (
+	"fmt"
 	"github.com/DataDog/gohai/cpu"
 	"github.com/DataDog/gohai/platform"
 	"strconv"
@@ -32,6 +33,12 @@ func CollectSystemInfo(cfg *config.AgentConfig) (*model.SystemInfo, error) {
 	// i.e. physCount * coreCount * 1 if not HT CPU
 	//      physCount * coreCount * 2 if an HT CPU.
 	logicalCount, _ := strconv.ParseInt(cpuInfo["cpu_logical_processors"], 10, 64)
+
+	// shouldn't be possible, as `cpu.GetCpuInfo()` should return an error in this case
+	// but double check before risking a divide by zero
+	if physCount == 0 {
+		return nil, fmt.Errorf("Returned zero physical processors")
+	}
 	logicalCountPerPhys := logicalCount / physCount
 	clockSpeed, _ := strconv.ParseInt(cpuInfo["mhz"], 10, 64)
 	l2Cache, _ := strconv.ParseInt(cpuInfo["cache_size_l2"], 10, 64)

--- a/pkg/process/checks/system_info_windows.go
+++ b/pkg/process/checks/system_info_windows.go
@@ -28,7 +28,11 @@ func CollectSystemInfo(cfg *config.AgentConfig) (*model.SystemInfo, error) {
 		return nil, err
 	}
 	physCount, _ := strconv.ParseInt(cpuInfo["cpu_pkgs"], 10, 64)
+	// logicalcount will be the total number of logical processors on the system
+	// i.e. physCount * coreCount * 1 if not HT CPU
+	//      physCount * coreCount * 2 if an HT CPU.
 	logicalCount, _ := strconv.ParseInt(cpuInfo["cpu_logical_processors"], 10, 64)
+	logicalCountPerPhys := logicalCount / physCount;
 	clockSpeed, _ := strconv.ParseInt(cpuInfo["mhz"], 10, 64)
 	l2Cache, _ := strconv.ParseInt(cpuInfo["cache_size_l2"], 10, 64)
 	cpus := make([]*model.CPUInfo, 0)
@@ -40,7 +44,7 @@ func CollectSystemInfo(cfg *config.AgentConfig) (*model.SystemInfo, error) {
 			Model:      cpuInfo["model"],
 			PhysicalId: "",
 			CoreId:     "",
-			Cores:      int32(logicalCount),
+			Cores:      int32(logicalCountPerPhys),
 			Mhz:        int64(clockSpeed),
 			CacheSize:  int32(l2Cache),
 		})

--- a/releasenotes/notes/fixprocesscpucount-77b101f29280c4ac.yaml
+++ b/releasenotes/notes/fixprocesscpucount-77b101f29280c4ac.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, using process agent, fixes the virtual CPU count when the 
+    device has more than one physical CPU (package)).


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the count of virtual CPUs. Our count was off by a factor of N, where N is the number
of physical CPUs (packages).  Since most machines have (1), this isn't a problem.  but if N>1, it is.

### Motivation

question from support channel


### Describe your test plan

Test on `metal` instance that has more than one phys cpu.
