### PR TITLE
Fix metric tags for sys obj detected profiles

### DIFF
--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -100,6 +100,15 @@ func (c *snmpConfig) getStaticTags() []string {
 	return tags
 }
 
+func (c *snmpConfig) validateEnrichMetricsAndTags() error {
+	errors := validateEnrichMetrics(c.metrics)
+	errors = append(errors, validateEnrichMetricTags(c.metricTags)...)
+	if len(errors) > 0 {
+		return fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
+	}
+	return nil
+}
+
 // toString used for logging snmpConfig without sensitive information
 func (c *snmpConfig) toString() string {
 	return fmt.Sprintf("snmpConfig: ipAddress=`%s`, port=`%d`, snmpVersion=`%s`, timeout=`%d`, retries=`%d`, "+
@@ -222,10 +231,10 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 			return snmpConfig{}, fmt.Errorf("failed to refresh with profile `%s`: %s", profile, err)
 		}
 	}
-	errors := validateEnrichMetrics(c.metrics)
-	errors = append(errors, validateEnrichMetricTags(c.metricTags)...)
-	if len(errors) > 0 {
-		return snmpConfig{}, fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
+
+	err = c.validateEnrichMetricsAndTags()
+	if err != nil {
+		return snmpConfig{}, err
 	}
 	return c, err
 }

--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -100,15 +100,6 @@ func (c *snmpConfig) getStaticTags() []string {
 	return tags
 }
 
-func (c *snmpConfig) validateEnrichMetricsAndTags() error {
-	errors := validateEnrichMetrics(c.metrics)
-	errors = append(errors, validateEnrichMetricTags(c.metricTags)...)
-	if len(errors) > 0 {
-		return fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
-	}
-	return nil
-}
-
 // toString used for logging snmpConfig without sensitive information
 func (c *snmpConfig) toString() string {
 	return fmt.Sprintf("snmpConfig: ipAddress=`%s`, port=`%d`, snmpVersion=`%s`, timeout=`%d`, retries=`%d`, "+
@@ -225,16 +216,17 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 	c.profiles = profiles
 	profile := instance.Profile
 
+	errors := validateEnrichMetrics(c.metrics)
+	errors = append(errors, validateEnrichMetricTags(c.metricTags)...)
+	if len(errors) > 0 {
+		return snmpConfig{}, fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
+	}
+
 	if profile != "" {
 		err = c.refreshWithProfile(profile)
 		if err != nil {
 			return snmpConfig{}, fmt.Errorf("failed to refresh with profile `%s`: %s", profile, err)
 		}
-	}
-
-	err = c.validateEnrichMetricsAndTags()
-	if err != nil {
-		return snmpConfig{}, err
 	}
 	return c, err
 }

--- a/pkg/collector/corechecks/snmp/config_test.go
+++ b/pkg/collector/corechecks/snmp/config_test.go
@@ -181,6 +181,17 @@ global_metrics:
 				"suffix": "\\2",
 			},
 		},
+		{
+			OID:     "1.3.6.1.2.1.1.5.0",
+			Name:    "sysName",
+			Match:   "(\\w)(\\w+)",
+			pattern: regexp.MustCompile("(\\w)(\\w+)"),
+			Tags: map[string]string{
+				"some_tag": "some_tag_value",
+				"prefix":   "\\1",
+				"suffix":   "\\2",
+			},
+		},
 		{Tag: "snmp_host", OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
 	}
 

--- a/pkg/collector/corechecks/snmp/profile.go
+++ b/pkg/collector/corechecks/snmp/profile.go
@@ -116,6 +116,12 @@ func readProfileDefinition(definitionFile string) (*profileDefinition, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshall %q: %v", filePath, err)
 	}
+	normalizeMetrics(profileDefinition.Metrics)
+	errors := validateEnrichMetrics(profileDefinition.Metrics)
+	errors = append(errors, validateEnrichMetricTags(profileDefinition.MetricTags)...)
+	if len(errors) > 0 {
+		return nil, fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
+	}
 	return profileDefinition, nil
 }
 

