### PR TITLE
[runtime-security] fix snapshot ancestors

### DIFF
--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -625,6 +625,11 @@ func (p *ProcessResolver) syncCache(proc *process.Process) (*model.ProcessCacheE
 		return nil, false
 	}
 
+	parent := p.entryCache[entry.PPid]
+	if parent != nil {
+		entry.Ancestor = parent
+	}
+
 	if entry = p.insertEntry(pid, entry); entry == nil {
 		return nil, false
 	}


### PR DESCRIPTION
### What does this PR do?

Fill the ancestors of the processes retrieved during snapshot

### Motivation

Processes that were already present when the security module is started were missing the ancestors list.