### PR TITLE
Fix sysprobe not restarting with the Agent on upstart

### DIFF
--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -1,6 +1,6 @@
 description "Datadog System Probe"
 
-start on starting datadog-agent
+start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -1,6 +1,6 @@
 description "Datadog System Probe"
 
-start on starting datadog-agent
+start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn


### PR DESCRIPTION
### What does this PR do?

Use `started` instead of `starting` like it's done for the trace and other agent binaries.

### Motivation

Restarting the Agent didn't restart the sysprobe.
