### PR TITLE
Do not make the liveness probe fail in case of network issue

### DIFF
--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -81,7 +81,7 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 
 	sc := &scheduledCollector{
 		sendTimer:    newTimer(interval),
-		healthHandle: health.RegisterLiveness("metadata-" + name),
+		healthHandle: health.RegisterReadiness("metadata-" + name),
 	}
 
 	go func() {


### PR DESCRIPTION
### What does this PR do?

Do not make the liveness probe fail in case of network issue.

### Motivation

This is a followup of #7579 which appeared to be incomplete.
When the network of an agent pod is black-holed, the `ad-dockerlistener` and `ad-config-provider-kubernetes` are becoming unhealthy quite quickly.
That’s the reason why those components have been moved from the liveness probe to the readiness probe in #7579.

However, after a longer period of time, we see the `metadata-host`, `metadata-inventories`, `metadata-resources` and `metadata-agent_checks` components becoming unhealthy as well.
It took more time because metadata are collected less often.
That’s why this PR is now moving those components from the liveness probe to the readiness one as well.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

See test plan in #7579.
