### PR TITLE
[corechecks/snmp] Reduce bulkMaxRepetition to 10

### DIFF
--- a/pkg/collector/corechecks/snmp/session.go
+++ b/pkg/collector/corechecks/snmp/session.go
@@ -9,9 +9,11 @@ import (
 
 const sysObjectIDOid = "1.3.6.1.2.1.1.2.0"
 
-// Java SNMP uses 50, snmp-net uses 10
-// Same max repetition as gosnmp.defaultMaxRepetitions
-const bulkMaxRepetition = 50
+// Same max repetition as snmp-net default value
+// - Java SNMP and gosnmp (gosnmp.defaultMaxRepetitions) uses 50
+// - snmp-net uses 10
+// Using too high max reptition might lead to tooBig SNMP error messages.
+const bulkMaxRepetition = 10
 
 type sessionAPI interface {
 	Configure(config snmpConfig) error

--- a/pkg/collector/corechecks/snmp/session.go
+++ b/pkg/collector/corechecks/snmp/session.go
@@ -9,10 +9,9 @@ import (
 
 const sysObjectIDOid = "1.3.6.1.2.1.1.2.0"
 
-// Same max repetition as snmp-net default value
+// Using too high max repetitions might lead to tooBig SNMP error messages.
 // - Java SNMP and gosnmp (gosnmp.defaultMaxRepetitions) uses 50
 // - snmp-net uses 10
-// Using too high max reptition might lead to tooBig SNMP error messages.
 const bulkMaxRepetition = 10
 
 type sessionAPI interface {


### PR DESCRIPTION
### What does this PR do?

Reduce bulkMaxRepetition to 10

Using 10 might be a good enough default value:
- large value is only beneficial to table with number of rows higher than 10. That happen, but I think that's not the most common case. See also, simple benchmark in "Additional Notes" section.
- having a large max rep (e.g. 50) in combination with a large default oid_batch_size (default 60) might lead to max 3000 OIDs being retrieved at one, which might be too big for some devices.

### Motivation

Using too high max repetition might lead to tooBig SNMP error messages.

GetBulk message size depend on the oid_batch_size (number of OIDs/columns we are requesting per call), and the max_repetitions (number of rows per column we want to retrieve).

`oid_batch_size` is now configurable since:
- https://github.com/DataDog/datadog-agent/pull/7818
- https://github.com/DataDog/datadog-agent/pull/7821

`max_repetitions` is currently NOT configurable, it's not sure if there is a need to make it configurable.
Using 10 might be a good enough default value. We can still make it configurable later if needed.

Note also that, we used bulk max rep `10` in Python SNMP. But GetBulk was enabled via config in Python SNMP, and wasn't enabled in most cases.

### Additional Notes

```
Config Used:

init_config:
instances:
- # community_string: cisco-nexus
  ip_address: localhost
  name: localhost
  port: 1161
  loader: core
  version: 3
  user: datadogSHADES
  authKey: doggiepass
  authProtocol: sha
  privKey: doggiePRIVkey
  privProtocol: des
  context_name: cisco-nexus


WITH MAX REP 50
➜  datadog-agent sudo -u dd-agent time ./bin/agent/agent check snmp -l debug --check-times 10 | grep 'fetch column: request oids' | wc -l
0.50user 0.19system 0:04.31elapsed 16%CPU
    100
=> 100 snmp getbulk calls for MAX REP 50


WITH MAX REP 10
➜  datadog-agent sudo -u dd-agent time ./bin/agent/agent check snmp -l debug --check-times 10 | grep 'fetch column: request oids' | wc
0.58user 0.12system 0:04.37elapsed 16%CPU
    100    3890  129780
=> 100 snmp getbulk calls for MAX REP 10, same as for MAX REP 50


WITH MAX REP 2
➜  datadog-agent sudo -u dd-agent time ./bin/agent/agent check snmp -l debug --check-times 10 | grep 'fetch column: request oids' | wc
0.54user 0.32system 0:07.83elapsed 11%CPU (0avgtext+0avgdata 79672maxresident)k
0inputs+0outputs (5817major+15171minor)pagefaults 0swaps
    210    6420  190500
=> 210 snmp getbulk calls for MAX REP 2, ~ double the # of calls compared to MAX REP 50
```


### Describe your test plan

Check the option works by looking at the debug logs. The max number of oids in log `fetch column: request oids ... ` should match the max defined in this PR.
