### PR TITLE
snmp: add tags to snmp listener config

### DIFF
--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -86,7 +86,4 @@ instances:
     ##
     ## Learn more about tagging: https://docs.datadoghq.com/tagging/
     #
-    tags:
-      # The autodiscovery subnet the device is part of.
-      # Used by Agent autodiscovery to pass subnet name.
-      - "autodiscovery_subnet:%%extra_autodiscovery_subnet%%"
+    tags: %%extra_tags%%

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -415,6 +415,11 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 		return []byte(s.config.Network), nil
 	case "loader":
 		return []byte(s.config.Loader), nil
+	case "tags":
+		tags := []string{"autodiscovery_subnet:" + s.config.Network}
+		tags = append(tags, s.config.Tags...)
+		tagsAsJsonStr, _  := json.Marshal(tags)
+		return tagsAsJsonStr, nil
 	}
 	return []byte{}, ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -418,7 +418,7 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 	case "tags":
 		tags := []string{"autodiscovery_subnet:" + s.config.Network}
 		tags = append(tags, s.config.Tags...)
-		tagsAsJSONStr, _  := json.Marshal(tags)
+		tagsAsJSONStr, _ := json.Marshal(tags)
 		return tagsAsJSONStr, nil
 	}
 	return []byte{}, ErrNotSupported

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -418,8 +418,8 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 	case "tags":
 		tags := []string{"autodiscovery_subnet:" + s.config.Network}
 		tags = append(tags, s.config.Tags...)
-		tagsAsJsonStr, _  := json.Marshal(tags)
-		return tagsAsJsonStr, nil
+		tagsAsJSONStr, _  := json.Marshal(tags)
+		return tagsAsJSONStr, nil
 	}
 	return []byte{}, ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -163,6 +163,7 @@ func TestExtraConfig(t *testing.T) {
 		Community: "public",
 		Timeout:   5,
 		Retries:   2,
+		Tags:      []string{"tag1:val1", "tag2:val2"},
 	}
 
 	svc := SNMPService{
@@ -188,6 +189,10 @@ func TestExtraConfig(t *testing.T) {
 	info, err = svc.GetExtraConfig([]byte("retries"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "2", string(info))
+
+	info, err = svc.GetExtraConfig([]byte("tags"))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "[\"autodiscovery_subnet:192.168.0.0/24\",\"tag1:val1\",\"tag2:val2\"]", string(info))
 }
 
 func TestExtraConfigv3(t *testing.T) {

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -54,6 +54,7 @@ type Config struct {
 	IgnoredIPAddresses map[string]bool `mapstructure:"ignored_ip_addresses"`
 	ADIdentifier       string          `mapstructure:"ad_identifier"`
 	Loader             string          `mapstructure:"loader"`
+	Tags               []string        `mapstructure:"tags"`
 }
 
 // NewListenerConfig parses configuration and returns a built ListenerConfig


### PR DESCRIPTION
Closed in favour of https://github.com/DataDog/datadog-agent/pull/7680

### What does this PR do?

snmp: add tags to snmp listener config

### Motivation

user request to have subnet specific tags to be passed as instance tags

### Additional Notes

### Describe your test plan

Test using a `snmp_listener.configs` config with `tags` like this:

```
snmp_listener:
  configs:
    - network: 192.168.1.16/29
      version: 2
      port: 1161
      community: cisco_icm
      tags:
      - tag1:val1
      - tag2:val2
```

Check if metrics reported by snmp integration contain the tags from snmp_listener config.

1/ Test with single agent autodiscovery using snmp_listener: Setup guide: https://datadoghq.dev/integrations-core/architecture/snmp/#standalone-agent
2/ Test with DCA autodiscovery using snmp_listener. Setup guide: https://datadoghq.dev/integrations-core/architecture/snmp/#cluster-agent-support
