### PR TITLE
Change the way we count CPUs for container limits and process metrics

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd.go
@@ -9,7 +9,6 @@ package containerd
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 	"time"
 
@@ -34,6 +33,7 @@ import (
 	ddContainers "github.com/DataDog/datadog-agent/pkg/util/containers"
 	cgroup "github.com/DataDog/datadog-agent/pkg/util/containers/providers/cgroup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 const (
@@ -346,7 +346,6 @@ func parseAndSubmitMem(metricName string, sender aggregator.Sender, stat *v1.Mem
 	sender.Gauge(fmt.Sprintf("%s.failcnt", metricName), float64(stat.Failcnt), "", tags)
 	sender.Gauge(fmt.Sprintf("%s.limit", metricName), float64(stat.Limit), "", tags)
 	sender.Gauge(fmt.Sprintf("%s.max", metricName), float64(stat.Max), "", tags)
-
 }
 
 func computeCPU(sender aggregator.Sender, cpu *v1.CPUStat, cpuLimits *specs.LinuxCPU, startTime, currentTime time.Time, tags []string) {
@@ -365,7 +364,7 @@ func computeCPU(sender aggregator.Sender, cpu *v1.CPUStat, cpuLimits *specs.Linu
 
 	timeDiff := float64(currentTime.Sub(startTime).Nanoseconds()) // cpu.total is in nanoseconds
 	if timeDiff > 0 {
-		cpuLimitPct := float64(runtime.NumCPU())
+		cpuLimitPct := float64(system.HostCPUCount())
 		if cpuLimits != nil && cpuLimits.Period != nil && *cpuLimits.Period > 0 && cpuLimits.Quota != nil && *cpuLimits.Quota > 0 {
 			cpuLimitPct = float64(*cpuLimits.Quota) / float64(*cpuLimits.Period)
 		}

--- a/pkg/collector/corechecks/containers/containerd/containerd_test.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd_test.go
@@ -9,7 +9,6 @@ package containerd
 
 import (
 	"encoding/json"
-	"runtime"
 	"sort"
 	"testing"
 	"time"
@@ -29,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	containersutil "github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 func int64Ptr(v int64) *int64 {
@@ -110,26 +110,28 @@ func TestComputeEvents(t *testing.T) {
 		},
 		{
 			name: "Events on wrong type",
-			events: []containerdEvent{{
-				Topic: "/containers/delete/extra",
-			}, {
-				Topic: "containers/delete",
-			},
+			events: []containerdEvent{
+				{
+					Topic: "/containers/delete/extra",
+				}, {
+					Topic: "containers/delete",
+				},
 			},
 			expectedTitle: "",
 			numberEvents:  0,
 		},
 		{
 			name: "High cardinality Events with one invalid",
-			events: []containerdEvent{{
-				Topic:     "/containers/delete",
-				Timestamp: time.Now(),
-				Extra:     map[string]string{"foo": "bar"},
-				Message:   "Container xxx deleted",
-				ID:        "xxx",
-			}, {
-				Topic: "containers/delete",
-			},
+			events: []containerdEvent{
+				{
+					Topic:     "/containers/delete",
+					Timestamp: time.Now(),
+					Extra:     map[string]string{"foo": "bar"},
+					Message:   "Container xxx deleted",
+					ID:        "xxx",
+				}, {
+					Topic: "containers/delete",
+				},
 			},
 			expectedTitle: "Event on containers from Containerd",
 			expectedTags:  []string{"foo:bar"},
@@ -137,13 +139,14 @@ func TestComputeEvents(t *testing.T) {
 		},
 		{
 			name: "Low cardinality Event",
-			events: []containerdEvent{{
-				Topic:     "/images/update",
-				Timestamp: time.Now(),
-				Extra:     map[string]string{"foo": "baz"},
-				Message:   "Image yyy updated",
-				ID:        "yyy",
-			},
+			events: []containerdEvent{
+				{
+					Topic:     "/images/update",
+					Timestamp: time.Now(),
+					Extra:     map[string]string{"foo": "baz"},
+					Message:   "Image yyy updated",
+					ID:        "yyy",
+				},
 			},
 			expectedTitle: "Event on images from Containerd",
 			expectedTags:  []string{"foo:baz"},
@@ -151,13 +154,14 @@ func TestComputeEvents(t *testing.T) {
 		},
 		{
 			name: "Filtered event",
-			events: []containerdEvent{{
-				Topic:     "/images/create",
-				Timestamp: time.Now(),
-				Extra:     map[string]string{},
-				Message:   "Image kubernetes/pause created",
-				ID:        "kubernetes/pause",
-			},
+			events: []containerdEvent{
+				{
+					Topic:     "/images/create",
+					Timestamp: time.Now(),
+					Extra:     map[string]string{},
+					Message:   "Image kubernetes/pause created",
+					ID:        "kubernetes/pause",
+				},
 			},
 			expectedTitle: "Event on images from Containerd",
 			expectedTags:  nil,
@@ -211,7 +215,7 @@ func TestComputeCPU(t *testing.T) {
 				"containerd.cpu.system": 10,
 				"containerd.cpu.total":  40,
 				"containerd.cpu.user":   30,
-				"containerd.cpu.limit":  1e10 * float64(runtime.NumCPU()),
+				"containerd.cpu.limit":  1e10 * float64(system.HostCPUCount()),
 			},
 		},
 		{

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -1,7 +1,6 @@
 package checks
 
 import (
-	"runtime"
 	"sync"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	containercollectors "github.com/DataDog/datadog-agent/pkg/util/containers/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 // Container is a singleton ContainerCheck.
@@ -133,7 +133,7 @@ func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.Co
 		lastCtr = fillNilRates(lastCtr)
 
 		ifStats := ctr.Network.SumInterfaces()
-		cpus := runtime.NumCPU()
+		cpus := system.HostCPUCount()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 
 		// Retrieves metadata tags

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -1,7 +1,6 @@
 package checks
 
 import (
-	"runtime"
 	"time"
 
 	model "github.com/DataDog/agent-payload/process"
@@ -10,6 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	containercollectors "github.com/DataDog/datadog-agent/pkg/util/containers/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 // RTContainer is a singleton RTContainerCheck.
@@ -68,7 +68,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 		messages = append(messages, &model.CollectorContainerRealTime{
 			HostName:          cfg.HostName,
 			Stats:             chunked[i],
-			NumCpus:           int32(runtime.NumCPU()),
+			NumCpus:           int32(system.HostCPUCount()),
 			TotalMemory:       r.sysInfo.TotalMemory,
 			GroupId:           groupID,
 			GroupSize:         int32(groupSize),
@@ -106,7 +106,7 @@ func fmtContainerStats(
 		lastCtr = fillNilRates(lastCtr)
 
 		ifStats := ctr.Network.SumInterfaces()
-		cpus := runtime.NumCPU()
+		cpus := system.HostCPUCount()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 		chunk = append(chunk, &model.ContainerStat{
 			Id:          ctr.ID,

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -4,11 +4,11 @@ package checks
 
 import (
 	"os/user"
-	"runtime"
 	"strconv"
 
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
 	"github.com/DataDog/gopsutil/cpu"
 )
 
@@ -34,7 +34,7 @@ func formatUser(fp *procutil.Process) *model.ProcessUser {
 }
 
 func formatCPU(fp *procutil.Stats, t2, t1 *procutil.CPUTimesStat, syst2, syst1 cpu.TimesStat) *model.CPUStat {
-	numCPU := float64(runtime.NumCPU())
+	numCPU := float64(system.HostCPUCount())
 	deltaSys := syst2.Total() - syst1.Total()
 	return &model.CPUStat{
 		LastCpu:    "cpu",

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -12,23 +12,19 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 // NanoToUserHZDivisor holds the divisor to convert cpu.usage to the
 // same unit as cpu.system (USER_HZ = 1/100)
 // TODO: get USER_HZ from gopsutil? Needs to patch it
 const NanoToUserHZDivisor float64 = 1e9 / 100
-
-var (
-	numCPU = float64(runtime.NumCPU())
-)
 
 // Mem returns the memory statistics for a Cgroup. If the cgroup file is not
 // available then we return an empty stats file.
@@ -285,7 +281,7 @@ func (c ContainerCgroup) CPUPeriods() (throttledNr uint64, throttledTime float64
 // If the limits files aren't available (on older version) then
 // we'll return the default value of numCPU * 100.
 func (c ContainerCgroup) CPULimit() (float64, error) {
-	limit := numCPU * 100.0
+	limit := float64(system.HostCPUCount()) * 100.0
 
 	periodFile := c.cgroupFilePath("cpu", "cpu.cfs_period_us")
 	quotaFile := c.cgroupFilePath("cpu", "cpu.cfs_quota_us")

--- a/pkg/util/system/cpu.go
+++ b/pkg/util/system/cpu.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package system
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	maxHostCPUFailedAttempts = 3
+)
+
+var (
+	hostCPUCount           int64 = 0
+	hostCPUFailedAttempts  int   = 0
+	hostCPUCountUpdateLock sync.Mutex
+	cpuInfoFunc            func(context.Context, bool) (int, error)
+)
+
+// HostCPUCount returns the number of logical CPUs from host
+func HostCPUCount() int {
+	if v := atomic.LoadInt64(&hostCPUCount); v != 0 {
+		return int(v)
+	}
+
+	hostCPUCountUpdateLock.Lock()
+	defer hostCPUCountUpdateLock.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cpuCount, err := cpuInfoFunc(ctx, true)
+	if err != nil {
+		hostCPUFailedAttempts++
+		log.Debugf("Unable to get host cpu count, err: %v", err)
+
+		// To maximize backward compatibility and still be able to return
+		// a value which is accurate in most cases.
+		// After max attempts, we give up and cache this value
+		if hostCPUFailedAttempts >= maxHostCPUFailedAttempts {
+			log.Debugf("Permafail while getting host cpu count, will use runtime.NumCPU(), err: %v", err)
+			cpuCount = runtime.NumCPU()
+		} else {
+			return runtime.NumCPU()
+		}
+	}
+	atomic.StoreInt64(&hostCPUCount, int64(cpuCount))
+
+	return cpuCount
+}

--- a/pkg/util/system/cpu_test.go
+++ b/pkg/util/system/cpu_test.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package system
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeCPUCount struct {
+	count int
+	err   error
+}
+
+func newFakeCPUCount(count int, err error) *fakeCPUCount {
+	f := fakeCPUCount{count: count, err: err}
+	cpuInfoFunc = f.info
+	hostCPUCount = 0
+	hostCPUFailedAttempts = 0
+	return &f
+}
+
+func (f *fakeCPUCount) info(context.Context, bool) (int, error) {
+	return f.count, f.err
+}
+
+func TestHostCPUCount(t *testing.T) {
+	f := newFakeCPUCount(10000, nil)
+	assert.Equal(t, f.count, HostCPUCount())
+
+	f = newFakeCPUCount(10000, errors.New("Some error"))
+	assert.Equal(t, runtime.NumCPU(), HostCPUCount())
+	f.err = nil
+	assert.Equal(t, f.count, HostCPUCount())
+
+	// Test permafail
+	f = newFakeCPUCount(10000, errors.New("Some error"))
+	for i := 0; i < maxHostCPUFailedAttempts; i++ {
+		assert.Equal(t, runtime.NumCPU(), HostCPUCount())
+	}
+	f.err = nil
+	assert.Equal(t, runtime.NumCPU(), HostCPUCount())
+}

--- a/pkg/util/system/cpu_unix.go
+++ b/pkg/util/system/cpu_unix.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build !windows
+
+package system
+
+import (
+	"github.com/shirou/gopsutil/cpu"
+)
+
+func init() {
+	cpuInfoFunc = cpu.CountsWithContext
+}

--- a/pkg/util/system/cpu_windows.go
+++ b/pkg/util/system/cpu_windows.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package system
+
+import (
+	"context"
+	"runtime"
+)
+
+func init() {
+	// TODO: Implement proper CPU Count for Windows too
+	// As runtime.NumCPU() supports Windows CPU Affinity
+	cpuInfoFunc = func(context.Context, bool) (int, error) {
+		return runtime.NumCPU(), nil
+	}
+}

--- a/releasenotes/notes/fix-cpu-count-3a30311a32d37788.yaml
+++ b/releasenotes/notes/fix-cpu-count-3a30311a32d37788.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Replace usage of `runtime.NumCPU` when used to compute metrics related to CPU Hosts. On some Unix systems, `runtime.NumCPU` can be influenced by CPU affinity set on the Agent, which should not affect the metrics computed for other processes/containers. Affects the CPU Limits metrics (docker/containerd) as well as the live containers page metrics.


### PR DESCRIPTION
### What does this PR do?

When the Agent runs on a Host (or K8S) with some CPUs dedicated to specific tasks or to the Agent, `runtime.NumCPU()` will report the number of CPU the Agent can use, not the total number of CPUs.
This change aims at using a better value when possible

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Run the Agent on a K8S node with `cpuManagerPolicy: static`, run some workload in `Guaranteed` QOS.
In Live Container View, verify that the % of CPU is reported against the number of host CPUs.
