### PR TITLE
[hack-a-dog] Native golang dynamic plugins - DO NOT MERGE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ pkg/network/netlink/testdata/message_dump*
 # serverless
 .layers
 .extension
+
+# Experimental
+go-native-plugins/

--- a/examples/native_golang_plugins/cpu_plugin/.gitignore
+++ b/examples/native_golang_plugins/cpu_plugin/.gitignore
@@ -1,0 +1,5 @@
+// Our shared library artifact
+cpu_plugin.so
+
+// We don't really care about checksums for the example
+go.sum

--- a/examples/native_golang_plugins/cpu_plugin/build.sh
+++ b/examples/native_golang_plugins/cpu_plugin/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+output_file="cpu_plugin.so"
+
+echo "Compiling plugin..."
+go build -o "$output_file" -buildmode=plugin plugin.go
+
+echo "Artifact: $output_file"
+echo "Place this file in '<CURRENT_DIR>/go-native-plugins' directory before starting the agent"
+echo "Compiling plugin: OK"

--- a/examples/native_golang_plugins/cpu_plugin/plugin.go
+++ b/examples/native_golang_plugins/cpu_plugin/plugin.go
@@ -1,0 +1,160 @@
+// +build !windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/shirou/gopsutil/cpu"
+
+	"github.com/DataDog/datadog-agent/pkg/api/plugin"
+)
+
+const cpuCheckName = "cpu_plugin"
+const version = "0.0.1"
+
+// For testing purpose
+var times = cpu.Times
+var cpuInfo = cpu.Info
+
+// CPUCheck holds all the info about this plugin
+type CPUCheck struct {
+	// CheckBase
+	checkName      string
+	checkID        string
+	latestWarnings []error
+	checkInterval  time.Duration
+	source         string
+	telemetry      bool
+
+	nbCPU       float64
+	lastNbCycle float64
+	lastTimes   cpu.TimesStat
+}
+
+// Run runs the check
+func (c *CPUCheck) Run(sender plugin.Sender) error {
+	if sender == nil {
+		return errors.New("system.plugin.CPUCheck: Sender for the check invocation was empty")
+	}
+
+	cpuTimes, err := times(false)
+	if err != nil {
+		log.Printf("system.plugin.CPUCheck: could not retrieve cpu stats: %s", err)
+		return err
+	} else if len(cpuTimes) < 1 {
+		errEmpty := fmt.Errorf("no cpu stats retrieve (empty results)")
+		log.Printf("system.plugin.CPUCheck: %s", errEmpty)
+		return errEmpty
+	}
+	t := cpuTimes[0]
+
+	nbCycle := t.Total() / c.nbCPU
+
+	if c.lastNbCycle != 0 {
+		// gopsutil return the sum of every CPU
+		toPercent := 100 / (nbCycle - c.lastNbCycle)
+
+		user := ((t.User + t.Nice) - (c.lastTimes.User + c.lastTimes.Nice)) / c.nbCPU
+		system := ((t.System + t.Irq + t.Softirq) - (c.lastTimes.System + c.lastTimes.Irq + c.lastTimes.Softirq)) / c.nbCPU
+		iowait := (t.Iowait - c.lastTimes.Iowait) / c.nbCPU
+		idle := (t.Idle - c.lastTimes.Idle) / c.nbCPU
+		stolen := (t.Steal - c.lastTimes.Steal) / c.nbCPU
+		guest := (t.Guest - c.lastTimes.Guest) / c.nbCPU
+
+		sender.Gauge("system.cpu_plugin.user", user*toPercent, "", nil)
+		sender.Gauge("system.cpu_plugin.system", system*toPercent, "", nil)
+		sender.Gauge("system.cpu_plugin.iowait", iowait*toPercent, "", nil)
+		sender.Gauge("system.cpu_plugin.idle", idle*toPercent, "", nil)
+		sender.Gauge("system.cpu_plugin.stolen", stolen*toPercent, "", nil)
+		sender.Gauge("system.cpu_plugin.guest", guest*toPercent, "", nil)
+	}
+
+	sender.Gauge("system.cpu_plugin.num_cores", c.nbCPU, "", nil)
+	sender.Commit()
+
+	c.lastNbCycle = nbCycle
+	c.lastTimes = t
+	return nil
+}
+
+// FIXME: Do something here with config stuff
+func (c *CPUCheck) commonConfigure(data []byte, source string) error {
+	c.source = source
+	return nil
+}
+
+// Configure the CPU check
+func (c *CPUCheck) Configure(data []byte, initConfig []byte, source string) error {
+	err := c.commonConfigure(data, source)
+	if err != nil {
+		return err
+	}
+	// NOTE: This runs before the python checks, so we should be good, but cpuInfo()
+	//       on windows initializes COM to the multithreaded model. Therefore,
+	//       if a python check has run on this native windows thread prior and
+	//       CoInitialized() the thread to a different model (ie. single-threaded)
+	//       This will cause cpuInfo() to fail.
+	info, err := cpuInfo()
+	if err != nil {
+		return fmt.Errorf("system.plugin.CPUCheck: could not query CPU info")
+	}
+	for _, i := range info {
+		c.nbCPU += float64(i.Cores)
+	}
+	return nil
+}
+
+// Canned API below
+
+// Cancel cancels the check. Cancel is called when the check is unscheduled:
+// - unlike Stop, it is called even if the check is not running when it's unscheduled
+// - if the check is running, Cancel is called after Stop and may be called before the call to Stop completes
+func (c *CPUCheck) Cancel() {}
+
+// ConfigSource returns the configuration source of the check
+func (c *CPUCheck) ConfigSource() string { return c.source }
+
+// GetMetricStats gets metric stats from the sender
+func (c *CPUCheck) GetMetricStats() (map[string]int64, error) {
+	return map[string]int64{}, nil
+}
+
+// GetWarnings returns the last warning registered by the check
+func (c *CPUCheck) GetWarnings() []error { return []error{} }
+
+// ID provides a unique identifier for every check instance
+func (c *CPUCheck) ID() string { return c.checkID }
+
+// Interval returns the interval time for the check
+func (c *CPUCheck) Interval() time.Duration { return 5 * time.Second }
+
+// IsTelemetryEnabled returns if telemetry is enabled for this check
+func (c *CPUCheck) IsTelemetryEnabled() bool { return false }
+
+// Stop stops the check if it's running
+func (c *CPUCheck) Stop() {}
+
+// String provides a printable version of the check name
+func (c *CPUCheck) String() string { return fmt.Sprintf("plugin: %s", c.checkID) }
+
+// Version returns the version of the check if available
+func (c *CPUCheck) Version() string { return version }
+
+// NewCheck creates a new instance of a CPUCheck
+func NewCheck() plugin.Check {
+	return &CPUCheck{
+		checkID: cpuCheckName,
+	}
+}
+
+// PluginInfo contains the plugin main metadata
+func PluginInfo() map[string]string {
+	return map[string]string{
+		"id":      cpuCheckName,
+		"version": version,
+	}
+}

