### PR TITLE
 [runtime-security] fix array approvers

### DIFF
--- a/pkg/security/model/accessors.go
+++ b/pkg/security/model/accessors.go
@@ -1399,12 +1399,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.cap_effective":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1422,8 +1416,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1433,12 +1425,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.cap_permitted":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1456,8 +1442,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1467,12 +1451,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.comm":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1490,8 +1468,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1501,12 +1477,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.cookie":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1524,8 +1494,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1535,12 +1503,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.egid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1558,8 +1520,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1569,12 +1529,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.egroup":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1592,8 +1546,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1603,12 +1555,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.euid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1626,8 +1572,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1637,12 +1581,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.euser":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1660,8 +1598,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1671,12 +1607,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.container_path":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1694,8 +1624,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1705,12 +1633,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.filesystem":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1728,8 +1650,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1739,12 +1659,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1762,8 +1676,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1773,12 +1685,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.group":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1796,8 +1702,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1807,12 +1711,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.inode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1830,8 +1728,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1841,12 +1737,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.mode":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1864,8 +1754,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1875,12 +1763,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.mount_id":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1898,8 +1780,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1909,12 +1789,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1932,8 +1806,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1943,12 +1815,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -1966,8 +1832,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -1977,12 +1841,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2000,8 +1858,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2011,12 +1867,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.file.user":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2034,8 +1884,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2045,12 +1893,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.fsgid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2068,8 +1910,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2079,12 +1919,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.fsgroup":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2102,8 +1936,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2113,12 +1945,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.fsuid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2136,8 +1962,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2147,12 +1971,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.fsuser":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2170,8 +1988,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2181,12 +1997,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.gid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2204,8 +2014,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2215,12 +2023,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.group":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2238,8 +2040,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2249,12 +2049,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.id":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2272,8 +2066,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2283,12 +2075,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.pid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2306,8 +2092,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2317,12 +2101,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.ppid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2340,8 +2118,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2351,12 +2127,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.tid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2374,8 +2144,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2385,12 +2153,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.tty_name":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2408,8 +2170,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2419,12 +2179,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.uid":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]int)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []int
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2442,8 +2196,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					value = iterator.Next()
 				}
 
-				ctx.Cache[field] = unsafe.Pointer(&results)
-
 				return results
 			}, Field: field,
 
@@ -2453,12 +2205,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 	case "process.ancestors.user":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
-				if ptr := ctx.Cache[field]; ptr != nil {
-					if result := (*[]string)(ptr); result != nil {
-						return *result
-					}
-				}
-
 				var results []string
 
 				iterator := &ProcessAncestorsIterator{}
@@ -2475,8 +2221,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
-				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
 			}, Field: field,

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -156,15 +156,35 @@ func (m *Module) Reload() error {
 
 	rsa := sprobe.NewRuleSetApplier(m.config, m.probe)
 
-	ruleSet := m.probe.NewRuleSet(rules.NewOptsWithParams(model.SECLConstants, sprobe.SupportedDiscarders, m.getEventTypeEnabled(), sprobe.AllCustomRuleIDs(), model.SECLLegacyAttributes, agentLogger.DatadogAgentLogger{}))
+	ruleSetOpts := rules.NewOptsWithParams(
+		model.SECLConstants,
+		sprobe.SupportedDiscarders,
+		m.getEventTypeEnabled(),
+		sprobe.AllCustomRuleIDs(),
+		model.SECLLegacyAttributes,
+		agentLogger.DatadogAgentLogger{})
+
+	ruleSet := m.probe.NewRuleSet(ruleSetOpts)
 
 	loadErr := rules.LoadPolicies(m.config.PoliciesDir, ruleSet)
 	if loadErr.ErrorOrNil() != nil {
 		log.Errorf("error while loading policies: %+v", loadErr.Error())
 	}
 
+	model := &sprobe.Model{}
+	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, ruleSetOpts)
+	loadErr = rules.LoadPolicies(m.config.PoliciesDir, approverRuleSet)
+	if loadErr.ErrorOrNil() != nil {
+		log.Errorf("error while loading policies: %+v", loadErr.Error())
+	}
+
+	approvers, err := approverRuleSet.GetApprovers(sprobe.GetCapababilities())
+	if err != nil {
+		return err
+	}
+
 	// analyze the ruleset, push default policies in the kernel and generate the policy report
