### PR TITLE
Agent.build now honors embedded_path for rtloader

### DIFF
--- a/docs/dev/agent_build.md
+++ b/docs/dev/agent_build.md
@@ -53,7 +53,7 @@ the `pkg-config` folder.
 
 ## Testing Agent changes in containerized environments
 
-Building an Agent Docker image from strach through an embedded build is a slow process.
+Building an Agent Docker image from scratch through an embedded build is a slow process.
 Sometimes, you may want to quickly test a change or bufix in a containerized environment (Docker, Kubernetes, ECS, etc.).
 
 One way to do it is to patch the Agent binary from official Docker image, with a simple Dockerfile:

--- a/docs/dev/agent_build.md
+++ b/docs/dev/agent_build.md
@@ -54,7 +54,7 @@ the `pkg-config` folder.
 ## Testing Agent changes in containerized environments
 
 Building an Agent Docker image from scratch through an embedded build is a slow process.
-Sometimes, you may want to quickly test a change or bufix in a containerized environment (Docker, Kubernetes, ECS, etc.).
+Sometimes, you may want to quickly test a change or bugfix in a containerized environment (Docker, Kubernetes, ECS, etc.).
 
 One way to do it is to patch the Agent binary from official Docker image, with a simple Dockerfile:
 

--- a/docs/dev/agent_build.md
+++ b/docs/dev/agent_build.md
@@ -54,9 +54,9 @@ the `pkg-config` folder.
 ## Testing Agent changes in containerized environments
 
 Building an Agent Docker image from scratch through an embedded build is a slow process.
-Sometimes, you may want to quickly test a change or bugfix in a containerized environment (Docker, Kubernetes, ECS, etc.).
+You can quickly test a change or bug fix in a containerized environment (such as Docker, Kubernetes, or ECS).
 
-One way to do it is to patch the Agent binary from official Docker image, with a simple Dockerfile:
+One way to do this is to patch the Agent binary from an official Docker image, with a Dockerfile:
 
 ```
 FROM datadog/agent:<AGENT_VERSION>
@@ -64,10 +64,10 @@ FROM datadog/agent:<AGENT_VERSION>
 COPY agent /opt/datadog-agent/bin/agent/agent
 ```
 
-However, for this to work properly, two things are important:
-- Your change needs to be done on top of `<AGENT_VERSION>` tag from our repository.
-- You need to run invoke task with proper embedded path `inv -e agent.build -e /opt/datadog-agent/embedded`.
+For this to work properly, two things are important:
+- Your change needs to be done on top of the `<AGENT_VERSION>` tag from the DataDog repository.
+- You need to run the invoke task with the proper embedded path `inv -e agent.build -e /opt/datadog-agent/embedded`.
 
-Note that this will make `invoke` to install the builds artifacts in `/opt/datadog-agent/embedded` folder. Make sure folder exists and current user has write permissions.
+**Note**: This makes `invoke` install the build's artifacts in the `/opt/datadog-agent/embedded` folder. Make sure the folder exists and the current user has write permissions.
 
 [dev-env]: agent_dev_env.md

--- a/docs/dev/agent_build.md
+++ b/docs/dev/agent_build.md
@@ -51,4 +51,23 @@ We use `pkg-config` to make compilers and linkers aware of Python. If you need
 to adjust the build for your specific configuration, add or edit the files within
 the `pkg-config` folder.
 
+## Testing Agent changes in containerized environments
+
+Building an Agent Docker image from strach through an embedded build is a slow process.
+Sometimes, you may want to quickly test a change or bufix in a containerized environment (Docker, Kubernetes, ECS, etc.).
+
+One way to do it is to patch the Agent binary from official Docker image, with a simple Dockerfile:
+
+```
+FROM datadog/agent:<AGENT_VERSION>
+
+COPY agent /opt/datadog-agent/bin/agent/agent
+```
+
+However, for this to work properly, two things are important:
+- Your change needs to be done on top of `<AGENT_VERSION>` tag from our repository.
+- You need to run invoke task with proper embedded path `inv -e agent.build -e /opt/datadog-agent/embedded`.
+
+Note that this will make `invoke` to install the builds artifacts in `/opt/datadog-agent/embedded` folder. Make sure folder exists and current user has write permissions.
+
 [dev-env]: agent_dev_env.md

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -102,7 +102,9 @@ def build(
     """
 
     if not exclude_rtloader and not iot:
-        rtloader_make(ctx, python_runtimes=python_runtimes)
+        # If embedded_path is set, we should give it to rtloader as it should install the headers/libs
+        # in the embedded path folder because that's what is used in get_build_flags()
+        rtloader_make(ctx, python_runtimes=python_runtimes, install_prefix=embedded_path)
         rtloader_install(ctx)
 
     ldflags, gcflags, env = get_build_flags(


### PR DESCRIPTION
### What does this PR do?

Currently building the Agent with `agent.build` will not work properly with custom `embedded_path` as implicitly built rtloader will not be installed there but in `./dev` anyway.
It's useful to build Agent binaries that can be hotswapped easily in containers.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

No QA
