### PR TITLE
Add support for arm64 system-probe kitchen testing in ec2

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -14,7 +14,7 @@
     - when: manual
       allow_failure: true
   stage: functional_test
-  needs: ["tests_ebpf"]
+  needs: ["tests_ebpf_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -30,7 +30,7 @@
     - when: manual
       allow_failure: true
   stage: functional_test
-  needs: ["tests_ebpf"]
+  needs: ["tests_ebpf_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -29,7 +29,7 @@
     - .kitchen_azure_location_north_central_us
   needs: [ "tests_ebpf_x64" ]
   variables:
-    KITCHEN_ARCH: x64
+    KITCHEN_ARCH: x86_64
 
 .kitchen_test_system_probe_arm64:
   extends:

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -9,7 +9,6 @@
   extends:
     - .kitchen_common
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_north_central_us
   rules:
     - changes:
         - pkg/ebpf/**/*
@@ -18,15 +17,31 @@
     - when: manual
       allow_failure: true
   stage: functional_test
-  needs: ["tests_ebpf"]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   script:
     - bash -l tasks/run-test-kitchen.sh system-probe-test $AGENT_MAJOR_VERSION
 
-kitchen_centos_sysprobe:
-  extends: .kitchen_test_system_probe
+.kitchen_test_system_probe_x64:
+  extends:
+    - .kitchen_test_system_probe
+    - .kitchen_azure_location_north_central_us
+  needs: [ "tests_ebpf_x64" ]
+  variables:
+    KITCHEN_ARCH: x64
+
+.kitchen_test_system_probe_arm64:
+  extends:
+    - .kitchen_test_system_probe
+  needs: [ "tests_ebpf_arm64" ]
+  variables:
+    KITCHEN_ARCH: arm64
+    KITCHEN_PROVIDER: ec2
+    KITCHEN_EC2_INSTANCE_TYPE: "t4g.large"
+
+kitchen_centos_sysprobe_x64:
+  extends: .kitchen_test_system_probe_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="centos"
@@ -34,20 +49,56 @@ kitchen_centos_sysprobe:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_ubuntu_sysprobe:
-  extends: .kitchen_test_system_probe
+kitchen_ubuntu_sysprobe_x64:
+  extends: .kitchen_test_system_probe_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
-    - export KITCHEN_PLATFORM=ubuntu
+    - export KITCHEN_PLATFORM="ubuntu"
     - export KITCHEN_OSVERS="ubuntu-16-04,ubuntu-18-04,ubuntu-20-04"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_debian_sysprobe:
-  extends: .kitchen_test_system_probe
+kitchen_debian_sysprobe_x64:
+  extends: .kitchen_test_system_probe_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="debian"
     - export KITCHEN_OSVERS="debian-10"
+    - cd $DD_AGENT_TESTING_DIR
+    - bash -l tasks/kitchen_setup.sh
+
+kitchen_centos_sysprobe_arm64:
+  extends: .kitchen_test_system_probe_arm64
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+    - export KITCHEN_PLATFORM="centos"
+    - export KITCHEN_OSVERS="centos-78,rhel-83"
+    - cd $DD_AGENT_TESTING_DIR
+    - bash -l tasks/kitchen_setup.sh
+
+kitchen_debian_sysprobe_arm64:
+  extends: .kitchen_test_system_probe_arm64
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+    - export KITCHEN_PLATFORM="debian"
+    - export KITCHEN_OSVERS="debian-9,debian-10"
+    - cd $DD_AGENT_TESTING_DIR
+    - bash -l tasks/kitchen_setup.sh
+
+kitchen_suse_sysprobe_arm64:
+  extends: .kitchen_test_system_probe_arm64
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+    - export KITCHEN_PLATFORM="suse"
+    - export KITCHEN_OSVERS="sles-15"
+    - cd $DD_AGENT_TESTING_DIR
+    - bash -l tasks/kitchen_setup.sh
+
+kitchen_ubuntu_sysprobe_arm64:
+  extends: .kitchen_test_system_probe_arm64
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+    - export KITCHEN_PLATFORM="ubuntu"
+    - export KITCHEN_OSVERS="ubuntu-16-04,ubuntu-18-04,ubuntu-20-04"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -40,7 +40,7 @@
     KITCHEN_PROVIDER: ec2
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.large"
     KITCHEN_EC2_SUBNET: subnet-c18341ed
-    KITCHEN_EC2_SG_IDS: sg-75ef800b
+    KITCHEN_EC2_SG_IDS: sg-0f5617ceb3e5a6c39
     KITCHEN_EC2_IAM_PROFILE_NAME: ci-datadog-agent-e2e-runner
 
 kitchen_centos_sysprobe_x64:
@@ -84,7 +84,7 @@ kitchen_debian_sysprobe_arm64:
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="debian"
-    - export KITCHEN_OSVERS="debian-9,debian-10"
+    - export KITCHEN_OSVERS="debian-10"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
@@ -94,6 +94,7 @@ kitchen_suse_sysprobe_arm64:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="suse"
     - export KITCHEN_OSVERS="sles-15"
+    - export KITCHEN_EC2_SPOT_PRICE=nil
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
@@ -102,6 +103,6 @@ kitchen_ubuntu_sysprobe_arm64:
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="ubuntu"
-    - export KITCHEN_OSVERS="ubuntu-16-04,ubuntu-18-04,ubuntu-20-04"
+    - export KITCHEN_OSVERS="ubuntu-18-04,ubuntu-20-04"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -34,15 +34,12 @@
 .kitchen_test_system_probe_arm64:
   extends:
     - .kitchen_test_system_probe
+    - .kitchen_ec2_location_us_east_1
+    - .kitchen_ec2_spot_instances
   needs: [ "tests_ebpf_arm64" ]
   variables:
     KITCHEN_ARCH: arm64
-    KITCHEN_PROVIDER: ec2
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.large"
-    KITCHEN_EC2_SUBNET: subnet-c18341ed
-    KITCHEN_EC2_SG_IDS: sg-0f5617ceb3e5a6c39
-    KITCHEN_EC2_IAM_PROFILE_NAME: ci-datadog-agent-e2e-runner
-    KITCHEN_EC2_SPOT_PRICE: on-demand
 
 kitchen_centos_sysprobe_x64:
   extends: .kitchen_test_system_probe_x64

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -41,6 +41,7 @@
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.large"
     KITCHEN_EC2_SUBNET: subnet-c18341ed
     KITCHEN_EC2_SG_IDS: sg-75ef800b
+    KITCHEN_EC2_IAM_PROFILE_NAME: ci-datadog-agent-e2e-runner
 
 kitchen_centos_sysprobe_x64:
   extends: .kitchen_test_system_probe_x64

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -42,6 +42,7 @@
     KITCHEN_EC2_SUBNET: subnet-c18341ed
     KITCHEN_EC2_SG_IDS: sg-0f5617ceb3e5a6c39
     KITCHEN_EC2_IAM_PROFILE_NAME: ci-datadog-agent-e2e-runner
+    KITCHEN_EC2_SPOT_PRICE: on-demand
 
 kitchen_centos_sysprobe_x64:
   extends: .kitchen_test_system_probe_x64
@@ -85,16 +86,6 @@ kitchen_debian_sysprobe_arm64:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="debian"
     - export KITCHEN_OSVERS="debian-10"
-    - cd $DD_AGENT_TESTING_DIR
-    - bash -l tasks/kitchen_setup.sh
-
-kitchen_suse_sysprobe_arm64:
-  extends: .kitchen_test_system_probe_arm64
-  before_script:
-    - rsync -azr --delete ./ $SRC_PATH
-    - export KITCHEN_PLATFORM="suse"
-    - export KITCHEN_OSVERS="sles-15"
-    - export KITCHEN_EC2_SPOT_PRICE=nil
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -39,6 +39,8 @@
     KITCHEN_ARCH: arm64
     KITCHEN_PROVIDER: ec2
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.large"
+    KITCHEN_EC2_SUBNET: subnet-c18341ed
+    KITCHEN_EC2_SG_IDS: sg-75ef800b
 
 kitchen_centos_sysprobe_x64:
   extends: .kitchen_test_system_probe_x64

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -20,6 +20,8 @@
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
+    # we need chef >= 15 for arm64 and for the arm? helper
+    CHEF_VERSION: 15.16.4
   script:
     - bash -l tasks/run-test-kitchen.sh system-probe-test $AGENT_MAJOR_VERSION
 

--- a/.gitlab/functional_test_cleanup.yml
+++ b/.gitlab/functional_test_cleanup.yml
@@ -14,6 +14,6 @@ cleanup_kitchen_functional_test:
     - when: manual
       allow_failure: true
   stage: functional_test_cleanup
-  needs: ["tests_ebpf"]
+  needs: ["tests_ebpf_x64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -19,6 +19,17 @@
       - $CI_PROJECT_DIR/kitchen_logs
   retry: 1
 
+# Kitchen: providers
+# ---------------
+
+.kitchen_ec2:
+  variables:
+    KITCHEN_PROVIDER: ec2
+    KITCHEN_EC2_IAM_PROFILE_NAME: ci-datadog-agent-e2e-runner
+
+.kitchen_ec2_spot_instances:
+  variables:
+    KITCHEN_EC2_SPOT_PRICE: on-demand
 
 # Kitchen: agents
 # ---------------
@@ -109,6 +120,18 @@
   variables:
     KITCHEN_PROVIDER: azure
     AZURE_LOCATION: "South Central US"
+
+
+# Kitchen: EC2 locations
+# -------------------------------
+
+.kitchen_ec2_location_us_east_1:
+  extends:
+    - .kitchen_ec2
+  variables:
+    KITCHEN_EC2_REGION: us-east-1
+    KITCHEN_EC2_SUBNET: subnet-c18341ed
+    KITCHEN_EC2_SG_IDS: sg-0f5617ceb3e5a6c39
 
 
 # Kitchen: Test types (test suite * agent flavor + azure location)

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -92,18 +92,22 @@
 
 .kitchen_azure_location_north_central_us:
   variables:
+    KITCHEN_PROVIDER: azure
     AZURE_LOCATION: "North Central US"
 
 .kitchen_azure_location_west_central_us:
   variables:
+    KITCHEN_PROVIDER: azure
     AZURE_LOCATION: "West Central US"
 
 .kitchen_azure_location_central_us:
   variables:
+    KITCHEN_PROVIDER: azure
     AZURE_LOCATION: "Central US"
 
 .kitchen_azure_location_south_central_us:
   variables:
+    KITCHEN_PROVIDER: azure
     AZURE_LOCATION: "South Central US"
 
 

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -10,31 +10,20 @@
   tar -xvf /tmp/libbcc.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
   tar -xvf /tmp/clang.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
 
+.build_sysprobe_artifacts: &build_sysprobe_artifacts |
+  inv -e system-probe.object-files
+  inv -e system-probe.kitchen-prepare
+  cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.o
+  cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer-debug.o
+  cp $SRC_PATH/pkg/ebpf/bytecode/build/offset-guess.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess.o
+  cp $SRC_PATH/pkg/ebpf/bytecode/build/offset-guess-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess-debug.o
+  cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/tracer.c $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.c
+  cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/runtime-security.c $CI_PROJECT_DIR/.tmp/binary-ebpf/runtime-security.c
+  cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/conntrack.c $CI_PROJECT_DIR/.tmp/binary-ebpf/conntrack.c
+
 # Run tests for eBPF code
 .tests_ebpf:
   stage: source_test
-  script:
-    - inv -e system-probe.object-files
-    - inv -e system-probe.kitchen-prepare
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.o
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/tracer-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer-debug.o
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/offset-guess.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess.o
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/offset-guess-debug.o $CI_PROJECT_DIR/.tmp/binary-ebpf/offset-guess-debug.o
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/tracer.c $CI_PROJECT_DIR/.tmp/binary-ebpf/tracer.c
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/runtime-security.c $CI_PROJECT_DIR/.tmp/binary-ebpf/runtime-security.c
-    - cp $SRC_PATH/pkg/ebpf/bytecode/build/runtime/conntrack.c $CI_PROJECT_DIR/.tmp/binary-ebpf/conntrack.c
-    # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite
-    # Compile runtime security stress tests to be executed in kitchen tests
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
-    # Compile master version for comparison, uncomment following lines when merged
-    - git checkout master
-    - git pull
-    - inv -e deps
-    - inv -e system-probe.build --bundle-ebpf --incremental-build
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
-    - git reset --hard
-    - git checkout -
   artifacts:
     when: always
     paths:
@@ -54,6 +43,21 @@ tests_ebpf_x64:
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
     - cd $SRC_PATH
     - *retrieve_sysprobe_deps
+  script:
+    - *build_sysprobe_artifacts
+    # Compile runtime security functional tests to be executed in kitchen tests
+    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite
+    # Compile runtime security stress tests to be executed in kitchen tests
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
+    # Compile master version for comparison, uncomment following lines when merged
+    - git checkout master
+    - git pull
+    - inv -e deps
+    - inv -e system-probe.build --bundle-ebpf --incremental-build
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
+    - git reset --hard
+    - git checkout -
+
 
 tests_ebpf_arm64:
   extends: .tests_ebpf
@@ -70,3 +74,5 @@ tests_ebpf_arm64:
     - cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog
     - cd $SRC_PATH
     - *retrieve_sysprobe_deps
+  script:
+    - *build_sysprobe_artifacts

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -4,19 +4,16 @@
   rm -f modcache.tar.gz
 
 # Run tests for eBPF code
-tests_ebpf:
+.tests_ebpf:
   stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
-  needs: ["linux_x64_go_deps"]
   before_script:
     - *retrieve_linux_go_deps
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
     - cd $SRC_PATH
     - python3 -m pip install -r requirements.txt
     # Retrieve libbcc from S3
-    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/libbcc-amd64-$BCC_VERSION.tar.xz /tmp/libbcc.tar.xz
-    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-amd64-11.0.1.tar.xz /tmp/clang.tar.xz
+    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/libbcc-$ARCH-$BCC_VERSION.tar.xz /tmp/libbcc.tar.xz
+    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$ARCH-11.0.1.tar.xz /tmp/clang.tar.xz
     - mkdir -p $DATADOG_AGENT_EMBEDDED_PATH
     - tar -xvf /tmp/libbcc.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
     - tar -xvf /tmp/clang.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
@@ -48,3 +45,19 @@ tests_ebpf:
       - $CI_PROJECT_DIR/.tmp/binary-ebpf
       - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files
       - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
+
+tests_ebpf_x64:
+  extends: .tests_ebpf
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: [ "runner:main", "size:large" ]
+  needs: [ "linux_x64_go_deps" ]
+  variables:
+    ARCH: amd64
+
+tests_ebpf_arm64:
+  extends: .tests_ebpf
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["runner:docker-arm", "platform:arm64"]
+  needs: [ "linux_arm64_go_deps" ]
+  variables:
+    ARCH: arm64

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -3,20 +3,16 @@
   mkdir -p $GOPATH/pkg/mod && tar xzf modcache.tar.gz -C $GOPATH/pkg/mod
   rm -f modcache.tar.gz
 
+.retrieve_sysprobe_deps: &retrieve_sysprobe_deps |
+  $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/libbcc-$ARCH-$BCC_VERSION.tar.xz /tmp/libbcc.tar.xz
+  $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$ARCH-11.0.1.tar.xz /tmp/clang.tar.xz
+  mkdir -p $DATADOG_AGENT_EMBEDDED_PATH
+  tar -xvf /tmp/libbcc.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
+  tar -xvf /tmp/clang.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
+
 # Run tests for eBPF code
 .tests_ebpf:
   stage: source_test
-  before_script:
-    - *retrieve_linux_go_deps
-    - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
-    - cd $SRC_PATH
-    - python3 -m pip install -r requirements.txt
-    # Retrieve libbcc from S3
-    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/libbcc-$ARCH-$BCC_VERSION.tar.xz /tmp/libbcc.tar.xz
-    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$ARCH-11.0.1.tar.xz /tmp/clang.tar.xz
-    - mkdir -p $DATADOG_AGENT_EMBEDDED_PATH
-    - tar -xvf /tmp/libbcc.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
-    - tar -xvf /tmp/clang.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
   script:
     - inv -e system-probe.object-files
     - inv -e system-probe.kitchen-prepare
@@ -53,6 +49,11 @@ tests_ebpf_x64:
   needs: [ "linux_x64_go_deps" ]
   variables:
     ARCH: amd64
+  before_script:
+    - *retrieve_linux_go_deps
+    - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
+    - cd $SRC_PATH
+    - *retrieve_sysprobe_deps
 
 tests_ebpf_arm64:
   extends: .tests_ebpf
@@ -61,3 +62,11 @@ tests_ebpf_arm64:
   needs: [ "linux_arm64_go_deps" ]
   variables:
     ARCH: arm64
+  before_script:
+    - *retrieve_linux_go_deps
+    - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
+    # Hack to work around the cloning issue with arm runners
+    - mkdir -p $GOPATH/src/github.com/DataDog
+    - cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog
+    - cd $SRC_PATH
+    - *retrieve_sysprobe_deps

--- a/pkg/ebpf/bytecode/runtime/runtime_asset.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_asset.go
@@ -21,7 +21,7 @@ var (
 	defaultFlags = []string{
 		"-DCONFIG_64BIT",
 		"-D__BPF_TRACING__",
-		`-DKBUILD_MODNAME='"ddsysprobe"'`,
+		`-DKBUILD_MODNAME="ddsysprobe"`,
 		"-Wno-unused-value",
 		"-Wno-pointer-sign",
 		"-Wno-compare-distinct-pointer-types",

--- a/pkg/network/tracer/gateway_lookup.go
+++ b/pkg/network/tracer/gateway_lookup.go
@@ -98,6 +98,10 @@ func (g *gatewayLookup) Lookup(cs *network.ConnectionStats) *network.Via {
 	return &network.Via{Subnet: s}
 }
 
+func (g *gatewayLookup) purge() {
+	g.subnetCache = make(map[int]network.Subnet)
+}
+
 func ec2SubnetForHardwareAddr(hwAddr net.HardwareAddr) (network.Subnet, error) {
 	snet, err := ec2.GetSubnetForHardwareAddr(hwAddr)
 	if err != nil {

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -29,7 +29,7 @@ LLC_CMD = "llc -march=bpf -filetype=obj -o '{obj_file}' '{bc_file}'"
 
 DATADOG_AGENT_EMBEDDED_PATH = '/opt/datadog-agent/embedded'
 
-KITCHEN_DIR = os.path.join("test", "kitchen")
+KITCHEN_DIR = os.getenv('DD_AGENT_TESTING_DIR') or os.path.normpath(os.path.join(os.getcwd(), "test", "kitchen"))
 KITCHEN_ARTIFACT_DIR = os.path.join(KITCHEN_DIR, "site-cookbooks", "dd-system-probe-check", "files", "default", "tests")
 TEST_PACKAGES_LIST = ["./pkg/ebpf/...", "./pkg/network/..."]
 TEST_PACKAGES = " ".join(TEST_PACKAGES_LIST)
@@ -494,7 +494,7 @@ def get_ebpf_build_flags():
         '-D__KERNEL__',
         '-DCONFIG_64BIT',
         '-D__BPF_TRACING__',
-        '-DKBUILD_MODNAME=\'"ddsysprobe"\'',
+        '-DKBUILD_MODNAME=\\"ddsysprobe\\"',
         '-Wno-unused-value',
         '-Wno-pointer-sign',
         '-Wno-compare-distinct-pointer-types',

--- a/test/kitchen/README.md
+++ b/test/kitchen/README.md
@@ -221,7 +221,7 @@ and then adding the desired test suite(s) from the test-definitions directory.
 There is an invoke task for creating the completed `kitchen.yml`.  The usage for 
 the invoke task is:
 
-  invoke kitchen.genconfig --platform=platform --osversions=osversions --provider=provider --testfiles=testfiles
+  invoke kitchen.genconfig --platform=platform --osversions=osversions --provider=provider --arch=arch --testfiles=testfiles
 
 where:
   platform is an index into the platforms.json.  It is (currently) one of:
@@ -242,11 +242,15 @@ where:
   - vagrant
   - hyperv (with a user-supplied platforms file)
 
+  arch is:
+  - x64
+  - arm64
+
   Testfiles is the name of the test-specific file(s) (found in [test-definitions](test-definitions) ) to be
   added.  The testfiles define the tests that are run, on what OS, on the given provider.
 
 An example command would be
-  invoke kitchen.genconfig --platform ubuntu --osversions all --provider azure --testfiles install-script-test
+  invoke kitchen.genconfig --platform ubuntu --osversions all --provider azure --arch x64 --testfiles install-script-test
 
   This will generate a kitchen.yml which executes the `install-script-test` on all of the defined `ubuntu` 
   OS images in azure.

--- a/test/kitchen/README.md
+++ b/test/kitchen/README.md
@@ -243,14 +243,14 @@ where:
   - hyperv (with a user-supplied platforms file)
 
   arch is:
-  - x64
+  - x86_64
   - arm64
 
   Testfiles is the name of the test-specific file(s) (found in [test-definitions](test-definitions) ) to be
   added.  The testfiles define the tests that are run, on what OS, on the given provider.
 
 An example command would be
-  invoke kitchen.genconfig --platform ubuntu --osversions all --provider azure --arch x64 --testfiles install-script-test
+  invoke kitchen.genconfig --platform ubuntu --osversions all --provider azure --arch x86_64 --testfiles install-script-test
 
   This will generate a kitchen.yml which executes the `install-script-test` on all of the defined `ubuntu` 
   OS images in azure.

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -17,7 +17,8 @@
 provisioner:
   name: chef_solo
   product_name: chef
-  product_version: 14.12.9
+  product_version: 15.16.4
+  chef_license: accept
   install_strategy: always
   # the following settings make it possible to do a reboot during setup
   # (necessary for FIPS tests which reboot to enable FIPS mode)

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -17,7 +17,8 @@
 provisioner:
   name: chef_solo
   product_name: chef
-  product_version: 15.16.4
+  # allow overriding of chef version since we need >= 15 for arm64 testing
+  product_version: <%= ENV['CHEF_VERSION'] ||= '14.12.9' %>
   chef_license: accept
   install_strategy: always
   # the following settings make it possible to do a reboot during setup

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -129,7 +129,7 @@ platforms:
     <% else %>
     connection_retries: 30
     connection_retry_sleep: 2
-    ssh_key: <%= ENV['AZURE_SSH_KEY_PATH'] %>
+    ssh_key: <%= ENV['KITCHEN_SSH_KEY_PATH'] %>
     <% end %>
 
 <% end %>

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -1,7 +1,8 @@
 provisioner:
   name: chef_solo
   product_name: chef
-  product_version: 13.9.4
+  product_version: 15.16.4
+  chef_license: accept
   install_strategy: always
   # the following settings make it possible to do a reboot during setup
   # (necessary for FIPS tests which reboot to enable FIPS mode)
@@ -13,7 +14,7 @@ provisioner:
 driver:
   name: ec2
   aws_ssh_key_id: <%= ENV['KITCHEN_EC2_SSH_ID'] %>
-  security_group_ids: <%= [ENV['KITCHEN_EC2_SG_IDS'] || "sg-7fedd80a","sg-46506837"] %>
+  security_group_ids: <%= [ENV['KITCHEN_EC2_SG_IDS']] || ["sg-7fedd80a","sg-46506837"] %>
   region: <%= ENV['KITCHEN_EC2_REGION'] ||= "us-east-1" %>
   instance_type: <%= ENV['KITCHEN_EC2_INSTANCE_TYPE'] ||= 't3.xlarge' %>
   associate_public_ip: false

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -1,7 +1,8 @@
 provisioner:
   name: chef_solo
   product_name: chef
-  product_version: 15.16.4
+  # allow overriding of chef version since we need >= 15 for arm64 testing
+  product_version: <%= ENV['CHEF_VERSION'] ||= '14.12.9' %>
   chef_license: accept
   install_strategy: always
   # the following settings make it possible to do a reboot during setup

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -18,7 +18,9 @@ driver:
   instance_type: <%= ENV['KITCHEN_EC2_INSTANCE_TYPE'] ||= 't3.xlarge' %>
   associate_public_ip: false
   subnet_id: <%= ENV['KITCHEN_EC2_SUBNET'] ||= 'subnet-b89e00e2' %>
-  iam_profile_name: <%= ENV['KITCHEN_EC2_IAM_PROFILE_NAME'] || null %>
+  iam_profile_name: <%= ENV['KITCHEN_EC2_IAM_PROFILE_NAME'] ||= null %>
+  spot_price: <%= ENV['KITCHEN_EC2_SPOT_PRICE'] ||= 'on-demand' %>
+  block_duration_minutes: <%= ENV['KITCHEN_EC2_SPOT_DURATION'] ||= 60 %>
   tags:
     created-by: test-kitchen
     creator: <%= ENV['KITCHEN_EC2_TAG_CREATOR'] || "kitchen-user" %>

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -20,7 +20,7 @@ driver:
   subnet_id: <%= ENV['KITCHEN_EC2_SUBNET'] ||= 'subnet-b89e00e2' %>
   iam_profile_name: <%= ENV['KITCHEN_EC2_IAM_PROFILE_NAME'] ||= null %>
   spot_price: <%= ENV['KITCHEN_EC2_SPOT_PRICE'] ||= 'on-demand' %>
-  block_duration_minutes: <%= ENV['KITCHEN_EC2_SPOT_DURATION'] ||= 60 %>
+  block_duration_minutes: <%= ENV['KITCHEN_EC2_SPOT_DURATION'] ||= '60' %>
   tags:
     created-by: test-kitchen
     creator: <%= ENV['KITCHEN_EC2_TAG_CREATOR'] || "kitchen-user" %>

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -18,6 +18,7 @@ driver:
   instance_type: <%= ENV['KITCHEN_EC2_INSTANCE_TYPE'] ||= 't3.xlarge' %>
   associate_public_ip: false
   subnet_id: <%= ENV['KITCHEN_EC2_SUBNET'] ||= 'subnet-b89e00e2' %>
+  iam_profile_name: <%= ENV['KITCHEN_EC2_IAM_PROFILE_NAME'] || null %>
   tags:
     created-by: test-kitchen
     creator: <%= ENV['KITCHEN_EC2_TAG_CREATOR'] || "kitchen-user" %>

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -12,7 +12,6 @@ provisioner:
 
 driver:
   name: ec2
-  aws_ssh_key: <%= ENV['KITCHEN_EC2_SSH_KEY'] %>
   aws_ssh_key_id: <%= ENV['KITCHEN_EC2_SSH_ID'] %>
   security_group_ids: <%= [ENV['KITCHEN_EC2_SG_IDS'] || "sg-7fedd80a","sg-46506837"] %>
   region: <%= ENV['KITCHEN_EC2_REGION'] ||= "us-east-1" %>

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -20,7 +20,7 @@ driver:
   associate_public_ip: false
   subnet_id: <%= ENV['KITCHEN_EC2_SUBNET'] ||= 'subnet-b89e00e2' %>
   iam_profile_name: <%= ENV['KITCHEN_EC2_IAM_PROFILE_NAME'] ||= null %>
-  spot_price: <%= ENV['KITCHEN_EC2_SPOT_PRICE'] ||= 'on-demand' %>
+  spot_price: <%= ENV['KITCHEN_EC2_SPOT_PRICE'] %>
   block_duration_minutes: <%= ENV['KITCHEN_EC2_SPOT_DURATION'] ||= '60' %>
   tags:
     created-by: test-kitchen
@@ -91,6 +91,9 @@ platforms:
     <% else %>
     connection_retries: 30
     connection_retry_sleep: 2
+    <% end %>
+    <% if sles15 %>
+    username: ec2-user
     <% end %>
     ssh_key: <%= ENV['KITCHEN_EC2_SSH_KEY'] %>
     

--- a/test/kitchen/drivers/hyperv-driver.yml
+++ b/test/kitchen/drivers/hyperv-driver.yml
@@ -101,7 +101,7 @@ platforms:
     <% else %>
     connection_retries: 30
     connection_retry_sleep: 2
-    ssh_key: <%= ENV['AZURE_SSH_KEY_PATH'] %>
+    ssh_key: <%= ENV['KITCHEN_SSH_KEY_PATH'] %>
     <% end %>
 
 <% end %>

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -1,7 +1,7 @@
 {
     "centos" : {
         "azure" : {
-            "x64": {
+            "x86_64": {
                 "centos-69": "urn,OpenLogic:CentOS:6.9:6.9.20180530",
                 "centos-76": "urn,OpenLogic:CentOS:7.6:7.6.201909120",
                 "centos-77": "urn,OpenLogic:CentOS:7.7:7.7.201912090",
@@ -15,14 +15,16 @@
             }
         },
         "vagrant" : {
-            "centos-76": "bento/centos-7.6",
-            "centos7": "roboxes/centos7",
-            "centos8": "roboxes/centos8"
+            "x86_64": {
+                "centos-76": "bento/centos-7.6",
+                "centos7": "roboxes/centos7",
+                "centos8": "roboxes/centos8"
+            }
         }
     },
     "debian" : {
         "azure" : {
-            "x64": {
+            "x86_64": {
                 "debian-8": "urn,credativ:Debian:8:8.0.201901221",
                 "debian-9": "urn,credativ:Debian:9:9.20200722.0",
                 "debian-10": "urn,Debian:debian-10:10:0.20210208.542"
@@ -37,7 +39,7 @@
     },
     "suse" : {
         "azure": {
-            "x64": {
+            "x86_64": {
                 "sles-12": "urn,SUSE:sles-12-sp5-byos:gen1:2020.09.21",
                 "sles-15": "urn,SUSE:sles-15-sp2-byos:gen1:2020.09.21"
             }
@@ -50,7 +52,7 @@
     },
     "ubuntu" : {
         "azure": {
-            "x64": {
+            "x86_64": {
                 "ubuntu-14-04": "urn,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140",
                 "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201604203",
                 "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
@@ -65,12 +67,14 @@
             }
         },
         "vagrant" : {
-            "ubuntu-16-04": "bento/ubuntu-16.04"
+            "x86_64": {
+                "ubuntu-16-04": "bento/ubuntu-16.04"
+            }
         }
     },
     "windows": {
         "azure" : {
-            "x64": {
+            "x86_64": {
                 "win2008r2": "id,/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/kitchen-test-images/providers/Microsoft.Compute/galleries/kitchenimages/images/Windows2008-R2-SP1/versions/1.0.0",
                 "win2012": "urn,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190410",
                 "win2012r2": "urn,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20190416",
@@ -83,7 +87,7 @@
             }
         },
         "ec2" : {
-            "x64": {
+            "x86_64": {
                 "win2012r2": "ami-0f2688fe4ee9b2443",
                 "comment-win2012r2": "EC2LaunchV2_Preview-Windows_Server-2012_R2_RTM-English-Core-Base-2021.02.10",
                 "win2016": "ami-0e3ee9d1a707d7f8c",

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -1,10 +1,18 @@
 {
     "centos" : {
         "azure" : {
-            "centos-69": "urn,OpenLogic:CentOS:6.9:6.9.20180530",
-            "centos-76": "urn,OpenLogic:CentOS:7.6:7.6.201909120",
-            "centos-77": "urn,OpenLogic:CentOS:7.7:7.7.201912090",
-            "rhel-81": "urn,RedHat:RHEL:8.1:8.1.2020020415"
+            "x64": {
+                "centos-69": "urn,OpenLogic:CentOS:6.9:6.9.20180530",
+                "centos-76": "urn,OpenLogic:CentOS:7.6:7.6.201909120",
+                "centos-77": "urn,OpenLogic:CentOS:7.7:7.7.201912090",
+                "rhel-81": "urn,RedHat:RHEL:8.1:8.1.2020020415"
+            }
+        },
+        "ec2": {
+            "arm64": {
+                "centos-78": "ami-0271a6516c34c6be9",
+                "rhel-83": "ami-0698b90665a2ddcf1"
+            }
         },
         "vagrant" : {
             "centos-76": "bento/centos-7.6",
@@ -14,24 +22,47 @@
     },
     "debian" : {
         "azure" : {
-            "debian-8": "urn,credativ:Debian:8:8.0.201901221",
-            "debian-9": "urn,credativ:Debian:9:9.20200722.0",
-            "debian-10": "urn,Debian:debian-10:10:0.20210208.542"
+            "x64": {
+                "debian-8": "urn,credativ:Debian:8:8.0.201901221",
+                "debian-9": "urn,credativ:Debian:9:9.20200722.0",
+                "debian-10": "urn,Debian:debian-10:10:0.20210208.542"
+            }
+        },
+        "ec2": {
+            "arm64": {
+                "debian-9": "ami-06c5943bf1c4c1b81",
+                "debian-10": "ami-08b2293fdd2deba2a"
+            }
         }
     },
     "suse" : {
         "azure": {
-            "sles-12": "urn,SUSE:sles-12-sp5-byos:gen1:2020.09.21",
-            "sles-15": "urn,SUSE:sles-15-sp2-byos:gen1:2020.09.21"
+            "x64": {
+                "sles-12": "urn,SUSE:sles-12-sp5-byos:gen1:2020.09.21",
+                "sles-15": "urn,SUSE:sles-15-sp2-byos:gen1:2020.09.21"
+            }
+        },
+        "ec2": {
+            "arm64": {
+                "sles-15": "ami-05f2f5f76d89313bb"
+            }
         }
     },
     "ubuntu" : {
         "azure": {
-            "ubuntu-14-04": "urn,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140",
-            "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201604203",
-            "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
-            "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230"
-
+            "x64": {
+                "ubuntu-14-04": "urn,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140",
+                "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201604203",
+                "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
+                "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230"
+            }
+        },
+        "ec2": {
+            "arm64": {
+                "ubuntu-16-04": "ami-07bb67a394017b190",
+                "ubuntu-18-04": "ami-02ed82f3a38303e6f",
+                "ubuntu-20-04": "ami-0b75998a97c952252"
+            }
         },
         "vagrant" : {
             "ubuntu-16-04": "bento/ubuntu-16.04"
@@ -39,31 +70,35 @@
     },
     "windows": {
         "azure" : {
-            "win2008r2": "id,/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/kitchen-test-images/providers/Microsoft.Compute/galleries/kitchenimages/images/Windows2008-R2-SP1/versions/1.0.0",
-            "win2012": "urn,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190410",
-            "win2012r2": "urn,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20190416",
-            "win2016": "urn,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:2016.127.20190416",
-            "win2019": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:2019.0.20190410",
-            "win1903": "urn,MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1903-with-Containers-smalldisk:18362.1256.2012032308",
-            "win1909": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-1909-with-containers-smalldisk:18363.1316.2101130054",
-            "win2004": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:19041.746.2101092327",
-            "win20h2": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-20h2-with-containers-smalldisk:19042.746.2101092352"
+            "x64": {
+                "win2008r2": "id,/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/kitchen-test-images/providers/Microsoft.Compute/galleries/kitchenimages/images/Windows2008-R2-SP1/versions/1.0.0",
+                "win2012": "urn,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20190410",
+                "win2012r2": "urn,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20190416",
+                "win2016": "urn,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:2016.127.20190416",
+                "win2019": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:2019.0.20190410",
+                "win1903": "urn,MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1903-with-Containers-smalldisk:18362.1256.2012032308",
+                "win1909": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-1909-with-containers-smalldisk:18363.1316.2101130054",
+                "win2004": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:19041.746.2101092327",
+                "win20h2": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-20h2-with-containers-smalldisk:19042.746.2101092352"
+            }
         },
         "ec2" : {
-            "win2012r2": "ami-0f2688fe4ee9b2443",
-            "comment-win2012r2": "EC2LaunchV2_Preview-Windows_Server-2012_R2_RTM-English-Core-Base-2021.02.10",
-            "win2016": "ami-0e3ee9d1a707d7f8c",
-            "comment-win2016": "# Windows_Server-2016-English-Core-Containers-2021.02.10",
-            "win2019": "ami-0f45398f32b5f1258",
-            "comment-win2019": "Windows_Server-2019-English-Core-ContainersLatest-2021.02.10",
-            "win1903": "ami-08ff2690dd0f54a52",
-            "comment-win1903": "Windows_Server-1903-English-Core-Base-2021.02.10",
-            "win1909": "ami-077b088208b7b1541" ,
-            "comment-win1909": "Windows_Server-1909-English-Core-Base-2021.02.10",
-            "win2004": "ami-001b0b8376afad6d4",
-            "comment-win2004": "# Windows_Server-2004-English-Core-Base-2021.02.10",
-            "win20H2": "ami-03661d5caaa2f79c1",
-            "comment-win20h2": "Windows_Server-20H2-English-Core-Base-2021.02.10"
+            "x64": {
+                "win2012r2": "ami-0f2688fe4ee9b2443",
+                "comment-win2012r2": "EC2LaunchV2_Preview-Windows_Server-2012_R2_RTM-English-Core-Base-2021.02.10",
+                "win2016": "ami-0e3ee9d1a707d7f8c",
+                "comment-win2016": "# Windows_Server-2016-English-Core-Containers-2021.02.10",
+                "win2019": "ami-0f45398f32b5f1258",
+                "comment-win2019": "Windows_Server-2019-English-Core-ContainersLatest-2021.02.10",
+                "win1903": "ami-08ff2690dd0f54a52",
+                "comment-win1903": "Windows_Server-1903-English-Core-Base-2021.02.10",
+                "win1909": "ami-077b088208b7b1541",
+                "comment-win1909": "Windows_Server-1909-English-Core-Base-2021.02.10",
+                "win2004": "ami-001b0b8376afad6d4",
+                "comment-win2004": "# Windows_Server-2004-English-Core-Base-2021.02.10",
+                "win20H2": "ami-03661d5caaa2f79c1",
+                "comment-win20h2": "Windows_Server-20H2-English-Core-Base-2021.02.10"
+            }
         }
     }
 }

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -32,8 +32,7 @@
         },
         "ec2": {
             "arm64": {
-                "debian-9": "ami-06c5943bf1c4c1b81",
-                "debian-10": "ami-08b2293fdd2deba2a"
+                "debian-10": "ami-0529ba3d56c0866bb"
             }
         }
     },
@@ -61,7 +60,6 @@
         },
         "ec2": {
             "arm64": {
-                "ubuntu-16-04": "ami-07bb67a394017b190",
                 "ubuntu-18-04": "ami-02ed82f3a38303e6f",
                 "ubuntu-20-04": "ami-0b75998a97c952252"
             }

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/attributes/default.rb
@@ -2,5 +2,13 @@ if platform?('centos')
   default['yum-centos']['vault_repos'][node[:platform_version]]['enabled'] = true
   default['yum-centos']['vault_repos'][node[:platform_version]]['managed'] = true
   default['yum-centos']['vault_repos'][node[:platform_version]]['make_cache'] = true
+
+  if arm?
+    if node['platform_version'].to_i < 8
+      default['yum']['base']['gpgkey'] = ['file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever-$basearch', 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever']
+      default['yum']['updates']['gpgkey'] = ['file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever-$basearch', 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever']
+      default['yum']['extras']['gpgkey'] = ['file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever-$basearch', 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever']
+    end
+  end
 end
 

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
@@ -5,7 +5,12 @@
 # Copyright (C) 2020-present Datadog
 #
 if platform?('centos')
-  include_recipe 'yum-centos::vault'
+  include_recipe '::old_vault'
+end
+
+case node[:platform]
+  when 'ubuntu', 'debian'
+    apt_update
 end
 
 kernel_version = `uname -r`.strip
@@ -19,6 +24,11 @@ package 'kernel headers' do
 end
 
 package 'python3'
+
+case node[:platform]
+  when 'centos', 'redhat'
+    package 'iptables'
+end
 
 package 'conntrack'
 
@@ -60,12 +70,12 @@ execute 'ensure conntrack is enabled' do
   action :run
 end
 
-execute 'disable firewalld on redhat' do
-  command "systemctl disable --now firewalld"
+systemd_unit 'firewalld.service' do
   user "root"
+  ignore_failure true
   case node[:platform]
   when 'redhat'
-    action :run
+    action :disable
   else
     action :nothing
   end

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/default.rb
@@ -70,12 +70,13 @@ execute 'ensure conntrack is enabled' do
   action :run
 end
 
-systemd_unit 'firewalld.service' do
+execute 'disable firewalld on redhat' do
+  command "systemctl disable --now firewalld"
   user "root"
   ignore_failure true
   case node[:platform]
   when 'redhat'
-    action :disable
+    action :run
   else
     action :nothing
   end

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/old_vault.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/old_vault.rb
@@ -1,0 +1,53 @@
+return unless platform_family?('rhel')
+
+include_recipe 'yum-centos::default'
+
+node['yum-centos']['vault_repos'].each do |release, _config|
+  node['yum-centos']['repos'].each do |id|
+    next unless node['yum'][id]['managed']
+    next unless node['yum-centos']['vault_repos'][release]['managed']
+    dir =
+      case id
+      when 'base'
+        value_for_platform(%w(centos redhat) =>
+          {
+            '>= 8.0' => 'BaseOS',
+            '< 8.0' => 'os',
+          })
+      when 'appstream'
+        'AppStream'
+      when 'powertools'
+        'PowerTools'
+      when 'updates', 'extras', 'centosplus', 'fasttrack'
+        id
+      else
+        next
+      end
+
+    yum_repository "centos-vault-#{release}-#{id}" do
+      description "CentOS-#{release} Vault - #{id.capitalize}"
+      case node['platform_version'].to_i
+      when 7
+        if arm?
+            baseurl "http://vault.centos.org/altarch/#{release}/#{dir}/$basearch/"
+            gpgkey ['file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever-$basearch', 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever']
+        else
+            baseurl "http://vault.centos.org/#{release}/#{dir}/$basearch/"
+            gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'
+        end
+      when 8
+        baseurl "http://vault.centos.org/#{release}/#{dir}/$basearch/os/"
+        gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
+      end
+      node['yum-centos']['vault_repos'][release].each do |config, value|
+        case config
+        when 'managed' # rubocop: disable Lint/EmptyWhen
+        when 'baseurl'
+          send(config.to_sym, lazy { value })
+        else
+          send(config.to_sym, value) unless value.nil?
+        end
+      end
+    end
+  end
+end

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -18,7 +18,7 @@ def genconfig(
     platformfile="platforms.json",
     platlist=None,
     fips=False,
-	arch="x86_64",
+    arch="x86_64",
 ):
     """
     Create a kitchen config

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -18,6 +18,7 @@ def genconfig(
     platformfile="platforms.json",
     platlist=None,
     fips=False,
+	arch="x64",
 ):
     """
     Create a kitchen config
@@ -36,6 +37,9 @@ def genconfig(
     if not platlist and not provider:
         provider = "azure"
 
+    if not arch:
+        arch = "x64"
+
     platforms = load_platforms(ctx, platformfile=platformfile)
 
     # create the TEST_PLATFORMS environment variable
@@ -50,9 +54,8 @@ def genconfig(
                 ),
                 code=2,
             )
-            raise Exit(2)
 
-        ## check to see if the OS is configured for the given provider
+        # check to see if the OS is configured for the given provider
         prov = plat.get(provider)
         if not prov:
             raise Exit(
@@ -62,20 +65,29 @@ def genconfig(
                 code=3,
             )
 
-        ## get list of target OSes
+        ar = prov.get(arch)
+        if not ar:
+            raise Exit(
+                message="Unknown architecture {arch}. "
+                        "Known architectures for platform {plat} provider {prov} are {avail}\n"
+                        .format(arch=arch, prov=provider, plat=platform, avail=list(prov.keys())),
+                code=4,
+            )
+
+        # get list of target OSes
         if osversions.lower() == "all":
             osversions = ".*"
 
-        osimages = load_targets(ctx, prov, osversions)
+        osimages = load_targets(ctx, ar, osversions)
 
         print("Chose os targets {}\n".format(osimages))
         for osimage in osimages:
-            testplatformslist.append("{},{}".format(osimage, prov[osimage]))
+            testplatformslist.append("{},{}".format(osimage, ar[osimage]))
 
     elif platlist:
-        # platform list should be in the form of driver,os,image
+        # platform list should be in the form of driver,os,arch,image
         for entry in platlist:
-            driver, os, image = entry.split(",")
+            driver, os, arch, image = entry.split(",")
             if provider and driver != provider:
                 raise Exit(
                     message="Can only use one driver type per config ( {} != {} )\n".format(provider, driver), code=1
@@ -89,10 +101,13 @@ def genconfig(
             if not platforms[os].get(driver):
                 raise Exit(message="Unknown driver in {}\n".format(entry), code=5)
 
-            if not platforms[os][driver].get(image):
+            if not platforms[os][driver].get(arch):
+                raise Exit(message="Unknown architecture in {}\n".format(entry), code=5)
+
+            if not platforms[os][driver][arch].get(image):
                 raise Exit(message="Unknown image in {}\n".format(entry), code=6)
 
-            testplatformslist.append("{},{}".format(image, platforms[os][driver][image]))
+            testplatformslist.append("{},{}".format(image, platforms[os][driver][arch][image]))
 
     print("Using the following test platform(s)\n")
     for logplat in testplatformslist:

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -69,8 +69,9 @@ def genconfig(
         if not ar:
             raise Exit(
                 message="Unknown architecture {arch}. "
-                        "Known architectures for platform {plat} provider {prov} are {avail}\n"
-                        .format(arch=arch, prov=provider, plat=platform, avail=list(prov.keys())),
+                "Known architectures for platform {plat} provider {prov} are {avail}\n".format(
+                    arch=arch, prov=provider, plat=platform, avail=list(prov.keys())
+                ),
                 code=4,
             )
 

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -18,7 +18,7 @@ def genconfig(
     platformfile="platforms.json",
     platlist=None,
     fips=False,
-	arch="x64",
+	arch="x86_64",
 ):
     """
     Create a kitchen config
@@ -38,7 +38,7 @@ def genconfig(
         provider = "azure"
 
     if not arch:
-        arch = "x64"
+        arch = "x86_64"
 
     platforms = load_platforms(ctx, platformfile=platformfile)
 

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -37,9 +37,6 @@ def genconfig(
     if not platlist and not provider:
         provider = "azure"
 
-    if not arch:
-        arch = "x86_64"
-
     platforms = load_platforms(ctx, platformfile=platformfile)
 
     # create the TEST_PLATFORMS environment variable

--- a/test/kitchen/tasks/run-test-kitchen.ps1
+++ b/test/kitchen/tasks/run-test-kitchen.ps1
@@ -12,7 +12,7 @@ $keyfile = "$PSScriptRoot\ssh-key"
 Write-Host -ForegroundColor Green "Generating $PSScriptRoot\ssh-key"
 & 'ssh-keygen.exe' -f $keyfile -P """" -t rsa -b 2048
 
-$AZURE_SSH_KEY_PATH=$keyfile
+$KITCHEN_SSH_KEY_PATH=$keyfile
 & 'ssh-agent.exe' -s
 & 'ssh-add' $keyfile
 

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -7,23 +7,24 @@ IFS=$'\n\t'
 set -euxo pipefail
 
 # Ensure that the ssh key is never reused between tests
-if [ -f $(pwd)/ssh-key ]; then
+if [ -f "$(pwd)/ssh-key" ]; then
   rm ssh-key
 fi
-if [ -f $(pwd)/ssh-key.pub ]; then
+if [ -f "$(pwd)/ssh-key.pub" ]; then
   rm ssh-key.pub
 fi
 
-ssh-keygen -f $(pwd)/ssh-key -P "" -t rsa -b 2048
-export AZURE_SSH_KEY_PATH="$(pwd)/ssh-key"
+ssh-keygen -f "$(pwd)/ssh-key" -P "" -t rsa -b 2048
+KITCHEN_SSH_KEY_PATH="$(pwd)/ssh-key"
+export KITCHEN_SSH_KEY_PATH
 
 # show that the ssh key is there
-echo $(pwd)/ssh-key
-echo $AZURE_SSH_KEY_PATH
+echo "$(pwd)/ssh-key"
+echo "$KITCHEN_SSH_KEY_PATH"
 
 # start the ssh-agent and add the key
-eval $(ssh-agent -s)
-ssh-add "$AZURE_SSH_KEY_PATH"
+eval "$(ssh-agent -s)"
+ssh-add "$KITCHEN_SSH_KEY_PATH"
 
 # in docker we cannot interact to do this so we must disable it
 mkdir -p ~/.ssh

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -75,7 +75,7 @@ if [ "$KITCHEN_PROVIDER" == "azure" ]; then
   set -x
 
 elif [ "$KITCHEN_PROVIDER" == "ec2" ]; then
-  echo "ec2"
+  echo "using ec2 kitchen provider"
 fi
 
 # Generate a password to use for the windows servers
@@ -118,4 +118,4 @@ cp kitchen.yml ./.kitchen/generated_kitchen.yml
 rm -rf cookbooks
 rm -f Berksfile.lock
 berks vendor ./cookbooks
-bundle exec kitchen test "'^dd*.*-${KITCHEN_PROVIDER}\$'" -c -d always
+bundle exec kitchen test "^dd*.*-${KITCHEN_PROVIDER}\$" -c -d always

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -80,8 +80,7 @@ fi
 
 # Generate a password to use for the windows servers
 if [ -z ${SERVER_PASSWORD+x} ]; then
-  SERVER_PASSWORD="$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)0aZ"
-  export SERVER_PASSWORD
+  export SERVER_PASSWORD="$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)0aZ"
 fi
 
 if [[ $# == 0 ]]; then

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -107,7 +107,7 @@ if [ -z ${AGENT_VERSION+x} ]; then
   popd
 fi
 
-invoke -e kitchen.genconfig --platform="$KITCHEN_PLATFORM" --osversions="$KITCHEN_OSVERS" --provider="$KITCHEN_PROVIDER" --arch="$KITCHEN_ARCH" --testfiles="$1" ${KITCHEN_FIPS:+--fips}
+invoke -e kitchen.genconfig --platform="$KITCHEN_PLATFORM" --osversions="$KITCHEN_OSVERS" --provider="$KITCHEN_PROVIDER" --arch="${KITCHEN_ARCH:-x86_64}" --testfiles="$1" ${KITCHEN_FIPS:+--fips}
 
 bundle exec kitchen diagnose --no-instances --loader
 

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -80,7 +80,8 @@ fi
 
 # Generate a password to use for the windows servers
 if [ -z ${SERVER_PASSWORD+x} ]; then
-  export SERVER_PASSWORD="$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)0aZ"
+  SERVER_PASSWORD="$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)0aZ"
+  export SERVER_PASSWORD
 fi
 
 if [[ $# == 0 ]]; then
@@ -100,12 +101,14 @@ export MAJOR_VERSION=$2
 # on linux it can just download the latest version from the package manager
 if [ -z ${AGENT_VERSION+x} ]; then
   pushd ../..
-    export AGENT_VERSION=`inv agent.version --url-safe --git-sha-length=7 --major-version $MAJOR_VERSION`
-    export DD_AGENT_EXPECTED_VERSION=`inv agent.version --url-safe --git-sha-length=7 --major-version $MAJOR_VERSION`
+    AGENT_VERSION=$(inv agent.version --url-safe --git-sha-length=7 --major-version "$MAJOR_VERSION")
+    export AGENT_VERSION
+    DD_AGENT_EXPECTED_VERSION=$(inv agent.version --url-safe --git-sha-length=7 --major-version "$MAJOR_VERSION")
+    export DD_AGENT_EXPECTED_VERSION
   popd
 fi
 
-invoke -e kitchen.genconfig --platform=$KITCHEN_PLATFORM --osversions=$KITCHEN_OSVERS --provider=$KITCHEN_PROVIDER --arch=$KITCHEN_ARCH --testfiles=$1 ${KITCHEN_FIPS:+--fips}
+invoke -e kitchen.genconfig --platform="$KITCHEN_PLATFORM" --osversions="$KITCHEN_OSVERS" --provider="$KITCHEN_PROVIDER" --arch="$KITCHEN_ARCH" --testfiles="$1" ${KITCHEN_FIPS:+--fips}
 
 bundle exec kitchen diagnose --no-instances --loader
 

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -95,7 +95,7 @@ if [ -z ${AGENT_VERSION+x} ]; then
   popd
 fi
 
-invoke -e kitchen.genconfig --platform=$KITCHEN_PLATFORM --osversions=$KITCHEN_OSVERS --provider=azure --testfiles=$1 ${KITCHEN_FIPS:+--fips}
+invoke -e kitchen.genconfig --platform=$KITCHEN_PLATFORM --osversions=$KITCHEN_OSVERS --provider=$KITCHEN_PROVIDER --arch=$KITCHEN_ARCH --testfiles=$1 ${KITCHEN_FIPS:+--fips}
 
 bundle exec kitchen diagnose --no-instances --loader
 


### PR DESCRIPTION
### What does this PR do?

Adds support for the CI kitchen tests to launch EC2 instances, which allows us to test on arm64 instances. Adds arm64 testing of the system-probe. Thanks @KSerrania for his help!

### Motivation

We want to officially support arm64, which means we need CI support.
