### PR TITLE
[runtime-security] add 'args_flags' and 'args_options' SECL helpers

### DIFF
--- a/pkg/security/model/accessors.go
+++ b/pkg/security/model/accessors.go
@@ -483,6 +483,30 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "exec.args_flags":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).Exec.Argv
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.args_options":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).Exec.Argv
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "exec.args_truncated":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
@@ -492,6 +516,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.argv":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).Exec.Argv
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.cap_effective":
@@ -4033,7 +4069,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.args",
 
+		"exec.args_flags",
+
+		"exec.args_options",
+
 		"exec.args_truncated",
+
+		"exec.argv",
 
 		"exec.cap_effective",
 
@@ -4730,9 +4772,21 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Exec.Args, nil
 
+	case "exec.args_flags":
+
+		return e.Exec.Argv, nil
+
+	case "exec.args_options":
+
+		return e.Exec.Argv, nil
+
 	case "exec.args_truncated":
 
 		return e.Exec.ArgsTruncated, nil
+
+	case "exec.argv":
+
+		return e.Exec.Argv, nil
 
 	case "exec.cap_effective":
 
@@ -6526,7 +6580,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.args":
 		return "exec", nil
 
+	case "exec.args_flags":
+		return "exec", nil
+
+	case "exec.args_options":
+		return "exec", nil
+
 	case "exec.args_truncated":
+		return "exec", nil
+
+	case "exec.argv":
 		return "exec", nil
 
 	case "exec.cap_effective":
@@ -7496,9 +7559,21 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.args_flags":
+
+		return reflect.String, nil
+
+	case "exec.args_options":
+
+		return reflect.String, nil
+
 	case "exec.args_truncated":
 
 		return reflect.Bool, nil
+
+	case "exec.argv":
+
+		return reflect.String, nil
 
 	case "exec.cap_effective":
 
@@ -8976,12 +9051,45 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.args_flags":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+		}
+		e.Exec.Argv = append(e.Exec.Argv, str)
+
+		return nil
+
+	case "exec.args_options":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+		}
+		e.Exec.Argv = append(e.Exec.Argv, str)
+
+		return nil
+
 	case "exec.args_truncated":
 
 		var ok bool
 		if e.Exec.ArgsTruncated, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.ArgsTruncated"}
 		}
