### PR TITLE
[DCA][AdmissionController] Use namespaced secrets informer

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -224,14 +224,14 @@ func getInformerFactory() (informers.SharedInformerFactory, error) {
 	return informers.NewSharedInformerFactory(client, resyncPeriodSeconds*time.Second), nil
 }
 
-func getInformerFactoryWithOption(options informers.SharedInformerOption) (informers.SharedInformerFactory, error) {
+func getInformerFactoryWithOption(options ...informers.SharedInformerOption) (informers.SharedInformerFactory, error) {
 	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
 	client, err := getKubeClient(0) // No timeout for the Informers, to allow long watch.
 	if err != nil {
 		log.Errorf("Could not get apiserver client: %v", err)
 		return nil, err
 	}
-	return informers.NewSharedInformerFactoryWithOptions(client, resyncPeriodSeconds*time.Second, options), nil
+	return informers.NewSharedInformerFactoryWithOptions(client, resyncPeriodSeconds*time.Second, options...), nil
 }
 
 func (c *APIClient) connect() error {
@@ -272,6 +272,7 @@ func (c *APIClient) connect() error {
 		}
 		c.CertificateSecretInformerFactory, err = getInformerFactoryWithOption(
 			informers.WithTweakListOptions(optionsForService),
+			informers.WithNamespace(common.GetResourcesNamespace()),
 		)
 
 		optionsForWebhook := func(options *metav1.ListOptions) {

--- a/releasenotes-dca/notes/dca-namespaced-secret-informer-45b8f0bbbbd2eee0.yaml
+++ b/releasenotes-dca/notes/dca-namespaced-secret-informer-45b8f0bbbbd2eee0.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Datadog Cluster Agent's Admission Controller now uses a namespaced secrets informer.
+    It no longer needs permissions to watch secrets at the cluster scope.


### PR DESCRIPTION
### What does this PR do?

The DCA's Admission Controller now uses a namespaced secrets informer.

### Motivation

The DCA no longer needs permissions to watch secrets at the cluster scope.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Enable the Admission Controller, give the DCA secrets permissions in a role instead of a cluster role, the secrets controller must be able to create and watch the cert secret.

```
Admission Controller
====================

    Webhooks info
    -------------
      MutatingWebhookConfigurations name: datadog-webhook
      Created at: 2021-03-29T14:30:23Z
      ---------
        Name: datadog.webhook.config
        CA bundle digest: c0f856bd843af0af
        Object selector: &LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:admission.datadoghq.com/enabled,Operator:NotIn,Values:[false],},},}
        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
        Service: default/datadog-cluster-agent-admission-controller - Port: 443 - Path: /injectconfig
      ---------
        Name: datadog.webhook.tags
        CA bundle digest: c0f856bd843af0af
        Object selector: &LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:admission.datadoghq.com/enabled,Operator:NotIn,Values:[false],},},}
        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
        Service: default/datadog-cluster-agent-admission-controller - Port: 443 - Path: /injecttags

    Secret info
    -----------
    Secret name: webhook-certificate
    Secret namespace: default
    Created at: 2021-03-29T14:30:23Z
    CA bundle digest: c0f856bd843af0af
    Duration before certificate expiration: 8759h53m44.855933131s
```