--- a/pkg/api/plugin/check.go
+++ b/pkg/api/plugin/check.go
@@ -1,0 +1,35 @@
+package plugin
+
+import (
+	"time"
+)
+
+// Check is an interface for types capable to run checks
+type Check interface {
+	// Run runs the check
+	Run(Sender) error
+	// Stop stops the check if it's running
+	Stop()
+	// Cancel cancels the check. Cancel is called when the check is unscheduled:
+	// - unlike Stop, it is called even if the check is not running when it's unscheduled
+	// - if the check is running, Cancel is called after Stop and may be called before the call to Stop completes
+	Cancel()
+	// String provides a printable version of the check name
+	String() string
+	// Configure configures the check
+	Configure(config, initConfig []byte, source string) error
+	// Interval returns the interval time for the check
+	Interval() time.Duration
+	// ID provides a unique identifier for every check instance
+	ID() string
+	// GetWarnings returns the last warning registered by the check
+	GetWarnings() []error
+	// GetMetricStats gets metric stats from the sender
+	GetMetricStats() (map[string]int64, error)
+	// Version returns the version of the check if available
+	Version() string
+	// ConfigSource returns the configuration source of the check
+	ConfigSource() string
+	// IsTelemetryEnabled returns if telemetry is enabled for this check
+	IsTelemetryEnabled() bool
+}

