### PR TITLE
[python runtime tests] Add ability to instantiate mock `rtloader_*_t` structs

### DIFF
--- a/pkg/collector/python/test_check.go
+++ b/pkg/collector/python/test_check.go
@@ -188,8 +188,7 @@ void reset_check_mock() {
 import "C"
 
 func testRunCheck(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	check, err := NewPythonFakeCheck()
@@ -197,7 +196,7 @@ func testRunCheck(t *testing.T) {
 		return
 	}
 
-	check.instance = &C.rtloader_pyobject_t{}
+	check.instance = newMockPyObjectPtr()
 
 	C.reset_check_mock()
 	C.run_check_return = C.CString("")
@@ -217,8 +216,7 @@ func testRunCheck(t *testing.T) {
 }
 
 func testRunCheckWithRuntimeNotInitializedError(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	check, err := NewPythonFakeCheck()
@@ -226,7 +224,7 @@ func testRunCheckWithRuntimeNotInitializedError(t *testing.T) {
 		return
 	}
 
-	check.instance = &C.rtloader_pyobject_t{}
+	check.instance = newMockPyObjectPtr()
 
 	C.reset_check_mock()
 	C.run_check_return = C.CString("")
@@ -267,8 +265,7 @@ func testInitiCheckWithRuntimeNotInitialized(t *testing.T) {
 }
 
 func testCheckCancel(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	check, err := NewPythonFakeCheck()
@@ -277,7 +274,7 @@ func testCheckCancel(t *testing.T) {
 	}
 
 	C.reset_check_mock()
-	check.instance = &C.rtloader_pyobject_t{}
+	check.instance = newMockPyObjectPtr()
 	C.run_check_return = C.CString("")
 
 	err = check.runCheck(false)
@@ -305,8 +302,7 @@ func testCheckCancel(t *testing.T) {
 }
 
 func testCheckCancelWhenRuntimeUnloaded(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	check, err := NewPythonFakeCheck()
@@ -315,7 +311,7 @@ func testCheckCancelWhenRuntimeUnloaded(t *testing.T) {
 	}
 
 	C.reset_check_mock()
-	check.instance = &C.rtloader_pyobject_t{}
+	check.instance = newMockPyObjectPtr()
 	C.run_check_return = C.CString("")
 
 	err = check.runCheck(false)
@@ -341,8 +337,7 @@ func testCheckCancelWhenRuntimeUnloaded(t *testing.T) {
 }
 
 func testFinalizer(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() {
 		// We have to wrap this in locks otherwise the race detector complains
 		pyDestroyLock.Lock()
@@ -356,7 +351,7 @@ func testFinalizer(t *testing.T) {
 	}
 
 	C.reset_check_mock()
-	check.instance = &C.rtloader_pyobject_t{}
+	check.instance = newMockPyObjectPtr()
 	C.run_check_return = C.CString("")
 
 	err = check.runCheck(false)
@@ -386,8 +381,7 @@ func testFinalizer(t *testing.T) {
 }
 
 func testFinalizerWhenRuntimeUnloaded(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() {
 		// We have to wrap this in locks otherwise the race detector complains
 		pyDestroyLock.Lock()
@@ -401,7 +395,7 @@ func testFinalizerWhenRuntimeUnloaded(t *testing.T) {
 	}
 
 	C.reset_check_mock()
-	check.instance = &C.rtloader_pyobject_t{}
+	check.instance = newMockPyObjectPtr()
 	C.run_check_return = C.CString("")
 
 	err = check.runCheck(false)
@@ -432,8 +426,7 @@ func testFinalizerWhenRuntimeUnloaded(t *testing.T) {
 }
 
 func testRunErrorNil(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	check, err := NewPythonFakeCheck()
@@ -441,7 +434,7 @@ func testRunErrorNil(t *testing.T) {
 		return
 	}
 
-	check.instance = &C.rtloader_pyobject_t{}
+	check.instance = newMockPyObjectPtr()
 
 	C.reset_check_mock()
 	C.run_check_return = nil
@@ -461,8 +454,7 @@ func testRunErrorNil(t *testing.T) {
 }
 
 func testRunErrorReturn(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	check, err := NewPythonFakeCheck()
@@ -470,7 +462,7 @@ func testRunErrorReturn(t *testing.T) {
 		return
 	}
 
-	check.instance = &C.rtloader_pyobject_t{}
+	check.instance = newMockPyObjectPtr()
 
 	C.reset_check_mock()
 	C.run_check_return = C.CString("not OK")
@@ -491,8 +483,7 @@ func testRun(t *testing.T) {
 	sender := mocksender.NewMockSender(check.ID("testID"))
 	sender.SetupAcceptAll()
 
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	c, err := NewPythonFakeCheck()
@@ -500,7 +491,7 @@ func testRun(t *testing.T) {
 		return
 	}
 
-	c.instance = &C.rtloader_pyobject_t{}
+	c.instance = newMockPyObjectPtr()
 	c.id = check.ID("testID")
 
 	C.reset_check_mock()
@@ -525,8 +516,7 @@ func testRunSimple(t *testing.T) {
 	sender := mocksender.NewMockSender(check.ID("testID"))
 	sender.SetupAcceptAll()
 
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	c, err := NewPythonFakeCheck()
@@ -534,7 +524,7 @@ func testRunSimple(t *testing.T) {
 		return
 	}
 
-	c.instance = &C.rtloader_pyobject_t{}
+	c.instance = newMockPyObjectPtr()
 	c.id = check.ID("testID")
 
 	C.reset_check_mock()
@@ -556,8 +546,7 @@ func testRunSimple(t *testing.T) {
 }
 
 func testConfigure(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	c, err := NewPythonFakeCheck()
@@ -565,12 +554,12 @@ func testConfigure(t *testing.T) {
 		return
 	}
 
-	c.class = &C.rtloader_pyobject_t{}
+	c.class = newMockPyObjectPtr()
 
 	C.reset_check_mock()
 
 	C.get_check_return = 1
-	C.get_check_check = &C.rtloader_pyobject_t{}
+	C.get_check_check = newMockPyObjectPtr()
 	err = c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
 	assert.Nil(t, err)
 
@@ -591,8 +580,7 @@ func testConfigure(t *testing.T) {
 }
 
 func testConfigureDeprecated(t *testing.T) {
-	// Initialize rtloader pointer
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	c, err := NewPythonFakeCheck()
@@ -600,12 +588,12 @@ func testConfigureDeprecated(t *testing.T) {
 		return
 	}
 
-	c.class = &C.rtloader_pyobject_t{}
+	c.class = newMockPyObjectPtr()
 
 	C.reset_check_mock()
 
 	C.get_check_return = 0
-	C.get_check_deprecated_check = &C.rtloader_pyobject_t{}
+	C.get_check_deprecated_check = newMockPyObjectPtr()
 	C.get_check_deprecated_return = 1
 	err = c.Configure(integration.Data("{\"val\": 21}"), integration.Data("{\"val\": 21}"), "test")
 	assert.Nil(t, err)

--- a/pkg/collector/python/test_loader.go
+++ b/pkg/collector/python/test_loader.go
@@ -89,8 +89,7 @@ func testLoadCustomCheck(t *testing.T) {
 		InitConfig: integration.Data("{}"),
 	}
 
-	// init rtloader
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	loader, err := NewPythonCheckLoader()
@@ -98,8 +97,8 @@ func testLoadCustomCheck(t *testing.T) {
 
 	// testing loading custom checks
 	C.get_class_return = 1
-	C.get_class_py_module = &C.rtloader_pyobject_t{}
-	C.get_class_py_class = &C.rtloader_pyobject_t{}
+	C.get_class_py_module = newMockPyObjectPtr()
+	C.get_class_py_class = newMockPyObjectPtr()
 	C.get_attr_string_return = 0
 
 	check, err := loader.Load(conf, conf.Instances[0])
@@ -123,8 +122,7 @@ func testLoadWheelCheck(t *testing.T) {
 		InitConfig: integration.Data("{}"),
 	}
 
-	// init rtloader
-	rtloader = &C.rtloader_t{}
+	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
 	loader, err := NewPythonCheckLoader()
@@ -132,8 +130,8 @@ func testLoadWheelCheck(t *testing.T) {
 
 	// testing loading dd wheels
 	C.get_class_dd_wheel_return = 1
-	C.get_class_dd_wheel_py_module = &C.rtloader_pyobject_t{}
-	C.get_class_dd_wheel_py_class = &C.rtloader_pyobject_t{}
+	C.get_class_dd_wheel_py_module = newMockPyObjectPtr()
+	C.get_class_dd_wheel_py_class = newMockPyObjectPtr()
 	C.get_attr_string_return = 1
 	C.get_attr_string_attr_value = C.CString("1.2.3")
 

--- a/pkg/collector/python/test_rtloader_helpers.go
+++ b/pkg/collector/python/test_rtloader_helpers.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build python,test
+
+package python
+
+import (
+	"unsafe"
+)
+
+// #include <datadog_agent_rtloader.h>
+//
+import "C"
+
+var (
+	// Real object addresses of size 0 that we can use as mock pointers
+	mockRtLoaderPtr         = [0]byte{}
+	mockRtLoaderPyObjectPtr = [0]byte{}
+)
+
+// Since Golang 1.15, we are no longer able to instantiate an opaque pointer to a
+// struct since it was an incomplete type. To ensure that we can unit test our
+// rtloader supporting logic that does a lot of sanity checks like `somePtr != nil`
+// we have to have a non-nil pointer that we can pass around (but not directly use).
+// By casting the location of our 0-size arrays to the proper type, we are able to
+// create such mock objects for the sole purpose of testing while also making CGO
+// compilation happy.
+
+func newMockRtLoaderPtr() *C.rtloader_t {
+	return (*C.rtloader_t)(unsafe.Pointer(&mockRtLoaderPtr))
+}
+
+func newMockPyObjectPtr() *C.rtloader_pyobject_t {
+	return (*C.rtloader_pyobject_t)(unsafe.Pointer(&mockRtLoaderPyObjectPtr))
+}


### PR DESCRIPTION
### What does this PR do?

Since Golang 1.15, we are no longer able to instantiate an opaque pointer to a
struct (`rtloader_*_t`) since it was an incomplete type within Golang itself which
was commonly used in tests. To ensure that we can unit test our rtloader supporting
logic that does a lot of sanity checks like `somePtr != nil` we have to have a non-nil
pointer that we can pass around (but not directly use). By adding in helpers that can
create such mock pointers, we can ensure that tests using these opaque pointers are
usable.

### Motivation

This change is required for upgrades of Golang to 1.15 in the agent

### Additional Notes

~Requires merged/rebased https://github.com/DataDog/datadog-agent/pull/7761 - currently those commits have been manually cherry-picked.~ 
**Rebased**

### Describe your test plan

- Ensure that all `./pkg/collector/python` tests pass on Go 1.15 builders