### PR TITLE
[runtime-security] fix macro loading

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "f275e25b8b5f466d718a1a050b498ca576b7ae798732a23dcaad6179f04dc7fd")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e8e6d8ebacf660c8f07190d10122f1f12f3b8d8ba52bd43e66acde27073fa0fd")

--- a/pkg/security/ebpf/c/approvers.h
+++ b/pkg/security/ebpf/c/approvers.h
@@ -3,7 +3,7 @@
 
 #include "syscalls.h"
 
-#define BASENAME_FILTER_SIZE 32
+#define BASENAME_FILTER_SIZE 255
 
 struct basename_t {
     char value[BASENAME_FILTER_SIZE];

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -156,23 +156,25 @@ func (m *Module) Reload() error {
 
 	rsa := sprobe.NewRuleSetApplier(m.config, m.probe)
 
-	ruleSetOpts := rules.NewOptsWithParams(
-		model.SECLConstants,
-		sprobe.SupportedDiscarders,
-		m.getEventTypeEnabled(),
-		sprobe.AllCustomRuleIDs(),
-		model.SECLLegacyAttributes,
-		agentLogger.DatadogAgentLogger{})
+	newRuleSetOpts := func() *rules.Opts {
+		return rules.NewOptsWithParams(
+			model.SECLConstants,
+			sprobe.SupportedDiscarders,
+			m.getEventTypeEnabled(),
+			sprobe.AllCustomRuleIDs(),
+			model.SECLLegacyAttributes,
+			agentLogger.DatadogAgentLogger{})
+	}
 
-	ruleSet := m.probe.NewRuleSet(ruleSetOpts)
+	ruleSet := m.probe.NewRuleSet(newRuleSetOpts())
 
 	loadErr := rules.LoadPolicies(m.config.PoliciesDir, ruleSet)
 	if loadErr.ErrorOrNil() != nil {
 		log.Errorf("error while loading policies: %+v", loadErr.Error())
 	}
 
-	model := &sprobe.Model{}
-	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, ruleSetOpts)
+	model := &model.Model{}
+	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, newRuleSetOpts())
 	loadErr = rules.LoadPolicies(m.config.PoliciesDir, approverRuleSet)
 	if loadErr.ErrorOrNil() != nil {
 		log.Errorf("error while loading policies: %+v", loadErr.Error())

--- a/pkg/security/probe/policy.go
+++ b/pkg/security/probe/policy.go
@@ -32,7 +32,7 @@ const (
 	PolicyFlagMode     PolicyFlag = 4
 
 	// need to be aligned with the kernel size
-	BasenameFilterSize = 32
+	BasenameFilterSize = 255
 )
 
 func (m PolicyMode) String() string {

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -305,7 +305,12 @@ func (rs *RuleSet) GetBucket(eventType eval.EventType) *RuleBucket {
 func (rs *RuleSet) GetApprovers(fieldCaps map[eval.EventType]FieldCapabilities) (map[eval.EventType]Approvers, error) {
 	approvers := make(map[eval.EventType]Approvers)
 	for _, eventType := range rs.GetEventTypes() {
-		eventApprovers, err := rs.GetEventApprovers(eventType, fieldCaps[eventType])
+		caps, exists := fieldCaps[eventType]
+		if !exists {
+			continue
+		}
+
+		eventApprovers, err := rs.GetEventApprovers(eventType, caps)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
### What does this PR do?

Fix system-probe loading of macros

### Motivation

When using macros, the security agent module would complain for the macros being defined twice.