### PR TITLE
[integrations] Pin setuptools-scm to 5.0.2

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -309,10 +309,6 @@ build do
       patch :source => "create-regex-at-runtime.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/yaml/reader.py"
     end
 
-    # Remove setuptools-scm build-time dep
-    command "#{pip} uninstall -y setuptools-scm"
-
-
     # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
     if windows?
       command "#{python} -m pip check"

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -310,7 +310,7 @@ build do
     end
 
     # Remove setuptools-scm build-time dep
-    command "#{pip} uninstall setuptools-scm"
+    command "#{pip} uninstall -y setuptools-scm"
 
 
     # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -141,7 +141,7 @@ build do
     # install the core integrations.
     #
     command "#{pip} install wheel==0.34.1"
-    command "#{pip} install setuptools-scm==5.0.2"
+    command "#{pip} install setuptools-scm==5.0.2" # Pin to the last version that supports Python 2
     command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -141,6 +141,7 @@ build do
     # install the core integrations.
     #
     command "#{pip} install wheel==0.34.1"
+    command "#{pip} install setuptools-scm==5.0.2"
     command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -143,7 +143,7 @@ build do
     command "#{pip} install wheel==0.34.1"
     command "#{pip} install setuptools-scm==5.0.2" # Pin to the last version that supports Python 2
     command "#{pip} install pip-tools==5.4.0"
-    uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools', 'setuptools-scm']
+    uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {
       "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
@@ -308,6 +308,10 @@ build do
     else
       patch :source => "create-regex-at-runtime.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/yaml/reader.py"
     end
+
+    # Remove setuptools-scm build-time dep
+    command "#{pip} uninstall setuptools-scm"
+
 
     # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
     if windows?

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -143,7 +143,7 @@ build do
     command "#{pip} install wheel==0.34.1"
     command "#{pip} install setuptools-scm==5.0.2" # Pin to the last version that supports Python 2
     command "#{pip} install pip-tools==5.4.0"
-    uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
+    uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools', 'setuptools-scm']
     nix_build_env = {
       "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -297,7 +297,7 @@ build do
     end
 
     # Remove setuptools-scm build-time dep
-    command "#{pip} uninstall setuptools-scm"
+    command "#{pip} uninstall -y setuptools-scm"
 
     # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
     if windows?

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -135,6 +135,7 @@ build do
     # install the core integrations.
     #
     command "#{pip} install wheel==0.34.1"
+    command "#{pip} install setuptools-scm==5.0.2"
     command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -135,7 +135,7 @@ build do
     # install the core integrations.
     #
     command "#{pip} install wheel==0.34.1"
-    command "#{pip} install setuptools-scm==5.0.2"
+    command "#{pip} install setuptools-scm==5.0.2" # Pin to the last version that supports Python 2
     command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -296,6 +296,9 @@ build do
       end
     end
 
+    # Remove setuptools-scm build-time dep
+    command "#{pip} uninstall setuptools-scm"
+
     # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
     if windows?
       command "#{python} -m pip check"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -135,7 +135,6 @@ build do
     # install the core integrations.
     #
     command "#{pip} install wheel==0.34.1"
-    command "#{pip} install setuptools-scm==5.0.2" # Pin to the last version that supports Python 2
     command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {
@@ -295,9 +294,6 @@ build do
         command "#{pip} install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
       end
     end
-
-    # Remove setuptools-scm build-time dep
-    command "#{pip} uninstall -y setuptools-scm"
 
     # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
     if windows?


### PR DESCRIPTION
### What does this PR do?

Pins setuptools-scm to the last version that supports Python 2.

### Motivation

Failures in ARM builds when running the `piptools compile` command on Python 2.
