### PR TITLE
[backport to 7.26.x] Use Sonatype for `jmxfetch` artifact download endpoint

### DIFF
--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -15,7 +15,7 @@ end
 default_version jmxfetch_version
 source sha256: jmxfetch_hash
 
-source url: "https://dl.bintray.com/datadog/datadog-maven/com/datadoghq/jmxfetch/#{version}/jmxfetch-#{version}-jar-with-dependencies.jar",
+source url: "https://oss.sonatype.org/service/local/repositories/releases/content/com/datadoghq/jmxfetch/#{version}/jmxfetch-#{version}-jar-with-dependencies.jar",
        target_filename: "jmxfetch.jar"
 
 


### PR DESCRIPTION
Since our jmxfetch artifacts no longer get pushed to bintray, we are switching
to Sonatype as the source for this artifact.

### Motivation

Bintray shutting down

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- Run jmxfetch check
- Ensure that it works
