### PR TITLE
[runtime-security] Add file.rights SECL helper

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -259,6 +259,7 @@ core,"github.com/emicklei/go-restful-swagger12",MIT
 core,"github.com/emicklei/go-restful/log",MIT
 core,"github.com/evanphx/json-patch",NewBSD
 core,"github.com/fatih/color",MIT
+core,"github.com/fatih/structtag",NewBSD
 core,"github.com/florianl/go-conntrack",MIT
 core,"github.com/florianl/go-conntrack/internal/unix",MIT
 core,"github.com/florianl/go-tc",MIT

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/elastic/go-libaudit v0.4.0
 	github.com/emicklei/go-restful-swagger12 v0.0.0-20170926063155-7524189396c6 // indirect
 	github.com/fatih/color v1.9.0
+	github.com/fatih/structtag v1.2.0
 	github.com/florianl/go-conntrack v0.1.1-0.20191002182014-06743d3a59db
 	github.com/frapposelli/wwhrd v0.2.4
 	github.com/freddierice/go-losetup v0.0.0-20170407175016-fc9adea44124

--- a/go.sum
+++ b/go.sum
@@ -455,6 +455,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
+github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/florianl/go-conntrack v0.2.0 h1:JEB4w895ZX35tvNH5JjNM9pxa+Qn73paiA37VeCZGfc=
 github.com/florianl/go-conntrack v0.2.0/go.mod h1:HRSlXmrl5M//9hiHmkwyLDwlaoba2sVDcBpHFRiVo1Q=
 github.com/florianl/go-tc v0.2.0 h1:k3Dr3rtmMP2KCRlWgRUC6XKBZA5lL9rNBAr80H50/6k=

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d0e6cd67665fd50af85617a95ddbf876d4943cecaf82c02c4f4a71aa48022d69")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "034db82b19db09d1dcf23e15b064ffa7d761442ae6d7ca3321cb4d878be97997")

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -27,7 +27,7 @@ int __attribute__((always_inline)) trace__sys_chmod(umode_t mode) {
         .type = SYSCALL_CHMOD,
         .policy = policy,
         .setattr = {
-            .mode = mode
+            .mode = mode & S_IALLUGO,
         }
     };
 

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -36,7 +36,7 @@ int __attribute__((always_inline)) trace__sys_openat(int flags, umode_t mode) {
         .policy = policy,
         .open = {
             .flags = flags,
-            .mode = mode,
+            .mode = mode & S_IALLUGO,
         }
     };
 

--- a/pkg/security/model/accessors.go
+++ b/pkg/security/model/accessors.go
@@ -109,6 +109,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "chmod.file.destination.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.Mode)
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "chmod.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -202,6 +213,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Chmod.File.PathnameStr
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.Mode)
 			},
 			Field: field,
 
@@ -389,6 +411,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Chown.File.PathnameStr
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.Mode)
 			},
 			Field: field,
 
@@ -671,6 +704,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "exec.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.Process.FileFields.Mode)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "exec.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -924,6 +968,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.destination.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.Mode)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.file.destination.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1045,6 +1100,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.Mode)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1090,6 +1156,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 
 	case "mkdir.file.destination.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.Mode)
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.destination.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -1193,6 +1270,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Mkdir.File.PathnameStr
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.Mode)
 			},
 			Field: field,
 
@@ -1347,6 +1435,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Open.File.PathnameStr
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "open.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.Mode)
 			},
 			Field: field,
 
@@ -1827,6 +1926,32 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*ProcessCacheEntry)(value)
 
 					result = element.ProcessContext.Process.PathnameStr
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.rights":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				var results []int
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result int
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = int(element.ProcessContext.Process.FileFields.Mode)
 
 					results = append(results, result)
 
@@ -2416,6 +2541,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "process.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.Mode)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "process.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2702,6 +2838,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "removexattr.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.Mode)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "removexattr.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2856,6 +3003,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "rename.file.destination.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.Mode)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "rename.file.destination.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2971,6 +3129,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Rename.Old.PathnameStr
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.Mode)
 			},
 			Field: field,
 
@@ -3114,6 +3283,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Rmdir.File.PathnameStr
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.Mode)
 			},
 			Field: field,
 
@@ -3417,6 +3597,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "setxattr.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.Mode)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "setxattr.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3554,6 +3745,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Unlink.File.PathnameStr
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "unlink.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.Mode)
 			},
 			Field: field,
 
@@ -3703,6 +3905,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "utimes.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.Mode)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "utimes.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3752,6 +3965,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"chmod.file.destination.mode",
 
+		"chmod.file.destination.rights",
+
 		"chmod.file.filesystem",
 
 		"chmod.file.gid",
@@ -3769,6 +3984,8 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.name",
 
 		"chmod.file.path",
+
+		"chmod.file.rights",
 
 		"chmod.file.uid",
 
