### PR TITLE
[corechecks/snmp] Add oid batch size configuration

### DIFF
--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -19,6 +19,7 @@ var defaultTimeout = 2
 type snmpInitConfig struct {
 	Profiles      profileConfigMap `yaml:"profiles"`
 	GlobalMetrics []metricsConfig  `yaml:"global_metrics"`
+	OidBatchSize  Number           `yaml:"oid_batch_size"`
 }
 
 type snmpInstanceConfig struct {
@@ -28,6 +29,7 @@ type snmpInstanceConfig struct {
 	SnmpVersion      string            `yaml:"snmp_version"`
 	Timeout          Number            `yaml:"timeout"`
 	Retries          Number            `yaml:"retries"`
+	OidBatchSize     Number            `yaml:"oid_batch_size"`
 	User             string            `yaml:"user"`
 	AuthProtocol     string            `yaml:"authProtocol"`
 	AuthKey          string            `yaml:"authKey"`
@@ -177,8 +179,13 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 
 	c.metrics = instance.Metrics
 
-	// Let's use a default batch for now and expose it as configuration if needed.
-	c.oidBatchSize = defaultOidBatchSize
+	if instance.OidBatchSize != 0 {
+		c.oidBatchSize = int(instance.OidBatchSize)
+	} else if initConfig.OidBatchSize != 0 {
+		c.oidBatchSize = int(initConfig.OidBatchSize)
+	} else {
+		c.oidBatchSize = defaultOidBatchSize
+	}
 
 	// metrics Configs
 	if instance.UseGlobalMetrics {

--- a/pkg/collector/corechecks/snmp/config_test.go
+++ b/pkg/collector/corechecks/snmp/config_test.go
@@ -102,10 +102,12 @@ global_metrics:
 - symbol:
     OID: 1.2.3.4
     name: aGlobalMetric
+oid_batch_size: 10
 `)
 	err := check.Configure(rawInstanceConfig, rawInitConfig, "test")
 
 	assert.Nil(t, err)
+	assert.Equal(t, 10, check.config.oidBatchSize)
 	assert.Equal(t, "1.2.3.4", check.config.ipAddress)
 	assert.Equal(t, uint16(1161), check.config.port)
 	assert.Equal(t, 7, check.config.timeout)
@@ -252,6 +254,63 @@ community_string: abc
 	err = check.Configure(rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 	assert.Equal(t, uint16(1234), check.config.port)
+}
+
+func TestBatchSizeConfiguration(t *testing.T) {
+	setConfdPathAndCleanProfiles()
+	// TEST Default batch size
+	check := Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: abc
+`)
+	err := check.Configure(rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+	assert.Equal(t, 60, check.config.oidBatchSize)
+
+	// TEST Instance config batch size
+	check = Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: abc
+oid_batch_size: 10
+`)
+	err = check.Configure(rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+	assert.Equal(t, 10, check.config.oidBatchSize)
+
+	// TEST Init config batch size
+	check = Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: abc
+`)
+	// language=yaml
+	rawInitConfig := []byte(`
+oid_batch_size: 15
+`)
+	err = check.Configure(rawInstanceConfig, rawInitConfig, "test")
+	assert.Nil(t, err)
+	assert.Equal(t, 15, check.config.oidBatchSize)
+
+	// TEST Instance & Init config batch size
+	check = Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: abc
+oid_batch_size: 20
+`)
+	// language=yaml
+	rawInitConfig = []byte(`
+oid_batch_size: 15
+`)
+	err = check.Configure(rawInstanceConfig, rawInitConfig, "test")
+	assert.Nil(t, err)
+	assert.Equal(t, 20, check.config.oidBatchSize)
 }
 
 func TestGlobalMetricsConfigurations(t *testing.T) {

--- a/releasenotes/notes/add_snmp_batch_size_config-ae6cac1ed8417330.yaml
+++ b/releasenotes/notes/add_snmp_batch_size_config-ae6cac1ed8417330.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``oid_batch_size`` configuration as init and instance config


### PR DESCRIPTION
### What does this PR do?

Add oid batch size configuration

### Motivation

Some devices might raise SNMP `tooBig` error with [default batchSize set to 60](https://github.com/DataDog/datadog-agent/blob/e23fccd76506b853473cb0a75d95a3bd8ec27d03/pkg/collector/corechecks/snmp/config.go#L14)

By providing `oid_batch_size` the user can lower the value and avoid this error.

### Additional Notes

Related PR: https://github.com/DataDog/integrations-core/pull/9109

### Describe your test plan

oid_batch_size to a lower value and check in debug logs if the requests contain the expected number of OIDs set by batch size.
