### PR TITLE
Scrub community, authentication_key, privacy_key

### DIFF
--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -59,8 +59,8 @@ func init() {
 		Repl:  []byte(`$1 ********`),
 	}
 	snmpReplacer := Replacer{
-		Regex: matchYAMLKey(`(community_string|authKey|privKey)`),
-		Hints: []string{"community_string", "authKey", "privKey"},
+		Regex: matchYAMLKey(`(community|community_string|authKey|privKey|authentication_key|privacy_key)`),
+		Hints: []string{"community_string", "authKey", "privKey", "community", "authentication_key", "privacy_key"},
 		Repl:  []byte(`$1 ********`),
 	}
 	certReplacer := Replacer{

--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -59,7 +59,7 @@ func init() {
 		Repl:  []byte(`$1 ********`),
 	}
 	snmpReplacer := Replacer{
-		Regex: matchYAMLKey(`(community|community_string|authKey|privKey|authentication_key|privacy_key)`),
+		Regex: matchYAMLKey(`(community_string|authKey|privKey|community|authentication_key|privacy_key)`),
 		Hints: []string{"community_string", "authKey", "privKey", "community", "authentication_key", "privacy_key"},
 		Repl:  []byte(`$1 ********`),
 	}

--- a/pkg/util/log/strip_test.go
+++ b/pkg/util/log/strip_test.go
@@ -251,6 +251,15 @@ func TestSNMPConfig(t *testing.T) {
 	assertClean(t,
 		`   community_string:   'password'   `,
 		`   community_string: ********`)
+	assertClean(t,
+		`community: password`,
+		`community: ********`)
+	assertClean(t,
+		`authentication_key: password`,
+		`authentication_key: ********`)
+	assertClean(t,
+		`privacy_key: password`,
+		`privacy_key: ********`)
 }
 
 func TestYamlConfig(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Scrub community, authentication_key, privacy_key

### Motivation

community, authentication_key, privacy_key are sensitive info

### Additional Notes

Before in flare `runtime_config_dump.yaml`:
```
snmp_listener:
  configs:
  - authentication_key: abc
    authentication_protocol: abc
    community: public
    network: 172.19.0.0/30
    port: 161
    privacy_key: "123"
    privacy_protocol: "123"
    retries: 2
    tags:
    - tag1:val1
    - foo:bar
    timeout: 1
    version: 2
  discovery_interval: 10
  workers: 5
```


With this PR: 
```
snmp_listener:
  configs:
  - authentication_key: ********
    authentication_protocol: abc
    community: ********
    network: 172.19.0.0/30
    port: 161
    privacy_key: ********
    privacy_protocol: "123"
    retries: 2
    tags:
    - tag1:val1
    - foo:bar
    timeout: 1
    version: 2
  discovery_interval: 10
  workers: 5
```

### Describe your test plan

1/ Add config like this in `datadog.yaml`

```
snmp_listener:
  configs:
  - authentication_key: abc
    authentication_protocol: abc
    community: public
    network: 172.19.0.0/30
    port: 161
    privacy_key: "123"
    privacy_protocol: "123"
    retries: 2
    tags:
    - tag1:val1
    - foo:bar
    timeout: 1
    version: 2
  discovery_interval: 10
  workers: 5
```

2/ Restart Agent

3/ Check that `agent flare`  (make sure to NOT upload flare to support for QA/testing) will generate a flare without the credentials scrubbed in the PR.


II-266