### PR TITLE
[kitchen] Allow C:/Windows/Assembly/Tmp in system files check

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -775,6 +775,7 @@ shared_examples_for 'an Agent that is removed' do
     it 'should not make changes to system files' do
       exclude = [
             'C:/Windows/Assembly/Temp/',
+            'C:/Windows/Assembly/Tmp/',
             'C:/Windows/Temp/',
             'C:/Windows/Prefetch/',
             'C:/Windows/Installer/',


### PR DESCRIPTION
### What does this PR do?

Adds `C:/Windows/Assembly/Tmp/` to the list of allowed directories when checking missing files after the Agent removal.

### Motivation

Remove source of flaky failures in kitchen tests.
