### PR TITLE
[networks] Improve ENOMEM handling in HTTP monitoring

### DIFF
--- a/pkg/network/http/ebpf.go
+++ b/pkg/network/http/ebpf.go
@@ -94,6 +94,11 @@ func (e *ebpfProgram) Init() error {
 					Section: string(probes.SocketHTTPFilter),
 				},
 			},
+			&manager.ProbeSelector{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					Section: string(probes.TCPSendMsgReturn),
+				},
+			},
 		},
 	})
 }

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -46,7 +46,7 @@ func TestHTTPMonitorIntegration(t *testing.T) {
 	// Perform a number of random requests
 	requestFn := requestGenerator(t)
 	var requests []*nethttp.Request
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 100; i++ {
 		requests = append(requests, requestFn())
 	}
 

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestHTTPMonitorIntegration(t *testing.T) {
-	t.Skip("flaky test, investigating")
 	currKernelVersion, err := kernel.HostVersion()
 	require.NoError(t, err)
 	if currKernelVersion < kernel.VersionCode(4, 1, 0) {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -1031,7 +1031,7 @@ func newHTTPMonitor(supported bool, c *config.Config) *http.Monitor {
 	}
 
 	if err != nil {
-		log.Error("could not enable http monitoring: %s", err)
+		log.Errorf("could not enable http monitoring: %s", err)
 		return nil
 	}
 


### PR DESCRIPTION
### What does this PR do?

* Fix socket filter attachment which was clobbering the initialization errors
* Provide directions for customers when they hit an ENOMEM error
* Remove unnecessary calls to `perfMap.Start()`
* Fix missing kretprobe activation responsible for flushing events

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

1. Write down your original `sudo sysctl -a | grep optmem_max`
2. Reduce it to trigger an enomem: `sudo sysctl -w net.core.optmem_max= 10240` (this represents 50% of the default value for most linux distributions)
3. Enable HTTP monitoring via
```
network_config:
  enable_http_monitoring: true
```
4. Verify you see a proper error message indicating HTTP monitoring could not be started
5. Restore `optmem_max` to the original value
6. Verify you see `http monitoring enabled`
