### PR TITLE
[runtime-security] enable overlayfs on overlayfs tests

### DIFF
--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -48,7 +48,7 @@ func TestOverlayFS(t *testing.T) {
 		sles12 = kv.IsSLES12Kernel()
 	}
 
-	if testEnvironment == DockerEnvironment || sles12 {
+	if sles12 {
 		t.Skip()
 	}
 


### PR DESCRIPTION
### What does this PR do?

Ensure inode correctness when using overlayfs on top of overlayfs