--- a/pkg/api/plugin/sender.go
+++ b/pkg/api/plugin/sender.go
@@ -1,0 +1,25 @@
+package plugin
+
+// Sender allows sending metrics from checks/a check
+type Sender interface {
+	Gauge(metric string, value float64, hostname string, tags []string)
+	Rate(metric string, value float64, hostname string, tags []string)
+	Count(metric string, value float64, hostname string, tags []string)
+	MonotonicCount(metric string, value float64, hostname string, tags []string)
+	MonotonicCountWithFlushFirstValue(metric string, value float64, hostname string, tags []string, flushFirstValue bool)
+	Counter(metric string, value float64, hostname string, tags []string)
+	Histogram(metric string, value float64, hostname string, tags []string)
+	Historate(metric string, value float64, hostname string, tags []string)
+	HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string)
+	GetMetricStats() map[string]int64
+	DisableDefaultHostname(disable bool)
+	SetCheckCustomTags(tags []string)
+	SetCheckService(service string)
+	FinalizeCheckServiceTag()
+
+	//	ServiceCheck(checkName string, status metrics.ServiceCheckStatus, hostname string, tags []string, message string)
+	//	Event(e metrics.Event)
+	//	OrchestratorMetadata(msgs []serializer.ProcessMessageBody, clusterID, payloadType string)
+
+	Commit()
+}

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -11,8 +11,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/plugin"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+//HACK: Force import
+var _ plugin.GoNativePluginCheckLoader
 
 // CheckFactory factory function type to instantiate checks
 type CheckFactory func() check.Check

--- a/pkg/plugin/go_native_loader.go
+++ b/pkg/plugin/go_native_loader.go
@@ -1,0 +1,217 @@
+package plugin
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"plugin"
+	"strings"
+
+	pluginApi "github.com/DataDog/datadog-agent/pkg/api/plugin"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// CheckFactory is an alias for a check factory function in a plugin
+type CheckFactory func() pluginApi.Check
+
+// GoNativePluginCheckLoader is a structure to hold our loaded check factories from
+// plugins
+type GoNativePluginCheckLoader struct {
+	checks map[string]CheckFactory
+}
+
+type pluginLibrary interface {
+	Lookup(string) (plugin.Symbol, error)
+}
+
+// PluginPathSuffix is a path that will be added to the current working directory as
+// a plugin library repository
+const PluginPathSuffix = "go-native-plugins"
+
+func init() {
+	loaderFactory := func() (check.Loader, error) {
+		loader, err := NewGoNativePluginCheckLoader()
+		if err != nil {
+			log.Error(err)
+		}
+
+		return loader, nil
+	}
+
+	loaders.RegisterLoader(10, loaderFactory)
+}
+
+func loadPlugins(filePaths []string) (map[string]pluginLibrary, error) {
+	pluginLibraries := map[string]pluginLibrary{}
+	for _, filePath := range filePaths {
+		fileName := path.Base(filePath)
+		if !strings.HasSuffix(fileName, ".so") {
+			log.Warnf("Ignoring '%s' - wrong extension ", fileName)
+			continue
+		}
+
+		pluginObj, err := plugin.Open(filePath)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+
+		log.Warnf("*** Loaded plugin '%s' ***", fileName)
+
+		pluginLibraries[fileName[:len(fileName)-3]] = pluginObj
+	}
+
+	return pluginLibraries, nil
+}
+
+func getPluginFiles(pluginDir string) (map[string]pluginLibrary, error) {
+	_, err := os.Stat(pluginDir)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("Plugin dir '%s' not found", pluginDir)
+	}
+
+	files, err := ioutil.ReadDir(pluginDir)
+	if err != nil {
+		return nil, err
+	}
+
+	filePaths := []string{}
+	for _, file := range files {
+		filePaths = append(filePaths, path.Join(pluginDir, file.Name()))
+	}
+
+	return loadPlugins(filePaths)
+}
+
+func (loader *GoNativePluginCheckLoader) symbol(
+	library pluginLibrary,
+	symbolName string,
+) (plugin.Symbol, error) {
+
+	symbol, err := library.Lookup(symbolName)
+	if err != nil {
+		return nil, err
+	}
+
+	return symbol, nil
+}
+
+func (loader *GoNativePluginCheckLoader) loadPlugin(
+	library pluginLibrary,
+) (map[string]string, CheckFactory, error) {
+	infoSymbol, err := loader.symbol(library, "PluginInfo")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	info, ok := infoSymbol.(func() map[string]string)
+	if !ok {
+		log.Errorf("Could not cast PluginInfo symbol: %s", err)
+		return nil, nil, err
+	}
+
+	factorySymbol, err := loader.symbol(library, "NewCheck")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	checkFactoryFunc, ok := factorySymbol.(func() pluginApi.Check)
+	if !ok {
+		log.Errorf("Could not cast NewCheck symbol: %s", err)
+		return nil, nil, err
+	}
+
+	return info(), checkFactoryFunc, nil
+}
+
+// NewGoNativePluginCheckLoader creates a new loader object for native Golang plugins
+func NewGoNativePluginCheckLoader() (*GoNativePluginCheckLoader, error) {
+	currDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"golang-native-plugin.loader: Could not get current working dir: %s",
+			err,
+		)
+	}
+
+	loadingPath := path.Join(currDir, PluginPathSuffix)
+	log.Infof("GoNativePluginCheckLoader using path: %s", loadingPath)
+
+	loader := &GoNativePluginCheckLoader{
+		checks: map[string]CheckFactory{},
+	}
+
+	return loader, loader.loadAllPlugins(loadingPath)
+}
+
+func (loader *GoNativePluginCheckLoader) loadAllPlugins(pluginDir string) error {
+	log.Warnf("Loading all plugins in %s", pluginDir)
+
+	pluginLibraries, err := getPluginFiles(pluginDir)
+	if err != nil {
+		log.Warn(err)
+		return err
+	}
+
+	for pluginFsName, pluginLibrary := range pluginLibraries {
+		log.Warnf("   -> Caching: %s: %v", pluginFsName, pluginLibrary)
+
+		pluginInfo, newCheckFunc, err := loader.loadPlugin(pluginLibrary)
+		if err != nil {
+			return err
+		}
+
+		pluginName := pluginInfo["id"]
+
+		log.Warnf(
+			"****** Loaded plugin >>>>> %s@%s <<<<< *****",
+			pluginName,
+			pluginInfo["version"],
+		)
+
+		loader.checks[pluginName] = newCheckFunc
+	}
+
+	return nil
+}
+
+// Load returns a Go check given a configuration object and its initialization data
+func (loader *GoNativePluginCheckLoader) Load(
+	config integration.Config,
+	instance integration.Data,
+) (check.Check, error) {
+
+	factory, found := loader.checks[config.Name]
+	if !found {
+		return nil, fmt.Errorf(
+			"golang-native-plugin.loader: Check %s not found in Golang native loader",
+			config.Name,
+		)
+	}
+
+	log.Warnf("golang-native-plugin.loader: Found plugin %s - attempting to load it...", config.Name)
+
+	c := NewPluginCheckAdapter(factory())
+	if err := c.Configure(instance, config.InitConfig, config.Source); err != nil {
+		return nil, fmt.Errorf(
+			"golang-native-plugin.loader: Could not configure check %s: %s",
+			c,
+			err,
+		)
+	}
+
+	return c, nil
+}
+
+// Name return returns Go loader name
+func (loader *GoNativePluginCheckLoader) Name() string {
+	return "golang-native-plugin"
+}
+
+func (loader *GoNativePluginCheckLoader) String() string {
+	return "Go Native Plugin Check Loader"
+}

