### PR TITLE
[CI] Move license linting to a separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,14 @@ jobs:
           command: inv -e lint-milestone
           name: run PR check for milestone assignment
 
+  licenses_linting:
+    <<: *job_template
+    steps:
+      - restore_cache: *restore_source
+      - run:
+          name: run license linting
+          command: inv -e lint-licenses
+
   filename_linting:
     <<: *job_template
     steps:
@@ -316,6 +324,9 @@ workflows:
           filters:
             branches:
               ignore: master
+          requires:
+            - dependencies
+      - licenses_linting:
           requires:
             - dependencies
       - filename_linting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,7 @@ jobs:
     <<: *job_template
     steps:
       - restore_cache: *restore_source
+      - restore_cache: *restore_deps
       - run:
           name: run license linting
           command: inv -e lint-licenses

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -17,7 +17,7 @@ from .agent import integration_tests as agent_integration_tests
 from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from .cluster_agent import integration_tests as dca_integration_tests
 from .dogstatsd import integration_tests as dsd_integration_tests
-from .go import fmt, generate, golangci_lint, ineffassign, lint, lint_licenses, misspell, staticcheck, vet
+from .go import fmt, generate, golangci_lint, ineffassign, lint, misspell, staticcheck, vet
 from .modules import DEFAULT_MODULES, GoModule
 from .trace_agent import integration_tests as trace_integration_tests
 from .utils import get_build_flags
@@ -101,14 +101,8 @@ def test(
     generate(ctx)
 
     if skip_linters:
-        print("--- [skipping linters]")
+        print("--- [skipping Go linters]")
     else:
-        print("--- Linting licenses:")
-        lint_licenses(ctx)
-
-        print("--- Linting filenames:")
-        lint_filenames(ctx)
-
         # Until all packages whitelisted in .golangci.yml are fixed and removed
         # from the 'skip-dirs' list we need to keep using the old functions that
         # lint without build flags (linting some file is better than no linting).


### PR DESCRIPTION
### What does this PR do?

- Create a new `licenses_linting` CircleCI job to lint licenses file.
- Remove `lint_licenses` task from `test` task.
- Remove `lint_filenames` task from `test` task (we already have a `filename_linting` CircleCI job).

### Motivation

- Run license linting only once on the CI, on a separate job
- Help move #7678 forward

### Additional Notes

- Contributors no longer have this as a check when running `inv test`. Maybe we can add a flag for this?

### Describe your test plan

- Pipeline passes.