### PR TITLE
[build] Update CircleCI runner image to use Golang 1.15 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: datadog/datadog-agent-runner-circle:go11412
+      - image: datadog/datadog-agent-runner-circle:go11510
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent

--- a/.circleci/images/runner/Dockerfile
+++ b/.circleci/images/runner/Dockerfile
@@ -12,7 +12,7 @@ RUN set -ex \
         doxygen graphviz
 
 # Golang
-ENV GIMME_GO_VERSION 1.14.12
+ENV GIMME_GO_VERSION 1.15.10
 ENV GOROOT /root/.gimme/versions/go$GIMME_GO_VERSION.linux.amd64
 ENV GOPATH /go
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH

--- a/.circleci/images/runner/Dockerfile
+++ b/.circleci/images/runner/Dockerfile
@@ -3,13 +3,30 @@ FROM ubuntu:18.04
 # Pre-requisites
 # python3.7-dev is required by rtloader
 RUN set -ex \
-    && apt-get update && apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        doxygen \
+        file \
+        g++ \
+        gcc \
+        git \
         gnupg ca-certificates \
-        gcc g++ make git ssh curl pkg-config file \
+        graphviz \
+        libpq-dev \
+        libsnmp-base \
+        libsnmp-dev \
+        libssl-dev \
+        libsystemd-dev \
+        make \
+        pkg-config \
         python3.7-dev \
-        python3-setuptools python3-distutils python3-pip python3-yaml \
-        libssl-dev libsnmp-base libsnmp-dev libpq-dev snmp-mibs-downloader libsystemd-dev \
-        doxygen graphviz
+        python3-distutils \
+        python3-pip \
+        python3-setuptools \
+        python3-yaml \
+        snmp-mibs-downloader \
+        ssh
 
 # Golang
 ENV GIMME_GO_VERSION 1.15.10
@@ -37,7 +54,8 @@ RUN set -ex \
     # clang-format v8
     && echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/sources.list \
     && curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-    && apt-get update && apt-get -t llvm-toolchain-bionic-8 install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get -t llvm-toolchain-bionic-8 install -y --no-install-recommends \
         clang-format-8
 
 # Setup entrypoint


### PR DESCRIPTION
### What does this PR do?

Updates the CircleCI runner image to use Golang 1.15.10 instead of 1.14.x

### Motivation

AC-846: Regularly scheduled Golang update

### Additional Notes

N/A

### Describe your test plan

Check that CircleCI tests do not fail
