### PR TITLE
Fix log file source not added to main source list

### DIFF
--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -56,7 +56,6 @@ type Launcher struct {
 	tailFromFile           bool                      // If true docker will be tailed from the corresponding log file
 	fileSourcesByContainer map[string]sourceInfoPair // Keep track of locally generated sources
 	sources                *config.LogSources        // To schedule file source when taileing container from file
-
 }
 
 // NewLauncher returns a new launcher

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -55,6 +55,8 @@ type Launcher struct {
 	forceTailingFromFile   bool                      // will ignore known offset and always tail from file
 	tailFromFile           bool                      // If true docker will be tailed from the corresponding log file
 	fileSourcesByContainer map[string]sourceInfoPair // Keep track of locally generated sources
+	sources                *config.LogSources        // To schedule file source when taileing container from file
+
 }
 
 // NewLauncher returns a new launcher
@@ -75,6 +77,7 @@ func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services
 		lock:                   &sync.Mutex{},
 		readTimeout:            readTimeout,
 		serviceNameFunc:        input.ServiceNameFromTags,
+		sources:                sources,
 		forceTailingFromFile:   forceTailingFromFile,
 		tailFromFile:           tailFromFile,
 		fileSourcesByContainer: make(map[string]sourceInfoPair),
@@ -326,14 +329,18 @@ func (l *Launcher) scheduleFileSource(container *Container, source *config.LogSo
 		log.Warnf("Can't tail twice the same container: %v", ShortContainerID(containerID))
 		return
 	}
-	// fileSource is a new source using the original source as its parent - keep track for later unscheduling
-	l.fileSourcesByContainer[containerID] = l.getFileSource(container, source)
+	// fileSource is a new source using the original source as its parent
+	fileSource := l.getFileSource(container, source)
+	// Keep source for later unscheduling
+	l.fileSourcesByContainer[containerID] = fileSource
+	l.sources.AddSource(fileSource.source)
 }
 
 func (l *Launcher) unscheduleFileSource(containerID string) {
 	if sourcePair, exists := l.fileSourcesByContainer[containerID]; exists {
 		sourcePair.info.RemoveMessage(containerID)
 		delete(l.fileSourcesByContainer, containerID)
+		l.sources.RemoveSource(sourcePair.source)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix regression where docker file sources were not registered with the main source list

### Motivation

Fix issue found in QA

### Describe your test plan

tested with (on this branch image)
```
docker run --rm --name agent -e DD_API_KEY=abc -e DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE=true -e DD_LOGS_ENABLED=true -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -v /var/lib/docker/containers:/var/lib/docker/containers:ro datadog/agent-dev:brian-fix-source-being-removed-py3-jm
```
+ start another container, verify logs work (and status is ok), then stop it and verify status again. 