### PR TITLE
Initialize memory to zero; fixes intermittent probe startup failure

### DIFF
--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -587,6 +587,7 @@ func prepareCompletionBuffers(h windows.Handle, count int) (iocp windows.Handle,
 	buffers = make([]*readbuffer, count)
 	for i := 0; i < count; i++ {
 		buf := (*readbuffer)(C.malloc(C.size_t(unsafe.Sizeof(readbuffer{}))))
+		C.memset(unsafe.Pointer(buf), 0, C.size_t(unsafe.Sizeof(readbuffer{})))
 		buffers[i] = buf
 
 		err = windows.ReadFile(h, buf.data[:], nil, &(buf.ol))


### PR DESCRIPTION
(hopefully)

### What does this PR do?

initialize memory from C.malloc() to zero

### Motivation

intermittent, nondeterministic failure on sysprobe startup