+		return nil
+
+	case "exec.argv":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+		}
+		e.Exec.Argv = append(e.Exec.Argv, str)
+
 		return nil
 
 	case "exec.cap_effective":

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -260,6 +260,7 @@ type ExecEvent struct {
 	Process
 
 	Args          string   `field:"args,ResolveExecArgs"`
+	Argv          []string `field:"argv,ResolveExecArgv" field:"args_flags,ResolveExecArgsFlags" field:"args_options,ResolveExecArgsOptions"`
 	ArgsTruncated bool     `field:"args_truncated"`
 	Envs          []string `field:"envs,ResolveExecEnvs"`
 	EnvsTruncated bool     `field:"envs_truncated"`

--- a/pkg/security/model/strings.go
+++ b/pkg/security/model/strings.go
@@ -9,6 +9,15 @@ package model
 
 import "unicode"
 
+var (
+	alphaNumericRange = []*unicode.RangeTable{unicode.L, unicode.Digit}
+)
+
+// IsAlphaNumeric returns whether a character is either a digit or a letter
+func IsAlphaNumeric(r rune) bool {
+	return unicode.IsOneOf(alphaNumericRange, r)
+}
+
 // IsPrintable returns whether the string does contain only ascii
 func IsPrintable(s string) bool {
 	for _, c := range s {

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -484,6 +484,30 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "exec.args_flags":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ResolveExecArgsFlags(&(*Event)(ctx.Object).Exec)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "exec.args_options":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ResolveExecArgsOptions(&(*Event)(ctx.Object).Exec)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "exec.args_truncated":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
@@ -493,6 +517,18 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field: field,
 
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.argv":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ResolveExecArgv(&(*Event)(ctx.Object).Exec)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "exec.cap_effective":
@@ -4232,7 +4268,13 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.args",
 
+		"exec.args_flags",
+
+		"exec.args_options",
+
 		"exec.args_truncated",
+
+		"exec.argv",
 
 		"exec.cap_effective",
 
@@ -4929,9 +4971,21 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveExecArgs(&e.Exec), nil
 
+	case "exec.args_flags":
+
+		return e.ResolveExecArgsFlags(&e.Exec), nil
+
+	case "exec.args_options":
+
+		return e.ResolveExecArgsOptions(&e.Exec), nil
+
 	case "exec.args_truncated":
 
 		return e.Exec.ArgsTruncated, nil
+
+	case "exec.argv":
+
+		return e.ResolveExecArgv(&e.Exec), nil
 
 	case "exec.cap_effective":
 
@@ -6725,7 +6779,16 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.args":
 		return "exec", nil
 
+	case "exec.args_flags":
+		return "exec", nil
+
+	case "exec.args_options":
+		return "exec", nil
+
 	case "exec.args_truncated":
+		return "exec", nil
+
+	case "exec.argv":
 		return "exec", nil
 
 	case "exec.cap_effective":
@@ -7695,9 +7758,21 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.args_flags":
+
+		return reflect.String, nil
+
+	case "exec.args_options":
+
+		return reflect.String, nil
+
 	case "exec.args_truncated":
 
 		return reflect.Bool, nil
+
+	case "exec.argv":
+
+		return reflect.String, nil
 
 	case "exec.cap_effective":
 
@@ -9175,12 +9250,45 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.args_flags":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+		}
+		e.Exec.Argv = append(e.Exec.Argv, str)
+
+		return nil
+
+	case "exec.args_options":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+		}
+		e.Exec.Argv = append(e.Exec.Argv, str)
+
+		return nil
+
 	case "exec.args_truncated":
 
 		var ok bool
 		if e.Exec.ArgsTruncated, ok = value.(bool); !ok {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.ArgsTruncated"}
 		}
+		return nil
+
+	case "exec.argv":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+		}
+		e.Exec.Argv = append(e.Exec.Argv, str)
+
 		return nil
 
 	case "exec.cap_effective":

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -286,6 +286,71 @@ func (ev *Event) ResolveExecArgs(e *model.ExecEvent) string {
 	return ev.Exec.Args
 }
 
+// ResolveExecArgv resolves the args of the event as an array
+func (ev *Event) ResolveExecArgv(e *model.ExecEvent) []string {
+	if len(ev.Exec.Argv) == 0 && len(ev.ProcessContext.ArgsArray) > 0 {
+		ev.Exec.Argv = ev.ProcessContext.ArgsArray
+	}
+	return ev.Exec.Argv
+}
+
+// ResolveExecArgsFlags resolves the arguments flags of the event
+func (ev *Event) ResolveExecArgsFlags(e *model.ExecEvent) (flags []string) {
+	for _, arg := range ev.ProcessContext.ArgsArray {
+		if len(arg) > 1 && arg[0] == '-' {
+			isFlag := true
+			name := arg[1:]
+			if len(name) >= 1 && name[0] == '-' {
+				name = name[1:]
+				isFlag = false
+			}
+
+			isOption := false
+			for _, r := range name {
+				isFlag = isFlag && model.IsAlphaNumeric(r)
+				isOption = isOption || r == '='
+			}
+
+			if len(name) > 0 {
+				if isFlag {
+					for _, r := range name {
+						flags = append(flags, string(r))
+					}
+				}
+				if !isOption && len(name) > 1 {
+					flags = append(flags, name)
+				}
+			}
+		}
+	}
+	return
+}
+
+// ResolveExecArgsOptions resolves the arguments options of the event
+func (ev *Event) ResolveExecArgsOptions(e *model.ExecEvent) (options []string) {
+	args := ev.ProcessContext.ArgsArray
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if len(arg) > 1 && arg[0] == '-' {
+			name := arg[1:]
+			if len(name) >= 1 && name[0] == '-' {
+				name = name[1:]
+			}
+			if len(name) > 0 && model.IsAlphaNumeric(rune(name[0])) {
+				if index := strings.IndexRune(name, '='); index == -1 {
+					if i < len(args)-1 && args[i+1][0] != '-' {
+						options = append(options, name+"="+args[i+1])
+						i++
+					}
+				} else {
+					options = append(options, name)
+				}
+			}
+		}
+	}
+	return
+}
+
 // ResolveExecEnvs resolves the envs of the event
 func (ev *Event) ResolveExecEnvs(e *model.ExecEvent) []string {
 	if len(ev.Exec.Envs) == 0 && len(ev.ProcessContext.EnvsArray) > 0 {

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -9,8 +9,10 @@ package probe
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/security/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
@@ -72,5 +74,107 @@ func TestSetFieldValue(t *testing.T) {
 		default:
 			t.Fatalf("type unknown: %v", kind)
 		}
+	}
+}
+
+func TestExecArgsFlags(t *testing.T) {
+	e := Event{
+		Event: model.Event{
+			ProcessContext: model.ProcessContext{
+				Process: model.Process{
+					ArgsArray: []string{
+						"-abc", "--verbose", "test",
+						"-v=1", "--host=myhost",
+						"-9", "-", "--",
+					},
+				},
+			},
+			Exec: model.ExecEvent{},
+		},
+	}
+
+	flags := e.ResolveExecArgsFlags(&e.Exec)
+	sort.Sort(sort.StringSlice(flags))
+
+	hasFlag := func(flags []string, flag string) bool {
+		i := sort.SearchStrings(flags, flag)
+		return i < len(flags) && flags[i] == flag
+	}
+
+	if !hasFlag(flags, "a") {
+		t.Error("flags 'a' not found")
+	}
+
+	if !hasFlag(flags, "b") {
+		t.Error("flags 'b' not found")
+	}
+
+	if hasFlag(flags, "v") {
+		t.Error("flags 'v' found")
+	}
+
+	if !hasFlag(flags, "9") {
+		t.Error("flags '9' not found found")
+	}
+
+	if !hasFlag(flags, "abc") {
+		t.Error("flags 'abc' not found")
+	}
+
+	if !hasFlag(flags, "verbose") {
+		t.Error("flags 'verbose' not found")
+	}
+
+	if len(flags) != 6 {
+		t.Errorf("expected 6 flags, got %d", len(flags))
+	}
+}
+
+func TestExecArgsOptions(t *testing.T) {
+	e := Event{
+		Event: model.Event{
+			ProcessContext: model.ProcessContext{
+				Process: model.Process{
+					ArgsArray: []string{
+						"--config", "/etc/myfile", "--host=myhost", "--verbose",
+						"-c", "/etc/myfile", "-h=myhost", "-v",
+						"--", "---", "-9",
+					},
+				},
+			},
+			Exec: model.ExecEvent{},
+		},
+	}
+
+	options := e.ResolveExecArgsOptions(&e.Exec)
+	sort.Sort(sort.StringSlice(options))
+
+	hasOption := func(options []string, option string) bool {
+		i := sort.SearchStrings(options, option)
+		return i < len(options) && options[i] == option
+	}
+
+	if !hasOption(options, "config=/etc/myfile") {
+		t.Error("option 'config=/etc/myfile' not found")
+	}
+
+	if !hasOption(options, "c=/etc/myfile") {
+		t.Error("option 'c=/etc/myfile' not found")
+	}
+
+	if !hasOption(options, "host=myhost") {
+		t.Error("option 'host=myhost' not found")
+	}
+
+	if !hasOption(options, "h=myhost") {
+		t.Error("option 'h=myhost' not found")
+	}
+
+	if hasOption(options, "verbose=") {
+		t.Error("option 'verbose=' found")
+	}
+
+	if len(options) != 4 {
+		t.Errorf("expected 4 options, got %d", len(options))
 	}
 }

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -262,7 +262,7 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 							module.EventTypes[event] = true
 							delete(dejavu, fieldName)
 
