### PR TITLE
[install_script] Add CURRENT RPM key, get keys from keys.datadoghq.com

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -19,9 +19,11 @@ CONF="$ETCDIR/datadog.yaml"
 # D75CEA17048B9ACBF186794B32637D44F14F620E expires in 2032
 APT_GPG_KEYS=("A2923DFF56EDA6E76E55E492D3A80E30382E94DE" "D75CEA17048B9ACBF186794B32637D44F14F620E")
 
+# DATADOG_RPM_KEY_CURRENT.public always contains key used to sign current
+# repodata and newly released packages
 # DATADOG_RPM_KEY_E09422B3.public expires in 2022
-# DATADOG_RPM_KEY_20200908.public expires in 2024
-RPM_GPG_KEYS=("DATADOG_RPM_KEY_E09422B3.public" "DATADOG_RPM_KEY_20200908.public")
+# DATADOG_RPM_KEY_FD4BF915.public expires in 2024
+RPM_GPG_KEYS=("DATADOG_RPM_KEY_CURRENT.public" "DATADOG_RPM_KEY_E09422B3.public" "DATADOG_RPM_KEY_FD4BF915.public")
 
 # RPM_GPG_KEYS_A6 contains keys we only install for the A6 repo.
 # DATADOG_RPM_KEY.public is only useful to install old (< 6.14) Agent packages.
@@ -127,6 +129,12 @@ if [ -n "$REPO_URL" ]; then
     repository_url=$REPO_URL
 else
     repository_url="datadoghq.com"
+fi
+
+if [ -n "$TESTING_KEYS_URL" ]; then
+  keys_url=$TESTING_KEYS_URL
+else
+  keys_url="keys.datadoghq.com"
 fi
 
 if [ -n "$TESTING_YUM_URL" ]; then
@@ -251,19 +259,19 @@ if [ "$OS" = "RedHat" ]; then
     fi
 
     if [ "$agent_major_version" -eq 7 ]; then
-      gpgkeys="https://${yum_url}/DATADOG_RPM_KEY_E09422B3.public"
+      gpgkeys="https://${keys_url}/DATADOG_RPM_KEY_E09422B3.public"
     else
-      gpgkeys="https://${yum_url}/DATADOG_RPM_KEY.public\n       https://$yum_url/DATADOG_RPM_KEY_E09422B3.public"
+      gpgkeys="https://${keys_url}/DATADOG_RPM_KEY.public\n       https://${keys_url}/DATADOG_RPM_KEY_E09422B3.public"
     fi
 
     gpgkeys=''
     separator='\n       '
     for key_path in "${RPM_GPG_KEYS[@]}"; do
-      gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${yum_url}/${key_path}"
+      gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
     done
     if [ "$agent_major_version" -eq 6 ]; then
       for key_path in "${RPM_GPG_KEYS_A6[@]}"; do
-        gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${yum_url}/${key_path}"
+        gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
       done
     fi
 
@@ -355,22 +363,22 @@ elif [ "$OS" = "SUSE" ]; then
   if [ "$SUSE11" == "yes" ]; then
     # SUSE 11 special case
     for key_path in "${RPM_GPG_KEYS[@]}"; do
-      $sudo_cmd curl -o "/tmp/${key_path}" "https://${yum_url}/${key_path}"
+      $sudo_cmd curl -o "/tmp/${key_path}" "https://${keys_url}/${key_path}"
       $sudo_cmd rpm --import "/tmp/${key_path}"
     done
     if [ "$agent_major_version" -eq 6 ]; then
       for key_path in "${RPM_GPG_KEYS_A6[@]}"; do
-        $sudo_cmd curl -o "/tmp/${key_path}" "https://${yum_url}/${key_path}"
+        $sudo_cmd curl -o "/tmp/${key_path}" "https://${keys_url}/${key_path}"
         $sudo_cmd rpm --import "/tmp/${key_path}"
       done
     fi
   else
     for key_path in "${RPM_GPG_KEYS[@]}"; do
-      $sudo_cmd rpm --import "https://${yum_url}/${key_path}"
+      $sudo_cmd rpm --import "https://${keys_url}/${key_path}"
     done
     if [ "$agent_major_version" -eq 6 ]; then
       for key_path in "${RPM_GPG_KEYS_A6[@]}"; do
-        $sudo_cmd rpm --import "https://${yum_url}/${key_path}"
+        $sudo_cmd rpm --import "https://${keys_url}/${key_path}"
       done
     fi
   fi
@@ -381,15 +389,15 @@ elif [ "$OS" = "SUSE" ]; then
     gpgkeys=''
     separator='\n       '
     for key_path in "${RPM_GPG_KEYS[@]}"; do
-      gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${yum_url}/${key_path}"
+      gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
     done
     if [ "$agent_major_version" -eq 6 ]; then
       for key_path in "${RPM_GPG_KEYS_A6[@]}"; do
-        gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${yum_url}/${key_path}"
+        gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
       done
     fi
   else
-    gpgkeys="https://${yum_url}/DATADOG_RPM_KEY_CURRENT.public"
+    gpgkeys="https://${keys_url}/DATADOG_RPM_KEY_CURRENT.public"
   fi
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"

--- a/releasenotes-installscript/notes/rpm-gpgkeys-improvements-3456dc45d103b818.yaml
+++ b/releasenotes-installscript/notes/rpm-gpgkeys-improvements-3456dc45d103b818.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-INSTALLSCRIPT.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    * Add a `gpgkey=` entry pointing to a keyfile that always contains key used to signed current RPM repodata.
+    * Change RPM key location from yum.datadoghq.com to keys.datadoghq.com.

--- a/releasenotes-installscript/notes/rpm-gpgkeys-improvements-3456dc45d103b818.yaml
+++ b/releasenotes-installscript/notes/rpm-gpgkeys-improvements-3456dc45d103b818.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    * Add a `gpgkey=` entry pointing to a keyfile that always contains key used to signed current RPM repodata.
+    * Add a `gpgkey=` entry ensuring that `dnf`/`yum`/`zypper` always have access to the key used to sign current repodata.
     * Change RPM key location from yum.datadoghq.com to keys.datadoghq.com.


### PR DESCRIPTION
### What does this PR do?

* Adds a `gpgkey=` entry pointing to a keyfile that always contains key used to signed current RPM repodata.
* Changes RPM key location from yum.datadoghq.com to keys.datadoghq.com.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Ensure that install script works fine on a Red Hat machine (e.g. CentOS) and on a SUSE machine that didn't previously have keys imported into RPM and/or yum/dnf/zypper cache.