### PR TITLE
Use case-insensitive compare for DNS domain and joined domain

### DIFF
--- a/releasenotes/notes/dns-joined-domain-case-insensitive-compare-5824053dce4ce3da.yaml
+++ b/releasenotes/notes/dns-joined-domain-case-insensitive-compare-5824053dce4ce3da.yaml
@@ -1,4 +1,4 @@
 fixes:
   - |
     The Windows installer compares the DNS domain name and the joined domain name using a case-insensitive compare.
-    This avoids incorrect warning when the domain names match but otherwise have different cases.
+    This avoids an incorrect warning when the domain names match but otherwise have different cases.

--- a/releasenotes/notes/dns-joined-domain-case-insensitive-compare-5824053dce4ce3da.yaml
+++ b/releasenotes/notes/dns-joined-domain-case-insensitive-compare-5824053dce4ce3da.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    The Windows installer compares the DNS domain name and the joined domain name using a case-insensitive compare.
+    This avoids incorrect warning when the domain names match but otherwise have different cases.

--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -198,7 +198,7 @@ DWORD TargetMachine::DetectDomainInformation()
 
     if (_isDomainJoined)
     {
-        if (_dnsDomainName != _joinedDomain)
+        if (_wcsicmp(_dnsDomainName.c_str(), _joinedDomain.c_str()) != 0)
         {
             WcaLog(LOGMSG_STANDARD, "DNS domain name \"%S\" doesn't match the joined domain \"%S\"",
                    _dnsDomainName.c_str(), _joinedDomain.c_str());


### PR DESCRIPTION
### What does this PR do?

Uses a case insensitive compare fore the DNS domain name and the joined domain name.

### Motivation

Avoid producing a warning when comparing DNS domain name and joined domain name.
