### PR TITLE
Empty output from /proc/net/if_inet6 should be treated as IPv6 disabled

### DIFF
--- a/pkg/util/kernel/ip.go
+++ b/pkg/util/kernel/ip.go
@@ -5,12 +5,13 @@ package kernel
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
 // IsIPv6Enabled returns whether or not IPv6 has been enabled on the host
 func IsIPv6Enabled() bool {
-	_, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
-	return err == nil
+	ints, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
+	return err == nil && len(strings.TrimSpace(string(ints))) != 0
 }

--- a/pkg/util/kernel/ip.go
+++ b/pkg/util/kernel/ip.go
@@ -13,5 +13,5 @@ import (
 // IsIPv6Enabled returns whether or not IPv6 has been enabled on the host
 func IsIPv6Enabled() bool {
 	ints, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
-	return err == nil && len(strings.TrimSpace(string(ints))) != 0
+	return err == nil && strings.TrimSpace(string(ints)) != ""
 }


### PR DESCRIPTION
### What does this PR do?

Treats empty output from `/proc/net/if_inet6`, meaning there are no IPv6 interfaces, the same as IPv6 being disabled at the kernel level.

### Motivation

The following error with system-probe offset guessing in GKE:
```
new module `network_tracer` error: error guessing offsets: no IPv6 link local address found
```

### Describe your test plan

Deploy to a container in GKE.