### PR TITLE
[networks] Add custom object pool

### DIFF
--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -55,8 +55,16 @@ func modelConnections(conns *network.Connections) *model.Connections {
 
 	for i, conn := range conns.Conns {
 		httpKey := http.NewKey(conn.Source, conn.Dest, conn.SPort, conn.DPort, "")
-		agentConns[i] = FormatConnection(conn, domainSet, routeIndex, httpIndex[httpKey])
+		httpAggregations := httpIndex[httpKey]
+		agentConns[i] = FormatConnection(conn, domainSet, routeIndex, httpAggregations)
 		delete(httpIndex, httpKey)
+		returnHTTPStats(httpAggregations)
+	}
+
+	// Delete orphan entries (those that can't be associated to a TCP connection)
+	// TODO: investigate the source of this (perf misses on the TCP codepath?)
+	for _, httpAggregations := range httpIndex {
+		returnHTTPStats(httpAggregations)
 	}
 
 	domains := make([]string, len(domainSet))

--- a/pkg/network/encoding/format_test.go
+++ b/pkg/network/encoding/format_test.go
@@ -5,6 +5,9 @@ import (
 
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/http"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,5 +74,67 @@ func TestFormatRouteIdx(t *testing.T) {
 				require.Equal(t, v, otherv, "routes in and out are not equal, expected: %v, actual: %v", te.routesOut, te.routesIn)
 			}
 		})
+	}
+}
+
+func TestFormatHTTPStats(t *testing.T) {
+	key1 := http.NewKey(
+		util.AddressFromString("10.1.1.1"),
+		util.AddressFromString("10.2.2.2"),
+		1000,
+		9000,
+		"/path-1",
+	)
+
+	key2 := http.NewKey(
+		util.AddressFromString("10.1.1.1"),
+		util.AddressFromString("10.2.2.2"),
+		1000,
+		9000,
+		"/path-2",
+	)
+
+	stats1 := http.RequestStats{
+		{Count: 1},
+		{Count: 2},
+		{Count: 3},
+		{Count: 4},
+		{Count: 5},
+	}
+
+	stats2 := http.RequestStats{
+		{Count: 6},
+		{Count: 7},
+		{Count: 8},
+		{Count: 9},
+		{Count: 10},
+	}
+
+	httpData := map[http.Key]http.RequestStats{
+		key1: stats1,
+		key2: stats2,
+	}
+
+	formatted := FormatHTTPStats(httpData)
+	aggregatedKey := http.NewKey(
+		util.AddressFromString("10.1.1.1"),
+		util.AddressFromString("10.2.2.2"),
+		1000,
+		9000,
+		"",
+	)
+
+	assert.Len(t, formatted, 1)
+	assert.Contains(t, formatted, aggregatedKey)
+	statsByPath := formatted[aggregatedKey].ByPath
+
+	for key, stats := range httpData {
+		path := key.Path
+		assert.Contains(t, statsByPath, path)
+		statsByCode := statsByPath[path].StatsByResponseStatus
+		require.Len(t, statsByCode, http.NumStatusClasses)
+		for i := 0; i < http.NumStatusClasses; i++ {
+			assert.Equal(t, stats[i].Count, int(statsByCode[i].Count))
+		}
 	}
 }

