### PR TITLE
Enhance the health framework to enqueue a deadline instead of an empty token

### DIFF
--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -109,7 +109,7 @@ func TestGetHealthy(t *testing.T) {
 
 	// Start responding, become healthy
 	<-token.C
-	cat.pingComponents()
+	cat.pingComponents(time.Time{})
 	status = cat.getStatus()
 	assert.Len(t, status.Healthy, 2)
 	assert.Len(t, status.Unhealthy, 0)
@@ -117,7 +117,7 @@ func TestGetHealthy(t *testing.T) {
 	// Make sure we keep staying healthy
 	for i := 1; i < 10; i++ {
 		<-token.C
-		cat.pingComponents()
+		cat.pingComponents(time.Time{})
 	}
 	status = cat.getStatus()
 	assert.Len(t, status.Healthy, 2)


### PR DESCRIPTION
### What does this PR do?

The health framework works by enqueuing tokens in a channel and checking that the monitored components are regularly popping those tokens from the channel.
This change adds a deadline inside the token so that the monitored components can know when they absolutely need to come back popping elements from the health channel before being considered as stuck and being flagged as unhealthy.

### Motivation

The deadline conveyed through the health channel token can then be used to build a `context.Context` that can be cascaded down to the remote API calls like how it is done in #7605 in the [`ad-service` component](https://github.com/DataDog/datadog-agent/pull/7605/files#diff-fb8adbf842c9af6d8e48eda9d22bb532eb7e6c32c95af36ad5528d216aba7398), the [`ad-config-provider-*` component](https://github.com/DataDog/datadog-agent/pull/7605/files#diff-58f9ae7d0828338124fa3e4f60294cb30aab29aefd2938e12d4b72d1999f0c64), the [`ad-dockerlistener` component](https://github.com/DataDog/datadog-agent/pull/7605/files#diff-54a54cebe9abd3782047f686390c744ed650d853216722d54c2bdb6fd17b5983), the [`ad-ecslistener` component](https://github.com/DataDog/datadog-agent/pull/7605/files#diff-cbd65fce38e1a015af0a884c7a4cd118f86e8728725abd66c8c47bc78cb9fc72), the [`ad-kubeletlistener` component](https://github.com/DataDog/datadog-agent/pull/7605/files#diff-a81c8d71f6ff63b50f0e6aefe9008ff759e218d38719254355991059d2d80495), etc.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

This change cannot be tested alone. It’s part of #7605.
