### PR TITLE
Add Docker images based on Windows Core

### DIFF
--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -109,6 +109,10 @@ deploy_google_container_registry_linux-a7:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win2004
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1909-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1909-core
@@ -245,6 +249,7 @@ deploy_google_container_registry-dogstatsd:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
@@ -253,6 +258,7 @@ deploy_google_container_registry-dogstatsd:
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
@@ -341,6 +347,7 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
@@ -349,6 +356,7 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
@@ -357,6 +365,7 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
@@ -365,6 +374,7 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -249,19 +249,21 @@ deploy_google_container_registry-dogstatsd:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
+      --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
+    - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag ${VERSION}-servercore
       --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
-      --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag ${VERSION}-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx,linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
+      --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
+    - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag ${VERSION}-servercore-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
-      --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
 
 deploy_docker_hub_manifests-a7:
   extends:
@@ -347,37 +349,41 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
+      --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
+    - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag latest-servercore
       --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
-      --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag latest-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx,linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
+      --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
+    - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag latest-servercore-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
-      --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7
       --image ${REPOSITORY}-amd64:${VERSION},linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
+      --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
+    - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7-servercore
       --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
-      --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx,linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
+      --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
+    - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7-servercore-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
-      --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
 
 deploy_latest_manifests_docker_hub-a7:
   extends:

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -109,6 +109,18 @@ deploy_google_container_registry_linux-a7:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win2004
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1909-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1909-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win2004-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win2004-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win2004-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
     - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64:${Env:DATADOG_AGENT_WINBUILDIMAGES} powershell -C C:\mnt\ci-scripts\publish.ps1
@@ -138,7 +150,7 @@ deploy_docker_hub_windows-a7:
     SIGNING_ARGS: --signed-push
 
 deploy_google_container_registry_windows-a7:
-  extends: 
+  extends:
     - .google_container_registry_tag_windows_job_definition
     - .deploy_docker_windows-a7
   rules:
@@ -237,12 +249,18 @@ deploy_google_container_registry-dogstatsd:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag ${VERSION}-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx,linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
 
 deploy_docker_hub_manifests-a7:
@@ -329,24 +347,36 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag latest-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx,linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7
       --image ${REPOSITORY}-amd64:${VERSION},linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx,linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
 
 deploy_latest_manifests_docker_hub-a7:
@@ -380,7 +410,7 @@ deploy_latest_manifests_docker_hub-a7:
   variables:
     REPOSITORY: datadog/agent
     SIGNING_ARGS: --signed-push
