### PR TITLE
pkg/trace/api: Disable stats endpoint

### DIFF
--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -567,6 +567,7 @@ func (m *mockStatsProcessor) Got() (p pb.ClientStatsPayload, lang, tracerVersion
 }
 
 func TestHandleStats(t *testing.T) {
+	t.Skip("temporarily disabled")
 	bucket := func(start, duration uint64) pb.ClientStatsBucket {
 		return pb.ClientStatsBucket{
 			Start:    start,

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -70,6 +70,7 @@ var endpoints = []endpoint{
 	{
 		Pattern: "/v0.5/stats",
 		Handler: func(r *HTTPReceiver) http.Handler { return http.HandlerFunc(r.handleStats) },
+		Hidden:  true,
 	},
 	{
 		Pattern: "/profiling/v1/input",

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -68,11 +68,6 @@ var endpoints = []endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return r.handleWithVersion(v05, r.handleTraces) },
 	},
 	{
-		Pattern: "/v0.5/stats",
-		Handler: func(r *HTTPReceiver) http.Handler { return http.HandlerFunc(r.handleStats) },
-		Hidden:  true,
-	},
-	{
 		Pattern: "/profiling/v1/input",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.profileProxyHandler() },
 	},

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -68,7 +68,7 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		BuildDate:     info.BuildDate,
 		Endpoints:     all,
 		FeatureFlags:  config.Features(),
-		ClientDropP0s: true,
+		ClientDropP0s: false,
 		Config: reducedConfig{
 			DefaultEnv:             r.conf.DefaultEnv,
 			TargetTPS:              r.conf.TargetTPS,

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -117,13 +117,12 @@ func TestInfoHandler(t *testing.T) {
 		"/v0.4/traces",
 		"/v0.4/services",
 		"/v0.5/traces",
-		"/v0.5/stats",
 		"/profiling/v1/input"
 	],
 	"feature_flags": [
 		"feature_flag"
 	],
-	"client_drop_p0s": true,
+	"client_drop_p0s": false,
 	"config": {
 		"default_env": "prod",
 		"target_tps": 11,

--- a/pkg/trace/test/testsuite/stats_test.go
+++ b/pkg/trace/test/testsuite/stats_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestClientStats(t *testing.T) {
+	t.Skip()
 	var r test.Runner
 	if err := r.Start(); err != nil {
 		t.Fatal(err)

--- a/pkg/trace/test/testsuite/stats_test.go
+++ b/pkg/trace/test/testsuite/stats_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestClientStats(t *testing.T) {
-	t.Skip()
+	t.Skip("temporarily disabled")
 	var r test.Runner
 	if err := r.Start(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Hide stats endpoint. To avoid it being used until an aggregation layer is added (stats from different tracers must be aggregated into 1 payload).