### PR TITLE
corechecks/snmp: Avoid expensive error message

### DIFF
--- a/pkg/collector/corechecks/snmp/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/report_metrics_test.go
@@ -319,8 +319,8 @@ func Test_metricSender_reportMetrics(t *testing.T) {
 			},
 			values: &resultValueStore{},
 			expectedLogs: []logCount{
-				{"[DEBUG] reportColumnMetrics: report column: error getting column value: value for Column OID `1.3.6.1.2.1.2.2.1.13` not found in `map[]`", 1},
-				{"[DEBUG] reportColumnMetrics: report column: error getting column value: value for Column OID `1.3.6.1.2.1.2.2.1.14` not found in `map[]`", 1},
+				{"[DEBUG] reportColumnMetrics: report column: error getting column value: value for Column OID `1.3.6.1.2.1.2.2.1.13` not found in results", 1},
+				{"[DEBUG] reportColumnMetrics: report column: error getting column value: value for Column OID `1.3.6.1.2.1.2.2.1.14` not found in results", 1},
 			},
 		},
 		{

--- a/pkg/collector/corechecks/snmp/values.go
+++ b/pkg/collector/corechecks/snmp/values.go
@@ -26,7 +26,7 @@ func (v *resultValueStore) getScalarValue(oid string) (snmpValueType, error) {
 func (v *resultValueStore) getColumnValues(oid string) (map[string]snmpValueType, error) {
 	values, ok := v.columnValues[oid]
 	if !ok {
-		return nil, fmt.Errorf("value for Column OID `%s` not found in `%v`", oid, v.columnValues)
+		return nil, fmt.Errorf("value for Column OID `%s` not found in results", oid)
 	}
 	retValues := make(map[string]snmpValueType, len(values))
 	for index, value := range values {


### PR DESCRIPTION
### What does this PR do?

Avoid expensive error message

### Motivation

`value for Column OID `%s` not found` is called frequently and it's expensive to build the error msg.

The error is not that useful since we already debug log snmp calls reponses.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
