### PR TITLE
[networks] Reduce HTTP monitoring footprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.63.0+incompatible
+	github.com/DataDog/agent-payload v4.63.1-0.20210329150802-e96c27c6f3cc+incompatible
 	github.com/DataDog/datadog-go v4.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.3.1
 	github.com/DataDog/ebpf v0.0.0-20210301225224-1e8911b1b835

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.63.1-0.20210329150802-e96c27c6f3cc+incompatible
+	github.com/DataDog/agent-payload v4.63.1-0.20210331191159-fca851b5a4f8+incompatible
 	github.com/DataDog/datadog-go v4.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.3.1
 	github.com/DataDog/ebpf v0.0.0-20210301225224-1e8911b1b835

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/DataDog/agent-payload v4.62.0+incompatible h1:FiomA80IYIweqtdIkOOYpnj
 github.com/DataDog/agent-payload v4.62.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/agent-payload v4.63.0+incompatible h1:UB2wPXfwn7qc59RopJ4ZbBjFM97pm6wNwbuSfi3tNbc=
 github.com/DataDog/agent-payload v4.63.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.63.1-0.20210329150802-e96c27c6f3cc+incompatible h1:EkyPpPbpqaIDLOCrc0d94zaji8nGmF181UWpUAKLi+s=
+github.com/DataDog/agent-payload v4.63.1-0.20210329150802-e96c27c6f3cc+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/DataDog/agent-payload v4.63.0+incompatible h1:UB2wPXfwn7qc59RopJ4ZbBj
 github.com/DataDog/agent-payload v4.63.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/agent-payload v4.63.1-0.20210329150802-e96c27c6f3cc+incompatible h1:EkyPpPbpqaIDLOCrc0d94zaji8nGmF181UWpUAKLi+s=
 github.com/DataDog/agent-payload v4.63.1-0.20210329150802-e96c27c6f3cc+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.63.1-0.20210331191159-fca851b5a4f8+incompatible h1:X39+EmZCL3VdM5PPz2bzHbRq4Gmn+G+5ZsLeECgJYAU=
