### PR TITLE
[config] add `extra_tags` setting

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -241,12 +241,8 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 	}
 
 	// extra tags to append to all logs / metrics
-	extraTags := config.Datadog.GetStringSlice("tags")
+	extraTags := config.GetConfiguredTags(true)
 	extraTags = append(extraTags, aws.GetARNTags()...)
-
-	if dsdTags := config.Datadog.GetStringSlice("dogstatsd_tags"); len(dsdTags) > 0 {
-		extraTags = append(extraTags, dsdTags...)
-	}
 	log.Debugf("Adding tags to telemetry: %s", extraTags)
 
 	// adaptive flush configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1355,3 +1355,21 @@ func getValidHostAliasesWithConfig(config Config) []string {
 
 	return aliases
 }
+
+// GetConfiguredTags returns complete list of user configured tags
+func GetConfiguredTags(includeDogstatsd bool) []string {
+	tags := Datadog.GetStringSlice("tags")
+	extraTags := Datadog.GetStringSlice("extra_tags")
+
+	var dsdTags []string
+	if includeDogstatsd {
+		dsdTags = Datadog.GetStringSlice("dogstatsd_tags")
+	}
+
+	combined := make([]string, 0, len(tags)+len(extraTags)+len(dsdTags))
+	combined = append(combined, tags...)
+	combined = append(combined, extraTags...)
+	combined = append(combined, dsdTags...)
+
+	return combined
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -163,6 +163,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("skip_ssl_validation", false)
 	config.BindEnvAndSetDefault("hostname", "")
 	config.BindEnvAndSetDefault("tags", []string{})
+	config.BindEnvAndSetDefault("extra_tags", []string{})
 	config.BindEnv("env") //nolint:errcheck
 	config.BindEnvAndSetDefault("tag_value_split_separator", map[string]string{})
 	config.BindEnvAndSetDefault("conf_path", ".")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -71,20 +71,12 @@ api_key:
 ## @param tags  - list of key:value elements - optional
 ## List of host tags. Attached in-app to every metric, event, log, trace, and service check emitted by this Agent.
 ##
+## Additional tags can be supplied using the `DD_EXTRA_TAGS` environment variable.
+##
 ## Learn more about tagging: https://docs.datadoghq.com/tagging/
 #
 # tags:
 #   - environment:dev
-#   - <TAG_KEY>:<TAG_VALUE>
-
-## @param extra_tags - list of key:value elements - optional
-## List of aditional host tags. Attached in-app to every metric, event, log,
-## trace, and service check emitted by this Agent.
-##
-## This list is combined with the `tags` setting. This setting can be used to
-## specify additional tags when `DD_TAGS` environment variable is used.
-#
-# extra_tags:
 #   - <TAG_KEY>:<TAG_VALUE>
 
 ## @param env - string - optional

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -77,6 +77,16 @@ api_key:
 #   - environment:dev
 #   - <TAG_KEY>:<TAG_VALUE>
 
+## @param extra_tags - list of key:value elements - optional
+## List of aditional host tqgs. Attached in-app to every metric, event, log,
+## trace, and service check emitted by this Agent.
+##
+## This list is combined with the `tags` setting. This setting can be used to
+## specify additional tags when `DD_TAGS` environment variable is used.
+#
+# extra_tags:
+#   - <TAG_KEY>:<TAG_VALUE>
+
 ## @param env - string - optional
 ## The environment name where the agent is running. Attached in-app to every
 ## metric, event, log, trace, and service check emitted by this Agent.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -78,7 +78,7 @@ api_key:
 #   - <TAG_KEY>:<TAG_VALUE>
 
 ## @param extra_tags - list of key:value elements - optional
-## List of aditional host tqgs. Attached in-app to every metric, event, log,
+## List of aditional host tags. Attached in-app to every metric, event, log,
 ## trace, and service check emitted by this Agent.
 ##
 ## This list is combined with the `tags` setting. This setting can be used to

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -67,8 +67,10 @@ func GetHostTags(cached bool) *Tags {
 	}
 
 	rawHostTags := config.Datadog.GetStringSlice("tags")
-	hostTags := make([]string, 0, len(rawHostTags))
+	rawExtraTags := config.Datadog.GetStringSlice("extra_tags")
+	hostTags := make([]string, 0, len(rawHostTags)+len(rawExtraTags))
 	hostTags = appendToHostTags(hostTags, rawHostTags)
+	hostTags = appendToHostTags(hostTags, rawExtraTags)
 
 	env := config.Datadog.GetString("env")
 	if env != "" {

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -66,11 +66,9 @@ func GetHostTags(cached bool) *Tags {
 		return appendAndSplitTags(old, new, splits)
 	}
 
-	rawHostTags := config.Datadog.GetStringSlice("tags")
-	rawExtraTags := config.Datadog.GetStringSlice("extra_tags")
-	hostTags := make([]string, 0, len(rawHostTags)+len(rawExtraTags))
+	rawHostTags := config.GetConfiguredTags(false)
+	hostTags := make([]string, 0, len(rawHostTags))
 	hostTags = appendToHostTags(hostTags, rawHostTags)
-	hostTags = appendToHostTags(hostTags, rawExtraTags)
 
 	env := config.Datadog.GetString("env")
 	if env != "" {

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -147,7 +147,7 @@ func GetHostTags(cached bool) *Tags {
 	}
 
 	t := &Tags{
-		System:              hostTags,
+		System:              util.SortUniqInPlace(hostTags),
 		GoogleCloudPlatform: gceTags,
 	}
 

--- a/pkg/metadata/host/host_tags_test.go
+++ b/pkg/metadata/host/host_tags_test.go
@@ -74,3 +74,15 @@ func TestMarshalEmptyHostTags(t *testing.T) {
 	// `System` should be marshaled as an empty list
 	assert.Equal(t, string(marshaled), `{"system":[]}`)
 }
+
+func TestCombineExtraTags(t *testing.T) {
+	mockConfig := config.Mock()
+	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag4"})
+	mockConfig.Set("extra_tags", []string{"tag1:value2", "tag3", "tag4"})
+	defer mockConfig.Set("tags", nil)
+	defer mockConfig.Set("extra_tags", nil)
+
+	hostTags := GetHostTags(false)
+	assert.NotNil(t, hostTags.System)
+	assert.Equal(t, []string{"tag1:value1", "tag2", "tag4", "tag1:value2", "tag3", "tag4"}, hostTags.System)
+}

--- a/pkg/metadata/host/host_tags_test.go
+++ b/pkg/metadata/host/host_tags_test.go
@@ -37,7 +37,7 @@ func TestGetHostTagsWithSplits(t *testing.T) {
 
 	hostTags := GetHostTags(false)
 	assert.NotNil(t, hostTags.System)
-	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0", "kafka_partition:1", "kafka_partition:2"}, hostTags.System)
+	assert.Equal(t, []string{"kafka_partition:0", "kafka_partition:1", "kafka_partition:2", "tag1:value1", "tag2", "tag3"}, hostTags.System)
 }
 
 func TestGetHostTagsWithoutSplits(t *testing.T) {
@@ -48,7 +48,7 @@ func TestGetHostTagsWithoutSplits(t *testing.T) {
 
 	hostTags := GetHostTags(false)
 	assert.NotNil(t, hostTags.System)
-	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"}, hostTags.System)
+	assert.Equal(t, []string{"kafka_partition:0,1,2", "tag1:value1", "tag2", "tag3"}, hostTags.System)
 }
 
 func TestGetHostTagsWithEnv(t *testing.T) {
@@ -60,7 +60,7 @@ func TestGetHostTagsWithEnv(t *testing.T) {
 
 	hostTags := GetHostTags(false)
 	assert.NotNil(t, hostTags.System)
-	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "env:prod", "env:preprod"}, hostTags.System)
+	assert.Equal(t, []string{"env:preprod", "env:prod", "tag1:value1", "tag2", "tag3"}, hostTags.System)
 }
 
 func TestMarshalEmptyHostTags(t *testing.T) {
@@ -84,5 +84,5 @@ func TestCombineExtraTags(t *testing.T) {
 
 	hostTags := GetHostTags(false)
 	assert.NotNil(t, hostTags.System)
-	assert.Equal(t, []string{"tag1:value1", "tag2", "tag4", "tag1:value2", "tag3", "tag4"}, hostTags.System)
+	assert.Equal(t, []string{"tag1:value1", "tag1:value2", "tag2", "tag3", "tag4"}, hostTags.System)
 }

--- a/pkg/tagger/collectors/static_main.go
+++ b/pkg/tagger/collectors/static_main.go
@@ -26,7 +26,7 @@ type StaticCollector struct {
 func (c *StaticCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 	c.infoOut = out
 	// Extract DD_TAGS environment variable
-	c.ddTagsEnvVar = config.Datadog.GetStringSlice("tags")
+	c.ddTagsEnvVar = config.GetConfiguredTags(false)
 
 	return FetchOnlyCollection, nil
 }

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -192,8 +192,8 @@ func (c *AgentConfig) applyDatadogConfig() error {
 	} else if config.Datadog.IsSet("env") {
 		c.DefaultEnv = config.Datadog.GetString("env")
 		log.Debugf("Setting DefaultEnv to %q (from 'env' config option)", c.DefaultEnv)
-	} else if config.Datadog.IsSet("tags") {
-		for _, tag := range config.Datadog.GetStringSlice("tags") {
+	} else {
+		for _, tag := range config.GetConfiguredTags(false) {
 			if strings.HasPrefix(tag, "env:") {
 				c.DefaultEnv = strings.TrimPrefix(tag, "env:")
 				log.Debugf("Setting DefaultEnv to %q (from `env:` entry under the 'tags' config option: %q)", c.DefaultEnv, tag)

--- a/releasenotes/notes/add-extra-tags-f9c833522bd9cb80.yaml
+++ b/releasenotes/notes/add-extra-tags-f9c833522bd9cb80.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    New `extra_tags` setting and `DD_EXTRA_TAGS` environment variable can be
+    used to specify additional host tags.


### PR DESCRIPTION
### What does this PR do?

`extra_tags` specifies additional tags that will be appended to the host tags. Allows tags to be set via both the configuration file and environment variable at the same time. Duplicates will be removed.

### Describe your test plan

Provide some tags in `datadog.yaml` and set `DD_EXTRA_TAGS` to a different set of tags. Verify that tags from both sources are being sent.