### PR TITLE
[kitchen] Clean up NPM driver kitchen tests definition

### DIFF
--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -102,15 +102,11 @@ kitchen_windows_installer_npm_install_scenarios-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_windows_installer_npm
-  allow_failure: false
-  retry: 0
 
 kitchen_windows_installer_npm_driver-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_windows_installer_driver
-  allow_failure: false
-  retry: 0
 
 kitchen_windows_installer_agent-a6:
   extends:


### PR DESCRIPTION
### What does this PR do?

Cleans up the NPM driver kitchen test definition after #7609.

### Motivation

`allow_failure: false` is the default value, no need to specify it.
Let these tests retry the same number of times as the others, to reduce the impact of flakes.