### PR TITLE
[integrations] Do not set -std=c99 on MacOS

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -140,12 +140,24 @@ build do
     nix_build_env = {
       # Specify C99 standard explicitly to avoid issues while building some
       # wheels (eg. ddtrace)
-      "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc -std=c99",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
       "LD_RUN_PATH" => "#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
       "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
     }
+
+    # On Linux & Windows, specify the C99 standard explicitly to avoid issues while building some
+    # wheels (eg. ddtrace).
+    # Not explicitly setting that option has caused us problems in the past on SUSE, where the ddtrace
+    # wheel has to be manually built, as the C code in ddtrace doesn't follow the C89 standard (the default value of std).
+    # Note: We don't set this on MacOS, as on MacOS we need to build a bunch of packages & C extensions that
+    # don't have precompiled MacOS wheels. When building C extensions, the CFLAGS variable is added to
+    # the command-line parameters, even when compiling C++ code, where -std=c99 is invalid.
+    # See: https://github.com/python/cpython/blob/v3.8.8/Lib/distutils/sysconfig.py#L227
+    if linux? || windows?
+      nix_build_env["CFLAGS"] += " -std=c99"
+    end
 
     #
     # Prepare the requirements file containing ALL the dependencies needed by


### PR DESCRIPTION
### What does this PR do?

On MacOS, do not set the `-std=c99` option when building wheels for integrations as it breaks C extension builds.

### Motivation

Fix broken MacOS build.

### Describe your test plan

Test Agent 7 build: https://github.com/DataDog/datadog-agent-macos-build/runs/2335793781?check_suite_focus=true