### PR TITLE
[runtime-security] remove seelog dependency from secl/rules packages

### DIFF
--- a/pkg/security/log/logger.go
+++ b/pkg/security/log/logger.go
@@ -22,6 +22,11 @@ func (l DatadogAgentLogger) Debugf(format string, params ...interface{}) {
 }
 
 // Errorf is used to print an error
-func (l DatadogAgentLogger) Errorf(format string, params ...interface{}) error {
-	return log.Errorf(format, params...)
+func (l DatadogAgentLogger) Errorf(format string, params ...interface{}) {
+	_ = log.Errorf(format, params...)
+}
+
+// Infof is used to print an error
+func (l DatadogAgentLogger) Infof(format string, params ...interface{}) {
+	log.Infof(format, params...)
 }

--- a/pkg/security/rules/logger.go
+++ b/pkg/security/rules/logger.go
@@ -5,33 +5,33 @@
 
 package rules
 
-import log "github.com/cihub/seelog"
-
 // Logger interface used to remove the dependency of this package to the logger of the agent
 type Logger interface {
+	// Infof is used to print a info level log
+	Infof(format string, params ...interface{})
 	// Tracef is used to print a trace level log
 	Tracef(format string, params ...interface{})
 	// Debugf is used to print a trace level log
 	Debugf(format string, params ...interface{})
 	// Errorf is used to print an error
-	Errorf(format string, params ...interface{}) error
+	Errorf(format string, params ...interface{})
 }
 
-// DefaultLogger is a wrapper for the agent logger that we use to prevent a dependency on packages that we cannot
-// import outside of the agent repository
-type DefaultLogger struct{}
+// NullLogger is a default implementation of the Logger interface
+type NullLogger struct{}
 
 // Tracef is used to print a trace level log
-func (l DefaultLogger) Tracef(format string, params ...interface{}) {
-	log.Tracef(format, params...)
+func (l NullLogger) Tracef(format string, params ...interface{}) {
 }
 
 // Debugf is used to print a trace level log
-func (l DefaultLogger) Debugf(format string, params ...interface{}) {
-	log.Debugf(format, params...)
+func (l NullLogger) Debugf(format string, params ...interface{}) {
 }
 
 // Errorf is used to print an error
-func (l DefaultLogger) Errorf(format string, params ...interface{}) error {
-	return log.Errorf(format, params...)
+func (l NullLogger) Errorf(format string, params ...interface{}) {
+}
+
+// Infof is used to print an info
+func (l NullLogger) Infof(format string, params ...interface{}) {
 }

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -80,7 +80,7 @@ type Opts struct {
 // NewOptsWithParams initializes a new Opts instance with Debug and Constants parameters
 func NewOptsWithParams(constants map[string]interface{}, supportedDiscarders map[eval.Field]bool, eventTypeEnabled map[eval.EventType]bool, reservedRuleIDs []RuleID, legacyAttributes map[eval.Field]eval.Field, logger ...Logger) *Opts {
 	if len(logger) == 0 {
-		logger = []Logger{DefaultLogger{}}
+		logger = []Logger{NullLogger{}}
 	}
 	return &Opts{
 		Opts: eval.Opts{


### PR DESCRIPTION
### What does this PR do?

Removes seelog dependency from secl/rules packages so that they can be used outside of the agent.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
