### PR TITLE
Upstart: change respawn limit to 4 times in 25 seconds

### DIFF
--- a/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
@@ -4,7 +4,7 @@ start on started networking
 stop on runlevel [!2345]
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_debian.process.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.process.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_debian.security.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.security.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -4,7 +4,7 @@ start on starting datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_debian.trace.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.trace.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
@@ -4,7 +4,7 @@ start on started network
 stop on runlevel [!2345]
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.process.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.process.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.security.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.security.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -4,7 +4,7 @@ start on starting datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.trace.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.trace.conf.erb
@@ -4,7 +4,7 @@ start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 console output

--- a/omnibus/config/templates/datadog-dogstatsd/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-dogstatsd/upstart_debian.conf.erb
@@ -4,7 +4,7 @@ start on started networking or started network
 stop on runlevel [!2345]
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 console log # redirect daemon's outputs to `/var/log/upstart/dogstatsd.log`

--- a/omnibus/config/templates/datadog-dogstatsd/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-dogstatsd/upstart_redhat.conf.erb
@@ -4,7 +4,7 @@ start on started networking or started network
 stop on runlevel [!2345]
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 # console log is not available before upstart 1.4. CentOS/RHEL6 use an earlier version of upstart.

--- a/omnibus/config/templates/datadog-iot-agent/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-iot-agent/upstart_debian.conf.erb
@@ -4,7 +4,7 @@ start on started networking
 stop on runlevel [!2345]
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or

--- a/omnibus/config/templates/datadog-iot-agent/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-iot-agent/upstart_redhat.conf.erb
@@ -4,7 +4,7 @@ start on started network
 stop on runlevel [!2345]
 
 respawn
-respawn limit 5 10
+respawn limit 4 25
 normal exit 0
 
 console output


### PR DESCRIPTION
### What does this PR do?

The previous value (5 times in 10 seconds) would still lead to infinite
startup loop, as on slow machines the startup itself sometimes takes
up to 5 seconds. Trying 4 times in 25 seconds seems to be safe
for even extremely slow machines (1 CPU + 2 GB memory).

### Motivation

Make the agent start correctly with upstart even on slow machines.

### Additional Notes

N/A

### Describe your test plan

Same as https://github.com/DataDog/datadog-agent/pull/7294 (this issue was found while testing solution implemented in that PR).
