### PR TITLE
Do not abort installation if NetServerGetInfo fails

### DIFF
--- a/releasenotes/notes/windows-installer-no-server-34a3175cff0cad89.yaml
+++ b/releasenotes/notes/windows-installer-no-server-34a3175cff0cad89.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Windows installer will not abort if the Server service is not running (introduced in 6.24.0/7.24.0).

--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -83,7 +83,7 @@ DWORD TargetMachine::DetectMachineType()
     if (status != NERR_Success)
     {
         // NetServerGetInfo failed. This is most likely due to the Server service not running, which we can safely ignore.
-        WcaLog(LOGMSG_STANDARD, "Failed to get server info: %d %d. Continuing assuming type is SV_TYPE_WORKSTATION. This might not work.", status, GetLastError());
+        WcaLog(LOGMSG_STANDARD, "Failed to get server info: %d %d. Continuing assuming type is SV_TYPE_WORKSTATION.", status, GetLastError());
         _serverType = SV_TYPE_WORKSTATION;
         return ERROR_SUCCESS;
     }

--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -82,11 +82,11 @@ DWORD TargetMachine::DetectMachineType()
     DWORD status = NetServerGetInfo(nullptr, 101, reinterpret_cast<LPBYTE *>(&serverInfo));
     if (status != NERR_Success)
     {
-        WcaLog(LOGMSG_STANDARD, "Failed to get server info: %d %d.", status, GetLastError());
         if (status == NERR_ServerNotStarted || status == NERR_ServiceNotInstalled || status == NERR_WkstaNotStarted)
         {
             // NetServerGetInfo will fail if the Server service isn't running,
             // but in that case it's safe to assume we are a workstation.
+            WcaLog(LOGMSG_STANDARD, "Failed to get server info: %S", FormatErrorMessage(status));
             WcaLog(LOGMSG_STANDARD, "Continuing assuming machine type is SV_TYPE_WORKSTATION.");
             _serverType = SV_TYPE_WORKSTATION;
             return ERROR_SUCCESS;

--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -93,8 +93,9 @@ DWORD TargetMachine::DetectMachineType()
          *  - ERROR_NOT_ENOUGH_MEMORY
          *  Insufficient memory is available.
          */
-        WcaLog(LOGMSG_STANDARD, "Failed to get server info: %d %d", status, GetLastError());
-        return status;
+        WcaLog(LOGMSG_STANDARD, "Failed to get server info: %d %d. Continuing assuming type is SV_TYPE_WORKSTATION. This might not work.", status, GetLastError());
+        _serverType = SV_TYPE_WORKSTATION;
+        return ERROR_SUCCESS;
     }
     _serverType = serverInfo->sv101_type;
     if (SV_TYPE_WORKSTATION & _serverType)

--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -82,17 +82,7 @@ DWORD TargetMachine::DetectMachineType()
     DWORD status = NetServerGetInfo(nullptr, 101, reinterpret_cast<LPBYTE *>(&serverInfo));
     if (status != NERR_Success)
     {
-        /*
-         * If the function fails, the return value can be one of the following error codes.
-         *   - ERROR_ACCESS_DENIED
-         *  The user does not have access to the requested information.
-         *  -  ERROR_INVALID_LEVEL
-         *  The value specified for the level parameter is invalid.
-         *  - ERROR_INVALID_PARAMETER
-         *  The specified parameter is invalid.
-         *  - ERROR_NOT_ENOUGH_MEMORY
-         *  Insufficient memory is available.
-         */
+        // NetServerGetInfo failed. This is most likely due to the Server service not running, which we can safely ignore.
         WcaLog(LOGMSG_STANDARD, "Failed to get server info: %d %d. Continuing assuming type is SV_TYPE_WORKSTATION. This might not work.", status, GetLastError());
         _serverType = SV_TYPE_WORKSTATION;
         return ERROR_SUCCESS;


### PR DESCRIPTION
### What does this PR do?

Assume machine type is `SV_TYPE_WORKSTATION`, log a warning and continue with the installation.

### Motivation

Customer bug report.

If the 'Server' service is not running, NetServerGetInfo will fail with code 2114 (The server service is not started). Since 7.24.0 (#6318), this now aborts the installation.

In most cases, however, we can recover from that situation and carry on by assuming it's a workstation (behavior pre-7.24.0).

### Test plan

Stop and disable the "Server" service. Try to install a version > 7.24.0: it fails. Install a version with this fix: it succeeds.
