### PR TITLE
[process-agent] Fix exit parameters for process tasks

### DIFF
--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -160,6 +160,7 @@ class TempDir:
         print("created tempdir: {name}".format(name=self.fname))
         return self.fname
 
+    # The _ in front of the unused arguments are needed to pass lint check
     def __exit__(self, _exception_type, _exception_value, _exception_traceback):
         print("deleting tempdir: {name}".format(name=self.fname))
         shutil.rmtree(self.fname)

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -160,6 +160,6 @@ class TempDir:
         print("created tempdir: {name}".format(name=self.fname))
         return self.fname
 
-    def __exit__(self, exception_type, exception_value, exception_traceback):
+    def __exit__(self, _, _, _):
         print("deleting tempdir: {name}".format(name=self.fname))
         shutil.rmtree(self.fname)

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -160,6 +160,6 @@ class TempDir:
         print("created tempdir: {name}".format(name=self.fname))
         return self.fname
 
-    def __exit__(self):
+    def __exit__(self, exception_type, exception_value, exception_traceback):
         print("deleting tempdir: {name}".format(name=self.fname))
         shutil.rmtree(self.fname)

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -160,6 +160,6 @@ class TempDir:
         print("created tempdir: {name}".format(name=self.fname))
         return self.fname
 
-    def __exit__(self, _, _, _):
+    def __exit__(self, _exception_type, _exception_value, _exception_traceback):
         print("deleting tempdir: {name}".format(name=self.fname))
         shutil.rmtree(self.fname)


### PR DESCRIPTION
### What does this PR do?

The parameter list of the `__exit__` function was recently modified as they were not being directly used: https://github.com/DataDog/datadog-agent/pull/7499/files#diff-2bdcc25ad3b160e80d6d20029f9343c6f51997a3ea92d73900705b9b8c58a53dL157

But those parameters are part of the signature of the `__exit__` function for ContextManager.

Without the params, we see the following error:

```
  File "/usr/local/lib/python3.8/dist-packages/invoke/tasks.py", line 127, in __call__
    result = self.body(*args, **kwargs)
  File "/home/vagrant/go/src/github.com/DataDog/datadog-agent/tasks/process_agent.py", line 147, in build_dev_image
    ctx.run(
TypeError: __exit__() takes 1 positional argument but 4 were given
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