--- a/pkg/plugin/plugin_check_adapter.go
+++ b/pkg/plugin/plugin_check_adapter.go
@@ -1,0 +1,47 @@
+package plugin
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	pluginApi "github.com/DataDog/datadog-agent/pkg/api/plugin"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
+type checkAdapter struct {
+	check pluginApi.Check
+}
+
+// NewPluginCheckAdapter creates a new adapter that can shuffle information
+// between a pluginApi check and a check.Check
+func NewPluginCheckAdapter(pluginCheck pluginApi.Check) check.Check {
+	return &checkAdapter{
+		check: pluginCheck,
+	}
+}
+
+func (ca *checkAdapter) Run() error {
+	sender, err := aggregator.GetSender(ca.ID())
+	if err != nil {
+		return err
+	}
+
+	return ca.check.Run(sender)
+}
+
+func (ca *checkAdapter) Stop()          { ca.check.Stop() }
+func (ca *checkAdapter) Cancel()        { ca.check.Cancel() }
+func (ca *checkAdapter) String() string { return ca.check.String() }
+func (ca *checkAdapter) Configure(config, initConfig integration.Data, source string) error {
+	return ca.check.Configure(config, initConfig, source)
+}
+func (ca *checkAdapter) Interval() time.Duration { return ca.check.Interval() }
+func (ca *checkAdapter) ID() check.ID            { return check.ID(ca.check.ID()) }
+func (ca *checkAdapter) GetWarnings() []error    { return ca.check.GetWarnings() }
+func (ca *checkAdapter) GetMetricStats() (map[string]int64, error) {
+	return ca.check.GetMetricStats()
+}
+func (ca *checkAdapter) Version() string          { return ca.check.Version() }
+func (ca *checkAdapter) ConfigSource() string     { return ca.check.ConfigSource() }
+func (ca *checkAdapter) IsTelemetryEnabled() bool { return ca.check.IsTelemetryEnabled() }


