### PR TITLE
Re-activate env AD for Cluster Agent

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	confad "github.com/DataDog/datadog-agent/pkg/config/autodiscovery"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -34,7 +33,7 @@ func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaS
 
 	var extraEnvProviders []config.ConfigurationProviders
 	var extraEnvListeners []config.Listeners
-	if config.IsAutoconfigEnabled() && flavor.GetFlavor() == flavor.DefaultAgent && !config.IsCLCRunner() {
+	if config.IsAutoconfigEnabled() && !config.IsCLCRunner() {
 		extraEnvProviders, extraEnvListeners = confad.DiscoverComponentsFromEnv()
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -1306,7 +1306,6 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
-github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20180825020608-02ddb050ef6b/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=

--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -40,6 +40,11 @@ func DiscoverComponentsFromEnv() ([]config.ConfigurationProviders, []config.List
 	// We automatically activate the environment listener
 	detectedListeners = append(detectedListeners, config.Listeners{Name: "environment"})
 
+	// Automatic handling of AD providers/listeners should only run in Core agent.
+	if flavor.GetFlavor() != flavor.DefaultAgent {
+		return detectedProviders, detectedListeners
+	}
+
 	if config.IsFeaturePresent(config.Docker) {
 		detectedProviders = append(detectedProviders, config.ConfigurationProviders{Name: "docker", Polling: true, PollInterval: "1s"})
 		if !config.IsFeaturePresent(config.Kubernetes) {

--- a/pkg/config/environment_detection.go
+++ b/pkg/config/environment_detection.go
@@ -71,7 +71,6 @@ func IsFeaturePresent(feature Feature) bool {
 }
 
 // IsAutoconfigEnabled returns if autoconfig from environment is activated or not
-// We cannot rely on Datadog config as this function may be called before configuration is read
 func IsAutoconfigEnabled() bool {
 	// Usage of pure environment variables should be deprecated
 	for _, envVar := range []string{autoconfEnvironmentVariable, autoconfEnvironmentVariableWithTypo} {


### PR DESCRIPTION
### What does this PR do?

Re-activate environment autodiscovery in Cluster Agent as required for Orchestrator Explorer.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Verify the `orchestrator` checks is scheduled when activated.
