### PR TITLE
Return early when check sampler monotonic bucket is not found

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -90,17 +90,18 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
 	if bucket.Monotonic {
 		lastBucketValue, bucketFound := cs.lastBucketValue[contextKey]
 		rawValue := bucket.Value
-		if bucketFound {
-			cs.lastSeenBucket[contextKey] = time.Now()
-			bucket.Value = rawValue - lastBucketValue
-		}
-		cs.lastBucketValue[contextKey] = rawValue
+
 		cs.lastSeenBucket[contextKey] = time.Now()
+		cs.lastBucketValue[contextKey] = rawValue
 
 		// Return early so we don't report the first raw value instead of the delta which will cause spikes
 		if !bucketFound {
 			return
 		}
+
+		bucket.Value = rawValue - lastBucketValue
+		cs.lastBucketValue[contextKey] = rawValue
+		cs.lastSeenBucket[contextKey] = time.Now()
 	}
 
 	if bucket.Value < 0 {

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -100,8 +100,6 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
 		}
 
 		bucket.Value = rawValue - lastBucketValue
-		cs.lastBucketValue[contextKey] = rawValue
-		cs.lastSeenBucket[contextKey] = time.Now()
 	}
 
 	if bucket.Value < 0 {

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -96,6 +96,11 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
 		}
 		cs.lastBucketValue[contextKey] = rawValue
 		cs.lastSeenBucket[contextKey] = time.Now()
+
+		// Return early so we don't report the first raw value instead of the delta which will cause spikes
+		if !bucketFound {
+			return
+		}
 	}
 
 	if bucket.Value < 0 {

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -216,21 +216,11 @@ func TestCheckHistogramBucketSampling(t *testing.T) {
 
 	checkSampler.commit(12349.0)
 	_, flushed := checkSampler.flush()
-	assert.Equal(t, 1, len(flushed))
+	assert.Equal(t, 0, len(flushed))
 
 	expSketch := &quantile.Sketch{}
 	// linear interpolated values
 	expSketch.Insert(quantile.Default(), 10.0, 12.5, 15.0, 17.5)
-
-	// ~3% error seen in this test case for sums (sum error is additive so it's always the worst)
-	metrics.AssertSketchSeriesApproxEqual(t, metrics.SketchSeries{
-		Name: "my.histogram",
-		Tags: []string{"foo", "bar"},
-		Points: []metrics.SketchPoint{
-			{Ts: 12345.0, Sketch: expSketch},
-		},
-		ContextKey: generateContextKey(bucket1),
-	}, flushed[0], .03)
 
 	bucket2 := &metrics.HistogramBucket{
 		Name:       "my.histogram",


### PR DESCRIPTION
### What does this PR do?

When a monotonic histogram bucket is aggregated into a sketch if a previous value does not exist the agent will report the raw value (incorrectly) causing a spike in the app. This is noticeable when the agent restarts. This change causes the agent to record the value without reporting it when a previous bucket is not found. 

### Describe your test plan

Needs further testing. 
