### PR TITLE
Log which collector had an error when pulling

### DIFF
--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -206,10 +206,10 @@ func (t *Tagger) registerCollectors(replies []collectorReply) {
 
 func (t *Tagger) pull() {
 	t.RLock()
-	for _, puller := range t.pullers {
+	for name, puller := range t.pullers {
 		err := puller.Pull()
 		if err != nil {
-			log.Warnf("%s", err.Error())
+			log.Warnf("error pulling from %s: %s", name, err.Error())
 		}
 	}
 	t.RUnlock()

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -209,7 +209,7 @@ func (t *Tagger) pull() {
 	for name, puller := range t.pullers {
 		err := puller.Pull()
 		if err != nil {
-			log.Warnf("error pulling from %s: %s", name, err.Error())
+			log.Warnf("Error pulling from %s: %s", name, err.Error())
 		}
 	}
 	t.RUnlock()


### PR DESCRIPTION
### What does this PR do?

Previously, *Tagger.pull() would log only that an error happened,
without specifying which collector the error was coming from. It isn't
always obvious by the error itself (for instance, both the kube metadata
and kubelet collectors can error out when getting the pod list from the
kubelet), so now we prefix the log message with the collector name.

### Describe your test plan

Blackhole traffic to the kubelet as below. Note that this only works if #7605 is merged, otherwise the tagger will hang and no error will be shown.

```
$ docker run -it --rm --privileged --pid=host alpine:edge nsenter -t 1 -m -u -n -i sh
# ps | grep "agent run"
2926852 root      0:57 agent run
2931843 root      0:00 grep agent run
# AGENT_PID=2926852
# ps | grep "/usr/bin/kubelet"
43659 root      2h24 /usr/bin/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --fail-swap-on=false --node-ip=172.18.0.2 --provider-id=kind://docker/kind/kind-control-plane --fail-swap-on=false --cgroup-root=/kubelet
2944246 root      0:00 grep /usr/bin/kubelet
# KUBELET_IP=172.18.0.2
# nsenter -n -t $AGENT_PID iptables -A OUTPUT -d $KUBELET_IP -p tcp --dport 10250 -j DROP
```

Check that the logs no longer look like this:

```
2021-04-16 12:16:23 UTC | CORE | WARN | (pkg/tagger/local/tagger.go:217 in pull) | couldn't fetch "podlist": error performing kubelet query https://172.18.0.2:10250/pods: Get "https://172.18.0.2:10250/pods": context canceled
```

But instead look like this:

```
2021-04-16 12:16:23 UTC | CORE | WARN | (pkg/tagger/local/tagger.go:217 in pull) | error pulling from kubelet: couldn't fetch "podlist": error performing kubelet query https://172.18.0.2:10250/pods: Get "https://172.18.0.2:10250/pods": context canceled
```