### PR TITLE
[serializer] compress processes payload

### DIFF
--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -29,7 +29,7 @@ func (rp *ResourcesCollector) Send(s *serializer.Serializer) error {
 	payload := map[string]interface{}{
 		"resources": resources.GetPayload(hostname),
 	}
-	if err := s.SendJSONToV1Intake(payload); err != nil {
+	if err := s.SendProcessesMetadata(payload); err != nil {
 		return fmt.Errorf("unable to serialize processes metadata payload, %s", err)
 	}
 	return nil

--- a/pkg/serializer/README.md
+++ b/pkg/serializer/README.md
@@ -10,9 +10,3 @@ support both API. That is why the serializer is here to choose a serialization
 protocol depending on the content and use the correct Forwarder method.
 
 To be sent, a payload needs to implement the **Marshaler** interface.
-
-### Old V1 intake endpoint
-
-The **intake** endpoint from the V1 API could ingest a large variety of JSON
-structs. To send arbitrary payloads to this endpoint use `SendJSONToV1Intake`
-that do not require a **Marshaler** object.

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -97,7 +97,7 @@ type MetricSerializer interface {
 	SendSketch(sketches marshaler.Marshaler) error
 	SendMetadata(m marshaler.Marshaler) error
 	SendHostMetadata(m marshaler.Marshaler) error
-	SendJSONToV1Intake(data interface{}) error
+	SendProcessesMetadata(data interface{}) error
 	SendOrchestratorMetadata(msgs []ProcessMessageBody, hostName, clusterID, payloadType string) error
 }
 
@@ -375,9 +375,9 @@ func (s *Serializer) sendMetadata(m marshaler.Marshaler, submit func(payload for
 	return nil
 }
 
-// SendJSONToV1Intake serializes a payload and sends it to the forwarder. Some code sends
-// arbitrary payload the v1 API.
-func (s *Serializer) SendJSONToV1Intake(data interface{}) error {
+// SendProcessesMetadata serializes a payload and sends it to the forwarder.
+// Used only by the legacy processes metadata collector.
+func (s *Serializer) SendProcessesMetadata(data interface{}) error {
 	if !s.enableJSONToV1Intake {
 		log.Debug("JSON to V1 intake endpoint payloads are disabled: dropping it")
 		return nil
@@ -385,11 +385,11 @@ func (s *Serializer) SendJSONToV1Intake(data interface{}) error {
 
 	payload, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("could not serialize v1 payload: %s", err)
+		return fmt.Errorf("could not serialize processes metadata payload: %s", err)
 	}
 	compressedPayload, err := compression.Compress(nil, payload)
 	if err != nil {
-		return fmt.Errorf("could not compress v1 payload: %s", err)
+		return fmt.Errorf("could not compress processes metadata payload: %s", err)
 	}
 	if err := s.Forwarder.SubmitV1Intake(forwarder.Payloads{&compressedPayload}, jsonExtraHeadersWithCompression); err != nil {
 		return err

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -387,7 +387,11 @@ func (s *Serializer) SendJSONToV1Intake(data interface{}) error {
 	if err != nil {
 		return fmt.Errorf("could not serialize v1 payload: %s", err)
 	}
-	if err := s.Forwarder.SubmitV1Intake(forwarder.Payloads{&payload}, jsonExtraHeaders); err != nil {
+	compressedPayload, err := compression.Compress(nil, payload)
+	if err != nil {
+		return fmt.Errorf("could not compress v1 payload: %s", err)
+	}
+	if err := s.Forwarder.SubmitV1Intake(forwarder.Payloads{&compressedPayload}, jsonExtraHeadersWithCompression); err != nil {
 		return err
 	}
 

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -389,7 +389,7 @@ func TestSendMetadata(t *testing.T) {
 	require.NotNil(t, err)
 }
 
-func TestSendJSONToV1Intake(t *testing.T) {
+func TestSendProcessesMetadata(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	payload := []byte("\"test\"")
 	payloads, _ := mkPayloads(payload, true)
@@ -397,17 +397,17 @@ func TestSendJSONToV1Intake(t *testing.T) {
 
 	s := NewSerializer(f, nil)
 
-	err := s.SendJSONToV1Intake("test")
+	err := s.SendProcessesMetadata("test")
 	require.Nil(t, err)
 	f.AssertExpectations(t)
 
 	f.On("SubmitV1Intake", payloads, jsonExtraHeadersWithCompression).Return(fmt.Errorf("some error")).Times(1)
-	err = s.SendJSONToV1Intake("test")
+	err = s.SendProcessesMetadata("test")
 	require.NotNil(t, err)
 	f.AssertExpectations(t)
 
 	errPayload := &testErrorPayload{}
-	err = s.SendJSONToV1Intake(errPayload)
+	err = s.SendProcessesMetadata(errPayload)
 	require.NotNil(t, err)
 }
 
@@ -439,7 +439,7 @@ func TestSendWithDisabledKind(t *testing.T) {
 	s.SendSeries(payload)
 	s.SendSketch(payload)
 	s.SendServiceChecks(payload)
-	s.SendJSONToV1Intake("test")
+	s.SendProcessesMetadata("test")
 
 	f.AssertNotCalled(t, "SubmitMetadata")
 	f.AssertNotCalled(t, "SubmitEvents")

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -392,8 +392,8 @@ func TestSendMetadata(t *testing.T) {
 func TestSendJSONToV1Intake(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	payload := []byte("\"test\"")
-	payloads, _ := mkPayloads(payload, false)
-	f.On("SubmitV1Intake", payloads, jsonExtraHeaders).Return(nil).Times(1)
+	payloads, _ := mkPayloads(payload, true)
+	f.On("SubmitV1Intake", payloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
 	s := NewSerializer(f, nil)
 
@@ -401,7 +401,7 @@ func TestSendJSONToV1Intake(t *testing.T) {
 	require.Nil(t, err)
 	f.AssertExpectations(t)
 
-	f.On("SubmitV1Intake", payloads, jsonExtraHeaders).Return(fmt.Errorf("some error")).Times(1)
+	f.On("SubmitV1Intake", payloads, jsonExtraHeadersWithCompression).Return(fmt.Errorf("some error")).Times(1)
 	err = s.SendJSONToV1Intake("test")
 	require.NotNil(t, err)
 	f.AssertExpectations(t)

--- a/pkg/serializer/test_common.go
+++ b/pkg/serializer/test_common.go
@@ -48,9 +48,8 @@ func (s *MockSerializer) SendHostMetadata(m marshaler.Marshaler) error {
 	return s.Called(m).Error(0)
 }
 
-// SendJSONToV1Intake serializes a payload and sends it to the forwarder. Some code sends
-// arbitrary payload the v1 API.
-func (s *MockSerializer) SendJSONToV1Intake(data interface{}) error {
+// SendProcessesMetadata serializes a legacy process metadata payload and sends it to the forwarder.
+func (s *MockSerializer) SendProcessesMetadata(data interface{}) error {
 	return s.Called(data).Error(0)
 }
 

--- a/releasenotes/notes/compress-processes-34bb37ada5d05abb.yaml
+++ b/releasenotes/notes/compress-processes-34bb37ada5d05abb.yaml
@@ -1,3 +1,0 @@
-enhancements:
-  - |
-    Compress legacy processes metadata payload.

--- a/releasenotes/notes/compress-processes-34bb37ada5d05abb.yaml
+++ b/releasenotes/notes/compress-processes-34bb37ada5d05abb.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Compress legacy processes metadata payload.


### PR DESCRIPTION
### What does this PR do?

Compress the processes metadata payload. Rename serializer method to highlight its legacy function.

### Describe your test plan

Run the agent with a new hostname and `resources` collector enabled, and check that the "Processes memory usage" widget on the host inspector pane is populated.
