### PR TITLE
Fix Metadata APIs in DCA when cluster checks are disabled

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -57,7 +57,6 @@ func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Ha
 
 // StartServer creates the router and starts the HTTP server
 func StartServer() error {
-
 	initializeTLS()
 
 	// get the transport we're going to use under HTTP

--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -199,8 +199,8 @@ func run(cmd *cobra.Command, args []string) error {
 	var clusterCheckHandler *clusterchecks.Handler
 	clusterCheckHandler, err = setupClusterCheck(mainCtx)
 	if err == nil {
-		api.ModifyRouter(func(r *mux.Router) {
-			dcav1.Install(r.PathPrefix("/api/v1").Subrouter(), clusteragent.ServerContext{ClusterCheckHandler: clusterCheckHandler})
+		api.ModifyAPIRouter(func(r *mux.Router) {
+			dcav1.InstallChecksEndpoints(r, clusteragent.ServerContext{ClusterCheckHandler: clusterCheckHandler})
 		})
 	} else {
 		log.Errorf("Error while setting up cluster check Autodiscovery %v", err)

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -23,23 +23,29 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/agent"
+	v1 "github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 var (
-	listener net.Listener
-	router   *mux.Router
+	listener  net.Listener
+	router    *mux.Router
+	apiRouter *mux.Router
 )
 
 // StartServer creates the router and starts the HTTP server
 func StartServer() error {
 	// create the root HTTP router
 	router = mux.NewRouter()
+	apiRouter = router.PathPrefix("/api/v1").Subrouter()
 
 	// IPC REST API server
 	agent.SetupHandlers(router)
+
+	// API V1 Metadata APIs
+	v1.InstallMetadataEndpoints(apiRouter)
 
 	// Validate token for every request
 	router.Use(validateToken)
@@ -98,9 +104,9 @@ func StartServer() error {
 	return nil
 }
 
-// ModifyRouter allows to pass in a function to modify router used in server
-func ModifyRouter(f func(*mux.Router)) {
-	f(router)
+// ModifyAPIRouter allows to pass in a function to modify router used in server
+func ModifyAPIRouter(f func(*mux.Router)) {
+	f(apiRouter)
 }
 
 // StopServer closes the connection and the server

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
@@ -25,13 +26,19 @@ func incrementRequestMetric(handler string, status int) {
 	apiRequests.Inc(handler, strconv.Itoa(status))
 }
 
-// Install registers v1 API endpoints
-func Install(r *mux.Router, sc clusteragent.ServerContext) {
+// InstallMetadataEndpoints registers endpoints for metadata
+func InstallMetadataEndpoints(r *mux.Router) {
+	log.Debug("Registering metadata endpoints")
 	if config.Datadog.GetBool("cloud_foundry") {
 		installCloudFoundryMetadataEndpoints(r)
 	} else {
 		installKubernetesMetadataEndpoints(r)
 	}
+}
+
+// InstallChecksEndpoints registers endpoints for cluster checks
+func InstallChecksEndpoints(r *mux.Router, sc clusteragent.ServerContext) {
+	log.Debug("Registering checks endpoints")
 	installClusterCheckEndpoints(r, sc)
 	installEndpointsCheckEndpoints(r, sc)
 }

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -299,8 +299,8 @@ func start(cmd *cobra.Command, args []string) error {
 		// Start the cluster check Autodiscovery
 		clusterCheckHandler, err := setupClusterCheck(mainCtx)
 		if err == nil {
-			api.ModifyRouter(func(r *mux.Router) {
-				dcav1.Install(r.PathPrefix("/api/v1").Subrouter(), clusteragent.ServerContext{ClusterCheckHandler: clusterCheckHandler})
+			api.ModifyAPIRouter(func(r *mux.Router) {
+				dcav1.InstallChecksEndpoints(r, clusteragent.ServerContext{ClusterCheckHandler: clusterCheckHandler})
 			})
 		} else {
 			log.Errorf("Error while setting up cluster check Autodiscovery, CLC API endpoints won't be available, err: %v", err)


### PR DESCRIPTION
### What does this PR do?

Fix bug following refactor in #7407 where metadata endpoints in `/api/v1` are not registered if cluster checks are not enabled.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Run DCA with and without cluster checks enabled, the metadata endpoints, like `/api/v1/tags/pod` are accessible.
From DCA POD:
```
curl -k -H "Authorization: Bearer $DD_CLUSTER_AGENT_AUTH_TOKEN" https://127.0.0.1:5005/api/v1/tags/pod
```
