### PR TITLE
[runtime-security] Use tail call to parse args and envs

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "5534dd729acee2bc2549de286134ac7af54afe88904d84956c0f9002df89c637")
+var Conntrack = NewRuntimeAsset("conntrack.c", "71f78a0a4185d7df3dea535d750ceb6a0a62eff82ea734eb54400685ecd98a5b")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ee690d01aede14f71c07f1302892d091aa570087eed3568292385d742edbb550")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6046ce84734628b49480045cc1e211f94a93aa0280600ac80392ef23a71d1ea5")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "895679d539d3f7a6cc0d5396990a96b428a0c14feaef388f8f4276fd9e44b096")
+var Tracer = NewRuntimeAsset("tracer.c", "22d19c9e2f9253537946d5272970c95316e5746b4d8f8b0907622b8f4acbae0b")

--- a/pkg/ebpf/c/bpf_helpers.h
+++ b/pkg/ebpf/c/bpf_helpers.h
@@ -56,6 +56,7 @@ static unsigned long long (*bpf_get_prandom_u32)(void) = (void*)BPF_FUNC_get_pra
 static int (*bpf_skb_store_bytes)(void* ctx, int off, void* from, int len, int flags) = (void*)BPF_FUNC_skb_store_bytes;
 static int (*bpf_l3_csum_replace)(void* ctx, int off, int from, int to, int flags) = (void*)BPF_FUNC_l3_csum_replace;
 static int (*bpf_l4_csum_replace)(void* ctx, int off, int from, int to, int flags) = (void*)BPF_FUNC_l4_csum_replace;
+static int (*bpf_tail_call)(void* ctx, void* map, int key) = (void*)BPF_FUNC_tail_call;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
 static u64 (*bpf_get_current_task)(void) = (void*)BPF_FUNC_get_current_task;

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -9,7 +9,7 @@
 
 #define MAX_PERF_STR_BUFF_LEN 128
 #define MAX_STR_BUFF_LEN (1 << 15)
-#define MAX_ARRAY_ELEMENT 40
+#define MAX_ARRAY_ELEMENT 32
 #define MAX_ARRAY_ELEMENT_SIZE 4096
 
 struct args_envs_event_t {
@@ -21,6 +21,20 @@ struct args_envs_event_t {
 
 struct str_array_buffer_t {
     char value[MAX_STR_BUFF_LEN];
+};
+
+struct bpf_map_def SEC("maps/args_progs") args_progs = {
+    .type = BPF_MAP_TYPE_PROG_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u32),
+    .max_entries = 10,
+};
+
+struct bpf_map_def SEC("maps/envs_progs") envs_progs = {
+    .type = BPF_MAP_TYPE_PROG_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u32),
+    .max_entries = 10,
 };
 
 struct bpf_map_def SEC("maps/str_array_buffers") str_array_buffers = {
@@ -62,9 +76,12 @@ struct _tracepoint_sched_process_fork
     pid_t child_pid;
 };
 