@@ -3803,6 +4020,8 @@ func (e *Event) GetFields() []eval.Field {
 		"chown.file.name",
 
 		"chown.file.path",
+
+		"chown.file.rights",
 
 		"chown.file.uid",
 
@@ -3854,6 +4073,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.file.path",
 
+		"exec.file.rights",
+
 		"exec.file.uid",
 
 		"exec.file.user",
@@ -3900,6 +4121,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.destination.path",
 
+		"link.file.destination.rights",
+
 		"link.file.destination.uid",
 
 		"link.file.destination.user",
@@ -3922,6 +4145,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.path",
 
+		"link.file.rights",
+
 		"link.file.uid",
 
 		"link.file.user",
@@ -3931,6 +4156,8 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.container_path",
 
 		"mkdir.file.destination.mode",
+
+		"mkdir.file.destination.rights",
 
 		"mkdir.file.filesystem",
 
@@ -3949,6 +4176,8 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.name",
 
 		"mkdir.file.path",
+
+		"mkdir.file.rights",
 
 		"mkdir.file.uid",
 
@@ -3977,6 +4206,8 @@ func (e *Event) GetFields() []eval.Field {
 		"open.file.name",
 
 		"open.file.path",
+
+		"open.file.rights",
 
 		"open.file.uid",
 
@@ -4019,6 +4250,8 @@ func (e *Event) GetFields() []eval.Field {
 		"process.ancestors.file.name",
 
 		"process.ancestors.file.path",
+
+		"process.ancestors.file.rights",
 
 		"process.ancestors.file.uid",
 
@@ -4084,6 +4317,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.file.path",
 
+		"process.file.rights",
+
 		"process.file.uid",
 
 		"process.file.user",
@@ -4136,6 +4371,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"removexattr.file.path",
 
+		"removexattr.file.rights",
+
 		"removexattr.file.uid",
 
 		"removexattr.file.user",
@@ -4164,6 +4401,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.file.destination.path",
 
+		"rename.file.destination.rights",
+
 		"rename.file.destination.uid",
 
 		"rename.file.destination.user",
@@ -4185,6 +4424,8 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.name",
 
 		"rename.file.path",
+
+		"rename.file.rights",
 
 		"rename.file.uid",
 
@@ -4211,6 +4452,8 @@ func (e *Event) GetFields() []eval.Field {
 		"rmdir.file.name",
 
 		"rmdir.file.path",
+
+		"rmdir.file.rights",
 
 		"rmdir.file.uid",
 
@@ -4266,6 +4509,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setxattr.file.path",
 
+		"setxattr.file.rights",
+
 		"setxattr.file.uid",
 
 		"setxattr.file.user",
@@ -4291,6 +4536,8 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.name",
 
 		"unlink.file.path",
+
+		"unlink.file.rights",
 
 		"unlink.file.uid",
 
@@ -4318,6 +4565,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"utimes.file.path",
 
+		"utimes.file.rights",
+
 		"utimes.file.uid",
 
 		"utimes.file.user",
@@ -4342,6 +4591,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Chmod.File.ContainerPath, nil
 
 	case "chmod.file.destination.mode":
+
+		return int(e.Chmod.Mode), nil
+
+	case "chmod.file.destination.rights":
 
 		return int(e.Chmod.Mode), nil
 
@@ -4380,6 +4633,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.file.path":
 
 		return e.Chmod.File.PathnameStr, nil
+
+	case "chmod.file.rights":
+
+		return int(e.Chmod.File.FileFields.Mode), nil
 
 	case "chmod.file.uid":
 
@@ -4448,6 +4705,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chown.file.path":
 
 		return e.Chown.File.PathnameStr, nil
+
+	case "chown.file.rights":
+
+		return int(e.Chown.File.FileFields.Mode), nil
 
 	case "chown.file.uid":
 
@@ -4549,6 +4810,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Exec.Process.PathnameStr, nil
 
+	case "exec.file.rights":
+
+		return int(e.Exec.Process.FileFields.Mode), nil
+
 	case "exec.file.uid":
 
 		return int(e.Exec.Process.FileFields.UID), nil
@@ -4641,6 +4906,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Link.Target.PathnameStr, nil
 
+	case "link.file.destination.rights":
+
+		return int(e.Link.Target.FileFields.Mode), nil
+
 	case "link.file.destination.uid":
 
 		return int(e.Link.Target.FileFields.UID), nil
@@ -4685,6 +4954,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Link.Source.PathnameStr, nil
 
+	case "link.file.rights":
+
+		return int(e.Link.Source.FileFields.Mode), nil
+
 	case "link.file.uid":
 
 		return int(e.Link.Source.FileFields.UID), nil
@@ -4702,6 +4975,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.Mkdir.File.ContainerPath, nil
 
 	case "mkdir.file.destination.mode":
+
+		return int(e.Mkdir.Mode), nil
+
+	case "mkdir.file.destination.rights":
 
 		return int(e.Mkdir.Mode), nil
 
@@ -4740,6 +5017,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mkdir.file.path":
 
 		return e.Mkdir.File.PathnameStr, nil
+
+	case "mkdir.file.rights":
+
+		return int(e.Mkdir.File.FileFields.Mode), nil
 
 	case "mkdir.file.uid":
 
@@ -4796,6 +5077,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "open.file.path":
 
 		return e.Open.File.PathnameStr, nil
+
+	case "open.file.rights":
+
+		return int(e.Open.File.FileFields.Mode), nil
 
 	case "open.file.uid":
 
@@ -5179,6 +5464,28 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*ProcessCacheEntry)(ptr)
 
 			result := element.ProcessContext.Process.PathnameStr
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.rights":
+
+		var values []int
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.Process.FileFields.Mode)
 
 			values = append(values, result)
 
@@ -5585,6 +5892,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ProcessContext.Process.PathnameStr, nil
 
+	case "process.file.rights":
+
+		return int(e.ProcessContext.Process.FileFields.Mode), nil
+
 	case "process.file.uid":
 
 		return int(e.ProcessContext.Process.FileFields.UID), nil
@@ -5689,6 +6000,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.RemoveXAttr.File.PathnameStr, nil
 
+	case "removexattr.file.rights":
+
+		return int(e.RemoveXAttr.File.FileFields.Mode), nil
+
 	case "removexattr.file.uid":
 
 		return int(e.RemoveXAttr.File.FileFields.UID), nil
@@ -5745,6 +6060,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Rename.New.PathnameStr, nil
 
+	case "rename.file.destination.rights":
+
+		return int(e.Rename.New.FileFields.Mode), nil
+
 	case "rename.file.destination.uid":
 
 		return int(e.Rename.New.FileFields.UID), nil
@@ -5788,6 +6107,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.path":
 
 		return e.Rename.Old.PathnameStr, nil
+
+	case "rename.file.rights":
+
+		return int(e.Rename.Old.FileFields.Mode), nil
 
 	case "rename.file.uid":
 
@@ -5840,6 +6163,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rmdir.file.path":
 
 		return e.Rmdir.File.PathnameStr, nil
+
+	case "rmdir.file.rights":
+
+		return int(e.Rmdir.File.FileFields.Mode), nil
 
 	case "rmdir.file.uid":
 
@@ -5949,6 +6276,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.SetXAttr.File.PathnameStr, nil
 
+	case "setxattr.file.rights":
+
+		return int(e.SetXAttr.File.FileFields.Mode), nil
+
 	case "setxattr.file.uid":
 
 		return int(e.SetXAttr.File.FileFields.UID), nil
@@ -6000,6 +6331,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.file.path":
 
 		return e.Unlink.File.PathnameStr, nil
+
+	case "unlink.file.rights":
+
+		return int(e.Unlink.File.FileFields.Mode), nil
 
 	case "unlink.file.uid":
 
@@ -6053,6 +6388,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Utimes.File.PathnameStr, nil
 
+	case "utimes.file.rights":
+
+		return int(e.Utimes.File.FileFields.Mode), nil
+
 	case "utimes.file.uid":
 
 		return int(e.Utimes.File.FileFields.UID), nil
@@ -6085,6 +6424,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "chmod.file.destination.mode":
 		return "chmod", nil
 
+	case "chmod.file.destination.rights":
+		return "chmod", nil
+
 	case "chmod.file.filesystem":
 		return "chmod", nil
 
@@ -6110,6 +6452,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chmod", nil
 
 	case "chmod.file.path":
+		return "chmod", nil
+
+	case "chmod.file.rights":
 		return "chmod", nil
 
 	case "chmod.file.uid":
@@ -6161,6 +6506,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chown", nil
 
 	case "chown.file.path":
+		return "chown", nil
+
+	case "chown.file.rights":
 		return "chown", nil
 
 	case "chown.file.uid":
@@ -6238,6 +6586,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.file.path":
 		return "exec", nil
 
+	case "exec.file.rights":
+		return "exec", nil
+
 	case "exec.file.uid":
 		return "exec", nil
 
@@ -6307,6 +6658,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.destination.path":
 		return "link", nil
 
+	case "link.file.destination.rights":
+		return "link", nil
+
 	case "link.file.destination.uid":
 		return "link", nil
 
@@ -6340,6 +6694,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.path":
 		return "link", nil
 
+	case "link.file.rights":
+		return "link", nil
+
 	case "link.file.uid":
 		return "link", nil
 
@@ -6353,6 +6710,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 
 	case "mkdir.file.destination.mode":
+		return "mkdir", nil
+
+	case "mkdir.file.destination.rights":
 		return "mkdir", nil
 
 	case "mkdir.file.filesystem":
@@ -6380,6 +6740,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 
 	case "mkdir.file.path":
+		return "mkdir", nil
+
+	case "mkdir.file.rights":
 		return "mkdir", nil
 
 	case "mkdir.file.uid":
@@ -6422,6 +6785,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "open", nil
 
 	case "open.file.path":
+		return "open", nil
+
+	case "open.file.rights":
 		return "open", nil
 
 	case "open.file.uid":
@@ -6485,6 +6851,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.file.path":
+		return "*", nil
+
+	case "process.ancestors.file.rights":
 		return "*", nil
 
 	case "process.ancestors.file.uid":
@@ -6583,6 +6952,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.file.path":
 		return "*", nil
 
+	case "process.file.rights":
+		return "*", nil
+
 	case "process.file.uid":
 		return "*", nil
 
@@ -6661,6 +7033,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "removexattr.file.path":
 		return "removexattr", nil
 
+	case "removexattr.file.rights":
+		return "removexattr", nil
+
 	case "removexattr.file.uid":
 		return "removexattr", nil
 
@@ -6703,6 +7078,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.destination.path":
 		return "rename", nil
 
+	case "rename.file.destination.rights":
+		return "rename", nil
+
 	case "rename.file.destination.uid":
 		return "rename", nil
 
@@ -6734,6 +7112,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 
 	case "rename.file.path":
+		return "rename", nil
+
+	case "rename.file.rights":
 		return "rename", nil
 
 	case "rename.file.uid":
@@ -6773,6 +7154,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rmdir", nil
 
 	case "rmdir.file.path":
+		return "rmdir", nil
+
+	case "rmdir.file.rights":
 		return "rmdir", nil
 
 	case "rmdir.file.uid":
@@ -6856,6 +7240,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setxattr.file.path":
 		return "setxattr", nil
 
+	case "setxattr.file.rights":
+		return "setxattr", nil
+
 	case "setxattr.file.uid":
 		return "setxattr", nil
 
@@ -6895,6 +7282,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "unlink.file.path":
 		return "unlink", nil
 
+	case "unlink.file.rights":
+		return "unlink", nil
+
 	case "unlink.file.uid":
 		return "unlink", nil
 
@@ -6932,6 +7322,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "utimes", nil
 
 	case "utimes.file.path":
+		return "utimes", nil
+
+	case "utimes.file.rights":
 		return "utimes", nil
 
 	case "utimes.file.uid":
@@ -6967,6 +7360,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "chmod.file.destination.rights":
+
+		return reflect.Int, nil
+
 	case "chmod.file.filesystem":
 
 		return reflect.String, nil
@@ -7002,6 +7399,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.file.path":
 
 		return reflect.String, nil
+
+	case "chmod.file.rights":
+
+		return reflect.Int, nil
 
 	case "chmod.file.uid":
 
@@ -7070,6 +7471,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chown.file.path":
 
 		return reflect.String, nil
+
+	case "chown.file.rights":
+
+		return reflect.Int, nil
 
 	case "chown.file.uid":
 
@@ -7171,6 +7576,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.file.rights":
+
+		return reflect.Int, nil
+
 	case "exec.file.uid":
 
 		return reflect.Int, nil
@@ -7263,6 +7672,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.destination.rights":
+
+		return reflect.Int, nil
+
 	case "link.file.destination.uid":
 
 		return reflect.Int, nil
@@ -7307,6 +7720,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.rights":
+
+		return reflect.Int, nil
+
 	case "link.file.uid":
 
 		return reflect.Int, nil
@@ -7324,6 +7741,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 
 	case "mkdir.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.destination.rights":
 
 		return reflect.Int, nil
 
@@ -7362,6 +7783,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mkdir.file.path":
 
 		return reflect.String, nil
+
+	case "mkdir.file.rights":
+
+		return reflect.Int, nil
 
 	case "mkdir.file.uid":
 
@@ -7418,6 +7843,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "open.file.path":
 
 		return reflect.String, nil
+
+	case "open.file.rights":
+
+		return reflect.Int, nil
 
 	case "open.file.uid":
 
@@ -7502,6 +7931,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.ancestors.file.path":
 
 		return reflect.String, nil
+
+	case "process.ancestors.file.rights":
+
+		return reflect.Int, nil
 
 	case "process.ancestors.file.uid":
 
@@ -7631,6 +8064,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.file.rights":
+
+		return reflect.Int, nil
+
 	case "process.file.uid":
 
 		return reflect.Int, nil
@@ -7735,6 +8172,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "removexattr.file.rights":
+
+		return reflect.Int, nil
+
 	case "removexattr.file.uid":
 
 		return reflect.Int, nil
@@ -7791,6 +8232,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "rename.file.destination.rights":
+
+		return reflect.Int, nil
+
 	case "rename.file.destination.uid":
 
 		return reflect.Int, nil
@@ -7834,6 +8279,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.path":
 
 		return reflect.String, nil
+
+	case "rename.file.rights":
+
+		return reflect.Int, nil
 
 	case "rename.file.uid":
 
@@ -7886,6 +8335,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rmdir.file.path":
 
 		return reflect.String, nil
+
+	case "rmdir.file.rights":
+
+		return reflect.Int, nil
 
 	case "rmdir.file.uid":
 
@@ -7995,6 +8448,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "setxattr.file.rights":
+
+		return reflect.Int, nil
+
 	case "setxattr.file.uid":
 
 		return reflect.Int, nil
@@ -8047,6 +8504,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "unlink.file.rights":
+
+		return reflect.Int, nil
+
 	case "unlink.file.uid":
 
 		return reflect.Int, nil
@@ -8098,6 +8559,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "utimes.file.path":
 
 		return reflect.String, nil
+
+	case "utimes.file.rights":
+
+		return reflect.Int, nil
 
 	case "utimes.file.uid":
 
@@ -8151,6 +8616,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 
 	case "chmod.file.destination.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.Mode"}
+		}
+		e.Chmod.Mode = uint32(v)
+		return nil
+
+	case "chmod.file.destination.rights":
 
 		var ok bool
 		v, ok := value.(int)
