### PR TITLE
Fix ebpf crash on older kernels (ubuntu 16.04)

### DIFF
--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "e8faf4583451e5009db42d02675a3e2f23417adec486870139ac3588082c1504")
+var Tracer = NewRuntimeAsset("tracer.c", "d47b9901d07a05f2642459dc36b196929beaaeb202ee9053db65a044b13cdc7a")

--- a/pkg/network/ebpf/c/tracer-telemetry.h
+++ b/pkg/network/ebpf/c/tracer-telemetry.h
@@ -47,7 +47,7 @@ static __always_inline void increment_telemetry_count(enum telemetry_counter cou
 static __always_inline void sockaddr_to_addr(struct sockaddr * sa, u64 * addr_h, u64 * addr_l, u16 * port) {
     if (!sa) return;
 
-    u16 family;
+    u16 family = 0;
     bpf_probe_read(&family, sizeof(family), &sa->sa_family);
 
     struct sockaddr_in * sin;


### PR DESCRIPTION
### What does this PR do?

Fixes this error when loading ebpf code:

```        	Error:      	Received unexpected error:
        	            	failed to init ebpf manager: couldn't load eBPF programs: program kretprobe/udp_recvmsg: can't load program: permission denied: 0: (bf) r6 = r1
        	            	1: (85) call 14
        	            	2: (7b) *(u64 *)(r10 -48) = r0
        	            	3: (bf) r2 = r10
        	            	4: (07) r2 += -48
        	            	5: (18) r1 = 0xffff880036bb4780
        	            	7: (85) call 1
        	            	8: (bf) r7 = r0
        	            	9: (15) if r7 == 0x0 goto pc+324
        	            	 R0=map_value_or_null(ks=8,vs=16) R6=ctx R7=map_value(ks=8,vs=16) R10=fp
        	            	10: (bf) r2 = r10
        	            	11: (07) r2 += -48
        	            	12: (18) r1 = 0xffff880036bb4780
        	            	14: (85) call 3
        	            	15: (79) r9 = *(u64 *)(r6 +80)
        	            	16: (bf) r1 = r9
        	            	17: (67) r1 <<= 32
        	            	18: (c7) r1 s>>= 32
        	            	19: (b7) r6 = 0
        	            	20: (6d) if r6 s> r1 goto pc+313
        	            	 R0=inv R1=inv R6=imm0 R7=map_value(ks=8,vs=16) R9=inv R10=fp
        	            	21: (7b) *(u64 *)(r10 -56) = r6
        	            	22: (79) r3 = *(u64 *)(r7 +8)
        	            	23: (15) if r3 == 0x0 goto pc+5
        	            	 R0=inv R1=inv R3=inv R6=imm0 R7=map_value(ks=8,vs=16) R9=inv R10=fp
        	            	24: (bf) r1 = r10
        	            	25: (07) r1 += -56
        	            	26: (b7) r2 = 8
        	            	27: (85) call 4
        	            	28: (79) r6 = *(u64 *)(r10 -56)
        	            	29: (b7) r8 = 0
        	            	30: (7b) *(u64 *)(r10 -64) = r8
        	            	31: (7b) *(u64 *)(r10 -72) = r8
        	            	32: (7b) *(u64 *)(r10 -80) = r8
        	            	33: (7b) *(u64 *)(r10 -88) = r8
        	            	34: (7b) *(u64 *)(r10 -96) = r8
        	            	35: (7b) *(u64 *)(r10 -104) = r8
        	            	36: (bf) r1 = r10
        	            	37: (07) r1 += -70
        	            	38: (7b) *(u64 *)(r10 -112) = r1
        	            	39: (bf) r1 = r10
        	            	40: (07) r1 += -80
        	            	41: (7b) *(u64 *)(r10 -120) = r1
        	            	42: (bf) r1 = r10
        	            	43: (07) r1 += -88
        	            	44: (7b) *(u64 *)(r10 -128) = r1
        	            	45: (15) if r6 == 0x0 goto pc+31
        	            	 R0=inv R1=fp-88 R6=inv R7=map_value(ks=8,vs=16) R8=imm0 R9=inv R10=fp fp-128=fp fp-120=fp fp-112=fp
        	            	46: (bf) r1 = r10
        	            	47: (07) r1 += -32
        	            	48: (b7) r2 = 2
        	            	49: (bf) r3 = r6
        	            	50: (85) call 4
        	            	invalid indirect read from stack off -32+0 size 2
```

