### PR TITLE
[gitlab] Rework some arm job dependencies

### DIFF
--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -34,7 +34,7 @@ build_dogstatsd-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["tests_deb-x64-py3", "linux_arm64_go_deps"]
+  needs: ["tests_deb-arm64-py3", "linux_arm64_go_deps"]
   variables:
     ARCH: arm64
   before_script:
@@ -64,7 +64,7 @@ build_iot_agent-deb_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["tests_deb-x64-py3", "linux_arm64_go_deps"]
+  needs: ["tests_deb-arm64-py3", "linux_arm64_go_deps"]
   variables:
     ARCH: arm64
   before_script:

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -36,7 +36,7 @@ build_system-probe-x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["runner:main", "size:large"]
-  needs: ["build_libbcc_x64", "tests_deb-x64-py3"]
+  needs: ["build_libbcc_x64", "go_mod_tidy_check"]
   extends: .system-probe_build_common
   variables:
     ARCH: amd64


### PR DESCRIPTION
### What does this PR do?

Change some dependencies of binary build jobs: arm jobs were depending on x64 source tests.
Align `build_system-probe` job dependencies.

### Motivation

We have arm64 source tests since #7428, so we can make arm64 jobs depend on them.
Having `build_system-probe-x64` depend on a debian job is confusing, as it meant rpm package builds (which use the artifacts from `build_system-probe-x64`) depended on a debian job.
