### PR TITLE
Refactor/clean up system-probe invoke tasks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,122 +1,106 @@
 ---
-Language:        Cpp
+Language: Cpp
 AccessModifierOffset: -4
-AlignAfterOpenBracket: AlwaysBreak
+AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Right
-AlignOperands:   false
+AlignEscapedNewlines: Left
+AlignOperands: true
 AlignTrailingComments: false
-AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
+AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-  AfterCaseLabel:  false
-  AfterClass:      false
+  AfterCaseLabel: false
+  AfterClass: false
   AfterControlStatement: Never
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: true
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
+  AfterStruct: false
+  AfterUnion: false
   AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: All
+BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeColon
-BreakBeforeTernaryOperators: true
+BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit:     0
-CommentPragmas:  '^ IWYU pragma:'
+BreakStringLiterals: false
+ColumnLimit: 0
+CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
-DisableFormat:   false
+DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IncludeBlocks:   Preserve
+IncludeBlocks: Preserve
 IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
-    Priority:        1
+  - Regex: '.*'
+    Priority: 1
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: false
 IndentPPDirectives: None
-IndentWidth:     4
+IndentWidth: 4
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
-MacroBlockEnd:   ''
+MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: Inner
+NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 4
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyBreakTemplateDeclaration: 10
-PenaltyExcessCharacter: 1000000
+PenaltyBreakAssignment: 10
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
-ReflowComments:  true
-SortIncludes:    true
-SortUsingDeclarations: true
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCpp11BracedList: true
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
+SpacesInAngles: false
+SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
-StatementMacros:
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
-TabWidth:        8
-UseTab:          Never
-...
-
+Standard: Cpp03
+TabWidth: 4
+UseTab: Never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,7 +133,6 @@ variables:
   DATADOG_AGENT_SYSPROBE_BUILDIMAGES: v3508219-2619f3d
   DATADOG_AGENT_LIBBCC_BUILDIMAGES: v2894686-d80c3ce
   BCC_VERSION: v0.12.0
-  SYSTEM_PROBE_GO_VERSION: 1.14.12
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded
   DEB_GPG_KEY_NAME: "Datadog, Inc <package@datadoghq.com>"
   DEB_GPG_KEY_SSM_NAME: ci.datadog-agent.deb_signing_private_key_8387EEAF

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -18,7 +18,7 @@
     - tar -xvf /tmp/libbcc.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
     - tar -xvf /tmp/clang.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
   script:
-    - inv -e system-probe.build --go-version=$SYSTEM_PROBE_GO_VERSION --embedded-path=$DATADOG_AGENT_EMBEDDED_PATH
+    - inv -e system-probe.build --embedded-path=$DATADOG_AGENT_EMBEDDED_PATH
     # fail if references to glibc >= 2.18
     - objdump -p $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe | egrep 'GLIBC_2\.(1[8-9]|[2-9][0-9])' && exit 1
     - $S3_CP_CMD $SRC_PATH/$SYSTEM_PROBE_BINARIES_DIR/system-probe $S3_ARTIFACTS_URI/system-probe.$ARCH

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,4 @@ repos:
       language: system
       require_serial: true
       files: '^pkg/(ebpf|network|security)/.*\.(c|h)$'
+      exclude: '^pkg/ebpf/(c/bpf_endian|c/bpf_helpers|compiler/clang-stdarg).h$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,10 @@ repos:
       entry: 'python3 tasks/git-hooks/gofmt.py'
       language: system
       files: \.go$
+    - id: clang-format
+      name: clang-format
+      description: clang-format
+      entry: 'python3 tasks/git-hooks/clang-format.py'
+      language: system
+      require_serial: true
+      files: '^pkg/(ebpf|network|security)/.*\.(c|h)$'

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
@@ -42,15 +44,6 @@ var opts struct {
 	version     bool
 	console     bool // windows only; execute on console rather than via SCM
 }
-
-// Version info sourced from build flags
-var (
-	GoVersion string
-	Version   string
-	GitCommit string
-	GitBranch string
-	BuildDate string
-)
 
 const loggerName = ddconfig.LoggerName("SYS-PROBE")
 
