### PR TITLE
[build] Update Appveyor tasks to use Golang 1.15

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ clone_folder: C:\gopath\src\github.com\DataDog\datadog-agent
 # environment must be set for python 64 bit
 environment:
   GOPATH: C:\gopath
-  GOVERSION: '1.14.12'
-  GOROOT: C:\go_1.14.12
+  GOVERSION: '1.15.11'
+  GOROOT: C:\go_1.15.11
   GOLANGCI_LINT_VERSION: "1.27.0"
   # Give hints to CMake to find Pythons
   Python2_ROOT_DIR: C:\Python27-x64


### PR DESCRIPTION
### What does this PR do?

This commit bumps the version of Golang used by the Appveyor from 1.14
to 1.15 as part of the regularly scheduled version update.

### Motivation

AC-846: Regularly scheduled Golang update

### Additional Notes

N/A

### Describe your test plan

Check that Appveyor builds do not fail