### PR TITLE
pkg/trace: Merge duplicate stats groups

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1094,3 +1094,88 @@ func TestConvertStats(t *testing.T) {
 		assert.Equal(t, testCase.out, out)
 	}
 }
+
+func TestMergeDuplicates(t *testing.T) {
+	in := pb.ClientStatsBucket{
+		Stats: []pb.ClientGroupedStats{
+			{
+				Service:      "s1",
+				Resource:     "r1",
+				Name:         "n1",
+				Hits:         2,
+				TopLevelHits: 2,
+				Errors:       1,
+				Duration:     123,
+			},
+			{
+				Service:      "s2",
+				Resource:     "r1",
+				Name:         "n1",
+				Hits:         2,
+				TopLevelHits: 2,
+				Errors:       0,
+				Duration:     123,
+			},
+			{
+				Service:      "s1",
+				Resource:     "r1",
+				Name:         "n1",
+				Hits:         2,
+				TopLevelHits: 2,
+				Errors:       1,
+				Duration:     123,
+			},
+			{
+				Service:      "s2",
+				Resource:     "r1",
+				Name:         "n1",
+				Hits:         2,
+				TopLevelHits: 2,
+				Errors:       0,
+				Duration:     123,
+			},
+		},
+	}
+	expected := pb.ClientStatsBucket{
+		Stats: []pb.ClientGroupedStats{
+			{
+				Service:      "s1",
+				Resource:     "r1",
+				Name:         "n1",
+				Hits:         4,
+				TopLevelHits: 2,
+				Errors:       2,
+				Duration:     246,
+			},
+			{
+				Service:      "s2",
+				Resource:     "r1",
+				Name:         "n1",
+				Hits:         4,
+				TopLevelHits: 2,
+				Errors:       0,
+				Duration:     246,
+			},
+			{
+				Service:      "s1",
+				Resource:     "r1",
+				Name:         "n1",
+				Hits:         0,
+				TopLevelHits: 2,
+				Errors:       0,
+				Duration:     0,
+			},
+			{
+				Service:      "s2",
+				Resource:     "r1",
+				Name:         "n1",
+				Hits:         0,
+				TopLevelHits: 2,
+				Errors:       0,
+				Duration:     0,
+			},
+		},
+	}
+	mergeDuplicates(in)
+	assert.Equal(t, expected, in)
+}

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -25,6 +25,7 @@ type Aggregation struct {
 	Env        string
 	Resource   string
 	Service    string
+	Name       string
 	Type       string
 	Hostname   string
 	StatusCode uint32
@@ -56,10 +57,25 @@ func NewAggregationFromSpan(s *pb.Span, env string, agentHostname string) Aggreg
 		Env:        env,
 		Resource:   s.Resource,
 		Service:    s.Service,
+		Name:       s.Name,
 		Type:       s.Type,
 		Hostname:   hostname,
 		StatusCode: getStatusCode(s),
 		Version:    traceutil.GetMetaDefault(s, tagVersion, ""),
 		Synthetics: synthetics,
+	}
+}
+
+// NewAggregationFromGroup gets the Aggregation key of grouped stats.
+func NewAggregationFromGroup(env, hostname, version string, g pb.ClientGroupedStats) Aggregation {
+	return Aggregation{
+		Env:        env,
+		Hostname:   hostname,
+		Version:    version,
+		Resource:   g.Resource,
+		Service:    g.Service,
+		Name:       g.Name,
+		StatusCode: g.HTTPStatusCode,
+		Synthetics: g.Synthetics,
 	}
 }

--- a/pkg/trace/stats/statsraw_test.go
+++ b/pkg/trace/stats/statsraw_test.go
@@ -22,6 +22,7 @@ func TestGrain(t *testing.T) {
 		Env:      "default",
 		Hostname: "default",
 		Service:  "thing",
+		Name:     "other",
 		Resource: "yo",
 	}, aggr)
 }
@@ -34,6 +35,7 @@ func TestGrainWithExtraTags(t *testing.T) {
 		Env:        "default",
 		Service:    "thing",
 		Resource:   "yo",
+		Name:       "other",
 		Hostname:   "host-id",
 		StatusCode: 418,
 		Version:    "v0",


### PR DESCRIPTION
Post normalization / obfuscation, some stats groups can be the same. This PR ensured they are merged.

Same PR as https://github.com/DataDog/datadog-agent/pull/7887 but created a new one because the old one had wrong reviewers set on it.