### PR TITLE
Release process handle on each check run (and reaquire on the next)

### DIFF
--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -128,7 +128,7 @@ func getAllProcesses(probe *procutil.Probe) (map[int32]*procutil.Process, error)
 			cachedProcesses[pid] = cp
 		} else {
 			if err := cp.openProcHandle(pe32.Th32ProcessID); err != nil {
-				log.Debugf(" Could not reopen process handle for pid %v %v", pid, err)
+				log.Debugf("Could not reopen process handle for pid %v %v", pid, err)
 				continue
 			}
 		}
@@ -299,7 +299,7 @@ type cachedProcess struct {
 func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error) {
 	err = cp.openProcHandle(pe32.Th32ProcessID)
 	if err != nil {
-		return err;
+		return err
 	}
 	var usererr error
 	cp.userName, usererr = getUsernameForProcess(cp.procHandle)
@@ -319,9 +319,9 @@ func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error)
 }
 
 func (cp *cachedProcess) openProcHandle(pid uint32) (err error) {
-    // 0x1000 is PROCESS_QUERY_LIMITED_INFORMATION, but that constant isn't
+	// 0x1000 is PROCESS_QUERY_LIMITED_INFORMATION, but that constant isn't 
+	//        defined in x/sys/windows
 	// 0x10   is PROCESS_VM_READ
-	// defined in x/sys/windows
 
 	cp.procHandle, err = windows.OpenProcess(0x1010, false, uint32(pid))
 	if err != nil {

--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -126,7 +126,14 @@ func getAllProcesses(probe *procutil.Probe) (map[int32]*procutil.Process, error)
 				continue
 			}
 			cachedProcesses[pid] = cp
+		} else {
+			if err := cp.openProcHandle(pe32.Th32ProcessID); err != nil {
+				log.Debugf(" Could not reopen process handle for pid %v %v", pid, err)
+				continue
+			}
 		}
+		defer cp.close()
+
 		procHandle := cp.procHandle
 
 		var CPU windows.Rusage
@@ -290,17 +297,9 @@ type cachedProcess struct {
 }
 
 func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error) {
-	// 0x1000 is PROCESS_QUERY_LIMITED_INFORMATION, but that constant isn't
-	// 0x10   is PROCESS_VM_READ
-	// defined in x/sys/windows
-	cp.procHandle, err = windows.OpenProcess(0x1010, false, uint32(pe32.Th32ProcessID))
+	err = cp.openProcHandle(pe32.Th32ProcessID)
 	if err != nil {
-		log.Debugf("Couldn't open process with PROCESS_VM_READ %v %v", pe32.Th32ProcessID, err)
-		cp.procHandle, err = windows.OpenProcess(0x1000, false, uint32(pe32.Th32ProcessID))
-		if err != nil {
-			log.Debugf("Couldn't open process %v %v", pe32.Th32ProcessID, err)
-			return err
-		}
+		return err;
 	}
 	var usererr error
 	cp.userName, usererr = getUsernameForProcess(cp.procHandle)
@@ -319,6 +318,26 @@ func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error)
 	return
 }
 
+func (cp *cachedProcess) openProcHandle(pid uint32) (err error) {
+    // 0x1000 is PROCESS_QUERY_LIMITED_INFORMATION, but that constant isn't
+	// 0x10   is PROCESS_VM_READ
+	// defined in x/sys/windows
+
+	cp.procHandle, err = windows.OpenProcess(0x1010, false, uint32(pid))
+	if err != nil {
+		log.Debugf("Couldn't open process with PROCESS_VM_READ %v %v", pid, err)
+		cp.procHandle, err = windows.OpenProcess(0x1000, false, uint32(pid))
+		if err != nil {
+			log.Debugf("Couldn't open process %v %v", pid, err)
+			return err
+		}
+	}
+	return
+}
 func (cp *cachedProcess) close() {
-	windows.CloseHandle(cp.procHandle)
+	if cp.procHandle != windows.Handle(0) {
+		windows.CloseHandle(cp.procHandle)
+		cp.procHandle = windows.Handle(0)
+	}
+	return
 }

--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -319,7 +319,7 @@ func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error)
 }
 
 func (cp *cachedProcess) openProcHandle(pid uint32) (err error) {
-	// 0x1000 is PROCESS_QUERY_LIMITED_INFORMATION, but that constant isn't 
+	// 0x1000 is PROCESS_QUERY_LIMITED_INFORMATION, but that constant isn't
 	//        defined in x/sys/windows
 	// 0x10   is PROCESS_VM_READ
 

--- a/releasenotes/notes/fixwinprocesshandleshang-bce162f5c0fee73f.yaml
+++ b/releasenotes/notes/fixwinprocesshandleshang-bce162f5c0fee73f.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, fixes problem in process agent wherein windows processes
+    could not completely exit.


### PR DESCRIPTION


### What does this PR do?

Instead of holding on to process handles across check runs, release the process
handle and reacquire on each run

### Motivation

Multiple customer reports of process agent preventing other windows processes from hanging.

### Additional Notes

it's not clear _why_ this was causing the failure.  PRocess handles are waitable objects and, as such, can 
be kept open.  However, multiple different customers confirmed the bad behavior, and that the fix
actually fixed.

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