--- a/pkg/network/encoding/pool.go
+++ b/pkg/network/encoding/pool.go
@@ -1,0 +1,142 @@
+package encoding
+
+import (
+	"container/list"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type pool struct {
+	New func() interface{}
+	TTL time.Duration
+
+	mux    sync.Mutex
+	now    func() int64
+	ttlSec int64
+	list   *list.List
+	// divider is a sentinel value that partitions the list in two
+	// 1. we do this so we can pool not only the client code objects but also the underlying list.Element objects
+	// 2. we can't have two lists instead because standard library doesn't let you move elements between lists
+	// list structure:
+	// FRONT [empty list.Element objects | divider | filled list.Element objects] BACK
+	divider *list.Element
+}
+
+type entry struct {
+	obj      interface{}
+	deadline int64
+}
+
+func (p *pool) Get() interface{} {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	if p.list == nil {
+		p.init()
+		p.start()
+	}
+
+	if el := p.list.Back(); el != nil && el != p.divider {
+		entry := el.Value.(*entry)
+		obj := entry.obj
+
+		// here we recycle the *list.Element object itself and move it to the first partition of the list
+		entry.obj = nil
+		entry.deadline = p.now() + p.ttlSec
+		p.list.MoveBefore(el, p.divider)
+
+		return obj
+	}
+
+	return p.New()
+}
+
+func (p *pool) Put(obj interface{}) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	if el := p.divider.Prev(); el != nil {
+		// Recycle *list.Element if available
+		entry := el.Value.(*entry)
+		entry.obj = obj
+		entry.deadline = p.now() + p.ttlSec
+
+		p.list.MoveToBack(el)
+		return
+	}
+
+	entry := &entry{obj: obj, deadline: p.now() + p.ttlSec}
+	p.list.PushBack(entry)
+}
+
+// we lazily initiate stuff to match the sync.Pool API
+func (p *pool) init() {
+	if p.TTL == 0 {
+		// 40 seconds ensures that objects will be pooled until the next agent check
+		p.TTL = 40 * time.Second
+	}
+
+	p.ttlSec = int64(p.TTL.Seconds())
+	p.now = clock.now
+	p.list = list.New()
+	p.divider = p.list.PushBack(nil)
+}
+
+func (p *pool) start() {
+	clearInterval := time.Duration(p.TTL.Nanoseconds() / 2)
+	ticker := time.NewTicker(clearInterval)
+	go func() {
+		for range ticker.C {
+			p.clear()
+		}
+	}()
+}
+
+func (p *pool) clear() {
+	now := p.now()
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	// Clear old empty list.Element objects
+	p.clearSegment(p.list.Front(), now)
+	// Clear old list.Element objects carrying pooled objects
+	p.clearSegment(p.divider.Next(), now)
+}
+
+func (p *pool) clearSegment(el *list.Element, now int64) {
+	for el != nil && el != p.divider {
+		if entry := el.Value.(*entry); now < entry.deadline {
+			break
+		}
+
+		next := el.Next()
+		p.list.Remove(el)
+		el = next
+	}
+}
+
+var clock *sampledClock
+
+type sampledClock struct {
+	nowTS int64
+}
+
+func newSampledClock(resolution time.Duration) *sampledClock {
+	c := &sampledClock{nowTS: time.Now().Unix()}
+	go func() {
+		ticker := time.NewTicker(resolution)
+		for t := range ticker.C {
+			atomic.StoreInt64(&c.nowTS, t.Unix())
+		}
+	}()
+	return c
+}
+
+func (c *sampledClock) now() int64 {
+	return atomic.LoadInt64(&c.nowTS)
+}
+
+func init() {
+	clock = newSampledClock(time.Second)
+}

--- a/pkg/network/encoding/pool_test.go
+++ b/pkg/network/encoding/pool_test.go
@@ -1,0 +1,82 @@
+package encoding
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPool(t *testing.T) {
+	const numObjects = 10
+	allocs := 0
+	inUse := make([][]byte, numObjects)
+
+	myPool := pool{
+		New: func() interface{} {
+			allocs++
+			return make([]byte, 10)
+		},
+		TTL: time.Minute,
+	}
+
+	// called explicitly just for testing
+	myPool.init()
+
+	retrieveObjects := func() {
+		for i := 0; i < numObjects; i++ {
+			inUse[i] = myPool.Get().([]byte)
+		}
+
+		for i := 0; i < numObjects; i++ {
+			myPool.Put(inUse[i])
+			inUse[i] = nil
+		}
+	}
+
+	now := time.Now()
+	setTime(now, &myPool)
+	retrieveObjects()
+	assert.Equal(t, numObjects, allocs)
+
+	// all calls to pool now should be served from pooled objects
+	allocs = 0
+	now = now.Add(30 * time.Second)
+	setTime(now, &myPool)
+	myPool.clear()
+	retrieveObjects()
+	assert.Equal(t, 0, allocs)
+
+	// we're past the TTL now so all objects should have been freed (except by the sentinel value)
+	now = now.Add(myPool.TTL + time.Second)
+	setTime(now, &myPool)
+	myPool.clear()
+	assert.Equal(t, 1, myPool.list.Len())
+
+	// objects should should be allocated again
+	allocs = 0
+	retrieveObjects()
+	assert.Equal(t, numObjects, allocs)
+}
+
+func setTime(now time.Time, pool *pool) {
+	pool.now = func() int64 {
+		return now.Unix()
+	}
+}
+
+func BenchmarkPoolSameObject(b *testing.B) {
+	pool := pool{
+		New: func() interface{} {
+			return time.Now()
+		},
+	}
+
+	var obj interface{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		obj = pool.Get()
+		pool.Put(obj)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Pool HTTP encoding objects which were being responsible for nearly 10% of the total allocations in system-probe.
My first attempt was to use `sync.Pool`, but then I noticed that sync.Pool wasn't helping at all since under memory pressure the whole pool gets cleared before they can be re-used in the network check (when the serialization process kicks in again).

This PR adds a custom pool implementation that can be used as a drop-in replacement for sync.Pool and that is a better fit for this allocation pattern (batches of objects every 30seconds)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
