### PR TITLE
Modify install execute sequence

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -431,7 +431,7 @@
       <!-- go ahead and always stop the services; if they're not installed (new install) it won't have any impact -->
 
       <!-- always stop the services, regardless of what's going on -->
-      <Custom Action='StopDDServices' After='StopServices'> </Custom>
+      <Custom Action='StopDDServices' Before='StopServices'> </Custom>
 
       <!-- only run the FinalizeInstall action on INSTALL (for now) Note this
            is from the perspective of the installer being run; on upgrade the
@@ -439,10 +439,10 @@
            installer is called with _UPGRADE, and then the new installer
            is called with _INSTALL -->
       <Custom Action='SetFinalizeProperty' Before='FinalizeInstall'> <![CDATA[Installed="" OR REMOVE="" ]]> </Custom>
-      <Custom Action='FinalizeInstall' After='InstallServices'>      <![CDATA[Installed="" OR REMOVE="" ]]> </Custom>
+      <Custom Action='FinalizeInstall' Before='StartServices'>      <![CDATA[Installed="" OR REMOVE="" ]]> </Custom>
 
       <!-- Same deal here -->
-      <Custom Action='StartDDServices' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL"]]></Custom>
+      <Custom Action='StartDDServices' After='StartServices'>  <![CDATA[REMOVE<>"ALL"]]></Custom>
 
       <!-- only do the uninstall (which removes the user state and file perms)
            on a full uninstall -->


### PR DESCRIPTION
Was trying to start the service before the driver was installed.  This
had a number of bad consequences.
Also make sure main service is stopped before trying to stop driver for
uninstall

### What does this PR do?

Fixes the installexecutesequence to be more predictable

### Motivation

Testing uncovered a couple of related problems
- The installation was attempting to start the DD services prior to the driver being installed.  This would be hidden by the fact that the system probe won't start w/o specific config, so the normal install/change config/restart would hide the problem
- when testing uninstall/reinstall scenarios, with a config already present, this would lead to unusual logs indicating the service(s) couldn't be started, when in fact they were.  THis was because the initial start would fail, but the retry would kick in, and would eventually be able to start the system-probe once the npm driver was finally installed.

