### PR TITLE
[doc] Fix documentation of `logs_config.expected_tags_duration`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -600,8 +600,8 @@ func InitConfig(config Config) {
 	config.BindEnv("logs_config.api_key") //nolint:errcheck
 	config.BindEnvAndSetDefault("logs_config.logs_no_ssl", false)
 
-	// Duration in minutes during which the host tags will be submitted with log events.
-	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", 0) // in minutes
+	// Duration during which the host tags will be submitted with log events.
+	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", 0) // duration-formatted string (parsed by `time.ParseDuration`)
 	// send the logs to the port 443 of the logs-backend via TCP:
 	config.BindEnvAndSetDefault("logs_config.use_port_443", false)
 	// increase the read buffer size of the UDP sockets:


### PR DESCRIPTION
### What does this PR do?

The value is actually interpreted as a duration-formatted string since https://github.com/DataDog/datadog-agent/pull/7284, but inline comments hadn't been updated.

### Motivation

Fix comments.

### Describe your test plan

Nothing to test, only a comment update.
