### PR TITLE
[system-probe] Fix default dogstatsd host and port for system-probe

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -132,6 +132,9 @@ func load(configPath string) (*Config, error) {
 		LogLevel:  cfg.GetString(key(spNS, "log_level")),
 		DebugPort: cfg.GetInt(key(spNS, "debug_port")),
 
+		StatsdHost: aconfig.GetBindHost(),
+		StatsdPort: cfg.GetInt("dogstatsd_port"),
+
 		ProfilingEnabled:     cfg.GetBool(key(spNS, "profiling.enabled")),
 		ProfilingSite:        cfg.GetString(key(spNS, "profiling.site")),
 		ProfilingURL:         cfg.GetString(key(spNS, "profiling.profile_dd_url")),


### PR DESCRIPTION
### What does this PR do?

This PR ensures that a default value is provided for both the host and the port of system-probe's dogstatsd configuration.

### Motivation

Without those defaults, metrics aren't sent when a host and a port are not provided.
