### PR TITLE
[networks] Fix eBPF invalid memory read

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "e91f71b09170ec0b970acc6f3ba98b3f411a30ea823356fbff56010238e8d4fa")
+var Conntrack = NewRuntimeAsset("conntrack.c", "5534dd729acee2bc2549de286134ac7af54afe88904d84956c0f9002df89c637")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "e8faf4583451e5009db42d02675a3e2f23417adec486870139ac3588082c1504")
+var Tracer = NewRuntimeAsset("tracer.c", "547c7f22b1bfc9aecd8f30731ce533f36b08961eecdfd04c221b160e50dee460")

--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -30,6 +30,7 @@ int kprobe___nf_conntrack_hash_insert(struct pt_regs* ctx) {
     }
 
     struct nf_conntrack_tuple_hash tuplehash[IP_CT_DIR_MAX];
+    __builtin_memset(tuplehash, 0, sizeof(tuplehash));
     bpf_probe_read(&tuplehash, sizeof(tuplehash), &ct->tuplehash);
 
     struct nf_conntrack_tuple orig = tuplehash[IP_CT_DIR_ORIGINAL].tuple;

--- a/pkg/network/ebpf/c/tracer-telemetry.h
+++ b/pkg/network/ebpf/c/tracer-telemetry.h
@@ -47,7 +47,7 @@ static __always_inline void increment_telemetry_count(enum telemetry_counter cou
 static __always_inline void sockaddr_to_addr(struct sockaddr * sa, u64 * addr_h, u64 * addr_l, u16 * port) {
     if (!sa) return;
 
-    u16 family;
+    u16 family = 0;
     bpf_probe_read(&family, sizeof(family), &sa->sa_family);
 
     struct sockaddr_in * sin;

--- a/pkg/network/ebpf/c/tracer.h
+++ b/pkg/network/ebpf/c/tracer.h
@@ -119,6 +119,8 @@ typedef struct {
     // this is useful for detecting race conditions that result in a batch being overrriden
     // before it gets consumed from userspace
     __u64 idx;
+    // pos indicates the batch slot where the next http transaction should be written to
+    __u8 pos;
     // idx_to_notify is used to track which batch completions were notified to userspace
     // * if idx_to_notify == idx, the current index is still being appended to;
     // * if idx_to_notify < idx, the batch at idx_to_notify needs to be sent to userspace;

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -270,6 +270,7 @@ def kitchen_prepare(ctx):
             ctx,
             packages=pkg,
             skip_object_files=(i != 0),
+            skip_linters=True,
             bundle_ebpf=False,
             output_path=os.path.join(target_path, "testsuite"),
         )

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -28,7 +28,7 @@
     "ubuntu" : {
         "azure": {
             "ubuntu-14-04": "urn,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140",
-            "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201906170",
+            "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201604203",
             "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
             "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230"
         


### PR DESCRIPTION
### What does this PR do?

Fix invalid memory read that is causing system-probe to crash on older kernels (4.4.0)
Additionally we noticed that the Ubuntu 16.04 image our CI was using had a relatively new Kernel (4.15), so we're updating the image we use as well.

```
2021-03-10 16:24:03 UTC | SYS-PROBE | ERROR | (cmd/system-probe/loader.go:39 in Register) | new module `network_tracer` error: failed to init ebpf manager: couldn't load eBPF programs: program kretprobe/udp_recvmsg: can't load program: permission denied:
...
 R0=inv R1=fp-88 R6=inv R7=map_value(ks=8,vs=16) R8=imm0 R9=inv R10=fp fp-128=fp fp-120=fp fp-112=fp
46: (bf) r1 = r10
47: (07) r1 += -32
48: (b7) r2 = 2
49: (bf) r3 = r6
50: (85) call 4
invalid indirect read from stack off -32+0 size 2
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
