### PR TITLE
[Tagger][ECS] Support replacing colon characters in ecs ec2 resource tag keys

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -525,6 +525,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected
 	config.BindEnvAndSetDefault("ecs_agent_container_name", "ecs-agent")
 	config.BindEnvAndSetDefault("ecs_collect_resource_tags_ec2", false)
+	config.BindEnvAndSetDefault("ecs_resource_tags_replace_colon", false)
 	config.BindEnvAndSetDefault("ecs_metadata_timeout", 500) // value in milliseconds
 
 	// GCE

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1731,6 +1731,11 @@ api_key:
 #
 # ecs_collect_resource_tags_ec2: false
 
+## @param ecs_resource_tags_replace_colon - boolean - optional - default: false
+## The Agent replaces colon `:` characters in the ECS resource tag keys by underscores `_`.
+#
+# ecs_resource_tags_replace_colon: false
+
 ## @param ecs_metadata_timeout - integer - optional - default: 500
 ## Timeout in milliseconds on calls to the AWS ECS metadata endpoints.
 #

--- a/pkg/tagger/collectors/ecs_common.go
+++ b/pkg/tagger/collectors/ecs_common.go
@@ -8,6 +8,7 @@ package collectors
 import (
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 )
 
@@ -17,6 +18,11 @@ func addResourceTags(t *utils.TagList, m map[string]string) {
 		if strings.HasPrefix(k, "aws:") {
 			continue
 		}
+
+		if config.Datadog.GetBool("ecs_resource_tags_replace_colon") {
+			k = strings.ReplaceAll(k, ":", "_")
+		}
+
 		t.AddLow(strings.ToLower(k), strings.ToLower(v))
 	}
 }

--- a/pkg/tagger/collectors/ecs_common_test.go
+++ b/pkg/tagger/collectors/ecs_common_test.go
@@ -8,24 +8,99 @@ package collectors
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAddTaskResourceTags(t *testing.T) {
-	tags := utils.NewTagList()
-	taskTags := map[string]string{
-		"environment":         "sandbox",
-		"project":             "ecs-test",
-		"aws:ecs:clusterName": "test-cluster",
-		"aws:ecs:serviceName": "nginx-awsvpc",
+func TestAddResourceTags(t *testing.T) {
+	tests := []struct {
+		name      string
+		taskTags  map[string]string
+		loadFunc  func() *utils.TagList
+		resetFunc func()
+	}{
+		{
+			name: "nominal case",
+			taskTags: map[string]string{
+				"environment":         "sandbox",
+				"project":             "ecs-test",
+				"aws:ecs:clusterName": "test-cluster",
+				"aws:ecs:serviceName": "nginx-awsvpc",
+			},
+			loadFunc: func() *utils.TagList {
+				expectedTags := utils.NewTagList()
+				expectedTags.AddLow("environment", "sandbox")
+				expectedTags.AddLow("project", "ecs-test")
+				return expectedTags
+			},
+			resetFunc: func() {},
+		},
+		{
+			name: "replace colon enabled, replace tag key",
+			taskTags: map[string]string{
+				"environment":         "sandbox",
+				"project":             "ecs-test",
+				"foo:bar:baz":         "val",
+				"aws:ecs:clusterName": "test-cluster",
+				"aws:ecs:serviceName": "nginx-awsvpc",
+			},
+			loadFunc: func() *utils.TagList {
+				expectedTags := utils.NewTagList()
+				expectedTags.AddLow("environment", "sandbox")
+				expectedTags.AddLow("project", "ecs-test")
+				expectedTags.AddLow("foo_bar_baz", "val")
+				config.Datadog.Set("ecs_resource_tags_replace_colon", true)
+				return expectedTags
+			},
+			resetFunc: func() { config.Datadog.Set("ecs_resource_tags_replace_colon", false) },
+		},
+		{
+			name: "replace colon enabled, do not replace tag value",
+			taskTags: map[string]string{
+				"environment":         "sandbox",
+				"project":             "ecs-test",
+				"foo:bar:baz":         "val1:val2",
+				"aws:ecs:clusterName": "test-cluster",
+				"aws:ecs:serviceName": "nginx-awsvpc",
+			},
+			loadFunc: func() *utils.TagList {
+				expectedTags := utils.NewTagList()
+				expectedTags.AddLow("environment", "sandbox")
+				expectedTags.AddLow("project", "ecs-test")
+				expectedTags.AddLow("foo_bar_baz", "val1:val2")
+				config.Datadog.Set("ecs_resource_tags_replace_colon", true)
+				return expectedTags
+			},
+			resetFunc: func() { config.Datadog.Set("ecs_resource_tags_replace_colon", false) },
+		},
+		{
+			name: "replace colon disabled",
+			taskTags: map[string]string{
+				"environment":         "sandbox",
+				"project":             "ecs-test",
+				"foo:bar:baz":         "val",
+				"aws:ecs:clusterName": "test-cluster",
+				"aws:ecs:serviceName": "nginx-awsvpc",
+			},
+			loadFunc: func() *utils.TagList {
+				expectedTags := utils.NewTagList()
+				expectedTags.AddLow("environment", "sandbox")
+				expectedTags.AddLow("project", "ecs-test")
+				expectedTags.AddLow("foo:bar:baz", "val")
+				return expectedTags
+			},
+			resetFunc: func() {},
+		},
 	}
-
-	expectedTags := utils.NewTagList()
-	expectedTags.AddLow("environment", "sandbox")
-	expectedTags.AddLow("project", "ecs-test")
-
-	addResourceTags(tags, taskTags)
-
-	assert.Equal(t, expectedTags, tags)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer tt.resetFunc()
+			tags := utils.NewTagList()
+			expectedTags := tt.loadFunc()
+			addResourceTags(tags, tt.taskTags)
+			assert.Equal(t, expectedTags, tags)
+		})
+	}
 }

--- a/releasenotes/notes/ecs-resource-tags-replace-colon-28c50aa903be8b0e.yaml
+++ b/releasenotes/notes/ecs-resource-tags-replace-colon-28c50aa903be8b0e.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The Agent can be configured to replace colon ``:`` characters in the ECS resource tag keys by underscores ``_``.
+    This can be done by enabling ``ecs_resource_tags_replace_colon: true`` in the Agent config file
+    or by configuring the environment variable ``DD_ECS_RESOURCE_TAGS_REPLACE_COLON=true``.


### PR DESCRIPTION
### What does this PR do?

The Agent can be configured to replace colon `:` characters in the ECS resource tag keys by underscores `_`.

### Motivation

- T0 FR
- It is common to use colon characters in ECS EC2 resource tag keys, this causes an undesired behaviour on DD. Example: the ECS EC2 resource tag `part1:part2:val` would be interpreted by DD as key : `part1` value: `part2:val`.  This PR makes it possible to replace the first colon so that DD interprets the tag correctly -> key : `part1_part2` value: `val`.

### Describe your test plan

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html

Define ECS EC2 resource tags with colon characters in the tag keys, then deploy the agent on the ECS EC2 cluster with `ecs_collect_resource_tags_ec2` and `ecs_resource_tags_replace_colon` enabled.
