### PR TITLE
Deprecate undocumented `process_agent_config.host_ips` in favor of `process_config.docker_host_ips`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -583,6 +583,7 @@ func InitConfig(config Config) {
 	}
 
 	config.BindEnv("process_config.process_dd_url", "") //nolint:errcheck
+	config.BindEnvAndSetDefault("process_config.docker_host_ips", []string{})
 
 	// Logs Agent
 
@@ -767,6 +768,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.log_file")
 	config.SetKnown("process_config.profiling.enabled")
 	config.SetKnown("process_config.remote_tagger")
+	config.SetKnown("process_config.docker_host_ips")
 
 	// System probe
 	config.SetKnown("system_probe_config.enabled")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -926,6 +926,13 @@ api_key:
   #   - 'sql*'
   #   - '*pass*d*'
 
+  ## @param docker_host_ips - list of strings - optional
+  ## Overrides the default host IPs for containerized applications.
+  #
+  # docker_host_ips:
+  #   - <IP_ADDRESS_1>
+  #   - <IP_ADDRESS_2>
+
 {{- if .Profiling -}}
   ## @param profiling - custom object - optional
   ## Enter specific configurations for profiling.

--- a/pkg/util/docker/host_ip_provider.go
+++ b/pkg/util/docker/host_ip_provider.go
@@ -64,7 +64,16 @@ func tryProviders(providers []hostIPProvider) []string {
 }
 
 func getHostIPsFromConfig() ([]string, error) {
-	hostIPs := config.Datadog.GetStringSlice("process_agent_config.host_ips")
+	hostIPs := []string{}
+
+	if config.Datadog.IsSet("process_agent_config.host_ips") {
+		log.Warn(`"process_agent_config.host_ips" is deprecated, use "process_config.docker_host_ips" instead`)
+		hostIPs = config.Datadog.GetStringSlice("process_agent_config.host_ips")
+	}
+
+	if dockerHostIps := config.Datadog.GetStringSlice("process_config.docker_host_ips"); len(dockerHostIps) > 0 {
+		hostIPs = dockerHostIps
+	}
 
 	if len(hostIPs) == 0 {
 		return nil, fmt.Errorf("no hostIPs were configured")

--- a/pkg/util/docker/host_ip_provider_test.go
+++ b/pkg/util/docker/host_ip_provider_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,4 +47,35 @@ func TestProvider(t *testing.T) {
 	assert.True(t, providersCalled[0])
 	assert.True(t, providersCalled[1])
 	assert.False(t, providersCalled[2])
+}
+
+func TestGetHostIPsFromConfig(t *testing.T) {
+	mockConfig := config.Mock()
+	mockConfig.Set("process_agent_config.host_ips", "10.0.0.3")
+	mockConfig.Set("process_config.docker_host_ips", "10.0.0.1 10.0.0.2")
+
+	ips, err := getHostIPsFromConfig()
+
+	assert.ElementsMatch(t, []string{"10.0.0.1", "10.0.0.2"}, ips)
+	assert.NoError(t, err)
+}
+
+func TestGetHostIPsFromConfigFallback(t *testing.T) {
+	mockConfig := config.Mock()
+	mockConfig.Set("process_agent_config.host_ips", "10.0.0.1 10.0.0.2")
+
+	ips, err := getHostIPsFromConfig()
+
+	assert.ElementsMatch(t, []string{"10.0.0.1", "10.0.0.2"}, ips)
+	assert.NoError(t, err)
+}
+
+func TestGetHostIPsInvalidIp(t *testing.T) {
+	mockConfig := config.Mock()
+	mockConfig.Set("process_config.docker_host_ips", "invalid_ip")
+
+	ips, err := getHostIPsFromConfig()
+
+	assert.Empty(t, ips)
+	assert.Error(t, err)
 }

--- a/releasenotes/notes/proces-agent-add-docs-host-ip-config-1cd97e31ec2ae586.yaml
+++ b/releasenotes/notes/proces-agent-add-docs-host-ip-config-1cd97e31ec2ae586.yaml
@@ -1,4 +1,4 @@
-# Each section from every release note are combined when the
+# Each section from every release note is combined when the
 # CHANGELOG.rst is rendered. So the text needs to be worded so that
 # it does not depend on any information only available in another
 # section. This may mean repeating some details, but each section
@@ -8,11 +8,11 @@
 ---
 deprecations:
   - |
-    Changed the attribute name to define the host IPs for the process agent
-    docker container from `process_agent_config.host_ips` to
+    Changed the attribute name to define the host IPs for the process Agent
+    Docker container from `process_agent_config.host_ips` to
     `process_config.docker_host_ips`. `process_agent_config.host_ips` is
     still supported.
 fixes:
   - |
-    The process agent no longer logs a cast warning message when no
-    host IPs have been configured.
+    The process Agent no longer logs a cast warning message when no
+    host IPs are configured.

--- a/releasenotes/notes/proces-agent-add-docs-host-ip-config-1cd97e31ec2ae586.yaml
+++ b/releasenotes/notes/proces-agent-add-docs-host-ip-config-1cd97e31ec2ae586.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    Changed the attribute name to define the host IPs for the process agent
+    docker container from `process_agent_config.host_ips` to
+    `process_config.docker_host_ips`. `process_agent_config.host_ips` is
+    still supported.
+fixes:
+  - |
+    The process agent no longer logs a cast warning message when no
+    host IPs have been configured.


### PR DESCRIPTION
### What does this PR do?

Fixes #5081 
- Get rid of the class cast warning noise when trying to read the `process_agent_config.host_ips` property
- Deprecated `process_agent_config.host_ips` in favor of `process_config.docker_host_ips`. The old variables naming scheme is incosistent with other properties for the process agent. The old property is still supported. When both properties are used, the new one will take precedence.
- Added missing documentation for this property
- Added sane default (list of empty string)
- This bit of code was hardly tested, so I've added a couple of tests

### Motivation

I am opening this pull request to address the issue described in https://github.com/DataDog/datadog-agent/issues/5081. The default configuration for the process agent causes a warning to be logged every couple of hours. This is just noise, that can lead to confusion. The main reason seems to be an incorrect default (nil vs empty list)

### Additional Notes

This is my first PR for the datadog-agent. I tried to follow allow the guidelines, but please do let me know if I have missed something.

### Describe your test plan

- The automatic tests should pass
- Set the new property in the config and verify that the property is picked up.
- Set both the new and the deprecated property in the config. Verify that the new property is picked up.
- Set the deprecated property in the config. Verify that the deprecated property is picked up.
- Using the default process_agent config, verify that the log line `2020-03-05 05:45:40 UTC | PROCESS | WARN | (pkg/config/viper.go:168 in GetStringSlice) | failed to get configuration value for key "process_agent_config.host_ips": unable to cast <nil> of type <nil> to []string` is not printed
