### PR TITLE
[runtime-security] send either runtime or fim metrics but not both

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -267,8 +267,7 @@ func (m *Module) metricsSender() {
 			tags := []string{fmt.Sprintf("version:%s", version.AgentVersion)}
 			if m.config.RuntimeEnabled {
 				_ = m.statsdClient.Gauge(metrics.MetricsSecurityAgentRuntimeRunning, 1, tags, 1)
-			}
-			if m.config.FIMEnabled {
+			} else if m.config.FIMEnabled {
 				_ = m.statsdClient.Gauge(metrics.MetricsSecurityAgentFIMRunning, 1, tags, 1)
 			}
 		case <-m.ctx.Done():


### PR DESCRIPTION
### What does this PR do?

Do not send fim metrics when runtime is activated as fim is enabled when runtime is enabled.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
