### PR TITLE
[runtime-security] call cancel function on module close

### DIFF
--- a/pkg/security/model/process_cache_entry.go
+++ b/pkg/security/model/process_cache_entry.go
@@ -53,20 +53,16 @@ func (pc *ProcessCacheEntry) Exec(entry *ProcessCacheEntry) {
 func (pc *ProcessCacheEntry) Fork(childEntry *ProcessCacheEntry) {
 	childEntry.PPid = pc.Pid
 	childEntry.Ancestor = pc
+	childEntry.TTYName = pc.TTYName
+	childEntry.Comm = pc.Comm
+	childEntry.FileFields = pc.FileFields
+	childEntry.PathnameStr = pc.PathnameStr
+	childEntry.BasenameStr = pc.BasenameStr
+	childEntry.ContainerPath = pc.ContainerPath
+	childEntry.ExecTimestamp = pc.ExecTimestamp
+	childEntry.Cookie = pc.Cookie
 
-	// keep some context if not present in the ebpf event
-	if childEntry.ExecTime.IsZero() {
-		childEntry.TTYName = pc.TTYName
-		childEntry.Comm = pc.Comm
-		childEntry.FileFields = pc.FileFields
-		childEntry.PathnameStr = pc.PathnameStr
-		childEntry.BasenameStr = pc.BasenameStr
-		childEntry.ContainerPath = pc.ContainerPath
-		childEntry.ExecTimestamp = pc.ExecTimestamp
-		childEntry.Cookie = pc.Cookie
-
-		copyProcessContext(pc, childEntry)
-	}
+	copyProcessContext(pc, childEntry)
 }
 
 func (pc *ProcessCacheEntry) String() string {

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -194,6 +194,7 @@ func (m *Module) Reload() error {
 // Close the module
 func (m *Module) Close() {
 	close(m.sigupChan)
+	m.cancelFnc()
 
 	if m.grpcServer != nil {
 		m.grpcServer.Stop()

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -266,16 +266,7 @@ func (p *ProcessResolver) retrieveInodeInfo(inode uint64) (*model.FileFields, er
 	return &info, nil
 }
 
-func (p *ProcessResolver) insertForkEntry(pid uint32, entry *model.ProcessCacheEntry) *model.ProcessCacheEntry {
-	if prev := p.entryCache[pid]; prev != nil {
-		// this shouldn't happen but it is better to exit the prev and let the new one replace it
-		prev.Exit(entry.ForkTime)
-	}
-
-	parent := p.entryCache[entry.PPid]
-	if parent != nil {
-		parent.Fork(entry)
-	}
+func (p *ProcessResolver) insertEntry(pid uint32, entry *model.ProcessCacheEntry) *model.ProcessCacheEntry {
 	p.entryCache[pid] = entry
 
 	_ = p.client.Count(metrics.MetricProcessResolverAdded, 1, []string{}, 1.0)
@@ -291,23 +282,26 @@ func (p *ProcessResolver) insertForkEntry(pid uint32, entry *model.ProcessCacheE
 	return entry
 }
 
+func (p *ProcessResolver) insertForkEntry(pid uint32, entry *model.ProcessCacheEntry) *model.ProcessCacheEntry {
+	if prev := p.entryCache[pid]; prev != nil {
+		// this shouldn't happen but it is better to exit the prev and let the new one replace it
+		prev.Exit(entry.ForkTime)
+	}
+
+	parent := p.entryCache[entry.PPid]
+	if parent != nil {
+		parent.Fork(entry)
+	}
+
+	return p.insertEntry(pid, entry)
+}
+
 func (p *ProcessResolver) insertExecEntry(pid uint32, entry *model.ProcessCacheEntry) *model.ProcessCacheEntry {
 	if prev := p.entryCache[pid]; prev != nil {
 		prev.Exec(entry)
 	}
 
-	p.entryCache[pid] = entry
-
-	_ = p.client.Count(metrics.MetricProcessResolverAdded, 1, []string{}, 1.0)
-
-	if p.opts.DebugCacheSize {
-		atomic.AddInt64(&p.cacheSize, 1)
-
-		runtime.SetFinalizer(entry, func(obj interface{}) {
-			atomic.AddInt64(&p.cacheSize, -1)
-		})
-	}
-	return entry
+	return p.insertEntry(pid, entry)
 }
 
 func (p *ProcessResolver) deleteEntry(pid uint32, exitTime time.Time) {
@@ -631,7 +625,7 @@ func (p *ProcessResolver) syncCache(proc *process.Process) (*model.ProcessCacheE
 		return nil, false
 	}
 
-	if entry = p.insertForkEntry(pid, entry); entry == nil {
+	if entry = p.insertEntry(pid, entry); entry == nil {
 		return nil, false
 	}
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -85,7 +85,7 @@ func TestProcessContext(t *testing.T) {
 		},
 		{
 			ID:         "test_rule_args",
-			Expression: `exec.args in ["-al"]`,
+			Expression: `exec.args in [~"*-al*"]`,
 		},
 		{
 			ID:         "test_rule_tty",
@@ -160,12 +160,12 @@ func TestProcessContext(t *testing.T) {
 			t.Error(err)
 		} else {
 			args, err := event.GetFieldValue("exec.args")
-			if err != nil || len(args.([]string)) == 0 {
+			if err != nil || len(args.(string)) == 0 {
 				t.Error("not able to get args")
 			}
 
 			contains := func(s string) bool {
-				for _, arg := range args.([]string) {
+				for _, arg := range strings.Split(args.(string), " ") {
 					if s == arg {
 						return true
 					}
@@ -218,11 +218,12 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("not able to get args")
 			}
 
-			if len(args.([]string)) != 2 {
+			argv := strings.Split(args.(string), " ")
+			if len(argv) != 2 {
 				t.Errorf("incorrect number of args")
 			}
 
-			if !strings.HasSuffix(args.([]string)[1], "...") {
+			if !strings.HasSuffix(argv[1], "...") {
 				t.Error("arg not truncated")
 			}
 		}
@@ -244,12 +245,13 @@ func TestProcessContext(t *testing.T) {
 				t.Errorf("not able to get args")
 			}
 
-			n := len(args.([]string))
+			argv := strings.Split(args.(string), " ")
+			n := len(argv)
 			if n == 0 || n > 100 {
 				t.Errorf("incorrect number of args")
 			}
 
-			if args.([]string)[n-1] != "..." {
+			if argv[n-1] != "..." {
 				t.Error("arg not truncated")
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Cancel context when closing security module

### Motivation

In rare cases, the security module forbid system-probe to stop when eBPF objects are closed when sending stats