-void __attribute__((always_inline)) parse_str_array(struct pt_regs *ctx, struct str_array_ref_t *array_ref, const char **data) {
-    u32 id = bpf_get_prandom_u32();
-    array_ref->id = id;
+void __attribute__((always_inline)) parse_str_array(struct pt_regs *ctx, struct str_array_ref_t *array_ref, u64 event_type) {
+    const char **array = array_ref->array;
+    int index = array_ref->index;
+    if (index == 255) {
+        return;
+    }
 
     u32 key = 0;
     struct str_array_buffer_t *buff = bpf_map_lookup_elem(&str_array_buffers, &key);
@@ -72,75 +89,113 @@ void __attribute__((always_inline)) parse_str_array(struct pt_regs *ctx, struct 
         return;
     }
 
-    int a = 1;
-
     const char *str;
-    bpf_probe_read(&str, sizeof(str), (void *)&data[a]);
+    bpf_probe_read(&str, sizeof(str), (void *)&array[index]);
 
     struct args_envs_event_t event = {
-        .id = id,
+        .id = array_ref->id,
     };
 
-    int i = 0, n = 0, offset = 0;
-    int perf_offset = 0;
+    int i = 0, n = 0, buff_offset = 0, perf_offset = 0;
 
     #pragma unroll
     for (i = 0; i < MAX_ARRAY_ELEMENT; i++) {
-        void *ptr = &(buff->value[(offset + sizeof(n)) & (MAX_STR_BUFF_LEN - MAX_ARRAY_ELEMENT_SIZE - 1)]);
+        void *ptr = &(buff->value[(buff_offset + sizeof(n)) & (MAX_STR_BUFF_LEN - MAX_ARRAY_ELEMENT_SIZE - 1)]);
 
         n = bpf_probe_read_str(ptr, MAX_ARRAY_ELEMENT_SIZE, (void *)str);
         if (n > 0) {
             n--; // remove trailing 0
-            bpf_probe_read(&(buff->value[offset&(MAX_STR_BUFF_LEN - MAX_ARRAY_ELEMENT_SIZE - 1)]), sizeof(n), &n);
-            bpf_probe_read(&str, sizeof(str), (void *)&data[++a]);
 
             int len = n + sizeof(n);
-            offset += len;
+            bpf_probe_read(&(buff->value[buff_offset&(MAX_STR_BUFF_LEN - MAX_ARRAY_ELEMENT_SIZE - 1)]), sizeof(n), &n);
 
-            if (event.size + len > MAX_PERF_STR_BUFF_LEN) {
+            if (event.size + len >= MAX_PERF_STR_BUFF_LEN) {
                 void *perf_ptr = &(buff->value[perf_offset&(MAX_STR_BUFF_LEN - MAX_ARRAY_ELEMENT_SIZE - 1)]);
                 bpf_probe_read(&event.value, MAX_PERF_STR_BUFF_LEN, perf_ptr);
 
-                // current argument overflow the perf buff size, thus send it truncated
-                if (len > MAX_PERF_STR_BUFF_LEN) {
+                if (event.size == 0) {
                     event.size = MAX_PERF_STR_BUFF_LEN;
+                }
+                send_event(ctx, event_type, event);
 
-                    perf_offset = offset;
-                    len = 0;
+                if (event.size == MAX_PERF_STR_BUFF_LEN) {
+                    perf_offset += len;
+                    event.size = 0;
                 } else {
                     perf_offset += event.size;
+                    event.size += len;
                 }
 
-                send_event(ctx, EVENT_ARGS_ENVS, event);
-                event.size = 0;
+                if (event.size > MAX_PERF_STR_BUFF_LEN) {
+                    event.size = 0;
+                } else {
+                    buff_offset += len;
+                    index++;
+                }
+            } else {
+                event.size += len;
+                buff_offset += len;
+                index++;
             }
-            event.size += len;
+
+            bpf_probe_read(&str, sizeof(str), (void *)&array[index]);
         } else {
+            index = 255; // stop here
             break;
         }
     }
+    array_ref->index = index;
     array_ref->truncated = i == MAX_ARRAY_ELEMENT;
 
     // flush remaining values
     if (event.size > 0) {
-        if (event.size > MAX_PERF_STR_BUFF_LEN) {
-            event.size = MAX_PERF_STR_BUFF_LEN;
-        }
         void *perf_ptr = &(buff->value[perf_offset&(MAX_STR_BUFF_LEN - MAX_ARRAY_ELEMENT_SIZE - 1)]);
         bpf_probe_read(&event.value, MAX_PERF_STR_BUFF_LEN, perf_ptr);
 
-        send_event(ctx, EVENT_ARGS_ENVS, event);
+        send_event(ctx, event_type, event);
     }
 }
+
+#define PARSE_STR_ARRAY(type,map,n,field,array_ref,event,next) \
+    SEC("kprobe/" #map "_" #n) \
+    int map ## _ ##n(struct pt_regs *ctx) { \
+        struct syscall_cache_t *syscall = peek_syscall(type); \
+        if (!syscall) return 0; \
+        parse_str_array(ctx, &syscall->field.array_ref,event); \
+        next; \
+        return 0; \
+    }
+
+PARSE_STR_ARRAY(SYSCALL_EXEC, args_progs, 0, exec, args, EVENT_ARGS_ENVS, bpf_tail_call(ctx, &args_progs, 1))
+PARSE_STR_ARRAY(SYSCALL_EXEC, args_progs, 1, exec, args, EVENT_ARGS_ENVS, bpf_tail_call(ctx, &args_progs, 2))
+PARSE_STR_ARRAY(SYSCALL_EXEC, args_progs, 2, exec, args, EVENT_ARGS_ENVS, bpf_tail_call(ctx, &envs_progs, 3))
+PARSE_STR_ARRAY(SYSCALL_EXEC, args_progs, 3, exec, args, EVENT_ARGS_ENVS, bpf_tail_call(ctx, &args_progs, 4))
+PARSE_STR_ARRAY(SYSCALL_EXEC, args_progs, 4, exec, args, EVENT_ARGS_ENVS, bpf_tail_call(ctx, &args_progs, 0))
+PARSE_STR_ARRAY(SYSCALL_EXEC, envs_progs, 0, exec, envs, EVENT_ARGS_ENVS, bpf_tail_call(ctx, &envs_progs, 1))
+PARSE_STR_ARRAY(SYSCALL_EXEC, envs_progs, 1, exec, envs, EVENT_ARGS_ENVS, bpf_tail_call(ctx, &envs_progs, 2))
+PARSE_STR_ARRAY(SYSCALL_EXEC, envs_progs, 2, exec, envs, EVENT_ARGS_ENVS, bpf_tail_call(ctx, &envs_progs, 3))
+PARSE_STR_ARRAY(SYSCALL_EXEC, envs_progs, 3, exec, envs, EVENT_ARGS_ENVS, bpf_tail_call(ctx, &envs_progs, 4))
+PARSE_STR_ARRAY(SYSCALL_EXEC, envs_progs, 4, exec, envs, EVENT_ARGS_ENVS, )
 
 int __attribute__((always_inline)) trace__sys_execveat(struct pt_regs *ctx, const char **argv, const char **env) {
     struct syscall_cache_t syscall = {
         .type = SYSCALL_EXEC,
+        .exec = {
+            .args = {
+                .id = bpf_get_prandom_u32(),
+                .array = argv,
+                .index = 1,
+            },
+            .envs = {
+                .id = bpf_get_prandom_u32(),
+                .array = env,
+            }
+        }
     };
-    parse_str_array(ctx, &syscall.exec.args, argv);
-    //parse_str_array(ctx, &syscall.exec.envs, env);
-
     cache_syscall(&syscall);
+
+    bpf_tail_call(ctx, &args_progs, 0);
+
     return 0;
 }
 

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -104,6 +104,7 @@ struct syscall_cache_t {
             struct file_t file;
             struct str_array_ref_t args;
             struct str_array_ref_t envs;
+            u32 next_tail;
             u8 is_parsed;
         } exec;
     };

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -8,7 +8,9 @@
 
 struct str_array_ref_t {
     u32 id;
+    u8 index;
     u8 truncated;
+    const char **array;
 };
 
 struct syscall_cache_t {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -94,6 +94,15 @@ func AllPerfMaps() []*manager.PerfMap {
 	}
 }
 
+// AllTailRoutes returns the list of all the tail call routes
+func AllTailRoutes() []manager.TailCallRoute {
+	var routes []manager.TailCallRoute
+
+	routes = append(routes, getExecTailCallRoutes()...)
+
+	return routes
+}
+
 // GetPerfBufferStatisticsMaps returns the list of maps used to monitor the performances of each perf buffers
 func GetPerfBufferStatisticsMaps() map[string]string {
 	return map[string]string{

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -110,23 +110,12 @@ func getExecProbes() []*manager.Probe {
 func getExecTailCallRoutes() []manager.TailCallRoute {
 	var routes []manager.TailCallRoute
 
-	for i := uint32(0); i != 5; i++ {
+	for i := uint32(0); i != 10; i++ {
 		route := manager.TailCallRoute{
-			ProgArrayName: "args_progs",
+			ProgArrayName: "args_envs_progs",
 			Key:           i,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: fmt.Sprintf("kprobe/args_progs_%d", i),
-			},
-		}
-		routes = append(routes, route)
-	}
-
-	for i := uint32(0); i != 5; i++ {
-		route := manager.TailCallRoute{
-			ProgArrayName: "envs_progs",
-			Key:           i,
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: fmt.Sprintf("kprobe/envs_progs_%d", i),
+				Section: fmt.Sprintf("kprobe/parse_args_envs"),
 			},
 		}
 		routes = append(routes, route)

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -8,6 +8,8 @@
 package probes
 
 import (
+	"fmt"
+
 	"github.com/DataDog/ebpf/manager"
 )
 
@@ -103,4 +105,32 @@ func getExecProbes() []*manager.Probe {
 	}
 
 	return execProbes
+}
+
+func getExecTailCallRoutes() []manager.TailCallRoute {
+	var routes []manager.TailCallRoute
+
+	for i := uint32(0); i != 5; i++ {
+		route := manager.TailCallRoute{
+			ProgArrayName: "args_progs",
+			Key:           i,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: fmt.Sprintf("kprobe/args_progs_%d", i),
+			},
+		}
+		routes = append(routes, route)
+	}
+
+	for i := uint32(0); i != 5; i++ {
+		route := manager.TailCallRoute{
+			ProgArrayName: "envs_progs",
+			Key:           i,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: fmt.Sprintf("kprobe/envs_progs_%d", i),
+			},
+		}
+		routes = append(routes, route)
+	}
+
+	return routes
 }

--- a/pkg/security/model/accessors.go
+++ b/pkg/security/model/accessors.go
@@ -528,8 +528,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 
 	case "exec.envs":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
 
 				return (*Event)(ctx.Object).Exec.Envs
 			},
@@ -8557,7 +8558,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.Envs"}
 		}
-		e.Exec.Envs = str
+		e.Exec.Envs = append(e.Exec.Envs, str)
 
 		return nil
 

--- a/pkg/security/model/events.go
+++ b/pkg/security/model/events.go
@@ -123,7 +123,7 @@ func (t EventType) String() string {
 	case CapsetEventType:
 		return "capset"
 	case ArgsEnvsEventType:
-		return "args_envs_dentry"
+		return "args_envs"
 
 	case CustomLostReadEventType:
 		return "lost_events_read"

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -90,14 +90,14 @@ type ChownEvent struct {
 	SyscallEvent
 	File  FileEvent `field:"file"`
 	UID   uint32    `field:"file.destination.uid"`
-	User  string    `field:"file.destination.user" handler:"ResolveChownUID,string"`
+	User  string    `field:"file.destination.user" handler:"ResolveChownUID"`
 	GID   uint32    `field:"file.destination.gid"`
-	Group string    `field:"file.destination.group" handler:"ResolveChownGID,string"`
+	Group string    `field:"file.destination.group" handler:"ResolveChownGID"`
 }
 
 // ContainerContext holds the container context of an event
 type ContainerContext struct {
-	ID string `field:"id" handler:"ResolveContainerID,string"`
+	ID string `field:"id" handler:"ResolveContainerID"`
 }
 
 // Event represents an event sent from the kernel
@@ -158,21 +158,21 @@ func (e *Event) GetPointer() unsafe.Pointer {
 // SetuidEvent represents a setuid event
 type SetuidEvent struct {
 	UID    uint32 `field:"uid"`
-	User   string `field:"user" handler:"ResolveSetuidUser,string"`
+	User   string `field:"user" handler:"ResolveSetuidUser"`
 	EUID   uint32 `field:"euid"`
-	EUser  string `field:"euser" handler:"ResolveSetuidEUser,string"`
+	EUser  string `field:"euser" handler:"ResolveSetuidEUser"`
 	FSUID  uint32 `field:"fsuid"`
-	FSUser string `field:"fsuser" handler:"ResolveSetuidFSUser,string"`
+	FSUser string `field:"fsuser" handler:"ResolveSetuidFSUser"`
 }
 
 // SetgidEvent represents a setgid event
 type SetgidEvent struct {
 	GID     uint32 `field:"gid"`
-	Group   string `field:"group" handler:"ResolveSetgidGroup,string"`
+	Group   string `field:"group" handler:"ResolveSetgidGroup"`
 	EGID    uint32 `field:"egid"`
-	EGroup  string `field:"egroup" handler:"ResolveSetgidEGroup,string"`
+	EGroup  string `field:"egroup" handler:"ResolveSetgidEGroup"`
 	FSGID   uint32 `field:"fsgid"`
-	FSGroup string `field:"fsgroup" handler:"ResolveSetgidFSGroup,string"`
+	FSGroup string `field:"fsgroup" handler:"ResolveSetgidFSGroup"`
 }
 
 // CapsetEvent represents a capset event
@@ -183,23 +183,23 @@ type CapsetEvent struct {
 
 // Credentials represents the kernel credentials of a process
 type Credentials struct {
-	UID   uint32 `field:"uid" handler:"ResolveCredentialsUID,int"`
-	GID   uint32 `field:"gid" handler:"ResolveCredentialsGID,int"`
-	User  string `field:"user" handler:"ResolveCredentialsUser,string"`
-	Group string `field:"group" handler:"ResolveCredentialsGroup,string"`
+	UID   uint32 `field:"uid" handler:"ResolveCredentialsUID"`
+	GID   uint32 `field:"gid" handler:"ResolveCredentialsGID"`
+	User  string `field:"user" handler:"ResolveCredentialsUser"`
+	Group string `field:"group" handler:"ResolveCredentialsGroup"`
 
-	EUID   uint32 `field:"euid" handler:"ResolveCredentialsEUID,int"`
-	EGID   uint32 `field:"egid" handler:"ResolveCredentialsEGID,int"`
-	EUser  string `field:"euser" handler:"ResolveCredentialsEUser,string"`
-	EGroup string `field:"egroup" handler:"ResolveCredentialsEGroup,string"`
+	EUID   uint32 `field:"euid" handler:"ResolveCredentialsEUID"`
+	EGID   uint32 `field:"egid" handler:"ResolveCredentialsEGID"`
+	EUser  string `field:"euser" handler:"ResolveCredentialsEUser"`
+	EGroup string `field:"egroup" handler:"ResolveCredentialsEGroup"`
 
-	FSUID   uint32 `field:"fsuid" handler:"ResolveCredentialsFSUID,int"`
-	FSGID   uint32 `field:"fsgid" handler:"ResolveCredentialsFSGID,int"`
-	FSUser  string `field:"fsuser" handler:"ResolveCredentialsFSUser,string"`
-	FSGroup string `field:"fsgroup" handler:"ResolveCredentialsFSGroup,string"`
+	FSUID   uint32 `field:"fsuid" handler:"ResolveCredentialsFSUID"`
+	FSGID   uint32 `field:"fsgid" handler:"ResolveCredentialsFSGID"`
+	FSUser  string `field:"fsuser" handler:"ResolveCredentialsFSUser"`
+	FSGroup string `field:"fsgroup" handler:"ResolveCredentialsFSGroup"`
 
-	CapEffective uint64 `field:"cap_effective" handler:"ResolveCredentialsCapEffective,int"`
-	CapPermitted uint64 `field:"cap_permitted" handler:"ResolveCredentialsCapPermitted,int"`
+	CapEffective uint64 `field:"cap_effective" handler:"ResolveCredentialsCapEffective"`
+	CapPermitted uint64 `field:"cap_permitted" handler:"ResolveCredentialsCapPermitted"`
 }
 
 // GetPathResolutionError returns the path resolution error as a string if there is one
@@ -216,17 +216,17 @@ type Process struct {
 	// (container context is parsed in Event.Container)
 	FileFields FileFields `field:"file"`
 
-	PathnameStr         string `field:"file.path" handler:"ResolveProcessInode,string"`
-	ContainerPath       string `field:"file.container_path" handler:"ResolveProcessContainerPath,string"`
-	BasenameStr         string `field:"file.name" handler:"ResolveProcessBasename,string"`
-	Filesystem          string `field:"file.filesystem" handler:"ResolveProcessFilesystem,string"`
+	PathnameStr         string `field:"file.path" handler:"ResolveProcessInode"`
+	ContainerPath       string `field:"file.container_path" handler:"ResolveProcessContainerPath"`
+	BasenameStr         string `field:"file.name" handler:"ResolveProcessBasename"`
+	Filesystem          string `field:"file.filesystem" handler:"ResolveProcessFilesystem"`
 	PathResolutionError error  `field:"-"`
 
 	ExecTimestamp uint64    `field:"-"`
 	ExecTime      time.Time `field:"-"`
 
-	TTYName string `field:"tty_name" handler:"ResolveProcessTTY,string"`
-	Comm    string `field:"comm" handler:"ResolveProcessComm,string"`
+	TTYName string `field:"tty_name" handler:"ResolveProcessTTY"`
+	Comm    string `field:"comm" handler:"ResolveProcessComm"`
 
 	// pid_cache_t
 	ForkTimestamp uint64    `field:"-"`
@@ -235,8 +235,8 @@ type Process struct {
 	ExitTimestamp uint64    `field:"-"`
 	ExitTime      time.Time `field:"-"`
 
-	Cookie uint32 `field:"cookie" handler:"ResolveProcessCookie,int"`
-	PPid   uint32 `field:"ppid" handler:"ResolveProcessPPID,int"`
+	Cookie uint32 `field:"cookie" handler:"ResolveProcessCookie"`
+	PPid   uint32 `field:"ppid" handler:"ResolveProcessPPID"`
 
 	// credentials_t section of pid_cache_t
 	Credentials
@@ -254,18 +254,18 @@ type Process struct {
 type ExecEvent struct {
 	Process
 
-	Args          string `field:"args" handler:"ResolveExecArgs,string"`
-	ArgsTruncated bool   `field:"args_truncated"`
-	Envs          string `field:"envs" handler:"ResolveExecEnvs,string"`
-	EnvsTruncated bool   `field:"envs_truncated"`
+	Args          string   `field:"args" handler:"ResolveExecArgs"`
+	ArgsTruncated bool     `field:"args_truncated"`
+	Envs          []string `field:"envs" handler:"ResolveExecEnvs"`
+	EnvsTruncated bool     `field:"envs_truncated"`
 }
 
 // FileFields holds the information required to identify a file
 type FileFields struct {
 	UID   uint32    `field:"uid"`
-	User  string    `field:"user" handler:"ResolveUser,string"`
+	User  string    `field:"user" handler:"ResolveUser"`
 	GID   uint32    `field:"gid"`
-	Group string    `field:"group" handler:"ResolveGroup,string"`
+	Group string    `field:"group" handler:"ResolveGroup"`
 	Mode  uint16    `field:"mode"`
 	CTime time.Time `field:"-"`
 	MTime time.Time `field:"-"`
@@ -289,11 +289,11 @@ func (f *FileFields) GetInUpperLayer() bool {
 // FileEvent is the common file event type
 type FileEvent struct {
 	FileFields
-	PathnameStr   string `field:"path" handler:"ResolveFileInode,string"`
-	ContainerPath string `field:"container_path" handler:"ResolveFileContainerPath,string"`
-	BasenameStr   string `field:"name" handler:"ResolveFileBasename,string"`
-	Filesytem     string `field:"filesystem" handler:"ResolveFileFilesystem,string"`
-	InUpperLayer  bool   `field:"in_upper_layer" handler:"ResolveFileInUpperLayer,bool"`
+	PathnameStr   string `field:"path" handler:"ResolveFileInode"`
+	ContainerPath string `field:"container_path" handler:"ResolveFileContainerPath"`
+	BasenameStr   string `field:"name" handler:"ResolveFileBasename"`
+	Filesytem     string `field:"filesystem" handler:"ResolveFileFilesystem"`
+	InUpperLayer  bool   `field:"in_upper_layer" handler:"ResolveFileInUpperLayer"`
 
 	PathResolutionError error `field:"-"`
 }
@@ -452,8 +452,8 @@ type RmdirEvent struct {
 type SetXAttrEvent struct {
 	SyscallEvent
 	File      FileEvent `field:"file"`
-	Namespace string    `field:"file.destination.namespace" handler:"GetXAttrNamespace,string"`
-	Name      string    `field:"file.destination.name" handler:"GetXAttrName,string"`
+	Namespace string    `field:"file.destination.namespace" handler:"GetXAttrNamespace"`
+	Name      string    `field:"file.destination.name" handler:"GetXAttrName"`
 
 	NameRaw [200]byte
 }

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -529,8 +529,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 
 	case "exec.envs":
-		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string {
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
 
 				return (*Event)(ctx.Object).ResolveExecEnvs(&(*Event)(ctx.Object).Exec)
 			},
@@ -8750,7 +8751,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		if !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.Envs"}
 		}
-		e.Exec.Envs = str
+		e.Exec.Envs = append(e.Exec.Envs, str)
 
 		return nil
 

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -274,12 +274,18 @@ func (ev *Event) ResolveProcessComm(e *model.Process) string {
 
 // ResolveExecArgs resolves the args of the event
 func (ev *Event) ResolveExecArgs(e *model.ExecEvent) string {
-	return strings.Join(ev.ProcessContext.ArgsArray, " ")
+	if ev.Exec.Args == "" && len(ev.ProcessContext.ArgsArray) > 0 {
+		ev.Exec.Args = strings.Join(ev.ProcessContext.ArgsArray, " ")
+	}
+	return ev.Exec.Args
 }
 
-// ResolveExecEnvs resolves the args of the event
-func (ev *Event) ResolveExecEnvs(e *model.ExecEvent) string {
-	return strings.Join(ev.ProcessContext.EnvsArray, " ")
+// ResolveExecEnvs resolves the envs of the event
+func (ev *Event) ResolveExecEnvs(e *model.ExecEvent) []string {
+	if len(ev.Exec.Envs) == 0 && len(ev.ProcessContext.EnvsArray) > 0 {
+		ev.Exec.Envs = ev.ProcessContext.EnvsArray
+	}
+	return ev.Exec.Envs
 }
 
 // ResolveCredentialsUID resolves the user id of the process

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -783,6 +783,9 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, erpc.GetConstants()...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)
 
+	// tail calls
+	p.managerOptions.TailCallRouter = probes.AllTailRoutes()
+
 	resolvers, err := NewResolvers(p, client)
 	if err != nil {
 		return nil, err

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -453,7 +454,14 @@ func (p *ProcessResolver) SetProcessEnvs(pce *model.ProcessCacheEntry) {
 	if e, found := p.argsEnvsCache.Get(pce.EnvsID); found {
 		entry := e.(*argsEnvsCacheEntry)
 
-		pce.EnvsArray = entry.Values
+		// keep only keys
+		pce.EnvsArray = make([]string, len(entry.Values))
+		for i, env := range entry.Values {
+			if els := strings.SplitN(env, "=", 2); len(els) > 0 {
+				pce.EnvsArray[i] = els[0]
+			}
+		}
+
 		if pce.EnvsTruncated {
 			pce.EnvsArray = append(pce.EnvsArray, "...")
 		}

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -10,7 +10,6 @@
 package probe
 
 import (
-	"strings"
 	"syscall"
 	"time"
 
@@ -317,35 +316,24 @@ func newCredentialsSerializerWithResolvers(ce *model.Credentials, r *Resolvers) 
 	}
 }
 
-func scrubArgsEnvs(process *model.Process, e *Event) ([]string, []string) {
+func scrubArgs(process *model.Process, e *Event) []string {
 	args := process.ArgsArray
-	envs := process.EnvsArray
 
 	// scrub args, do not send args if no scrubber instance is passed
 	// can be the case for some custom event
 	if e.scrubber == nil {
 		args = []string{}
-		envs = []string{}
 	} else {
 		if newArgs, changed := e.scrubber.ScrubCommand(args); changed {
 			args = newArgs
 		}
-
-		// for envs, we just keep the keys
-		var newEnvs []string
-		for _, env := range envs {
-			if els := strings.SplitN(env, "=", 2); len(els) > 0 {
-				newEnvs = append(newEnvs, els[0])
-			}
-		}
-		envs = newEnvs
 	}
 
-	return args, envs
+	return args
 }
 
 func newProcessCacheEntrySerializer(pce *model.ProcessCacheEntry, e *Event, topLevel bool) *ProcessCacheEntrySerializer {
-	args, envs := scrubArgsEnvs(&pce.Process, e)
+	args := scrubArgs(&pce.Process, e)
 
 	pceSerializer := &ProcessCacheEntrySerializer{
 		Inode:               pce.FileFields.Inode,
@@ -365,7 +353,7 @@ func newProcessCacheEntrySerializer(pce *model.ProcessCacheEntry, e *Event, topL
 		Executable:    newProcessFileSerializer(&pce.Process, e),
 		Args:          args,
 		ArgsTruncated: pce.Process.ArgsTruncated,
-		Envs:          envs,
+		Envs:          pce.EnvsArray,
 		EnvsTruncated: pce.Process.EnvsTruncated,
 	}
 

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -189,21 +189,21 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 								alias = aliasPrefix + "." + fieldAlias
 							}
 
-							var OrigType string
-							var IsOrigTypePtr bool
-							var IsArray bool
+							var origType string
+							var isOrigTypePtr bool
+							var isArray bool
 
 							if ft, ok := field.Type.(*ast.Ident); ok {
-								OrigType = ft.Name
+								origType = ft.Name
 							} else if ft, ok := field.Type.(*ast.StarExpr); ok {
 								if ident, ok := ft.X.(*ast.Ident); ok {
-									OrigType = ident.Name
-									IsOrigTypePtr = true
+									origType = ident.Name
+									isOrigTypePtr = true
 								}
 							} else if ft, ok := field.Type.(*ast.ArrayType); ok {
-								IsArray = true
+								isArray = true
 								if ident, ok := ft.Elt.(*ast.Ident); ok {
-									OrigType = ident.Name
+									origType = ident.Name
 								}
 							}
 
@@ -221,38 +221,44 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 								ReturnType:    pkgType(it),
 								Public:        true,
 								Event:         event,
-								OrigType:      pkgType(OrigType),
-								IsOrigTypePtr: IsOrigTypePtr,
-								IsArray:       IsArray,
+								OrigType:      pkgType(origType),
+								IsOrigTypePtr: isOrigTypePtr,
+								IsArray:       isArray,
 							}
 
 							fieldIterator = module.Iterators[alias]
 						}
 
 						if handler, found := tag.Lookup("handler"); found {
-							els := strings.Split(handler, ",")
-							if len(els) != 2 {
-								panic("handler definition should be `FunctionName,ReturnType`")
-							}
-							fnc, kind := els[0], els[1]
-
 							if aliasPrefix != "" {
 								fieldAlias = aliasPrefix + "." + fieldAlias
 							}
 
-							fieldType, ok := field.Type.(*ast.Ident)
+							var origType string
+							var isArray bool
+
+							if ft, ok := field.Type.(*ast.Ident); ok {
+								origType = ft.Name
+							} else if ft, ok := field.Type.(*ast.ArrayType); ok {
+								isArray = true
+								if ident, ok := ft.Elt.(*ast.Ident); ok {
+									origType = ident.Name
+								}
+							}
+
 							if ok {
 								module.Fields[fieldAlias] = &structField{
 									Prefix:     prefix,
 									Name:       fmt.Sprintf("%s.%s", prefix, fieldName),
-									BasicType:  origTypeToBasicType(fieldType.Name),
+									BasicType:  origTypeToBasicType(origType),
 									Struct:     typeSpec.Name.Name,
-									Handler:    fnc,
-									ReturnType: kind,
+									Handler:    handler,
+									ReturnType: origTypeToBasicType(origType),
 									Public:     true,
 									Event:      event,
-									OrigType:   fieldType.Name,
+									OrigType:   origType,
 									Iterator:   fieldIterator,
+									IsArray:    isArray,
 								}
 								module.EventTypes[event] = true
 							}
@@ -465,17 +471,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	{{$Mock := .Mock}}
 	{{range $Name, $Field := .Fields}}
 	{{$EvaluatorType := "eval.StringEvaluator"}}
-	{{if $Field.Iterator}}
+	{{if or $Field.Iterator $Field.IsArray}}
 		{{$EvaluatorType = "eval.StringArrayEvaluator"}}
 	{{end}}
 	{{if eq $Field.ReturnType "int"}}
 		{{$EvaluatorType = "eval.IntEvaluator"}}
-		{{if $Field.Iterator}}
+		{{if or $Field.Iterator $Field.IsArray}}
 			{{$EvaluatorType = "eval.IntArrayEvaluator"}}
 		{{end}}
 	{{else if eq $Field.ReturnType "bool"}}
 		{{$EvaluatorType = "eval.BoolEvaluator"}}
-		{{if $Field.Iterator}}
+		{{if or $Field.Iterator $Field.IsArray}}
 			{{$EvaluatorType = "eval.BoolArrayEvaluator"}}
 		{{end}}
 	{{end}}
@@ -533,14 +539,30 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					return results
 				},
 			{{- else}}
-				EvalFnc: func(ctx *eval.Context) {{$Field.ReturnType}} {
+				{{- $ArrayPrefix := ""}}
+				{{- if $Field.IsArray}}
+					{{$ArrayPrefix = "[]"}}
+				{{end}}
+				EvalFnc: func(ctx *eval.Context) {{$ArrayPrefix}}{{$Field.ReturnType}} {
 					{{$Return := $Field.Name | printf "(*Event)(ctx.Object).%s"}}
-					{{if and (ne $Field.Handler "") (not $Mock)}}
+					{{- if and (ne $Field.Handler "") (not $Mock)}}
 						{{$Return = print "(*Event)(ctx.Object)." $Field.Handler "(&(*Event)(ctx.Object)." $Field.Prefix ")"}}
 					{{end}}
 
 					{{- if eq $Field.ReturnType "int"}}
-						return int({{$Return}})
+						{{- if and ($Field.IsArray) (ne $Field.OrigType "int") }}
+							result := make([]int, len({{$Return}}))
+							for i, v := range {{$Return}} {
+								result[i] = in(v)
+							}
+							return result
+						{{- else}}
+							{{- if ne $Field.OrigType "int"}}
+								return int({{$Return}})
+							{{- else}}
+								return {{$Return}}
+							{{end -}}
+						{{end -}}
 					{{- else}}
 						return {{$Return}}
 					{{end -}}
@@ -598,7 +620,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 					{{$Return = print "(*Event)(ctx.Object)." $Handler "(&element." $Field.Struct ")"}}
 				{{end}}
 
-				{{if eq $Field.ReturnType "int"}}
+				{{if and (eq $Field.ReturnType "int") (ne $Field.OrigType "int")}}
 					result := int({{$Return}})
 				{{else}}
 					result := {{$Return}}
@@ -616,10 +638,27 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 				{{$Return = print "e." $Field.Handler "(&e." $Field.Prefix ")"}}
 			{{end}}
 
+			{{- $ArrayPrefix := ""}}
+			{{- if $Field.IsArray}}
+				{{$ArrayPrefix = "[]"}}
+			{{end}}
+
 			{{if eq $Field.ReturnType "string"}}
 				return {{$Return}}, nil
 			{{else if eq $Field.ReturnType "int"}}
-				return int({{$Return}}), nil
+				{{- if and ($Field.IsArray) (ne $Field.OrigType "int") }}
+					result := make([]int, len({{$Return}}))
+					for i, v := range {{$Return}} {
+						result[i] = in(v)
+					}
+					return result, nil
+				{{- else}}
+					{{- if ne $Field.OrigType "int"}}
+						return int({{$Return}}), nil
+					{{- else}}
+						return {{$Return}}, nil
+					{{end -}}
+				{{end -}}
 			{{else if eq $Field.ReturnType "bool"}}
 				return {{$Return}}, nil
 			{{end}}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -553,7 +553,7 @@ func TestProcessLineage(t *testing.T) {
 
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: fmt.Sprintf(`exec.file.path == "%s"`, executable),
+		Expression: fmt.Sprintf(`exec.file.path == "%s" && exec.args in [~"*01010101*"]`, executable),
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
@@ -562,7 +562,7 @@ func TestProcessLineage(t *testing.T) {
 	}
 	defer test.Close()
 
-	cmd := exec.Command(executable, "/dev/null")
+	cmd := exec.Command(executable, "-t", "01010101", "/dev/null")
 	if _, err := cmd.CombinedOutput(); err != nil {
 		t.Error(err)
 	}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -243,9 +243,11 @@ func TestProcessContext(t *testing.T) {
 			assert.Equal(t, strings.HasSuffix(argv[1], "..."), true, "args not truncated")
 		}
 
+		nArgs := 200
+
 		// number of args overflow
 		num := []string{"-al"}
-		for i := 0; i != 100; i++ {
+		for i := 0; i != nArgs; i++ {
 			num = append(num, "aaa")
 		}
 		cmd = exec.Command(executable, num...)
@@ -263,12 +265,12 @@ func TestProcessContext(t *testing.T) {
 
 			argv := strings.Split(args.(string), " ")
 			n := len(argv)
-			if n == 0 || n > 100 {
-				t.Errorf("incorrect number of args")
+			if n == 0 || n > nArgs {
+				t.Errorf("incorrect number of args %d: %s", n, args.(string))
 			}
 
 			if argv[n-1] != "..." {
-				t.Error("arg not truncated")
+				t.Errorf("arg not truncated: %s", args.(string))
 			}
 		}
 	})

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -766,7 +766,7 @@ func testContainerPath(t *testing.T, event *sprobe.Event, fieldPath string) {
 	}
 
 	if !strings.Contains(path.(string), "docker") {
-		t.Errorf("incorrect container_path, should contain `docker`: %s", path)
+		t.Errorf("incorrect container_path, should contain `docker`: %s \n %v", path, event)
 	}
 }
 

--- a/releasenotes/notes/runtime-process-envs-a002ddab45a74df3.yaml
+++ b/releasenotes/notes/runtime-process-envs-a002ddab45a74df3.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Runtime security reports environment variables.

--- a/releasenotes/notes/runtime-security-args-3636e9611a1096d5.yaml
+++ b/releasenotes/notes/runtime-security-args-3636e9611a1096d5.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    Runtime security now report command line arguments as part of the
+    Runtime security now reports command line arguments as part of the
     exec events.


### PR DESCRIPTION
### What does this PR do?

Use tail call to parse more arguments and to add environment variables.

### Motivation

Tail allow to bypass limitation on kernel 4.15(bionic)

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Environment variables should be part of the event
