### PR TITLE
[system-probe] do not require API key when forwarding profiles to the trace agent

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -162,6 +162,10 @@ func enableProfiling(cfg *config.AgentConfig) error {
 	// check if TRACE_AGENT_URL is set, in which case, forward the profiles to the trace agent
 	if traceAgentURL := os.Getenv("TRACE_AGENT_URL"); len(traceAgentURL) > 0 {
 		site = fmt.Sprintf(profiling.ProfilingLocalURLTemplate, traceAgentURL)
+		if cfg.ProfilingAPIKey == "" {
+			// when forwarding to the trace agent, its api key will be used
+			cfg.ProfilingAPIKey = "xxx"
+		}
 	} else {
 		// allow full url override for development use
 		s := ddconfig.DefaultSite


### PR DESCRIPTION
### What does this PR do?

Use a fake API key when forwarding system probe profiles to a local trace agent

### Motivation

When using a local trace agent to send profiles, no API key is required as the one from the trace agent will be used. Without this change, the profile code will complain about a missing API key in the configuration file, even if it is not required.