### PR TITLE
[runtime-security] add regexp support in SECL

### DIFF
--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -34,10 +34,14 @@ func (m *Model) NewEvent() eval.Event {
 }
 
 // ValidateField validates the value of a field
-func (m *Model) ValidateField(key string, field eval.FieldValue) error {
+func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) error {
 	// check that all path are absolute
-	if strings.HasSuffix(key, "path") {
-		if value, ok := field.Value.(string); ok {
+	if strings.HasSuffix(field, "path") {
+		if fieldValue.Type == eval.RegexpValueType {
+			return fmt.Errorf("regexp not supported on path `%s`", field)
+		}
+
+		if value, ok := fieldValue.Value.(string); ok {
 			errAbs := fmt.Errorf("invalid path `%s`, all the path have to be absolute", value)
 			errDepth := fmt.Errorf("invalid path `%s`, path depths have to be shorter than %d", value, MaxPathDepth)
 			errSegment := fmt.Errorf("invalid path `%s`, each segment of a path must be shorter than %d", value, MaxSegmentLength)
@@ -67,10 +71,10 @@ func (m *Model) ValidateField(key string, field eval.FieldValue) error {
 		}
 	}
 
-	switch key {
+	switch field {
 
 	case "event.retval":
-		if value := field.Value; value != -int(syscall.EPERM) && value != -int(syscall.EACCES) {
+		if value := fieldValue.Value; value != -int(syscall.EPERM) && value != -int(syscall.EACCES) {
 			return errors.New("return value can only be tested against EPERM or EACCES")
 		}
 	}

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -264,10 +264,12 @@ func isParentPathDiscarder(rs *rules.RuleSet, regexCache *simplelru.LRU, eventTy
 					if regexDir.MatchString(dirname) {
 						return false, nil
 					}
-				} else {
+				} else if value.Type == eval.ScalarValueType {
 					if strings.HasPrefix(value.Value.(string), dirname) {
 						return false, nil
 					}
+				} else {
+					return false, nil
 				}
 			}
 

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
-func TestAbsolutePath(t *testing.T) {
+func TestPathValidation(t *testing.T) {
 	model := &Model{}
 	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "/var/log/*"}); err != nil {
 		t.Fatalf("shouldn't return an error: %s", err)
@@ -36,6 +36,14 @@ func TestAbsolutePath(t *testing.T) {
 	}
 	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "f59226f52267c120c1accfe3d158aa2f201ff02f45692a1c574da29c07fb985ef59226f52267c120c1accfe3d158aa2f201ff02f45692a1c574da29c07fb985e"}); err == nil {
 		t.Fatal("should return an error")
+	}
+
+	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: ".*", Type: eval.RegexpValueType}); err == nil {
+		t.Fatal("should return an error")
+	}
+
+	if err := model.ValidateField("open.file.path", eval.FieldValue{Value: "/etc/*", Type: eval.PatternValueType}); err != nil {
+		t.Fatal("shouldn't return an error")
 	}
 }
 

--- a/pkg/security/rules/capabilities.go
+++ b/pkg/security/rules/capabilities.go
@@ -5,7 +5,9 @@
 
 package rules
 
-import "github.com/DataDog/datadog-agent/pkg/security/secl/eval"
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
+)
 
 // FieldCapabilities holds a list of field capabilities
 type FieldCapabilities []FieldCapability

