### PR TITLE
[build] Update CircleCI runner image to use Golang 1.15.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: datadog/datadog-agent-runner-circle:go11510
+      - image: datadog/datadog-agent-runner-circle:go11511
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent

--- a/.circleci/images/runner/Dockerfile
+++ b/.circleci/images/runner/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex \
         ssh
 
 # Golang
-ENV GIMME_GO_VERSION 1.15.10
+ENV GIMME_GO_VERSION 1.15.11
 ENV GOROOT /root/.gimme/versions/go$GIMME_GO_VERSION.linux.amd64
 ENV GOPATH /go
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
Golang v1.15.10 had issues building Windows binaries that were fixed in
the latest version (v1.15.11). This change ensures that we are using the
fixed version for our CI.

Upstream fix merge: https://go-review.googlesource.com/c/go/+/300692/

### Motivation

https://github.com/golang/go/issues/40795 symptoms on Windows builds due to `buildmode` default change to `pie` in Golang v1.15

### Describe your test plan

- Ensure that all circleci tests pass
