### PR TITLE
[ksmcore][DCA] Support workerless setup

### DIFF
--- a/pkg/collector/corechecks/cluster/common.go
+++ b/pkg/collector/corechecks/cluster/common.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build kubeapiserver
+
+package cluster
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
+)
+
+// RunLeaderElection runs the leader election engine and identifies the leader.
+// It returns leader name and a nil error if leader.
+// It returns leader name and a ErrNotLeader error if not leader.
+func RunLeaderElection() (string, error) {
+	leaderEngine, err := leaderelection.GetLeaderEngine()
+	if err != nil {
+		return "", err
+	}
+
+	err = leaderEngine.EnsureLeaderElectionRuns()
+	if err != nil {
+		return "", err
+	}
+
+	if !leaderEngine.IsLeader() {
+		return leaderEngine.GetLeader(), apiserver.ErrNotLeader
+	}
+
+	return leaderEngine.GetLeader(), nil
+}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -16,6 +16,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	kubestatemetrics "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
@@ -82,15 +84,20 @@ type KSMConfig struct {
 	// Telemetry enables telemetry check's metrics, default false.
 	// Metrics can be found under kubernetes_state.telemetry
 	Telemetry bool `yaml:"telemetry"`
+
+	// LeaderSkip forces ignoring the leader election when running the check
+	// Can be useful when running the check as cluster check
+	LeaderSkip bool `yaml:"skip_leader_election"`
 }
 
 // KSMCheck wraps the config and the metric stores needed to run the check
 type KSMCheck struct {
 	core.CheckBase
-	instance  *KSMConfig
-	store     []cache.Store
-	telemetry *telemetryCache
-	cancel    context.CancelFunc
+	instance    *KSMConfig
+	store       []cache.Store
+	telemetry   *telemetryCache
+	cancel      context.CancelFunc
+	isCLCRunner bool
 }
 
 // JoinsConfig contains the config parameters for label joins
@@ -229,6 +236,28 @@ func (k *KSMCheck) Run() error {
 	sender, err := aggregator.GetSender(k.ID())
 	if err != nil {
 		return err
+	}
+
+	// If the check is configured as a cluster check, the cluster check worker needs to skip the leader election section.
+	// we also do a safety check for dedicated runners to avoid trying the leader election
+	if !k.isCLCRunner || !k.instance.LeaderSkip {
+		// Only run if Leader Election is enabled.
+		if !config.Datadog.GetBool("leader_election") {
+			return log.Error("Leader Election not enabled. The cluster-agent will not run the kube-state-metrics core check.")
+		}
+
+		leader, errLeader := cluster.RunLeaderElection()
+		if errLeader != nil {
+			if errLeader == apiserver.ErrNotLeader {
+				log.Debugf("Not leader (leader is %q). Skipping the kube-state-metrics core check", leader)
+				return nil
+			}
+
+			_ = k.Warn("Leader Election error. Not running the kube-state-metrics core check.")
+			return err
+		}
+
+		log.Tracef("Current leader: %q, running kube-state-metrics core check", leader)
 	}
 
 	defer sender.Commit()
@@ -470,9 +499,10 @@ func KubeStateMetricsFactoryWithParam(labelsMapper map[string]string, labelJoins
 
 func newKSMCheck(base core.CheckBase, instance *KSMConfig) *KSMCheck {
 	return &KSMCheck{
-		CheckBase: base,
-		instance:  instance,
-		telemetry: newTelemetryCache(),
+		CheckBase:   base,
+		instance:    instance,
+		telemetry:   newTelemetryCache(),
+		isCLCRunner: config.IsCLCRunner(),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

- Make the follower DCA not running the ksm core check (in workerless setup)
- Refactor `RunLeaderElection` used by the kube apiserver, orchestrator and ksm core checks

### Motivation

- Do not duplicate the ksm core checks when multiple DCA instances exist

### Additional Notes

Related to https://github.com/DataDog/helm-charts/pull/219

### Describe your test plan

- Run multiple DCA instances, make sure only the leader runs the check
- Kill the leader, make sure the follower picks up the check when it's elected
- Make sure the refactoring didn't break the orchestrator and the kube apiserver checks
