### PR TITLE
logs/sender: improve throughput with concurrency

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,6 +51,9 @@ const (
 	// DefaultBatchWait is the default HTTP batch wait in second for logs
 	DefaultBatchWait = 5
 
+	// DefaultBatchMaxConcurrentSend is the default HTTP batch max concurrent send for logs
+	DefaultBatchMaxConcurrentSend = 0
+
 	// DefaultAuditorTTL is the default logs auditor TTL in hours
 	DefaultAuditorTTL = 23
 

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -89,7 +89,7 @@ func (suite *AgentTestSuite) TestAgent() {
 	defer l.Close()
 
 	endpoint := tcp.AddrToEndPoint(l.Addr())
-	endpoints := config.NewEndpoints(endpoint, nil, true, false, 0)
+	endpoints := config.NewEndpoints(endpoint, nil, true, false, 0, 0)
 
 	agent, sources, _ := createAgent(endpoints)
 
@@ -120,7 +120,7 @@ func (suite *AgentTestSuite) TestAgent() {
 
 func (suite *AgentTestSuite) TestAgentStopsWithWrongBackend() {
 	endpoint := config.Endpoint{Host: "fake:", Port: 0}
-	endpoints := config.NewEndpoints(endpoint, nil, true, false, 0)
+	endpoints := config.NewEndpoints(endpoint, nil, true, false, 0, 0)
 
 	agent, sources, _ := createAgent(endpoints)
 
@@ -146,7 +146,7 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongAdditionalBackend() {
 	endpoint := tcp.AddrToEndPoint(l.Addr())
 	additionalEndpoint := config.Endpoint{Host: "still_fake", Port: 0}
 
-	endpoints := config.NewEndpoints(endpoint, []config.Endpoint{additionalEndpoint}, true, false, 0)
+	endpoints := config.NewEndpoints(endpoint, []config.Endpoint{additionalEndpoint}, true, false, 0, 0)
 
 	agent, sources, _ := createAgent(endpoints)
 

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -42,21 +42,27 @@ type Destination struct {
 	destinationsContext *client.DestinationsContext
 	once                sync.Once
 	payloadChan         chan []byte
+	climit              chan struct{} // semaphore for limiting concurrent background sends
 }
 
 // NewDestination returns a new Destination.
 // TODO: add support for SOCKS5
-func NewDestination(endpoint config.Endpoint, contentType string, destinationsContext *client.DestinationsContext) *Destination {
-	return newDestination(endpoint, contentType, destinationsContext, time.Second*10)
+func NewDestination(endpoint config.Endpoint, contentType string, destinationsContext *client.DestinationsContext, maxConcurrentBackgroundSends int) *Destination {
+	return newDestination(endpoint, contentType, destinationsContext, time.Second*10, maxConcurrentBackgroundSends)
 }
 
-func newDestination(endpoint config.Endpoint, contentType string, destinationsContext *client.DestinationsContext, timeout time.Duration) *Destination {
+func newDestination(endpoint config.Endpoint, contentType string, destinationsContext *client.DestinationsContext, timeout time.Duration, maxConcurrentBackgroundSends int) *Destination {
+	var climit chan struct{}
+	if maxConcurrentBackgroundSends > 0 {
+		climit = make(chan struct{}, maxConcurrentBackgroundSends)
+	}
 	return &Destination{
 		url:                 buildURL(endpoint),
 		contentType:         contentType,
 		contentEncoding:     buildContentEncoding(endpoint),
 		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(timeout)),
 		destinationsContext: destinationsContext,
+		climit:              climit,
 	}
 }
 
@@ -129,7 +135,15 @@ func (d *Destination) sendInBackground(payloadChan chan []byte) {
 		for {
 			select {
 			case payload := <-payloadChan:
-				d.Send(payload) //nolint:errcheck
+				if d.climit == nil {
+					d.Send(payload) //nolint:errcheck
+					break
+				}
+				d.climit <- struct{}{}
+				go func() {
+					d.Send(payload) //nolint:errcheck
+					<-d.climit
+				}()
 			case <-ctx.Done():
 				return
 			}
@@ -178,7 +192,7 @@ func CheckConnectivity(endpoint config.Endpoint) config.HTTPConnectivity {
 	ctx.Start()
 	defer ctx.Stop()
 	// Lower the timeout to 5s because HTTP connectivity test is done synchronously during the agent bootstrap sequence
-	destination := newDestination(endpoint, JSONContentType, ctx, time.Second*5)
+	destination := newDestination(endpoint, JSONContentType, ctx, time.Second*5, 0)
 	log.Infof("Sending HTTP connectivity request to %s...", destination.url)
 	err := destination.Send(emptyPayload)
 	if err != nil {

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -39,7 +39,7 @@ func NewHTTPServerTest(statusCode int) *HTTPServerTest {
 		Port:   port,
 		UseSSL: false,
 	}
-	dest := NewDestination(endpoint, JSONContentType, destCtx)
+	dest := NewDestination(endpoint, JSONContentType, destCtx, 0)
 	return &HTTPServerTest{
 		httpServer:  ts,
 		destCtx:     destCtx,

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -178,7 +178,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsEnvVar() {
 		UseCompression:   true,
 		CompressionLevel: 2}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true, time.Second)
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true, time.Second, 0)
 	endpoints, err := BuildHTTPEndpoints()
 
 	suite.Nil(err)
@@ -212,7 +212,7 @@ func (suite *ConfigTestSuite) TestMultipleTCPEndpointsEnvVar() {
 		CompressionLevel: 0,
 		ProxyAddress:     "proxy.test:3128"}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false, 0)
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false, 0, 0)
 	endpoints, err := buildTCPEndpoints()
 
 	suite.Nil(err)
@@ -264,7 +264,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig() {
 		UseCompression:   true,
 		CompressionLevel: 2}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true, time.Second)
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true, time.Second, 0)
 	endpoints, err := BuildHTTPEndpoints()
 
 	suite.Nil(err)
@@ -303,7 +303,7 @@ func (suite *ConfigTestSuite) TestMultipleTCPEndpointsInConf() {
 		CompressionLevel: 0,
 		ProxyAddress:     "proxy.test:3128"}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false, 0)
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false, 0, 0)
 	endpoints, err := buildTCPEndpoints()
 
 	suite.Nil(err)

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -23,20 +23,22 @@ type Endpoint struct {
 
 // Endpoints holds the main endpoint and additional ones to dualship logs.
 type Endpoints struct {
-	Main        Endpoint
-	Additionals []Endpoint
-	UseProto    bool
-	UseHTTP     bool
-	BatchWait   time.Duration
+	Main                   Endpoint
+	Additionals            []Endpoint
+	UseProto               bool
+	UseHTTP                bool
+	BatchWait              time.Duration
+	BatchMaxConcurrentSend int
 }
 
 // NewEndpoints returns a new endpoints composite.
-func NewEndpoints(main Endpoint, additionals []Endpoint, useProto bool, useHTTP bool, batchWait time.Duration) *Endpoints {
+func NewEndpoints(main Endpoint, additionals []Endpoint, useProto bool, useHTTP bool, batchWait time.Duration, batchMaxConcurrentSend int) *Endpoints {
 	return &Endpoints{
-		Main:        main,
-		Additionals: additionals,
-		UseProto:    useProto,
-		UseHTTP:     useHTTP,
-		BatchWait:   batchWait,
+		Main:                   main,
+		Additionals:            additionals,
+		UseProto:               useProto,
+		UseHTTP:                useHTTP,
+		BatchWait:              batchWait,
+		BatchMaxConcurrentSend: batchMaxConcurrentSend,
 	}
 }

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -29,10 +29,10 @@ type Pipeline struct {
 func NewPipeline(outputChan chan *message.Message, processingRules []*config.ProcessingRule, endpoints *config.Endpoints, destinationsContext *client.DestinationsContext, diagnosticMessageReceiver diagnostic.MessageReceiver, serverless bool) *Pipeline {
 	var destinations *client.Destinations
 	if endpoints.UseHTTP {
-		main := http.NewDestination(endpoints.Main, http.JSONContentType, destinationsContext)
+		main := http.NewDestination(endpoints.Main, http.JSONContentType, destinationsContext, endpoints.BatchMaxConcurrentSend)
 		additionals := []client.Destination{}
 		for _, endpoint := range endpoints.Additionals {
-			additionals = append(additionals, http.NewDestination(endpoint, http.JSONContentType, destinationsContext))
+			additionals = append(additionals, http.NewDestination(endpoint, http.JSONContentType, destinationsContext, endpoints.BatchMaxConcurrentSend))
 		}
 		destinations = client.NewDestinations(main, additionals)
 	} else {
@@ -48,7 +48,7 @@ func NewPipeline(outputChan chan *message.Message, processingRules []*config.Pro
 
 	var strategy sender.Strategy
 	if endpoints.UseHTTP || serverless {
-		strategy = sender.NewBatchStrategy(sender.ArraySerializer, endpoints.BatchWait)
+		strategy = sender.NewBatchStrategy(sender.ArraySerializer, endpoints.BatchWait, endpoints.BatchMaxConcurrentSend)
 	} else {
 		strategy = sender.StreamStrategy
 	}

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -30,7 +30,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 		numberOfPipelines: 3,
 		auditor:           suite.a,
 		pipelines:         []*Pipeline{},
-		endpoints:         config.NewEndpoints(config.Endpoint{}, nil, true, false, 0),
+		endpoints:         config.NewEndpoints(config.Endpoint{}, nil, true, false, 0, 0),
 	}
 }
 

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -23,104 +23,127 @@ const (
 
 // batchStrategy contains all the logic to send logs in batch.
 type batchStrategy struct {
-	buffer     *MessageBuffer
-	serializer Serializer
-	batchWait  time.Duration
+	buffer           *MessageBuffer
+	serializer       Serializer
+	batchWait        time.Duration
+	climit           chan struct{}  // semaphore for limiting concurrent sends
+	pendingSends     sync.WaitGroup // waitgroup for concurrent sends
+	syncFlushTrigger chan struct{}  // trigger a synchronous flush
+	syncFlushDone    chan struct{}  // wait for a synchronous flush to finish
 }
 
-// NewBatchStrategy returns a new batchStrategy.
-func NewBatchStrategy(serializer Serializer, batchWait time.Duration) Strategy {
+// NewBatchStrategy returns a new batch concurrent strategy that will send at most `maxConcurrent` batches in parallel.
+func NewBatchStrategy(serializer Serializer, batchWait time.Duration, maxConcurrent int) Strategy {
+	return newBatchStrategyWithSize(serializer, batchWait, maxConcurrent, maxBatchSize, maxContentSize)
+}
+
+func newBatchStrategyWithSize(serializer Serializer, batchWait time.Duration, maxConcurrent int, maxBatchSize int, maxContentSize int) *batchStrategy {
+	var climit chan struct{}
+	if maxConcurrent > 0 {
+		climit = make(chan struct{}, maxConcurrent)
+	}
 	return &batchStrategy{
-		buffer:     NewMessageBuffer(maxBatchSize, maxContentSize),
-		serializer: serializer,
-		batchWait:  batchWait,
+		buffer:           NewMessageBuffer(maxBatchSize, maxContentSize),
+		serializer:       serializer,
+		batchWait:        batchWait,
+		climit:           climit,
+		syncFlushTrigger: make(chan struct{}),
+		syncFlushDone:    make(chan struct{}),
+	}
+
+}
+
+func (s *batchStrategy) Flush(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		return
+	default:
+		s.syncFlushTrigger <- struct{}{}
+		<-s.syncFlushDone
 	}
 }
 
-func (s *batchStrategy) Flush(ctx context.Context, inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error, mu *sync.Mutex) {
-	mu.Lock()
-	defer mu.Unlock()
+func (s *batchStrategy) syncFlush(inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error) {
+	defer func() {
+		s.flushBuffer(outputChan, send)
+		s.pendingSends.Wait()
+	}()
 	for {
 		select {
-		case <-ctx.Done():
-			return
-		default:
-			if len(inputChan) == 0 {
-				s.sendBuffer(outputChan, send)
+		case m, isOpen := <-inputChan:
+			if !isOpen {
 				return
 			}
-			message := <-inputChan
-			added := s.buffer.AddMessage(message)
-			if !added || s.buffer.IsFull() {
-				s.sendBuffer(outputChan, send)
-			}
-			if !added {
-				// it's possible that the message could not be added because the buffer was full
-				// so we need to retry once again
-				s.buffer.AddMessage(message)
-			}
+			s.processMessage(m, outputChan, send)
+		default:
+			return
 		}
 	}
 }
 
 // Send accumulates messages to a buffer and sends them when the buffer is full or outdated.
-func (s *batchStrategy) Send(inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error, mu *sync.Mutex) {
+func (s *batchStrategy) Send(inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error) {
 	flushTimer := time.NewTimer(s.batchWait)
 	defer func() {
+		s.flushBuffer(outputChan, send)
 		flushTimer.Stop()
+		s.pendingSends.Wait()
 	}()
-
 	for {
 		select {
-		case message, isOpen := <-inputChan:
+		case m, isOpen := <-inputChan:
 			if !isOpen {
-				// inputChan has been closed, no more payload are expected
-				s.sendBuffer(outputChan, send)
+				// inputChan has been closed, no more payloads are expected
 				return
 			}
-			if message.Origin != nil {
-				message.Origin.LogSource.LatencyStats.Add(message.GetLatency())
-			}
-			added := s.buffer.AddMessage(message)
-			if !added || s.buffer.IsFull() {
-				// message buffer is full, either reaching max batch size or max content size,
-				// send the payload now
-				if !flushTimer.Stop() {
-					// make sure the timer won't tick concurrently
-					select {
-					case <-flushTimer.C:
-					default:
-					}
-				}
-				s.sendBuffer(outputChan, send)
-				flushTimer.Reset(s.batchWait)
-			}
-			if !added {
-				// it's possible that the message could not be added because the buffer was full
-				// so we need to retry once again
-				s.buffer.AddMessage(message)
-			}
+			s.processMessage(m, outputChan, send)
 		case <-flushTimer.C:
-			// the first message that was added to the buffer has been here for too long,
-			// send the payload now
-			s.sendBuffer(outputChan, send)
-			flushTimer.Reset(s.batchWait)
+			// the first message that was added to the buffer has been here for too long, send the payload now
+			s.flushBuffer(outputChan, send)
+		case <-s.syncFlushTrigger:
+			s.syncFlush(inputChan, outputChan, send)
+			s.syncFlushDone <- struct{}{}
 		}
-		mu.Lock() // block here if we're synchronously sending
-		mu.Unlock()
 	}
 }
 
-// sendBuffer sends all the messages that are stored in the buffer and forwards them
+func (s *batchStrategy) processMessage(m *message.Message, outputChan chan *message.Message, send func([]byte) error) {
+	if m.Origin != nil {
+		m.Origin.LogSource.LatencyStats.Add(m.GetLatency())
+	}
+	added := s.buffer.AddMessage(m)
+	if !added || s.buffer.IsFull() {
+		s.flushBuffer(outputChan, send)
+	}
+	if !added {
+		// it's possible that the m could not be added because the buffer was full
+		// so we need to retry once again
+		s.buffer.AddMessage(m)
+	}
+}
+
+// flushBuffer sends all the messages that are stored in the buffer and forwards them
 // to the next stage of the pipeline.
-func (s *batchStrategy) sendBuffer(outputChan chan *message.Message, send func([]byte) error) {
+func (s *batchStrategy) flushBuffer(outputChan chan *message.Message, send func([]byte) error) {
 	if s.buffer.IsEmpty() {
 		return
 	}
-
 	messages := s.buffer.GetMessages()
-	defer s.buffer.Clear()
+	s.buffer.Clear()
+	if s.climit == nil {
+		s.sendMessages(messages, outputChan, send)
+		return
+	}
+	s.climit <- struct{}{}
+	s.pendingSends.Add(1)
+	go func() {
+		s.sendMessages(messages, outputChan, send)
+		s.pendingSends.Done()
+		<-s.climit
+	}()
+}
 
+func (s *batchStrategy) sendMessages(messages []*message.Message, outputChan chan *message.Message, send func([]byte) error) {
 	err := send(s.serializer.Serialize(messages))
 	if err != nil {
 		if shouldStopSending(err) {

--- a/pkg/logs/sender/message_buffer.go
+++ b/pkg/logs/sender/message_buffer.go
@@ -38,7 +38,8 @@ func (p *MessageBuffer) AddMessage(message *message.Message) bool {
 
 // Clear reinitializes the buffer.
 func (p *MessageBuffer) Clear() {
-	p.messageBuffer = p.messageBuffer[:0]
+	// create a new buffer to avoid race conditions
+	p.messageBuffer = make([]*message.Message, 0, cap(p.messageBuffer))
 	p.contentSize = 0
 }
 

--- a/pkg/logs/sender/stream_strategy.go
+++ b/pkg/logs/sender/stream_strategy.go
@@ -7,7 +7,6 @@ package sender
 
 import (
 	"context"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -21,12 +20,12 @@ var StreamStrategy Strategy = &streamStrategy{}
 // streamStrategy contains all the logic to send one log at a time.
 type streamStrategy struct{}
 
-func (s *streamStrategy) Flush(ctx context.Context, inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error, mu *sync.Mutex) {
+func (s *streamStrategy) Flush(ctx context.Context) {
 	// nothing to do
 }
 
 // Send sends one message at a time and forwards them to the next stage of the pipeline.
-func (s *streamStrategy) Send(inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error, mu *sync.Mutex) {
+func (s *streamStrategy) Send(inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error) {
 	for message := range inputChan {
 		if message.Origin != nil {
 			message.Origin.LogSource.LatencyStats.Add(message.GetLatency())

--- a/pkg/logs/sender/stream_strategy_test.go
+++ b/pkg/logs/sender/stream_strategy_test.go
@@ -24,7 +24,7 @@ func TestStreamStrategy(t *testing.T) {
 		return nil
 	}
 
-	go StreamStrategy.Send(input, output, success, nil)
+	go StreamStrategy.Send(input, output, success)
 
 	content = []byte("a")
 	message1 := message.NewMessage(content, nil, "", 0)
@@ -54,7 +54,7 @@ func TestStreamStrategyShouldNotBlockWhenForceStopping(t *testing.T) {
 		close(input)
 	}()
 
-	StreamStrategy.Send(input, output, success, nil)
+	StreamStrategy.Send(input, output, success)
 }
 
 func TestStreamStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
@@ -73,5 +73,5 @@ func TestStreamStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 		assert.Equal(t, message, <-output)
 	}()
 
-	StreamStrategy.Send(input, output, success, nil)
+	StreamStrategy.Send(input, output, success)
 }

--- a/releasenotes/notes/logs-sender-improve-concurrency-927cc9994290c20f.yaml
+++ b/releasenotes/notes/logs-sender-improve-concurrency-927cc9994290c20f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve `logs/sender` throughput by adding optional concurrency for serializing & sending payloads.


### PR DESCRIPTION
### What does this PR do?

Enable `logs/sender` to send payloads concurrently in order to improve throughput.

Core changes:
* `logs/sender/batch_strategy` now sends at most `maxConcurrent` payloads concurrently.
* `logs/client/http/destination` now sends at most `maxConcurrentBackgroundSends` payloads concurrently.
  * In order for the sender throughput to increase both the batch_strategy and the http destination need to be sending payloads concurrently.
* New logs config parameter: `logs_config.batch_max_concurrent_send`
  * The default behavior is zero concurrency, which is the same behavior as it was before the change.
* Simplify `logs/sender` concurrency: remove mutex in favor of channel based coordination

### Motivation

Without concurrent payload sending the whole sender is blocked waiting on each payload to be sent one by one, significantly limiting the maximum throughput. 

Increased throughput is needed for an upcoming database monitoring feature (https://github.com/DataDog/datadog-agent/pull/7735) which will be sending events from python checks to a custom intake using the agent `logs/sender`. While working on that we found that a single `sender` has a throughput limit of ~ 500 events/s (testing locally). With these concurrency changes we can reach ~4k events/s which is what we would expect a heavily loaded agent monitoring many high query cardinality databases to be producing. 

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