@@ -8250,6 +8725,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chmod.File.PathnameStr = str
 
+		return nil
+
+	case "chmod.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.Mode"}
+		}
+		e.Chmod.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "chmod.file.uid":
@@ -8426,6 +8911,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chown.File.PathnameStr = str
 
+		return nil
+
+	case "chown.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Mode"}
+		}
+		e.Chown.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "chown.file.uid":
@@ -8686,6 +9181,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Mode"}
+		}
+		e.Exec.Process.FileFields.Mode = uint16(v)
+		return nil
+
 	case "exec.file.uid":
 
 		var ok bool
@@ -8926,6 +9431,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.destination.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Mode"}
+		}
+		e.Link.Target.FileFields.Mode = uint16(v)
+		return nil
+
 	case "link.file.destination.uid":
 
 		var ok bool
@@ -9039,6 +9554,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Mode"}
+		}
+		e.Link.Source.FileFields.Mode = uint16(v)
+		return nil
+
 	case "link.file.uid":
 
 		var ok bool
@@ -9082,6 +9607,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 
 	case "mkdir.file.destination.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.Mode"}
+		}
+		e.Mkdir.Mode = uint32(v)
+		return nil
+
+	case "mkdir.file.destination.rights":
 
 		var ok bool
 		v, ok := value.(int)
@@ -9181,6 +9716,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.File.PathnameStr = str
 
+		return nil
+
+	case "mkdir.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.Mode"}
+		}
+		e.Mkdir.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "mkdir.file.uid":
@@ -9325,6 +9870,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Open.File.PathnameStr = str
 
+		return nil
+
+	case "open.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Mode"}
+		}
+		e.Open.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "open.file.uid":
@@ -9612,6 +10167,20 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.PathnameStr = str
 
+		return nil
+
+	case "process.ancestors.file.rights":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
 		return nil
 
 	case "process.ancestors.file.uid":
@@ -10009,6 +10578,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Mode"}
+		}
+		e.ProcessContext.Process.FileFields.Mode = uint16(v)
+		return nil
+
 	case "process.file.uid":
 
 		var ok bool
@@ -10280,6 +10859,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "removexattr.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.Mode"}
+		}
+		e.RemoveXAttr.File.FileFields.Mode = uint16(v)
+		return nil
+
 	case "removexattr.file.uid":
 
 		var ok bool
@@ -10425,6 +11014,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "rename.file.destination.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.Mode"}
+		}
+		e.Rename.New.FileFields.Mode = uint16(v)
+		return nil
+
 	case "rename.file.destination.uid":
 
 		var ok bool
@@ -10536,6 +11135,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rename.Old.PathnameStr = str
 
+		return nil
+
+	case "rename.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.Mode"}
+		}
+		e.Rename.Old.FileFields.Mode = uint16(v)
 		return nil
 
 	case "rename.file.uid":
@@ -10670,6 +11279,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rmdir.File.PathnameStr = str
 
+		return nil
+
+	case "rmdir.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Mode"}
+		}
+		e.Rmdir.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "rmdir.file.uid":
@@ -10954,6 +11573,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "setxattr.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.Mode"}
+		}
+		e.SetXAttr.File.FileFields.Mode = uint16(v)
+		return nil
+
 	case "setxattr.file.uid":
 
 		var ok bool
@@ -11088,6 +11717,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "unlink.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Mode"}
+		}
+		e.Unlink.File.FileFields.Mode = uint16(v)
+		return nil
+
 	case "unlink.file.uid":
 
 		var ok bool
@@ -11220,6 +11859,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Utimes.File.PathnameStr = str
 
+		return nil
+
+	case "utimes.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Mode"}
+		}
+		e.Utimes.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "utimes.file.uid":

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -94,14 +94,14 @@ type ChownEvent struct {
 	SyscallEvent
 	File  FileEvent `field:"file"`
 	UID   uint32    `field:"file.destination.uid"`
-	User  string    `field:"file.destination.user" handler:"ResolveChownUID"`
+	User  string    `field:"file.destination.user,ResolveChownUID"`
 	GID   uint32    `field:"file.destination.gid"`
-	Group string    `field:"file.destination.group" handler:"ResolveChownGID"`
+	Group string    `field:"file.destination.group,ResolveChownGID"`
 }
 
 // ContainerContext holds the container context of an event
 type ContainerContext struct {
-	ID string `field:"id" handler:"ResolveContainerID"`
+	ID string `field:"id,ResolveContainerID"`
 }
 
 // Event represents an event sent from the kernel
