### PR TITLE
[networks] Remove reliance on external IPs during offset guessing

### DIFF
--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -126,7 +126,6 @@ var tcpKprobeCalledString = map[C.__u64]string{
 }
 
 const listenIPv4 = "127.0.0.2"
-const googlePublicDNSIPv4 = "8.8.4.4"
 const interfaceLocalMulticastIPv6 = "ff01::1"
 
 var zero uint64
@@ -706,6 +705,7 @@ type eventGenerator struct {
 	conn     net.Conn
 	udpConn  net.Conn
 	udp6Conn *net.UDPConn
+	udpDone  func()
 }
 
 func newEventGenerator(ipv6 bool) (*eventGenerator, error) {
@@ -718,6 +718,12 @@ func newEventGenerator(ipv6 bool) (*eventGenerator, error) {
 
 	go acceptHandler(l)
 
+	// Spin up UDP server
+	udpAddr, udpDone, err := newUDPServer(addr)
+	if err != nil {
+		return nil, err
+	}
+
 	// Establish connection that will be used in the offset guessing
 	c, err := net.Dial(l.Addr().Network(), l.Addr().String())
 	if err != nil {
@@ -725,7 +731,7 @@ func newEventGenerator(ipv6 bool) (*eventGenerator, error) {
 		return nil, err
 	}
 
-	udpConn, err := net.Dial("udp", net.JoinHostPort(googlePublicDNSIPv4, "53"))
+	udpConn, err := net.Dial("udp", udpAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -743,7 +749,7 @@ func newEventGenerator(ipv6 bool) (*eventGenerator, error) {
 		}
 	}
 
-	return &eventGenerator{listener: l, conn: c, udpConn: udpConn, udp6Conn: udp6Conn}, nil
+	return &eventGenerator{listener: l, conn: c, udpConn: udpConn, udp6Conn: udp6Conn, udpDone: udpDone}, nil
 }
 
 // Generate an event for offset guessing
@@ -831,6 +837,10 @@ func (e *eventGenerator) Close() {
 	if e.udp6Conn != nil {
 		e.udp6Conn.Close()
 	}
+
+	if e.udpDone != nil {
+		e.udpDone()
+	}
 }
 
 func acceptHandler(l net.Listener) {
@@ -881,4 +891,31 @@ func logAndAdvance(status *tracerStatus, offset C.__u64, next C.__u64) {
 		log.Debugf("Started offset guessing for %v", whatString[next])
 		status.what = next
 	}
+}
+
+func newUDPServer(addr string) (string, func(), error) {
+	ln, err := net.ListenPacket("udp", addr)
+	if err != nil {
+		return "", nil, err
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		b := make([]byte, 10)
+		for {
+			ln.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+			_, _, err := ln.ReadFrom(b)
+			if err != nil && !os.IsTimeout(err) {
+				return
+			}
+		}
+	}()
+
+	doneFn := func() {
+		ln.Close()
+		<-done
+	}
+	return ln.LocalAddr().String(), doneFn, nil
 }

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1755,7 +1755,7 @@ func TestUnconnectedUDPSendIPv4(t *testing.T) {
 	defer tr.Stop()
 
 	remotePort := rand.Int()%5000 + 15000
-	remoteAddr := &net.UDPAddr{IP: net.ParseIP(googlePublicDNSIPv4), Port: remotePort}
+	remoteAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: remotePort}
 	// Use ListenUDP instead of DialUDP to create a "connectionless" UDP connection
 	conn, err := net.ListenUDP("udp", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Ensure that the system-probe doesn't need to reach `8.8.4.4:53` to guess UDP offsets.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
