### PR TITLE
[system-probe] Increase max dns stats value

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -67,7 +67,7 @@ func setupSystemProbe(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "collect_dns_stats"), true, "DD_COLLECT_DNS_STATS")
 	cfg.BindEnvAndSetDefault(join(spNS, "collect_local_dns"), false, "DD_COLLECT_LOCAL_DNS")
 	cfg.BindEnvAndSetDefault(join(spNS, "collect_dns_domains"), false, "DD_COLLECT_DNS_DOMAINS")
-	cfg.BindEnvAndSetDefault(join(spNS, "max_dns_stats"), 10000)
+	cfg.BindEnvAndSetDefault(join(spNS, "max_dns_stats"), 20000, "DD_MAX_DNS_STATS")
 	cfg.BindEnvAndSetDefault(join(spNS, "dns_timeout_in_s"), 15)
 
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_conntrack"), true)

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -67,7 +67,7 @@ func setupSystemProbe(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "collect_dns_stats"), true, "DD_COLLECT_DNS_STATS")
 	cfg.BindEnvAndSetDefault(join(spNS, "collect_local_dns"), false, "DD_COLLECT_LOCAL_DNS")
 	cfg.BindEnvAndSetDefault(join(spNS, "collect_dns_domains"), false, "DD_COLLECT_DNS_DOMAINS")
-	cfg.BindEnvAndSetDefault(join(spNS, "max_dns_stats"), 20000, "DD_MAX_DNS_STATS")
+	cfg.BindEnvAndSetDefault(join(spNS, "max_dns_stats"), 20000)
 	cfg.BindEnvAndSetDefault(join(spNS, "dns_timeout_in_s"), 15)
 
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_conntrack"), true)

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -213,6 +213,7 @@ func TestSettingMaxDNSStats(t *testing.T) {
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
+		newConfig()
 		os.Unsetenv("DD_SYSTEM_PROBE_CONFIG_MAX_DNS_STATS")
 		_, err := sysconfig.New("")
 		require.NoError(t, err)

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -199,3 +199,33 @@ func TestEnablingDNSDomainCollection(t *testing.T) {
 		assert.True(t, cfg.CollectDNSDomains)
 	})
 }
+
+func TestSettingMaxDNSStats(t *testing.T) {
+	newConfig()
+	defer restoreGlobalConfig()
+
+	t.Run("via YAML", func(t *testing.T) {
+		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSDomains.yaml")
+		require.NoError(t, err)
+		cfg := New()
+
+		assert.Equal(t, 100, cfg.MaxDNSStats)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		os.Unsetenv("DD_MAX_DNS_STATS")
+		_, err := sysconfig.New("")
+		require.NoError(t, err)
+		cfg := New()
+
+		assert.Equal(t, 20000, cfg.MaxDNSStats) // default value
+
+		newConfig()
+		os.Setenv("DD_MAX_DNS_STATS", "10000")
+		_, err = sysconfig.New("")
+		require.NoError(t, err)
+		cfg = New()
+
+		assert.Equal(t, 10000, cfg.MaxDNSStats)
+	})
+}

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -213,7 +213,7 @@ func TestSettingMaxDNSStats(t *testing.T) {
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
-		os.Unsetenv("DD_MAX_DNS_STATS")
+		os.Unsetenv("DD_SYSTEM_PROBE_CONFIG_MAX_DNS_STATS")
 		_, err := sysconfig.New("")
 		require.NoError(t, err)
 		cfg := New()
@@ -221,7 +221,7 @@ func TestSettingMaxDNSStats(t *testing.T) {
 		assert.Equal(t, 20000, cfg.MaxDNSStats) // default value
 
 		newConfig()
-		os.Setenv("DD_MAX_DNS_STATS", "10000")
+		os.Setenv("DD_SYSTEM_PROBE_CONFIG_MAX_DNS_STATS", "10000")
 		_, err = sysconfig.New("")
 		require.NoError(t, err)
 		cfg = New()

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSDomains.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSDomains.yaml
@@ -1,2 +1,3 @@
 system_probe_config:
     collect_dns_domains: true
+    max_dns_stats: 100


### PR DESCRIPTION
### What does this PR do?

Increases `MaxDNSStats` by `2x`

### Motivation

Our initial cap of `10000` was pretty conservative.

<img width="675" alt="Screen Shot 2021-04-16 at 12 05 35 PM" src="https://user-images.githubusercontent.com/6791023/115059386-1c391a80-9eac-11eb-9a1f-1bf61bb16f97.png">

It is causing us to drop many DNS stats in our prod hosts though they do NOT have domain collection turned on.
This is resulting in underreporting of DNS query rate.

#### If we increase the cap, won't we run into OOM issues again?

No - as long as we have domain stats collection turned off. We plan to keep it turned off (except staging) until we have made some improvements in our agent backend code.

#### How do we know that it won't be an issue when Domain collection is turned off?

We know because we did not run into a single memory issue in our infra when we had NO cap for more than 6 months.
The only memory issue we are aware of was reported by a customer who had a host with exceptionally high query rate (more than 90k queries/second).  That case should get handled by the limit. 


### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

If we run `system-probe` without changing the default value, we will see the following in the logs:

`UTC | SYS-PROBE | INFO | (pkg/network/dns_snooper.go:71 in NewSocketFilterSnooper) | DNS Stats Collection has been enabled. Maximum number of stats objects: 20000`