@@ -163,21 +163,21 @@ func (e *Event) GetPointer() unsafe.Pointer {
 // SetuidEvent represents a setuid event
 type SetuidEvent struct {
 	UID    uint32 `field:"uid"`
-	User   string `field:"user" handler:"ResolveSetuidUser"`
+	User   string `field:"user,ResolveSetuidUser"`
 	EUID   uint32 `field:"euid"`
-	EUser  string `field:"euser" handler:"ResolveSetuidEUser"`
+	EUser  string `field:"euser,ResolveSetuidEUser"`
 	FSUID  uint32 `field:"fsuid"`
-	FSUser string `field:"fsuser" handler:"ResolveSetuidFSUser"`
+	FSUser string `field:"fsuser,ResolveSetuidFSUser"`
 }
 
 // SetgidEvent represents a setgid event
 type SetgidEvent struct {
 	GID     uint32 `field:"gid"`
-	Group   string `field:"group" handler:"ResolveSetgidGroup"`
+	Group   string `field:"group,ResolveSetgidGroup"`
 	EGID    uint32 `field:"egid"`
-	EGroup  string `field:"egroup" handler:"ResolveSetgidEGroup"`
+	EGroup  string `field:"egroup,ResolveSetgidEGroup"`
 	FSGID   uint32 `field:"fsgid"`
-	FSGroup string `field:"fsgroup" handler:"ResolveSetgidFSGroup"`
+	FSGroup string `field:"fsgroup,ResolveSetgidFSGroup"`
 }
 
 // CapsetEvent represents a capset event
@@ -188,23 +188,23 @@ type CapsetEvent struct {
 
 // Credentials represents the kernel credentials of a process
 type Credentials struct {
-	UID   uint32 `field:"uid" handler:"ResolveCredentialsUID"`
-	GID   uint32 `field:"gid" handler:"ResolveCredentialsGID"`
-	User  string `field:"user" handler:"ResolveCredentialsUser"`
-	Group string `field:"group" handler:"ResolveCredentialsGroup"`
+	UID   uint32 `field:"uid,ResolveCredentialsUID"`
+	GID   uint32 `field:"gid,ResolveCredentialsGID"`
+	User  string `field:"user,ResolveCredentialsUser"`
+	Group string `field:"group,ResolveCredentialsGroup"`
 
-	EUID   uint32 `field:"euid" handler:"ResolveCredentialsEUID"`
-	EGID   uint32 `field:"egid" handler:"ResolveCredentialsEGID"`
-	EUser  string `field:"euser" handler:"ResolveCredentialsEUser"`
-	EGroup string `field:"egroup" handler:"ResolveCredentialsEGroup"`
+	EUID   uint32 `field:"euid,ResolveCredentialsEUID"`
+	EGID   uint32 `field:"egid,ResolveCredentialsEGID"`
+	EUser  string `field:"euser,ResolveCredentialsEUser"`
+	EGroup string `field:"egroup,ResolveCredentialsEGroup"`
 
-	FSUID   uint32 `field:"fsuid" handler:"ResolveCredentialsFSUID"`
-	FSGID   uint32 `field:"fsgid" handler:"ResolveCredentialsFSGID"`
-	FSUser  string `field:"fsuser" handler:"ResolveCredentialsFSUser"`
-	FSGroup string `field:"fsgroup" handler:"ResolveCredentialsFSGroup"`
+	FSUID   uint32 `field:"fsuid,ResolveCredentialsFSUID"`
+	FSGID   uint32 `field:"fsgid,ResolveCredentialsFSGID"`
+	FSUser  string `field:"fsuser,ResolveCredentialsFSUser"`
+	FSGroup string `field:"fsgroup,ResolveCredentialsFSGroup"`
 
-	CapEffective uint64 `field:"cap_effective" handler:"ResolveCredentialsCapEffective"`
-	CapPermitted uint64 `field:"cap_permitted" handler:"ResolveCredentialsCapPermitted"`
+	CapEffective uint64 `field:"cap_effective,ResolveCredentialsCapEffective"`
+	CapPermitted uint64 `field:"cap_permitted,ResolveCredentialsCapPermitted"`
 }
 
 // GetPathResolutionError returns the path resolution error as a string if there is one
@@ -221,17 +221,17 @@ type Process struct {
 	// (container context is parsed in Event.Container)
 	FileFields FileFields `field:"file"`
 
-	PathnameStr         string `field:"file.path" handler:"ResolveProcessInode"`
-	ContainerPath       string `field:"file.container_path" handler:"ResolveProcessContainerPath"`
-	BasenameStr         string `field:"file.name" handler:"ResolveProcessBasename"`
-	Filesystem          string `field:"file.filesystem" handler:"ResolveProcessFilesystem"`
+	PathnameStr         string `field:"file.path,ResolveProcessInode"`
+	ContainerPath       string `field:"file.container_path,ResolveProcessContainerPath"`
+	BasenameStr         string `field:"file.name,ResolveProcessBasename"`
+	Filesystem          string `field:"file.filesystem,ResolveProcessFilesystem"`
 	PathResolutionError error  `field:"-"`
 
 	ExecTimestamp uint64    `field:"-"`
 	ExecTime      time.Time `field:"-"`
 
-	TTYName string `field:"tty_name" handler:"ResolveProcessTTY"`
-	Comm    string `field:"comm" handler:"ResolveProcessComm"`
+	TTYName string `field:"tty_name,ResolveProcessTTY"`
+	Comm    string `field:"comm,ResolveProcessComm"`
 
 	// pid_cache_t
 	ForkTimestamp uint64    `field:"-"`
@@ -240,8 +240,8 @@ type Process struct {
 	ExitTimestamp uint64    `field:"-"`
 	ExitTime      time.Time `field:"-"`
 
-	Cookie uint32 `field:"cookie" handler:"ResolveProcessCookie"`
-	PPid   uint32 `field:"ppid" handler:"ResolveProcessPPID"`
+	Cookie uint32 `field:"cookie,ResolveProcessCookie"`
+	PPid   uint32 `field:"ppid,ResolveProcessPPID"`
 
 	// credentials_t section of pid_cache_t
 	Credentials
@@ -259,18 +259,18 @@ type Process struct {
 type ExecEvent struct {
 	Process
 
-	Args          string   `field:"args" handler:"ResolveExecArgs"`
+	Args          string   `field:"args,ResolveExecArgs"`
 	ArgsTruncated bool     `field:"args_truncated"`
-	Envs          []string `field:"envs" handler:"ResolveExecEnvs"`
+	Envs          []string `field:"envs,ResolveExecEnvs"`
 	EnvsTruncated bool     `field:"envs_truncated"`
 }
 
 // FileFields holds the information required to identify a file
 type FileFields struct {
 	UID   uint32    `field:"uid"`
-	User  string    `field:"user" handler:"ResolveUser"`
+	User  string    `field:"user,ResolveUser"`
 	GID   uint32    `field:"gid"`
-	Group string    `field:"group" handler:"ResolveGroup"`
+	Group string    `field:"group,ResolveGroup"`
 	Mode  uint16    `field:"mode"`
 	CTime time.Time `field:"-"`
 	MTime time.Time `field:"-"`
@@ -294,11 +294,11 @@ func (f *FileFields) GetInUpperLayer() bool {
 // FileEvent is the common file event type
 type FileEvent struct {
 	FileFields
-	PathnameStr   string `field:"path" handler:"ResolveFileInode"`
-	ContainerPath string `field:"container_path" handler:"ResolveFileContainerPath"`
-	BasenameStr   string `field:"name" handler:"ResolveFileBasename"`
-	Filesytem     string `field:"filesystem" handler:"ResolveFileFilesystem"`
-	InUpperLayer  bool   `field:"in_upper_layer" handler:"ResolveFileInUpperLayer"`
+	PathnameStr   string `field:"path,ResolveFileInode"`
+	ContainerPath string `field:"container_path,ResolveFileContainerPath"`
+	BasenameStr   string `field:"name,ResolveFileBasename"`
+	Filesytem     string `field:"filesystem,ResolveFileFilesystem"`
+	InUpperLayer  bool   `field:"in_upper_layer,ResolveFileInUpperLayer"`
 
 	PathResolutionError error `field:"-"`
 }
@@ -441,7 +441,7 @@ type ProcessContext struct {
 	Pid uint32 `field:"pid"`
 	Tid uint32 `field:"tid"`
 
-	Ancestor *ProcessCacheEntry `field:"ancestors" iterator:"ProcessAncestorsIterator"`
+	Ancestor *ProcessCacheEntry `field:"ancestors,,ProcessAncestorsIterator"`
 }
 
 // RenameEvent represents a rename event
@@ -463,8 +463,8 @@ type RmdirEvent struct {
 type SetXAttrEvent struct {
 	SyscallEvent
 	File      FileEvent `field:"file"`
-	Namespace string    `field:"file.destination.namespace" handler:"GetXAttrNamespace"`
-	Name      string    `field:"file.destination.name" handler:"GetXAttrName"`
+	Namespace string    `field:"file.destination.namespace,GetXAttrNamespace"`
+	Name      string    `field:"file.destination.name,GetXAttrName"`
 
 	NameRaw [200]byte
 }

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -86,7 +86,7 @@ func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) erro
 type ChmodEvent struct {
 	SyscallEvent
 	File FileEvent `field:"file"`
-	Mode uint32    `field:"file.destination.mode"`
+	Mode uint32    `field:"file.destination.mode" field:"file.destination.rights"`
 }
 
 // ChownEvent represents a chown event
@@ -271,7 +271,7 @@ type FileFields struct {
 	User  string    `field:"user,ResolveUser"`
 	GID   uint32    `field:"gid"`
 	Group string    `field:"group,ResolveGroup"`
-	Mode  uint16    `field:"mode"`
+	Mode  uint16    `field:"mode" field:"rights,ResolveRights"`
 	CTime time.Time `field:"-"`
 	MTime time.Time `field:"-"`
 
@@ -335,7 +335,7 @@ type LinkEvent struct {
 type MkdirEvent struct {
 	SyscallEvent
 	File FileEvent `field:"file"`
-	Mode uint32    `field:"file.destination.mode"`
+	Mode uint32    `field:"file.destination.mode" field:"file.destination.rights"`
 }
 
 // ArgsEnvsEvent defines a args/envs event

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -110,6 +110,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "chmod.file.destination.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.Mode)
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "chmod.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -203,6 +214,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Chmod.File)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chmod.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Chmod.File.FileFields))
 			},
 			Field: field,
 
@@ -390,6 +412,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Chown.File)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "chown.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Chown.File.FileFields))
 			},
 			Field: field,
 
@@ -672,6 +705,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "exec.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Exec.Process.FileFields))
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "exec.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -925,6 +969,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.destination.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Link.Target.FileFields))
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.file.destination.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1046,6 +1101,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "link.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Link.Source.FileFields))
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "link.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1091,6 +1157,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		}, nil
 
 	case "mkdir.file.destination.mode":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.Mode)
+			},
+			Field: field,
+
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.destination.rights":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
 
@@ -1194,6 +1271,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Mkdir.File)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "mkdir.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Mkdir.File.FileFields))
 			},
 			Field: field,
 
@@ -1348,6 +1436,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Open.File)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "open.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Open.File.FileFields))
 			},
 			Field: field,
 
