### PR TITLE
On Windows, replace backslash in base_dir

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -472,7 +472,7 @@ def omnibus_build(
     if sys.platform == 'win32':
         # On Windows, prevent backslashes in the base_dir path otherwise omnibus will fail with
         # error 'no matched files for glob copy' at the end of the build.
-        base_dir = base_dir.replace('\\', '/')
+        base_dir = base_dir.replace(os.path.sep, '/')
 
     env = get_omnibus_env(
         ctx,

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -469,6 +469,11 @@ def omnibus_build(
     # base dir (can be overridden through env vars, command line takes precedence)
     base_dir = base_dir or os.environ.get("OMNIBUS_BASE_DIR")
 
+    if sys.platform == 'win32':
+        # On Windows, prevent backslashes in the base_dir path otherwise omnibus will fail with
+        # error 'no matched files for glob copy' at the end of the build.
+        base_dir = base_dir.replace('\\', '/')
+
     env = get_omnibus_env(
         ctx,
         skip_sign=skip_sign,


### PR DESCRIPTION
### What does this PR do?

This PR updates the `agent.omnibus-build` task to replace any backslash for the omnibus base directory.

### Motivation

On Windows, Omnibus will fail the build with error 'no matched files for glob copy' at the end of the build if there is a backslash in its path.

