### PR TITLE
Ensure system-probe other features are usable when the network tracer can’t start

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -143,6 +143,8 @@ func runAgent(exit <-chan struct{}) {
 		cleanupAndExit(1)
 	}
 
+	httpMux.HandleFunc("/status", func(w http.ResponseWriter, req *http.Request) {})
+
 	// Register stats endpoint
 	httpMux.HandleFunc("/debug/stats", func(w http.ResponseWriter, req *http.Request) {
 		stats := loader.GetStats()

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -143,8 +143,6 @@ func runAgent(exit <-chan struct{}) {
 		cleanupAndExit(1)
 	}
 
-	httpMux.HandleFunc("/status", func(w http.ResponseWriter, req *http.Request) {})
-
 	// Register stats endpoint
 	httpMux.HandleFunc("/debug/stats", func(w http.ResponseWriter, req *http.Request) {
 		stats := loader.GetStats()

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -62,8 +62,6 @@ func (nt *networkTracer) GetStats() map[string]interface{} {
 func (nt *networkTracer) Register(httpMux *http.ServeMux) error {
 	var runCounter uint64
 
-	httpMux.HandleFunc("/status", func(w http.ResponseWriter, req *http.Request) {})
-
 	httpMux.HandleFunc("/connections", func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 		id := getClientID(req)

--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -157,10 +157,10 @@ func newSystemProbe() *RemoteSysProbeUtil {
 }
 
 func (r *RemoteSysProbeUtil) init() error {
-	if resp, err := r.httpClient.Get(statusURL); err != nil {
+	if resp, err := r.httpClient.Get(statsURL); err != nil {
 		return err
 	} else if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("remote tracer status check failed: socket %s, url: %s, status code: %d", r.path, statusURL, resp.StatusCode)
+		return fmt.Errorf("remote tracer status check failed: socket %s, url: %s, status code: %d", r.path, statsURL, resp.StatusCode)
 	}
 	return nil
 }

--- a/pkg/process/net/common_linux.go
+++ b/pkg/process/net/common_linux.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	statusURL      = "http://unix/status"
 	connectionsURL = "http://unix/connections"
 	statsURL       = "http://unix/debug/stats"
 	netType        = "unix"

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -5,7 +5,6 @@ package net
 import "fmt"
 
 const (
-	statusURL      = "http://localhost:3333/status"
 	connectionsURL = "http://localhost:3333/connections"
 	statsURL       = "http://localhost:3333/debug/stats"
 	netType        = "tcp"


### PR DESCRIPTION
### What does this PR do?

`system-probe` now implements several independent features:
* network tracer
* OOM kill check
* TCP queue length check
* runtime security

All those features should be independent and it should be possible to use any of them without having to enable the others.

The other agents are using a `RemoteSysProbeUtil` object to communicate with `system-probe`.
[When this object is instantiated, it tries to `GET` `http://unix/status` to validate that the communication with `system-probe` can be established`](https://github.com/DataDog/datadog-agent/blob/7.27.0-rc.1/pkg/process/net/common.go#L160).

The problem is that [this path is registered by the network tracer module](https://github.com/DataDog/datadog-agent/blob/7.27.0-rc.1/cmd/system-probe/modules/network_tracer.go#L65).

The consequence is that, if we try to enable the OOM kill check and/or the TCP queue length check while the network tracer module couldn’t be loaded, it fails with the following errors:
```
2021-03-10 12:38:09 UTC | CORE | ERROR | (pkg/collector/runner/runner.go:292 in work) | Error running check tcp_queue_length: temporary failure in system-probe-util, will retry later: remote tracer status check failed: socket /var/run/sysprobe/sysprobe.sock, url: http://unix/status, status code: 404
```

This PR ensures that the `/status` endpoint is always exposed by `system-probe` even when the network tracer isn’t enabled so that the other checks can work.

### Motivation

`system-probe` features should be independent.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Check that the `OOM kill` and `TCP queue length` checks are working when the network tracer isn’t running.