### PR TITLE
Log the goroutines stack when a healthprobe fails

### DIFF
--- a/pkg/api/healthprobe/healthprobe.go
+++ b/pkg/api/healthprobe/healthprobe.go
@@ -70,6 +70,7 @@ func healthHandler(getStatusNonBlocking func() (health.Status, error), w http.Re
 	if len(health.Unhealthy) > 0 {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Infof("Healthcheck failed on: %v", health.Unhealthy)
+		log.Infof("goroutines stack: \n%s\n", allStack())
 	}
 
 	jsonHealth, err := json.Marshal(health)

--- a/pkg/api/healthprobe/healthprobe.go
+++ b/pkg/api/healthprobe/healthprobe.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gorilla/mux"
@@ -70,7 +71,9 @@ func healthHandler(getStatusNonBlocking func() (health.Status, error), w http.Re
 	if len(health.Unhealthy) > 0 {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Infof("Healthcheck failed on: %v", health.Unhealthy)
-		log.Infof("goroutines stack: \n%s\n", allStack())
+		if config.Datadog.GetBool("log_all_goroutines_when_unhealthy") {
+			log.Infof("Goroutines stack: \n%s\n", allStack())
+		}
 	}
 
 	jsonHealth, err := json.Marshal(health)

--- a/pkg/api/healthprobe/stack.go
+++ b/pkg/api/healthprobe/stack.go
@@ -1,0 +1,19 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+
+package healthprobe
+
+import (
+	"runtime"
+)
+
+// inspired by https://golang.org/src/runtime/debug/stack.go?s=587:606#L11
+func allStack() []byte {
+	buf := make([]byte, 1024)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return buf[:n]
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -196,6 +196,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("log_to_syslog", false)
 	config.BindEnvAndSetDefault("log_to_console", true)
 	config.BindEnvAndSetDefault("log_format_rfc3339", false)
+	config.BindEnvAndSetDefault("log_all_goroutines_when_unhealthy", false)
 	config.BindEnvAndSetDefault("logging_frequency", int64(500))
 	config.BindEnvAndSetDefault("disable_file_logging", false)
 	config.BindEnvAndSetDefault("syslog_uri", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -12,7 +12,7 @@ api_key:
 ## @param site - string - optional - default: datadoghq.com
 ## The site of the Datadog intake to send Agent data to.
 ## Set to 'datadoghq.eu' to send data to the EU site.
-## Set to 'us3.datadoghq.com' to send data to the US3 site. 
+## Set to 'us3.datadoghq.com' to send data to the US3 site.
 ## Set to 'ddog-gov.com' to send data to the US1-FED site.
 #
 # site: datadoghq.com
@@ -1475,6 +1475,12 @@ api_key:
 ## If enabled the Agent will log using the RFC3339 format for the log time.
 #
 # log_format_rfc3339: false
+
+## @param log_all_goroutines_when_unhealthy - boolean - optional - default false
+## If enabled, when the health probe of an internal component fails, the stack traces
+## of all the goroutines are logged.
+#
+# log_all_goroutines_when_unhealthy: false
 
 {{ end -}}
 {{- if .Autoconfig }}

--- a/releasenotes/notes/log_stacktraces_of_unhealthy_components-543d12280765a266.yaml
+++ b/releasenotes/notes/log_stacktraces_of_unhealthy_components-543d12280765a266.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When a component is unhealthy, log the stacktraces of the goroutines to ease the investigation

--- a/releasenotes/notes/log_stacktraces_of_unhealthy_components-543d12280765a266.yaml
+++ b/releasenotes/notes/log_stacktraces_of_unhealthy_components-543d12280765a266.yaml
@@ -8,4 +8,5 @@
 ---
 enhancements:
   - |
-    When a component is unhealthy, log the stacktraces of the goroutines to ease the investigation
+    If the new ``log_all_goroutines_when_unhealthy`` configuration parameter is set to true,
+    when a component is unhealthy, log the stacktraces of the goroutines to ease the investigation.


### PR DESCRIPTION
### What does this PR do?

When a component is unhealthy, log the goroutines stacktrace so that we can understand where it is stuck.

### Motivation

With #7605, the only reason for a component to be unhealthy should be bug (the goroutine exited abnormally or is definitively blocked somewhere). In such a situation, we need the stacktrace to understand where the goroutine is stuck.

### Additional Notes

Ideally, I would have preferred to log only the stacktrace of the stuck goroutine but I only found functions to dump the stacktrace of the current goroutine or all the goroutines.

This change is the piece of code that I used to get the stacktraces in the description of #7605.

This log is extremely verbose but we have evidences that unhealthy components is quite uncommon.
Indeed, on Kubernetes, components health is used as a liveness probe so that, when a component is unhealthy, Kubernetes kills the agent and restart it.
If it was happening often, it would have already been a problem.

### Describe your test plan

This PR can be tested only without #7605. In this case, following the testing instructions of it would lead some components to become unhealthy and the stacktraces should be logged if and only if `log_all_goroutines_when_unhealthy` is set to `true`.