### PR TITLE
[runtime-security] do not generate event for umount error

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "034db82b19db09d1dcf23e15b064ffa7d761442ae6d7ca3321cb4d878be97997")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "7f7943296d30c49dad42f2ad84b5434e31d9d5c8917830e0fb8189480e0a5b54")

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -81,6 +81,10 @@ SYSCALL_COMPAT_KRETPROBE(mount) {
     if (!syscall)
         return 0;
 
+    int retval = PT_REGS_RC(ctx);
+    if (retval)
+        return 0;
+
     struct dentry *dentry = get_mountpoint_dentry(syscall->mount.dest_mountpoint);
     struct path_key_t path_key = {
         .mount_id = get_mount_mount_id(syscall->mount.dest_mnt),
@@ -88,7 +92,7 @@ SYSCALL_COMPAT_KRETPROBE(mount) {
     };
 
     struct mount_event_t event = {
-        .syscall.retval = PT_REGS_RC(ctx),
+        .syscall.retval = retval,
         .mount_id = get_mount_mount_id(syscall->mount.src_mnt),
         .group_id = get_mount_peer_group_id(syscall->mount.src_mnt),
         .device = get_mount_dev(syscall->mount.src_mnt),

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -33,10 +33,14 @@ SYSCALL_KRETPROBE(umount) {
     if (!syscall)
         return 0;
 
+    int retval = PT_REGS_RC(ctx);
+    if (retval)
+        return 0;
+
     int mount_id = get_vfsmount_mount_id(syscall->umount.vfs);
 
     struct umount_event_t event = {
-        .syscall .retval = PT_REGS_RC(ctx),
+        .syscall .retval = retval,
         .mount_id = mount_id
     };
 

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -112,10 +112,10 @@ var (
 
 	// Security Agent metrics
 
-	// MetricsSecurityAgentRuntimeRunning is reported when the security agent `Runtime` feature is enabled
-	MetricsSecurityAgentRuntimeRunning = newAgentMetric(".runtime.running")
-	// MetricsSecurityAgentFIMRunning is reported when the security agent `FIM` feature is enabled
-	MetricsSecurityAgentFIMRunning = newAgentMetric(".fim.running")
+	// MetricSecurityAgentRuntimeRunning is reported when the security agent `Runtime` feature is enabled
+	MetricSecurityAgentRuntimeRunning = newAgentMetric(".runtime.running")
+	// MetricSecurityAgentFIMRunning is reported when the security agent `FIM` feature is enabled
+	MetricSecurityAgentFIMRunning = newAgentMetric(".fim.running")
 )
 
 func newRuntimeMetric(name string) string {

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -106,9 +106,6 @@ var (
 	// MetricRuleSetLoaded is the name of the metric used to report that a new ruleset was loaded
 	// Tags: -
 	MetricRuleSetLoaded = newRuntimeMetric(".ruleset_loaded")
-	// MetricForkBomb is the name of the metric used to report the number of processes that crossed the fork bomb
-	// threshold. Tags: -
-	MetricForkBomb = newRuntimeMetric(".fork_bomb")
 
 	// Security Agent metrics
 

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -289,9 +289,9 @@ func (m *Module) metricsSender() {
 		case <-heartbeatTicker.C:
 			tags := []string{fmt.Sprintf("version:%s", version.AgentVersion)}
 			if m.config.RuntimeEnabled {
-				_ = m.statsdClient.Gauge(metrics.MetricsSecurityAgentRuntimeRunning, 1, tags, 1)
+				_ = m.statsdClient.Gauge(metrics.MetricSecurityAgentRuntimeRunning, 1, tags, 1)
 			} else if m.config.FIMEnabled {
-				_ = m.statsdClient.Gauge(metrics.MetricsSecurityAgentFIMRunning, 1, tags, 1)
+				_ = m.statsdClient.Gauge(metrics.MetricSecurityAgentFIMRunning, 1, tags, 1)
 			}
 		case <-m.ctx.Done():
 			return

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -68,7 +68,6 @@ runtime_security_config:
   flush_discarder_window: 0
   load_controller:
     events_count_threshold: {{ .EventsCountThreshold }}
-    fork_bomb_threshold: {{ .ForkBombThreshold }}
 {{if .DisableFilters}}
   enable_kernel_filters: false
 {{end}}


### PR DESCRIPTION
### What does this PR do?

Stop sending umount kernel event for umount syscall error. This avoid a warn log for unknown mount point.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