@@ -1929,6 +2028,38 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*model.ProcessCacheEntry)(value)
 
 					result = (*Event)(ctx.Object).ResolveProcessInode(&element.Process)
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.rights":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]int)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []int
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result int
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = int((*Event)(ctx.Object).ResolveRights(&element.FileFields))
 
 					results = append(results, result)
 
@@ -2609,6 +2740,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "process.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).ProcessContext.Process.FileFields))
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "process.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2895,6 +3037,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "removexattr.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).RemoveXAttr.File.FileFields))
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "removexattr.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3049,6 +3202,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "rename.file.destination.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Rename.New.FileFields))
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "rename.file.destination.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3164,6 +3328,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Rename.Old)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rename.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Rename.Old.FileFields))
 			},
 			Field: field,
 
@@ -3307,6 +3482,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Rmdir.File)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "rmdir.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Rmdir.File.FileFields))
 			},
 			Field: field,
 
@@ -3610,6 +3796,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "setxattr.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).SetXAttr.File.FileFields))
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "setxattr.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3747,6 +3944,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFileInode(&(*Event)(ctx.Object).Unlink.File)
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "unlink.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Unlink.File.FileFields))
 			},
 			Field: field,
 
@@ -3896,6 +4104,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "utimes.file.rights":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ResolveRights(&(*Event)(ctx.Object).Utimes.File.FileFields))
+			},
+			Field: field,
+
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "utimes.file.uid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3945,6 +4164,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"chmod.file.destination.mode",
 
+		"chmod.file.destination.rights",
+
 		"chmod.file.filesystem",
 
 		"chmod.file.gid",
@@ -3962,6 +4183,8 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.name",
 
 		"chmod.file.path",
+
+		"chmod.file.rights",
 
 		"chmod.file.uid",
 
