### PR TITLE
[kitchen] Fix tests not running on SLES 15

### DIFF
--- a/.gitlab/kitchen_testing/suse.yml
+++ b/.gitlab/kitchen_testing/suse.yml
@@ -18,7 +18,7 @@
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="suse"
-    - export KITCHEN_OSVERS="sles-12,sles15"
+    - export KITCHEN_OSVERS="sles-12,sles-15"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -137,15 +137,19 @@ def load_targets(_, targethash, selections):
     for selection in selections.split(","):
         selectionpattern = re.compile("^{}$".format(selection))
 
+        matched = False
         for key in targethash:
             if commentpattern.match(key):
                 continue
             if selectionpattern.search(key):
+                matched = True
                 if key not in returnlist:
                     returnlist.append(key)
                 else:
                     print("Skipping duplicate target key {} (matched search {})\n".format(key, selection))
 
+        if not matched:
+            raise Exit(message="Couldn't find any match for target {}\n".format(selection), code=7)
     return returnlist
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes the kitchen CI jobs to actually run kitchen tests on SLES 15.
Adds a check to make sure all targets specified as input are found.

### Motivation

Follow-up of #7457. We weren't running our kitchen tests on SLES 15.

