### PR TITLE
Make check_sampler bucket expiry configurable

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -346,7 +346,7 @@ func (agg *BufferedAggregator) registerSender(id check.ID) error {
 	if _, ok := agg.checkSamplers[id]; ok {
 		return fmt.Errorf("Sender with ID '%s' has already been registered, will use existing sampler", id)
 	}
-	agg.checkSamplers[id] = newCheckSampler()
+	agg.checkSamplers[id] = newCheckSampler(config.Datadog.GetDuration("check_sampler_bucket_expiry") * time.Second)
 	return nil
 }
 

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -346,7 +346,7 @@ func (agg *BufferedAggregator) registerSender(id check.ID) error {
 	if _, ok := agg.checkSamplers[id]; ok {
 		return fmt.Errorf("Sender with ID '%s' has already been registered, will use existing sampler", id)
 	}
-	agg.checkSamplers[id] = newCheckSampler(config.Datadog.GetDuration("check_sampler_bucket_expiry") * time.Second)
+	agg.checkSamplers[id] = newCheckSampler(time.Duration(config.Datadog.GetInt("check_sampler_bucket_expiry")) * time.Second)
 	return nil
 }
 

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -30,7 +30,7 @@ type CheckSampler struct {
 }
 
 // newCheckSampler returns a newly initialized CheckSampler
-func newCheckSampler() *CheckSampler {
+func newCheckSampler(bucketExpiry time.Duration) *CheckSampler {
 	return &CheckSampler{
 		series:          make([]*metrics.Serie, 0),
 		sketches:        make(metrics.SketchSeriesList, 0),
@@ -39,7 +39,7 @@ func newCheckSampler() *CheckSampler {
 		sketchMap:       make(sketchMap),
 		lastBucketValue: make(map[ckey.ContextKey]int64),
 		lastSeenBucket:  make(map[ckey.ContextKey]time.Time),
-		bucketExpiry:    1 * time.Minute,
+		bucketExpiry:    bucketExpiry,
 	}
 }
 

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -24,7 +24,7 @@ func benchmarkAddBucket(bucketValue int64, b *testing.B) {
 		forwarder.NewOptions(map[string][]string{"hello": {"world"}})),
 		nil,
 	)
-	checkSampler := newCheckSampler()
+	checkSampler := newCheckSampler(60 * time.Second)
 
 	bucket := &metrics.HistogramBucket{
 		Name:       "my.histogram",
@@ -44,7 +44,7 @@ func benchmarkAddBucket(bucketValue int64, b *testing.B) {
 }
 
 func benchmarkAddBucketWideBounds(bucketValue int64, b *testing.B) {
-	checkSampler := newCheckSampler()
+	checkSampler := newCheckSampler(60 * time.Second)
 
 	bounds := []float64{0, .0005, .001, .003, .005, .007, .01, .015, .02, .025, .03, .04, .05, .06, .07, .08, .09, .1, .5, 1, 5, 10}
 	bucket := &metrics.HistogramBucket{

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -32,7 +32,7 @@ func generateContextKey(sample metrics.MetricSampleContext) ckey.ContextKey {
 }
 
 func TestCheckGaugeSampling(t *testing.T) {
-	checkSampler := newCheckSampler()
+	checkSampler := newCheckSampler(60 * time.Second)
 
 	mSample1 := metrics.MetricSample{
 		Name:       "my.metric.name",
@@ -91,7 +91,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 }
 
 func TestCheckRateSampling(t *testing.T) {
-	checkSampler := newCheckSampler()
+	checkSampler := newCheckSampler(60 * time.Second)
 
 	mSample1 := metrics.MetricSample{
 		Name:       "my.metric.name",
@@ -140,7 +140,7 @@ func TestCheckRateSampling(t *testing.T) {
 }
 
 func TestHistogramIntervalSampling(t *testing.T) {
-	checkSampler := newCheckSampler()
+	checkSampler := newCheckSampler(60 * time.Second)
 
 	mSample1 := metrics.MetricSample{
 		Name:       "my.metric.name",
@@ -198,8 +198,7 @@ func TestHistogramIntervalSampling(t *testing.T) {
 }
 
 func TestCheckHistogramBucketSampling(t *testing.T) {
-	checkSampler := newCheckSampler()
-	checkSampler.bucketExpiry = 10 * time.Millisecond
+	checkSampler := newCheckSampler(10 * time.Millisecond)
 
 	bucket1 := &metrics.HistogramBucket{
 		Name:       "my.histogram",
@@ -271,8 +270,7 @@ func TestCheckHistogramBucketSampling(t *testing.T) {
 }
 
 func TestCheckHistogramBucketInfinityBucket(t *testing.T) {
-	checkSampler := newCheckSampler()
-	checkSampler.bucketExpiry = 10 * time.Millisecond
+	checkSampler := newCheckSampler(10 * time.Millisecond)
 
 	bucket1 := &metrics.HistogramBucket{
 		Name:       "my.histogram",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -198,6 +198,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
+	config.BindEnvAndSetDefault("check_sampler_bucket_expiry", 60) // in seconds
 
 	// overridden in IoT Agent main
 	config.BindEnvAndSetDefault("iot_host", false)

--- a/releasenotes/notes/check-sampler-timeout-8236aefd48ed4738.yaml
+++ b/releasenotes/notes/check-sampler-timeout-8236aefd48ed4738.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Make the check_sampler bucket expiry configurable


### PR DESCRIPTION
### What does this PR do?

In some cases where checks run for a long time (> 1m) some histogram metrics would be incorrectly calculated when converted to sketches causing irregular (and incorrect) spikes in data to show up in the app. In order to mitigate this, this change allows the bucket expiry to be configurable to account for these cases of very long running checks. 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

UT's
Manual testing

QA:
1. Enable the openmetrics check with `send_distribution_buckets: true` and point it to a test app that produces an ever increasing histogram metric. 
Here is a python script that exposes a metric and increments it's value every time the endpoint is polled: 

```python
from http.server import BaseHTTPRequestHandler, HTTPServer
import time

hostName = "localhost"
serverPort = 8000
i = 0

class MyServer(BaseHTTPRequestHandler):
    def do_GET(self):
        global i
        i += 10
        self.send_response(200)
        self.send_header("Content-type", "text")
        self.end_headers()
        self.wfile.write(bytes("# HELP brian_histogram_test brian test data\n", "utf-8"))
        self.wfile.write(bytes("# TYPE brian_histogram_test histogram\n", "utf-8"))
        self.wfile.write(bytes('brian_histogram_test_bucket{le="10.0"} ' + str(i), "utf-8"))

if __name__ == "__main__":
    webServer = HTTPServer((hostName, serverPort), MyServer)
    print("Server started http://%s:%s" % (hostName, serverPort))

    try:
        webServer.serve_forever()
    except KeyboardInterrupt:
        pass

    webServer.server_close()
```

2. add a hardcoded sleep to the open metrics check to make the check take longer than 60 seconds
3. When you see the data in app, you will see it increases forever because the raw value is being incorrectly reported. 
4. extend the bucket expiry value to be longer than the hardcoded sleep in the check
5. The values in app should be correctly reported as the delta instead of the raw value
