### PR TITLE
[DCA][DDM] Support tags templating in DDM queries

### DIFF
--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher_test.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher_test.go
@@ -147,69 +147,79 @@ func TestUpdateAutoscalerReferences(t *testing.T) {
 		}),
 	}
 
-	f.store.Set("default/dd-metric-0", model.DatadogMetricInternal{
+	ddm := model.DatadogMetricInternal{
 		ID:         "default/dd-metric-0",
 		Active:     false,
-		Query:      "metric query0",
 		Valid:      true,
 		Value:      10.0,
 		UpdateTime: updateTime,
 		Error:      nil,
-	}, "utest")
-	f.store.Set("default/dd-metric-1", model.DatadogMetricInternal{
+	}
+	ddm.SetQueries("metric query0")
+	f.store.Set("default/dd-metric-0", ddm, "utest")
+
+	ddm = model.DatadogMetricInternal{
 		ID:         "default/dd-metric-1",
 		Active:     true,
-		Query:      "metric query1",
 		Valid:      true,
 		Value:      11.0,
 		UpdateTime: updateTime,
 		Error:      nil,
-	}, "utest")
-	f.store.Set("default/dd-metric-2", model.DatadogMetricInternal{
+	}
+	ddm.SetQueries("metric query1")
+	f.store.Set("default/dd-metric-1", ddm, "utest")
+
+	ddm = model.DatadogMetricInternal{
 		ID:                   "default/dd-metric-2",
 		Active:               true,
-		Query:                "metric query2",
 		Valid:                true,
 		Value:                12.0,
 		UpdateTime:           updateTime,
 		AutoscalerReferences: "ns1/hpa1",
 		Error:                nil,
-	}, "utest")
+	}
+	ddm.SetQueries("metric query2")
+	f.store.Set("default/dd-metric-2", ddm, "utest")
 
 	f.runWatcherUpdate()
 
 	// Check internal store content
 	assert.Equal(t, 3, f.store.Count())
-	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
+	ddm = model.DatadogMetricInternal{
 		ID:                   "default/dd-metric-0",
 		Active:               true,
-		Query:                "metric query0",
 		Valid:                true,
 		Value:                10.0,
 		UpdateTime:           updateTime,
 		Error:                nil,
 		AutoscalerReferences: "ns0/hpa0",
-	}, f.store.Get("default/dd-metric-0"))
-	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
+	}
+	ddm.SetQueries("metric query0")
+	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dd-metric-0"))
+
+	ddm = model.DatadogMetricInternal{
 		ID:                   "default/dd-metric-1",
 		Active:               true,
-		Query:                "metric query1",
 		Valid:                true,
 		Value:                11.0,
 		UpdateTime:           updateTime,
 		Error:                nil,
 		AutoscalerReferences: "ns0/wpa0",
-	}, f.store.Get("default/dd-metric-1"))
-	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
+	}
+	ddm.SetQueries("metric query1")
+	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dd-metric-1"))
+
+	ddm = model.DatadogMetricInternal{
 		ID:                   "default/dd-metric-2",
 		Active:               false,
-		Query:                "metric query2",
 		Valid:                false,
 		Value:                12.0,
 		UpdateTime:           updateTime,
 		Error:                nil,
 		AutoscalerReferences: "",
-	}, f.store.Get("default/dd-metric-2"))
+	}
+	ddm.SetQueries("metric query2")
+	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dd-metric-2"))
 }
 
 func TestCreateAutogenDatadogMetrics(t *testing.T) {
@@ -256,33 +266,35 @@ func TestCreateAutogenDatadogMetrics(t *testing.T) {
 		}),
 	}
 
-	f.store.Set("default/dd-metric-0", model.DatadogMetricInternal{
+	ddm := model.DatadogMetricInternal{
 		ID:         "default/dd-metric-0",
 		Active:     true,
-		Query:      "metric query0",
 		Valid:      true,
 		Value:      10.0,
 		UpdateTime: updateTime,
 		Error:      nil,
-	}, "utest")
+	}
+	ddm.SetQuery("metric query0")
+	f.store.Set("default/dd-metric-0", ddm, "utest")
 
 	f.runWatcherUpdate()
 
 	// Check internal store content
 	assert.Equal(t, 3, f.store.Count())
-	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
+	ddm = model.DatadogMetricInternal{
 		ID:         "default/dd-metric-0",
 		Active:     false,
-		Query:      "metric query0",
 		Valid:      false,
 		Value:      10.0,
 		UpdateTime: updateTime,
 		Error:      nil,
-	}, f.store.Get("default/dd-metric-0"))
-	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
+	}
+	ddm.SetQuery("metric query0")
+	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dd-metric-0"))
+
+	ddm = model.DatadogMetricInternal{
 		ID:                   "default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22",
 		Active:               true,
-		Query:                "avg:docker.cpu.usage{foo:bar}.rollup(30)",
 		Valid:                false,
 		Autogen:              true,
 		ExternalMetricName:   "docker.cpu.usage",
@@ -290,11 +302,13 @@ func TestCreateAutogenDatadogMetrics(t *testing.T) {
 		UpdateTime:           updateTime,
 		Error:                nil,
 		AutoscalerReferences: "ns0/hpa0",
-	}, f.store.Get("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22"))
-	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
+	}
+	ddm.SetQuery("avg:docker.cpu.usage{foo:bar}.rollup(30)")
+	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22"))
+
+	ddm = model.DatadogMetricInternal{
 		ID:                   "default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412",
 		Active:               true,
-		Query:                "avg:docker.cpu.usage{bar:foo}.rollup(30)",
 		Valid:                false,
 		Autogen:              true,
 		ExternalMetricName:   "docker.cpu.usage",
@@ -302,7 +316,9 @@ func TestCreateAutogenDatadogMetrics(t *testing.T) {
 		UpdateTime:           updateTime,
 		Error:                nil,
 		AutoscalerReferences: "ns0/wpa0",
-	}, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))
+	}
+	ddm.SetQuery("avg:docker.cpu.usage{bar:foo}.rollup(30)")
+	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))
 }
 
 func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
@@ -312,20 +328,21 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 	expiredUpdateTime := time.Now().Add(time.Duration(-90) * time.Minute)
 
 	// This DatadogMetric is expired, but it's not an autogen one - should not touch it
