### PR TITLE
[runtime-security] convert args from array to string

### DIFF
--- a/pkg/security/model/accessors.go
+++ b/pkg/security/model/accessors.go
@@ -19,12 +19,6 @@ var (
 func (m *Model) GetIterator(field eval.Field) (eval.Iterator, error) {
 	switch field {
 
-	case "exec.args":
-		return &ExecArgsIterator{}, nil
-
-	case "exec.envs":
-		return &ExecEnvsIterator{}, nil
-
 	case "process.ancestors":
 		return &ProcessAncestorsIterator{}, nil
 
@@ -483,24 +477,12 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				var result string
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-
-					elementPtr := (*string)(reg.Value)
-					element := *elementPtr
-
-					result = element
-
-				}
-
-				return result
+				return (*Event)(ctx.Object).Exec.Args
 
 			},
 			Field: field,
 
-			Weight: eval.IteratorWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.args_truncated":
@@ -591,24 +573,12 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				var result string
-
-				reg := ctx.Registers[regID]
-				if reg.Value != nil {
-
-					elementPtr := (*string)(reg.Value)
-					element := *elementPtr
-
-					result = element
-
-				}
-
-				return result
+				return (*Event)(ctx.Object).Exec.Envs
 
 			},
 			Field: field,
 
-			Weight: eval.IteratorWeight,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.envs_truncated":
@@ -4658,27 +4628,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "exec.args":
 
-		var values []string
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &ExecArgsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-
-			elementPtr := (*string)(ptr)
-			element := *elementPtr
-
-			result := element
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
+		return e.Exec.Args, nil
 
 	case "exec.args_truncated":
 
@@ -4710,27 +4660,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "exec.envs":
 
-		var values []string
-
-		ctx := &eval.Context{}
-		ctx.SetObject(unsafe.Pointer(e))
-
-		iterator := &ExecEnvsIterator{}
-		ptr := iterator.Front(ctx)
-
-		for ptr != nil {
-
-			elementPtr := (*string)(ptr)
-			element := *elementPtr
-
-			result := element
-
-			values = append(values, result)
-
-			ptr = iterator.Next()
-		}
-
-		return values, nil
+		return e.Exec.Envs, nil
 
 	case "exec.envs_truncated":
 
@@ -8740,7 +8670,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.Args"}
 		}
-		e.Exec.Args = append(e.Exec.Args, str)
+		e.Exec.Args = str
 
 		return nil
 
@@ -8821,7 +8751,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.Envs"}
 		}
-		e.Exec.Envs = append(e.Exec.Envs, str)
+		e.Exec.Envs = str
 
 		return nil
 

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -202,60 +202,6 @@ type Credentials struct {
 	CapPermitted uint64 `field:"cap_permitted" handler:"ResolveCredentialsCapPermitted,int"`
 }
 
