### PR TITLE
[integrations] Enforce `-std=c99` when building wheels

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -145,7 +145,9 @@ build do
     command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {
-      "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
+      # Specify C99 standard explicitly to avoid issues while building some
+      # wheels (eg. ddtrace)
+      "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc -std=c99",
       "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
       "LD_RUN_PATH" => "#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -138,6 +138,8 @@ build do
     command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {
+      # Specify C99 standard explicitly to avoid issues while building some
+      # wheels (eg. ddtrace)
       "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc -std=c99",
       "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -138,7 +138,7 @@ build do
     command "#{pip} install pip-tools==5.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {
-      "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc -std=c99",
       "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
       "LD_RUN_PATH" => "#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",


### PR DESCRIPTION
### What does this PR do?

Adds `-std=c99` to the `CFLAGS` used when building Python wheels.

### Motivation

Some dependencies have code that is only valid for given standards that may not be the default on the host.
Notably, the `ddtrace==0.48.0` wheel build fails on our SUSE builders with:
```
  ddtrace/profiling/collector/_utils.h:63:9: error: 'for' loop initial declarations are only allowed in C99 mode
           for (size_type i = 0; i < arr->count; i++) {                                                                   \
           ^
...
  ddtrace/profiling/collector/_utils.h:63:9: note: use option -std=c99 or -std=gnu99 to compile your code
           for (size_type i = 0; i < arr->count; i++) {                                                                   \
           ^

```

### Describe your test plan

Check that all builds pass.
TODO: run integrations E2E tests on this build.