-	f.store.Set("default/dd-metric-0", model.DatadogMetricInternal{
+	ddm := model.DatadogMetricInternal{
 		ID:         "default/dd-metric-0",
 		Active:     true,
-		Query:      "metric query0",
 		Valid:      true,
 		Value:      10.0,
 		UpdateTime: expiredUpdateTime,
 		Error:      nil,
-	}, "utest")
+	}
+	ddm.SetQueries("metric query0")
+	f.store.Set("default/dd-metric-0", ddm, "utest")
+
 	// HPA has been deleted but last update time was 30 minutes ago, we should keep it
-	f.store.Set("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22", model.DatadogMetricInternal{
+	ddm = model.DatadogMetricInternal{
 		ID:                 "default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22",
 		Active:             true,
-		Query:              "avg:docker.cpu.usage{foo:bar}.rollup(30)",
 		Valid:              false,
 		Autogen:            true,
 		ExternalMetricName: "docker.cpu.usage",
@@ -333,12 +350,14 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 		Value:              0.0,
 		UpdateTime:         oldUpdateTime,
 		Error:              nil,
-	}, "utest")
+	}
+	ddm.SetQueries("avg:docker.cpu.usage{foo:bar}.rollup(30)")
+	f.store.Set("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22", ddm, "utest")
+
 	// WPA has been deleted for 90 minutes, we should flag this as deleted
-	f.store.Set("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412", model.DatadogMetricInternal{
+	ddm = model.DatadogMetricInternal{
 		ID:                 "default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412",
 		Active:             true,
-		Query:              "avg:docker.cpu.usage{bar:foo}.rollup(30)",
 		Valid:              false,
 		Autogen:            true,
 		ExternalMetricName: "docker.cpu.usage",
@@ -346,26 +365,29 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 		Value:              0.0,
 		UpdateTime:         expiredUpdateTime,
 		Error:              nil,
-	}, "utest")
+	}
+	ddm.SetQueries("avg:docker.cpu.usage{bar:foo}.rollup(30)")
+	f.store.Set("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412", ddm, "utest")
 
 	f.runWatcherUpdate()
 
 	// Check internal store content
 	assert.Equal(t, 3, f.store.Count())
-	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
+	ddm = model.DatadogMetricInternal{
 		ID:         "default/dd-metric-0",
 		Active:     false,
-		Query:      "metric query0",
 		Valid:      false,
 		Deleted:    false,
 		Value:      10.0,
 		UpdateTime: expiredUpdateTime,
 		Error:      nil,
-	}, f.store.Get("default/dd-metric-0"))
-	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
+	}
+	ddm.SetQueries("metric query0")
+	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dd-metric-0"))
+
+	ddm = model.DatadogMetricInternal{
 		ID:                 "default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22",
 		Active:             false,
-		Query:              "avg:docker.cpu.usage{foo:bar}.rollup(30)",
 		Valid:              false,
 		Autogen:            true,
 		ExternalMetricName: "docker.cpu.usage",
@@ -373,11 +395,13 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 		Value:              0.0,
 		UpdateTime:         oldUpdateTime,
 		Error:              nil,
-	}, f.store.Get("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22"))
-	compareDatadogMetricInternal(t, &model.DatadogMetricInternal{
+	}
+	ddm.SetQueries("avg:docker.cpu.usage{foo:bar}.rollup(30)")
+	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22"))
+
+	ddm = model.DatadogMetricInternal{
 		ID:                 "default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412",
 		Active:             false,
-		Query:              "avg:docker.cpu.usage{bar:foo}.rollup(30)",
 		Valid:              false,
 		Autogen:            true,
 		ExternalMetricName: "docker.cpu.usage",
@@ -385,5 +409,7 @@ func TestCleanUpAutogenDatadogMetrics(t *testing.T) {
 		Value:              0.0,
 		UpdateTime:         expiredUpdateTime,
 		Error:              nil,
-	}, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))
+	}
+	ddm.SetQueries("avg:docker.cpu.usage{bar:foo}.rollup(30)")
+	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))
 }

--- a/pkg/clusteragent/externalmetrics/datadogmetric_controller.go
+++ b/pkg/clusteragent/externalmetrics/datadogmetric_controller.go
@@ -271,7 +271,7 @@ func (c *DatadogMetricController) createDatadogMetric(ns, name string, datadogMe
 			Name:      name,
 		},
 		Spec: datadoghq.DatadogMetricSpec{
-			Query: datadogMetricInternal.Query,
+			Query: datadogMetricInternal.RawQuery(),
 		},
 		Status: *datadogMetricInternal.BuildStatus(nil),
 	}

--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -87,8 +87,9 @@ func (mr *MetricsRetriever) retrieveMetricsValues() {
 			continue
 		}
 