--- a/pkg/collector/corechecks/snmp/profile_test.go
+++ b/pkg/collector/corechecks/snmp/profile_test.go
@@ -37,7 +37,19 @@ func mockProfilesDefinitions() profileDefinitionMap {
 		Extends:      []string{"_base.yaml", "_generic-if.yaml"},
 		Device:       deviceMeta{Vendor: "f5"},
 		SysObjectIds: StringArray{"1.3.6.1.4.1.3375.2.1.3.4.*"},
-		MetricTags:   []metricTagConfig{{Tag: "snmp_host", Index: 0x0, Column: symbolConfig{OID: "", Name: ""}, OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
+		MetricTags: []metricTagConfig{
+			{
+				OID:   "1.3.6.1.2.1.1.5.0",
+				Name:  "sysName",
+				Match: "(\\w)(\\w+)",
+				Tags: map[string]string{
+					"some_tag": "some_tag_value",
+					"prefix":   "\\1",
+					"suffix":   "\\2",
+				},
+			},
+			{Tag: "snmp_host", Index: 0x0, Column: symbolConfig{OID: "", Name: ""}, OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+		},
 	}}
 }
 

--- a/pkg/collector/corechecks/snmp/profile_test.go
+++ b/pkg/collector/corechecks/snmp/profile_test.go
@@ -81,6 +81,7 @@ func Test_loadProfiles(t *testing.T) {
 
 	profileWithInvalidExtends, _ := filepath.Abs(filepath.Join(".", "test", "test_profiles", "profile_with_invalid_extends.yaml"))
 	invalidYamlProfile, _ := filepath.Abs(filepath.Join(".", "test", "test_profiles", "invalid_yaml_file.yaml"))
+	validationErrorProfile, _ := filepath.Abs(filepath.Join(".", "test", "test_profiles", "validation_error.yaml"))
 	type logCount struct {
 		log   string
 		count int
@@ -161,6 +162,18 @@ func Test_loadProfiles(t *testing.T) {
 			expectedProfileDefMap: profileDefinitionMap{},
 			expectedLogs: []logCount{
 				{"failed to read profile definition `f5-big-ip`: failed to unmarshall", 1},
+			},
+		},
+		{
+			name: "validation error profile",
+			inputProfileConfigMap: profileConfigMap{
+				"f5-big-ip": {
+					validationErrorProfile,
+				},
+			},
+			expectedProfileDefMap: profileDefinitionMap{},
+			expectedLogs: []logCount{
+				{"validation errors: cannot compile `match`", 1},
 			},
 		},
 	}

--- a/pkg/collector/corechecks/snmp/profile_test.go
+++ b/pkg/collector/corechecks/snmp/profile_test.go
@@ -173,7 +173,8 @@ func Test_loadProfiles(t *testing.T) {
 			},
 			expectedProfileDefMap: profileDefinitionMap{},
 			expectedLogs: []logCount{
-				{"validation errors: cannot compile `match`", 1},
+				{"cannot compile `match` (`global_metric_tags[\\w)(\\w+)`)", 1},
+				{"cannot compile `match` (`table_match[\\w)`)", 1},
 			},
 		},
 	}

--- a/pkg/collector/corechecks/snmp/profile_test.go
+++ b/pkg/collector/corechecks/snmp/profile_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/cihub/seelog"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -39,9 +40,10 @@ func mockProfilesDefinitions() profileDefinitionMap {
 		SysObjectIds: StringArray{"1.3.6.1.4.1.3375.2.1.3.4.*"},
 		MetricTags: []metricTagConfig{
 			{
-				OID:   "1.3.6.1.2.1.1.5.0",
-				Name:  "sysName",
-				Match: "(\\w)(\\w+)",
+				OID:     "1.3.6.1.2.1.1.5.0",
+				Name:    "sysName",
+				Match:   "(\\w)(\\w+)",
+				pattern: regexp.MustCompile("(\\w)(\\w+)"),
 				Tags: map[string]string{
 					"some_tag": "some_tag_value",
 					"prefix":   "\\1",

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -86,10 +86,6 @@ func (c *Check) processSnmpMetrics(staticTags []string) ([]string, error) {
 			// Should not happen since the profile is one of those we matched in getProfileForSysObjectID
 			return tags, fmt.Errorf("failed to refresh with profile `%s` detected using sysObjectID `%s`: %s", profile, sysObjectID, err)
 		}
-		err = c.config.validateEnrichMetricsAndTags()
-		if err != nil {
-			return tags, fmt.Errorf("validation error: %s", err)
-		}
 	}
 	tags = append(tags, c.config.profileTags...)
 

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -86,6 +86,10 @@ func (c *Check) processSnmpMetrics(staticTags []string) ([]string, error) {
 			// Should not happen since the profile is one of those we matched in getProfileForSysObjectID
 			return tags, fmt.Errorf("failed to refresh with profile `%s` detected using sysObjectID `%s`: %s", profile, sysObjectID, err)
 		}
+		err = c.config.validateEnrichMetricsAndTags()
+		if err != nil {
+			return tags, fmt.Errorf("validation error: %s", err)
+		}
 	}
 	tags = append(tags, c.config.profileTags...)
 

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -337,6 +337,11 @@ profiles:
 				Value: []byte("foo_sys_name"),
 			},
 			{
+				Name:  "1.3.6.1.2.1.1.5.0",
+				Type:  gosnmp.OctetString,
+				Value: []byte("foo_sys_name"),
+			},
+			{
 				Name:  "1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
 				Type:  gosnmp.Integer,
 				Value: 30,
@@ -414,7 +419,7 @@ profiles:
 		},
 	}
 
