### PR TITLE
[corechecks/snmp] Do not print scalarValues

### DIFF
--- a/pkg/collector/corechecks/snmp/values.go
+++ b/pkg/collector/corechecks/snmp/values.go
@@ -14,7 +14,7 @@ type resultValueStore struct {
 func (v *resultValueStore) getScalarValue(oid string) (snmpValueType, error) {
 	value, ok := v.scalarValues[oid]
 	if !ok {
-		return snmpValueType{}, fmt.Errorf("value for Scalar OID `%s` not found in `%v`", oid, v.scalarValues)
+		return snmpValueType{}, fmt.Errorf("value for Scalar OID `%s` not found in results", oid)
 	}
 	return value, nil
 }


### PR DESCRIPTION
### What does this PR do?

Do not print scalarValues

### Motivation

Similar to https://github.com/DataDog/datadog-agent/pull/7731

`value for Scalar OID `%s` not found` is called frequently and it's expensive to build the error msg.

The error is not that useful since we already debug log snmp calls reponses.

### Additional Notes

### Describe your test plan

