### PR TITLE
remove symlinks from confd path

### DIFF
--- a/Dockerfiles/cluster-agent/entrypoint.sh
+++ b/Dockerfiles/cluster-agent/entrypoint.sh
@@ -13,8 +13,8 @@ if [[ -z "$DD_API_KEY" ]]; then
     exit 1
 fi
 
-##### Copy the custom confs #####
-find /conf.d -name '*.yaml' -exec cp --parents -fv {} /etc/datadog-agent/ \;
+##### Copy the custom confs removing any ".." folder in the paths #####
+find /conf.d -name '*.yaml' | sed -E "s#/\.\.[^/]+##" | xargs -I{} cp --parents -fv {} /etc/datadog-agent/
 
 ##### Starting up #####
 export PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/":$PATH

--- a/releasenotes-dca/notes/cluster-agent-entrypoint-5277fa344bf8e065.yaml
+++ b/releasenotes-dca/notes/cluster-agent-entrypoint-5277fa344bf8e065.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The cluster-agent container now tries to remove any folder beginning by ``..`` in paths of
+    files mounted in ``/conf.d`` while copying them to the cluster-agent config folder


### PR DESCRIPTION
### What does this PR do?

The cluster-agent container now tries to remove any folder beginning by `..` in paths of files mounted in `/conf.d` while copying them to the cluster-agent config folder.

### Motivation

This is done to avoid broken path due to configmap symlinking done by Kubernetes and support https://github.com/DataDog/helm-charts/pull/196

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
