### PR TITLE
[system-probe][NET-1157] Add limit to the number of DNS stats objects created by DNSStatkeeper

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -794,6 +794,7 @@ func InitConfig(config Config) {
 	config.SetKnown("system_probe_config.closed_channel_size")
 	config.SetKnown("system_probe_config.dns_timeout_in_s")
 	config.SetKnown("system_probe_config.collect_dns_stats")
+	config.SetKnown("system_probe_config.max_dns_stats")
 	config.SetKnown("system_probe_config.collect_dns_domains")
 	config.SetKnown("system_probe_config.offset_guess_threshold")
 	config.SetKnown("system_probe_config.enable_tcp_queue_length")

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -42,6 +42,10 @@ type Config struct {
 	// DNSTimeout determines the length of time to wait before considering a DNS Query to have timed out
 	DNSTimeout time.Duration
 
+	// MaxDNSStats determines the number of separate DNS Stats objects DNSStatkeeper can have at any given time
+	// These stats objects get flushed on every client request (default 30s check interval)
+	MaxDNSStats int
+
 	// EnableHTTPMonitoring specifies whether the tracer should monitor HTTP traffic
 	EnableHTTPMonitoring bool
 
@@ -159,6 +163,7 @@ func NewDefaultConfig() *Config {
 		CollectDNSStats:      true,
 		CollectDNSDomains:    false,
 		DNSTimeout:           15 * time.Second,
+		MaxDNSStats:          10000,
 		OffsetGuessThreshold: 400,
 		EnableMonotonicCount: false,
 	}

--- a/pkg/network/config/tracer_config.go
+++ b/pkg/network/config/tracer_config.go
@@ -47,6 +47,10 @@ func TracerConfigFromConfig(cfg *config.AgentConfig) *Config {
 	tracerConfig.CollectDNSStats = cfg.CollectDNSStats
 	tracerConfig.CollectDNSDomains = cfg.CollectDNSDomains
 
+	if cfg.MaxDNSStats > 0 {
+		tracerConfig.MaxDNSStats = cfg.MaxDNSStats
+	}
+
 	if to := cfg.DNSTimeout; to > 0 {
 		tracerConfig.DNSTimeout = cfg.DNSTimeout
 	}

--- a/pkg/network/dns_snooper.go
+++ b/pkg/network/dns_snooper.go
@@ -128,6 +128,11 @@ func (s *SocketFilterSnooper) GetStats() map[string]int64 {
 	stats["queries"] = atomic.LoadInt64(&s.queries)
 	stats["successes"] = atomic.LoadInt64(&s.successes)
 	stats["errors"] = atomic.LoadInt64(&s.errors)
+	if s.statKeeper != nil {
+		numStats, droppedStats := s.statKeeper.GetNumStats()
+		stats["num_stats"] = int64(numStats)
+		stats["dropped_stats"] = int64(droppedStats)
+	}
 	return stats
 }
 

--- a/pkg/network/dns_snooper.go
+++ b/pkg/network/dns_snooper.go
@@ -67,8 +67,8 @@ func NewSocketFilterSnooper(cfg *config.Config, source PacketSource) (*SocketFil
 	cache := newReverseDNSCache(dnsCacheSize, dnsCacheTTL, dnsCacheExpirationPeriod)
 	var statKeeper *dnsStatKeeper
 	if cfg.CollectDNSStats {
-		statKeeper = newDNSStatkeeper(cfg.DNSTimeout)
-		log.Infof("DNS Stats Collection has been enabled.")
+		statKeeper = newDNSStatkeeper(cfg.DNSTimeout, cfg.MaxDNSStats)
+		log.Infof("DNS Stats Collection has been enabled. Maximum number of stats objects: %d", cfg.MaxDNSStats)
 		if cfg.CollectDNSDomains {
 			log.Infof("DNS domain collection has been enabled")
 		}

--- a/pkg/network/dns_snooper_test.go
+++ b/pkg/network/dns_snooper_test.go
@@ -98,6 +98,7 @@ func getSnooper(
 			CollectLocalDNS:   collectLocalDNS,
 			DNSTimeout:        dnsTimeout,
 			CollectDNSDomains: collectDNSDomains,
+			MaxDNSStats:       10000,
 		},
 		packetSrc,
 	)

--- a/pkg/network/dns_stats.go
+++ b/pkg/network/dns_stats.go
@@ -148,7 +148,7 @@ func (d *dnsStatKeeper) GetAndResetAllStats() map[DNSKey]map[string]DNSStats {
 	defer d.mux.Unlock()
 	ret := d.stats // No deep copy needed since `d.stats` gets reset
 	d.stats = make(map[DNSKey]map[string]DNSStats)
-	log.Infof("Number of processed stats: %d, Number of dropped stats: %d", d.numStats, d.droppedStats)
+	log.Debugf("[DNS Stats] Number of processed stats: %d, Number of dropped stats: %d", d.numStats, d.droppedStats)
 	d.numStats = 0
 	d.droppedStats = 0
 	return ret

--- a/pkg/network/dns_stats_test.go
+++ b/pkg/network/dns_stats_test.go
@@ -34,7 +34,7 @@ func testLatency(
 	expectedTimeouts uint32,
 ) {
 	var d = "abc.com"
-	sk := newDNSStatkeeper(DNSTimeoutSecs * time.Second)
+	sk := newDNSStatkeeper(DNSTimeoutSecs*time.Second, 10000)
 	key := getSampleDNSKey()
 	qPkt := dnsPacketInfo{transactionID: 1, pktType: Query, key: key, question: d}
 	then := time.Now()
@@ -71,7 +71,7 @@ func TestTimeout(t *testing.T) {
 }
 
 func TestExpiredStateRemoval(t *testing.T) {
-	sk := newDNSStatkeeper(DNSTimeoutSecs * time.Second)
+	sk := newDNSStatkeeper(DNSTimeoutSecs*time.Second, 10000)
 	key := getSampleDNSKey()
 	var d = "abc.com"
 	qPkt1 := dnsPacketInfo{transactionID: 1, pktType: Query, key: key, question: d}
@@ -115,7 +115,7 @@ func BenchmarkStats(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				sk := newDNSStatkeeper(1000 * time.Second)
+				sk := newDNSStatkeeper(1000*time.Second, 10000)
 				for j := 0; j < numPackets; j++ {
 					sk.ProcessPacketInfo(packets[j], ts)
 				}

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -148,6 +148,7 @@ type AgentConfig struct {
 	CollectDNSStats   bool
 	DNSTimeout        time.Duration
 	CollectDNSDomains bool
+	MaxDNSStats       int
 
 	// Check config
 	EnabledChecks  []string

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -50,6 +50,10 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		a.CollectDNSStats = config.Datadog.GetBool(key(spNS, "collect_dns_stats"))
 	}
 
+	if config.Datadog.IsSet(key(spNS, "max_dns_stats")) {
+		a.MaxDNSStats = config.Datadog.GetInt(key(spNS, "max_dns_stats"))
+	}
+
 	if config.Datadog.IsSet(key(spNS, "collect_dns_domains")) {
 		a.CollectDNSDomains = config.Datadog.GetBool(key(spNS, "collect_dns_domains"))
 	}

--- a/releasenotes/notes/add-limit-for-dns-stats-be2110d5d18ad671.yaml
+++ b/releasenotes/notes/add-limit-for-dns-stats-be2110d5d18ad671.yaml
@@ -1,4 +1,3 @@
 fixes:
   - |
-    Adds a limit to the number of DNS stats objects the DNSStatkeeper can have at any given time.
-
+    Adds a limit to the number of DNS stats objects the DNSStatkeeper can have at any given time. This can alleviate memory issues on hosts doing high numbers of DNS requests where network performance monitoring is enabled. 

--- a/releasenotes/notes/add-limit-for-dns-stats-be2110d5d18ad671.yaml
+++ b/releasenotes/notes/add-limit-for-dns-stats-be2110d5d18ad671.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Adds a limit to the number of DNS stats objects the DNSStatkeeper can have at any given time.
+


### PR DESCRIPTION
### What does this PR do?
- Adds a limit to the number of `DNSStats` objects that can be maintained by `DNSStatkeeper` at any given time

Related support ticket: https://datadoghq.atlassian.net/browse/NTWK-102

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

When started, we should see a line
```
SYS-PROBE | INFO | (pkg/network/dns_snooper.go:71 in NewSocketFilterSnooper) | DNS Stats Collection has been enabled. Maximum number of stats objects: 10000
```

If we override that from `system-probe.yaml`:
```yaml
system_probe_config:
  max_dns_stats: 100
```

and restart the agent, we should see it being reflected in 

```
SYS-PROBE | INFO | (pkg/network/dns_snooper.go:71 in NewSocketFilterSnooper) | DNS Stats Collection has been enabled. Maximum number of stats objects: 100
```

Then, we can run [flamethrower](https://github.com/DNS-OARC/flamethrower) to send some queries:

```
docker run ns1labs/flame -Q 500 8.8.8.8,8.8.4.4 -g randomlabel lblsize=10 lblcount=4 count=1000
```

In the log, we should see output like the following:

```
2021-03-16 19:09:59 UTC | SYS-PROBE | INFO | (pkg/network/dns_stats.go:151 in GetAndResetAllStats) | Number of processed stats: 100, Number of dropped stats: 730
```
