### PR TITLE
fix copy-paste error in system probe invoke task

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -94,7 +94,7 @@ def build(
             "-i cmd/system-probe/windows_resources/system-probe.rc "
             "--target {target_arch} "
             "-O coff "
-            "-o cmd/process-agent/rsrc.syso".format(
+            "-o cmd/system-probe/rsrc.syso".format(
                 maj_ver=maj_ver, min_ver=min_ver, patch_ver=patch_ver, target_arch=windres_target
             )
         )

--- a/tasks/winbuildscripts/setupforagent.bat
+++ b/tasks/winbuildscripts/setupforagent.bat
@@ -1,7 +1,0 @@
-set Python2_ROOT_DIR=c:\opt\datadog-agent\embedded2
-set Python3_ROOT_DIR=c:\opt\datadog-agent\embedded3
-set CMAKE_INSTALL_PREFIX=c:\opt\datadog-agent\embedded2
-SET PATH=%PATH%;%GOPATH%/bin
-call ridk enable
-REM "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded --arch #{platform} #{do_windows_sysprobe}", env: env
-doskey buildagent=inv -e agent.build --exclude-rtloader --python-runtimes 3 --major-version 7 --rtloader-root=c:/omnibus-ruby/src/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader  --no-development --embedded-path=c:/opt/datadog-agent/embedded --arch x64

--- a/tasks/winbuildscripts/setupforagent.bat
+++ b/tasks/winbuildscripts/setupforagent.bat
@@ -1,0 +1,7 @@
+set Python2_ROOT_DIR=c:\opt\datadog-agent\embedded2
+set Python3_ROOT_DIR=c:\opt\datadog-agent\embedded3
+set CMAKE_INSTALL_PREFIX=c:\opt\datadog-agent\embedded2
+SET PATH=%PATH%;%GOPATH%/bin
+call ridk enable
+REM "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rtloader-root=#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader --rebuild --no-development --embedded-path=#{install_dir}/embedded --arch #{platform} #{do_windows_sysprobe}", env: env
+doskey buildagent=inv -e agent.build --exclude-rtloader --python-runtimes 3 --major-version 7 --rtloader-root=c:/omnibus-ruby/src/datadog-agent/src/github.com/DataDog/datadog-agent/rtloader  --no-development --embedded-path=c:/opt/datadog-agent/embedded --arch x64


### PR DESCRIPTION
### What does this PR do?

Makes the datadog icon show up in task manager, file manager, etc.
makes sure the version resource is included in the binary

### Motivation

makes it consistent with rest of product

### Additional Notes

Was copy/paste error in invoke task; no actual code change.