### PR TITLE
[runtime-security] Reduce perf_buffer metric cardinality

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -854,6 +854,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.flush_discarder_window", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.syscall_monitor.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.events_stats.polling_interval", 20)
+	config.BindEnvAndSetDefault("runtime_security_config.events_stats.tags_cardinality", "high")
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.retention", 6)

--- a/pkg/dogstatsd/enrich.go
+++ b/pkg/dogstatsd/enrich.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	hostTagPrefix        = "host:"
-	entityIDTagPrefix    = "dd.internal.entity_id:"
-	entityIDIgnoreValue  = "none"
+	hostTagPrefix       = "host:"
+	entityIDTagPrefix   = "dd.internal.entity_id:"
+	entityIDIgnoreValue = "none"
 	// CardinalityTagPrefix is used to set the dynamic cardinality
 	CardinalityTagPrefix = "dd.internal.card:"
 )

--- a/pkg/dogstatsd/enrich.go
+++ b/pkg/dogstatsd/enrich.go
@@ -11,7 +11,8 @@ var (
 	hostTagPrefix        = "host:"
 	entityIDTagPrefix    = "dd.internal.entity_id:"
 	entityIDIgnoreValue  = "none"
-	cardinalityTagPrefix = "dd.internal.card:"
+	// CardinalityTagPrefix is used to set the dynamic cardinality
+	CardinalityTagPrefix = "dd.internal.card:"
 )
 
 func extractTagsMetadata(tags []string, defaultHostname string, originTags string, entityIDPrecedenceEnabled bool) ([]string, string, string, string, string) {
@@ -24,8 +25,8 @@ func extractTagsMetadata(tags []string, defaultHostname string, originTags strin
 			host = tag[len(hostTagPrefix):]
 		} else if strings.HasPrefix(tag, entityIDTagPrefix) {
 			entityIDValue = tag[len(entityIDTagPrefix):]
-		} else if strings.HasPrefix(tag, cardinalityTagPrefix) {
-			cardinality = tag[len(cardinalityTagPrefix):]
+		} else if strings.HasPrefix(tag, CardinalityTagPrefix) {
+			cardinality = tag[len(CardinalityTagPrefix):]
 		} else {
 			tags[n] = tag
 			n++

--- a/pkg/dogstatsd/enrich_test.go
+++ b/pkg/dogstatsd/enrich_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
 
 var (
@@ -953,7 +955,7 @@ func TestEnrichTags(t *testing.T) {
 		{
 			name: "entityId=42 cardinality=high present entityIDPrecendenceEnabled=false, host=foo, should call the originTagsFunc()",
 			args: args{
-				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), cardinalityTagPrefix + "high"},
+				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + collectors.HighCardinalityString},
 				defaultHostname:            "foo",
 				originTags:                 "originID",
 				entityIDPrecendenceEnabled: false,
@@ -967,7 +969,7 @@ func TestEnrichTags(t *testing.T) {
 		{
 			name: "entityId=42 cardinality=orchestrator present entityIDPrecendenceEnabled=false, host=foo, should call the originTagsFunc()",
 			args: args{
-				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), cardinalityTagPrefix + "orchestrator"},
+				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + collectors.OrchestratorCardinalityString},
 				defaultHostname:            "foo",
 				originTags:                 "originID",
 				entityIDPrecendenceEnabled: false,
@@ -981,7 +983,7 @@ func TestEnrichTags(t *testing.T) {
 		{
 			name: "entityId=42 cardinality=low present entityIDPrecendenceEnabled=false, host=foo, should call the originTagsFunc()",
 			args: args{
-				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), cardinalityTagPrefix + "low"},
+				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + collectors.LowCardinalityString},
 				defaultHostname:            "foo",
 				originTags:                 "originID",
 				entityIDPrecendenceEnabled: false,
@@ -995,7 +997,7 @@ func TestEnrichTags(t *testing.T) {
 		{
 			name: "entityId=42 cardinality=unknown present entityIDPrecendenceEnabled=false, host=foo, should call the originTagsFunc()",
 			args: args{
-				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), cardinalityTagPrefix + "unknown"},
+				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + collectors.UnknownCardinalityString},
 				defaultHostname:            "foo",
 				originTags:                 "originID",
 				entityIDPrecendenceEnabled: false,
@@ -1009,7 +1011,7 @@ func TestEnrichTags(t *testing.T) {
 		{
 			name: "entityId=42 cardinality='' present entityIDPrecendenceEnabled=false, host=foo, should call the originTagsFunc()",
 			args: args{
-				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), cardinalityTagPrefix},
+				tags:                       []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix},
 				defaultHostname:            "foo",
 				originTags:                 "originID",
 				entityIDPrecendenceEnabled: false,

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "dbb004ad20a8f192b4e6e38882f6a18df8e733d3542762dc90e7c96e30113fbb")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "7dd7286b17711f57afb4df4b752c48e6dfb14e6348c944245a52856ec050cf37")

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -61,6 +61,8 @@ type Config struct {
 	LoadControllerControlPeriod time.Duration
 	// StatsPollingInterval determines how often metrics should be polled
 	StatsPollingInterval time.Duration
+	// StatsTagsCardinality determines the cardinality level of the tags added to the exported metrics
+	StatsTagsCardinality string
 	// StatsdAddr defines the statsd address
 	StatsdAddr string
 	// AgentMonitoringEvents determines if the monitoring events of the agent should be sent to Datadog
@@ -104,6 +106,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		LoadControllerDiscarderTimeout:     time.Duration(aconfig.Datadog.GetInt("runtime_security_config.load_controller.discarder_timeout")) * time.Second,
 		LoadControllerControlPeriod:        time.Duration(aconfig.Datadog.GetInt("runtime_security_config.load_controller.control_period")) * time.Second,
 		StatsPollingInterval:               time.Duration(aconfig.Datadog.GetInt("runtime_security_config.events_stats.polling_interval")) * time.Second,
+		StatsTagsCardinality:               aconfig.Datadog.GetString("runtime_security_config.events_stats.tags_cardinality"),
 		StatsdAddr:                         fmt.Sprintf("%s:%d", cfg.StatsdHost, cfg.StatsdPort),
 		AgentMonitoringEvents:              aconfig.Datadog.GetBool("runtime_security_config.agent_monitoring_events"),
 		CustomSensitiveWords:               aconfig.Datadog.GetStringSlice("runtime_security_config.custom_sensitive_words"),

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -221,6 +221,7 @@ SEC("kprobe/dentry_resolver_erpc")
 int kprobe__dentry_resolver_erpc(struct pt_regs *ctx) {
     u32 key = 0;
     struct path_leaf_t *map_value = 0;
+    struct path_key_t iteration_key = {};
 
     struct dr_erpc_state_t *state = bpf_map_lookup_elem(&dr_erpc_state, &key);
     if (state == NULL) {
@@ -232,7 +233,8 @@ int kprobe__dentry_resolver_erpc(struct pt_regs *ctx) {
 #pragma unroll
     for (int i = 0; i < DR_MAX_ITERATION_DEPTH; i++)
     {
-        map_value = bpf_map_lookup_elem(&pathnames, &state->key);
+        iteration_key = state->key;
+        map_value = bpf_map_lookup_elem(&pathnames, &iteration_key);
         if (map_value == NULL)
             goto exit;
 

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -7,9 +7,8 @@ package metrics
 
 import (
 	"fmt"
-	
+
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
-	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
 
 var (
@@ -132,8 +131,8 @@ var (
 )
 
 // SetTagsWithCardinality returns the array of tags and set the requested cardinality
-func SetTagsWithCardinality(cardinality collectors.TagCardinality, tags ...string) []string {
-	return append(tags, fmt.Sprintf("%s:%s", dogstatsd.CardinalityTagPrefix, collectors.TagCardinalityToString(cardinality)))
+func SetTagsWithCardinality(cardinality string, tags ...string) []string {
+	return append(tags, fmt.Sprintf("%s:%s", dogstatsd.CardinalityTagPrefix, cardinality))
 }
 
 func newRuntimeMetric(name string) string {

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -5,6 +5,13 @@
 
 package metrics
 
+import (
+	"fmt"
+	
+	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+)
+
 var (
 	// MetricRuntimePrefix is the prefix of the metrics sent by the runtime security module
 	MetricRuntimePrefix = "datadog.runtime_security"
@@ -50,32 +57,34 @@ var (
 
 	// MetricPerfBufferLostWrite is the name of the metric used to count the number of lost events, as reported by a
 	// dedicated count in kernel space
-	// Tags: map, cpu, event_type
+	// Tags: map, event_type
 	MetricPerfBufferLostWrite = newRuntimeMetric(".perf_buffer.lost_events.write")
 	// MetricPerfBufferLostRead is the name of the metric used to count the number of lost events, as reported in user
 	// space by a perf buffer
-	// Tags: map, cpu
+	// Tags: map
 	MetricPerfBufferLostRead = newRuntimeMetric(".perf_buffer.lost_events.read")
 
 	// MetricPerfBufferEventsWrite is the name of the metric used to count the number of events written to a perf buffer
-	// Tags: map, cpu, event_type
+	// Tags: map, event_type
 	MetricPerfBufferEventsWrite = newRuntimeMetric(".perf_buffer.events.write")
 	// MetricPerfBufferEventsRead is the name of the metric used to count the number of events read from a perf buffer
-	// Tags: map, cpu
+	// Tags: map
 	MetricPerfBufferEventsRead = newRuntimeMetric(".perf_buffer.events.read")
 
 	// MetricPerfBufferBytesWrite is the name of the metric used to count the number of bytes written to a perf buffer
-	// Tags: map, cpu, event_type
+	// Tags: map, event_type
 	MetricPerfBufferBytesWrite = newRuntimeMetric(".perf_buffer.bytes.write")
 	// MetricPerfBufferBytesRead is the name of the metric used to count the number of bytes read from a perf buffer
-	// Tags: map, cpu
+	// Tags: map
 	MetricPerfBufferBytesRead = newRuntimeMetric(".perf_buffer.bytes.read")
 	// MetricPerfBufferSortingError is the name of the metric used to report events reordering issues.
-	// Tags: map, cpu, event_type
+	// Tags: map, event_type
 	MetricPerfBufferSortingError = newRuntimeMetric(".perf_buffer.sorting_error")
 	// MetricPerfBufferSortingQueueSize is the name of the metric used to report reordering queue size.
+	// Tags: -
 	MetricPerfBufferSortingQueueSize = newRuntimeMetric(".perf_buffer.sorting_queue_size")
 	// MetricPerfBufferSortingAvgOp is the name of the metric used to report average sorting operations.
+	// Tags: -
 	MetricPerfBufferSortingAvgOp = newRuntimeMetric(".perf_buffer.sorting_avg_op")
 
 	// Process Resolver metrics
@@ -121,6 +130,11 @@ var (
 	// `FIM` feature is enabled
 	MetricSecurityAgentFIMContainersRunning = newAgentMetric(".fim.containers_running")
 )
+
+// SetTagsWithCardinality returns the array of tags and set the requested cardinality
+func SetTagsWithCardinality(cardinality collectors.TagCardinality, tags ...string) []string {
+	return append(tags, fmt.Sprintf("%s:%s", dogstatsd.CardinalityTagPrefix, collectors.TagCardinalityToString(cardinality)))
+}
 
 func newRuntimeMetric(name string) string {
 	return MetricRuntimePrefix + name

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -104,7 +104,7 @@ func newRule(ruleDef *rules.RuleDefinition) *rules.Rule {
 type EventLostRead struct {
 	Timestamp time.Time `json:"date"`
 	Name      string    `json:"map"`
-	Lost      float64     `json:"lost"`
+	Lost      float64   `json:"lost"`
 }
 
 // NewEventLostReadEvent returns the rule and a populated custom event for a lost_events_read event

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -104,11 +104,11 @@ func newRule(ruleDef *rules.RuleDefinition) *rules.Rule {
 type EventLostRead struct {
 	Timestamp time.Time `json:"date"`
 	Name      string    `json:"map"`
-	Lost      int64     `json:"lost"`
+	Lost      float64     `json:"lost"`
 }
 
 // NewEventLostReadEvent returns the rule and a populated custom event for a lost_events_read event
-func NewEventLostReadEvent(mapName string, lost int64) (*rules.Rule, *CustomEvent) {
+func NewEventLostReadEvent(mapName string, lost float64) (*rules.Rule, *CustomEvent) {
 	return newRule(&rules.RuleDefinition{
 			ID: LostEventsRuleID,
 		}), newCustomEvent(model.CustomLostReadEventType, EventLostRead{

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -783,7 +783,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(in *jle
 		case "map":
 			out.Name = string(in.String())
 		case "lost":
-			out.Lost = int64(in.Int64())
+			out.Lost = float64(in.Float64())
 		default:
 			in.SkipRecursive()
 		}
@@ -811,7 +811,7 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jw
 	{
 		const prefix string = ",\"lost\":"
 		out.RawString(prefix)
-		out.Int64(int64(in.Lost))
+		out.Float64(float64(in.Lost))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/model"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
 
 // PerfMapStats contains the collected metrics for one event and one cpu in a perf buffer statistics map
@@ -296,14 +297,12 @@ func (pbm *PerfBufferMonitor) CountLostEvent(count uint64, m *manager.PerfMap, c
 func (pbm *PerfBufferMonitor) CountEvent(eventType model.EventType, timestamp uint64, count uint64, size uint64, m *manager.PerfMap, cpu int) {
 	// check event order
 	if timestamp < pbm.lastTimestamp && pbm.lastTimestamp != 0 {
-		// Comment this out for now, until we fix the cardinality of the perf_buffer.* metrics.
-		//
-		// tags := []string{
-		// 	fmt.Sprintf("map:%s", m.Name),
-		// 	fmt.Sprintf("cpu:%d", cpu),
-		// 	fmt.Sprintf("event_type:%s", eventType),
-		// }
-		// _ = pbm.statsdClient.Count(metrics.MetricPerfBufferSortingError, 1, tags, 1.0)
+		//tags := metrics.SetTagsWithCardinality(
+		//	collectors.HighCardinality,
+		//	fmt.Sprintf("map:%s", m.Name),
+		//	fmt.Sprintf("event_type:%s", eventType),
+		//)
+		//_ = pbm.statsdClient.Distribution(metrics.MetricPerfBufferSortingError, 1, tags, 1.0)
 	} else {
 		pbm.lastTimestamp = timestamp
 	}
@@ -322,18 +321,24 @@ func (pbm *PerfBufferMonitor) sendEventsAndBytesReadStats(client *statsd.Client)
 		for cpu := range pbm.stats[m] {
 			for eventType := range pbm.stats[m][cpu] {
 				evtType := model.EventType(eventType)
-				tags := []string{
+				tags := metrics.SetTagsWithCardinality(
+					collectors.HighCardinality,
 					fmt.Sprintf("map:%s", m),
-					fmt.Sprintf("cpu:%d", cpu),
 					fmt.Sprintf("event_type:%s", evtType),
+				)
+
+				count := float64(pbm.getAndResetEventCount(evtType, m, cpu))
+				if count > 0 {
+					if err := client.Distribution(metrics.MetricPerfBufferEventsRead, count, tags, 1.0); err != nil {
+						return err
+					}
 				}
 
-				if err := client.Count(metrics.MetricPerfBufferEventsRead, int64(pbm.getAndResetEventCount(evtType, m, cpu)), tags, 1.0); err != nil {
-					return err
-				}
-
-				if err := client.Count(metrics.MetricPerfBufferBytesRead, int64(pbm.getAndResetEventBytes(evtType, m, cpu)), tags, 1.0); err != nil {
-					return err
+				count = float64(pbm.getAndResetEventBytes(evtType, m, cpu))
+				if count > 0 {
+					if err := client.Distribution(metrics.MetricPerfBufferBytesRead, count, tags, 1.0); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -343,19 +348,19 @@ func (pbm *PerfBufferMonitor) sendEventsAndBytesReadStats(client *statsd.Client)
 
 func (pbm *PerfBufferMonitor) sendLostEventsReadStats(client *statsd.Client) error {
 	for m := range pbm.readLostEvents {
-		var total int64
+		var total float64
 
 		for cpu := range pbm.readLostEvents[m] {
-			tags := []string{
+			tags := metrics.SetTagsWithCardinality(
+				collectors.HighCardinality,
 				fmt.Sprintf("map:%s", m),
-				fmt.Sprintf("cpu:%d", cpu),
+			)
+			if count := float64(pbm.getAndResetReadLostCount(m, cpu)); count > 0 {
+				if err := client.Distribution(metrics.MetricPerfBufferLostRead, count, tags, 1.0); err != nil {
+					return err
+				}
+				total += count
 			}
-			count := int64(pbm.getAndResetReadLostCount(m, cpu))
-			if err := client.Count(metrics.MetricPerfBufferLostRead, count, tags, 1.0); err != nil {
-				return err
-			}
-
-			total += count
 		}
 
 		if total > 0 {
@@ -404,11 +409,11 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client *statsd.Client) e
 				}
 
 				// prepare metrics tags
-				tags = []string{
+				tags = metrics.SetTagsWithCardinality(
+					collectors.HighCardinality,
 					fmt.Sprintf("map:%s", perfMapName),
-					fmt.Sprintf("cpu:%d", cpu),
 					fmt.Sprintf("event_type:%s", evtType),
-				}
+				)
 
 				// Update stats to avoid sending twice the same data points
 				if tmpCount = pbm.swapKernelEventBytes(evtType, perfMapName, cpu, stats.Bytes); tmpCount <= stats.Bytes {
@@ -445,15 +450,25 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client *statsd.Client) e
 }
 
 func (pbm *PerfBufferMonitor) sendKernelStats(client *statsd.Client, stats PerfMapStats, tags []string) error {
-	if err := client.Count(metrics.MetricPerfBufferEventsWrite, int64(stats.Count), tags, 1.0); err != nil {
-		return err
+	if stats.Count > 0 {
+		if err := client.Distribution(metrics.MetricPerfBufferEventsWrite, float64(stats.Count), tags, 1.0); err != nil {
+			return err
+		}
 	}
 
-	if err := client.Count(metrics.MetricPerfBufferBytesWrite, int64(stats.Bytes), tags, 1.0); err != nil {
-		return err
+	if stats.Bytes > 0 {
+		if err := client.Distribution(metrics.MetricPerfBufferBytesWrite, float64(stats.Bytes), tags, 1.0); err != nil {
+			return err
+		}
 	}
 
-	return client.Count(metrics.MetricPerfBufferLostWrite, int64(stats.Lost), tags, 1.0)
+	if stats.Lost > 0 {
+		if err := client.Distribution(metrics.MetricPerfBufferLostWrite, float64(stats.Lost), tags, 1.0); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // SendStats send event stats using the provided statsd client

--- a/pkg/tagger/collectors/utils.go
+++ b/pkg/tagger/collectors/utils.go
@@ -6,22 +6,27 @@ import (
 )
 
 const (
-	lowCardinalityString               = "low"
-	orchestratorCardinalityString      = "orchestrator"
-	shortOrchestratorCardinalityString = "orch"
-	highCardinalityString              = "high"
-	unknownCardinalityString           = "unknown"
+	// LowCardinalityString is the string representation of the low cardinality
+	LowCardinalityString               = "low"
+	// OrchestratorCardinalityString is the string representation of the orchestrator cardinality
+	OrchestratorCardinalityString      = "orchestrator"
+	// ShortOrchestratorCardinalityString is the short string representation of the orchestrator cardinality
+	ShortOrchestratorCardinalityString = "orch"
+	// HighCardinalityString is the string representation of the high cardinality
+	HighCardinalityString              = "high"
+	// UnknownCardinalityString represents an unknown level of cardinality
+	UnknownCardinalityString           = "unknown"
 )
 
 // StringToTagCardinality extracts a TagCardinality from a string.
 // In case of failure to parse, returns an error and defaults to Low.
 func StringToTagCardinality(c string) (TagCardinality, error) {
 	switch strings.ToLower(c) {
-	case highCardinalityString:
+	case HighCardinalityString:
 		return HighCardinality, nil
-	case shortOrchestratorCardinalityString, orchestratorCardinalityString:
+	case ShortOrchestratorCardinalityString, OrchestratorCardinalityString:
 		return OrchestratorCardinality, nil
-	case lowCardinalityString:
+	case LowCardinalityString:
 		return LowCardinality, nil
 	default:
 		return LowCardinality, fmt.Errorf("unsupported value %s received for tag cardinality", c)
@@ -33,12 +38,12 @@ func StringToTagCardinality(c string) (TagCardinality, error) {
 func TagCardinalityToString(c TagCardinality) string {
 	switch c {
 	case HighCardinality:
-		return highCardinalityString
+		return HighCardinalityString
 	case OrchestratorCardinality:
-		return orchestratorCardinalityString
+		return OrchestratorCardinalityString
 	case LowCardinality:
-		return lowCardinalityString
+		return LowCardinalityString
 	default:
-		return unknownCardinalityString
+		return UnknownCardinalityString
 	}
 }

--- a/pkg/tagger/collectors/utils.go
+++ b/pkg/tagger/collectors/utils.go
@@ -7,15 +7,15 @@ import (
 
 const (
 	// LowCardinalityString is the string representation of the low cardinality
-	LowCardinalityString               = "low"
+	LowCardinalityString = "low"
 	// OrchestratorCardinalityString is the string representation of the orchestrator cardinality
-	OrchestratorCardinalityString      = "orchestrator"
+	OrchestratorCardinalityString = "orchestrator"
 	// ShortOrchestratorCardinalityString is the short string representation of the orchestrator cardinality
 	ShortOrchestratorCardinalityString = "orch"
 	// HighCardinalityString is the string representation of the high cardinality
-	HighCardinalityString              = "high"
+	HighCardinalityString = "high"
 	// UnknownCardinalityString represents an unknown level of cardinality
-	UnknownCardinalityString           = "unknown"
+	UnknownCardinalityString = "unknown"
 )
 
 // StringToTagCardinality extracts a TagCardinality from a string.


### PR DESCRIPTION
### What does this PR do?

This PR reduces the cardinality of the `datadog.runtime_security.perf_buffer.*` metrics by:
- removing the CPU tag
- setting the cardinality to `orchestrator` (see https://github.com/DataDog/datadog-agent/pull/7535 )

### Motivation

The cardinality of the `perf_buffer` metrics is too high, querying those metrics takes too much time.
