### PR TITLE
[profiling] rename profiling to internal_profiling to avoid confusion

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -578,9 +578,9 @@ func InitConfig(config Config) {
 	// Go_expvar server port
 	config.BindEnvAndSetDefault("expvar_port", "5000")
 
-	// Profiling
-	config.BindEnvAndSetDefault("profiling.enabled", false)
-	config.BindEnv("profiling.profile_dd_url", "") //nolint:errcheck
+	// internal profiling
+	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
+	config.BindEnv("internal_profiling.profile_dd_url", "") //nolint:errcheck
 
 	// Process agent
 	config.SetDefault("process_config.enabled", "false")
@@ -783,7 +783,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.intervals.connections")
 	config.SetKnown("process_config.expvar_port")
 	config.SetKnown("process_config.log_file")
-	config.SetKnown("process_config.profiling.enabled")
+	config.SetKnown("process_config.internal_profiling.enabled")
 	config.SetKnown("process_config.remote_tagger")
 
 	setupSystemProbe(config)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -620,7 +620,7 @@ api_key:
 
 {{- if .Profiling -}}
 ## @param profiling - custom object - optional
-## Enter specific configurations for profiling.
+## Enter specific configurations for internal profiling.
 ## Uncomment this parameter and the one below to enable profiling.
 ## See https://docs.datadoghq.com/tracing/profiling/
 #
@@ -628,10 +628,10 @@ api_key:
 ##       unexpected side-effects (ie. agent profiles showing with your
 ##       services).
 #
-# profiling:
+# internal_profiling:
 #
   ## @param enabled - boolean - optional - default: false
-  ## Enable profiling for the Agent process.
+  ## Enable internal profiling for the Agent process.
   #
   # enabled: false
 
@@ -928,7 +928,7 @@ api_key:
 
 {{- if .Profiling -}}
   ## @param profiling - custom object - optional
-  ## Enter specific configurations for profiling.
+  ## Enter specific configurations for internal profiling.
   ## Uncomment this parameter and the one below to enable profiling.
   ## See https://docs.datadoghq.com/tracing/profiling/
   #
@@ -936,10 +936,10 @@ api_key:
   ##       other features (e.g. process-agent profiles showing with your
   ##       services).
   #
-  # profiling:
+  # internal_profiling:
   #
   ## @param enabled - boolean - optional - default: false
-  ## Enable profiling for the Process Agent process.
+  ## Enable internal profiling for the Process Agent process.
   #
   # enabled: false
 
@@ -997,7 +997,7 @@ api_key:
 
 {{- if .Profiling -}}
   ## @param profiling - custom object - optional
-  ## Enter specific configurations for profiling.
+  ## Enter specific configurations for internal profiling.
   ## Uncomment this parameter and the one below to enable profiling.
   ## See https://docs.datadoghq.com/tracing/profiling/
   #
@@ -1005,10 +1005,10 @@ api_key:
   ##       unexpected side-effects (ie. system probe profiles showing with your
   ##       services).
   #
-  # profiling:
+  # internal_profiling:
   #
     ## @param enabled - boolean - optional - default: false
-    ## Enable profiling for the System Probe process.
+    ## Enable internal profiling for the System Probe process.
     #
     # enabled: false
 

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -34,11 +34,11 @@ func setupSystemProbe(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_host"), "127.0.0.1")
 	cfg.BindEnvAndSetDefault(join(spNS, "dogstatsd_port"), 8125)
 
-	cfg.BindEnvAndSetDefault(join(spNS, "profiling.enabled"), false, "DD_SYSTEM_PROBE_PROFILING_ENABLED")
-	cfg.BindEnvAndSetDefault(join(spNS, "profiling.site"), DefaultSite, "DD_SYSTEM_PROBE_PROFILING_SITE", "DD_SITE")
-	cfg.BindEnvAndSetDefault(join(spNS, "profiling.profile_dd_url"), "", "DD_SYSTEM_PROBE_PROFILING_DD_URL", "DD_APM_PROFILING_DD_URL")
-	cfg.BindEnvAndSetDefault(join(spNS, "profiling.api_key"), "", "DD_SYSTEM_PROBE_PROFILING_API_KEY", "DD_API_KEY")
-	cfg.BindEnvAndSetDefault(join(spNS, "profiling.env"), "", "DD_SYSTEM_PROBE_PROFILING_ENV", "DD_ENV")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enabled"), false, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENABLED")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.site"), DefaultSite, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_SITE", "DD_SITE")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.profile_dd_url"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_DD_URL", "DD_APM_INTERNAL_PROFILING_DD_URL")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.api_key"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_API_KEY", "DD_API_KEY")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.env"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENV", "DD_ENV")
 
 	// ebpf general settings
 	cfg.BindEnvAndSetDefault(join(spNS, "bpf_debug"), false)

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -377,7 +377,7 @@ func loadEnvVariables() {
 		{"DD_SCRUB_ARGS", "process_config.scrub_args"},
 		{"DD_STRIP_PROCESS_ARGS", "process_config.strip_proc_arguments"},
 		{"DD_PROCESS_AGENT_URL", "process_config.process_dd_url"},
-		{"DD_PROCESS_AGENT_PROFILING_ENABLED", "process_config.profiling.enabled"},
+		{"DD_PROCESS_AGENT_INTERNAL_PROFILING_ENABLED", "process_config.internal_profiling.enabled"},
 		{"DD_PROCESS_AGENT_REMOTE_TAGGER", "process_config.remote_tagger"},
 		{"DD_ORCHESTRATOR_URL", "orchestrator_explorer.orchestrator_dd_url"},
 		{"DD_HOSTNAME", "hostname"},

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -192,12 +192,12 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		}
 	}
 
-	// use `profiling.enabled` field in `process_config` section to enable/disable profiling for process-agent,
+	// use `internal_profiling.enabled` field in `process_config` section to enable/disable profiling for process-agent,
 	// but use the configuration from main agent to fill the settings
-	if config.Datadog.IsSet(key(ns, "profiling.enabled")) {
-		a.ProfilingEnabled = config.Datadog.GetBool(key(ns, "profiling.enabled"))
+	if config.Datadog.IsSet(key(ns, "internal_profiling.enabled")) {
+		a.ProfilingEnabled = config.Datadog.GetBool(key(ns, "internal_profiling.enabled"))
 		a.ProfilingSite = config.Datadog.GetString("site")
-		a.ProfilingURL = config.Datadog.GetString("profiling.profile_dd_url")
+		a.ProfilingURL = config.Datadog.GetString("internal_profiling.profile_dd_url")
 		a.ProfilingAPIKey = config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 		a.ProfilingEnvironment = config.Datadog.GetString("env")
 	}

--- a/releasenotes/notes/rename-internal-profiling-config-12f4e4980fb1587c.yaml
+++ b/releasenotes/notes/rename-internal-profiling-config-12f4e4980fb1587c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    For internal profiling of agent processes the `profiling` option
+    has been renamed to `internal_profiling` to avoid confusion.


### PR DESCRIPTION
### What does this PR do?

Renames the `profiling` option to `internal_profiling` to avoid confusion as this does not pertain to the enabling of the profiling product, but rather to the internal profiling of our agent processes. We just aim to limit confusion. This is mostly a troubleshooting feature.  

### Motivation

Avoid customer confusion.

### Additional Notes

None

### Describe your test plan

Make sure the new option applies correctly everywhere. Also, we will need to update the environment variables used in our deployments to enable/disable this correctly in our infrastructure.
