### PR TITLE
[kitchen] Disable system RPM repos in all kitchen tests that don't use them

### DIFF
--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -13,6 +13,7 @@ cookbook 'apt', '< 4.0'
 cookbook 'docker', '< 7.3.0'
 cookbook 'selinux'
 
+cookbook 'dd-agent-disable-system-repos', path: './site-cookbooks/dd-agent-disable-system-repos'
 cookbook 'dd-agent-install', path: './site-cookbooks/dd-agent-install'
 cookbook 'dd-agent-reinstall', path: './site-cookbooks/dd-agent-reinstall'
 cookbook 'dd-agent-upgrade', path: './site-cookbooks/dd-agent-upgrade'

--- a/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/.gitignore
+++ b/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/.gitignore
@@ -1,0 +1,15 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+

--- a/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/Berksfile
+++ b/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+metadata

--- a/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/Gemfile
+++ b/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'bundler', '1.17.3'
+gem 'berkshelf'

--- a/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/README.md
+++ b/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/README.md
@@ -1,0 +1,3 @@
+# dd-agent-disable-system-repos cookbook
+
+Cookbook that disables all system package repositories (if applicable)

--- a/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/chefignore
+++ b/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/metadata.rb
@@ -1,0 +1,5 @@
+name             "dd-agent-disable-system-repos"
+maintainer       "Datadog"
+description      "Cookbook that disables all system package repositories (if applicable)"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "0.0.1"

--- a/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-disable-system-repos/recipes/default.rb
@@ -1,0 +1,18 @@
+#
+# Cookbook Name:: dd-agent-disable-system-repos
+# Recipe:: default
+#
+# Copyright (C) 2021-present Datadog
+#
+# All rights reserved - Do Not Redistribute
+#
+
+if ['redhat', 'centos', 'fedora'].include?(node[:platform])
+  execute 'disable all yum repositories' do
+    command 'yum-config-manager --disable "*"'
+  end
+elsif ['suse', 'opensuseleap'].include?(node[:platform])
+  execute 'disable all zypper repositories' do
+    command 'zypper mr -da'
+  end
+end

--- a/test/kitchen/test-definitions/chef-test.yml
+++ b/test/kitchen/test-definitions/chef-test.yml
@@ -3,6 +3,7 @@ suites:
 # Install the latest release candidate using Chef
 - name: dd-agent
   run_list:
+    - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-system-files-check::list-files-before-install]"
     - "recipe[dd-agent-install]"

--- a/test/kitchen/test-definitions/install-script-test.yml
+++ b/test/kitchen/test-definitions/install-script-test.yml
@@ -9,6 +9,7 @@ suites:
     <% end %>
   <% end %>
   run_list:
+    - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install-script]"
   attributes:

--- a/test/kitchen/test-definitions/step-by-step-test.yml
+++ b/test/kitchen/test-definitions/step-by-step-test.yml
@@ -3,6 +3,7 @@ suites:
 # Installs the latest release candidate using the step-by-step instructions (on dogweb)
 - name: dd-agent-step-by-step
   run_list:
+    - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-step-by-step]"
   attributes:

--- a/test/kitchen/test-definitions/upgrade5-test.yml
+++ b/test/kitchen/test-definitions/upgrade5-test.yml
@@ -11,6 +11,7 @@ suites:
     - <%= p %>
     <% end %>
   run_list:
+    - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-rhel-workaround]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-5]"  # Setup agent 5

--- a/test/kitchen/test-definitions/upgrade6-test.yml
+++ b/test/kitchen/test-definitions/upgrade6-test.yml
@@ -4,6 +4,7 @@ suites:
 # candidate
 - name: dd-agent-upgrade-agent6
   run_list:
+    - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-rhel-workaround]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install]"

--- a/test/kitchen/test-definitions/upgrade7-test.yml
+++ b/test/kitchen/test-definitions/upgrade7-test.yml
@@ -4,6 +4,7 @@ suites:
 # candidate
 - name: dd-agent-upgrade-agent7
   run_list:
+    - "recipe[dd-agent-disable-system-repos]"
     - "recipe[dd-agent-rhel-workaround]"
     - "recipe[dd-agent-sles-workaround]"
     - "recipe[dd-agent-install]"


### PR DESCRIPTION
### What does this PR do?

Disables system RPM repos in all RPM based testing scenarios that don't need to install packages. This will reduce flakiness in case repos are inaccessible and also possibly speed up tests, because repodata of these repos will not be downloaded.

### Motivation

Occasional flakiness when downloading repodata on kitchen instances.

### Additional Notes

None.

### Describe your test plan

N/A - as long as all the kitchen tests pass, this has no effect on the artifacts produced by the pipeline.