@@ -3996,6 +4219,8 @@ func (e *Event) GetFields() []eval.Field {
 		"chown.file.name",
 
 		"chown.file.path",
+
+		"chown.file.rights",
 
 		"chown.file.uid",
 
@@ -4047,6 +4272,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.file.path",
 
+		"exec.file.rights",
+
 		"exec.file.uid",
 
 		"exec.file.user",
@@ -4093,6 +4320,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.destination.path",
 
+		"link.file.destination.rights",
+
 		"link.file.destination.uid",
 
 		"link.file.destination.user",
@@ -4115,6 +4344,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.path",
 
+		"link.file.rights",
+
 		"link.file.uid",
 
 		"link.file.user",
@@ -4124,6 +4355,8 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.container_path",
 
 		"mkdir.file.destination.mode",
+
+		"mkdir.file.destination.rights",
 
 		"mkdir.file.filesystem",
 
@@ -4142,6 +4375,8 @@ func (e *Event) GetFields() []eval.Field {
 		"mkdir.file.name",
 
 		"mkdir.file.path",
+
+		"mkdir.file.rights",
 
 		"mkdir.file.uid",
 
@@ -4170,6 +4405,8 @@ func (e *Event) GetFields() []eval.Field {
 		"open.file.name",
 
 		"open.file.path",
+
+		"open.file.rights",
 
 		"open.file.uid",
 
@@ -4212,6 +4449,8 @@ func (e *Event) GetFields() []eval.Field {
 		"process.ancestors.file.name",
 
 		"process.ancestors.file.path",
+
+		"process.ancestors.file.rights",
 
 		"process.ancestors.file.uid",
 
@@ -4277,6 +4516,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.file.path",
 
+		"process.file.rights",
+
 		"process.file.uid",
 
 		"process.file.user",
@@ -4329,6 +4570,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"removexattr.file.path",
 
+		"removexattr.file.rights",
+
 		"removexattr.file.uid",
 
 		"removexattr.file.user",
@@ -4357,6 +4600,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.file.destination.path",
 
+		"rename.file.destination.rights",
+
 		"rename.file.destination.uid",
 
 		"rename.file.destination.user",
@@ -4378,6 +4623,8 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.name",
 
 		"rename.file.path",
+
+		"rename.file.rights",
 
 		"rename.file.uid",
 
@@ -4404,6 +4651,8 @@ func (e *Event) GetFields() []eval.Field {
 		"rmdir.file.name",
 
 		"rmdir.file.path",
+
+		"rmdir.file.rights",
 
 		"rmdir.file.uid",
 
@@ -4459,6 +4708,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setxattr.file.path",
 
+		"setxattr.file.rights",
+
 		"setxattr.file.uid",
 
 		"setxattr.file.user",
@@ -4484,6 +4735,8 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.name",
 
 		"unlink.file.path",
+
+		"unlink.file.rights",
 
 		"unlink.file.uid",
 
@@ -4511,6 +4764,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"utimes.file.path",
 
+		"utimes.file.rights",
+
 		"utimes.file.uid",
 
 		"utimes.file.user",
@@ -4535,6 +4790,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileContainerPath(&e.Chmod.File), nil
 
 	case "chmod.file.destination.mode":
+
+		return int(e.Chmod.Mode), nil
+
+	case "chmod.file.destination.rights":
 
 		return int(e.Chmod.Mode), nil
 
@@ -4573,6 +4832,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.file.path":
 
 		return e.ResolveFileInode(&e.Chmod.File), nil
+
+	case "chmod.file.rights":
+
+		return int(e.ResolveRights(&e.Chmod.File.FileFields)), nil
 
 	case "chmod.file.uid":
 
@@ -4641,6 +4904,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chown.file.path":
 
 		return e.ResolveFileInode(&e.Chown.File), nil
+
+	case "chown.file.rights":
+
+		return int(e.ResolveRights(&e.Chown.File.FileFields)), nil
 
 	case "chown.file.uid":
 
@@ -4742,6 +5009,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveProcessInode(&e.Exec.Process), nil
 
+	case "exec.file.rights":
+
+		return int(e.ResolveRights(&e.Exec.Process.FileFields)), nil
+
 	case "exec.file.uid":
 
 		return int(e.Exec.Process.FileFields.UID), nil
@@ -4834,6 +5105,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileInode(&e.Link.Target), nil
 
+	case "link.file.destination.rights":
+
+		return int(e.ResolveRights(&e.Link.Target.FileFields)), nil
+
 	case "link.file.destination.uid":
 
 		return int(e.Link.Target.FileFields.UID), nil
@@ -4878,6 +5153,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileInode(&e.Link.Source), nil
 
+	case "link.file.rights":
+
+		return int(e.ResolveRights(&e.Link.Source.FileFields)), nil
+
 	case "link.file.uid":
 
 		return int(e.Link.Source.FileFields.UID), nil
@@ -4895,6 +5174,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return e.ResolveFileContainerPath(&e.Mkdir.File), nil
 
 	case "mkdir.file.destination.mode":
+
+		return int(e.Mkdir.Mode), nil
+
+	case "mkdir.file.destination.rights":
 
 		return int(e.Mkdir.Mode), nil
 
@@ -4933,6 +5216,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "mkdir.file.path":
 
 		return e.ResolveFileInode(&e.Mkdir.File), nil
+
+	case "mkdir.file.rights":
+
+		return int(e.ResolveRights(&e.Mkdir.File.FileFields)), nil
 
 	case "mkdir.file.uid":
 
@@ -4989,6 +5276,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "open.file.path":
 
 		return e.ResolveFileInode(&e.Open.File), nil
+
+	case "open.file.rights":
+
+		return int(e.ResolveRights(&e.Open.File.FileFields)), nil
 
 	case "open.file.uid":
 
@@ -5372,6 +5663,28 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*model.ProcessCacheEntry)(ptr)
 
 			result := (*Event)(ctx.Object).ResolveProcessInode(&element.Process)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.rights":
+
+		var values []int
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := int((*Event)(ctx.Object).ResolveRights(&element.FileFields))
 
 			values = append(values, result)
 
@@ -5778,6 +6091,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveProcessInode(&e.ProcessContext.Process), nil
 
+	case "process.file.rights":
+
+		return int(e.ResolveRights(&e.ProcessContext.Process.FileFields)), nil
+
 	case "process.file.uid":
 
 		return int(e.ProcessContext.Process.FileFields.UID), nil
@@ -5882,6 +6199,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileInode(&e.RemoveXAttr.File), nil
 
+	case "removexattr.file.rights":
+
+		return int(e.ResolveRights(&e.RemoveXAttr.File.FileFields)), nil
+
 	case "removexattr.file.uid":
 
 		return int(e.RemoveXAttr.File.FileFields.UID), nil
@@ -5938,6 +6259,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileInode(&e.Rename.New), nil
 
+	case "rename.file.destination.rights":
+
+		return int(e.ResolveRights(&e.Rename.New.FileFields)), nil
+
 	case "rename.file.destination.uid":
 
 		return int(e.Rename.New.FileFields.UID), nil
@@ -5981,6 +6306,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.path":
 
 		return e.ResolveFileInode(&e.Rename.Old), nil
+
+	case "rename.file.rights":
+
+		return int(e.ResolveRights(&e.Rename.Old.FileFields)), nil
 
 	case "rename.file.uid":
 
@@ -6033,6 +6362,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rmdir.file.path":
 
 		return e.ResolveFileInode(&e.Rmdir.File), nil
+
+	case "rmdir.file.rights":
+
+		return int(e.ResolveRights(&e.Rmdir.File.FileFields)), nil
 
 	case "rmdir.file.uid":
 
@@ -6142,6 +6475,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileInode(&e.SetXAttr.File), nil
 
+	case "setxattr.file.rights":
+
+		return int(e.ResolveRights(&e.SetXAttr.File.FileFields)), nil
+
 	case "setxattr.file.uid":
 
 		return int(e.SetXAttr.File.FileFields.UID), nil
@@ -6193,6 +6530,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.file.path":
 
 		return e.ResolveFileInode(&e.Unlink.File), nil
+
+	case "unlink.file.rights":
+
+		return int(e.ResolveRights(&e.Unlink.File.FileFields)), nil
 
 	case "unlink.file.uid":
 
@@ -6246,6 +6587,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileInode(&e.Utimes.File), nil
 
+	case "utimes.file.rights":
+
+		return int(e.ResolveRights(&e.Utimes.File.FileFields)), nil
+
 	case "utimes.file.uid":
 
 		return int(e.Utimes.File.FileFields.UID), nil
@@ -6278,6 +6623,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "chmod.file.destination.mode":
 		return "chmod", nil
 
+	case "chmod.file.destination.rights":
+		return "chmod", nil
+
 	case "chmod.file.filesystem":
 		return "chmod", nil
 
@@ -6303,6 +6651,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chmod", nil
 
 	case "chmod.file.path":
+		return "chmod", nil
+
+	case "chmod.file.rights":
 		return "chmod", nil
 
 	case "chmod.file.uid":
@@ -6354,6 +6705,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chown", nil
 
 	case "chown.file.path":
+		return "chown", nil
+
+	case "chown.file.rights":
 		return "chown", nil
 
 	case "chown.file.uid":
@@ -6431,6 +6785,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.file.path":
 		return "exec", nil
 
+	case "exec.file.rights":
+		return "exec", nil
+
 	case "exec.file.uid":
 		return "exec", nil
 
@@ -6500,6 +6857,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.destination.path":
 		return "link", nil
 
+	case "link.file.destination.rights":
+		return "link", nil
+
 	case "link.file.destination.uid":
 		return "link", nil
 
@@ -6533,6 +6893,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.path":
 		return "link", nil
 
+	case "link.file.rights":
+		return "link", nil
+
 	case "link.file.uid":
 		return "link", nil
 
@@ -6546,6 +6909,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 
 	case "mkdir.file.destination.mode":
+		return "mkdir", nil
+
+	case "mkdir.file.destination.rights":
 		return "mkdir", nil
 
 	case "mkdir.file.filesystem":
@@ -6573,6 +6939,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "mkdir", nil
 
 	case "mkdir.file.path":
+		return "mkdir", nil
+
+	case "mkdir.file.rights":
 		return "mkdir", nil
 
 	case "mkdir.file.uid":
@@ -6615,6 +6984,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "open", nil
 
 	case "open.file.path":
+		return "open", nil
+
+	case "open.file.rights":
 		return "open", nil
 
 	case "open.file.uid":
@@ -6678,6 +7050,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.file.path":
+		return "*", nil
+
+	case "process.ancestors.file.rights":
 		return "*", nil
 
 	case "process.ancestors.file.uid":
@@ -6776,6 +7151,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.file.path":
 		return "*", nil
 
+	case "process.file.rights":
+		return "*", nil
+
 	case "process.file.uid":
 		return "*", nil
 
@@ -6854,6 +7232,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "removexattr.file.path":
 		return "removexattr", nil
 
+	case "removexattr.file.rights":
+		return "removexattr", nil
+
 	case "removexattr.file.uid":
 		return "removexattr", nil
 
@@ -6896,6 +7277,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.destination.path":
 		return "rename", nil
 
+	case "rename.file.destination.rights":
+		return "rename", nil
+
 	case "rename.file.destination.uid":
 		return "rename", nil
 
@@ -6927,6 +7311,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 
 	case "rename.file.path":
+		return "rename", nil
+
+	case "rename.file.rights":
 		return "rename", nil
 
 	case "rename.file.uid":
@@ -6966,6 +7353,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rmdir", nil
 
 	case "rmdir.file.path":
+		return "rmdir", nil
+
+	case "rmdir.file.rights":
 		return "rmdir", nil
 
 	case "rmdir.file.uid":
@@ -7049,6 +7439,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setxattr.file.path":
 		return "setxattr", nil
 
+	case "setxattr.file.rights":
+		return "setxattr", nil
+
 	case "setxattr.file.uid":
 		return "setxattr", nil
 
@@ -7088,6 +7481,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "unlink.file.path":
 		return "unlink", nil
 
+	case "unlink.file.rights":
+		return "unlink", nil
+
 	case "unlink.file.uid":
 		return "unlink", nil
 
@@ -7125,6 +7521,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "utimes", nil
 
 	case "utimes.file.path":
+		return "utimes", nil
+
+	case "utimes.file.rights":
 		return "utimes", nil
 
 	case "utimes.file.uid":
@@ -7160,6 +7559,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "chmod.file.destination.rights":
+
+		return reflect.Int, nil
+
 	case "chmod.file.filesystem":
 
 		return reflect.String, nil
@@ -7195,6 +7598,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chmod.file.path":
 
 		return reflect.String, nil
+
+	case "chmod.file.rights":
+
+		return reflect.Int, nil
 
 	case "chmod.file.uid":
 
@@ -7263,6 +7670,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "chown.file.path":
 
 		return reflect.String, nil
+
+	case "chown.file.rights":
+
+		return reflect.Int, nil
 
 	case "chown.file.uid":
 
@@ -7364,6 +7775,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.file.rights":
+
+		return reflect.Int, nil
+
 	case "exec.file.uid":
 
 		return reflect.Int, nil
@@ -7456,6 +7871,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.destination.rights":
+
+		return reflect.Int, nil
+
 	case "link.file.destination.uid":
 
 		return reflect.Int, nil
@@ -7500,6 +7919,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.rights":
+
+		return reflect.Int, nil
+
 	case "link.file.uid":
 
 		return reflect.Int, nil
@@ -7517,6 +7940,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 
 	case "mkdir.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.destination.rights":
 
 		return reflect.Int, nil
 
@@ -7555,6 +7982,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "mkdir.file.path":
 
 		return reflect.String, nil
+
+	case "mkdir.file.rights":
+
+		return reflect.Int, nil
 
 	case "mkdir.file.uid":
 
@@ -7611,6 +8042,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "open.file.path":
 
 		return reflect.String, nil
+
+	case "open.file.rights":
+
+		return reflect.Int, nil
 
 	case "open.file.uid":
 
@@ -7695,6 +8130,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.ancestors.file.path":
 
 		return reflect.String, nil
+
+	case "process.ancestors.file.rights":
+
+		return reflect.Int, nil
 
 	case "process.ancestors.file.uid":
 
@@ -7824,6 +8263,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.file.rights":
+
+		return reflect.Int, nil
+
 	case "process.file.uid":
 
 		return reflect.Int, nil
@@ -7928,6 +8371,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "removexattr.file.rights":
+
+		return reflect.Int, nil
+
 	case "removexattr.file.uid":
 
 		return reflect.Int, nil
@@ -7984,6 +8431,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "rename.file.destination.rights":
+
+		return reflect.Int, nil
+
 	case "rename.file.destination.uid":
 
 		return reflect.Int, nil
@@ -8027,6 +8478,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rename.file.path":
 
 		return reflect.String, nil
+
+	case "rename.file.rights":
+
+		return reflect.Int, nil
 
 	case "rename.file.uid":
 
@@ -8079,6 +8534,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "rmdir.file.path":
 
 		return reflect.String, nil
+
+	case "rmdir.file.rights":
+
+		return reflect.Int, nil
 
 	case "rmdir.file.uid":
 
@@ -8188,6 +8647,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "setxattr.file.rights":
+
+		return reflect.Int, nil
+
 	case "setxattr.file.uid":
 
 		return reflect.Int, nil
@@ -8240,6 +8703,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "unlink.file.rights":
+
+		return reflect.Int, nil
+
 	case "unlink.file.uid":
 
 		return reflect.Int, nil
@@ -8291,6 +8758,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "utimes.file.path":
 
 		return reflect.String, nil
+
+	case "utimes.file.rights":
+
+		return reflect.Int, nil
 
 	case "utimes.file.uid":
 
@@ -8344,6 +8815,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 
 	case "chmod.file.destination.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.Mode"}
+		}
+		e.Chmod.Mode = uint32(v)
+		return nil
+
+	case "chmod.file.destination.rights":
 
 		var ok bool
 		v, ok := value.(int)
@@ -8443,6 +8924,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chmod.File.PathnameStr = str
 
+		return nil
+
+	case "chmod.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.Mode"}
+		}
+		e.Chmod.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "chmod.file.uid":
@@ -8619,6 +9110,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Chown.File.PathnameStr = str
 