-	session.On("Get", []string{"1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.3.0"}).Return(&packet, nil)
+	session.On("Get", []string{"1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.3.0"}).Return(&packet, nil)
 	session.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.13", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}).Return(&bulkPacket, nil)
 
 	err = check.Run()
@@ -555,13 +560,14 @@ profiles:
 	}
 
 	session.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&sysObjectIDPacket, nil)
-	session.On("Get", []string{"1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.3.0"}).Return(&packet, nil)
+	session.On("Get", []string{"1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.3.0"}).Return(&packet, nil)
 	session.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.13", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}).Return(&bulkPacket, nil)
 
 	err = check.Run()
 	assert.Nil(t, err)
 
-	snmpTags := []string{"snmp_device:1.2.3.4", "snmp_profile:f5-big-ip", "device_vendor:f5", "snmp_host:foo_sys_name"}
+	snmpTags := []string{"snmp_device:1.2.3.4", "snmp_profile:f5-big-ip", "device_vendor:f5", "snmp_host:foo_sys_name",
+		"some_tag:some_tag_value", "prefix:f", "suffix:oo_sys_name"}
 	row1Tags := append(copyStrings(snmpTags), "interface:nameRow1", "interface_alias:descRow1")
 	row2Tags := append(copyStrings(snmpTags), "interface:nameRow2", "interface_alias:descRow2")
 
@@ -685,6 +691,11 @@ func TestCheck_Run(t *testing.T) {
 				Value: []byte("foo_sys_name"),
 			},
 			{
+				Name:  "1.3.6.1.2.1.1.5.0",
+				Type:  gosnmp.OctetString,
+				Value: []byte("foo_sys_name"),
+			},
+			{
 				Name:  "1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
 				Type:  gosnmp.Integer,
 				Value: 30,
@@ -736,7 +747,7 @@ func TestCheck_Run(t *testing.T) {
 			sysObjectIDPacket: sysObjectIDPacketOkMock,
 			valuesPacket:      valuesPacketErrMock,
 			valuesError:       fmt.Errorf("no value"),
-			expectedErr:       "failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[1.3.6.1.4.1.3375.2.1.1.2.1.44.0 1.3.6.1.4.1.3375.2.1.1.2.1.44.999 1.2.3.4.5 1.3.6.1.2.1.1.5.0 1.3.6.1.2.1.1.3.0]`: no value",
+			expectedErr:       "failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[1.3.6.1.4.1.3375.2.1.1.2.1.44.0 1.3.6.1.4.1.3375.2.1.1.2.1.44.999 1.2.3.4.5 1.3.6.1.2.1.1.5.0 1.3.6.1.2.1.1.5.0 1.3.6.1.2.1.1.3.0]`: no value",
 		},
 	}
 	for _, tt := range tests {
@@ -763,7 +774,7 @@ ip_address: 1.2.3.4
 			mocksender.SetSender(sender, check.ID())
 
 			session.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&tt.sysObjectIDPacket, tt.sysObjectIDError)
-			session.On("Get", []string{"1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.3.0"}).Return(&tt.valuesPacket, tt.valuesError)
+			session.On("Get", []string{"1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.3.0"}).Return(&tt.valuesPacket, tt.valuesError)
 
 			sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()

--- a/pkg/collector/corechecks/snmp/test/conf.d/snmp.d/profiles/f5-big-ip.yaml
+++ b/pkg/collector/corechecks/snmp/test/conf.d/snmp.d/profiles/f5-big-ip.yaml
@@ -10,6 +10,15 @@ device:
 
 sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
 
+metric_tags:
+  - OID: 1.3.6.1.2.1.1.5.0
+    symbol: sysName
+    match: '(\w)(\w+)'
+    tags:
+      some_tag: some_tag_value
+      prefix: \1
+      suffix: \2
+
 metrics:
   - MIB: F5-BIGIP-SYSTEM-MIB
     forced_type: gauge

