### PR TITLE
[windows] Fix libyajl gem install failure

### DIFF
--- a/tasks/winbuildscripts/libyajl2_install.ps1
+++ b/tasks/winbuildscripts/libyajl2_install.ps1
@@ -8,8 +8,13 @@ cd libyajl2
 
 # Remove existing rake install, we don't need it and its version is too high
 gem uninstall -x rake
+
+# We don't need the development_extras group, we're not running tests
+bundle config set --local without 'development_extras'
+
 # Install dev dependencies - maybe --path should be used to do a local install, but unsure how this will affect the next commands
 bundle install
+
 # Prepare the repo
 rake prep
 # Install the gem


### PR DESCRIPTION
### What does this PR do?

Stop installing testing gems when building libyajl2 on Windows.

### Motivation

The gem dependency resolver sometimes fails while retrieving the `droplet_kit` gem (a dependency of `kitchen-digitalocean`, one of the `development_extras` deps). In some rare cases, it fetches `3.13.0`, which is not compatible with ruby 2.4 (the version in our builder), whereas it should be using `3.7.0`.

Not installing the `development_extras` group (which is only used for tests, which we don't do in the build) removes that issue.

### Describe your test plan

Successful Windows Agent build.