### PR TITLE
corechecks/snmp: Add core loader tag to telemetry metrics

### DIFF
--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -26,7 +26,7 @@ type Check struct {
 
 // Run executes the check
 func (c *Check) Run() error {
-	start := time.Now()
+	startTime := time.Now()
 
 	sender, err := aggregator.GetSender(c.ID())
 	if err != nil {
@@ -44,12 +44,7 @@ func (c *Check) Run() error {
 		c.sender.serviceCheck("snmp.can_check", metrics.ServiceCheckOK, "", tags, "")
 	}
 
-	c.sender.gauge("snmp.devices_monitored", float64(1), "", tags)
-
-	// SNMP Performance metrics
-	c.sender.monotonicCount("datadog.snmp.check_interval", time.Duration(start.UnixNano()).Seconds(), "", tags)
-	c.sender.gauge("datadog.snmp.check_duration", time.Since(start).Seconds(), "", tags)
-	c.sender.gauge("datadog.snmp.submitted_metrics", float64(c.sender.submittedMetrics), "", tags)
+	c.submitTelemetryMetrics(startTime, tags)
 
 	// Commit
 	sender.Commit()
@@ -102,6 +97,17 @@ func (c *Check) processSnmpMetrics(staticTags []string) ([]string, error) {
 		c.sender.reportMetrics(c.config.metrics, valuesStore, tags)
 	}
 	return tags, nil
+}
+
+func (c *Check) submitTelemetryMetrics(startTime time.Time, tags []string) {
+	newTags := append(copyStrings(tags), "loader:core")
+
+	c.sender.gauge("snmp.devices_monitored", float64(1), "", newTags)
+
+	// SNMP Performance metrics
+	c.sender.monotonicCount("datadog.snmp.check_interval", time.Duration(startTime.UnixNano()).Seconds(), "", newTags)
+	c.sender.gauge("datadog.snmp.check_duration", time.Since(startTime).Seconds(), "", newTags)
+	c.sender.gauge("datadog.snmp.submitted_metrics", float64(c.sender.submittedMetrics), "", newTags)
 }
 
 // Configure configures the snmp checks

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	snmpCheckName = "snmp"
+	snmpLoaderTag = "loader:core"
 )
 
 // Check aggregates metrics from one Check instance
@@ -100,7 +101,7 @@ func (c *Check) processSnmpMetrics(staticTags []string) ([]string, error) {
 }
 
 func (c *Check) submitTelemetryMetrics(startTime time.Time, tags []string) {
-	newTags := append(copyStrings(tags), "loader:core")
+	newTags := append(copyStrings(tags), snmpLoaderTag)
 
 	c.sender.gauge("snmp.devices_monitored", float64(1), "", newTags)
 

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -219,6 +219,7 @@ tags:
 
 	snmpTags := []string{"snmp_device:1.2.3.4"}
 	snmpGlobalTags := append(copyStrings(snmpTags), "snmp_host:foo_sys_name")
+	snmpGlobalTagsWithLoader := append(copyStrings(snmpGlobalTags), "loader:core")
 	row1Tags := append(copyStrings(snmpGlobalTags), "if_index:1", "if_desc:desc1")
 	row2Tags := append(copyStrings(snmpGlobalTags), "if_index:2", "if_desc:desc2")
 	scalarTags := append(copyStrings(snmpGlobalTags), "symboltag1:1", "symboltag2:2")
@@ -232,9 +233,9 @@ tags:
 	sender.AssertMetric(t, "Gauge", "snmp.ifOutErrors", float64(201), "", row1Tags)
 	sender.AssertMetric(t, "Gauge", "snmp.ifOutErrors", float64(202), "", row2Tags)
 
-	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", snmpTags)
-	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", snmpGlobalTags)
-	sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 7, "", snmpGlobalTags)
+	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", snmpGlobalTagsWithLoader)
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", snmpGlobalTagsWithLoader)
+	sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 7, "", snmpGlobalTagsWithLoader)
 }
 
 func TestSupportedMetricTypes(t *testing.T) {

--- a/releasenotes/notes/snmp_add_loader_tag-6c32a0c3f8e326a9.yaml
+++ b/releasenotes/notes/snmp_add_loader_tag-6c32a0c3f8e326a9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add loader tag to snmp telemetry metrics


### PR DESCRIPTION
Related PR: https://github.com/DataDog/integrations-core/pull/9038

### What does this PR do?

Add loader tag to telemetry metrics

### Motivation

- Help comparing corecheck vs python performance
- Help knowing which loader/implementation is used (core or python)

### Additional Notes

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
