### PR TITLE
pkg/trace/agent: add "component2name" feature flag to facilitate Opentracing

### DIFF
--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -186,6 +187,28 @@ func TestNormalizeNoTraceID(t *testing.T) {
 	s.TraceID = 0
 	assert.Error(t, normalize(ts, s))
 	assert.Equal(t, tsDropped(&info.TracesDropped{TraceIDZero: 1}), ts)
+}
+
+func TestNormalizeComponent2Name(t *testing.T) {
+	ts := newTagStats()
+	assert := assert.New(t)
+
+	defer testutil.WithFeatures("component2name")()
+
+	t.Run("with", func(t *testing.T) {
+		s := newTestSpan()
+		assert.NotEqual(s.Name, "component")
+		s.Meta["component"] = "component"
+		assert.NoError(normalize(ts, s))
+		assert.Equal(s.Name, "component")
+	})
+
+	t.Run("without", func(t *testing.T) {
+		s := newTestSpan()
+		assert.Empty(s.Meta["component"])
+		assert.NoError(normalize(ts, s))
+		assert.Equal(s.Name, "django.controller")
+	})
 }
 
 func TestNormalizeSpanIDPassThru(t *testing.T) {

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -193,19 +193,27 @@ func TestNormalizeComponent2Name(t *testing.T) {
 	ts := newTagStats()
 	assert := assert.New(t)
 
-	defer testutil.WithFeatures("component2name")()
+	t.Run("on", func(t *testing.T) {
+		defer testutil.WithFeatures("component2name")()
 
-	t.Run("with", func(t *testing.T) {
-		s := newTestSpan()
-		assert.NotEqual(s.Name, "component")
-		s.Meta["component"] = "component"
-		assert.NoError(normalize(ts, s))
-		assert.Equal(s.Name, "component")
+		t.Run("with", func(t *testing.T) {
+			s := newTestSpan()
+			s.Meta["component"] = "component"
+			assert.NoError(normalize(ts, s))
+			assert.Equal(s.Name, "component")
+		})
+
+		t.Run("without", func(t *testing.T) {
+			s := newTestSpan()
+			assert.Empty(s.Meta["component"])
+			assert.NoError(normalize(ts, s))
+			assert.Equal(s.Name, "django.controller")
+		})
 	})
 
-	t.Run("without", func(t *testing.T) {
+	t.Run("off", func(t *testing.T) {
 		s := newTestSpan()
-		assert.Empty(s.Meta["component"])
+		s.Meta["component"] = "component"
 		assert.NoError(normalize(ts, s))
 		assert.Equal(s.Name, "django.controller")
 	})

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -1044,8 +1044,7 @@ func TestWatchdog(t *testing.T) {
 		if testing.Short() {
 			return
 		}
-		os.Setenv("DD_APM_FEATURES", "429")
-		defer os.Unsetenv("DD_APM_FEATURES")
+		defer testutil.WithFeatures("429")()
 
 		conf := config.New()
 		conf.Endpoints[0].APIKey = "apikey_2"

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -4,12 +4,12 @@ import (
 	"log"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
 )
 
 // TestInfoHandler ensures that the keys returned by the /info handler do not
@@ -93,13 +93,7 @@ func TestInfoHandler(t *testing.T) {
 	defer func(old string) { info.Version = old }(info.Version)
 	defer func(old string) { info.GitCommit = old }(info.GitCommit)
 	defer func(old string) { info.BuildDate = old }(info.BuildDate)
-	ff, ok := os.LookupEnv("DD_APM_FEATURES")
-	if !ok {
-		defer os.Unsetenv("DD_APM_FEATURES")
-	} else {
-		defer func(old string) { os.Setenv("DD_APM_FEATURES", old) }(ff)
-	}
-	os.Setenv("DD_APM_FEATURES", "feature_flag")
+	defer testutil.WithFeatures("feature_flag")()
 	info.Version = "0.99.0"
 	info.GitCommit = "fab047e10"
 	info.BuildDate = "2020-12-04 15:57:06.74187 +0200 EET m=+0.029001792"

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -280,19 +280,41 @@ func prepareConfig(path string) (*AgentConfig, error) {
 	return cfg, nil
 }
 
+// features keeps a map of all APM features as defined by the DD_APM_FEATURES
+// environment variable at startup.
+var features = map[string]struct{}{}
+
+func init() {
+	// Whoever imports this package, should have features readily available.
+	SetFeatures(os.Getenv("DD_APM_FEATURES"))
+}
+
+// SetFeatures sets the given list of comma-separated features as active.
+func SetFeatures(feats string) {
+	for k := range features {
+		delete(features, k)
+	}
+	all := strings.Split(feats, ",")
+	for _, f := range all {
+		features[strings.TrimSpace(f)] = struct{}{}
+	}
+	if active := Features(); len(active) > 0 {
+		log.Debugf("Loaded features: %v", active)
+	}
+}
+
 // HasFeature returns true if the feature f is present. Features are values
 // of the DD_APM_FEATURES environment variable.
 func HasFeature(f string) bool {
-	return strings.Contains(os.Getenv("DD_APM_FEATURES"), f)
+	_, ok := features[f]
+	return ok
 }
 
 // Features returns a list of all the features configured by means of DD_APM_FEATURES.
 func Features() []string {
 	var all []string
-	if fenv := os.Getenv("DD_APM_FEATURES"); fenv != "" {
-		for _, f := range strings.Split(fenv, ",") {
-			all = append(all, strings.TrimSpace(f))
-		}
+	for f := range features {
+		all = append(all, f)
 	}
 	return all
 }

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -9,12 +9,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"sync/atomic"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -148,8 +148,7 @@ func TestSQLUTF8(t *testing.T) {
 
 func TestSQLTableNames(t *testing.T) {
 	t.Run("on", func(t *testing.T) {
-		os.Setenv("DD_APM_FEATURES", "table_names")
-		defer os.Unsetenv("DD_APM_FEATURES")
+		defer testutil.WithFeatures("table_names")()
 
 		span := &pb.Span{
 			Resource: "SELECT * FROM users WHERE id = 42",
@@ -172,8 +171,7 @@ func TestSQLTableNames(t *testing.T) {
 
 func TestSQLQuantizeTableNames(t *testing.T) {
 	t.Run("on", func(t *testing.T) {
-		os.Setenv("DD_APM_FEATURES", "quantize_sql_tables")
-		defer os.Unsetenv("DD_APM_FEATURES")
+		defer testutil.WithFeatures("quantize_sql_tables")()
 
 		for _, tt := range []struct {
 			query      string
@@ -217,8 +215,7 @@ func TestSQLQuantizeTableNames(t *testing.T) {
 
 func TestSQLTableFinderAndQuantizeTableNames(t *testing.T) {
 	t.Run("on", func(t *testing.T) {
-		os.Setenv("DD_APM_FEATURES", "table_names,quantize_sql_tables")
-		defer os.Unsetenv("DD_APM_FEATURES")
+		defer testutil.WithFeatures("table_names,quantize_sql_tables")()
 
 		for _, tt := range []struct {
 			query      string

--- a/pkg/trace/test/testutil/features.go
+++ b/pkg/trace/test/testutil/features.go
@@ -1,0 +1,16 @@
+package testutil
+
+import (
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+)
+
+// WithFeatures sets the given list of comma-separated features as active and
+// returns a function which resets the features to their previous state.
+func WithFeatures(feats string) (undo func()) {
+	config.SetFeatures(feats)
+	return func() {
+		config.SetFeatures(os.Getenv("DD_APM_FEATURES"))
+	}
+}

--- a/pkg/trace/test/testutil/features_test.go
+++ b/pkg/trace/test/testutil/features_test.go
@@ -1,0 +1,18 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithFeatures(t *testing.T) {
+	assert.False(t, config.HasFeature("unknown_feature"))
+	undo := WithFeatures("unknown_feature,other")
+	assert.True(t, config.HasFeature("unknown_feature"))
+	assert.True(t, config.HasFeature("other"))
+	undo()
+	assert.False(t, config.HasFeature("unknown_feature"))
+	assert.False(t, config.HasFeature("other"))
+}

--- a/releasenotes/notes/apm-component2name-4cbfbeec7785dd93.yaml
+++ b/releasenotes/notes/apm-component2name-4cbfbeec7785dd93.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Add a new feature flag "component2name" which determines the "component" tag value
+    on a span to become its operation name. This facititates compatibility with Opentracing.


### PR DESCRIPTION
The "component2name" feature flag determines the span component tag to become
the span operation name.

It works around the incompatibility between Opentracing and Datadog where the
Opentracing operation name is many times invalid as a Datadog operation name (e.g. "/")
and in Datadog terms it's the resource. Here, we aim to make the component the
operation name to provide a better product experience.