### PR TITLE
[compliance] allow setting cluster agent logs endpoints

### DIFF
--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -131,33 +131,6 @@ func newLogContext(logsConfig config.LogsConfigKeys, endpointPrefix string) (*co
 	return endpoints, destinationsCtx, nil
 }
 
-func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, error) {
-	logsConfigComplianceKeys := config.LogsConfigKeys{
-		CompressionLevel:        "compliance_config.endpoints.compression_level",
-		ConnectionResetInterval: "compliance_config.endpoints.connection_reset_interval",
-		LogsDDURL:               "compliance_config.endpoints.logs_dd_url",
-		DDURL:                   "compliance_config.endpoints.dd_url",
-		DevModeNoSSL:            "compliance_config.endpoints.dev_mode_no_ssl",
-		AdditionalEndpoints:     "compliance_config.endpoints.additional_endpoints",
-		BatchWait:               "compliance_config.endpoints.batch_wait",
-	}
-	return newLogContext(logsConfigComplianceKeys, "compliance-http-intake.logs.")
-}
-
-// This function will only be used on Linux. The only platforms where the runtime agent runs
-func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) { // nolint: deadcode, unused
-	logsConfigRuntimeKeys := config.LogsConfigKeys{
-		CompressionLevel:        "runtime_security_config.endpoints.compression_level",
-		ConnectionResetInterval: "runtime_security_config.endpoints.connection_reset_interval",
-		LogsDDURL:               "runtime_security_config.endpoints.logs_dd_url",
-		DDURL:                   "runtime_security_config.endpoints.dd_url",
-		DevModeNoSSL:            "runtime_security_config.endpoints.dev_mode_no_ssl",
-		AdditionalEndpoints:     "runtime_security_config.endpoints.additional_endpoints",
-		BatchWait:               "runtime_security_config.endpoints.batch_wait",
-	}
-	return newLogContext(logsConfigRuntimeKeys, "runtime-security-http-intake.logs.")
-}
-
 func start(cmd *cobra.Command, args []string) error {
 	// Main context passed to components
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -149,6 +149,12 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 	return event.NewReporter(logSource, pipelineProvider.NextPipelineChan()), nil
 }
 
