### PR TITLE
[runtime-security] Fix fstype for mount events

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ac1ea7371a39bd4c93ac7eb9226ea083db65a803f945bf8100d9520ad85fdea6")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d839516e956eb972c1dcc84c2b26e9b7bd2982beedda8c79d80de1e5aaa4982d")

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -113,6 +113,18 @@ struct dentry * __attribute__((always_inline)) get_vfsmount_dentry(struct vfsmou
     return dentry;
 }
 
+struct super_block * __attribute__((always_inline)) get_dentry_sb(struct dentry *dentry) {
+    struct super_block *sb;
+    bpf_probe_read(&sb, sizeof(sb), &dentry->d_sb);
+    return sb;
+}
+
+struct file_system_type * __attribute__((always_inline)) get_super_block_fs(struct super_block *sb) {
+    struct file_system_type *fs;
+    bpf_probe_read(&fs, sizeof(fs), &sb->s_type);
+    return fs;
+}
+
 struct super_block * __attribute__((always_inline)) get_vfsmount_sb(struct vfsmount *mnt) {
     struct super_block *sb;
     bpf_probe_read(&sb, sizeof(sb), &mnt->mnt_sb);

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -331,6 +331,16 @@ type FileFields struct {
 	Flags   int32  `field:"-"`
 }
 
+// GetInLowerLayer returns whether a file is in a lower layer
+func (f *FileFields) GetInLowerLayer() bool {
+	return f.Flags&LowerLayer != 0
+}
+
+// GetInUpperLayer returns whether a file is in the upper layer
+func (f *FileFields) GetInUpperLayer() bool {
+	return f.Flags&UpperLayer != 0
+}
+
 // FileEvent is the common file event type
 type FileEvent struct {
 	FileFields

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -82,12 +82,12 @@ func (ev *Event) ResolveFileContainerPath(f *model.FileEvent) string {
 
 // ResolveFileFilesystem resolves the filesystem a file resides in
 func (ev *Event) ResolveFileFilesystem(f *model.FileEvent) string {
-	return ev.resolvers.ResolveFilesystem(&f.FileFields)
+	return ev.resolvers.MountResolver.GetFilesystem(f.FileFields.MountID)
 }
 
 // ResolveFileInUpperLayer resolves whether the file is in an upper layer
 func (ev *Event) ResolveFileInUpperLayer(f *model.FileEvent) bool {
-	return ev.resolvers.ResolveInUpperLayer(&f.FileFields)
+	return f.FileFields.GetInUpperLayer()
 }
 
 // GetXAttrName returns the string representation of the extended attribute name
@@ -256,7 +256,7 @@ func (ev *Event) ResolveProcessTTY(e *model.Process) string {
 func (ev *Event) ResolveProcessFilesystem(e *model.Process) string {
 	if e.Filesystem == "" && ev != nil {
 		if entry := ev.ResolveProcessCacheEntry(); entry != nil {
-			e.Filesystem = ev.resolvers.ResolveFilesystem(&entry.FileFields)
+			e.Filesystem = ev.resolvers.MountResolver.GetFilesystem(entry.FileFields.MountID)
 		}
 	}
 	return e.Filesystem

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -188,16 +188,6 @@ func (r *Resolvers) ResolveProcessContextGroup(p *model.ProcessContext) string {
 	return p.Group
 }
 
-// ResolveFilesystem resolves the filesystem a file resides in
-func (r *Resolvers) ResolveFilesystem(f *model.FileFields) string {
-	return r.MountResolver.GetFilesystem(f.MountID)
-}
-
-// ResolveInUpperLayer resolves whether the file is in an upper layer
-func (r *Resolvers) ResolveInUpperLayer(f *model.FileFields) bool {
-	return f.Flags&model.UpperLayer != 0
-}
-
 // Start the resolvers
 func (r *Resolvers) Start(ctx context.Context) error {
 	if err := r.ProcessResolver.Start(ctx); err != nil {

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -187,11 +187,12 @@ type EventSerializer struct {
 }
 
 func getInUpperLayer(r *Resolvers, f *model.FileFields) *bool {
-	if r.ResolveFilesystem(f) != "overlay" {
+	lowerLayer := f.GetInLowerLayer()
+	upperLayer := f.GetInUpperLayer()
+	if !lowerLayer && !upperLayer {
 		return nil
 	}
-	b := r.ResolveInUpperLayer(f)
-	return &b
+	return &upperLayer
 }
 
 func newFileSerializer(fe *model.FileEvent, e *Event) *FileSerializer {
@@ -245,7 +246,7 @@ func newProcessFileSerializerWithResolvers(process *model.Process, r *Resolvers)
 		ContainerPath:       process.ContainerPath,
 		Inode:               getUint64Pointer(&process.FileFields.Inode),
 		MountID:             getUint32Pointer(&process.FileFields.MountID),
-		Filesystem:          r.ResolveFilesystem(&process.FileFields),
+		Filesystem:          r.MountResolver.GetFilesystem(process.FileFields.MountID),
 		InUpperLayer:        getInUpperLayer(r, &process.FileFields),
 		Mode:                getUint32Pointer(&mode),
 		UID:                 process.FileFields.UID,

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -72,7 +72,7 @@ func TestMount(t *testing.T) {
 			}
 
 			// use accessor to parse properly the mount type
-			if fs := event.Mount.GetFSType(); fs != "bind" {
+			if fs := event.Mount.GetFSType(); fs != "ext4" {
 				t.Errorf("expected a bind mount, got %v", fs)
 			}
 			mntID = event.Mount.MountID

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"golang.org/x/sys/unix"
 	"io/ioutil"
 	"net"
 	"os"
@@ -24,6 +23,8 @@ import (
 	"text/template"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/cihub/seelog"
 	"github.com/pkg/errors"
@@ -460,8 +461,8 @@ func (tm *testModule) GetProbeEvent(timeout time.Duration, eventType ...eval.Eve
 	}
 }
 
-func (tm *testModule) Path(filename string) (string, unsafe.Pointer, error) {
-	return tm.st.Path(filename)
+func (tm *testModule) Path(filename ...string) (string, unsafe.Pointer, error) {
+	return tm.st.Path(filename...)
 }
 
 func (tm *testModule) CreateWithOptions(filename string, user, group, mode int) (string, unsafe.Pointer, error) {
@@ -588,13 +589,15 @@ func (t *simpleTest) ProcessName() string {
 	return path.Base(executable)
 }
 
-func (t *simpleTest) Path(filename string) (string, unsafe.Pointer, error) {
-	filename = path.Join(t.root, filename)
-	filenamePtr, err := syscall.BytePtrFromString(filename)
+func (t *simpleTest) Path(filename ...string) (string, unsafe.Pointer, error) {
+	components := []string{t.root}
+	components = append(components, filename...)
+	path := path.Join(components...)
+	filenamePtr, err := syscall.BytePtrFromString(path)
 	if err != nil {
 		return "", nil, err
 	}
-	return filename, unsafe.Pointer(filenamePtr), nil
+	return path, unsafe.Pointer(filenamePtr), nil
 }
 
 func (t *simpleTest) load(macros []*rules.MacroDefinition, rules []*rules.RuleDefinition) (err error) {

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -31,13 +31,15 @@ func (td *testDrive) Root() string {
 	return td.mountPoint
 }
 
-func (td *testDrive) Path(filename string) (string, unsafe.Pointer, error) {
-	filename = path.Join(td.mountPoint, filename)
-	filenamePtr, err := syscall.BytePtrFromString(filename)
+func (td *testDrive) Path(filename ...string) (string, unsafe.Pointer, error) {
+	components := []string{td.mountPoint}
+	components = append(components, filename...)
+	path := path.Join(components...)
+	filenamePtr, err := syscall.BytePtrFromString(path)
 	if err != nil {
 		return "", nil, err
 	}
-	return filename, unsafe.Pointer(filenamePtr), nil
+	return path, unsafe.Pointer(filenamePtr), nil
 }
 
 func newTestDrive(fsType string, mountOpts []string) (*testDrive, error) {


### PR DESCRIPTION
### What does this PR do?

Fix the reported fstype for mount events

### Motivation

The fstype reported for mounts was the syscall argument `fstype`. In the case of bind mounts, it is ignored and can be a meaningless value.