### PR TITLE
[runtime-security] make policy and rule version part of events

### DIFF
--- a/pkg/security/module/event.go
+++ b/pkg/security/module/event.go
@@ -11,6 +11,7 @@ package module
 // easyjson:json
 type AgentContext struct {
 	RuleID        string `json:"rule_id"`
+	RuleVersion   string `json:"rule_version,omitempty"`
 	PolicyName    string `json:"policy_name,omitempty"`
 	PolicyVersion string `json:"policy_version,omitempty"`
 }

--- a/pkg/security/module/event_easyjson.go
+++ b/pkg/security/module/event_easyjson.go
@@ -131,6 +131,8 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule1(in *jl
 		switch key {
 		case "rule_id":
 			out.RuleID = string(in.String())
+		case "rule_version":
+			out.RuleVersion = string(in.String())
 		case "policy_name":
 			out.PolicyName = string(in.String())
 		case "policy_version":
@@ -153,6 +155,11 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(out *j
 		const prefix string = ",\"rule_id\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.RuleID))
+	}
+	if in.RuleVersion != "" {
+		const prefix string = ",\"rule_version\":"
+		out.RawString(prefix)
+		out.String(string(in.RuleVersion))
 	}
 	if in.PolicyName != "" {
 		const prefix string = ",\"policy_name\":"

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -326,7 +326,7 @@ func NewModule(cfg *config.Config) (api.Module, error) {
 
 	// custom limiters
 	limits := make(map[rules.RuleID]Limit)
-	limits[sprobe.AbnormalPathRuleID] = Limit{Limit: 5, Burst: 10}
+	limits[sprobe.AbnormalPathRuleID] = Limit{Limit: 0, Burst: 0}
 
 	m := &Module{
 		config:         cfg,

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -98,7 +98,8 @@ func (a *APIServer) DumpProcessCache(ctx context.Context, params *api.DumpProces
 // SendEvent forwards events sent by the runtime security module to Datadog
 func (a *APIServer) SendEvent(rule *rules.Rule, event Event) {
 	agentContext := &AgentContext{
-		RuleID: rule.Definition.ID,
+		RuleID:      rule.Definition.ID,
+		RuleVersion: rule.Definition.Version,
 	}
 
 	ruleEvent := &Signal{

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -46,18 +46,33 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 		case "policies":
 			if in.IsNull() {
 				in.Skip()
+				out.PoliciesLoaded = nil
 			} else {
-				in.Delim('{')
-				out.Policies = make(map[string]string)
-				for !in.IsDelim('}') {
-					key := string(in.String())
-					in.WantColon()
-					var v1 string
-					v1 = string(in.String())
-					(out.Policies)[key] = v1
+				in.Delim('[')
+				if out.PoliciesLoaded == nil {
+					if !in.IsDelim(']') {
+						out.PoliciesLoaded = make([]*PolicyLoaded, 0, 8)
+					} else {
+						out.PoliciesLoaded = []*PolicyLoaded{}
+					}
+				} else {
+					out.PoliciesLoaded = (out.PoliciesLoaded)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v1 *PolicyLoaded
+					if in.IsNull() {
+						in.Skip()
+						v1 = nil
+					} else {
+						if v1 == nil {
+							v1 = new(PolicyLoaded)
+						}
+						(*v1).UnmarshalEasyJSON(in)
+					}
+					out.PoliciesLoaded = append(out.PoliciesLoaded, v1)
 					in.WantComma()
 				}
-				in.Delim('}')
+				in.Delim(']')
 			}
 		case "policies_ignored":
 			if in.IsNull() {
@@ -74,49 +89,25 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 		case "macros_loaded":
 			if in.IsNull() {
 				in.Skip()
-				out.Macros = nil
+				out.MacrosLoaded = nil
 			} else {
 				in.Delim('[')
-				if out.Macros == nil {
+				if out.MacrosLoaded == nil {
 					if !in.IsDelim(']') {
-						out.Macros = make([]string, 0, 4)
+						out.MacrosLoaded = make([]string, 0, 4)
 					} else {
-						out.Macros = []string{}
+						out.MacrosLoaded = []string{}
 					}
 				} else {
-					out.Macros = (out.Macros)[:0]
+					out.MacrosLoaded = (out.MacrosLoaded)[:0]
 				}
 				for !in.IsDelim(']') {
 					var v2 string
 					v2 = string(in.String())
-					out.Macros = append(out.Macros, v2)
+					out.MacrosLoaded = append(out.MacrosLoaded, v2)
 					in.WantComma()
 				}
 				in.Delim(']')
-			}
-		case "rules_loaded":
-			if in.IsNull() {
-				in.Skip()
-				out.Rules = nil
-			} else {
-				if out.Rules == nil {
-					out.Rules = new(RuleSetLoaded)
-				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Rules).UnmarshalJSON(data))
-				}
-			}
-		case "rules_ignored":
-			if in.IsNull() {
-				in.Skip()
-				out.RulesIgnored = nil
-			} else {
-				if out.RulesIgnored == nil {
-					out.RulesIgnored = new(RulesIgnored)
-				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.RulesIgnored).UnmarshalJSON(data))
-				}
 			}
 		default:
 			in.SkipRecursive()
@@ -140,22 +131,21 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 	{
 		const prefix string = ",\"policies\":"
 		out.RawString(prefix)
-		if in.Policies == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
-			out.RawString(`null`)
+		if in.PoliciesLoaded == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
 		} else {
-			out.RawByte('{')
-			v3First := true
-			for v3Name, v3Value := range in.Policies {
-				if v3First {
-					v3First = false
-				} else {
+			out.RawByte('[')
+			for v3, v4 := range in.PoliciesLoaded {
+				if v3 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v3Name))
-				out.RawByte(':')
-				out.String(string(v3Value))
+				if v4 == nil {
+					out.RawString("null")
+				} else {
+					(*v4).MarshalEasyJSON(out)
+				}
 			}
-			out.RawByte('}')
+			out.RawByte(']')
 		}
 	}
 	if in.PoliciesIgnored != nil {
@@ -166,32 +156,18 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 	{
 		const prefix string = ",\"macros_loaded\":"
 		out.RawString(prefix)
-		if in.Macros == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		if in.MacrosLoaded == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v4, v5 := range in.Macros {
-				if v4 > 0 {
+			for v5, v6 := range in.MacrosLoaded {
+				if v5 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v5))
+				out.String(string(v6))
 			}
 			out.RawByte(']')
 		}
-	}
-	{
-		const prefix string = ",\"rules_loaded\":"
-		out.RawString(prefix)
-		if in.Rules == nil {
-			out.RawString("null")
-		} else {
-			out.Raw((*in.Rules).MarshalJSON())
-		}
-	}
-	if in.RulesIgnored != nil {
-		const prefix string = ",\"rules_ignored\":"
-		out.RawString(prefix)
-		out.Raw((*in.RulesIgnored).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -219,7 +195,333 @@ func (v *RulesetLoadedEvent) UnmarshalJSON(data []byte) error {
 func (v *RulesetLoadedEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jlexer.Lexer, out *NoisyProcessEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jlexer.Lexer, out *RuleLoaded) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = string(in.String())
+		case "version":
+			out.Version = string(in.String())
+		case "expression":
+			out.Expression = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jwriter.Writer, in RuleLoaded) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"id\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.ID))
+	}
+	if in.Version != "" {
+		const prefix string = ",\"version\":"
+		out.RawString(prefix)
+		out.String(string(in.Version))
+	}
+	{
+		const prefix string = ",\"expression\":"
+		out.RawString(prefix)
+		out.String(string(in.Expression))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v RuleLoaded) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v RuleLoaded) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *RuleLoaded) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *RuleLoaded) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(l, v)
+}
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jlexer.Lexer, out *RuleIgnored) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = string(in.String())
+		case "version":
+			out.Version = string(in.String())
+		case "expression":
+			out.Expression = string(in.String())
+		case "reason":
+			out.Reason = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jwriter.Writer, in RuleIgnored) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"id\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.ID))
+	}
+	if in.Version != "" {
+		const prefix string = ",\"version\":"
+		out.RawString(prefix)
+		out.String(string(in.Version))
+	}
+	{
+		const prefix string = ",\"expression\":"
+		out.RawString(prefix)
+		out.String(string(in.Expression))
+	}
+	{
+		const prefix string = ",\"reason\":"
+		out.RawString(prefix)
+		out.String(string(in.Reason))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v RuleIgnored) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v RuleIgnored) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *RuleIgnored) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *RuleIgnored) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(l, v)
+}
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jlexer.Lexer, out *PolicyLoaded) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "rules_loaded":
+			if in.IsNull() {
+				in.Skip()
+				out.RulesLoaded = nil
+			} else {
+				in.Delim('[')
+				if out.RulesLoaded == nil {
+					if !in.IsDelim(']') {
+						out.RulesLoaded = make([]*RuleLoaded, 0, 8)
+					} else {
+						out.RulesLoaded = []*RuleLoaded{}
+					}
+				} else {
+					out.RulesLoaded = (out.RulesLoaded)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v7 *RuleLoaded
+					if in.IsNull() {
+						in.Skip()
+						v7 = nil
+					} else {
+						if v7 == nil {
+							v7 = new(RuleLoaded)
+						}
+						(*v7).UnmarshalEasyJSON(in)
+					}
+					out.RulesLoaded = append(out.RulesLoaded, v7)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "rules_ignored":
+			if in.IsNull() {
+				in.Skip()
+				out.RulesIgnored = nil
+			} else {
+				in.Delim('[')
+				if out.RulesIgnored == nil {
+					if !in.IsDelim(']') {
+						out.RulesIgnored = make([]*RuleIgnored, 0, 8)
+					} else {
+						out.RulesIgnored = []*RuleIgnored{}
+					}
+				} else {
+					out.RulesIgnored = (out.RulesIgnored)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v8 *RuleIgnored
+					if in.IsNull() {
+						in.Skip()
+						v8 = nil
+					} else {
+						if v8 == nil {
+							v8 = new(RuleIgnored)
+						}
+						(*v8).UnmarshalEasyJSON(in)
+					}
+					out.RulesIgnored = append(out.RulesIgnored, v8)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jwriter.Writer, in PolicyLoaded) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"rules_loaded\":"
+		out.RawString(prefix[1:])
+		if in.RulesLoaded == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v9, v10 := range in.RulesLoaded {
+				if v9 > 0 {
+					out.RawByte(',')
+				}
+				if v10 == nil {
+					out.RawString("null")
+				} else {
+					(*v10).MarshalEasyJSON(out)
+				}
+			}
+			out.RawByte(']')
+		}
+	}
+	if len(in.RulesIgnored) != 0 {
+		const prefix string = ",\"rules_ignored\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('[')
+			for v11, v12 := range in.RulesIgnored {
+				if v11 > 0 {
+					out.RawByte(',')
+				}
+				if v12 == nil {
+					out.RawString("null")
+				} else {
+					(*v12).MarshalEasyJSON(out)
+				}
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v PolicyLoaded) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PolicyLoaded) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *PolicyLoaded) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PolicyLoaded) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(l, v)
+}
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jlexer.Lexer, out *NoisyProcessEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -274,7 +576,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jwriter.Writer, in NoisyProcessEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jwriter.Writer, in NoisyProcessEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -323,27 +625,27 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 // MarshalJSON supports json.Marshaler interface
 func (v NoisyProcessEvent) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(&w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v NoisyProcessEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *NoisyProcessEvent) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(&r, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *NoisyProcessEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jlexer.Lexer, out *EventLostWrite) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(in *jlexer.Lexer, out *EventLostWrite) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -377,9 +679,9 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v6 uint64