+		return nil
+
+	case "chown.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Mode"}
+		}
+		e.Chown.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "chown.file.uid":
@@ -8879,6 +9380,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Mode"}
+		}
+		e.Exec.Process.FileFields.Mode = uint16(v)
+		return nil
+
 	case "exec.file.uid":
 
 		var ok bool
@@ -9119,6 +9630,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.destination.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Mode"}
+		}
+		e.Link.Target.FileFields.Mode = uint16(v)
+		return nil
+
 	case "link.file.destination.uid":
 
 		var ok bool
@@ -9232,6 +9753,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.Mode"}
+		}
+		e.Link.Source.FileFields.Mode = uint16(v)
+		return nil
+
 	case "link.file.uid":
 
 		var ok bool
@@ -9275,6 +9806,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return nil
 
 	case "mkdir.file.destination.mode":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.Mode"}
+		}
+		e.Mkdir.Mode = uint32(v)
+		return nil
+
+	case "mkdir.file.destination.rights":
 
 		var ok bool
 		v, ok := value.(int)
@@ -9374,6 +9915,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Mkdir.File.PathnameStr = str
 
+		return nil
+
+	case "mkdir.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.Mode"}
+		}
+		e.Mkdir.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "mkdir.file.uid":
@@ -9518,6 +10069,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Open.File.PathnameStr = str
 
+		return nil
+
+	case "open.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Mode"}
+		}
+		e.Open.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "open.file.uid":
@@ -9805,6 +10366,20 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.PathnameStr = str
 
+		return nil
+
+	case "process.ancestors.file.rights":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
 		return nil
 
 	case "process.ancestors.file.uid":
@@ -10202,6 +10777,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Mode"}
+		}
+		e.ProcessContext.Process.FileFields.Mode = uint16(v)
+		return nil
+
 	case "process.file.uid":
 
 		var ok bool
@@ -10473,6 +11058,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "removexattr.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.Mode"}
+		}
+		e.RemoveXAttr.File.FileFields.Mode = uint16(v)
+		return nil
+
 	case "removexattr.file.uid":
 
 		var ok bool
@@ -10618,6 +11213,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "rename.file.destination.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.Mode"}
+		}
+		e.Rename.New.FileFields.Mode = uint16(v)
+		return nil
+
 	case "rename.file.destination.uid":
 
 		var ok bool
@@ -10729,6 +11334,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rename.Old.PathnameStr = str
 
+		return nil
+
+	case "rename.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.Mode"}
+		}
+		e.Rename.Old.FileFields.Mode = uint16(v)
 		return nil
 
 	case "rename.file.uid":
@@ -10863,6 +11478,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Rmdir.File.PathnameStr = str
 
+		return nil
+
+	case "rmdir.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Mode"}
+		}
+		e.Rmdir.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "rmdir.file.uid":
@@ -11147,6 +11772,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "setxattr.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.Mode"}
+		}
+		e.SetXAttr.File.FileFields.Mode = uint16(v)
+		return nil
+
 	case "setxattr.file.uid":
 
 		var ok bool
@@ -11281,6 +11916,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "unlink.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Mode"}
+		}
+		e.Unlink.File.FileFields.Mode = uint16(v)
+		return nil
+
 	case "unlink.file.uid":
 
 		var ok bool
@@ -11413,6 +12058,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.Utimes.File.PathnameStr = str
 
+		return nil
+
+	case "utimes.file.rights":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Mode"}
+		}
+		e.Utimes.File.FileFields.Mode = uint16(v)
 		return nil
 
 	case "utimes.file.uid":

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"path"
 	"strings"
+	"syscall"
 	"time"
 
 	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
@@ -172,6 +173,11 @@ func (ev *Event) ResolveGroup(e *model.FileFields) string {
 		e.Group, _ = ev.resolvers.UserGroupResolver.ResolveGroup(int(e.GID))
 	}
 	return e.Group
+}
+
+// ResolveRights resolves the rights of a file
+func (ev *Event) ResolveRights(e *model.FileFields) int {
+	return int(e.Mode) & (syscall.S_ISUID | syscall.S_ISGID | syscall.S_ISVTX | syscall.S_IRWXU | syscall.S_IRWXG | syscall.S_IRWXO)
 }
 
 // ResolveChownUID resolves the user id of a chown event to a username

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -19,11 +19,12 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"text/template"
-	"unicode"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/fatih/structtag"
 	"golang.org/x/tools/go/loader"
 )
 
