### PR TITLE
Ensure base_dir is not None in omnibus_build

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -469,7 +469,7 @@ def omnibus_build(
     # base dir (can be overridden through env vars, command line takes precedence)
     base_dir = base_dir or os.environ.get("OMNIBUS_BASE_DIR")
 
-    if sys.platform == 'win32':
+    if base_dir is not None and sys.platform == 'win32':
         # On Windows, prevent backslashes in the base_dir path otherwise omnibus will fail with
         # error 'no matched files for glob copy' at the end of the build.
         base_dir = base_dir.replace(os.path.sep, '/')


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/7626 broke the CI since `OMNIBUS_BASE_DIR` is None in the CI.
This PR adds a check for None before doing the replacement.
