### PR TITLE
[KSMcore] Add `pod.age` and `pod.uptime` metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -178,7 +178,7 @@ func (k *KSMCheck) Configure(config, initConfig integration.Data, source string)
 
 	builder.WithNamespaces(namespaces)
 
-	allowDenyList, err := allowdenylist.New(options.MetricSet{}, deniedMetrics)
+	allowDenyList, err := allowdenylist.New(options.MetricSet{}, buildDeniedMetricsSet(collectors))
 	if err != nil {
 		return err
 	}
@@ -503,4 +503,21 @@ func isKnownMetric(name string) bool {
 		return true
 	}
 	return false
+}
+
+// buildDeniedMetricsSet adds *_created metrics to the default denied metric rules.
+// It denies all *_created metrics except for kube_node_created and kube_pod_created.
+// buildDeniedMetricsSet allows us to get kube_node_created and kube_pod_created and deny
+// the rest of *_created metrics without relying on a unmaintainable and unreadable regex.
+func buildDeniedMetricsSet(collectors []string) options.MetricSet {
+	deniedMetrics := defaultDeniedMetrics
+	for _, resource := range collectors {
+		// resource format: pods, nodes, jobs, deployments...
+		if resource == "pods" || resource == "nodes" {
+			continue
+		}
+		deniedMetrics["kube_"+strings.TrimRight(resource, "s")+"_created"] = struct{}{}
+	}
+
+	return deniedMetrics
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -506,8 +506,7 @@ func isKnownMetric(name string) bool {
 }
 
 // buildDeniedMetricsSet adds *_created metrics to the default denied metric rules.
-// It denies all *_created metrics except for kube_node_created and kube_pod_created.
-// buildDeniedMetricsSet allows us to get kube_node_created and kube_pod_created and deny
+// It allows us to get kube_node_created and kube_pod_created and deny
 // the rest of *_created metrics without relying on a unmaintainable and unreadable regex.
 func buildDeniedMetricsSet(collectors []string) options.MetricSet {
 	deniedMetrics := defaultDeniedMetrics

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -54,7 +54,7 @@
 | `kubernetes_state.pod.unschedulable` | Describes the unschedulable status for the pod.   | `kube_namespace` `pod_name` (`env` `service` `version` from standard labels)   |
 | `kubernetes_state.pod.status_phase` | The pods current phase.   | `kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels)    |
 | `kubernetes_state.pod.age` | The time in seconds since the creation of the pod.   | `kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels)    |
-| `kubernetes_state.pod.uptime` | The time in seconds since the pod started.   | `kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels)    |
+| `kubernetes_state.pod.uptime` | The time in seconds since the pod has been scheduled and acknowledged by the Kubelet.   | `kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels)    |
 | `kubernetes_state.persistentvolumeclaim.status` | The phase the persistent volume claim is currently in.   | `kube_namespace` `persistentvolumeclaim` `phase` `storageclass`   |
 | `kubernetes_state.persistentvolumeclaim.access_mode` | The access mode(s) specified by the persistent volume claim.   | `kube_namespace` `persistentvolumeclaim` `access_mode` `storageclass`   |
 | `kubernetes_state.persistentvolumeclaim.request_storage` | The capacity of storage requested by the persistent volume claim.   | `kube_namespace` `persistentvolumeclaim` `storageclass`   |

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -53,6 +53,8 @@
 | `kubernetes_state.pod.volumes.persistentvolumeclaims_readonly` | Describes whether a persistentvolumeclaim is mounted read only.   | `kube_namespace` `pod_name` `volume` `persistentvolumeclaim` (`env` `service` `version` from standard labels)   |
 | `kubernetes_state.pod.unschedulable` | Describes the unschedulable status for the pod.   | `kube_namespace` `pod_name` (`env` `service` `version` from standard labels)   |
 | `kubernetes_state.pod.status_phase` | The pods current phase.   | `kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels)    |
+| `kubernetes_state.pod.age` | The time in seconds since the creation of the pod.   | `kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels)    |
+| `kubernetes_state.pod.uptime` | The time in seconds since the pod started.   | `kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels)    |
 | `kubernetes_state.persistentvolumeclaim.status` | The phase the persistent volume claim is currently in.   | `kube_namespace` `persistentvolumeclaim` `phase` `storageclass`   |
 | `kubernetes_state.persistentvolumeclaim.access_mode` | The access mode(s) specified by the persistent volume claim.   | `kube_namespace` `persistentvolumeclaim` `access_mode` `storageclass`   |
 | `kubernetes_state.persistentvolumeclaim.request_storage` | The capacity of storage requested by the persistent volume claim.   | `kube_namespace` `persistentvolumeclaim` `storageclass`   |

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -120,16 +120,15 @@ var (
 	// but shouldn't be submitted to Datadog
 	metadataMetricsRegex = regexp.MustCompile(".*_(info|labels)")
 
-	// deniedMetrics used to configure the KSM store to ignore these metrics by KSM engine
-	deniedMetrics = options.MetricSet{
-		// deny all *_created metrics except for kube_node_created
-		"^_created|^(?:[^k]|k[^u]|ku[^b]|kub[^e]|kube[^_]|kube_[^n]|kube_n[^o]|kube_no[^d]|kube_nod[^e]|kube_node.).*_created": {},
+	// defaultDeniedMetrics used to configure the KSM store to ignore these metrics by KSM engine
+	defaultDeniedMetrics = options.MetricSet{
 		".*_generation":                                    {},
 		".*_metadata_resource_version":                     {},
 		"kube_pod_owner":                                   {},
 		"kube_pod_status_reason":                           {},
 		"kube_pod_restart_policy":                          {},
-		"kube_pod_.*_time":                                 {},
+		"kube_pod_completion_time":                         {},
+		"kube_pod_status_scheduled_time":                   {},
 		"kube_cronjob_status_active":                       {},
 		"kube_node_status_phase":                           {},
 		"kube_cronjob_spec_starting_deadline_seconds":      {},

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -868,6 +868,7 @@ func TestResourceNameFromMetric(t *testing.T) {
 }
 
 func TestAllowDeny(t *testing.T) {
+	deniedMetrics := buildDeniedMetricsSet(options.DefaultResources.AsSlice())
 	allowDenyList, err := allowdenylist.New(options.MetricSet{}, deniedMetrics)
 	assert.NoError(t, err)
 
@@ -901,20 +902,19 @@ func TestAllowDeny(t *testing.T) {
 }
 
 func TestCreationMetricsFiltering(t *testing.T) {
-	allowDenyList, err := allowdenylist.New(options.MetricSet{}, deniedMetrics)
+	allowDenyList, err := allowdenylist.New(options.MetricSet{}, buildDeniedMetricsSet(options.DefaultResources.AsSlice()))
 	assert.NoError(t, err)
 
 	err = allowDenyList.Parse()
 	assert.NoError(t, err)
 
-	included := []string{"kube_node_created"}
+	included := []string{"kube_node_created", "kube_pod_created"}
 	for _, metric := range included {
 		assert.True(t, allowDenyList.IsIncluded(metric))
 		assert.False(t, allowDenyList.IsExcluded(metric))
 	}
 
 	excluded := []string{
-		"kube_pod_created",
 		"kube_cronjob_created",
 		"kube_daemonset_created",
 		"kube_deployment_created",

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -28,6 +28,8 @@ var (
 	// These metrics require more than a name translation to generate Datadog metrics, as opposed to the metrics in metricNamesMapper
 	// For reference see METRIC_TRANSFORMERS in KSM check V1
 	metricTransformers = map[string]metricTransformerFunc{
+		"kube_pod_created":                            podCreationTransformer,
+		"kube_pod_start_time":                         podStartTimeTransformer,
 		"kube_pod_status_phase":                       podPhaseTransformer,
 		"kube_pod_container_status_waiting_reason":    containerWaitingReasonTransformer,
 		"kube_pod_container_status_terminated_reason": containerTerminatedReasonTransformer,
@@ -148,9 +150,25 @@ func nodeUnschedulableTransformer(s aggregator.Sender, name string, metric ksmst
 	s.Gauge(ksmMetricPrefix+"node.status", 1, hostname, tags)
 }
 
+// submitAge generates a resource age or uptime metric based on a given timestamp
+// The metric value must corresponds to a timestamp
+func submitAge(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+	s.Gauge(name, float64(now().Unix())-metric.Val, hostname, tags)
+}
+
 // nodeCreationTransformer generates the node age metric based on the creation timestamp
 func nodeCreationTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
-	s.Gauge(ksmMetricPrefix+"node.age", float64(now().Unix())-metric.Val, hostname, tags)
+	submitAge(s, ksmMetricPrefix+"node.age", metric, hostname, tags)
+}
+
+// podCreationTransformer generates the pod age metric based on the creation timestamp
+func podCreationTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+	submitAge(s, ksmMetricPrefix+"pod.age", metric, hostname, tags)
+}
+
+// podStartTimeTransformer generates the pod age metric based on the start time timestamp
+func podStartTimeTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
+	submitAge(s, ksmMetricPrefix+"pod.uptime", metric, hostname, tags)
 }
 
 // podPhaseTransformer sends status phase metrics for pods, the tag phase has the pod status

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -151,7 +151,7 @@ func nodeUnschedulableTransformer(s aggregator.Sender, name string, metric ksmst
 }
 
 // submitAge generates a resource age or uptime metric based on a given timestamp
-// The metric value must corresponds to a timestamp
+// The metric value must correspond to a timestamp
 func submitAge(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
 	s.Gauge(name, float64(now().Unix())-metric.Val, hostname, tags)
 }
@@ -166,7 +166,7 @@ func podCreationTransformer(s aggregator.Sender, name string, metric ksmstore.DD
 	submitAge(s, ksmMetricPrefix+"pod.age", metric, hostname, tags)
 }
 
-// podStartTimeTransformer generates the pod age metric based on the start time timestamp
+// podStartTimeTransformer generates the pod uptime metric based on the start time timestamp
 func podStartTimeTransformer(s aggregator.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string) {
 	submitAge(s, ksmMetricPrefix+"pod.uptime", metric, hostname, tags)
 }

--- a/releasenotes/notes/ksm-pod-age-and-uptime-metrics-5a0d96fb35d1ea98.yaml
+++ b/releasenotes/notes/ksm-pod-age-and-uptime-metrics-5a0d96fb35d1ea98.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The `kubernetes_state_core` check now collects two new metrics `kubernetes_state.pod.age` and `kubernetes_state.pod.uptime`.


### PR DESCRIPTION
### What does this PR do?

- Add `kubernetes_state.pod.age`: The time in seconds since the creation of the pod.
- Add `kubernetes_state.pod.uptime`: The time in seconds since the pod started.
- Rework the filtering logic of `*_created` metrics

### Motivation

FR

### Describe your test plan

- The check submits the new metrics
- The refactoring didn't break `kubernetes_state.node.age`
- The refactoring didn't break the `*_created` metrics filtering
