### PR TITLE
Remove outdated out-of-order connection checking

### DIFF
--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "5d3ca04ec2ca674393048e67fcf97b76d3d44916bc6d824af5c05448e872215f")
+var Tracer = NewRuntimeAsset("tracer.c", "c670dfdf801a9bb4d6110d3130f031452e32ee0c0d1e9f88f153d80282a0cbed")

--- a/pkg/network/ebpf/c/tracer-events.h
+++ b/pkg/network/ebpf/c/tracer-events.h
@@ -42,9 +42,9 @@ static __always_inline void cleanup_conn(conn_tuple_t* tup) {
     bpf_map_delete_elem(&conn_stats, &(conn.tup));
 
     if (cst) {
-        cst->timestamp = bpf_ktime_get_ns();
         conn.conn_stats = *cst;
     }
+    conn.conn_stats.timestamp = bpf_ktime_get_ns();
 
     // Batch TCP closed connections before generating a perf event
     batch_t* batch_ptr = bpf_map_lookup_elem(&conn_close_batch, &cpu);

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1100,7 +1100,6 @@ func TestUnorderedCloseEvent(t *testing.T) {
 
 	// Ensure we don't have underflows / unordered conns
 	assert.Zero(t, state.(*networkState).telemetry.statsResets)
-	assert.Zero(t, state.(*networkState).telemetry.unorderedConns)
 
 	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections, 0)
 }

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -87,7 +87,6 @@ func TestTracerExpvar(t *testing.T) {
 		},
 		"state": {
 			"StatsResets",
-			"UnorderedConns",
 			"ClosedConnDropped",
 			"ConnDropped",
 			"TimeSyncCollisions",


### PR DESCRIPTION
### What does this PR do?

Removes the check for out-of-order connections, because we can no longer guarantee connections arrive in the order they close. It also fixes a bug where the connection updated timestamp wouldn't be set if there wasn't an object in the `conn_stats` map.

Before we introduced connection batching before sending them to userspace, we were guaranteed connections would arrive in the order they were closed. With batching, that is no longer the case.

Example, where the connections have identical tuples:
Connection A on CPU 0 closes, placed in batch Y
Connection B on CPU 1 closes, placed in batch Z
4 more connections on CPU 1 close, which causes batch Z to flush, Connection B arrives to userspace.
...time passes
4 more connections on CPU 0 close, which causes batch Y to flush, Connection A arrives to userspace.

Userspace will receive the connections in order B, A but they closed in A, B order. Thus we cannot use the updated timestamp for ordering.

Furthermore, the guard was an attempt at preventing double-counting of the same connection which we haven't seen occur in practice.