-// ExecArgsIterator represents an exec args iterator
-type ExecArgsIterator struct {
-	args  []string
-	index int
-}
-
-// Front returns the first arg
-func (e *ExecArgsIterator) Front(ctx *eval.Context) unsafe.Pointer {
-	e.args = (*Event)(ctx.Object).ProcessContext.Args
-	if len(e.args) > 0 {
-		e.index = 1
-		return unsafe.Pointer(&e.args[0])
-	}
-	return nil
-}
-
-// Next returns the next arg
-func (e *ExecArgsIterator) Next() unsafe.Pointer {
-	if e.index < len(e.args) {
-		value := e.args[e.index]
-		e.index++
-		return unsafe.Pointer(&value)
-	}
-
-	return nil
-}
-
-// ExecEnvsIterator represents an exec envs iterator
-type ExecEnvsIterator struct {
-	envs  []string
-	index int
-}
-
-// Front returns the first env variable
-func (e *ExecEnvsIterator) Front(ctx *eval.Context) unsafe.Pointer {
-	e.envs = (*Event)(ctx.Object).ProcessContext.Envs
-	if len(e.envs) > 0 {
-		e.index = 1
-		return unsafe.Pointer(&e.envs[0])
-	}
-	return nil
-}
-
-// Next returns the next env variable
-func (e *ExecEnvsIterator) Next() unsafe.Pointer {
-	if e.index < len(e.envs) {
-		value := e.envs[e.index]
-		e.index++
-		return unsafe.Pointer(&value)
-	}
-
-	return nil
-}
-
 // GetPathResolutionError returns the path resolution error as a string if there is one
 func (e *Process) GetPathResolutionError() string {
 	if e.PathResolutionError != nil {
@@ -295,9 +241,9 @@ type Process struct {
 	// credentials_t section of pid_cache_t
 	Credentials
 
-	Args          []string `field:"-"`
+	ArgsArray     []string `field:"-"`
 	ArgsTruncated bool     `field:"-"`
-	Envs          []string `field:"-"`
+	EnvsArray     []string `field:"-"`
 	EnvsTruncated bool     `field:"-"`
 
 	ArgsID uint32 `field:"-"`
@@ -308,11 +254,10 @@ type Process struct {
 type ExecEvent struct {
 	Process
 
-	// override Process fields so that SECL can expose them
-	Args          []string `field:"args" iterator:"ExecArgsIterator"`
-	ArgsTruncated bool     `field:"args_truncated"`
-	Envs          []string `field:"envs" iterator:"ExecEnvsIterator"`
-	EnvsTruncated bool     `field:"envs_truncated"`
+	Args          string `field:"args" handler:"ResolveExecArgs,string"`
+	ArgsTruncated bool   `field:"args_truncated"`
+	Envs          string `field:"envs" handler:"ResolveExecEnvs,string"`
+	EnvsTruncated bool   `field:"envs_truncated"`
 }
 
 // FileFields holds the information required to identify a file

--- a/pkg/security/model/process_cache_entry.go
+++ b/pkg/security/model/process_cache_entry.go
@@ -32,8 +32,8 @@ func copyProcessContext(parent, child *ProcessCacheEntry) {
 
 func (pc *ProcessCacheEntry) compactArgsEnvs() {
 	// TODO: do not copy for the moment, need to handle memory usage properly
-	pc.Args = []string{}
-	pc.Envs = []string{}
+	pc.ArgsArray = []string{}
+	pc.EnvsArray = []string{}
 }
 
 // Exec replace a process
@@ -70,13 +70,13 @@ func (pc *ProcessCacheEntry) Fork(childEntry *ProcessCacheEntry) {
 }
 
 func (pc *ProcessCacheEntry) String() string {
-	s := fmt.Sprintf("filename: %s[%s] pid:%d ppid:%d args:%v\n", pc.PathnameStr, pc.Comm, pc.Pid, pc.PPid, pc.Args)
+	s := fmt.Sprintf("filename: %s[%s] pid:%d ppid:%d args:%v\n", pc.PathnameStr, pc.Comm, pc.Pid, pc.PPid, pc.ArgsArray)
 	ancestor := pc.Ancestor
 	for i := 0; ancestor != nil; i++ {
 		for j := 0; j <= i; j++ {
 			s += "\t"
 		}
-		s += fmt.Sprintf("filename: %s[%s] pid:%d ppid:%d args:%v\n", ancestor.PathnameStr, ancestor.Comm, ancestor.Pid, ancestor.PPid, ancestor.Args)
+		s += fmt.Sprintf("filename: %s[%s] pid:%d ppid:%d args:%v\n", ancestor.PathnameStr, ancestor.Comm, ancestor.Pid, ancestor.PPid, ancestor.ArgsArray)
 		ancestor = ancestor.Ancestor
 	}
 	return s

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -272,6 +272,16 @@ func (ev *Event) ResolveProcessComm(e *model.Process) string {
 	return e.Comm
 }
 
+// ResolveExecArgs resolves the args of the event
+func (ev *Event) ResolveExecArgs(e *model.ExecEvent) string {
+	return strings.Join(ev.ProcessContext.ArgsArray, " ")
+}
+
+// ResolveExecEnvs resolves the args of the event
+func (ev *Event) ResolveExecEnvs(e *model.ExecEvent) string {
+	return strings.Join(ev.ProcessContext.EnvsArray, " ")
+}
+
 // ResolveCredentialsUID resolves the user id of the process
 func (ev *Event) ResolveCredentialsUID(e *model.Credentials) int {
 	if e.UID == 0 && ev != nil {
@@ -504,9 +514,9 @@ func (ev *Event) ResolveEventTimestamp() time.Time {
 
 func (ev *Event) setProcessContextWithProcessCacheEntry(entry *model.ProcessCacheEntry) {
 	ev.ProcessContext.Ancestor = entry.Ancestor
-	ev.ProcessContext.Args = entry.Args
+	ev.ProcessContext.ArgsArray = entry.ArgsArray
 	ev.ProcessContext.ArgsTruncated = entry.ArgsTruncated
-	ev.ProcessContext.Envs = entry.Envs
+	ev.ProcessContext.EnvsArray = entry.EnvsArray
 	ev.ProcessContext.EnvsTruncated = entry.EnvsTruncated
 }
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -446,9 +446,9 @@ func (p *ProcessResolver) SetProcessArgs(pce *model.ProcessCacheEntry) {
 	if e, found := p.argsEnvsCache.Get(pce.ArgsID); found {
 		entry := e.(*argsEnvsCacheEntry)
 
-		pce.Args = entry.Values
+		pce.ArgsArray = entry.Values
 		if pce.ArgsTruncated {
-			pce.Args = append(pce.Args, "...")
+			pce.ArgsArray = append(pce.ArgsArray, "...")
 		}
 		pce.ArgsTruncated = pce.ArgsTruncated || entry.IsTruncated
 	}
@@ -459,9 +459,9 @@ func (p *ProcessResolver) SetProcessEnvs(pce *model.ProcessCacheEntry) {
 	if e, found := p.argsEnvsCache.Get(pce.EnvsID); found {
 		entry := e.(*argsEnvsCacheEntry)
 
-		pce.Envs = entry.Values
+		pce.EnvsArray = entry.Values
 		if pce.EnvsTruncated {
-			pce.Envs = append(pce.Envs, "...")
+			pce.EnvsArray = append(pce.EnvsArray, "...")
 		}
 		pce.EnvsTruncated = pce.EnvsTruncated || entry.IsTruncated
 	}

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -318,8 +318,8 @@ func newCredentialsSerializerWithResolvers(ce *model.Credentials, r *Resolvers) 
 }
 
 func scrubArgsEnvs(process *model.Process, e *Event) ([]string, []string) {
-	args := process.Args
-	envs := process.Envs
+	args := process.ArgsArray
+	envs := process.EnvsArray
 
 	// scrub args, do not send args if no scrubber instance is passed
 	// can be the case for some custom event


### PR DESCRIPTION
### What does this PR do?

Convert exec.args from array to string in SECL so that the following expression works as expected:

```
exec.args not in [ ~"*localhost*", ~"*127.0.0.1*" ]
```

This convertion allows to keep the exact same syntax and should not change once the array in array matching will work.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
