### PR TITLE
Add logs when hitting connection tracking limit

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "f19f18507b499512d9299df9022ec1a3a4e08ff14418757bd558ab57d1d1e649")
+var Conntrack = NewRuntimeAsset("conntrack.c", "4b3883ab55c92b307cc8a97bd3f03eaa66b7ed58d3355d49bf569e4ca98b86d4")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "0a5dc6cf27f78cc2d842308f4a0342f48cba6456c86565f1f15e61f657db4bcb")
+var Tracer = NewRuntimeAsset("tracer.c", "625719bb782782c25b53ce9714a30b2c5f9bd769de9f2f751d4c6095aca42a8b")

--- a/pkg/network/ebpf/c/tracer-stats.h
+++ b/pkg/network/ebpf/c/tracer-stats.h
@@ -33,7 +33,9 @@ static __always_inline void update_conn_stats(conn_tuple_t* t, size_t sent_bytes
     // initialize-if-no-exist the connection stat, and load it
     conn_stats_ts_t empty = {};
     __builtin_memset(&empty, 0, sizeof(conn_stats_ts_t));
-    bpf_map_update_elem(&conn_stats, t, &empty, BPF_NOEXIST);
+    if (bpf_map_update_elem(&conn_stats, t, &empty, BPF_NOEXIST) == -E2BIG) {
+        increment_telemetry_count(conn_stats_max_entries_hit);
+    }
     val = bpf_map_lookup_elem(&conn_stats, t);
 
     if (!val) return;

--- a/pkg/network/ebpf/c/tracer-telemetry.h
+++ b/pkg/network/ebpf/c/tracer-telemetry.h
@@ -14,6 +14,7 @@ enum telemetry_counter {
     missed_udp_close,
     udp_send_processed,
     udp_send_missed,
+    conn_stats_max_entries_hit,
 };
 
 static __always_inline void increment_telemetry_count(enum telemetry_counter counter_name) {
@@ -33,11 +34,15 @@ static __always_inline void increment_telemetry_count(enum telemetry_counter cou
         break;
     case missed_udp_close:
         __sync_fetch_and_add(&val->missed_udp_close, 1);
+        break;
     case udp_send_processed:
         __sync_fetch_and_add(&val->udp_sends_processed, 1);
         break;
     case udp_send_missed:
         __sync_fetch_and_add(&val->udp_sends_missed, 1);
+        break;
+    case conn_stats_max_entries_hit:
+        __sync_fetch_and_add(&val->conn_stats_max_entries_hit, 1);
         break;
     }
     return;

--- a/pkg/network/ebpf/c/tracer.h
+++ b/pkg/network/ebpf/c/tracer.h
@@ -189,6 +189,7 @@ typedef struct {
     __u64 missed_udp_close;
     __u64 udp_sends_processed;
     __u64 udp_sends_missed;
+    __u64 conn_stats_max_entries_hit;
 } telemetry_t;
 
 #define PORT_LISTENING 1

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -861,11 +861,12 @@ func (t *Tracer) getEbpfTelemetry() map[string]int64 {
 	}
 
 	return map[string]int64{
-		"tcp_sent_miscounts":  int64(telemetry.tcp_sent_miscounts),
-		"missed_tcp_close":    int64(telemetry.missed_tcp_close),
-		"missed_udp_close":    int64(telemetry.missed_udp_close),
-		"udp_sends_processed": int64(telemetry.udp_sends_processed),
-		"udp_sends_missed":    int64(telemetry.udp_sends_missed),
+		"tcp_sent_miscounts":         int64(telemetry.tcp_sent_miscounts),
+		"missed_tcp_close":           int64(telemetry.missed_tcp_close),
+		"missed_udp_close":           int64(telemetry.missed_udp_close),
+		"udp_sends_processed":        int64(telemetry.udp_sends_processed),
+		"udp_sends_missed":           int64(telemetry.udp_sends_missed),
+		"conn_stats_max_entries_hit": int64(telemetry.conn_stats_max_entries_hit),
 	}
 }
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -552,6 +552,9 @@ func loadSysProbeEnvVariables() {
 		{"DD_RUNTIME_COMPILER_OUTPUT_DIR", "system_probe_config.runtime_compiler_output_dir"},
 		{"DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP", "network_config.enable_gateway_lookup"},
 		{"DD_SYSTEM_PROBE_PROCESS_ENABLED", "system_probe_config.process_config.enabled"},
+		{"DD_SYSTEM_PROBE_NETWORK_MAX_TRACKED_CONNECTIONS", "system_probe_config.max_tracked_connections"},
+		{"DD_SYSTEM_PROBE_NETWORK_MAX_CLOSED_CONNS_BUFFERED", "system_probe_config.max_closed_connections_buffered"},
+		{"DD_SYSTEM_PROBE_NETWORK_MAX_CONN_STATE_BUFFERED", "system_probe_config.max_connection_state_buffered"},
 	} {
 		if v, ok := os.LookupEnv(variable.env); ok {
 			config.Datadog.Set(variable.cfg, v)

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -135,16 +135,16 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 
 	// MaxClosedConnectionsBuffered represents the maximum number of closed connections we'll buffer in memory. These closed connections
 	// get flushed on every client request (default 30s check interval)
-	if k := "max_closed_connections_buffered"; config.Datadog.IsSet(k) {
-		if mcb := config.Datadog.GetInt(key(spNS, k)); mcb > 0 {
+	if k := key(spNS, "max_closed_connections_buffered"); config.Datadog.IsSet(k) {
+		if mcb := config.Datadog.GetInt(k); mcb > 0 {
 			a.MaxClosedConnectionsBuffered = mcb
 		}
 	}
 
 	// MaxConnectionsStateBuffered represents the maximum number of state objects that we'll store in memory. These state objects store
 	// the stats for a connection so we can accurately determine traffic change between client requests.
-	if k := "max_connection_state_buffered"; config.Datadog.IsSet(k) {
-		if mcsb := config.Datadog.GetInt(key(spNS, k)); mcsb > 0 {
+	if k := key(spNS, "max_connection_state_buffered"); config.Datadog.IsSet(k) {
+		if mcsb := config.Datadog.GetInt(k); mcsb > 0 {
 			a.MaxConnectionsStateBuffered = mcsb
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

This increases the default limit from `65536` to `131072`. It also:

- adds environment variables to set some of these limits, and fixes a bug which would've prevented some of the limits from taking effect.
- Adds an expvar to indicate how many times the limit has been hit.
- Adds log messages when you are approaching and/or have hit the limit.

### Motivation

A thorough investigation of an undercounting issue in our load-testing cluster revealed we were hitting the connection tracking limit. This is mainly due to the high volume of UDP DNS requests, which can sit in the map for ~2 minutes. At a request rate of 3k/sec UDP requests and 1k/sec TCP requests, it quickly filled up.


