### PR TITLE
[tagger] fix stack trace when entity not found in the store

### DIFF
--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -129,11 +129,7 @@ func (t *Tagger) Stop() error {
 func (t *Tagger) Tag(entityID string, cardinality collectors.TagCardinality) ([]string, error) {
 	telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality))
 
-	entity, err := t.store.getEntity(entityID)
-	if err != nil {
-		return nil, err
-	}
-
+	entity := t.store.getEntity(entityID)
 	if entity != nil {
 		return entity.GetTags(cardinality), nil
 	}
@@ -152,9 +148,9 @@ func (t *Tagger) TagBuilder(entityID string, cardinality collectors.TagCardinali
 
 // Standard returns the standard tags for a given entity.
 func (t *Tagger) Standard(entityID string) ([]string, error) {
-	entity, err := t.store.getEntity(entityID)
-	if err != nil {
-		return nil, err
+	entity := t.store.getEntity(entityID)
+	if entity == nil {
+		return []string{}, nil
 	}
 
 	return entity.StandardTags, nil

--- a/pkg/tagger/remote/tagstore.go
+++ b/pkg/tagger/remote/tagstore.go
@@ -63,11 +63,11 @@ func (s *tagStore) processEvents(events []types.EntityEvent, replace bool) error
 	return nil
 }
 
-func (s *tagStore) getEntity(entityID string) (*types.Entity, error) {
+func (s *tagStore) getEntity(entityID string) *types.Entity {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.store[entityID], nil
+	return s.store[entityID]
 }
 
 func (s *tagStore) listEntities() []*types.Entity {

--- a/pkg/tagger/remote/tagstore_test.go
+++ b/pkg/tagger/remote/tagstore_test.go
@@ -42,10 +42,7 @@ func TestProcessEvent_AddAndModify(t *testing.T) {
 	store := newTagStore()
 	store.processEvents(events, false)
 
-	entity, err := store.getEntity(entityID)
-	if err != nil {
-		t.Fatalf("got unexpected error: %s", err)
-	}
+	entity := store.getEntity(entityID)
 
 	assert.Equal(t, []string{"foo", "bar"}, entity.LowCardinalityTags)
 	assert.Equal(t, []string{"baz"}, entity.OrchestratorCardinalityTags)
@@ -80,17 +77,11 @@ func TestProcessEvent_AddAndDelete(t *testing.T) {
 	store := newTagStore()
 	store.processEvents(events, false)
 
-	entity, err := store.getEntity(entityID)
-	if err != nil {
-		t.Fatalf("got unexpected error: %s", err)
-	}
+	entity := store.getEntity(entityID)
 
 	assert.Nil(t, entity)
 
-	entity, err = store.getEntity(anotherEntityID)
-	if err != nil {
-		t.Fatalf("got unexpected error: %s", err)
-	}
+	entity = store.getEntity(anotherEntityID)
 
 	assert.NotNil(t, entity)
 }
@@ -118,17 +109,11 @@ func TestProcessEvent_Replace(t *testing.T) {
 		},
 	}, true)
 
-	entity, err := store.getEntity(entityID)
-	if err != nil {
-		t.Fatalf("got unexpected error: %s", err)
-	}
+	entity := store.getEntity(entityID)
 
 	assert.Nil(t, entity)
 
-	entity, err = store.getEntity(anotherEntityID)
-	if err != nil {
-		t.Fatalf("got unexpected error: %s", err)
-	}
+	entity = store.getEntity(anotherEntityID)
 
 	assert.NotNil(t, entity)
 }


### PR DESCRIPTION
### What does this PR do?

Fix a stack trace when the getEntity returns nil in the Standard function of the remote tagger. It also removes getEntity error checks as it never returns error. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