+// This function will only be used on Linux. The only platforms where the runtime agent runs
+func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) { // nolint: deadcode, unused
+	logsConfigComplianceKeys := config.NewLogsConfigKeys("runtime_security_config.endpoints.")
+	return newLogContext(logsConfigComplianceKeys, "runtime-security-http-intake.logs.")
+}
+
 func startRuntimeSecurity(hostname string, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {
 	enabled := coreconfig.Datadog.GetBool("runtime_security_config.enabled")
 	if !enabled {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -638,7 +638,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.use_http", false)
 	config.BindEnvAndSetDefault("logs_config.use_tcp", false)
 
-	bindLogsConfigKeys(config, "logs_config.")
+	bindEnvAndSetLogsConfigKeys(config, "logs_config.")
 
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
@@ -801,7 +801,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
 	config.BindEnvAndSetDefault("compliance_config.run_path", defaultRunPath)
-	bindLogsConfigKeys(config, "compliance_config.endpoints.")
+	bindEnvAndSetLogsConfigKeys(config, "compliance_config.endpoints.")
 
 	// Datadog security agent (runtime)
 	config.BindEnvAndSetDefault("runtime_security_config.enabled", false)
@@ -824,7 +824,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.agent_monitoring_events", true)
 	config.BindEnvAndSetDefault("runtime_security_config.custom_sensitive_words", []string{})
 	config.BindEnvAndSetDefault("runtime_security_config.remote_tagger", true)
-	bindLogsConfigKeys(config, "runtime_security_config.endpoints.")
+	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")
@@ -1057,7 +1057,7 @@ func GetMultipleEndpoints() (map[string][]string, error) {
 	return getMultipleEndpointsWithConfig(Datadog)
 }
 
-func bindLogsConfigKeys(config Config, prefix string) {
+func bindEnvAndSetLogsConfigKeys(config Config, prefix string) {
 	config.BindEnv(prefix + "logs_dd_url")          //nolint:errcheck // Send the logs to a proxy. Must respect format '<HOST>:<PORT>' and '<PORT>' to be an integer
 	config.BindEnv(prefix + "dd_url")               //nolint:errcheck
 	config.BindEnv(prefix + "additional_endpoints") //nolint:errcheck

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -603,11 +603,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.container_collect_all", false)
 	// add a socks5 proxy:
 	config.BindEnvAndSetDefault("logs_config.socks5_proxy_address", "")
-	// send the logs to a proxy:
-	config.BindEnv("logs_config.logs_dd_url") //nolint:errcheck // must respect format '<HOST>:<PORT>' and '<PORT>' to be an integer
 	// specific logs-agent api-key
 	config.BindEnv("logs_config.api_key") //nolint:errcheck
-	config.BindEnvAndSetDefault("logs_config.logs_no_ssl", false)
 
 	// Duration during which the host tags will be submitted with log events.
 	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", 0) // duration-formatted string (parsed by `time.ParseDuration`)
@@ -638,13 +635,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.docker_client_read_timeout", 30)
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
-	config.BindEnv("logs_config.dd_url") //nolint:errcheck
 	config.BindEnvAndSetDefault("logs_config.use_http", false)
 	config.BindEnvAndSetDefault("logs_config.use_tcp", false)
-	config.BindEnvAndSetDefault("logs_config.use_compression", true)
-	config.BindEnvAndSetDefault("logs_config.compression_level", 6) // Default level for the gzip/deflate algorithm
-	config.BindEnvAndSetDefault("logs_config.batch_wait", DefaultBatchWait)
-	config.BindEnvAndSetDefault("logs_config.connection_reset_interval", 0) // in seconds, 0 means disabled
+
+	bindLogsConfigKeys(config, "logs_config.")
+
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
@@ -656,7 +651,6 @@ func InitConfig(config Config) {
 	// It may be useful to increase it when logs writing is slowed down, that
 	// could happen while serializing large objects on log lines.
 	config.BindEnvAndSetDefault("logs_config.aggregation_timeout", 1000)
-	config.BindEnv("logs_config.additional_endpoints") //nolint:errcheck
 
 	// The cardinality of tags to send for checks and dogstatsd respectively.
 	// Choices are: low, orchestrator, high.
@@ -807,6 +801,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
 	config.BindEnvAndSetDefault("compliance_config.run_path", defaultRunPath)
+	bindLogsConfigKeys(config, "compliance_config.endpoints.")
 
 	// Datadog security agent (runtime)
 	config.BindEnvAndSetDefault("runtime_security_config.enabled", false)
@@ -829,6 +824,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.agent_monitoring_events", true)
 	config.BindEnvAndSetDefault("runtime_security_config.custom_sensitive_words", []string{})
 	config.BindEnvAndSetDefault("runtime_security_config.remote_tagger", true)
+	bindLogsConfigKeys(config, "runtime_security_config.endpoints.")
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")
@@ -1059,6 +1055,18 @@ func GetMainEndpoint(prefix string, ddURLKey string) string {
 // GetMultipleEndpoints returns the api keys per domain specified in the main agent config
 func GetMultipleEndpoints() (map[string][]string, error) {
 	return getMultipleEndpointsWithConfig(Datadog)
+}
+
+func bindLogsConfigKeys(config Config, prefix string) {
+	config.BindEnv(prefix + "logs_dd_url")          //nolint:errcheck // Send the logs to a proxy. Must respect format '<HOST>:<PORT>' and '<PORT>' to be an integer
+	config.BindEnv(prefix + "dd_url")               //nolint:errcheck
+	config.BindEnv(prefix + "additional_endpoints") //nolint:errcheck
+	config.BindEnvAndSetDefault(prefix+"use_compression", true)
+	config.BindEnvAndSetDefault(prefix+"compression_level", 6) // Default level for the gzip/deflate algorithm
+	config.BindEnvAndSetDefault(prefix+"batch_wait", DefaultBatchWait)
+	config.BindEnvAndSetDefault(prefix+"connection_reset_interval", 0) // in seconds, 0 means disabled
+	config.BindEnvAndSetDefault(prefix+"logs_no_ssl", false)
+	config.BindEnvAndSetDefault(prefix+"batch_max_concurrent_send", DefaultBatchMaxConcurrentSend)
 }
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -201,17 +201,22 @@ type LogsConfigKeys struct {
 }
 
 // logsConfigDefaultKeys defines the default YAML keys used to retrieve logs configuration
-var logsConfigDefaultKeys = LogsConfigKeys{
-	UseCompression:          "logs_config.use_compression",
-	CompressionLevel:        "logs_config.compression_level",
-	ConnectionResetInterval: "logs_config.connection_reset_interval",
-	LogsDDURL:               "logs_config.logs_dd_url",
-	LogsNoSSL:               "logs_config.logs_no_ssl",
-	DDURL:                   "logs_config.dd_url",
-	DevModeNoSSL:            "logs_config.dev_mode_no_ssl",
-	AdditionalEndpoints:     "logs_config.additional_endpoints",
-	BatchWait:               "logs_config.batch_wait",
-	BatchMaxConcurrentSend:  "logs_config.batch_max_concurrent_send",
+var logsConfigDefaultKeys = NewLogsConfigKeys("logs_config.")
+
+// LogsConfigKeys returns a new logs configuration keys set
+func NewLogsConfigKeys(configPrefix string) LogsConfigKeys {
+	return LogsConfigKeys{
+		UseCompression:          configPrefix + "use_compression",
+		CompressionLevel:        configPrefix + "compression_level",
+		ConnectionResetInterval: configPrefix + "connection_reset_interval",
+		LogsDDURL:               configPrefix + "logs_dd_url",
+		LogsNoSSL:               configPrefix + "logs_no_ssl",
+		DDURL:                   configPrefix + "dd_url",
+		DevModeNoSSL:            configPrefix + "dev_mode_no_ssl",
+		AdditionalEndpoints:     configPrefix + "additional_endpoints",
+		BatchWait:               configPrefix + "batch_wait",
+		BatchMaxConcurrentSend:  configPrefix + "batch_max_concurrent_send",
+	}
 }
 
 // BuildHTTPEndpoints returns the HTTP endpoints to send logs to.

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -203,7 +203,7 @@ type LogsConfigKeys struct {
 // logsConfigDefaultKeys defines the default YAML keys used to retrieve logs configuration
 var logsConfigDefaultKeys = NewLogsConfigKeys("logs_config.")
 
-// LogsConfigKeys returns a new logs configuration keys set
+// NewLogsConfigKeys returns a new logs configuration keys set
 func NewLogsConfigKeys(configPrefix string) LogsConfigKeys {
 	return LogsConfigKeys{
 		UseCompression:          configPrefix + "use_compression",

--- a/releasenotes-dca/notes/logs-endpoints-config-aee92f1690da0dc3.yaml
+++ b/releasenotes-dca/notes/logs-endpoints-config-aee92f1690da0dc3.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    The cluster agent now uses the same configuration than the security agent for
+    the logs endpoints configuration. The parameters (such as `logs_dd_url` can be
+    either be specified in the `compliance_config.endpoints` section or through
+    environment variables (such as DD_COMPLIANCE_CONFIG_ENDPOINTS_LOGS_DD_URL).


### PR DESCRIPTION
### What does this PR do?

Make the compliance part of the cluster-agent fetch the logs endpoints from
the configuration file or from environment variables.