### PR TITLE
pkg/trace/writer: assume 408 code is retriable

### DIFF
--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -32,6 +32,24 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestIsRetriable(t *testing.T) {
+	for code, want := range map[int]bool{
+		400: false,
+		404: false,
+		408: true,
+		409: false,
+		500: true,
+		503: true,
+		505: true,
+		200: false,
+		204: false,
+		306: false,
+		101: false,
+	} {
+		assert.Equal(t, isRetriable(code), want)
+	}
+}
+
 func TestSender(t *testing.T) {
 	const climit = 100
 	testSenderConfig := func(serverURL string) *senderConfig {
@@ -143,7 +161,7 @@ func TestSender(t *testing.T) {
 		}
 
 		s := newSender(testSenderConfig(server.URL))
-		s.Push(expectResponses(503, 503, 200))
+		s.Push(expectResponses(503, 408, 200))
 		s.Stop()
 
 		assert.Equal([]int{0, 1, 2}, backoffCalls)

--- a/pkg/trace/writer/testserver.go
+++ b/pkg/trace/writer/testserver.go
@@ -141,10 +141,10 @@ func (ts *testServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
 	statusCode := ts.getNextCode(slurp)
 	w.WriteHeader(statusCode)
-	switch statusCode / 100 {
-	case 5: // 5xx
+	switch {
+	case isRetriable(statusCode):
 		atomic.AddUint64(&ts.retried, 1)
-	case 2: // 2xx
+	case statusCode/100 == 2: // 2xx
 		atomic.AddUint64(&ts.accepted, 1)
 		// for 2xx, we store the payload contents too
 		headers := make(map[string]string, len(req.Header))

--- a/releasenotes/notes/apm-sender-retry-408-e7895b8f22705a36.yaml
+++ b/releasenotes/notes/apm-sender-retry-408-e7895b8f22705a36.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: The trace writer will now consider 408 errors to be retriable.


### PR DESCRIPTION
This change ensures that the writer will retry status code 408 (client request timeout).

Fixes #7890 
