### PR TITLE
[container utils] Log a warning when an unknown filter is configured

### DIFF
--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -97,6 +98,8 @@ func parseFilters(filters []string) (imageFilters, nameFilters, namespaceFilters
 				return nil, nil, nil, fmt.Errorf("invalid regex '%s': %s", pat, err)
 			}
 			namespaceFilters = append(namespaceFilters, r)
+		default:
+			log.Warnf("Container filter %q is unknown, Ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'", filter)
 		}
 	}
 	return imageFilters, nameFilters, namespaceFilters, nil


### PR DESCRIPTION
### What does this PR do?

Log a warning when an unknown container filter is configured

### Motivation

https://github.com/DataDog/helm-charts/issues/191

### Additional Notes

Related docs PR https://github.com/DataDog/documentation/pull/10030

### Describe your test plan

Add a configuration that triggers that code path and see the warning.
