### PR TITLE
[CI] Make `deps_vendored` run in silent mode by default

### DIFF
--- a/.gitlab/package_build/apk.yml
+++ b/.gitlab/package_build/apk.yml
@@ -18,7 +18,7 @@ agent_android_apk:
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
-    - inv -e deps-vendored --verbose
+    - inv -e deps-vendored
     - cd $SRC_PATH
     - python3 -m pip install -r requirements.txt
   script:

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -350,7 +350,7 @@ def generate_licenses(ctx, filename='LICENSE-3rdparty.csv', verbose=False):
 # FIXME: This doesn't include licenses for non-go dependencies, like the javascript libs we use for the web gui
 def get_licenses_list(ctx):
     # FIXME: Remove when https://github.com/frapposelli/wwhrd/issues/39 is fixed
-    deps_vendored(ctx, verbose=True)
+    deps_vendored(ctx)
 
     # Read the list of packages to exclude from the list from wwhrd's
     exceptions_wildcard = []


### PR DESCRIPTION
### What does this PR do?

- Have `deps_vendored` be silent by default

### Motivation

- Logs are too spammy for no real advantage