### PR TITLE
Fix `call to (*T).Fatal from a non-test goroutine`

### DIFF
--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -47,6 +48,7 @@ func TestConcurrencyUnmarshalling(t *testing.T) {
 	config.SetDefault("baz", "test")
 
 	var wg sync.WaitGroup
+	errs := make(chan error, 100)
 
 	wg.Add(2)
 	go func() {
@@ -62,12 +64,22 @@ func TestConcurrencyUnmarshalling(t *testing.T) {
 		for n := 0; n <= 1000; n++ {
 			err := config.UnmarshalKey("foo", &s)
 			if err != nil {
-				t.Fatalf("unable to decode into struct, %v", err)
+				errs <- fmt.Errorf("unable to decode into struct, %w", err)
+				return
 			}
 		}
 	}()
 
-	wg.Wait()
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 }
 
 func TestGetConfigEnvVars(t *testing.T) {

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -48,7 +48,7 @@ func TestConcurrencyUnmarshalling(t *testing.T) {
 	config.SetDefault("baz", "test")
 
 	var wg sync.WaitGroup
-	errs := make(chan error, 100)
+	errs := make(chan error, 1000)
 
 	wg.Add(2)
 	go func() {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -638,48 +638,29 @@ func TestClientComputedStatsHeader(t *testing.T) {
 			if on {
 				req.Header.Set(headerComputedStats, "yes")
 			}
-			errs := make(chan error, 2)
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
-					errs <- err
+					t.Error(err)
 					return
 				}
 				if resp.StatusCode != 200 {
-					errs <- fmt.Errorf("%d", resp.StatusCode)
+					t.Error(resp.StatusCode)
 					return
 				}
 			}()
-
-			var wg2 sync.WaitGroup
-			wg2.Add(1)
-			go func() {
-				defer wg2.Done()
-				timeout := time.After(time.Second)
-				for {
-					select {
-					case p := <-rcv.out:
-						assert.Equal(t, p.ClientComputedStats, on)
-						wg.Wait()
-						return
-					case <-timeout:
-						errs <- fmt.Errorf("no output")
-						return
-					}
-				}
-			}()
-
-			go func() {
-				wg2.Wait()
-				close(errs)
-			}()
-
-			for err := range errs {
-				if err != nil {
-					t.Fatal(err)
+			timeout := time.After(time.Second)
+			for {
+				select {
+				case p := <-rcv.out:
+					assert.Equal(t, p.ClientComputedStats, on)
+					wg.Wait()
+					return
+				case <-timeout:
+					t.Fatal("no output")
 				}
 			}
 		}
@@ -769,47 +750,29 @@ func TestClientComputedTopLevel(t *testing.T) {
 			if on {
 				req.Header.Set(headerComputedTopLevel, "yes")
 			}
-			errs := make(chan error, 2)
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
-					errs <- err
+					t.Error(err)
 					return
 				}
 				if resp.StatusCode != 200 {
-					errs <- fmt.Errorf("%d", resp.StatusCode)
+					t.Error(resp.StatusCode)
 					return
 				}
 			}()
-			var wg2 sync.WaitGroup
-			wg2.Add(1)
-			go func() {
-				defer wg2.Done()
-				timeout := time.After(time.Second)
-				for {
-					select {
-					case p := <-rcv.out:
-						assert.Equal(t, p.ClientComputedTopLevel, on)
-						wg.Wait()
-						return
-					case <-timeout:
-						errs <- fmt.Errorf("no output")
-						return
-					}
-				}
-			}()
-
-			go func() {
-				wg2.Wait()
-				close(errs)
-			}()
-
-			for err := range errs {
-				if err != nil {
-					t.Fatal(err)
+			timeout := time.After(time.Second)
+			for {
+				select {
+				case p := <-rcv.out:
+					assert.Equal(t, p.ClientComputedTopLevel, on)
+					wg.Wait()
+					return
+				case <-timeout:
+					t.Fatal("no output")
 				}
 			}
 		}

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -638,27 +638,48 @@ func TestClientComputedStatsHeader(t *testing.T) {
 			if on {
 				req.Header.Set(headerComputedStats, "yes")
 			}
+			errs := make(chan error, 2)
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
-					t.Fatal(err)
+					errs <- err
+					return
 				}
 				if resp.StatusCode != 200 {
-					t.Fatal(resp.StatusCode)
+					errs <- fmt.Errorf("%d", resp.StatusCode)
+					return
 				}
 			}()
-			timeout := time.After(time.Second)
-			for {
-				select {
-				case p := <-rcv.out:
-					assert.Equal(t, p.ClientComputedStats, on)
-					wg.Wait()
-					return
-				case <-timeout:
-					t.Fatal("no output")
+
+			var wg2 sync.WaitGroup
+			wg2.Add(1)
+			go func() {
+				defer wg2.Done()
+				timeout := time.After(time.Second)
+				for {
+					select {
+					case p := <-rcv.out:
+						assert.Equal(t, p.ClientComputedStats, on)
+						wg.Wait()
+						return
+					case <-timeout:
+						errs <- fmt.Errorf("no output")
+						return
+					}
+				}
+			}()
+
+			go func() {
+				wg2.Wait()
+				close(errs)
+			}()
+
+			for err := range errs {
+				if err != nil {
+					t.Fatal(err)
 				}
 			}
 		}
@@ -748,27 +769,47 @@ func TestClientComputedTopLevel(t *testing.T) {
 			if on {
 				req.Header.Set(headerComputedTopLevel, "yes")
 			}
+			errs := make(chan error, 2)
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
-					t.Fatal(err)
+					errs <- err
+					return
 				}
 				if resp.StatusCode != 200 {
-					t.Fatal(resp.StatusCode)
+					errs <- fmt.Errorf("%d", resp.StatusCode)
+					return
 				}
 			}()
-			timeout := time.After(time.Second)
-			for {
-				select {
-				case p := <-rcv.out:
-					assert.Equal(t, p.ClientComputedTopLevel, on)
-					wg.Wait()
-					return
-				case <-timeout:
-					t.Fatal("no output")
+			var wg2 sync.WaitGroup
+			wg2.Add(1)
+			go func() {
+				defer wg2.Done()
+				timeout := time.After(time.Second)
+				for {
+					select {
+					case p := <-rcv.out:
+						assert.Equal(t, p.ClientComputedTopLevel, on)
+						wg.Wait()
+						return
+					case <-timeout:
+						errs <- fmt.Errorf("no output")
+						return
+					}
+				}
+			}()
+
+			go func() {
+				wg2.Wait()
+				close(errs)
+			}()
+
+			for err := range errs {
+				if err != nil {
+					t.Fatal(err)
 				}
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Fix `call to (*T).Fatal from a non-test goroutine` go 1.16 vet errors:

```
--- Vetting and linting (legacy):
----- Module '/home/datadog/devel/DataDog/datadog-agent'
# github.com/DataDog/datadog-agent/pkg/config
pkg/config/viper_test.go:65:5: call to (*T).Fatalf from a non-test goroutine
# github.com/DataDog/datadog-agent/pkg/trace/api
pkg/trace/api/api_oom_test.go:55:5: call to (*T).Fatal from a non-test goroutine
pkg/trace/api/api_test.go:647:6: call to (*T).Fatal from a non-test goroutine
pkg/trace/api/api_test.go:650:6: call to (*T).Fatal from a non-test goroutine
pkg/trace/api/api_test.go:757:6: call to (*T).Fatal from a non-test goroutine
pkg/trace/api/api_test.go:760:6: call to (*T).Fatal from a non-test goroutine
```

### Motivation

`inv test` doesn’t pass with GO 1.16.

### Additional Notes

Description of the problem: https://golang.org/doc/go1.16#vet

Rather than converting `(*T).Fatal` to `(*T).Error`, I choosed to keep the `(*T).Fatal` but to move their invocation from the secondary goroutines to the main goroutine running the test an to convey the `error` between the two through a `chan`.

### Describe your test plan

Run `inv test` with GO 1.16.
