### PR TITLE
[Windows installer] Only warn once if a property cannot be replaced

### DIFF
--- a/releasenotes/notes/win-installer-warn-once-if-prop-cannot-be-replaced-c8477cc437dab791.yaml
+++ b/releasenotes/notes/win-installer-warn-once-if-prop-cannot-be-replaced-c8477cc437dab791.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+     The Windows installer now log only once when it fails to replace a property.

--- a/tools/windows/install-help/cal/PropertyReplacer.cpp
+++ b/tools/windows/install-help/cal/PropertyReplacer.cpp
@@ -224,5 +224,13 @@ std::wstring replace_yaml_properties(
         }
     }
 
+    // Remove duplicated entries
+    if (failedToReplace != nullptr)
+    {
+        std::sort(failedToReplace->begin(), failedToReplace->end());
+        auto last = std::unique(failedToReplace->begin(), failedToReplace->end());
+        failedToReplace->erase(last, failedToReplace->end());
+    }
+
     return input;
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes duplicated warning log lines when replacing a property in the installer.

### Motivation

Clearer install logs.