### PR TITLE
[process-agent] Increase grpc global timeout to 60 seconds to the main agent and adjust backoff configs.

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -37,7 +37,7 @@ const (
 	// defaultRuntimeCompilerOutputDir is the default path for output from the system-probe runtime compiler
 	defaultRuntimeCompilerOutputDir = "/var/tmp/datadog-agent/system-probe/build"
 
-	grpcAgentTimeout = 2 * time.Second
+	grpcAgentTimeout = 60 * time.Second
 )
 
 // Name for check performed by process-agent or system-probe

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -22,8 +22,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
-	"github.com/DataDog/datadog-agent/pkg/util/grpc"
+	ddgrpc "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -595,7 +596,7 @@ func getHostname(ddAgentBin string, grpcConnectionTimeout time.Duration) (string
 	}
 
 	// Get the hostname via gRPC from the main agent if a hostname has not been set either from config/fargate
-	hostname, err := getHostnameFromGRPC(grpc.GetDDAgentClient, grpcConnectionTimeout)
+	hostname, err := getHostnameFromGRPC(ddgrpc.GetDDAgentClient, grpcConnectionTimeout)
 	if err == nil {
 		return hostname, nil
 	}
@@ -638,7 +639,7 @@ func getHostnameFromCmd(ddAgentBin string, cmdFn cmdFunc) (string, error) {
 }
 
 // getHostnameFromGRPC retrieves the hostname from the main datadog agent via GRPC
-func getHostnameFromGRPC(grpcClientFn func(ctx context.Context) (pb.AgentClient, error), grpcConnectionTimeout time.Duration) (string, error) {
+func getHostnameFromGRPC(grpcClientFn func(ctx context.Context, opts ...grpc.DialOption) (pb.AgentClient, error), grpcConnectionTimeout time.Duration) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), grpcConnectionTimeout)
 	defer cancel()
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -37,7 +37,7 @@ const (
 	// defaultRuntimeCompilerOutputDir is the default path for output from the system-probe runtime compiler
 	defaultRuntimeCompilerOutputDir = "/var/tmp/datadog-agent/system-probe/build"
 
-	grpcAgentTimeout = 60 * time.Second
+	defaultGRPCConnectionTimeout = 60 * time.Second
 )
 
 // Name for check performed by process-agent or system-probe
@@ -157,6 +157,8 @@ type AgentConfig struct {
 
 	// Windows-specific config
 	Windows WindowsConfig
+
+	grpcConnectionTimeout time.Duration
 }
 
 // CheckIsEnabled returns a bool indicating if the given check name is enabled.
@@ -285,6 +287,8 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 			EnableMonotonicCount: false,
 			DriverBufferSize:     1024,
 		},
+
+		grpcConnectionTimeout: defaultGRPCConnectionTimeout,
 	}
 
 	// Set default values for proc/sys paths if unset.
