### PR TITLE
[runtime-security] clean dentry cache on mount event

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -812,6 +812,7 @@ func InitConfig(config Config) {
 	config.SetKnown("runtime_security_config.fim_enabled")
 	config.BindEnvAndSetDefault("runtime_security_config.policies.dir", DefaultRuntimePoliciesDir)
 	config.BindEnvAndSetDefault("runtime_security_config.socket", "/opt/datadog-agent/run/runtime-security.sock")
+	config.BindEnvAndSetDefault("runtime_security_config.enable_approvers", true)
 	config.BindEnvAndSetDefault("runtime_security_config.enable_kernel_filters", true)
 	config.BindEnvAndSetDefault("runtime_security_config.flush_discarder_window", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.syscall_monitor.enabled", false)

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "6df2cfa0d09eb69665b98ae2733c5bf11e33be747cb4f1b6a89ba4e55bc28b6c")
+var Conntrack = NewRuntimeAsset("conntrack.c", "21c86ee505aab730aa5632f744cb0cc39553181f46adc130f9fccb3607e6d2f1")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "7f7943296d30c49dad42f2ad84b5434e31d9d5c8917830e0fb8189480e0a5b54")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "eaa93a41577a76465e71cea02bb6cf4f04df541e598e59367e36027696ea5479")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "ed3009e10626138fbbe493c4c8bd7040361a4e46f9ec3e356999610a7bb0d16b")
+var Tracer = NewRuntimeAsset("tracer.c", "c3a2dd7b42dae5b0ed0fae55d33021d081057cbd49af07e380766dcf46e35eb6")

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -123,6 +123,36 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "capset"}, EntryAndExit),
 		},
 
+		// Open probes
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_truncate"}},
+		}},
+		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "open"}, EntryAndExit, true),
+		},
+		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "creat"}, EntryAndExit),
+		},
+		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "truncate"}, EntryAndExit, true),
+		},
+		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "openat"}, EntryAndExit, true),
+		},
+		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "openat2"}, EntryAndExit),
+		},
+		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "open_by_handle_at"}, EntryAndExit, true),
+		},
+		&manager.BestEffort{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/io_openat2"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kretprobe/io_openat2"}},
+		}},
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/filp_close"}},
+		}},
+
 		// Mount probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/attach_recursive_mnt"}},
@@ -257,38 +287,6 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
 			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "mkdirat"}, EntryAndExit),
 		},
-	},
-
-	// List of probes to activate to capture open events
-	"open": {
-		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_truncate"}},
-		}},
-		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "open"}, EntryAndExit, true),
-		},
-		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "creat"}, EntryAndExit),
-		},
-		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "truncate"}, EntryAndExit, true),
-		},
-		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "openat"}, EntryAndExit, true),
-		},
-		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "openat2"}, EntryAndExit),
-		},
-		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "open_by_handle_at"}, EntryAndExit, true),
-		},
-		&manager.BestEffort{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/io_openat2"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kretprobe/io_openat2"}},
-		}},
-		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/filp_close"}},
-		}},
 	},
 
 	// List of probes to activate to capture removexattr events

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -359,6 +359,14 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		event.ResolveMountRoot(&event.Mount)
 		// Insert new mount point in cache
 		p.resolvers.MountResolver.Insert(event.Mount)
+
+		// There could be entries of a previous mount_id in the cache for instance,
+		// runc does the following : it bind mounts itself (using /proc/exe/self),
+		// opens a file descriptor on the new file with O_CLOEXEC then umount the bind mount using
+		// MNT_DETACH. It then does an exec syscall, that will cause the fd to be closed.
+		// Our dentry resolution of the exec event causes the inode/mount_id to be put in cache,
+		// so we remove all dentry entries belonging to the mountID.
+		p.resolvers.DentryResolver.DelCacheEntries(event.Mount.MountID)
 	case model.FileUmountEventType:
 		if _, err := event.Umount.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode umount event: %s (offset %d, len %d)", err, offset, dataLen)

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -206,6 +206,8 @@ func (r *Resolvers) Snapshot() error {
 		return errors.Wrap(err, "unable to snapshot processes")
 	}
 
