### PR TITLE
Allow the iot agent to report as the regular agent when iot_host is false

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -232,7 +232,9 @@ func NewBufferedAggregator(s serializer.MetricSerializer, hostname string, flush
 	bufferSize := config.Datadog.GetInt("aggregator_buffer_size")
 
 	agentName := flavor.GetFlavor()
-	if config.Datadog.GetBool("iot_host") {
+	if agentName == flavor.IotAgent && !config.Datadog.GetBool("iot_host") {
+		agentName = flavor.DefaultAgent
+	} else if config.Datadog.GetBool("iot_host") {
 		// Override the agentName if this Agent is configured to report as IotAgent
 		agentName = flavor.IotAgent
 	}


### PR DESCRIPTION
### What does this PR do?

Add an additional condition so not only the regular Agent can report as an IoT Agent, but also the IoT Agent can report as a regular Agent.

