### PR TITLE
Fix issues with container runtime autodiscovery on-host and add an exclude list

### DIFF
--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -48,6 +49,9 @@ var statusCmd = &cobra.Command{
 			color.NoColor = true
 		}
 
+		// Prevent autoconfig to run when running status as it logs before logger is setup
+		// Cannot rely on config.Override as env detection is run before overrides are set
+		os.Setenv("DD_AUTOCONFIG_FROM_ENVIRONMENT", "false")
 		err := common.SetupConfigWithoutSecrets(confFilePath, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/DataDog/agent-payload v4.62.0+incompatible h1:FiomA80IYIweqtdIkOOYpnj6VIVk1+phXrWaT/8V0Z4=
-github.com/DataDog/agent-payload v4.62.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/agent-payload v4.63.0+incompatible h1:UB2wPXfwn7qc59RopJ4ZbBjFM97pm6wNwbuSfi3tNbc=
 github.com/DataDog/agent-payload v4.63.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -145,7 +145,6 @@ func init() {
 	Datadog = NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	// Configuration defaults
 	InitConfig(Datadog)
-	detectFeatures()
 }
 
 // InitConfig initializes the config defaults on a config
@@ -418,6 +417,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("extra_listeners", []string{})
 	config.BindEnvAndSetDefault("extra_config_providers", []string{})
 	config.BindEnvAndSetDefault("ignore_autoconf", []string{})
+	config.BindEnvAndSetDefault("autoconfig_from_environment", true)
+	config.BindEnvAndSetDefault("autoconfig_exclude_features", []string{})
 
 	// Docker
 	config.BindEnvAndSetDefault("docker_query_timeout", int64(5))
@@ -1014,6 +1015,9 @@ func load(config Config, origin string, loadSecret bool) (*Warnings, error) {
 
 	loadProxyFromEnv(config)
 	SanitizeAPIKeyConfig(config, "api_key")
+	// Environment feature detection needs to run before applying override funcs
+	// as it may provide such overrides
+	detectFeatures()
 	applyOverrideFuncs(config)
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	warnings.TraceMallocEnabledWithPy2 = setTracemallocEnabled(config)

--- a/pkg/config/environment_containers.go
+++ b/pkg/config/environment_containers.go
@@ -1,0 +1,166 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"os"
+	"path"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
+)
+
+const (
+	// Docker socket present
+	Docker Feature = "docker"
+	// Containerd socket present
+	Containerd Feature = "containerd"
+	// Cri is any cri socket present
+	Cri Feature = "cri"
+	// Kubernetes environment
+	Kubernetes Feature = "kubernetes"
+	// ECSFargate environment
+	ECSFargate Feature = "ecsfargate"
+	// EKSFargate environment
+	EKSFargate Feature = "eksfargate"
+	// KubeOrchestratorExplorer can be enabled
+	KubeOrchestratorExplorer Feature = "orchestratorExplorer"
+
+	defaultLinuxDockerSocket       = "/var/run/docker.sock"
+	defaultWindowsDockerSocketPath = "//./pipe/docker_engine"
+	defaultLinuxContainerdSocket   = "/var/run/containerd/containerd.sock"
+	defaultLinuxCrioSocket         = "/var/run/crio/crio.sock"
+	defaultHostMountPrefix         = "/host"
+	unixSocketPrefix               = "unix://"
+	winNamedPipePrefix             = "npipe://"
+
+	socketTimeout = 500 * time.Millisecond
+)
+
+func detectContainerFeatures(features FeatureMap) {
+	detectKubernetes(features)
+	detectDocker(features)
+	detectContainerd(features)
+	detectFargate(features)
+}
+
+func detectKubernetes(features FeatureMap) {
+	if IsKubernetes() {
+		features[Kubernetes] = struct{}{}
+		if Datadog.GetBool("orchestrator_explorer.enabled") {
+			features[KubeOrchestratorExplorer] = struct{}{}
+		}
+	}
+}
+
+func detectDocker(features FeatureMap) {
+	if _, dockerHostSet := os.LookupEnv("DOCKER_HOST"); dockerHostSet {
+		features[Docker] = struct{}{}
+	} else {
+		for _, defaultDockerSocketPath := range getDefaultDockerPaths() {
+			exists, reachable := system.CheckSocketAvailable(defaultDockerSocketPath, socketTimeout)
+			if exists && !reachable {
+				log.Infof("Agent found Docker socket at: %s but socket not reachable (permissions?)", defaultDockerSocketPath)
+				continue
+			}
+
+			if exists && reachable {
+				features[Docker] = struct{}{}
+
+				// Even though it does not modify configuration, using the OverrideFunc mechanism for uniformity
+				AddOverrideFunc(func(Config) {
+					os.Setenv("DOCKER_HOST", getDefaultDockerSocketType()+defaultDockerSocketPath)
+				})
+				break
+			}
+		}
+	}
+}
+
+func detectContainerd(features FeatureMap) {
+	// CRI Socket - Do not automatically default socket path if the Agent runs in Docker
+	// as we'll very likely discover the containerd instance wrapped by Docker.
+	criSocket := Datadog.GetString("cri_socket_path")
+	if criSocket == "" && !IsDockerRuntime() {
+		for _, defaultCriPath := range getDefaultCriPaths() {
+			exists, reachable := system.CheckSocketAvailable(defaultCriPath, socketTimeout)
+			if exists && !reachable {
+				log.Infof("Agent found cri socket at: %s but socket not reachable (permissions?)", defaultCriPath)
+				continue
+			}
+
+			if exists && reachable {
+				criSocket = defaultCriPath
+				AddOverride("cri_socket_path", defaultCriPath)
+				// Currently we do not support multiple CRI paths
+				break
+			}
+		}
+	}
+
+	if criSocket != "" {
+		// Containerd support was historically meant for K8S
+		// However, containerd is now used standalone elsewhere.
+		// TODO: Consider having a dedicated setting for containerd standalone
+		if IsKubernetes() {
+			features[Cri] = struct{}{}
+		}
+
+		if strings.Contains(criSocket, "containerd") {
+			features[Containerd] = struct{}{}
+		}
+	}
+}
+
+func detectFargate(features FeatureMap) {
+	if IsECSFargate() {
+		features[ECSFargate] = struct{}{}
+		return
+	}
+
+	if Datadog.GetBool("eks_fargate") {
+		features[EKSFargate] = struct{}{}
+		features[Kubernetes] = struct{}{}
+	}
+}
+
+func getHostMountPrefixes() []string {
+	if IsContainerized() {
+		return []string{"", defaultHostMountPrefix}
+	}
+	return []string{""}
+}
+
+func getDefaultDockerSocketType() string {
+	if runtime.GOOS == "windows" {
+		return winNamedPipePrefix
+	}
+
+	return unixSocketPrefix
+}
+
+func getDefaultDockerPaths() []string {
+	if runtime.GOOS == "windows" {
+		return []string{defaultWindowsDockerSocketPath}
+	}
+
+	paths := []string{}
+	for _, prefix := range getHostMountPrefixes() {
+		paths = append(paths, path.Join(prefix, defaultLinuxDockerSocket))
+	}
+	return paths
+}
+
+func getDefaultCriPaths() []string {
+	paths := []string{}
+	for _, prefix := range getHostMountPrefixes() {
+		paths = append(paths, path.Join(prefix, defaultLinuxContainerdSocket), path.Join(prefix, defaultLinuxCrioSocket))
+	}
+	return paths
+}

--- a/pkg/config/environment_detection.go
+++ b/pkg/config/environment_detection.go
@@ -7,60 +7,65 @@ package config
 
 import (
 	"os"
-	"path"
-	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Feature represents a feature of current environment
-type Feature int
+type Feature string
 
 const (
-	// Docker socket present
-	Docker Feature = iota
-	// Containerd socket present
-	Containerd
-	// Cri is any cri socket present
-	Cri
-	// Kubernetes environment
-	Kubernetes
-	// ECSFargate environment
-	ECSFargate
-	// EKSFargate environment
-	EKSFargate
-	// KubeOrchestratorExplorer can be enabled
-	KubeOrchestratorExplorer
-)
-
-const (
-	autoconfEnvironmentVariable = "AUTCONFIG_FROM_ENVIRONMENT"
-
-	defaultLinuxDockerSocket       = "/var/run/docker.sock"
-	defaultWindowsDockerSocketPath = "//./pipe/docker_engine"
-	defaultLinuxContainerdSocket   = "/var/run/containerd/containerd.sock"
-	defaultLinuxCrioSocket         = "/var/run/crio/crio.sock"
-	defaultHostMountPrefix         = "/host"
-	unixSocketPrefix               = "unix://"
-	winNamedPipePrefix             = "npipe://"
+	autoconfEnvironmentVariable         = "AUTOCONFIG_FROM_ENVIRONMENT"
+	autoconfEnvironmentVariableWithTypo = "AUTCONFIG_FROM_ENVIRONMENT"
 )
 
 // FeatureMap represents all detected features
 type FeatureMap map[Feature]struct{}
 
+func (fm FeatureMap) String() string {
+	features := make([]string, 0, len(fm))
+	for f := range fm {
+		features = append(features, string(f))
+	}
+
+	return strings.Join(features, ",")
+}
+
 var (
-	detectedFeatures = make(FeatureMap)
+	detectedFeatures FeatureMap
+	featureLock      sync.RWMutex
 )
 
 // GetDetectedFeatures returns all detected features (detection only performed once)
 func GetDetectedFeatures() FeatureMap {
+	featureLock.RLock()
+	defer featureLock.RUnlock()
+
+	if detectedFeatures == nil {
+		// If this function is called while feature detection has not run
+		// it means Confifguration has not been loaded, which is an unexpected flow in our code
+		// It's not useful to do lazy detection as it would also mean Configuration has not been loaded
+		panic("Trying to access features before detection has run")
+	}
+
 	return detectedFeatures
 }
 
 // IsFeaturePresent returns if a particular feature is activated
 func IsFeaturePresent(feature Feature) bool {
+	featureLock.RLock()
+	defer featureLock.RUnlock()
+
+	if detectedFeatures == nil {
+		// If this function is called while feature detection has not run
+		// it means Confifguration has not been loaded, which is an unexpected flow in our code
+		// It's not useful to do lazy detection as it would also mean Configuration has not been loaded
+		panic("Trying to access features before detection has run")
+	}
+
 	_, found := detectedFeatures[feature]
 	return found
 }
@@ -68,137 +73,38 @@ func IsFeaturePresent(feature Feature) bool {
 // IsAutoconfigEnabled returns if autoconfig from environment is activated or not
 // We cannot rely on Datadog config as this function may be called before configuration is read
 func IsAutoconfigEnabled() bool {
-	if autoconfStr, found := os.LookupEnv(autoconfEnvironmentVariable); found {
-		activateAutoconfFromEnv, err := strconv.ParseBool(autoconfStr)
-		if err != nil {
-			log.Errorf("Unable to parse Autoconf value: '%s', err: %v - autoconfig from environment will be deactivated", autoconfStr, err)
-			return false
-		}
+	// Usage of pure environment variables should be deprecated
+	for _, envVar := range []string{autoconfEnvironmentVariable, autoconfEnvironmentVariableWithTypo} {
+		if autoconfStr, found := os.LookupEnv(envVar); found {
+			activateAutoconfFromEnv, err := strconv.ParseBool(autoconfStr)
+			if err != nil {
+				log.Errorf("Unable to parse Autoconf value: '%s', err: %v - autoconfig from environment will be deactivated", autoconfStr, err)
+				return false
+			}
 
-		return activateAutoconfFromEnv
+			log.Warnf("Usage of '%s' variable is deprecated - please use DD_AUTOCONFIG_FROM_ENVIRONMENT or 'autoconfig_from_environment' in config file", envVar)
+			return activateAutoconfFromEnv
+		}
 	}
 
-	return true
+	return Datadog.GetBool("autoconfig_from_environment")
 }
 
+// We guarantee that Datadog configuration is entirely loaded (env + YAML)
+// before this function is called
 func detectFeatures() {
+	featureLock.Lock()
+	defer featureLock.Unlock()
+
+	newFeatures := make(FeatureMap)
 	if IsAutoconfigEnabled() {
-		detectContainerFeatures()
-		log.Infof("Features detected from environment: %v", detectedFeatures)
-	}
-}
-
-func detectContainerFeatures() {
-	if IsKubernetes() {
-		detectedFeatures[Kubernetes] = struct{}{}
-		if Datadog.GetBool("orchestrator_explorer.enabled") {
-			detectedFeatures[KubeOrchestratorExplorer] = struct{}{}
-		}
-	}
-
-	// Docker
-	if _, dockerHostSet := os.LookupEnv("DOCKER_HOST"); dockerHostSet {
-		detectedFeatures[Docker] = struct{}{}
-	} else {
-		for _, defaultDockerSocketPath := range getDefaultDockerPaths() {
-			if checkSocketExists(defaultDockerSocketPath) {
-				detectedFeatures[Docker] = struct{}{}
-
-				// Even though it does not modify configuration, using the OverrideFunc mechanism for uniformity
-				AddOverrideFunc(func(Config) {
-					os.Setenv("DOCKER_HOST", getDefaultDockerSocketType()+defaultDockerSocketPath)
-				})
-				break
-			}
-		}
-	}
-
-	// CRI Socket - Do not automatically default socket path if the Agent runs in Docker
-	// as we'll very likely discover the containerd instance wrapped by Docker.
-	criSocket := Datadog.GetString("cri_socket_path")
-	if criSocket == "" && !IsDockerRuntime() {
-		for _, defaultCriPath := range getDefaultCriPaths() {
-			if checkSocketExists(defaultCriPath) {
-				criSocket = defaultCriPath
-				AddOverride("cri_socket_path", defaultCriPath)
-				// Currently we do not support multiple CRI paths
-				break
-			}
-		}
-	}
-
-	if criSocket != "" {
-		// Containerd support was historically meant for K8S
-		// However, containerd is now used standalone elsewhere.
-		// TODO: Consider having a dedicated setting for containerd standalone
-		if IsKubernetes() {
-			detectedFeatures[Cri] = struct{}{}
+		detectContainerFeatures(newFeatures)
+		excludedFeatures := Datadog.GetStringSlice("autoconfig_exclude_features")
+		for _, ef := range excludedFeatures {
+			delete(newFeatures, Feature(ef))
 		}
 
-		if strings.Contains(criSocket, "containerd") {
-			detectedFeatures[Containerd] = struct{}{}
-		}
+		log.Infof("Features detected from environment: %v", newFeatures)
 	}
-
-	if IsECSFargate() {
-		detectedFeatures[ECSFargate] = struct{}{}
-	}
-
-	if Datadog.GetBool("eks_fargate") {
-		detectedFeatures[EKSFargate] = struct{}{}
-		detectedFeatures[Kubernetes] = struct{}{}
-	}
-}
-
-func checkSocketExists(path string) bool {
-	f, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-
-	// On Windows, we cannot easily verify that a path is a named pipe
-	if runtime.GOOS == "windows" {
-		return true
-	}
-
-	if f.Mode()&os.ModeSocket != 0 {
-		return true
-	}
-
-	return false
-}
-
-func getHostMountPrefixes() []string {
-	if IsContainerized() {
-		return []string{"", defaultHostMountPrefix}
-	}
-	return []string{""}
-}
-
-func getDefaultDockerSocketType() string {
-	if runtime.GOOS == "windows" {
-		return winNamedPipePrefix
-	}
-
-	return unixSocketPrefix
-}
-
-func getDefaultDockerPaths() []string {
-	if runtime.GOOS == "windows" {
-		return []string{defaultWindowsDockerSocketPath}
-	}
-
-	paths := []string{}
-	for _, prefix := range getHostMountPrefixes() {
-		paths = append(paths, path.Join(prefix, defaultLinuxDockerSocket))
-	}
-	return paths
-}
-
-func getDefaultCriPaths() []string {
-	paths := []string{}
-	for _, prefix := range getHostMountPrefixes() {
-		paths = append(paths, path.Join(prefix, defaultLinuxContainerdSocket), path.Join(prefix, defaultLinuxCrioSocket))
-	}
-	return paths
+	detectedFeatures = newFeatures
 }

--- a/pkg/util/system/socket.go
+++ b/pkg/util/system/socket.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build !windows
+
+package system
+
+import (
+	"errors"
+	"net"
+	"os"
+	"time"
+)
+
+// CheckSocketAvailable returns if a socket at path is available
+// first boolean returns if socket path exists
+// second boolean returns if socket is reachable
+func CheckSocketAvailable(path string, timeout time.Duration) (bool, bool) {
+	if !checkSocketExists(path) {
+		return false, false
+	}
+
+	// Assuming socket file exists (bind() done)
+	// -> but we don't have permission: permission denied
+	// -> but no process associated to socket anymore: connection refused
+	// -> but process did not call listen(): connection refused
+	// -> but process does not call accept(): no error
+	// We'll consider socket available in all cases except if permission is denied
+	// as if a path exists and we do have access, it's likely that a process will re-use it later.
+	conn, err := net.DialTimeout("unix", path, timeout)
+	if err != nil && errors.Is(err, os.ErrPermission) {
+		return true, false
+	}
+
+	if conn != nil {
+		conn.Close()
+	}
+
+	return true, true
+}
+
+func checkSocketExists(path string) bool {
+	f, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	if f.Mode()&os.ModeSocket != 0 {
+		return true
+	}
+
+	return false
+}

--- a/pkg/util/system/socket_windows.go
+++ b/pkg/util/system/socket_windows.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package system
+
+import (
+	"os"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// CheckSocketAvailable returns named pipe availability
+// as on Windows, sockets do not exist
+func CheckSocketAvailable(path string, timeout time.Duration) (bool, bool) {
+	if !checkSocketExists(path) {
+		return false, false
+	}
+
+	conn, err := winio.DialPipe(path, &timeout)
+	if err != nil {
+		return true, false
+	}
+
+	if conn != nil {
+		conn.Close()
+	}
+
+	return true, true
+}
+
+func checkSocketExists(path string) bool {
+	_, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	// On Windows there's not easy to check if a path is a named pipe
+	return true
+}

--- a/releasenotes/notes/fix-container-ad-91a2820cc181c490.yaml
+++ b/releasenotes/notes/fix-container-ad-91a2820cc181c490.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes scheduling of non-working container checks introduced by environment autodiscovery in 7.26. Features can now be exluded from autodiscovery results through `autoconfig_exclude_features`.
+    Example: autoconfig_exclude_features: ["docker","cri"] or DD_AUTOCONFIG_EXCLUDE_FEATURES="docker cri"
+    Fix typo in variable used to disable environment autodiscovery and make it usable in `datadog.yaml`. You should now set `autoconfig_from_environment: false` or `DD_AUTOCONFIG_FROM_ENVIRONMENT=false`


### PR DESCRIPTION
### What does this PR do?

Fixes scheduling of non-working container checks introduced by environment autodiscovery in 7.26. Features can now be exluded from autodiscovery results through `autoconfig_exclude_features`.
    Example: autoconfig_exclude_features: ["docker","cri"] or DD_AUTOCONFIG_EXCLUDE_FEATURES="docker cri"
    Fix typo in variable used to disable environment autodiscovery and make it usable in `datadog.yaml`. You should now set `autoconfig_from_environment: false` or `DD_AUTOCONFIG_FROM_ENVIRONMENT=false`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

On-host:
- Install Datadog Agent without changing dd-agent groups with Docker and/or containerd installed, make sure no container checks are scheduled if no access to socket.

In container:
- Datadog Agent deployment (with sockets mounted) should still auto-schedule containers check as before.

Any:
- Verify that using `autoconfig_exclude_features` or `DD_AUTOCONFIG_EXCLUDE_FEATURES` effectively remove feature from detected list