### PR TITLE
[procutil] return Probe object on NewProcessProbe in unsupported environment

### DIFF
--- a/pkg/process/procutil/process_unsupported.go
+++ b/pkg/process/procutil/process_unsupported.go
@@ -26,9 +26,9 @@ func WithPermission(enabled bool) Option {
 	}
 }
 
-// NewProcessProbe is currently not implemented in non-linux environments
+// NewProcessProbe returns a Probe object
 func NewProcessProbe(options ...Option) *Probe {
-	return nil
+	return &Probe{}
 }
 
 // Probe is an unimplemented struct for unsupported platforms


### PR DESCRIPTION
### What does this PR do?

This is a bug that caused process-agent in Windows to crash on nil pointer error.

@DataDog/processes 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