-							continue FIELD
+							continue
 						}
 
 						dejavu[fieldName] = true

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -32,7 +33,6 @@ import (
 	"github.com/pkg/errors"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/module"
@@ -262,10 +262,10 @@ func assertFieldEqual(t *testing.T, e *probe.Event, field string, value interfac
 	}
 }
 
-func setTestConfig(dir string, opts testOpts) error {
+func setTestConfig(dir string, opts testOpts) (string, error) {
 	tmpl, err := template.New("test-config").Parse(testConfig)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if opts.eventsCountThreshold == 0 {
@@ -279,11 +279,17 @@ func setTestConfig(dir string, opts testOpts) error {
 		"DisableDiscarders":    opts.disableDiscarders,
 		"EventsCountThreshold": opts.eventsCountThreshold,
 	}); err != nil {
-		return err
+		return "", err
 	}
 
-	aconfig.Datadog.SetConfigType("yaml")
-	return aconfig.Datadog.ReadConfig(buffer)
+	sysprobeConfig, err := os.Create(path.Join(opts.testDir, "system-probe.yaml"))
+	if err != nil {
+		return "", err
+	}
+	defer sysprobeConfig.Close()
+
+	_, err = io.Copy(sysprobeConfig, buffer)
+	return sysprobeConfig.Name(), err
 }
 
 func setTestPolicy(dir string, macros []*rules.MacroDefinition, rules []*rules.RuleDefinition) (string, error) {
@@ -333,7 +339,8 @@ func newTestModule(macros []*rules.MacroDefinition, rules []*rules.RuleDefinitio
 		return nil, err
 	}
 
-	if err := setTestConfig(st.root, opts); err != nil {
+	sysprobeConfig, err := setTestConfig(st.root, opts)
+	if err != nil {
 		return nil, err
 	}
 
@@ -352,7 +359,7 @@ func newTestModule(macros []*rules.MacroDefinition, rules []*rules.RuleDefinitio
 		testMod.cleanup()
 	}
 
-	agentConfig, err := sysconfig.New("")
+	agentConfig, err := sysconfig.New(sysprobeConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create config")
 	}

--- a/releasenotes/notes/runtime-security-args-helpers-3365494428bd4033.yaml
+++ b/releasenotes/notes/runtime-security-args-helpers-3365494428bd4033.yaml
@@ -1,0 +1,15 @@
+---
+features:
+  - |
+    The `args_flags` and `args_options` were added to the SECL
+    language to ease the writing of runtime security rules based
+    on command line arguments.
+    `args_flags` is used to catch arguments that start by either one
+    or two hyphen characters but do not accept any associated value.
+
+    Examples:
+
+    - `version` is part of `args_flags` for the command `cat --version`
+    - `l` and `n` both are in `args_flags` for the command `netstat -ln`
+    - `T=8` and `width=8` both are in `args_options` for the command
+      `ls -T 8 --width=8`.


### PR DESCRIPTION
### What does this PR do?

Add SECL helpers to parse command line arguments

### Motivation

Handling command line arguments using regular expression can be pretty hard
as arguments sometimes accepts an argument, sometimes not. This can argument can
be specified using '=' or specified as the next argument. To ease the writing of runtime
security rules on command line arguments, 2 helpers (`args_flags` and `args_options` helpers
are added by this PR)
