### PR TITLE
[notify] Remove notifications for go subtests

### DIFF
--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -58,6 +58,13 @@ def get_failed_tests(project_name, job, owners_file=".github/CODEOWNERS"):
         for line in test_output.iter_lines():
             json_test = json.loads(line)
             if 'Test' in json_test and json_test["Action"] == "fail":
+                # Ignore subtests, only the parent test should be reported for now
+                # to avoid multiple reports on the same test
+                # NTH: maybe the Test object should be more flexible to incorporate
+                # subtests? This would require some postprocessing of the Test objects
+                # we yield here to merge child Test objects with their parents.
+                if '/' in json_test["Test"]:  # Subtests have a name of the form "Test/Subtest"
+                    continue
                 yield Test(owners, json_test['Test'], json_test['Package'])
 
 


### PR DESCRIPTION
### What does this PR do?

Removes lines about go subtests in the failure notifications.

### Motivation

Having separate lines for each failing subtest makes the output heavier and doesn't provide much value, as the parent test is already reported.
The subtests made the ownership logic fail: we `grep` the test name as a function name in the code, but `Test/Subtest` functions do not exist.
