### PR TITLE
[Fix][Tagger] Fix entities leak in the tagger

### DIFF
--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -116,7 +116,7 @@ func (t *Tagger) run() error {
 		case <-t.pullTicker.C:
 			go t.pull()
 		case <-t.pruneTicker.C:
-			t.store.prune() //nolint:errcheck
+			t.store.prune()
 		case <-t.telemetryTicker.C:
 			t.store.collectTelemetry()
 		}

--- a/pkg/tagger/local/tagstore.go
+++ b/pkg/tagger/local/tagstore.go
@@ -262,6 +262,9 @@ func (s *tagStore) pruneDeletedEntities() {
 }
 
 // pruneEmptyEntries will lock the store and delete tags for entities with empty entries.
+// Empty entries are added by the `Tag()` method on partial cache miss when a source doesn't find the entity.
+// When the entity comes back empty to the store, we will avoid to fetch it again.
+// If some sources detect the deletion of the entity, this method will wipe the empty entries for the other sources.
 func (s *tagStore) pruneEmptyEntries() {
 	s.Lock()
 	defer s.Unlock()

--- a/pkg/tagger/telemetry/telemetry.go
+++ b/pkg/tagger/telemetry/telemetry.go
@@ -2,6 +2,16 @@ package telemetry
 
 import "github.com/DataDog/datadog-agent/pkg/telemetry"
 
+// PruneType represents the `prune_type` tag for the pruned_entities metric
+type PruneType string
+
+const (
+	// DeletedEntity refers to deleting entities due to a deletion event
+	DeletedEntity PruneType = "deletion_event"
+	// EmptyEntry refers to deleting entities with empty entries
+	EmptyEntry PruneType = "empty_entries"
+)
+
 var (
 	// StoredEntities tracks how many entities are stored in the tagger.
 	StoredEntities = telemetry.NewGaugeWithOpts("tagger", "stored_entities",
@@ -11,6 +21,11 @@ var (
 	// UpdatedEntities tracks the number of updates to tagger entities.
 	UpdatedEntities = telemetry.NewCounterWithOpts("tagger", "updated_entities",
 		[]string{}, "Number of updates made to entities.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	// PrunedEntities tracks the number of pruned tagger entities.
+	PrunedEntities = telemetry.NewGaugeWithOpts("tagger", "pruned_entities",
+		[]string{"prune_type"}, "Number of pruned tagger entities.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// Queries tracks the number of queries made against the tagger.

--- a/releasenotes/notes/fix-tagger-leak-cfbfcad140ab342a.yaml
+++ b/releasenotes/notes/fix-tagger-leak-cfbfcad140ab342a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a small leak where the Agent in some cases keeps in memory identifiers corresponding to dead objects (pods, containers).


### PR DESCRIPTION
### What does this PR do?

- Extend the entities pruning logic in the tagger to delete entities with empty entries
- Add telemetry around pruning entities 

### Motivation

Leaks are bad, even when they're tiny like this one.

### Additional Notes

The leak s happening because of two factors
- When we fetch an entity and one of sources (collectors) doesn't find it, we store an empty entry of that entity for the source in question (this has been like this since the early days of the tagger, the goal is to speedup the look up in the next queries). This fix doesn't aim to change this design. 
- Since https://github.com/DataDog/datadog-agent/pull/6624, the empty entry would never be deleted for the source in question if it doesn't track the entity in the first place (example: the docker collector doesn't process pod entities but will have a empty pod entities pushed when fetching pod tags)

### Describe your test plan

Cron jobs can be used to reproduce the leak, with the fix we should no longer see entities like this
```
=== Entity kubernetes_pod_uid://f2c52209-23b6-48d3-b9a7-8eab14a210f1 ===
== Source kube-metadata-collector ==
Tags: []
===
...
=== Entity container_id://b3d3b540b10cdf19e19534c5291ffe7494dac3bd14f8846faf607bb58b181976 ===
== Source kube-metadata-collector ==
Tags: []
===
```
