### PR TITLE
[runtime-security] fix greater than/lesser than in SECL

### DIFF
--- a/pkg/security/secl/ast/secl.go
+++ b/pkg/security/secl/ast/secl.go
@@ -129,7 +129,7 @@ type Comparison struct {
 type ScalarComparison struct {
 	Pos lexer.Position
 
-	Op   *string     `parser:"@( \">\" | \">\" \"=\" | \"<\" | \"<\" \"=\" | \"!\" \"=\" | \"=\" \"=\" | \"=\" \"~\" | \"!\" \"~\" )"`
+	Op   *string     `parser:"@( \">\" \"=\" | \">\" | \"<\" \"=\" | \"<\" | \"!\" \"=\" | \"=\" \"=\" | \"=\" \"~\" | \"!\" \"~\" )"`
 	Next *Comparison `parser:"@@"`
 }
 

--- a/pkg/security/secl/eval/eval_test.go
+++ b/pkg/security/secl/eval/eval_test.go
@@ -736,6 +736,11 @@ func TestRegister(t *testing.T) {
 		{Expr: `process.list[_].key != 10`, Expected: false},
 		{Expr: `process.list[_].key != 9999`, Expected: true},
 
+		{Expr: `process.list[_].key >= 200`, Expected: true},
+		{Expr: `process.list[_].key > 100`, Expected: true},
+		{Expr: `process.list[_].key <= 200`, Expected: true},
+		{Expr: `process.list[_].key < 100`, Expected: true},
+
 		{Expr: `10 == process.list[_].key`, Expected: true},
 		{Expr: `9999 == process.list[_].key`, Expected: false},
 		{Expr: `10 != process.list[_].key`, Expected: false},


### PR DESCRIPTION
### What does this PR do?

This PR fixes parsing of `>=` and `<=` operator in SECL.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Unit tests have been added