-					v6 = uint64(in.Uint64())
-					(out.Lost)[key] = v6
+					var v13 uint64
+					v13 = uint64(in.Uint64())
+					(out.Lost)[key] = v13
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -394,7 +696,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jwriter.Writer, in EventLostWrite) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(out *jwriter.Writer, in EventLostWrite) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -415,16 +717,16 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v7First := true
-			for v7Name, v7Value := range in.Lost {
-				if v7First {
-					v7First = false
+			v14First := true
+			for v14Name, v14Value := range in.Lost {
+				if v14First {
+					v14First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v7Name))
+				out.String(string(v14Name))
 				out.RawByte(':')
-				out.Uint64(uint64(v7Value))
+				out.Uint64(uint64(v14Value))
 			}
 			out.RawByte('}')
 		}
@@ -435,27 +737,27 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 // MarshalJSON supports json.Marshaler interface
 func (v EventLostWrite) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventLostWrite) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *EventLostWrite) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&r, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventLostWrite) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jlexer.Lexer, out *EventLostRead) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(in *jlexer.Lexer, out *EventLostRead) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -492,7 +794,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jwriter.Writer, in EventLostRead) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jwriter.Writer, in EventLostRead) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -517,27 +819,27 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 // MarshalJSON supports json.Marshaler interface
 func (v EventLostRead) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventLostRead) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *EventLostRead) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&r, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventLostRead) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(l, v)
 }
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jlexer.Lexer, out *AbnormalPathEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(in *jlexer.Lexer, out *AbnormalPathEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -582,7 +884,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jwriter.Writer, in AbnormalPathEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(out *jwriter.Writer, in AbnormalPathEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -611,23 +913,23 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 // MarshalJSON supports json.Marshaler interface
 func (v AbnormalPathEvent) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AbnormalPathEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(w, v)
+	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *AbnormalPathEvent) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&r, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AbnormalPathEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(l, v)
+	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(l, v)
 }

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -21,7 +21,14 @@ type MacroID = string
 // MacroDefinition holds the definition of a macro
 type MacroDefinition struct {
 	ID         MacroID `yaml:"id"`
+	Version    string  `yaml:"version"`
 	Expression string  `yaml:"expression"`
+}
+
+// Macro describes a macro of a ruleset
+type Macro struct {
+	*eval.Macro
+	Definition *MacroDefinition
 }
 
 // RuleID represents the ID of a rule
