### PR TITLE
[runtime-security] delay mount point deletion from cache

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "7db0e7a0394d1eae73cea262b915e578d325781b2a4699f671002ef67ca3465d")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "eeb6a29f7acf5b37b45434394ed8c8ba1d05299064ca79e3b6b15707fe76f8ce")

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -10,13 +10,13 @@ struct mount_event_t {
     struct process_context_t process;
     struct container_context_t container;
     struct syscall_t syscall;
-    int mount_id;
-    int group_id;
+    u32 mount_id;
+    u32 group_id;
     dev_t device;
-    int parent_mount_id;
+    u32 parent_mount_id;
     unsigned long parent_ino;
     unsigned long root_ino;
-    int root_mount_id;
+    u32 root_mount_id;
     u32 padding;
     char fstype[FSTYPE_LEN];
 };

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -8,8 +8,7 @@ struct umount_event_t {
     struct process_context_t process;
     struct container_context_t container;
     struct syscall_t syscall;
-    int mount_id;
-    u32 discarder_revision;
+    u32 mount_id;
 };
 
 SYSCALL_KPROBE0(umount) {
@@ -38,14 +37,15 @@ SYSCALL_KRETPROBE(umount) {
 
     struct umount_event_t event = {
         .syscall .retval = PT_REGS_RC(ctx),
-        .mount_id = mount_id,
-        .discarder_revision = bump_discarder_revision(mount_id),
+        .mount_id = mount_id
     };
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
 
     send_event(ctx, EVENT_UMOUNT, event);
+
+    umounted(ctx, mount_id);
 
     return 0;
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -286,6 +286,9 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/io_openat2"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kretprobe/io_openat2"}},
 		}},
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/filp_close"}},
+		}},
 	},
 
 	// List of probes to activate to capture removexattr events

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -33,6 +33,10 @@ var openProbes = []*manager.Probe{
 		UID:     SecurityAgentUID,
 		Section: "kretprobe/io_openat2",
 	},
+	{
+		UID:     SecurityAgentUID,
+		Section: "kprobe/filp_close",
+	},
 }
 
 func getOpenProbes() []*manager.Probe {

--- a/pkg/security/model/events.go
+++ b/pkg/security/model/events.go
@@ -55,6 +55,8 @@ const (
 	CapsetEventType
 	// ArgsEnvsEventType args and envs event
 	ArgsEnvsEventType
+	// MountReleasedEventType sent when a mount point is released
+	MountReleasedEventType
 	// MaxEventType is used internally to get the maximum number of kernel events.
 	MaxEventType
 
@@ -124,6 +126,8 @@ func (t EventType) String() string {
 		return "capset"
 	case ArgsEnvsEventType:
 		return "args_envs"
+	case MountReleasedEventType:
+		return "mount_released"
 
 	case CustomLostReadEventType:
 		return "lost_events_read"

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -136,6 +136,7 @@ type Event struct {
 	Umount           UmountEvent           `field:"-"`
 	InvalidateDentry InvalidateDentryEvent `field:"-"`
 	ArgsEnvs         ArgsEnvsEvent         `field:"-"`
+	MountReleased    MountReleasedEvent    `field:"-"`
 }
 
 // GetType returns the event type
@@ -317,6 +318,12 @@ type InvalidateDentryEvent struct {
 	DiscarderRevision uint32
 }
 
+// MountReleasedEvent defines a mount released event
+type MountReleasedEvent struct {
+	MountID           uint32
+	DiscarderRevision uint32
+}
+
 // LinkEvent represents a link event
 type LinkEvent struct {
 	SyscallEvent
@@ -478,8 +485,7 @@ type UnlinkEvent struct {
 // UmountEvent represents an umount event
 type UmountEvent struct {
 	SyscallEvent
-	MountID           uint32
-	DiscarderRevision uint32 `field:"-"`
+	MountID uint32
 }
 
 // UtimesEvent represents a utime event

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -405,12 +405,11 @@ func (e *UmountEvent) UnmarshalBinary(data []byte) (int, error) {
 	}
 
 	data = data[n:]
-	if len(data) < 8 {
+	if len(data) < 4 {
 		return 0, ErrNotEnoughData
 	}
 
 	e.MountID = ByteOrder.Uint32(data[0:4])
-	e.DiscarderRevision = ByteOrder.Uint32(data[4:8])
 
 	return 8, nil
 }
@@ -467,4 +466,16 @@ func UnmarshalBinary(data []byte, binaryUnmarshalers ...BinaryUnmarshaler) (int,
 		}
 	}
 	return read, nil
+}
+
+// UnmarshalBinary unmarshals a binary representation of itself
+func (e *MountReleasedEvent) UnmarshalBinary(data []byte) (int, error) {
+	if len(data) < 8 {
+		return 0, ErrNotEnoughData
+	}
+
+	e.MountID = ByteOrder.Uint32(data[0:4])
+	e.DiscarderRevision = ByteOrder.Uint32(data[4:8])
+
+	return 8, nil
 }

--- a/pkg/security/probe/mount_test.go
+++ b/pkg/security/probe/mount_test.go
@@ -9,6 +9,7 @@ package probe
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/model"
 	"github.com/stretchr/testify/assert"
@@ -334,6 +335,9 @@ func TestMountResolver(t *testing.T) {
 					}
 				}
 			}
+
+			mr.dequeue(time.Now().Add(1 * time.Minute))
+
 			for _, testC := range tt.args.cases {
 				cp, p, _, err := mr.GetMountPath(testC.mountID)
 				if err != nil {

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -195,6 +195,7 @@ func (r *Resolvers) Start(ctx context.Context) error {
 	if err := r.ProcessResolver.Start(ctx); err != nil {
 		return err
 	}
+	r.MountResolver.Start(ctx)
 
 	return r.DentryResolver.Start()
 }


### PR DESCRIPTION
### What does this PR do?

A delay before removing a mount point from the user cache, to handle reordering potential issues. It also introduces a new mechanism to remove mount points which relies on FD as mount references. A mount released event is emitted where there is no more FD opened for a mount point.

### Motivation

Avoid error in mount point resolution.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
