### PR TITLE
[runtime-security] Report policy version in ruleset_loaded event

### DIFF
--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -191,6 +191,7 @@ type RuleLoaded struct {
 // PolicyLoaded is used to report policy was loaded
 // easyjson:json
 type PolicyLoaded struct {
+	Version      string
 	RulesLoaded  []*RuleLoaded  `json:"rules_loaded"`
 	RulesIgnored []*RuleIgnored `json:"rules_ignored,omitempty"`
 }
@@ -216,7 +217,7 @@ func NewRuleSetLoadedEvent(rs *rules.RuleSet, err *multierror.Error) (*rules.Rul
 		policyName := rule.Definition.Policy.Name
 
 		if policy, exists = mp[policyName]; !exists {
-			policy = &PolicyLoaded{}
+			policy = &PolicyLoaded{Version: rule.Definition.Policy.Version}
 			mp[policyName] = policy
 		}
 		policy.RulesLoaded = append(policy.RulesLoaded, &RuleLoaded{

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -381,6 +381,8 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(in *jle
 			continue
 		}
 		switch key {
+		case "Version":
+			out.Version = string(in.String())
 		case "rules_loaded":
 			if in.IsNull() {
 				in.Skip()
@@ -458,8 +460,13 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 	first := true
 	_ = first
 	{
-		const prefix string = ",\"rules_loaded\":"
+		const prefix string = ",\"Version\":"
 		out.RawString(prefix[1:])
+		out.String(string(in.Version))
+	}
+	{
+		const prefix string = ",\"rules_loaded\":"
+		out.RawString(prefix)
 		if in.RulesLoaded == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 			out.RawString("null")
 		} else {


### PR DESCRIPTION
### What does this PR do?

Report the policy version in the ruleset_loaded custom event

### Motivation

The ruleset_loaded event only reports the rules that successfully or failed to load. Having the policy version helps understanding the exact set of rules deployed