### PR TITLE
corechecks/snmp: Disable gosnmp logger

### DIFF
--- a/pkg/collector/corechecks/snmp/session.go
+++ b/pkg/collector/corechecks/snmp/session.go
@@ -86,6 +86,9 @@ func (s *snmpSession) Configure(config snmpConfig) error {
 }
 
 func (s *snmpSession) Connect() error {
+	// Setting Logger everytime GoSNMP.Connect is called is need to avoid gosnmp
+	// logging to be enabled. Related upstream issue https://github.com/gosnmp/gosnmp/issues/313
+	s.gosnmpInst.Logger = nil
 	return s.gosnmpInst.Connect()
 }
 


### PR DESCRIPTION
### What does this PR do?

Disable gosnmp logger

### Motivation

See https://github.com/gosnmp/gosnmp/issues/313

### Additional Notes


### Describe your test plan

We need to check `s.gosnmpInst.loggingEnable` is false, but since the field is not exported, I didn't manage to unit test it. We can test manually as described below.

Add this test to session_test.go and verify that the `s.gosnmpInst.loggingEnable` is false using a debugger.

```

func Test_snmpSession_Connect(t *testing.T) {
	s := &snmpSession{}
	config := snmpConfig{
		ipAddress: "1.2.3.4",
		port:      uint16(1234),
	}
	err := s.Configure(config)
	assert.NotNil(t, err)

	s.Connect()
	s.Connect()
}   // breakpoint here and check that s.gosnmpInst.loggingEnable is `false`

```