### PR TITLE
Update datadopy used in tests

### DIFF
--- a/test/integration/dogstatsd/testdata/origin_detection/Dockerfile
+++ b/test/integration/dogstatsd/testdata/origin_detection/Dockerfile
@@ -1,8 +1,7 @@
 FROM datadog/docker-library:python_2_7-alpine3_6
 
 # datadog-py has no release with UDS support yet, using a commit hash
-RUN pip install --no-cache-dir https://github.com/DataDog/datadogpy/archive/8b19b0b6e2d5e898dc05800f8257430b68156471.zip
-
+RUN pip install --no-cache-dir https://github.com/DataDog/datadogpy/archive/af1c23bf9cd187208d336f4a1468535f06f43acd.zip
 COPY sender.py /sender.py
 
 CMD [ "python", "/sender.py" ]


### PR DESCRIPTION
We need to not use the broken decorator release.