### PR TITLE
[runtime-security] fix tty parsing

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d839516e956eb972c1dcc84c2b26e9b7bd2982beedda8c79d80de1e5aaa4982d")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "f275e25b8b5f466d718a1a050b498ca576b7ae798732a23dcaad6179f04dc7fd")

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -15,7 +15,7 @@ struct proc_cache_t {
     char comm[TASK_COMM_LEN];
 };
 
-static __attribute__((always_inline)) u32 copy_tty_name(char dst[TTY_NAME_LEN], char src[TTY_NAME_LEN]) {
+static __attribute__((always_inline)) u32 copy_tty_name(char src[TTY_NAME_LEN], char dst[TTY_NAME_LEN]) {
     if (src[0] == 0) {
         return 0;
     }

--- a/pkg/security/model/strings.go
+++ b/pkg/security/model/strings.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build linux
+
+package model
+
+import "unicode"
+
+// IsPrintable returns whether the string does contain only ascii
+func IsPrintable(s string) bool {
+	for _, c := range s {
+		if !unicode.IsOneOf(unicode.PrintRanges, c) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/security/model/strings_test.go
+++ b/pkg/security/model/strings_test.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build linux
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPrintable(t *testing.T) {
+	assert.Equal(t, true, IsPrintable("A-B"))
+	assert.Equal(t, true, IsPrintable("A/B"))
+	assert.Equal(t, false, IsPrintable("\n"))
+	assert.Equal(t, false, IsPrintable("\u001d"))
+}

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -150,7 +150,10 @@ func (e *Process) UnmarshalBinary(data []byte) (int, error) {
 
 	var ttyRaw [64]byte
 	SliceToArray(data[read:read+64], unsafe.Pointer(&ttyRaw))
-	e.TTYName = string(bytes.Trim(ttyRaw[:], "\x00"))
+	ttyName := string(bytes.Trim(ttyRaw[:], "\x00"))
+	if IsPrintable(ttyName) {
+		e.TTYName = ttyName
+	}
 	read += 64
 
 	var commRaw [16]byte

--- a/pkg/security/module/event.go
+++ b/pkg/security/module/event.go
@@ -11,8 +11,8 @@ package module
 // easyjson:json
 type AgentContext struct {
 	RuleID        string `json:"rule_id"`
-	PolicyName    string `json:"policy_name"`
-	PolicyVersion string `json:"policy_version"`
+	PolicyName    string `json:"policy_name,omitempty"`
+	PolicyVersion string `json:"policy_version,omitempty"`
 }
 
 // Signal - Rule event wrapper used to send an event to the backend

--- a/pkg/security/module/event_easyjson.go
+++ b/pkg/security/module/event_easyjson.go
@@ -29,7 +29,7 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule(in *jle
 	out.AgentContext = new(AgentContext)
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()
@@ -121,7 +121,7 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule1(in *jl
 	}
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()
@@ -154,12 +154,12 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(out *j
 		out.RawString(prefix[1:])
 		out.String(string(in.RuleID))
 	}
-	{
+	if in.PolicyName != "" {
 		const prefix string = ",\"policy_name\":"
 		out.RawString(prefix)
 		out.String(string(in.PolicyName))
 	}
-	{
+	if in.PolicyVersion != "" {
 		const prefix string = ",\"policy_version\":"
 		out.RawString(prefix)
 		out.String(string(in.PolicyVersion))

--- a/pkg/security/probe/compile_test.go
+++ b/pkg/security/probe/compile_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 // +build linux_bpf
 
 package probe

--- a/pkg/security/probe/kernel.go
+++ b/pkg/security/probe/kernel.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build linux
+
+package probe
+
+import (
+	"strings"
+
+	"github.com/cobaugh/osrelease"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+)
+
+var (
+	// KERNEL_VERSION(a,b,c) = (a << 16) + (b << 8) + (c)
+	kernel4_13 = kernel.VersionCode(4, 13, 0) //nolint:deadcode,unused
+	kernel4_16 = kernel.VersionCode(4, 16, 0) //nolint:deadcode,unused
+	kernel5_3  = kernel.VersionCode(5, 3, 0)  //nolint:deadcode,unused
+)
+
+// KernelVersion defines a kernel version helper
+type KernelVersion struct {
+	osrelease map[string]string
+}
+
+// NewKernelVersion returns a new kernel version helper
+func NewKernelVersion() (*KernelVersion, error) {
+	osrelease, err := osrelease.Read()
+	if err != nil {
+		return nil, err
+	}
+	return &KernelVersion{
+		osrelease: osrelease,
+	}, nil
+}
+
+// IsRH7Kernel returns whether the kernel is a rh7 kernel
+func (k *KernelVersion) IsRH7Kernel() bool {
+	return (k.osrelease["ID"] == "centos" || k.osrelease["ID"] == "rhel") && k.osrelease["VERSION_ID"] == "7"
+}
+
+// IsRH8Kernel returns whether the kernel is a rh8 kernel
+func (k *KernelVersion) IsRH8Kernel() bool {
+	return k.osrelease["PLATFORM_ID"] == "platform:el8"
+}
+
+// IsSuseKernel returns whether the kernel is a suse kernel
+func (k *KernelVersion) IsSuseKernel() bool {
+	return k.osrelease["ID"] == "sles" || k.osrelease["ID"] == "opensuse-leap"
+}
+
+// IsSLES12Kernel returns whether the kernel is a sles 12 kernel
+func (k *KernelVersion) IsSLES12Kernel() bool {
+	return k.IsSuseKernel() && strings.HasPrefix(k.osrelease["VERSION_ID"], "12")
+}
+
+// IsSLES15Kernel returns whether the kernel is a sles 15 kernel
+func (k *KernelVersion) IsSLES15Kernel() bool {
+	return k.IsSuseKernel() && strings.HasPrefix(k.osrelease["VERSION_ID"], "15")
+}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -246,7 +246,7 @@ func (ev *Event) ResolveProcessCookie(e *model.Process) int {
 func (ev *Event) ResolveProcessTTY(e *model.Process) string {
 	if e.TTYName == "" && ev != nil {
 		if entry := ev.ResolveProcessCacheEntry(); entry != nil {
-			e.TTYName = entry.TTYName
+			e.TTYName = ev.resolvers.ProcessResolver.SetTTY(entry)
 		}
 	}
 	return e.TTYName

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -779,6 +779,7 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 			Value: getSuperBlockMagicOffset(p),
 		},
 	)
+	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, TTYConstants(p)...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, erpc.GetConstants()...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -467,6 +467,18 @@ func (p *ProcessResolver) SetProcessEnvs(pce *model.ProcessCacheEntry) {
 	}
 }
 
+// SetTTY resolves TTY and cache the result
+func (p *ProcessResolver) SetTTY(pce *model.ProcessCacheEntry) string {
+	if pce.TTYName == "" {
+		tty := utils.PidTTY(int32(pce.Pid))
+		if tty == "" {
+			tty = "null"
+		}
+		pce.TTYName = tty
+	}
+	return pce.TTYName
+}
+
 // Get returns the cache entry for a specified pid
 func (p *ProcessResolver) Get(pid uint32) *model.ProcessCacheEntry {
 	p.RLock()

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	lib "github.com/DataDog/ebpf"
+	"github.com/DataDog/ebpf/manager"
 	"github.com/DataDog/gopsutil/process"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pkg/errors"
@@ -49,6 +50,38 @@ func getDoForkInput(probe *Probe) uint64 {
 		return doForkStructInput
 	}
 	return doForkListInput
+}
+
+// TTYConstants returns the tty constants
+func TTYConstants(probe *Probe) []manager.ConstantEditor {
+	ttyOffset, nameOffset := uint64(400), uint64(368)
+
+	kv, err := NewKernelVersion()
+	if err == nil {
+		switch {
+		case kv.IsRH7Kernel():
+			ttyOffset, nameOffset = 416, 312
+		case kv.IsRH8Kernel():
+			ttyOffset, nameOffset = 392, 368
+		case kv.IsSLES12Kernel():
+			ttyOffset, nameOffset = 376, 368
+		case kv.IsSLES15Kernel():
+			ttyOffset, nameOffset = 408, 368
+		case probe.kernelVersion != 0 && probe.kernelVersion < kernel5_3:
+			ttyOffset, nameOffset = 368, 368
+		}
+	}
+
+	return []manager.ConstantEditor{
+		{
+			Name:  "tty_offset",
+			Value: ttyOffset,
+		},
+		{
+			Name:  "tty_name_offset",
+			Value: nameOffset,
+		},
+	}
 }
 
 // InodeInfo holds information related to inode from kernel

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -530,10 +530,14 @@ func newEventSerializer(event *Event) *EventSerializer {
 	case model.FileOpenEventType:
 		s.FileEventSerializer = &FileEventSerializer{
 			FileSerializer: *newFileSerializer(&event.Open.File, event),
-			Destination: &FileSerializer{
-				Mode: &event.Open.Mode,
-			},
 		}
+
+		if event.Open.Flags&syscall.O_CREAT > 0 {
+			s.FileEventSerializer.Destination = &FileSerializer{
+				Mode: &event.Open.Mode,
+			}
+		}
+
 		s.FileSerializer.Flags = model.OpenFlags(event.Open.Flags).StringArray()
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(event.Open.Retval)
 	case model.FileMkdirEventType:

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -10,16 +10,15 @@ package tests
 import (
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
 	"unsafe"
 
-	"github.com/cobaugh/osrelease"
 	"golang.org/x/sys/unix"
 	"gotest.tools/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
 
@@ -42,10 +41,11 @@ func createOverlayLayers(t *testing.T, test *testModule) (string, string, string
 }
 
 func TestOverlayFS(t *testing.T) {
-	sles12 := false
-	osrelease, err := osrelease.Read()
+	var sles12 bool
+
+	kv, err := probe.NewKernelVersion()
 	if err == nil {
-		sles12 = osrelease["NAME"] == "SLES" && strings.HasPrefix(osrelease["VERSION_ID"], "12")
+		sles12 = kv.IsSLES12Kernel()
 	}
 
 	if testEnvironment == DockerEnvironment || sles12 {


### PR DESCRIPTION
### What does this PR do?

This PR fixes TTY report. It also re-enable the functional tests that was disable because of Suse kernel. It uses predefined offsets and add a fallback.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

TTY field should be part of the events generated.
