### PR TITLE
Fix `tests_ebpf` GitLab job on `7.27.x` branch

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -34,14 +34,14 @@ tests_ebpf:
     - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
-    # Compile master version for comparison, uncomment following lines when merged
-    - git checkout master
-    - git pull
-    - inv -e deps
-    - inv -e system-probe.build --bundle-ebpf --incremental-build
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
-    - git reset --hard
-    - git checkout -
+    # # Compile master version for comparison, uncomment following lines when merged
+    # - git checkout master
+    # - git pull
+    # - inv -e deps
+    # - inv -e system-probe.build --bundle-ebpf --incremental-build
+    # - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
+    # - git reset --hard
+    # - git checkout -
   artifacts:
     when: always
     paths:


### PR DESCRIPTION
### What does this PR do?

Fix `Tests_ebpf` job on the `7.27.x` branch.

### Motivation

Merge of #7699 on `master` broke branch `7.27.x` because we cannot mix the version of `libbcc` from `7.26.x` with the version of `gobpf` from `master`.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
