### PR TITLE
Update `CODEOWNERS`: `/pkg/util/containerd` belongs to `container-integrations`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -156,6 +156,7 @@
 /pkg/tagger/collectors/garden*.go       @DataDog/integrations-tools-and-libraries
 /pkg/util/cloudfoundry/                 @DataDog/integrations-tools-and-libraries
 /pkg/util/clusteragent/                 @DataDog/container-integrations
+/pkg/util/containerd/                   @DataDog/container-integrations
 /pkg/util/containers/                   @DataDog/container-integrations
 /pkg/util/containers/collectors/cloudfoundry.go              @DataDog/integrations-tools-and-libraries
 /pkg/util/docker/                       @DataDog/container-integrations


### PR DESCRIPTION
### What does this PR do?

Update `CODEOWNERS`: `/pkg/util/containerd` belongs to `@DataDog/container-integrations`

### Motivation

Avoid inappropriate reviewers list.

### Additional Notes

### Describe your test plan

N/A