-	report, err := rsa.Apply(ruleSet)
+	report, err := rsa.Apply(ruleSet, approvers)
 	if err != nil {
 		return err
 	}

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -1405,7 +1405,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1422,7 +1421,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1439,7 +1437,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1456,7 +1453,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1473,7 +1469,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1490,7 +1485,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1507,7 +1501,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1524,7 +1517,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1541,7 +1533,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1558,7 +1549,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1575,7 +1565,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1592,7 +1581,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1609,7 +1597,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1626,7 +1613,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1643,7 +1629,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1660,7 +1645,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1677,7 +1661,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1694,7 +1677,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1711,7 +1693,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1728,7 +1709,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1745,7 +1725,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1762,7 +1741,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1779,7 +1757,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1796,7 +1773,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1813,7 +1789,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1830,7 +1805,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1847,7 +1821,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1864,7 +1837,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1881,7 +1853,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1898,7 +1869,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1915,7 +1885,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1932,7 +1901,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1949,7 +1917,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -1966,7 +1933,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -1983,7 +1949,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2000,7 +1965,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2017,7 +1981,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2034,7 +1997,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2051,7 +2013,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2068,7 +2029,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2085,7 +2045,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2102,7 +2061,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2119,7 +2077,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2136,7 +2093,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2153,7 +2109,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2170,7 +2125,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2187,7 +2141,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2204,7 +2157,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2221,7 +2173,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2238,7 +2189,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2255,7 +2205,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2272,7 +2221,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2289,7 +2237,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2306,7 +2253,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2323,7 +2269,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2340,7 +2285,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2357,7 +2301,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2374,7 +2317,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2391,7 +2333,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2408,7 +2349,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2425,7 +2365,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []int
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2442,7 +2381,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results
@@ -2459,7 +2397,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						return *result
 					}
 				}
-
 				var results []string
 
 				iterator := &model.ProcessAncestorsIterator{}
@@ -2476,7 +2413,6 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 					value = iterator.Next()
 				}
-
 				ctx.Cache[field] = unsafe.Pointer(&results)
 
 				return results

--- a/pkg/security/probe/applier.go
+++ b/pkg/security/probe/applier.go
@@ -50,7 +50,7 @@ func (rsa *RuleSetApplier) applyApprovers(eventType eval.EventType, approvers ru
 	return nil
 }
 