-		if queryResult, found := results[datadogMetric.Query]; found {
-			log.Debugf("QueryResult from DD: %v", queryResult)
+		query := datadogMetric.Query()
+		if queryResult, found := results[query]; found {
+			log.Debugf("QueryResult from DD for %q: %v", query, queryResult)
 
 			if queryResult.Valid {
 				datadogMetricFromStore.Value = queryResult.Value
@@ -100,12 +101,12 @@ func (mr *MetricsRetriever) retrieveMetricsValues() {
 					datadogMetricFromStore.UpdateTime = time.Unix(queryResult.Timestamp, 0).UTC()
 				} else {
 					datadogMetricFromStore.Valid = false
-					datadogMetricFromStore.Error = fmt.Errorf(invalidMetricOutdatedErrorMessage, datadogMetric.Query)
+					datadogMetricFromStore.Error = fmt.Errorf(invalidMetricOutdatedErrorMessage, query)
 					datadogMetricFromStore.UpdateTime = currentTime
 				}
 			} else {
 				datadogMetricFromStore.Valid = false
-				datadogMetricFromStore.Error = fmt.Errorf(invalidMetricBackendErrorMessage, datadogMetric.Query)
+				datadogMetricFromStore.Error = fmt.Errorf(invalidMetricBackendErrorMessage, query)
 				datadogMetricFromStore.UpdateTime = currentTime
 			}
 		} else {
@@ -113,7 +114,7 @@ func (mr *MetricsRetriever) retrieveMetricsValues() {
 			if globalError {
 				datadogMetricFromStore.Error = fmt.Errorf(invalidMetricGlobalErrorMessage)
 			} else {
-				datadogMetricFromStore.Error = fmt.Errorf(invalidMetricNoDataErrorMessage, datadogMetric.Query)
+				datadogMetricFromStore.Error = fmt.Errorf(invalidMetricNoDataErrorMessage, query)
 			}
 			datadogMetricFromStore.UpdateTime = currentTime
 		}
@@ -126,9 +127,10 @@ func getUniqueQueries(datadogMetrics []model.DatadogMetricInternal) []string {
 	queries := make([]string, 0, len(datadogMetrics))
 	unique := make(map[string]struct{}, len(queries))
 	for _, datadogMetric := range datadogMetrics {
-		if _, found := unique[datadogMetric.Query]; !found {
-			unique[datadogMetric.Query] = struct{}{}
-			queries = append(queries, datadogMetric.Query)
+		query := datadogMetric.Query()
+		if _, found := unique[query]; !found {
+			unique[query] = struct{}{}
+			queries = append(queries, query)
 		}
 	}
 

--- a/pkg/clusteragent/externalmetrics/metrics_retriever_test.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever_test.go
@@ -36,13 +36,18 @@ func (p *mockedProcessor) ProcessEMList(emList []custommetrics.ExternalMetricVal
 	return nil
 }
 
+type ddmWithQuery struct {
+	ddm   model.DatadogMetricInternal
+	query string
+}
+
 type metricsFixture struct {
 	desc         string
 	maxAge       int64
-	storeContent []model.DatadogMetricInternal
+	storeContent []ddmWithQuery
 	queryResults map[string]autoscalers.Point
 	queryError   error
-	expected     []model.DatadogMetricInternal
+	expected     []ddmWithQuery
 }
 
 func (f *metricsFixture) run(t *testing.T, testTime time.Time) {
@@ -51,7 +56,8 @@ func (f *metricsFixture) run(t *testing.T, testTime time.Time) {
 	// Create and fill store
 	store := NewDatadogMetricsInternalStore()
 	for _, datadogMetric := range f.storeContent {
-		store.Set(datadogMetric.ID, datadogMetric, "utest")
+		datadogMetric.ddm.SetQueries(datadogMetric.query)
+		store.Set(datadogMetric.ddm.ID, datadogMetric.ddm, "utest")
 	}
 
 	// Create MetricsRetriever
@@ -64,19 +70,20 @@ func (f *metricsFixture) run(t *testing.T, testTime time.Time) {
 	metricsRetriever.retrieveMetricsValues()
 
 	for _, expectedDatadogMetric := range f.expected {
-		datadogMetric := store.Get(expectedDatadogMetric.ID)
+		expectedDatadogMetric.ddm.SetQueries(expectedDatadogMetric.query)
+		datadogMetric := store.Get(expectedDatadogMetric.ddm.ID)
 
 		// Update time will be set to a value (as metricsRetriever uses time.Now()) that should be > testTime
 		// Thus, aligning updateTime to have a working comparison
-		if !expectedDatadogMetric.Valid && datadogMetric != nil && datadogMetric.Active {
-			assert.Condition(t, func() bool { return datadogMetric.UpdateTime.After(expectedDatadogMetric.UpdateTime) })
+		if !expectedDatadogMetric.ddm.Valid && datadogMetric != nil && datadogMetric.Active {
+			assert.Condition(t, func() bool { return datadogMetric.UpdateTime.After(expectedDatadogMetric.ddm.UpdateTime) })
 
 			alignedTime := time.Now().UTC()
-			expectedDatadogMetric.UpdateTime = alignedTime
+			expectedDatadogMetric.ddm.UpdateTime = alignedTime
 			datadogMetric.UpdateTime = alignedTime
 		}
 
-		assert.Equal(t, &expectedDatadogMetric, datadogMetric)
+		assert.Equal(t, &expectedDatadogMetric.ddm, datadogMetric)
 	}
 }
 
@@ -90,22 +97,26 @@ func TestRetrieveMetricsBasic(t *testing.T) {
 		{
 			maxAge: 30,
 			desc:   "Test nominal case - no errors while retrieving metric values",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     true,
-					Query:      "query-metric1",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      false,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     true,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      false,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 			queryResults: map[string]autoscalers.Point{
@@ -121,24 +132,28 @@ func TestRetrieveMetricsBasic(t *testing.T) {
 				},
 			},
 			queryError: nil,
-			expected: []model.DatadogMetricInternal{
+			expected: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					Value:      10.0,
-					UpdateTime: defaultTestTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						Value:      10.0,
+						UpdateTime: defaultTestTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     true,
-					Query:      "query-metric1",
-					Value:      11.0,
-					UpdateTime: defaultTestTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     true,
+						Value:      11.0,
+						UpdateTime: defaultTestTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 		},
@@ -161,22 +176,26 @@ func TestRetrieveMetricsErrorCases(t *testing.T) {
 		{
 			maxAge: 5,
 			desc:   "Test expired data from backend",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     true,
-					Query:      "query-metric1",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      false,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     true,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      false,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 			queryResults: map[string]autoscalers.Point{
@@ -192,48 +211,56 @@ func TestRetrieveMetricsErrorCases(t *testing.T) {
 				},
 			},
 			queryError: nil,
-			expected: []model.DatadogMetricInternal{
+			expected: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					Value:      10.0,
-					UpdateTime: defaultTestTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						Value:      10.0,
+						UpdateTime: defaultTestTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:     "metric1",
-					Active: true,
-					Query:  "query-metric1",
-					Value:  11.0,
-					Valid:  false,
-					Error:  fmt.Errorf(invalidMetricOutdatedErrorMessage, "query-metric1"),
-					// UpdateTime not set as it will not be compared directly
+					ddm: model.DatadogMetricInternal{
+						ID:     "metric1",
+						Active: true,
+						Value:  11.0,
+						Valid:  false,
+						Error:  fmt.Errorf(invalidMetricOutdatedErrorMessage, "query-metric1"),
+						// UpdateTime not set as it will not be compared directly
+					},
+					query: "query-metric1",
 				},
 			},
 		},
 		{
 			maxAge: 30,
 			desc:   "Test backend error (single metric)",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					Value:      8.0,
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						Value:      8.0,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     true,
-					Query:      "query-metric1",
-					Value:      11.0,
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     true,
+						Value:      11.0,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 			queryResults: map[string]autoscalers.Point{
@@ -249,94 +276,110 @@ func TestRetrieveMetricsErrorCases(t *testing.T) {
 				},
 			},
 			queryError: nil,
-			expected: []model.DatadogMetricInternal{
+			expected: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					Value:      10.0,
-					UpdateTime: defaultTestTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						Value:      10.0,
+						UpdateTime: defaultTestTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:     "metric1",
-					Active: true,
-					Query:  "query-metric1",
-					Value:  11.0,
-					Valid:  false,
-					Error:  fmt.Errorf(invalidMetricBackendErrorMessage, "query-metric1"),
-					// UpdateTime not set as it will not be compared directly
+					ddm: model.DatadogMetricInternal{
+						ID:     "metric1",
+						Active: true,
+						Value:  11.0,
+						Valid:  false,
+						Error:  fmt.Errorf(invalidMetricBackendErrorMessage, "query-metric1"),
+						// UpdateTime not set as it will not be compared directly
+					},
+					query: "query-metric1",
 				},
 			},
 		},
 		{
 			maxAge: 30,
 			desc:   "Test global error from backend",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					Value:      1.0,
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						Value:      1.0,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     true,
-					Query:      "query-metric1",
-					Value:      2.0,
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      false,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     true,
+						Value:      2.0,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      false,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 			queryResults: map[string]autoscalers.Point{},
 			queryError:   fmt.Errorf("Backend error 500"),
-			expected: []model.DatadogMetricInternal{
+			expected: []ddmWithQuery{
 				{
-					ID:     "metric0",
-					Active: true,
-					Query:  "query-metric0",
-					Value:  1.0,
-					Valid:  false,
-					Error:  fmt.Errorf(invalidMetricGlobalErrorMessage),
-					// UpdateTime not set as it will not be compared directly
+					ddm: model.DatadogMetricInternal{
+						ID:     "metric0",
+						Active: true,
+						Value:  1.0,
+						Valid:  false,
+						Error:  fmt.Errorf(invalidMetricGlobalErrorMessage),
+						// UpdateTime not set as it will not be compared directly
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:     "metric1",
-					Active: true,
-					Query:  "query-metric1",
-					Value:  2.0,
-					Valid:  false,
-					Error:  fmt.Errorf(invalidMetricGlobalErrorMessage),
-					// UpdateTime not set as it will not be compared directly
+					ddm: model.DatadogMetricInternal{
+						ID:     "metric1",
+						Active: true,
+						Value:  2.0,
+						Valid:  false,
+						Error:  fmt.Errorf(invalidMetricGlobalErrorMessage),
+						// UpdateTime not set as it will not be compared directly
+					},
+					query: "query-metric1",
 				},
 			},
 		},
 		{
 			maxAge: 30,
 			desc:   "Test missing query response from backend",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					Value:      1.0,
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						Value:      1.0,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     true,
-					Query:      "query-metric1",
-					Value:      2.0,
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      false,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     true,
+						Value:      2.0,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      false,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 			queryResults: map[string]autoscalers.Point{
@@ -347,24 +390,28 @@ func TestRetrieveMetricsErrorCases(t *testing.T) {
 				},
 			},
 			queryError: fmt.Errorf("Backend error 500"),
-			expected: []model.DatadogMetricInternal{
+			expected: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					Value:      10.0,
-					UpdateTime: defaultTestTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						Value:      10.0,
+						UpdateTime: defaultTestTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:     "metric1",
-					Active: true,
-					Query:  "query-metric1",
-					Value:  2.0,
-					Valid:  false,
-					Error:  fmt.Errorf(invalidMetricNoDataErrorMessage, "query-metric1"),
-					// UpdateTime not set as it will not be compared directly
+					ddm: model.DatadogMetricInternal{
+						ID:     "metric1",
+						Active: true,
+						Value:  2.0,
+						Valid:  false,
+						Error:  fmt.Errorf(invalidMetricNoDataErrorMessage, "query-metric1"),
+						// UpdateTime not set as it will not be compared directly
+					},
+					query: "query-metric1",
 				},
 			},
 		},
@@ -387,22 +434,26 @@ func TestRetrieveMetricsNotActive(t *testing.T) {
 		{
 			maxAge: 30,
 			desc:   "Test some metrics are not active",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     false,
-					Query:      "query-metric1",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      false,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     false,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      false,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 			queryResults: map[string]autoscalers.Point{
@@ -418,45 +469,53 @@ func TestRetrieveMetricsNotActive(t *testing.T) {
 				},
 			},
 			queryError: nil,
-			expected: []model.DatadogMetricInternal{
+			expected: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     true,
-					Query:      "query-metric0",
-					Value:      10.0,
-					UpdateTime: defaultTestTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						Value:      10.0,
+						UpdateTime: defaultTestTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     false,
-					Query:      "query-metric1",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      false,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     false,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      false,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 		},
 		{
 			maxAge: 30,
 			desc:   "Test no active metrics",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     false,
-					Query:      "query-metric0",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     false,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     false,
-					Query:      "query-metric1",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      false,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     false,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      false,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 			queryResults: map[string]autoscalers.Point{
@@ -472,22 +531,26 @@ func TestRetrieveMetricsNotActive(t *testing.T) {
 				},
 			},
 			queryError: nil,
-			expected: []model.DatadogMetricInternal{
+			expected: []ddmWithQuery{
 				{
-					ID:         "metric0",
-					Active:     false,
-					Query:      "query-metric0",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      true,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     false,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "metric1",
-					Active:     false,
-					Query:      "query-metric1",
-					UpdateTime: defaultPreviousUpdateTime,
-					Valid:      false,
-					Error:      nil,
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     false,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      false,
+						Error:      nil,
+					},
+					query: "query-metric1",
 				},
 			},
 		},

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -28,7 +28,8 @@ const (
 // DatadogMetricInternal is a flatten, easier to use, representation of `DatadogMetric` CRD
 type DatadogMetricInternal struct {
 	ID                   string
-	Query                string
+	query                string
+	resolvedQuery        *string
 	Valid                bool
 	Active               bool
 	Deleted              bool
@@ -45,7 +46,7 @@ type DatadogMetricInternal struct {
 func NewDatadogMetricInternal(id string, datadogMetric datadoghq.DatadogMetric) DatadogMetricInternal {
 	internal := DatadogMetricInternal{
 		ID:                   id,
-		Query:                datadogMetric.Spec.Query,
+		query:                datadogMetric.Spec.Query,
 		Valid:                false,
 		Active:               false,
 		Deleted:              false,
@@ -71,6 +72,8 @@ func NewDatadogMetricInternal(id string, datadogMetric datadoghq.DatadogMetric) 
 		}
 	}
 
+	internal.resolveQuery(internal.query)
+
 	// If UpdateTime is not set, it means it's a newly created DatadogMetric
 	// We'll need a proper update time to generate status, so setting to current time
 	if internal.UpdateTime.IsZero() {
@@ -95,7 +98,7 @@ func NewDatadogMetricInternal(id string, datadogMetric datadoghq.DatadogMetric) 
 func NewDatadogMetricInternalFromExternalMetric(id, query, metricName, autoscalerReference string) DatadogMetricInternal {
 	return DatadogMetricInternal{
 		ID:                   id,
-		Query:                query,
+		query:                query,
 		Valid:                false,
 		Active:               true,
 		Deleted:              false,
@@ -106,9 +109,30 @@ func NewDatadogMetricInternalFromExternalMetric(id, query, metricName, autoscale
 	}
 }
 
-// UpdateFrom updates the `DatadogMetricInternal` from `DatadogMetric` Spec, returns modified instance
+// Query returns the query that should be used to fetch metrics
+func (d *DatadogMetricInternal) Query() string {
+	if d.resolvedQuery != nil {
+		return *d.resolvedQuery
+	}
+	return d.query
+}
+
+// RawQuery returns the query that should be used to create DDM objects
+func (d *DatadogMetricInternal) RawQuery() string {
+	return d.query
+}
+
+// UpdateFrom updates the `DatadogMetricInternal` from `DatadogMetric` Spec
 func (d *DatadogMetricInternal) UpdateFrom(currentSpec datadoghq.DatadogMetricSpec) {
-	d.Query = currentSpec.Query
+	if d.shouldResolveQuery(currentSpec) {
+		d.resolveQuery(currentSpec.Query)
+	}
+	d.query = currentSpec.Query
+}
+
+// shouldResolveQuery returns whether we should try to resolve a new query
+func (d *DatadogMetricInternal) shouldResolveQuery(spec datadoghq.DatadogMetricSpec) bool {
+	return d.resolvedQuery == nil || d.query != spec.Query
 }
 
 // IsNewerThan returns true if the current `DatadogMetricInternal` has been updated more recently than `DatadogMetric` Status
@@ -204,4 +228,33 @@ func (d *DatadogMetricInternal) newCondition(status bool, updateTime metav1.Time
 	}
 
 	return condition
+}
+
+// resolveQuery tries to resolve the query and set the DatadogMetricInternal fields accordingly
+func (d *DatadogMetricInternal) resolveQuery(query string) {
+	resolvedQuery, err := resolveQuery(query)
+	if err != nil {
+		log.Errorf("Unable to resolve DatadogMetric query %q: %w", d.query, err)
+		d.Valid = false
+		d.Error = fmt.Errorf("Cannot resolve query: %v", err)
+		d.UpdateTime = time.Now().UTC()
+		d.resolvedQuery = nil
+		return
+	}
+	if resolvedQuery != "" {
+		d.resolvedQuery = &resolvedQuery
+		return
+	}
+	d.resolvedQuery = &d.query
+}
+
+// SetQueries is only used for testing in other packages
+func (d *DatadogMetricInternal) SetQueries(q string) {
+	d.query = q
+	d.resolvedQuery = &q
+}
+
+// SetQueries is only used for testing in other packages
+func (d *DatadogMetricInternal) SetQuery(q string) {
+	d.query = q
 }

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal_test.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal_test.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build kubeapiserver
+
+package model
+
+import (
+	"errors"
+	"testing"
+
+	datadoghq "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	simpleQuery           = "avg:nginx.net.request_per_s{kube_container_name:nginx}"
+	simpleQueryWithRollup = "avg:nginx.net.request_per_s{kube_container_name:nginx}.rollup(60)"
+	templatedQuery        = "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%tag_kube_cluster_name%%}"
+	invalidTemplatedQuery = "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%tag_foo%%}"
+	resolvedQuery         = "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:cluster-foo}"
+)
+
+func TestDatadogMetricInternal_UpdateFrom(t *testing.T) {
+	templatedTags = templatedTagsStub
+	tests := []struct {
+		name                  string
+		ddmInternal           *DatadogMetricInternal
+		newSpec               datadoghq.DatadogMetricSpec
+		expectedQuery         string
+		expectedResolvedQuery *string
+	}{
+		{
+			name: "same query",
+			ddmInternal: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+			newSpec: datadoghq.DatadogMetricSpec{
+				Query: simpleQuery,
+			},
+			expectedQuery:         simpleQuery,
+			expectedResolvedQuery: &simpleQuery,
+		},
+		{
+			name: "new query, no templating",
+			ddmInternal: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+			newSpec: datadoghq.DatadogMetricSpec{
+				Query: simpleQueryWithRollup,
+			},
+			expectedQuery:         simpleQueryWithRollup,
+			expectedResolvedQuery: &simpleQueryWithRollup,
+		},
+		{
+			name: "same query, nil ResolvedQuery",
+			ddmInternal: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: nil,
+			},
+			newSpec: datadoghq.DatadogMetricSpec{
+				Query: simpleQuery,
+			},
+			expectedQuery:         simpleQuery,
+			expectedResolvedQuery: &simpleQuery,
+		},
+		{
+			name: "new templated query",
+			ddmInternal: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+			newSpec: datadoghq.DatadogMetricSpec{
+				Query: templatedQuery,
+			},
+			expectedQuery:         templatedQuery,
+			expectedResolvedQuery: &resolvedQuery,
+		},
+		{
+			name: "cannot resolve query",
+			ddmInternal: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+			newSpec: datadoghq.DatadogMetricSpec{
+				Query: invalidTemplatedQuery,
+			},
+			expectedQuery:         invalidTemplatedQuery,
+			expectedResolvedQuery: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.ddmInternal.UpdateFrom(tt.newSpec)
+			assert.Equal(t, tt.expectedQuery, tt.ddmInternal.query)
+			if tt.expectedResolvedQuery == nil {
+				assert.Nil(t, tt.ddmInternal.resolvedQuery)
+			} else {
+				assert.Equal(t, *tt.expectedResolvedQuery, *tt.ddmInternal.resolvedQuery)
+			}
+		})
+	}
+}
+
+func TestDatadogMetricInternal_resolveQuery(t *testing.T) {
+	templatedTags = templatedTagsStub
+	tests := []struct {
+		name        string
+		query       string
+		ddmInternal *DatadogMetricInternal
+		expected    *DatadogMetricInternal
+	}{
+		{
+			name:  "simple query",
+			query: simpleQuery,
+			ddmInternal: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: nil,
+			},
+			expected: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+		},
+		{
+			name:  "same templated query",
+			query: templatedQuery,
+			ddmInternal: &DatadogMetricInternal{
+				query:         templatedQuery,
+				resolvedQuery: nil,
+			},
+			expected: &DatadogMetricInternal{
+				query:         templatedQuery,
+				resolvedQuery: &resolvedQuery,
+			},
+		},
+		{
+			name:  "new templated query",
+			query: templatedQuery,
+			ddmInternal: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+			expected: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: &resolvedQuery,
+			},
+		},
+		{
+			name:  "invalid templated query",
+			query: invalidTemplatedQuery,
+			ddmInternal: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+			expected: &DatadogMetricInternal{
+				query:         simpleQuery,
+				resolvedQuery: nil,
+				Valid:         false,
+				Error:         errors.New(`Cannot resolve query: cannot resolve tag template "foo": tag is not supported`),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.ddmInternal.resolveQuery(tt.query)
+			assert.Equal(t, tt.expected.query, tt.ddmInternal.query)
+			assert.Equal(t, tt.expected.resolvedQuery, tt.ddmInternal.resolvedQuery)
+			assert.Equal(t, tt.expected.Valid, tt.ddmInternal.Valid)
+			assert.Equal(t, tt.expected.Error, tt.ddmInternal.Error)
+			if tt.expected.Error != nil {
+				assert.NotEqual(t, tt.expected.UpdateTime, tt.ddmInternal.UpdateTime)
+			}
+		})
+	}
+}

--- a/pkg/clusteragent/externalmetrics/model/utils_test.go
+++ b/pkg/clusteragent/externalmetrics/model/utils_test.go
@@ -1,0 +1,154 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build kubeapiserver
+
+package model
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var templatedTagsStub = map[string]tagGetter{"kube_cluster_name": func() (string, error) { return "cluster-foo", nil }}
+
+func Test_resolveQuery(t *testing.T) {
+	tests := []struct {
+		name          string
+		q             string
+		templatedTags map[string]tagGetter
+		loadFunc      func()
+		cleanupFunc   func()
+		want          string
+		wantErr       bool
+	}{
+		{
+			name:          "nominal case",
+			q:             "avg:nginx.net.request_per_s{kube_container_name:nginx}.rollup(60)",
+			templatedTags: templatedTagsStub,
+			loadFunc:      func() {},
+			cleanupFunc:   func() {},
+			want:          "",
+			wantErr:       false,
+		},
+		{
+			name:          "1 tag",
+			q:             "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%tag_kube_cluster_name%%}.rollup(60)",
+			templatedTags: templatedTagsStub,
+			loadFunc:      func() {},
+			cleanupFunc:   func() {},
+			want:          "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:cluster-foo}.rollup(60)",
+			wantErr:       false,
+		},
+		{
+			name:          "1 env",
+			q:             "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%env_DD_CLUSTER_NAME%%}.rollup(60)",
+			templatedTags: map[string]tagGetter{},
+			loadFunc:      func() { os.Setenv("DD_CLUSTER_NAME", "cluster-foo") },
+			cleanupFunc:   func() { os.Unsetenv("DD_CLUSTER_NAME") },
+			want:          "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:cluster-foo}.rollup(60)",
+			wantErr:       false,
+		},
+		{
+			name:          "1 tag, multiple references",
+			q:             "avg:nginx.connections.accepted{kube_cluster_name:%%tag_kube_cluster_name%%,kube_service:nginx}/avg:nginx.net.connections{kube_cluster_name:%%tag_kube_cluster_name%%,kube_service:nginx}",
+			templatedTags: templatedTagsStub,
+			loadFunc:      func() {},
+			cleanupFunc:   func() {},
+			want:          "avg:nginx.connections.accepted{kube_cluster_name:cluster-foo,kube_service:nginx}/avg:nginx.net.connections{kube_cluster_name:cluster-foo,kube_service:nginx}",
+			wantErr:       false,
+		},
+		{
+			name:          "1 env, multiple references",
+			q:             "avg:nginx.connections.accepted{kube_cluster_name:%%env_DD_CLUSTER_NAME%%,kube_service:nginx}/avg:nginx.net.connections{kube_cluster_name:%%env_DD_CLUSTER_NAME%%,kube_service:nginx}",
+			templatedTags: map[string]tagGetter{},
+			loadFunc:      func() { os.Setenv("DD_CLUSTER_NAME", "cluster-foo") },
+			cleanupFunc:   func() { os.Unsetenv("DD_CLUSTER_NAME") },
+			want:          "avg:nginx.connections.accepted{kube_cluster_name:cluster-foo,kube_service:nginx}/avg:nginx.net.connections{kube_cluster_name:cluster-foo,kube_service:nginx}",
+			wantErr:       false,
+		},
+		{
+			name: "multiple tag values",
+			q:    "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%tag_kube_cluster_name%%,datacenter:%%tag_datacenter%%}.rollup(60)",
+			templatedTags: map[string]tagGetter{
+				"kube_cluster_name": func() (string, error) { return "cluster-foo", nil },
+				"datacenter":        func() (string, error) { return "dc-foo", nil },
+			},
+			loadFunc:    func() {},
+			cleanupFunc: func() {},
+			want:        "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:cluster-foo,datacenter:dc-foo}.rollup(60)",
+			wantErr:     false,
+		},
+		{
+			name:          "multiple env values",
+			q:             "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%env_DD_CLUSTER_NAME%%,datacenter:%%env_DATACENTER%%}.rollup(60)",
+			templatedTags: map[string]tagGetter{},
+			loadFunc:      func() { os.Setenv("DD_CLUSTER_NAME", "cluster-foo"); os.Setenv("DATACENTER", "dc-foo") },
+			cleanupFunc:   func() {},
+			want:          "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:cluster-foo,datacenter:dc-foo}.rollup(60)",
+			wantErr:       false,
+		},
+		{
+			name:          "mixing env and tag",
+			q:             "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%tag_kube_cluster_name%%,datacenter:%%env_DATACENTER%%}.rollup(60)",
+			templatedTags: templatedTagsStub,
+			loadFunc:      func() { os.Setenv("DATACENTER", "dc-foo") },
+			cleanupFunc:   func() { os.Unsetenv("DATACENTER") },
+			want:          "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:cluster-foo,datacenter:dc-foo}.rollup(60)",
+			wantErr:       false,
+		},
+		{
+			name: "cannot get tag",
+			q:    "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%tag_kube_cluster_name%%}.rollup(60)",
+			templatedTags: map[string]tagGetter{
+				"kube_cluster_name": func() (string, error) { return "", errors.New("cannot get tag") },
+			},
+			loadFunc:    func() {},
+			cleanupFunc: func() {},
+			want:        "",
+			wantErr:     true,
+		},
+		{
+			name:          "unknown tag",
+			q:             "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%tag_unknown%%}.rollup(60)",
+			templatedTags: templatedTagsStub,
+			loadFunc:      func() {},
+			cleanupFunc:   func() {},
+			want:          "",
+			wantErr:       true,
+		},
+		{
+			name:          "env not found",
+			q:             "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%env_NOT_FOUND%%}.rollup(60)",
+			templatedTags: map[string]tagGetter{},
+			loadFunc:      func() {},
+			cleanupFunc:   func() {},
+			want:          "",
+			wantErr:       true,
+		},
+		{
+			name:          "unknown template variable",
+			q:             "avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%foo_unknown%%}.rollup(60)",
+			templatedTags: templatedTagsStub,
+			loadFunc:      func() {},
+			cleanupFunc:   func() {},
+			want:          "",
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			templatedTags = tt.templatedTags
+			tt.loadFunc()
+			defer tt.cleanupFunc()
+			got, err := resolveQuery(tt.q)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/clusteragent/externalmetrics/provider_test.go
+++ b/pkg/clusteragent/externalmetrics/provider_test.go
@@ -26,7 +26,7 @@ import (
 
 type providerFixture struct {
 	desc                       string
-	storeContent               []model.DatadogMetricInternal
+	storeContent               []ddmWithQuery
 	queryNamespace             string
 	queryMetricName            string
 	querySelector              map[string]string
@@ -44,7 +44,8 @@ func (f *providerFixture) runGetExternalMetric(t *testing.T) {
 		autogenNamespace: "default",
 	}
 	for _, datadogMetric := range f.storeContent {
-		datadogMetricProvider.store.Set(datadogMetric.ID, datadogMetric, "utest")
+		datadogMetric.ddm.SetQueries(datadogMetric.query)
+		datadogMetricProvider.store.Set(datadogMetric.ddm.ID, datadogMetric.ddm, "utest")
 	}
 
 	externalMetrics, err := datadogMetricProvider.getExternalMetric(f.queryNamespace, labels.Set(f.querySelector).AsSelector(), provider.ExternalMetricInfo{Metric: f.queryMetricName})
@@ -66,7 +67,8 @@ func (f *providerFixture) runListAllExternalMetrics(t *testing.T) {
 		store: NewDatadogMetricsInternalStore(),
 	}
 	for _, datadogMetric := range f.storeContent {
-		datadogMetricProvider.store.Set(datadogMetric.ID, datadogMetric, "utest")
+		datadogMetric.ddm.SetQueries(datadogMetric.query)
+		datadogMetricProvider.store.Set(datadogMetric.ddm.ID, datadogMetric.ddm, "utest")
 	}
 
 	expectedExternalMetricInfo := datadogMetricProvider.ListAllExternalMetrics()
@@ -80,14 +82,16 @@ func TestGetExternalMetrics(t *testing.T) {
 	fixtures := []providerFixture{
 		{
 			desc: "Test nominal case - DatadogMetric exists and is valid",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "ns/metric0",
-					Query:      "query-metric0",
-					UpdateTime: defaultUpdateTime,
-					Valid:      true,
-					Error:      nil,
-					Value:      42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:         "ns/metric0",
+						UpdateTime: defaultUpdateTime,
+						Valid:      true,
+						Error:      nil,
+						Value:      42.0,
+					},
+					query: "query-metric0",
 				},
 			},
 			queryMetricName: "datadogmetric@ns:metric0",
@@ -102,14 +106,16 @@ func TestGetExternalMetrics(t *testing.T) {
 		},
 		{
 			desc: "Test DatadogMetric is invalid",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "ns/metric0",
-					Query:      "query-metric0",
-					UpdateTime: defaultUpdateTime,
-					Valid:      false,
-					Error:      fmt.Errorf("Some error"),
-					Value:      42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:         "ns/metric0",
+						UpdateTime: defaultUpdateTime,
+						Valid:      false,
+						Error:      fmt.Errorf("Some error"),
+						Value:      42.0,
+					},
+					query: "query-metric0",
 				},
 			},
 			queryMetricName:         "datadogmetric@ns:metric0",
@@ -118,14 +124,16 @@ func TestGetExternalMetrics(t *testing.T) {
 		},
 		{
 			desc: "Test DatadogMetric not found",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "ns/metric0",
-					Query:      "query-metric0",
-					UpdateTime: defaultUpdateTime,
-					Valid:      true,
-					Error:      nil,
-					Value:      42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:         "ns/metric0",
+						UpdateTime: defaultUpdateTime,
+						Valid:      true,
+						Error:      nil,
+						Value:      42.0,
+					},
+					query: "query-metric0",
 				},
 			},
 			queryMetricName:         "datadogmetric@ns:metric1",
@@ -134,14 +142,16 @@ func TestGetExternalMetrics(t *testing.T) {
 		},
 		{
 			desc: "Test DatadogMetric not found",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "ns/metric0",
-					Query:      "query-metric0",
-					UpdateTime: defaultUpdateTime,
-					Valid:      true,
-					Error:      nil,
-					Value:      42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:         "ns/metric0",
+						UpdateTime: defaultUpdateTime,
+						Valid:      true,
+						Error:      nil,
+						Value:      42.0,
+					},
+					query: "query-metric0",
 				},
 			},
 			queryMetricName:         "datadogmetric@ns:metric1",
@@ -150,14 +160,16 @@ func TestGetExternalMetrics(t *testing.T) {
 		},
 		{
 			desc: "Test ExternalMetric use wrong DatadogMetric format",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "ns/metric0",
-					Query:      "query-metric0",
-					UpdateTime: defaultUpdateTime,
-					Valid:      true,
-					Error:      nil,
-					Value:      42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:         "ns/metric0",
+						UpdateTime: defaultUpdateTime,
+						Valid:      true,
+						Error:      nil,
+						Value:      42.0,
+					},
+					query: "query-metric0",
 				},
 			},
 			queryMetricName:         "datadogmetric@metric1",
@@ -166,14 +178,16 @@ func TestGetExternalMetrics(t *testing.T) {
 		},
 		{
 			desc: "Test ExternalMetric does not use DatadogMetric format",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "ns/metric0",
-					Query:      "query-metric0",
-					UpdateTime: defaultUpdateTime,
-					Valid:      true,
-					Error:      nil,
-					Value:      42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:         "ns/metric0",
+						UpdateTime: defaultUpdateTime,
+						Valid:      true,
+						Error:      nil,
+						Value:      42.0,
+					},
+					query: "query-metric0",
 				},
 			},
 			queryMetricName:         "nginx.net.request_per_s",
@@ -195,47 +209,55 @@ func TestListAllExternalMetrics(t *testing.T) {
 	fixtures := []providerFixture{
 		{
 			desc:                       "Test no metrics in store",
-			storeContent:               []model.DatadogMetricInternal{},
+			storeContent:               []ddmWithQuery{},
 			expectedExternalMetricInfo: []provider.ExternalMetricInfo{},
 		},
 		{
 			desc: "Test with metrics in store",
-			storeContent: []model.DatadogMetricInternal{
+			storeContent: []ddmWithQuery{
 				{
-					ID:         "ns/metric0",
-					Query:      "query-metric0",
-					UpdateTime: defaultUpdateTime,
-					Valid:      true,
-					Error:      nil,
-					Value:      42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:         "ns/metric0",
+						UpdateTime: defaultUpdateTime,
+						Valid:      true,
+						Error:      nil,
+						Value:      42.0,
+					},
+					query: "query-metric0",
 				},
 				{
-					ID:         "ns/metric1",
-					Query:      "query-metric1",
-					UpdateTime: defaultUpdateTime,
-					Valid:      false,
-					Error:      nil,
-					Value:      42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:         "ns/metric1",
+						UpdateTime: defaultUpdateTime,
+						Valid:      false,
+						Error:      nil,
+						Value:      42.0,
+					},
+					query: "query-metric1",
 				},
 				{
-					ID:                 "autogen-foo",
-					Query:              "query-metric2",
-					UpdateTime:         defaultUpdateTime,
-					ExternalMetricName: "metric2",
-					Autogen:            true,
-					Valid:              false,
-					Error:              nil,
-					Value:              42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:                 "autogen-foo",
+						UpdateTime:         defaultUpdateTime,
+						ExternalMetricName: "metric2",
+						Autogen:            true,
+						Valid:              false,
+						Error:              nil,
+						Value:              42.0,
+					},
+					query: "query-metric2",
 				},
 				{
-					ID:                 "autogen-bar",
-					Query:              "query-metric3",
-					UpdateTime:         defaultUpdateTime,
-					ExternalMetricName: "metric2",
-					Autogen:            true,
-					Valid:              false,
-					Error:              nil,
-					Value:              42.0,
+					ddm: model.DatadogMetricInternal{
+						ID:                 "autogen-bar",
+						UpdateTime:         defaultUpdateTime,
+						ExternalMetricName: "metric2",
+						Autogen:            true,
+						Valid:              false,
+						Error:              nil,
+						Value:              42.0,
+					},
+					query: "query-metric3",
 				},
 			},
 			expectedExternalMetricInfo: []provider.ExternalMetricInfo{

--- a/releasenotes-dca/notes/ddm-tags-templating-3d9d3dc214f04a28.yaml
+++ b/releasenotes-dca/notes/ddm-tags-templating-3d9d3dc214f04a28.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    It's now possible to template the kube_cluster_name tag in DatadogMetric queries
+    Example: avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%tag_kube_cluster_name%%}
+  - |
+    It's now possible to template any environment variable (as seen by the Datadog Cluster Agent) as tag in DatadogMetric queries
+    Example: avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%env_DD_CLUSTER_NAME%%}


### PR DESCRIPTION
### What does this PR do?

- It's now possible to template the kube_cluster_name tag in DatadogMetric queries
Example: `avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%tag_kube_cluster_name%%}`
- It's now possible to template any environment variable (as seen by the Datadog Cluster Agent) as tag in DatadogMetric queries
Example: `avg:nginx.net.request_per_s{kube_container_name:nginx,kube_cluster_name:%%env_DD_CLUSTER_NAME%%}`

### Motivation

Feature request

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- Test the nominal cases where like mentioned above, make sure the cluster agent resolves the queries (can check the logs or the prometheus metrics)
- Test the failure mode, make sure the DDM becomes invalid when we reference an invalid tag or env, make sure it recovers after fixing the query
