### PR TITLE
update `invoke test` to handle already existing wildcard

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -219,7 +219,7 @@ def test(
 
         with ctx.cd(module.full_path()):
             ctx.run(
-                cmd.format(pkg_folder=' '.join("{}/...".format(t) for t in module.targets), **args),
+                cmd.format(pkg_folder=' '.join("{}/...".format(t) if not t.endswith("/...") else t for t in module.targets), **args),
                 env=env,
                 out_stream=test_profiler,
             )

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -219,7 +219,10 @@ def test(
 
         with ctx.cd(module.full_path()):
             ctx.run(
-                cmd.format(pkg_folder=' '.join("{}/...".format(t) if not t.endswith("/...") else t for t in module.targets), **args),
+                cmd.format(
+                    pkg_folder=' '.join("{}/...".format(t) if not t.endswith("/...") else t for t in module.targets),
+                    **args
+                ),
                 env=env,
                 out_stream=test_profiler,
             )


### PR DESCRIPTION
### What does this PR do?

Don't add the `/...` wildcard if it is already on the target.

Example, when running: `invoke test --targets=./pkg/aggregator/... `

* Prior behavior: ` ./pkg/aggregator/.../...`
* Fixed: ` ./pkg/aggregator/...`

### Motivation

Fix `invoke test` broken behavior when targets have existing wildcards. 

