### PR TITLE
[DCA][AdmissionController] Support custom timeout

### DIFF
--- a/pkg/clusteragent/admission/util.go
+++ b/pkg/clusteragent/admission/util.go
@@ -70,6 +70,7 @@ func getWebhookSkeleton(nameSuffix, path string) admiv1beta1.MutatingWebhook {
 	failurePolicy := admiv1beta1.Ignore
 	sideEffects := admiv1beta1.SideEffectClassNone
 	servicePort := int32(443)
+	timeout := config.Datadog.GetInt32("admission_controller.timeout_seconds")
 	return admiv1beta1.MutatingWebhook{
 		Name: strings.ReplaceAll(fmt.Sprintf("%s.%s", config.Datadog.GetString("admission_controller.webhook_name"), nameSuffix), "-", "."),
 		ClientConfig: admiv1beta1.WebhookClientConfig{
@@ -92,7 +93,8 @@ func getWebhookSkeleton(nameSuffix, path string) admiv1beta1.MutatingWebhook {
 				},
 			},
 		},
-		FailurePolicy: &failurePolicy,
-		SideEffects:   &sideEffects,
+		FailurePolicy:  &failurePolicy,
+		SideEffects:    &sideEffects,
+		TimeoutSeconds: &timeout,
 	}
 }

--- a/pkg/clusteragent/admission/util_test.go
+++ b/pkg/clusteragent/admission/util_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+
+	"github.com/stretchr/testify/assert"
 	admiv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,14 +23,45 @@ func Test_getWebhookSkeleton(t *testing.T) {
 	sideEffects := admiv1beta1.SideEffectClassNone
 	port := int32(443)
 	path := "/bar"
+	defaultTimeout := config.Datadog.GetInt32("admission_controller.timeout_seconds")
+	customTimeout := int32(2)
+	webhook := func(to *int32) admiv1beta1.MutatingWebhook {
+		return admiv1beta1.MutatingWebhook{
+			Name: "datadog.webhook.foo",
+			ClientConfig: admiv1beta1.WebhookClientConfig{
+				Service: &admiv1beta1.ServiceReference{
+					Namespace: "default",
+					Name:      "datadog-admission-controller",
+					Port:      &port,
+					Path:      &path,
+				},
+			},
+			Rules: []admiv1beta1.RuleWithOperations{
+				{
+					Operations: []admiv1beta1.OperationType{
+						admiv1beta1.Create,
+					},
+					Rule: admiv1beta1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				},
+			},
+			FailurePolicy:  &failurePolicy,
+			SideEffects:    &sideEffects,
+			TimeoutSeconds: to,
+		}
+	}
 	type args struct {
 		nameSuffix string
 		path       string
 	}
 	tests := []struct {
-		name string
-		args args
-		want admiv1beta1.MutatingWebhook
+		name    string
+		args    args
+		timeout *int32
+		want    admiv1beta1.MutatingWebhook
 	}{
 		{
 			name: "nominal case",
@@ -36,38 +69,25 @@ func Test_getWebhookSkeleton(t *testing.T) {
 				nameSuffix: "foo",
 				path:       "/bar",
 			},
-			want: admiv1beta1.MutatingWebhook{
-				Name: "datadog.webhook.foo",
-				ClientConfig: admiv1beta1.WebhookClientConfig{
-					Service: &admiv1beta1.ServiceReference{
-						Namespace: "default",
-						Name:      "datadog-admission-controller",
-						Port:      &port,
-						Path:      &path,
-					},
-				},
-				Rules: []admiv1beta1.RuleWithOperations{
-					{
-						Operations: []admiv1beta1.OperationType{
-							admiv1beta1.Create,
-						},
-						Rule: admiv1beta1.Rule{
-							APIGroups:   []string{""},
-							APIVersions: []string{"v1"},
-							Resources:   []string{"pods"},
-						},
-					},
-				},
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffects,
+			want: webhook(&defaultTimeout),
+		},
+		{
+			name: "custom timeout",
+			args: args{
+				nameSuffix: "foo",
+				path:       "/bar",
 			},
+			timeout: &customTimeout,
+			want:    webhook(&customTimeout),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getWebhookSkeleton(tt.args.nameSuffix, tt.args.path); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getWebhookSkeleton() = %v, want %v", got, tt.want)
+			if tt.timeout != nil {
+				config.Datadog.Set("admission_controller.timeout_seconds", *tt.timeout)
+				defer config.Datadog.SetDefault("admission_controller.timeout_seconds", defaultTimeout)
 			}
+			assert.EqualValues(t, tt.want, getWebhookSkeleton(tt.args.nameSuffix, tt.args.path))
 		})
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -708,6 +708,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.mutate_unlabelled", false)
 	config.BindEnvAndSetDefault("admission_controller.port", 8000)
+	config.BindEnvAndSetDefault("admission_controller.timeout_seconds", 30) // 30s corresponds to the default value set by the Kubernetes API
 	config.BindEnvAndSetDefault("admission_controller.service_name", "datadog-admission-controller")
 	config.BindEnvAndSetDefault("admission_controller.certificate.validity_bound", 365*24)             // validity bound of the certificate created by the controller (in hours, default 1 year)
 	config.BindEnvAndSetDefault("admission_controller.certificate.expiration_threshold", 30*24)        // how long before its expiration a certificate should be refreshed (in hours, default 1 month)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -34,6 +34,7 @@ type Config interface {
 	GetString(key string) string
 	GetBool(key string) bool
 	GetInt(key string) int
+	GetInt32(key string) int32
 	GetInt64(key string) int64
 	GetFloat64(key string) float64
 	GetTime(key string) time.Time

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -123,6 +123,17 @@ func (c *safeConfig) GetInt(key string) int {
 	return val
 }
 
+// GetInt32 wraps Viper for concurrent access
+func (c *safeConfig) GetInt32(key string) int32 {
+	c.RLock()
+	defer c.RUnlock()
+	val, err := c.Viper.GetInt32E(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
+}
+
 // GetInt64 wraps Viper for concurrent access
 func (c *safeConfig) GetInt64(key string) int64 {
 	c.RLock()

--- a/releasenotes-dca/notes/dca-admission-controller-timeout-991223eaa8bbd0de.yaml
+++ b/releasenotes-dca/notes/dca-admission-controller-timeout-991223eaa8bbd0de.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    It is now possible to configure a custom timeout for the MutatingWebhookConfigurations
+    objects controlled by the Cluster Agent via DD_ADMISSION_CONTROLLER_TIMEOUT_SECONDS. (Default: 30 seconds)


### PR DESCRIPTION
### What does this PR do?

- Allow configuring a custom timeout for the DCA's admission controller

### Motivation

FR

### Additional Notes

Added a `GetInt32` method to the Viper interface

### Describe your test plan

Enable the Admission Controller + `k get mutatingwebhookconfigurations datadog-webhook -oyaml`
- Make sure the `timeoutSeconds` value is 30
- Configure `DD_ADMISSION_CONTROLLER_TIMEOUT_SECONDS`, make sure the custom value is applied to `timeoutSeconds` 