@@ -201,18 +194,19 @@ func gracefulExit() {
 
 // versionString returns the version information filled in at build time
 func versionString(sep string) string {
-	addString := func(buf *bytes.Buffer, s, arg string, sep string) {
-		if arg != "" {
-			fmt.Fprintf(buf, s, arg, sep)
+	addString := func(buf *bytes.Buffer, format string, args ...interface{}) {
+		if len(args) > 0 && args[0] != "" {
+			_, _ = fmt.Fprintf(buf, format, args...)
 		}
 	}
 
+	av, _ := version.Agent()
+
 	var buf bytes.Buffer
-	addString(&buf, "Version: %s%s", Version, sep)
-	addString(&buf, "Git hash: %s%s", GitCommit, sep)
-	addString(&buf, "Git branch: %s%s", GitBranch, sep)
-	addString(&buf, "Build date: %s%s", BuildDate, sep)
-	addString(&buf, "Go Version: %s%s", GoVersion, sep)
+	addString(&buf, "Version: %s %s%s", av.GetNumberAndPre(), av.Meta, sep)
+	addString(&buf, "Commit: %s%s", av.Commit, sep)
+	addString(&buf, "Serialization Version: %s%s", serializer.AgentPayloadVersion, sep)
+	addString(&buf, "Go Version: %s%s", runtime.Version(), sep)
 	return buf.String()
 }
 

--- a/tasks/git-hooks/clang-format.py
+++ b/tasks/git-hooks/clang-format.py
@@ -1,16 +1,368 @@
 #!/usr/bin/env python3
+"""A wrapper script around clang-format, suitable for linting multiple files
+and to use for continuous integration.
 
+This is an alternative API for the clang-format command line.
+It runs over multiple files and directories in parallel.
+A diff output is produced and a sensible exit code is returned.
+
+From https://github.com/Sarcasm/run-clang-format
+"""
+
+from __future__ import print_function, unicode_literals
+
+import argparse
+import codecs
+import difflib
+import errno
+import fnmatch
+import io
+import multiprocessing
+import os
+import signal
 import subprocess
 import sys
-
-# Exclude non .c/.h files
-targets = [path for path in sys.argv[1:] if path.endswith(".c") or path.endswith(".h")]
-
-# Call invoke command
-cmd = 'inv -e system-probe.clang-format --fail-on-issue --targets {}'.format(",".join(targets))
+import traceback
+from functools import partial
 
 try:
-    subprocess.run(cmd, shell=True, check=True)
-except subprocess.CalledProcessError:
-    # Signal failure to pre-commit
-    sys.exit(-1)
+    from subprocess import DEVNULL  # py3k
+except ImportError:
+    DEVNULL = open(os.devnull, "wb")
+
+
+DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
+DEFAULT_CLANG_FORMAT_IGNORE = '.clang-format-ignore'
+
+
+class ExitStatus:
+    SUCCESS = 0
+    DIFF = 1
+    TROUBLE = 2
+
+
+def excludes_from_file(ignore_file):
+    excludes = []
+    try:
+        with io.open(ignore_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                if line.startswith('#'):
+                    # ignore comments
+                    continue
+                pattern = line.rstrip()
+                if not pattern:
+                    # allow empty lines
+                    continue
+                excludes.append(pattern)
+    except EnvironmentError as e:
+        if e.errno != errno.ENOENT:
+            raise
+    return excludes
+
+
+def list_files(files, recursive=False, extensions=None, exclude=None):
+    if extensions is None:
+        extensions = []
+    if exclude is None:
+        exclude = []
+
+    out = []
+    for file in files:
+        if recursive and os.path.isdir(file):
+            for dirpath, dnames, fnames in os.walk(file):
+                fpaths = [os.path.join(dirpath, fname) for fname in fnames]
+                for pattern in exclude:
+                    # os.walk() supports trimming down the dnames list
+                    # by modifying it in-place,
+                    # to avoid unnecessary directory listings.
+                    dnames[:] = [x for x in dnames if not fnmatch.fnmatch(os.path.join(dirpath, x), pattern)]
+                    fpaths = [x for x in fpaths if not fnmatch.fnmatch(x, pattern)]
+                for f in fpaths:
+                    ext = os.path.splitext(f)[1][1:]
+                    if ext in extensions:
+                        out.append(f)
+        else:
+            out.append(file)
+    return out
+
+
+def make_diff(file, original, reformatted):
+    return list(
+        difflib.unified_diff(
+            original, reformatted, fromfile='{}\t(original)'.format(file), tofile='{}\t(reformatted)'.format(file), n=3
+        )
+    )
+
+
+class DiffError(Exception):
+    def __init__(self, message, errs=None):
+        super(DiffError, self).__init__(message)
+        self.errs = errs or []
+
+
+class UnexpectedError(Exception):
+    def __init__(self, message, exc=None):
+        super(UnexpectedError, self).__init__(message)
+        self.formatted_traceback = traceback.format_exc()
+        self.exc = exc
+
+
+def run_clang_format_diff_wrapper(args, file):
+    try:
+        ret = run_clang_format_diff(args, file)
+        return ret
+    except DiffError:
+        raise
+    except Exception as e:
+        raise UnexpectedError('{}: {}: {}'.format(file, e.__class__.__name__, e), e)
+
+
+def run_clang_format_diff(args, file):
+    try:
+        with io.open(file, 'r', encoding='utf-8') as f:
+            original = f.readlines()
+    except IOError as exc:
+        raise DiffError(str(exc))
+
+    if args.in_place:
+        invocation = [args.clang_format_executable, '-i', file]
+    else:
+        invocation = [args.clang_format_executable, file]
+
+    if args.style:
+        invocation.extend(['--style', args.style])
+
+    if args.dry_run:
+        print(" ".join(invocation))
+        return [], []
+
+    # Use of utf-8 to decode the process output.
+    #
+    # Hopefully, this is the correct thing to do.
+    #
+    # It's done due to the following assumptions (which may be incorrect):
+    # - clang-format will returns the bytes read from the files as-is,
+    #   without conversion, and it is already assumed that the files use utf-8.
+    # - if the diagnostics were internationalized, they would use utf-8:
+    #   > Adding Translations to Clang
+    #   >
+    #   > Not possible yet!
+    #   > Diagnostic strings should be written in UTF-8,
+    #   > the client can translate to the relevant code page if needed.
+    #   > Each translation completely replaces the format string
+    #   > for the diagnostic.
+    #   > -- http://clang.llvm.org/docs/InternalsManual.html#internals-diag-translation
+    #
+    # It's not pretty, due to Python 2 & 3 compatibility.
+    encoding_py3 = {}
+    if sys.version_info[0] >= 3:
+        encoding_py3['encoding'] = 'utf-8'
+
+    try:
+        proc = subprocess.Popen(
+            invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, **encoding_py3
+        )
+    except OSError as exc:
+        raise DiffError("Command '{}' failed to start: {}".format(subprocess.list2cmdline(invocation), exc))
+    proc_stdout = proc.stdout
+    proc_stderr = proc.stderr
+    if sys.version_info[0] < 3:
+        # make the pipes compatible with Python 3,
+        # reading lines should output unicode
+        encoding = 'utf-8'
+        proc_stdout = codecs.getreader(encoding)(proc_stdout)
+        proc_stderr = codecs.getreader(encoding)(proc_stderr)
+    # hopefully the stderr pipe won't get full and block the process
+    outs = list(proc_stdout.readlines())
+    errs = list(proc_stderr.readlines())
+    proc.wait()
+    if proc.returncode:
+        raise DiffError(
+            "Command '{}' returned non-zero exit status {}".format(
+                subprocess.list2cmdline(invocation), proc.returncode
+            ),
+            errs,
+        )
+    if args.in_place:
+        return [], errs
+    return make_diff(file, original, outs), errs
+
+
+def bold_red(s):
+    return '\x1b[1m\x1b[31m' + s + '\x1b[0m'
+
+
+def colorize(diff_lines):
+    def bold(s):
+        return '\x1b[1m' + s + '\x1b[0m'
+
+    def cyan(s):
+        return '\x1b[36m' + s + '\x1b[0m'
+
+    def green(s):
+        return '\x1b[32m' + s + '\x1b[0m'
+
+    def red(s):
+        return '\x1b[31m' + s + '\x1b[0m'
+
+    for line in diff_lines:
+        if line[:4] in ['--- ', '+++ ']:
+            yield bold(line)
+        elif line.startswith('@@ '):
+            yield cyan(line)
+        elif line.startswith('+'):
+            yield green(line)
+        elif line.startswith('-'):
+            yield red(line)
+        else:
+            yield line
+
+
+def print_diff(diff_lines, use_color):
+    if use_color:
+        diff_lines = colorize(diff_lines)
+    if sys.version_info[0] < 3:
+        sys.stdout.writelines((l.encode('utf-8') for l in diff_lines))
+    else:
+        sys.stdout.writelines(diff_lines)
+
+
+def print_trouble(prog, message, use_colors):
+    error_text = 'error:'
+    if use_colors:
+        error_text = bold_red(error_text)
+    print("{}: {} {}".format(prog, error_text, message), file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--clang-format-executable',
+        metavar='EXECUTABLE',
+        help='path to the clang-format executable',
+        default='clang-format',
+    )
+    parser.add_argument(
+        '--extensions',
+        help='comma separated list of file extensions (default: {})'.format(DEFAULT_EXTENSIONS),
+        default=DEFAULT_EXTENSIONS,
+    )
+    parser.add_argument('-r', '--recursive', action='store_true', help='run recursively over directories')
+    parser.add_argument('-d', '--dry-run', action='store_true', help='just print the list of files')
+    parser.add_argument('-i', '--in-place', action='store_true', help='format file instead of printing differences')
+    parser.add_argument('files', metavar='file', nargs='+')
+    parser.add_argument('-q', '--quiet', action='store_true', help="disable output, useful for the exit code")
+    parser.add_argument(
+        '-j',
+        metavar='N',
+        type=int,
+        default=0,
+        help='run N clang-format jobs in parallel' ' (default number of cpus + 1)',
+    )
+    parser.add_argument(
+        '--color', default='auto', choices=['auto', 'always', 'never'], help='show colored diff (default: auto)'
+    )
+    parser.add_argument(
+        '-e',
+        '--exclude',
+        metavar='PATTERN',
+        action='append',
+        default=[],
+        help='exclude paths matching the given glob-like pattern(s)' ' from recursive search',
+    )
+    parser.add_argument('--style', help='formatting style to apply (LLVM, Google, Chromium, Mozilla, WebKit)')
+
+    args = parser.parse_args()
+
+    # use default signal handling, like diff return SIGINT value on ^C
+    # https://bugs.python.org/issue14229#msg156446
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    try:
+        signal.SIGPIPE
+    except AttributeError:
+        # compatibility, SIGPIPE does not exist on Windows
+        pass
+    else:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    colored_stdout = False
+    colored_stderr = False
+    if args.color == 'always':
+        colored_stdout = True
+        colored_stderr = True
+    elif args.color == 'auto':
+        colored_stdout = sys.stdout.isatty()
+        colored_stderr = sys.stderr.isatty()
+
+    version_invocation = [args.clang_format_executable, str("--version")]
+    try:
+        subprocess.check_call(version_invocation, stdout=DEVNULL)
+    except subprocess.CalledProcessError as e:
+        print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+        return ExitStatus.TROUBLE
+    except OSError as e:
+        print_trouble(
+            parser.prog,
+            "Command '{}' failed to start: {}".format(subprocess.list2cmdline(version_invocation), e),
+            use_colors=colored_stderr,
+        )
+        return ExitStatus.TROUBLE
+
+    retcode = ExitStatus.SUCCESS
+
+    excludes = excludes_from_file(DEFAULT_CLANG_FORMAT_IGNORE)
+    excludes.extend(args.exclude)
+
+    files = list_files(args.files, recursive=args.recursive, exclude=excludes, extensions=args.extensions.split(','))
+
+    if not files:
+        return
+
+    njobs = args.j
+    if njobs == 0:
+        njobs = multiprocessing.cpu_count() + 1
+    njobs = min(len(files), njobs)
+
+    if njobs == 1:
+        # execute directly instead of in a pool,
+        # less overhead, simpler stacktraces
+        it = (run_clang_format_diff_wrapper(args, file) for file in files)
+        pool = None
+    else:
+        pool = multiprocessing.Pool(njobs)
+        it = pool.imap_unordered(partial(run_clang_format_diff_wrapper, args), files)
+        pool.close()
+    while True:
+        try:
+            outs, errs = next(it)
+        except StopIteration:
+            break
+        except DiffError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            retcode = ExitStatus.TROUBLE
+            sys.stderr.writelines(e.errs)
+        except UnexpectedError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            sys.stderr.write(e.formatted_traceback)
+            retcode = ExitStatus.TROUBLE
+            # stop at the first unexpected error,
+            # something could be very wrong,
+            # don't process all files unnecessarily
+            if pool:
+                pool.terminate()
+            break
+        else:
+            sys.stderr.writelines(errs)
+            if outs == []:
+                continue
+            if not args.quiet:
+                print_diff(outs, use_color=colored_stdout)
+            if retcode == ExitStatus.SUCCESS:
+                retcode = ExitStatus.DIFF
+    if pool:
+        pool.join()
+    return retcode
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tasks/git-hooks/clang-format.py
+++ b/tasks/git-hooks/clang-format.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+
+# Exclude non .c/.h files
+targets = [path for path in sys.argv[1:] if path.endswith(".c") or path.endswith(".h")]
+
+# Call invoke command
+cmd = 'inv -e system-probe.clang-format --fail-on-issue {}'.format(",".join(targets))
+
+try:
+    subprocess.run(cmd, shell=True, check=True)
+except subprocess.CalledProcessError:
+    # Signal failure to pre-commit
+    sys.exit(-1)

--- a/tasks/git-hooks/clang-format.py
+++ b/tasks/git-hooks/clang-format.py
@@ -7,7 +7,7 @@ import sys
 targets = [path for path in sys.argv[1:] if path.endswith(".c") or path.endswith(".h")]
 
 # Call invoke command
-cmd = 'inv -e system-probe.clang-format --fail-on-issue {}'.format(",".join(targets))
+cmd = 'inv -e system-probe.clang-format --fail-on-issue --targets {}'.format(",".join(targets))
 
 try:
     subprocess.run(cmd, shell=True, check=True)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -152,10 +152,11 @@ def test(
     ctx,
     packages=TEST_PACKAGES,
     skip_object_files=False,
-    bundle_ebpf=True,
+    bundle_ebpf=False,
     output_path=None,
     runtime_compiled=False,
     skip_linters=False,
+    run=None,
 ):
     """
     Run tests on eBPF parts
@@ -185,13 +186,14 @@ def test(
         "build_tags": ",".join(build_tags),
         "output_params": "-c -o " + output_path if output_path else "",
         "pkgs": packages,
+        "run": "-run " + run if run else "",
     }
 
     _, _, env = get_build_flags(ctx)
     if runtime_compiled:
         env['DD_TESTS_RUNTIME_COMPILED'] = "1"
 
-    cmd = 'go test -mod=mod -v -tags {build_tags} {output_params} {pkgs}'
+    cmd = 'go test -mod=mod -v -tags {build_tags} {output_params} {pkgs} {run}'
     if not is_root():
         cmd = 'sudo -E ' + cmd
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -213,7 +213,7 @@ def kitchen_prepare(ctx):
     target_packages = []
     for pkg in TEST_PACKAGES_LIST:
         target_packages += (
-            check_output("go list -f '{{ .Dir }}' -tags linux_bpf %s" % pkg, shell=True)
+            check_output("go list -f '{{{{ .Dir }}}}' -tags {tags} {pkg}".format(tags=BPF_TAG, pkg=pkg), shell=True)
             .decode('utf-8')
             .strip()
             .split("\n")
@@ -263,7 +263,7 @@ def nettop(ctx, incremental_build=False, go_mod="mod"):
     """
     build_object_files(ctx, bundle_ebpf=False)
 
-    cmd = 'go build -mod={go_mod} {build_type} -tags linux_bpf -o {bin_path} {path}'
+    cmd = 'go build -mod={go_mod} {build_type} -tags {tags} -o {bin_path} {path}'
     bin_path = os.path.join(BIN_DIR, "nettop")
     # Build
     ctx.run(
@@ -272,6 +272,7 @@ def nettop(ctx, incremental_build=False, go_mod="mod"):
             bin_path=bin_path,
             go_mod=go_mod,
             build_type="" if incremental_build else "-a",
+            tags=BPF_TAG,
         )
     )
 
@@ -613,7 +614,7 @@ def generate_runtime_files(ctx):
         "./pkg/security/probe/compile.go",
     ]
     for f in runtime_compiler_files:
-        ctx.run("go generate -mod=mod -tags linux_bpf {}".format(f))
+        ctx.run("go generate -mod=mod -tags {tags} {file}".format(file=f, tags=BPF_TAG))
 
 
 def bundle_files(ctx, bindata_files, dir_prefix, go_dir):

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -172,7 +172,7 @@ def test(
 
     if not skip_linters:
         clang_format(ctx)
-        ctidy(ctx)
+        clang_tidy(ctx)
 
     if not skip_object_files:
         build_object_files(ctx, bundle_ebpf=bundle_ebpf)
@@ -316,14 +316,13 @@ def clang_format(ctx, targets=None, fix=False, fail_on_issue=False):
 
 
 @task
-def ctidy(ctx, fix=False, fail_on_issue=False):
+def clang_tidy(ctx, fix=False, fail_on_issue=False):
     """
     Lint C code using clang-tidy
     """
 
     print("checking for clang-tidy executable...")
     ctx.run("which clang-tidy")
-    print("found clang-tidy")
 
     build_flags = get_ebpf_build_flags()
     build_flags.append("-DDEBUG=1")

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -182,13 +182,12 @@ def test(
         build_tags.append(BUNDLE_TAG)
 
     args = {
-        "path": os.environ['PATH'],
         "build_tags": ",".join(build_tags),
         "output_params": "-c -o " + output_path if output_path else "",
         "pkgs": packages,
     }
 
-    env = {'CGO_LDFLAGS_ALLOW': "-Wl,--wrap=.*"}
+    _, _, env = get_build_flags(ctx)
     if runtime_compiled:
         env['DD_TESTS_RUNTIME_COMPILED'] = "1"
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -283,7 +283,7 @@ def nettop(ctx, incremental_build=False, go_mod="mod"):
 
 
 @task
-def clang_format(ctx, targets, fix=False, fail_on_issue=False):
+def clang_format(ctx, targets=None, fix=False, fail_on_issue=False):
     """
     Format C code using clang-format
     """
@@ -292,6 +292,9 @@ def clang_format(ctx, targets, fix=False, fail_on_issue=False):
         # when this function is called from the command line, targets are passed
         # as comma separated tokens in a string
         targets = targets.split(',')
+
+    if not targets:
+        targets = get_ebpf_targets()
 
     # remove externally maintained files
     ignored_files = [

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -131,7 +131,7 @@ def build_in_docker(
             {builder} \
             {cmd}"
 
-    if should_use_sudo(ctx):
+    if should_docker_use_sudo(ctx):
         docker_cmd = "sudo " + docker_cmd
 
     cmd = "invoke -e system-probe.build --major-version {}".format(major_version)
@@ -276,7 +276,7 @@ def nettop(ctx, incremental_build=False, go_mod="mod"):
     )
 
     # Run
-    if should_use_sudo(ctx):
+    if not is_root():
         ctx.sudo(bin_path)
     else:
         ctx.run(bin_path)
@@ -632,7 +632,7 @@ def build_ebpf_builder(ctx):
 
     cmd = "docker build -t {image} -f {file} ."
 
-    if should_use_sudo(ctx):
+    if should_docker_use_sudo(ctx):
         cmd = "sudo " + cmd
 
     ctx.run(cmd.format(image=EBPF_BUILDER_IMAGE, file=EBPF_BUILDER_FILE))
@@ -642,7 +642,7 @@ def is_root():
     return os.getuid() == 0
 
 
-def should_use_sudo(_):
+def should_docker_use_sudo(_):
     # We are already root
     if is_root():
         return False


### PR DESCRIPTION
### What does this PR do?

- Update system-probe build task to use `pkg/version`
- Add pre-commit hook for eBPF C code using `clang-format`
- Refactor tasks to be easier to read/understand
- Add `--run` option to `system-probe.test` to passthrough to `go test -run`

### Motivation

Prevent inconsistently formatted eBPF C code from entering the codebase.