+	r.ProcessResolver.SetState(snapshotted)
+
 	return nil
 }
 

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -16,15 +16,20 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
+	"golang.org/x/sys/unix"
 	"gotest.tools/assert"
 )
 
 func TestMount(t *testing.T) {
 	dstMntBasename := "test-dest-mount"
-	rule := &rules.RuleDefinition{
+
+	rules := []*rules.RuleDefinition{{
 		ID:         "test_rule",
 		Expression: fmt.Sprintf(`chmod.file.path == "{{.Root}}/%s/test-mount"`, dstMntBasename),
-	}
+	}, {
+		ID:         "test_rule_pending",
+		Expression: fmt.Sprintf(`chown.file.path == "{{.Root}}/%s/test-release"`, dstMntBasename),
+	}}
 
 	testDrive, err := newTestDrive("xfs", []string{})
 	if err != nil {
@@ -32,7 +37,7 @@ func TestMount(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{testDir: testDrive.Root(), wantProbeEvents: true})
+	test, err := newTestModule(nil, rules, testOpts{testDir: testDrive.Root(), wantProbeEvents: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,13 +57,13 @@ func TestMount(t *testing.T) {
 	os.MkdirAll(dstMntPath, 0755)
 	defer os.RemoveAll(dstMntPath)
 
+	// Test mount
+	if err := syscall.Mount(mntPath, dstMntPath, "bind", syscall.MS_BIND, ""); err != nil {
+		t.Fatalf("could not create bind mount: %s", err)
+	}
+
 	var mntID uint32
 	t.Run("mount", func(t *testing.T) {
-		// Test mount
-		if err := syscall.Mount(mntPath, dstMntPath, "bind", syscall.MS_BIND, ""); err != nil {
-			t.Fatalf("could not create bind mount: %s", err)
-		}
-
 		event, err := test.GetProbeEvent(3*time.Second, "mount")
 		if err != nil {
 			t.Error(err)
@@ -100,18 +105,38 @@ func TestMount(t *testing.T) {
 		}
 	})
 
-	t.Run("umount", func(t *testing.T) {
-		// Test umount
-		if err := syscall.Unmount(dstMntPath, syscall.MNT_DETACH); err != nil {
-			t.Fatalf("could not unmount test-mount: %s", err)
-		}
+	releaseFile, err := os.Create(path.Join(dstMntPath, "test-release"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseFile.Close()
 
+	// Test umount
+	if err := syscall.Unmount(dstMntPath, syscall.MNT_DETACH); err != nil {
+		t.Fatalf("could not unmount test-mount: %s", err)
+	}
+
+	t.Run("umount", func(t *testing.T) {
 		event, err := test.GetProbeEvent(3*time.Second, "umount")
 		if err != nil {
 			t.Error(err)
 		} else {
 			assert.Equal(t, event.GetType(), "umount", "wrong event type")
 			assert.Equal(t, event.Umount.MountID, mntID, "wrong mount id")
+		}
+	})
+
+	t.Run("release-mount", func(t *testing.T) {
+		if err := syscall.Fchownat(int(releaseFile.Fd()), "", 123, 123, unix.AT_EMPTY_PATH); err != nil {
+			t.Fatal(err)
+		}
+
+		event, rule, err := test.GetEvent()
+		if err != nil {
+			t.Error(err)
+		} else {
+			assert.Equal(t, event.GetType(), "chown", "wrong event type")
+			assertTriggeredRule(t, rule, "test_rule_pending")
 		}
 	})
 }

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -194,7 +194,7 @@ def build_functional_tests(
 
     if static:
         ldflags += '-extldflags "-static"'
-        build_tags += ',osusergo'
+        build_tags += ',osusergo,netgo'
 
     cmd = 'go test -mod=mod -tags {build_tags} -ldflags="{ldflags}" -c -o {output} '
     cmd += '{repo_path}/pkg/security/tests'


### PR DESCRIPTION
### What does this PR do?

Fix resolution of previously used mount ids.

### Motivation

There could be entries of a previous mount_id in the cache for instance,
runc does the following : it bind mounts itself (using /proc/exe/self),
opens a file descriptor on the new file with O_CLOEXEC then umount the bind mount using
MNT_DETACH. It then does an exec syscall, that will cause the fd to be closed.
Our dentry resolution of the exec event causes the inode/mount_id to be put in cache,
so we remove all dentry entries belonging to the mountID.
