### PR TITLE
pkg/trace/obfuscate: add support for Postgres dollar-quoted strings

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -106,7 +106,7 @@ func (f *replaceFilter) Filter(token, lastToken TokenKind, buffer []byte) (token
 		}
 	}
 	switch token {
-	case String, Number, Null, Variable, PreparedStatement, BooleanLiteral, EscapeSequence:
+	case DollarQuotedString, String, Number, Null, Variable, PreparedStatement, BooleanLiteral, EscapeSequence:
 		return markFilteredGroupable(token), questionMark, nil
 	case '?':
 		// Cases like 'ARRAY [ ?, ? ]' should be collapsed into 'ARRAY [ ? ]'

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -39,6 +39,7 @@ const (
 	Null
 	String
 	DoubleQuotedString
+	DollarQuotedString // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
 	Number
 	BooleanLiteral
 	ValueArg
@@ -295,7 +296,13 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 			// modulo operator (e.g. 'id % 8')
 			return TokenKind(ch), tkn.bytes()
 		case '$':
-			return tkn.scanPreparedStatement('$')
+			if isDigit(tkn.lastChar) {
+				// TODO(gbbr): the first digit after $ does not necessarily guarantee
+				// that this isn't a dollar-quoted string constant. We might eventually
+				// want to cover for this use-case too (e.g. $1$some text$1$).
+				return tkn.scanPreparedStatement('$')
+			}
+			return tkn.scanDollarQuotedString()
 		case '{':
 			if tkn.pos == 1 || tkn.curlys > 0 {
 				// Do not fully obfuscate top-level SQL escape sequences like {{[?=]call procedure-name[([parameter][,parameter]...)]}.
@@ -420,6 +427,43 @@ func (tkn *SQLTokenizer) scanVariableIdentifier(prefix rune) (TokenKind, []byte)
 func (tkn *SQLTokenizer) scanFormatParameter(prefix rune) (TokenKind, []byte) {
 	tkn.advance()
 	return Variable, tkn.bytes()
+}
+
+// scanDollarQuotedString scans a Postgres dollar-quoted string constant.
+// See: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
+func (tkn *SQLTokenizer) scanDollarQuotedString() (TokenKind, []byte) {
+	kind, tag := tkn.scanString('$', String)
+	if kind == LexError {
+		return kind, tkn.bytes()
+	}
+	var (
+		got int
+		buf bytes.Buffer
+	)
+	delim := string(tag)
+	if delim != "$$" {
+		delim = "$" + delim + "$"
+	}
+	for {
+		ch := tkn.lastChar
+		tkn.advance()
+		if ch == EndChar {
+			tkn.setErr("unexpected EOF in dollar-quoted string")
+			return LexError, buf.Bytes()
+		}
+		if byte(ch) == delim[got] {
+			got++
+			if got == len(delim) {
+				break
+			}
+			continue
+		}
+		if got > 0 {
+			got = 0
+		}
+		buf.WriteRune(ch)
+	}
+	return DollarQuotedString, buf.Bytes()
 }
 
 func (tkn *SQLTokenizer) scanPreparedStatement(prefix rune) (TokenKind, []byte) {

--- a/releasenotes/notes/apm-obfuscate-dollar-quoted-string-debf32e6ed769431.yaml
+++ b/releasenotes/notes/apm-obfuscate-dollar-quoted-string-debf32e6ed769431.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Add obfuscator support for Postgres dollar-quoted string constants.


### PR DESCRIPTION
This change adds support for a previously unsupported Postgres features.
See https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING