### PR TITLE
pkg/trace/traceutil: Fix name and service normalization

### DIFF
--- a/pkg/trace/traceutil/normalize.go
+++ b/pkg/trace/traceutil/normalize.go
@@ -37,14 +37,16 @@ func NormalizeName(name string) (string, error) {
 	if name == "" {
 		return DefaultSpanName, ErrEmpty
 	}
+	var err error
 	if len(name) > MaxNameLen {
-		return TruncateUTF8(name, MaxNameLen), ErrTooLong
+		name = TruncateUTF8(name, MaxNameLen)
+		err = ErrTooLong
 	}
 	name, ok := normMetricNameParse(name)
 	if !ok {
 		return DefaultSpanName, ErrInvalid
 	}
-	return name, nil
+	return name, err
 }
 
 // NormalizeService normalizes a span service and returns an error describing the reason
@@ -53,14 +55,16 @@ func NormalizeService(svc string, lang string) (string, error) {
 	if svc == "" {
 		return fallbackService(lang), ErrEmpty
 	}
+	var err error
 	if len(svc) > MaxServiceLen {
-		return TruncateUTF8(svc, MaxServiceLen), ErrTooLong
+		svc = TruncateUTF8(svc, MaxServiceLen)
+		err = ErrTooLong
 	}
 	s := NormalizeTag(svc)
 	if s == "" {
 		return fallbackService(lang), ErrInvalid
 	}
-	return s, nil
+	return s, err
 }
 
 // fallbackServiceNames is a cache of default service names to use

--- a/pkg/trace/traceutil/normalize_test.go
+++ b/pkg/trace/traceutil/normalize_test.go
@@ -85,3 +85,71 @@ func BenchmarkNormalizeTag(b *testing.B) {
 	b.Run("plenty", benchNormalizeTag("fun:ky_ta@#g/1"))
 	b.Run("more", benchNormalizeTag("fun:k####y_ta@#g/1_@@#"))
 }
+
+func TestNormalizeName(t *testing.T) {
+	testCases := []struct {
+		name       string
+		normalized string
+		err        error
+	}{
+		{
+			name:       "",
+			normalized: DefaultSpanName,
+			err:        ErrEmpty,
+		},
+		{
+			name:       "good",
+			normalized: "good",
+			err:        nil,
+		},
+		{
+			name:       "Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.Too-Long-.",
+			normalized: "Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.Too_Long.",
+			err:        ErrTooLong,
+		},
+		{
+			name:       "bad-name",
+			normalized: "bad_name",
+			err:        nil,
+		},
+	}
+	for _, testCase := range testCases {
+		out, err := NormalizeName(testCase.name)
+		assert.Equal(t, testCase.normalized, out)
+		assert.Equal(t, testCase.err, err)
+	}
+}
+func TestNormalizeService(t *testing.T) {
+	testCases := []struct {
+		service    string
+		lang       string
+		normalized string
+		err        error
+	}{
+		{
+			service:    "",
+			normalized: DefaultServiceName,
+			err:        ErrEmpty,
+		},
+		{
+			service:    "good",
+			normalized: "good",
+			err:        nil,
+		},
+		{
+			service:    "Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.",
+			normalized: "too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.",
+			err:        ErrTooLong,
+		},
+		{
+			service:    "bad$service",
+			normalized: "bad_service",
+			err:        nil,
+		},
+	}
+	for _, testCase := range testCases {
+		out, err := NormalizeService(testCase.service, testCase.lang)
+		assert.Equal(t, testCase.normalized, out)
+		assert.Equal(t, testCase.err, err)
+	}
+}

--- a/releasenotes/notes/apm-normalization-a539e419151a9723.yaml
+++ b/releasenotes/notes/apm-normalization-a539e419151a9723.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes bug where long service names and operation names were not normalized correctly.

--- a/releasenotes/notes/apm-normalization-a539e419151a9723.yaml
+++ b/releasenotes/notes/apm-normalization-a539e419151a9723.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fixes bug where long service names and operation names were not normalized correctly.
+    APM: Fixes bug where long service names and operation names were not normalized correctly.


### PR DESCRIPTION
Right now, when the same / service is too long, it's only truncated, the rest of the normalization isn't done.