### PR TITLE
[listeners/snmp] Add oid_batch_size config

### DIFF
--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -97,3 +97,9 @@ instances:
     ##  extra_tags: "tag1:val1,tag2:val2"
     #
     extra_tags: "%%extra_tags%%"
+
+    ## @param oid_batch_size - integer - optional - default: 60
+    ## The number of OIDs handled by each batch. Increasing this number improves performance but
+    ## uses more resources.
+    #
+    oid_batch_size: "%%extra_oid_batch_size%%"

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -397,6 +397,8 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 		return []byte(fmt.Sprintf("%d", s.config.Timeout)), nil
 	case "retries":
 		return []byte(fmt.Sprintf("%d", s.config.Retries)), nil
+	case "oid_batch_size":
+		return []byte(fmt.Sprintf("%d", s.config.OidBatchSize)), nil
 	case "community":
 		return []byte(s.config.Community), nil
 	case "user":

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -159,10 +159,11 @@ func TestSNMPListenerIgnoredAdresses(t *testing.T) {
 
 func TestExtraConfig(t *testing.T) {
 	snmpConfig := snmp.Config{
-		Network:   "192.168.0.0/24",
-		Community: "public",
-		Timeout:   5,
-		Retries:   2,
+		Network:      "192.168.0.0/24",
+		Community:    "public",
+		Timeout:      5,
+		Retries:      2,
+		OidBatchSize: 10,
 	}
 
 	svc := SNMPService{
@@ -188,6 +189,10 @@ func TestExtraConfig(t *testing.T) {
 	info, err = svc.GetExtraConfig([]byte("retries"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "2", string(info))
+
+	info, err = svc.GetExtraConfig([]byte("oid_batch_size"))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "10", string(info))
 
 	info, err = svc.GetExtraConfig([]byte("tags"))
 	assert.Equal(t, nil, err)

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -43,6 +43,7 @@ type Config struct {
 	Version            string          `mapstructure:"version"`
 	Timeout            int             `mapstructure:"timeout"`
 	Retries            int             `mapstructure:"retries"`
+	OidBatchSize       int             `mapstructure:"oid_batch_size"`
 	Community          string          `mapstructure:"community"`
 	User               string          `mapstructure:"user"`
 	AuthKey            string          `mapstructure:"authentication_key"`

--- a/releasenotes/notes/add_snmp_listener_batch_size_config-0a46f962b63cb474.yaml
+++ b/releasenotes/notes/add_snmp_listener_batch_size_config-0a46f962b63cb474.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``oid_batch_size`` config to snmp_listener


### PR DESCRIPTION
### What does this PR do?

Add oid_batch_size config

### Motivation

https://github.com/DataDog/datadog-agent/pull/7818

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test using Standalone Agent AD: https://datadoghq.dev/integrations-core/architecture/snmp/#agent-auto-discovery

Or Cluster Agent AD: https://datadoghq.dev/integrations-core/architecture/snmp/#cluster-agent-support


II-253