-func (rsa *RuleSetApplier) setupFilters(rs *rules.RuleSet, eventType eval.EventType) error {
+func (rsa *RuleSetApplier) setupFilters(rs *rules.RuleSet, eventType eval.EventType, approvers rules.Approvers) error {
 	if !rsa.config.EnableKernelFilters {
 		if err := rsa.applyFilterPolicy(eventType, PolicyModeNoFilter, math.MaxUint8); err != nil {
 			return err
@@ -68,8 +68,7 @@ func (rsa *RuleSetApplier) setupFilters(rs *rules.RuleSet, eventType eval.EventT
 		return rsa.applyFilterPolicy(eventType, PolicyModeAccept, math.MaxUint8)
 	}
 
-	approvers, err := rs.GetApprovers(eventType, capabilities.GetFieldCapabilities())
-	if err != nil {
+	if len(approvers) == 0 {
 		if err := rsa.applyFilterPolicy(eventType, PolicyModeAccept, math.MaxUint8); err != nil {
 			return err
 		}
@@ -92,7 +91,7 @@ func (rsa *RuleSetApplier) setupFilters(rs *rules.RuleSet, eventType eval.EventT
 }
 
 // Apply setup the filters for the provided set of rules and returns the policy report.
-func (rsa *RuleSetApplier) Apply(rs *rules.RuleSet) (*Report, error) {
+func (rsa *RuleSetApplier) Apply(rs *rules.RuleSet, approvers map[eval.EventType]rules.Approvers) (*Report, error) {
 	if rsa.probe != nil {
 		if err := rsa.probe.FlushDiscarders(); err != nil {
 			return nil, errors.Wrap(err, "failed to flush discarders")
@@ -105,7 +104,7 @@ func (rsa *RuleSetApplier) Apply(rs *rules.RuleSet) (*Report, error) {
 	}
 
 	for _, eventType := range rs.GetEventTypes() {
-		if err := rsa.setupFilters(rs, eventType); err != nil {
+		if err := rsa.setupFilters(rs, eventType, approvers[eventType]); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/security/probe/capabilities.go
+++ b/pkg/security/probe/capabilities.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
+// allCapabilities hold all the supported filtering capabilities
 var allCapabilities = make(map[eval.EventType]Capabilities)
 
 // Capability represents the type of values we are able to filter kernel side
@@ -89,6 +90,15 @@ func twoBasenameCapabilities(event string, field1, field2 string) Capabilities {
 			FieldValueTypes: eval.ScalarValueType,
 		},
 	}
+}
+
+// GetCapababilities returns all the filtering capabilities
+func GetCapababilities() map[eval.EventType]rules.FieldCapabilities {
+	capabilities := make(map[eval.EventType]rules.FieldCapabilities)
+	for eventType, eventCapabilities := range allCapabilities {
+		capabilities[eventType] = eventCapabilities.GetFieldCapabilities()
+	}
+	return capabilities
 }
 
 func init() {

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -301,8 +301,22 @@ func (rs *RuleSet) GetBucket(eventType eval.EventType) *RuleBucket {
 	return nil
 }
 
-// GetApprovers returns Approvers for the given event type and the fields
-func (rs *RuleSet) GetApprovers(eventType eval.EventType, fieldCaps FieldCapabilities) (Approvers, error) {
+// GetApprovers returns all approvers
+func (rs *RuleSet) GetApprovers(fieldCaps map[eval.EventType]FieldCapabilities) (map[eval.EventType]Approvers, error) {
+	approvers := make(map[eval.EventType]Approvers)
+	for _, eventType := range rs.GetEventTypes() {
+		eventApprovers, err := rs.GetEventApprovers(eventType, fieldCaps[eventType])
+		if err != nil {
+			continue
+		}
+		approvers[eventType] = eventApprovers
+	}
+
+	return approvers, nil
+}
+
+// GetEventApprovers returns approvers for the given event type and the fields
+func (rs *RuleSet) GetEventApprovers(eventType eval.EventType, fieldCaps FieldCapabilities) (Approvers, error) {
 	bucket, exists := rs.eventRuleBuckets[eventType]
 	if !exists {
 		return nil, ErrNoEventTypeBucket{EventType: eventType}

--- a/pkg/security/rules/ruleset_test.go
+++ b/pkg/security/rules/ruleset_test.go
@@ -182,7 +182,7 @@ func TestRuleSetFilters1(t *testing.T) {
 		},
 	}
 
-	approvers, err := rs.GetApprovers("open", caps)
+	approvers, err := rs.GetEventApprovers("open", caps)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestRuleSetFilters1(t *testing.T) {
 		},
 	}
 
-	approvers, err = rs.GetApprovers("open", caps)
+	approvers, err = rs.GetEventApprovers("open", caps)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestRuleSetFilters1(t *testing.T) {
 		},
 	}
 
-	_, err = rs.GetApprovers("open", caps)
+	_, err = rs.GetEventApprovers("open", caps)
 	if err == nil {
 		t.Fatal("shouldn't get any approver")
 	}
@@ -242,7 +242,7 @@ func TestRuleSetFilters2(t *testing.T) {
 		},
 	}
 
-	_, err := rs.GetApprovers("open", caps)
+	_, err := rs.GetEventApprovers("open", caps)
 	if err == nil {
 		t.Fatal("shouldn't get any approver")
 	}
@@ -262,7 +262,7 @@ func TestRuleSetFilters2(t *testing.T) {
 		},
 	}
 
-	approvers, err := rs.GetApprovers("open", caps)
+	approvers, err := rs.GetEventApprovers("open", caps)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func TestRuleSetFilters3(t *testing.T) {
 		},
 	}
 
-	approvers, err := rs.GetApprovers("open", caps)
+	approvers, err := rs.GetEventApprovers("open", caps)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestRuleSetFilters4(t *testing.T) {
 		},
 	}
 
-	if _, err := rs.GetApprovers("open", caps); err == nil {
+	if _, err := rs.GetEventApprovers("open", caps); err == nil {
 		t.Fatal("shouldn't get any approver")
 	}
 
@@ -332,7 +332,7 @@ func TestRuleSetFilters4(t *testing.T) {
 		},
 	}
 
-	if _, err := rs.GetApprovers("open", caps); err != nil {
+	if _, err := rs.GetEventApprovers("open", caps); err != nil {
 		t.Fatal("expected approver not found")
 	}
 }
@@ -354,7 +354,7 @@ func TestRuleSetFilters5(t *testing.T) {
 		},
 	}
 
-	if _, err := rs.GetApprovers("open", caps); err != nil {
+	if _, err := rs.GetEventApprovers("open", caps); err != nil {
 		t.Fatal("expected approver not found")
 	}
 }
@@ -375,7 +375,7 @@ func TestRuleSetFilters6(t *testing.T) {
 		},
 	}
 
-	if _, err := rs.GetApprovers("open", caps); err == nil {
+	if _, err := rs.GetEventApprovers("open", caps); err == nil {
 		t.Fatal("shouldn't get any approver")
 	}
 }

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -484,11 +484,13 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &{{$EvaluatorType}}{
 			{{- if $Field.Iterator}}
 				EvalFnc: func(ctx *eval.Context) []{{$Field.ReturnType}} {
+					{{- if not $Mock }}
 					if ptr := ctx.Cache[field]; ptr != nil {
 						if result := (*[]{{$Field.ReturnType}})(ptr); result != nil {
 							return *result
 						}
 					}
+					{{end -}}
 
 					var results []{{$Field.ReturnType}}
 
@@ -524,7 +526,9 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 						value = iterator.Next()
 					}
 
+					{{- if not $Mock }}
 					ctx.Cache[field] = unsafe.Pointer(&results)
+					{{end}}
 
 					return results
 				},


### PR DESCRIPTION
### What does this PR do?

Do not use cache in mock model and use mock model to find approvers

### Motivation

When a field that used array where used in rules, approvers could not be found for this rule.