-  
+
 deploy_latest_manifests_google_container_registry-a7:
   extends:
     - .google_container_registry_tag_job_definition

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -109,10 +109,6 @@ deploy_google_container_registry_linux-a7:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win2004
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1809-core
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1809-core
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1909-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1909-core
@@ -249,7 +245,6 @@ deploy_google_container_registry-dogstatsd:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
@@ -258,7 +253,6 @@ deploy_google_container_registry-dogstatsd:
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
@@ -347,7 +341,6 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
@@ -356,7 +349,6 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
@@ -365,7 +357,6 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
@@ -374,7 +365,6 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -109,17 +109,17 @@ deploy_google_container_registry_linux-a7:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win2004
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1809-core
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1809-servercore-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1809-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1809-core
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-servercore-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1809-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1909-core
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win1909-servercore-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win1909-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1909-core
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-servercore-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win1909-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win2004-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win2004-core
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-win2004-servercore-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-win2004-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win2004-core
+      inv -e docker.publish-bulk ${SIGNING_ARGS} --platform windows/amd64 --src-template ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-servercore-ARCH --dst-template ${REPOSITORY}-ARCH:`${VERSION}-jmx-win2004-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
@@ -251,9 +251,9 @@ deploy_google_container_registry-dogstatsd:
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag ${VERSION}-servercore
-      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1809-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1909-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag ${VERSION}-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx,linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
@@ -261,9 +261,9 @@ deploy_google_container_registry-dogstatsd:
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag ${VERSION}-servercore-jmx
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-servercore,windows/amd64
 
 deploy_docker_hub_manifests-a7:
   extends:
@@ -351,9 +351,9 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag latest-servercore
-      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1809-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1909-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag latest-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx,linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
@@ -361,9 +361,9 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag latest-servercore-jmx
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7
       --image ${REPOSITORY}-amd64:${VERSION},linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-win1809,windows/amd64
@@ -371,9 +371,9 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-win2004,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION},linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7-servercore
-      --image ${REPOSITORY}-amd64:${VERSION}-win1809-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-win1909-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-win2004-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1809-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win1909-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7-jmx
       --image ${REPOSITORY}-amd64:${VERSION}-jmx,linux/amd64
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809,windows/amd64
@@ -381,9 +381,9 @@ deploy_google_container_registry_manifests-a7:
       --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004,windows/amd64
       --image ${REPOSITORY}-arm64:${VERSION}-jmx,linux/arm64
     - inv -e docker.publish-manifest ${SIGNING_ARGS} --name ${REPOSITORY} --tag 7-servercore-jmx
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-core,windows/amd64
-      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-core,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1809-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win1909-servercore,windows/amd64
+      --image ${REPOSITORY}-amd64:${VERSION}-jmx-win2004-servercore,windows/amd64
 
 deploy_latest_manifests_docker_hub-a7:
   extends:

--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -48,11 +48,11 @@
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
-    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservernano-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"
-    - $TARGET_TAG = "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
     - cp ${OMNIBUS_PACKAGE_DIR}/datadog-agent-7*-x86_64.zip ${BUILD_CONTEXT}/datadog-agent-7-latest.amd64.zip
     - cp entrypoint.exe ${BUILD_CONTEXT}/entrypoint.exe
     - get-childitem ${BUILD_CONTEXT}
@@ -127,3 +127,74 @@ docker_build_agent7_windows2004_jmx:
     VARIANT: 2004
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
+
+docker_build_agent7_windows1809_core:
+  extends:
+    - .docker_build_windows_job_definition
+    - .docker_build_agent7_windows_common
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  variables:
+    VARIANT: 1809
+    TAG_SUFFIX: -7
+    WITH_JMX: "false"
+
+docker_build_agent7_windows1809_core_jmx:
+  extends:
+    - .docker_build_windows_job_definition
+    - .docker_build_agent7_windows_common
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  variables:
+    VARIANT: 1809
+    TAG_SUFFIX: -7-jmx
+    WITH_JMX: "true"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"
+
+docker_build_agent7_windows1909_core:
+  extends:
+    - .docker_build_windows_job_definition
+    - .docker_build_agent7_windows_common
+  tags: ["runner:windows-docker", "windowsversion:1909"]
+  variables:
+    VARIANT: 1909
+    TAG_SUFFIX: -7
+    WITH_JMX: "false"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"
+
+docker_build_agent7_windows1909_core_jmx:
+  extends:
+    - .docker_build_windows_job_definition
+    - .docker_build_agent7_windows_common
+  tags: ["runner:windows-docker", "windowsversion:1909"]
+  variables:
+    VARIANT: 1909
+    TAG_SUFFIX: -7-jmx
+    WITH_JMX: "true"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"
+
+docker_build_agent7_windows2004_core:
+  extends:
+    - .docker_build_windows_job_definition
+    - .docker_build_agent7_windows_common
+  tags: ["runner:windows-docker", "windowsversion:2004"]
+  variables:
+    VARIANT: 2004
+    TAG_SUFFIX: "-7"
+    WITH_JMX: "false"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"
+
+docker_build_agent7_windows2004_core_jmx:
+  extends:
+    - .docker_build_windows_job_definition
+    - .docker_build_agent7_windows_common
+  tags: ["runner:windows-docker", "windowsversion:2004"]
+  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
+  variables:
+    VARIANT: 2004
+    TAG_SUFFIX: -7-jmx
+    WITH_JMX: "true"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"

--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -148,7 +148,7 @@ docker_build_agent7_windows1809_core_jmx:
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
     BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows1909_core:
   extends:
@@ -160,7 +160,7 @@ docker_build_agent7_windows1909_core:
     TAG_SUFFIX: -7
     WITH_JMX: "false"
     BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows1909_core_jmx:
   extends:
@@ -172,7 +172,7 @@ docker_build_agent7_windows1909_core_jmx:
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
     BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows2004_core:
   extends:
@@ -184,7 +184,7 @@ docker_build_agent7_windows2004_core:
     TAG_SUFFIX: "-7"
     WITH_JMX: "false"
     BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows2004_core_jmx:
   extends:
@@ -197,4 +197,4 @@ docker_build_agent7_windows2004_core_jmx:
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
     BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-core-amd64"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"

--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -48,7 +48,7 @@
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservernano-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
     TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -48,7 +48,7 @@
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
-    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}
+    BUILD_ARG: --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -137,6 +137,8 @@ docker_build_agent7_windows1809_core:
     VARIANT: 1809
     TAG_SUFFIX: -7
     WITH_JMX: "false"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows1809_core_jmx:
   extends:

--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -57,10 +57,6 @@ dev_branch_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-core
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-core
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core
@@ -69,9 +65,9 @@ dev_branch_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-core,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
@@ -118,10 +114,6 @@ dev_master_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win --image datadog/agent-dev:master-py3-jmx-win1809,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win1909,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:master-py3-win1809-core
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:master-py3-jmx-win1809-core
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:master-py3-win1909-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:master-py3-jmx-win1909-core
@@ -130,9 +122,9 @@ dev_master_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:master-py3-jmx-win2004-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-win-core --image datadog/agent-dev:master-py3-win1809-core,windows/amd64 --image datadog/agent-dev:master-py3-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-win-core --image datadog/agent-dev:master-py3-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-win2004-core,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win-core --image datadog/agent-dev:master-py3-jmx-win1809-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win-core --image datadog/agent-dev:master-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004-core,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
@@ -180,10 +172,6 @@ dev_nightly_docker_hub-a7-windows:
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win2004
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win2004
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1809-core
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1809-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1909-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }

--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -57,6 +57,10 @@ dev_branch_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core
@@ -65,9 +69,9 @@ dev_branch_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-core,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
@@ -114,6 +118,10 @@ dev_master_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win --image datadog/agent-dev:master-py3-jmx-win1809,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win1909,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:master-py3-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:master-py3-jmx-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:master-py3-win1909-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:master-py3-jmx-win1909-core
@@ -122,9 +130,9 @@ dev_master_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:master-py3-jmx-win2004-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-win-core --image datadog/agent-dev:master-py3-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-win-core --image datadog/agent-dev:master-py3-win1809-core,windows/amd64 --image datadog/agent-dev:master-py3-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-win2004-core,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win-core --image datadog/agent-dev:master-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win-core --image datadog/agent-dev:master-py3-jmx-win1809-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004-core,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
@@ -172,6 +180,10 @@ dev_nightly_docker_hub-a7-windows:
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win2004
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win2004
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1809-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1909-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }

--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -57,6 +57,22 @@ dev_branch_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-core,windows/amd64
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core,windows/amd64
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
     - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64:${Env:DATADOG_AGENT_WINBUILDIMAGES} powershell -C C:\mnt\ci-scripts\publish.ps1
@@ -102,6 +118,22 @@ dev_master_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win --image datadog/agent-dev:master-py3-jmx-win1809,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win1909,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:master-py3-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:master-py3-jmx-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:master-py3-win1909-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:master-py3-jmx-win1909-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-core-amd64 datadog/agent-dev:master-py3-win2004-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:master-py3-jmx-win2004-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-win-core --image datadog/agent-dev:master-py3-win1809-core,windows/amd64 --image datadog/agent-dev:master-py3-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-win2004-core,windows/amd64
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win-core --image datadog/agent-dev:master-py3-jmx-win1809-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004-core,windows/amd64
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
     - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_${Env:VARIANT}_x64:${Env:DATADOG_AGENT_WINBUILDIMAGES} powershell -C C:\mnt\ci-scripts\publish.ps1
@@ -125,6 +157,12 @@ dev_nightly_docker_hub-a7-windows:
     - docker_build_agent7_windows1909_jmx
     - docker_build_agent7_windows2004
     - docker_build_agent7_windows2004_jmx
+    - docker_build_agent7_windows1809_core
+    - docker_build_agent7_windows1809_core_jmx
+    - docker_build_agent7_windows1909_core
+    - docker_build_agent7_windows1909_core_jmx
+    - docker_build_agent7_windows2004_core
+    - docker_build_agent7_windows2004_core_jmx
   variables:
     VARIANT: 2004
   script:
@@ -142,6 +180,18 @@ dev_nightly_docker_hub-a7-windows:
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win2004
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win2004
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1809-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1909-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1909-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win2004-core
+      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win2004-core
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1

--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -57,21 +57,21 @@ dev_branch_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-servercore-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-servercore-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-servercore-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-servercore-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-servercore-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-servercore-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-servercore,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-servercore,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
@@ -118,21 +118,21 @@ dev_master_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win --image datadog/agent-dev:master-py3-jmx-win1809,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win1909,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:master-py3-win1809-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-servercore-amd64 datadog/agent-dev:master-py3-win1809-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:master-py3-jmx-win1809-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-servercore-amd64 datadog/agent-dev:master-py3-jmx-win1809-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:master-py3-win1909-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-servercore-amd64 datadog/agent-dev:master-py3-win1909-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:master-py3-jmx-win1909-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-servercore-amd64 datadog/agent-dev:master-py3-jmx-win1909-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-core-amd64 datadog/agent-dev:master-py3-win2004-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-servercore-amd64 datadog/agent-dev:master-py3-win2004-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:master-py3-jmx-win2004-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-servercore-amd64 datadog/agent-dev:master-py3-jmx-win2004-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-win-core --image datadog/agent-dev:master-py3-win1809-core,windows/amd64 --image datadog/agent-dev:master-py3-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-win-servercore --image datadog/agent-dev:master-py3-win1809-servercore,windows/amd64 --image datadog/agent-dev:master-py3-win1909-servercore,windows/amd64 --image datadog/agent-dev:master-py3-win2004-servercore,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win-core --image datadog/agent-dev:master-py3-jmx-win1809-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win1909-core,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004-core,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag master-py3-jmx-win-servercore --image datadog/agent-dev:master-py3-jmx-win1809-servercore,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win1909-servercore,windows/amd64 --image datadog/agent-dev:master-py3-jmx-win2004-servercore,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1
@@ -181,17 +181,17 @@ dev_nightly_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win2004
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1809-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1809-servercore-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1809-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1809-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1809-servercore-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1809-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1909-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win1909-servercore-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win1909-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1909-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win1909-servercore-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win1909-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win2004-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-win2004-servercore-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win2004-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-core-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win2004-core
+      inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-servercore-amd64 datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win2004-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1

--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -69,9 +69,9 @@ dev_branch_docker_hub-a7-windows:
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-7-jmx-win2004-servercore-amd64 datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-servercore
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-servercore,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-win-servercore --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1809-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win1909-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-win2004-servercore,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-servercore,windows/amd64
+      inv -e docker.publish-manifest --signed-push --name datadog/agent-dev --tag ${CI_COMMIT_REF_SLUG}-py3-jmx-win-servercore --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1809-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win1909-servercore,windows/amd64 --image datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win2004-servercore,windows/amd64
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | Add-Content ci-scripts/publish.ps1
     - cat ci-scripts/publish.ps1

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -64,24 +64,36 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag latest-jmx
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7},linux/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7-jmx
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish --signed-pull --signed-push datadog/dogstatsd:${NEW_LATEST_RELEASE_7} datadog/dogstatsd:latest
     - inv -e docker.publish --signed-pull --signed-push datadog/dogstatsd:${NEW_LATEST_RELEASE_7} datadog/dogstatsd:7
@@ -120,24 +132,36 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag latest-jmx
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7},linux/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7-jmx
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish gcr.io/datadoghq/dogstatsd:${NEW_LATEST_RELEASE_7} gcr.io/datadoghq/dogstatsd:latest
     - inv -e docker.publish gcr.io/datadoghq/dogstatsd:${NEW_LATEST_RELEASE_7} gcr.io/datadoghq/dogstatsd:7

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -66,9 +66,9 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag latest-servercore
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-servercore,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-servercore,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag latest-jmx
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
@@ -76,9 +76,9 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag latest-servercore-jmx
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-servercore,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-servercore,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7},linux/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
@@ -86,9 +86,9 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7-servercore
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-servercore,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-servercore,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7-jmx
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
@@ -96,9 +96,9 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7-servercore-jmx
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-servercore,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-servercore,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-servercore,windows/amd64
     - inv -e docker.publish --signed-pull --signed-push datadog/dogstatsd:${NEW_LATEST_RELEASE_7} datadog/dogstatsd:latest
     - inv -e docker.publish --signed-pull --signed-push datadog/dogstatsd:${NEW_LATEST_RELEASE_7} datadog/dogstatsd:7
 
@@ -138,9 +138,9 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag latest-servercore
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-servercore,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-servercore,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag latest-jmx
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
@@ -148,9 +148,9 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag latest-servercore-jmx
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-servercore,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-servercore,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7},linux/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
@@ -158,9 +158,9 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7-servercore
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-servercore,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-servercore,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-servercore,windows/amd64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7-jmx
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
@@ -168,9 +168,9 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7-servercore-jmx
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-servercore,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-servercore,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-servercore,windows/amd64
     - inv -e docker.publish gcr.io/datadoghq/dogstatsd:${NEW_LATEST_RELEASE_7} gcr.io/datadoghq/dogstatsd:latest
     - inv -e docker.publish gcr.io/datadoghq/dogstatsd:${NEW_LATEST_RELEASE_7} gcr.io/datadoghq/dogstatsd:7
 

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -64,6 +64,7 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
@@ -72,6 +73,7 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
@@ -80,6 +82,7 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
@@ -88,6 +91,7 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
@@ -128,6 +132,7 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
@@ -136,6 +141,7 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
@@ -144,6 +150,7 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
@@ -152,6 +159,7 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -64,7 +64,6 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
@@ -73,7 +72,6 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
@@ -82,7 +80,6 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
@@ -91,7 +88,6 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
-      --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
@@ -132,7 +128,6 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
@@ -141,7 +136,6 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
@@ -150,7 +144,6 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
@@ -159,7 +152,6 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
-      --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
       --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -64,37 +64,41 @@ revert_latest_7_docker_hub:
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
+    - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag latest-servercore
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
-      --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag latest-jmx
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
+    - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag latest-servercore-jmx
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
-      --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7},linux/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
+    - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7-servercore
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
-      --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7-jmx
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
+    - inv -e docker.publish-manifest --signed-push --name datadog/agent --tag 7-servercore-jmx
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image datadog/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
-      --image datadog/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish --signed-pull --signed-push datadog/dogstatsd:${NEW_LATEST_RELEASE_7} datadog/dogstatsd:latest
     - inv -e docker.publish --signed-pull --signed-push datadog/dogstatsd:${NEW_LATEST_RELEASE_7} datadog/dogstatsd:7
 
@@ -132,37 +136,41 @@ revert_latest_7_google_container_registry:
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
+    - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag latest-servercore
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
-      --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag latest-jmx
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
+    - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag latest-servercore-jmx
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
-      --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7},linux/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
+    - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7-servercore
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-win2004-core,windows/amd64
-      --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7},linux/arm64
     - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7-jmx
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx,linux/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004,windows/amd64
+      --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
+    - inv -e docker.publish-manifest --name gcr.io/datadoghq/agent --tag 7-servercore-jmx
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1809-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win1909-core,windows/amd64
       --image gcr.io/datadoghq/agent-amd64:${NEW_LATEST_RELEASE_7}-jmx-win2004-core,windows/amd64
-      --image gcr.io/datadoghq/agent-arm64:${NEW_LATEST_RELEASE_7}-jmx,linux/arm64
     - inv -e docker.publish gcr.io/datadoghq/dogstatsd:${NEW_LATEST_RELEASE_7} gcr.io/datadoghq/dogstatsd:latest
     - inv -e docker.publish gcr.io/datadoghq/dogstatsd:${NEW_LATEST_RELEASE_7} gcr.io/datadoghq/dogstatsd:7
 

--- a/releasenotes/notes/windows-docker-core-bbd4993c906964d0.yaml
+++ b/releasenotes/notes/windows-docker-core-bbd4993c906964d0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Windows Docker images are now based on the larger Windows Core image instead of Windows Nano.

--- a/releasenotes/notes/windows-docker-core-bbd4993c906964d0.yaml
+++ b/releasenotes/notes/windows-docker-core-bbd4993c906964d0.yaml
@@ -1,11 +1,4 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
 upgrade:
   - |
-    Windows Docker images are now based on the larger Windows Core image instead of Windows Nano.
+    Windows Docker images based on Windows Core are now provided. Checks that didn't work on Nano should work on Core.


### PR DESCRIPTION
### What does this PR do?

Build Docker images for Windows based on Windows Core (larger image, includes more Windows DLLs) in addition of Windows Nano (way smaller image, but lots of things missing).

### Motivation

Python's win32wnet is broken on Nano, which the IIS check and other Windows-specific checks need.