--- a/pkg/security/secl/ast/secl.go
+++ b/pkg/security/secl/ast/secl.go
@@ -17,6 +17,7 @@ import (
 var (
 	seclLexer = lexer.Must(ebnf.New(`
 Comment = ("#" | "//") { "\u0000"…"\uffff"-"\n" } .
+Regexp = "r\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Ident = (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } .
 String = "\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Pattern = "~\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
@@ -44,7 +45,7 @@ func buildParser(obj interface{}) (*participle.Parser, error) {
 		participle.Lexer(seclLexer),
 		participle.Elide("Whitespace", "Comment"),
 		participle.Unquote("String"),
-		participle.Map(unquotePattern, "Pattern"),
+		participle.Map(unquotePattern, "Pattern", "Regexp"),
 	)
 }
 
@@ -168,6 +169,7 @@ type Primary struct {
 	Number        *int        `parser:"| @Int"`
 	String        *string     `parser:"| @String"`
 	Pattern       *string     `parser:"| @Pattern"`
+	Regexp        *string     `parser:"| @Regexp"`
 	SubExpression *Expression `parser:"| \"(\" @@ \")\""`
 }
 
@@ -177,6 +179,7 @@ type StringMember struct {
 
 	String  *string `parser:"@String"`
 	Pattern *string `parser:"| @Pattern"`
+	Regexp  *string `parser:"| @Regexp"`
 }
 
 // Array describes an array of values

--- a/pkg/security/secl/ast/secl_test.go
+++ b/pkg/security/secl/ast/secl_test.go
@@ -186,3 +186,21 @@ func TestArrayPattern(t *testing.T) {
 
 	print(t, rule)
 }
+
+func TestRegexp(t *testing.T) {
+	rule, err := ParseRule(`process.name == r"/usr/bin/ls"`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}
+
+func TestArrayRegexp(t *testing.T) {
+	rule, err := ParseRule(`process.name in [r"/usr/bin/ls", "/usr/sbin/ls"]`)
+	if err != nil {
+		t.Error(err)
+	}
+
+	print(t, rule)
+}

--- a/pkg/security/secl/eval/errors.go
+++ b/pkg/security/secl/eval/errors.go
@@ -31,6 +31,15 @@ func (e ErrInvalidPattern) Error() string {
 	return fmt.Sprintf("invalid pattern `%s`", e.Pattern)
 }
 
+// ErrInvalidRegexp is returned for an invalid regular expression
+type ErrInvalidRegexp struct {
+	Regexp string
+}
+
+func (e ErrInvalidRegexp) Error() string {
+	return fmt.Sprintf("invalid regexp `%s`", e.Regexp)
+}
+
 // ErrAstToEval describes an error that occurred during the conversion from the AST to an evaluator
 type ErrAstToEval struct {
 	Pos  lexer.Position

--- a/pkg/security/secl/eval/eval.go
+++ b/pkg/security/secl/eval/eval.go
@@ -27,9 +27,10 @@ type FieldValueType int
 
 // Field value types
 const (
-	ScalarValueType  FieldValueType = 1
-	PatternValueType FieldValueType = 2
-	BitmaskValueType FieldValueType = 4
+	ScalarValueType  FieldValueType = 1 << 0
+	PatternValueType FieldValueType = 1 << 1
+	RegexpValueType  FieldValueType = 1 << 2
+	BitmaskValueType FieldValueType = 1 << 3
 )
 
 // defines factor applied by specific operator
@@ -37,7 +38,7 @@ const (
 	FunctionWeight       = 5
 	InArrayWeight        = 10
 	HandlerWeight        = 50
-	PatternWeight        = 100
+	RegexpWeight         = 100
 	InPatternArrayWeight = 1000
 	IteratorWeight       = 2000
 )
@@ -108,8 +109,10 @@ type StringEvaluator struct {
 	Value   string
 	Weight  int
 
-	isPattern bool
+	isRegexp  bool
 	isPartial bool
+
+	valueType FieldValueType
 
 	// cache
 	regexp *regexp.Regexp
@@ -127,8 +130,10 @@ type StringArrayEvaluator struct {
 	Values  []string
 	Weight  int
 
-	isPattern bool
+	isRegexp  bool
 	isPartial bool
+
+	valueTypes []FieldValueType
 
 	// cache
 	regexps []*regexp.Regexp
@@ -188,24 +193,6 @@ func extractField(field string) (Field, Field, RegisterID, error) {
 	field, itField := re.ReplaceAllString(field, `$1$2`), re.ReplaceAllString(field, `$1`)
 
 	return field, itField, regID, nil
-}
-
-func patternToRegexp(pattern string) (*regexp.Regexp, error) {
-	// do not accept full wildcard value
-	if matched, err := regexp.Match(`[a-zA-Z0-9\.]+`, []byte(pattern)); err != nil || !matched {
-		return nil, &ErrInvalidPattern{Pattern: pattern}
-	}
-
-	// quote eveything except wilcard
-	re := regexp.MustCompile(`[\.*+?()|\[\]{}^$]`)
-	quoted := re.ReplaceAllStringFunc(pattern, func(s string) string {
-		if s != "*" {
-			return "\\" + s
-		}
-		return ".*"
-	})
-
-	return regexp.Compile("^" + quoted + "$")
 }
 
 type ident struct {
@@ -299,6 +286,81 @@ func identToEvaluator(obj *ident, opts *Opts, state *state) (interface{}, lexer.
 	state.UpdateFields(field)
 
 	return accessor, obj.Pos, nil
+}
+
+func arrayToEvaluator(array *ast.Array, opts *Opts, state *state) (interface{}, lexer.Position, error) {
+	if len(array.Numbers) != 0 {
+		return &IntArrayEvaluator{
+			Values: array.Numbers,
+		}, array.Pos, nil
+	} else if len(array.StringMembers) != 0 {
+		var strs []string
+		var valueTypes []FieldValueType
+
+		isPlainStringArray := true
+		for _, member := range array.StringMembers {
+			if member.String != nil {
+				strs = append(strs, *member.String)
+				valueTypes = append(valueTypes, ScalarValueType)
+			} else if member.Pattern != nil {
+				strs = append(strs, *member.Pattern)
+				valueTypes = append(valueTypes, PatternValueType)
+				isPlainStringArray = false
+			} else {
+				strs = append(strs, *member.Regexp)
+				valueTypes = append(valueTypes, RegexpValueType)
+				isPlainStringArray = false
+			}
+		}
+
+		if isPlainStringArray {
+			return &StringArrayEvaluator{
+				Values:     strs,
+				valueTypes: valueTypes,
+			}, array.Pos, nil
+		}
+
+		var reg *regexp.Regexp
+		var regs []*regexp.Regexp
+		var err error
+
+		for _, member := range array.StringMembers {
+			if member.String != nil {
+				// escape wildcard
+				str := strings.ReplaceAll(*member.String, "*", "\\*")
+
+				if reg, err = patternToRegexp(str); err != nil {
+					return nil, array.Pos, NewError(array.Pos, fmt.Sprintf("invalid pattern '%s': %s", *member.String, err))
+				}
+			} else if member.Pattern != nil {
+				if reg, err = patternToRegexp(*member.Pattern); err != nil {
+					return nil, array.Pos, NewError(array.Pos, fmt.Sprintf("invalid pattern '%s': %s", *member.Pattern, err))
+				}
+			} else {
+				if reg, err = regexp.Compile(*member.Regexp); err != nil {
+					return nil, array.Pos, NewError(array.Pos, fmt.Sprintf("invalid regexp '%s': %s", *member.Regexp, err))
+				}
+			}
+			regs = append(regs, reg)
+		}
+		return &StringArrayEvaluator{
+			Values:     strs,
+			regexps:    regs,
+			isRegexp:   true,
+			valueTypes: valueTypes,
+		}, array.Pos, nil
+	} else if array.Ident != nil {
+		if state.macros != nil {
+			if macro, ok := state.macros[*array.Ident]; ok {
+				return macro.Value, array.Pos, nil
+			}
+		}
+
+		// could be an iterator
+		return identToEvaluator(&ident{Pos: array.Pos, Ident: array.Ident}, opts, state)
+	}
+
+	return nil, array.Pos, NewError(array.Pos, "unknow array element type")
 }
 
 func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, lexer.Position, error) {
@@ -539,17 +601,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, le
 					}
 					return Not(boolEvaluator, opts, state), obj.Pos, nil
 				case "!~":
-					// consider the value as regexp
 					if nextString.EvalFnc != nil {
 						return nil, obj.Pos, &ErrNonStaticPattern{Field: nextString.Field}
 					}
 
-					reg, err := patternToRegexp(nextString.Value)
-					if err != nil {
-						return nil, obj.Pos, NewError(obj.Pos, fmt.Sprintf("invalid pattern '%s': %s", nextString.Value, err))
+					if err := toPattern(nextString); err != nil {
+						return nil, obj.Pos, NewError(obj.Pos, err.Error())
 					}
-					nextString.isPattern = true
-					nextString.regexp = reg
 
 					boolEvaluator, err := StringEquals(unary, nextString, opts, state)
 					if err != nil {
@@ -563,17 +621,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, le
 					}
 					return boolEvaluator, obj.Pos, nil
 				case "=~":
-					// consider the value as regexp
 					if nextString.EvalFnc != nil {
 						return nil, obj.Pos, &ErrNonStaticPattern{Field: nextString.Field}
 					}
 
-					reg, err := patternToRegexp(nextString.Value)
-					if err != nil {
-						return nil, obj.Pos, NewError(obj.Pos, fmt.Sprintf("invalid pattern '%s': %s", nextString.Value, err))
+					if err := toPattern(nextString); err != nil {
+						return nil, obj.Pos, NewError(obj.Pos, err.Error())
 					}
-					nextString.isPattern = true
-					nextString.regexp = reg
 
 					boolEvaluator, err := StringEquals(unary, nextString, opts, state)
 					if err != nil {
@@ -602,17 +656,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, le
 					}
 					return boolEvaluator, obj.Pos, nil
 				case "!~":
-					// consider the value as regexp
 					if nextString.EvalFnc != nil {
 						return nil, obj.Pos, &ErrNonStaticPattern{Field: nextString.Field}
 					}
 
-					reg, err := patternToRegexp(nextString.Value)
-					if err != nil {
-						return nil, obj.Pos, NewError(obj.Pos, fmt.Sprintf("invalid pattern '%s': %s", nextString.Value, err))
+					if err := toPattern(nextString); err != nil {
+						return nil, obj.Pos, NewError(obj.Pos, err.Error())
 					}
-					nextString.isPattern = true
-					nextString.regexp = reg
 
 					boolEvaluator, err := ArrayStringContains(nextString, unary, opts, state)
 					if err != nil {
@@ -620,17 +670,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, le
 					}
 					return Not(boolEvaluator, opts, state), obj.Pos, nil
 				case "=~":
-					// consider the value as regexp
 					if nextString.EvalFnc != nil {
 						return nil, obj.Pos, &ErrNonStaticPattern{Field: nextString.Field}
 					}
 
-					reg, err := patternToRegexp(nextString.Value)
-					if err != nil {
-						return nil, obj.Pos, NewError(obj.Pos, fmt.Sprintf("invalid pattern '%s': %s", nextString.Value, err))
+					if err := toPattern(nextString); err != nil {
+						return nil, obj.Pos, NewError(obj.Pos, err.Error())
 					}
-					nextString.isPattern = true
-					nextString.regexp = reg
 
 					boolEvaluator, err := ArrayStringContains(nextString, unary, opts, state)
 					if err != nil {
@@ -829,7 +875,8 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, le
 			}, obj.Pos, nil
 		case obj.String != nil:
 			return &StringEvaluator{
-				Value: *obj.String,
+				Value:     *obj.String,
+				valueType: ScalarValueType,
 			}, obj.Pos, nil
 		case obj.Pattern != nil:
 			reg, err := patternToRegexp(*obj.Pattern)
@@ -839,8 +886,21 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, le
 
 			return &StringEvaluator{
 				Value:     *obj.Pattern,
-				isPattern: true,
+				isRegexp:  true,
 				regexp:    reg,
+				valueType: PatternValueType,
+			}, obj.Pos, nil
+		case obj.Regexp != nil:
+			reg, err := regexp.Compile(*obj.Regexp)
+			if err != nil {
+				return nil, obj.Pos, NewError(obj.Pos, fmt.Sprintf("invalid regexp '%s': %s", *obj.Regexp, err))
+			}
+
+			return &StringEvaluator{
+				Value:     *obj.Regexp,
+				isRegexp:  true,
+				regexp:    reg,
+				valueType: RegexpValueType,
 			}, obj.Pos, nil
 		case obj.SubExpression != nil:
 			return nodeToEvaluator(obj.SubExpression, opts, state)
@@ -848,63 +908,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, le
 			return nil, obj.Pos, NewError(obj.Pos, fmt.Sprintf("unknown primary '%s'", reflect.TypeOf(obj)))
 		}
 	case *ast.Array:
-		if len(obj.Numbers) != 0 {
-			return &IntArrayEvaluator{
-				Values: obj.Numbers,
-			}, obj.Pos, nil
-		} else if len(obj.StringMembers) != 0 {
-			var strs []string
-			var hasPatterns bool
-
-			for _, member := range obj.StringMembers {
-				if member.String != nil {
-					strs = append(strs, *member.String)
-				} else {
-					strs = append(strs, *member.Pattern)
-					hasPatterns = true
-				}
-			}
-
-			if hasPatterns {
-				var regs []*regexp.Regexp
-				var reg *regexp.Regexp
-				var err error
-
-				for _, member := range obj.StringMembers {
-					if member.String != nil {
-						// escape wildcard
-						str := strings.ReplaceAll(*member.String, "*", "\\*")
-
-						if reg, err = patternToRegexp(str); err != nil {
-							return nil, obj.Pos, NewError(obj.Pos, fmt.Sprintf("invalid pattern '%s': %s", *member.String, err))
-						}
-					} else {
-						if reg, err = patternToRegexp(*member.Pattern); err != nil {
-							return nil, obj.Pos, NewError(obj.Pos, fmt.Sprintf("invalid pattern '%s': %s", *member.Pattern, err))
-						}
-					}
-					regs = append(regs, reg)
-				}
-				return &StringArrayEvaluator{
-					Values:    strs,
-					regexps:   regs,
-					isPattern: true,
-				}, obj.Pos, nil
-			}
-
-			return &StringArrayEvaluator{
-				Values: strs,
-			}, obj.Pos, nil
-		} else if obj.Ident != nil {
-			if state.macros != nil {
-				if macro, ok := state.macros[*obj.Ident]; ok {
-					return macro.Value, obj.Pos, nil
-				}
-			}
-
-			// could be an iterator
-			return identToEvaluator(&ident{Pos: obj.Pos, Ident: obj.Ident}, opts, state)
-		}
+		return arrayToEvaluator(obj, opts, state)
 	}
 
 	return nil, lexer.Position{}, NewError(lexer.Position{}, fmt.Sprintf("unknown entity '%s'", reflect.TypeOf(obj)))

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -297,6 +297,11 @@ func TestRegexp(t *testing.T) {
 		{Expr: `process.name =~ ~"/usr/bin/*"`, Expected: true},
 		{Expr: `process.name =~ "/usr/bin/c$t"`, Expected: true},
 		{Expr: `process.name =~ "/usr/bin/c$taaa"`, Expected: false},
+		{Expr: `process.name =~ r".*/bin/.*"`, Expected: true},
+		{Expr: `process.name =~ r".*/[usr]+/bin/.*"`, Expected: true},
+		{Expr: `process.name =~ r".*/[abc]+/bin/.*"`, Expected: false},
+		{Expr: `process.name == r".*/bin/.*"`, Expected: true},
+		{Expr: `r".*/bin/.*" == process.name`, Expected: true},
 	}
 
 	for _, test := range tests {
@@ -771,6 +776,9 @@ func TestRegister(t *testing.T) {
 		{Expr: `~"ZZ*" in process.list[_].value`, Expected: false},
 		{Expr: `~"AA*" not in process.list[_].value`, Expected: false},
 		{Expr: `~"ZZ*" not in process.list[_].value`, Expected: true},
+
+		{Expr: `r"[A]{1,3}" in process.list[_].value`, Expected: true},
+		{Expr: `process.list[_].value in [r"[A]{1,3}", "nnnnn"]`, Expected: true},
 
 		{Expr: `process.list[_].value == ~"AA*"`, Expected: true},
 		{Expr: `process.list[_].value == ~"ZZ*"`, Expected: false},

--- a/pkg/security/secl/eval/pattern.go
+++ b/pkg/security/secl/eval/pattern.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package eval
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func patternToRegexp(pattern string) (*regexp.Regexp, error) {
+	// do not accept full wildcard value
+	if matched, err := regexp.Match(`[a-zA-Z0-9\.]+`, []byte(pattern)); err != nil || !matched {
+		return nil, &ErrInvalidPattern{Pattern: pattern}
+	}
+
+	// quote eveything except wilcard
+	re := regexp.MustCompile(`[\.*+?()|\[\]{}^$]`)
+	quoted := re.ReplaceAllStringFunc(pattern, func(s string) string {
+		if s != "*" {
+			return "\\" + s
+		}
+		return ".*"
+	})
+
+	return regexp.Compile("^" + quoted + "$")
+}
+
+func toPattern(se *StringEvaluator) error {
+	if se.isRegexp {
+		return nil
+	}
+
+	reg, err := patternToRegexp(se.Value)
+	if err != nil {
+		return fmt.Errorf("invalid pattern '%s': %s", se.Value, err)
+	}
+	se.valueType = PatternValueType
+	se.isRegexp = true
+	se.regexp = reg
+
+	return nil
+}

--- a/releasenotes/notes/regexp-in-secl-087bd7fe101d1046.yaml
+++ b/releasenotes/notes/regexp-in-secl-087bd7fe101d1046.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Runtime Security now supports regexp in SECL rules.


### PR DESCRIPTION
### What does this PR do?

This PR add regexp support in SECL. Currently SECL support patterns that are used for path matching only. Pattern can be used on other field too. Regexp are allowed on non path field only. To use them regexp have to be prefixed by `r`. Ex:

```
process.ancestors.name =~ r"mysql.*"
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
