### PR TITLE
Allow to have containerd without cri check if not K8S

### DIFF
--- a/pkg/config/environment_detection.go
+++ b/pkg/config/environment_detection.go
@@ -89,6 +89,13 @@ func detectFeatures() {
 }
 
 func detectContainerFeatures() {
+	if IsKubernetes() {
+		detectedFeatures[Kubernetes] = struct{}{}
+		if Datadog.GetBool("orchestrator_explorer.enabled") {
+			detectedFeatures[KubeOrchestratorExplorer] = struct{}{}
+		}
+	}
+
 	// Docker
 	if _, dockerHostSet := os.LookupEnv("DOCKER_HOST"); dockerHostSet {
 		detectedFeatures[Docker] = struct{}{}
@@ -121,16 +128,15 @@ func detectContainerFeatures() {
 	}
 
 	if criSocket != "" {
-		detectedFeatures[Cri] = struct{}{}
+		// Containerd support was historically meant for K8S
+		// However, containerd is now used standalone elsewhere.
+		// TODO: Consider having a dedicated setting for containerd standalone
+		if IsKubernetes() {
+			detectedFeatures[Cri] = struct{}{}
+		}
+
 		if strings.Contains(criSocket, "containerd") {
 			detectedFeatures[Containerd] = struct{}{}
-		}
-	}
-
-	if IsKubernetes() {
-		detectedFeatures[Kubernetes] = struct{}{}
-		if Datadog.GetBool("orchestrator_explorer.enabled") {
-			detectedFeatures[KubeOrchestratorExplorer] = struct{}{}
 		}
 	}
 

--- a/releasenotes/notes/fix-containerd-cri-ab31a6f133934082.yaml
+++ b/releasenotes/notes/fix-containerd-cri-ab31a6f133934082.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixes limitation of runtime autodiscovery which would not allow to run containerd check without cri check enabled. Fixes error logs in non-Kubernetes environments.


### PR DESCRIPTION
### What does this PR do?

Allow to have` containerd` without `cri` check if not K8S without scheduling `cri` check (which produces many error logs)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy Agent on any host with `containerd` (but not in K8S), mount `containerd` socket. Make sure the `containerd` check is scheduled but not the `cri` check.