### PR TITLE
[runtime-security] enable FIM even if system_probe_config.enabled is set to false

### DIFF
--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -182,8 +182,8 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		a.EnabledChecks = append(a.EnabledChecks, OOMKillCheckName)
 	}
 
-	if config.Datadog.GetBool("runtime_security_config.enabled") {
-		log.Info("runtime_security_config.enabled=true, enabling system-probe")
+	if config.Datadog.GetBool("runtime_security_config.enabled") || config.Datadog.GetBool("runtime_security_config.fim_enabled") {
+		log.Info("runtime_security_config.enabled or runtime_security_config.fim_enabled detected, enabling system-probe")
 		a.EnableSystemProbe = true
 	}
 

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	CustomSensitiveWords []string
 }
 
-// IsEnabled returns true if any feature is enabled
+// IsEnabled returns true if any feature is enabled. Has to be applied in config package too
 func (c *Config) IsEnabled() bool {
 	return c.RuntimeEnabled || c.FIMEnabled
 }


### PR DESCRIPTION
### What does this PR do?

 enable FIM even if system_probe_config.enabled is set to false. System-probe will be enabled if runtime or fim is enabled.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