@@ -30,6 +37,7 @@ type RuleID = string
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
 	ID          RuleID            `yaml:"id"`
+	Version     string            `yaml:"version"`
 	Expression  string            `yaml:"expression"`
 	Description string            `yaml:"description"`
 	Tags        map[string]string `yaml:"tags"`
@@ -93,7 +101,8 @@ type RuleSet struct {
 	opts             *Opts
 	loadedPolicies   map[string]string
 	eventRuleBuckets map[eval.EventType]*RuleBucket
-	rules            map[eval.RuleID]*eval.Rule
+	rules            map[eval.RuleID]*Rule
+	macros           map[eval.RuleID]*Macro
 	model            eval.Model
 	eventCtor        func() eval.Event
 	listeners        []RuleSetListener
@@ -112,7 +121,7 @@ func (rs *RuleSet) ListRuleIDs() []RuleID {
 }
 
 // GetRules returns the active rules
-func (rs *RuleSet) GetRules() map[eval.RuleID]*eval.Rule {
+func (rs *RuleSet) GetRules() map[eval.RuleID]*Rule {
 	return rs.rules
 }
 
@@ -123,11 +132,6 @@ func (rs *RuleSet) ListMacroIDs() []MacroID {
 		ids = append(ids, macroID)
 	}
 	return ids
-}
-
-// ListPolicies returns the list of loaded policies and their version
-func (rs *RuleSet) ListPolicies() map[string]string {
-	return rs.loadedPolicies
 }
 
 // AddMacros parses the macros AST and adds them to the list of macros of the ruleset
@@ -150,9 +154,12 @@ func (rs *RuleSet) AddMacro(macroDef *MacroDefinition) (*eval.Macro, error) {
 		return nil, &ErrMacroLoad{Definition: macroDef, Err: errors.New("multiple definition with the same ID")}
 	}
 
-	macro := &eval.Macro{
-		ID:         macroDef.ID,
-		Expression: macroDef.Expression,
+	macro := &Macro{
+		Macro: &eval.Macro{
+			ID:         macroDef.ID,
+			Expression: macroDef.Expression,
+		},
+		Definition: macroDef,
 	}
 
 	if err := macro.Parse(); err != nil {
@@ -163,9 +170,9 @@ func (rs *RuleSet) AddMacro(macroDef *MacroDefinition) (*eval.Macro, error) {
 		return nil, &ErrMacroLoad{Definition: macroDef, Err: errors.Wrap(err, "compilation error")}
 	}
 
-	rs.opts.Macros[macro.ID] = macro
+	rs.opts.Macros[macro.ID] = macro.Macro
 
-	return macro, nil
+	return macro.Macro, nil
 }
 
 // AddRules adds rules to the ruleset and generate their partials
@@ -253,7 +260,7 @@ func (rs *RuleSet) AddRule(ruleDef *RuleDefinition) (*eval.Rule, error) {
 	// Merge the fields of the new rule with the existing list of fields of the ruleset
 	rs.AddFields(rule.GetEvaluator().GetFields())
 
-	rs.rules[ruleDef.ID] = rule.Rule
+	rs.rules[ruleDef.ID] = rule
 
 	return rule.Rule, nil
 }
@@ -441,7 +448,8 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts) *Rule
 		eventCtor:        eventCtor,
 		opts:             opts,
 		eventRuleBuckets: make(map[eval.EventType]*RuleBucket),
-		rules:            make(map[eval.RuleID]*eval.Rule),
+		rules:            make(map[eval.RuleID]*Rule),
+		macros:           make(map[eval.RuleID]*Macro),
 		loadedPolicies:   make(map[string]string),
 		logger:           opts.Logger,
 	}


### PR DESCRIPTION
### What does this PR do?

policy version and rule version were not part of rule_loaded events nor security events.

### Motivation

Backend is supposed to receive them as part of the rules and policies attributes.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
