### PR TITLE
Revert "trace/agent: missing API key is now logged with the logger and not just stdout (#7570)"

### DIFF
--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -43,22 +43,9 @@ func Run(ctx context.Context) {
 	}
 
 	cfg, err := config.Load(flags.ConfigPath)
-	if err := coreconfig.SetupLogger(
-		coreconfig.LoggerName("TRACE"),
-		cfg.LogLevel,
-		cfg.LogFilePath,
-		coreconfig.GetSyslogURI(),
-		coreconfig.Datadog.GetBool("syslog_rfc"),
-		coreconfig.Datadog.GetBool("log_to_console"),
-		coreconfig.Datadog.GetBool("log_format_json"),
-	); err != nil {
-		osutil.Exitf("Cannot create logger: %v", err)
-	}
-	defer log.Flush()
-
 	if err != nil {
 		if err == config.ErrMissingAPIKey {
-			log.Critical(config.ErrMissingAPIKey)
+			fmt.Println(config.ErrMissingAPIKey)
 
 			// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
 			// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
@@ -83,6 +70,19 @@ func Run(ctx context.Context) {
 		}
 		return
 	}
+
+	if err := coreconfig.SetupLogger(
+		coreconfig.LoggerName("TRACE"),
+		cfg.LogLevel,
+		cfg.LogFilePath,
+		coreconfig.GetSyslogURI(),
+		coreconfig.Datadog.GetBool("syslog_rfc"),
+		coreconfig.Datadog.GetBool("log_to_console"),
+		coreconfig.Datadog.GetBool("log_format_json"),
+	); err != nil {
+		osutil.Exitf("Cannot create logger: %v", err)
+	}
+	defer log.Flush()
 
 	if !cfg.Enabled {
 		log.Info(messageAgentDisabled)

--- a/releasenotes/notes/apm-start-up-error-logging-3e927cdbb059db57.yaml
+++ b/releasenotes/notes/apm-start-up-error-logging-3e927cdbb059db57.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    APM: Ensured missing API key at startup is correctly logged.


### PR DESCRIPTION
This reverts commit 4e9245b348915d2b8026ee2a9084102a7ac1e0bd (PR #7570).