+github.com/DataDog/agent-payload v4.63.1-0.20210331191159-fca851b5a4f8+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -156,7 +156,7 @@ func NewDefaultConfig() *Config {
 		MaxClosedConnectionsBuffered: 50000,
 		MaxConnectionsStateBuffered:  75000,
 		MaxDNSStatsBufferred:         75000,
-		MaxHTTPStatsBuffered:         75000,
+		MaxHTTPStatsBuffered:         100000,
 		ClientStateExpiry:            2 * time.Minute,
 		ClosedChannelSize:            500,
 		// DNS Stats related configurations

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -5,6 +5,7 @@ import (
 
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/gogo/protobuf/jsonpb"
 )
 
@@ -50,9 +51,11 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	agentConns := make([]*model.Connection, len(conns.Conns))
 	domainSet := make(map[string]int)
 	routeIndex := make(map[string]RouteIdx)
+	httpIndex := FormatHTTPStats(conns.HTTP)
 
 	for i, conn := range conns.Conns {
-		agentConns[i] = FormatConnection(conn, domainSet, routeIndex)
+		httpKey := http.NewKey(conn.Source, conn.Dest, conn.SPort, conn.DPort, "")
+		agentConns[i] = FormatConnection(conn, domainSet, routeIndex, httpIndex[httpKey])
 	}
 
 	domains := make([]string, len(domainSet))

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -56,6 +56,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	for i, conn := range conns.Conns {
 		httpKey := http.NewKey(conn.Source, conn.Dest, conn.SPort, conn.DPort, "")
 		agentConns[i] = FormatConnection(conn, domainSet, routeIndex, httpIndex[httpKey])
+		delete(httpIndex, httpKey)
 	}
 
 	domains := make([]string, len(domainSet))

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -236,15 +236,17 @@ func TestSerialization(t *testing.T) {
 func TestFormatHTTPStatsByPath(t *testing.T) {
 	var httpReqStats http.RequestStats
 	httpReqStats.AddRequest(100, 12.5)
+	httpReqStats.AddRequest(100, 12.5)
+	httpReqStats.AddRequest(405, 3.5)
 	httpReqStats.AddRequest(405, 3.5)
 
 	// Verify the latency data is correct prior to serialization
-	latencies := httpReqStats.Latencies(model.HTTPResponseStatus_Info)
-	assert.Equal(t, 1.0, latencies.GetCount())
+	latencies := httpReqStats[model.HTTPResponseStatus_Info].Latencies
+	assert.Equal(t, 2.0, latencies.GetCount())
 	verifyQuantile(t, latencies, 0.5, 12.5)
 
-	latencies = httpReqStats.Latencies(model.HTTPResponseStatus_ClientErr)
-	assert.Equal(t, 1.0, latencies.GetCount())
+	latencies = httpReqStats[model.HTTPResponseStatus_ClientErr].Latencies
+	assert.Equal(t, 2.0, latencies.GetCount())
 	verifyQuantile(t, latencies, 0.5, 3.5)
 
 	statsByPath := map[string]http.RequestStats{
@@ -258,12 +260,12 @@ func TestFormatHTTPStatsByPath(t *testing.T) {
 
 	serializedLatencies := statsByResponseStatus[model.HTTPResponseStatus_Info].Latencies
 	sketch := unmarshalSketch(t, serializedLatencies)
-	assert.Equal(t, 1.0, sketch.GetCount())
+	assert.Equal(t, 2.0, sketch.GetCount())
 	verifyQuantile(t, sketch, 0.5, 12.5)
 
 	serializedLatencies = statsByResponseStatus[model.HTTPResponseStatus_ClientErr].Latencies
 	sketch = unmarshalSketch(t, serializedLatencies)
-	assert.Equal(t, 1.0, sketch.GetCount())
+	assert.Equal(t, 2.0, sketch.GetCount())
 	verifyQuantile(t, sketch, 0.5, 3.5)
 
 	serializedLatencies = statsByResponseStatus[model.HTTPResponseStatus_Success].Latencies

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -60,7 +60,7 @@ func FormatConnection(conn network.ConnectionStats, domainSet map[string]int, ro
 	c.LastTcpClosed = conn.LastTCPClosed
 	c.DnsStatsByDomain = formatDNSStatsByDomain(conn.DNSStatsByDomain, domainSet)
 	c.RouteIdx = formatRouteIdx(conn.Via, routes)
-	c.HttpStatsByPath = formatHTTPStatsByPath(conn.HTTPStatsByPath)
+	// c.HttpStatsByPath = formatHTTPStatsByPath(conn.HTTPStatsByPath)
 	return c
 }
 

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -129,6 +129,7 @@ func FormatCompilationTelemetry(telByAsset map[string]network.RuntimeCompilation
 	return ret
 }
 
+// FormatHTTPStats converts the HTTP map into a suitable format for serialization
 func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]map[string]*model.HTTPStats {
 	aggregated := make(map[http.Key]map[string]*model.HTTPStats, len(httpData))
 	for key, stats := range httpData {

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -32,7 +32,7 @@ type RouteIdx struct {
 }
 
 // FormatConnection converts a ConnectionStats into an model.Connection
-func FormatConnection(conn network.ConnectionStats, domainSet map[string]int, routes map[string]RouteIdx) *model.Connection {
+func FormatConnection(conn network.ConnectionStats, domainSet map[string]int, routes map[string]RouteIdx, httpStats map[string]*model.HTTPStats) *model.Connection {
 	c := connPool.Get().(*model.Connection)
 	c.Pid = int32(conn.Pid)
 	c.Laddr = formatAddr(conn.Source, conn.SPort)
@@ -60,7 +60,7 @@ func FormatConnection(conn network.ConnectionStats, domainSet map[string]int, ro
 	c.LastTcpClosed = conn.LastTCPClosed
 	c.DnsStatsByDomain = formatDNSStatsByDomain(conn.DNSStatsByDomain, domainSet)
 	c.RouteIdx = formatRouteIdx(conn.Via, routes)
-	c.HttpStatsByPath = formatHTTPStatsByPath(conn.HTTPStatsByPath)
+	c.HttpStatsByPath = httpStats
 	return c
 }
 
@@ -127,6 +127,40 @@ func FormatCompilationTelemetry(telByAsset map[string]network.RuntimeCompilation
 		ret[asset] = t
 	}
 	return ret
+}
+
+func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]map[string]*model.HTTPStats {
+	aggregated := make(map[http.Key]map[string]*model.HTTPStats, len(httpData))
+	for key, stats := range httpData {
+		path := key.Path
+		key.Path = ""
+
+		statsByPath := aggregated[key]
+		if statsByPath == nil {
+			statsByPath = make(map[string]*model.HTTPStats)
+			aggregated[key] = statsByPath
+		}
+
+		ms := &model.HTTPStats{
+			StatsByResponseStatus: make([]*model.HTTPStats_Data, 5),
+		}
+
+		for i := 0; i < 5; i++ {
+			data := new(model.HTTPStats_Data)
+			data.Count = uint32(stats[i].Count)
+			if latencies := stats[i].Latencies; latencies != nil {
+				blob, _ := proto.Marshal(latencies.ToProto())
+				data.Latencies = blob
+			} else {
+				data.FirstLatencySample = uint64(stats[i].FirstLatencySample)
+			}
+			ms.StatsByResponseStatus[i] = data
+		}
+
+		statsByPath[path] = ms
+	}
+
+	return aggregated
 }
 
 func returnToPool(c *model.Connections) {
@@ -248,29 +282,4 @@ func formatRouteIdx(v *network.Via, routes map[string]RouteIdx) int32 {
 
 func routeKey(v *network.Via) string {
 	return v.Subnet.Alias
-}
-
-func formatHTTPStatsByPath(statsByPath map[string]http.RequestStats) map[string]*model.HTTPStats {
-	formattedStatsByPath := make(map[string]*model.HTTPStats)
-
-	for path, stats := range statsByPath {
-		var ms model.HTTPStats
-		ms.StatsByResponseStatus = make([]*model.HTTPStats_Data, 5)
-
-		for i := 0; i < 5; i++ {
-			data := new(model.HTTPStats_Data)
-			data.Count = uint32(stats[i].Count)
-			if latencies := stats[i].Latencies; latencies != nil {
-				blob, _ := proto.Marshal(latencies.ToProto())
-				data.Latencies = blob
-			} else {
-				data.FirstLatencySample = uint64(stats[i].FirstLatencySample)
-			}
-			ms.StatsByResponseStatus[i] = data
-		}
-
-		formattedStatsByPath[path] = &ms
-	}
-
-	return formattedStatsByPath
 }

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -83,6 +83,7 @@ type Connections struct {
 	Conns                       []ConnectionStats
 	ConnTelemetry               *ConnectionsTelemetry
 	CompilationTelemetryByAsset map[string]RuntimeCompilationTelemetry
+	HTTP                        map[http.Key]http.RequestStats
 }
 
 // ConnectionsTelemetry stores telemetry from the system probe related to connections collection
@@ -157,8 +158,6 @@ type ConnectionStats struct {
 	DNSStatsByDomain       map[string]DNSStats
 
 	Via *Via
-
-	HTTPStatsByPath map[string]http.RequestStats
 }
 
 // Via has info about the routing decision for a flow

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -9,35 +9,49 @@ import (
 type httpStatKeeper struct {
 	stats  map[Key]map[string]RequestStats
 	buffer []byte
+
+	// map containing interned path strings
+	// this is rotated together with the stats map
+	interned map[string]string
 }
 
 func newHTTPStatkeeper() *httpStatKeeper {
 	return &httpStatKeeper{
-		stats:  make(map[Key]map[string]RequestStats),
-		buffer: make([]byte, HTTPBufferSize),
+		stats:    make(map[Key]map[string]RequestStats),
+		buffer:   make([]byte, HTTPBufferSize),
+		interned: make(map[string]string),
 	}
 }
 
 func (h *httpStatKeeper) Process(transactions []httpTX) {
 	for _, tx := range transactions {
 		key := tx.ToKey()
-		path := tx.Path(h.buffer)
-		statusClass := tx.StatusClass()
-		latency := tx.RequestLatency()
-
 		if _, ok := h.stats[key]; !ok {
 			h.stats[key] = make(map[string]RequestStats)
 		}
-		stats := h.stats[key][string(path)]
+
+		path := tx.Path(h.buffer)
+		statusClass := tx.StatusClass()
+		latency := tx.RequestLatency()
+		pathString := h.intern(path)
+		stats := h.stats[key][pathString]
 		stats.AddRequest(statusClass, latency)
-		h.stats[key][string(path)] = stats
+		h.stats[key][pathString] = stats
 	}
 }
 
 func (h *httpStatKeeper) GetAndResetAllStats() map[Key]map[string]RequestStats {
 	ret := h.stats // No deep copy needed since `h.stats` gets reset
 	h.stats = make(map[Key]map[string]RequestStats)
+	h.interned = make(map[string]string)
 	return ret
 }
 
-func (h *httpStatKeeper) Close() {}
+func (h *httpStatKeeper) intern(b []byte) string {
+	v, ok := h.interned[string(b)]
+	if !ok {
+		v = string(b)
+		h.interned[v] = v
+	}
+	return v
+}

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -7,17 +7,19 @@ import (
 )
 
 type httpStatKeeper struct {
-	stats  map[Key]map[string]RequestStats
+	stats map[Key]RequestStats
+
+	// http path buffer
 	buffer []byte
 
 	// map containing interned path strings
-	// this is rotated together with the stats map
+	// this is rotated  with the stats map
 	interned map[string]string
 }
 
 func newHTTPStatkeeper() *httpStatKeeper {
 	return &httpStatKeeper{
-		stats:    make(map[Key]map[string]RequestStats),
+		stats:    make(map[Key]RequestStats),
 		buffer:   make([]byte, HTTPBufferSize),
 		interned: make(map[string]string),
 	}
@@ -25,26 +27,33 @@ func newHTTPStatkeeper() *httpStatKeeper {
 
 func (h *httpStatKeeper) Process(transactions []httpTX) {
 	for _, tx := range transactions {
-		key := tx.ToKey()
-		if _, ok := h.stats[key]; !ok {
-			h.stats[key] = make(map[string]RequestStats)
-		}
-
-		path := tx.Path(h.buffer)
-		statusClass := tx.StatusClass()
-		latency := tx.RequestLatency()
-		pathString := h.intern(path)
-		stats := h.stats[key][pathString]
-		stats.AddRequest(statusClass, latency)
-		h.stats[key][pathString] = stats
+		key := h.newKey(tx)
+		stats := h.stats[key]
+		stats.AddRequest(tx.StatusClass(), tx.RequestLatency())
+		h.stats[key] = stats
 	}
 }
 
-func (h *httpStatKeeper) GetAndResetAllStats() map[Key]map[string]RequestStats {
+func (h *httpStatKeeper) GetAndResetAllStats() map[Key]RequestStats {
 	ret := h.stats // No deep copy needed since `h.stats` gets reset
-	h.stats = make(map[Key]map[string]RequestStats)
+	h.stats = make(map[Key]RequestStats)
 	h.interned = make(map[string]string)
 	return ret
+}
+
+func (h *httpStatKeeper) newKey(tx httpTX) Key {
+	path := tx.Path(h.buffer)
+	pathString := h.intern(path)
+
+	return Key{
+		SrcIPHigh: uint64(tx.tup.saddr_h),
+		SrcIPLow:  uint64(tx.tup.saddr_l),
+		SrcPort:   uint16(tx.tup.sport),
+		DstIPHigh: uint64(tx.tup.daddr_h),
+		DstIPLow:  uint64(tx.tup.daddr_l),
+		DstPort:   uint16(tx.tup.dport),
+		Path:      pathString,
+	}
 }
 
 func (h *httpStatKeeper) intern(b []byte) string {

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -20,12 +20,7 @@ func newHTTPStatkeeper() *httpStatKeeper {
 
 func (h *httpStatKeeper) Process(transactions []httpTX) {
 	for _, tx := range transactions {
-		key := Key{
-			SourceIP:   tx.SourceIP(),
-			DestIP:     tx.DestIP(),
-			SourcePort: tx.SourcePort(),
-			DestPort:   tx.DestPort(),
-		}
+		key := tx.ToKey()
 		path := tx.Path(h.buffer)
 		statusClass := tx.StatusClass()
 		latency := tx.RequestLatency()

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -4,11 +4,9 @@ package http
 
 import (
 	"C"
-	"sync"
 )
 
 type httpStatKeeper struct {
-	mux   sync.Mutex
 	stats  map[Key]map[string]RequestStats
 	buffer []byte
 }
@@ -21,9 +19,6 @@ func newHTTPStatkeeper() *httpStatKeeper {
 }
 
 func (h *httpStatKeeper) Process(transactions []httpTX) {
-	h.mux.Lock()
-	defer h.mux.Unlock()
-
 	for _, tx := range transactions {
 		key := Key{
 			SourceIP:   tx.SourceIP(),
@@ -45,9 +40,6 @@ func (h *httpStatKeeper) Process(transactions []httpTX) {
 }
 
 func (h *httpStatKeeper) GetAndResetAllStats() map[Key]map[string]RequestStats {
-	h.mux.Lock()
-	defer h.mux.Unlock()
-
 	ret := h.stats // No deep copy needed since `h.stats` gets reset
 	h.stats = make(map[Key]map[string]RequestStats)
 	return ret

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -5,6 +5,7 @@ package http
 import (
 	"C"
 )
+import "sync/atomic"
 
 type httpStatKeeper struct {
 	stats      map[Key]RequestStats
@@ -43,7 +44,8 @@ func (h *httpStatKeeper) Process(transactions []httpTX) {
 		h.stats[key] = stats
 	}
 
-	h.telemetry.dropped(dropped)
+	atomic.AddInt64(&h.telemetry.dropped, int64(dropped))
+	atomic.StoreInt64(&h.telemetry.aggregations, int64(len(h.stats)))
 }
 
 func (h *httpStatKeeper) GetAndResetAllStats() map[Key]RequestStats {

--- a/pkg/network/http/http_statkeeper_test.go
+++ b/pkg/network/http/http_statkeeper_test.go
@@ -38,13 +38,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 
 	assert.Equal(t, len(stats), 1)
 	for key, statsMap := range stats {
-		assert.Equal(t, key, Key{
-			SourceIP:   sourceIP,
-			SourcePort: uint16(sourcePort),
-			DestIP:     destIP,
-			DestPort:   uint16(destPort),
-		})
-
+		assert.Equal(t, txs[0].ToKey(), key)
 		assert.Equal(t, len(statsMap), 10)
 		for path, stats := range statsMap {
 			assert.Equal(t, "/testpath", path[:9])

--- a/pkg/network/http/http_statkeeper_test.go
+++ b/pkg/network/http/http_statkeeper_test.go
@@ -75,3 +75,23 @@ func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourceP
 
 	return tx
 }
+
+func BenchmarkProcessSameConn(b *testing.B) {
+	sk := newHTTPStatkeeper()
+	tx := generateIPv4HTTPTransaction(
+		util.AddressFromString("1.1.1.1"),
+		util.AddressFromString("2.2.2.2"),
+		1234,
+		8080,
+		"foobar",
+		404,
+		float64(30000),
+	)
+	transactions := []httpTX{tx}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sk.Process(transactions)
+	}
+}

--- a/pkg/network/http/http_statkeeper_test.go
+++ b/pkg/network/http/http_statkeeper_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestProcessHTTPTransactions(t *testing.T) {
-	sk := newHTTPStatkeeper()
+	sk := newHTTPStatkeeper(1000, newTelemetry())
 	txs := make([]httpTX, 100)
 
 	sourceIP := util.AddressFromString("1.1.1.1")
@@ -72,7 +72,7 @@ func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourceP
 }
 
 func BenchmarkProcessSameConn(b *testing.B) {
-	sk := newHTTPStatkeeper()
+	sk := newHTTPStatkeeper(1000, newTelemetry())
 	tx := generateIPv4HTTPTransaction(
 		util.AddressFromString("1.1.1.1"),
 		util.AddressFromString("2.2.2.2"),

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -72,6 +72,7 @@ func (r *RequestStats) CombineWith(newStats RequestStats) {
 			// The other bucket (newStats) has multiple samples and therefore a DDSketch object
 			// We first ensure that the bucket we're merging to has a DDSketch object
 			if r[i].Latencies == nil {
+				// TODO: Consider calling Copy() on the other sketch instead
 				if err := r.initSketch(i); err != nil {
 					continue
 				}

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/sketches-go/ddsketch"
@@ -16,9 +15,12 @@ type Key struct {
 	DstIPHigh uint64
 	DstIPLow  uint64
 	DstPort   uint16
+
+	Path string
 }
 
-func NewKey(saddr, daddr util.Address, sport, dport uint16) Key {
+// NewKey generates a new Key
+func NewKey(saddr, daddr util.Address, sport, dport uint16, path string) Key {
 	saddrl, saddrh := util.ToLowHigh(saddr)
 	daddrl, daddrh := util.ToLowHigh(daddr)
 	return Key{
@@ -28,6 +30,7 @@ func NewKey(saddr, daddr util.Address, sport, dport uint16) Key {
 		DstIPHigh: daddrh,
 		DstIPLow:  daddrl,
 		DstPort:   dport,
+		Path:      path,
 	}
 }
 
@@ -42,83 +45,84 @@ type RequestStats [5]struct {
 	// Note: every time we add a latency value to the DDSketch below, it's possible for the sketch to discard that value
 	// (ie if it is outside the range that is tracked by the sketch). For that reason, in order to keep an accurate count
 	// the number of http transactions processed, we have our own count field (rather than relying on DDSketch.GetCount())
-	count     int
-	latencies *ddsketch.DDSketch
+	Count     int
+	Latencies *ddsketch.DDSketch
 
-	firstLatency float64
+	// This field holds the value (in milliseconds) of the first HTTP request
+	// in this bucket. We do this as optimization to avoid creating sketches with
+	// a single value. This is quite common in the context of HTTP requests without
+	// keep-alives where a short-lived TCP connection is used for a single request.
+	FirstLatencySample float64
 }
 
 // CombineWith merges the data in 2 RequestStats objects
+// newStats is kept as it is, while the method receiver gets mutated
 func (r *RequestStats) CombineWith(newStats RequestStats) {
-	for i := 0; i < 5; i++ {
+	for i := 0; i < len(r); i++ {
 		statusClass := 100 * (i + 1)
-
-		if newStats[i].count == 0 {
+		switch newStats[i].Count {
+		case 0:
+			// No data to be merged
 			continue
-		}
-
-		if newStats[i].count == 1 {
-			r.AddRequest(statusClass, newStats[i].firstLatency)
+		case 1:
+			// The other bucket has a single latency sample, so we "manually" add it
+			r.AddRequest(statusClass, newStats[i].FirstLatencySample)
 			continue
-		}
+		default:
+			// The other bucket (newStats) has multiple samples and therefore a DDSketch object
+			// We first ensure that the bucket we're merging to has a DDSketch object
+			if r[i].Latencies == nil {
+				if err := r.initSketch(i); err != nil {
+					continue
+				}
 
-		if r[i].latencies == nil {
-			if err := r.initSketch(i); err != nil {
-				continue
+				// If we had a latency sample in this bucket we now add it to the DDSketch
+				if r[i].Count == 1 {
+					r[i].Latencies.Add(r[i].FirstLatencySample)
+				}
 			}
 
-			if r[i].count == 1 {
-				r[i].latencies.Add(r[i].firstLatency)
+			// Finally merge both sketches
+			r[i].Count += newStats[i].Count
+			err := r[i].Latencies.MergeWith(newStats[i].Latencies)
+			if err != nil {
+				log.Debugf("error merging http transactions: %v", err)
 			}
-		}
-
-		r[i].count += newStats[i].count
-		err := r[i].latencies.MergeWith(newStats[i].latencies)
-		if err != nil {
-			log.Debugf("error merging http transactions: %v", err)
 		}
 	}
-}
-
-// Count returns the number of requests made which received a response of status class s
-func (r *RequestStats) Count(s model.HTTPResponseStatus) int {
-	return r[s].count
-}
-
-// Latencies returns a sketch of the latencies of the requests made which received
-// a response of status class s
-func (r *RequestStats) Latencies(s model.HTTPResponseStatus) *ddsketch.DDSketch {
-	return r[s].latencies
 }
 
 // AddRequest takes information about a HTTP transaction and adds it to the request stats
 func (r *RequestStats) AddRequest(statusClass int, latency float64) {
 	i := statusClass/100 - 1
-	r[i].count++
-
-	// We postpone the creation of histograms when we have only one latency sample
-	if r[i].count == 1 {
-		r[i].firstLatency = latency
+	if i >= len(r) {
 		return
 	}
 
-	if r[i].latencies == nil {
+	r[i].Count++
+	if r[i].Count == 1 {
+		// We postpone the creation of histograms when we have only one latency sample
+		r[i].FirstLatencySample = latency
+		return
+	}
+
+	if r[i].Latencies == nil {
 		if err := r.initSketch(i); err != nil {
 			return
 		}
 
 		// Add the defered latency sample
-		r[i].latencies.Add(r[i].firstLatency)
+		r[i].Latencies.Add(r[i].FirstLatencySample)
 	}
 
-	err := r[i].latencies.Add(latency)
+	err := r[i].Latencies.Add(latency)
 	if err != nil {
 		log.Debugf("error recording http transaction latency: could not add latency to ddsketch: %v", err)
 	}
 }
 
 func (r *RequestStats) initSketch(i int) (err error) {
-	r[i].latencies, err = ddsketch.NewDefaultDDSketch(RelativeAccuracy)
+	r[i].Latencies, err = ddsketch.NewDefaultDDSketch(RelativeAccuracy)
 	if err != nil {
 		log.Debugf("error recording http transaction latency: could not create new ddsketch: %v", err)
 	}

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -9,10 +9,26 @@ import (
 
 // Key is an identifier for a group of HTTP transactions
 type Key struct {
-	SourceIP   util.Address
-	DestIP     util.Address
-	SourcePort uint16
-	DestPort   uint16
+	SrcIPHigh uint64
+	SrcIPLow  uint64
+	SrcPort   uint16
+
+	DstIPHigh uint64
+	DstIPLow  uint64
+	DstPort   uint16
+}
+
+func NewKey(saddr, daddr util.Address, sport, dport uint16) Key {
+	saddrl, saddrh := util.ToLowHigh(saddr)
+	daddrl, daddrh := util.ToLowHigh(daddr)
+	return Key{
+		SrcIPHigh: saddrh,
+		SrcIPLow:  saddrl,
+		SrcPort:   sport,
+		DstIPHigh: daddrh,
+		DstIPLow:  daddrl,
+		DstPort:   dport,
+	}
 }
 
 // RelativeAccuracy defines the acceptable error in quantile values calculated by DDSketch.

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -83,9 +83,12 @@ func (r *RequestStats) CombineWith(newStats RequestStats) {
 				continue
 			}
 
-			// If we had a latency sample in this bucket we now add it to the DDSketch
+			// If we have a latency sample in this bucket we now add it to the DDSketch
 			if r[i].Count == 1 {
-				r[i].Latencies.Add(r[i].FirstLatencySample)
+				err := r[i].Latencies.Add(r[i].FirstLatencySample)
+				if err != nil {
+					log.Debugf("could not add request latency to ddsketch: %v", err)
+				}
 			}
 		}
 
@@ -118,12 +121,15 @@ func (r *RequestStats) AddRequest(statusClass int, latency float64) {
 		}
 
 		// Add the defered latency sample
-		r[i].Latencies.Add(r[i].FirstLatencySample)
+		err := r[i].Latencies.Add(r[i].FirstLatencySample)
+		if err != nil {
+			log.Debugf("could not add request latency to ddsketch: %v", err)
+		}
 	}
 
 	err := r[i].Latencies.Add(latency)
 	if err != nil {
-		log.Debugf("error recording http transaction latency: could not add latency to ddsketch: %v", err)
+		log.Debugf("could not add request latency to ddsketch: %v", err)
 	}
 }
 

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -39,9 +39,12 @@ func NewKey(saddr, daddr util.Address, sport, dport uint16, path string) Key {
 // will be between 99 and 101
 const RelativeAccuracy = 0.01
 
+// NumStatusClasses represents the number of HTTP status classes (1XX, 2XX, 3XX, 4XX, 5XX)
+const NumStatusClasses = 5
+
 // RequestStats stores stats for HTTP requests to a particular path, organized by the class
 // of the response code (1XX, 2XX, 3XX, 4XX, 5XX)
-type RequestStats [5]struct {
+type RequestStats [NumStatusClasses]struct {
 	// Note: every time we add a latency value to the DDSketch below, it's possible for the sketch to discard that value
 	// (ie if it is outside the range that is tracked by the sketch). For that reason, in order to keep an accurate count
 	// the number of http transactions processed, we have our own count field (rather than relying on DDSketch.GetCount())

--- a/pkg/network/http/http_stats_test.go
+++ b/pkg/network/http/http_stats_test.go
@@ -17,15 +17,15 @@ func TestAddRequest(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		if i == 3 {
-			assert.Equal(t, 3, stats[i].count)
-			assert.Equal(t, 3.0, stats[i].latencies.GetCount())
+			assert.Equal(t, 3, stats[i].Count)
+			assert.Equal(t, 3.0, stats[i].Latencies.GetCount())
 
-			verifyQuantile(t, stats[i].latencies, 0.0, 10.0)  // min item
-			verifyQuantile(t, stats[i].latencies, 0.99, 15.0) // median
-			verifyQuantile(t, stats[i].latencies, 1.0, 20.0)  // max item
+			verifyQuantile(t, stats[i].Latencies, 0.0, 10.0)  // min item
+			verifyQuantile(t, stats[i].Latencies, 0.99, 15.0) // median
+			verifyQuantile(t, stats[i].Latencies, 1.0, 20.0)  // max item
 		} else {
-			assert.Equal(t, 0, stats[i].count)
-			assert.True(t, stats[i].latencies == nil)
+			assert.Equal(t, 0, stats[i].Count)
+			assert.Nil(t, stats[i].Latencies)
 		}
 	}
 }
@@ -33,8 +33,8 @@ func TestAddRequest(t *testing.T) {
 func TestCombineWith(t *testing.T) {
 	var stats RequestStats
 	for i := 0; i < 5; i++ {
-		assert.Equal(t, 0, stats[i].count)
-		assert.True(t, stats[i].latencies == nil)
+		assert.Equal(t, 0, stats[i].Count)
+		assert.True(t, stats[i].Latencies == nil)
 	}
 
 	var stats2, stats3, stats4 RequestStats
@@ -48,13 +48,13 @@ func TestCombineWith(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		if i == 3 {
-			assert.Equal(t, 3, stats[i].count)
-			verifyQuantile(t, stats[i].latencies, 0.0, 10.0)
-			verifyQuantile(t, stats[i].latencies, 0.5, 15.0)
-			verifyQuantile(t, stats[i].latencies, 1.0, 20.0)
+			assert.Equal(t, 3, stats[i].Count)
+			verifyQuantile(t, stats[i].Latencies, 0.0, 10.0)
+			verifyQuantile(t, stats[i].Latencies, 0.5, 15.0)
+			verifyQuantile(t, stats[i].Latencies, 1.0, 20.0)
 		} else {
-			assert.Equal(t, 0, stats[i].count, "eita deu ruim %v", i)
-			assert.True(t, stats[i].latencies == nil)
+			assert.Equal(t, 0, stats[i].Count, "eita deu ruim %v", i)
+			assert.True(t, stats[i].Latencies == nil)
 		}
 	}
 }

--- a/pkg/network/http/http_stats_test.go
+++ b/pkg/network/http/http_stats_test.go
@@ -53,7 +53,7 @@ func TestCombineWith(t *testing.T) {
 			verifyQuantile(t, stats[i].latencies, 0.5, 15.0)
 			verifyQuantile(t, stats[i].latencies, 1.0, 20.0)
 		} else {
-			assert.Equal(t, 0, stats[i].count)
+			assert.Equal(t, 0, stats[i].count, "eita deu ruim %v", i)
 			assert.True(t, stats[i].latencies == nil)
 		}
 	}

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -84,17 +84,6 @@ func (tx *httpTX) Method() string {
 	}
 }
 
-func (tx *httpTX) ToKey() Key {
-	return Key{
-		SrcIPHigh: uint64(tx.tup.saddr_h),
-		SrcIPLow:  uint64(tx.tup.saddr_l),
-		SrcPort:   uint16(tx.tup.sport),
-		DstIPHigh: uint64(tx.tup.daddr_h),
-		DstIPLow:  uint64(tx.tup.daddr_l),
-		DstPort:   uint16(tx.tup.dport),
-	}
-}
-
 // RequestLatency returns the latency of the request in ms
 func (tx *httpTX) RequestLatency() float64 {
 	return float64((tx.response_last_seen - tx.request_started) / (1000000))

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -43,8 +43,8 @@ func (k *httpBatchKey) Prepare(n httpNotification) {
 // GET variables excluded.
 // Example:
 // For a request fragment "GET /foo?var=bar HTTP/1.1", this method will return "/foo"
-func (tx *httpTX) Path() string {
-	b := C.GoBytes(unsafe.Pointer(&tx.request_fragment), C.int(C.HTTP_BUFFER_SIZE))
+func (tx *httpTX) Path(buffer []byte) []byte {
+	b := *(*[HTTPBufferSize]byte)(unsafe.Pointer(&tx.request_fragment))
 
 	var i, j int
 	for i = 0; i < len(b) && b[i] != ' '; i++ {
@@ -56,10 +56,11 @@ func (tx *httpTX) Path() string {
 	}
 
 	if i < j && j <= len(b) {
-		return string(b[i:j])
+		n := copy(buffer, b[i:j])
+		return buffer[:n]
 	}
 
-	return ""
+	return nil
 }
 
 // StatusClass returns an integer representing the status code class

--- a/pkg/network/http/model_test.go
+++ b/pkg/network/http/model_test.go
@@ -3,6 +3,7 @@
 package http
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,24 @@ func TestPath(t *testing.T) {
 		),
 	}
 
-	assert.Equal(t, "/foo/bar", tx.Path())
+	b := make([]byte, HTTPBufferSize)
+	assert.Equal(t, "/foo/bar", string(tx.Path(b)))
+}
+
+func BenchmarkPath(b *testing.B) {
+	tx := httpTX{
+		request_fragment: requestFragment(
+			[]byte("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
+		),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	buf := make([]byte, HTTPBufferSize)
+	for i := 0; i < b.N; i++ {
+		_ = tx.Path(buf)
+	}
+	runtime.KeepAlive(buf)
 }
 
 func requestFragment(fragment []byte) [HTTPBufferSize]_Ctype_char {

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -182,9 +182,6 @@ func (m *Monitor) Stop() {
 	m.perfHandler.Stop()
 	close(m.pollRequests)
 	m.eventLoopWG.Wait()
-	if m.statkeeper != nil {
-		m.statkeeper.Close()
-	}
 	m.stopped = true
 }
 

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -28,7 +28,7 @@ type Monitor struct {
 	perfMap      *manager.PerfMap
 	perfHandler  *ddebpf.PerfHandler
 	telemetry    *telemetry
-	pollRequests chan chan map[Key]map[string]RequestStats
+	pollRequests chan chan map[Key]RequestStats
 	statkeeper   *httpStatKeeper
 
 	// termination
@@ -82,7 +82,7 @@ func NewMonitor(procRoot string, mgr *manager.Manager, h *ddebpf.PerfHandler) (*
 		perfMap:       pm,
 		perfHandler:   h,
 		telemetry:     newTelemetry(),
-		pollRequests:  make(chan chan map[Key]map[string]RequestStats),
+		pollRequests:  make(chan chan map[Key]RequestStats),
 		closeFilterFn: closeFilterFn,
 		statkeeper:    statkeeper,
 	}, nil
@@ -139,8 +139,8 @@ func (m *Monitor) Start() error {
 }
 
 // GetHTTPStats returns a map of HTTP stats stored in the following format:
-// [source, dest tuple] -> [request path] -> RequestStats object
-func (m *Monitor) GetHTTPStats() map[Key]map[string]RequestStats {
+// [source, dest tuple, request path] -> RequestStats object
+func (m *Monitor) GetHTTPStats() map[Key]RequestStats {
 	if m == nil {
 		return nil
 	}
@@ -151,7 +151,7 @@ func (m *Monitor) GetHTTPStats() map[Key]map[string]RequestStats {
 		return nil
 	}
 
-	reply := make(chan map[Key]map[string]RequestStats, 1)
+	reply := make(chan map[Key]RequestStats, 1)
 	defer close(reply)
 	m.pollRequests <- reply
 	return <-reply

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -128,6 +128,10 @@ func (m *Monitor) Start() error {
 
 				transactions := m.batchManager.GetPendingTransactions()
 				m.process(transactions, nil)
+
+				delta := m.telemetry.reset()
+				delta.report()
+
 				reply <- m.statkeeper.GetAndResetAllStats()
 			case <-report.C:
 				transactions := m.batchManager.GetPendingTransactions()
@@ -151,9 +155,6 @@ func (m *Monitor) GetHTTPStats() map[Key]RequestStats {
 	if m.stopped {
 		return nil
 	}
-
-	// This will log some HTTP stats until we figure out a better way to handle HTTP telemetry
-	defer m.telemetry.get()
 
 	reply := make(chan map[Key]RequestStats, 1)
 	defer close(reply)

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -53,7 +53,7 @@ func TestHTTPMonitorIntegration(t *testing.T) {
 
 	// Ensure all captured transactions get sent to user-space
 	time.Sleep(10 * time.Millisecond)
-	monitor.Sync()
+	monitor.GetHTTPStats()
 
 	// Assert all requests made were correctly captured by the monitor
 	for _, req := range requests {

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -63,8 +63,9 @@ func TestHTTPMonitorIntegration(t *testing.T) {
 
 func hasMatchingTX(t *testing.T, req *nethttp.Request, transactions []httpTX) {
 	expectedStatus := statusFromPath(req.URL.Path)
+	buffer := make([]byte, HTTPBufferSize)
 	for _, tx := range transactions {
-		if tx.Path() == req.URL.Path && int(tx.response_status_code) == expectedStatus && tx.Method() == req.Method {
+		if string(tx.Path(buffer)) == req.URL.Path && int(tx.response_status_code) == expectedStatus && tx.Method() == req.Method {
 			return
 		}
 	}

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -107,7 +107,7 @@ func serverSetup(t *testing.T) func() {
 
 func monitorSetup(t *testing.T, handlerFn func([]httpTX)) (*Monitor, func()) {
 	mgr, perfHandler := eBPFSetup(t)
-	monitor, err := NewMonitor("/proc", mgr, perfHandler)
+	monitor, err := NewMonitor("/proc", 10000, mgr, perfHandler)
 	require.NoError(t, err)
 	monitor.handler = handlerFn
 

--- a/pkg/network/http/telemetry.go
+++ b/pkg/network/http/telemetry.go
@@ -3,7 +3,6 @@
 package http
 
 import (
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -11,10 +10,13 @@ import (
 )
 
 type telemetry struct {
-	then   int64
-	hits   [5]int64
-	misses int64 // this happens when we can't cope with the rate of events
-	drops  int64 // this happens when httpStatKeeper reaches capacity
+	then    int64
+	elapsed int64
+
+	hits         [5]int64
+	misses       int64 // this happens when we can't cope with the rate of events
+	dropped      int64 // this happens when httpStatKeeper reaches capacity
+	aggregations int64
 }
 
 func newTelemetry() *telemetry {
@@ -35,47 +37,38 @@ func (t *telemetry) aggregate(txs []httpTX, err error) {
 	}
 }
 
-func (t *telemetry) dropped(count int) {
-	atomic.AddInt64(&t.drops, int64(count))
-}
+func (t *telemetry) reset() telemetry {
+	now := time.Now()
+	then := atomic.SwapInt64(&t.then, now.Unix())
 
-func (t *telemetry) get() (time.Time, map[string]int64) {
-	var (
-		now        = time.Now()
-		then       = atomic.SwapInt64(&t.then, now.Unix())
-		misses     = atomic.SwapInt64(&t.misses, 0)
-		drops      = atomic.SwapInt64(&t.drops, 0)
-		data       = make(map[string]int64)
-		elapsed    = now.Unix() - then
-		totalCount = int64(0)
-	)
-
-	if elapsed == 0 {
-		return now, nil
+	delta := telemetry{
+		misses:       atomic.SwapInt64(&t.misses, 0),
+		dropped:      atomic.SwapInt64(&t.dropped, 0),
+		aggregations: atomic.SwapInt64(&t.aggregations, 0),
+		elapsed:      now.Unix() - then,
 	}
 
 	for i := range t.hits {
-		count := atomic.SwapInt64(&t.hits[i], 0)
-		totalCount += count
-
-		data[fmt.Sprintf("%dXX_request_count", i+1)] = count
-		data[fmt.Sprintf("%dXX_request_rate", i+1)] = count / elapsed
+		delta.hits[i] = atomic.SwapInt64(&t.hits[i], 0)
 	}
 
-	data["requests_dropped_count"] = drops
-	data["requests_dropped_rate"] = drops / elapsed
-	data["requests_missed_count"] = misses
-	data["requests_missed_rate"] = misses / elapsed
+	return delta
+}
+
+func (t *telemetry) report() {
+	var totalRequests int64
+	for _, n := range t.hits {
+		totalRequests += n
+	}
 
 	log.Debugf(
-		"http stats summary. requests_processed=%d(%.2f/s) requests_missed=%d(%.2f/s) requests_dropped=%d(%.2f/s)",
-		totalCount,
-		float64(totalCount)/float64(elapsed),
-		misses,
-		float64(misses)/float64(elapsed),
-		drops,
-		float64(drops)/float64(elapsed),
+		"http stats summary: requests_processed=%d(%.2f/s) requests_missed=%d(%.2f/s) requests_dropped=%d(%.2f/s) aggregations=%d",
+		totalRequests,
+		float64(totalRequests)/float64(t.elapsed),
+		t.misses,
+		float64(t.misses)/float64(t.elapsed),
+		t.dropped,
+		float64(t.dropped)/float64(t.elapsed),
+		t.aggregations,
 	)
-
-	return now, data
 }

--- a/pkg/network/http/telemetry.go
+++ b/pkg/network/http/telemetry.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"sync/atomic"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type telemetry struct {
 	then   int64
 	hits   [5]int64
-	misses int64
+	misses int64 // this happens when we can't cope with the rate of events
+	drops  int64 // this happens when httpStatKeeper reaches capacity
 }
 
 func newTelemetry() *telemetry {
@@ -32,13 +35,19 @@ func (t *telemetry) aggregate(txs []httpTX, err error) {
 	}
 }
 
+func (t *telemetry) dropped(count int) {
+	atomic.AddInt64(&t.drops, int64(count))
+}
+
 func (t *telemetry) get() (time.Time, map[string]int64) {
 	var (
-		now     = time.Now()
-		then    = atomic.SwapInt64(&t.then, now.Unix())
-		misses  = atomic.SwapInt64(&t.misses, 0)
-		data    = make(map[string]int64)
-		elapsed = now.Unix() - then
+		now        = time.Now()
+		then       = atomic.SwapInt64(&t.then, now.Unix())
+		misses     = atomic.SwapInt64(&t.misses, 0)
+		drops      = atomic.SwapInt64(&t.drops, 0)
+		data       = make(map[string]int64)
+		elapsed    = now.Unix() - then
+		totalCount = int64(0)
 	)
 
 	if elapsed == 0 {
@@ -47,12 +56,26 @@ func (t *telemetry) get() (time.Time, map[string]int64) {
 
 	for i := range t.hits {
 		count := atomic.SwapInt64(&t.hits[i], 0)
+		totalCount += count
+
 		data[fmt.Sprintf("%dXX_request_count", i+1)] = count
 		data[fmt.Sprintf("%dXX_request_rate", i+1)] = count / elapsed
 	}
 
+	data["requests_dropped_count"] = drops
+	data["requests_dropped_rate"] = drops / elapsed
 	data["requests_missed_count"] = misses
 	data["requests_missed_rate"] = misses / elapsed
+
+	log.Debugf(
+		"http stats summary. requests_processed=%d(%.2f/s) requests_missed=%d(%.2f/s) requests_dropped=%d(%.2f/s)",
+		totalCount,
+		float64(totalCount)/float64(elapsed),
+		misses,
+		float64(misses)/float64(elapsed),
+		drops,
+		float64(drops)/float64(elapsed),
+	)
 
 	return now, data
 }

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -272,13 +272,7 @@ func (ns *networkState) addDNSStats(id string, conns []ConnectionStats) {
 func (ns *networkState) addHTTPStats(id string, conns []ConnectionStats) {
 	for i := range conns {
 		conn := &conns[i]
-		key := http.Key{
-			SourceIP:   conn.Source,
-			DestIP:     conn.Dest,
-			SourcePort: conn.SPort,
-			DestPort:   conn.DPort,
-		}
-
+		key := http.NewKey(conn.Source, conn.Dest, conn.SPort, conn.DPort)
 		if _, ok := ns.clients[id].httpStatsDelta[key]; ok {
 			conn.HTTPStatsByPath = ns.clients[id].httpStatsDelta[key]
 		}

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -30,7 +30,7 @@ const (
 // - closed connections
 // - sent and received bytes per connection
 type State interface {
-	// Connections returns the list of connections for the given client when provided the latest set of active connections
+	// GetDelta returns the a Delta object for  given client when provided the latest set of active connections
 	GetDelta(
 		clientID string,
 		latestTime uint64,
@@ -58,7 +58,7 @@ type State interface {
 	DumpState(clientID string) map[string]interface{}
 }
 
-// Delta representes a delta of network data compared to the last call to State.
+// Delta represents a delta of network data compared to the last call to State.
 type Delta struct {
 	Connections []ConnectionStats
 	HTTP        map[http.Key]http.RequestStats

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1294,12 +1294,11 @@ func TestHTTPStats(t *testing.T) {
 		DPort:  80,
 	}
 
-	key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort)
+	key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, "/testpath")
 
-	httpStats := make(map[http.Key]map[string]http.RequestStats)
-	httpStats[key] = make(map[string]http.RequestStats)
+	httpStats := make(map[http.Key]http.RequestStats)
 	var rs http.RequestStats
-	httpStats[key]["/testpath"] = rs
+	httpStats[key] = rs
 
 	// Register client & pass in HTTP stats
 	state := newDefaultState()
@@ -1323,12 +1322,11 @@ func TestHTTPStatsWithMultipleClients(t *testing.T) {
 		DPort:  80,
 	}
 
-	getStats := func(path string) map[http.Key]map[string]http.RequestStats {
-		httpStats := make(map[http.Key]map[string]http.RequestStats)
-		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort)
-		httpStats[key] = make(map[string]http.RequestStats)
+	getStats := func(path string) map[http.Key]http.RequestStats {
+		httpStats := make(map[http.Key]http.RequestStats)
+		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, path)
 		var rs http.RequestStats
-		httpStats[key][path] = rs
+		httpStats[key] = rs
 		return httpStats
 	}
 

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1294,12 +1294,7 @@ func TestHTTPStats(t *testing.T) {
 		DPort:  80,
 	}
 
-	key := http.Key{
-		SourceIP:   c.Source,
-		DestIP:     c.Dest,
-		SourcePort: c.SPort,
-		DestPort:   c.DPort,
-	}
+	key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort)
 
 	httpStats := make(map[http.Key]map[string]http.RequestStats)
 	httpStats[key] = make(map[string]http.RequestStats)
@@ -1330,12 +1325,7 @@ func TestHTTPStatsWithMultipleClients(t *testing.T) {
 
 	getStats := func(path string) map[http.Key]map[string]http.RequestStats {
 		httpStats := make(map[http.Key]map[string]http.RequestStats)
-		key := http.Key{
-			SourceIP:   c.Source,
-			DestIP:     c.Dest,
-			SourcePort: c.SPort,
-			DestPort:   c.DPort,
-		}
+		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort)
 		httpStats[key] = make(map[string]http.RequestStats)
 		var rs http.RequestStats
 		httpStats[key][path] = rs

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -36,7 +36,7 @@ func BenchmarkStoreClosedConnection(b *testing.B) {
 	} {
 		b.Run(fmt.Sprintf("StoreClosedConnection-%d", bench.connCount), func(b *testing.B) {
 			ns := newDefaultState()
-			ns.Connections(DEBUGCLIENT, latestEpochTime(), nil, nil, nil) // Initial fetch to set up client
+			ns.GetDelta(DEBUGCLIENT, latestEpochTime(), nil, nil, nil) // Initial fetch to set up client
 
 			b.ResetTimer()
 			b.ReportAllocs()
@@ -111,7 +111,7 @@ func BenchmarkConnectionsGet(b *testing.B) {
 			ns := newDefaultState()
 
 			// Initial fetch to set up client
-			ns.Connections(DEBUGCLIENT, latestTime, nil, nil, nil)
+			ns.GetDelta(DEBUGCLIENT, latestTime, nil, nil, nil)
 
 			for _, c := range closed[:bench.closedCount] {
 				ns.StoreClosedConnection(&c)
@@ -121,7 +121,7 @@ func BenchmarkConnectionsGet(b *testing.B) {
 			b.ReportAllocs()
 
 			for n := 0; n < b.N; n++ {
-				ns.Connections(DEBUGCLIENT, latestTime, conns[:bench.connCount], nil, nil)
+				ns.GetDelta(DEBUGCLIENT, latestTime, conns[:bench.connCount], nil, nil)
 			}
 		})
 	}
@@ -151,10 +151,10 @@ func TestRemoveConnections(t *testing.T) {
 
 	clientID := "1"
 	state := newDefaultState().(*networkState)
-	conns := state.Connections(clientID, latestEpochTime(), nil, nil, nil)
+	conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil).Connections
 	assert.Equal(t, 0, len(conns))
 
-	conns = state.Connections(clientID, latestEpochTime(), []ConnectionStats{conn}, nil, nil)
+	conns = state.GetDelta(clientID, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Connections
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, conn, conns[0])
 
@@ -188,7 +188,7 @@ func TestRetrieveClosedConnection(t *testing.T) {
 	t.Run("without prior registration", func(t *testing.T) {
 		state := newDefaultState()
 		state.StoreClosedConnection(&conn)
-		conns := state.Connections(clientID, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil).Connections
 
 		assert.Equal(t, 0, len(conns))
 	})
@@ -196,21 +196,21 @@ func TestRetrieveClosedConnection(t *testing.T) {
 	t.Run("with registration", func(t *testing.T) {
 		state := newDefaultState()
 
-		conns := state.Connections(clientID, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		state.StoreClosedConnection(&conn)
 
-		conns = state.Connections(clientID, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientID, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, conn, conns[0])
 
 		// An other client that is not registered should not have the closed connection
-		conns = state.Connections("2", latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta("2", latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// It should no more have connections stored
-		conns = state.Connections(clientID, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientID, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 	})
 }
@@ -222,7 +222,7 @@ func TestCleanupClient(t *testing.T) {
 	clients := state.(*networkState).getClients()
 	assert.Equal(t, 0, len(clients))
 
-	conns := state.Connections(clientID, latestEpochTime(), nil, nil, nil)
+	conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil).Connections
 	assert.Equal(t, 0, len(conns))
 
 	// Should be a no op
@@ -272,15 +272,15 @@ func TestLastStats(t *testing.T) {
 	conn3.MonotonicRetransmits += dRetransmits
 
 	// First get, we should not have any connections stored
-	conns := state.Connections(client1, latestEpochTime(), nil, nil, nil)
+	conns := state.GetDelta(client1, latestEpochTime(), nil, nil, nil).Connections
 	assert.Equal(t, 0, len(conns))
 
 	// Same for an other client
-	conns = state.Connections(client2, latestEpochTime(), nil, nil, nil)
+	conns = state.GetDelta(client2, latestEpochTime(), nil, nil, nil).Connections
 	assert.Equal(t, 0, len(conns))
 
 	// We should have only one connection but with last stats equal to monotonic
-	conns = state.Connections(client1, latestEpochTime(), []ConnectionStats{conn}, nil, nil)
+	conns = state.GetDelta(client1, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Connections
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, conn.MonotonicSentBytes, conns[0].LastSentBytes)
 	assert.Equal(t, conn.MonotonicRecvBytes, conns[0].LastRecvBytes)
@@ -290,7 +290,7 @@ func TestLastStats(t *testing.T) {
 	assert.Equal(t, conn.MonotonicRetransmits, conns[0].MonotonicRetransmits)
 
 	// This client didn't collect the first connection so last stats = monotonic
-	conns = state.Connections(client2, latestEpochTime(), []ConnectionStats{conn2}, nil, nil)
+	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{conn2}, nil, nil).Connections
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, conn2.MonotonicSentBytes, conns[0].LastSentBytes)
 	assert.Equal(t, conn2.MonotonicRecvBytes, conns[0].LastRecvBytes)
@@ -300,7 +300,7 @@ func TestLastStats(t *testing.T) {
 	assert.Equal(t, conn2.MonotonicRetransmits, conns[0].MonotonicRetransmits)
 
 	// client 1 should have conn3 - conn1 since it did not collected conn2
-	conns = state.Connections(client1, latestEpochTime(), []ConnectionStats{conn3}, nil, nil)
+	conns = state.GetDelta(client1, latestEpochTime(), []ConnectionStats{conn3}, nil, nil).Connections
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, 2*dSent, conns[0].LastSentBytes)
 	assert.Equal(t, 2*dRecv, conns[0].LastRecvBytes)
@@ -310,7 +310,7 @@ func TestLastStats(t *testing.T) {
 	assert.Equal(t, conn3.MonotonicRetransmits, conns[0].MonotonicRetransmits)
 
 	// client 2 should have conn3 - conn2
-	conns = state.Connections(client2, latestEpochTime(), []ConnectionStats{conn3}, nil, nil)
+	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{conn3}, nil, nil).Connections
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, dSent, conns[0].LastSentBytes)
 	assert.Equal(t, dRecv, conns[0].LastRecvBytes)
@@ -347,11 +347,11 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 	conn2.MonotonicRetransmits += dRetransmits
 
 	// First get, we should not have any connections stored
-	conns := state.Connections(clientID, latestEpochTime(), nil, nil, nil)
+	conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil).Connections
 	assert.Equal(t, 0, len(conns))
 
 	// We should have one connection with last stats equal to monotonic stats
-	conns = state.Connections(clientID, latestEpochTime(), []ConnectionStats{conn}, nil, nil)
+	conns = state.GetDelta(clientID, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Connections
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, conn.MonotonicSentBytes, conns[0].LastSentBytes)
 	assert.Equal(t, conn.MonotonicRecvBytes, conns[0].LastRecvBytes)
@@ -363,7 +363,7 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 	state.StoreClosedConnection(&conn2)
 
 	// We should have one connection with last stats
-	conns = state.Connections(clientID, latestEpochTime(), nil, nil, nil)
+	conns = state.GetDelta(clientID, latestEpochTime(), nil, nil, nil).Connections
 
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, dSent, conns[0].LastSentBytes)
@@ -414,7 +414,7 @@ func TestRaceConditions(t *testing.T) {
 				case <-timer.C:
 					return
 				default:
-					state.Connections(c, latestEpochTime(), genConns(nConns), nil, nil)
+					state.GetDelta(c, latestEpochTime(), genConns(nConns), nil, nil)
 				}
 			}
 		}(fmt.Sprintf("%d", i))
@@ -453,14 +453,14 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
 		state.StoreClosedConnection(&conn)
 
 		// Second get, we should have monotonic and last stats = 3
-		conns = state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -482,7 +482,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
@@ -495,7 +495,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(&conn2)
 
 		// Second get, we should have monotonic and last stats = 8
-		conns = state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 8, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 8, int(conns[0].LastSentBytes))
@@ -519,7 +519,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get for client c, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Len(t, conns, 0)
 
 		conn := ConnectionStats{
@@ -534,7 +534,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		}
 
 		// Simulate this connection starting
-		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Connections
 		require.Len(t, conns, 1)
 		assert.EqualValues(t, 1, conns[0].LastSentBytes)
 		assert.EqualValues(t, 1, conns[0].MonotonicSentBytes)
@@ -547,7 +547,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn.MonotonicSentBytes = 1
 		conn.LastUpdateEpoch = latestEpochTime()
 		// Retrieve the connections
-		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Connections
 		require.Len(t, conns, 1)
 		assert.EqualValues(t, 2, conns[0].LastSentBytes)
 		assert.EqualValues(t, 3, conns[0].MonotonicSentBytes)
@@ -557,7 +557,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		// Store the connection as closed
 		state.StoreClosedConnection(&conn)
 
-		conns = state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		require.Len(t, conns, 1)
 		assert.EqualValues(t, 1, conns[0].LastSentBytes)
 		assert.EqualValues(t, 2, conns[0].MonotonicSentBytes)
@@ -581,7 +581,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
@@ -594,7 +594,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs := []ConnectionStats{conn2}
 
 		// Second get, we should have monotonic and last stats = 5
-		conns = state.Connections(client, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil).Connections
 		require.Equal(t, 1, len(conns))
 		assert.Equal(t, 5, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -611,7 +611,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn3}
 
 		// Third get, we should have monotonic = 6 and last stats = 4
-		conns = state.Connections(client, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 6, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 4, int(conns[0].LastSentBytes))
@@ -621,7 +621,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(&conn3)
 
 		// 4th get, we should have monotonic = 3 and last stats = 2
-		conns = state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 2, int(conns[0].LastSentBytes))
@@ -643,14 +643,14 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// this is to register we should not have anything
-		conns := state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as opened
 		cs := []ConnectionStats{conn}
 
 		// First get, we should have monotonic = 3 and last seen = 3
-		conns = state.Connections(client, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -661,7 +661,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(&conn2)
 
 		// Second get, we should have monotonic = 8 and last stats = 5
-		conns = state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 8, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -701,18 +701,18 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get for client c, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// First get for client d, we should have nothing
-		conns = state.Connections(clientD, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
 		state.StoreClosedConnection(&conn)
 
 		// Second get for client d we should have monotonic and last stats = 3
-		conns = state.Connections(clientD, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -724,7 +724,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs := []ConnectionStats{conn2}
 
 		// Second get, for client c we should have monotonic and last stats = 5
-		conns = state.Connections(client, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 5, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -735,7 +735,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn2}
 
 		// Third get, for client d we should have monotonic = 3 and last stats = 3
-		conns = state.Connections(clientD, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), cs, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -752,7 +752,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn3}
 
 		// Third get, for client c, we should have monotonic = 6 and last stats = 4
-		conns = state.Connections(client, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 6, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 4, int(conns[0].LastSentBytes))
@@ -763,7 +763,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn3}
 
 		// 4th get, for client d, we should have monotonic = 7 and last stats = 4
-		conns = state.Connections(clientD, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), cs, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 7, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 4, int(conns[0].LastSentBytes))
@@ -774,13 +774,13 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(&conn3)
 
 		// 4th get, for client c we should have monotonic = 3 and last stats = 2
-		conns = state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 2, int(conns[0].LastSentBytes))
 
 		// 5th get, for client d we should have monotonic = 3 and last stats = 1
-		conns = state.Connections(clientD, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 1, int(conns[0].LastSentBytes))
@@ -828,15 +828,15 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get for client c, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// First get for client d, we should have nothing
-		conns = state.Connections(clientD, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// First get for client e, we should have nothing
-		conns = state.Connections(clientE, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientE, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection
@@ -845,7 +845,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs := []ConnectionStats{conn}
 
 		// Second get for client e we should have monotonic and last stats = 2
-		conns = state.Connections(clientE, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(clientE, latestEpochTime(), cs, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 2, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 2, int(conns[0].LastSentBytes))
@@ -856,13 +856,13 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(&conn)
 
 		// Second get for client d we should have monotonic and last stats = 3
-		conns = state.Connections(clientD, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
 
 		// Third get for client e we should have monotonic = 3and last stats = 1
-		conns = state.Connections(clientE, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientE, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 1, int(conns[0].LastSentBytes))
@@ -874,7 +874,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn2}
 
 		// Second get, for client c we should have monotonic and last stats = 5
-		conns = state.Connections(client, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 5, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -885,7 +885,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn2}
 
 		// Third get, for client d we should have monotonic = 3 and last stats = 3
-		conns = state.Connections(clientD, latestEpochTime(), cs, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), cs, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -896,7 +896,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(&conn2)
 
 		// 4th get, for client e we should have monotonic = 5 and last stats = 5
-		conns = state.Connections(clientE, latestEpochTime(), nil, nil, nil)
+		conns = state.GetDelta(clientE, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 5, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -932,11 +932,11 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get for client c, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), nil, nil, nil)
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 		assert.Equal(t, 0, len(conns))
 
 		// Second get for client c we should have monotonic and last stats = 3
-		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Connections
 		assert.Len(t, conns, 1)
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -946,7 +946,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn2.LastUpdateEpoch++
 
 		// First get for client d we should have monotonic = 4 and last bytes = 4
-		conns = state.Connections(clientD, latestEpochTime(), []ConnectionStats{conn2}, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), []ConnectionStats{conn2}, nil, nil).Connections
 		assert.Len(t, conns, 1)
 		assert.Equal(t, 4, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 0, int(conns[0].LastSentBytes))
@@ -956,7 +956,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn3.LastUpdateEpoch++
 
 		// Third get for client c we should have monotonic = 7 and last bytes = 4
-		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{conn3}, nil, nil)
+		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn3}, nil, nil).Connections
 		assert.Len(t, conns, 1)
 		assert.Equal(t, 7, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 4, int(conns[0].LastSentBytes))
@@ -966,7 +966,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn4.LastUpdateEpoch++
 
 		// Second get for client d we should have monotonic = 9 and last bytes = 5
-		conns = state.Connections(clientD, latestEpochTime(), []ConnectionStats{conn4}, nil, nil)
+		conns = state.GetDelta(clientD, latestEpochTime(), []ConnectionStats{conn4}, nil, nil).Connections
 		assert.Len(t, conns, 1)
 		assert.Equal(t, 9, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -989,10 +989,10 @@ func TestStatsResetOnUnderflow(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the client
-	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections, 0)
 
 	// Get the connections once to register stats
-	conns := state.Connections(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil)
+	conns := state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Connections
 	require.Len(t, conns, 1)
 
 	// Expect LastStats to be 3
@@ -1002,7 +1002,7 @@ func TestStatsResetOnUnderflow(t *testing.T) {
 	// Get the connections again but by simulating an underflow
 	conn.MonotonicSentBytes--
 
-	conns = state.Connections(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil)
+	conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Connections
 	require.Len(t, conns, 1)
 	expected := conn
 	expected.LastSentBytes = 2
@@ -1032,8 +1032,8 @@ func TestDoubleCloseOnTwoClients(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the clients
-	assert.Len(t, state.Connections(client1, latestEpochTime(), nil, nil, nil), 0)
-	assert.Len(t, state.Connections(client2, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil).Connections, 0)
 
 	// Store the closed connection twice
 	state.StoreClosedConnection(&conn)
@@ -1042,12 +1042,12 @@ func TestDoubleCloseOnTwoClients(t *testing.T) {
 
 	expectedConn.LastUpdateEpoch = conn.LastUpdateEpoch
 	// Get the connections for client1 we should have only one with stats = 2*conn
-	conns := state.Connections(client1, latestEpochTime(), nil, nil, nil)
+	conns := state.GetDelta(client1, latestEpochTime(), nil, nil, nil).Connections
 	require.Len(t, conns, 1)
 	assert.Equal(t, expectedConn, conns[0])
 
 	// Same for client2
-	conns = state.Connections(client2, latestEpochTime(), nil, nil, nil)
+	conns = state.GetDelta(client2, latestEpochTime(), nil, nil, nil).Connections
 	require.Len(t, conns, 1)
 	assert.Equal(t, expectedConn, conns[0])
 }
@@ -1066,7 +1066,7 @@ func TestUnorderedCloseEvent(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the client
-	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections, 0)
 
 	// Simulate storing a closed connection while we were reading from the eBPF map
 	// in this case the closed conn will have an earlier epoch
@@ -1078,22 +1078,22 @@ func TestUnorderedCloseEvent(t *testing.T) {
 	conn.LastUpdateEpoch--
 	conn.MonotonicSentBytes--
 	conn.MonotonicRecvBytes = 0
-	conns := state.Connections(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil)
+	conns := state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil).Connections
 	require.Len(t, conns, 1)
 	assert.EqualValues(t, 4, conns[0].LastSentBytes)
 	assert.EqualValues(t, 1, conns[0].LastRecvBytes)
 
 	// Simulate some other gets
-	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil, nil), 0)
-	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil, nil), 0)
-	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections, 0)
 
 	// Simulate having the connection getting active again
 	conn.LastUpdateEpoch = latestEpochTime()
 	conn.MonotonicSentBytes--
 	state.StoreClosedConnection(&conn)
 
-	conns = state.Connections(client, latestEpochTime(), nil, nil, nil)
+	conns = state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections
 	require.Len(t, conns, 1)
 	assert.EqualValues(t, 2, conns[0].LastSentBytes)
 	assert.EqualValues(t, 0, conns[0].LastRecvBytes)
@@ -1102,7 +1102,7 @@ func TestUnorderedCloseEvent(t *testing.T) {
 	assert.Zero(t, state.(*networkState).telemetry.statsResets)
 	assert.Zero(t, state.(*networkState).telemetry.unorderedConns)
 
-	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections, 0)
 }
 
 func TestAggregateClosedConnectionsTimestamp(t *testing.T) {
@@ -1119,7 +1119,7 @@ func TestAggregateClosedConnectionsTimestamp(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the client
-	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections, 0)
 
 	conn.LastUpdateEpoch = latestEpochTime()
 	state.StoreClosedConnection(&conn)
@@ -1131,7 +1131,8 @@ func TestAggregateClosedConnectionsTimestamp(t *testing.T) {
 	state.StoreClosedConnection(&conn)
 
 	// Make sure the connections we get has the latest timestamp
-	assert.Equal(t, conn.LastUpdateEpoch, state.Connections(client, latestEpochTime(), nil, nil, nil)[0].LastUpdateEpoch)
+	delta := state.GetDelta(client, latestEpochTime(), nil, nil, nil)
+	assert.Equal(t, conn.LastUpdateEpoch, delta.Connections[0].LastUpdateEpoch)
 }
 
 func TestDNSStatsWithMultipleClients(t *testing.T) {
@@ -1164,23 +1165,23 @@ func TestDNSStatsWithMultipleClients(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the first two clients
-	assert.Len(t, state.Connections(client1, latestEpochTime(), nil, nil, nil), 0)
-	assert.Len(t, state.Connections(client2, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil).Connections, 0)
 
 	c.LastUpdateEpoch = latestEpochTime()
 	state.StoreClosedConnection(&c)
 
-	conns := state.Connections(client1, latestEpochTime(), nil, getStats(), nil)
+	conns := state.GetDelta(client1, latestEpochTime(), nil, getStats(), nil).Connections
 	require.Len(t, conns, 1)
 	assert.EqualValues(t, 1, conns[0].DNSSuccessfulResponses)
 
 	// Register the third client but also pass in dns stats
-	conns = state.Connections(client3, latestEpochTime(), []ConnectionStats{c}, getStats(), nil)
+	conns = state.GetDelta(client3, latestEpochTime(), []ConnectionStats{c}, getStats(), nil).Connections
 	require.Len(t, conns, 1)
 	// DNS stats should be available for the new client
 	assert.EqualValues(t, 1, conns[0].DNSSuccessfulResponses)
 
-	conns = state.Connections(client2, latestEpochTime(), []ConnectionStats{c}, getStats(), nil)
+	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{c}, getStats(), nil).Connections
 	require.Len(t, conns, 1)
 	// 2nd client should get accumulated stats
 	assert.EqualValues(t, 3, conns[0].DNSSuccessfulResponses)
@@ -1215,27 +1216,27 @@ func TestDNSStatsWithMultipleClientsWithDomainCollectionEnabled(t *testing.T) {
 	state := NewState(2*time.Minute, 50000, 75000, 75000, 7500, true)
 
 	// Register the first two clients
-	assert.Len(t, state.Connections(client1, latestEpochTime(), nil, nil, nil), 0)
-	assert.Len(t, state.Connections(client2, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil).Connections, 0)
 
 	c.LastUpdateEpoch = latestEpochTime()
 	state.StoreClosedConnection(&c)
 
-	conns := state.Connections(client1, latestEpochTime(), nil, getStats(), nil)
+	conns := state.GetDelta(client1, latestEpochTime(), nil, getStats(), nil).Connections
 	require.Len(t, conns, 1)
 	assert.EqualValues(t, 1, conns[0].DNSStatsByDomain[d].DNSCountByRcode[DNSResponseCodeNoError])
 	// domain agnostic stats should be 0
 	assert.EqualValues(t, 0, conns[0].DNSSuccessfulResponses)
 
 	// Register the third client but also pass in dns stats
-	conns = state.Connections(client3, latestEpochTime(), []ConnectionStats{c}, getStats(), nil)
+	conns = state.GetDelta(client3, latestEpochTime(), []ConnectionStats{c}, getStats(), nil).Connections
 	require.Len(t, conns, 1)
 	// DNS stats should be available for the new client
 	assert.EqualValues(t, 1, conns[0].DNSStatsByDomain[d].DNSCountByRcode[DNSResponseCodeNoError])
 	// domain agnostic stats should be 0
 	assert.EqualValues(t, 0, conns[0].DNSSuccessfulResponses)
 
-	conns = state.Connections(client2, latestEpochTime(), []ConnectionStats{c}, getStats(), nil)
+	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{c}, getStats(), nil).Connections
 	require.Len(t, conns, 1)
 	// 2nd client should get accumulated stats
 	assert.EqualValues(t, 3, conns[0].DNSStatsByDomain[d].DNSCountByRcode[DNSResponseCodeNoError])
@@ -1267,7 +1268,7 @@ func TestDNSStatsPIDCollisions(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the client
-	assert.Len(t, state.Connections(client, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil).Connections, 0)
 
 	c.LastUpdateEpoch = latestEpochTime()
 	state.StoreClosedConnection(&c)
@@ -1276,7 +1277,7 @@ func TestDNSStatsPIDCollisions(t *testing.T) {
 	c.Pid++
 	state.StoreClosedConnection(&c)
 
-	conns := state.Connections(client, latestEpochTime(), nil, statsByDomain, nil)
+	conns := state.GetDelta(client, latestEpochTime(), nil, statsByDomain, nil).Connections
 	require.Len(t, conns, 2)
 	successes := 0
 	for _, conn := range conns {
@@ -1302,16 +1303,14 @@ func TestHTTPStats(t *testing.T) {
 
 	// Register client & pass in HTTP stats
 	state := newDefaultState()
-	conns := state.Connections("client", latestEpochTime(), []ConnectionStats{c}, nil, httpStats)
+	delta := state.GetDelta("client", latestEpochTime(), []ConnectionStats{c}, nil, httpStats)
 
 	// Verify connection has HTTP data embedded in it
-	assert.Len(t, conns, 1)
-	assert.Len(t, conns[0].HTTPStatsByPath, 1)
+	assert.Len(t, delta.HTTP, 1)
 
 	// Verify HTTP data has been flushed
-	conns = state.Connections("client", latestEpochTime(), []ConnectionStats{c}, nil, nil)
-	assert.Len(t, conns, 1)
-	assert.Len(t, conns[0].HTTPStatsByPath, 0)
+	delta = state.GetDelta("client", latestEpochTime(), []ConnectionStats{c}, nil, nil)
+	assert.Len(t, delta.HTTP, 0)
 }
 
 func TestHTTPStatsWithMultipleClients(t *testing.T) {
@@ -1336,45 +1335,38 @@ func TestHTTPStatsWithMultipleClients(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the first two clients
-	assert.Len(t, state.Connections(client1, latestEpochTime(), nil, nil, nil), 0)
-	assert.Len(t, state.Connections(client2, latestEpochTime(), nil, nil, nil), 0)
+	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil).HTTP, 0)
+	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil).HTTP, 0)
 
 	// Store the connection to both clients & pass HTTP stats to the first client
 	c.LastUpdateEpoch = latestEpochTime()
 	state.StoreClosedConnection(&c)
 
-	conns := state.Connections(client1, latestEpochTime(), nil, nil, getStats("/testpath"))
-	assert.Len(t, conns, 1)
-	assert.Len(t, conns[0].HTTPStatsByPath, 1)
+	delta := state.GetDelta(client1, latestEpochTime(), nil, nil, getStats("/testpath"))
+	assert.Len(t, delta.HTTP, 1)
 
 	// Verify that the HTTP stats were also stored in the second client
-	conns = state.Connections(client2, latestEpochTime(), nil, nil, nil)
-	assert.Len(t, conns, 1)
-	assert.Len(t, conns[0].HTTPStatsByPath, 1)
+	delta = state.GetDelta(client2, latestEpochTime(), nil, nil, nil)
+	assert.Len(t, delta.HTTP, 1)
 
 	// Register a third client & verify that it does not have the HTTP stats
-	conns = state.Connections(client3, latestEpochTime(), []ConnectionStats{c}, nil, nil)
-	assert.Len(t, conns, 1)
-	assert.Len(t, conns[0].HTTPStatsByPath, 0)
+	delta = state.GetDelta(client3, latestEpochTime(), []ConnectionStats{c}, nil, nil)
+	assert.Len(t, delta.HTTP, 0)
 
 	c.LastUpdateEpoch = latestEpochTime()
 	state.StoreClosedConnection(&c)
 
 	// Pass in new HTTP stats to the first client
-	conns = state.Connections(client1, latestEpochTime(), nil, nil, getStats("/testpath2"))
-	assert.Len(t, conns, 1)
-	assert.Len(t, conns[0].HTTPStatsByPath, 1)
+	delta = state.GetDelta(client1, latestEpochTime(), nil, nil, getStats("/testpath2"))
+	assert.Len(t, delta.HTTP, 1)
 
 	// And the second client
-	conns = state.Connections(client2, latestEpochTime(), nil, nil, getStats("/testpath3"))
-	assert.Len(t, conns, 1)
-	// Second client should have accumulated both new HTTP stats
-	assert.Len(t, conns[0].HTTPStatsByPath, 2)
+	delta = state.GetDelta(client2, latestEpochTime(), nil, nil, getStats("/testpath3"))
+	assert.Len(t, delta.HTTP, 2)
 
 	// Verify that the third client also accumulated both new HTTP stats
-	conns = state.Connections(client3, latestEpochTime(), nil, nil, nil)
-	require.Len(t, conns, 1)
-	assert.Len(t, conns[0].HTTPStatsByPath, 2)
+	delta = state.GetDelta(client3, latestEpochTime(), nil, nil, nil)
+	assert.Len(t, delta.HTTP, 2)
 }
 
 func generateRandConnections(n int) []ConnectionStats {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -945,10 +945,6 @@ func (t *Tracer) GetStats() (map[string]interface{}, error) {
 		"dns":       t.reverseDNS.GetStats(),
 	}
 
-	if t.httpMonitor != nil {
-		ret["http"] = t.httpMonitor.GetStats()
-	}
-
 	return ret, nil
 }
 
@@ -1032,7 +1028,7 @@ func newHTTPMonitor(supported bool, c *config.Config, m *manager.Manager, h *dde
 		return nil
 	}
 
-	monitor, err := http.NewMonitor(c.ProcRoot, m, h)
+	monitor, err := http.NewMonitor(c.ProcRoot, c.MaxHTTPStatsBuffered, m, h)
 	if err != nil {
 		log.Errorf("could not enable http monitoring: %s", err)
 		return nil

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/config/sysctl"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
+	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/network/netlink"
 	"github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -2096,23 +2097,25 @@ func TestHTTPStats(t *testing.T) {
 	resp.Body.Close()
 
 	// Iterate through active connections until we find connection created above
-	var matchingConns []network.ConnectionStats
+	var httpReqStats http.RequestStats
 	require.Eventuallyf(t, func() bool {
-		conns := getConnections(t, tr)
-		matchingConns = searchConnections(conns, func(cs network.ConnectionStats) bool {
-			return fmt.Sprintf("%s:%d", cs.Dest, cs.DPort) == serverAddr && len(cs.HTTPStatsByPath) == 1
-		})
+		payload, err := tr.GetActiveConnections("1")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-		return len(matchingConns) == 1
+		for key, stats := range payload.HTTP {
+			if key.Path == "/test" {
+				httpReqStats = stats
+				return true
+			}
+		}
+
+		return false
 	}, 3*time.Second, 10*time.Millisecond, "couldn't find http connection matching: %s", serverAddr)
 
 	// Verify HTTP stats
-	conn := matchingConns[0]
-	assert.Equal(t, conn.Direction, network.OUTGOING, "connection direction must be outgoing")
-	httpReqStats, ok := conn.HTTPStatsByPath["/test"]
-	assert.True(t, ok)
 	assert.Equal(t, 0, httpReqStats[0].Count, "100s") // number of requests with response status 100
-	// it sees both sides of the req/resp so will register two 200s
 	assert.Equal(t, 1, httpReqStats[1].Count, "200s") // 200
 	assert.Equal(t, 0, httpReqStats[2].Count, "300s") // 300
 	assert.Equal(t, 0, httpReqStats[3].Count, "400s") // 400

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -2111,12 +2111,12 @@ func TestHTTPStats(t *testing.T) {
 	assert.Equal(t, conn.Direction, network.OUTGOING, "connection direction must be outgoing")
 	httpReqStats, ok := conn.HTTPStatsByPath["/test"]
 	assert.True(t, ok)
-	assert.Equal(t, 0, httpReqStats.Count(0), "100s") // number of requests with response status 100
+	assert.Equal(t, 0, httpReqStats[0].Count, "100s") // number of requests with response status 100
 	// it sees both sides of the req/resp so will register two 200s
-	assert.Equal(t, 1, httpReqStats.Count(1), "200s") // 200
-	assert.Equal(t, 0, httpReqStats.Count(2), "300s") // 300
-	assert.Equal(t, 0, httpReqStats.Count(3), "400s") // 400
-	assert.Equal(t, 0, httpReqStats.Count(4), "500s") // 500
+	assert.Equal(t, 1, httpReqStats[1].Count, "200s") // 200
+	assert.Equal(t, 0, httpReqStats[2].Count, "300s") // 300
+	assert.Equal(t, 0, httpReqStats[3].Count, "400s") // 400
+	assert.Equal(t, 0, httpReqStats[4].Count, "500s") // 500
 }
 
 func TestRuntimeCompilerEnvironmentVar(t *testing.T) {

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -164,7 +164,8 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	// check for expired clients in the state
 	t.state.RemoveExpiredClients(time.Now())
 
-	conns := t.state.Connections(clientID, uint64(time.Now().Nanosecond()), activeConnStats, t.reverseDNS.GetDNSStats(), nil)
+	delta := t.state.GetDelta(clientID, uint64(time.Now().Nanosecond()), activeConnStats, t.reverseDNS.GetDNSStats(), nil)
+	conns := delta.Connections
 	names := t.reverseDNS.Resolve(conns)
 	return &network.Connections{Conns: conns, DNS: names}, nil
 }

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -36,6 +36,17 @@ func NetIPFromAddress(addr Address) net.IP {
 	return net.IP(addr.Bytes())
 }
 
+func ToLowHigh(addr Address) (l, h uint64) {
+	switch b := addr.Bytes(); len(b) {
+	case 4:
+		return uint64(binary.LittleEndian.Uint32(b[:4])), uint64(0)
+	case 16:
+		return binary.LittleEndian.Uint64(b[8:]), binary.LittleEndian.Uint64(b[:8])
+	}
+
+	return
+}
+
 type v4Address [4]byte
 
 // V4Address creates an Address using the uint32 representation of an v4 IP

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -37,6 +37,10 @@ func NetIPFromAddress(addr Address) net.IP {
 }
 
 func ToLowHigh(addr Address) (l, h uint64) {
+	if addr == nil {
+		return
+	}
+
 	switch b := addr.Bytes(); len(b) {
 	case 4:
 		return uint64(binary.LittleEndian.Uint32(b[:4])), uint64(0)

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -36,6 +36,7 @@ func NetIPFromAddress(addr Address) net.IP {
 	return net.IP(addr.Bytes())
 }
 
+// ToLowHigh converts an address into a pair of uint64 numbers
 func ToLowHigh(addr Address) (l, h uint64) {
 	if addr == nil {
 		return


### PR DESCRIPTION
### What does this PR do?

Refactor some bits of the HTTP monitoring code in order to reduce its overhead.
I tested these changes against a load test server processing ~12k requests/second and saw a ~40% reduction in memory usage and a ~10% decrease in CPU.

- [x] Reduce allocations from the HTTP hot path;
- [x] Flatten HTTP map;
- [x] Remove unnecessary mutex from the main event loop;
- [x] Avoid creation of sketches for the single latency samples;
- [x] Intern HTTP path strings;
- [x]  Add hard limit for number of HTTP map entries;

<img width="850" alt="benchmark" src="https://user-images.githubusercontent.com/692520/112852766-397f8380-907a-11eb-9011-6e7382a8370c.png">

Requires https://github.com/DataDog/agent-payload/pull/93

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
