### PR TITLE
[gitlab] Remove unused build_dogstatsd_static-deb_arm64 job

### DIFF
--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -30,24 +30,6 @@ build_dogstatsd-deb_x64:
     - inv -e dogstatsd.build --major-version 7
     - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/dogstatsd/dogstatsd
 
-build_dogstatsd_static-deb_arm64:
-  stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
-  tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["tests_deb-x64-py3", "linux_arm64_go_deps"]
-  variables:
-    ARCH: arm64
-  before_script:
-    - *retrieve_linux_go_deps
-    - source /root/.bashrc && conda activate ddpy3
-    # Hack to work around the cloning issue with arm runners
-    - mkdir -p $GOPATH/src/github.com/DataDog
-    - cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog
-    - cd $SRC_PATH
-  script:
-    - inv -e dogstatsd.build --static --major-version 7
-    - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd.$ARCH
-
 build_dogstatsd-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES

--- a/.gitlab/integration_test.yml
+++ b/.gitlab/integration_test.yml
@@ -14,20 +14,6 @@ dogstatsd_x64_size_test:
   script:
     - inv -e dogstatsd.size-test --skip-build
 
-dogstatsd_arm64_size_test:
-  stage: integration_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
-  tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["build_dogstatsd_static-deb_arm64"]
-  variables:
-    ARCH: arm64
-  before_script:
-    - source /root/.bashrc && conda activate ddpy3
-    - mkdir -p $STATIC_BINARIES_DIR
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/static/dogstatsd.$ARCH $STATIC_BINARIES_DIR/dogstatsd
-  script:
-    - inv -e dogstatsd.size-test --skip-build
-
 # run benchmarks on deb
 # benchmarks-deb_x64:
 #   stage: integration_test


### PR DESCRIPTION
### What does this PR do?

Removes unused job.

It was added in #4634 but the pipeline never pushed the built packages to S3 so they aren't available anyway.

If we want to release dogstatsd for arm64 at some point, we need to 1. revert this 2. add a corresponding `deploy_staging_` job and 3. add job in the release pipeline to promote them to the prod repos.