@@ -64,7 +65,6 @@ type structField struct {
 	BasicType     string
 	ReturnType    string
 	IsArray       bool
-	Public        bool
 	Event         string
 	Handler       string
 	OrigType      string
@@ -91,31 +91,18 @@ func origTypeToBasicType(kind string) string {
 func handleBasic(name, alias, kind, event string, iterator *structField, isArray bool) {
 	fmt.Printf("handleBasic %s %s\n", name, kind)
 
-	switch kind {
-	case "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64":
-		module.Fields[alias] = &structField{Name: name, ReturnType: "int", Public: true, Event: event, OrigType: kind, BasicType: origTypeToBasicType(kind), Iterator: iterator}
-		module.EventTypes[event] = true
-	default:
-		public := false
-		firstChar := strings.TrimPrefix(kind, "[]")
-		if splits := strings.Split(firstChar, "."); len(splits) > 1 {
-			firstChar = splits[len(splits)-1]
-		}
-		if unicode.IsUpper(rune(firstChar[0])) {
-			public = true
-		}
-		module.Fields[alias] = &structField{
-			Name:       name,
-			BasicType:  origTypeToBasicType(kind),
-			ReturnType: kind,
-			IsArray:    strings.HasPrefix(kind, "[]") || isArray,
-			Public:     public,
-			Event:      event,
-			OrigType:   kind,
-			Iterator:   iterator,
-		}
-		module.EventTypes[event] = true
+	basicType := origTypeToBasicType(kind)
+	module.Fields[alias] = &structField{
+		Name:       name,
+		BasicType:  basicType,
+		ReturnType: basicType,
+		IsArray:    strings.HasPrefix(kind, "[]") || isArray,
+		Event:      event,
+		OrigType:   kind,
+		Iterator:   iterator,
 	}
+
+	module.EventTypes[event] = true
 }
 
 func handleField(astFile *ast.File, name, alias, prefix, aliasPrefix, pkgName string, fieldType *ast.Ident, event string, iterator *structField, dejavu map[string]bool, isArray bool) error {
@@ -128,13 +115,14 @@ func handleField(astFile *ast.File, name, alias, prefix, aliasPrefix, pkgName st
 			alias = aliasPrefix + "." + alias
 		}
 		handleBasic(name, alias, fieldType.Name, event, iterator, isArray)
+
 	default:
 		symbol, err := resolveSymbol(pkgName, fieldType.Name)
 		if err != nil {
-			return fmt.Errorf("Failed to resolve symbol for %+v in %s: %s", fieldType, pkgName, err)
+			return fmt.Errorf("failed to resolve symbol for %+v in %s: %s", fieldType, pkgName, err)
 		}
 		if symbol == nil {
-			return fmt.Errorf("Failed to resolve symbol for %+v in %s", fieldType, pkgName)
+			return fmt.Errorf("failed to resolve symbol for %+v in %s", fieldType, pkgName)
 		}
 
 		if prefix != "" {
@@ -150,6 +138,27 @@ func handleField(astFile *ast.File, name, alias, prefix, aliasPrefix, pkgName st
 	}
 
 	return nil
+}
+
+func getFieldIdent(field *ast.Field) (ident *ast.Ident, isPointer, isArray bool) {
+	if fieldType, ok := field.Type.(*ast.Ident); ok {
+		return fieldType, false, false
+	} else if fieldType, ok := field.Type.(*ast.StarExpr); ok {
+		if ident, ok := fieldType.X.(*ast.Ident); ok {
+			return ident, true, false
+		}
+	} else if ft, ok := field.Type.(*ast.ArrayType); ok {
+		if ident, ok := ft.Elt.(*ast.Ident); ok {
+			return ident, false, true
+		}
+	}
+	return nil, false, false
+}
+
+type seclField struct {
+	name     string
+	iterator string
+	handler  string
 }
 
 func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event string, iterator *structField, dejavu map[string]bool) {
@@ -172,42 +181,46 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 
 				if isEmbedded := len(field.Names) == 0; !isEmbedded {
 					fieldName := field.Names[0].Name
-					fieldAlias := fieldName
 
 					if dejavu[fieldName] {
 						continue
 					}
 
-					if fieldTag, found := tag.Lookup("field"); found {
-						if fieldAlias = fieldTag; fieldAlias == "-" {
-							continue FIELD
+					var fields []seclField
+					fieldType, isPointer, isArray := getFieldIdent(field)
+
+					if tags, err := structtag.Parse(string(tag)); err == nil && len(tags.Tags()) != 0 {
+						for _, fieldTag := range tags.Tags() {
+							if fieldTag.Key == "field" {
+								splitted := strings.SplitN(fieldTag.Value(), ",", 3)
+								alias := splitted[0]
+								if alias == "-" {
+									continue FIELD
+								}
+								field := seclField{name: alias}
+								if len(splitted) > 1 {
+									field.handler = splitted[1]
+								}
+								if len(splitted) > 2 {
+									debug.PrintStack()
+									field.iterator = splitted[2]
+								}
+								fields = append(fields, field)
+							}
+						}
+					} else {
+						fields = append(fields, seclField{name: fieldName})
+					}
+
+					for _, seclField := range fields {
+						fieldAlias := seclField.name
+						alias := fieldAlias
+						if aliasPrefix != "" {
+							alias = aliasPrefix + "." + fieldAlias
 						}
 
-						if it, found := tag.Lookup("iterator"); found {
-							alias := fieldAlias
-							if aliasPrefix != "" {
-								alias = aliasPrefix + "." + fieldAlias
-							}
-
-							var origType string
-							var isOrigTypePtr bool
-							var isArray bool
-
-							if ft, ok := field.Type.(*ast.Ident); ok {
-								origType = ft.Name
-							} else if ft, ok := field.Type.(*ast.StarExpr); ok {
-								if ident, ok := ft.X.(*ast.Ident); ok {
-									origType = ident.Name
-									isOrigTypePtr = true
-								}
-							} else if ft, ok := field.Type.(*ast.ArrayType); ok {
-								isArray = true
-								if ident, ok := ft.Elt.(*ast.Ident); ok {
-									origType = ident.Name
-								}
-							}
-
-							pkgType := func(t string) string {
+						if iterator := seclField.iterator; iterator != "" {
+							qualifiedType := func(t string) string {
 								switch t {
 								case "int", "string", "bool":
 									return t
@@ -218,93 +231,56 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 
 							module.Iterators[alias] = &structField{
 								Name:          fmt.Sprintf("%s.%s", prefix, fieldName),
-								ReturnType:    pkgType(it),
-								Public:        true,
+								ReturnType:    qualifiedType(iterator),
 								Event:         event,
-								OrigType:      pkgType(origType),
-								IsOrigTypePtr: isOrigTypePtr,
+								OrigType:      qualifiedType(fieldType.Name),
+								IsOrigTypePtr: isPointer,
 								IsArray:       isArray,
 							}
 
 							fieldIterator = module.Iterators[alias]
 						}
 
-						if handler, found := tag.Lookup("handler"); found {
+						if handler := seclField.handler; handler != "" {
 							if aliasPrefix != "" {
 								fieldAlias = aliasPrefix + "." + fieldAlias
 							}
 
-							var origType string
-							var isArray bool
-
-							if ft, ok := field.Type.(*ast.Ident); ok {
-								origType = ft.Name
-							} else if ft, ok := field.Type.(*ast.ArrayType); ok {
-								isArray = true
-								if ident, ok := ft.Elt.(*ast.Ident); ok {
-									origType = ident.Name
-								}
+							module.Fields[fieldAlias] = &structField{
+								Prefix:     prefix,
+								Name:       fmt.Sprintf("%s.%s", prefix, fieldName),
+								BasicType:  origTypeToBasicType(fieldType.Name),
+								Struct:     typeSpec.Name.Name,
+								Handler:    handler,
+								ReturnType: origTypeToBasicType(fieldType.Name),
+								Event:      event,
+								OrigType:   fieldType.Name,
+								Iterator:   fieldIterator,
+								IsArray:    isArray,
 							}
 
-							if ok {
-								module.Fields[fieldAlias] = &structField{
-									Prefix:     prefix,
-									Name:       fmt.Sprintf("%s.%s", prefix, fieldName),
-									BasicType:  origTypeToBasicType(origType),
-									Struct:     typeSpec.Name.Name,
-									Handler:    handler,
-									ReturnType: origTypeToBasicType(origType),
-									Public:     true,
-									Event:      event,
-									OrigType:   origType,
-									Iterator:   fieldIterator,
-									IsArray:    isArray,
-								}
-								module.EventTypes[event] = true
-							}
+							module.EventTypes[event] = true
 							delete(dejavu, fieldName)
 
-							continue
+							continue FIELD
 						}
-					}
 
-					dejavu[fieldName] = true
+						dejavu[fieldName] = true
 
-					if fieldType, ok := field.Type.(*ast.Ident); ok {
-						if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, filepath.Base(pkgname), fieldType, event, fieldIterator, dejavu, false); err != nil {
-							log.Print(err)
-						}
-						delete(dejavu, fieldName)
-
-						continue
-					} else if fieldType, ok := field.Type.(*ast.StarExpr); ok {
-						if ident, ok := fieldType.X.(*ast.Ident); ok {
-							if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, filepath.Base(pkgname), ident, event, fieldIterator, dejavu, false); err != nil {
-								log.Print(err)
-							}
-							delete(dejavu, fieldName)
-
-							continue
-						}
-					} else if ft, ok := field.Type.(*ast.ArrayType); ok {
-						if ident, ok := ft.Elt.(*ast.Ident); ok {
-							if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, filepath.Base(pkgname), ident, event, fieldIterator, dejavu, true); err != nil {
+						if fieldType != nil {
+							if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, filepath.Base(pkgname), fieldType, event, fieldIterator, dejavu, false); err != nil {
 								log.Print(err)
 							}
 
 							delete(dejavu, fieldName)
-
-							continue
 						}
-					}
 
-					delete(dejavu, fieldName)
-
-					if strict {
-						log.Panicf("Don't know what to do with %s: %s", fieldName, spew.Sdump(field.Type))
-					}
-					if verbose {
-						log.Printf("Don't know what to do with %s: %s", fieldName, spew.Sdump(field.Type))
+						if strict {
+							log.Panicf("Don't know what to do with %s: %s", fieldName, spew.Sdump(field.Type))
+						}
+						if verbose {
+							log.Printf("Don't know what to do with %s: %s", fieldName, spew.Sdump(field.Type))
+						}
 					}
 				} else {
 					if fieldTag, found := tag.Lookup("field"); found && fieldTag == "-" {

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -19,7 +19,7 @@ import (
 func TestChmod(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `chmod.file.path == "{{.Root}}/test-chmod" && chmod.file.destination.mode in [0707, 0717, 0757] && chmod.file.uid == 98 && chmod.file.gid == 99`,
+		Expression: `chmod.file.path == "{{.Root}}/test-chmod" && chmod.file.destination.rights in [0707, 0717, 0757] && chmod.file.uid == 98 && chmod.file.gid == 99`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{})


### PR DESCRIPTION
### What does this PR do?

Add a `file.rights` helper based on `file.mode`

### Motivation

The `mode` attributes of a file holds flags that can only be specified by the kernel. So, to write rules
using it, we had to apply a bit mask first. The new `rights` already has the bit mask applied to make
it easier to write rules.