### PR DESCRIPTION
### What does this PR do?

#### **EXPERIMENTAL - DO NOT MERGE**

Adds experimental code for use of [dynamic native Golang plugins](https://golang.org/pkg/plugin/) and a sample plugin that uses this feature

### Motivation

Currently the only dynamic plugin extensibility we can have on the agent is via Python which isn't as performant as Golang

### Additional Notes

**EXPERIMENTAL**

### Describe your test plan

```sh
$ # Build the plugin
$ cd examples/native_golang_plugins/cpu_plugin
$ ./build.sh
...
$ # Copy the plugin to the appropriate dir of the agent (currently <CURR_DIR>/go-native-plugins)
$ mkdir -p ../../../../datadog-agent/go-native-plugins/
$ cp cpu_plugin.so ../../../../datadog-agent/go-native-plugins/
...
$ # Optional - enable the check
$ sudo mkdir. -p /opt/datadog-agent/etc/conf.d/cpu_plugin.d
$ sudo chown -R $(id -un) /opt/datadog-agent/etc/conf.d
$ echo -e "instances:\n  - {}" > /opt/datadog-agent/etc/conf.d/cpu_plugin.d/conf.yaml.default
...
$ # Build and run the agent
cd ../../../..  # Base agent dir
$ inv agent.build --python-runtimes 3 
$ ./bin/agent/agent run -c ....
```

In the output you should see something like:
```
...
2021-03-12 10:40:49 CST | CORE | INFO | (pkg/plugin/go_native_loader.go:142 in NewGoNativePluginCheckLoader) | GoNativePluginCheckLoader using path: /Users/srdjan.grubor/checkout/tmp/datadog-agent/go-native-plugins
2021-03-12 10:40:49 CST | CORE | WARN | (pkg/plugin/go_native_loader.go:152 in loadAllPlugins) | Loading all plugins in /Users/srdjan.grubor/checkout/tmp/datadog-agent/go-native-plugins
2021-03-12 10:40:49 CST | CORE | WARN | (pkg/plugin/go_native_loader.go:63 in loadPlugins) | *** Loaded plugin 'cpu_plugin.so' ***
2021-03-12 10:40:49 CST | CORE | WARN | (pkg/plugin/go_native_loader.go:161 in loadAllPlugins) |    -> Caching: cpu_plugin: &{plugin/unnamed-***********************************7050c  0xc00072e480 map[NewCheck:0x14d870e0 PluginInfo:0x14d87160]}
2021-03-12 10:40:49 CST | CORE | WARN | (pkg/plugin/go_native_loader.go:170 in loadAllPlugins) | ****** Loaded plugin >>>>> cpu_plugin@0.0.1 <<<<< *****
...
2021-03-12 10:40:49 CST | CORE | WARN | (pkg/plugin/go_native_loader.go:196 in Load) | golang-native-plugin.loader: Found plugin cpu_plugin - attempting to load it...
...
2021-03-12 10:40:51 CST | CORE | INFO | (pkg/collector/scheduler/scheduler.go:85 in Enter) | Scheduling check plugin: cpu_plugin with an interval of 5s
...
2021-03-12 10:40:52 CST | CORE | INFO | (pkg/collector/runner/runner.go:261 in work) | check:plugin: cpu_plugin | Running check
...
2021-03-12 10:40:52 CST | CORE | INFO | (pkg/collector/runner/runner.go:327 in work) | check:plugin: cpu_plugin | Done running check
```

The plugin reports almost all the same metrics as the cpu check but with a `cpu_plugin` selector:
```sg
system.cpu_plugin.user
system.cpu_plugin.system
system.cpu_plugin.iowait
system.cpu_plugin.idle
system.cpu_plugin.stolen
system.cpu_plugin.guest
system.cpu_plugin.num_cores
```

