### PR TITLE
Fix ksm_core *.count from _labels metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -265,17 +265,18 @@ func (k *KSMCheck) Cancel() {
 func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][]ksmstore.DDMetricsFam, labelJoiner *labelJoiner) {
 	for _, metricsList := range metrics {
 		for _, metricFamily := range metricsList {
-			if metadataMetricsRegex.MatchString(metricFamily.Name) {
-				// metadata metrics are only used by the check for label joins
-				// they shouldn't be forwarded to Datadog
-				continue
-			}
+			// First check for aggregator, because the check use _labels metrics to aggregate values.
 			if aggregator, found := metricAggregators[metricFamily.Name]; found {
 				for _, m := range metricFamily.ListMetrics {
 					aggregator.accumulate(m)
 				}
 				// Some metrics can be aggregated and consumed as-is or by a transformer.
 				// So, let’s continue the processing.
+			}
+			if metadataMetricsRegex.MatchString(metricFamily.Name) {
+				// metadata metrics are only used by the check for label joins
+				// they shouldn't be forwarded to Datadog
+				continue
 			}
 			if transform, found := metricTransformers[metricFamily.Name]; found {
 				for _, m := range metricFamily.ListMetrics {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -127,7 +127,6 @@ var (
 		"kube_pod_restart_policy":                          {},
 		"kube_pod_.*_time":                                 {},
 		"kube_cronjob_status_active":                       {},
-		"kube_namespace_status_phase":                      {},
 		"kube_node_status_phase":                           {},
 		"kube_cronjob_spec_starting_deadline_seconds":      {},
 		"kube_job_spec_active_dealine_seconds":             {},


### PR DESCRIPTION
### What does this PR do?

It fixes a bug on a new `kubernetes_state_core` check feature. The check now try to find an aggregator on any ksm metrics processed. Like this `_labels` metrics can also be used by an aggregator.

Fix for #7342

### Motivation

The `*.count` metrics on several kubernetes resources wasn't present due to a "sort path" implemented in the check of process `*_label` ksm metrics like others.

### Additional Notes

N/A

### Describe your test plan

metrics to check:
* deployment.count
* daemonset.count
* statefulset.count