--- a/pkg/collector/corechecks/snmp/test/test_profiles/validation_error.yaml
+++ b/pkg/collector/corechecks/snmp/test/test_profiles/validation_error.yaml
@@ -13,9 +13,34 @@ sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
 metric_tags:
   - OID: 1.3.6.1.2.1.1.5.0
     symbol: sysName
-    match: '[\w)(\w+)'  # invalid regex
+    match: 'global_metric_tags[\w)(\w+)'  # invalid regex
     tags:
       some_tag: some_tag_value
       prefix: \1
       suffix: \2
 
+
+metrics:
+  - MIB: IF-MIB
+    table:
+      OID: 1.3.6.1.2.1.2.2
+      name: ifTable
+    forced_type: monotonic_count
+    symbols:
+      - OID: 1.3.6.1.2.1.2.2.1.14
+        name: ifInErrors
+      - OID: 1.3.6.1.2.1.2.2.1.13
+        name: ifInDiscards
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.2.1.31.1.1.1.1
+          name: ifName
+        table: ifXTable
+        tag: interface
+      - OID: 1.3.6.1.2.1.1.5.0
+        symbol: sysName
+        match: 'table_match[\w)'  # invalid regex
+        tags:
+          some_tag: some_tag_value
+          prefix: \1
+          suffix: \2

--- a/pkg/collector/corechecks/snmp/test/test_profiles/validation_error.yaml
+++ b/pkg/collector/corechecks/snmp/test/test_profiles/validation_error.yaml
@@ -1,0 +1,21 @@
+# Profile for F5 BIG-IP devices
+#
+extends:
+  - does_not_exist.yaml
+
+device:
+  vendor: "f5"
+
+
+sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
+
+
+metric_tags:
+  - OID: 1.3.6.1.2.1.1.5.0
+    symbol: sysName
+    match: '[\w)(\w+)'  # invalid regex
+    tags:
+      some_tag: some_tag_value
+      prefix: \1
+      suffix: \2
+

--- a/pkg/collector/corechecks/snmp/test/valid_invalid_conf.d/snmp.d/profiles/f5-big-ip.yaml
+++ b/pkg/collector/corechecks/snmp/test/valid_invalid_conf.d/snmp.d/profiles/f5-big-ip.yaml
@@ -10,6 +10,15 @@ device:
 
 sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
 
+metric_tags:
+  - OID: 1.3.6.1.2.1.1.5.0
+    symbol: sysName
+    match: '(\w)(\w+)'
+    tags:
+      some_tag: some_tag_value
+      prefix: \1
+      suffix: \2
+
 metrics:
   - MIB: F5-BIGIP-SYSTEM-MIB
     forced_type: gauge


### PR DESCRIPTION
### What does this PR do?

Fix metric tags for sys obj detected profiles

The fix is about validating/enriching metrics early on, when profiles are parsed/loaded.


### Motivation

Previously, we didn't applied `validateEnrichMetrics` and `validateEnrichMetricTags` to respectively `metrics` and `metricTags` added using sys obj id detection [here](https://github.com/DataDog/datadog-agent/blob/3cd13948ba45597a4a6aa0f22942801ea8ff1f17/pkg/collector/corechecks/snmp/snmp.go#L84).

Note that, similar to invalid profiles (e.g. invalid yaml), this might trigger more warnings since all profiles with validation errors will now raise warnings on profile loading. The integration will still work for devices matching valid profiles.

### Additional Notes

### Describe your test plan

Use case to test: https://github.com/DataDog/integrations-core/commit/30e5e1c30b698ddadb4542e2bf9cff38b6e9069c

Add to `snmp/datadog_checks/snmp/data/profiles/aruba.yaml`:
```
metric_tags:
  - OID: 1.3.6.1.2.1.1.1
    symbol: sysDescr
    match: 'ArubaOS \(MODEL: (.*)\), Version(.*) \((.*)\)' # ArubaOS (MODEL: Aruba7205), Version8.999.999.7 (70587)
    tags:
      device_type: controller
      device_model: \1
      os_version: \2
      os_rev: \3
```

Add to `snmp/tests/compose/data/aruba.snmprec`:
```
1.3.6.1.2.1.1.1.0|4|ArubaOS (MODEL: Aruba7205), Version8.999.999.7 (70587)
```

At this point, we expect the tags added to the profile to be present by running `agent check snmp`