@@ -384,7 +388,7 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 
 	if cfg.HostName == "" {
 		// lookup hostname if there is no config override
-		if hostname, err := getHostname(cfg.DDAgentBin); err == nil {
+		if hostname, err := getHostname(cfg.DDAgentBin, cfg.grpcConnectionTimeout); err == nil {
 			cfg.HostName = hostname
 		} else {
 			log.Errorf("Cannot get hostname: %v", err)
@@ -580,7 +584,7 @@ func isAffirmative(value string) (bool, error) {
 
 // getHostname attempts to resolve the hostname in the following order: the main datadog agent via grpc, the main agent
 // via cli and lastly falling back to os.Hostname() if it is unavailable
-func getHostname(ddAgentBin string) (string, error) {
+func getHostname(ddAgentBin string, grpcConnectionTimeout time.Duration) (string, error) {
 	// Fargate is handled as an exceptional case (there is no concept of a host, so we use the ARN in-place).
 	if fargate.IsFargateInstance() {
 		hostname, err := fargate.GetFargateHost()
@@ -591,7 +595,7 @@ func getHostname(ddAgentBin string) (string, error) {
 	}
 
 	// Get the hostname via gRPC from the main agent if a hostname has not been set either from config/fargate
-	hostname, err := getHostnameFromGRPC(grpc.GetDDAgentClient)
+	hostname, err := getHostnameFromGRPC(grpc.GetDDAgentClient, grpcConnectionTimeout)
 	if err == nil {
 		return hostname, nil
 	}
@@ -634,8 +638,8 @@ func getHostnameFromCmd(ddAgentBin string, cmdFn cmdFunc) (string, error) {
 }
 
 // getHostnameFromGRPC retrieves the hostname from the main datadog agent via GRPC
-func getHostnameFromGRPC(grpcClientFn func(ctx context.Context) (pb.AgentClient, error)) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), grpcAgentTimeout)
+func getHostnameFromGRPC(grpcClientFn func(ctx context.Context) (pb.AgentClient, error), grpcConnectionTimeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), grpcConnectionTimeout)
 	defer cancel()
 
 	ddAgentClient, err := grpcClientFn(ctx)

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -286,7 +286,7 @@ func TestIgnoreConntrackInitFailure(t *testing.T) {
 
 func TestGetHostname(t *testing.T) {
 	cfg := NewDefaultAgentConfig(false)
-	h, err := getHostname(cfg.DDAgentBin)
+	h, err := getHostname(cfg.DDAgentBin, 0)
 	assert.Nil(t, err)
 	// verify we fall back to getting os hostname
 	expectedHostname, _ := os.Hostname()
@@ -709,7 +709,7 @@ func TestGetHostnameFromGRPC(t *testing.T) {
 	t.Run("hostname returns from grpc", func(t *testing.T) {
 		hostname, err := getHostnameFromGRPC(func(ctx context.Context) (pb.AgentClient, error) {
 			return mockClient, nil
-		})
+		}, defaultGRPCConnectionTimeout)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "unit-test-hostname", hostname)
@@ -719,7 +719,7 @@ func TestGetHostnameFromGRPC(t *testing.T) {
 		grpcErr := errors.New("no grpc client")
 		hostname, err := getHostnameFromGRPC(func(ctx context.Context) (pb.AgentClient, error) {
 			return nil, grpcErr
-		})
+		}, defaultGRPCConnectionTimeout)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, grpcErr, errors.Unwrap(err))

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 var originalConfig = config.Datadog
@@ -707,7 +708,7 @@ func TestGetHostnameFromGRPC(t *testing.T) {
 	).Return(&pb.HostnameReply{Hostname: "unit-test-hostname"}, nil)
 
 	t.Run("hostname returns from grpc", func(t *testing.T) {
-		hostname, err := getHostnameFromGRPC(func(ctx context.Context) (pb.AgentClient, error) {
+		hostname, err := getHostnameFromGRPC(func(ctx context.Context, opts ...grpc.DialOption) (pb.AgentClient, error) {
 			return mockClient, nil
 		}, defaultGRPCConnectionTimeout)
 
@@ -717,7 +718,7 @@ func TestGetHostnameFromGRPC(t *testing.T) {
 
 	t.Run("grpc client is unavailable", func(t *testing.T) {
 		grpcErr := errors.New("no grpc client")
-		hostname, err := getHostnameFromGRPC(func(ctx context.Context) (pb.AgentClient, error) {
+		hostname, err := getHostnameFromGRPC(func(ctx context.Context, opts ...grpc.DialOption) (pb.AgentClient, error) {
 			return nil, grpcErr
 		}, defaultGRPCConnectionTimeout)
 

--- a/pkg/process/config/testdata/TestDDAgentConfigYamlOnly.yaml
+++ b/pkg/process/config/testdata/TestDDAgentConfigYamlOnly.yaml
@@ -3,6 +3,7 @@ api_key: apikey_20
 process_agent_enabled: true
 process_config:
   enabled: 'true'
+  grpc_connection_timeout_secs: 0
   queue_size: 10
   intervals:
       container: 8

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -369,6 +369,11 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		}
 	}
 
+	// Overrides the grpc connection timeout setting to the main agent.
+	if k := key(ns, "grpc_connection_timeout_secs"); config.Datadog.IsSet(k) {
+		a.grpcConnectionTimeout = config.Datadog.GetDuration(k) * time.Second
+	}
+
 	// Windows: Sets windows process table refresh rate (in number of check runs)
 	if argRefresh := config.Datadog.GetInt(key(ns, "windows", "args_refresh_interval")); argRefresh != 0 {
 		a.Windows.ArgsRefreshInterval = argRefresh

--- a/pkg/util/grpc/agent_client.go
+++ b/pkg/util/grpc/agent_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/pb"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -20,7 +21,12 @@ func GetDDAgentClient(ctx context.Context) (pb.AgentClient, error) {
 	tlsConf := tls.Config{InsecureSkipVerify: true}
 
 	opts := []grpc.DialOption{
-		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoff.DefaultConfig}),
+		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoff.Config{
+			BaseDelay:  1.0 * time.Second,
+			Multiplier: 1.1,
+			Jitter:     0.2,
+			MaxDelay:   2 * time.Second,
+		}}),
 		grpc.WithBlock(),
 		grpc.WithTransportCredentials(credentials.NewTLS(&tlsConf)),
 	}

--- a/pkg/util/grpc/agent_client.go
+++ b/pkg/util/grpc/agent_client.go
@@ -14,22 +14,30 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// GetDDAgentClient creates a pb.AgentClient for IPC with the main agent via gRPC. This call is blocking, so
+var defaultBackoffConfig = backoff.Config{
+	BaseDelay:  1.0 * time.Second,
+	Multiplier: 1.1,
+	Jitter:     0.2,
+	MaxDelay:   2 * time.Second,
+}
+
+// defaultAgentDialOpts default dial options to the main agent which blocks and retries based on the backoffConfig
+var defaultAgentDialOpts = []grpc.DialOption{
+	grpc.WithConnectParams(grpc.ConnectParams{Backoff: defaultBackoffConfig}),
+	grpc.WithBlock(),
+}
+
+// GetDDAgentClient creates a pb.AgentClient for IPC with the main agent via gRPC. This call is blocking by default, so
 // it is up to the caller to supply a context with appropriate timeout/cancel options
-func GetDDAgentClient(ctx context.Context) (pb.AgentClient, error) {
+func GetDDAgentClient(ctx context.Context, opts ...grpc.DialOption) (pb.AgentClient, error) {
 	// This is needed as the server hangs when using "grpc.WithInsecure()"
 	tlsConf := tls.Config{InsecureSkipVerify: true}
 
-	opts := []grpc.DialOption{
-		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoff.Config{
-			BaseDelay:  1.0 * time.Second,
-			Multiplier: 1.1,
-			Jitter:     0.2,
-			MaxDelay:   2 * time.Second,
-		}}),
-		grpc.WithBlock(),
-		grpc.WithTransportCredentials(credentials.NewTLS(&tlsConf)),
+	if len(opts) == 0 {
+		opts = defaultAgentDialOpts
 	}
+
+	opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tlsConf)))
 
 	target, err := getIPCAddressPort()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?
Increases the grpc connection timeout from process agent to the main agent. 
The main agent may take a little longer to startup in certain environments such as when running in a container or in k8s as it needs to reach out to external API services to retrieve the hostname.

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

#### Verify Process Agent gets hostname from main agent

1. Enable process agent and debug logging in the config (datadog.yaml)
```yaml
process_config:
   enabled: true
logs_enabled: true
log_level: 'debug' 
```
2. Start or Restart Process agent
3. Verify process data appears with expected hostname in Datadog
4. Verify logs show host name is coming via grpc 
```
2021-02-26 13:32:32 UTC | PROCESS | DEBUG | (pkg/process/config/config.go:613 in getHostnameFromGRPC) | retrieved hostname:agent-dev-william from datadog agent via grpc
```