### PR TITLE
Fix panic in Docker AD listener if dockerUtil.Inspect fails

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -236,22 +236,23 @@ func (l *DockerListener) createService(cID string) {
 	var isKube bool
 	cInspect, err := l.dockerUtil.Inspect(cID, false)
 	if err != nil {
-		log.Errorf("Failed to inspect container %s - %s", cID[:12], err)
-	} else {
-		containerImage, err = l.dockerUtil.ResolveImageNameFromContainer(cInspect)
-		if err != nil {
-			log.Warnf("error while resolving image name: %s", err)
-			containerImage = ""
-		}
-		// Detect AD exclusion
-		containerName = cInspect.Name
-		if l.filters.IsExcluded(containers.GlobalFilter, containerName, containerImage, "") {
-			log.Debugf("container %s filtered out: name %q image %q", cID[:12], containerName, containerImage)
-			return
-		}
-		if findKubernetesInLabels(cInspect.Config.Labels) {
-			isKube = true
-		}
+		log.Errorf("Failed to inspect container '%s', not creating AD service, err: %s", cID[:12], err)
+		return
+	}
+
+	containerImage, err = l.dockerUtil.ResolveImageNameFromContainer(cInspect)
+	if err != nil {
+		log.Warnf("error while resolving image name: %s", err)
+		containerImage = ""
+	}
+	// Detect AD exclusion
+	containerName = cInspect.Name
+	if l.filters.IsExcluded(containers.GlobalFilter, containerName, containerImage, "") {
+		log.Debugf("container %s filtered out: name %q image %q", cID[:12], containerName, containerImage)
+		return
+	}
+	if findKubernetesInLabels(cInspect.Config.Labels) {
+		isKube = true
 	}
 
 	checkNames, err := getCheckNamesFromLabels(cInspect.Config.Labels)

--- a/releasenotes/notes/fix-panic-docker-ad-dd22e97e6afe61b0.yaml
+++ b/releasenotes/notes/fix-panic-docker-ad-dd22e97e6afe61b0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a `panic` that could occur in Docker AD listener when doing `docker inspect` fails


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

Failure report

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

It may be very difficult to intentionally reproduce this error. The idea would be to test the Docker-based AD and make sure we don't see any panic.
